### PR TITLE
feat(analytics,desktop): wire streaks + relocate mission-control (#2, #9)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/streaks/page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/streaks/page.spec.tsx
@@ -1,0 +1,7 @@
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import * as PageModule from './page';
+
+runPageModuleTests(
+  'apps/app/app/(protected)/analytics/streaks/page',
+  PageModule,
+);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/streaks/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/streaks/page.tsx
@@ -1,0 +1,14 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import StreaksPage from '@pages/streaks/streaks-page';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import { Suspense } from 'react';
+
+export const generateMetadata = createPageMetadata('Streaks');
+
+export default function AnalyticsStreaksPage() {
+  return (
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+      <StreaksPage />
+    </Suspense>
+  );
+}

--- a/apps/app/packages/config/menu-items.config.test.ts
+++ b/apps/app/packages/config/menu-items.config.test.ts
@@ -68,6 +68,7 @@ describe('APP_MENU_ITEMS', () => {
       'Hooks',
       'Performance Lab',
       'Trend Turnover',
+      'Streaks',
     ]);
   });
 

--- a/apps/app/packages/config/menu-items.config.ts
+++ b/apps/app/packages/config/menu-items.config.ts
@@ -190,6 +190,14 @@ export const APP_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiArrowTrendingUp,
   },
   {
+    group: 'Analytics',
+    href: '/analytics/streaks',
+    label: 'Streaks',
+    matchPaths: ['/analytics/streaks'],
+    outline: HiOutlineSparkles,
+    solid: HiSparkles,
+  },
+  {
     drillDown: true,
     group: 'Posts',
     href: '/posts/analytics',

--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { AgentsView } from './views/AgentsView';
 import { AnalyticsView } from './views/AnalyticsView';
 import { ConversationView } from './views/ConversationView';
 import { LibraryView } from './views/LibraryView';
+import { MissionControlView } from './views/MissionControlView';
 import { TrendsView } from './views/TrendsView';
 import { WorkflowsView } from './views/WorkflowsView';
 
@@ -198,6 +199,8 @@ export const App = () => {
         return <WorkflowsView />;
       case 'agents':
         return <AgentsView />;
+      case 'mission-control':
+        return <MissionControlView />;
       case 'analytics':
         return <AnalyticsView workspaceId={selectedWorkspaceId} />;
       case 'library':

--- a/apps/desktop/app/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/app/src/renderer/components/Sidebar.tsx
@@ -17,6 +17,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { icon: '⚡', id: 'workflows', label: 'Automations' },
   { icon: '🤖', id: 'agents', label: 'Agents' },
+  { icon: '🧪', id: 'mission-control', label: 'Mission Control' },
   { icon: '📊', id: 'analytics', label: 'Analytics' },
   { icon: '📂', id: 'library', label: 'Library' },
   { icon: '📈', id: 'trends', label: 'Trends' },

--- a/apps/desktop/app/src/renderer/nav-view.ts
+++ b/apps/desktop/app/src/renderer/nav-view.ts
@@ -3,5 +3,6 @@ export type NavView =
   | 'analytics'
   | 'conversation'
   | 'library'
+  | 'mission-control'
   | 'trends'
   | 'workflows';

--- a/apps/desktop/app/src/renderer/views/MissionControlView.test.tsx
+++ b/apps/desktop/app/src/renderer/views/MissionControlView.test.tsx
@@ -1,8 +1,8 @@
-import MissionControlAgentLabPage from '@pages/mission-control/mission-control-agent-lab';
 import type { TableProps } from '@props/ui/display/table.props';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { MissionControlView } from './MissionControlView';
 
 vi.mock('@ui/banners/low-credits/LowCreditsBanner', () => ({
   default: () => <div data-testid="low-credits-banner" />,
@@ -93,9 +93,9 @@ vi.mock('@ui/display/table/Table', () => ({
   },
 }));
 
-describe('MissionControlAgentLabPage', () => {
+describe('MissionControlView', () => {
   it('keeps the composer anchored inside the active agent surface', () => {
-    render(<MissionControlAgentLabPage />);
+    render(<MissionControlView />);
 
     fireEvent.click(screen.getAllByText('Ask Agent')[0]);
 
@@ -115,7 +115,7 @@ describe('MissionControlAgentLabPage', () => {
   });
 
   it('preserves selection and conversation context when switching modes', () => {
-    render(<MissionControlAgentLabPage />);
+    render(<MissionControlView />);
 
     fireEvent.click(screen.getByLabelText('select-lab-row-1'));
     fireEvent.click(screen.getAllByText('Ask Agent')[0]);
@@ -141,7 +141,7 @@ describe('MissionControlAgentLabPage', () => {
   });
 
   it('keeps filters stable while opening and closing the comparison surface', () => {
-    render(<MissionControlAgentLabPage />);
+    render(<MissionControlView />);
 
     const search = screen.getByPlaceholderText(
       'Search assets, channels, owners, or status',

--- a/apps/desktop/app/src/renderer/views/MissionControlView.tsx
+++ b/apps/desktop/app/src/renderer/views/MissionControlView.tsx
@@ -475,7 +475,7 @@ function AgentLabSurface({
   );
 }
 
-export default function MissionControlAgentLabPage() {
+export function MissionControlView() {
   const [mode, setMode] = useState<AgentLabMode>('rail');
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<AgentLabStatus | 'all'>(

--- a/biome.json
+++ b/biome.json
@@ -76,6 +76,7 @@
       "includes": [
         "apps/app/src/components/**",
         "apps/app/src/hooks/**",
+        "apps/desktop/app/src/renderer/views/**",
         "packages/agent/src/**",
         "packages/hooks/**",
         "packages/pages/**",

--- a/packages/pages/TO_REVIEW.md
+++ b/packages/pages/TO_REVIEW.md
@@ -53,8 +53,7 @@ These still need resolution via routing, issue tracking, or per-file verificatio
 
 ### Prepared features with open GitHub issues (will be wired in follow-up PRs)
 
-- `packages/pages/streaks/streaks-page.tsx` — **Issue: #2** — will be wired to `/analytics/streaks` in PR 4.
-- `packages/pages/mission-control/mission-control-agent-lab.tsx` — **Issue: #9** — will be relocated to `apps/desktop/app/src/renderer/views/MissionControlView.tsx` in PR 4.
+_None remaining — all tracked features have been wired._
 
 ### Wired in earlier PRs (kept here as a change log)
 
@@ -63,6 +62,8 @@ These still need resolution via routing, issue tracking, or per-file verificatio
 - `packages/pages/analytics/trends/trend-detail/trend-detail.tsx` — PR 3 wired at `/analytics/trends/detail/[id]`. The existing trends list in `apps/app/.../analytics/trends/analytics-trends.tsx` was also repointed from a broken `router.push('/research/${item.id}')` (wrong: an id was being shoved into a `[platform]` slot) to the new detail route.
 - `packages/pages/trends/list/components/HookRemixModal.tsx` — PR 3 wired into the viral video leaderboard on `/analytics/trends`. Clicking a video now opens the hook remix modal (falls back to the video URL only when the video is missing an id).
 - `packages/pages/trends/platform-detail/trends-platform-detail.tsx` — PR 3 moved from `apps/app/.../research/[platform]/trends-platform-detail.tsx` to `packages/pages/trends/platform-detail/` so both `/research/[platform]` and the new `/analytics/trends/platforms/[platform]` route can consume the same component. `SocialsNavigation` + `TrendsPlatformDetail` now accept an optional `basePath` prop so in-surface tab navigation stays consistent ('/research' vs '/analytics/trends').
+- `packages/pages/streaks/streaks-page.tsx` — PR 4 wired at `/analytics/streaks`. Added to the Analytics sidebar group in `apps/app/packages/config/menu-items.config.ts`; the corresponding `analyticsLabels` assertion in `menu-items.config.test.ts` was updated to include 'Streaks'.
+- `packages/pages/mission-control/mission-control-agent-lab.tsx` — PR 4 moved to `apps/desktop/app/src/renderer/views/MissionControlView.tsx` (Epic #9 scopes mission control to the desktop app; the existing `menu-items.config.test.ts` assertion that `/mission-control` is NOT in the web APP_MENU_ITEMS stays valid). The default export was renamed from `MissionControlAgentLabPage` to a named export `MissionControlView` to match the desktop view convention (`AgentsView`, `AnalyticsView`, etc.). Wired into `apps/desktop/app/src/renderer/nav-view.ts`, `App.tsx` (new `'mission-control'` case), and `Sidebar.tsx` (new NAV_ITEMS entry). The `packages/pages/mission-control/` directory was deleted entirely.
 
 ### Studio subtree (reachable via StudioGenerateLayout, not orphaned)
 


### PR DESCRIPTION
## Summary

PR 4 of the `packages/pages/TO_REVIEW.md` cleanup plan. Wires the last two tracked features: **Streaks** (#2) gets a web route under `/analytics`, and **Mission Control** (#9) moves to the desktop app to match Epic #9's scope.

**Stacked on [#145](https://github.com/genfeedai/genfeed.ai/pull/145)** (which is stacked on #144 → #143).

After this PR lands, the \"prepared features\" section of `TO_REVIEW.md` is explicitly empty — every GitHub-tracked orphan has been wired.

## Streaks — new web route (#2)

- **New** `apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/streaks/page.tsx` renders `StreaksPage` via the standard analytics-route pattern (`createPageMetadata` + `Suspense` + `LazyLoadingFallback`)
- **New** `page.spec.tsx` smoke test via `runPageModuleTests`
- **Sidebar**: Added `'Streaks'` entry to the Analytics group in `menu-items.config.ts` with the Sparkles icon
- **Test**: `menu-items.config.test.ts` `analyticsLabels` assertion updated to include `'Streaks'`

## Mission Control — desktop relocation (#9)

Epic #9 (Desktop Content OS) scopes mission control to the desktop app, and the existing web `menu-items.config.test.ts` explicitly asserts `/mission-control` is NOT in `APP_MENU_ITEMS`. This PR makes that real:

- **Moved** `packages/pages/mission-control/mission-control-agent-lab.{tsx,test.tsx}` → `apps/desktop/app/src/renderer/views/MissionControlView.{tsx,test.tsx}`
- **Renamed export**: `export default function MissionControlAgentLabPage()` → `export const MissionControlView` / `export function MissionControlView()` to match the desktop view convention (`AgentsView`, `AnalyticsView`, `ConversationView`, `LibraryView`, `TrendsView`, `WorkflowsView`)
- **Test updated**: default import → named import, component JSX renamed, describe block renamed
- **Deleted**: `packages/pages/mission-control/` directory entirely

All imports in the relocated file use repo-wide path aliases (`@genfeedai/*`, `@ui/*`, `@helpers/*`, `@props/*`, `@ui-constants/*`) which resolve from `apps/desktop/app/tsconfig.json` without any changes — verified before the move.

### Desktop nav wiring

- `nav-view.ts`: added `'mission-control'` to the `NavView` union
- `App.tsx`: added import + `case 'mission-control'` in `renderMainView`
- `Sidebar.tsx`: added `NAV_ITEMS` entry `{ icon: '🧪', id: 'mission-control', label: 'Mission Control' }` between Agents and Analytics

### Biome lint override

The relocated view has pre-existing a11y patterns (static `<div>` with `onClick` acting as an overlay close handler at line 460) that were allowed by the `packages/pages/**` biome override. Added `apps/desktop/app/src/renderer/views/**` to the same override group in `biome.json` so lint rules stay consistent across view files that share pragmatic mouse-only handlers.

## Ledger updates (`packages/pages/TO_REVIEW.md`)

- Dropped `streaks-page.tsx` and `mission-control-agent-lab.tsx` from \"prepared features\" — the section is now explicitly empty (_\"None remaining — all tracked features have been wired.\"_)
- Added both entries to the \"wired in earlier PRs\" change log with relocation + rename rationale

## Files changed (11, +45/−8)

- **New** 2 streaks route files (page.tsx + page.spec.tsx)
- **Modified** menu-items.config.ts + .test.ts (Streaks sidebar entry)
- **Modified** 3 desktop nav files (nav-view.ts, App.tsx, Sidebar.tsx)
- **Renamed+modified** 2 mission-control files (default→named export, test import fix)
- **Modified** biome.json (new path in a11y override)
- **Modified** packages/pages/TO_REVIEW.md

## Test plan

- [ ] Manual: `/analytics/streaks` renders `StreaksPage`; the sidebar shows a new \"Streaks\" item under the Analytics group
- [ ] Manual: desktop app boots and the sidebar shows \"Mission Control\" between Agents and Analytics; clicking renders the `MissionControlView`
- [ ] Manual: `/mission-control` is still NOT routable on the web (the `menu-items.config.test.ts` assertion stays valid)
- [ ] CI: `@genfeedai/app` `menu-items.config.test.ts` passes (Streaks entry assertion updated)
- [ ] CI: `@genfeedai/app` `streaks/page.spec.tsx` passes
- [ ] CI: desktop `MissionControlView.test.tsx` passes (import + describe + JSX renames)

## ⚠️ Pre-push checklist status

Same pre-existing `@genfeedai/ui#build` baseline failure as [#143](https://github.com/genfeedai/genfeed.ai/pull/143), [#144](https://github.com/genfeedai/genfeed.ai/pull/144), [#145](https://github.com/genfeedai/genfeed.ai/pull/145). Another agent is landing the fix in a parallel PR. Local `biome check` passes on all 10 changed files (including the new `biome.json` override).

## Linked issues

- #2 — Streaks: Content Creation Gamification
- #9 — Epic: Desktop Content OS (macOS-first Installed App)

🤖 Generated with [Claude Code](https://claude.com/claude-code)