### PR TITLE
fix(test): remove extra expect.anything() from AbortError logger assertion

### DIFF
--- a/apps/server/workers/src/services/hugging-face-discovery.service.spec.ts
+++ b/apps/server/workers/src/services/hugging-face-discovery.service.spec.ts
@@ -223,7 +223,6 @@ describe('HuggingFaceDiscoveryService', () => {
       // No crash, errors logged
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('timed out'),
-        expect.anything(),
       );
       // Still returns whatever other tags produced
       expect(Array.isArray(models)).toBe(true);


### PR DESCRIPTION
The AbortError branch in `HuggingFaceDiscoveryService` calls `logger.error(message)` with one argument. The test was asserting `toHaveBeenCalledWith(stringContaining('timed out'), expect.anything())` — the second `expect.anything()` doesn't match `undefined`, so it always fails.

Removed the extra matcher. The message still asserts the correct content.