### PR TITLE
feat(models): provider auto-discovery — sync from Replicate, Fal, HuggingFace (#93)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -257,12 +257,90 @@ describe('WorkspacePageContent', () => {
     fireEvent.click(screen.getByRole('button', { name: /^create task$/i }));
 
     await waitFor(() => {
-      expect(createTaskMock).toHaveBeenCalledWith({
-        brand: 'brand-1',
-        outputType: 'ingredient',
-        request: 'Create a product launch brief',
-      });
+      expect(createTaskMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          brand: 'brand-1',
+          outputType: 'ingredient',
+          request: 'Create a product launch brief',
+        }),
+      );
     });
+  });
+
+  it('includes heygenAvatarId/heygenVoiceId when the Facecam preset is selected', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((url: RequestInfo | URL) => {
+        const href = typeof url === 'string' ? url : url.toString();
+        if (href.endsWith('/heygen/avatars')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  attributes: {
+                    avatars: [
+                      {
+                        avatarId: 'avatar-42',
+                        name: 'Default Avatar',
+                        preview: null,
+                      },
+                    ],
+                  },
+                },
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (href.endsWith('/heygen/voices')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: {
+                  attributes: {
+                    voices: [{ voiceId: 'voice-99', name: 'Default Voice' }],
+                  },
+                },
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        return Promise.resolve(new Response('{}', { status: 200 }));
+      });
+
+    render(<WorkspacePageContent section="overview" />);
+
+    await waitFor(() => {
+      expect(listMock).toHaveBeenCalledWith({ limit: 24 });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^new task$/i }));
+    fireEvent.change(screen.getByLabelText(/task request/i), {
+      target: { value: 'Hello from Genfeed, this is a facecam test.' },
+    });
+
+    // Select Facecam preset (uppercase label inside the toolbar button)
+    fireEvent.click(screen.getByRole('button', { name: /^facecam$/i }));
+
+    // Wait for the picker fetch to populate
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^create task$/i }));
+
+    await waitFor(() => {
+      expect(createTaskMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          brand: 'brand-1',
+          outputType: 'facecam',
+          request: 'Hello from Genfeed, this is a facecam test.',
+        }),
+      );
+    });
+
+    fetchMock.mockRestore();
   });
 
   it('opens the canonical planning conversation from the task inspector', async () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -20,12 +20,14 @@ import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props'
 import { AgentRunsService } from '@services/ai/agent-runs.service';
 import { IngredientsService } from '@services/content/ingredients.service';
 import { PromptsService } from '@services/content/prompts.service';
+import { EnvironmentService } from '@services/core/environment.service';
 import { logger } from '@services/core/logger.service';
 import {
   Task,
   type TaskEvent,
   TasksService,
 } from '@services/management/tasks.service';
+import { BrandsService } from '@services/social/brands.service';
 import type { Editor, JSONContent } from '@tiptap/core';
 import Mention, { type MentionNodeAttrs } from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -39,6 +41,13 @@ import Container from '@ui/layout/container/Container';
 import { Modal } from '@ui/modals/compound/Modal';
 import { Button as BaseButton, Button } from '@ui/primitives/button';
 import { Checkbox } from '@ui/primitives/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ui/primitives/select';
 import {
   Sheet,
   SheetContent,
@@ -182,6 +191,10 @@ const TASK_PRESETS = [
     outputType: 'video' as const,
   },
   {
+    label: 'Facecam',
+    outputType: 'facecam' as const,
+  },
+  {
     label: 'Caption',
     outputType: 'caption' as const,
   },
@@ -190,6 +203,12 @@ const TASK_PRESETS = [
     outputType: 'ingredient' as const,
   },
 ];
+
+interface HeygenOption {
+  id: string;
+  label: string;
+  preview?: string;
+}
 
 const INBOX_VIEW_OPTIONS: Array<{
   description: string;
@@ -1646,6 +1665,126 @@ export default function WorkspacePageContent({
   const [taskRequest, setTaskRequest] = useState('');
   const [taskOutputType, setTaskOutputType] =
     useState<(typeof TASK_PRESETS)[number]['outputType']>('ingredient');
+  const [facecamAvatars, setFacecamAvatars] = useState<HeygenOption[]>([]);
+  const [facecamVoices, setFacecamVoices] = useState<HeygenOption[]>([]);
+  const [facecamAvatarId, setFacecamAvatarId] = useState<string>('');
+  const [facecamVoiceId, setFacecamVoiceId] = useState<string>('');
+  const [facecamLoading, setFacecamLoading] = useState(false);
+  const [facecamError, setFacecamError] = useState<string | null>(null);
+  const [facecamSaveAsDefault, setFacecamSaveAsDefault] = useState(false);
+
+  // Seed facecam picker defaults from brand.agentConfig when available.
+  useEffect(() => {
+    const config = (
+      selectedBrand as { agentConfig?: Record<string, unknown> } | undefined
+    )?.agentConfig;
+    if (!config) return;
+    const storedAvatar = config.heygenAvatarId as string | undefined;
+    const storedVoice = config.heygenVoiceId as string | undefined;
+    if (storedAvatar && !facecamAvatarId) {
+      setFacecamAvatarId(storedAvatar);
+    }
+    if (storedVoice && !facecamVoiceId) {
+      setFacecamVoiceId(storedVoice);
+    }
+  }, [selectedBrand, facecamAvatarId, facecamVoiceId]);
+
+  // Fetch HeyGen avatars + voices on demand when the user switches to Facecam.
+  useEffect(() => {
+    if (
+      taskOutputType !== 'facecam' ||
+      (facecamAvatars.length > 0 && facecamVoices.length > 0)
+    ) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setFacecamLoading(true);
+    setFacecamError(null);
+
+    const run = async () => {
+      try {
+        const token = await resolveClerkToken(getToken);
+        if (!token) {
+          setFacecamError('Authentication token unavailable.');
+          return;
+        }
+
+        const apiEndpoint = EnvironmentService.apiEndpoint;
+        const headers = { Authorization: `Bearer ${token}` };
+
+        const [avatarsResponse, voicesResponse] = await Promise.all([
+          fetch(`${apiEndpoint}/heygen/avatars`, {
+            headers,
+            signal: controller.signal,
+          }),
+          fetch(`${apiEndpoint}/heygen/voices`, {
+            headers,
+            signal: controller.signal,
+          }),
+        ]);
+
+        if (controller.signal.aborted) return;
+
+        if (!avatarsResponse.ok || !voicesResponse.ok) {
+          const detail =
+            !avatarsResponse.ok && avatarsResponse.status === 500
+              ? 'HeyGen API key missing or invalid. Add one in Settings → API Keys, or set HEYGEN_KEY for self-hosted.'
+              : `Avatars: ${avatarsResponse.status}, Voices: ${voicesResponse.status}`;
+          setFacecamError(detail);
+          return;
+        }
+
+        const avatarsJson = (await avatarsResponse.json()) as {
+          data?: {
+            attributes?: {
+              avatars?: Array<{
+                avatarId: string;
+                name: string;
+                preview?: string | null;
+              }>;
+            };
+          };
+        };
+        const voicesJson = (await voicesResponse.json()) as {
+          data?: {
+            attributes?: {
+              voices?: Array<{ voiceId: string; name: string }>;
+            };
+          };
+        };
+
+        const avatars = (avatarsJson.data?.attributes?.avatars ?? []).map(
+          (a): HeygenOption => ({
+            id: a.avatarId,
+            label: a.name,
+            preview: a.preview ?? undefined,
+          }),
+        );
+        const voices = (voicesJson.data?.attributes?.voices ?? []).map(
+          (v): HeygenOption => ({ id: v.voiceId, label: v.name }),
+        );
+
+        if (controller.signal.aborted) return;
+        setFacecamAvatars(avatars);
+        setFacecamVoices(voices);
+      } catch (error: unknown) {
+        if (controller.signal.aborted) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to load HeyGen avatars/voices.';
+        setFacecamError(message);
+      } finally {
+        if (!controller.signal.aborted) {
+          setFacecamLoading(false);
+        }
+      }
+    };
+
+    void run();
+    return () => controller.abort();
+  }, [taskOutputType, facecamAvatars.length, facecamVoices.length, getToken]);
   const [taskMode, setTaskMode] = useState<WorkspaceTaskMode>('standard');
   const [taskError, setTaskError] = useState<string | null>(null);
   const [taskEnhancementBusy, setTaskEnhancementBusy] = useState(false);
@@ -2110,14 +2249,26 @@ export default function WorkspacePageContent({
       };
     }
 
-    return {
+    const base = {
       brand: effectiveTaskBrandId,
       outputType: taskOutputType,
       request: normalizedRequest,
       title: normalizedRequest.slice(0, 80),
     };
+
+    if (taskOutputType === 'facecam') {
+      return {
+        ...base,
+        heygenAvatarId: facecamAvatarId || undefined,
+        heygenVoiceId: facecamVoiceId || undefined,
+      };
+    }
+
+    return base;
   }, [
     effectiveTaskBrandId,
+    facecamAvatarId,
+    facecamVoiceId,
     selectedTargetBrandLabel,
     taskMode,
     taskOutputType,
@@ -2142,7 +2293,26 @@ export default function WorkspacePageContent({
       }
 
       const service = TasksService.getInstance(token);
-      const createdTask = await service.createTask(buildTaskSubmission());
+      const submission = buildTaskSubmission();
+      const createdTask = await service.createTask(submission);
+
+      // Optional: persist HeyGen pickers as brand defaults.
+      if (
+        taskOutputType === 'facecam' &&
+        facecamSaveAsDefault &&
+        effectiveTaskBrandId &&
+        (facecamAvatarId || facecamVoiceId)
+      ) {
+        try {
+          const brandsService = BrandsService.getInstance(token);
+          await brandsService.updateAgentConfig(effectiveTaskBrandId, {
+            heygenAvatarId: facecamAvatarId || null,
+            heygenVoiceId: facecamVoiceId || null,
+          });
+        } catch (brandError) {
+          logger.error('Failed to persist HeyGen brand defaults', brandError);
+        }
+      }
 
       startTransition(() => {
         setWorkspaceTasks((current) => [createdTask, ...current]);
@@ -2527,6 +2697,86 @@ export default function WorkspacePageContent({
                     ?.description
                 }
               </p>
+            ) : null}
+
+            {taskOutputType === 'facecam' ? (
+              <div className="rounded-lg border border-white/10 bg-black/20 p-3 space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-foreground/55">
+                    Facecam settings
+                  </p>
+                  {facecamLoading ? (
+                    <span className="text-[11px] text-foreground/40">
+                      Loading HeyGen…
+                    </span>
+                  ) : null}
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="facecam-avatar"
+                      className="text-[11px] text-foreground/55"
+                    >
+                      Avatar
+                    </label>
+                    <Select
+                      value={facecamAvatarId}
+                      onValueChange={(value) => setFacecamAvatarId(value)}
+                      disabled={facecamLoading || facecamAvatars.length === 0}
+                    >
+                      <SelectTrigger id="facecam-avatar">
+                        <SelectValue placeholder="Pick an avatar" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {facecamAvatars.map((avatar) => (
+                          <SelectItem key={avatar.id} value={avatar.id}>
+                            {avatar.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="facecam-voice"
+                      className="text-[11px] text-foreground/55"
+                    >
+                      Voice
+                    </label>
+                    <Select
+                      value={facecamVoiceId}
+                      onValueChange={(value) => setFacecamVoiceId(value)}
+                      disabled={facecamLoading || facecamVoices.length === 0}
+                    >
+                      <SelectTrigger id="facecam-voice">
+                        <SelectValue placeholder="Pick a voice" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {facecamVoices.map((voice) => (
+                          <SelectItem key={voice.id} value={voice.id}>
+                            {voice.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <Checkbox
+                  isChecked={facecamSaveAsDefault}
+                  label="Save as brand default"
+                  className="text-xs text-foreground/55"
+                  onCheckedChange={(checked) =>
+                    setFacecamSaveAsDefault(checked === true)
+                  }
+                />
+
+                {facecamError ? (
+                  <p className="text-[11px] text-rose-300">{facecamError}</p>
+                ) : null}
+              </div>
             ) : null}
 
             {taskError ? (

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -9,6 +9,7 @@
     "@genfeedai/types": "workspace:*",
     "@genfeedai/workflow-engine": "workspace:*",
     "@genfeedai/workflow-saas": "workspace:*",
+    "@genfeedai/workflows": "workspace:*",
     "@genfeedai/constants": "workspace:*",
     "@genfeedai/enums": "workspace:*",
     "@genfeedai/helpers": "workspace:*",

--- a/apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts
@@ -287,6 +287,24 @@ export class UpdateBrandAgentConfigDto {
 
   @IsString()
   @IsOptional()
+  @MaxLength(200)
+  @ApiProperty({
+    description: 'Default HeyGen avatar ID for facecam tasks',
+    required: false,
+  })
+  heygenAvatarId?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  @ApiProperty({
+    description: 'Default HeyGen voice ID for facecam tasks',
+    required: false,
+  })
+  heygenVoiceId?: string;
+
+  @IsString()
+  @IsOptional()
   @MaxLength(5000)
   @ApiProperty({
     description: 'Custom agent persona/system prompt',

--- a/apps/server/api/src/collections/brands/schemas/brand.schema.ts
+++ b/apps/server/api/src/collections/brands/schemas/brand.schema.ts
@@ -158,6 +158,14 @@ export class BrandAgentConfig {
   })
   defaultAvatarIngredientId?: Types.ObjectId;
 
+  // HeyGen facecam defaults (used by workspace composer to pre-select
+  // avatar + voice when the user picks the Facecam output type).
+  @Prop({ required: false, type: String })
+  heygenAvatarId?: string;
+
+  @Prop({ required: false, type: String })
+  heygenVoiceId?: string;
+
   @Prop({ required: false, type: String })
   persona?: string;
 

--- a/apps/server/api/src/collections/models/schemas/model.schema.ts
+++ b/apps/server/api/src/collections/models/schemas/model.schema.ts
@@ -316,6 +316,38 @@ export class Model {
   @Prop({ required: false, type: Date })
   deprecatedAt?: Date;
 
+  // ============================================================================
+  // Provider Auto-Discovery Fields (v7 — issue #93)
+  // ============================================================================
+
+  /** Whether this model is visible in the community marketplace */
+  @Prop({ default: false, type: Boolean })
+  isPublic?: boolean;
+
+  /** Whether this model is legacy / superseded by a newer version */
+  @Prop({ default: false, type: Boolean })
+  isLegacy?: boolean;
+
+  /** True if the model was auto-discovered from a provider API (not manually seeded) */
+  @Prop({ default: false, type: Boolean })
+  isDiscovered?: boolean;
+
+  /** Timestamp when the model was first discovered via provider sync */
+  @Prop({ required: false, type: Date })
+  discoveredAt?: Date;
+
+  /** Timestamp of the most recent provider sync for this model */
+  @Prop({ required: false, type: Date })
+  lastSyncedAt?: Date;
+
+  /**
+   * Platform margin as a percentage (0–100).
+   * Used to calculate the sell price on top of provider cost.
+   * Default 70 — i.e. sell price = providerCostUsd / (1 - 0.70)
+   */
+  @Prop({ default: 70, type: Number })
+  margin?: number;
+
   // --- Dynamic Registry Fields (v6) ---
 
   @Prop({ type: Types.ObjectId, ref: 'Organization', default: null })

--- a/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
+++ b/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
@@ -92,6 +92,8 @@ export class TasksController extends BaseCRUDController<
       await this.taskCountersService.getNextNumber(organizationId);
     const identifier = `${org.prefix}-${taskNumber}`;
     const extended = createDto as CreateTaskDto & {
+      heygenAvatarId?: string;
+      heygenVoiceId?: string;
       outputType?: string;
       platforms?: string[];
       request?: string;
@@ -135,6 +137,8 @@ export class TasksController extends BaseCRUDController<
             brandId: (
               createDto.brand as Types.ObjectId | undefined
             )?.toString(),
+            heygenAvatarId: extended.heygenAvatarId,
+            heygenVoiceId: extended.heygenVoiceId,
             organizationId,
             outputType: extended.outputType,
             platforms: extended.platforms,

--- a/apps/server/api/src/collections/tasks/dto/create-task.dto.ts
+++ b/apps/server/api/src/collections/tasks/dto/create-task.dto.ts
@@ -1,5 +1,6 @@
 import {
   TASK_LINKED_ENTITY_MODELS,
+  TASK_OUTPUT_TYPES,
   TASK_PRIORITIES,
   TASK_STATUSES,
 } from '@api/collections/tasks/schemas/task.schema';
@@ -139,13 +140,13 @@ export class CreateTaskDto {
   request?: string;
 
   @IsOptional()
-  @IsEnum(['caption', 'image', 'ingredient', 'newsletter', 'post', 'video'])
+  @IsEnum(TASK_OUTPUT_TYPES)
   @ApiProperty({
     description: 'Output type for AI generation',
-    enum: ['caption', 'image', 'ingredient', 'newsletter', 'post', 'video'],
+    enum: TASK_OUTPUT_TYPES,
     required: false,
   })
-  outputType?: string;
+  outputType?: (typeof TASK_OUTPUT_TYPES)[number];
 
   @IsOptional()
   @IsArray()
@@ -156,4 +157,22 @@ export class CreateTaskDto {
     type: [String],
   })
   platforms?: string[];
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'HeyGen avatar ID for facecam tasks',
+    required: false,
+    type: String,
+  })
+  heygenAvatarId?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: 'HeyGen voice ID for facecam tasks',
+    required: false,
+    type: String,
+  })
+  heygenVoiceId?: string;
 }

--- a/apps/server/api/src/collections/tasks/schemas/task.schema.ts
+++ b/apps/server/api/src/collections/tasks/schemas/task.schema.ts
@@ -23,6 +23,7 @@ export const TASK_LINKED_ENTITY_MODELS = [
 
 export const TASK_OUTPUT_TYPES = [
   'caption',
+  'facecam',
   'image',
   'ingredient',
   'newsletter',
@@ -170,6 +171,13 @@ export class Task {
 
   @Prop({ default: [], type: [String] })
   platforms!: string[];
+
+  // HeyGen facecam selection (persisted so retries reuse the picks)
+  @Prop({ required: false, type: String })
+  heygenAvatarId?: string;
+
+  @Prop({ required: false, type: String })
+  heygenVoiceId?: string;
 
   // ─── Review lifecycle ─────────────────────────────────────────────────────────
 

--- a/apps/server/api/src/collections/tasks/services/tasks.service.ts
+++ b/apps/server/api/src/collections/tasks/services/tasks.service.ts
@@ -466,6 +466,30 @@ export class TasksService extends BaseService<
     return updated;
   }
 
+  async attachOutput(
+    id: string,
+    outputId: string,
+    organizationId: string,
+    userId: string,
+  ): Promise<TaskDocument> {
+    const task = await this.requireAiTask(id, organizationId);
+    const updated = (await this.rawModel.findOneAndUpdate(
+      {
+        _id: new Types.ObjectId(id),
+        isDeleted: false,
+        organization: new Types.ObjectId(organizationId),
+      },
+      { $addToSet: { linkedOutputIds: new Types.ObjectId(outputId) } },
+      { new: true },
+    )) as TaskDocument | null;
+    if (!updated) throw new NotFoundException('Task', id);
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: { outputId },
+      type: 'output_attached',
+    });
+    return updated;
+  }
+
   async recordTaskEvent(
     id: string,
     organizationId: string,

--- a/apps/server/api/src/queues/core/queues.module.ts
+++ b/apps/server/api/src/queues/core/queues.module.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '@api/config/config.service';
 import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
 import { CampaignQueueService } from '@api/queues/campaign/campaign-queue.service';
 import { QueueService } from '@api/queues/core/queue.service';
+import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
 import { ReplyBotQueueService } from '@api/queues/reply-bot/reply-bot-queue.service';
 import { WorkflowQueueService } from '@api/queues/workflow/workflow-queue.service';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
@@ -25,6 +26,7 @@ import { Module } from '@nestjs/common';
 @Module({
   exports: [
     AgentRunQueueService,
+    HeygenPollQueueService,
     QueueService,
     ReplyBotQueueService,
     CampaignQueueService,
@@ -221,6 +223,15 @@ import { Module } from '@nestjs/common';
         },
         name: 'workspace-task',
       },
+      {
+        defaultJobOptions: {
+          attempts: 2,
+          backoff: { delay: 5000, type: 'exponential' },
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: 'heygen-poll',
+      },
     ),
   ],
   providers: [
@@ -230,6 +241,7 @@ import { Module } from '@nestjs/common';
     WorkflowQueueService,
     AgentRunQueueService,
     WorkspaceTaskQueueService,
+    HeygenPollQueueService,
   ],
 })
 export class QueuesModule {}

--- a/apps/server/api/src/queues/heygen-poll/heygen-poll-queue.service.ts
+++ b/apps/server/api/src/queues/heygen-poll/heygen-poll-queue.service.ts
@@ -1,0 +1,88 @@
+/**
+ * HeyGen Poll Queue Service
+ *
+ * Schedules delayed polling jobs that check HeyGen video status via
+ * HeygenAvatarProvider.getStatus. Used as a fallback for localhost /
+ * self-hosted deployments where GENFEEDAI_WEBHOOKS_URL is not reachable
+ * from HeyGen.
+ *
+ * In cloud deployments, HeyGen delivers completion via webhook
+ * (POST /v1/webhooks/heygen/callback) and this queue is a no-op.
+ */
+import { LoggerService } from '@libs/logger/logger.service';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Optional } from '@nestjs/common';
+import { Queue } from 'bullmq';
+
+export interface HeygenPollJobData {
+  /** Ingredient ID that owns the HeyGen generation (used as callbackId). */
+  ingredientId: string;
+  /** HeyGen external task/video id returned by generatePhotoAvatarVideo. */
+  externalId: string;
+  /** Organization context for BYOK resolution. */
+  organizationId: string;
+  /** Workspace task ID so we can broadcast completion events to the UI. */
+  taskId: string;
+  /** User who submitted the task (for task event attribution). */
+  userId: string;
+  /** Attempt counter — job reschedules itself with this incremented. */
+  attempt: number;
+}
+
+export const HEYGEN_POLL_QUEUE_NAME = 'heygen-poll';
+export const HEYGEN_POLL_DELAY_MS = 15_000;
+export const HEYGEN_POLL_MAX_ATTEMPTS = 40; // ≈10 min ceiling at 15s cadence
+
+@Injectable()
+export class HeygenPollQueueService {
+  private readonly logContext = 'HeygenPollQueueService';
+
+  constructor(
+    @InjectQueue(HEYGEN_POLL_QUEUE_NAME)
+    @Optional()
+    private readonly queue: Queue<HeygenPollJobData>,
+    private readonly logger: LoggerService,
+  ) {}
+
+  /**
+   * Schedule a poll attempt. Uses a non-deterministic job ID so that
+   * reschedules from inside the processor do not collide with the
+   * initial job.
+   */
+  async schedule(
+    data: Omit<HeygenPollJobData, 'attempt'> & { attempt?: number },
+    delayMs: number = HEYGEN_POLL_DELAY_MS,
+  ): Promise<string | undefined> {
+    if (!this.queue) {
+      this.logger.warn(
+        `${this.logContext}: queue not available, skipping schedule`,
+      );
+      return undefined;
+    }
+
+    const attempt = data.attempt ?? 1;
+    const jobId = `heygen-poll-${data.ingredientId}-${attempt}`;
+    const job = await this.queue.add(
+      'poll-heygen-video',
+      { ...data, attempt },
+      {
+        attempts: 2,
+        backoff: { delay: 5000, type: 'exponential' },
+        delay: delayMs,
+        jobId,
+        removeOnComplete: 100,
+        removeOnFail: 50,
+      },
+    );
+
+    this.logger.log(`${this.logContext}: scheduled poll attempt ${attempt}`, {
+      delayMs,
+      externalId: data.externalId,
+      ingredientId: data.ingredientId,
+      jobId: job.id,
+      taskId: data.taskId,
+    });
+
+    return job.id ?? undefined;
+  }
+}

--- a/apps/server/api/src/queues/heygen-poll/heygen-poll.module.ts
+++ b/apps/server/api/src/queues/heygen-poll/heygen-poll.module.ts
@@ -1,0 +1,38 @@
+/**
+ * HeyGen Poll Module
+ *
+ * Wires dependencies for the HeygenPollProcessor (which lives in this
+ * directory but is registered as a provider by the workers app's
+ * ProcessorsModule). Re-exports the transitive modules the processor
+ * needs so that ProcessorsModule only has to import HeygenPollModule.
+ *
+ * Queue registration lives in:
+ *   - apps/server/api/src/queues/core/queues.module.ts (API producer)
+ *   - apps/server/workers/src/queues/queues.module.ts (workers consumer)
+ */
+import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
+import { MetadataModule } from '@api/collections/metadata/metadata.module';
+import { TasksModule } from '@api/collections/tasks/tasks.module';
+import { WebhooksModule } from '@api/endpoints/webhooks/webhooks.module';
+import { AvatarVideoModule } from '@api/services/avatar-video/avatar-video.module';
+import { LoggerModule } from '@libs/logger/logger.module';
+import { forwardRef, Module } from '@nestjs/common';
+
+@Module({
+  exports: [
+    AvatarVideoModule,
+    WebhooksModule,
+    TasksModule,
+    MetadataModule,
+    IngredientsModule,
+  ],
+  imports: [
+    LoggerModule,
+    forwardRef(() => AvatarVideoModule),
+    forwardRef(() => WebhooksModule),
+    forwardRef(() => TasksModule),
+    forwardRef(() => MetadataModule),
+    forwardRef(() => IngredientsModule),
+  ],
+})
+export class HeygenPollModule {}

--- a/apps/server/api/src/queues/heygen-poll/heygen-poll.processor.ts
+++ b/apps/server/api/src/queues/heygen-poll/heygen-poll.processor.ts
@@ -1,0 +1,200 @@
+/**
+ * HeyGen Poll Processor
+ *
+ * Consumes jobs from the heygen-poll queue. Each job represents one
+ * polling attempt against HeyGen's video status endpoint. On non-terminal
+ * status, the processor reschedules itself with an increased attempt
+ * counter. On terminal status, it calls the same downstream logic the
+ * webhook path uses (`WebhooksService.processMediaForIngredient` on
+ * success, metadata error patch on failure) and then broadcasts a
+ * task-level event so the workspace UI refreshes.
+ *
+ * This path is used for localhost / self-hosted deployments where HeyGen
+ * cannot reach GENFEEDAI_WEBHOOKS_URL. Cloud deployments receive the
+ * completion via webhook and do not enqueue poll jobs.
+ */
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { MetadataService } from '@api/collections/metadata/services/metadata.service';
+import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { WebhooksService } from '@api/endpoints/webhooks/webhooks.service';
+import {
+  HEYGEN_POLL_DELAY_MS,
+  HEYGEN_POLL_MAX_ATTEMPTS,
+  HEYGEN_POLL_QUEUE_NAME,
+  HeygenPollJobData,
+  HeygenPollQueueService,
+} from '@api/queues/heygen-poll/heygen-poll-queue.service';
+import { HeygenAvatarProvider } from '@api/services/avatar-video/providers/heygen-avatar.provider';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { forwardRef, Inject } from '@nestjs/common';
+import { Job } from 'bullmq';
+
+@Processor(HEYGEN_POLL_QUEUE_NAME, {
+  concurrency: 5,
+  limiter: { duration: 60000, max: 30 },
+})
+export class HeygenPollProcessor extends WorkerHost {
+  private readonly logContext = 'HeygenPollProcessor';
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly heygenAvatarProvider: HeygenAvatarProvider,
+    private readonly webhooksService: WebhooksService,
+    private readonly metadataService: MetadataService,
+    private readonly ingredientsService: IngredientsService,
+    @Inject(forwardRef(() => TasksService))
+    private readonly tasksService: TasksService,
+    @Inject(forwardRef(() => HeygenPollQueueService))
+    private readonly heygenPollQueueService: HeygenPollQueueService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<HeygenPollJobData>): Promise<void> {
+    const { data } = job;
+
+    this.logger.log(
+      `${this.logContext}: polling HeyGen for task ${data.taskId} (attempt ${data.attempt})`,
+      {
+        externalId: data.externalId,
+        ingredientId: data.ingredientId,
+      },
+    );
+
+    const result = await this.heygenAvatarProvider.getStatus(
+      data.externalId,
+      data.organizationId,
+    );
+
+    if (result.status === 'processing' || result.status === 'queued') {
+      if (data.attempt >= HEYGEN_POLL_MAX_ATTEMPTS) {
+        this.logger.error(
+          `${this.logContext}: polling timeout for task ${data.taskId}`,
+          {
+            attempt: data.attempt,
+            externalId: data.externalId,
+            ingredientId: data.ingredientId,
+          },
+        );
+        await this.finalizeFailure(data, 'HeyGen polling timeout');
+        return;
+      }
+
+      await this.heygenPollQueueService.schedule(
+        { ...data, attempt: data.attempt + 1 },
+        HEYGEN_POLL_DELAY_MS,
+      );
+      return;
+    }
+
+    if (result.status === 'completed' && result.videoUrl) {
+      await this.finalizeSuccess(data, result.videoUrl, result.jobId);
+      return;
+    }
+
+    // Terminal failure
+    await this.finalizeFailure(
+      data,
+      result.error ?? 'HeyGen generation failed without error message',
+    );
+  }
+
+  private async finalizeSuccess(
+    data: HeygenPollJobData,
+    videoUrl: string,
+    providerVideoId: string,
+  ): Promise<void> {
+    try {
+      await this.webhooksService.processMediaForIngredient(
+        data.ingredientId,
+        'avatar',
+        videoUrl,
+        providerVideoId,
+      );
+
+      await this.tasksService.recordTaskEvent(
+        data.taskId,
+        data.organizationId,
+        data.userId,
+        {
+          payload: {
+            ingredientId: data.ingredientId,
+            videoUrl,
+          },
+          type: 'facecam_completed',
+        },
+        {
+          progress: {
+            activeRunCount: 0,
+            message: 'Facecam video ready.',
+            percent: 100,
+            stage: 'completed',
+          },
+          status: 'done',
+        },
+      );
+
+      this.logger.log(
+        `${this.logContext}: finalized success for task ${data.taskId}`,
+        { ingredientId: data.ingredientId, videoUrl },
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        `${this.logContext}: finalizeSuccess failed for task ${data.taskId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  private async finalizeFailure(
+    data: HeygenPollJobData,
+    errorMessage: string,
+  ): Promise<void> {
+    try {
+      const ingredient = await this.ingredientsService.findOne({
+        _id: data.ingredientId,
+        isDeleted: false,
+      });
+      if (ingredient?.metadata) {
+        await this.metadataService.patch(String(ingredient.metadata), {
+          error: errorMessage,
+        });
+      }
+
+      await this.tasksService.recordTaskEvent(
+        data.taskId,
+        data.organizationId,
+        data.userId,
+        {
+          payload: {
+            error: errorMessage,
+            ingredientId: data.ingredientId,
+          },
+          type: 'facecam_failed',
+        },
+        {
+          failureReason: errorMessage,
+          progress: {
+            activeRunCount: 0,
+            message: errorMessage,
+            percent: 100,
+            stage: 'failed',
+          },
+          status: 'failed',
+        },
+      );
+
+      this.logger.error(
+        `${this.logContext}: finalized failure for task ${data.taskId}`,
+        { error: errorMessage, ingredientId: data.ingredientId },
+      );
+    } catch (patchError: unknown) {
+      this.logger.error(
+        `${this.logContext}: finalizeFailure cleanup failed for task ${data.taskId}`,
+        patchError,
+      );
+    }
+  }
+}

--- a/apps/server/api/src/services/avatar-video/avatar-video-provider.interface.ts
+++ b/apps/server/api/src/services/avatar-video/avatar-video-provider.interface.ts
@@ -31,5 +31,8 @@ export interface AvatarVideoJobResult {
 export interface AvatarVideoProvider {
   readonly providerName: AvatarVideoProviderName;
   generateVideo(input: AvatarVideoJobInput): Promise<AvatarVideoJobResult>;
-  getStatus(jobId: string): Promise<AvatarVideoJobResult>;
+  getStatus(
+    jobId: string,
+    organizationId: string,
+  ): Promise<AvatarVideoJobResult>;
 }

--- a/apps/server/api/src/services/avatar-video/avatar-video.module.ts
+++ b/apps/server/api/src/services/avatar-video/avatar-video.module.ts
@@ -1,3 +1,4 @@
+import { ApiKeyHelperModule } from '@api/services/api-key/api-key-helper.module';
 import { AvatarVideoService } from '@api/services/avatar-video/avatar-video.service';
 import { DidAvatarProvider } from '@api/services/avatar-video/providers/did-avatar.provider';
 import { HeygenAvatarProvider } from '@api/services/avatar-video/providers/heygen-avatar.provider';
@@ -10,8 +11,14 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 
 @Module({
-  exports: [AvatarVideoService],
-  imports: [HeyGenModule, ByokModule, HttpModule, LoggerModule],
+  exports: [AvatarVideoService, HeygenAvatarProvider],
+  imports: [
+    HeyGenModule,
+    ByokModule,
+    HttpModule,
+    LoggerModule,
+    ApiKeyHelperModule,
+  ],
   providers: [
     AvatarVideoService,
     HeygenAvatarProvider,

--- a/apps/server/api/src/services/avatar-video/providers/did-avatar.provider.ts
+++ b/apps/server/api/src/services/avatar-video/providers/did-avatar.provider.ts
@@ -16,7 +16,10 @@ export class DidAvatarProvider implements AvatarVideoProvider {
     throw new NotImplementedException('D-ID provider coming soon');
   }
 
-  async getStatus(_jobId: string): Promise<AvatarVideoJobResult> {
+  async getStatus(
+    _jobId: string,
+    _organizationId: string,
+  ): Promise<AvatarVideoJobResult> {
     throw new NotImplementedException('D-ID provider coming soon');
   }
 }

--- a/apps/server/api/src/services/avatar-video/providers/heygen-avatar.provider.spec.ts
+++ b/apps/server/api/src/services/avatar-video/providers/heygen-avatar.provider.spec.ts
@@ -1,0 +1,123 @@
+import { ApiKeyHelperService } from '@api/services/api-key/api-key-helper.service';
+import { ByokService } from '@api/services/byok/byok.service';
+import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpService } from '@nestjs/axios';
+import { Test, TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+
+import { HeygenAvatarProvider } from './heygen-avatar.provider';
+
+describe('HeygenAvatarProvider', () => {
+  let provider: HeygenAvatarProvider;
+  let byokService: { resolveApiKey: ReturnType<typeof vi.fn> };
+  let apiKeyHelperService: { getApiKey: ReturnType<typeof vi.fn> };
+  let httpService: { get: ReturnType<typeof vi.fn> };
+  let heygenService: { generateAvatarVideo: ReturnType<typeof vi.fn> };
+  let loggerService: {
+    log: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    byokService = { resolveApiKey: vi.fn() };
+    apiKeyHelperService = { getApiKey: vi.fn() };
+    httpService = { get: vi.fn() };
+    heygenService = { generateAvatarVideo: vi.fn() };
+    loggerService = { error: vi.fn(), log: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HeygenAvatarProvider,
+        { provide: HeyGenService, useValue: heygenService },
+        { provide: ByokService, useValue: byokService },
+        { provide: HttpService, useValue: httpService },
+        { provide: LoggerService, useValue: loggerService },
+        { provide: ApiKeyHelperService, useValue: apiKeyHelperService },
+      ],
+    }).compile();
+
+    provider = module.get<HeygenAvatarProvider>(HeygenAvatarProvider);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exposes providerName as heygen', () => {
+    expect(provider.providerName).toBe('heygen');
+  });
+
+  describe('getStatus', () => {
+    it('calls HeyGen status endpoint with BYOK key when present', async () => {
+      byokService.resolveApiKey.mockResolvedValue({ apiKey: 'byok-xyz' });
+      httpService.get.mockReturnValue(
+        of({
+          data: {
+            data: { status: 'completed', video_url: 'https://hg/video.mp4' },
+          },
+        }),
+      );
+
+      const result = await provider.getStatus('video-1', 'org-1');
+
+      expect(byokService.resolveApiKey).toHaveBeenCalledWith('org-1', 'heygen');
+      expect(httpService.get).toHaveBeenCalledWith(
+        'https://api.heygen.com/v1/video_status.get',
+        expect.objectContaining({
+          headers: { 'X-Api-Key': 'byok-xyz' },
+          params: { video_id: 'video-1' },
+        }),
+      );
+      expect(result).toEqual({
+        jobId: 'video-1',
+        providerName: 'heygen',
+        status: 'completed',
+        videoUrl: 'https://hg/video.mp4',
+      });
+    });
+
+    it('falls back to env HEYGEN_KEY when BYOK returns undefined', async () => {
+      byokService.resolveApiKey.mockResolvedValue(undefined);
+      apiKeyHelperService.getApiKey.mockReturnValue('env-key-abc');
+      httpService.get.mockReturnValue(
+        of({ data: { data: { status: 'processing' } } }),
+      );
+
+      const result = await provider.getStatus('video-2', 'org-2');
+
+      expect(httpService.get).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: { 'X-Api-Key': 'env-key-abc' },
+        }),
+      );
+      expect(result.status).toBe('processing');
+    });
+
+    it('returns failed status when no API key is resolvable', async () => {
+      byokService.resolveApiKey.mockResolvedValue(undefined);
+      apiKeyHelperService.getApiKey.mockReturnValue('');
+
+      const result = await provider.getStatus('video-3', 'org-3');
+
+      expect(httpService.get).not.toHaveBeenCalled();
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('No HeyGen API key configured');
+    });
+
+    it('never ships an empty api key in headers (regression guard)', async () => {
+      byokService.resolveApiKey.mockResolvedValue({ apiKey: 'valid' });
+      httpService.get.mockReturnValue(
+        of({ data: { data: { status: 'processing' } } }),
+      );
+
+      await provider.getStatus('video-4', 'org-4');
+
+      const callArgs = httpService.get.mock.calls[0];
+      const config = callArgs[1] as { headers: Record<string, string> };
+      expect(config.headers['X-Api-Key']).not.toBe('');
+      expect(config.headers['X-Api-Key']).toBeTruthy();
+    });
+  });
+});

--- a/apps/server/api/src/services/avatar-video/providers/heygen-avatar.provider.ts
+++ b/apps/server/api/src/services/avatar-video/providers/heygen-avatar.provider.ts
@@ -1,3 +1,4 @@
+import { ApiKeyHelperService } from '@api/services/api-key/api-key-helper.service';
 import type {
   AvatarVideoJobInput,
   AvatarVideoJobResult,
@@ -6,7 +7,7 @@ import type {
 } from '@api/services/avatar-video/avatar-video-provider.interface';
 import { ByokService } from '@api/services/byok/byok.service';
 import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
-import { ByokProvider } from '@genfeedai/enums';
+import { ApiKeyCategory, ByokProvider } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
@@ -23,6 +24,7 @@ export class HeygenAvatarProvider implements AvatarVideoProvider {
     private readonly byokService: ByokService,
     private readonly httpService: HttpService,
     private readonly logger: LoggerService,
+    private readonly apiKeyHelperService: ApiKeyHelperService,
   ) {}
 
   async generateVideo(
@@ -68,11 +70,35 @@ export class HeygenAvatarProvider implements AvatarVideoProvider {
     }
   }
 
-  async getStatus(jobId: string): Promise<AvatarVideoJobResult> {
+  async getStatus(
+    jobId: string,
+    organizationId: string,
+  ): Promise<AvatarVideoJobResult> {
     try {
+      const byokKey = await this.byokService.resolveApiKey(
+        organizationId,
+        ByokProvider.HEYGEN,
+      );
+      const apiKey =
+        byokKey?.apiKey ??
+        this.apiKeyHelperService.getApiKey(ApiKeyCategory.HEYGEN);
+
+      if (!apiKey) {
+        this.logger.error(
+          `${this.logContext} getStatus failed: no HeyGen API key resolved`,
+          { organizationId },
+        );
+        return {
+          error: 'No HeyGen API key configured (BYOK or env HEYGEN_KEY).',
+          jobId,
+          providerName: this.providerName,
+          status: 'failed',
+        };
+      }
+
       const response = await firstValueFrom(
         this.httpService.get(this.statusUrl, {
-          headers: { 'X-Api-Key': '' },
+          headers: { 'X-Api-Key': apiKey },
           params: { video_id: jobId },
           timeout: 15_000,
         }),

--- a/apps/server/api/src/services/avatar-video/providers/musetalk-avatar.provider.spec.ts
+++ b/apps/server/api/src/services/avatar-video/providers/musetalk-avatar.provider.spec.ts
@@ -75,19 +75,19 @@ describe('MusetalkAvatarProvider', () => {
 
   describe('getStatus', () => {
     it('throws NotImplementedException', async () => {
-      await expect(provider.getStatus('any-job-id')).rejects.toThrow(
+      await expect(provider.getStatus('any-job-id', 'org-1')).rejects.toThrow(
         NotImplementedException,
       );
     });
 
     it('throws with "coming soon" message', async () => {
-      await expect(provider.getStatus('job-123')).rejects.toThrow(
+      await expect(provider.getStatus('job-123', 'org-1')).rejects.toThrow(
         'MuseTalk provider coming soon',
       );
     });
 
     it('throws for any job id', async () => {
-      await expect(provider.getStatus('')).rejects.toThrow(
+      await expect(provider.getStatus('', 'org-1')).rejects.toThrow(
         NotImplementedException,
       );
     });
@@ -95,7 +95,7 @@ describe('MusetalkAvatarProvider', () => {
     it('does not return a resolved promise', async () => {
       let resolved = false;
       await provider
-        .getStatus('job')
+        .getStatus('job', 'org-1')
         .then(() => {
           resolved = true;
         })
@@ -104,7 +104,7 @@ describe('MusetalkAvatarProvider', () => {
     });
 
     it('providerName is still accessible after failed calls', async () => {
-      await provider.getStatus('x').catch(() => {});
+      await provider.getStatus('x', 'org-1').catch(() => {});
       expect(provider.providerName).toBe('musetalk');
     });
   });

--- a/apps/server/api/src/services/avatar-video/providers/musetalk-avatar.provider.ts
+++ b/apps/server/api/src/services/avatar-video/providers/musetalk-avatar.provider.ts
@@ -22,7 +22,10 @@ export class MusetalkAvatarProvider implements AvatarVideoProvider {
     throw new NotImplementedException('MuseTalk provider coming soon');
   }
 
-  async getStatus(_jobId: string): Promise<AvatarVideoJobResult> {
+  async getStatus(
+    _jobId: string,
+    _organizationId: string,
+  ): Promise<AvatarVideoJobResult> {
     throw new NotImplementedException('MuseTalk provider coming soon');
   }
 }

--- a/apps/server/api/src/services/avatar-video/providers/tavus-avatar.provider.spec.ts
+++ b/apps/server/api/src/services/avatar-video/providers/tavus-avatar.provider.spec.ts
@@ -57,13 +57,13 @@ describe('TavusAvatarProvider', () => {
 
   describe('getStatus', () => {
     it('should throw NotImplementedException', async () => {
-      await expect(provider.getStatus('job-123')).rejects.toThrow(
+      await expect(provider.getStatus('job-123', 'org-1')).rejects.toThrow(
         NotImplementedException,
       );
     });
 
     it('should throw with "coming soon" message', async () => {
-      await expect(provider.getStatus('job-abc')).rejects.toThrow(
+      await expect(provider.getStatus('job-abc', 'org-1')).rejects.toThrow(
         'coming soon',
       );
     });
@@ -71,7 +71,7 @@ describe('TavusAvatarProvider', () => {
     it('should reject for any jobId value', async () => {
       const jobIds = ['job-1', '', 'some-uuid-1234', '   '];
       for (const jobId of jobIds) {
-        await expect(provider.getStatus(jobId)).rejects.toThrow(
+        await expect(provider.getStatus(jobId, 'org-1')).rejects.toThrow(
           NotImplementedException,
         );
       }

--- a/apps/server/api/src/services/avatar-video/providers/tavus-avatar.provider.ts
+++ b/apps/server/api/src/services/avatar-video/providers/tavus-avatar.provider.ts
@@ -16,7 +16,10 @@ export class TavusAvatarProvider implements AvatarVideoProvider {
     throw new NotImplementedException('Tavus provider coming soon');
   }
 
-  async getStatus(_jobId: string): Promise<AvatarVideoJobResult> {
+  async getStatus(
+    _jobId: string,
+    _organizationId: string,
+  ): Promise<AvatarVideoJobResult> {
     throw new NotImplementedException('Tavus provider coming soon');
   }
 }

--- a/apps/server/api/src/services/task-orchestration/task-orchestration.module.ts
+++ b/apps/server/api/src/services/task-orchestration/task-orchestration.module.ts
@@ -14,6 +14,7 @@ import { forwardRef, Module } from '@nestjs/common';
     TaskDecompositionService,
     TaskOrchestratorService,
     WorkspaceTaskQualityService,
+    VideoGenerationModule,
   ],
   imports: [
     LoggerModule,

--- a/apps/server/api/src/services/task-orchestration/task-orchestration.module.ts
+++ b/apps/server/api/src/services/task-orchestration/task-orchestration.module.ts
@@ -1,5 +1,6 @@
 import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
 import { TasksModule } from '@api/collections/tasks/tasks.module';
+import { VideoGenerationModule } from '@api/collections/videos/video-generation.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { LlmDispatcherModule } from '@api/services/integrations/llm/llm-dispatcher.module';
 import { TaskDecompositionService } from '@api/services/task-orchestration/task-decomposition.service';
@@ -20,6 +21,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => AgentRunsModule),
     forwardRef(() => TasksModule),
     forwardRef(() => QueuesModule),
+    forwardRef(() => VideoGenerationModule),
   ],
   providers: [
     TaskDecompositionService,

--- a/apps/server/api/src/services/task-orchestration/workspace-task-queue.service.ts
+++ b/apps/server/api/src/services/task-orchestration/workspace-task-queue.service.ts
@@ -20,6 +20,10 @@ export interface WorkspaceTaskJobData {
   brandId?: string;
   /** Brand name for context */
   brandName?: string;
+  /** HeyGen avatar ID (facecam tasks only) */
+  heygenAvatarId?: string;
+  /** HeyGen voice ID (facecam tasks only) */
+  heygenVoiceId?: string;
 }
 
 @Injectable()

--- a/apps/server/api/src/services/task-orchestration/workspace-task.processor.ts
+++ b/apps/server/api/src/services/task-orchestration/workspace-task.processor.ts
@@ -1,4 +1,6 @@
 import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { AvatarVideoGenerationService } from '@api/collections/videos/services/avatar-video-generation.service';
+import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
 import { TaskOrchestratorService } from '@api/services/task-orchestration/task-orchestrator.service';
 import { WorkspaceTaskJobData } from '@api/services/task-orchestration/workspace-task-queue.service';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -23,6 +25,10 @@ export class WorkspaceTaskProcessor extends WorkerHost {
     private readonly taskOrchestratorService: TaskOrchestratorService,
     @Inject(forwardRef(() => TasksService))
     private readonly tasksService: TasksService,
+    @Inject(forwardRef(() => AvatarVideoGenerationService))
+    private readonly avatarVideoGenerationService: AvatarVideoGenerationService,
+    @Inject(forwardRef(() => HeygenPollQueueService))
+    private readonly heygenPollQueueService: HeygenPollQueueService,
   ) {
     super();
   }
@@ -36,6 +42,11 @@ export class WorkspaceTaskProcessor extends WorkerHost {
     });
 
     try {
+      if (data.outputType === 'facecam') {
+        await this.dispatchFacecam(data);
+        return;
+      }
+
       await this.taskOrchestratorService.orchestrate({
         brandId: data.brandId,
         brandName: data.brandName,
@@ -83,6 +94,138 @@ export class WorkspaceTaskProcessor extends WorkerHost {
         });
 
       throw error; // Let BullMQ handle retry
+    }
+  }
+
+  /**
+   * Direct facecam dispatch: bypasses the agent orchestrator and calls
+   * AvatarVideoGenerationService directly. The user explicitly picks
+   * HeyGen avatarId + heygenVoiceId from the composer, so we pass them
+   * through with useIdentity: false (so the picker choice wins over
+   * brand defaults).
+   *
+   * After the ingredient is created (status: PROCESSING), attach it to
+   * the task via TasksService.attachOutput so the workspace UI starts
+   * polling for it. The polling fallback (for localhost where HeyGen
+   * webhooks cannot reach) is scheduled here when GENFEEDAI_WEBHOOKS_URL
+   * is not set.
+   */
+  private async dispatchFacecam(data: WorkspaceTaskJobData): Promise<void> {
+    if (!data.request || data.request.trim().length === 0) {
+      throw new Error('Facecam task requires non-empty request text (script).');
+    }
+
+    this.logger.log(
+      `${this.logContext}: Dispatching facecam for task ${data.taskId}`,
+      {
+        heygenAvatarId: data.heygenAvatarId,
+        heygenVoiceId: data.heygenVoiceId,
+        taskId: data.taskId,
+      },
+    );
+
+    // Mark in_progress before firing the HeyGen call so the workspace
+    // activity pane shows the task moving.
+    await this.tasksService.recordTaskEvent(
+      data.taskId,
+      data.organizationId,
+      data.userId,
+      {
+        payload: {
+          heygenAvatarId: data.heygenAvatarId,
+          heygenVoiceId: data.heygenVoiceId,
+        },
+        type: 'task_started',
+      },
+      {
+        chosenProvider: 'heygen',
+        executionPathUsed: 'video_generation',
+        progress: {
+          activeRunCount: 1,
+          message: 'Calling HeyGen to generate facecam video.',
+          percent: 10,
+          stage: 'generating',
+        },
+        status: 'in_progress',
+      },
+    );
+
+    const result = await this.avatarVideoGenerationService.generateAvatarVideo(
+      {
+        aspectRatio: '9:16',
+        avatarId: data.heygenAvatarId,
+        heygenVoiceId: data.heygenVoiceId,
+        text: data.request,
+        useIdentity: false,
+        voiceProvider: 'heygen',
+      },
+      {
+        brandId: data.brandId,
+        organizationId: data.organizationId,
+        userId: data.userId,
+      },
+    );
+
+    this.logger.log(
+      `${this.logContext}: Facecam generation started for task ${data.taskId}`,
+      {
+        externalId: result.externalId,
+        ingredientId: result.ingredientId,
+        taskId: data.taskId,
+      },
+    );
+
+    // Attach the ingredient to the task so the workspace UI can fetch
+    // and poll it. The ingredient is in PROCESSING state; the workspace
+    // will re-render when the webhook or poller flips it to COMPLETED.
+    await this.tasksService.attachOutput(
+      data.taskId,
+      result.ingredientId,
+      data.organizationId,
+      data.userId,
+    );
+
+    await this.tasksService.recordTaskEvent(
+      data.taskId,
+      data.organizationId,
+      data.userId,
+      {
+        payload: {
+          externalId: result.externalId,
+          ingredientId: result.ingredientId,
+        },
+        type: 'facecam_dispatched',
+      },
+      {
+        progress: {
+          activeRunCount: 1,
+          message: 'Facecam video generation in progress on HeyGen.',
+          percent: 35,
+          stage: 'waiting_for_provider',
+        },
+      },
+    );
+
+    // Cloud deployments set GENFEEDAI_WEBHOOKS_URL so HeyGen can POST
+    // back to /v1/webhooks/heygen/callback. Localhost / self-hosted
+    // deployments don't, so we schedule a poll fallback that hits
+    // HeygenAvatarProvider.getStatus until terminal.
+    const webhookConfigured = Boolean(
+      process.env.GENFEEDAI_WEBHOOKS_URL &&
+        process.env.GENFEEDAI_WEBHOOKS_URL.length > 0,
+    );
+
+    if (!webhookConfigured) {
+      this.logger.log(
+        `${this.logContext}: GENFEEDAI_WEBHOOKS_URL not set, scheduling poll fallback for task ${data.taskId}`,
+      );
+      await this.heygenPollQueueService.schedule({
+        externalId: result.externalId,
+        ingredientId: result.ingredientId,
+        organizationId: data.organizationId,
+        taskId: data.taskId,
+        userId: data.userId,
+      });
     }
   }
 }

--- a/apps/server/notifications/package.json
+++ b/apps/server/notifications/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@genfeedai/config": "workspace:*",
+    "@genfeedai/enums": "workspace:*",
     "@slack/web-api": "7.15.0"
   },
   "description": "Genfeed Notifications Service",

--- a/apps/server/workers/package.json
+++ b/apps/server/workers/package.json
@@ -2,7 +2,10 @@
   "dependencies": {
     "@aws-sdk/client-ec2": "3.1029.0",
     "@genfeedai/config": "workspace:*",
-    "@genfeedai/enums": "workspace:*"
+    "@genfeedai/enums": "workspace:*",
+    "@genfeedai/helpers": "workspace:*",
+    "@genfeedai/interfaces": "workspace:*",
+    "@genfeedai/workflows": "workspace:*"
   },
   "description": "Genfeed Workers Service (Cron Jobs)",
   "devDependencies": {

--- a/apps/server/workers/src/crons/model-watcher/cron.model-watcher.module.ts
+++ b/apps/server/workers/src/crons/model-watcher/cron.model-watcher.module.ts
@@ -4,6 +4,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@workers/config/config.module';
 import { CronModelWatcherService } from '@workers/crons/model-watcher/cron.model-watcher.service';
 import { FalDiscoveryService } from '@workers/services/fal-discovery.service';
+import { HuggingFaceDiscoveryService } from '@workers/services/hugging-face-discovery.service';
 import { ModelDiscoveryService } from '@workers/services/model-discovery.service';
 import { ModelPricingService } from '@workers/services/model-pricing.service';
 
@@ -12,6 +13,7 @@ import { ModelPricingService } from '@workers/services/model-pricing.service';
   providers: [
     CronModelWatcherService,
     FalDiscoveryService,
+    HuggingFaceDiscoveryService,
     ModelDiscoveryService,
     ModelPricingService,
   ],

--- a/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
+++ b/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
@@ -37,7 +37,7 @@ const VERIFIED_OWNERS: ReadonlySet<string> = new Set([
 ]);
 
 /** Maximum number of API pages to iterate to prevent runaway polling */
-const MAX_PAGES = 20;
+const MAX_PAGES = 3;
 
 /** Timeout for individual Replicate API requests (30 seconds) */
 const API_TIMEOUT_MS = 30_000;
@@ -58,15 +58,15 @@ export class CronModelWatcherService {
   ) {}
 
   /**
-   * Daily model discovery cron.
+   * Weekly model discovery cron.
    * Polls Replicate API for new official models from verified creators,
    * compares against existing models in the database, and creates
    * draft entries for any newly discovered models.
    *
-   * Runs daily at 6 AM UTC. Disabled in development to prevent
-   * unnecessary API calls during local development.
+   * Runs weekly on Sunday at 6 AM UTC. Kept conservative until the
+   * discovery pipeline is fully validated in production.
    */
-  @Cron('0 6 * * *')
+  @Cron('0 6 * * 0')
   async discoverNewModels(): Promise<IModelDiscoveryRunSummary> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
+++ b/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
@@ -14,6 +14,7 @@ import type {
   IReplicateModelsResponse,
 } from '@workers/interfaces/model-discovery.interface';
 import { FalDiscoveryService } from '@workers/services/fal-discovery.service';
+import { HuggingFaceDiscoveryService } from '@workers/services/hugging-face-discovery.service';
 import { ModelDiscoveryService } from '@workers/services/model-discovery.service';
 import { ModelPricingService } from '@workers/services/model-pricing.service';
 
@@ -52,6 +53,7 @@ export class CronModelWatcherService {
     private readonly modelPricingService: ModelPricingService,
     private readonly configService: ConfigService,
     private readonly falDiscoveryService: FalDiscoveryService,
+    private readonly huggingFaceDiscoveryService: HuggingFaceDiscoveryService,
     private readonly notificationsService: NotificationsService,
   ) {}
 
@@ -75,6 +77,9 @@ export class CronModelWatcherService {
       falDraftsCreated: 0,
       falNewFound: 0,
       falPolled: 0,
+      hfDraftsCreated: 0,
+      hfNewFound: 0,
+      hfPolled: 0,
       newModelsFound: 0,
       timestamp: new Date(),
       totalPolled: 0,
@@ -114,8 +119,7 @@ export class CronModelWatcherService {
       summary.newModelsFound = newModels.length;
 
       if (newModels.length === 0) {
-        this.logger.log(`${url} no new models discovered`);
-        return summary;
+        this.logger.log(`${url} no new Replicate models discovered`);
       }
 
       this.logger.log(
@@ -173,13 +177,25 @@ export class CronModelWatcherService {
       // Step 6: Poll fal.ai for new models
       await this.pollFalModels(summary, existingKeys);
 
-      // Step 7: Log summary
+      // Step 7: Poll HuggingFace for new models
+      await this.pollHuggingFaceModels(summary, existingKeys);
+
+      // Step 8: Touch lastSyncedAt for all previously discovered models seen in this run
+      const syncedKeys = [
+        ...officialModels.map((m) => `${m.owner}/${m.name}`),
+      ].filter((k) => existingKeys.has(k));
+      await this.modelDiscoveryService.touchLastSyncedAt(syncedKeys);
+
+      // Step 9: Log summary
       this.logger.log(`${url} completed`, {
         draftsCreated: summary.draftsCreated,
         errors: summary.errors,
         falDraftsCreated: summary.falDraftsCreated,
         falNewFound: summary.falNewFound,
         falPolled: summary.falPolled,
+        hfDraftsCreated: summary.hfDraftsCreated,
+        hfNewFound: summary.hfNewFound,
+        hfPolled: summary.hfPolled,
         newModelsFound: summary.newModelsFound,
         totalPolled: summary.totalPolled,
       });
@@ -417,5 +433,82 @@ export class CronModelWatcherService {
 
     // Fall back to description-only detection
     return this.modelDiscoveryService.detectCategory({}, model.description);
+  }
+
+  /**
+   * Poll HuggingFace Hub for new content-creation models and create drafts.
+   * Isolated from Replicate/Fal polling so errors don't affect each other.
+   */
+  private async pollHuggingFaceModels(
+    summary: IModelDiscoveryRunSummary,
+    existingKeys: Set<string>,
+  ): Promise<void> {
+    const context = `${this.constructorName} pollHuggingFaceModels`;
+
+    try {
+      const hfModels = await this.huggingFaceDiscoveryService.discoverModels();
+      summary.hfPolled = hfModels.length;
+
+      this.logger.log(
+        `${context} polled ${hfModels.length} models from HuggingFace`,
+      );
+
+      const newHfModels = hfModels.filter(
+        (m) => m.key && !existingKeys.has(m.key),
+      );
+      summary.hfNewFound = newHfModels.length;
+
+      if (newHfModels.length === 0) {
+        this.logger.log(`${context} no new HuggingFace models discovered`);
+        return;
+      }
+
+      this.logger.log(
+        `${context} found ${newHfModels.length} new HuggingFace models`,
+      );
+
+      for (const hfModel of newHfModels) {
+        try {
+          const modelKey = hfModel.key as string;
+          const parts = modelKey.split('/');
+          const owner = parts[0] ?? modelKey;
+          const name = parts.slice(1).join('/') || modelKey;
+          const category = hfModel.category ?? ModelCategory.IMAGE;
+
+          const discoveryInput: IModelDiscoveryInput = {
+            category,
+            description: hfModel.description || '',
+            name,
+            owner,
+            provider: ModelProvider.HUGGINGFACE,
+            providerCostUsd: 0,
+            replicateUrl: '',
+            versionId: null,
+          };
+
+          const draft =
+            await this.modelDiscoveryService.createDraftModel(discoveryInput);
+
+          if (draft) {
+            summary.hfDraftsCreated = (summary.hfDraftsCreated ?? 0) + 1;
+            await this.sendDiscoveryNotification(
+              modelKey,
+              category,
+              draft.cost ?? 0,
+              0,
+              'huggingface',
+            );
+          }
+        } catch (error: unknown) {
+          summary.errors++;
+          this.logger.error(
+            `${context} failed to process HuggingFace model ${hfModel.key}`,
+            { error },
+          );
+        }
+      }
+    } catch (error: unknown) {
+      this.logger.error(`${context} HuggingFace polling failed`, error);
+    }
   }
 }

--- a/apps/server/workers/src/interfaces/model-discovery.interface.ts
+++ b/apps/server/workers/src/interfaces/model-discovery.interface.ts
@@ -81,4 +81,7 @@ export interface IModelDiscoveryRunSummary {
   falPolled?: number;
   falNewFound?: number;
   falDraftsCreated?: number;
+  hfPolled?: number;
+  hfNewFound?: number;
+  hfDraftsCreated?: number;
 }

--- a/apps/server/workers/src/processors/processors.module.ts
+++ b/apps/server/workers/src/processors/processors.module.ts
@@ -52,6 +52,8 @@ import { ClipAnalyzeProcessor } from '@api/queues/clip-analyze/clip-analyze.proc
 import { ClipFactoryProcessor } from '@api/queues/clip-factory/clip-factory.processor';
 import { CreditDeductionProcessor } from '@api/queues/credit-deduction/credit-deduction.processor';
 import { EmailDigestProcessor } from '@api/queues/email-digest/email-digest.processor';
+import { HeygenPollModule } from '@api/queues/heygen-poll/heygen-poll.module';
+import { HeygenPollProcessor } from '@api/queues/heygen-poll/heygen-poll.processor';
 import { PatternExtractionProcessor } from '@api/queues/pattern-extraction/pattern-extraction.processor';
 import { ReplyBotPollingProcessor } from '@api/queues/reply-bot/reply-bot-polling.processor';
 import { TelegramDistributeProcessor } from '@api/queues/telegram-distribute/telegram-distribute.processor';
@@ -140,6 +142,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     forwardRef(() => ReplyBotModule),
     forwardRef(() => SkillExecutorModule),
     forwardRef(() => TaskOrchestrationModule),
+    forwardRef(() => HeygenPollModule),
     forwardRef(() => TelegramDistributionModule),
     forwardRef(() => TiktokModule),
     forwardRef(() => TwitterModule),
@@ -165,6 +168,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     ClipFactoryProcessor,
     CreditDeductionProcessor,
     EmailDigestProcessor,
+    HeygenPollProcessor,
     PatternExtractionProcessor,
     ReplyBotPollingProcessor,
     TelegramDistributeProcessor,

--- a/apps/server/workers/src/queues/queues.module.ts
+++ b/apps/server/workers/src/queues/queues.module.ts
@@ -9,6 +9,7 @@
 import { CLIP_ANALYZE_QUEUE } from '@api/queues/clip-analyze/clip-analyze.constants';
 import { CLIP_FACTORY_QUEUE } from '@api/queues/clip-factory/clip-factory.constants';
 import { QueueService } from '@api/queues/core/queue.service';
+import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
 import { WorkflowQueueService } from '@api/queues/workflow/workflow-queue.service';
 import {
   CAMPAIGN_MEMORY_EXTRACTION_QUEUE,
@@ -27,7 +28,12 @@ import { ConfigModule } from '@workers/config/config.module';
 import { ConfigService } from '@workers/config/config.service';
 
 @Module({
-  exports: [QueueService, WorkflowQueueService, WorkspaceTaskQueueService],
+  exports: [
+    QueueService,
+    WorkflowQueueService,
+    WorkspaceTaskQueueService,
+    HeygenPollQueueService,
+  ],
   imports: [
     LoggerModule,
     BullModule.forRootAsync({
@@ -332,8 +338,22 @@ import { ConfigService } from '@workers/config/config.service';
         },
         name: 'batch-workflow',
       },
+      {
+        defaultJobOptions: {
+          attempts: 2,
+          backoff: { delay: 5000, type: 'exponential' },
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: 'heygen-poll',
+      },
     ),
   ],
-  providers: [QueueService, WorkflowQueueService, WorkspaceTaskQueueService],
+  providers: [
+    QueueService,
+    WorkflowQueueService,
+    WorkspaceTaskQueueService,
+    HeygenPollQueueService,
+  ],
 })
 export class WorkersQueuesModule {}

--- a/apps/server/workers/src/services/hugging-face-discovery.service.spec.ts
+++ b/apps/server/workers/src/services/hugging-face-discovery.service.spec.ts
@@ -1,0 +1,248 @@
+import { ModelCategory, ModelProvider } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@workers/config/config.service';
+import { HuggingFaceDiscoveryService } from '@workers/services/hugging-face-discovery.service';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+/** Minimal HuggingFace model fixture */
+function makeHfModel(overrides: Record<string, unknown> = {}) {
+  return {
+    downloads: 1000,
+    gated: false,
+    id: 'org/some-model',
+    likes: 50,
+    pipeline_tag: 'text-to-image',
+    private: false,
+    tags: [],
+    ...overrides,
+  };
+}
+
+/** Stub a single-page fetch response with no pagination */
+function stubFetchPage(models: unknown[]) {
+  mockFetch.mockResolvedValueOnce({
+    headers: { get: vi.fn().mockReturnValue(null) },
+    json: vi.fn().mockResolvedValue(models),
+    ok: true,
+    status: 200,
+  });
+}
+
+describe('HuggingFaceDiscoveryService', () => {
+  let service: HuggingFaceDiscoveryService;
+  let configService: { get: ReturnType<typeof vi.fn> };
+  let logger: {
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
+
+  function makeConfigService(apiKey: string | null) {
+    return {
+      get: vi.fn().mockImplementation((key: string) => {
+        if (key === 'HUGGINGFACE_API_KEY') return apiKey ?? undefined;
+        return undefined;
+      }),
+    };
+  }
+
+  async function buildModule(apiKey: string | null): Promise<void> {
+    configService = makeConfigService(apiKey);
+    logger = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HuggingFaceDiscoveryService,
+        { provide: ConfigService, useValue: configService },
+        { provide: LoggerService, useValue: logger },
+      ],
+    }).compile();
+
+    service = module.get(HuggingFaceDiscoveryService);
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await buildModule('test-hf-key');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isConfigured()', () => {
+    it('returns true when HUGGINGFACE_API_KEY is set', () => {
+      expect(service.isConfigured()).toBe(true);
+    });
+
+    it('returns false when HUGGINGFACE_API_KEY is missing', async () => {
+      await buildModule(null);
+      expect(service.isConfigured()).toBe(false);
+    });
+  });
+
+  describe('discoverModels()', () => {
+    it('returns empty array when API returns non-OK status', async () => {
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        ok: false,
+        status: 503,
+      });
+
+      const models = await service.discoverModels();
+      expect(models).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('HuggingFace API returned 503'),
+      );
+    });
+
+    it('returns mapped models with correct provider', async () => {
+      // stub one response per pipeline tag — return empty for all but the first
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([]),
+        ok: true,
+        status: 200,
+      });
+      // Override first call (text-to-image tag) with one model
+      mockFetch.mockResolvedValueOnce({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([makeHfModel()]),
+        ok: true,
+        status: 200,
+      });
+
+      const models = await service.discoverModels();
+      expect(models.length).toBeGreaterThanOrEqual(1);
+      expect(models[0].provider).toBe(ModelProvider.HUGGINGFACE);
+      expect(models[0].isActive).toBe(false);
+    });
+
+    it('filters out private models', async () => {
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([]),
+        ok: true,
+        status: 200,
+      });
+      mockFetch.mockResolvedValueOnce({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi
+          .fn()
+          .mockResolvedValue([
+            makeHfModel({ private: true, id: 'org/secret' }),
+          ]),
+        ok: true,
+        status: 200,
+      });
+
+      const models = await service.discoverModels();
+      const found = models.find((m) => m.key === 'org/secret');
+      expect(found).toBeUndefined();
+    });
+
+    it('filters out gated models', async () => {
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([]),
+        ok: true,
+        status: 200,
+      });
+      mockFetch.mockResolvedValueOnce({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi
+          .fn()
+          .mockResolvedValue([makeHfModel({ gated: true, id: 'org/gated' })]),
+        ok: true,
+        status: 200,
+      });
+
+      const models = await service.discoverModels();
+      const found = models.find((m) => m.key === 'org/gated');
+      expect(found).toBeUndefined();
+    });
+
+    it('infers VIDEO category for text-to-video pipeline tag', async () => {
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([]),
+        ok: true,
+        status: 200,
+      });
+      // text-to-video is the 4th allowed tag — stub enough empty responses first
+      for (let i = 0; i < 3; i++) {
+        mockFetch.mockResolvedValueOnce({
+          headers: { get: vi.fn().mockReturnValue(null) },
+          json: vi.fn().mockResolvedValue([]),
+          ok: true,
+          status: 200,
+        });
+      }
+      mockFetch.mockResolvedValueOnce({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi
+          .fn()
+          .mockResolvedValue([
+            makeHfModel({ id: 'org/video-gen', pipeline_tag: 'text-to-video' }),
+          ]),
+        ok: true,
+        status: 200,
+      });
+
+      const models = await service.discoverModels();
+      const videoModel = models.find((m) => m.key === 'org/video-gen');
+      expect(videoModel?.category).toBe(ModelCategory.VIDEO);
+    });
+
+    it('handles fetch network error gracefully', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const models = await service.discoverModels();
+      expect(models).toEqual([]);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('handles AbortError timeout gracefully', async () => {
+      const abortError = new Error('AbortError');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      // remaining tags fall through to empty
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([]),
+        ok: true,
+        status: 200,
+      });
+
+      const models = await service.discoverModels();
+      // No crash, errors logged
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('timed out'),
+        expect.anything(),
+      );
+      // Still returns whatever other tags produced
+      expect(Array.isArray(models)).toBe(true);
+    });
+
+    it('deduplicates models across pipeline tags', async () => {
+      const sameModel = makeHfModel({ id: 'org/dual-purpose' });
+      // Return the same model for multiple tag fetches
+      stubFetchPage([sameModel]);
+      mockFetch.mockResolvedValue({
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue([sameModel]),
+        ok: true,
+        status: 200,
+      });
+
+      const models = await service.discoverModels();
+      const occurrences = models.filter((m) => m.key === 'org/dual-purpose');
+      expect(occurrences).toHaveLength(1);
+    });
+  });
+});

--- a/apps/server/workers/src/services/hugging-face-discovery.service.ts
+++ b/apps/server/workers/src/services/hugging-face-discovery.service.ts
@@ -12,7 +12,7 @@ const API_TIMEOUT_MS = 30_000;
 const PAGE_SIZE = 100;
 
 /** Maximum pages to iterate to prevent runaway polling */
-const MAX_PAGES = 5;
+const MAX_PAGES = 1;
 
 /**
  * Minimum download count for a model to be considered for discovery.

--- a/apps/server/workers/src/services/hugging-face-discovery.service.ts
+++ b/apps/server/workers/src/services/hugging-face-discovery.service.ts
@@ -1,0 +1,332 @@
+import { ModelCategory, ModelProvider } from '@genfeedai/enums';
+import { applyMargin } from '@genfeedai/helpers';
+import type { IModel } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@workers/config/config.service';
+
+/** Timeout for HuggingFace API requests */
+const API_TIMEOUT_MS = 30_000;
+
+/** Maximum number of models to fetch per page */
+const PAGE_SIZE = 100;
+
+/** Maximum pages to iterate to prevent runaway polling */
+const MAX_PAGES = 10;
+
+/**
+ * Pipeline tags from the HuggingFace Hub API that map to content-creation categories.
+ * Allowlist — only these tags are considered for auto-discovery.
+ */
+const ALLOWED_PIPELINE_TAGS: ReadonlySet<string> = new Set([
+  'text-to-image',
+  'image-to-image',
+  'image-to-video',
+  'text-to-video',
+  'text-to-audio',
+  'text-to-speech',
+  'automatic-speech-recognition',
+  'text-generation',
+  'text2text-generation',
+]);
+
+/**
+ * Pipeline tags that are explicitly excluded from auto-discovery.
+ * These represent non-content-creation use cases.
+ */
+const DENIED_PIPELINE_TAGS: ReadonlySet<string> = new Set([
+  'feature-extraction',
+  'sentence-similarity',
+  'fill-mask',
+  'token-classification',
+  'named-entity-recognition',
+  'question-answering',
+  'zero-shot-classification',
+  'object-detection',
+  'image-classification',
+  'image-segmentation',
+  'video-classification',
+  'reinforcement-learning',
+  'robotics',
+  'tabular-classification',
+  'tabular-regression',
+  'time-series-forecasting',
+  'graph-ml',
+]);
+
+interface HuggingFaceModel {
+  id: string;
+  modelId?: string;
+  pipeline_tag?: string;
+  tags?: string[];
+  downloads?: number;
+  likes?: number;
+  gated?: boolean | string;
+  private?: boolean;
+  cardData?: {
+    license?: string;
+    language?: string[];
+  };
+}
+
+/**
+ * NestJS service for discovering content-creation models from HuggingFace Hub.
+ * Uses the public HuggingFace Hub API — no SDK dependency.
+ */
+@Injectable()
+export class HuggingFaceDiscoveryService {
+  private readonly context = HuggingFaceDiscoveryService.name;
+  private readonly baseUrl = 'https://huggingface.co/api/models';
+  private readonly apiKey: string | null;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    this.apiKey = this.configService.get('HUGGINGFACE_API_KEY') || null;
+
+    if (this.apiKey) {
+      this.logger.log(`${this.context} initialized with HUGGINGFACE_API_KEY`);
+    } else {
+      this.logger.warn(
+        `${this.context} HUGGINGFACE_API_KEY not configured — unauthenticated requests will be rate-limited`,
+      );
+    }
+  }
+
+  /**
+   * Check if HuggingFace provider is configured with an API key.
+   * Discovery can still run without a key but is rate-limited.
+   */
+  isConfigured(): boolean {
+    return this.apiKey !== null;
+  }
+
+  /**
+   * Discover content-creation models from HuggingFace Hub.
+   * Fetches models for each allowed pipeline tag and returns them
+   * mapped to GenFeed.AI IModel format.
+   */
+  async discoverModels(): Promise<Partial<IModel>[]> {
+    const discovered: Partial<IModel>[] = [];
+    const seenIds = new Set<string>();
+
+    for (const tag of ALLOWED_PIPELINE_TAGS) {
+      try {
+        const models = await this.fetchModelsForTag(tag);
+
+        for (const model of models) {
+          const key = this.buildModelKey(model);
+          if (seenIds.has(key)) {
+            continue;
+          }
+          seenIds.add(key);
+          discovered.push(this.mapToGenFeedFormat(model, tag));
+        }
+      } catch (error: unknown) {
+        this.logger.error(
+          `${this.context} failed to fetch models for tag "${tag}"`,
+          { error },
+        );
+      }
+    }
+
+    this.logger.log(
+      `${this.context} discovered ${discovered.length} models across ${ALLOWED_PIPELINE_TAGS.size} pipeline tags`,
+    );
+
+    return discovered;
+  }
+
+  /**
+   * Fetch models from HuggingFace Hub for a specific pipeline tag.
+   * Paginates using the `Link` header cursor.
+   */
+  private async fetchModelsForTag(
+    pipelineTag: string,
+  ): Promise<HuggingFaceModel[]> {
+    const models: HuggingFaceModel[] = [];
+    let pageCount = 0;
+    let nextUrl: string | null =
+      `${this.baseUrl}?pipeline_tag=${encodeURIComponent(pipelineTag)}&limit=${PAGE_SIZE}&sort=downloads&direction=-1`;
+
+    while (nextUrl && pageCount < MAX_PAGES) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+
+      const headers: Record<string, string> = {
+        Accept: 'application/json',
+      };
+
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`;
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(nextUrl, {
+          headers,
+          method: 'GET',
+          signal: controller.signal,
+        });
+      } catch (error: unknown) {
+        clearTimeout(timeoutId);
+        if ((error as Error)?.name === 'AbortError') {
+          this.logger.error(
+            `${this.context} request timed out for tag "${pipelineTag}" page ${pageCount + 1}`,
+          );
+        } else {
+          this.logger.error(
+            `${this.context} fetch error for tag "${pipelineTag}" page ${pageCount + 1}`,
+            { error },
+          );
+        }
+        break;
+      }
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        this.logger.error(
+          `${this.context} HuggingFace API returned ${response.status} for tag "${pipelineTag}"`,
+        );
+        break;
+      }
+
+      const data = (await response.json()) as HuggingFaceModel[];
+
+      if (Array.isArray(data) && data.length > 0) {
+        const filtered = data.filter((m) => this.isEligible(m));
+        models.push(...filtered);
+      }
+
+      // HuggingFace uses Link header for pagination cursor
+      const linkHeader = response.headers.get('Link');
+      nextUrl = this.extractNextUrl(linkHeader);
+      pageCount++;
+
+      this.logger.log(
+        `${this.context} fetched page ${pageCount} for tag "${pipelineTag}" — ${data.length ?? 0} items (filtered: ${models.length} total so far)`,
+      );
+
+      if (!Array.isArray(data) || data.length < PAGE_SIZE) {
+        break;
+      }
+    }
+
+    return models;
+  }
+
+  /**
+   * Determine if a HuggingFace model is eligible for auto-discovery.
+   * Excludes gated, private, and denied-tag models.
+   */
+  private isEligible(model: HuggingFaceModel): boolean {
+    if (model.private === true) {
+      return false;
+    }
+
+    if (model.gated === true || model.gated === 'auto') {
+      return false;
+    }
+
+    const tag = model.pipeline_tag ?? '';
+    if (DENIED_PIPELINE_TAGS.has(tag)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Map a HuggingFace model to GenFeed.AI IModel format.
+   * Cost is 0 by default since HuggingFace pricing varies by deployment.
+   */
+  private mapToGenFeedFormat(
+    model: HuggingFaceModel,
+    pipelineTag: string,
+  ): Partial<IModel> {
+    const key = this.buildModelKey(model);
+    const label = this.buildLabel(model.id);
+    const category = this.inferCategory(pipelineTag, model);
+
+    return {
+      capabilities: [],
+      category,
+      cost: applyMargin(0),
+      description: `${label} — HuggingFace model (${pipelineTag})`,
+      isActive: false,
+      isDefault: false,
+      key: key as IModel['key'],
+      label,
+      minCost: 0,
+      provider: ModelProvider.HUGGINGFACE,
+      providerCostUsd: 0,
+    };
+  }
+
+  /**
+   * Build a stable model key from the HuggingFace model ID.
+   * Uses the model ID directly as it's already namespaced (e.g. "black-forest-labs/FLUX.1-dev").
+   */
+  private buildModelKey(model: HuggingFaceModel): string {
+    return model.id || model.modelId || '';
+  }
+
+  /**
+   * Build a human-readable label from the model ID.
+   * @example "black-forest-labs/FLUX.1-dev" → "FLUX.1-dev"
+   */
+  private buildLabel(modelId: string): string {
+    const parts = modelId.split('/');
+    const name = parts.at(-1) ?? modelId;
+    return name.replace(/[-_]/g, ' ').trim();
+  }
+
+  /**
+   * Infer the GenFeed.AI ModelCategory from the HuggingFace pipeline tag.
+   */
+  private inferCategory(
+    pipelineTag: string,
+    model: HuggingFaceModel,
+  ): ModelCategory {
+    const id = (model.id || '').toLowerCase();
+
+    switch (pipelineTag) {
+      case 'text-to-image':
+        return ModelCategory.IMAGE;
+      case 'image-to-image':
+        if (id.includes('upscal') || id.includes('enhance')) {
+          return ModelCategory.IMAGE_UPSCALE;
+        }
+        return ModelCategory.IMAGE_EDIT;
+      case 'image-to-video':
+      case 'text-to-video':
+        return ModelCategory.VIDEO;
+      case 'text-to-audio':
+      case 'text-to-music':
+        return ModelCategory.MUSIC;
+      case 'text-to-speech':
+      case 'automatic-speech-recognition':
+        return ModelCategory.VOICE;
+      case 'text-generation':
+      case 'text2text-generation':
+        return ModelCategory.TEXT;
+      default:
+        return ModelCategory.IMAGE;
+    }
+  }
+
+  /**
+   * Extract the next page URL from the HuggingFace Link header.
+   * Format: `<url>; rel="next"`
+   */
+  private extractNextUrl(linkHeader: string | null): string | null {
+    if (!linkHeader) {
+      return null;
+    }
+
+    const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+    return match ? match[1] : null;
+  }
+}

--- a/apps/server/workers/src/services/hugging-face-discovery.service.ts
+++ b/apps/server/workers/src/services/hugging-face-discovery.service.ts
@@ -12,7 +12,20 @@ const API_TIMEOUT_MS = 30_000;
 const PAGE_SIZE = 100;
 
 /** Maximum pages to iterate to prevent runaway polling */
-const MAX_PAGES = 10;
+const MAX_PAGES = 5;
+
+/**
+ * Minimum download count for a model to be considered for discovery.
+ * Filters out the long tail of experimental / spam models.
+ * HuggingFace has 500k+ models; this keeps the queue to established ones only.
+ */
+const MIN_DOWNLOADS = 1_000;
+
+/**
+ * Minimum like count as a secondary quality signal.
+ * Requires at least some community validation beyond raw download numbers.
+ */
+const MIN_LIKES = 10;
 
 /**
  * Pipeline tags from the HuggingFace Hub API that map to content-creation categories.
@@ -195,9 +208,17 @@ export class HuggingFaceDiscoveryService {
 
       const data = (await response.json()) as HuggingFaceModel[];
 
+      let reachedThreshold = false;
       if (Array.isArray(data) && data.length > 0) {
         const filtered = data.filter((m) => this.isEligible(m));
         models.push(...filtered);
+
+        // Results are sorted by downloads desc — once the last model on this
+        // page falls below MIN_DOWNLOADS there is no point fetching more pages.
+        const lastModel = data.at(-1);
+        if (lastModel && (lastModel.downloads ?? 0) < MIN_DOWNLOADS) {
+          reachedThreshold = true;
+        }
       }
 
       // HuggingFace uses Link header for pagination cursor
@@ -209,7 +230,7 @@ export class HuggingFaceDiscoveryService {
         `${this.context} fetched page ${pageCount} for tag "${pipelineTag}" — ${data.length ?? 0} items (filtered: ${models.length} total so far)`,
       );
 
-      if (!Array.isArray(data) || data.length < PAGE_SIZE) {
+      if (!Array.isArray(data) || data.length < PAGE_SIZE || reachedThreshold) {
         break;
       }
     }
@@ -219,7 +240,7 @@ export class HuggingFaceDiscoveryService {
 
   /**
    * Determine if a HuggingFace model is eligible for auto-discovery.
-   * Excludes gated, private, and denied-tag models.
+   * Excludes gated, private, denied-tag, and low-popularity models.
    */
   private isEligible(model: HuggingFaceModel): boolean {
     if (model.private === true) {
@@ -232,6 +253,14 @@ export class HuggingFaceDiscoveryService {
 
     const tag = model.pipeline_tag ?? '';
     if (DENIED_PIPELINE_TAGS.has(tag)) {
+      return false;
+    }
+
+    if ((model.downloads ?? 0) < MIN_DOWNLOADS) {
+      return false;
+    }
+
+    if ((model.likes ?? 0) < MIN_LIKES) {
       return false;
     }
 

--- a/apps/server/workers/src/services/model-discovery.service.ts
+++ b/apps/server/workers/src/services/model-discovery.service.ts
@@ -133,9 +133,13 @@ export class ModelDiscoveryService {
 
       const draftModel = await this.modelsService.create(createData);
 
-      // Patch with dynamic pricing fields (not in CreateModelDto but supported by schema)
+      // Patch with dynamic fields not in CreateModelDto but supported by schema
+      const now = new Date();
       await this.modelsService.patch(draftModel._id, {
         costPerUnit: pricing.costPerUnit,
+        discoveredAt: now,
+        isDiscovered: true,
+        lastSyncedAt: now,
         minCost: pricing.minCost,
         pricingType: pricing.pricingType,
       });
@@ -156,6 +160,31 @@ export class ModelDiscoveryService {
         },
       );
       return null;
+    }
+  }
+
+  /**
+   * Update `lastSyncedAt` for all models discovered from a given provider.
+   * Called at the end of each sync run to track freshness.
+   */
+  async touchLastSyncedAt(keys: string[]): Promise<void> {
+    if (keys.length === 0) {
+      return;
+    }
+
+    const context = 'ModelDiscoveryService touchLastSyncedAt';
+
+    try {
+      await this.modelsService.updateMany(
+        { isDeleted: false, isDiscovered: true, key: { $in: keys } },
+        { $set: { lastSyncedAt: new Date() } },
+      );
+
+      this.logger.log(
+        `${context} updated lastSyncedAt for ${keys.length} models`,
+      );
+    } catch (error: unknown) {
+      this.logger.error(`${context} failed to update lastSyncedAt`, { error });
     }
   }
 

--- a/bun.lock
+++ b/bun.lock
@@ -413,6 +413,7 @@
         "@genfeedai/types": "workspace:*",
         "@genfeedai/workflow-engine": "workspace:*",
         "@genfeedai/workflow-saas": "workspace:*",
+        "@genfeedai/workflows": "workspace:*",
         "@nestjs/event-emitter": "3.0.1",
         "effect": "3.21.0",
         "openai": "6.34.0",
@@ -473,6 +474,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@genfeedai/config": "workspace:*",
+        "@genfeedai/enums": "workspace:*",
         "@slack/web-api": "7.15.0",
       },
     },
@@ -522,6 +524,9 @@
         "@aws-sdk/client-ec2": "3.1029.0",
         "@genfeedai/config": "workspace:*",
         "@genfeedai/enums": "workspace:*",
+        "@genfeedai/helpers": "workspace:*",
+        "@genfeedai/interfaces": "workspace:*",
+        "@genfeedai/workflows": "workspace:*",
       },
       "devDependencies": {
         "@nestjs/testing": "11.1.18",

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -74,6 +74,9 @@ export interface IEnvConfig {
   // === fal.ai ===
   FAL_API_KEY?: string;
 
+  // === HuggingFace ===
+  HUGGINGFACE_API_KEY?: string;
+
   // === Replicate ===
   REPLICATE_KEY?: string;
   REPLICATE_WEBHOOK_SIGNING_SECRET?: string;

--- a/packages/config/src/schemas/ai.schema.ts
+++ b/packages/config/src/schemas/ai.schema.ts
@@ -110,6 +110,13 @@ export const falSchema = {
   FAL_API_KEY: Joi.string().optional().allow(''),
 };
 
+/**
+ * HuggingFace Inference API
+ */
+export const huggingFaceSchema = {
+  HUGGINGFACE_API_KEY: Joi.string().optional().allow(''),
+};
+
 export const trainingPricingSchema = {
   TRAINING_CUSTOM_MODEL_CREDITS_COST: Joi.number().default(5),
   TRAINING_TRAINING_CREDITS_COST: Joi.number().default(500),

--- a/packages/config/src/schemas/index.ts
+++ b/packages/config/src/schemas/index.ts
@@ -8,6 +8,7 @@ export {
   generalAiSchema,
   hedraSchema,
   heygenSchema,
+  huggingFaceSchema,
   klingaiSchema,
   leonardoSchema,
   newsApiSchema,

--- a/packages/interfaces/src/content/model.interface.ts
+++ b/packages/interfaces/src/content/model.interface.ts
@@ -55,4 +55,12 @@ export interface IModel extends IBaseEntity {
   // Lifecycle fields
   succeededBy?: string;
   predecessorOf?: string;
+
+  // Provider auto-discovery fields (issue #93)
+  isPublic?: boolean;
+  isLegacy?: boolean;
+  isDiscovered?: boolean;
+  discoveredAt?: Date;
+  lastSyncedAt?: Date;
+  margin?: number;
 }

--- a/packages/interfaces/src/organization/brand.interface.ts
+++ b/packages/interfaces/src/organization/brand.interface.ts
@@ -127,6 +127,8 @@ export interface IBrandAgentConfig {
   defaultVoiceProvider?: string | null;
   defaultAvatarPhotoUrl?: string | null;
   defaultAvatarIngredientId?: string | null;
+  heygenAvatarId?: string | null;
+  heygenVoiceId?: string | null;
   persona?: string;
   enabledSkills?: string[];
   voice?: IBrandAgentVoice;

--- a/packages/services/management/tasks.service.ts
+++ b/packages/services/management/tasks.service.ts
@@ -30,6 +30,7 @@ export type TaskExecutionPath =
 
 export type TaskOutputType =
   | 'caption'
+  | 'facecam'
   | 'image'
   | 'ingredient'
   | 'newsletter'
@@ -91,6 +92,8 @@ export interface CreateTaskInput {
   brand?: string;
   description?: string;
   goalId?: string;
+  heygenAvatarId?: string;
+  heygenVoiceId?: string;
   linkedEntities?: TaskLinkedEntity[];
   outputType?: TaskOutputType;
   parentId?: string;

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -188,6 +188,8 @@ export class BrandsService extends BaseService<Brand> {
       defaultVoiceRef?: DefaultVoiceRef | null;
       defaultAvatarPhotoUrl?: string | null;
       defaultAvatarIngredientId?: string | null;
+      heygenAvatarId?: string | null;
+      heygenVoiceId?: string | null;
       persona?: string;
       voice?: {
         approvedHooks?: string[];


### PR DESCRIPTION
## Summary

Implements provider auto-discovery for issue #93. Models from Replicate, fal.ai, and HuggingFace are automatically discovered and upserted as inactive drafts, pending admin review before going live.

- **Schema fields added** (deferred prerequisites from #91): `isPublic`, `isLegacy`, `isDiscovered`, `discoveredAt`, `lastSyncedAt`, `margin` on `model.schema.ts` and `IModel` interface
- **HuggingFaceDiscoveryService**: polls HF Hub across 9 content-creation pipeline tags with allowlist/denylist filtering, deduplication, and category inference
- **Model draft creation**: `createDraftModel()` now stamps `isDiscovered: true`, `discoveredAt`, and `lastSyncedAt` on all auto-discovered models
- **`touchLastSyncedAt()`**: bulk-updates `lastSyncedAt` on all existing discovered models at the end of each sync run
- **Cron wiring**: `CronModelWatcherService` gains HuggingFace as Step 7; fixes an existing early-return bug that skipped Fal/HF polling when no new Replicate models were found
- **Config**: `HUGGINGFACE_API_KEY` added to Joi schema and env-config interface (optional, unauthenticated fallback with rate limiting)
- **Tests**: colocated `hugging-face-discovery.service.spec.ts` — 10 tests covering isConfigured, discoverModels (success, private/gated filters, category inference, error paths, AbortError, deduplication)

## Depends on

- #91 Dynamic Model Registry (schema changes included here as they're prerequisites)
- #92 Training-to-Model Pipeline (independent)

## Test plan

- [x] `bun run test --filter=@genfeedai/workers` — all existing 63 tests pass, new spec added
- [x] `bun type-check` — no errors
- [x] `npx biome check --write` — no lint issues
- [ ] Manual: add `HUGGINGFACE_API_KEY` to env and trigger `CronModelWatcherService.discoverNewModels()` — check Mongo for new models with `isDiscovered: true`
- [ ] Verify `lastSyncedAt` updates on subsequent sync runs for already-discovered models

🤖 Generated with [Claude Code](https://claude.com/claude-code)