### PR TITLE
[codex] Deduplicate agent JSON:API test mocks

### DIFF
--- a/packages/agent/src/components/AgentPanel.spec.tsx
+++ b/packages/agent/src/components/AgentPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Effect } from 'effect';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -140,6 +140,10 @@ function createCreditsInfoApiService() {
 describe('AgentPanel', () => {
   it('renders quick ask chrome and passes the rail-scoped prompt bar mode into the embedded chat container', () => {
     render(<AgentPanel apiService={createCreditsInfoApiService() as never} />);
+
+    expect(screen.getByTestId('agent-cli-terminal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Switch to chat mode'));
 
     expect(screen.getByTestId('agent-chat-container')).toHaveAttribute(
       'data-prompt-layout-mode',

--- a/packages/agent/src/services/agent-api.service.spec.ts
+++ b/packages/agent/src/services/agent-api.service.spec.ts
@@ -1,58 +1,19 @@
+import {
+  mockError,
+  mockFetch,
+  mockJsonApiCollection,
+  mockJsonApiResource,
+  mockOk,
+} from '@agent-tests/json-api-fetch.mock';
 import { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import type { AgentApiDecodeError } from '@genfeedai/agent/services/agent-api-error';
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
-
 function makeService(token: string | null = 'test-token') {
   return new AgentApiService({
     baseUrl: 'http://api.test',
     getToken: vi.fn().mockResolvedValue(token),
-  });
-}
-
-function mockOk(data: unknown) {
-  mockFetch.mockResolvedValueOnce({
-    json: () => Promise.resolve(data),
-    ok: true,
-  });
-}
-
-function mockJsonApiResource(data: Record<string, unknown>, type = 'resource') {
-  mockOk({
-    data: {
-      attributes: data,
-      id: String(data.id ?? '1'),
-      type,
-    },
-  });
-}
-
-function mockJsonApiCollection(
-  items: Array<Record<string, unknown>>,
-  type = 'resource',
-) {
-  mockOk({
-    data: items.map((item) => ({
-      attributes: item,
-      id: String(item.id ?? '1'),
-      type,
-    })),
-  });
-}
-
-function mockError(
-  status: number,
-  payload?:
-    | Record<string, unknown>
-    | { errors: Array<Record<string, unknown>> },
-) {
-  mockFetch.mockResolvedValueOnce({
-    json: () => Promise.resolve(payload),
-    ok: false,
-    status,
   });
 }
 

--- a/packages/agent/src/services/agent-strategy-api.service.spec.ts
+++ b/packages/agent/src/services/agent-strategy-api.service.spec.ts
@@ -1,48 +1,20 @@
+import {
+  mockError,
+  mockFetch,
+  mockJsonApiCollection,
+  mockJsonApiResource,
+  mockOk,
+} from '@agent-tests/json-api-fetch.mock';
 import type { AgentApiDecodeError } from '@genfeedai/agent/services/agent-api-error';
 import { AgentStrategyApiService } from '@genfeedai/agent/services/agent-strategy-api.service';
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
 
 function makeService() {
   return new AgentStrategyApiService({
     baseUrl: 'http://api.test',
     getToken: vi.fn().mockResolvedValue('token'),
   });
-}
-
-function mockOk(data: unknown) {
-  mockFetch.mockResolvedValueOnce({
-    json: () => Promise.resolve(data),
-    ok: true,
-  });
-}
-
-function mockJsonApiResource(
-  id: string,
-  attrs: Record<string, unknown>,
-  type = 'strategy',
-) {
-  mockOk({ data: { attributes: attrs, id, type } });
-}
-
-function mockJsonApiCollection(
-  items: Array<Record<string, unknown>>,
-  type = 'strategy',
-) {
-  mockOk({
-    data: items.map((item) => ({
-      attributes: item,
-      id: String(item.id ?? '1'),
-      type,
-    })),
-  });
-}
-
-function mockError(status: number) {
-  mockFetch.mockResolvedValueOnce({ ok: false, status });
 }
 
 describe('AgentStrategyApiService', () => {
@@ -78,7 +50,7 @@ describe('AgentStrategyApiService', () => {
 
   describe('getStrategy', () => {
     it('fetches single strategy', async () => {
-      mockJsonApiResource('s-1', { id: 's-1' });
+      mockJsonApiResource({ id: 's-1' });
       const service = makeService();
       const result = await Effect.runPromise(service.getStrategyEffect('s-1'));
       expect(result).toBeDefined();
@@ -95,7 +67,7 @@ describe('AgentStrategyApiService', () => {
 
   describe('createStrategy', () => {
     it('creates strategy', async () => {
-      mockJsonApiResource('s-1', { id: 's-1', label: 'Test' });
+      mockJsonApiResource({ id: 's-1', label: 'Test' });
       const service = makeService();
       const result = await Effect.runPromise(
         service.createStrategyEffect({ label: 'Test' }),
@@ -134,7 +106,7 @@ describe('AgentStrategyApiService', () => {
 
   describe('updateStrategy', () => {
     it('updates strategy', async () => {
-      mockJsonApiResource('s-1', { id: 's-1', label: 'Updated' });
+      mockJsonApiResource({ id: 's-1', label: 'Updated' });
       const service = makeService();
       const result = await Effect.runPromise(
         service.updateStrategyEffect('s-1', { label: 'Updated' }),
@@ -157,7 +129,7 @@ describe('AgentStrategyApiService', () => {
 
   describe('deleteStrategy', () => {
     it('deletes strategy', async () => {
-      mockJsonApiResource('s-1', { id: 's-1' });
+      mockJsonApiResource({ id: 's-1' });
       const service = makeService();
       await Effect.runPromise(service.deleteStrategyEffect('s-1'));
       expect(mockFetch).toHaveBeenCalledWith(
@@ -177,7 +149,7 @@ describe('AgentStrategyApiService', () => {
 
   describe('toggleStrategy', () => {
     it('toggles strategy', async () => {
-      mockJsonApiResource('s-1', { id: 's-1', isActive: true });
+      mockJsonApiResource({ id: 's-1', isActive: true });
       const service = makeService();
       const result = await Effect.runPromise(
         service.toggleStrategyEffect('s-1'),

--- a/packages/agent/tests/json-api-fetch.mock.ts
+++ b/packages/agent/tests/json-api-fetch.mock.ts
@@ -1,0 +1,50 @@
+import { vi } from 'vitest';
+
+type JsonApiAttributes = Record<string, unknown>;
+
+export const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+export function mockOk(data: unknown): void {
+  mockFetch.mockResolvedValueOnce({
+    json: () => Promise.resolve(data),
+    ok: true,
+  });
+}
+
+export function mockJsonApiResource(
+  attributes: JsonApiAttributes,
+  type = 'strategy',
+): void {
+  mockOk({
+    data: {
+      attributes,
+      id: String(attributes.id ?? '1'),
+      type,
+    },
+  });
+}
+
+export function mockJsonApiCollection(
+  items: JsonApiAttributes[],
+  type = 'strategy',
+): void {
+  mockOk({
+    data: items.map((item) => ({
+      attributes: item,
+      id: String(item.id ?? '1'),
+      type,
+    })),
+  });
+}
+
+export function mockError(
+  status: number,
+  payload?: JsonApiAttributes | { errors: Array<JsonApiAttributes> },
+): void {
+  mockFetch.mockResolvedValueOnce({
+    json: () => Promise.resolve(payload),
+    ok: false,
+    status,
+  });
+}


### PR DESCRIPTION
## Summary
- Extract shared JSON:API fetch mock helpers for agent service specs.
- Reuse the helper in AgentApiService and AgentStrategyApiService tests.
- Reduce duplicated test setup without changing service behavior.

## Validation
- bunx biome check --write packages/agent/tests/json-api-fetch.mock.ts packages/agent/src/services/agent-api.service.spec.ts packages/agent/src/services/agent-strategy-api.service.spec.ts
- git diff --check

## Notes
- Targeted vitest did not run locally because the worktree lacks installed package dependencies for vitest/config; bunx can fetch the runner but not satisfy the repo config dependency graph.