### PR TITLE
docs: refresh docs.genfeed.ai for open-source release

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -69,7 +69,7 @@ export default async function RootLayout({
           navbar={navbar}
           footer={footer}
           pageMap={await getPageMap()}
-          docsRepositoryBase="https://github.com/genfeedai/docs/tree/main"
+          docsRepositoryBase="https://github.com/genfeedai/genfeed.ai/tree/master/apps/docs"
           sidebar={{ defaultMenuCollapseLevel: 1, toggleButton: true }}
           toc={{ backToTop: true }}
         >

--- a/apps/docs/content/_meta.ts
+++ b/apps/docs/content/_meta.ts
@@ -1,25 +1,31 @@
 export default {
-  '---': {
+  index: 'Welcome',
+
+  // -- Products --
+  'sep-products': {
     title: 'Products',
     type: 'separator',
   },
-  '----': {
+  core: 'Genfeed Core (OSS)',
+  cloud: 'Genfeed Cloud',
+  deployment: 'Deployment Options',
+
+  // -- Learn --
+  'sep-learn': {
     title: 'Learn',
     type: 'separator',
   },
-  '-----': {
-    title: 'Reference',
-    type: 'separator',
-  },
-  advanced: 'Advanced',
-  'api-reference': 'API Reference',
-  cloud: 'Genfeed Cloud',
-  core: 'Genfeed Core (OSS)',
-  deployment: 'Deployment Options',
-  faq: 'FAQ',
   features: 'Features',
   'getting-started': 'Getting Started',
   guides: 'Guides & Tutorials',
-  index: 'Welcome',
   models: 'AI Models',
+  faq: 'FAQ',
+
+  // -- Reference --
+  'sep-reference': {
+    title: 'Reference',
+    type: 'separator',
+  },
+  'api-reference': 'API Reference',
+  advanced: 'Advanced',
 };

--- a/apps/docs/content/cloud/index.mdx
+++ b/apps/docs/content/cloud/index.mdx
@@ -4,8 +4,8 @@ Managed SaaS platform for teams who want one control plane for generation, publi
 
 ## Last Verified
 
-- **Date:** 2026-03-12
-- **Implemented state source:** `cloud/` codebase
+- **Date:** 2026-04-07
+- **Implemented state source:** `apps/` codebase
 - **Delivery state source:** GitHub issues + Mission Control project (#11)
 
 ## What Cloud Adds
@@ -16,7 +16,7 @@ Managed SaaS platform for teams who want one control plane for generation, publi
 | Brand operations | Brand profiles and content context |
 | Team operations | Member and access workflows |
 | Publishing | Multi-platform workflows |
-| Management UI | Admin/app/marketplace/website/chatgpt surfaces |
+| Management UI | Admin panel, studio app, marketing website |
 
 ## Quick Start
 

--- a/apps/docs/content/core/configuration.mdx
+++ b/apps/docs/content/core/configuration.mdx
@@ -1,43 +1,93 @@
+import { Callout } from 'nextra/components'
+
 # Configuration
 
-Environment variables and settings for Genfeed Core.
-
-## Environment Variables
-
-Create a `.env.local` file in your project root:
+Environment variables and settings for Genfeed Core. Create a `.env.local` file in your project root:
 
 ```bash
 cp .env.example .env.local
 ```
 
-### Required Variables
+<Callout type="warning">
+**Never commit secrets.** Add `.env.local` to your `.gitignore`. Never commit API keys, tokens, or credentials to version control.
+</Callout>
 
-```bash
-# Database
-MONGODB_URI=mongodb://localhost:27017/genfeed
-REDIS_URL=redis://localhost:6379
+---
 
-# API Keys (at least one required)
-OPENAI_API_KEY=sk-...
-REPLICATE_API_TOKEN=r8_...
-ANTHROPIC_API_KEY=sk-ant-...
-```
+## Database
 
-### Optional Variables
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MONGODB_URI` | Yes | -- | MongoDB connection string (e.g. `mongodb://localhost:27017/genfeed`) |
+| `REDIS_URL` | Yes | -- | Redis connection string for BullMQ job queues and caching (e.g. `redis://localhost:6379`) |
 
-```bash
-# ElevenLabs (for voice)
-ELEVENLABS_API_KEY=...
+---
 
-# Google (for Gemini)
-GOOGLE_API_KEY=...
+## Authentication
 
-# Storage (defaults to local)
-S3_BUCKET=...
-S3_REGION=...
-AWS_ACCESS_KEY_ID=...
-AWS_SECRET_ACCESS_KEY=...
-```
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `JWT_SECRET` | Yes | -- | Secret key for signing JWT tokens. Use a long random string. |
+| `CLERK_SECRET_KEY` | Cloud only | -- | Clerk backend secret key for user authentication |
+| `CLERK_PUBLISHABLE_KEY` | Cloud only | -- | Clerk frontend publishable key |
+
+---
+
+## AI Providers
+
+Add keys for the providers you want to use. At least one is required for content generation.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | No | OpenAI API key for GPT models and DALL-E image generation |
+| `ANTHROPIC_API_KEY` | No | Anthropic API key for Claude models |
+| `GOOGLE_API_KEY` | No | Google API key for Gemini models |
+| `REPLICATE_API_TOKEN` | No | Replicate API token for open-source image and video models (Flux, SDXL, Kling, etc.) |
+| `FAL_KEY` | No | fal.ai API key for fast image and video inference |
+| `ELEVENLABS_API_KEY` | No | ElevenLabs API key for voice synthesis and text-to-speech |
+
+---
+
+## Storage
+
+By default, generated assets are stored locally. For production, configure S3-compatible storage.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AWS_ACCESS_KEY_ID` | No | -- | AWS access key for S3 storage |
+| `AWS_SECRET_ACCESS_KEY` | No | -- | AWS secret key for S3 storage |
+| `S3_BUCKET` | No | -- | S3 bucket name for storing generated assets |
+| `S3_REGION` | No | `us-east-1` | AWS region for your S3 bucket |
+
+---
+
+## Payments (Cloud only)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `STRIPE_SECRET_KEY` | Cloud only | -- | Stripe secret key for subscription billing |
+| `STRIPE_WEBHOOK_SECRET` | Cloud only | -- | Stripe webhook signing secret for payment event verification |
+
+---
+
+## URLs
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `APP_URL` | No | `http://localhost:3102` | Frontend application URL |
+| `API_URL` | No | `http://localhost:3001` | Backend API URL |
+| `MARKETPLACE_API_URL` | No | -- | Marketplace API endpoint (cloud only, for marketplace.genfeed.ai integration) |
+
+---
+
+## Application
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NODE_ENV` | No | `development` | Environment mode (`development`, `production`, `test`) |
+| `PORT` | No | `3001` | API server port |
+
+---
 
 ## Database Setup
 
@@ -63,7 +113,10 @@ brew services start redis
 docker run -d -p 6379:6379 redis:7
 ```
 
+---
+
 ## Next Steps
 
-- [Installation Guide](/core/installation) — Full setup walkthrough
-- [Contributing](/core/contributing) — How to contribute
+- [Installation Guide](/core/installation) -- Full setup walkthrough
+- [Self-Hosted vs Cloud](/core/self-hosted-vs-cloud) -- Compare editions
+- [Contributing](/core/contributing) -- How to contribute

--- a/apps/docs/content/core/installation.mdx
+++ b/apps/docs/content/core/installation.mdx
@@ -18,7 +18,7 @@ Before you begin, ensure you have:
 
 ### API Keys (Optional but Recommended)
 
-To use AI generation features, you'll need API keys from providers:
+To use AI generation features, you need API keys from at least one provider:
 
 | Provider | For | Get Key |
 |----------|-----|---------|
@@ -58,7 +58,7 @@ Create a `.env.local` file in the project root:
 cp .env.example .env.local
 ```
 
-Edit `.env.local` with your settings:
+Edit `.env.local` with your settings. See [Configuration](/core/configuration) for the full reference.
 
 ```env
 # Database
@@ -76,14 +76,14 @@ NODE_ENV=development
 PORT=3001
 JWT_SECRET=your-secure-random-string
 
-# Optional: External services
+# Optional: External storage
 # AWS_ACCESS_KEY_ID=...
 # AWS_SECRET_ACCESS_KEY=...
 # S3_BUCKET=your-bucket
 ```
 
 <Callout type="warning">
-  **Never Commit API Keys** — Add `.env.local` to your `.gitignore`. Never commit API keys to version control.
+**Never commit API keys.** Add `.env.local` to your `.gitignore`. Never commit API keys or secrets to version control.
 </Callout>
 
 ### 4. Start Services
@@ -127,29 +127,17 @@ Open your browser and visit:
 http://localhost:3001/health
 ```
 
-You should see:
-
-```json
-{
-  "status": "ok",
-  "version": "1.0.0",
-  "services": {
-    "database": "connected",
-    "redis": "connected",
-    "queue": "ready"
-  }
-}
-```
+You should see a JSON response confirming the API, database, and Redis are connected and ready.
 
 ---
 
 ## Running the Frontend (Optional)
 
-Genfeed Core includes the API only. To run a full cloud web interface from the workspace monorepo:
+Genfeed Core includes the API only. To run the full web interface from the workspace monorepo:
 
 ```bash
-# In a separate terminal, from the `cloud/` workspace root
-cd cloud/apps/web/app
+# In a separate terminal, from the monorepo root
+cd apps/app
 bun install
 bun run dev
 ```
@@ -214,27 +202,13 @@ volumes:
 
 ---
 
-## Configuration Reference
-
-### Environment Variables
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `MONGODB_URI` | Yes | - | MongoDB connection string |
-| `REDIS_URL` | Yes | - | Redis connection string |
-| `PORT` | No | 3001 | API server port |
-| `NODE_ENV` | No | development | Environment mode |
-| `JWT_SECRET` | Yes | - | Secret for JWT tokens |
-| `OPENAI_API_KEY` | No | - | OpenAI API key |
-| `REPLICATE_API_TOKEN` | No | - | Replicate API token |
-
-### Resource Requirements
+## Resource Requirements
 
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
 | CPU | 2 cores | 4+ cores |
 | RAM | 4 GB | 8+ GB |
-| Storage | 20 GB | 100+ GB (for assets) |
+| Storage | 20 GB | 100+ GB (for generated assets) |
 
 ---
 
@@ -299,8 +273,9 @@ bun dev
 
 ## Next Steps
 
-- [API Reference](/api-reference/overview) — Explore the REST API
-- [Documentation](https://docs.genfeed.ai) — Full platform documentation
+- [Configuration](/core/configuration) -- Full environment variable reference
+- [API Reference](/api-reference/overview) -- Explore the REST API
+- [Self-Hosted vs Cloud](/core/self-hosted-vs-cloud) -- Compare editions
 
 ---
 
@@ -308,6 +283,5 @@ bun dev
 
 - **GitHub Issues:** [github.com/genfeedai/core/issues](https://github.com/genfeedai/core/issues)
 - **Discord:** [discord.gg/TmfHg42xVb](https://discord.gg/TmfHg42xVb)
-- **Documentation:** You're here!
 
 For production support, consider [Genfeed Cloud](/deployment/overview) or an [Enterprise License](mailto:enterprise@genfeed.ai).

--- a/apps/docs/content/core/self-hosted-vs-cloud.mdx
+++ b/apps/docs/content/core/self-hosted-vs-cloud.mdx
@@ -2,31 +2,37 @@ import { Callout } from 'nextra/components'
 
 # Self-Hosted vs. Cloud
 
-GenFeed is available as an open source core (self-hosted) and a fully managed cloud platform. Here's how to decide.
+Genfeed is available as an open-source core (self-hosted) and a fully managed cloud platform. This is the canonical comparison page -- other docs link here for the full breakdown.
 
 ## Comparison
 
-| | Self-Hosted (Core) | GenFeed Cloud |
+| | Self-Hosted (Core) | Genfeed Cloud |
 |---|---|---|
-| **Setup** | You manage infrastructure | Instant — sign up and start |
+| **Setup** | You manage infrastructure | Instant -- sign up and start |
 | **Cost** | Your compute + API costs | Subscription (free tier available) |
 | **Image generation** | Yes | Yes |
 | **Video generation** | Yes | Yes |
+| **Text generation** | Yes | Yes |
+| **Audio / voice generation** | Yes | Yes |
 | **Brand kits** | Yes | Yes |
 | **Model selection** | Full control (any model) | Curated best models |
-| **Multi-tenancy** | No | Yes — manage multiple brands |
-| **Publisher** | No | Yes — auto-post to X, LinkedIn, Instagram, YouTube |
-| **Analytics** | No | Yes — engagement, revenue per post |
-| **Team collaboration** | No | Yes — roles, approvals, workspaces |
+| **Multi-tenancy** | No | Yes -- manage multiple brands |
+| **Publisher** | No | Yes -- auto-post to X, LinkedIn, Instagram, YouTube |
+| **Analytics** | No | Yes -- engagement, revenue per post |
+| **Team collaboration** | No | Yes -- roles, approvals, workspaces |
 | **Manager (templates, ingredients)** | No | Yes |
 | **Studio (full editor)** | No | Yes |
-| **Marketplace** | No | Yes — prompts, workflows, brand kits |
+| **Marketplace** | No | Yes -- workflows, prompts, presets, brand kits |
 | **API** | Yes (REST) | Yes (REST + SDK) |
 | **Webhooks** | Yes | Yes |
 | **NSFW content** | Yes (your models) | SFW only |
 | **Support** | Community (GitHub) | Priority support + SLA |
 | **Updates** | Manual (git pull) | Automatic |
-| **License** | AGPL-3.0 | Commercial |
+| **License** | AGPL-3.0 (enterprise features under commercial license in `ee/`) | Commercial |
+
+<Callout type="info">
+**Marketplace** -- [marketplace.genfeed.ai](https://marketplace.genfeed.ai) is a separate cloud product where creators buy and sell workflows, prompts, presets, and brand kits. It is not available in the self-hosted edition.
+</Callout>
 
 ## When to Self-Host
 
@@ -40,7 +46,7 @@ Self-hosting is right for you if:
 
 ## When to Use Cloud
 
-GenFeed Cloud is right for you if:
+Genfeed Cloud is right for you if:
 
 - You want to **start generating content immediately**
 - You need **multi-brand management** (agencies, teams)
@@ -62,18 +68,20 @@ GenFeed Cloud is right for you if:
 - **Your time:** Zero infrastructure management
 
 <Callout type="info">
-**The math:** If you generate fewer than 500 images/month, Cloud is more cost-effective when you factor in infrastructure and maintenance time. Above 500/month, self-hosting saves money — but you lose Publisher, Analytics, and multi-tenancy.
+**The math:** If you generate fewer than 500 images/month, Cloud is more cost-effective when you factor in infrastructure and maintenance time. Above 500/month, self-hosting saves money -- but you lose Publisher, Analytics, and multi-tenancy.
 </Callout>
 
 ## Migration Path
 
-Start with either option — migration is straightforward:
+Start with either option -- migration is straightforward:
 
-**Core → Cloud:** Export your brand kits and templates, import into Cloud. Your content and settings transfer.
+**Core to Cloud:** Export your brand kits and templates, import into Cloud. Your content and settings transfer.
 
-**Cloud → Core:** Export your configuration. Self-host with the same brand kits and generation settings.
+**Cloud to Core:** Export your configuration. Self-host with the same brand kits and generation settings.
 
 ## Get Started
 
-- **Self-Hosted:** [Self-Host GenFeed in 5 Minutes](/guides/self-host-quickstart)
-- **Cloud:** [Sign up for GenFeed Cloud](https://genfeed.ai)
+- **Self-Hosted:** [Self-Host Genfeed in 5 Minutes](/guides/self-host-quickstart)
+- **Cloud:** [Sign up for Genfeed Cloud](https://app.genfeed.ai)
+
+For detailed deployment options, see [Deployment Options](/deployment).

--- a/apps/docs/content/deployment/overview.mdx
+++ b/apps/docs/content/deployment/overview.mdx
@@ -2,17 +2,7 @@
 
 Genfeed.ai is available in two deployment modes: **Genfeed Cloud** (hosted SaaS) and **Genfeed Core** (self-hosted open source). Choose the option that best fits your needs.
 
-## Quick Comparison
-
-| Feature | Genfeed Cloud | Genfeed Core (OSS) |
-|---------|--------------|-------------------|
-| **Setup Time** | Instant | 15-30 minutes |
-| **Infrastructure** | Fully managed | Self-managed |
-| **Updates** | Automatic | Manual |
-| **Data Location** | Our servers | Your servers |
-| **Cost** | Subscription-based | Free + your infra costs |
-| **Support** | Email + Priority | Community |
-| **Best For** | Teams wanting to start fast | Developers wanting full control |
+For a detailed comparison of self-hosted vs cloud, see [Self-Hosted vs Cloud](/core/self-hosted-vs-cloud).
 
 ---
 
@@ -22,22 +12,22 @@ Genfeed.ai is available in two deployment modes: **Genfeed Cloud** (hosted SaaS)
 
 ### Why Choose Cloud?
 
-- **Zero DevOps** — No servers to manage, no databases to configure
-- **Always Updated** — Get new features and models automatically
-- **Built-in Scaling** — Handle any workload without configuration
-- **Priority Support** — Direct access to our team
-- **Compliance Ready** — SOC2, GDPR compliant infrastructure
+- **Zero DevOps** -- No servers to manage, no databases to configure
+- **Always Updated** -- Get new features and models automatically
+- **Built-in Scaling** -- Handle any workload without configuration
+- **Priority Support** -- Direct access to our team
+- **Compliance Ready** -- SOC2, GDPR compliant infrastructure
 
 ### Getting Started with Cloud
 
-1. Visit [genfeed.ai](https://genfeed.ai)
+1. Visit [app.genfeed.ai](https://app.genfeed.ai)
 2. Create your account
 3. Choose your plan
 4. Start creating content
 
 **That's it.** No installation, no configuration.
 
-[**Start with Genfeed Cloud →**](https://genfeed.ai/signup)
+[**Start with Genfeed Cloud -->**](https://app.genfeed.ai)
 
 ---
 
@@ -47,38 +37,40 @@ Genfeed.ai is available in two deployment modes: **Genfeed Cloud** (hosted SaaS)
 
 ### Why Choose Self-Hosted?
 
-- **Full Control** — Your data stays on your servers
-- **Customizable** — Modify and extend as needed
-- **No Vendor Lock-in** — AGPL-3.0 licensed core
-- **Cost Efficient at Scale** — Pay only for your infrastructure
-- **Air-gapped Deployments** — Works in isolated environments
+- **Full Control** -- Your data stays on your servers
+- **Customizable** -- Modify and extend as needed
+- **No Vendor Lock-in** -- AGPL-3.0 licensed core
+- **Cost Efficient at Scale** -- Pay only for your infrastructure
+- **Air-gapped Deployments** -- Works in isolated environments
 
 ### What's Included in Core?
 
-The open source core includes:
+The open-source core includes:
 
+- AI content generation pipeline (images, video, text, audio)
 - Workflow engine
-- Node execution system
 - REST API
-- Basic templates
-- Single-user mode
+- Brand kits
 - Queue management (BullMQ)
+- Single-user mode
 
 ### What's Cloud-Only?
 
 Some features require Genfeed Cloud:
 
-- Multi-tenancy & organization management
+- Multi-tenancy and organization management
 - Role-based access control (RBAC)
-- SSO/SAML integration
-- Advanced analytics dashboard
-- White-labeling
-- Priority queue management
+- Social publishing (X, LinkedIn, Instagram, YouTube)
+- Analytics dashboard
+- Team collaboration
+- Marketplace access ([marketplace.genfeed.ai](https://marketplace.genfeed.ai))
 - Managed AI model access
 
 ### Getting Started Self-Hosted
 
-[**Self-Hosted Installation Guide →**](/guides/self-host-quickstart)
+[**Self-Hosted Installation Guide -->**](/core/installation)
+
+Quick start: [Self-Host Genfeed in 5 Minutes](/guides/self-host-quickstart)
 
 ---
 
@@ -89,7 +81,7 @@ Many teams use both:
 - **Development/Testing:** Self-hosted Core for local development
 - **Production:** Genfeed Cloud for reliability and scale
 
-The SDK and API are identical between both deployments, making migration seamless.
+The API is compatible between both deployments, making migration straightforward.
 
 ---
 
@@ -103,4 +95,4 @@ The SDK and API are identical between both deployments, making migration seamles
 | Agency managing multiple clients | Genfeed Cloud (Team/Enterprise) |
 | Hobby project | Self-Hosted (free) |
 
-**Still unsure?** [Contact us](mailto:support@genfeed.ai) — we're happy to help you choose.
+**Still unsure?** [Contact us](mailto:support@genfeed.ai) -- we're happy to help you choose.

--- a/apps/docs/content/features.mdx
+++ b/apps/docs/content/features.mdx
@@ -1,26 +1,12 @@
 # Features
 
-Genfeed.ai is available in two editions: **Core** (free, open source) and **Cloud** (managed SaaS).
+Genfeed.ai is available in two editions: **Core** (free, open source) and **Cloud** (managed SaaS). Core gives you the full AI generation engine. Cloud adds team, publishing, and analytics features on top.
 
-## Quick Comparison
-
-| Feature | Core (Free) | Cloud |
-|---------|-------------|-------------|
-| Workflow Engine | ✅ | ✅ |
-| AI Content Generation | ✅ | ✅ |
-| Multi-Format Output | ✅ | ✅ |
-| Self-Hosted | ✅ | - |
-| Organizations | - | ✅ |
-| Brands & Brand Kits | - | ✅ |
-| Voices & Tones | - | ✅ |
-| Team Collaboration | - | ✅ |
-| Social Publishing | - | ✅ |
-| Analytics Dashboard | - | ✅ |
-| Marketplace Access | - | ✅ |
+For a detailed comparison, see [Self-Hosted vs Cloud](/core/self-hosted-vs-cloud).
 
 ---
 
-## Core Features (Free & Open Source)
+## Core Features (Free and Open Source)
 
 Everything you need to generate AI content. Self-hosted, bring your own API keys.
 
@@ -28,14 +14,14 @@ Everything you need to generate AI content. Self-hosted, bring your own API keys
 
 The heart of Genfeed. Build automated content pipelines:
 
-- **Visual workflow builder** — Drag-and-drop nodes
-- **Triggers** — Schedule, webhook, or manual
-- **Actions** — Generate, transform, export
-- **Conditions** — Branch logic based on outputs
+- **Visual workflow builder** -- Drag-and-drop nodes
+- **Triggers** -- Schedule, webhook, or manual
+- **Actions** -- Generate, transform, export
+- **Conditions** -- Branch logic based on outputs
 
 ### Multi-Model AI Generation
 
-Connect your API keys and access 40+ models:
+Connect your API keys and access models from leading providers:
 
 | Provider | Models |
 |----------|--------|
@@ -49,25 +35,25 @@ Connect your API keys and access 40+ models:
 
 Generate any content type:
 
-- **Text** — Articles, social posts, scripts, emails
-- **Images** — Photos, artwork, graphics, logos
-- **Video** — Clips, animations, reels
-- **Audio** — Voiceovers, music, sound effects
+- **Text** -- Articles, social posts, scripts, emails
+- **Images** -- Photos, artwork, graphics, logos
+- **Video** -- Clips, animations, reels
+- **Audio** -- Voiceovers, music, sound effects
 
 ### Full Control
 
-- **Self-hosted** — Your servers, your data
-- **Open source** — MIT license, modify freely
-- **No limits** — Only your API costs
-- **Privacy** — Nothing leaves your infrastructure
+- **Self-hosted** -- Your servers, your data
+- **Open source** -- AGPL-3.0 license (enterprise features under commercial license in `ee/`)
+- **No limits** -- Only your API costs
+- **Privacy** -- Nothing leaves your infrastructure
 
-[**Get Started with Core →**](/core)
+[**Get Started with Core -->**](/core)
 
 ---
 
 ## Cloud Features
 
-Everything in Core, plus enterprise features for teams and brands.
+Everything in Core, plus features for teams and brands.
 
 ### Organizations
 
@@ -78,32 +64,32 @@ Multi-tenant workspaces for agencies and teams:
 - Switch between orgs instantly
 - Invite clients to their own workspace
 
-### Brands & Brand Kits
+### Brands and Brand Kits
 
 Maintain brand consistency across all content:
 
-- **Brand profiles** — Logo, colors, fonts, guidelines
-- **Asset libraries** — Centralized brand assets
-- **Templates** — Brand-approved starting points
-- **Guardrails** — Ensure on-brand output
+- **Brand profiles** -- Logo, colors, fonts, guidelines
+- **Asset libraries** -- Centralized brand assets
+- **Templates** -- Brand-approved starting points
+- **Guardrails** -- Ensure on-brand output
 
-### Voices & Tones
+### Voices and Tones
 
 Define how your brand sounds:
 
-- **Voice profiles** — Personality, style, vocabulary
-- **Tone settings** — Formal, casual, playful, professional
-- **Per-brand voices** — Different voices for different brands
-- **AI enforcement** — Automatically applies voice to all content
+- **Voice profiles** -- Personality, style, vocabulary
+- **Tone settings** -- Formal, casual, playful, professional
+- **Per-brand voices** -- Different voices for different brands
+- **AI enforcement** -- Automatically applies voice to all content
 
 ### Team Collaboration
 
 Work together seamlessly:
 
-- **Seats** — Add team members
-- **Roles** — Admin, editor, viewer permissions
-- **Approval workflows** — Review before publish
-- **Shared assets** — Team-wide access to content
+- **Seats** -- Add team members
+- **Roles** -- Admin, editor, viewer permissions
+- **Approval workflows** -- Review before publish
+- **Shared assets** -- Team-wide access to content
 
 ### Social Publishing
 
@@ -123,19 +109,19 @@ Track everything:
 - Team activity
 - Content engagement metrics
 
-### Marketplace Access
+### Marketplace
 
-Buy and sell content:
+[marketplace.genfeed.ai](https://marketplace.genfeed.ai) is a separate cloud product where creators buy and sell:
 
-- **Browse** — Thousands of templates, prompts, workflows
-- **Sell** — Monetize your creations
-- **Commercial license** — Use in client work
+- Workflows, prompts, and presets
+- Brand kits and templates
+- Commercial license for client work
 
-[**Explore Cloud Docs →**](/cloud)
+[**Explore Cloud Docs -->**](/cloud)
 
 ---
 
-## Security & Privacy
+## Security and Privacy
 
 ### Enterprise-Grade (Cloud)
 
@@ -150,14 +136,3 @@ Buy and sell content:
 - No data leaves your servers
 - Full audit control
 - Air-gapped deployment option
-
----
-
-## Choose Your Edition
-
-| | Core | Cloud |
-|---|---|---|
-| **Price** | Free | See [/cloud/billing](/cloud/billing) |
-| **Best For** | Developers, privacy-focused | Teams, agencies, brands |
-| **Setup** | 15 min self-host | Instant |
-| | [**Self-Host →**](/core) | [**Cloud Billing →**](/cloud/billing) |

--- a/apps/docs/content/getting-started.mdx
+++ b/apps/docs/content/getting-started.mdx
@@ -1,53 +1,64 @@
 # Getting Started
 
-This guide covers the fastest path to use Genfeed productively.
+Choose the path that fits your needs, then follow the steps to generate your first content.
 
-## Last Verified
+---
 
-- **Date:** 2026-03-24
-- **Implemented state source:** local repos and app structure
-- **Delivery state source:** GitHub issues/project
+## Cloud (Recommended for most users)
 
-## Choose Your Path
+The fastest way to start. No installation required.
 
-## 1) Genfeed Cloud (Recommended for most teams)
+1. **Sign up** at [app.genfeed.ai](https://app.genfeed.ai)
+2. **Create an organization** -- this is your workspace for brands and team members
+3. **Create a brand** -- define your brand's voice, colors, and guidelines
+4. **Generate content** -- use the Studio to create images, videos, text, or audio
+5. **Publish** -- schedule and post directly to X, LinkedIn, Instagram, YouTube, and more
 
-1. Sign up and create your organization
-2. Add your first brand profile
-3. Connect publishing accounts
-4. Generate content in the app
-5. Publish and track performance
+Cloud includes all Core features plus organizations, multi-brand management, social publishing, analytics, team collaboration, and [Marketplace](https://marketplace.genfeed.ai) access.
 
-## 2) Self-Hosted Core (Developers)
+---
+
+## Core (Self-Hosted)
+
+Run the full generation engine on your own infrastructure. You bring your own API keys and control your data.
+
+For the complete walkthrough, see the [Self-Host Quickstart Guide](/guides/self-host-quickstart).
+
+Quick version:
 
 ```bash
 git clone https://github.com/genfeedai/core.git
 cd core
+cp .env.example .env.local
 bun install
 bun dev
 ```
 
----
-
-## What You’ll Use First
-
-- **App**: content generation and operations
-- **Brand setup**: keep outputs aligned
-- **Publishing flows**: schedule and distribute content
-- **Analytics views**: track outcomes
+Prerequisites: Node.js 18+, Bun (or npm), MongoDB 6+, Redis 7+. Full details in the [Installation Guide](/core/installation).
 
 ---
 
-## Dual-State Note
+## CLI
 
-- Features visible in UI may be ahead of, behind, or different from project-board status.
-- Treat code + running app behavior as implementation truth.
-- Treat GitHub project/issues as delivery planning truth.
+Install the Genfeed CLI for terminal-based workflows:
+
+```bash
+npm install -g @genfeedai/cli
+```
+
+Basic usage:
+
+```bash
+genfeed generate --prompt "A sunset over mountains" --model flux
+genfeed workflows list
+genfeed workflows run my-workflow
+```
 
 ---
 
-## Need Help
+## What to Explore Next
 
-- Docs index: [/](/)
-- Cloud docs: [/cloud](/cloud)
-- Core docs: [/core](/core)
+- [Features](/features) -- Full feature list for Core and Cloud
+- [Self-Hosted vs Cloud](/core/self-hosted-vs-cloud) -- Detailed comparison to help you decide
+- [Configuration](/core/configuration) -- Environment variables and settings
+- [API Reference](/api-reference/overview) -- REST API documentation

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -1,65 +1,29 @@
-# Welcome
+# Genfeed.ai
 
-Genfeed.ai is an AI-powered content creation platform with two operating modes: self-hosted OSS (`core`) and managed SaaS (`cloud`).
+**Open-source AI OS for content creation.**
 
-## Last Verified
+Genfeed is a full-stack platform for generating images, videos, music, text, and more using AI models. Build automated content pipelines, manage brands, publish to social platforms, and track performance -- all from one system.
 
-- **Date:** 2026-03-24
-- **Implemented state source:** local `cloud/`, `core/`, `cli/`, `docs/` codebases
-- **Delivery state source:** GitHub issues + Mission Control project (#11)
+## Two Ways to Run Genfeed
 
-## Choose Your Edition
-
-| | Core (Self-Hosted) | Cloud (Managed) |
+| | Core (Self-Hosted) | Cloud (Managed SaaS) |
 |---|---|---|
-| Workflow engine | ✅ | ✅ |
-| Self-host | ✅ | — |
-| Organizations / brands / team UX | Limited | ✅ |
-| Publishing + SaaS operations | Build yourself | ✅ |
-| Billing managed by Genfeed | — | ✅ |
-| | [**Self-Host →**](/core) | [**Cloud Docs →**](/cloud) |
+| **What it is** | Open-source engine you deploy on your own infrastructure | Fully managed platform at [app.genfeed.ai](https://app.genfeed.ai) |
+| **License** | AGPL-3.0 (enterprise features under commercial license in `ee/`) | Commercial |
+| **Best for** | Developers wanting full control, privacy, or custom models | Teams, agencies, and creators who want to start immediately |
+| **Includes** | AI generation pipeline, workflow engine, REST API | Everything in Core + organizations, brands, publishing, analytics, team collaboration |
+| | [Self-Host Guide](/core/installation) | [Get Started with Cloud](/getting-started) |
 
----
+For a detailed breakdown, see [Self-Hosted vs Cloud](/core/self-hosted-vs-cloud).
 
-## Dual-State Snapshot
+## Marketplace
 
-### Implemented State (Code)
+[marketplace.genfeed.ai](https://marketplace.genfeed.ai) is a separate cloud product where creators buy and sell workflows, prompts, presets, and brand kits. Marketplace access is available exclusively on Genfeed Cloud.
 
-- `core/`: open-source workflow editor and API.
-- `cloud/`: multi-app SaaS with `admin`, `app`, `chatgpt`, `marketplace`, `website`.
-- `cli/`: terminal workflows for generation and management.
+## Quick Links
 
-### Delivery State (GitHub)
-
-- Active roadmap execution is tracked in GitHub Issues and Mission Control project #11.
-- Documentation should treat project status as planning/delivery metadata, not implementation proof.
-
----
-
-## Quick Start
-
-### Core (Self-Hosted)
-
-```bash
-git clone https://github.com/genfeedai/core.git
-cd core
-bun install
-bun dev
-```
-
-### Cloud
-
-1. Create an account on Genfeed Cloud
-2. Create organization + brand
-3. Start generating and publishing content from the app
-
----
-
-## Documentation
-
-- [**Core**](/core)
-- [**Cloud**](/cloud)
-- [**Guides**](/guides)
-- [**Models**](/models)
-- [**API Reference**](/api-reference/overview)
-- [**FAQ**](/faq)
+- [Getting Started](/getting-started) -- Choose your path and generate your first content
+- [Self-Hosting Guide](/guides/self-host-quickstart) -- Deploy Genfeed Core in minutes
+- [API Reference](/api-reference/overview) -- REST API documentation
+- [Features](/features) -- Full feature breakdown
+- [GitHub](https://github.com/genfeedai/core) -- Source code and issue tracker

--- a/apps/docs/content/models.mdx
+++ b/apps/docs/content/models.mdx
@@ -1,5 +1,7 @@
 # Available AI Models
 
+> **Note:** Model availability, pricing, and capabilities change frequently. Check your dashboard for the current list of available models. The information below is provided as a reference and may not reflect the latest state.
+
 Genfeed.ai provides access to cutting-edge AI models from leading providers. Each model is optimized for specific use cases and content types.
 
 ## Image Generation Models


### PR DESCRIPTION
## Summary

Critical docs refresh for the next production release. All 37 pages build successfully.

### Fixes
- GitHub edit link pointed to archived `genfeedai/docs` repo — now points to monorepo
- License error in features.mdx said "MIT" — corrected to "AGPL-3.0"
- cloud/index.mdx referenced "marketplace/chatgpt" management surfaces — updated
- models.mdx missing disclaimer for dynamic model registry — added
- `_meta.ts` had messy separator syntax and alphabetical ordering — cleaned up

### Content rewrites
- **Welcome page** — Clear product narrative, Core vs Cloud comparison, quick links
- **Getting started** — Concrete paths for Cloud, Core (Docker), and CLI
- **Self-hosted vs cloud** — Designated as canonical comparison page, added marketplace callout
- **Installation** — Fixed stale paths (`cloud/apps/web/app` → `apps/app`)
- **Configuration** — Grouped env vars with descriptions (Database, Auth, AI, Storage, Payments, URLs)
- **Features + Deployment** — Removed duplicate comparison tables, link to canonical page instead

### Verification
- [x] `bunx next build` — 37/37 pages generated, zero errors
- [x] All pre-commit hooks pass (secretlint, biome, lint-no-raw-html)

Ref: #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)