### PR TITLE
refactor: complete raw HTML to @ui primitives migration (#104)

### DIFF
--- a/apps/admin/packages/ui/forms/pickers/color-picker/form-color-picker/FormColorPicker.tsx
+++ b/apps/admin/packages/ui/forms/pickers/color-picker/form-color-picker/FormColorPicker.tsx
@@ -111,11 +111,12 @@ export default function FormColorPicker({
 
           {displayColorPicker && (
             <>
-              <button
+              <Button
                 type="button"
+                variant={ButtonVariant.UNSTYLED}
                 className="fixed inset-0 z-10"
                 onClick={handleClose}
-                aria-label="Close color picker"
+                ariaLabel="Close color picker"
               />
               <div
                 className={`absolute z-20 mt-2 ${position === 'right' ? 'right-0' : 'left-0'}`}

--- a/apps/app/packages/components/research/ads/AdsResearchPageClient.tsx
+++ b/apps/app/packages/components/research/ads/AdsResearchPageClient.tsx
@@ -259,8 +259,9 @@ function AdGridCard({
   const previewUrl = item.previewUrl || item.imageUrls?.[0];
 
   return (
-    <button
+    <Button
       type="button"
+      variant={ButtonVariant.UNSTYLED}
       onClick={() => onSelect(item)}
       className={cn(
         'group rounded-xl border border-white/[0.06] bg-card p-4 text-left transition-all duration-200 hover:border-white/[0.10]',
@@ -328,7 +329,7 @@ function AdGridCard({
           </span>
         )}
       </div>
-    </button>
+    </Button>
   );
 }
 

--- a/apps/app/packages/ui/forms/pickers/color-picker/form-color-picker/FormColorPicker.tsx
+++ b/apps/app/packages/ui/forms/pickers/color-picker/form-color-picker/FormColorPicker.tsx
@@ -111,11 +111,12 @@ export default function FormColorPicker({
 
           {displayColorPicker && (
             <>
-              <button
+              <Button
                 type="button"
+                variant={ButtonVariant.UNSTYLED}
                 className="fixed inset-0 z-10"
                 onClick={handleClose}
-                aria-label="Close color picker"
+                ariaLabel="Close color picker"
               />
               <div
                 className={`absolute z-20 mt-2 ${position === 'right' ? 'right-0' : 'left-0'}`}

--- a/apps/app/src/features/workflows/components/WorkflowSidebarContent.tsx
+++ b/apps/app/src/features/workflows/components/WorkflowSidebarContent.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { ButtonVariant } from '@genfeedai/enums';
 import { Kbd } from '@genfeedai/ui';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { EnvironmentService } from '@services/core/environment.service';
 import { logger } from '@services/core/logger.service';
+import Button from '@ui/buttons/base/Button';
 import SidebarBackRow from '@ui/menus/sidebar-back-row/SidebarBackRow';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -89,8 +91,9 @@ export function WorkflowSidebarContent({
     <div className="flex h-full flex-col">
       <SidebarBackRow label="Automations" href={href('/overview')} />
       <div className="px-3 py-2">
-        <button
+        <Button
           type="button"
+          variant={ButtonVariant.UNSTYLED}
           onClick={handleOpenSearch}
           className="flex w-full items-center gap-3 rounded border border-white/[0.08] bg-white/[0.04] px-3 py-2.5 text-sm text-white/40 transition-colors duration-150 hover:border-white/[0.12] hover:bg-white/[0.06] hover:text-white/60"
         >
@@ -99,7 +102,7 @@ export function WorkflowSidebarContent({
           <Kbd variant="subtle" size="xs">
             {'\u2318'}K
           </Kbd>
-        </button>
+        </Button>
       </div>
 
       {/* Header */}

--- a/apps/app/src/features/workflows/components/editor/CloudEditorDropdown.tsx
+++ b/apps/app/src/features/workflows/components/editor/CloudEditorDropdown.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { ButtonVariant } from '@genfeedai/enums';
+import Button from '@ui/buttons/base/Button';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { HiOutlineChevronDown } from 'react-icons/hi2';
@@ -52,14 +54,15 @@ export function CloudEditorDropdown({
 
   return (
     <div ref={menuRef} className="relative">
-      <button
+      <Button
         type="button"
+        variant={ButtonVariant.UNSTYLED}
         onClick={() => setIsOpen((current) => !current)}
         className="flex items-center gap-1 rounded px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-secondary hover:text-foreground"
       >
         {label}
         <HiOutlineChevronDown aria-hidden="true" className="h-3.5 w-3.5" />
-      </button>
+      </Button>
 
       {isOpen && (
         <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] rounded-lg border border-border bg-card py-1 shadow-lg whitespace-nowrap">
@@ -69,15 +72,16 @@ export function CloudEditorDropdown({
             }
 
             return (
-              <button
+              <Button
                 key={item.id}
                 type="button"
+                variant={ButtonVariant.UNSTYLED}
                 onClick={() => {
                   if (item.disabled || !item.onClick) return;
                   item.onClick();
                   setIsOpen(false);
                 }}
-                disabled={item.disabled}
+                isDisabled={item.disabled}
                 className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-foreground transition hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
               >
                 <span className="h-4 w-4 shrink-0">{item.icon}</span>
@@ -87,7 +91,7 @@ export function CloudEditorDropdown({
                     ↗
                   </span>
                 )}
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/apps/app/src/features/workflows/components/editor/CloudWorkflowToolbar.tsx
+++ b/apps/app/src/features/workflows/components/editor/CloudWorkflowToolbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ButtonVariant } from '@genfeedai/enums';
 import { usePaneActions } from '@genfeedai/workflow-ui/hooks';
 import {
   selectIsDirty,
@@ -7,6 +8,7 @@ import {
   useWorkflowStore,
 } from '@genfeedai/workflow-ui/stores';
 import { SaveIndicator, Toolbar } from '@genfeedai/workflow-ui/toolbar';
+import Button from '@ui/buttons/base/Button';
 import type { KeyboardEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -110,14 +112,15 @@ export function CloudWorkflowToolbar({
                   className="cloud-workflow-title-input h-7 w-full rounded border border-border bg-secondary/70 px-2.5 text-sm font-medium text-foreground outline-none transition focus:border-primary/60 focus:bg-card focus:ring-1 focus:ring-primary/40"
                 />
               ) : (
-                <button
+                <Button
                   type="button"
+                  variant={ButtonVariant.UNSTYLED}
                   onClick={() => setIsEditing(true)}
                   className="cloud-workflow-title block max-w-full truncate text-left text-sm font-medium text-foreground transition hover:text-white"
-                  title="Rename workflow"
+                  tooltip="Rename workflow"
                 >
                   {workflowName || 'Untitled Workflow'}
-                </button>
+                </Button>
               )}
             </div>
           </div>

--- a/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
@@ -133,8 +133,9 @@ function WorkflowCardDropdown({
 
   return (
     <div ref={dropdownRef} className="relative">
-      <button
+      <Button
         type="button"
+        variant={ButtonVariant.UNSTYLED}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -143,12 +144,13 @@ function WorkflowCardDropdown({
         className="rounded p-1 text-foreground/40 transition-colors hover:bg-white/[0.06] hover:text-foreground"
       >
         <HiOutlineEllipsisVertical className="size-4" />
-      </button>
+      </Button>
 
       {isOpen && (
         <div className="absolute right-0 top-7 z-20 min-w-[140px] rounded-lg border border-white/10 bg-card py-1 shadow-lg">
-          <button
+          <Button
             type="button"
+            variant={ButtonVariant.UNSTYLED}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -159,9 +161,10 @@ function WorkflowCardDropdown({
           >
             <HiOutlineDocumentDuplicate className="size-4" />
             Duplicate
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant={ButtonVariant.UNSTYLED}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -172,7 +175,7 @@ function WorkflowCardDropdown({
           >
             <HiOutlineTrash className="size-4" />
             Delete
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/apps/website/packages/ui/forms/pickers/color-picker/form-color-picker/FormColorPicker.tsx
+++ b/apps/website/packages/ui/forms/pickers/color-picker/form-color-picker/FormColorPicker.tsx
@@ -111,11 +111,12 @@ export default function FormColorPicker({
 
           {displayColorPicker && (
             <>
-              <button
+              <Button
                 type="button"
+                variant={ButtonVariant.UNSTYLED}
                 className="fixed inset-0 z-10"
                 onClick={handleClose}
-                aria-label="Close color picker"
+                ariaLabel="Close color picker"
               />
               <div
                 className={`absolute z-20 mt-2 ${position === 'right' ? 'right-0' : 'left-0'}`}

--- a/packages/pages/studio/edit-detail/StudioEditDetail.tsx
+++ b/packages/pages/studio/edit-detail/StudioEditDetail.tsx
@@ -705,9 +705,10 @@ export default function StudioEditDetail({
                       })}
 
                       {results.map((result) => (
-                        <button
+                        <Button
                           key={result.id}
                           type="button"
+                          variant={ButtonVariant.UNSTYLED}
                           onClick={() =>
                             router.push(href(`/edit/${result.id}`))
                           }
@@ -749,7 +750,7 @@ export default function StudioEditDetail({
                               </p>
                             )}
                           </Card>
-                        </button>
+                        </Button>
                       ))}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Migrated 11 remaining raw `<button>` elements to `<Button>` primitives across 9 files
- All remaining raw HTML (~26 elements) are in primitive/form-field definitions where raw HTML is the correct implementation
- Closes the tail of #104 (was 609 elements, now 100% migrated)

## Files changed
- `StudioEditDetail.tsx` — button migrated to `Button variant={ButtonVariant.UNSTYLED}`
- `FormColorPicker.tsx` (app/website/admin) — backdrop close button migrated
- `AdsResearchPageClient.tsx` — card-style button migrated
- `WorkflowSidebarContent.tsx` — search trigger button migrated
- `CloudEditorDropdown.tsx` — 2 buttons migrated
- `CloudWorkflowToolbar.tsx` — rename trigger button migrated
- `WorkflowLibraryPage.tsx` — 3 dropdown buttons migrated

## Test plan
- [ ] Verify workflow editor UI renders correctly (sidebar, toolbar, dropdowns)
- [ ] Verify studio edit detail page renders correctly
- [ ] Verify color picker backdrop close works in all 3 apps
- [ ] Verify ads research page card buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)