### PR TITLE
feat(analytics): wire brand-scoped platform detail route (#36, #38, #72)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/brands/[id]/platforms/[platform]/page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/brands/[id]/platforms/[platform]/page.spec.tsx
@@ -1,0 +1,7 @@
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import * as PageModule from './page';
+
+runPageModuleTests(
+  'apps/app/app/(protected)/analytics/brands/[id]/platforms/[platform]/page',
+  PageModule,
+);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/brands/[id]/platforms/[platform]/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/brands/[id]/platforms/[platform]/page.tsx
@@ -1,0 +1,20 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import AnalyticsPlatformDetail from '@pages/analytics/platform-detail/analytics-platform-detail';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import { Suspense } from 'react';
+
+export const generateMetadata = createPageMetadata('Platform Analytics');
+
+export default async function AnalyticsBrandPlatformDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; platform: string }>;
+}) {
+  const { id, platform } = await params;
+
+  return (
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+      <AnalyticsPlatformDetail brandId={id} platform={platform} />
+    </Suspense>
+  );
+}

--- a/packages/pages/TO_REVIEW.md
+++ b/packages/pages/TO_REVIEW.md
@@ -53,12 +53,15 @@ These still need resolution via routing, issue tracking, or per-file verificatio
 
 ### Prepared features with open GitHub issues (will be wired in follow-up PRs)
 
-- `packages/pages/analytics/overview/analytics-agent-dashboard.tsx` — **Issue: #36, #38** — misclassified as orphan; actually live via dynamic import in `analytics-overview.tsx:120-126`, rendered at `:769`. Will be removed from ledger in PR 2 without a code change.
-- `packages/pages/analytics/platform-detail/analytics-platform-detail.tsx` — **Issue: #36, #38** — will be wired to `/analytics/platforms/[platform]` in PR 2.
 - `packages/pages/analytics/trends/trend-detail/trend-detail.tsx` — **Issue: #35** — will be wired to `/analytics/trends/[id]` in PR 3.
 - `packages/pages/trends/list/components/HookRemixModal.tsx` — **Issue: #35** — will be wired into the trends list in PR 3.
 - `packages/pages/streaks/streaks-page.tsx` — **Issue: #2** — will be wired to `/analytics/streaks` in PR 4.
 - `packages/pages/mission-control/mission-control-agent-lab.tsx` — **Issue: #9** — will be relocated to `apps/desktop/app/src/renderer/views/MissionControlView.tsx` in PR 4.
+
+### Wired in earlier PRs (kept here as a change log)
+
+- `packages/pages/analytics/overview/analytics-agent-dashboard.tsx` — PR 2 removed from ledger; live via dynamic import in `analytics-overview.tsx:120-126`, rendered at `:769`.
+- `packages/pages/analytics/platform-detail/analytics-platform-detail.tsx` — PR 2 wired at `/analytics/brands/[id]/platforms/[platform]` (brand-scoped route; the component requires a `brandId` prop it cannot obtain from a standalone `/analytics/platforms/[platform]` URL). Drill-through links added under the Platform Comparison card in `analytics-brand-overview.tsx`.
 
 ### Studio subtree (reachable via StudioGenerateLayout, not orphaned)
 

--- a/packages/pages/analytics/brand-overview/analytics-brand-overview.tsx
+++ b/packages/pages/analytics/brand-overview/analytics-brand-overview.tsx
@@ -331,6 +331,21 @@ export default function AnalyticsBrandOverview({
               isLoading={isLoading}
               height={300}
             />
+            {platformComparisonData.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-4">
+                {platformComparisonData.map(({ platform }) => (
+                  <Link
+                    key={platform}
+                    href={`/analytics/brands/${brandId}/platforms/${platform}`}
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground/70 hover:text-foreground transition-colors px-3 py-1.5 border border-border hover:border-primary/40"
+                  >
+                    {getPlatformIcon(platform, 'w-4 h-4')}
+                    <span className="capitalize">{platform}</span>
+                    <HiArrowRight className="w-3 h-3" />
+                  </Link>
+                ))}
+              </div>
+            )}
           </Card>
 
           <Card label="Performance Trends">


### PR DESCRIPTION
## Summary

PR 2 of the `packages/pages/TO_REVIEW.md` cleanup plan. Wires the `AnalyticsPlatformDetail` component that has been sitting unrouted in `packages/pages/analytics/platform-detail/` and adds drill-through links from the brand overview.

**Stacked on [#143](https://github.com/genfeedai/genfeed.ai/pull/143).** Base branch is `feat/cleanup-to-review-1-promote-delete` so this PR only shows its own changes. GitHub will auto-retarget to `develop` when PR 1 merges.

## Design correction from the plan

The plan originally said "new sidebar entry at `/analytics/platforms/[platform]`". Per-file inspection revealed `AnalyticsPlatformDetail` requires a `brandId` prop (it fetches a specific brand's posts then filters by platform) — a standalone `/analytics/platforms/[platform]` URL has no brandId source. Correct surface is **brand-nested**: `/analytics/brands/[id]/platforms/[platform]`, reached via drill-through from the Platform Comparison chart on `/analytics/brands/[id]`.

No `menu-items.config.ts` change: a sidebar link cannot encode the `[id]` param, and the `analyticsLabels` test in `menu-items.config.test.ts` explicitly asserts the exact Analytics group member list.

## Files changed (4, +47/−2)

- **New** `apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/brands/[id]/platforms/[platform]/page.tsx` — mirrors the existing `brands/[id]/page.tsx` pattern (`createPageMetadata` + async `params` + `Suspense` + `LazyLoadingFallback`)
- **New** `apps/app/.../brands/[id]/platforms/[platform]/page.spec.tsx` — smoke test via `runPageModuleTests`, same harness the brand-detail page uses
- **Modified** `packages/pages/analytics/brand-overview/analytics-brand-overview.tsx` — platform chip row under the Platform Comparison card, each chip links to `/analytics/brands/${brandId}/platforms/${platform}`. Uses imports already present (`Link`, `getPlatformIcon`, `HiArrowRight`). Guarded by `platformComparisonData.length > 0` so brands with no posts don't render an empty row.
- **Modified** `packages/pages/TO_REVIEW.md` — drops `analytics-platform-detail.tsx` and `analytics-agent-dashboard.tsx` from the "prepared features" section; adds a "wired in earlier PRs" change log for traceability

### Re: `analytics-agent-dashboard.tsx`

Also removed from the ledger per PR 1's promise. **No code change** for it here — it is already live via dynamic import at `analytics-overview.tsx:120-126` / `:769`. The original 0-consumer sweep missed it because the import is dynamic.

## Test plan

- [ ] Manual: `/analytics/brands/[id]` still renders; new platform chips appear under "Platform Comparison" with icon + name + arrow
- [ ] Manual: clicking a chip navigates to `/analytics/brands/[id]/platforms/[platform]` and the detail page loads with correct brandName + platform-filtered posts
- [ ] Manual: `/analytics/brands/[id]` for a brand with zero posts does NOT render the chip row
- [ ] CI: `@genfeedai/app` route tests pass (page.spec.tsx smoke test)
- [ ] CI: `@genfeedai/pages` brand-overview tests pass

## ⚠️ Pre-push checklist status

`bunx turbo lint` + `bun type-check` still blocked by the pre-existing `@genfeedai/ui#build` baseline failure carried over from `develop` (same root cause as [#143](https://github.com/genfeedai/genfeed.ai/pull/143)). Another agent is landing the fix in a parallel PR. Local `biome check` passes on the 4 changed files.

## Linked issues

- genfeedai/genfeed.ai#72 — Workflow Cost Tracking & Analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

