### PR TITLE
Remove placeholder specs

### DIFF
--- a/apps/server/files/src/helpers/decorators/cache.decorator.spec.ts
+++ b/apps/server/files/src/helpers/decorators/cache.decorator.spec.ts
@@ -1,8 +1,0 @@
-describe('CacheDecorator', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for CacheDecorator
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/helpers/exceptions/validation.exception.spec.ts
+++ b/apps/server/files/src/helpers/exceptions/validation.exception.spec.ts
@@ -1,8 +1,0 @@
-describe('ValidationException', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for ValidationException
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/instrument.spec.ts
+++ b/apps/server/files/src/instrument.spec.ts
@@ -1,8 +1,0 @@
-describe('Instrument', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for Instrument
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/processors/file.processor.spec.ts
+++ b/apps/server/files/src/processors/file.processor.spec.ts
@@ -1,8 +1,0 @@
-describe('FileProcessor', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for FileProcessor
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/processors/image.processor.spec.ts
+++ b/apps/server/files/src/processors/image.processor.spec.ts
@@ -1,8 +1,0 @@
-describe('ImageProcessor', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for ImageProcessor
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/processors/youtube.processor.spec.ts
+++ b/apps/server/files/src/processors/youtube.processor.spec.ts
@@ -1,8 +1,0 @@
-describe('YoutubeProcessor', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for YoutubeProcessor
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/queues/queue.constants.spec.ts
+++ b/apps/server/files/src/queues/queue.constants.spec.ts
@@ -1,8 +1,0 @@
-describe('QueueConstants', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for QueueConstants
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/services/ffmpeg/config/ffmpeg.config.spec.ts
+++ b/apps/server/files/src/services/ffmpeg/config/ffmpeg.config.spec.ts
@@ -1,8 +1,0 @@
-describe('FfmpegConfig', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for FfmpegConfig
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/services/files/files.service.test.spec.ts
+++ b/apps/server/files/src/services/files/files.service.test.spec.ts
@@ -1,8 +1,0 @@
-describe('FilesServiceTest', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for FilesServiceTest
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/caption.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/caption.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('CaptionInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for CaptionInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/decorators.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/decorators.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('DecoratorsInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for DecoratorsInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/env-config.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/env-config.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('EnvConfigInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for EnvConfigInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/ffmpeg.interfaces.spec.ts
+++ b/apps/server/files/src/shared/interfaces/ffmpeg.interfaces.spec.ts
@@ -1,8 +1,0 @@
-describe('FfmpegInterfaces', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for FfmpegInterfaces
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/job.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/job.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('JobInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for JobInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/performance.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/performance.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('PerformanceInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for PerformanceInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/prompt.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/prompt.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('PromptInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for PromptInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/serializer.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/serializer.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('SerializerInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for SerializerInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/files/src/shared/interfaces/utils.interface.spec.ts
+++ b/apps/server/files/src/shared/interfaces/utils.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('UtilsInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for UtilsInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/mcp/src/instrument.spec.ts
+++ b/apps/server/mcp/src/instrument.spec.ts
@@ -1,8 +1,0 @@
-describe('Instrument', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for Instrument
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/mcp/src/shared/interfaces/analytics.interface.spec.ts
+++ b/apps/server/mcp/src/shared/interfaces/analytics.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('AnalyticsInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for AnalyticsInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/mcp/src/shared/interfaces/env-config.interface.spec.ts
+++ b/apps/server/mcp/src/shared/interfaces/env-config.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('EnvConfigInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for EnvConfigInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/mcp/src/shared/interfaces/mcp-server.interface.spec.ts
+++ b/apps/server/mcp/src/shared/interfaces/mcp-server.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('McpServerInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for McpServerInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/mcp/src/shared/interfaces/video.interface.spec.ts
+++ b/apps/server/mcp/src/shared/interfaces/video.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('VideoInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for VideoInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/mcp/test/app.e2e-spec.spec.ts
+++ b/apps/server/mcp/test/app.e2e-spec.spec.ts
@@ -1,8 +1,0 @@
-describe('AppE2eSpec', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for AppE2eSpec
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/notifications/src/config/services/validation.config.spec.ts
+++ b/apps/server/notifications/src/config/services/validation.config.spec.ts
@@ -1,8 +1,0 @@
-describe('ValidationConfig', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for ValidationConfig
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/notifications/src/instrument.spec.ts
+++ b/apps/server/notifications/src/instrument.spec.ts
@@ -1,8 +1,0 @@
-describe('Instrument', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for Instrument
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/notifications/src/shared/interfaces/env-config.interface.spec.ts
+++ b/apps/server/notifications/src/shared/interfaces/env-config.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('EnvConfigInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for EnvConfigInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/apps/server/notifications/src/shared/interfaces/webhooks.interface.spec.ts
+++ b/apps/server/notifications/src/shared/interfaces/webhooks.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('WebhooksInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for WebhooksInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/packages/libs/interfaces/cache.interface.spec.ts
+++ b/packages/libs/interfaces/cache.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('CacheInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for CacheInterface
-  // Consider what needs to be tested based on the file type and functionality
-});

--- a/packages/libs/interfaces/query.interface.spec.ts
+++ b/packages/libs/interfaces/query.interface.spec.ts
@@ -1,8 +1,0 @@
-describe('QueryInterface', () => {
-  it('should be defined', () => {
-    expect(true).toBeDefined();
-  });
-
-  // TODO: Add comprehensive tests for QueryInterface
-  // Consider what needs to be tested based on the file type and functionality
-});


### PR DESCRIPTION
## Summary
- Deleted 30 placeholder spec files that only asserted `expect(true).toBeDefined()` and carried TODO comments.
- Kept the change scoped to dead test scaffolding; no runtime behavior changed.

## Testing
- Not run (not requested)
- Verified the staged diff is a pure deletion set with no formatting issues