### PR TITLE
ci: add format check + deploy on release only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+      - run: bun install --frozen-lockfile
+      - run: bun run format:check
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -47,7 +58,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck]
+    needs: [format, lint, typecheck]
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- Add `format` job to CI (runs `bun run format:check` via biome)
- Build now depends on format + lint + typecheck all passing
- Deploy production triggers on release only (already merged in #129)

## Test plan
- [ ] CI runs format check on PRs
- [ ] Build fails if format check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)