### PR TITLE
[codex] Extract shared query stage assertions

### DIFF
--- a/apps/server/api/src/collections/elements/camera-movements/controllers/camera-movements.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/camera-movements/controllers/camera-movements.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsCameraMovementsService } from '@api/collections/elements/camera
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { CameraMovementSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -23,12 +24,6 @@ const createBaseQuery = (
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/elements/cameras/controllers/cameras.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/cameras/controllers/cameras.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsCamerasService } from '@api/collections/elements/cameras/servic
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { CameraSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -23,12 +24,6 @@ const createBaseQuery = (
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/elements/lenses/controllers/lenses.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/lenses/controllers/lenses.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsLensesService } from '@api/collections/elements/lenses/services
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { LensSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -23,12 +24,6 @@ const createBaseQuery = (
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/elements/lightings/controllers/lightings.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/lightings/controllers/lightings.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsLightingsService } from '@api/collections/elements/lightings/se
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { LightingSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -23,12 +24,6 @@ const createBaseQuery = (
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/elements/moods/controllers/moods.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/moods/controllers/moods.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsMoodsService } from '@api/collections/elements/moods/services/m
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -19,12 +20,6 @@ const createBaseQuery = (partial: Partial<BaseQueryDto> = {}): BaseQueryDto =>
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/elements/scenes/controllers/scenes.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/scenes/controllers/scenes.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsScenesService } from '@api/collections/elements/scenes/services
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { SceneSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -36,12 +37,6 @@ const createBaseQuery = (partial: Partial<BaseQueryDto> = {}): BaseQueryDto =>
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/elements/sounds/controllers/sounds.controller.spec.ts
+++ b/apps/server/api/src/collections/elements/sounds/controllers/sounds.controller.spec.ts
@@ -5,6 +5,7 @@ import { ElementsSoundsService } from '@api/collections/elements/sounds/services
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { User } from '@clerk/backend';
 import { SoundCategory } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -20,12 +21,6 @@ const createBaseQuery = (partial: Partial<BaseQueryDto> = {}): BaseQueryDto =>
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts
+++ b/apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts
@@ -13,6 +13,7 @@ import { SubscriptionGuard } from '@api/helpers/guards/subscription/subscription
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import type { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
+import { asMatchStage, asSortStage } from '@api/test/query-stage-assertions';
 import type { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
 import type { User } from '@clerk/backend';
 import { MODEL_KEYS } from '@genfeedai/constants';
@@ -32,12 +33,6 @@ const createTrainingsQuery = (
     pagination: true,
     ...partial,
   }) as TrainingsQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
-
-const asSortStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $sort: Record<string, unknown> };
 
 vi.mock('@genfeedai/helpers', async () => ({
   ...(await vi.importActual('@genfeedai/helpers')),

--- a/apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.spec.ts
@@ -4,6 +4,7 @@ import { PostsService } from '@api/collections/posts/services/posts.service';
 import { PublicPostsController } from '@api/endpoints/public/controllers/posts/public.posts.controller';
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { asMatchStage } from '@api/test/query-stage-assertions';
 import type { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
 import { AssetScope, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -19,9 +20,6 @@ const createBaseQuery = (partial: Partial<BaseQueryDto> = {}): BaseQueryDto =>
     sort: 'createdAt: -1',
     ...partial,
   }) as BaseQueryDto;
-
-const asMatchStage = (stage: Record<string, unknown>) =>
-  stage as Record<string, unknown> & { $match: Record<string, unknown> };
 
 vi.mock('@api/helpers/utils/response/response.util', () => ({
   returnNotFound: vi.fn((type, id) => ({

--- a/apps/server/api/src/test/query-stage-assertions.ts
+++ b/apps/server/api/src/test/query-stage-assertions.ts
@@ -1,0 +1,13 @@
+export type MatchStage = Record<string, unknown> & {
+  $match: Record<string, unknown>;
+};
+
+export type SortStage = Record<string, unknown> & {
+  $sort: Record<string, unknown>;
+};
+
+export const asMatchStage = (stage: Record<string, unknown>): MatchStage =>
+  stage as MatchStage;
+
+export const asSortStage = (stage: Record<string, unknown>): SortStage =>
+  stage as SortStage;


### PR DESCRIPTION
## Summary
- Extract shared API query stage assertion helpers for `$match` and `$sort` pipeline stages.
- Replace duplicated local cast helpers across element, training, and public posts controller specs.

## Impact
Test-only cleanup. No production behavior changes.

## Verification
- `bunx biome check apps/server/api/src/test/query-stage-assertions.ts apps/server/api/src/collections/elements/camera-movements/controllers/camera-movements.controller.spec.ts apps/server/api/src/collections/elements/cameras/controllers/cameras.controller.spec.ts apps/server/api/src/collections/elements/lenses/controllers/lenses.controller.spec.ts apps/server/api/src/collections/elements/lightings/controllers/lightings.controller.spec.ts apps/server/api/src/collections/elements/moods/controllers/moods.controller.spec.ts apps/server/api/src/collections/elements/scenes/controllers/scenes.controller.spec.ts apps/server/api/src/collections/elements/sounds/controllers/sounds.controller.spec.ts apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.spec.ts`
- `git diff --check origin/develop...HEAD`

Focused Vitest remains blocked in this worktree because `vitest` is not installed on PATH for `bun run --cwd apps/server/api test:file ...`.
