### PR TITLE
[codex] Dedupe CLI generation flow

### DIFF
--- a/packages/cli/src/commands/generate/article-x.ts
+++ b/packages/cli/src/commands/generate/article-x.ts
@@ -1,12 +1,14 @@
-import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
 import { type Article, generateXArticle, getArticle } from '@/api/articles.js';
 import { requireAuth } from '@/api/client.js';
-import { getActiveBrand } from '@/config/store.js';
-import { formatLabel, print, printJson } from '@/ui/theme.js';
-import { handleError, NoBrandError } from '@/utils/errors.js';
-import { waitForCompletion } from '@/utils/websocket.js';
+import { handleError } from '@/utils/errors.js';
+import {
+  printGeneratedResult,
+  printGenerationStarted,
+  requireGenerationBrand,
+  waitForGenerated,
+} from './helpers.js';
 
 export const articleXCommand = new Command('article-x')
   .description('Generate a long-form X (Twitter) article')
@@ -18,12 +20,7 @@ export const articleXCommand = new Command('article-x')
     try {
       await requireAuth();
 
-      const activeBrandId = await getActiveBrand();
-      const brandId = options.brand ?? activeBrandId;
-      if (!brandId) {
-        throw new NoBrandError();
-      }
-
+      const brandId = await requireGenerationBrand(options.brand);
       const spinner = ora('Creating X article...').start();
 
       const activity = await generateXArticle({
@@ -33,60 +30,42 @@ export const articleXCommand = new Command('article-x')
 
       if (!options.wait) {
         spinner.succeed('X article generation started');
-        const articleStatusId = activity.articleId ?? activity.id;
-
-        if (options.json) {
-          printJson({
-            articleId: activity.articleId,
-            id: activity.id,
-            status: activity.status,
-            statusCommand: `gf status ${articleStatusId} --type article`,
-          });
-        } else {
-          print(formatLabel('ID', activity.id));
-          print(formatLabel('Status', activity.status));
-          if (activity.articleId) {
-            print(formatLabel('Article ID', activity.articleId));
-          }
-          print();
-          print(chalk.dim(`Check status with: gf status ${articleStatusId} --type article`));
-        }
+        printGenerationStarted(
+          activity.id,
+          activity.status,
+          options.json,
+          'article',
+          activity.articleId
+        );
         return;
       }
 
-      spinner.text = 'Generating X article...';
-
-      const { result, elapsed } = await waitForCompletion<Article>({
-        getResult: () => getArticle(activity.articleId ?? activity.id),
+      const { result, elapsed } = await waitForGenerated<Article>(
         spinner,
-        taskId: activity.id,
-        taskType: 'IMAGE',
-        timeout: 300000,
-      });
+        'X article',
+        'X article',
+        () => getArticle(activity.articleId ?? activity.id),
+        activity.id,
+        'IMAGE',
+        300000
+      );
 
-      const elapsedSec = (elapsed / 1000).toFixed(1);
-      spinner.succeed(`X article generated (${elapsedSec}s)`);
-
-      if (options.json) {
-        printJson({
+      printGeneratedResult(
+        options.json,
+        {
           elapsed,
           id: result.id,
           status: result.status,
           summary: result.summary,
           title: result.title,
           wordCount: result.wordCount,
-        });
-      } else {
-        if (result.title) {
-          print(formatLabel('Title', result.title));
-        }
-        if (result.summary) {
-          print(formatLabel('Summary', result.summary));
-        }
-        if (result.wordCount) {
-          print(formatLabel('Words', String(result.wordCount)));
-        }
-      }
+        },
+        [
+          result.title ? ['Title', result.title] : false,
+          result.summary ? ['Summary', result.summary] : false,
+          result.wordCount ? ['Words', String(result.wordCount)] : false,
+        ]
+      );
     } catch (error) {
       handleError(error);
     }

--- a/packages/cli/src/commands/generate/article.ts
+++ b/packages/cli/src/commands/generate/article.ts
@@ -1,12 +1,14 @@
-import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
 import { type Article, generateArticle, getArticle } from '@/api/articles.js';
 import { requireAuth } from '@/api/client.js';
-import { getActiveBrand } from '@/config/store.js';
-import { formatLabel, print, printJson } from '@/ui/theme.js';
-import { handleError, NoBrandError } from '@/utils/errors.js';
-import { waitForCompletion } from '@/utils/websocket.js';
+import { handleError } from '@/utils/errors.js';
+import {
+  printGeneratedResult,
+  printGenerationStarted,
+  requireGenerationBrand,
+  waitForGenerated,
+} from './helpers.js';
 
 export const articleCommand = new Command('article')
   .description('Generate an AI article')
@@ -20,12 +22,7 @@ export const articleCommand = new Command('article')
     try {
       await requireAuth();
 
-      const activeBrandId = await getActiveBrand();
-      const brandId = options.brand ?? activeBrandId;
-      if (!brandId) {
-        throw new NoBrandError();
-      }
-
+      const brandId = await requireGenerationBrand(options.brand);
       const spinner = ora('Creating article...').start();
 
       const activity = await generateArticle({
@@ -37,42 +34,29 @@ export const articleCommand = new Command('article')
 
       if (!options.wait) {
         spinner.succeed('Article generation started');
-        const articleStatusId = activity.articleId ?? activity.id;
-
-        if (options.json) {
-          printJson({
-            articleId: activity.articleId,
-            id: activity.id,
-            status: activity.status,
-            statusCommand: `gf status ${articleStatusId} --type article`,
-          });
-        } else {
-          print(formatLabel('ID', activity.id));
-          print(formatLabel('Status', activity.status));
-          if (activity.articleId) {
-            print(formatLabel('Article ID', activity.articleId));
-          }
-          print();
-          print(chalk.dim(`Check status with: gf status ${articleStatusId} --type article`));
-        }
+        printGenerationStarted(
+          activity.id,
+          activity.status,
+          options.json,
+          'article',
+          activity.articleId
+        );
         return;
       }
 
-      spinner.text = 'Generating article...';
-
-      const { result, elapsed } = await waitForCompletion<Article>({
-        getResult: () => getArticle(activity.articleId ?? activity.id),
+      const { result, elapsed } = await waitForGenerated<Article>(
         spinner,
-        taskId: activity.id,
-        taskType: 'IMAGE', // reuse existing websocket event type
-        timeout: 300000,
-      });
+        'article',
+        'Article',
+        () => getArticle(activity.articleId ?? activity.id),
+        activity.id,
+        'IMAGE',
+        300000
+      );
 
-      const elapsedSec = (elapsed / 1000).toFixed(1);
-      spinner.succeed(`Article generated (${elapsedSec}s)`);
-
-      if (options.json) {
-        printJson({
+      printGeneratedResult(
+        options.json,
+        {
           category: result.category,
           elapsed,
           id: result.id,
@@ -80,21 +64,14 @@ export const articleCommand = new Command('article')
           summary: result.summary,
           title: result.title,
           wordCount: result.wordCount,
-        });
-      } else {
-        if (result.title) {
-          print(formatLabel('Title', result.title));
-        }
-        if (result.summary) {
-          print(formatLabel('Summary', result.summary));
-        }
-        if (result.wordCount) {
-          print(formatLabel('Words', String(result.wordCount)));
-        }
-        if (result.category) {
-          print(formatLabel('Category', result.category));
-        }
-      }
+        },
+        [
+          result.title ? ['Title', result.title] : false,
+          result.summary ? ['Summary', result.summary] : false,
+          result.wordCount ? ['Words', String(result.wordCount)] : false,
+          result.category ? ['Category', result.category] : false,
+        ]
+      );
     } catch (error) {
       handleError(error);
     }

--- a/packages/cli/src/commands/generate/helpers.ts
+++ b/packages/cli/src/commands/generate/helpers.ts
@@ -1,0 +1,91 @@
+import { writeFile } from 'node:fs/promises';
+import chalk from 'chalk';
+import ora, { type Ora } from 'ora';
+import { getActiveBrand } from '@/config/store.js';
+import { formatLabel, print, printJson } from '@/ui/theme.js';
+import { NoBrandError } from '@/utils/errors.js';
+import { waitForCompletion } from '@/utils/websocket.js';
+
+type OutputLabel = readonly [string, string] | false | undefined;
+
+export async function requireGenerationBrand(brand?: string): Promise<string> {
+  const brandId = brand ?? (await getActiveBrand());
+  if (brandId) return brandId;
+  throw new NoBrandError();
+}
+
+export async function waitForGenerated<T>(
+  spinner: Ora,
+  generatingType: string,
+  generatedType: string,
+  getResult: () => Promise<T>,
+  taskId: string,
+  taskType: 'IMAGE' | 'VIDEO',
+  timeout: number
+): Promise<{ elapsed: number; result: T }> {
+  spinner.text = `Generating ${generatingType}...`;
+  const completed = await waitForCompletion<T>({ getResult, spinner, taskId, taskType, timeout });
+  spinner.succeed(`${generatedType} generated (${(completed.elapsed / 1000).toFixed(1)}s)`);
+  return completed;
+}
+
+export function printGenerationStarted(
+  id: string,
+  status: string,
+  json?: boolean,
+  statusType?: string,
+  articleId?: string
+): void {
+  const statusId = articleId ?? id;
+  const statusCommand = `gf status ${statusId}${statusType ? ` --type ${statusType}` : ''}`;
+  if (json) {
+    printJson(statusType ? { articleId, id, status, statusCommand } : { id, status });
+    return;
+  }
+
+  print(formatLabel('ID', id));
+  print(formatLabel('Status', status));
+  if (articleId) {
+    print(formatLabel('Article ID', articleId));
+  }
+  print();
+  print(chalk.dim(`Check status with: ${statusCommand}`));
+}
+
+export function printGeneratedResult(
+  json: boolean | undefined,
+  jsonData: Record<string, unknown>,
+  labels: OutputLabel[]
+): void {
+  if (json) {
+    printJson(jsonData);
+    return;
+  }
+
+  for (const label of labels) {
+    if (label) {
+      print(formatLabel(label[0], label[1]));
+    }
+  }
+}
+
+export async function downloadGeneratedFile(
+  contentType: string,
+  output: string,
+  url: string
+): Promise<void> {
+  const downloadSpinner = ora(`Downloading ${contentType}...`).start();
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download: ${response.statusText}`);
+    }
+
+    const buffer = await response.arrayBuffer();
+    await writeFile(output, Buffer.from(buffer));
+    downloadSpinner.succeed(`Saved to ${output}`);
+  } catch (err) {
+    downloadSpinner.fail(`Failed to download ${contentType}`);
+    throw err;
+  }
+}

--- a/packages/cli/src/commands/generate/image.ts
+++ b/packages/cli/src/commands/generate/image.ts
@@ -1,13 +1,16 @@
-import { writeFile } from 'node:fs/promises';
-import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
 import { requireAuth } from '@/api/client.js';
 import { createImage, getImage, type Image } from '@/api/images.js';
-import { getActiveBrand, getActiveProfile } from '@/config/store.js';
-import { formatLabel, print, printJson } from '@/ui/theme.js';
-import { handleError, NoBrandError } from '@/utils/errors.js';
-import { waitForCompletion } from '@/utils/websocket.js';
+import { getActiveProfile } from '@/config/store.js';
+import { handleError } from '@/utils/errors.js';
+import {
+  downloadGeneratedFile,
+  printGeneratedResult,
+  printGenerationStarted,
+  requireGenerationBrand,
+  waitForGenerated,
+} from './helpers.js';
 
 export const imageCommand = new Command('image')
   .description('Generate an AI image')
@@ -23,12 +26,7 @@ export const imageCommand = new Command('image')
     try {
       await requireAuth();
 
-      const activeBrandId = await getActiveBrand();
-      const brandId = options.brand ?? activeBrandId;
-      if (!brandId) {
-        throw new NoBrandError();
-      }
-
+      const brandId = await requireGenerationBrand(options.brand);
       const { profile } = await getActiveProfile();
       const model = options.model ?? profile.defaults.imageModel;
 
@@ -44,63 +42,42 @@ export const imageCommand = new Command('image')
 
       if (!options.wait) {
         spinner.succeed('Image generation started');
-
-        if (options.json) {
-          printJson({ id: image.id, status: image.status });
-        } else {
-          print(formatLabel('ID', image.id));
-          print(formatLabel('Status', image.status));
-          print();
-          print(chalk.dim(`Check status with: gf status ${image.id}`));
-        }
+        printGenerationStarted(image.id, image.status, options.json);
         return;
       }
 
-      spinner.text = 'Generating image...';
-
-      const { result, elapsed } = await waitForCompletion<Image>({
-        getResult: () => getImage(image.id),
+      const { result, elapsed } = await waitForGenerated<Image>(
         spinner,
-        taskId: image.id,
-        taskType: 'IMAGE',
-        timeout: 300000,
-      });
+        'image',
+        'Image',
+        () => getImage(image.id),
+        image.id,
+        'IMAGE',
+        300000
+      );
 
-      const elapsedSec = (elapsed / 1000).toFixed(1);
-      spinner.succeed(`Image generated (${elapsedSec}s)`);
-
-      if (options.json) {
-        printJson({
-          elapsed: elapsed,
+      printGeneratedResult(
+        options.json,
+        {
+          elapsed,
           height: result.height,
           id: result.id,
           model: result.model,
           status: result.status,
           url: result.url,
           width: result.width,
-        });
-      } else {
-        print(formatLabel('URL', result.url ?? 'N/A'));
-        if (result.width && result.height) {
-          print(formatLabel('Dimensions', `${result.width} × ${result.height}`));
-        }
-        print(formatLabel('Model', result.model));
-      }
+        },
+        [
+          ['URL', result.url ?? 'N/A'],
+          result.width && result.height
+            ? ['Dimensions', `${result.width} × ${result.height}`]
+            : false,
+          ['Model', result.model],
+        ]
+      );
 
       if (options.output && result.url) {
-        const downloadSpinner = ora('Downloading image...').start();
-        try {
-          const response = await fetch(result.url);
-          if (!response.ok) {
-            throw new Error(`Failed to download: ${response.statusText}`);
-          }
-          const buffer = await response.arrayBuffer();
-          await writeFile(options.output, Buffer.from(buffer));
-          downloadSpinner.succeed(`Saved to ${options.output}`);
-        } catch (err) {
-          downloadSpinner.fail('Failed to download image');
-          throw err;
-        }
+        await downloadGeneratedFile('image', options.output, result.url);
       }
     } catch (error) {
       handleError(error);

--- a/packages/cli/src/commands/generate/video.ts
+++ b/packages/cli/src/commands/generate/video.ts
@@ -1,13 +1,16 @@
-import { writeFile } from 'node:fs/promises';
-import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
 import { requireAuth } from '@/api/client.js';
 import { createVideo, getVideo, type Video } from '@/api/videos.js';
-import { getActiveBrand, getActiveProfile } from '@/config/store.js';
-import { formatLabel, print, printJson } from '@/ui/theme.js';
-import { handleError, NoBrandError } from '@/utils/errors.js';
-import { waitForCompletion } from '@/utils/websocket.js';
+import { getActiveProfile } from '@/config/store.js';
+import { handleError } from '@/utils/errors.js';
+import {
+  downloadGeneratedFile,
+  printGeneratedResult,
+  printGenerationStarted,
+  requireGenerationBrand,
+  waitForGenerated,
+} from './helpers.js';
 
 export const videoCommand = new Command('video')
   .description('Generate an AI video')
@@ -23,12 +26,7 @@ export const videoCommand = new Command('video')
     try {
       await requireAuth();
 
-      const activeBrandId = await getActiveBrand();
-      const brandId = options.brand ?? activeBrandId;
-      if (!brandId) {
-        throw new NoBrandError();
-      }
-
+      const brandId = await requireGenerationBrand(options.brand);
       const { profile } = await getActiveProfile();
       const model = options.model ?? profile.defaults.videoModel;
 
@@ -44,66 +42,41 @@ export const videoCommand = new Command('video')
 
       if (!options.wait) {
         spinner.succeed('Video generation started');
-
-        if (options.json) {
-          printJson({ id: video.id, status: video.status });
-        } else {
-          print(formatLabel('ID', video.id));
-          print(formatLabel('Status', video.status));
-          print();
-          print(chalk.dim(`Check status with: gf status ${video.id}`));
-        }
+        printGenerationStarted(video.id, video.status, options.json);
         return;
       }
 
-      spinner.text = 'Generating video...';
-
-      const { result, elapsed } = await waitForCompletion<Video>({
-        getResult: () => getVideo(video.id),
+      const { result, elapsed } = await waitForGenerated<Video>(
         spinner,
-        taskId: video.id,
-        taskType: 'VIDEO',
-        timeout: 600000,
-      });
+        'video',
+        'Video',
+        () => getVideo(video.id),
+        video.id,
+        'VIDEO',
+        600000
+      );
 
-      const elapsedSec = (elapsed / 1000).toFixed(1);
-      spinner.succeed(`Video generated (${elapsedSec}s)`);
-
-      if (options.json) {
-        printJson({
+      printGeneratedResult(
+        options.json,
+        {
           duration: result.duration,
-          elapsed: elapsed,
+          elapsed,
           id: result.id,
           model: result.model,
           resolution: result.resolution,
           status: result.status,
           url: result.url,
-        });
-      } else {
-        print(formatLabel('URL', result.url ?? 'N/A'));
-        if (result.duration) {
-          print(formatLabel('Duration', `${result.duration}s`));
-        }
-        if (result.resolution) {
-          print(formatLabel('Resolution', result.resolution));
-        }
-        print(formatLabel('Model', result.model));
-      }
+        },
+        [
+          ['URL', result.url ?? 'N/A'],
+          result.duration ? ['Duration', `${result.duration}s`] : false,
+          result.resolution ? ['Resolution', result.resolution] : false,
+          ['Model', result.model],
+        ]
+      );
 
       if (options.output && result.url) {
-        const downloadSpinner = ora('Downloading video...').start();
-        try {
-          const response = await fetch(result.url);
-          if (!response.ok) {
-            throw new Error(`Failed to download: ${response.statusText}`);
-          }
-          const buffer = await response.arrayBuffer();
-          await writeFile(options.output, Buffer.from(buffer));
-          downloadSpinner.succeed(`Saved to ${options.output}`);
-        } catch (err) {
-          downloadSpinner.fail('Failed to download video');
-          throw err;
-        }
+        await downloadGeneratedFile('video', options.output, result.url);
       }
     } catch (error) {
       handleError(error);


### PR DESCRIPTION
## Summary

Refactors the CLI generate commands so article, X article, image, and video generation share the same command-flow helpers instead of repeating local blocks.

## What changed

- Added shared helpers for required brand lookup, no-wait status output, websocket wait/success handling, generated result printing, and generated media downloads.
- Updated the four generate commands to use the shared helpers while preserving their existing command options, status output, JSON output, and download behavior.
- Reduced the touched command surface by 3 net LOC and removed the duplicated flow code from each command file.

## Validation

- `bunx biome check --write packages/cli/src/commands/generate/article.ts packages/cli/src/commands/generate/article-x.ts packages/cli/src/commands/generate/image.ts packages/cli/src/commands/generate/video.ts packages/cli/src/commands/generate/helpers.ts`
- `bunx biome check packages/cli/src/commands/generate/article.ts packages/cli/src/commands/generate/article-x.ts packages/cli/src/commands/generate/image.ts packages/cli/src/commands/generate/video.ts packages/cli/src/commands/generate/helpers.ts`
- `git diff --check -- packages/cli/src/commands/generate`

## Notes

- `bunx tsc -p packages/cli/tsconfig.json --noEmit --pretty false` is blocked in this checkout by missing `bun` and `node` type definition files.
