### PR TITLE
ci: deploy production on release only + sync deps

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,22 +1,13 @@
 # Production Deployment — thin caller for the reusable _deploy.yml workflow
-# ONLY triggers on master push. Contributors PR against develop; maintainers
-# merge develop → master to deploy. No external contributor can trigger this.
+# Triggers on GitHub release (like cal.com). Contributors PR against develop;
+# maintainers merge develop → master, then create a release to deploy.
+# Manual dispatch is also available for hotfixes.
 
 name: Deploy Production
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'apps/server/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'docker/**'
-      - 'scripts/**'
-      - '.github/workflows/deploy-production.yml'
-      - '.github/workflows/_deploy.yml'
-      - '.github/actions/**'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       force_all:


### PR DESCRIPTION
## Summary

- **Deploy trigger**: Changed `deploy-production.yml` from `push to master` to `release published` (matches cal.com's pattern)
- **Deps sync**: Lockfile and package.json dependencies synced after port consolidation
- **Cleanup**: Removed nested tool configs from apps/docs

Production deploys now require creating a GitHub release. Manual dispatch still available for hotfixes.

## Test plan
- [ ] Merging to master does NOT trigger deployment
- [ ] Creating a release triggers deployment
- [ ] Manual dispatch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)