### PR TITLE
chore: add publish-package.sh for proper npm releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "build:web:parallel": "bunx turbo build --filter=@genfeedai/app --filter=@genfeedai/admin --filter=@genfeedai/website",
     "build:web:sequential": "bunx turbo build --filter=@genfeedai/app --filter=@genfeedai/admin --filter=@genfeedai/website --concurrency=1",
     "check:import-cycles": "bun run scripts/check-import-cycles.ts",
+    "publish:package": "./scripts/publish-package.sh",
     "check:multi-tenancy": "bun run scripts/check-multi-tenancy.ts",
     "check:nested-node-modules": "bun run scripts/check-nested-node-modules.ts",
     "check:package-api-surface": "bun run scripts/check-package-api-surface.ts",

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Publish a @genfeedai/* package to npm.
+#
+# Uses `bun publish` which automatically resolves workspace:* protocols
+# to real versions. Never use `npm publish` — it publishes workspace:*
+# literally, breaking external consumers.
+#
+# Usage:
+#   ./scripts/publish-package.sh packages/enums              # patch bump + publish
+#   ./scripts/publish-package.sh packages/interfaces minor    # minor bump + publish
+#   ./scripts/publish-package.sh packages/cli major           # major bump + publish
+#   ./scripts/publish-package.sh packages/enums --no-bump     # publish current version
+#
+# Requirements:
+#   - bun >= 1.2 (for workspace:* resolution)
+#   - NPM_TOKEN env var or ~/.npmrc with auth
+#   - Clean git working tree
+
+set -euo pipefail
+
+PKG_DIR="${1:?Usage: $0 <package-dir> [patch|minor|major|--no-bump]}"
+BUMP="${2:-patch}"
+
+if [ ! -f "$PKG_DIR/package.json" ]; then
+  echo "Error: $PKG_DIR/package.json not found"
+  exit 1
+fi
+
+PKG_NAME=$(grep '"name"' "$PKG_DIR/package.json" | head -1 | sed 's/.*"\(@[^"]*\)".*/\1/')
+HAS_PUBLISH_CONFIG=$(grep -c '"publishConfig"' "$PKG_DIR/package.json" || true)
+
+if [ "$HAS_PUBLISH_CONFIG" -eq 0 ]; then
+  echo "Error: $PKG_NAME has no publishConfig — not a publishable package"
+  exit 1
+fi
+
+echo "=== Publishing $PKG_NAME ==="
+
+# Build first
+echo "Building $PKG_NAME..."
+cd "$PKG_DIR"
+
+if grep -q '"build"' package.json; then
+  bun run build
+fi
+
+# Bump version (unless --no-bump)
+if [ "$BUMP" != "--no-bump" ]; then
+  echo "Bumping version ($BUMP)..."
+  npm version "$BUMP" --no-git-tag-version
+fi
+
+VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
+echo "Version: $VERSION"
+
+# Publish with bun (resolves workspace:* → real versions)
+echo "Publishing $PKG_NAME@$VERSION..."
+bun publish --access public
+
+echo ""
+echo "=== Published $PKG_NAME@$VERSION ==="
+echo ""
+echo "Verify: npm view $PKG_NAME@$VERSION dependencies"


### PR DESCRIPTION
## Problem

`npm publish` doesn't resolve `workspace:*` protocols — it publishes them literally, breaking any external consumer (like marketplace.genfeed.ai). This is why `@genfeedai/interfaces@2.3.19` shipped with `"@genfeedai/constants": "workspace:*"` in its published package.json.

## Fix

Added `scripts/publish-package.sh` which uses `bun publish` — bun automatically resolves `workspace:*` to real versions at publish time.

```bash
# Patch bump + publish
bun publish:package packages/enums

# Minor bump + publish  
bun publish:package packages/interfaces minor

# Publish without bumping
./scripts/publish-package.sh packages/cli --no-bump
```

The script: builds first, bumps version, publishes with `bun publish --access public`.

## Rule

**Never use `npm publish` for @genfeedai/* packages. Always use this script or `bun publish` directly.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)