### PR TITLE
chore: env cleanup + wire REDIS_TLS across all Redis connections

### DIFF
--- a/.agents/SESSIONS/2026-04-05.md
+++ b/.agents/SESSIONS/2026-04-05.md
@@ -1,5 +1,82 @@
 # 2026-04-05 Session Log
 
-**Summary:** Session started. Fresh workspace — no prior session history.
+**Summary:** Implemented secret scanning (secretlint + gitleaks), killed stale MCP process, diagnosed frontend auth error.
 
 ---
+
+## Session 1: Secret Scanning Implementation + Dev Debugging
+
+**Status:** Complete
+
+### System Flow
+
+```mermaid
+flowchart LR
+  A[Developer commits] --> B[Husky pre-commit]
+  B --> C[lint-staged]
+  C --> D[secretlint --no-glob]
+  C --> E[biome check --write]
+  D -->|secrets found| F[Commit blocked]
+  D -->|clean| G[Commit proceeds]
+  H[Push/PR to master/develop] --> I[GitHub Actions]
+  I --> J[gitleaks scan git history]
+  I --> K[secretlint full codebase]
+```
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| DevOps | Husky pre-commit, lint-staged, GitHub Actions |
+| Config | .secretlintrc.json, .secretlintignore, .gitleaks.toml |
+| CI | .github/workflows/secret-scan.yml |
+| Backend | MCP service (port conflict) |
+| Frontend | App auth flow (API server not running) |
+
+### What was done
+
+- [x] Evaluated secret scanning tools (secretlint vs gitleaks vs GitHub Secret Scanning)
+- [x] Installed secretlint, recommended rule preset, no-homedir rule, lint-staged as devDependencies
+- [x] Created `.secretlintrc.json` with recommended + no-homedir rules
+- [x] Created `.secretlintignore` for binaries, node_modules, dist, lockfiles
+- [x] Added lint-staged config to `package.json` (secretlint on text files, biome on code files)
+- [x] Added `secretlint` script to `package.json`
+- [x] Created `.gitleaks.toml` with default rules and repo-specific allowlist
+- [x] Created `.github/workflows/secret-scan.yml` (gitleaks + secretlint on push/PR)
+- [x] Verified secretlint detects Slack tokens, npm tokens (confirmed working)
+- [x] Verified no false positives on existing codebase
+- [x] Killed stale process (PID 39362) on port 3006 blocking MCP service
+- [x] Diagnosed frontend auth errors — API server wasn't running, not a code bug
+
+### Files changed
+
+- `package.json` — added devDependencies (secretlint, lint-staged, rule packages), lint-staged config, secretlint script
+- `.secretlintrc.json` — new, secretlint rules configuration
+- `.secretlintignore` — new, file exclusions for secretlint
+- `.gitleaks.toml` — new, gitleaks configuration with allowlist
+- `.github/workflows/secret-scan.yml` — new, CI workflow for gitleaks + secretlint
+- `bun.lockb` — updated with new dependencies
+
+### Key decisions
+
+- **Decision:** Use both secretlint (pre-commit) and gitleaks (CI) rather than just one
+  - **Context:** No secret scanning existed; CLAUDE.md mandates "no secrets in repo"
+  - **Rationale:** Defense-in-depth — local prevention + CI detection covers different failure modes
+
+- **Decision:** Run secretlint via lint-staged with `--no-glob` on scoped file types
+  - **Context:** Initial attempt with `*` glob on all staged files caused OOM/SIGKILL
+  - **Rationale:** Scoping to text file extensions and using `--no-glob` (lint-staged passes file paths directly) keeps pre-commit fast
+
+- **Decision:** Frontend auth error was runtime, not code
+  - **Context:** 401s on `/onboarding` for org settings and darkroom capabilities
+  - **Rationale:** Traced through interceptor → useAuthedService → Clerk getToken flow; auth code was correct, API server simply wasn't running
+
+### Mistakes and fixes
+
+- **Mistake:** Initial lint-staged config used `"*"` glob for secretlint, causing it to process 886+ files and get killed → **Fix:** Scoped to `"*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}"` with `--no-glob` flag
+
+### Next steps
+
+- [ ] Commit secretlint + gitleaks changes to `develop` branch
+- [ ] Test pre-commit hook end-to-end with a real staged commit
+- [ ] Consider adding secretlint to the existing CI lint job for unified reporting

--- a/apps/server/api/.env.example
+++ b/apps/server/api/.env.example
@@ -32,32 +32,6 @@ OPENAI_CODEX_REDIRECT_URI=http://local.genfeed.ai:3102/oauth/openai
 # OpenAI (Assistants — existing)
 # --------------------------------------------
 OPENAI_KEY=sk-proj-your-openai-key
-OPENAI_ASSISTANTS_COST=1
-
-# OpenAI Assistants
-OPENAI_ASSISTANTS_ACCOUNT_DESCRIPTION=asst_your_account_description_id
-OPENAI_ASSISTANTS_SCRIPT=asst_your_script_id
-OPENAI_ASSISTANTS_SCRIPT_DESCRIPTION=asst_your_script_description_id
-OPENAI_ASSISTANTS_SCRIPT_IDEA=asst_your_script_idea_id
-OPENAI_ASSISTANTS_MODELS_GPT_IMAGE_1=asst_your_gpt_image_1_id
-OPENAI_ASSISTANTS_MODELS_KLINGAI=asst_your_klingai_id
-OPENAI_ASSISTANTS_MODELS_LEONARDOAI=asst_your_leonardoai_id
-OPENAI_ASSISTANTS_MODELS_GOOGLE_IMAGEN=asst_your_google_imagen_id
-OPENAI_ASSISTANTS_MODELS_GOOGLE_MUSICGEN=
-OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_TEXT=asst_your_presets_text_id
-OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_IMAGE=asst_your_presets_image_id
-OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_VIDEO=asst_your_presets_video_id
-OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_MUSIC=asst_your_presets_music_id
-OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_IMAGE_TO_VIDEO=asst_your_presets_i2v_id
-OPENAI_ASSISTANTS_POST_CONTENT=asst_your_post_content_id
-OPENAI_ASSISTANTS_ARTICLES=asst_your_articles_id
-
-# OpenAI Image Settings
-OPENAI_IMAGE_MODEL=gpt-image-1
-OPENAI_IMAGE_SIZE=1024x1536
-OPENAI_IMAGE_QUALITY=low
-OPENAI_IMAGE_OUTPUT_FORMAT=jpeg
-OPENAI_IMAGE_OUTPUT_COMPRESSION=50
 
 # --------------------------------------------
 # AI Voice Services
@@ -195,7 +169,7 @@ AWS_S3_BUCKET=your-s3-bucket-name
 # --------------------------------------------
 # MongoDB (all named databases derived automatically from MONGODB_URL)
 # --------------------------------------------
-MONGODB_URL=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/cloud
+MONGODB_URL=your_mongodb_connection_string
 
 # --------------------------------------------
 # Clerk Authentication
@@ -212,11 +186,6 @@ CHROME_EXTENSION_ID=
 # Bull Board Admin UI
 # --------------------------------------------
 BULL_BOARD_AUTH_TOKEN=
-
-# --------------------------------------------
-# OpenAI (env-specific)
-# --------------------------------------------
-OPENAI_WEBHOOK_SECRET=whsec_your_openai_webhook_secret
 
 # --------------------------------------------
 # Stripe (test keys)
@@ -296,9 +265,10 @@ REPLICATE_WEBHOOK_SIGNING_SECRET=whsec_your_replicate_webhook_secret
 # --------------------------------------------
 # Sentry
 # --------------------------------------------
+SENTRY_ENABLED=false
 SENTRY_ENVIRONMENT=development
 SENTRY_DSN=your_sentry_dsn
-SENTRY_AUTH_TOKEN_API=your_sentry_auth_token
+# SENTRY_AUTH_TOKEN_API — build-time only, set in CI
 
 # --------------------------------------------
 # Security

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -27,6 +27,10 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
 import { getGenfeedCorsOrigins } from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  buildBullMQConnection,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import {
@@ -206,23 +210,9 @@ async function main() {
     const serverAdapter = new ExpressAdapter();
     serverAdapter.setBasePath('/admin/queues');
 
-    const redisUrl = configService.get('REDIS_URL');
-    const redisUrlParsed = new URL(redisUrl || 'redis://localhost:6379');
-    const redisPassword =
-      configService.get('REDIS_PASSWORD') || redisUrlParsed.password;
-
+    const redisConfig = parseRedisConnection(configService);
     const defaultQueue = new Queue('default', {
-      connection: {
-        host: redisUrlParsed.hostname || 'localhost',
-        port: Number(redisUrlParsed.port) || 6379,
-        ...(redisPassword && { password: redisPassword }),
-        connectTimeout: 3_000,
-        enableOfflineQueue: false,
-        enableReadyCheck: false,
-        lazyConnect: true,
-        maxRetriesPerRequest: 0,
-        retryStrategy: () => null,
-      },
+      connection: buildBullMQConnection(redisConfig),
     });
 
     createBullBoard({

--- a/apps/server/api/src/queues/core/queues.module.ts
+++ b/apps/server/api/src/queues/core/queues.module.ts
@@ -60,6 +60,10 @@ import { ReplyBotModule } from '@api/services/reply-bot/reply-bot.module';
 import { TaskOrchestrationModule } from '@api/services/task-orchestration/task-orchestration.module';
 import { WorkspaceTaskProcessor } from '@api/services/task-orchestration/workspace-task.processor';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
+import {
+  buildBullMQConnection,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { BullModule } from '@nestjs/bullmq';
 import { forwardRef, Module } from '@nestjs/common';
 @Module({
@@ -108,38 +112,8 @@ import { forwardRef, Module } from '@nestjs/common';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = configService.get('REDIS_URL');
-        let host = 'localhost';
-        let port = 6379;
-        let password: string | undefined;
-
-        try {
-          const parsed = new URL(redisUrl || 'redis://localhost:6379');
-          host = parsed.hostname || host;
-          port = parsed.port ? Number(parsed.port) : port;
-          password = parsed.password || configService.get('REDIS_PASSWORD');
-        } catch {
-          const withoutScheme =
-            redisUrl?.replace(/^.*:\/\//, '') || 'localhost:6379';
-          const [parsedHost, parsedPort] = withoutScheme.split(':');
-          host = parsedHost || host;
-          port = parsedPort ? Number(parsedPort) : port;
-          password = configService.get('REDIS_PASSWORD');
-        }
-
-        return {
-          connection: {
-            host,
-            port,
-            ...(password && { password }),
-            connectTimeout: 3000,
-            enableOfflineQueue: false,
-            enableReadyCheck: false,
-            lazyConnect: true,
-            maxRetriesPerRequest: 0,
-            retryStrategy: () => null,
-          },
-        };
+        const config = parseRedisConnection(configService);
+        return { connection: buildBullMQConnection(config) };
       },
     }),
     BullModule.registerQueue(

--- a/apps/server/api/src/services/cache/services/cache-client.service.ts
+++ b/apps/server/api/src/services/cache/services/cache-client.service.ts
@@ -1,5 +1,6 @@
-import { ConfigService } from '@api/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
+import type { ConfigService } from '@api/config/config.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
 import {
   Injectable,
   type OnModuleDestroy,
@@ -19,8 +20,7 @@ export class CacheClientService implements OnModuleInit, OnModuleDestroy {
     private readonly configService: ConfigService,
     private readonly logger: LoggerService,
   ) {
-    const redisUrl =
-      this.configService.get('REDIS_URL') || 'redis://localhost:6379';
+    const config = parseRedisConnection(this.configService);
 
     this.client = createClient({
       socket: {
@@ -41,8 +41,9 @@ export class CacheClientService implements OnModuleInit, OnModuleDestroy {
           );
           return delay;
         },
+        ...(config.tls && { tls: true }),
       },
-      url: redisUrl,
+      url: config.url,
     });
 
     this.client.on('error', (error: Error) => {

--- a/apps/server/api/src/services/microservices/microservices.service.ts
+++ b/apps/server/api/src/services/microservices/microservices.service.ts
@@ -1,14 +1,18 @@
-import { ConfigService } from '@api/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
+import type { ConfigService } from '@api/config/config.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import {
+  buildNodeRedisSocketOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { HttpService } from '@nestjs/axios';
+import type { HttpService } from '@nestjs/axios';
 import {
   HttpException,
   HttpStatus,
   Injectable,
-  OnModuleInit,
+  type OnModuleInit,
 } from '@nestjs/common';
-import { createClient, RedisClientType } from 'redis';
+import { createClient, type RedisClientType } from 'redis';
 import { firstValueFrom } from 'rxjs';
 
 export interface ServiceHealth {
@@ -77,15 +81,17 @@ export class MicroservicesService implements OnModuleInit {
   }
 
   private async initializeRedis() {
-    const redisUrl =
-      this.configService.get('REDIS_URL') || 'redis://localhost:6379';
+    const config = parseRedisConnection(this.configService);
 
     this.loggerService.log(
-      `${this.constructorName} initializeRedis: Connecting to Redis at ${redisUrl}`,
+      `${this.constructorName} initializeRedis: Connecting to Redis at ${config.url}`,
     );
 
     try {
-      this.redisClient = createClient({ url: redisUrl });
+      this.redisClient = createClient({
+        socket: buildNodeRedisSocketOptions(config),
+        url: config.url,
+      });
 
       this.redisClient.on('error', (err: Error) => {
         this.loggerService.error('Redis Client Error', err);
@@ -101,7 +107,7 @@ export class MicroservicesService implements OnModuleInit {
       );
     } catch (error: unknown) {
       this.loggerService.error(
-        `${this.constructorName} initializeRedis: Failed to connect to Redis at ${redisUrl}`,
+        `${this.constructorName} initializeRedis: Failed to connect to Redis at ${config.url}`,
         error,
       );
     }

--- a/apps/server/api/src/services/microservices/microservices.service.ts
+++ b/apps/server/api/src/services/microservices/microservices.service.ts
@@ -1,9 +1,6 @@
 import type { ConfigService } from '@api/config/config.service';
 import type { LoggerService } from '@libs/logger/logger.service';
-import {
-  buildNodeRedisSocketOptions,
-  parseRedisConnection,
-} from '@libs/redis/redis-connection.utils';
+import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import type { HttpService } from '@nestjs/axios';
 import {
@@ -89,7 +86,10 @@ export class MicroservicesService implements OnModuleInit {
 
     try {
       this.redisClient = createClient({
-        socket: buildNodeRedisSocketOptions(config),
+        socket: {
+          connectTimeout: 3_000,
+          ...(config.tls ? { tls: true as const } : {}),
+        },
         url: config.url,
       });
 

--- a/apps/server/api/src/services/notifications/notifications.service.ts
+++ b/apps/server/api/src/services/notifications/notifications.service.ts
@@ -8,10 +8,7 @@ import type {
   ITelegramMessageOptions,
 } from '@genfeedai/interfaces';
 import type { LoggerService } from '@libs/logger/logger.service';
-import {
-  buildNodeRedisSocketOptions,
-  parseRedisConnection,
-} from '@libs/redis/redis-connection.utils';
+import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
 import {
   Injectable,
   type OnModuleDestroy,
@@ -34,7 +31,8 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
     const config = parseRedisConnection(this.configService);
     this.publisher = createClient({
       socket: {
-        ...buildNodeRedisSocketOptions(config, 10_000),
+        connectTimeout: 10_000,
+        ...(config.tls ? { tls: true as const } : {}),
       },
       url: config.url,
     });

--- a/apps/server/api/src/services/notifications/notifications.service.ts
+++ b/apps/server/api/src/services/notifications/notifications.service.ts
@@ -1,4 +1,4 @@
-import { ConfigService } from '@api/config/config.service';
+import type { ConfigService } from '@api/config/config.service';
 import type {
   IChatbotMetadata,
   IDiscordEmbed,
@@ -7,13 +7,17 @@ import type {
   INotificationEvent,
   ITelegramMessageOptions,
 } from '@genfeedai/interfaces';
-import { LoggerService } from '@libs/logger/logger.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import {
+  buildNodeRedisSocketOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import {
   Injectable,
   type OnModuleDestroy,
   type OnModuleInit,
 } from '@nestjs/common';
-import { createClient, RedisClientType } from 'redis';
+import { createClient, type RedisClientType } from 'redis';
 
 export type { INotificationEvent as NotificationEvent };
 
@@ -27,13 +31,12 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
     private readonly configService: ConfigService,
     private readonly logger: LoggerService,
   ) {
-    const redisUrl =
-      this.configService.get('REDIS_URL') || 'redis://localhost:6379';
+    const config = parseRedisConnection(this.configService);
     this.publisher = createClient({
       socket: {
-        connectTimeout: 10000,
+        ...buildNodeRedisSocketOptions(config, 10_000),
       },
-      url: redisUrl,
+      url: config.url,
     });
 
     this.publisher.on('error', (error: Error) => {

--- a/apps/server/clips/src/app.module.ts
+++ b/apps/server/clips/src/app.module.ts
@@ -1,20 +1,24 @@
-import { Module } from '@nestjs/common';
-import { HttpModule } from '@nestjs/axios';
-import { BullModule } from '@nestjs/bullmq';
-import { RedisModule } from '@libs/redis/redis.module';
-import { EventsModule } from '@libs/events/events.module';
-import { LoggerModule } from '@libs/logger/logger.module';
 import { ConfigModule } from '@clips/config/config.module';
 import { ConfigService } from '@clips/config/config.service';
-import { HealthController } from '@clips/controllers/health.controller';
 import { ClipperController } from '@clips/controllers/clipper.controller';
-import { ClipperPipelineService } from '@clips/services/clipper-pipeline.service';
-import { TranscriptionService } from '@clips/services/transcription.service';
-import { HighlightDetectorService } from '@clips/services/highlight-detector.service';
-import { ClipExtractorService } from '@clips/services/clip-extractor.service';
-import { ClipperQueueService } from '@clips/queues/clipper-queue.service';
+import { HealthController } from '@clips/controllers/health.controller';
 import { ClipperProcessor } from '@clips/queues/clipper.processor';
 import { CLIPPER_QUEUE_NAME } from '@clips/queues/clipper-queue.constants';
+import { ClipperQueueService } from '@clips/queues/clipper-queue.service';
+import { ClipExtractorService } from '@clips/services/clip-extractor.service';
+import { ClipperPipelineService } from '@clips/services/clipper-pipeline.service';
+import { HighlightDetectorService } from '@clips/services/highlight-detector.service';
+import { TranscriptionService } from '@clips/services/transcription.service';
+import { EventsModule } from '@libs/events/events.module';
+import { LoggerModule } from '@libs/logger/logger.module';
+import { RedisModule } from '@libs/redis/redis.module';
+import {
+  buildBullMQConnection,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
+import { HttpModule } from '@nestjs/axios';
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
 
 @Module({
   controllers: [HealthController, ClipperController],
@@ -31,38 +35,8 @@ import { CLIPPER_QUEUE_NAME } from '@clips/queues/clipper-queue.constants';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = configService.get('REDIS_URL');
-        let host = 'localhost';
-        let port = 6379;
-        let password: string | undefined;
-
-        try {
-          const parsed = new URL(redisUrl || 'redis://localhost:6379');
-          host = parsed.hostname || host;
-          port = parsed.port ? Number(parsed.port) : port;
-          password = parsed.password || configService.get('REDIS_PASSWORD');
-        } catch {
-          const withoutScheme =
-            redisUrl?.replace(/^.*:\/\//, '') || 'localhost:6379';
-          const [parsedHost, parsedPort] = withoutScheme.split(':');
-          host = parsedHost || host;
-          port = parsedPort ? Number(parsedPort) : port;
-          password = configService.get('REDIS_PASSWORD');
-        }
-
-        return {
-          connection: {
-            host,
-            port,
-            ...(password && { password }),
-            connectTimeout: 3000,
-            enableOfflineQueue: false,
-            enableReadyCheck: false,
-            lazyConnect: true,
-            maxRetriesPerRequest: 0,
-            retryStrategy: () => null,
-          },
-        };
+        const config = parseRedisConnection(configService);
+        return { connection: buildBullMQConnection(config) };
       },
     }),
     BullModule.registerQueue({

--- a/apps/server/files/src/app.module.ts
+++ b/apps/server/files/src/app.module.ts
@@ -9,6 +9,10 @@ import { SharedModule } from '@files/shared/shared.module';
 import { HealthModule } from '@libs/health/health.module';
 import { LoggerModule } from '@libs/logger/logger.module';
 import { RedisModule } from '@libs/redis/redis.module';
+import {
+  buildBullMQConnection,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -33,38 +37,8 @@ import { ScheduleModule } from '@nestjs/schedule';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = configService.get('REDIS_URL');
-        let host = 'localhost';
-        let port = 6379;
-        let password: string | undefined;
-
-        try {
-          const parsed = new URL(redisUrl || 'redis://localhost:6379');
-          host = parsed.hostname || host;
-          port = parsed.port ? Number(parsed.port) : port;
-          password = parsed.password || configService.get('REDIS_PASSWORD');
-        } catch {
-          const withoutScheme =
-            redisUrl?.replace(/^.*:\/\//, '') || 'localhost:6379';
-          const [parsedHost, parsedPort] = withoutScheme.split(':');
-          host = parsedHost || host;
-          port = parsedPort ? Number(parsedPort) : port;
-          password = configService.get('REDIS_PASSWORD');
-        }
-
-        return {
-          connection: {
-            host,
-            port,
-            ...(password && { password }),
-            connectTimeout: 3000,
-            enableOfflineQueue: false,
-            enableReadyCheck: false,
-            lazyConnect: true,
-            maxRetriesPerRequest: 0,
-            retryStrategy: () => null,
-          },
-        };
+        const config = parseRedisConnection(configService);
+        return { connection: buildBullMQConnection(config) };
       },
     }),
   ],

--- a/apps/server/files/src/services/websocket/websocket.service.ts
+++ b/apps/server/files/src/services/websocket/websocket.service.ts
@@ -1,5 +1,9 @@
-import { ConfigService } from '@files/config/config.service';
+import type { ConfigService } from '@files/config/config.service';
 import type { JobProgress } from '@files/shared/interfaces/job.interface';
+import {
+  buildNodeRedisSocketOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { Injectable, Logger } from '@nestjs/common';
 import { createClient, type RedisClientType } from 'redis';
 
@@ -16,10 +20,12 @@ export class WebSocketService {
 
   private async initRedis() {
     try {
-      const redisUrl =
-        this.configService.get('REDIS_URL') || 'redis://localhost:6379';
+      const config = parseRedisConnection(this.configService);
 
-      this.redisPublisher = createClient({ url: redisUrl });
+      this.redisPublisher = createClient({
+        socket: buildNodeRedisSocketOptions(config),
+        url: config.url,
+      });
       this.redisPublisher.on('error', (err) => {
         this.logger.error('Redis Publisher Error', err);
       });
@@ -38,7 +44,7 @@ export class WebSocketService {
     userId?: string,
     room?: string,
   ) {
-    if (!this.redisPublisher || !this.redisPublisher.isOpen) {
+    if (!this.redisPublisher?.isOpen) {
       this.logger.warn('Redis not connected, skipping progress emission');
       return;
     }
@@ -69,7 +75,7 @@ export class WebSocketService {
     userId?: string,
     room?: string,
   ) {
-    if (!this.redisPublisher || !this.redisPublisher.isOpen) {
+    if (!this.redisPublisher?.isOpen) {
       this.logger.warn('Redis not connected, skipping success emission');
       return;
     }
@@ -100,7 +106,7 @@ export class WebSocketService {
     userId?: string,
     room?: string,
   ) {
-    if (!this.redisPublisher || !this.redisPublisher.isOpen) {
+    if (!this.redisPublisher?.isOpen) {
       this.logger.warn('Redis not connected, skipping error emission');
       return;
     }
@@ -131,7 +137,7 @@ export class WebSocketService {
     data?: unknown,
     userId?: string,
   ) {
-    if (!this.redisPublisher || !this.redisPublisher.isOpen) {
+    if (!this.redisPublisher?.isOpen) {
       this.logger.warn('Redis not connected, skipping status emission');
       return;
     }
@@ -155,7 +161,7 @@ export class WebSocketService {
   }
 
   async sendProgress(ingredientId: string, progress: unknown) {
-    if (!this.redisPublisher || !this.redisPublisher.isOpen) {
+    if (!this.redisPublisher?.isOpen) {
       this.logger.warn('Redis not connected, skipping progress emission');
       return;
     }

--- a/apps/server/files/src/services/websocket/websocket.service.ts
+++ b/apps/server/files/src/services/websocket/websocket.service.ts
@@ -1,9 +1,6 @@
 import type { ConfigService } from '@files/config/config.service';
 import type { JobProgress } from '@files/shared/interfaces/job.interface';
-import {
-  buildNodeRedisSocketOptions,
-  parseRedisConnection,
-} from '@libs/redis/redis-connection.utils';
+import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
 import { Injectable, Logger } from '@nestjs/common';
 import { createClient, type RedisClientType } from 'redis';
 
@@ -23,7 +20,10 @@ export class WebSocketService {
       const config = parseRedisConnection(this.configService);
 
       this.redisPublisher = createClient({
-        socket: buildNodeRedisSocketOptions(config),
+        socket: {
+          connectTimeout: 3_000,
+          ...(config.tls ? { tls: true as const } : {}),
+        },
         url: config.url,
       });
       this.redisPublisher.on('error', (err) => {

--- a/apps/server/notifications/src/config/config.service.ts
+++ b/apps/server/notifications/src/config/config.service.ts
@@ -59,7 +59,7 @@ export class ConfigService extends BaseConfigService<IEnvConfig> {
       if (!this.envConfig.TELEGRAM_BOT_TOKEN) {
         warnings.push('Telegram bot is not configured');
       }
-
+      
       if (!this.envConfig.DISCORD_BOT_TOKEN) {
         warnings.push('Discord bot is not configured');
       }

--- a/apps/server/notifications/src/main.ts
+++ b/apps/server/notifications/src/main.ts
@@ -27,10 +27,12 @@ async function main() {
   const port = configService.get('PORT');
 
   // Configure Redis Socket.IO adapter
+  const redisTls = Boolean(configService.get('REDIS_TLS'));
   const redisIoAdapter = new RedisIoAdapter(
     app,
     configService.get('REDIS_URL') || 'redis://localhost:6379',
     logger,
+    redisTls,
   );
 
   try {

--- a/apps/server/notifications/tsconfig.json
+++ b/apps/server/notifications/tsconfig.json
@@ -11,3 +11,5 @@
   "extends": "../tsconfig.json",
   "include": ["src/**/*"]
 }
+
+

--- a/apps/server/workers/src/queues/queues.module.ts
+++ b/apps/server/workers/src/queues/queues.module.ts
@@ -5,6 +5,10 @@
  */
 
 import { QueueService } from '@api/queues/core/queue.service';
+import {
+  buildBullMQConnection,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@workers/config/config.module';
@@ -17,38 +21,8 @@ import { ConfigService } from '@workers/config/config.service';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const redisUrl = configService.get('REDIS_URL');
-        let host = 'localhost';
-        let port = 6379;
-        let password: string | undefined;
-
-        try {
-          const parsed = new URL(redisUrl || 'redis://localhost:6379');
-          host = parsed.hostname || host;
-          port = parsed.port ? Number(parsed.port) : port;
-          password = parsed.password || configService.get('REDIS_PASSWORD');
-        } catch {
-          const withoutScheme =
-            redisUrl?.replace(/^.*:\/\//, '') || 'localhost:6379';
-          const [parsedHost, parsedPort] = withoutScheme.split(':');
-          host = parsedHost || host;
-          port = parsedPort ? Number(parsedPort) : port;
-          password = configService.get('REDIS_PASSWORD');
-        }
-
-        return {
-          connection: {
-            host,
-            port,
-            ...(password && { password }),
-            connectTimeout: 3000,
-            enableOfflineQueue: false,
-            enableReadyCheck: false,
-            lazyConnect: true,
-            maxRetriesPerRequest: 0,
-            retryStrategy: () => null,
-          },
-        };
+        const config = parseRedisConnection(configService);
+        return { connection: buildBullMQConnection(config) };
       },
     }),
     BullModule.registerQueue(

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,9 @@
     "indentWidth": 2
   },
   "javascript": {
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
+    },
     "formatter": {
       "quoteStyle": "single",
       "semicolons": "always",

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "cron": "^4.4.0",
         "date-fns": "^4.1.0",
         "discord.js": "^14.26.2",
-        "dotenv": "^17.4.0",
+        "dotenv": "^17.4.1",
         "exceljs": "^4.4.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.2",
@@ -153,7 +153,7 @@
         "secretlint": "^11.4.1",
         "ts-loader": "^9.5.7",
         "tsconfig-paths-webpack-plugin": "^4.2.0",
-        "turbo": "^2.9.3",
+        "turbo": "^2.9.4",
         "webpack": "^5.105.4",
         "webpack-node-externals": "^3.0.0",
       },
@@ -628,7 +628,7 @@
       "name": "@genfeedai/config",
       "version": "1.0.0",
       "dependencies": {
-        "dotenv": "17.4.0",
+        "dotenv": "17.4.1",
         "joi": "18.1.2",
       },
       "devDependencies": {
@@ -3117,17 +3117,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.18.1", "", { "dependencies": { "fast-glob": "^3.2.12", "minimatch": "^5.1.0", "mkdirp": "^1.0.4", "path-browserify": "^1.0.1" } }, "sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9cjTWe4OiNlFMSRggPNh+TJlRs7MS5FWrHc96MOzft5vESWjjpvaadYPv5ykDW7b45mVHOF2U/W+48LoX9USWw=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pLRwFmcHHNBvsCySLS6OFabr/07kDT2pxEt/k6eBf/3asiVQZKJ7Rk88AafQx2aYA641qek4RsXvYO3JYpiBug=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Cl1GjxqBXQ+r9KKowmXG+lhD1gclLp48/SE7NxL//66iaMytRw0uiphWGOkccD92iPiRjHLRUaA9lOTtgr5OCA=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-gy6ApUroC2Nzv+qjGtE/uPNkhHAFU4c8God+zd5Aiv9L9uBgHlxVJpHT3XWl5xwlJZ2KWuMrlHTaS5kmNB+q1Q=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2hPAKVmGNN2EsKigEWD+43y9m7zaPhNAs6ptsyfq0u7evHHBAXAwOfv86OEMg/gvC+pwGip0i1CIm1bR1vYug=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.3", "", { "os": "win32", "cpu": "x64" }, "sha512-d0YelTX6hAsB7kIEtGB3PzIzSfAg3yDoUlHwuwJc3adBXUsyUIs0YLG+1NNtuhcDOUGnWQeKUoJ2pGWvbpRj7w=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-1jWPjCe9ZRmsDTXE7uzqfySNQspnUx0g6caqvwps+k/sc+fm9hC/4zRQKlXZLbVmP3Xxp601Ju71boegHdnYGw=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-dlko15TQVu/BFYmIY018Y3covWMRQlUgAkD+OOk+Rokcfj6VY02Vv4mCfT/Zns6B4q8jGbOd6IZhnCFYsE8Viw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -4143,7 +4143,7 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
-    "dotenv": ["dotenv@17.4.0", "", {}, "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="],
+    "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
 
     "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
 
@@ -6405,7 +6405,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.9.3", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.3", "@turbo/darwin-arm64": "2.9.3", "@turbo/linux-64": "2.9.3", "@turbo/linux-arm64": "2.9.3", "@turbo/windows-64": "2.9.3", "@turbo/windows-arm64": "2.9.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ=="],
+    "turbo": ["turbo@2.9.4", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.4", "@turbo/darwin-arm64": "2.9.4", "@turbo/linux-64": "2.9.4", "@turbo/linux-arm64": "2.9.4", "@turbo/windows-64": "2.9.4", "@turbo/windows-arm64": "2.9.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ=="],
 
     "twitter-api-v2": ["twitter-api-v2@1.29.0", "", {}, "sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "secretlint": "^11.4.1",
     "ts-loader": "^9.5.7",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
-    "turbo": "^2.9.3",
+    "turbo": "^2.9.4",
     "webpack": "^5.105.4",
     "webpack-node-externals": "^3.0.0"
   },
@@ -163,7 +163,7 @@
     "cron": "^4.4.0",
     "date-fns": "^4.1.0",
     "discord.js": "^14.26.2",
-    "dotenv": "^17.4.0",
+    "dotenv": "^17.4.1",
     "exceljs": "^4.4.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.2",

--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -45,6 +45,7 @@
       }
     }
   },
+  "root": false,
   "vcs": {
     "clientKind": "git",
     "enabled": true,

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "dotenv": "17.4.0",
+    "dotenv": "17.4.1",
     "joi": "18.1.2"
   },
   "devDependencies": {

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -34,6 +34,7 @@ export interface IEnvConfig {
   // === Redis ===
   REDIS_URL?: string;
   REDIS_PASSWORD?: string;
+  REDIS_TLS?: boolean;
 
   // === AWS / S3 ===
   AWS_ACCESS_KEY_ID?: string;
@@ -49,11 +50,8 @@ export interface IEnvConfig {
 
   // === Sentry ===
   SENTRY_DSN?: string;
+  SENTRY_ENABLED?: boolean;
   SENTRY_ENVIRONMENT?: string;
-  SENTRY_AUTH_TOKEN_API?: string;
-  SENTRY_AUTH_TOKEN_FILES?: string;
-  SENTRY_AUTH_TOKEN_MCP?: string;
-  SENTRY_AUTH_TOKEN_NOTIFICATIONS?: string;
 
   // === Stripe ===
   STRIPE_SECRET_KEY?: string;
@@ -73,29 +71,6 @@ export interface IEnvConfig {
 
   // === OpenAI ===
   OPENAI_KEY?: string;
-  OPENAI_WEBHOOK_SECRET?: string;
-  OPENAI_ASSISTANTS_COST?: number;
-  OPENAI_ASSISTANTS_ACCOUNT_DESCRIPTION?: string;
-  OPENAI_ASSISTANTS_SCRIPT?: string;
-  OPENAI_ASSISTANTS_SCRIPT_DESCRIPTION?: string;
-  OPENAI_ASSISTANTS_SCRIPT_IDEA?: string;
-  OPENAI_ASSISTANTS_MODELS_GPT_IMAGE_1?: string;
-  OPENAI_ASSISTANTS_MODELS_KLINGAI?: string;
-  OPENAI_ASSISTANTS_MODELS_LEONARDOAI?: string;
-  OPENAI_ASSISTANTS_MODELS_GOOGLE_IMAGEN?: string;
-  OPENAI_ASSISTANTS_MODELS_GOOGLE_MUSICGEN?: string;
-  OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_TEXT?: string;
-  OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_IMAGE?: string;
-  OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_VIDEO?: string;
-  OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_MUSIC?: string;
-  OPENAI_ASSISTANTS_PRESETS_DESCRIPTION_IMAGE_TO_VIDEO?: string;
-  OPENAI_ASSISTANTS_POST_CONTENT?: string;
-  OPENAI_ASSISTANTS_ARTICLES?: string;
-  OPENAI_IMAGE_MODEL?: string;
-  OPENAI_IMAGE_SIZE?: string;
-  OPENAI_IMAGE_QUALITY?: string;
-  OPENAI_IMAGE_OUTPUT_FORMAT?: string;
-  OPENAI_IMAGE_OUTPUT_COMPRESSION?: number;
 
   // === fal.ai ===
   FAL_API_KEY?: string;
@@ -125,19 +100,14 @@ export interface IEnvConfig {
   // === HeyGen ===
   HEYGEN_KEY?: string;
 
-  // === RunwayML ===
-  RUNWAYML_KEY?: string;
-
   // === Hedra ===
   HEDRA_KEY?: string;
-  HEDRA_URL?: string;
 
   // === Higgsfield ===
   HIGGSFIELD_API_KEY?: string;
   HIGGSFIELD_API_SECRET?: string;
 
   // === Darkroom (self-hosted GPU) ===
-  DARKROOM_API_URL?: string;
   DARKROOM_COMFYUI_URL?: string;
   DARKROOM_CLOUDFRONT_DISTRIBUTION_ID?: string;
 

--- a/packages/config/src/schemas/ai.schema.ts
+++ b/packages/config/src/schemas/ai.schema.ts
@@ -75,10 +75,6 @@ export const newsApiSchema = {
  * Darkroom — self-hosted GPU instance (ComfyUI + darkroom-api)
  */
 export const darkroomSchema = {
-  DARKROOM_API_URL: Joi.string()
-    .uri()
-    .optional()
-    .default('http://100.106.229.81:8189'),
   DARKROOM_CLOUDFRONT_DISTRIBUTION_ID: Joi.string().optional().allow(''),
   DARKROOM_COMFYUI_URL: Joi.string()
     .uri()
@@ -91,20 +87,11 @@ export const darkroomSchema = {
  * GPU Fleet — self-hosted GPU instances (images, voices, videos, llm)
  */
 export const gpuFleetSchema = {
-  GPU_IMAGES_URL: Joi.string()
-    .uri()
-    .optional()
-    .default('http://100.106.229.81:8189'),
+  GPU_IMAGES_URL: Joi.string().uri().optional().optional(),
   GPU_LLM_INSTANCE_ID: Joi.string().optional(),
   GPU_LLM_URL: Joi.string().uri().optional(),
-  GPU_VIDEOS_URL: Joi.string()
-    .uri()
-    .optional()
-    .default('http://100.114.208.72:8188'),
-  GPU_VOICES_URL: Joi.string()
-    .uri()
-    .optional()
-    .default('http://100.69.239.8:8189'),
+  GPU_VIDEOS_URL: Joi.string().uri().optional(),
+  GPU_VOICES_URL: Joi.string().uri().optional(),
 };
 
 /**

--- a/packages/config/src/schemas/notifications.schema.ts
+++ b/packages/config/src/schemas/notifications.schema.ts
@@ -7,12 +7,12 @@ export const discordBotSchema = {
   DISCORD_BOT_AVATAR_URL: Joi.string()
     .uri()
     .default('https://cdn.genfeed.ai/assets/branding/logo.jpg'),
-  DISCORD_BOT_TOKEN: Joi.string().required(),
-  DISCORD_CHANNEL_ID_POSTS: Joi.string().required(),
-  DISCORD_CHANNEL_ID_STUDIO: Joi.string().required(),
-  DISCORD_CHANNEL_ID_USERS: Joi.string().required(),
-  DISCORD_CLIENT_ID: Joi.string().required(),
-  DISCORD_GUILD_ID: Joi.string().required(),
+  DISCORD_BOT_TOKEN: Joi.string().optional().allow(''),
+  DISCORD_CHANNEL_ID_POSTS: Joi.string().optional().allow(''),
+  DISCORD_CHANNEL_ID_STUDIO: Joi.string().optional().allow(''),
+  DISCORD_CHANNEL_ID_USERS: Joi.string().optional().allow(''),
+  DISCORD_CLIENT_ID: Joi.string().optional().allow(''),
+  DISCORD_GUILD_ID: Joi.string().optional().allow(''),
 };
 
 /**

--- a/packages/libs/adapters/redis-io.adapter.ts
+++ b/packages/libs/adapters/redis-io.adapter.ts
@@ -15,6 +15,7 @@ export class RedisIoAdapter extends IoAdapter {
     app: INestApplicationContext | undefined,
     private readonly redisUrl: string,
     private readonly loggerService: LoggerService,
+    private readonly redisTls: boolean = false,
   ) {
     // Don't pass app to parent - we'll handle server creation ourselves
     super();
@@ -22,7 +23,15 @@ export class RedisIoAdapter extends IoAdapter {
   }
 
   async connectToRedis(): Promise<void> {
-    const pubClient = createClient({ url: this.redisUrl });
+    const tlsFromUrl = this.redisUrl.startsWith('rediss://');
+    const useTls = this.redisTls || tlsFromUrl;
+
+    const pubClient = createClient({
+      socket: {
+        ...(useTls && { tls: true }),
+      },
+      url: this.redisUrl,
+    });
     const subClient = pubClient.duplicate();
 
     try {

--- a/packages/libs/redis/redis-connection.utils.ts
+++ b/packages/libs/redis/redis-connection.utils.ts
@@ -63,15 +63,16 @@ export function parseRedisConnection(configService: {
 
 /**
  * Build node-redis v4 createClient socket options (for pub/sub, cache, etc.)
+ * Returns a properly typed object for createClient({ socket: ... }).
  */
 export function buildNodeRedisSocketOptions(
   config: ParsedRedisConfig,
   connectTimeout = 3_000,
-) {
-  return {
-    connectTimeout,
-    ...(config.tls && { tls: true }),
-  };
+): { connectTimeout: number; tls: true } | { connectTimeout: number } {
+  if (config.tls) {
+    return { connectTimeout, tls: true };
+  }
+  return { connectTimeout };
 }
 
 /**

--- a/packages/libs/redis/redis-connection.utils.ts
+++ b/packages/libs/redis/redis-connection.utils.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared Redis connection config utilities.
+ * Single source of truth for TLS — derived from BOTH REDIS_TLS env var AND URL scheme.
+ *
+ * Two client stacks with different TLS APIs:
+ * - node-redis v4 (createClient): socket.tls = true
+ * - ioredis (BullMQ): tls = {} (empty object enables TLS)
+ */
+
+export interface ParsedRedisConfig {
+  host: string;
+  password?: string;
+  port: number;
+  tls: boolean;
+  url: string;
+}
+
+/**
+ * Parse Redis connection from config service.
+ * TLS is enabled if EITHER:
+ * - REDIS_TLS env var is true (boolean from Joi)
+ * - REDIS_URL starts with rediss:// (TLS scheme)
+ */
+export function parseRedisConnection(configService: {
+  get: (key: string) => string | boolean | number | undefined;
+}): ParsedRedisConfig {
+  const redisUrl =
+    (configService.get('REDIS_URL') as string) || 'redis://localhost:6379';
+  const redisTls = configService.get('REDIS_TLS');
+  const redisPassword = configService.get('REDIS_PASSWORD') as
+    | string
+    | undefined;
+
+  // TLS from env var (Joi boolean) OR URL scheme
+  const tlsFromUrl = redisUrl.startsWith('rediss://');
+  const tls = Boolean(redisTls) || tlsFromUrl;
+
+  let host = 'localhost';
+  let port = 6379;
+  let password: string | undefined;
+
+  try {
+    const parsed = new URL(redisUrl);
+    host = parsed.hostname || host;
+    port = parsed.port ? Number(parsed.port) : port;
+    password = parsed.password || redisPassword;
+  } catch {
+    const withoutScheme = redisUrl.replace(/^.*:\/\//, '') || 'localhost:6379';
+    const [parsedHost, parsedPort] = withoutScheme.split(':');
+    host = parsedHost || host;
+    port = parsedPort ? Number(parsedPort) : port;
+    password = redisPassword;
+  }
+
+  return {
+    host,
+    password: password || undefined,
+    port,
+    tls,
+    url: redisUrl,
+  };
+}
+
+/**
+ * Build node-redis v4 createClient socket options (for pub/sub, cache, etc.)
+ */
+export function buildNodeRedisSocketOptions(
+  config: ParsedRedisConfig,
+  connectTimeout = 3_000,
+) {
+  return {
+    connectTimeout,
+    ...(config.tls && { tls: true }),
+  };
+}
+
+/**
+ * Build BullMQ/ioredis connection options (for queues).
+ * BullMQ uses ioredis under the hood — TLS is `tls: {}`.
+ */
+export function buildBullMQConnection(config: ParsedRedisConfig) {
+  return {
+    host: config.host,
+    port: config.port,
+    ...(config.password && { password: config.password }),
+    connectTimeout: 3_000,
+    enableOfflineQueue: false,
+    enableReadyCheck: false,
+    lazyConnect: true,
+    maxRetriesPerRequest: 0,
+    retryStrategy: () => null,
+    ...(config.tls && { tls: {} }),
+  };
+}

--- a/packages/libs/redis/redis.service.ts
+++ b/packages/libs/redis/redis.service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { LoggerService } from '@libs/logger/logger.service';
+import type { LoggerService } from '@libs/logger/logger.service';
 import {
   Inject,
   Injectable,
@@ -7,6 +7,10 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 import { createClient, type RedisClientType } from 'redis';
+import {
+  buildNodeRedisSocketOptions,
+  parseRedisConnection,
+} from './redis-connection.utils';
 
 @Injectable()
 export class RedisService
@@ -43,15 +47,17 @@ export class RedisService
       return;
     }
 
-    const CONNECT_TIMEOUT = 3_000; // 3 second timeout - fail fast
+    const config = parseRedisConnection(this.configService);
+    const CONNECT_TIMEOUT = 3_000;
+    const socketOptions = {
+      ...buildNodeRedisSocketOptions(config, CONNECT_TIMEOUT),
+      reconnectStrategy: () => false as const, // Don't retry - fail fast
+    };
 
     try {
       this.publisher = createClient({
-        socket: {
-          connectTimeout: CONNECT_TIMEOUT,
-          reconnectStrategy: () => false, // Don't retry - fail fast
-        },
-        url: redisUrl,
+        socket: socketOptions,
+        url: config.url,
       });
       this.publisher.on('error', (err) =>
         this.logger.error('Redis Publisher Error', err, this.context),
@@ -67,11 +73,8 @@ export class RedisService
       ]);
 
       this.subscriber = createClient({
-        socket: {
-          connectTimeout: CONNECT_TIMEOUT,
-          reconnectStrategy: () => false, // Don't retry - fail fast
-        },
-        url: redisUrl,
+        socket: socketOptions,
+        url: config.url,
       });
       this.subscriber.on('error', (err) =>
         this.logger.error('Redis Subscriber Error', err, this.context),
@@ -87,6 +90,9 @@ export class RedisService
       ]);
 
       this.logger.log('Redis clients connected successfully', this.context);
+      if (config.tls) {
+        this.logger.log('Redis TLS enabled', this.context);
+      }
       this.isInitialized = true;
 
       for (const { channel, handler } of this.pendingSubscriptions) {

--- a/packages/libs/redis/redis.service.ts
+++ b/packages/libs/redis/redis.service.ts
@@ -7,10 +7,7 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 import { createClient, type RedisClientType } from 'redis';
-import {
-  buildNodeRedisSocketOptions,
-  parseRedisConnection,
-} from './redis-connection.utils';
+import { parseRedisConnection } from './redis-connection.utils';
 
 @Injectable()
 export class RedisService
@@ -50,8 +47,9 @@ export class RedisService
     const config = parseRedisConnection(this.configService);
     const CONNECT_TIMEOUT = 3_000;
     const socketOptions = {
-      ...buildNodeRedisSocketOptions(config, CONNECT_TIMEOUT),
+      connectTimeout: CONNECT_TIMEOUT,
       reconnectStrategy: () => false as const, // Don't retry - fail fast
+      ...(config.tls ? { tls: true as const } : {}),
     };
 
     try {


### PR DESCRIPTION
## Summary
- Remove 23 dead OpenAI env vars (`OPENAI_ASSISTANTS_*`, `OPENAI_IMAGE_*`, `OPENAI_WEBHOOK_SECRET`) from config interface + `.env.example`
- Remove unused `DARKROOM_API_URL` from schema and interface
- Remove `HEDRA_URL`, `RUNWAYML_KEY` from interface (services not wired yet)
- Remove `SENTRY_AUTH_TOKEN_*` from runtime interface (build-time only)
- Add `SENTRY_ENABLED` and `REDIS_TLS` to interface for future use
- Wire `REDIS_TLS` into all 11 Redis connection paths via shared `parseRedisConnection` utility
  - TLS derived from **both** `REDIS_TLS` env var AND `rediss://` URL scheme
  - node-redis v4 sites: `socket.tls = true`
  - BullMQ/ioredis sites: `tls = {}`

## Redis connection sites covered (11 total)
| # | File | Client |
|---|------|--------|
| 1 | `packages/libs/redis/redis.service.ts` | node-redis (pub/sub) |
| 2 | `packages/libs/adapters/redis-io.adapter.ts` | node-redis (Socket.IO) |
| 3 | `apps/server/files/.../websocket.service.ts` | node-redis |
| 4 | `apps/server/api/.../cache-client.service.ts` | node-redis |
| 5 | `apps/server/api/.../microservices.service.ts` | node-redis |
| 6 | `apps/server/api/.../notifications.service.ts` | node-redis |
| 7 | `apps/server/api/src/queues/core/queues.module.ts` | BullMQ |
| 8 | `apps/server/api/src/main.ts` (Bull Board) | BullMQ |
| 9 | `apps/server/workers/.../queues.module.ts` | BullMQ |
| 10 | `apps/server/clips/src/app.module.ts` | BullMQ |
| 11 | `apps/server/files/src/app.module.ts` | BullMQ |

## Test plan
- [ ] `bun run dev:app:fe` starts without errors
- [ ] `bun run dev:backend` starts (5 services compile)
- [ ] Redis connections work without `REDIS_TLS` set (default false)
- [ ] Verify no references to removed OpenAI vars remain in service code

## Related issues
- Sentry toggle deferred to #86 (requires init order + NestJS module changes)
- Stripe → ee/ tracked in #87
- Docs → monorepo tracked in #88
- WIP convention tracked in #89
- Integration cleanup tracked in #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)