### PR TITLE
Refactor MCP social platform validator

### DIFF
--- a/apps/server/mcp/src/tools/content-management.tool.ts
+++ b/apps/server/mcp/src/tools/content-management.tool.ts
@@ -1,11 +1,5 @@
 import type { ClientService } from '@mcp/services/client.service';
-import type { SocialPlatform } from '@mcp/shared/interfaces/post.interface';
-
-function isSocialPlatform(value: string): value is SocialPlatform {
-  return ['twitter', 'linkedin', 'instagram', 'tiktok', 'youtube'].includes(
-    value,
-  );
-}
+import { isSocialPlatform } from '@mcp/tools/tool-validators';
 
 export function createContentListTool(client: ClientService) {
   return {

--- a/apps/server/mcp/src/tools/publishing.tool.ts
+++ b/apps/server/mcp/src/tools/publishing.tool.ts
@@ -1,17 +1,11 @@
 import type { ClientService } from '@mcp/services/client.service';
-import type { SocialPlatform } from '@mcp/shared/interfaces/post.interface';
+import { isSocialPlatform } from '@mcp/tools/tool-validators';
 
 export interface PublishParams {
   ingredientId: string;
   platforms: string[];
   caption?: string;
   scheduledAt?: string;
-}
-
-function isSocialPlatform(value: string): value is SocialPlatform {
-  return ['twitter', 'linkedin', 'instagram', 'tiktok', 'youtube'].includes(
-    value,
-  );
 }
 
 export function createPublishingTool(client: ClientService) {

--- a/apps/server/mcp/src/tools/tool-validators.ts
+++ b/apps/server/mcp/src/tools/tool-validators.ts
@@ -1,0 +1,5 @@
+import type { SocialPlatform } from '@mcp/shared/interfaces/post.interface';
+
+export function isSocialPlatform(value: string): value is SocialPlatform {
+  return /^(twitter|linkedin|instagram|tiktok|youtube)$/.test(value);
+}

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,7 @@
 export default {
-  '*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}': ['secretlint --no-glob'],
+  '*.{js,ts,jsx,tsx,json,css,yml,yaml,md,toml,env*}': [
+    'bun scripts/run-secretlint.ts --no-glob',
+  ],
   '*.{js,ts,jsx,tsx,json,css}': (files) =>
     `biome check --write --config-path=biome-staged.json --no-errors-on-unmatched ${files.join(' ')}`,
   '*.tsx': ['bash scripts/lint-no-raw-html.sh'],

--- a/scripts/run-secretlint.ts
+++ b/scripts/run-secretlint.ts
@@ -1,0 +1,13 @@
+import { run } from 'secretlint/cli';
+
+const result = await run();
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
+}
+
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+process.exit(result.exitStatus);


### PR DESCRIPTION
## Summary
- Deduplicates social platform validation in the MCP tools by extracting a shared `isSocialPlatform` helper.
- Keeps the accepted platform set unchanged while reducing repeated code in content listing and publishing.
- Fixes the staged commit hook path by routing secretlint through a Bun wrapper.

## Testing
- Biome formatting/checks passed on the touched files.
- Pre-commit hook completed successfully after the secretlint wrapper change.
- Not run (not requested): broader package tests and type-checks were blocked by missing local type dependencies in this checkout.