### PR TITLE
fix(config/workers): HEDRA_URL allow empty, text-to-music discovery, publish clean-tree guard

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     env:
       PACKAGE_RELEASE_OUTPUT: .package-release-output.json
     steps:
@@ -48,18 +49,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-
-      - name: Configure npm auth
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NPM_TOKEN}" ]; then
-            echo "NPM_TOKEN is required"
-            exit 1
-          fi
-          cat <<EOF > ~/.npmrc
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-          EOF
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/apps/server/workers/src/services/hugging-face-discovery.service.ts
+++ b/apps/server/workers/src/services/hugging-face-discovery.service.ts
@@ -37,6 +37,7 @@ const ALLOWED_PIPELINE_TAGS: ReadonlySet<string> = new Set([
   'image-to-video',
   'text-to-video',
   'text-to-audio',
+  'text-to-music',
   'text-to-speech',
   'automatic-speech-recognition',
   'text-generation',

--- a/packages/config/src/schemas/ai.schema.ts
+++ b/packages/config/src/schemas/ai.schema.ts
@@ -70,7 +70,7 @@ export const heygenSchema = {
  */
 export const hedraSchema = {
   HEDRA_KEY: Joi.string().optional().allow(''),
-  HEDRA_URL: Joi.string().uri().optional(),
+  HEDRA_URL: Joi.string().uri().optional().allow(''),
 };
 
 /**

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -64,6 +64,12 @@ fi
 
 echo "=== Publishing $PKG_NAME ==="
 
+# Ensure clean working tree before publishing
+if ! git diff-index --quiet HEAD --; then
+  echo "Error: Working tree must be clean before publishing."
+  exit 1
+fi
+
 # Build first
 echo "Building $PKG_NAME..."
 cd "$PKG_DIR"
@@ -116,10 +122,10 @@ echo "Version: $VERSION"
 # Publish with bun (resolves workspace:* → real versions)
 if [ "$DRY_RUN" = true ]; then
   echo "Dry-run publishing $PKG_NAME@$VERSION..."
-  bun publish --access public --dry-run
+  bun publish --access public --provenance --dry-run
 else
   echo "Publishing $PKG_NAME@$VERSION..."
-  bun publish --access public
+  bun publish --access public --provenance
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

3 quality/config fixes from PR review comments (#134, #156, #158).

- **Fix 9** — `ai.schema.ts`: `HEDRA_URL` now accepts empty string — without `.allow('')`, Joi rejects `HEDRA_URL=''` in self-hosted deployments that don't use Hedra
- **Fix 11** — `hugging-face-discovery.service.ts`: add `'text-to-music'` to `ALLOWED_PIPELINE_TAGS` — `inferCategory` had a `case 'text-to-music': return ModelCategory.MUSIC` that was unreachable because the allowlist filtered it out before calling the method
- **Fix 12** — `scripts/publish-package.sh`: add `git diff-index --quiet HEAD` guard before publish so dirty working trees are rejected; also add `--provenance` flag to `bun publish`
- **Fix 12b** — `.github/workflows/publish-packages.yml`: grant `id-token: write` permission for npm provenance OIDC; remove manual `NPM_TOKEN` npmrc step (superseded by provenance auth)

## Test plan

- [ ] `HEDRA_URL=''` in env no longer fails config validation on startup
- [ ] HuggingFace discovery now includes `text-to-music` models (e.g., MusicGen)
- [ ] Running `./scripts/publish-package.sh` on a dirty working tree exits with error
- [ ] Running on a clean tree proceeds to build and publish
- [ ] Typecheck passes: `bunx turbo type-check --filter=@genfeedai/workers --filter=@genfeedai/config`