### PR TITLE
feat: self-hosted packaging (seed, Docker, CI)

### DIFF
--- a/.agents/SESSIONS/2026-04-06.md
+++ b/.agents/SESSIONS/2026-04-06.md
@@ -1,0 +1,74 @@
+# Session: 2026-04-06
+
+## Summary
+
+CI/CD overhaul, branch strategy, and full PR merge cleanup on develop.
+
+## CI/CD Fixes
+
+- **Secretlint**: was scanning entire repo (`**/*`), taking 20+ min per run. Changed to scan only changed files via `git diff`. Now takes seconds.
+- **Node.js 20 deprecation**: bumped `actions/checkout` v4 → v5 across 3 workflows. Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` for `gitleaks-action@v2` (no v3 yet).
+- **Desktop release phantom runs**: `workflow_dispatch`-only workflow was creating ghost failure entries on every push. Added `desktop-v*` tag trigger to stop them.
+- **`@genfeedai/types` build failure**: tsconfig had deprecated `moduleResolution: "node"` and `module: "commonjs"`. Updated to `"bundler"` and `"ESNext"`. Closes #121.
+- **Biome config**: migrated from schema 2.0.0 → 2.4.10 (`organizeImports` → `assist.actions.source.organizeImports`).
+- **`next-env.d.ts`**: added to `.gitignore`, removed from tracking (3 copies across apps).
+
+## Branch Strategy (cal.com pattern)
+
+- **PR trust gate** (`pr-trust-gate.yml`): external fork PRs need `run-ci` label from maintainer before CI runs. Prevents compute abuse.
+- **CI expanded**: now runs on `develop`, `staging`, and `master` branches.
+- **Deploy production**: stays master-only, documented in workflow comment.
+- **`run-ci` label**: created on GitHub repo.
+- **CONTRIBUTING.md**: updated with branch strategy table, fork workflow, CLA process for `ee/`.
+- **Gitleaks**: requires paid license for private org repos. Will be free once repo is open-sourced.
+
+## PR Merges (all 6 into develop)
+
+| PR | Branch | Conflicts |
+|---|---|---|
+| #85 | feat/skills-agent-loading | Clean |
+| #94 | chore/env-cleanup-redis-tls | Clean |
+| #119 | refactor/flatten-workflow-cloud | Clean |
+| #124 | epic/95-one-api-selfhosted | Clean (new PR for recovered WIP) |
+| #118 | feat/thread-context-compaction | 1 conflict resolved (agent-orchestrator imports) |
+| #120 | feat/dynamic-model-registry | 44 conflicts resolved (MODEL_KEYS + Epic #95 imports) |
+| #116 | refactor/migrate-raw-html-to-ui-primitives | 69 conflicts resolved (UI primitives + Epic #95 + workflow flatten) |
+
+## Epic #95 Recovery
+
+128 files of self-hosted decoupling work were sitting as uncommitted local edits (never pushed). Nearly lost during `git checkout -- .` cleanup. Recovered via `git fsck --unreachable` finding the dropped stash commit object. Pushed to `origin/epic/95-one-api-selfhosted`, then merged as PR #124.
+
+## GitHub Issues Created
+
+- **#121** — `@genfeedai/types` tsconfig build fix (CLOSED — fixed this session)
+- **#122** — UI package deduplication across apps (OPEN)
+- **#123** — `@genfeedai/create` still points to old core repo (OPEN)
+
+## Cleanup
+
+- Removed 5 stale worktrees (~21.5GB freed)
+- Deleted 7 merged remote branches from origin
+- Only `master`, `develop`, `staging` remain on origin
+- Zero open PRs
+
+## Decisions
+
+- Secretlint scans changed files only (not full repo)
+- cal.com-style branch strategy: contributors PR against develop, maintainers merge to master for deploy
+- Branch protection + `run-ci` label deferred until repo goes public
+- `@genfeedai/types` uses `moduleResolution: "bundler"` going forward
+- Desktop releases will use `desktop-v*` tags
+
+## Files Changed (this session's commits)
+
+- `.github/workflows/secret-scan.yml` — secretlint changed-files approach
+- `.github/workflows/ci.yml` — expanded branch triggers
+- `.github/workflows/pr-trust-gate.yml` — new trust gate workflow
+- `.github/workflows/deploy-production.yml` — documentation comment
+- `.github/workflows/desktop-release.yml` — tag trigger
+- `.github/workflows/codebase-health.yml` — checkout v5
+- `.secretlintignore` — expanded ignore patterns
+- `.gitignore` — added `next-env.d.ts`
+- `CONTRIBUTING.md` — branch strategy + CLA process
+- `packages/types/tsconfig.json` — moduleResolution fix
+- `biome.json` + `packages/cli/biome.json` — schema migration

--- a/.agents/SESSIONS/2026-04-07.md
+++ b/.agents/SESSIONS/2026-04-07.md
@@ -1,0 +1,194 @@
+# Session: 2026-04-07
+
+## Summary
+
+Removed Blacksmith CI runners in favor of standard GitHub-hosted runners to reduce CI costs. Implemented GitHub Secret Scanning Partner Program integration with auto-revocation webhook endpoint and custom gitleaks rule for detecting leaked `gf_*` API keys. Fixed 12 bugs from Codex bot PR reviews across 7 merged PRs.
+
+## Session 1: Remove Blacksmith Runners
+
+**Status:** Complete
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| CI/CD | `build-verify.yml`, `_deploy.yml` |
+
+### What was done
+
+- [x] Identified all Blacksmith runner references across GitHub workflows (2 files, 5 occurrences)
+- [x] Replaced `blacksmith-4vcpu-ubuntu-2404` and `blacksmith-8vcpu-ubuntu-2404` with `ubuntu-latest` in `_deploy.yml` (3 jobs: test-changed, build-unified-image, deploy-services)
+- [x] Replaced `blacksmith-4vcpu-ubuntu-2404` with `ubuntu-latest` in `build-verify.yml`
+- [x] Swapped `useblacksmith/setup-docker-builder@v1` with `docker/setup-buildx-action@v3` in `build-verify.yml`
+
+### Files changed
+
+- `.github/workflows/build-verify.yml` - runner changed to `ubuntu-latest`, Buildx action switched from Blacksmith to official Docker
+- `.github/workflows/_deploy.yml` - all 3 jobs (`test-changed`, `build-unified-image`, `deploy-services`) switched from Blacksmith to `ubuntu-latest`
+
+### Key decisions
+
+- **Decision:** Use `ubuntu-latest` (4-vCPU) for all jobs, including `build-unified-image` which was on 8-vCPU Blacksmith
+  - **Context:** Blacksmith runners were too expensive relative to value
+  - **Rationale:** Standard GitHub runners are free for public repos and included in plan minutes; if builds become slow, can upgrade to `ubuntu-latest-8-cores` (GitHub larger runner) later
+
+### Next steps
+
+- [ ] Commit and push changes to verify CI passes on GitHub-hosted runners
+- [ ] Monitor Docker build times on `build-unified-image` job — may need `ubuntu-latest-8-cores` if too slow
+- [ ] Remove any Blacksmith billing/integration from GitHub org settings if no longer needed
+
+## Session 2: GitHub Secret Scanning Partner Program + Auto-Revocation
+
+**Status:** Complete (pending GitHub partner enrollment confirmation)
+
+### System Flow
+
+```mermaid
+flowchart TD
+    A[GitHub scans all public repos] -->|Detects gf_live_* or gf_test_*| B[Sends webhook to /webhooks/github/callback]
+    B --> C{Validate x-hub-signature-256}
+    C -->|Invalid| D[401 Unauthorized]
+    C -->|Valid| E[Look up key via ApiKeysService.findByKey]
+    E -->|Not found / already revoked| F[Return false_positive]
+    E -->|Found| G[ApiKeysService.revoke]
+    G --> H[Email key owner with remediation steps]
+    G --> I[Discord alert to team]
+    H --> J[Return true_positive + token_revoked]
+    I --> J
+```
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Backend | Webhooks module, API Keys service, Notifications service |
+| Config | genfeedai.schema.ts, .env.example |
+| CI/CD | .gitleaks.toml (custom rule) |
+
+### What was done
+
+- [x] Added custom gitleaks rule to detect `gf_(live|test)_*` key patterns in CI scans
+- [x] Created `GitHubWebhookController` — `POST /webhooks/github/callback` with HMAC-SHA256 signature validation
+- [x] Created `GitHubWebhookService` — processes GitHub Secret Scanning alerts, auto-revokes keys, emails owners, sends Discord alerts
+- [x] Registered controller + service in `WebhooksModule` with `ApiKeysModule` import
+- [x] Added `GITHUB_WEBHOOK_SECRET` to config schema and `.env.example`
+- [x] Drafted and sent enrollment email to secret-scanning@github.com
+
+### Files changed
+
+- `.gitleaks.toml` — added `genfeedai-api-key` rule matching `gf_(live|test)_[A-Za-z0-9_\-]{20,}`
+- `apps/server/api/src/endpoints/webhooks/github/webhooks.github.controller.ts` — new file, webhook endpoint
+- `apps/server/api/src/endpoints/webhooks/github/webhooks.github.service.ts` — new file, alert processing + auto-revocation + notifications
+- `apps/server/api/src/endpoints/webhooks/webhooks.module.ts` — registered GitHub controller/service, added ApiKeysModule import
+- `packages/config/src/schemas/genfeedai.schema.ts` — added `GITHUB_WEBHOOK_SECRET` env var
+- `apps/server/api/.env.example` — added `GITHUB_WEBHOOK_SECRET` placeholder
+
+### Key decisions
+
+- **Decision:** Use GitHub Secret Scanning Partner Program (free) over GitGuardian ($300/mo)
+  - **Context:** Need to detect leaked `gf_*` keys across all public GitHub repos, not just our own
+  - **Rationale:** Free, covers all of GitHub, and we already have the webhook + revocation infrastructure to handle alerts
+
+- **Decision:** Reuse existing `ApiKeysService.findByKey()` for token lookup in the webhook handler
+  - **Context:** `findByKey()` uses SHA-256 fingerprint index for O(1) lookup + bcrypt verification
+  - **Rationale:** Already battle-tested, no need for a separate lookup method. It filters `isRevoked: false` so already-revoked keys return `false_positive` automatically
+
+- **Decision:** Follow existing webhook provider pattern (Vercel, Stripe, etc.) exactly
+  - **Context:** 9 existing webhook providers all follow the same controller/service/module pattern
+  - **Rationale:** Consistency, reviewability, and the existing pattern handles raw body parsing + signature validation correctly
+
+### Mistakes and fixes
+
+- None — straightforward implementation following established patterns
+
+### Next steps
+
+- [ ] Await GitHub's response to partner enrollment email and complete verification handshake
+- [ ] Set `GITHUB_WEBHOOK_SECRET` in production environment once GitHub provides it
+- [ ] Test endpoint with GitHub's test payloads during verification
+- [ ] Commit changes to develop branch and push
+- [ ] Consider adding a unit test for `GitHubWebhookService.validateSignature()` and `handleSecretAlert()`
+
+## Session 3: Fix Codex Bot PR Review Bugs
+
+**Status:** Complete
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Backend | NestJS DI imports (10 files), thread compaction, agent orchestrator, models guard, skill runtime |
+| Frontend | Issues list page, workflow templates page, workflow new page |
+
+### What was done
+
+**Batch 1: P0 — NestJS DI `import type` fixes (14 imports across 10 files)**
+- [x] `models.controller.ts` — ModelsService, LoggerService, ModuleRef
+- [x] `redis.service.ts` — LoggerService
+- [x] `models.guard.ts` — ModelRegistrationService
+- [x] `model-registration.service.ts` — OrganizationSettingsService, LoggerService
+- [x] `organization-settings.service.ts` — LoggerService, ModuleRef
+- [x] `websocket.service.ts` (files server) — ConfigService
+- [x] `replicate-prompt.builder.ts` — ConfigService
+- [x] `websockets.service.ts` (libs) — RedisService
+- [x] `websockets.gateway.ts` — LoggerService, RedisService
+- [x] `events.service.ts` — LoggerService, RedisService
+
+**Batch 2: P1 — Thread compaction safety**
+- [x] Added parse validation before advancing `lastIncorporatedMessageId` — prevents data loss on malformed LLM output
+- [x] Replaced hard-coded 200-message cap with cursor-based pagination using `lastIncorporatedMessageId`
+- [x] Fixed `messageCount` calculation (was always 0 on incremental compaction due to `n - n = 0`)
+- [x] Added `getAllMessages()` and `getAllMessagesAfter()` to AgentMessagesService
+
+**Batch 3: P1 — Agent orchestrator tools**
+- [x] Fixed `mergeSkillToolOverrides` to accept `undefined` baseTools (returns `undefined` to preserve unrestricted toolset)
+- [x] Updated both sync and streaming paths in agent-orchestrator to pass `undefined` instead of `[]` when no agentType
+
+**Batch 4: P1→P2 — Guard + Frontend fixes**
+- [x] Added model category validation to ModelsGuard — prevents cross-category model usage (IMAGE on VIDEO endpoint)
+- [x] Fixed `WorkflowTemplatesPage.tsx` — stabilized `href` with `useMemo` to prevent duplicate workflow creation
+- [x] Fixed `issues-list.tsx` — changed `SelectItem value=""` to `value="all"` (Radix UI crashes on empty string)
+- [x] Added ExecutionPanel to `WorkflowNewPageClient.tsx` with `rightPanel` prop
+
+### Files changed
+
+- `apps/server/api/src/collections/models/controllers/models.controller.ts` — DI imports
+- `packages/libs/redis/redis.service.ts` — DI imports
+- `apps/server/api/src/helpers/guards/models/models.guard.ts` — DI imports + category validation
+- `apps/server/api/src/collections/models/services/model-registration.service.ts` — DI imports
+- `apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts` — DI imports
+- `apps/server/files/src/services/websocket/websocket.service.ts` — DI imports
+- `apps/server/api/src/services/prompt-builder/builders/replicate-prompt.builder.ts` — DI imports
+- `packages/libs/websockets/websockets.service.ts` — DI imports
+- `packages/libs/websockets/websockets.gateway.ts` — DI imports
+- `packages/libs/events/events.service.ts` — DI imports
+- `apps/server/api/src/services/agent-threading/services/thread-context-compressor.service.ts` — parse validation, cursor pagination, messageCount fix
+- `apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts` — new getAllMessages/getAllMessagesAfter methods
+- `apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts` — undefined baseTools fix (2 paths)
+- `apps/server/api/src/services/skill-runtime/skill-runtime.service.ts` — handle undefined baseTools
+- `packages/pages/issues/list/issues-list.tsx` — SelectItem value fix
+- `apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx` — stable href ref
+- `apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx` — ExecutionPanel + rightPanel
+
+### Key decisions
+
+- **Decision:** Do a repo-wide sweep for `import type` DI bugs instead of only fixing Codex-flagged files
+  - **Context:** Codex adversarial review found 5 additional files beyond the original 3
+  - **Rationale:** The pattern is mechanical and the bug is silent until runtime — better to fix all at once
+
+- **Decision:** Use cursor-based pagination for compaction instead of raising the 200 limit
+  - **Context:** Any fixed limit can be exceeded; cursor-based approach processes exactly the right messages
+  - **Rationale:** No data loss regardless of backlog size
+
+### Deferred
+
+- Skill toggle race condition (`use-brand-enabled-skills.ts`) — low-probability UX issue
+- Discord channel IDs optional vs required (`notifications.schema.ts`) — only matters with partial Discord config
+
+### Next steps
+
+- [ ] Commit changes and push to develop
+- [ ] Verify builds pass: `bun run build --filter=@genfeedai/api`, `bun run build --filter=@genfeedai/redis`
+- [ ] Update `models.guard.spec.ts` to test `ModelRegistrationService.validateModelForOrg` flow + category validation
+- [ ] Add compaction tests for malformed LLM output, >200 message backlog, incremental messageCount

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/browser-extension-submit.yml
+++ b/.github/workflows/browser-extension-submit.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Cache bun modules
         uses: actions/cache@v5
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Get bun store directory
         id: bun-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           bun-version: '1.3.11'
       - run: bun install --frozen-lockfile
-      - run: bun run typecheck
+      - run: bun run type-check
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.12'
+          bun-version: '1.3.11'
       - run: bun install --frozen-lockfile
       - run: bun run lint
 
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.12'
+          bun-version: '1.3.11'
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.12'
+          bun-version: '1.3.11'
       - run: bun install --frozen-lockfile
       - run: bun run test
 
@@ -52,6 +52,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.12'
+          bun-version: '1.3.11'
       - run: bun install --frozen-lockfile
       - run: bun run build

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,60 @@
+name: Docker Publish (Self-Hosted)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag override (default: latest)"
+        required: false
+        default: "latest"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build & Push Self-Hosted Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.selfhosted
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Cache bun modules
         uses: actions/cache@v5
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Cache bun modules
         uses: actions/cache@v5

--- a/.github/workflows/ide-extension-ci.yml
+++ b/.github/workflows/ide-extension-ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Cache bun modules
         uses: actions/cache@v5

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Cache bun modules
         uses: actions/cache@v5
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: steps.changed.outputs.files != ''
         with:
-          bun-version: '1.2.12'
+          bun-version: '1.3.11'
 
       - run: bun install --frozen-lockfile
         if: steps.changed.outputs.files != ''

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.10"
+          bun-version: "1.3.11"
 
       - name: Build Docker image
         run: |

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,7 +13,7 @@ keywords = ["gf_live_", "gf_test_"]
 description = "Global allowlist"
 paths = [
   '''node_modules''',
-  '''bun\.lockb''',
+  '''bun\.lock''',
   '''\.secretlintrc\.json''',
   '''\.gitleaks\.toml''',
   '''package-lock\.json''',

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -28,6 +28,7 @@ import { useCallback, useMemo, useState } from 'react';
 import '@genfeedai/workflow-ui/styles';
 import '@/features/workflows/styles/workflow-scope.scss';
 
+import { ExecutionPanel } from '@/features/workflows/components/ExecutionPanel';
 import { CloudCreditsIndicator } from '@/features/workflows/components/editor/CloudCreditsIndicator';
 import { CloudWorkflowToolbar } from '@/features/workflows/components/editor/CloudWorkflowToolbar';
 import { useCloudWorkflow } from '@/features/workflows/hooks/useCloudWorkflow';
@@ -51,6 +52,10 @@ import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbar
 export default function WorkflowNewPageClient() {
   const { href } = useOrgUrl();
   const [isRunning, setIsRunning] = useState(false);
+  const [showExecutionPanel, setShowExecutionPanel] = useState(false);
+  const [activeExecutionId, setActiveExecutionId] = useState<
+    string | undefined
+  >();
   const getWorkflowService = useAuthedService(createWorkflowApiService);
 
   const {
@@ -133,7 +138,9 @@ export default function WorkflowNewPageClient() {
         throw new Error('Workflow must be saved before it can run');
       }
 
-      await service.execute(runnableWorkflowId);
+      const execution = await service.execute(runnableWorkflowId);
+      setActiveExecutionId(execution?._id);
+      setShowExecutionPanel(true);
     } catch (error) {
       logger.error('Failed to run workflow', {
         error,
@@ -166,6 +173,15 @@ export default function WorkflowNewPageClient() {
 
           <WorkflowEditorShell
             nodeTypes={cloudNodeTypes}
+            rightPanel={
+              showExecutionPanel ? (
+                <ExecutionPanel
+                  workflowId={currentWorkflowId ?? 'new'}
+                  onClose={() => setShowExecutionPanel(false)}
+                  runId={activeExecutionId}
+                />
+              ) : null
+            }
             toolbar={
               <CloudWorkflowToolbar
                 isSaving={isSaving}

--- a/apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx
+++ b/apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx
@@ -82,6 +82,11 @@ export default function WorkflowTemplatesPage() {
     };
   }, [loadTemplates]);
 
+  // Stable navigation callback — avoids re-running the bootstrap effect
+  // when useOrgUrl() returns a fresh href function on each render.
+  const hrefRef = useRef(href);
+  hrefRef.current = href;
+
   useEffect(() => {
     if (!templateId) {
       return;
@@ -109,7 +114,7 @@ export default function WorkflowTemplatesPage() {
         });
 
         if (!isCancelled) {
-          router.replace(href(`/workflows/${workflow._id}`));
+          router.replace(hrefRef.current(`/workflows/${workflow._id}`));
         }
       } catch (err) {
         logger.error('Failed to bootstrap workflow template', { error: err });
@@ -130,7 +135,7 @@ export default function WorkflowTemplatesPage() {
     return () => {
       isCancelled = true;
     };
-  }, [getService, href, router, templateId]);
+  }, [getService, router, templateId]);
 
   const filteredTemplates =
     selectedCategory === 'all'

--- a/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
+++ b/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
@@ -185,6 +185,54 @@ export class AgentMessagesService extends BaseService<AgentMessageDocument> {
     });
   }
 
+  /**
+   * Get ALL non-deleted messages in a thread, in chronological order.
+   * Used by compaction to process the full backlog when no prior state exists.
+   */
+  async getAllMessages(roomId: string): Promise<AgentMessageDocument[]> {
+    return (
+      this.model as unknown as {
+        find: (filter: Record<string, unknown>) => {
+          sort: (sort: Record<string, number>) => {
+            lean: () => Promise<AgentMessageDocument[]>;
+          };
+        };
+      }
+    )
+      .find({
+        isDeleted: false,
+        room: new Types.ObjectId(roomId),
+      })
+      .sort({ _id: 1 })
+      .lean() as Promise<AgentMessageDocument[]>;
+  }
+
+  /**
+   * Get ALL non-deleted messages after a boundary, in chronological order.
+   * Used by compaction to process uncompacted messages without a fixed cap.
+   */
+  async getAllMessagesAfter(
+    roomId: string,
+    afterMessageId: Types.ObjectId,
+  ): Promise<AgentMessageDocument[]> {
+    return (
+      this.model as unknown as {
+        find: (filter: Record<string, unknown>) => {
+          sort: (sort: Record<string, number>) => {
+            lean: () => Promise<AgentMessageDocument[]>;
+          };
+        };
+      }
+    )
+      .find({
+        _id: { $gt: afterMessageId },
+        isDeleted: false,
+        room: new Types.ObjectId(roomId),
+      })
+      .sort({ _id: 1 })
+      .lean() as Promise<AgentMessageDocument[]>;
+  }
+
   async copyMessages(
     sourceRoomId: string,
     targetRoomId: string,

--- a/apps/server/api/src/collections/models/controllers/models.controller.ts
+++ b/apps/server/api/src/collections/models/controllers/models.controller.ts
@@ -2,7 +2,8 @@ import type { CreateModelDto } from '@api/collections/models/dto/create-model.dt
 import type { ModelsQueryDto } from '@api/collections/models/dto/models-query.dto';
 import type { UpdateModelDto } from '@api/collections/models/dto/update-model.dto';
 import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
-import type { ModelsService } from '@api/collections/models/services/models.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { ModelsService } from '@api/collections/models/services/models.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import type { RequestWithContext } from '@api/common/middleware/request-context.middleware';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
@@ -23,7 +24,8 @@ import type {
   SortObject,
 } from '@genfeedai/interfaces';
 import { ModelSerializer } from '@genfeedai/serializers';
-import type { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
 import {
   Body,
   Controller,
@@ -33,7 +35,8 @@ import {
   Query,
   Req,
 } from '@nestjs/common';
-import type { ModuleRef } from '@nestjs/core';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { ModuleRef } from '@nestjs/core';
 import { Model, type PipelineStage, Types } from 'mongoose';
 
 @AutoSwagger()

--- a/apps/server/api/src/collections/models/services/model-registration.service.ts
+++ b/apps/server/api/src/collections/models/services/model-registration.service.ts
@@ -1,4 +1,5 @@
-import type { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
 import {
   BadRequestException,
   ForbiddenException,
@@ -8,7 +9,8 @@ import { InjectModel } from '@nestjs/mongoose';
 import type { Model as MongooseModel } from 'mongoose';
 import { Types } from 'mongoose';
 import { DB_CONNECTIONS } from '../../../constants/database.constants';
-import type { OrganizationSettingsService } from '../../organization-settings/services/organization-settings.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { OrganizationSettingsService } from '../../organization-settings/services/organization-settings.service';
 import {
   Training,
   type TrainingDocument,

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -15,9 +15,11 @@ import {
   ONBOARDING_JOURNEY_MISSIONS,
   type OnboardingJourneyMissionId,
 } from '@genfeedai/types';
-import type { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import type { ModuleRef } from '@nestjs/core';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { ModuleRef } from '@nestjs/core';
 import { InjectModel } from '@nestjs/mongoose';
 import { Types } from 'mongoose';
 

--- a/apps/server/api/src/helpers/guards/models/models.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/models/models.guard.spec.ts
@@ -1,25 +1,29 @@
-import type { ModelsService } from '@api/collections/models/services/models.service';
+import type { ModelRegistrationService } from '@api/collections/models/services/model-registration.service';
 import {
   ModelsGuard,
   ValidateModel,
 } from '@api/helpers/guards/models/models.guard';
 import { ModelCategory } from '@genfeedai/enums';
 import type { ExecutionContext } from '@nestjs/common';
-import { HttpException } from '@nestjs/common';
+import { ForbiddenException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { Types } from 'mongoose';
 
 describe('ModelsGuard', () => {
   let guard: ModelsGuard;
   let reflector: Reflector;
-  let modelsService: { findAll: ReturnType<typeof vi.fn> };
+  let modelRegistrationService: {
+    validateModelForOrg: ReturnType<typeof vi.fn>;
+  };
 
   const createContext = (
     body: Record<string, unknown> = {},
+    organizationId = new Types.ObjectId().toString(),
   ): ExecutionContext => {
     const req: Record<string, unknown> = {
       body,
+      context: { organizationId },
       selectedModel: undefined,
-      validModels: undefined,
     };
     return {
       getClass: vi.fn(),
@@ -30,11 +34,15 @@ describe('ModelsGuard', () => {
 
   beforeEach(() => {
     reflector = new Reflector();
-    modelsService = {
-      findAll: vi.fn().mockResolvedValue({ docs: [] }),
+    modelRegistrationService = {
+      validateModelForOrg: vi.fn().mockResolvedValue({
+        _id: new Types.ObjectId(),
+        category: ModelCategory.IMAGE,
+        key: 'stable-diffusion',
+      }),
     };
     guard = new ModelsGuard(
-      modelsService as unknown as ModelsService,
+      modelRegistrationService as unknown as ModelRegistrationService,
       reflector,
     );
   });
@@ -61,40 +69,90 @@ describe('ModelsGuard', () => {
     expect(result).toBe(true);
   });
 
-  it('returns true for a valid model key found in database', async () => {
+  it('returns true for a valid model key matching the required category', async () => {
     vi.spyOn(reflector, 'get').mockReturnValue({
       category: ModelCategory.IMAGE,
-    });
-    modelsService.findAll.mockResolvedValue({
-      docs: [{ key: 'stable-diffusion' }],
     });
     const ctx = createContext({ model: 'stable-diffusion' });
     const result = await guard.canActivate(ctx);
     expect(result).toBe(true);
+    expect(modelRegistrationService.validateModelForOrg).toHaveBeenCalledWith(
+      'stable-diffusion',
+      expect.any(Types.ObjectId),
+    );
   });
 
-  it('throws HttpException for an invalid model key', async () => {
+  it('sets selectedModel on request after validation', async () => {
+    const mockModel = {
+      _id: new Types.ObjectId(),
+      category: ModelCategory.IMAGE,
+      key: 'stable-diffusion',
+    };
+    modelRegistrationService.validateModelForOrg.mockResolvedValue(mockModel);
     vi.spyOn(reflector, 'get').mockReturnValue({
       category: ModelCategory.IMAGE,
     });
-    modelsService.findAll.mockResolvedValue({
-      docs: [{ key: 'stable-diffusion' }],
-    });
-    const ctx = createContext({ model: 'nonexistent-model' });
-    await expect(guard.canActivate(ctx)).rejects.toThrow(HttpException);
-  });
-
-  it('sets validModels and selectedModel on request', async () => {
-    const models = [{ key: 'stable-diffusion' }, { key: 'dall-e' }];
-    vi.spyOn(reflector, 'get').mockReturnValue({
-      category: ModelCategory.IMAGE,
-    });
-    modelsService.findAll.mockResolvedValue({ docs: models });
     const ctx = createContext({ model: 'stable-diffusion' });
     await guard.canActivate(ctx);
     const req = ctx.switchToHttp().getRequest() as Record<string, unknown>;
-    expect(req.validModels).toEqual(models);
-    expect(req.selectedModel).toEqual({ key: 'stable-diffusion' });
+    expect(req.selectedModel).toEqual(mockModel);
+  });
+
+  it('throws ForbiddenException when model category does not match', async () => {
+    modelRegistrationService.validateModelForOrg.mockResolvedValue({
+      _id: new Types.ObjectId(),
+      category: ModelCategory.IMAGE,
+      key: 'stable-diffusion',
+    });
+    vi.spyOn(reflector, 'get').mockReturnValue({
+      category: ModelCategory.VIDEO,
+    });
+    const ctx = createContext({ model: 'stable-diffusion' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('allows model when category matches exactly', async () => {
+    modelRegistrationService.validateModelForOrg.mockResolvedValue({
+      _id: new Types.ObjectId(),
+      category: ModelCategory.VIDEO,
+      key: 'sora-turbo',
+    });
+    vi.spyOn(reflector, 'get').mockReturnValue({
+      category: ModelCategory.VIDEO,
+    });
+    const ctx = createContext({ model: 'sora-turbo' });
+    const result = await guard.canActivate(ctx);
+    expect(result).toBe(true);
+  });
+
+  it('allows model when model has no category set', async () => {
+    modelRegistrationService.validateModelForOrg.mockResolvedValue({
+      _id: new Types.ObjectId(),
+      key: 'generic-model',
+    });
+    vi.spyOn(reflector, 'get').mockReturnValue({
+      category: ModelCategory.IMAGE,
+    });
+    const ctx = createContext({ model: 'generic-model' });
+    const result = await guard.canActivate(ctx);
+    expect(result).toBe(true);
+  });
+
+  it('throws ForbiddenException when organizationId is missing', async () => {
+    vi.spyOn(reflector, 'get').mockReturnValue({
+      category: ModelCategory.IMAGE,
+    });
+    const req: Record<string, unknown> = {
+      body: { model: 'stable-diffusion' },
+      context: {},
+      selectedModel: undefined,
+    };
+    const ctx = {
+      getClass: vi.fn(),
+      getHandler: vi.fn(),
+      switchToHttp: () => ({ getRequest: () => req }),
+    } as unknown as ExecutionContext;
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
   it('allows Replicate destination models to bypass validation', async () => {
@@ -104,7 +162,7 @@ describe('ModelsGuard', () => {
     const ctx = createContext({ model: 'owner/model:abc123' });
     const result = await guard.canActivate(ctx);
     expect(result).toBe(true);
-    expect(modelsService.findAll).not.toHaveBeenCalled();
+    expect(modelRegistrationService.validateModelForOrg).not.toHaveBeenCalled();
   });
 
   it('allows fal destinations to bypass validation', async () => {
@@ -114,22 +172,7 @@ describe('ModelsGuard', () => {
     const ctx = createContext({ model: 'fal-ai/flux-2-pro' });
     const result = await guard.canActivate(ctx);
     expect(result).toBe(true);
-    expect(modelsService.findAll).not.toHaveBeenCalled();
-  });
-
-  it('does not bypass validation for genfeed-ai self-hosted models', async () => {
-    vi.spyOn(reflector, 'get').mockReturnValue({
-      category: ModelCategory.IMAGE,
-    });
-    modelsService.findAll.mockResolvedValue({
-      docs: [{ key: 'genfeed-ai/z-image-turbo' }],
-    });
-
-    const ctx = createContext({ model: 'genfeed-ai/z-image-turbo' });
-    const result = await guard.canActivate(ctx);
-
-    expect(result).toBe(true);
-    expect(modelsService.findAll).toHaveBeenCalled();
+    expect(modelRegistrationService.validateModelForOrg).not.toHaveBeenCalled();
   });
 
   it('uses custom fieldName from options', async () => {
@@ -137,12 +180,13 @@ describe('ModelsGuard', () => {
       category: ModelCategory.IMAGE,
       fieldName: 'customModel',
     });
-    modelsService.findAll.mockResolvedValue({
-      docs: [{ key: 'dall-e' }],
-    });
-    const ctx = createContext({ customModel: 'dall-e' });
+    const ctx = createContext({ customModel: 'stable-diffusion' });
     const result = await guard.canActivate(ctx);
     expect(result).toBe(true);
+    expect(modelRegistrationService.validateModelForOrg).toHaveBeenCalledWith(
+      'stable-diffusion',
+      expect.any(Types.ObjectId),
+    );
   });
 
   it('ValidateModel is a Reflector decorator', () => {

--- a/apps/server/api/src/helpers/guards/models/models.guard.ts
+++ b/apps/server/api/src/helpers/guards/models/models.guard.ts
@@ -1,4 +1,5 @@
-import type { ModelRegistrationService } from '@api/collections/models/services/model-registration.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { ModelRegistrationService } from '@api/collections/models/services/model-registration.service';
 import {
   isFalDestination,
   isReplicateDestination,
@@ -64,6 +65,17 @@ export class ModelsGuard implements CanActivate {
       modelKey,
       organizationId,
     );
+
+    // Validate that the model belongs to the requested category
+    if (
+      options.category &&
+      model.category &&
+      model.category !== options.category
+    ) {
+      throw new ForbiddenException(
+        `Model "${modelKey}" is category "${model.category}", but this endpoint requires "${options.category}"`,
+      );
+    }
 
     request.selectedModel = model;
 

--- a/apps/server/api/src/seeds/self-hosted-seed.module.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.module.ts
@@ -1,0 +1,45 @@
+/**
+ * Self-Hosted Seed Module
+ * Registers Mongoose models required by the seed service and provides
+ * SelfHostedSeedService, which creates the default workspace on first boot
+ * when running in self-hosted mode (no Clerk).
+ */
+
+import {
+  Brand,
+  BrandSchema,
+} from '@api/collections/brands/schemas/brand.schema';
+import {
+  OrganizationSetting,
+  OrganizationSettingSchema,
+} from '@api/collections/organization-settings/schemas/organization-setting.schema';
+import {
+  Organization,
+  OrganizationSchema,
+} from '@api/collections/organizations/schemas/organization.schema';
+import { User, UserSchema } from '@api/collections/users/schemas/user.schema';
+import { DB_CONNECTIONS } from '@api/constants/database.constants';
+import { SelfHostedSeedService } from '@api/seeds/self-hosted-seed.service';
+import { LoggerModule } from '@libs/logger/logger.module';
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+
+@Module({
+  imports: [
+    LoggerModule,
+    MongooseModule.forFeature(
+      [
+        { name: User.name, schema: UserSchema },
+        { name: Organization.name, schema: OrganizationSchema },
+        { name: OrganizationSetting.name, schema: OrganizationSettingSchema },
+      ],
+      DB_CONNECTIONS.AUTH,
+    ),
+    MongooseModule.forFeature(
+      [{ name: Brand.name, schema: BrandSchema }],
+      DB_CONNECTIONS.CLOUD,
+    ),
+  ],
+  providers: [SelfHostedSeedService],
+})
+export class SelfHostedSeedModule {}

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -1,0 +1,118 @@
+/**
+ * Self-Hosted Seed Service
+ * Creates the default workspace (User, Organization, Brand, OrganizationSetting)
+ * on first application boot when running in self-hosted mode.
+ *
+ * Idempotent: skips seeding if a default organization already exists.
+ * Uses Model.create() to avoid triggering post-save hooks.
+ */
+
+import {
+  Brand,
+  type BrandDocument,
+} from '@api/collections/brands/schemas/brand.schema';
+import {
+  OrganizationSetting,
+  type OrganizationSettingDocument,
+} from '@api/collections/organization-settings/schemas/organization-setting.schema';
+import {
+  Organization,
+  type OrganizationDocument,
+} from '@api/collections/organizations/schemas/organization.schema';
+import {
+  User,
+  type UserDocument,
+} from '@api/collections/users/schemas/user.schema';
+import { DB_CONNECTIONS } from '@api/constants/database.constants';
+import { IS_SELF_HOSTED } from '@genfeedai/config';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable, type OnApplicationBootstrap } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { type Model, Types } from 'mongoose';
+
+@Injectable()
+export class SelfHostedSeedService implements OnApplicationBootstrap {
+  private readonly context = 'SelfHostedSeedService';
+
+  constructor(
+    @InjectModel(User.name, DB_CONNECTIONS.AUTH)
+    private readonly userModel: Model<UserDocument>,
+    @InjectModel(Organization.name, DB_CONNECTIONS.AUTH)
+    private readonly organizationModel: Model<OrganizationDocument>,
+    @InjectModel(OrganizationSetting.name, DB_CONNECTIONS.AUTH)
+    private readonly organizationSettingModel: Model<OrganizationSettingDocument>,
+    @InjectModel(Brand.name, DB_CONNECTIONS.CLOUD)
+    private readonly brandModel: Model<BrandDocument>,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (!IS_SELF_HOSTED) {
+      return;
+    }
+
+    const existingOrg = await this.organizationModel
+      .findOne({ isDefault: true })
+      .lean()
+      .exec();
+
+    if (existingOrg) {
+      this.logger.log(
+        'Default workspace already exists — skipping seed',
+        this.context,
+      );
+      return;
+    }
+
+    this.logger.log('Seeding default self-hosted workspace...', this.context);
+
+    const userId = new Types.ObjectId();
+    const orgId = new Types.ObjectId();
+    const brandId = new Types.ObjectId();
+    const settingsId = new Types.ObjectId();
+
+    await this.userModel.create({
+      _id: userId,
+      handle: 'admin',
+      email: 'admin@localhost',
+      firstName: 'Admin',
+      isDefault: true,
+      isOnboardingCompleted: true,
+    });
+
+    await this.organizationModel.create({
+      _id: orgId,
+      user: userId,
+      label: 'Default Workspace',
+      slug: 'default',
+      isDefault: true,
+      isSelected: true,
+      onboardingCompleted: true,
+    });
+
+    await this.organizationSettingModel.create({
+      _id: settingsId,
+      organization: orgId,
+      isFirstLogin: false,
+    });
+
+    await this.brandModel.create({
+      _id: brandId,
+      user: userId,
+      organization: orgId,
+      slug: 'default',
+      label: 'Default Brand',
+      description: 'Default brand for self-hosted instance',
+      isSelected: true,
+      isDefault: true,
+      primaryColor: '#000000',
+      secondaryColor: '#FFFFFF',
+      backgroundColor: 'transparent',
+    });
+
+    this.logger.log(
+      `Self-hosted workspace seeded (org=${orgId.toHexString()}, brand=${brandId.toHexString()})`,
+      this.context,
+    );
+  }
+}

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -61,14 +61,6 @@ import {
   SubscriptionTier,
 } from '@genfeedai/enums';
 import {
-  ActivitySource,
-  AgentAutonomyMode,
-  AgentExecutionTrigger,
-  AgentMessageRole,
-  type AgentType,
-  SubscriptionTier,
-} from '@genfeedai/enums';
-import {
   type AgentDashboardOperation,
   AgentToolName,
   type AgentUIBlock,
@@ -744,13 +736,15 @@ export class AgentOrchestratorService {
       const typeConfig = request.agentType
         ? getAgentTypeConfig(request.agentType)
         : null;
-      // Merge skill tool overrides into the base tool set (additive)
+      // Merge skill tool overrides into the base tool set (additive).
+      // When agentType is unset, pass undefined to preserve unrestricted toolset
+      // instead of [] which would wipe all base tools.
       const syncBaseTools =
         this.skillRuntimeService && context.resolvedSkills?.length
           ? (this.skillRuntimeService.mergeSkillToolOverrides(
-              typeConfig?.defaultTools ?? [],
+              typeConfig?.defaultTools,
               context.resolvedSkills,
-            ) as AgentToolName[])
+            ) as AgentToolName[] | undefined)
           : typeConfig?.defaultTools;
       const tools = this.buildToolDefinitions(
         this.mergeAllowedTools(
@@ -1439,13 +1433,15 @@ export class AgentOrchestratorService {
         streamCompressedCtx,
       );
       const typeConfig = agentType ? getAgentTypeConfig(agentType) : null;
-      // Merge skill tool overrides into the base tool set (additive)
+      // Merge skill tool overrides into the base tool set (additive).
+      // When agentType is unset, pass undefined to preserve unrestricted toolset
+      // instead of [] which would wipe all base tools.
       const baseTools =
         this.skillRuntimeService && context.resolvedSkills?.length
           ? (this.skillRuntimeService.mergeSkillToolOverrides(
-              typeConfig?.defaultTools ?? [],
+              typeConfig?.defaultTools,
               context.resolvedSkills,
-            ) as AgentToolName[])
+            ) as AgentToolName[] | undefined)
           : typeConfig?.defaultTools;
       const latestUserMessage =
         [...history]

--- a/apps/server/api/src/services/agent-threading/services/thread-context-compressor.service.spec.ts
+++ b/apps/server/api/src/services/agent-threading/services/thread-context-compressor.service.spec.ts
@@ -49,6 +49,7 @@ describe('ThreadContextCompressorService', () => {
   let llmDispatcher: Record<string, ReturnType<typeof vi.fn>>;
   let cacheService: Record<string, ReturnType<typeof vi.fn>>;
   let configService: Record<string, ReturnType<typeof vi.fn>>;
+  let loggerService: Record<string, ReturnType<typeof vi.fn>>;
 
   beforeEach(async () => {
     model = {
@@ -61,8 +62,9 @@ describe('ThreadContextCompressorService', () => {
     messagesService = {
       countMessages: vi.fn().mockResolvedValue(0),
       countMessagesAfter: vi.fn().mockResolvedValue(0),
+      getAllMessages: vi.fn().mockResolvedValue([]),
+      getAllMessagesAfter: vi.fn().mockResolvedValue([]),
       getMessagesAfter: vi.fn().mockResolvedValue([]),
-      getRecentMessages: vi.fn().mockResolvedValue([]),
     };
 
     llmDispatcher = {
@@ -89,6 +91,13 @@ describe('ThreadContextCompressorService', () => {
       }),
     };
 
+    loggerService = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
+
     const module = await Test.createTestingModule({
       providers: [
         ThreadContextCompressorService,
@@ -100,15 +109,7 @@ describe('ThreadContextCompressorService', () => {
         { provide: LlmDispatcherService, useValue: llmDispatcher },
         { provide: CacheService, useValue: cacheService },
         { provide: ConfigService, useValue: configService },
-        {
-          provide: LoggerService,
-          useValue: {
-            debug: vi.fn(),
-            error: vi.fn(),
-            log: vi.fn(),
-            warn: vi.fn(),
-          },
-        },
+        { provide: LoggerService, useValue: loggerService },
       ],
     }).compile();
 
@@ -137,7 +138,7 @@ describe('ThreadContextCompressorService', () => {
       const messages = Array.from({ length: 10 }, (_, i) =>
         makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
       );
-      messagesService.getRecentMessages.mockResolvedValue(messages);
+      messagesService.getAllMessages.mockResolvedValue(messages);
       model.findOneAndUpdate.mockResolvedValue({
         toObject: () => ({ _id: makeObjectId(), version: 1 }),
       });
@@ -157,7 +158,7 @@ describe('ThreadContextCompressorService', () => {
         version: 1,
       };
       cacheService.get.mockResolvedValue(existingState);
-      messagesService.countMessagesAfter.mockResolvedValue(3); // fits in window of 5
+      messagesService.countMessagesAfter.mockResolvedValue(3);
 
       const result = await service.getStateOrCompact(threadId, orgId);
 
@@ -173,12 +174,12 @@ describe('ThreadContextCompressorService', () => {
         version: 1,
       };
       cacheService.get.mockResolvedValue(existingState);
-      messagesService.countMessagesAfter.mockResolvedValue(8); // exceeds window of 5
+      messagesService.countMessagesAfter.mockResolvedValue(8);
 
       const messages = Array.from({ length: 13 }, (_, i) =>
         makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
       );
-      messagesService.getRecentMessages.mockResolvedValue(messages);
+      messagesService.getAllMessagesAfter.mockResolvedValue(messages);
       model.findOne.mockReturnValue({
         lean: vi.fn().mockResolvedValue(existingState),
       });
@@ -227,13 +228,183 @@ describe('ThreadContextCompressorService', () => {
       const messages = Array.from({ length: 10 }, (_, i) =>
         makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
       );
-      messagesService.getRecentMessages.mockResolvedValue(messages);
+      messagesService.getAllMessages.mockResolvedValue(messages);
       model.findOneAndUpdate.mockResolvedValue({
         toObject: () => ({ _id: makeObjectId(), version: 1 }),
       });
 
       await service.compressIfNeeded(threadId, orgId);
       expect(cacheService.withLock).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------
+  // Parse failure safety
+  // -----------------------------------------------------------
+  describe('parse failure safety', () => {
+    it('does not advance lastIncorporatedMessageId when LLM returns garbage', async () => {
+      messagesService.countMessages.mockResolvedValue(10);
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessages.mockResolvedValue(messages);
+
+      llmDispatcher.chatCompletion.mockResolvedValue(
+        makeLlmResponse('This is not a valid compression response at all.'),
+      );
+
+      await service.compressIfNeeded(threadId, orgId);
+
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('no valid sections'),
+        undefined,
+      );
+    });
+
+    it('does not advance state when LLM returns empty response', async () => {
+      messagesService.countMessages.mockResolvedValue(10);
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessages.mockResolvedValue(messages);
+
+      llmDispatcher.chatCompletion.mockResolvedValue(makeLlmResponse(''));
+
+      await service.compressIfNeeded(threadId, orgId);
+
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('advances state when LLM returns valid structured response', async () => {
+      messagesService.countMessages.mockResolvedValue(10);
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessages.mockResolvedValue(messages);
+      model.findOneAndUpdate.mockResolvedValue({
+        toObject: () => ({ _id: makeObjectId(), version: 1 }),
+      });
+
+      await service.compressIfNeeded(threadId, orgId);
+
+      expect(model.findOneAndUpdate).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------
+  // Cursor-based pagination (no 200 cap)
+  // -----------------------------------------------------------
+  describe('cursor-based pagination', () => {
+    it('uses getAllMessages when no prior state exists', async () => {
+      messagesService.countMessages.mockResolvedValue(10);
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessages.mockResolvedValue(messages);
+      model.findOneAndUpdate.mockResolvedValue({
+        toObject: () => ({ _id: makeObjectId(), version: 1 }),
+      });
+
+      await service.compressIfNeeded(threadId, orgId);
+
+      expect(messagesService.getAllMessages).toHaveBeenCalledWith(threadId);
+    });
+
+    it('uses getAllMessagesAfter with cursor when state exists', async () => {
+      const lastMsgId = makeObjectId();
+      const existingState = {
+        _id: makeObjectId(),
+        lastIncorporatedMessageId: lastMsgId,
+        messageCount: 50,
+        version: 3,
+      };
+      messagesService.countMessages.mockResolvedValue(100);
+      cacheService.get.mockResolvedValue(existingState);
+      messagesService.countMessagesAfter.mockResolvedValue(20);
+
+      const messages = Array.from({ length: 20 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessagesAfter.mockResolvedValue(messages);
+      model.findOne.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(existingState),
+      });
+      model.findOneAndUpdate.mockResolvedValue({
+        toObject: () => ({ ...existingState, version: 4 }),
+      });
+
+      await service.getStateOrCompact(threadId, orgId);
+
+      expect(messagesService.getAllMessagesAfter).toHaveBeenCalledWith(
+        threadId,
+        lastMsgId,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------
+  // messageCount correctness
+  // -----------------------------------------------------------
+  describe('messageCount', () => {
+    it('sets messageCount to compressBoundary on first compression', async () => {
+      messagesService.countMessages.mockResolvedValue(10);
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessages.mockResolvedValue(messages);
+      model.findOneAndUpdate.mockResolvedValue({
+        toObject: () => ({ _id: makeObjectId(), version: 1 }),
+      });
+
+      await service.compressIfNeeded(threadId, orgId);
+
+      // 10 messages - 5 window = 5 compressed
+      expect(model.findOneAndUpdate).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            messageCount: 5,
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('increments messageCount on incremental compression', async () => {
+      const existingState = {
+        _id: makeObjectId(),
+        lastIncorporatedMessageId: makeObjectId(),
+        messageCount: 20,
+        version: 2,
+      };
+      messagesService.countMessages.mockResolvedValue(40);
+      cacheService.get.mockResolvedValue(existingState);
+      messagesService.countMessagesAfter.mockResolvedValue(15);
+
+      const messages = Array.from({ length: 15 }, (_, i) =>
+        makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
+      );
+      messagesService.getAllMessagesAfter.mockResolvedValue(messages);
+      model.findOne.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(existingState),
+      });
+      model.findOneAndUpdate.mockResolvedValue({
+        toObject: () => ({ ...existingState, version: 3 }),
+      });
+
+      await service.getStateOrCompact(threadId, orgId);
+
+      // previousCount (20) + compressBoundary (15 - 5 window = 10) = 30
+      expect(model.findOneAndUpdate).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            messageCount: 30,
+          }),
+        }),
+        expect.any(Object),
+      );
     });
   });
 
@@ -317,7 +488,6 @@ describe('ThreadContextCompressorService', () => {
 
       const result = service.renderStateAsUserMessage(state, windowMessages);
 
-      // Short artifacts (<=50 chars) skip dedup
       expect(result).toContain('## Current Artifact');
     });
   });
@@ -331,7 +501,7 @@ describe('ThreadContextCompressorService', () => {
       const messages = Array.from({ length: 10 }, (_, i) =>
         makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
       );
-      messagesService.getRecentMessages.mockResolvedValue(messages);
+      messagesService.getAllMessages.mockResolvedValue(messages);
       model.findOneAndUpdate.mockResolvedValue({
         toObject: () => ({ _id: makeObjectId(), version: 1 }),
       });
@@ -346,7 +516,7 @@ describe('ThreadContextCompressorService', () => {
     });
 
     it('skips compression when lock is not acquired', async () => {
-      cacheService.withLock.mockResolvedValue(null); // lock not acquired
+      cacheService.withLock.mockResolvedValue(null);
       messagesService.countMessages.mockResolvedValue(10);
 
       await service.compressIfNeeded(threadId, orgId);
@@ -380,7 +550,7 @@ describe('ThreadContextCompressorService', () => {
       const messages = Array.from({ length: 10 }, (_, i) =>
         makeMessage(i % 2 === 0 ? 'user' : 'assistant', `msg ${i}`),
       );
-      messagesService.getRecentMessages.mockResolvedValue(messages);
+      messagesService.getAllMessages.mockResolvedValue(messages);
 
       const updatedDoc = {
         _id: makeObjectId(),
@@ -393,7 +563,6 @@ describe('ThreadContextCompressorService', () => {
 
       await service.compressIfNeeded(threadId, orgId);
 
-      // Should set cache with the new state
       expect(cacheService.set).toHaveBeenCalledWith(
         expect.stringContaining('thread-compact:state:'),
         expect.objectContaining({ version: 1 }),

--- a/apps/server/api/src/services/agent-threading/services/thread-context-compressor.service.ts
+++ b/apps/server/api/src/services/agent-threading/services/thread-context-compressor.service.ts
@@ -263,11 +263,15 @@ export class ThreadContextCompressorService {
         })
         .lean();
 
-      // Fetch messages — getRecentMessages returns chronological order (oldest first)
-      const allMessages = await this.agentMessagesService.getRecentMessages(
-        threadId,
-        200,
-      );
+      // Fetch all messages that need compression.
+      // When state exists, only fetch messages after the last compaction boundary;
+      // otherwise fetch all messages in the thread.
+      const allMessages = existingState?.lastIncorporatedMessageId
+        ? await this.agentMessagesService.getAllMessagesAfter(
+            threadId,
+            existingState.lastIncorporatedMessageId,
+          )
+        : await this.agentMessagesService.getAllMessages(threadId);
 
       if (allMessages.length <= this.windowSize) {
         return;
@@ -332,6 +336,20 @@ export class ThreadContextCompressorService {
       const responseText = response.choices?.[0]?.message?.content || '';
       const parsed = this.parseCompressionResponse(responseText);
 
+      // Validate parse result has at least one meaningful section before advancing state
+      const hasValidContent =
+        parsed.accumulatedRequirements ||
+        parsed.currentArtifact ||
+        parsed.keyDecisions ||
+        parsed.iterationHistory;
+
+      if (!hasValidContent) {
+        this.logger.warn(
+          `${this.constructorName}: Compression parse returned no valid sections for thread ${threadId}, skipping state update to prevent data loss`,
+        );
+        return;
+      }
+
       const currentVersion = existingState?.version ?? 0;
       const previousCount = existingState?.messageCount ?? 0;
 
@@ -350,10 +368,7 @@ export class ThreadContextCompressorService {
             lastIncorporatedMessageId: new Types.ObjectId(
               String(lastCompressedMessage._id),
             ),
-            messageCount:
-              previousCount +
-                (compressBoundary - (existingState ? compressBoundary : 0)) ||
-              compressBoundary,
+            messageCount: previousCount + compressBoundary,
             version: currentVersion + 1,
           },
           $setOnInsert: {

--- a/apps/server/api/src/services/prompt-builder/builders/replicate-prompt.builder.ts
+++ b/apps/server/api/src/services/prompt-builder/builders/replicate-prompt.builder.ts
@@ -1,4 +1,5 @@
-import type { ConfigService } from '@api/config/config.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { ConfigService } from '@api/config/config.service';
 import { DEFAULT_TEXT_MODEL } from '@api/constants/default-text-model.constant';
 import { BasePromptBuilder } from '@api/services/prompt-builder/builders/base-prompt.builder';
 import {

--- a/apps/server/api/src/services/skill-runtime/skill-runtime.service.ts
+++ b/apps/server/api/src/services/skill-runtime/skill-runtime.service.ts
@@ -80,12 +80,19 @@ export class SkillRuntimeService {
 
   /**
    * Merges skill tool overrides into the base tool set (additive only).
+   * When baseTools is undefined (no agentType), returns undefined to
+   * preserve unrestricted toolset — skill overrides are not needed
+   * when all tools are already available.
    * Invalid tool names are logged and dropped.
    */
   mergeSkillToolOverrides(
-    baseTools: string[],
+    baseTools: string[] | undefined,
     skills: ResolvedRuntimeSkill[],
-  ): string[] {
+  ): string[] | undefined {
+    if (!baseTools) {
+      return undefined;
+    }
+
     const toolSet = new Set(baseTools);
 
     for (const skill of skills) {

--- a/apps/server/files/src/services/websocket/websocket.service.ts
+++ b/apps/server/files/src/services/websocket/websocket.service.ts
@@ -1,4 +1,5 @@
-import type { ConfigService } from '@files/config/config.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { ConfigService } from '@files/config/config.service';
 import type { JobProgress } from '@files/shared/interfaces/job.interface';
 import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
 import { getUserRoomName } from '@libs/websockets/room-name.util';

--- a/apps/server/notifications/src/services/discord/discord-bot.service.ts
+++ b/apps/server/notifications/src/services/discord/discord-bot.service.ts
@@ -79,6 +79,10 @@ export class DiscordBotService implements OnModuleInit, OnModuleDestroy {
     channelId: string,
     webhookName: string,
   ): Promise<WebhookClient | null> {
+    if (!channelId) {
+      return null;
+    }
+
     const cacheKey = `${channelId}:${webhookName}`;
 
     const cached = this.webhookCache.get(cacheKey);
@@ -260,10 +264,12 @@ export class DiscordBotService implements OnModuleInit, OnModuleDestroy {
     ];
 
     const results = await Promise.all(
-      channels.map(async ({ name, channelId }) => ({
-        name,
-        ...(await this.testChannel(channelId)),
-      })),
+      channels
+        .filter(({ channelId }) => !!channelId)
+        .map(async ({ name, channelId }) => ({
+          name,
+          ...(await this.testChannel(channelId)),
+        })),
     );
 
     return { channels: results, success: true };

--- a/bun.lock
+++ b/bun.lock
@@ -205,7 +205,6 @@
         "@genfeedai/next-config": "*",
         "@genfeedai/serializers": "*",
         "@genfeedai/types": "*",
-        "@genfeedai/workflow": "*",
         "@genfeedai/workflow-engine": "*",
         "@genfeedai/workflow-saas": "*",
         "@genfeedai/workflow-ui": "*",
@@ -294,11 +293,18 @@
         "@genfeedai/next-config": "workspace:*",
         "@genfeedai/ui": "workspace:*",
         "@plasmohq/storage": "1.15.0",
+        "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slot": "^1.2.4",
         "@sentry/browser": "10.47.0",
         "axios": "1.14.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.7.0",
         "plasmo": "0.90.5",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "tailwind-merge": "^3.5.0",
         "zustand": "5.0.12",
       },
       "devDependencies": {
@@ -550,7 +556,6 @@
       "dependencies": {
         "@genfeedai/types": "workspace:*",
         "@genfeedai/ui": "workspace:*",
-        "@genfeedai/workflow": "workspace:*",
         "@tiptap/core": "3.22.2",
         "@tiptap/extension-mention": "3.22.2",
         "@tiptap/extension-placeholder": "3.22.2",
@@ -821,18 +826,6 @@
         "typescript": "5.9.3",
       },
     },
-    "packages/storage": {
-      "name": "@genfeedai/storage",
-      "version": "0.0.1",
-      "dependencies": {
-        "@aws-sdk/client-s3": "3.1024.0",
-        "@genfeedai/config": "workspace:*",
-      },
-      "devDependencies": {
-        "@types/node": "25.5.2",
-        "typescript": "5.9.3",
-      },
-    },
     "packages/tools": {
       "name": "@genfeedai/tools",
       "version": "0.1.3",
@@ -898,22 +891,6 @@
         "react": ">=18",
         "react-dom": ">=18",
         "tailwind-merge": "^3.5.0",
-      },
-    },
-    "packages/workflow-cloud": {
-      "name": "@genfeedai/workflow",
-      "version": "0.1.0",
-      "dependencies": {
-        "@genfeedai/constants": "workspace:*",
-        "@genfeedai/types": "workspace:*",
-        "@genfeedai/ui": "workspace:*",
-        "@genfeedai/workflow-engine": "workspace:*",
-        "@genfeedai/workflow-saas": "workspace:*",
-        "@genfeedai/workflow-ui": "workspace:*",
-        "@genfeedai/workflows": "workspace:*",
-        "@xyflow/react": "12.10.2",
-        "zundo": "2.3.0",
-        "zustand": "5.0.12",
       },
     },
     "packages/workflow-engine": {
@@ -1728,8 +1705,6 @@
 
     "@genfeedai/slack": ["@genfeedai/slack@workspace:apps/server/slack"],
 
-    "@genfeedai/storage": ["@genfeedai/storage@workspace:packages/storage"],
-
     "@genfeedai/telegram": ["@genfeedai/telegram@workspace:apps/server/telegram"],
 
     "@genfeedai/tools": ["@genfeedai/tools@workspace:packages/tools"],
@@ -1747,8 +1722,6 @@
     "@genfeedai/website": ["@genfeedai/website@workspace:apps/website"],
 
     "@genfeedai/workers": ["@genfeedai/workers@workspace:apps/server/workers"],
-
-    "@genfeedai/workflow": ["@genfeedai/workflow@workspace:packages/workflow-cloud"],
 
     "@genfeedai/workflow-engine": ["@genfeedai/workflow-engine@workspace:packages/workflow-engine"],
 
@@ -6959,8 +6932,6 @@
     "@genfeedai/prompts/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@genfeedai/serializers/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "@genfeedai/storage/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@genfeedai/tools/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -1,0 +1,126 @@
+# ==================================================
+# Self-Hosted Dockerfile
+# Single image with MongoDB 7, Redis, NestJS services, and Next.js
+# ==================================================
+
+# ==================================================
+# Stage 1: Base — system deps + runtime tools
+# ==================================================
+FROM node:20-bookworm-slim AS base
+
+# MongoDB 7 from official Debian bookworm repo + Redis + tini
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl gnupg redis-server tini && \
+    curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | \
+      gpg --dearmor -o /usr/share/keyrings/mongodb.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/mongodb.gpg] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" \
+      > /etc/apt/sources.list.d/mongodb.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+      mongodb-org-server mongodb-org-tools && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.12" && \
+    cp /root/.bun/bin/bun /usr/local/bin/bun
+ENV PATH="/usr/local/bin:${PATH}"
+
+# ==================================================
+# Stage 2: Builder — install deps + build everything
+# ==================================================
+FROM base AS builder
+WORKDIR /app
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
+# Copy workspace manifests for dependency resolution
+COPY package.json bun.lock turbo.json ./
+
+# Narrow workspace to server + web app only
+RUN node -e "\
+  const fs=require('fs');\
+  const p=JSON.parse(fs.readFileSync('package.json','utf8'));\
+  p.workspaces=['apps/server/*','apps/web','configs','packages/*'];\
+  if(p.dependencies?.resend==='~6.9.3') p.dependencies.resend='6.9.3';\
+  fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\n');"
+
+# Copy all workspace package.json files for Bun resolution
+RUN --mount=type=bind,source=.,target=/ctx \
+    for f in \
+      /ctx/configs/package.json \
+      /ctx/packages/*/package.json \
+      /ctx/apps/server/*/package.json \
+      /ctx/apps/web/package.json; do \
+      [ -f "$f" ] || continue; \
+      dir=$(echo "$f" | sed 's|^/ctx/||; s|/package.json$||'); \
+      mkdir -p "$dir" && cp "$f" "$dir/package.json"; \
+    done
+
+RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
+    HUSKY=0 bun install
+
+# Copy source
+COPY tsconfig.json tsconfig.build.json tsconfig.server.decorators.json webpack.base.config.js ./
+COPY configs/ configs/
+COPY packages/ packages/
+COPY apps/server/ apps/server/
+
+# Build shared workspace packages
+RUN set -e && \
+    bun --filter @genfeedai/cloud-types build & pid1=$! && \
+    bun --filter @genfeedai/config build & pid2=$! && \
+    bun --filter @genfeedai/workflow-engine build & pid3=$! && \
+    wait $pid1 $pid2 $pid3 && \
+    bun --filter @genfeedai/helpers build && \
+    bun --filter @genfeedai/integration-common build && \
+    bun --filter @genfeedai/cloud-serializers build && \
+    bun --filter @genfeedai/workflow-saas build
+
+# Disable deleteOutDir for parallel builds
+RUN sed -i 's/"deleteOutDir": true/"deleteOutDir": false/' apps/server/nest-cli.json
+
+# Build NestJS services
+RUN bun --filter @genfeedai/api build:prod
+RUN bun --filter @genfeedai/workers build:prod
+RUN set -e && \
+    bun --filter @genfeedai/files build:prod & pid1=$! && \
+    bun --filter @genfeedai/notifications build:prod & pid2=$! && \
+    wait $pid1 $pid2
+
+# Copy and build Next.js web app
+COPY apps/web/ apps/web/
+ENV NEXT_PUBLIC_API_URL=/v1
+ENV NEXT_PUBLIC_API_ENDPOINT=http://localhost:4001/v1
+ENV NEXT_PUBLIC_WS_ENDPOINT=http://localhost:3007
+ENV NEXT_PUBLIC_CDN_URL=http://localhost:3005
+RUN bun --filter @genfeedai/app build
+
+# ==================================================
+# Stage 3: Runtime — minimal production image
+# ==================================================
+FROM base AS runtime
+WORKDIR /app
+
+# Create data dirs + app user
+RUN mkdir -p /data/db /data/redis /data/files && \
+    useradd -m -u 1001 appuser && \
+    chown -R appuser:appuser /data
+
+# Copy built NestJS services
+COPY --from=builder --chown=appuser /app/apps/server/dist/ apps/server/dist/
+
+# Copy built Next.js app
+COPY --from=builder --chown=appuser /app/apps/web/.next/ apps/web/.next/
+COPY --from=builder --chown=appuser /app/apps/web/public/ apps/web/public/
+COPY --from=builder --chown=appuser /app/apps/web/package.json apps/web/package.json
+
+# Copy runtime deps
+COPY --from=builder --chown=appuser /app/node_modules/ node_modules/
+COPY --from=builder --chown=appuser /app/package.json .
+
+# Copy entrypoint
+COPY --chown=appuser docker/selfhosted-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+VOLUME /data
+EXPOSE 3102 4001
+USER appuser
+
+ENTRYPOINT ["tini", "--", "/entrypoint.sh"]

--- a/docker/docker-compose.selfhosted.yml
+++ b/docker/docker-compose.selfhosted.yml
@@ -1,0 +1,11 @@
+services:
+  genfeed:
+    image: ghcr.io/genfeedai/genfeed.ai:latest
+    ports:
+      - "3102:3102"  # Web UI
+      - "4001:4001"  # API
+    volumes:
+      - genfeed_data:/data
+
+volumes:
+  genfeed_data:

--- a/docker/selfhosted-entrypoint.sh
+++ b/docker/selfhosted-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Defaults (all overridable via environment variables)
+export MONGODB_URI=${MONGODB_URI:-mongodb://localhost:27017/genfeed}
+export REDIS_URL=${REDIS_URL:-redis://localhost:6379}
+export PORT=${PORT:-4001}
+export TOKEN_ENCRYPTION_KEY=${TOKEN_ENCRYPTION_KEY:-$(head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 32)}
+export GENFEEDAI_MICROSERVICES_FILES_URL=${GENFEEDAI_MICROSERVICES_FILES_URL:-http://localhost:3005}
+export GENFEEDAI_MICROSERVICES_NOTIFICATIONS_URL=${GENFEEDAI_MICROSERVICES_NOTIFICATIONS_URL:-http://localhost:3007}
+export GENFEEDAI_CDN_URL=${GENFEEDAI_CDN_URL:-http://localhost:3005}
+export GENFEEDAI_WEBHOOKS_URL=${GENFEEDAI_WEBHOOKS_URL:-http://localhost:4001}
+export GENFEEDAI_API_URL=${GENFEEDAI_API_URL:-http://localhost:4001}
+export GENFEEDAI_APP_URL=${GENFEEDAI_APP_URL:-http://localhost:3102}
+export GENFEEDAI_PUBLIC_URL=${GENFEEDAI_PUBLIC_URL:-http://localhost:3102}
+
+# Start infrastructure
+mongod --dbpath /data/db --wiredTigerCacheSizeGB 0.5 --fork --logpath /data/mongod.log
+redis-server --dir /data/redis --appendonly yes --daemonize yes
+
+# Start NestJS services (each needs its own PORT to avoid bind collisions)
+PORT=4001 node apps/server/dist/apps/api/main.js &
+PORT=4002 node apps/server/dist/apps/workers/main.js &
+PORT=3005 node apps/server/dist/apps/files/main.js &
+PORT=3007 node apps/server/dist/apps/notifications/main.js &
+
+# Start Next.js web app (foreground — keeps container alive)
+cd apps/web && bun run start

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test": "bunx turbo test",
     "test:e2e": "bunx playwright test",
     "test:e2e:full": "bunx playwright test --config=playwright-full.config.ts",
-    "typecheck": "bunx turbo type-check",
+    "type-check": "bunx turbo type-check",
     "secretlint": "secretlint '**/*'"
   },
   "lint-staged": {

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -42,7 +42,7 @@
     "generate": "bun run scripts/generate.ts --skip-on-error",
     "generate:strict": "bun run scripts/generate.ts",
     "prepublishOnly": "bun run build",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "type": "module",
   "version": "0.4.0"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -41,7 +41,7 @@
     "prepack": "npm run build",
     "test": "vitest run --config vitest.config.ts",
     "test:cov": "vitest run --config vitest.config.ts --coverage",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/deserializer/package.json
+++ b/packages/deserializer/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc --build --force",
     "prepack": "npm run build",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/enums/package.json
+++ b/packages/enums/package.json
@@ -30,7 +30,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -65,7 +65,7 @@
     "test:cov": "vitest run --coverage --config vitest.config.ts",
     "test:coverage": "vitest run --coverage --config vitest.config.ts",
     "test:watch": "vitest watch --config vitest.config.ts",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/hooks/data/skills/use-brand-enabled-skills.ts
+++ b/packages/hooks/data/skills/use-brand-enabled-skills.ts
@@ -37,12 +37,15 @@ export function useBrandEnabledSkills(): UseBrandEnabledSkillsReturn {
         ((selectedBrand as Record<string, unknown>)._id as string);
       if (!brandId) return;
 
-      const nextSlugs = enabledSlugs.includes(slug)
-        ? enabledSlugs.filter((s) => s !== slug)
-        : [...enabledSlugs, slug];
-
-      // Optimistic update
-      setEnabledSlugs(nextSlugs);
+      // Use functional update to derive next state from the latest value,
+      // preventing stale closures when multiple toggles fire in quick succession.
+      let nextSlugs: string[] = [];
+      setEnabledSlugs((prev) => {
+        nextSlugs = prev.includes(slug)
+          ? prev.filter((s) => s !== slug)
+          : [...prev, slug];
+        return nextSlugs;
+      });
 
       try {
         const token = await resolveClerkToken(getToken);
@@ -66,11 +69,15 @@ export function useBrandEnabledSkills(): UseBrandEnabledSkillsReturn {
           );
         }
       } catch {
-        // Revert on failure
-        setEnabledSlugs(enabledSlugs);
+        // Revert on failure using functional update to avoid stale state
+        setEnabledSlugs((prev) =>
+          slug && !prev.includes(slug)
+            ? [...prev, slug]
+            : prev.filter((s) => s !== slug),
+        );
       }
     },
-    [enabledSlugs, getToken, selectedBrand],
+    [getToken, selectedBrand],
   );
 
   return { enabledSlugs, isLoading, toggleSkill };

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -48,7 +48,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/libs/events/events.service.ts
+++ b/packages/libs/events/events.service.ts
@@ -1,5 +1,7 @@
-import type { LoggerService } from '@libs/logger/logger.service';
-import type { RedisService } from '@libs/redis/redis.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { Injectable, type OnModuleInit } from '@nestjs/common';
 
 @Injectable()

--- a/packages/libs/redis/redis.service.ts
+++ b/packages/libs/redis/redis.service.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
-import type { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
 import {
   Inject,
   Injectable,

--- a/packages/libs/websockets/websockets.gateway.ts
+++ b/packages/libs/websockets/websockets.gateway.ts
@@ -18,8 +18,10 @@ import type {
   VideoProgressEvent,
   VoteCreateMessage,
 } from '@libs/interfaces/websockets.interface';
-import type { LoggerService } from '@libs/logger/logger.service';
-import type { RedisService } from '@libs/redis/redis.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { Inject, Injectable } from '@nestjs/common';
 import {
   ConnectedSocket,

--- a/packages/libs/websockets/websockets.service.ts
+++ b/packages/libs/websockets/websockets.service.ts
@@ -4,7 +4,8 @@ import type {
   VideoCompleteEvent,
   VideoProgressEvent,
 } from '@libs/interfaces/websockets.interface';
-import type { RedisService } from '@libs/redis/redis.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { Injectable } from '@nestjs/common';
 import { getUserRoomName } from './room-name.util';
 

--- a/packages/pages/issues/list/issues-list.tsx
+++ b/packages/pages/issues/list/issues-list.tsx
@@ -307,16 +307,16 @@ export default function IssuesList() {
             New Issue
           </Button>
           <Select
-            value={statusFilter}
+            value={statusFilter || 'all'}
             onValueChange={(value) =>
-              setStatusFilter(value as IssueStatus | '')
+              setStatusFilter(value === 'all' ? '' : (value as IssueStatus))
             }
           >
             <SelectTrigger className="w-auto text-xs">
               <SelectValue placeholder="All Statuses" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All Statuses</SelectItem>
+              <SelectItem value="all">All Statuses</SelectItem>
               {STATUS_ORDER.map((s) => (
                 <SelectItem key={s} value={s}>
                   {STATUS_LABELS[s]}

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -29,7 +29,7 @@
     "build": "tsc --build --force && if [ -d dist/src ]; then mv dist/src/* dist/ 2>/dev/null && rm -rf dist/src; fi",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
     "lint": {
       "dependsOn": ["^build"]
     },
-    "typecheck": {
+    "type-check": {
       "dependsOn": ["^build"]
     },
     "test": {


### PR DESCRIPTION
## Summary

Phase 7 of the One API epic (#95). Delivers the self-hosted packaging layer.

- **Self-hosted seed service** — `OnApplicationBootstrap` hook that creates default org/brand/user on first boot when `IS_SELF_HOSTED`. Fixes broken `SelfHostedSeedModule` import in `app.module.ts`.
- **Single Docker image** — `Dockerfile.selfhosted` with MongoDB 7 + Redis + all NestJS services + Next.js in one container. Uses `tini` for process management, persistent `/data` volume.
- **Entrypoint** — Per-service PORT allocation (API 4001, Workers 4002, Files 3005, Notifications 3007), `mongod --fork`, `redis-server --daemonize`.
- **Docker Compose** — `docker-compose.selfhosted.yml` for one-command self-hosting.
- **CI workflow** — `docker-publish.yml` builds and pushes to `ghcr.io/genfeedai/genfeed.ai` on release.

## Files added (6)
- `apps/server/api/src/seeds/self-hosted-seed.service.ts`
- `apps/server/api/src/seeds/self-hosted-seed.module.ts`
- `docker/Dockerfile.selfhosted`
- `docker/selfhosted-entrypoint.sh`
- `docker/docker-compose.selfhosted.yml`
- `.github/workflows/docker-publish.yml`

## Test plan
- [ ] API compiles without broken import error
- [ ] `docker build -f docker/Dockerfile.selfhosted -t genfeed .` builds successfully
- [ ] `docker run -v genfeed:/data -p 3102:3102 -p 4001:4001 genfeed` starts all services, seeds on first boot
- [ ] Restart container — data persists
- [ ] Release triggers GHCR image push

## Related
- Epic: #95
- Issues: #113 #114 #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)