### PR TITLE
fix(packages): add license + repository fields to workflow-engine and workflow-saas for npm publish

### DIFF
--- a/packages/workflow-engine/package.json
+++ b/packages/workflow-engine/package.json
@@ -54,6 +54,7 @@
     "src"
   ],
   "main": "./dist/index.js",
+  "license": "AGPL-3.0",
   "name": "@genfeedai/workflow-engine",
   "publishConfig": {
     "access": "public",
@@ -65,6 +66,11 @@
     "dev": "tsc --watch",
     "prepublishOnly": "bun run build",
     "test": "vitest run"
+  },
+  "repository": {
+    "directory": "workflow-engine",
+    "type": "git",
+    "url": "git+https://github.com/genfeedai/packages.git"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/packages/workflow-saas/package.json
+++ b/packages/workflow-saas/package.json
@@ -35,6 +35,7 @@
     "src"
   ],
   "main": "./dist/index.js",
+  "license": "AGPL-3.0",
   "name": "@genfeedai/workflow-saas",
   "publishConfig": {
     "access": "public",
@@ -45,6 +46,11 @@
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",
     "prepublishOnly": "bun run build"
+  },
+  "repository": {
+    "directory": "workflow-saas",
+    "type": "git",
+    "url": "git+https://github.com/genfeedai/packages.git"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds missing `license` and `repository` fields to workflow-engine and workflow-saas package.json so the publish script policy check passes.