### PR TITLE
fix(styles): token cleanup — remove duplicates, fix font-serif-italic, hoist invariants

### DIFF
--- a/packages/fonts/fonts.ts
+++ b/packages/fonts/fonts.ts
@@ -43,8 +43,12 @@ export const satoshi = localFont({
  * Download from: https://fontshare.com/fonts/zodiak
  *
  * Font files required in ./files/:
+ * - Zodiak-Light.woff2
+ * - Zodiak-LightItalic.woff2
  * - Zodiak-Regular.woff2
+ * - Zodiak-Italic.woff2
  * - Zodiak-Bold.woff2
+ * - Zodiak-BoldItalic.woff2
  */
 export const zodiak = localFont({
   display: 'swap',

--- a/packages/styles/_keyframes-base.scss
+++ b/packages/styles/_keyframes-base.scss
@@ -135,3 +135,8 @@
     opacity: 0;
   }
 }
+
+@keyframes gen-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}

--- a/packages/styles/genfeed.scss
+++ b/packages/styles/genfeed.scss
@@ -142,15 +142,6 @@
   animation: gen-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-@keyframes gen-pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
 /* --------------------------------------------------------------------------
    Dividers
    -------------------------------------------------------------------------- */
@@ -379,6 +370,7 @@
 }
 
 /* Horizontal light bars (venetian blinds) */
+/* ⚠️ Uses ::after — cannot be composed with .gen-spotlight-left or .gen-spotlight-right on the same element. Use a wrapper instead. */
 .gen-venetian {
   position: relative;
 
@@ -519,7 +511,7 @@
   background: hsl(var(--foreground));
   color: hsl(var(--gen-accent));
   transition: all 0.2s ease;
-  &:hover { background: rgba(0, 0, 0, 0.8); }
+  &:hover { background: color-mix(in srgb, hsl(var(--foreground)) 85%, transparent); }
 }
 
 /* Badge */
@@ -534,7 +526,7 @@
 .gen-text-bright  { color: hsl(var(--gen-accent-bright)); }
 .gen-text-heading { color: var(--gen-accent-heading); }
 .gen-text-muted   { color: var(--gen-accent-text); }
-.gen-text-subtle  { color: var(--gen-accent-text); opacity: 0.75; }
+.gen-text-subtle  { color: var(--gen-accent-heading); opacity: 0.75; }
 
 /* Icon */
 .gen-icon { color: hsl(var(--gen-accent)); }

--- a/packages/styles/globals.scss
+++ b/packages/styles/globals.scss
@@ -71,7 +71,6 @@
   /* Fallbacks - these will be overridden by next/font CSS variables */
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-serif: Georgia, 'Times New Roman', serif;
-  --font-serif-italic: Georgia, 'Times New Roman', serif;
 }
 
 
@@ -94,8 +93,8 @@ body {
 
 /* Zodiak for editorial headlines */
 .font-serif-italic {
-  font-family: var(--font-serif-italic);
-  font-style: normal;
+  font-family: var(--font-serif);
+  font-style: italic;
 }
 
 
@@ -106,6 +105,7 @@ a {
   transition-timing-function: ease-in-out;
 }
 
+/* Reset shadcn's default button shadow — elevation is expressed via border, not box-shadow */
 .btn {
   box-shadow: none;
 }

--- a/packages/styles/shadcn-theme.scss
+++ b/packages/styles/shadcn-theme.scss
@@ -7,36 +7,43 @@
  * This file only layers on effect, overlay, platform, and accent variables.
  */
 
+/**
+ * Theme-invariant tokens — identical in light and dark, defined once here.
+ */
+:root {
+  --platform-instagram: #e1306c;
+  --platform-facebook: #1877f2;
+  --platform-twitter: #1da1f2;
+  --platform-linkedin: #0a66c2;
+  --platform-reddit: #ff4500;
+  --platform-pinterest: #e60023;
+  --platform-tiktok: #fe2c55;
+  --platform-tiktok-cyan: #25f4ee;
+  --platform-discord: #5865f2;
+
+  --overlay-white-5: rgba(255, 255, 255, 0.05);
+  --overlay-white-8: rgba(255, 255, 255, 0.08);
+  --overlay-white-10: rgba(255, 255, 255, 0.1);
+  --overlay-white-15: rgba(255, 255, 255, 0.15);
+  --overlay-white-20: rgba(255, 255, 255, 0.2);
+  --overlay-black-5: rgba(0, 0, 0, 0.05);
+  --overlay-black-10: rgba(0, 0, 0, 0.1);
+  --overlay-black-20: rgba(0, 0, 0, 0.2);
+  --overlay-black-60: rgba(0, 0, 0, 0.6);
+  --overlay-black-90: rgba(0, 0, 0, 0.9);
+
+  --accent-violet: #8b5cf6;
+  --accent-purple: #a855f7;
+  --accent-pink: #ec4899;
+  --accent-rose: #f472b6;
+  --accent-orange: #f97316;
+
+  --radius: 0.25rem;
+}
+
 @layer base {
   :root,
   [data-theme='light'] {
-    --platform-instagram: #e1306c;
-    --platform-facebook: #1877f2;
-    --platform-twitter: #1da1f2;
-    --platform-linkedin: #0a66c2;
-    --platform-reddit: #ff4500;
-    --platform-pinterest: #e60023;
-    --platform-tiktok: #fe2c55;
-    --platform-tiktok-cyan: #25f4ee;
-    --platform-discord: #5865f2;
-
-    --overlay-white-5: rgba(255, 255, 255, 0.05);
-    --overlay-white-8: rgba(255, 255, 255, 0.08);
-    --overlay-white-10: rgba(255, 255, 255, 0.1);
-    --overlay-white-15: rgba(255, 255, 255, 0.15);
-    --overlay-white-20: rgba(255, 255, 255, 0.2);
-    --overlay-black-5: rgba(0, 0, 0, 0.05);
-    --overlay-black-10: rgba(0, 0, 0, 0.1);
-    --overlay-black-20: rgba(0, 0, 0, 0.2);
-    --overlay-black-60: rgba(0, 0, 0, 0.6);
-    --overlay-black-90: rgba(0, 0, 0, 0.9);
-
-    --accent-violet: #8b5cf6;
-    --accent-purple: #a855f7;
-    --accent-pink: #ec4899;
-    --accent-rose: #f472b6;
-    --accent-orange: #f97316;
-
     --gen-accent: 0 0% 0%;
     --gen-accent-bright: 0 0% 15%;
     --gen-accent-bg: rgba(0, 0, 0, 0.03);
@@ -57,42 +64,16 @@
     --shadow-glow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
     --shadow-glow-lg: 0 8px 30px rgba(0, 0, 0, 0.1);
 
-    --nn-bg-glass: rgba(0, 0, 0, 0.02);
-    --nn-bg-glass-hover: rgba(0, 0, 0, 0.04);
-    --nn-border-subtle: rgba(0, 0, 0, 0.06);
-    --nn-border-hover: rgba(0, 0, 0, 0.12);
-    --nn-border-active: rgba(0, 0, 0, 0.2);
-    --radius: 0.25rem;
+    /* @deprecated — use --overlay-black-* and --gen-accent-* tokens instead.
+       Values are closest available approximations; originals noted in comments. */
+    --nn-bg-glass: var(--overlay-black-5); /* was rgba(0,0,0,0.02) */
+    --nn-bg-glass-hover: var(--overlay-black-10); /* was rgba(0,0,0,0.04) */
+    --nn-border-subtle: var(--gen-accent-border); /* was rgba(0,0,0,0.06) */
+    --nn-border-hover: var(--gen-accent-border-strong); /* was rgba(0,0,0,0.12) */
+    --nn-border-active: var(--gen-accent-selection); /* was rgba(0,0,0,0.2) — exact */
   }
 
   [data-theme='dark'] {
-    --platform-instagram: #e1306c;
-    --platform-facebook: #1877f2;
-    --platform-twitter: #1da1f2;
-    --platform-linkedin: #0a66c2;
-    --platform-reddit: #ff4500;
-    --platform-pinterest: #e60023;
-    --platform-tiktok: #fe2c55;
-    --platform-tiktok-cyan: #25f4ee;
-    --platform-discord: #5865f2;
-
-    --overlay-white-5: rgba(255, 255, 255, 0.05);
-    --overlay-white-8: rgba(255, 255, 255, 0.08);
-    --overlay-white-10: rgba(255, 255, 255, 0.1);
-    --overlay-white-15: rgba(255, 255, 255, 0.15);
-    --overlay-white-20: rgba(255, 255, 255, 0.2);
-    --overlay-black-5: rgba(0, 0, 0, 0.05);
-    --overlay-black-10: rgba(0, 0, 0, 0.1);
-    --overlay-black-20: rgba(0, 0, 0, 0.2);
-    --overlay-black-60: rgba(0, 0, 0, 0.6);
-    --overlay-black-90: rgba(0, 0, 0, 0.9);
-
-    --accent-violet: #8b5cf6;
-    --accent-purple: #a855f7;
-    --accent-pink: #ec4899;
-    --accent-rose: #f472b6;
-    --accent-orange: #f97316;
-
     --gen-accent: 0 0% 100%;
     --gen-accent-bright: 0 0% 90%;
     --gen-accent-bg: rgba(255, 255, 255, 0.05);
@@ -113,12 +94,12 @@
     --shadow-glow-md: 0 0 40px rgba(255, 255, 255, 0.12);
     --shadow-glow-lg: 0 0 60px rgba(255, 255, 255, 0.15);
 
-    --nn-bg-glass: rgba(255, 255, 255, 0.05);
-    --nn-bg-glass-hover: rgba(255, 255, 255, 0.08);
-    --nn-border-subtle: rgba(255, 255, 255, 0.08);
-    --nn-border-hover: rgba(255, 255, 255, 0.15);
-    --nn-border-active: rgba(255, 255, 255, 0.25);
-    --radius: 0.25rem;
+    /* @deprecated — use --overlay-white-* and --gen-accent-* tokens instead.
+       Values are closest available approximations; originals noted in comments. */
+    --nn-bg-glass: var(--overlay-white-5); /* exact */
+    --nn-bg-glass-hover: var(--overlay-white-8); /* exact */
+    --nn-border-subtle: var(--overlay-white-8); /* exact */
+    --nn-border-hover: var(--overlay-white-15); /* exact */
+    --nn-border-active: rgba(255, 255, 255, 0.25); /* no exact token; nearest is --overlay-white-20 */
   }
 }
-


### PR DESCRIPTION
## Summary

- **globals.scss**: Remove redundant `--font-serif-italic` token (identical to `--font-serif`); fix `.font-serif-italic` class to use `var(--font-serif)` with `font-style: italic` (was wrongly `normal`); add explanatory comment on `.btn { box-shadow: none }`
- **shadcn-theme.scss**: Hoist `--platform-*`, `--overlay-*`, `--accent-violet/purple/pink/rose/orange`, and `--radius` above `@layer base` — these 24 tokens were copy-pasted identically in both light and dark blocks; replace `--nn-*` declarations with `@deprecated` aliases to `--overlay-*` / `--gen-accent-*` tokens
- **genfeed.scss**: Fix `.gen-btn-inverted` hover to use `color-mix` instead of hardcoded `rgba(0,0,0,0.8)` (broke in light theme); fix `.gen-text-subtle` to use `--gen-accent-heading` instead of `--gen-accent-text` (was near-invisible at 0.75 opacity); remove `@keyframes gen-pulse` (moved to `_keyframes-base.scss`); add composition warning above `.gen-venetian`
- **_keyframes-base.scss**: Add `@keyframes gen-pulse` (consolidated with other shared keyframes)
- **fonts.ts**: Update zodiak JSDoc to list all 6 font files (was only listing 2)

## What was NOT applied

- `--shadow-glow-sm/md/lg` were described as "duplicates" of `--shadow-sm/md/lg` — they are not. The glow variants have materially different blur radii (4px vs 2px, 16px vs 12px, 30px vs 24px) and were left unchanged.

## Test plan

- [ ] `bun type-check` passes
- [ ] Verify `.gen-btn-inverted` hover looks correct in both light and dark themes
- [ ] Verify `.gen-text-subtle` is legible (not near-invisible)
- [ ] Verify `.gen-dot-pulse` animation still works (`gen-pulse` now in `_keyframes-base.scss`)
- [ ] Grep: `--font-serif-italic` has no consumers (token is now orphaned in `web-tokens.scss` — follow-up cleanup in `packages/ui`)