### PR TITLE
refactor: dedupe workflow routing and fix secretlint hook

### DIFF
--- a/apps/app/src/components/toolbar/Toolbar.tsx
+++ b/apps/app/src/components/toolbar/Toolbar.tsx
@@ -215,37 +215,45 @@ export function Toolbar() {
 
   // handleOpenFolder removed — desktop-only, not available in web
 
-  const handleDuplicate = useCallback(async () => {
-    if (!workflowId) return;
-    try {
+  const duplicateWorkflowAndRoute = useCallback(
+    async (renameTo?: string) => {
+      if (!workflowId) return false;
+
       const duplicated = await duplicateWorkflowApi(workflowId);
-      router.push(href(`/workflows/${duplicated._id}`));
+      const renameQuery = renameTo
+        ? `?rename=${encodeURIComponent(renameTo)}`
+        : '';
+
+      router.push(href(`/workflows/${duplicated._id}${renameQuery}`));
+      return true;
+    },
+    [workflowId, duplicateWorkflowApi, router, href],
+  );
+
+  const handleDuplicate = useCallback(async () => {
+    try {
+      await duplicateWorkflowAndRoute();
     } catch (error) {
       logger.error('Failed to duplicate workflow', error, {
         context: 'Toolbar',
       });
     }
-  }, [workflowId, duplicateWorkflowApi, router, href]);
+  }, [duplicateWorkflowAndRoute]);
 
   const handleSaveAs = useCallback(
     async (newName: string) => {
-      if (!workflowId) return;
       try {
-        const duplicated = await duplicateWorkflowApi(workflowId);
-        // Navigate to the duplicated workflow - the name will be set on the new workflow
-        router.push(
-          href(
-            `/workflows/${duplicated._id}?rename=${encodeURIComponent(newName)}`,
-          ),
-        );
-        setShowSaveAsDialog(false);
+        const didDuplicate = await duplicateWorkflowAndRoute(newName);
+        if (didDuplicate) {
+          setShowSaveAsDialog(false);
+        }
       } catch (error) {
         logger.error('Failed to save workflow as copy', error, {
           context: 'Toolbar',
         });
       }
     },
-    [workflowId, duplicateWorkflowApi, router, href],
+    [duplicateWorkflowAndRoute],
   );
 
   const handleScreenshot = useCallback(async () => {

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,7 @@
 export default {
-  '*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}': ['secretlint --no-glob'],
+  '*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}': [
+    'bun scripts/run-secretlint.ts --no-glob',
+  ],
   '*.{js,ts,jsx,tsx,json,css}': (files) =>
     `biome check --write --config-path=biome-staged.json --no-errors-on-unmatched ${files.join(' ')}`,
   '*.tsx': ['bash scripts/lint-no-raw-html.sh'],

--- a/scripts/run-secretlint.ts
+++ b/scripts/run-secretlint.ts
@@ -1,0 +1,13 @@
+import { run } from 'secretlint/cli';
+
+const result = await run();
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
+}
+
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+process.exit(result.exitStatus);


### PR DESCRIPTION
## Summary
- extract shared workflow duplication + routing logic in the toolbar
- keep duplicate/save-as behavior the same while removing local duplication
- fix lint-staged secretlint execution in this Bun workspace via a repo-local wrapper

## Verification
- bun scripts/run-secretlint.ts --no-glob apps/app/src/components/toolbar/Toolbar.tsx lint-staged.config.mjs scripts/run-secretlint.ts
- biome check --write --config-path=biome-staged.json --no-errors-on-unmatched apps/app/src/components/toolbar/Toolbar.tsx lint-staged.config.mjs scripts/run-secretlint.ts
- bash scripts/lint-no-raw-html.sh apps/app/src/components/toolbar/Toolbar.tsx