### PR TITLE
Dedupe notifications spec cleanup

### DIFF
--- a/apps/server/notifications/src/services/chatbot/chatbot.service.spec.ts
+++ b/apps/server/notifications/src/services/chatbot/chatbot.service.spec.ts
@@ -41,10 +41,6 @@ describe('ChatBotService', () => {
     genFeedService = module.get(GenFeedService);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('generates a response using GenFeedService', async () => {
     const res = await service.generateResponse('hello');
     expect(res).toBe('hi');

--- a/apps/server/notifications/src/services/genfeed/genfeed.service.spec.ts
+++ b/apps/server/notifications/src/services/genfeed/genfeed.service.spec.ts
@@ -3,15 +3,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@notifications/config/config.service';
 import { GenFeedService } from '@notifications/services/genfeed/genfeed.service';
 import axios from 'axios';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type Mocked,
-  vi,
-} from 'vitest';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 
 // Mock axios
 vi.mock('axios');
@@ -63,10 +55,6 @@ describe('GenFeedService', () => {
     service = module.get<GenFeedService>(GenFeedService);
     module.get<ConfigService>(ConfigService);
     module.get<LoggerService>(LoggerService);
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/apps/server/notifications/src/services/notification-handler.service.spec.ts
+++ b/apps/server/notifications/src/services/notification-handler.service.spec.ts
@@ -64,10 +64,6 @@ describe('NotificationHandlerService', () => {
     loggerService.log('NotificationHandlerService initialized');
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should be defined', () => {
     expect(service).toBeDefined();
   });

--- a/apps/server/notifications/src/services/telegram/telegram.api.service.spec.ts
+++ b/apps/server/notifications/src/services/telegram/telegram.api.service.spec.ts
@@ -30,10 +30,6 @@ describe('TelegramAPIService', () => {
     loggerService.log('TelegramAPIService initialized');
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should be defined', () => {
     expect(service).toBeDefined();
   });

--- a/apps/server/notifications/src/services/telegram/telegram.service.spec.ts
+++ b/apps/server/notifications/src/services/telegram/telegram.service.spec.ts
@@ -39,10 +39,6 @@ describe('TelegramService', () => {
     loggerService = module.get<LoggerService>(LoggerService);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should be defined', () => {
     expect(service).toBeDefined();
   });

--- a/apps/server/notifications/src/webhooks/webhooks.controller.spec.ts
+++ b/apps/server/notifications/src/webhooks/webhooks.controller.spec.ts
@@ -27,10 +27,6 @@ describe('WebhooksController', () => {
     webhooksService = module.get<WebhooksService>(WebhooksService);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });

--- a/apps/server/notifications/src/webhooks/webhooks.service.spec.ts
+++ b/apps/server/notifications/src/webhooks/webhooks.service.spec.ts
@@ -40,10 +40,6 @@ describe('WebhooksService (Notifications)', () => {
     eventsService = module.get<EventsService>(EventsService);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should be defined', () => {
     expect(service).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- Removes redundant local `afterEach(() => vi.clearAllMocks())` blocks from notifications specs.
- Relies on the existing notifications Vitest setup file, which already clears mocks globally after each test.
- Keeps behavior unchanged while cutting duplicate test cleanup code.

## Verification

- `npx biome check --write apps/server/notifications/src/services/chatbot/chatbot.service.spec.ts apps/server/notifications/src/services/genfeed/genfeed.service.spec.ts apps/server/notifications/src/services/notification-handler.service.spec.ts apps/server/notifications/src/services/telegram/telegram.api.service.spec.ts apps/server/notifications/src/services/telegram/telegram.service.spec.ts apps/server/notifications/src/webhooks/webhooks.controller.spec.ts apps/server/notifications/src/webhooks/webhooks.service.spec.ts`
- `bun run test -- src/services/chatbot/chatbot.service.spec.ts src/services/genfeed/genfeed.service.spec.ts src/services/notification-handler.service.spec.ts src/services/telegram/telegram.api.service.spec.ts src/services/telegram/telegram.service.spec.ts src/webhooks/webhooks.controller.spec.ts src/webhooks/webhooks.service.spec.ts`
