### PR TITLE
[codex] Fix CI test step expectations

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx
@@ -247,6 +247,9 @@ describe('ProvidersContent behavior', () => {
         screen.getByRole('link', { name: 'Add my own API keys' }),
       ).toBeInTheDocument();
     });
+    expect(
+      await screen.findByText('Runtime: server defaults are ready'),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('link', { name: 'Add my own API keys' }));
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.spec.tsx
@@ -119,9 +119,13 @@ describe('OrchestrationSkillsPage', () => {
       expect(listSkillsMock).toHaveBeenCalledTimes(1);
     });
     expect(screen.getByText('Acme Brand')).toBeInTheDocument();
-    const skillButtons = await screen.findAllByRole('button', {
-      name: /YouTube Script Setup/i,
-    });
+    const skillButtons = await screen.findAllByRole(
+      'button',
+      {
+        name: /YouTube Script Setup/i,
+      },
+      { timeout: 5000 },
+    );
     expect(skillButtons.length).toBeGreaterThan(0);
     expect(screen.getByText(/built in/i)).toBeInTheDocument();
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
@@ -399,65 +399,69 @@ export default function OrchestrationSkillsPage() {
               const isEnabled = enabledSlugs.includes(skill.slug);
 
               return (
-                <Button
-                  className={`h-auto w-full flex-col items-stretch rounded-2xl border p-4 text-left ${
+                <div
+                  className={`relative rounded-2xl border ${
                     isSelected
                       ? 'border-white/30 bg-white/[0.06]'
                       : 'border-white/10 bg-white/[0.03] hover:border-white/20'
                   } ${!isEnabled ? 'opacity-50' : ''}`}
                   key={skill.id}
-                  onClick={() => setSelectedSkillId(skill.id)}
-                  variant={ButtonVariant.UNSTYLED}
                 >
-                  <div className="mb-3 flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-semibold text-foreground">
-                      {skill.name}
-                    </span>
-                    <Badge
-                      className="px-2 py-1 text-[11px] uppercase tracking-[0.14em]"
-                      variant={getSourceBadgeVariant(skill.source)}
-                    >
-                      {skill.source.replace('_', ' ')}
-                    </Badge>
-                    <Badge
-                      className="px-2 py-1 text-[11px] uppercase tracking-[0.14em]"
-                      variant="ghost"
-                    >
-                      {skill.workflowStage}
-                    </Badge>
-                    <Switch
-                      checked={isEnabled}
-                      className="ml-auto"
-                      onClick={(event) => event.stopPropagation()}
-                      onCheckedChange={() => void toggleSkill(skill.slug)}
-                    />
-                  </div>
-
-                  <p className="mb-3 text-sm text-foreground/65">
-                    {skill.description}
-                  </p>
-
-                  <div className="flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.14em] text-foreground/45">
-                    {skill.modalities.map((modality) => (
+                  <Button
+                    className="h-auto w-full flex-col items-stretch rounded-2xl p-4 pr-16 text-left"
+                    onClick={() => setSelectedSkillId(skill.id)}
+                    variant={ButtonVariant.UNSTYLED}
+                    withWrapper={false}
+                  >
+                    <div className="mb-3 flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-semibold text-foreground">
+                        {skill.name}
+                      </span>
                       <Badge
                         className="px-2 py-1 text-[11px] uppercase tracking-[0.14em]"
-                        key={`${skill.id}-${modality}`}
-                        variant={getModalityBadgeVariant(modality)}
+                        variant={getSourceBadgeVariant(skill.source)}
                       >
-                        {modality}
+                        {skill.source.replace('_', ' ')}
                       </Badge>
-                    ))}
-                    {skill.channels.map((channel) => (
                       <Badge
                         className="px-2 py-1 text-[11px] uppercase tracking-[0.14em]"
-                        key={`${skill.id}-${channel}`}
-                        variant="outline"
+                        variant="ghost"
                       >
-                        {channel}
+                        {skill.workflowStage}
                       </Badge>
-                    ))}
-                  </div>
-                </Button>
+                    </div>
+
+                    <p className="mb-3 text-sm text-foreground/65">
+                      {skill.description}
+                    </p>
+
+                    <div className="flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.14em] text-foreground/45">
+                      {skill.modalities.map((modality) => (
+                        <Badge
+                          className="px-2 py-1 text-[11px] uppercase tracking-[0.14em]"
+                          key={`${skill.id}-${modality}`}
+                          variant={getModalityBadgeVariant(modality)}
+                        >
+                          {modality}
+                        </Badge>
+                      ))}
+                      {skill.channels.map((channel) => (
+                        <Badge
+                          className="px-2 py-1 text-[11px] uppercase tracking-[0.14em]"
+                          key={`${skill.id}-${channel}`}
+                          variant="outline"
+                        >
+                          {channel}
+                        </Badge>
+                      ))}
+                    </div>
+                  </Button>
+                  <Switch
+                    checked={isEnabled}
+                    className="absolute top-4 right-4"
+                    onCheckedChange={() => void toggleSkill(skill.slug)}
+                  />
+                </div>
               );
             })}
           </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.test.tsx
@@ -216,7 +216,7 @@ describe('Overview dashboard sections', () => {
   it('renders the status badge tone and label', () => {
     render(<OverviewStatusBadge status={AgentExecutionStatus.RUNNING} />);
 
-    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText(/running/i)).toBeInTheDocument();
   });
 
   it('renders compact top stats with accent copy', () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -157,6 +157,19 @@ function buildTask(overrides: Record<string, unknown> = {}) {
   };
 }
 
+async function openTaskComposerFromSidebar() {
+  fireEvent(window, new Event(OPEN_TASK_COMPOSER_EVENT));
+  expect(
+    await screen.findByText(
+      'New Task',
+      {},
+      {
+        timeout: 5000,
+      },
+    ),
+  ).toBeInTheDocument();
+}
+
 describe('WorkspacePageContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -239,11 +252,7 @@ describe('WorkspacePageContent', () => {
       expect(listMock).toHaveBeenCalledWith({});
     });
 
-    fireEvent(window, new Event(OPEN_TASK_COMPOSER_EVENT));
-
-    await waitFor(() => {
-      expect(screen.getByText('New Task')).toBeInTheDocument();
-    });
+    await openTaskComposerFromSidebar();
   });
 
   it('creates a task from the modal composer', async () => {
@@ -253,11 +262,7 @@ describe('WorkspacePageContent', () => {
       expect(listMock).toHaveBeenCalledWith({});
     });
 
-    fireEvent(window, new Event(OPEN_TASK_COMPOSER_EVENT));
-
-    await waitFor(() => {
-      expect(screen.getByText('New Task')).toBeInTheDocument();
-    });
+    await openTaskComposerFromSidebar();
 
     fireEvent.change(
       screen.getByPlaceholderText(
@@ -328,11 +333,7 @@ describe('WorkspacePageContent', () => {
       expect(listMock).toHaveBeenCalledWith({});
     });
 
-    fireEvent(window, new Event(OPEN_TASK_COMPOSER_EVENT));
-
-    await waitFor(() => {
-      expect(screen.getByText('New Task')).toBeInTheDocument();
-    });
+    await openTaskComposerFromSidebar();
 
     fireEvent.change(
       screen.getByPlaceholderText(

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-page.test.tsx
@@ -125,8 +125,41 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+function createLocalStorageMock() {
+  let store: Record<string, string> = {};
+
+  return {
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
 describe('SettingsProgressPage', () => {
   beforeEach(() => {
+    const localStorageMock = createLocalStorageMock();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+      writable: true,
+    });
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+      writable: true,
+    });
+
     mockCurrentUserState.currentUser = {
       id: 'user-123',
       settings: {

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/models/models-layout-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/models/models-layout-content.test.tsx
@@ -1,7 +1,13 @@
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import ModelsLayoutContent from './models-layout-content';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ brandSlug: 'brand', orgSlug: 'acme' }),
+  usePathname: () => '/acme/~/settings/models/all',
+  useSearchParams: () => new URLSearchParams(),
+}));
 
 describe('ModelsLayoutContent', () => {
   it('should render without crashing', () => {

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -467,26 +467,20 @@ describe('AppProtectedLayout', () => {
     expect(screen.getByTestId('agent-panel')).toBeInTheDocument();
   });
 
-  it('renders the workspace switcher before the workspace quick actions', () => {
+  it('renders the workspace quick actions in the sidebar top slot', () => {
     render(
       <AppProtectedLayout>
         <div>Protected content</div>
       </AppProtectedLayout>,
     );
 
-    const workspaceSwitcher = screen.getByTestId('workspace-switcher');
-    const newSearchButton = screen.getByRole('button', { name: 'New Search' });
     const newTaskButton = screen.getByRole('button', { name: 'New Task' });
+    const newSearchButton = screen.getByRole('button', { name: 'New Search' });
 
-    expect(workspaceSwitcher).toBeInTheDocument();
-    expect(newSearchButton).toBeInTheDocument();
     expect(newTaskButton).toBeInTheDocument();
+    expect(newSearchButton).toBeInTheDocument();
     expect(
-      workspaceSwitcher.compareDocumentPosition(newSearchButton) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      newSearchButton.compareDocumentPosition(newTaskButton) &
+      newTaskButton.compareDocumentPosition(newSearchButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/apps/app/packages/config/menu-items.config.test.ts
+++ b/apps/app/packages/config/menu-items.config.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   APP_LOGO_HREF,
   APP_MENU_ITEMS,
-  APP_SECONDARY_MENU_ITEMS,
   AppMenuGroup,
+  getAppSecondaryMenuItems,
 } from './menu-items.config';
 
 describe('APP_MENU_ITEMS', () => {
@@ -19,7 +19,12 @@ describe('APP_MENU_ITEMS', () => {
       (item) => item.group === AppMenuGroup.Root && !item.isPrimary,
     ).map((item) => item.label);
 
-    expect(ungroupedLabels).toEqual(['Dashboard', 'Inbox', 'Tasks']);
+    expect(ungroupedLabels).toEqual([
+      'Dashboard',
+      'Inbox',
+      'Tasks',
+      'Activity',
+    ]);
   });
 
   it('does not surface content drilldowns in the shared sidebar', () => {
@@ -42,7 +47,12 @@ describe('APP_MENU_ITEMS', () => {
       (item) => item.group === AppMenuGroup.Root,
     ).map((item) => item.label);
 
-    expect(workspaceLabels).toEqual(['Dashboard', 'Inbox', 'Tasks']);
+    expect(workspaceLabels).toEqual([
+      'Dashboard',
+      'Inbox',
+      'Tasks',
+      'Activity',
+    ]);
   });
 
   it('does not include analytics group items pointing to /analytics/* routes', () => {
@@ -55,14 +65,9 @@ describe('APP_MENU_ITEMS', () => {
     expect(analyticsGroupHrefs).toHaveLength(0);
   });
 
-  it('keeps activity out of primary navigation and exposes it as a secondary destination', () => {
-    expect(APP_SECONDARY_MENU_ITEMS).toEqual([
-      expect.objectContaining({
-        href: '/workspace/activity',
-        label: 'Activity',
-      }),
-    ]);
-    expect(APP_MENU_ITEMS.map((item) => item.href)).not.toContain(
+  it('keeps activity in the workspace navigation and no longer exposes secondary destinations', () => {
+    expect(getAppSecondaryMenuItems()).toEqual([]);
+    expect(APP_MENU_ITEMS.map((item) => item.href)).toContain(
       '/workspace/activity',
     );
   });

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -47,6 +47,10 @@ vi.mock('@ui/topbars/end/TopbarEnd', () => ({
   default: () => <div data-testid="topbar-end">Topbar End</div>,
 }));
 
+vi.mock('@/components/cloud-sync-indicator/CloudSyncIndicator', () => ({
+  default: () => <div data-testid="cloud-sync-indicator" />,
+}));
+
 vi.mock('next/link', () => ({
   default: ({
     children,
@@ -70,7 +74,7 @@ vi.mock('next/navigation', () => ({
 const { default: AppProtectedTopbar } = await import('./AppProtectedTopbar');
 
 describe('AppProtectedTopbar', () => {
-  it('places the app switcher in the left topbar cluster before breadcrumbs', () => {
+  it('places breadcrumbs before the app switcher', () => {
     render(<AppProtectedTopbar currentApp="workspace" orgSlug="acme" />);
 
     const appSwitcher = screen.getByTestId('app-switcher');
@@ -79,12 +83,12 @@ describe('AppProtectedTopbar', () => {
     expect(appSwitcher).toBeInTheDocument();
     expect(breadcrumbs).toBeInTheDocument();
     expect(
-      appSwitcher.compareDocumentPosition(breadcrumbs) &
+      breadcrumbs.compareDocumentPosition(appSwitcher) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 
-  it('renders the edition badge beside the terminal dock control', () => {
+  it('renders the cloud sync indicator beside the terminal dock control', () => {
     render(
       <AppProtectedTopbar
         currentApp="workspace"
@@ -97,11 +101,10 @@ describe('AppProtectedTopbar', () => {
     const terminalButton = screen.getByRole('button', {
       name: 'Open terminal dock',
     });
-    const editionBadge = screen.getByTestId('edition-badge');
+    const cloudSyncIndicator = screen.getByTestId('cloud-sync-indicator');
 
-    expect(editionBadge).toHaveTextContent('Core');
     expect(
-      terminalButton.compareDocumentPosition(editionBadge) &
+      terminalButton.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/apps/server/api/src/collections/content-intelligence/services/pattern-analyzer.service.spec.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/pattern-analyzer.service.spec.ts
@@ -396,9 +396,6 @@ describe('PatternAnalyzerService LLM response parsing', () => {
   });
 
   it('calls openrouter chatCompletion with correct model and post text', async () => {
-    // Note: validateTemplateCategory references undefined TemplateCategory enum at runtime,
-    // causing parseLLMResponse to catch the ReferenceError and return [].
-    // This test verifies the LLM is called correctly, even though patterns end up empty.
     const llmPatterns = [
       {
         description: 'Personal journey hook',
@@ -423,14 +420,9 @@ describe('PatternAnalyzerService LLM response parsing', () => {
         temperature: 0.3,
       }),
     );
-    // Due to runtime bug in validateTemplateCategory (undefined TemplateCategory),
-    // parseLLMResponse returns [] — this is known behavior until the bug is fixed.
   });
 
-  it('attempts to parse JSON from ```json code block (LLM succeeds, patterns empty due to known bug)', async () => {
-    // parseLLMResponse strips ```json fences before JSON.parse.
-    // However validateTemplateCategory throws ReferenceError (undefined TemplateCategory),
-    // causing the try-catch to return []. LLM is called but produces no patterns.
+  it('attempts to parse JSON from ```json code block', async () => {
     const llmPatterns = [
       {
         description: 'CTA',
@@ -447,10 +439,16 @@ describe('PatternAnalyzerService LLM response parsing', () => {
     });
 
     const { patterns } = await service.analyzeCreator(creatorId);
-    // LLM was invoked
+
     expect(mockOpenRouterService.chatCompletion).toHaveBeenCalled();
-    // No patterns due to runtime bug — validated behavior
-    expect(patterns).toHaveLength(0);
+    expect(patterns).toEqual([
+      expect.objectContaining({
+        description: 'CTA',
+        extractedFormula: 'Follow [ACCOUNT] for more',
+        patternType: ContentPatternType.CTA,
+        placeholders: ['ACCOUNT'],
+      }),
+    ]);
   });
 
   it('falls back to rule-based on invalid JSON from LLM', async () => {

--- a/apps/server/api/src/collections/elements/sounds/controllers/sounds.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/sounds/controllers/sounds.controller.spec.ts
@@ -166,7 +166,7 @@ describe('ElementsSoundsController', () => {
         isActive: true,
         isDefault: false,
         isDeleted: false,
-        organization: mockUser.publicMetadata.organization,
+        organizationId: mockUser.publicMetadata.organization,
         type: SoundCategory.MUSIC,
       };
 
@@ -194,7 +194,7 @@ describe('ElementsSoundsController', () => {
         isActive: true,
         isDefault: false,
         isDeleted: false,
-        organization: mockUser.publicMetadata.organization,
+        organizationId: mockUser.publicMetadata.organization,
         type: SoundCategory.MUSIC,
       };
 
@@ -205,7 +205,7 @@ describe('ElementsSoundsController', () => {
       await controller.create(mockRequest, mockUser, createDto);
 
       const createCall = soundsService.create.mock.calls[0][0];
-      expect(createCall).toHaveProperty('organization');
+      expect(createCall).toHaveProperty('organizationId');
     });
   });
 
@@ -225,7 +225,7 @@ describe('ElementsSoundsController', () => {
         key: 'old-sound',
         label: 'Old Sound',
         name: 'Old Sound',
-        organization: mockUser.publicMetadata.organization,
+        organizationId: mockUser.publicMetadata.organization,
         type: SoundCategory.MUSIC,
       };
 
@@ -281,7 +281,7 @@ describe('ElementsSoundsController', () => {
         key: 'sound-to-delete',
         label: 'Sound to Delete',
         name: 'Sound to Delete',
-        organization: mockUser.publicMetadata.organization,
+        organizationId: mockUser.publicMetadata.organization,
         type: SoundCategory.MUSIC,
       };
 
@@ -318,9 +318,7 @@ describe('ElementsSoundsController', () => {
       expect(pipeline).toHaveLength(2);
       const matchStage = asMatchStage(pipeline[0]);
       expect(matchStage.$match.$or).toBeDefined();
-      expect(
-        (matchStage.$match.$or as unknown[]).length,
-      ).toBeGreaterThanOrEqual(2);
+      expect(matchStage.$match.$or).toHaveLength(1);
       expect(matchStage.$match.isDeleted).toBe(false);
     });
 
@@ -332,8 +330,7 @@ describe('ElementsSoundsController', () => {
       );
 
       const matchStage = asMatchStage(pipeline[0]);
-      // Without org, falls back to $or with global items and user items
-      expect(matchStage.$match.$or).toBeDefined();
+      expect(matchStage.$match.$or).toBeUndefined();
       expect(matchStage.$match.isDeleted).toBe(false);
     });
 
@@ -362,7 +359,7 @@ describe('ElementsSoundsController', () => {
       expect(sortStage.$sort).toBeDefined();
     });
 
-    it('should load organization sounds or defaults', () => {
+    it('should load organization sounds', () => {
       const query = createBaseQuery();
       const pipeline = controller.buildFindAllPipeline(mockUser, query);
 
@@ -371,13 +368,12 @@ describe('ElementsSoundsController', () => {
         Record<string, unknown>
       >;
 
-      // orConditions[0] = global (no org, no user)
-      // orConditions[1] = org condition
-      expect(orConditions[0]).toEqual({
-        organization: { $exists: false },
-        user: { $exists: false },
-      });
-      expect(orConditions[1].organization).toEqual(
+      expect(orConditions).toEqual([
+        {
+          organizationId: mockUser.publicMetadata.organization as string,
+        },
+      ]);
+      expect(orConditions[0].organizationId).toEqual(
         mockUser.publicMetadata.organization as string,
       );
     });
@@ -528,7 +524,7 @@ describe('ElementsSoundsController', () => {
         key: 'sound-1',
         label: 'Sound 1',
         name: 'Sound 1',
-        organization: '507f191e810c19729de860ee',
+        organizationId: '507f191e810c19729de860ee',
         type: SoundCategory.MUSIC,
       };
       soundsService.findOne.mockResolvedValueOnce(

--- a/apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts
+++ b/apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts
@@ -3,7 +3,6 @@ import { ModelsService } from '@api/collections/models/services/models.service';
 import { TrainingsController } from '@api/collections/trainings/controllers/trainings.controller';
 import type { CreateTrainingDto } from '@api/collections/trainings/dto/create-training.dto';
 import type { TrainingsQueryDto } from '@api/collections/trainings/dto/trainings-query.dto';
-import { TrainingEntity } from '@api/collections/trainings/entities/training.entity';
 import type { TrainingDocument } from '@api/collections/trainings/schemas/training.schema';
 import { TrainingsService } from '@api/collections/trainings/services/trainings.service';
 import { ConfigService } from '@api/config/config.service';
@@ -277,7 +276,23 @@ describe('TrainingsController', () => {
 
       expect(ingredientsService.findAll).toHaveBeenCalled();
       expect(trainingsService.create).toHaveBeenCalledWith(
-        expect.any(TrainingEntity),
+        expect.objectContaining({
+          brandId: mockUser.publicMetadata.brand,
+          config: expect.objectContaining({
+            model: 'default-trainer-model',
+            status: IngredientStatus.PROCESSING,
+            steps: 1000,
+            trigger: 'NEWTOK',
+          }),
+          label: 'New Training',
+          organizationId: mockUser.publicMetadata.organization,
+          sources: {
+            connect: expect.arrayContaining([
+              { id: '507f191e810c19729de860ee' },
+            ]),
+          },
+          userId: mockUser.publicMetadata.user,
+        }),
       );
       expect(result).toBeDefined();
     });

--- a/apps/server/api/src/collections/votes/controllers/votes.controller.spec.ts
+++ b/apps/server/api/src/collections/votes/controllers/votes.controller.spec.ts
@@ -12,9 +12,9 @@ vi.mock('@api/helpers/utils/response/response.util', () => ({
 }));
 
 import { VotesController } from '@api/collections/votes/controllers/votes.controller';
-import { VoteEntity } from '@api/collections/votes/entities/vote.entity';
 import { VotesService } from '@api/collections/votes/services/votes.service';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { VoteEntityModel } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -35,6 +35,10 @@ describe('VotesController', () => {
   };
 
   const validEntityId = '507f191e810c19729de860ea';
+  const validCreateVoteDto = {
+    entity: validEntityId,
+    entityModel: VoteEntityModel.INGREDIENT,
+  };
 
   beforeEach(async () => {
     service = {
@@ -69,12 +73,16 @@ describe('VotesController', () => {
 
     const result = await controller.create(
       mockReq,
-      { entity: validEntityId },
+      validCreateVoteDto,
       mockUser as any,
     );
 
     expect(service.create).toHaveBeenCalledOnce();
-    expect(service.create).toHaveBeenCalledWith(expect.any(VoteEntity));
+    expect(service.create).toHaveBeenCalledWith({
+      entityId: validEntityId,
+      entityModel: VoteEntityModel.INGREDIENT,
+      userId: mockUser.publicMetadata.user,
+    });
     expect(result).toEqual(mockVote);
   });
 
@@ -98,36 +106,42 @@ describe('VotesController', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  // ── New tests for vote type and DELETE endpoint ──
-
-  it('creates an upvote with type field', async () => {
-    const mockVote = { _id: '2', entity: validEntityId, type: 'up' };
+  it('creates a prompt vote with entity model', async () => {
+    const mockVote = {
+      _id: '2',
+      entity: validEntityId,
+      entityModel: VoteEntityModel.PROMPT,
+    };
     service.create.mockResolvedValue(mockVote);
 
     const result = await controller.create(
       mockReq,
-      { entity: validEntityId, type: 'up' },
+      { entity: validEntityId, entityModel: VoteEntityModel.PROMPT },
       mockUser as any,
     );
 
     expect(service.create).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'up' }),
+      expect.objectContaining({ entityModel: VoteEntityModel.PROMPT }),
     );
     expect(result).toEqual(mockVote);
   });
 
-  it('creates a downvote with type field', async () => {
-    const mockVote = { _id: '3', entity: validEntityId, type: 'down' };
+  it('creates an ingredient vote with entity model', async () => {
+    const mockVote = {
+      _id: '3',
+      entity: validEntityId,
+      entityModel: VoteEntityModel.INGREDIENT,
+    };
     service.create.mockResolvedValue(mockVote);
 
     const result = await controller.create(
       mockReq,
-      { entity: validEntityId, type: 'down' },
+      validCreateVoteDto,
       mockUser as any,
     );
 
     expect(service.create).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'down' }),
+      expect.objectContaining({ entityModel: VoteEntityModel.INGREDIENT }),
     );
     expect(result).toEqual(mockVote);
   });

--- a/apps/server/api/src/endpoints/admin/announcements/announcements.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.service.spec.ts
@@ -145,8 +145,10 @@ describe('AdminAnnouncementsService', () => {
         announcementsCollectionService.createAnnouncement,
       ).toHaveBeenCalledWith(
         expect.objectContaining({
-          tweetId: 'tweet-123',
-          tweetUrl: expect.stringContaining('tweet-123'),
+          config: expect.objectContaining({
+            tweetId: 'tweet-123',
+            tweetUrl: expect.stringContaining('tweet-123'),
+          }),
         }),
       );
       expect(result).toBe(mockAnnouncement);
@@ -191,7 +193,11 @@ describe('AdminAnnouncementsService', () => {
       expect(result).toBe(mockAnnouncement);
       expect(
         announcementsCollectionService.createAnnouncement,
-      ).toHaveBeenCalledWith(expect.objectContaining({ tweetId: undefined }));
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ tweetId: undefined }),
+        }),
+      );
     });
 
     it('should continue and persist if discord publish fails', async () => {

--- a/apps/server/api/src/endpoints/integrations/shopify/shopify.controller.spec.ts
+++ b/apps/server/api/src/endpoints/integrations/shopify/shopify.controller.spec.ts
@@ -230,7 +230,10 @@ describe('ShopifyController', () => {
       const mockUser = { _id: '507f191e810c19729de860ee' };
       const mockBrand = { _id: '507f191e810c19729de860ee' };
       const mockApiKey = {
-        apiKey: { _id: '507f191e810c19729de860ee' },
+        apiKey: {
+          _id: '507f191e810c19729de860ee',
+          id: '507f191e810c19729de860ee',
+        },
         plainKey: 'gf_sk_success',
       };
 
@@ -244,7 +247,7 @@ describe('ShopifyController', () => {
       expect(loggerService.log).toHaveBeenCalledWith(
         expect.stringContaining('Account provisioned successfully'),
         expect.objectContaining({
-          apiKeyId: mockApiKey.apiKey._id,
+          apiKeyId: mockApiKey.apiKey.id,
           brandId: mockBrand._id,
           organizationId: mockOrg._id,
           shopDomain: 'success-shop.myshopify.com',

--- a/apps/server/api/src/helpers/guards/api-key/api-key.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/api-key/api-key.guard.spec.ts
@@ -17,15 +17,18 @@ describe('ApiKeyAuthGuard', () => {
     _id: '507f1f77bcf86cd799439011',
     allowedIps: ['192.168.1.1'],
     createdAt: new Date(),
+    id: '507f1f77bcf86cd799439011',
     isRevoked: false,
     key: 'hashed_key_value',
     name: 'Test API Key',
     organization: '507f1f77bcf86cd799439013',
+    organizationId: '507f1f77bcf86cd799439013',
     rateLimit: 60,
     scopes: ['videos:create', 'videos:read'],
     updatedAt: new Date(),
     usageCount: 0,
     user: '507f1f77bcf86cd799439012',
+    userId: '507f1f77bcf86cd799439012',
   };
 
   beforeEach(async () => {
@@ -166,18 +169,18 @@ describe('ApiKeyAuthGuard', () => {
       const mutatedRequest = mockContext.switchToHttp().getRequest();
       expect(result).toBe(true);
       expect(mutatedRequest.user).toEqual({
-        id: mockApiKey.user.toString(),
+        id: mockApiKey.userId.toString(),
         publicMetadata: {
           apiKeyId: mockApiKey._id.toString(),
-          brand: mockApiKey.organization.toString(),
+          brand: mockApiKey.organizationId.toString(),
           isApiKey: true,
-          organization: mockApiKey.organization.toString(),
+          organization: mockApiKey.organizationId.toString(),
           scopes: mockApiKey.scopes,
-          user: mockApiKey.user.toString(),
+          user: mockApiKey.userId.toString(),
         },
       });
       expect(apiKeysService.updateLastUsed).toHaveBeenCalledWith(
-        mockApiKey._id.toString(),
+        mockApiKey.id.toString(),
         '192.168.1.1',
       );
     });
@@ -231,7 +234,7 @@ describe('ApiKeyAuthGuard', () => {
 
       expect(result).toBe(true);
       expect(apiKeysService.updateLastUsed).toHaveBeenCalledWith(
-        mockApiKey._id.toString(),
+        mockApiKey.id.toString(),
         '192.168.1.2',
       );
     });

--- a/apps/server/api/src/services/ai-influencer/ai-influencer.service.spec.ts
+++ b/apps/server/api/src/services/ai-influencer/ai-influencer.service.spec.ts
@@ -70,7 +70,7 @@ describe('AiInfluencerService', () => {
       isDeleted: false,
       label: 'Luna AI',
       loraModelPath: 's3://models/luna-lora.safetensors',
-      loraStatus: LoraStatus.TRAINED,
+      loraStatus: LoraStatus.READY,
       niche: 'lifestyle',
       organization: mockOrganizationId,
       slug: 'luna-ai',
@@ -299,7 +299,7 @@ describe('AiInfluencerService', () => {
     it('should include LoRA in fal.ai request when persona has trained LoRA', async () => {
       const persona = createMockPersona({
         loraModelPath: 's3://models/luna-lora.safetensors',
-        loraStatus: LoraStatus.TRAINED,
+        loraStatus: LoraStatus.READY,
       });
       personasService.findOne.mockResolvedValue(persona);
       openRouterService.chatCompletion.mockResolvedValue(mockCaptionResponse);

--- a/apps/server/api/src/services/batch-content/batch-content.processor.spec.ts
+++ b/apps/server/api/src/services/batch-content/batch-content.processor.spec.ts
@@ -110,12 +110,16 @@ describe('BatchContentProcessor', () => {
       }),
     );
 
-    expect(skillExecutor.execute).toHaveBeenCalledWith({
-      brandId: 'brand-2',
-      organizationId: 'org-2',
-      params: { tone: 'formal' },
-      skillSlug: 'social-post',
-    });
+    expect(skillExecutor.execute).toHaveBeenCalledWith(
+      'social-post',
+      {
+        brandId: 'brand-2',
+        brandVoice: '',
+        organizationId: 'org-2',
+        platforms: [],
+      },
+      { tone: 'formal' },
+    );
   });
 
   it('should mark item completed with draft on success', async () => {

--- a/apps/server/api/src/services/batch-content/batch-content.service.spec.ts
+++ b/apps/server/api/src/services/batch-content/batch-content.service.spec.ts
@@ -227,7 +227,7 @@ describe('BatchContentService', () => {
   });
 
   describe('rankDrafts', () => {
-    it('should rank by confidenceScore descending', () => {
+    it('should rank by confidence descending', () => {
       const service = new BatchContentService(
         createMockQueueService(),
         createMockBrandsService(),
@@ -235,9 +235,9 @@ describe('BatchContentService', () => {
       );
 
       const result = service.rankDrafts([
-        { confidenceScore: 0.5, content: 'mid', skillSlug: 'skill' },
-        { confidenceScore: 0.9, content: 'best', skillSlug: 'skill' },
-        { confidenceScore: 0.1, content: 'worst', skillSlug: 'skill' },
+        { confidence: 0.5, content: 'mid', skillSlug: 'skill' },
+        { confidence: 0.9, content: 'best', skillSlug: 'skill' },
+        { confidence: 0.1, content: 'worst', skillSlug: 'skill' },
       ] as unknown as ContentDraft[]);
 
       expect(result[0].content).toBe('best');
@@ -253,9 +253,9 @@ describe('BatchContentService', () => {
       );
 
       const result = service.rankDrafts([
-        { confidenceScore: 0.9, content: 'short', skillSlug: 'skill' },
+        { confidence: 0.9, content: 'short', skillSlug: 'skill' },
         {
-          confidenceScore: 0.9,
+          confidence: 0.9,
           content: 'this is a much longer piece of content',
           skillSlug: 'skill',
         },
@@ -266,7 +266,7 @@ describe('BatchContentService', () => {
       expect(result[1].metadata?.rank).toBe(2);
     });
 
-    it('should handle drafts with undefined confidenceScore', () => {
+    it('should handle drafts with undefined confidence', () => {
       const service = new BatchContentService(
         createMockQueueService(),
         createMockBrandsService(),
@@ -275,7 +275,7 @@ describe('BatchContentService', () => {
 
       const result = service.rankDrafts([
         { content: 'no score', skillSlug: 'skill' },
-        { confidenceScore: 0.5, content: 'has score', skillSlug: 'skill' },
+        { confidence: 0.5, content: 'has score', skillSlug: 'skill' },
       ] as unknown as ContentDraft[]);
 
       expect(result[0].content).toBe('has score');
@@ -303,7 +303,7 @@ describe('BatchContentService', () => {
 
       const result = service.rankDrafts([
         {
-          confidenceScore: 0.9,
+          confidence: 0.9,
           content: 'a',
           metadata: { source: 'test' },
           skillSlug: 'skill',

--- a/apps/server/api/src/services/content-engine/content-engine.controller.spec.ts
+++ b/apps/server/api/src/services/content-engine/content-engine.controller.spec.ts
@@ -336,12 +336,10 @@ describe('ContentEngineController', () => {
         ['draft-1', 'draft-2'],
         userId,
       );
-      expect(result).toEqual({
-        data: [
-          { _id: 'draft-1', status: 'approved' },
-          { _id: 'draft-2', status: 'approved' },
-        ],
-      });
+      expect(result).toEqual([
+        { _id: 'draft-1', status: 'approved' },
+        { _id: 'draft-2', status: 'approved' },
+      ]);
     });
   });
 });

--- a/apps/server/api/src/services/harness/harness.service.ts
+++ b/apps/server/api/src/services/harness/harness.service.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { ConfigService } from '@api/config/config.service';
 import { isEEEnabled } from '@genfeedai/config';
 import {
@@ -165,7 +166,7 @@ export class ContentHarnessService {
     specifier: string,
   ): Promise<ContentHarnessPack | null> {
     try {
-      const imported = this.loadRuntimePackModule(specifier);
+      const imported = await this.loadRuntimePackModule(specifier);
       const candidate = imported.default ?? imported.CONTENT_HARNESS_PACK;
 
       if (!isContentHarnessPack(candidate)) {
@@ -189,7 +190,7 @@ export class ContentHarnessService {
     }
   }
 
-  private loadRuntimePackModule(specifier: string): PackModule {
+  private async loadRuntimePackModule(specifier: string): Promise<PackModule> {
     try {
       return this.runtimeRequireContext.require(specifier) as PackModule;
     } catch (error: unknown) {
@@ -203,7 +204,13 @@ export class ContentHarnessService {
       try {
         return workspaceRequire(specifier) as PackModule;
       } catch {
-        return workspaceRequire(workspacePackPaths.sourceEntry) as PackModule;
+        try {
+          return workspaceRequire(workspacePackPaths.sourceEntry) as PackModule;
+        } catch {
+          return (await import(
+            pathToFileURL(workspacePackPaths.sourceEntry).href
+          )) as PackModule;
+        }
       }
     }
   }

--- a/apps/server/api/src/services/harness/harness.service.ts
+++ b/apps/server/api/src/services/harness/harness.service.ts
@@ -29,9 +29,17 @@ type RuntimeRequireContext = {
   workspaceRoot: string | null;
 };
 
+type WorkspacePackPaths = {
+  packageJson: string;
+  sourceEntry: string;
+};
+
 const API_PACKAGE_NAME = '@genfeedai/api';
-const WORKSPACE_PACK_PACKAGE_JSON_PATHS: Record<string, string> = {
-  '@genfeedai/ee-harness': 'ee/packages/harness/package.json',
+const WORKSPACE_PACK_PATHS: Record<string, WorkspacePackPaths> = {
+  '@genfeedai/ee-harness': {
+    packageJson: 'ee/packages/harness/package.json',
+    sourceEntry: 'ee/packages/harness/src/index.ts',
+  },
 };
 
 function isApiPackageJsonPath(packageJsonPath: string): boolean {
@@ -186,29 +194,39 @@ export class ContentHarnessService {
     try {
       return this.runtimeRequireContext.require(specifier) as PackModule;
     } catch (error: unknown) {
-      const packageJsonPath = this.getWorkspacePackPackageJsonPath(specifier);
+      const workspacePackPaths = this.getWorkspacePackPaths(specifier);
 
-      if (!packageJsonPath || !isMissingRequestedModule(error, specifier)) {
+      if (!workspacePackPaths || !isMissingRequestedModule(error, specifier)) {
         throw error;
       }
 
-      return createRequire(packageJsonPath)(specifier) as PackModule;
+      const workspaceRequire = createRequire(workspacePackPaths.packageJson);
+      try {
+        return workspaceRequire(specifier) as PackModule;
+      } catch {
+        return workspaceRequire(workspacePackPaths.sourceEntry) as PackModule;
+      }
     }
   }
 
-  private getWorkspacePackPackageJsonPath(specifier: string): string | null {
-    const packageJsonRelativePath =
-      WORKSPACE_PACK_PACKAGE_JSON_PATHS[specifier];
+  private getWorkspacePackPaths(specifier: string): WorkspacePackPaths | null {
+    const workspacePackPaths = WORKSPACE_PACK_PATHS[specifier];
 
-    if (!packageJsonRelativePath || !this.runtimeRequireContext.workspaceRoot) {
+    if (!workspacePackPaths || !this.runtimeRequireContext.workspaceRoot) {
       return null;
     }
 
     const packageJsonPath = resolve(
       this.runtimeRequireContext.workspaceRoot,
-      packageJsonRelativePath,
+      workspacePackPaths.packageJson,
+    );
+    const sourceEntryPath = resolve(
+      this.runtimeRequireContext.workspaceRoot,
+      workspacePackPaths.sourceEntry,
     );
 
-    return existsSync(packageJsonPath) ? packageJsonPath : null;
+    return existsSync(packageJsonPath) && existsSync(sourceEntryPath)
+      ? { packageJson: packageJsonPath, sourceEntry: sourceEntryPath }
+      : null;
   }
 }

--- a/apps/server/api/src/services/harness/harness.service.ts
+++ b/apps/server/api/src/services/harness/harness.service.ts
@@ -79,15 +79,14 @@ function createRuntimeRequireContext(): RuntimeRequireContext {
   };
 }
 
-function isMissingRequestedModule(error: unknown, specifier: string): boolean {
+function isModuleResolutionError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
   }
 
-  return (
-    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND' &&
-    error.message.includes(`'${specifier}'`)
-  );
+  const code = (error as NodeJS.ErrnoException).code;
+
+  return code === 'MODULE_NOT_FOUND' || code === 'ERR_MODULE_NOT_FOUND';
 }
 
 @Injectable()
@@ -196,7 +195,7 @@ export class ContentHarnessService {
     } catch (error: unknown) {
       const workspacePackPaths = this.getWorkspacePackPaths(specifier);
 
-      if (!workspacePackPaths || !isMissingRequestedModule(error, specifier)) {
+      if (!workspacePackPaths || !isModuleResolutionError(error)) {
         throw error;
       }
 

--- a/apps/server/api/src/services/integrations/elevenlabs/elevenlabs.service.spec.ts
+++ b/apps/server/api/src/services/integrations/elevenlabs/elevenlabs.service.spec.ts
@@ -59,9 +59,9 @@ describe('ElevenLabsService', () => {
         forcedAlignment: { create: forcedAlignmentMock },
         textToSpeech: { convertWithTimestamps: ttsConvertMock },
         voices: {
-          add: voicesAddMock,
           delete: voicesDeleteMock,
           getAll: voicesGetAllMock,
+          ivc: { create: voicesAddMock },
         },
       };
     });
@@ -95,10 +95,10 @@ describe('ElevenLabsService', () => {
         voices: [
           {
             name: 'Rachel',
-            preview_url: 'https://preview.com/rachel.mp3',
-            voice_id: 'voice1',
+            previewUrl: 'https://preview.com/rachel.mp3',
+            voiceId: 'voice1',
           },
-          { name: 'Adam', preview_url: null, voice_id: 'voice2' },
+          { name: 'Adam', previewUrl: null, voiceId: 'voice2' },
         ],
       });
 
@@ -109,7 +109,7 @@ describe('ElevenLabsService', () => {
           preview: 'https://preview.com/rachel.mp3',
           voiceId: 'voice1',
         },
-        { name: 'Adam', preview: null, voiceId: 'voice2' },
+        { name: 'Adam', preview: undefined, voiceId: 'voice2' },
       ]);
     });
 
@@ -145,11 +145,10 @@ describe('ElevenLabsService', () => {
     it('should generate audio, upload to S3, and return URL with duration', async () => {
       const audioChunks = [Buffer.from('chunk1'), Buffer.from('chunk2')];
       ttsConvertMock.mockResolvedValue({
-        audio: audioChunks,
-        timestamps: [
-          { end: 2, start: 0 },
-          { end: 5, start: 2 },
-        ],
+        audioBase64: Buffer.concat(audioChunks).toString('base64'),
+        normalizedAlignment: {
+          characterEndTimesSeconds: [2, 5],
+        },
       });
 
       const result = await service.generateAndUploadAudio(
@@ -180,8 +179,8 @@ describe('ElevenLabsService', () => {
 
     it('should use upload result duration when available', async () => {
       ttsConvertMock.mockResolvedValue({
-        audio: [Buffer.from('audio')],
-        timestamps: [],
+        audioBase64: Buffer.from('audio').toString('base64'),
+        normalizedAlignment: { characterEndTimesSeconds: [] },
       });
       filesClientMock.uploadToS3.mockResolvedValue({
         duration: 10,
@@ -198,8 +197,8 @@ describe('ElevenLabsService', () => {
 
     it('should throw when upload fails to return public URL', async () => {
       ttsConvertMock.mockResolvedValue({
-        audio: [Buffer.from('audio')],
-        timestamps: [],
+        audioBase64: Buffer.from('audio').toString('base64'),
+        normalizedAlignment: { characterEndTimesSeconds: [] },
       });
       filesClientMock.uploadToS3.mockResolvedValue({
         duration: 0,
@@ -216,7 +215,7 @@ describe('ElevenLabsService', () => {
     it('should clone a voice and return voiceId and name', async () => {
       voicesAddMock.mockResolvedValue({
         name: 'My Voice',
-        voice_id: 'cloned_voice_123',
+        voiceId: 'cloned_voice_123',
       });
 
       const result = await service.cloneVoice(
@@ -232,9 +231,14 @@ describe('ElevenLabsService', () => {
       expect(voicesAddMock).toHaveBeenCalledWith(
         expect.objectContaining({
           description: 'Test voice',
-          files: [expect.any(Buffer)],
+          files: [
+            expect.objectContaining({
+              contentType: 'audio/mpeg',
+              filename: 'voice-sample-1.mp3',
+            }),
+          ],
           name: 'My Voice',
-          remove_background_noise: true,
+          removeBackgroundNoise: true,
         }),
       );
     });

--- a/apps/server/api/src/services/integrations/ghost/services/ghost.service.spec.ts
+++ b/apps/server/api/src/services/integrations/ghost/services/ghost.service.spec.ts
@@ -2,19 +2,12 @@ vi.mock('@api/shared/utils/encryption/encryption.util', () => ({
   EncryptionUtil: { decrypt: vi.fn((v: string) => `dec:${v}`) },
 }));
 
-vi.mock('jsonwebtoken', () => ({
-  default: {
-    sign: vi.fn().mockReturnValue('mock-jwt-token'),
-  },
-}));
-
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpService } from '@nestjs/axios';
 import { Test, type TestingModule } from '@nestjs/testing';
-import jwt from 'jsonwebtoken';
 import { of, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -73,15 +66,7 @@ describe('GhostService', () => {
     it('should generate a JWT from a valid API key', () => {
       const token = service.generateToken('abc123:deadbeef0123456789abcdef');
 
-      expect(jwt.sign).toHaveBeenCalledWith(
-        expect.objectContaining({ aud: '/admin/' }),
-        expect.any(Buffer),
-        expect.objectContaining({
-          algorithm: 'HS256',
-          header: expect.objectContaining({ kid: 'abc123' }),
-        }),
-      );
-      expect(token).toBe('mock-jwt-token');
+      expect(token.split('.')).toHaveLength(3);
     });
 
     it('should throw for invalid API key format (no colon)', () => {
@@ -209,7 +194,7 @@ describe('GhostService', () => {
       const headers = (
         httpService.post.mock.calls[0][2] as { headers: Record<string, string> }
       ).headers;
-      expect(headers.Authorization).toBe('Ghost mock-jwt-token');
+      expect(headers.Authorization).toMatch(/^Ghost [^.]+\.[^.]+\.[^.]+$/);
     });
 
     it('should call the correct API URL', async () => {
@@ -303,7 +288,7 @@ describe('GhostService', () => {
         'https://myblog.ghost.io/ghost/api/admin/site/',
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: 'Ghost mock-jwt-token',
+            Authorization: expect.stringMatching(/^Ghost [^.]+\.[^.]+\.[^.]+$/),
           }),
         }),
       );

--- a/apps/server/api/src/services/integrations/telegram/controllers/telegram.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/telegram/controllers/telegram.controller.spec.ts
@@ -17,7 +17,11 @@ describe('TelegramController', () => {
   const orgId = 'test-object-id';
   const brandId = 'test-object-id';
   const userId = 'test-object-id';
-  const mockUser = { _id: userId } as Record<string, unknown>;
+  const mockUser = {
+    publicMetadata: {
+      user: userId,
+    },
+  } as Record<string, unknown>;
 
   const validAuthData: TelegramAuthData = {
     auth_date: Math.floor(Date.now() / 1000),
@@ -115,11 +119,11 @@ describe('TelegramController', () => {
       ).rejects.toThrow(HttpException);
     });
 
-    it('should pass user._id.toString() as userId', async () => {
+    it('should pass publicMetadata.user as userId', async () => {
       await controller.verify(mockUser, orgId, brandId, validAuthData);
       const callArgs = telegramService.verifyAndSaveAuth.mock
         .calls[0] as unknown[];
-      expect(callArgs[2]).toBe(userId.toString());
+      expect(callArgs[2]).toBe(userId);
     });
   });
 

--- a/apps/server/api/src/services/preflight/preflight.service.spec.ts
+++ b/apps/server/api/src/services/preflight/preflight.service.spec.ts
@@ -9,6 +9,22 @@ const createMockConfig = (envConfig: Record<string, unknown> = {}) => ({
   envConfig,
 });
 
+function stubReadyEnv(overrides: Record<string, string> = {}) {
+  const env = {
+    AWS_ACCESS_KEY_ID: 'test-key',
+    AWS_S3_BUCKET: 'test-bucket',
+    DATABASE_URL: 'mongodb://localhost',
+    INSTAGRAM_CLIENT_ID: 'ig-id',
+    INSTAGRAM_CLIENT_SECRET: 'ig-secret',
+    OPENAI_API_KEY: 'sk-test',
+    ...overrides,
+  };
+
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+}
+
 describe('PreflightService', () => {
   let service: PreflightService;
 
@@ -28,6 +44,7 @@ describe('PreflightService', () => {
   });
 
   beforeEach(async () => {
+    stubReadyEnv();
     service = await buildModule({
       AWS_ACCESS_KEY_ID: 'test-key',
       AWS_S3_BUCKET: 'test-bucket',
@@ -45,7 +62,6 @@ describe('PreflightService', () => {
   });
 
   it('returns not_ready when env vars missing', async () => {
-    // Clear all env vars to ensure clean state
     vi.stubEnv('OPENAI_API_KEY', '');
     vi.stubEnv('AWS_S3_BUCKET', '');
     vi.stubEnv('AWS_ACCESS_KEY_ID', '');
@@ -60,7 +76,7 @@ describe('PreflightService', () => {
   });
 
   it('returns degraded when partial', async () => {
-    // Ensure storage env vars are absent so storage check fails
+    vi.stubEnv('OPENAI_API_KEY', 'sk');
     vi.stubEnv('AWS_S3_BUCKET', '');
     vi.stubEnv('AWS_ACCESS_KEY_ID', '');
     service = await buildModule({ OPENAI_API_KEY: 'sk' });

--- a/apps/server/api/src/services/skill-executor/skill-executor.service.spec.ts
+++ b/apps/server/api/src/services/skill-executor/skill-executor.service.spec.ts
@@ -23,7 +23,7 @@ describe('SkillExecutorService', () => {
 
   const mockSkillsService = {
     assertBrandSkillEnabled: vi.fn(),
-    getSkillBySlug: vi.fn(),
+    getSkillById: vi.fn(),
   };
 
   const mockContentRunsService = {
@@ -72,7 +72,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('executes a registered skill and tracks content run', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: true,
       requiredProviders: [],
       slug: 'content-writing',
@@ -130,7 +130,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('throws when skill does not exist', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue(null);
+    mockSkillsService.getSkillById.mockResolvedValue(null);
 
     await expect(
       service.execute('unknown-skill', baseContext),
@@ -138,7 +138,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('throws when skill is disabled', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: false,
       slug: 'content-writing',
     });
@@ -149,7 +149,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('marks run as failed when handler throws', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: true,
       requiredProviders: [],
       slug: 'content-writing',
@@ -173,7 +173,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('resolves BYOK source when skill has required providers', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: true,
       requiredProviders: [ByokProvider.OPENAI],
       slug: 'content-writing',
@@ -202,7 +202,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('marks run as failed for unregistered handler slug', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: true,
       requiredProviders: [],
       slug: 'video-editing',
@@ -223,7 +223,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('records duration on both success and failure', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: true,
       requiredProviders: [],
       slug: 'content-writing',
@@ -249,7 +249,7 @@ describe('SkillExecutorService', () => {
   });
 
   it('captures publish context when scheduling metadata is present', async () => {
-    mockSkillsService.getSkillBySlug.mockResolvedValue({
+    mockSkillsService.getSkillById.mockResolvedValue({
       isEnabled: true,
       requiredProviders: [],
       slug: 'content-writing',

--- a/apps/vitest.config.mts
+++ b/apps/vitest.config.mts
@@ -521,6 +521,10 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@ui\/charts$/,
+        replacement: path.resolve(repoRoot, './packages/ui/src/charts.ts'),
+      },
+      {
         find: /^@ui\/(.*)$/,
         replacement: path.resolve(repoRoot, './packages/ui/src/components/$1'),
       },

--- a/packages/agent/src/components/ClipWorkflowRunCard.spec.tsx
+++ b/packages/agent/src/components/ClipWorkflowRunCard.spec.tsx
@@ -62,12 +62,17 @@ describe('ClipWorkflowRunCard', () => {
 
     const runNextButton = screen.getByRole('button', { name: 'Run Next Step' });
 
-    await waitFor(() => {
-      fireEvent.click(runNextButton);
-    });
+    fireEvent.click(runNextButton);
 
     await waitFor(() => {
-      fireEvent.click(runNextButton);
+      expect(apiService.generateIngredientEffect).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText('Generated clips: 1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Next Step' }));
+
+    await waitFor(() => {
+      expect(apiService.reframeVideoEffect).toHaveBeenCalledTimes(1);
     });
 
     const reviewLink = await screen.findByRole('link', {

--- a/packages/ui/src/components/cards/progress-sidebar-card/ProgressSidebarCard.test.tsx
+++ b/packages/ui/src/components/cards/progress-sidebar-card/ProgressSidebarCard.test.tsx
@@ -333,7 +333,9 @@ describe('ProgressSidebarCard', () => {
     });
 
     expect(
-      globalThis.localStorage.getItem('genfeed:sidebar:progress-visible'),
+      globalThis.localStorage.getItem(
+        'genfeed:sidebar:progress-visible:user-123',
+      ),
     ).toBe('false');
     expect(mockPatchSettings).toHaveBeenCalledWith('user-123', {
       isSidebarProgressVisible: false,

--- a/packages/ui/src/components/menus/sidebar-action-trigger/SidebarActionTrigger.test.tsx
+++ b/packages/ui/src/components/menus/sidebar-action-trigger/SidebarActionTrigger.test.tsx
@@ -20,7 +20,7 @@ describe('SidebarActionTrigger', () => {
     expect(screen.getByText('⌘⇧N')).toHaveClass('opacity-0');
     expect(screen.getByText('New Task')).toHaveClass('min-w-0', 'flex-1');
     expect(button).toHaveClass(
-      'rounded-xl',
+      'rounded',
       'hover:bg-white/[0.035]',
       'focus-visible:ring-offset-background',
     );

--- a/packages/ui/src/components/pages/offline/OfflinePage.test.tsx
+++ b/packages/ui/src/components/pages/offline/OfflinePage.test.tsx
@@ -92,7 +92,7 @@ describe('OfflinePage', () => {
       const retryButton = screen.getByRole('button', {
         name: 'Try Again',
       });
-      expect(retryButton).toHaveClass('bg-primary');
+      expect(retryButton).toHaveClass('bg-accent', 'text-accent-foreground');
     });
   });
 

--- a/packages/ui/src/components/tests/setup.ts
+++ b/packages/ui/src/components/tests/setup.ts
@@ -195,6 +195,7 @@ global.fetch = vi.fn();
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
   usePathname: () => '/',
+  useParams: () => ({ brandSlug: 'brand-slug', orgSlug: 'acme' }),
   useRouter: () => ({
     back: vi.fn(),
     prefetch: vi.fn(),


### PR DESCRIPTION
## What changed

- Updated stale API/app/UI test expectations that were failing the CI `bun run test` step on `develop`.
- Added the missing app Vitest alias for `@ui/charts`.
- Fixed test fixtures for route params, localStorage, Telegram user metadata, preflight env isolation, vote create DTO shape, and current serializer/service response shapes.
- Updated the content harness workspace-pack resolver so the EE harness pack can load from the workspace source when package `dist` output is not present.

## Root cause

The failing workflow was running the root test command against current `develop`; several specs still expected older DTO/enum/response shapes or incomplete test runtime mocks. The root test also exposed one resolver gap for workspace harness packs without built package output.

## Validation

- `bun run test` from repo root: passed, 57 Turbo tasks successful.
- `bunx turbo lint`: passed.
- `bun type-check`: passed, 41 Turbo tasks successful.
- Focused reruns for the failing app/API/UI suites passed before the final root run.