### PR TITLE
refactor: dedupe page metadata helper

### DIFF
--- a/packages/helpers/src/media/metadata/page-metadata.helper.ts
+++ b/packages/helpers/src/media/metadata/page-metadata.helper.ts
@@ -1,6 +1,32 @@
 import { metadata } from '@helpers/media/metadata/metadata.helper';
 import type { Metadata, ResolvingMetadata } from 'next';
 
+function buildMetadata(
+  pageTitle: string,
+  images: NonNullable<Metadata['openGraph']>['images'],
+  description?: string,
+  canonicalPath?: string,
+): Metadata {
+  const title = `${pageTitle} | ${metadata.name}`;
+  const url = canonicalPath ? `${metadata.url}${canonicalPath}` : undefined;
+
+  return {
+    ...(url && { alternates: { canonical: url } }),
+    ...(description && { description }),
+    openGraph: {
+      ...(description && { description }),
+      images,
+      ...(description && { title }),
+      ...(url && { url }),
+    },
+    title,
+    twitter: {
+      ...(description && { description, title }),
+      images,
+    },
+  };
+}
+
 export function createPageMetadata(pageTitle: string) {
   return async function generateMetadata(
     _props: unknown,
@@ -8,15 +34,7 @@ export function createPageMetadata(pageTitle: string) {
   ): Promise<Metadata> {
     const previousImages = (await parent).openGraph?.images || [];
 
-    return {
-      openGraph: {
-        images: previousImages,
-      },
-      title: `${pageTitle} | ${metadata.name}`,
-      twitter: {
-        images: previousImages,
-      },
-    };
+    return buildMetadata(pageTitle, previousImages);
   };
 }
 
@@ -39,11 +57,7 @@ export function createDynamicPageMetadata<K extends string>(
     const previousImages = resolvedParent.openGraph?.images || [];
     const value = resolvedParams[paramKey];
 
-    return {
-      openGraph: { images: previousImages },
-      title: `${formatter(value)} | ${metadata.name}`,
-      twitter: { images: previousImages },
-    };
+    return buildMetadata(formatter(value), previousImages);
   };
 }
 
@@ -57,20 +71,7 @@ export function createPageMetadataWithDescription(
   ): Promise<Metadata> {
     const previousImages = (await parent).openGraph?.images || [];
 
-    return {
-      description,
-      openGraph: {
-        description,
-        images: previousImages,
-        title: `${pageTitle} | ${metadata.name}`,
-      },
-      title: `${pageTitle} | ${metadata.name}`,
-      twitter: {
-        description,
-        images: previousImages,
-        title: `${pageTitle} | ${metadata.name}`,
-      },
-    };
+    return buildMetadata(pageTitle, previousImages, description);
   };
 }
 
@@ -85,23 +86,6 @@ export function createPageMetadataWithCanonical(
   ): Promise<Metadata> {
     const previousImages = (await parent).openGraph?.images || [];
 
-    return {
-      alternates: {
-        canonical: `${metadata.url}${canonicalPath}`,
-      },
-      description,
-      openGraph: {
-        description,
-        images: previousImages,
-        title: `${pageTitle} | ${metadata.name}`,
-        url: `${metadata.url}${canonicalPath}`,
-      },
-      title: `${pageTitle} | ${metadata.name}`,
-      twitter: {
-        description,
-        images: previousImages,
-        title: `${pageTitle} | ${metadata.name}`,
-      },
-    };
+    return buildMetadata(pageTitle, previousImages, description, canonicalPath);
   };
 }


### PR DESCRIPTION
## Summary
- centralize repeated Next metadata object construction in the page metadata helper
- keep the existing exported metadata helper APIs unchanged
- reduce the helper by 16 net LOC

## Verification
- bun test packages/helpers/src/media/metadata/page-metadata.helper.test.ts
- npx biome check packages/helpers/src/media/metadata/page-metadata.helper.ts

## Notes
- bun run --cwd packages/helpers type-check still fails on existing fresh-worktree dependency/build setup issues: missing built workspace declaration outputs and unresolved dependency types such as next, date-fns, and clsx.