### PR TITLE
fix(build): unblock CI — TS6 ignoreDeprecations, storage tsconfig, files missing dep

### DIFF
--- a/apps/server/files/package.json
+++ b/apps/server/files/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "@genfeedai/config": "workspace:*",
-    "@genfeedai/enums": "workspace:*"
+    "@genfeedai/enums": "workspace:*",
+    "@genfeedai/storage": "workspace:*"
   },
   "description": "Genfeed Files Service",
   "devDependencies": {},

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2022"],

--- a/packages/prompts/tsconfig.json
+++ b/packages/prompts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
@@ -13,7 +14,8 @@
     "rootDir": "./src",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2022",
+    "types": ["node"]
   },
   "exclude": ["dist", "node_modules", "__tests__"],
   "include": ["src/**/*"]

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,12 +1,19 @@
 {
-  "extends": "@genfeedai/tsconfig/base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
     "sourceMap": true,
+    "strict": true,
+    "target": "es2022",
     "types": ["node"]
   },
+  "exclude": ["dist", "node_modules"],
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Pre-existing CI failures on develop — none introduced by open PRs.

- **`@genfeedai/errors` + `@genfeedai/prompts` build** — tsup bundles TypeScript 6.0 which deprecates `baseUrl`. Added `"ignoreDeprecations": "6.0"` to both tsconfigs. (`packages/core` already had this.)
- **`@genfeedai/prompts` DTS** — missing `"types": ["node"]` caused `Cannot find name 'node:fs'` in registry.ts. Added to tsconfig.
- **`@genfeedai/storage` tsconfig** — was extending `@genfeedai/tsconfig/base.json` which isn't linked in node_modules for this package. Inlined the options directly.
- **`@genfeedai/files` missing dep** — `upload.module.ts` imports `@genfeedai/storage` but it wasn't in `package.json`. Added `workspace:*`.

## Test plan

- [x] `bunx turbo build --filter='./packages/*'` — 24/24 success
- [x] `bun run test --filter=@genfeedai/files` — 219/219 passed