### PR TITLE
fix(proxy): narrow LOCAL mode OAuth redirect — platform callbacks must not redirect

### DIFF
--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -293,16 +293,20 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
   // Redirect root + all Clerk-dependent routes to the seeded default workspace.
   // SelfHostedSeedService always seeds org slug="default" and brand slug="default"
   // (apps/server/api/src/seeds/self-hosted-seed.service.ts:87,103).
-  // /login, /sign-up, /logout, /oauth/* render Clerk components — redirect them too.
+  // /login, /sign-up, /logout render Clerk components — redirect them.
+  // /oauth (bare) redirects, but /oauth/[platform] and /oauth/cli are integration
+  // callback pages that must NOT be redirected.
   if (!isCloudConnected) {
     const { pathname } = req.nextUrl;
     const redirectToWorkspace =
       pathname === '/' ||
       pathname.startsWith('/onboarding') ||
       pathname.startsWith('/login') ||
+      pathname.startsWith('/sign-in') ||
       pathname.startsWith('/sign-up') ||
       pathname.startsWith('/logout') ||
-      pathname.startsWith('/oauth');
+      pathname === '/oauth' ||
+      pathname === '/oauth/';
     if (redirectToWorkspace) {
       return NextResponse.redirect(
         new URL('/default/default/workspace/overview', req.url),


### PR DESCRIPTION
## Summary

- **Bug**: `pathname.startsWith('/oauth')` in the LOCAL (self-hosted, no Clerk) redirect block was redirecting ALL `/oauth/*` paths including integration OAuth callback pages to the default workspace — breaking OAuth integrations in self-hosted mode
- **Fix**: Narrow to exact match `pathname === '/oauth'` (the bare route that renders Clerk components) and exclude all sub-paths like `/oauth/[platform]` and `/oauth/cli`
- **Bonus**: Add `/sign-in` to the redirect list (was missing alongside `/sign-up`)

Fixes PR #154 CodeRabbit comment.

## Test plan

- [ ] Self-hosted mode: `/oauth` redirects to `/default/default/workspace/overview`
- [ ] Self-hosted mode: `/oauth/tiktok`, `/oauth/openai`, `/oauth/cli` do NOT redirect (fall through to `NextResponse.next()`)
- [ ] Cloud mode: no change in behavior
- [ ] Type-check passes: `bunx turbo type-check --filter=@genfeedai/app`