### PR TITLE
Remove empty Storybook scaffold TODOs

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/settings/models/models-layout-content.stories.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/models/models-layout-content.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import ModelsLayoutContent from './models-layout-content';
 
 const meta: Meta<typeof ModelsLayoutContent> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: ModelsLayoutContent,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof ModelsLayoutContent>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/apps/app/app/(public)/sign-up/sign-up-form.stories.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import SignUpForm from './sign-up-form';
 
 const meta: Meta<typeof SignUpForm> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: SignUpForm,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof SignUpForm>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,7 @@
 export default {
-  '*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}': ['secretlint --no-glob'],
+  '*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}': [
+    'bun scripts/run-secretlint.ts --no-glob',
+  ],
   '*.{js,ts,jsx,tsx,json,css}': (files) =>
     `biome check --write --config-path=biome-staged.json --no-errors-on-unmatched ${files.join(' ')}`,
   '*.tsx': ['bash scripts/lint-no-raw-html.sh'],

--- a/packages/contexts/models/models-context/models-context.stories.tsx
+++ b/packages/contexts/models/models-context/models-context.stories.tsx
@@ -2,9 +2,6 @@ import ModelsContext from '@genfeedai/contexts/models/models-context/models-cont
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof ModelsContext> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: ModelsContext,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof ModelsContext>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/contexts/models/trainings-context/trainings-context.stories.tsx
+++ b/packages/contexts/models/trainings-context/trainings-context.stories.tsx
@@ -2,9 +2,6 @@ import TrainingsContext from '@genfeedai/contexts/models/trainings-context/train
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof TrainingsContext> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: TrainingsContext,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof TrainingsContext>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/analytics/trends/trend-detail/trend-detail.stories.tsx
+++ b/packages/pages/analytics/trends/trend-detail/trend-detail.stories.tsx
@@ -2,9 +2,6 @@ import TrendDetail from '@pages/analytics/trends/trend-detail/trend-detail';
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof TrendDetail> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: TrendDetail,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof TrendDetail>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/models/list/models-list.stories.tsx
+++ b/packages/pages/models/list/models-list.stories.tsx
@@ -2,9 +2,6 @@ import ModelsList from '@pages/models/list/models-list';
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof ModelsList> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: ModelsList,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof ModelsList>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/posts/detail/components/PostDetailAnalytics.stories.tsx
+++ b/packages/pages/posts/detail/components/PostDetailAnalytics.stories.tsx
@@ -2,9 +2,6 @@ import PostDetailAnalytics from '@pages/posts/detail/components/PostDetailAnalyt
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof PostDetailAnalytics> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostDetailAnalytics,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostDetailAnalytics>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/posts/detail/components/PostDetailCard.stories.tsx
+++ b/packages/pages/posts/detail/components/PostDetailCard.stories.tsx
@@ -2,9 +2,6 @@ import PostDetailCard from '@pages/posts/detail/components/PostDetailCard';
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof PostDetailCard> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostDetailCard,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostDetailCard>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/posts/detail/components/PostDetailContent.stories.tsx
+++ b/packages/pages/posts/detail/components/PostDetailContent.stories.tsx
@@ -2,9 +2,6 @@ import PostDetailContent from '@pages/posts/detail/components/PostDetailContent'
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof PostDetailContent> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostDetailContent,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostDetailContent>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/posts/detail/components/PostDetailHeader.stories.tsx
+++ b/packages/pages/posts/detail/components/PostDetailHeader.stories.tsx
@@ -2,9 +2,6 @@ import PostDetailHeader from '@pages/posts/detail/components/PostDetailHeader';
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof PostDetailHeader> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostDetailHeader,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostDetailHeader>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/pages/posts/detail/post-detail.stories.tsx
+++ b/packages/pages/posts/detail/post-detail.stories.tsx
@@ -2,9 +2,6 @@ import PostDetail from '@pages/posts/detail/post-detail';
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
 const meta: Meta<typeof PostDetail> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostDetail,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostDetail>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/analytics/top-posts/TopPostsSection.stories.tsx
+++ b/packages/ui/src/components/analytics/top-posts/TopPostsSection.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import TopPostsSection from '@ui/analytics/top-posts/TopPostsSection';
 
 const meta: Meta<typeof TopPostsSection> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: TopPostsSection,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof TopPostsSection>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/card/empty/CardEmpty.stories.tsx
+++ b/packages/ui/src/components/card/empty/CardEmpty.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import CardEmpty from '@ui/card/empty/CardEmpty';
 
 const meta: Meta<typeof CardEmpty> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: CardEmpty,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof CardEmpty>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/display/html-content/HtmlContent.stories.tsx
+++ b/packages/ui/src/components/display/html-content/HtmlContent.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import HtmlContent from '@ui/display/html-content/HtmlContent';
 
 const meta: Meta<typeof HtmlContent> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: HtmlContent,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof HtmlContent>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/display/platform-badge/PlatformBadge.stories.tsx
+++ b/packages/ui/src/components/display/platform-badge/PlatformBadge.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import PlatformBadge from '@ui/display/platform-badge/PlatformBadge';
 
 const meta: Meta<typeof PlatformBadge> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PlatformBadge,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PlatformBadge>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/guards/credentials/CredentialsGuard.stories.tsx
+++ b/packages/ui/src/components/guards/credentials/CredentialsGuard.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import CredentialsGuard from '@ui/guards/credentials/CredentialsGuard';
 
 const meta: Meta<typeof CredentialsGuard> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: CredentialsGuard,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof CredentialsGuard>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/modals/content/generate-illustration/ModalGenerateIllustration.stories.tsx
+++ b/packages/ui/src/components/modals/content/generate-illustration/ModalGenerateIllustration.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import ModalGenerateIllustration from '@ui/modals/content/generate-illustration/ModalGenerateIllustration';
 
 const meta: Meta<typeof ModalGenerateIllustration> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: ModalGenerateIllustration,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof ModalGenerateIllustration>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/modals/content/remix/ModalPostRemix.stories.tsx
+++ b/packages/ui/src/components/modals/content/remix/ModalPostRemix.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import ModalPostRemix from '@ui/modals/content/remix/ModalPostRemix';
 
 const meta: Meta<typeof ModalPostRemix> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: ModalPostRemix,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof ModalPostRemix>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/modals/models/ModalModel.stories.tsx
+++ b/packages/ui/src/components/modals/models/ModalModel.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import ModalModel from '@ui/modals/models/ModalModel';
 
 const meta: Meta<typeof ModalModel> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: ModalModel,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof ModalModel>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/posts/enhancement-bar/post-enhancement-bar/PostEnhancementBar.stories.tsx
+++ b/packages/ui/src/components/posts/enhancement-bar/post-enhancement-bar/PostEnhancementBar.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import PostEnhancementBar from '@ui/posts/enhancement-bar/post-enhancement-bar/PostEnhancementBar';
 
 const meta: Meta<typeof PostEnhancementBar> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostEnhancementBar,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostEnhancementBar>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.stories.tsx
+++ b/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import PostDetailSidebar from '@ui/posts/post-detail-sidebar/PostDetailSidebar';
 
 const meta: Meta<typeof PostDetailSidebar> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PostDetailSidebar,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PostDetailSidebar>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/prompt-bars/components/divider/PromptBarDivider.stories.tsx
+++ b/packages/ui/src/components/prompt-bars/components/divider/PromptBarDivider.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import PromptBarDivider from '@ui/prompt-bars/components/divider/PromptBarDivider';
 
 const meta: Meta<typeof PromptBarDivider> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: PromptBarDivider,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof PromptBarDivider>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/packages/ui/src/components/storyboard/EaseCurveSelector.stories.tsx
+++ b/packages/ui/src/components/storyboard/EaseCurveSelector.stories.tsx
@@ -2,9 +2,6 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import EaseCurveSelector from '@ui/storyboard/EaseCurveSelector';
 
 const meta: Meta<typeof EaseCurveSelector> = {
-  argTypes: {
-    // TODO: Add argTypes for component props
-  },
   component: EaseCurveSelector,
   parameters: {
     layout: 'centered',
@@ -17,13 +14,9 @@ export default meta;
 type Story = StoryObj<typeof EaseCurveSelector>;
 
 export const Default: Story = {
-  args: {
-    // TODO: Add default props
-  },
+  args: {},
 };
 
 export const Interactive: Story = {
-  args: {
-    // TODO: Add interactive props
-  },
+  args: {},
 };

--- a/scripts/run-secretlint.ts
+++ b/scripts/run-secretlint.ts
@@ -1,0 +1,13 @@
+import { run } from 'secretlint/cli';
+
+const result = await run();
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
+}
+
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+process.exit(result.exitStatus);


### PR DESCRIPTION
## Summary
- remove generated empty Storybook argTypes TODO blocks
- collapse empty default/interactive args TODO blocks while preserving story exports
- fix lint-staged secretlint invocation by using the Bun wrapper

## Verification
- pre-commit passed: secretlint wrapper, staged Biome, raw HTML guard
- worktree clean after commit
