### PR TITLE
fix(tasks): PR review batch 1 — identifier/linkedIssueId/facecam/ConfigService/syncedKeys/sync JSON:API

### DIFF
--- a/apps/server/api/src/collections/tasks/schemas/task.schema.ts
+++ b/apps/server/api/src/collections/tasks/schemas/task.schema.ts
@@ -129,6 +129,9 @@ export class Task {
   goalId?: string;
 
   @Prop({ required: false, type: String })
+  linkedIssueId?: string;
+
+  @Prop({ required: false, type: String })
   assigneeUserId?: string;
 
   @Prop({ required: false, type: String })

--- a/apps/server/api/src/collections/tasks/services/tasks.service.ts
+++ b/apps/server/api/src/collections/tasks/services/tasks.service.ts
@@ -2,8 +2,10 @@ import { AgentMessagesService } from '@api/collections/agent-messages/services/a
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
 import { AgentThreadsService } from '@api/collections/agent-threads/services/agent-threads.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { SkillDocument } from '@api/collections/skills/schemas/skill.schema';
 import { SkillsService } from '@api/collections/skills/services/skills.service';
+import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
 import { CreateTaskDto } from '@api/collections/tasks/dto/create-task.dto';
 import { UpdateTaskDto } from '@api/collections/tasks/dto/update-task.dto';
 import {
@@ -120,6 +122,8 @@ export class TasksService extends BaseService<
     private readonly agentMessagesService: AgentMessagesService,
     private readonly agentRunsService: AgentRunsService,
     private readonly notificationsPublisher: NotificationsPublisherService,
+    private readonly taskCountersService: TaskCountersService,
+    private readonly organizationsService: OrganizationsService,
   ) {
     super(model, logger);
   }
@@ -596,19 +600,35 @@ export class TasksService extends BaseService<
       );
     }
 
+    const organizationId = task.organization?.toString();
+    const org = await this.organizationsService.findOne({
+      _id: new Types.ObjectId(organizationId),
+      isDeleted: false,
+    });
+
     return Promise.all(
-      followUpSteps.map((step) =>
-        this.create({
+      followUpSteps.map(async (step) => {
+        const taskNumber =
+          await this.taskCountersService.getNextNumber(organizationId);
+        const identifier = `${org?.prefix ?? 'TASK'}-${taskNumber}`;
+        return this.create({
           brand: task.brand?.toString(),
-          organization: task.organization?.toString(),
+          identifier,
+          organization: organizationId,
           outputType: step.outputType ?? task.outputType,
           platforms: task.platforms,
           priority: task.priority,
           request: step.request,
+          taskNumber,
           title: step.title,
           user: userId,
-        } as CreateTaskDto & { organization: string; user: string }),
-      ),
+        } as CreateTaskDto & {
+          identifier: string;
+          organization: string;
+          taskNumber: number;
+          user: string;
+        });
+      }),
     );
   }
 
@@ -727,7 +747,8 @@ export class TasksService extends BaseService<
     const executionPathUsed =
       taskIntent.outputType === 'image'
         ? 'image_generation'
-        : taskIntent.outputType === 'video'
+        : taskIntent.outputType === 'video' ||
+            taskIntent.outputType === 'facecam'
           ? 'video_generation'
           : taskIntent.outputType === 'caption' ||
               taskIntent.outputType === 'post' ||
@@ -784,6 +805,20 @@ export class TasksService extends BaseService<
           reviewTriggered: false,
           routingSummary:
             'Detected a short-form video request and routed it to the video generation path.',
+          skillsUsed: [],
+          skillVariantIds: [],
+          status: 'in_progress',
+        };
+      case 'facecam':
+        return {
+          chosenModel: 'auto',
+          chosenProvider: 'genfeed-router',
+          executionPathUsed: 'video_generation',
+          outputType: 'facecam',
+          reviewState: 'none',
+          reviewTriggered: false,
+          routingSummary:
+            'Detected a facecam video request and routed it to the video generation path.',
           skillsUsed: [],
           skillVariantIds: [],
           status: 'in_progress',
@@ -1243,6 +1278,7 @@ export class TasksService extends BaseService<
     if (!value) return null;
     return [
       'caption',
+      'facecam',
       'image',
       'ingredient',
       'newsletter',

--- a/apps/server/api/src/services/sync/sync.service.ts
+++ b/apps/server/api/src/services/sync/sync.service.ts
@@ -123,14 +123,25 @@ export class SyncService {
     let remoteResponse: { id: string };
     try {
       const { data } = await firstValueFrom(
-        this.httpService.post<{ id: string }>(importUrl, rewrittenFormat, {
-          headers: {
-            Authorization: `Bearer ${clerkToken}`,
-            'Content-Type': 'application/json',
+        this.httpService.post<{ data?: { id?: string } } | { id: string }>(
+          importUrl,
+          rewrittenFormat,
+          {
+            headers: {
+              Authorization: `Bearer ${clerkToken}`,
+              'Content-Type': 'application/json',
+            },
           },
-        }),
+        ),
       );
-      remoteResponse = data;
+      // /workflows/import returns JSON:API format: { data: { id, type, attributes } }
+      const remoteId =
+        (data as { data?: { id?: string } })?.data?.id ??
+        (data as { id?: string })?.id;
+      if (!remoteId) {
+        throw new Error('Import response missing workflow id');
+      }
+      remoteResponse = { id: remoteId };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error('Failed to push workflow to cloud', {

--- a/apps/server/api/src/services/task-orchestration/workspace-task.processor.ts
+++ b/apps/server/api/src/services/task-orchestration/workspace-task.processor.ts
@@ -1,5 +1,6 @@
 import { TasksService } from '@api/collections/tasks/services/tasks.service';
 import { AvatarVideoGenerationService } from '@api/collections/videos/services/avatar-video-generation.service';
+import { ConfigService } from '@api/config/config.service';
 import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
 import { TaskOrchestratorService } from '@api/services/task-orchestration/task-orchestrator.service';
 import { WorkspaceTaskJobData } from '@api/services/task-orchestration/workspace-task-queue.service';
@@ -29,6 +30,7 @@ export class WorkspaceTaskProcessor extends WorkerHost {
     private readonly avatarVideoGenerationService: AvatarVideoGenerationService,
     @Inject(forwardRef(() => HeygenPollQueueService))
     private readonly heygenPollQueueService: HeygenPollQueueService,
+    private readonly configService: ConfigService,
   ) {
     super();
   }
@@ -210,10 +212,8 @@ export class WorkspaceTaskProcessor extends WorkerHost {
     // back to /v1/webhooks/heygen/callback. Localhost / self-hosted
     // deployments don't, so we schedule a poll fallback that hits
     // HeygenAvatarProvider.getStatus until terminal.
-    const webhookConfigured = Boolean(
-      process.env.GENFEEDAI_WEBHOOKS_URL &&
-        process.env.GENFEEDAI_WEBHOOKS_URL.length > 0,
-    );
+    const webhooksUrl = this.configService.get('GENFEEDAI_WEBHOOKS_URL');
+    const webhookConfigured = Boolean(webhooksUrl && webhooksUrl.length > 0);
 
     if (!webhookConfigured) {
       this.logger.log(

--- a/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
+++ b/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
@@ -175,14 +175,19 @@ export class CronModelWatcherService {
       }
 
       // Step 6: Poll fal.ai for new models
-      await this.pollFalModels(summary, existingKeys);
+      const falSyncedKeys = await this.pollFalModels(summary, existingKeys);
 
       // Step 7: Poll HuggingFace for new models
-      await this.pollHuggingFaceModels(summary, existingKeys);
+      const hfSyncedKeys = await this.pollHuggingFaceModels(
+        summary,
+        existingKeys,
+      );
 
       // Step 8: Touch lastSyncedAt for all previously discovered models seen in this run
       const syncedKeys = [
         ...officialModels.map((m) => `${m.owner}/${m.name}`),
+        ...falSyncedKeys,
+        ...hfSyncedKeys,
       ].filter((k) => existingKeys.has(k));
       await this.modelDiscoveryService.touchLastSyncedAt(syncedKeys);
 
@@ -292,12 +297,12 @@ export class CronModelWatcherService {
   private async pollFalModels(
     summary: IModelDiscoveryRunSummary,
     existingKeys: Set<string>,
-  ): Promise<void> {
+  ): Promise<string[]> {
     const context = `${this.constructorName} pollFalModels`;
 
     if (!this.falDiscoveryService.isConfigured()) {
       this.logger.log(`${context} skipped — FAL_API_KEY not configured`);
-      return;
+      return [];
     }
 
     try {
@@ -308,6 +313,10 @@ export class CronModelWatcherService {
         `${context} polled ${falModels.length} models from fal.ai`,
       );
 
+      const syncedKeys = falModels
+        .filter((m) => m.key && existingKeys.has(m.key))
+        .map((m) => m.key as string);
+
       const newFalModels = falModels.filter(
         (m) => m.key && !existingKeys.has(m.key),
       );
@@ -315,7 +324,7 @@ export class CronModelWatcherService {
 
       if (newFalModels.length === 0) {
         this.logger.log(`${context} no new fal.ai models discovered`);
-        return;
+        return syncedKeys;
       }
 
       this.logger.log(
@@ -366,8 +375,11 @@ export class CronModelWatcherService {
           );
         }
       }
+
+      return syncedKeys;
     } catch (error: unknown) {
       this.logger.error(`${context} fal.ai polling failed`, error);
+      return [];
     }
   }
 
@@ -442,7 +454,7 @@ export class CronModelWatcherService {
   private async pollHuggingFaceModels(
     summary: IModelDiscoveryRunSummary,
     existingKeys: Set<string>,
-  ): Promise<void> {
+  ): Promise<string[]> {
     const context = `${this.constructorName} pollHuggingFaceModels`;
 
     try {
@@ -453,6 +465,10 @@ export class CronModelWatcherService {
         `${context} polled ${hfModels.length} models from HuggingFace`,
       );
 
+      const syncedKeys = hfModels
+        .filter((m) => m.key && existingKeys.has(m.key))
+        .map((m) => m.key as string);
+
       const newHfModels = hfModels.filter(
         (m) => m.key && !existingKeys.has(m.key),
       );
@@ -460,7 +476,7 @@ export class CronModelWatcherService {
 
       if (newHfModels.length === 0) {
         this.logger.log(`${context} no new HuggingFace models discovered`);
-        return;
+        return syncedKeys;
       }
 
       this.logger.log(
@@ -507,8 +523,11 @@ export class CronModelWatcherService {
           );
         }
       }
+
+      return syncedKeys;
     } catch (error: unknown) {
       this.logger.error(`${context} HuggingFace polling failed`, error);
+      return [];
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes 7 actionable PR review comments from CodeRabbit/Codex across PRs #153–#158.

- **Fix 1** — `createFollowUpTasks`: inject `TaskCountersService` + `OrganizationsService`, generate `identifier` and `taskNumber` per follow-up step (both required by schema, were missing)
- **Fix 2** — `task.schema.ts`: add `linkedIssueId` field — was serialized and used in frontend but silently dropped by Mongoose on save
- **Fix 3** — `buildFallbackRoutingDecision` + `buildSkillDrivenDecision`: add `facecam` case routing to `video_generation` path (both methods lacked it)
- **Fix 4** — `normalizeOutputType`: add `facecam` to valid output type list
- **Fix 5** — `workspace-task.processor`: replace `process.env.GENFEEDAI_WEBHOOKS_URL` with injected `ConfigService` (NestJS pattern)
- **Fix 6** — `cron.model-watcher`: `pollFalModels`/`pollHuggingFaceModels` now return existing keys so `syncedKeys` includes Fal/HF models in `touchLastSyncedAt`
- **Fix 7** — `sync.service.ts`: unwrap JSON:API `{ data: { id } }` envelope from `/workflows/import` response (confirmed runtime bug — `remoteResponse.id` was always undefined)

## Test plan

- [ ] Type-check passes: `bunx turbo type-check --filter=@genfeedai/api --filter=@genfeedai/workers`
- [ ] Biome clean: `npx biome check .`
- [ ] Follow-up tasks created via workspace planner have valid `identifier` (e.g. `ORG-42`) and `taskNumber`
- [ ] `linkedIssueId` persists in MongoDB after task save
- [ ] Facecam tasks route to `video_generation` path, not `agent_orchestrator`
- [ ] `GENFEEDAI_WEBHOOKS_URL` is read from config (not process.env) in facecam dispatch
- [ ] Model watcher syncs Fal/HF existing models' `lastSyncedAt` correctly
- [ ] Workflow push to cloud correctly reads `remoteId` from JSON:API response