### PR TITLE
[codex] Fix CI lockfile and test resolution issues

### DIFF
--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -1,0 +1,54 @@
+name: Setup Bun Environment
+description: Standardize Node, Bun, and cache setup for GitHub Actions jobs.
+
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: '22.x'
+  bun-version:
+    description: Bun version to install
+    required: false
+    default: '1.3.11'
+  install-command:
+    description: Dependency install command to run after toolchain setup
+    required: false
+    default: 'bun install --frozen-lockfile'
+  cache-turbo:
+    description: Whether to cache the local Turbo directory
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Cache bun modules
+      uses: actions/cache@v5
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Cache Turbo
+      if: ${{ inputs.cache-turbo == 'true' }}
+      uses: actions/cache@v5
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
+    - name: Install dependencies
+      shell: bash
+      run: ${{ inputs.install-command }}

--- a/apps/app/app/layout.test.tsx
+++ b/apps/app/app/layout.test.tsx
@@ -66,7 +66,7 @@ describe('app root layout', () => {
       } as never),
     );
 
-    expect(screen.getByText('App child')).toBeInTheDocument();
+    expect(screen.getByText('App child')).toBeTruthy();
     expect(appProvidersSpy).toHaveBeenCalledTimes(1);
     expect(appProvidersSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/vitest.config.mts
+++ b/apps/vitest.config.mts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
@@ -7,7 +8,10 @@ import {
 } from '../configs/vitest-warning-filter';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const appRoot = path.resolve(__dirname, './app');
+const appRoot = process.cwd();
+const localUiRoot = path.resolve(appRoot, './packages/ui');
+const hasLocalUiRoot = fs.existsSync(localUiRoot);
+const sharedUiRoot = path.resolve(__dirname, '../packages/ui/src/components');
 installVitestWarningFilter();
 const customLogger = createVitestWarningLogger();
 
@@ -29,6 +33,36 @@ export default defineConfig({
         replacement: path.resolve(appRoot, './packages/server'),
       },
       {
+        find: /^@genfeedai\/constants$/,
+        replacement: path.resolve(
+          __dirname,
+          '../packages/constants/dist/index.js',
+        ),
+      },
+      {
+        find: /^@genfeedai\/constants\/(.*)$/,
+        replacement: path.resolve(
+          __dirname,
+          '../packages/constants/dist/$1.js',
+        ),
+      },
+      {
+        find: /^@genfeedai\/fonts$/,
+        replacement: path.resolve(__dirname, '../packages/fonts/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/fonts\/(.*)$/,
+        replacement: path.resolve(__dirname, '../packages/fonts/$1'),
+      },
+      {
+        find: /^@genfeedai\/enums$/,
+        replacement: path.resolve(__dirname, '../packages/enums/dist/index.js'),
+      },
+      {
+        find: /^@genfeedai\/enums\/(.*)$/,
+        replacement: path.resolve(__dirname, '../packages/enums/dist/$1.js'),
+      },
+      {
         find: '@contexts',
         replacement: path.resolve(__dirname, '../packages/contexts'),
       },
@@ -38,6 +72,17 @@ export default defineConfig({
       },
       {
         find: /^@helpers\/(.*)$/,
+        replacement: path.resolve(__dirname, '../packages/helpers/src/$1'),
+      },
+      {
+        find: /^@genfeedai\/helpers$/,
+        replacement: path.resolve(
+          __dirname,
+          '../packages/helpers/src/index.ts',
+        ),
+      },
+      {
+        find: /^@genfeedai\/helpers\/(.*)$/,
         replacement: path.resolve(__dirname, '../packages/helpers/src/$1'),
       },
       {
@@ -57,8 +102,106 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../packages/services'),
       },
       {
+        find: '@public',
+        replacement: path.resolve(appRoot, './app/(public)'),
+      },
+      {
+        find: /^@public\/(.*)$/,
+        replacement: path.resolve(appRoot, './app/(public)/$1'),
+      },
+      {
+        find: '@protected',
+        replacement: path.resolve(appRoot, './app/(protected)'),
+      },
+      {
+        find: /^@protected\/(.*)$/,
+        replacement: path.resolve(appRoot, './app/(protected)/$1'),
+      },
+      {
+        find: '@pages',
+        replacement: path.resolve(appRoot, './src/page-modules'),
+      },
+      {
+        find: /^@pages\/(.*)$/,
+        replacement: path.resolve(appRoot, './src/page-modules/$1'),
+      },
+      {
+        find: '@website',
+        replacement: appRoot,
+      },
+      {
+        find: /^@website\/(.*)$/,
+        replacement: `${appRoot}/$1`,
+      },
+      {
+        find: '@web-components',
+        replacement: path.resolve(appRoot, './packages/components'),
+      },
+      {
+        find: /^@web-components\/(.*)$/,
+        replacement: path.resolve(appRoot, './packages/components/$1'),
+      },
+      {
+        find: '@styles',
+        replacement: path.resolve(__dirname, '../packages/styles'),
+      },
+      {
+        find: /^@styles\/(.*)$/,
+        replacement: path.resolve(__dirname, '../packages/styles/$1'),
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, '../tests'),
+      },
+      {
+        find: /^@shared\/(.*)$/,
+        replacement: path.resolve(__dirname, '../tests/$1'),
+      },
+      ...(hasLocalUiRoot
+        ? [
+            {
+              find: '@ui/providers',
+              replacement: path.resolve(localUiRoot, './providers'),
+            },
+            {
+              find: /^@ui\/providers\/(.*)$/,
+              replacement: path.resolve(localUiRoot, './providers/$1'),
+            },
+            {
+              find: '@ui/marketing/PricingStrip',
+              replacement: path.resolve(
+                localUiRoot,
+                './marketing/PricingStrip.tsx',
+              ),
+            },
+            {
+              find: '@ui/workflow-builder',
+              replacement: path.resolve(localUiRoot, './workflow-builder'),
+            },
+            {
+              find: /^@ui\/workflow-builder\/(.*)$/,
+              replacement: path.resolve(localUiRoot, './workflow-builder/$1'),
+            },
+          ]
+        : []),
+      {
+        find: '@ui/primitives',
+        replacement: path.resolve(__dirname, '../packages/ui/src/primitives'),
+      },
+      {
+        find: /^@ui\/primitives\/(.*)$/,
+        replacement: path.resolve(
+          __dirname,
+          '../packages/ui/src/primitives/$1',
+        ),
+      },
+      {
+        find: /^@ui\/(.*)$/,
+        replacement: `${sharedUiRoot}/$1`,
+      },
+      {
         find: '@ui',
-        replacement: path.resolve(__dirname, '../packages/ui'),
+        replacement: sharedUiRoot,
       },
       {
         find: '@ui-constants',
@@ -73,8 +216,8 @@ export default defineConfig({
         replacement: path.resolve(__dirname, './app/tests/server-only.stub.ts'),
       },
       {
-        find: '@/',
-        replacement: `${appRoot}/`,
+        find: /^@\//,
+        replacement: `${appRoot}/src/`,
       },
     ],
   },
@@ -83,6 +226,7 @@ export default defineConfig({
     exclude: ['**/node_modules/**'],
     globals: true,
     include: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
+    setupFiles: [path.resolve(appRoot, './vitest.setup.ts')],
     testTimeout: 15_000,
   },
 });

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -42,6 +42,8 @@
   },
   "version": "1.0.0",
   "devDependencies": {
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/apps/website/vitest.setup.ts
+++ b/apps/website/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "files": {
     "includes": [
       "**",
@@ -18,6 +18,8 @@
       "!**/bun.lock",
       "!**/.env",
       "!**/.env.*",
+      "!**/.agents",
+      "!**/.agents/**",
       "!.agents",
       "!.worktrees",
       "!.shipcode"

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "genfeed.ai",
       "dependencies": {
-        "@ai-sdk/anthropic": "3.0.68",
+        "@ai-sdk/anthropic": "3.0.69",
         "@ai-sdk/openai": "3.0.52",
         "@ai-sdk/react": "3.0.160",
         "@aws-sdk/client-s3": "3.1029.0",
         "@aws-sdk/lib-storage": "3.1029.0",
         "@aws-sdk/s3-request-presigner": "3.1029.0",
-        "@bull-board/api": "6.21.0",
-        "@bull-board/express": "6.21.0",
+        "@bull-board/api": "6.21.1",
+        "@bull-board/express": "6.21.1",
         "@clerk/backend": "3.2.8",
         "@clerk/nextjs": "7.0.12",
         "@clerk/themes": "2.4.57",
@@ -69,7 +69,7 @@
         "archiver": "7.0.1",
         "axios": "1.15.0",
         "bcrypt": "6.0.0",
-        "bullmq": "5.73.4",
+        "bullmq": "5.73.5",
         "cache-manager": "7.2.8",
         "cheerio": "1.2.0",
         "class-transformer": "0.5.1",
@@ -81,7 +81,7 @@
         "cron": "4.4.0",
         "date-fns": "4.1.0",
         "discord.js": "14.26.2",
-        "dotenv": "17.4.1",
+        "dotenv": "17.4.2",
         "exceljs": "4.4.0",
         "express": "5.2.1",
         "express-rate-limit": "8.3.2",
@@ -257,7 +257,7 @@
         "@genfeedai/desktop-shell": "workspace:*",
         "@genfeedai/enums": "workspace:*",
         "@sentry/browser": "10.48.0",
-        "better-sqlite3": "12.8.0",
+        "better-sqlite3": "12.9.0",
         "next": "16.2.3",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -400,7 +400,7 @@
       "name": "@genfeedai/api",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.87.0",
+        "@anthropic-ai/sdk": "0.88.0",
         "@aws-sdk/client-cloudfront": "3.1029.0",
         "@aws-sdk/client-ec2": "3.1029.0",
         "@genfeedai/config": "workspace:*",
@@ -561,6 +561,8 @@
         "tailwind-merge": "3.5.0",
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/react": "16.3.2",
         "@types/node": "25.6.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
@@ -675,7 +677,7 @@
       "name": "@genfeedai/config",
       "version": "1.0.0",
       "dependencies": {
-        "dotenv": "17.4.1",
+        "dotenv": "17.4.2",
         "joi": "18.1.2",
       },
       "devDependencies": {
@@ -940,6 +942,7 @@
         "ts-jsonapi": "2.1.3",
       },
       "devDependencies": {
+        "tsc-alias": "1.8.16",
         "typescript": "6.0.2",
       },
     },
@@ -1176,7 +1179,7 @@
 
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.68", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.69", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.95", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ=="],
 
@@ -1198,7 +1201,7 @@
 
     "@angular-devkit/schematics-cli": ["@angular-devkit/schematics-cli@19.2.24", "", { "dependencies": { "@angular-devkit/core": "19.2.24", "@angular-devkit/schematics": "19.2.24", "@inquirer/prompts": "7.3.2", "ansi-colors": "4.1.3", "symbol-observable": "4.0.0", "yargs-parser": "21.1.1" }, "bin": { "schematics": "bin/schematics.js" } }, "sha512-bsStZQG67J1HBqTmWxtIcobvgrn32L4UOdL7hGyOru5VxDWPNA8pRnDYavT3hnJeBkJYPoQIw8u7Dm0ecoQprw=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.87.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.88.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw=="],
 
     "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
 
@@ -1510,11 +1513,11 @@
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
-    "@bull-board/api": ["@bull-board/api@6.21.0", "", { "dependencies": { "redis-info": "^3.1.0" }, "peerDependencies": { "@bull-board/ui": "6.21.0" } }, "sha512-5bX3U8baU4OulDLeXwqWI6/FZolpi1APfoJVXndR4fKdmuYr9cdbH8cg7juublfzX01T+3zoiZkveX7iD5y8gA=="],
+    "@bull-board/api": ["@bull-board/api@6.21.1", "", { "dependencies": { "redis-info": "^3.1.0" }, "peerDependencies": { "@bull-board/ui": "6.21.1" } }, "sha512-F3R1rx3e2qtlEc4t/PjAtDxt6hEaMFUWFnKRxQk6Ymzh8Z0ec0wT/QdmqSuP3KL41NVPYNnd8uR1JsqB3ySGkA=="],
 
-    "@bull-board/express": ["@bull-board/express@6.21.0", "", { "dependencies": { "@bull-board/api": "6.21.0", "@bull-board/ui": "6.21.0", "ejs": "^3.1.10", "express": "^5.2.1" } }, "sha512-es5UhfDvF6YOa34mKUWUmopxmcLbNNCx5SlgeeyWQgs6WkMqahZ5kve7YCgclQomHdsycJIL3wCktXnTEQ6wRg=="],
+    "@bull-board/express": ["@bull-board/express@6.21.1", "", { "dependencies": { "@bull-board/api": "6.21.1", "@bull-board/ui": "6.21.1", "ejs": "^3.1.10", "express": "^5.2.1" } }, "sha512-G1gv3xYVO81k6nqNugMxiGw1ybccRPJlGyEJk2qTuQVox1IMlAt/Y830H/E/FCVV173eJoJClJI/6m5xL1kJ4Q=="],
 
-    "@bull-board/ui": ["@bull-board/ui@6.21.0", "", { "dependencies": { "@bull-board/api": "6.21.0" } }, "sha512-SemKRipdrZVqboae/Xhl7CTdIwWJ+F3G/DEP7XHi1Qt1kXZUIKJkySXlFHILunygCiHRpCJ6/Ax/XNdHI/n3QA=="],
+    "@bull-board/ui": ["@bull-board/ui@6.21.1", "", { "dependencies": { "@bull-board/api": "6.21.1" } }, "sha512-t63WffBn3WzfOTTK7C6Ic+kJaohmlrMI65DtsvBIjyO/hmmbPQpgHCztRzg0wDEMEjvRJCPtHdVWENav0kAFAA=="],
 
     "@cacheable/utils": ["@cacheable/utils@2.4.1", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA=="],
 
@@ -3838,7 +3841,7 @@
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
-    "better-sqlite3": ["better-sqlite3@12.8.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ=="],
+    "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
@@ -3912,7 +3915,7 @@
 
     "builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
-    "bullmq": ["bullmq@5.73.4", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.10.1", "msgpackr": "1.11.5", "node-abort-controller": "3.1.1", "semver": "7.7.4", "tslib": "2.8.1", "uuid": "11.1.0" } }, "sha512-Q+NeFLtdKSD3GDPYSX4pH+Mc9E4OZVKimXwrnZ5WmndNy31COMy4vQV9zfhgfHGSUFrlpsBicfKYbSjx9FbO+A=="],
+    "bullmq": ["bullmq@5.73.5", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.10.1", "msgpackr": "1.11.5", "node-abort-controller": "3.1.1", "semver": "7.7.4", "tslib": "2.8.1", "uuid": "11.1.0" } }, "sha512-bZu3t1c/1smbA8Jk46OrLA4JRHPTv4uLbqUP0uaviV7S4c/rSl/qKmg3twgKKz+3aB4E0NL0jcjQW5eHwGyQOw=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
@@ -4286,7 +4289,7 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
-    "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
 
@@ -7085,6 +7088,8 @@
     "@nestjs/cli/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@nestjs/cli/webpack": ["webpack@5.106.0", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.16.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.28.1", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.20.0", "es-module-lexer": "^2.0.0", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.3.1", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.3", "tapable": "^2.3.0", "terser-webpack-plugin": "^5.3.17", "watchpack": "^2.5.1", "webpack-sources": "^3.3.4" }, "bin": { "webpack": "bin/webpack.js" } }, "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA=="],
+
+    "@nestjs/config/dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
 
     "@nestjs/schematics/@angular-devkit/core": ["@angular-devkit/core@19.2.23", "", { "dependencies": { "ajv": "8.18.0", "ajv-formats": "3.0.1", "jsonc-parser": "3.3.1", "picomatch": "4.0.4", "rxjs": "7.8.1", "source-map": "0.7.4" }, "peerDependencies": { "chokidar": "^4.0.0" }, "optionalPeers": ["chokidar"] }, "sha512-RazHPQkUEsNU/OZ75w9UeHxGFMthRiuAW2B/uA7eXExBj/1meHrrBfoCA56ujW2GUxVjRtSrMjylKh4R4meiYA=="],
 

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -29,6 +29,14 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../enums/src/$1'),
       },
       {
+        find: /^@genfeedai\/constants$/,
+        replacement: path.resolve(__dirname, '../constants/src/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/constants\/(.*)$/,
+        replacement: path.resolve(__dirname, '../constants/src/$1'),
+      },
+      {
         find: /^@genfeedai\/helpers$/,
         replacement: path.resolve(__dirname, '../helpers/src/index.ts'),
       },

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         replacement: path.resolve(__dirname, './tests/$1'),
       },
       {
-        find: '@genfeedai/agent',
+        find: /^@genfeedai\/agent$/,
         replacement: path.resolve(__dirname, './src'),
       },
       {
@@ -21,15 +21,23 @@ export default defineConfig({
         replacement: path.resolve(__dirname, './src/$1'),
       },
       {
-        find: '@genfeedai/helpers',
-        replacement: path.resolve(__dirname, '../helpers/src'),
+        find: /^@genfeedai\/enums$/,
+        replacement: path.resolve(__dirname, '../enums/src/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/enums\/(.*)$/,
+        replacement: path.resolve(__dirname, '../enums/src/$1'),
+      },
+      {
+        find: /^@genfeedai\/helpers$/,
+        replacement: path.resolve(__dirname, '../helpers/src/index.ts'),
       },
       {
         find: /^@genfeedai\/helpers\/(.*)$/,
         replacement: path.resolve(__dirname, '../helpers/src/$1'),
       },
       {
-        find: '@genfeedai/contexts',
+        find: /^@genfeedai\/contexts$/,
         replacement: path.resolve(__dirname, '../contexts'),
       },
       {
@@ -37,7 +45,7 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../contexts/$1'),
       },
       {
-        find: '@genfeedai/models',
+        find: /^@genfeedai\/models$/,
         replacement: path.resolve(__dirname, '../models'),
       },
       {
@@ -45,7 +53,7 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../models/$1'),
       },
       {
-        find: '@genfeedai/pages',
+        find: /^@genfeedai\/pages$/,
         replacement: path.resolve(__dirname, '../pages'),
       },
       {
@@ -53,7 +61,7 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../pages/$1'),
       },
       {
-        find: '@genfeedai/props',
+        find: /^@genfeedai\/props$/,
         replacement: path.resolve(__dirname, '../props'),
       },
       {
@@ -61,7 +69,7 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../props/$1'),
       },
       {
-        find: '@genfeedai/services',
+        find: /^@genfeedai\/services$/,
         replacement: path.resolve(__dirname, '../services'),
       },
       {
@@ -69,15 +77,15 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../services/$1'),
       },
       {
-        find: '@genfeedai/serializers',
-        replacement: path.resolve(__dirname, '../serializers/src'),
+        find: /^@genfeedai\/serializers$/,
+        replacement: path.resolve(__dirname, '../serializers/src/index.ts'),
       },
       {
         find: /^@serializers\/(.*)$/,
         replacement: path.resolve(__dirname, '../serializers/src/$1'),
       },
       {
-        find: '@genfeedai/utils',
+        find: /^@genfeedai\/utils$/,
         replacement: path.resolve(__dirname, '../utils'),
       },
       {

--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,10 +1,22 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
-    alias: {
-      '@': './src',
-    },
+    alias: [
+      {
+        find: /^@genfeedai\/serializers$/,
+        replacement: path.resolve(__dirname, '../serializers/src/index.ts'),
+      },
+      {
+        find: /^@serializers\/(.*)$/,
+        replacement: path.resolve(__dirname, '../serializers/src/$1'),
+      },
+      {
+        find: '@',
+        replacement: path.resolve(__dirname, './src'),
+      },
+    ],
   },
   test: {
     coverage: {

--- a/packages/hooks/vitest.config.mts
+++ b/packages/hooks/vitest.config.mts
@@ -12,6 +12,9 @@ const customLogger = createVitestWarningLogger();
 
 const SERIALIZERS_SRC = path.resolve(__dirname, '../serializers/src');
 const HELPERS_SRC = path.resolve(__dirname, '../helpers/src');
+const ENUMS_SRC = path.resolve(__dirname, '../enums/src');
+const CONSTANTS_SRC = path.resolve(__dirname, '../constants/src');
+const INTERFACES_SRC = path.resolve(__dirname, '../interfaces/src');
 const CLIENT_SERIALIZERS_MOCK = path.resolve(
   __dirname,
   '../services/__mocks__/client-serializers.mock.ts',
@@ -40,6 +43,38 @@ export default defineConfig({
       {
         find: /^@serializers\/(.*)$/,
         replacement: path.join(SERIALIZERS_SRC, '$1'),
+      },
+      {
+        find: /^@genfeedai\/constants$/,
+        replacement: path.join(CONSTANTS_SRC, 'index.ts'),
+      },
+      {
+        find: /^@genfeedai\/constants\/(.*)$/,
+        replacement: path.join(CONSTANTS_SRC, '$1'),
+      },
+      {
+        find: /^@genfeedai\/enums$/,
+        replacement: path.join(ENUMS_SRC, 'index.ts'),
+      },
+      {
+        find: /^@genfeedai\/enums\/(.*)$/,
+        replacement: path.join(ENUMS_SRC, '$1'),
+      },
+      {
+        find: /^@genfeedai\/helpers$/,
+        replacement: path.join(HELPERS_SRC, 'index.ts'),
+      },
+      {
+        find: /^@genfeedai\/helpers\/(.*)$/,
+        replacement: path.join(HELPERS_SRC, '$1'),
+      },
+      {
+        find: /^@genfeedai\/interfaces$/,
+        replacement: path.join(INTERFACES_SRC, 'index.ts'),
+      },
+      {
+        find: /^@genfeedai\/interfaces\/(.*)$/,
+        replacement: path.join(INTERFACES_SRC, '$1'),
       },
       {
         find: '@xyflow/react',

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Genfeed.ai canonical JSON:API serializers",
   "devDependencies": {
+    "tsc-alias": "1.8.16",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -38,7 +39,7 @@
     "url": "git+https://github.com/genfeedai/packages.git"
   },
   "scripts": {
-    "build": "tsc --build --force && if [ -d dist/src ]; then mv dist/src/* dist/ 2>/dev/null && rm -rf dist/src; fi",
+    "build": "tsc --build --force && bunx tsc-alias -p tsconfig.json && if [ -d dist/src ]; then mv dist/src/* dist/ 2>/dev/null && rm -rf dist/src; fi",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",


### PR DESCRIPTION
## What changed

- fixed CI/setup issues around Bun lockfile handling and the missing local GitHub Action
- repaired Vitest/path alias resolution across CLI, hooks, agent, and shared app/website test config
- added the missing `@genfeedai/constants` alias for agent tests and committed the final cleanup on top

## Why

Recent CI failures were caused by a mix of broken test/module resolution and workflow setup gaps, which blocked the monorepo checks before product-level regressions were even visible.

## Validation

- `bun run format:check`
- `bunx turbo lint`
- `bun type-check`
- `bun run build`
- `bun run --filter=@genfeedai/agent test src/components/GenerationActionCard.spec.tsx`
- `bun run test` (still failing in app/ui/api packages; see notes below)

## Remaining blockers

- full repo-wide tests are still not green
- current failing areas include `@genfeedai/app`, `@genfeedai/ui`, and `@genfeedai/api` behavioral/spec regressions unrelated to the final agent alias cleanup
- examples observed in the full run include Automation overview, logout/onboarding flows, prompt bar UI, and image operations controller tests
