### PR TITLE
feat: close content loop gaps

### DIFF
--- a/apps/server/api/src/collections/posts/services/post-analytics.service.ts
+++ b/apps/server/api/src/collections/posts/services/post-analytics.service.ts
@@ -5,6 +5,8 @@ import { type PostDocument } from '@api/collections/posts/schemas/post.schema';
 import type { PostAnalyticsDocument } from '@api/collections/posts/schemas/post-analytics.schema';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
+import { LinkedInService } from '@api/services/integrations/linkedin/services/linkedin.service';
+import { MastodonService } from '@api/services/integrations/mastodon/services/mastodon.service';
 import { PinterestService } from '@api/services/integrations/pinterest/services/pinterest.service';
 import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok.service';
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
@@ -16,8 +18,12 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, Optional } from '@nestjs/common';
 
 const CREDENTIAL_PLATFORM = {
+  FACEBOOK: 'FACEBOOK' as CredentialPlatform,
   INSTAGRAM: 'INSTAGRAM' as CredentialPlatform,
+  LINKEDIN: 'LINKEDIN' as CredentialPlatform,
+  MASTODON: 'MASTODON' as CredentialPlatform,
   PINTEREST: 'PINTEREST' as CredentialPlatform,
+  THREADS: 'THREADS' as CredentialPlatform,
   TIKTOK: 'TIKTOK' as CredentialPlatform,
   TWITTER: 'TWITTER' as CredentialPlatform,
   YOUTUBE: 'YOUTUBE' as CredentialPlatform,
@@ -35,6 +41,8 @@ export class PostAnalyticsService extends BaseService<
 
     private readonly postsService: PostsService,
     @Optional() private readonly instagramService?: InstagramService,
+    @Optional() private readonly linkedInService?: LinkedInService,
+    @Optional() private readonly mastodonService?: MastodonService,
     @Optional() private readonly pinterestService?: PinterestService,
     @Optional() private readonly tiktokService?: TiktokService,
     @Optional() private readonly youtubeService?: YoutubeService,
@@ -752,6 +760,136 @@ export class PostAnalyticsService extends BaseService<
     } catch (error: unknown) {
       this.logger.error(
         `Failed to process Pinterest analytics for post ${postId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Process LinkedIn analytics and update post analytics
+   */
+  async processLinkedInAnalytics(
+    postId: string,
+    analytics: {
+      views: number;
+      likes: number;
+      comments: number;
+      shares?: number;
+      impressions?: number;
+      clicks?: number;
+      engagementRate?: number;
+      reach?: number;
+      mediaType?: 'text' | 'image' | 'video' | 'article' | 'document' | 'mixed';
+    },
+  ): Promise<void> {
+    try {
+      await this.updateTodayAnalytics(postId, CREDENTIAL_PLATFORM.LINKEDIN, {
+        totalComments: analytics.comments,
+        totalLikes: analytics.likes,
+        totalShares: analytics.shares || 0,
+        totalViews: analytics.impressions || analytics.views,
+      });
+
+      this.logger.log(`Updated LinkedIn analytics for post ${postId}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process LinkedIn analytics for post ${postId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Process Mastodon analytics and update post analytics
+   * Note: Mastodon API does not expose view counts — views default to 0
+   */
+  async processMastodonAnalytics(
+    postId: string,
+    analytics: {
+      views: number;
+      likes: number;
+      comments: number;
+      boosts: number;
+    },
+  ): Promise<void> {
+    try {
+      await this.updateTodayAnalytics(postId, CREDENTIAL_PLATFORM.MASTODON, {
+        totalComments: analytics.comments,
+        totalLikes: analytics.likes,
+        totalShares: analytics.boosts,
+        totalViews: 0, // Mastodon does not expose view counts
+      });
+
+      this.logger.log(`Updated Mastodon analytics for post ${postId}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process Mastodon analytics for post ${postId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Process Facebook analytics and update post analytics
+   */
+  async processFacebookAnalytics(
+    postId: string,
+    analytics: {
+      views: number;
+      likes: number;
+      comments: number;
+      shares: number;
+      reach?: number;
+      impressions?: number;
+      engagementRate?: number;
+    },
+  ): Promise<void> {
+    try {
+      await this.updateTodayAnalytics(postId, CREDENTIAL_PLATFORM.FACEBOOK, {
+        totalComments: analytics.comments,
+        totalLikes: analytics.likes,
+        totalShares: analytics.shares,
+        totalViews: analytics.impressions || analytics.views,
+      });
+
+      this.logger.log(`Updated Facebook analytics for post ${postId}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process Facebook analytics for post ${postId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Process Threads analytics and update post analytics
+   */
+  async processThreadsAnalytics(
+    postId: string,
+    analytics: {
+      views: number;
+      likes: number;
+      replies: number;
+      reposts: number;
+      quotes: number;
+    },
+  ): Promise<void> {
+    try {
+      await this.updateTodayAnalytics(postId, CREDENTIAL_PLATFORM.THREADS, {
+        totalComments: analytics.replies,
+        totalLikes: analytics.likes,
+        totalShares: analytics.reposts,
+        totalViews: analytics.views,
+      });
+
+      this.logger.log(`Updated Threads analytics for post ${postId}`);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process Threads analytics for post ${postId}`,
         error,
       );
       throw error;

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -1,6 +1,7 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CaptionEntity } from '@api/collections/captions/entities/caption.entity';
 import { CaptionsService } from '@api/collections/captions/services/captions.service';
+import { PerformanceSummaryService } from '@api/collections/content-performance/services/performance-summary.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
@@ -55,7 +56,9 @@ import type {
   ExecutionRunResult,
 } from '@genfeedai/workflow-engine';
 import {
+  createAnalyticsFeedbackExecutor,
   createBrandAssetExecutor,
+  createBrandContextExecutor,
   createImageGenExecutor,
   createLipSyncExecutor,
   createMentionTriggerExecutor,
@@ -64,9 +67,11 @@ import {
   createNewRepostTriggerExecutor,
   createPostReplyExecutor,
   createPromptConstructorExecutor,
+  createPublishExecutor,
   createReframeExecutor,
   createSendDmExecutor,
   createTextToSpeechExecutor,
+  createTrendTriggerExecutor,
   createUpscaleExecutor,
   type NodeExecutor,
   WorkflowEngine,
@@ -190,6 +195,7 @@ const NODE_TYPE_TO_EXECUTOR: Record<string, string> = {
   'trigger-new-follower': 'newFollowerTrigger',
   'trigger-new-like': 'newLikeTrigger',
   'trigger-new-repost': 'newRepostTrigger',
+  'analytics-feedback': 'analyticsFeedback',
 };
 
 /**
@@ -227,6 +233,8 @@ export class WorkflowEngineAdapterService {
     @Optional() private readonly replicateService?: ReplicateService,
     @Optional() private readonly promptBuilderService?: PromptBuilderService,
     @Optional() private readonly brandsService?: BrandsService,
+    @Optional()
+    private readonly performanceSummaryService?: PerformanceSummaryService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -249,6 +257,10 @@ export class WorkflowEngineAdapterService {
     this.registerUpscaleExecutor();
     this.registerDirectMediaInputExecutors();
     this.registerBrandAssetExecutor();
+    this.registerBrandContextExecutor();
+    this.registerAnalyticsFeedbackExecutor();
+    this.registerTrendTriggerExecutor();
+    this.registerPublishExecutor();
   }
 
   /**
@@ -486,6 +498,103 @@ export class WorkflowEngineAdapterService {
       },
     );
 
+    this.engine.registerExecutor(
+      executor.nodeType,
+      this.wrapEngineExecutor(executor),
+    );
+  }
+
+  private registerBrandContextExecutor(): void {
+    if (!this.brandsService) return;
+    const brandsService = this.brandsService;
+    const executor = createBrandContextExecutor(
+      async (brandId, organizationId) => {
+        const brand = await brandsService.findOne(
+          { _id: brandId, isDeleted: false, organization: organizationId },
+          ['detail'],
+        );
+        if (!brand) return null;
+        const brandDoc = brand as unknown as Record<string, unknown>;
+        return {
+          brandId: String(brandDoc._id),
+          colors:
+            (brandDoc.colors as {
+              primary: string;
+              secondary: string;
+              background: string;
+            } | null) ?? null,
+          fonts: (brandDoc.fonts as string | null) ?? null,
+          label: String(brandDoc.name ?? brandDoc.label ?? ''),
+          models: null,
+          slug: String(brandDoc.slug ?? ''),
+          voice: (brandDoc.voice as string | null) ?? null,
+        };
+      },
+    );
+    this.engine.registerExecutor(
+      executor.nodeType,
+      this.wrapEngineExecutor(executor),
+    );
+  }
+
+  private registerAnalyticsFeedbackExecutor(): void {
+    if (!this.performanceSummaryService) return;
+    const summaryService = this.performanceSummaryService;
+    const executor = createAnalyticsFeedbackExecutor(
+      async ({ organizationId, brandId, topN, worstN }) => {
+        const summary = await summaryService.getWeeklySummary(
+          organizationId,
+          brandId,
+          { topN, worstN },
+        );
+        const bestPlatform =
+          summary.avgEngagementByPlatform.length > 0
+            ? summary.avgEngagementByPlatform.reduce((best, current) =>
+                current.avgEngagementRate > best.avgEngagementRate
+                  ? current
+                  : best,
+              ).platform
+            : null;
+        return {
+          avgEngagementRate:
+            summary.avgEngagementByPlatform.length > 0
+              ? summary.avgEngagementByPlatform.reduce(
+                  (sum, p) => sum + p.avgEngagementRate,
+                  0,
+                ) / summary.avgEngagementByPlatform.length
+              : 0,
+          bestPlatform,
+          bestPostingTimes: summary.bestPostingTimes.map((t) => ({
+            avgEngagement: t.avgEngagementRate,
+            dayOfWeek: 0,
+            hour: t.hour,
+          })),
+          topHooks: summary.topHooks,
+          topTopics: summary.topPerformers.map((p) => p.title).filter(Boolean),
+          weekOverWeekChange: summary.weekOverWeekTrend.percentageChange,
+          weekOverWeekDirection: summary.weekOverWeekTrend.direction,
+          worstTopics: summary.worstPerformers
+            .map((p) => p.title)
+            .filter(Boolean),
+        };
+      },
+    );
+    this.engine.registerExecutor(
+      executor.nodeType,
+      this.wrapEngineExecutor(executor),
+    );
+  }
+
+  private registerTrendTriggerExecutor(): void {
+    const executor = createTrendTriggerExecutor();
+    this.engine.registerExecutor(
+      executor.nodeType,
+      this.wrapEngineExecutor(executor),
+    );
+  }
+
+  private registerPublishExecutor(): void {
+    const executor = createPublishExecutor();
     this.engine.registerExecutor(
       executor.nodeType,
       this.wrapEngineExecutor(executor),
@@ -1338,6 +1447,9 @@ export class WorkflowEngineAdapterService {
       ![
         'ai-avatar-video',
         'ai-generate-image',
+        'analytics-feedback',
+        'analyticsFeedback',
+        'brandContext',
         'imageGen',
         'ai-text-to-speech',
         'effect-captions',

--- a/apps/server/api/src/collections/workflows/templates/content-loop.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/content-loop.template.ts
@@ -1,0 +1,183 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+import { WorkflowStepCategory } from '@genfeedai/enums';
+
+export const CONTENT_LOOP_TEMPLATE: WorkflowTemplate = {
+  category: 'content',
+  description:
+    'Closed-loop content automation: read analytics → discover trends → generate on-brand content → publish. Repeats on schedule.',
+  edges: [
+    {
+      id: 'e-feedback-trend',
+      source: 'analytics-feedback',
+      sourceHandle: 'topTopics',
+      target: 'trend-trigger',
+      targetHandle: 'keywords',
+    },
+    {
+      id: 'e-feedback-platform',
+      source: 'analytics-feedback',
+      sourceHandle: 'bestPlatform',
+      target: 'trend-trigger',
+      targetHandle: 'platform',
+    },
+    {
+      id: 'e-trend-prompt',
+      source: 'trend-trigger',
+      sourceHandle: 'topic',
+      target: 'prompt-constructor',
+      targetHandle: 'topic',
+    },
+    {
+      id: 'e-brand-prompt',
+      source: 'brand-context',
+      sourceHandle: 'brandVoice',
+      target: 'prompt-constructor',
+      targetHandle: 'brandVoice',
+    },
+    {
+      id: 'e-prompt-gen',
+      source: 'prompt-constructor',
+      sourceHandle: 'prompt',
+      target: 'text-gen',
+      targetHandle: 'prompt',
+    },
+    {
+      id: 'e-gen-publish',
+      source: 'text-gen',
+      sourceHandle: 'content',
+      target: 'publish',
+      targetHandle: 'content',
+    },
+  ],
+  icon: 'repeat',
+  id: 'content-loop',
+  inputVariables: [
+    {
+      defaultValue: 'tiktok',
+      key: 'platform',
+      label: 'Platform',
+      required: true,
+      type: 'select',
+      validation: {
+        options: [
+          'tiktok',
+          'instagram',
+          'twitter',
+          'youtube',
+          'linkedin',
+          'threads',
+          'facebook',
+        ],
+      },
+    },
+    {
+      defaultValue: 70,
+      key: 'minViralScore',
+      label: 'Min Viral Score',
+      required: false,
+      type: 'number',
+      validation: { max: 100, min: 0 },
+    },
+  ],
+  name: 'Content Loop',
+  nodes: [
+    {
+      data: { config: { topN: 5, worstN: 3 }, label: 'Analytics Feedback' },
+      id: 'analytics-feedback',
+      position: { x: 0, y: 0 },
+      type: 'analytics-feedback',
+    },
+    {
+      data: { config: {}, label: 'Brand Context' },
+      id: 'brand-context',
+      position: { x: 0, y: 200 },
+      type: 'brandContext',
+    },
+    {
+      data: {
+        config: {
+          checkFrequency: '6hr',
+          minViralScore: 70,
+          platform: 'tiktok',
+          trendType: 'hashtag',
+        },
+        inputVariableKeys: ['platform', 'minViralScore'],
+        label: 'Trend Trigger',
+      },
+      id: 'trend-trigger',
+      position: { x: 400, y: 0 },
+      type: 'trendTrigger',
+    },
+    {
+      data: {
+        config: { includeHashtags: true, maxLength: 2200, tone: 'brand-voice' },
+        label: 'Prompt Constructor',
+      },
+      id: 'prompt-constructor',
+      position: { x: 800, y: 100 },
+      type: 'ai-prompt-constructor',
+    },
+    {
+      data: {
+        config: {
+          maxTokens: 1024,
+          model: 'openai/gpt-4o-mini',
+          temperature: 0.8,
+        },
+        label: 'Generate Content',
+      },
+      id: 'text-gen',
+      position: { x: 1200, y: 100 },
+      type: 'ai-llm',
+    },
+    {
+      data: {
+        config: { autoPost: false, schedulingMode: 'queue' },
+        label: 'Publish',
+      },
+      id: 'publish',
+      position: { x: 1600, y: 100 },
+      type: 'output-publish',
+    },
+  ],
+  steps: [
+    {
+      category: WorkflowStepCategory.TRIGGER,
+      config: { topN: 5, worstN: 3 },
+      id: 'step-analytics-feedback',
+      name: 'Read Analytics',
+    },
+    {
+      category: WorkflowStepCategory.TRIGGER,
+      config: {
+        checkFrequency: '6hr',
+        minViralScore: 70,
+        trendType: 'hashtag',
+      },
+      dependsOn: ['step-analytics-feedback'],
+      id: 'step-trend-trigger',
+      name: 'Find Matching Trend',
+    },
+    {
+      category: WorkflowStepCategory.PROCESSING,
+      config: { includeHashtags: true, tone: 'brand-voice' },
+      dependsOn: ['step-trend-trigger'],
+      id: 'step-prompt',
+      name: 'Build Prompt',
+    },
+    {
+      category: WorkflowStepCategory.GENERATION,
+      config: { model: 'openai/gpt-4o-mini', temperature: 0.8 },
+      dependsOn: ['step-prompt'],
+      id: 'step-generate',
+      name: 'Generate Content',
+    },
+    {
+      category: WorkflowStepCategory.OUTPUT,
+      config: { autoPost: false, schedulingMode: 'queue' },
+      dependsOn: ['step-generate'],
+      id: 'step-publish',
+      name: 'Publish',
+    },
+  ],
+};

--- a/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
+++ b/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
@@ -1,3 +1,4 @@
+import { CONTENT_LOOP_TEMPLATE } from '@api/collections/workflows/templates/content-loop.template';
 import { GENERATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/generation-templates';
 import { WorkflowStepCategory } from '@genfeedai/enums';
 
@@ -44,6 +45,7 @@ export interface WorkflowTemplate {
 
 export const WORKFLOW_TEMPLATES: Record<string, WorkflowTemplate> = {
   ...GENERATION_WORKFLOW_TEMPLATES,
+  'content-loop': CONTENT_LOOP_TEMPLATE,
   'ad-remix-review': {
     category: 'ads',
     description:

--- a/apps/server/api/src/queues/analytics-facebook/analytics-facebook.processor.ts
+++ b/apps/server/api/src/queues/analytics-facebook/analytics-facebook.processor.ts
@@ -1,0 +1,154 @@
+import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { FacebookService } from '@api/services/integrations/facebook/services/facebook.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
+import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
+import { CredentialPlatform } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Job } from 'bullmq';
+
+export interface FacebookAnalyticsJobData {
+  posts: Array<{
+    _id: string;
+    externalId: string;
+    organization: string;
+    brand: string;
+    platform: CredentialPlatform;
+  }>;
+}
+
+@Processor('analytics-facebook')
+export class AnalyticsFacebookProcessor extends WorkerHost {
+  private readonly DEFAULT_DELAY_MS = 2000;
+  private readonly circuitBreaker: ProcessorCircuitBreaker;
+
+  constructor(
+    private readonly credentialsService: CredentialsService,
+    private readonly facebookService: FacebookService,
+    private readonly postAnalyticsService: PostAnalyticsService,
+    private readonly postsService: PostsService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+    this.circuitBreaker = createProcessorCircuitBreaker(
+      'analytics-facebook',
+      this.logger,
+    );
+  }
+
+  async process(job: Job<FacebookAnalyticsJobData>): Promise<void> {
+    try {
+      return await this.circuitBreaker.execute(() => this.processInternal(job));
+    } catch (error: unknown) {
+      if (error instanceof BrokenCircuitError) {
+        this.logger.warn((error as Error).message);
+        throw error;
+      }
+      throw error;
+    }
+  }
+
+  private async processInternal(
+    job: Job<FacebookAnalyticsJobData>,
+  ): Promise<void> {
+    const { posts } = job.data;
+
+    this.logger.log(`Processing Facebook analytics for ${posts.length} posts`);
+
+    try {
+      await job.updateProgress(10);
+
+      if (posts.length === 0) {
+        this.logger.warn('No posts provided for Facebook analytics batch');
+        return;
+      }
+
+      let processed = 0;
+
+      for (const post of posts) {
+        try {
+          const credential = await this.credentialsService.findOne({
+            brand: post.brand,
+            isDeleted: false,
+            organization: post.organization,
+            platform: CredentialPlatform.FACEBOOK,
+          });
+
+          if (!credential?.accessToken) {
+            this.logger.warn(
+              `No Facebook credential found for post ${post._id}`,
+            );
+            continue;
+          }
+
+          const decryptedAccessToken = EncryptionUtil.decrypt(
+            credential.accessToken,
+          );
+
+          const analytics = await this.facebookService.getPostAnalytics(
+            post.externalId,
+            decryptedAccessToken,
+          );
+
+          await this.postAnalyticsService.processFacebookAnalytics(post._id, {
+            comments: analytics.comments,
+            engagementRate: analytics.engagementRate,
+            impressions: analytics.impressions,
+            likes: analytics.likes,
+            reach: analytics.reach,
+            shares: analytics.shares,
+            views: analytics.views,
+          });
+          processed++;
+
+          // Rate limiting delay
+          if (processed < posts.length) {
+            await this.delay(this.DEFAULT_DELAY_MS);
+          }
+        } catch (error: unknown) {
+          this.logger.error(
+            `Failed to fetch Facebook analytics for post ${post._id}`,
+            error,
+          );
+
+          // Disable analytics for this post to prevent repeated failures
+          try {
+            await this.postsService.patch(post._id, {
+              isAnalyticsEnabled: false,
+            });
+            this.logger.log(
+              `Disabled analytics tracking for post ${post._id} due to fetch failure`,
+            );
+          } catch (patchError: unknown) {
+            this.logger.error(
+              `Failed to disable analytics for post ${post._id}`,
+              patchError,
+            );
+          }
+        }
+      }
+
+      await job.updateProgress(100);
+
+      this.logger.log(
+        `Facebook analytics completed - ${processed}/${posts.length} posts`,
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process Facebook analytics batch`,
+        (error as Error).stack,
+      );
+      throw error;
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/apps/server/api/src/queues/analytics-social/analytics-social.processor.ts
+++ b/apps/server/api/src/queues/analytics-social/analytics-social.processor.ts
@@ -1,6 +1,8 @@
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
+import { LinkedInService } from '@api/services/integrations/linkedin/services/linkedin.service';
+import { MastodonService } from '@api/services/integrations/mastodon/services/mastodon.service';
 import { PinterestService } from '@api/services/integrations/pinterest/services/pinterest.service';
 import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok.service';
 import {
@@ -30,6 +32,8 @@ export class AnalyticsSocialProcessor extends WorkerHost {
 
   constructor(
     private readonly instagramService: InstagramService,
+    private readonly linkedInService: LinkedInService,
+    private readonly mastodonService: MastodonService,
     private readonly tiktokService: TiktokService,
     private readonly pinterestService: PinterestService,
     private readonly postAnalyticsService: PostAnalyticsService,
@@ -105,6 +109,22 @@ export class AnalyticsSocialProcessor extends WorkerHost {
         platformProcessors.push(
           this.processPinterestPosts(
             postsByPlatform.get(CredentialPlatform.PINTEREST)!,
+          ),
+        );
+      }
+
+      if (postsByPlatform.has(CredentialPlatform.LINKEDIN)) {
+        platformProcessors.push(
+          this.processLinkedInPosts(
+            postsByPlatform.get(CredentialPlatform.LINKEDIN)!,
+          ),
+        );
+      }
+
+      if (postsByPlatform.has(CredentialPlatform.MASTODON)) {
+        platformProcessors.push(
+          this.processMastodonPosts(
+            postsByPlatform.get(CredentialPlatform.MASTODON)!,
           ),
         );
       }
@@ -316,6 +336,118 @@ export class AnalyticsSocialProcessor extends WorkerHost {
 
     this.logger.log(
       `Pinterest analytics completed - ${processed}/${posts.length} posts`,
+    );
+  }
+
+  private async processLinkedInPosts(
+    posts: SocialAnalyticsJobData['posts'],
+  ): Promise<void> {
+    this.logger.log(`Processing ${posts.length} LinkedIn posts`);
+    let processed = 0;
+
+    for (const post of posts) {
+      try {
+        const analytics = await this.linkedInService.getMediaAnalytics(
+          post.organization,
+          post.brand,
+          post.externalId,
+        );
+
+        // LinkedIn returns reactions as an object — map fields explicitly (no spread)
+        await this.postAnalyticsService.processLinkedInAnalytics(post._id, {
+          clicks: analytics.clicks,
+          comments: analytics.comments,
+          engagementRate: analytics.engagementRate,
+          impressions: analytics.impressions,
+          likes: analytics.likes,
+          mediaType: analytics.mediaType,
+          reach: analytics.reach,
+          shares: analytics.shares,
+          views: analytics.views,
+        });
+        processed++;
+
+        // Rate limiting delay
+        if (processed < posts.length) {
+          await this.delay(this.DEFAULT_DELAY_MS);
+        }
+      } catch (error: unknown) {
+        this.logger.error(
+          `Failed to fetch LinkedIn analytics for post ${post._id}`,
+          error,
+        );
+
+        // Disable analytics for this post to prevent repeated failures
+        try {
+          await this.postsService.patch(post._id, {
+            isAnalyticsEnabled: false,
+          });
+          this.logger.log(
+            `Disabled analytics tracking for post ${post._id} due to fetch failure`,
+          );
+        } catch (patchError: unknown) {
+          this.logger.error(
+            `Failed to disable analytics for post ${post._id}`,
+            patchError,
+          );
+        }
+      }
+    }
+
+    this.logger.log(
+      `LinkedIn analytics completed - ${processed}/${posts.length} posts`,
+    );
+  }
+
+  private async processMastodonPosts(
+    posts: SocialAnalyticsJobData['posts'],
+  ): Promise<void> {
+    this.logger.log(`Processing ${posts.length} Mastodon posts`);
+    let processed = 0;
+
+    for (const post of posts) {
+      try {
+        const analytics = await this.mastodonService.getMediaAnalytics(
+          post.organization,
+          post.brand,
+          post.externalId,
+        );
+
+        await this.postAnalyticsService.processMastodonAnalytics(
+          post._id,
+          analytics,
+        );
+        processed++;
+
+        // Rate limiting delay
+        if (processed < posts.length) {
+          await this.delay(this.DEFAULT_DELAY_MS);
+        }
+      } catch (error: unknown) {
+        this.logger.error(
+          `Failed to fetch Mastodon analytics for post ${post._id}`,
+          error,
+        );
+
+        // Disable analytics for this post to prevent repeated failures
+        try {
+          await this.postsService.patch(post._id, {
+            isAnalyticsEnabled: false,
+          });
+          this.logger.log(
+            `Disabled analytics tracking for post ${post._id} due to fetch failure`,
+          );
+        } catch (patchError: unknown) {
+          this.logger.error(
+            `Failed to disable analytics for post ${post._id}`,
+            patchError,
+          );
+        }
+      }
+    }
+
+    this.logger.log(
+      `Mastodon analytics completed - ${processed}/${posts.length} posts`,
     );
   }
 

--- a/apps/server/api/src/queues/analytics-threads/analytics-threads.module.ts
+++ b/apps/server/api/src/queues/analytics-threads/analytics-threads.module.ts
@@ -1,0 +1,10 @@
+import { PostsModule } from '@api/collections/posts/posts.module';
+import { ThreadsModule } from '@api/services/integrations/threads/threads.module';
+import { forwardRef, Module } from '@nestjs/common';
+import { AnalyticsThreadsProcessor } from './analytics-threads.processor';
+
+@Module({
+  imports: [forwardRef(() => PostsModule), forwardRef(() => ThreadsModule)],
+  providers: [AnalyticsThreadsProcessor],
+})
+export class AnalyticsThreadsModule {}

--- a/apps/server/api/src/queues/analytics-threads/analytics-threads.processor.ts
+++ b/apps/server/api/src/queues/analytics-threads/analytics-threads.processor.ts
@@ -1,0 +1,129 @@
+import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { ThreadsService } from '@api/services/integrations/threads/services/threads.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
+import { CredentialPlatform } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Job } from 'bullmq';
+
+export interface ThreadsAnalyticsJobData {
+  posts: Array<{
+    _id: string;
+    externalId: string;
+    organization: string;
+    brand: string;
+    platform: CredentialPlatform;
+  }>;
+}
+
+@Processor('analytics-threads')
+export class AnalyticsThreadsProcessor extends WorkerHost {
+  private readonly DEFAULT_DELAY_MS = 2000;
+  private readonly circuitBreaker: ProcessorCircuitBreaker;
+
+  constructor(
+    private readonly threadsService: ThreadsService,
+    private readonly postAnalyticsService: PostAnalyticsService,
+    private readonly postsService: PostsService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+    this.circuitBreaker = createProcessorCircuitBreaker(
+      'analytics-threads',
+      this.logger,
+    );
+  }
+
+  async process(job: Job<ThreadsAnalyticsJobData>): Promise<void> {
+    try {
+      return await this.circuitBreaker.execute(() => this.processInternal(job));
+    } catch (error: unknown) {
+      if (error instanceof BrokenCircuitError) {
+        this.logger.warn((error as Error).message);
+        throw error;
+      }
+      throw error;
+    }
+  }
+
+  private async processInternal(
+    job: Job<ThreadsAnalyticsJobData>,
+  ): Promise<void> {
+    const { posts } = job.data;
+
+    this.logger.log(`Processing Threads analytics for ${posts.length} posts`);
+
+    try {
+      await job.updateProgress(10);
+
+      if (posts.length === 0) {
+        this.logger.warn('No posts provided for Threads analytics batch');
+        return;
+      }
+
+      let processed = 0;
+
+      for (const post of posts) {
+        try {
+          const analytics = await this.threadsService.getThreadInsights(
+            post.organization,
+            post.brand,
+            post.externalId,
+          );
+
+          await this.postAnalyticsService.processThreadsAnalytics(
+            post._id,
+            analytics,
+          );
+          processed++;
+
+          // Rate limiting delay
+          if (processed < posts.length) {
+            await this.delay(this.DEFAULT_DELAY_MS);
+          }
+        } catch (error: unknown) {
+          this.logger.error(
+            `Failed to fetch Threads analytics for post ${post._id}`,
+            error,
+          );
+
+          // Disable analytics for this post to prevent repeated failures
+          try {
+            await this.postsService.patch(post._id, {
+              isAnalyticsEnabled: false,
+            });
+            this.logger.log(
+              `Disabled analytics tracking for post ${post._id} due to fetch failure`,
+            );
+          } catch (patchError: unknown) {
+            this.logger.error(
+              `Failed to disable analytics for post ${post._id}`,
+              patchError,
+            );
+          }
+        }
+      }
+
+      await job.updateProgress(100);
+
+      this.logger.log(
+        `Threads analytics completed - ${processed}/${posts.length} posts`,
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to process Threads analytics batch`,
+        (error as Error).stack,
+      );
+      throw error;
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/apps/server/api/src/queues/core/queue.service.ts
+++ b/apps/server/api/src/queues/core/queue.service.ts
@@ -36,6 +36,10 @@ export class QueueService {
     private readonly adOptimizationQueue: Queue,
     @InjectQueue('telegram-distribute')
     private readonly telegramDistributeQueue: Queue,
+    @InjectQueue('analytics-facebook')
+    private readonly analyticsFacebookQueue: Queue,
+    @InjectQueue('analytics-threads')
+    private readonly analyticsThreadsQueue: Queue,
   ) {}
 
   add<T = Record<string, unknown>>(
@@ -73,6 +77,10 @@ export class QueueService {
         return this.adOptimizationQueue;
       case 'telegram-distribute':
         return this.telegramDistributeQueue;
+      case 'analytics-facebook':
+        return this.analyticsFacebookQueue;
+      case 'analytics-threads':
+        return this.analyticsThreadsQueue;
       default:
         return this.defaultQueue;
     }

--- a/apps/server/api/src/queues/core/queues.module.ts
+++ b/apps/server/api/src/queues/core/queues.module.ts
@@ -232,6 +232,24 @@ import { Module } from '@nestjs/common';
         },
         name: 'heygen-poll',
       },
+      {
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { delay: 2000, type: 'exponential' },
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: 'analytics-facebook',
+      },
+      {
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { delay: 2000, type: 'exponential' },
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: 'analytics-threads',
+      },
     ),
   ],
   providers: [

--- a/apps/server/api/src/services/skill-executor/handlers/trend-remix.handler.spec.ts
+++ b/apps/server/api/src/services/skill-executor/handlers/trend-remix.handler.spec.ts
@@ -1,0 +1,167 @@
+import { TrendsService } from '@api/collections/trends/services/trends.service';
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import { TrendRemixHandler } from '@api/services/skill-executor/handlers/trend-remix.handler';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('TrendRemixHandler', () => {
+  let handler: TrendRemixHandler;
+
+  const mockTrendsService = {
+    getTrendById: vi.fn(),
+    getTrendsWithAccessControl: vi.fn(),
+  };
+
+  const mockLlmDispatcherService = {
+    chatCompletion: vi.fn(),
+  };
+
+  const mockLoggerService = {
+    warn: vi.fn(),
+  };
+
+  const baseContext = {
+    brandId: 'brand-id',
+    brandVoice: 'Bold and witty',
+    organizationId: 'org-id',
+    platforms: ['instagram'],
+  };
+
+  const mockTrend = {
+    id: 'trend-id-1',
+    metadata: { hashtags: ['#aitrend', '#viral'] },
+    platform: 'instagram',
+    topic: 'AI-generated art',
+    viralityScore: 92,
+  };
+
+  const mockLlmSuccess = {
+    choices: [
+      {
+        finish_reason: 'stop',
+        message: {
+          content: 'Remixed trend content here! #aitrend #viral',
+          role: 'assistant',
+        },
+      },
+    ],
+    id: 'llm-1',
+    usage: { completion_tokens: 20, prompt_tokens: 80, total_tokens: 100 },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrendRemixHandler,
+        { provide: TrendsService, useValue: mockTrendsService },
+        { provide: LlmDispatcherService, useValue: mockLlmDispatcherService },
+        { provide: LoggerService, useValue: mockLoggerService },
+      ],
+    }).compile();
+
+    handler = module.get(TrendRemixHandler);
+  });
+
+  it('auto-selects first trend when no trendId is provided', async () => {
+    mockTrendsService.getTrendsWithAccessControl.mockResolvedValue({
+      connectedPlatforms: ['instagram'],
+      lockedPlatforms: [],
+      trends: [mockTrend],
+    });
+
+    mockLlmDispatcherService.chatCompletion.mockResolvedValue(mockLlmSuccess);
+
+    const result = await handler.execute(baseContext, {});
+
+    expect(mockTrendsService.getTrendsWithAccessControl).toHaveBeenCalledWith(
+      baseContext.organizationId,
+      baseContext.brandId,
+      'instagram',
+    );
+    expect(mockTrendsService.getTrendById).not.toHaveBeenCalled();
+    expect(result.skillSlug).toBe('trend-remix');
+    expect(result.type).toBe('text');
+    expect(result.content).toBe('Remixed trend content here! #aitrend #viral');
+    expect(result.confidence).toBe(0.78);
+    expect(result.metadata).toEqual({
+      trendId: 'trend-id-1',
+      trendTopic: 'AI-generated art',
+    });
+  });
+
+  it('uses explicit trendId when provided', async () => {
+    mockTrendsService.getTrendById.mockResolvedValue(mockTrend);
+    mockLlmDispatcherService.chatCompletion.mockResolvedValue(mockLlmSuccess);
+
+    const result = await handler.execute(baseContext, {
+      trendId: 'trend-id-1',
+    });
+
+    expect(mockTrendsService.getTrendById).toHaveBeenCalledWith(
+      'trend-id-1',
+      baseContext.organizationId,
+    );
+    expect(mockTrendsService.getTrendsWithAccessControl).not.toHaveBeenCalled();
+    expect(result.metadata).toEqual(
+      expect.objectContaining({ trendId: 'trend-id-1' }),
+    );
+  });
+
+  it('returns low-confidence fallback when no trends exist', async () => {
+    mockTrendsService.getTrendsWithAccessControl.mockResolvedValue({
+      connectedPlatforms: [],
+      lockedPlatforms: [],
+      trends: [],
+    });
+
+    const result = await handler.execute(baseContext, {});
+
+    expect(result.content).toBe('No active trends found...');
+    expect(result.confidence).toBe(0.3);
+    expect(result.skillSlug).toBe('trend-remix');
+    expect(result.type).toBe('text');
+    expect(mockLlmDispatcherService.chatCompletion).not.toHaveBeenCalled();
+  });
+
+  it('falls back gracefully on LLM failure', async () => {
+    mockTrendsService.getTrendsWithAccessControl.mockResolvedValue({
+      connectedPlatforms: ['instagram'],
+      lockedPlatforms: [],
+      trends: [mockTrend],
+    });
+
+    mockLlmDispatcherService.chatCompletion.mockRejectedValue(
+      new Error('LLM provider unavailable'),
+    );
+
+    const result = await handler.execute(baseContext, {});
+
+    expect(result.confidence).toBe(0.4);
+    expect(result.content).toContain('AI-generated art');
+    expect(result.skillSlug).toBe('trend-remix');
+    expect(result.type).toBe('text');
+    expect(mockLoggerService.warn).toHaveBeenCalledWith(
+      'trend-remix LLM call failed, using fallback',
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+
+  it('returns correct skillSlug and type on success', async () => {
+    mockTrendsService.getTrendsWithAccessControl.mockResolvedValue({
+      connectedPlatforms: ['instagram'],
+      lockedPlatforms: [],
+      trends: [mockTrend],
+    });
+
+    mockLlmDispatcherService.chatCompletion.mockResolvedValue(mockLlmSuccess);
+
+    const result = await handler.execute(baseContext, {});
+
+    expect(result.skillSlug).toBe('trend-remix');
+    expect(result.type).toBe('text');
+    expect(result.platforms).toEqual(baseContext.platforms);
+  });
+});

--- a/apps/server/api/src/services/skill-executor/handlers/trend-remix.handler.ts
+++ b/apps/server/api/src/services/skill-executor/handlers/trend-remix.handler.ts
@@ -1,0 +1,161 @@
+import { TrendsService } from '@api/collections/trends/services/trends.service';
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import {
+  type ContentDraft,
+  type SkillExecutionContext,
+  type SkillHandler,
+} from '@api/services/skill-executor/interfaces/skill-executor.interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+const PLATFORM_CHAR_LIMITS: Record<string, number> = {
+  instagram: 2200,
+  linkedin: 3000,
+  tiktok: 2200,
+  twitter: 280,
+  youtube: 5000,
+};
+
+@Injectable()
+export class TrendRemixHandler implements SkillHandler {
+  constructor(
+    private readonly trendsService: TrendsService,
+    private readonly llmDispatcherService: LlmDispatcherService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  async execute(
+    context: SkillExecutionContext,
+    params: Record<string, unknown>,
+  ): Promise<ContentDraft> {
+    const platform =
+      typeof params.platform === 'string'
+        ? params.platform
+        : context.platforms[0];
+
+    const trend = await this.resolveTrend(context, params, platform);
+
+    if (!trend) {
+      return {
+        confidence: 0.3,
+        content: 'No active trends found...',
+        metadata: {},
+        platforms: context.platforms,
+        skillSlug: 'trend-remix',
+        type: 'text',
+      };
+    }
+
+    const hashtags = Array.isArray(trend.metadata?.hashtags)
+      ? trend.metadata.hashtags.slice(0, 5).join(' ')
+      : '';
+
+    const charLimit = PLATFORM_CHAR_LIMITS[platform ?? ''] ?? 2200;
+    const tone =
+      typeof params.tone === 'string' ? params.tone : 'engaging and authentic';
+
+    const systemPrompt = [
+      `You are a social media content expert specializing in trend-based content creation.`,
+      `Brand voice: ${context.brandVoice || 'professional and engaging'}.`,
+      `Tone: ${tone}.`,
+      `Platform: ${platform ?? 'social media'} (max ${charLimit} characters).`,
+      `Your task: create a remix of the given trend that feels native to the platform while matching the brand voice.`,
+    ].join(' ');
+
+    const userPrompt = [
+      `Create a ${platform ?? 'social media'} post that remixes the following trend:`,
+      ``,
+      `Trend topic: ${trend.topic}`,
+      hashtags ? `Trending hashtags: ${hashtags}` : '',
+      ``,
+      `Requirements:`,
+      `- Stay within ${charLimit} characters`,
+      `- Match the brand voice: ${context.brandVoice || 'professional and engaging'}`,
+      `- Keep tone: ${tone}`,
+      `- Include 2-3 relevant hashtags naturally`,
+      `- Make it platform-native and engaging`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    try {
+      const response = await this.llmDispatcherService.chatCompletion(
+        {
+          messages: [
+            { content: systemPrompt, role: 'system' },
+            { content: userPrompt, role: 'user' },
+          ],
+          model:
+            typeof params.model === 'string'
+              ? params.model
+              : 'openai/gpt-4o-mini',
+          temperature: 0.8,
+        },
+        context.organizationId,
+      );
+
+      const content = response.choices[0]?.message?.content;
+
+      if (content) {
+        return {
+          confidence: 0.78,
+          content,
+          metadata: {
+            trendId: trend.id,
+            trendTopic: trend.topic,
+          },
+          platforms: context.platforms,
+          skillSlug: 'trend-remix',
+          type: 'text',
+        };
+      }
+    } catch (error: unknown) {
+      this.loggerService.warn('trend-remix LLM call failed, using fallback', {
+        error,
+      });
+    }
+
+    const fallbackContent = [
+      `${trend.topic} — here's our take:`,
+      context.brandVoice
+        ? `Brought to you with ${context.brandVoice} energy.`
+        : '',
+      hashtags,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    return {
+      confidence: 0.4,
+      content: fallbackContent,
+      metadata: {
+        trendId: trend.id,
+        trendTopic: trend.topic,
+      },
+      platforms: context.platforms,
+      skillSlug: 'trend-remix',
+      type: 'text',
+    };
+  }
+
+  private async resolveTrend(
+    context: SkillExecutionContext,
+    params: Record<string, unknown>,
+    platform: string | undefined,
+  ) {
+    if (typeof params.trendId === 'string') {
+      return this.trendsService.getTrendById(
+        params.trendId,
+        context.organizationId,
+      );
+    }
+
+    const response = await this.trendsService.getTrendsWithAccessControl(
+      context.organizationId,
+      context.brandId,
+      platform,
+    );
+
+    return response.trends[0] ?? null;
+  }
+}

--- a/apps/server/api/src/services/skill-executor/skill-executor.module.ts
+++ b/apps/server/api/src/services/skill-executor/skill-executor.module.ts
@@ -10,6 +10,7 @@ import { ReplicateModule } from '@api/services/integrations/replicate/replicate.
 import { ContentWritingHandler } from '@api/services/skill-executor/handlers/content-writing.handler';
 import { ImageGenerationHandler } from '@api/services/skill-executor/handlers/image-generation.handler';
 import { TrendDiscoveryHandler } from '@api/services/skill-executor/handlers/trend-discovery.handler';
+import { TrendRemixHandler } from '@api/services/skill-executor/handlers/trend-remix.handler';
 import { SkillExecutorService } from '@api/services/skill-executor/skill-executor.service';
 import { Module } from '@nestjs/common';
 
@@ -30,6 +31,7 @@ import { Module } from '@nestjs/common';
     ContentWritingHandler,
     ImageGenerationHandler,
     TrendDiscoveryHandler,
+    TrendRemixHandler,
     SkillExecutorService,
   ],
 })

--- a/apps/server/api/src/services/skill-executor/skill-executor.service.ts
+++ b/apps/server/api/src/services/skill-executor/skill-executor.service.ts
@@ -5,6 +5,7 @@ import { ByokProviderFactoryService } from '@api/services/byok/byok-provider-fac
 import { ContentWritingHandler } from '@api/services/skill-executor/handlers/content-writing.handler';
 import { ImageGenerationHandler } from '@api/services/skill-executor/handlers/image-generation.handler';
 import { TrendDiscoveryHandler } from '@api/services/skill-executor/handlers/trend-discovery.handler';
+import { TrendRemixHandler } from '@api/services/skill-executor/handlers/trend-remix.handler';
 import type {
   GatewayExecutionContext,
   GatewayExecutionResult,
@@ -35,11 +36,13 @@ export class SkillExecutorService {
     contentWritingHandler: ContentWritingHandler,
     imageGenerationHandler: ImageGenerationHandler,
     trendDiscoveryHandler: TrendDiscoveryHandler,
+    trendRemixHandler: TrendRemixHandler,
   ) {
     this.handlers = {
       'content-writing': contentWritingHandler,
       'image-generation': imageGenerationHandler,
       'trend-discovery': trendDiscoveryHandler,
+      'trend-remix': trendRemixHandler,
     };
   }
 

--- a/apps/server/workers/src/crons/analytics/cron.analytics-facebook.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-facebook.service.ts
@@ -1,7 +1,7 @@
 import { PostEntity } from '@api/collections/posts/entities/post.entity';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
-import type { SocialAnalyticsJobData } from '@api/queues/analytics-social/analytics-social.processor';
+import type { FacebookAnalyticsJobData } from '@api/queues/analytics-facebook/analytics-facebook.processor';
 import { QueueService } from '@api/queues/core/queue.service';
 import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -10,15 +10,15 @@ import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
 /**
- * Social Media Analytics Cron Service
- * Fetches analytics for Instagram, TikTok, and Pinterest posts every hour
- * These platforms don't support batch APIs, so posts are processed individually with parallel processing
+ * Facebook Analytics Cron Service
+ * Fetches analytics for Facebook posts every hour
+ * Facebook Graph API does not support batch analytics — posts are processed individually
  */
 @Injectable()
-export class CronAnalyticsSocialService {
+export class CronAnalyticsFacebookService {
   private readonly constructorName: string = String(this.constructor.name);
-  private readonly QUEUE_NAME = 'analytics-social';
-  private readonly CHUNK_SIZE = 50; // Process 50 posts per job for better parallelization
+  private readonly QUEUE_NAME = 'analytics-facebook';
+  private readonly CHUNK_SIZE = 50;
 
   constructor(
     private readonly logger: LoggerService,
@@ -27,27 +27,20 @@ export class CronAnalyticsSocialService {
   ) {}
 
   @Cron(CronExpression.EVERY_HOUR)
-  async trackSocialAnalytics(): Promise<void> {
+  async trackFacebookAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);
 
     try {
-      // Find all published social media posts with external IDs and analytics enabled
       const result = await this.postsService.findAll(
         {
           include: { credential: true },
           where: {
             externalId: { not: null },
-            isAnalyticsEnabled: { not: false }, // Track unless explicitly disabled
+            isAnalyticsEnabled: { not: false },
             isDeleted: false,
             platform: {
-              in: [
-                CredentialPlatform.INSTAGRAM,
-                CredentialPlatform.LINKEDIN,
-                CredentialPlatform.MASTODON,
-                CredentialPlatform.TIKTOK,
-                CredentialPlatform.PINTEREST,
-              ],
+              in: [CredentialPlatform.FACEBOOK],
             },
             status: PostStatus.PUBLIC,
           },
@@ -57,16 +50,16 @@ export class CronAnalyticsSocialService {
       const posts = result as unknown as { docs: PostEntity[] };
 
       if (!posts.docs || posts.docs.length === 0) {
-        this.logger.log(`${url} no social media posts to track`);
+        this.logger.log(`${url} no Facebook posts to track`);
         return;
       }
 
       this.logger.log(
-        `${url} found ${posts.docs.length} social media posts to track`,
+        `${url} found ${posts.docs.length} Facebook posts to track`,
       );
 
       // Group posts into chunks for parallel processing
-      const chunks: (typeof posts.docs)[] = [];
+      const chunks: PostEntity[][] = [];
       for (let i = 0; i < posts.docs.length; i += this.CHUNK_SIZE) {
         chunks.push(posts.docs.slice(i, i + this.CHUNK_SIZE));
       }
@@ -78,7 +71,7 @@ export class CronAnalyticsSocialService {
       // Add each chunk to the queue
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
-        const jobData: SocialAnalyticsJobData = {
+        const jobData: FacebookAnalyticsJobData = {
           posts: chunk.map((post: PostEntity) => ({
             _id: post._id.toString(),
             brand: post.brand.toString(),

--- a/apps/server/workers/src/crons/analytics/cron.analytics-sync.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-sync.service.ts
@@ -1,0 +1,61 @@
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import type { AnalyticsSyncJobData } from '@api/queues/analytics-sync/analytics-sync.processor';
+import { QueueService } from '@api/queues/core/queue.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+@Injectable()
+export class CronAnalyticsSyncService {
+  private readonly constructorName: string = String(this.constructor.name);
+  private readonly QUEUE_NAME = 'analytics-sync';
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly organizationsService: OrganizationsService,
+    private readonly queueService: QueueService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_6_HOURS)
+  async triggerAnalyticsSync(): Promise<void> {
+    const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.logger.log(`${url} started`);
+
+    try {
+      const orgs = await this.organizationsService.findAll(
+        { where: { isDeleted: false } },
+        { pagination: false },
+      );
+
+      const docs = (orgs as unknown as { docs: Array<{ _id: unknown }> }).docs;
+
+      if (!docs || docs.length === 0) {
+        this.logger.log(`${url} no organizations found`);
+        return;
+      }
+
+      this.logger.log(`${url} found ${docs.length} organizations to sync`);
+
+      for (const org of docs) {
+        const window = Math.floor(Date.now() / (6 * 60 * 60 * 1000));
+        const jobData: AnalyticsSyncJobData = {
+          incremental: true,
+          organizationId: org._id.toString(),
+        };
+
+        await this.queueService.add(this.QUEUE_NAME, jobData, {
+          attempts: 3,
+          backoff: { delay: 5000, type: 'exponential' },
+          jobId: `analytics-sync-${org._id.toString()}-${window}`,
+        });
+      }
+
+      this.logger.log(
+        `${url} completed - queued ${docs.length} analytics-sync jobs`,
+      );
+    } catch (error: unknown) {
+      this.logger.error(`${url} failed`, error);
+    }
+  }
+}

--- a/apps/server/workers/src/crons/analytics/cron.analytics-threads.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-threads.service.ts
@@ -1,7 +1,7 @@
 import { PostEntity } from '@api/collections/posts/entities/post.entity';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
-import type { SocialAnalyticsJobData } from '@api/queues/analytics-social/analytics-social.processor';
+import type { ThreadsAnalyticsJobData } from '@api/queues/analytics-threads/analytics-threads.processor';
 import { QueueService } from '@api/queues/core/queue.service';
 import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -10,15 +10,14 @@ import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
 /**
- * Social Media Analytics Cron Service
- * Fetches analytics for Instagram, TikTok, and Pinterest posts every hour
- * These platforms don't support batch APIs, so posts are processed individually with parallel processing
+ * Threads Analytics Cron Service
+ * Fetches analytics for Threads posts every hour
  */
 @Injectable()
-export class CronAnalyticsSocialService {
+export class CronAnalyticsThreadsService {
   private readonly constructorName: string = String(this.constructor.name);
-  private readonly QUEUE_NAME = 'analytics-social';
-  private readonly CHUNK_SIZE = 50; // Process 50 posts per job for better parallelization
+  private readonly QUEUE_NAME = 'analytics-threads';
+  private readonly CHUNK_SIZE = 50;
 
   constructor(
     private readonly logger: LoggerService,
@@ -27,27 +26,20 @@ export class CronAnalyticsSocialService {
   ) {}
 
   @Cron(CronExpression.EVERY_HOUR)
-  async trackSocialAnalytics(): Promise<void> {
+  async trackThreadsAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);
 
     try {
-      // Find all published social media posts with external IDs and analytics enabled
       const result = await this.postsService.findAll(
         {
           include: { credential: true },
           where: {
             externalId: { not: null },
-            isAnalyticsEnabled: { not: false }, // Track unless explicitly disabled
+            isAnalyticsEnabled: { not: false },
             isDeleted: false,
             platform: {
-              in: [
-                CredentialPlatform.INSTAGRAM,
-                CredentialPlatform.LINKEDIN,
-                CredentialPlatform.MASTODON,
-                CredentialPlatform.TIKTOK,
-                CredentialPlatform.PINTEREST,
-              ],
+              in: [CredentialPlatform.THREADS],
             },
             status: PostStatus.PUBLIC,
           },
@@ -57,16 +49,16 @@ export class CronAnalyticsSocialService {
       const posts = result as unknown as { docs: PostEntity[] };
 
       if (!posts.docs || posts.docs.length === 0) {
-        this.logger.log(`${url} no social media posts to track`);
+        this.logger.log(`${url} no Threads posts to track`);
         return;
       }
 
       this.logger.log(
-        `${url} found ${posts.docs.length} social media posts to track`,
+        `${url} found ${posts.docs.length} Threads posts to track`,
       );
 
       // Group posts into chunks for parallel processing
-      const chunks: (typeof posts.docs)[] = [];
+      const chunks: PostEntity[][] = [];
       for (let i = 0; i < posts.docs.length; i += this.CHUNK_SIZE) {
         chunks.push(posts.docs.slice(i, i + this.CHUNK_SIZE));
       }
@@ -78,7 +70,7 @@ export class CronAnalyticsSocialService {
       // Add each chunk to the queue
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
-        const jobData: SocialAnalyticsJobData = {
+        const jobData: ThreadsAnalyticsJobData = {
           posts: chunk.map((post: PostEntity) => ({
             _id: post._id.toString(),
             brand: post.brand.toString(),

--- a/apps/server/workers/src/crons/analytics/cron.analytics.module.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics.module.ts
@@ -1,22 +1,41 @@
 import { CredentialsModule } from '@api/collections/credentials/credentials.module';
+import { OrganizationsModule } from '@api/collections/organizations/organizations.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
+import { FacebookModule } from '@api/services/integrations/facebook/facebook.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
+import { LinkedInModule } from '@api/services/integrations/linkedin/linkedin.module';
+import { MastodonModule } from '@api/services/integrations/mastodon/mastodon.module';
+import { ThreadsModule } from '@api/services/integrations/threads/threads.module';
 import { TiktokModule } from '@api/services/integrations/tiktok/tiktok.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
 import { forwardRef, Module } from '@nestjs/common';
+import { CronAnalyticsFacebookService } from '@workers/crons/analytics/cron.analytics-facebook.service';
 import { CronAnalyticsSocialService } from '@workers/crons/analytics/cron.analytics-social.service';
+import { CronAnalyticsSyncService } from '@workers/crons/analytics/cron.analytics-sync.service';
+import { CronAnalyticsThreadsService } from '@workers/crons/analytics/cron.analytics-threads.service';
 import { CronAnalyticsTwitterService } from '@workers/crons/analytics/cron.analytics-twitter.service';
 import { WorkersQueuesModule } from '@workers/queues/queues.module';
 
 @Module({
   imports: [
     forwardRef(() => CredentialsModule),
+    forwardRef(() => FacebookModule),
     forwardRef(() => InstagramModule),
+    forwardRef(() => LinkedInModule),
+    forwardRef(() => MastodonModule),
+    forwardRef(() => OrganizationsModule),
     forwardRef(() => PostsModule),
-    forwardRef(() => WorkersQueuesModule),
+    forwardRef(() => ThreadsModule),
     forwardRef(() => TiktokModule),
     forwardRef(() => TwitterModule),
+    forwardRef(() => WorkersQueuesModule),
   ],
-  providers: [CronAnalyticsTwitterService, CronAnalyticsSocialService],
+  providers: [
+    CronAnalyticsFacebookService,
+    CronAnalyticsSocialService,
+    CronAnalyticsSyncService,
+    CronAnalyticsThreadsService,
+    CronAnalyticsTwitterService,
+  ],
 })
 export class CronAnalyticsModule {}

--- a/apps/server/workers/src/processors/processors.module.ts
+++ b/apps/server/workers/src/processors/processors.module.ts
@@ -43,8 +43,10 @@ import { AdSyncGoogleProcessor } from '@api/queues/ad-sync-google/ad-sync-google
 import { AdSyncMetaProcessor } from '@api/queues/ad-sync-meta/ad-sync-meta.processor';
 import { AdSyncTikTokProcessor } from '@api/queues/ad-sync-tiktok/ad-sync-tiktok.processor';
 import { AgentRunProcessor } from '@api/queues/agent-run/agent-run.processor';
+import { AnalyticsFacebookProcessor } from '@api/queues/analytics-facebook/analytics-facebook.processor';
 import { AnalyticsSocialProcessor } from '@api/queues/analytics-social/analytics-social.processor';
 import { AnalyticsSyncProcessor } from '@api/queues/analytics-sync/analytics-sync.processor';
+import { AnalyticsThreadsProcessor } from '@api/queues/analytics-threads/analytics-threads.processor';
 import { AnalyticsTwitterProcessor } from '@api/queues/analytics-twitter/analytics-twitter.processor';
 import { AnalyticsYouTubeProcessor } from '@api/queues/analytics-youtube/analytics-youtube.processor';
 import { CampaignProcessor } from '@api/queues/campaign/campaign.processor';
@@ -76,9 +78,11 @@ import { ContentOptimizationProcessor } from '@api/services/content-optimization
 import { ContentOrchestrationModule } from '@api/services/content-orchestration/content-orchestration.module';
 import { ContentPipelineProcessor } from '@api/services/content-orchestration/content-pipeline.processor';
 import { TelegramDistributionModule } from '@api/services/distribution/telegram/telegram-distribution.module';
+import { FacebookModule } from '@api/services/integrations/facebook/facebook.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
 import { MetaAdsModule } from '@api/services/integrations/meta-ads/meta-ads.module';
 import { PinterestModule } from '@api/services/integrations/pinterest/pinterest.module';
+import { ThreadsModule } from '@api/services/integrations/threads/threads.module';
 import { TiktokModule } from '@api/services/integrations/tiktok/tiktok.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
 import { YoutubeModule } from '@api/services/integrations/youtube/youtube.module';
@@ -135,6 +139,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     forwardRef(() => CampaignModule),
     forwardRef(() => ContentOptimizationModule),
     forwardRef(() => ContentOrchestrationModule),
+    forwardRef(() => FacebookModule),
     forwardRef(() => InstagramModule),
     forwardRef(() => MetaAdsModule),
     forwardRef(() => NotificationsModule),
@@ -144,6 +149,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     forwardRef(() => TaskOrchestrationModule),
     forwardRef(() => HeygenPollModule),
     forwardRef(() => TelegramDistributionModule),
+    forwardRef(() => ThreadsModule),
     forwardRef(() => TiktokModule),
     forwardRef(() => TwitterModule),
     forwardRef(() => WebhookClientModule),
@@ -151,7 +157,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     forwardRef(() => YoutubeModule),
   ],
   providers: [
-    // --- queues/ processors (20) ---
+    // --- queues/ processors (22) ---
     AdBulkUploadProcessor,
     AdInsightsAggregationProcessor,
     AdOptimizationProcessor,
@@ -159,7 +165,9 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     AdSyncMetaProcessor,
     AdSyncTikTokProcessor,
     AgentRunProcessor,
+    AnalyticsFacebookProcessor,
     AnalyticsSocialProcessor,
+    AnalyticsThreadsProcessor,
     AnalyticsSyncProcessor,
     AnalyticsTwitterProcessor,
     AnalyticsYouTubeProcessor,

--- a/apps/server/workers/src/queues/queues.module.ts
+++ b/apps/server/workers/src/queues/queues.module.ts
@@ -347,6 +347,24 @@ import { ConfigService } from '@workers/config/config.service';
         },
         name: 'heygen-poll',
       },
+      {
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { delay: 2000, type: 'exponential' },
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: 'analytics-facebook',
+      },
+      {
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: { delay: 2000, type: 'exponential' },
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: 'analytics-threads',
+      },
     ),
   ],
   providers: [

--- a/packages/workflow-engine/src/executors/saas/analytics-feedback-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/analytics-feedback-executor.ts
@@ -1,0 +1,115 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+export interface AnalyticsFeedbackOutput {
+  topTopics: string[];
+  topHooks: string[];
+  worstTopics: string[];
+  bestPlatform: string | null;
+  avgEngagementRate: number;
+  weekOverWeekDirection: 'up' | 'down' | 'stable';
+  weekOverWeekChange: number;
+  bestPostingTimes: Array<{
+    dayOfWeek: number;
+    hour: number;
+    avgEngagement: number;
+  }>;
+}
+
+export type AnalyticsFeedbackResolver = (params: {
+  organizationId: string;
+  brandId: string;
+  topN?: number;
+  worstN?: number;
+}) => Promise<AnalyticsFeedbackOutput>;
+
+export class AnalyticsFeedbackExecutor extends BaseExecutor {
+  readonly nodeType = 'analyticsFeedback';
+  private resolver: AnalyticsFeedbackResolver | null = null;
+
+  setResolver(resolver: AnalyticsFeedbackResolver): void {
+    this.resolver = resolver;
+  }
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+
+    const topN = node.config.topN;
+    if (
+      topN !== undefined &&
+      (typeof topN !== 'number' || topN < 1 || topN > 50)
+    ) {
+      errors.push('topN must be between 1 and 50');
+    }
+
+    const worstN = node.config.worstN;
+    if (
+      worstN !== undefined &&
+      (typeof worstN !== 'number' || worstN < 1 || worstN > 50)
+    ) {
+      errors.push('worstN must be between 1 and 50');
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, context } = input;
+
+    if (!this.resolver) {
+      throw new Error('Analytics feedback resolver not configured');
+    }
+
+    const topN = this.getOptionalConfig<number>(node.config, 'topN', 5);
+    const worstN = this.getOptionalConfig<number>(node.config, 'worstN', 5);
+
+    const brandId =
+      this.getOptionalConfig<string | null>(node.config, 'brandId', null) ??
+      ((context as unknown as Record<string, unknown>).brandId as
+        | string
+        | undefined);
+
+    if (!brandId) {
+      return {
+        data: {
+          avgEngagementRate: 0,
+          bestPlatform: null,
+          bestPostingTimes: [],
+          topHooks: [],
+          topTopics: [],
+          weekOverWeekChange: 0,
+          weekOverWeekDirection: 'stable' as const,
+          worstTopics: [],
+        } satisfies AnalyticsFeedbackOutput,
+        metadata: { reason: 'no_brand_id', skipped: true },
+      };
+    }
+
+    const feedback = await this.resolver({
+      brandId,
+      organizationId: context.organizationId,
+      topN,
+      worstN,
+    });
+
+    return {
+      data: feedback,
+      metadata: { resolvedAt: new Date().toISOString() },
+    };
+  }
+}
+
+export function createAnalyticsFeedbackExecutor(
+  resolver?: AnalyticsFeedbackResolver,
+): AnalyticsFeedbackExecutor {
+  const executor = new AnalyticsFeedbackExecutor();
+  if (resolver) {
+    executor.setResolver(resolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/executors/saas/index.ts
+++ b/packages/workflow-engine/src/executors/saas/index.ts
@@ -1,3 +1,4 @@
+export * from '@workflow-engine/executors/saas/analytics-feedback-executor';
 export * from '@workflow-engine/executors/saas/beat-analysis-executor';
 export * from '@workflow-engine/executors/saas/beat-sync-editor-executor';
 export * from '@workflow-engine/executors/saas/brand-asset-executor';

--- a/packages/workflow-saas/src/nodes/analytics-feedback.ts
+++ b/packages/workflow-saas/src/nodes/analytics-feedback.ts
@@ -1,0 +1,44 @@
+export interface AnalyticsFeedbackNodeData {
+  label: string;
+  status: 'idle' | 'running' | 'completed' | 'error';
+  topN: number;
+  worstN: number;
+  brandId: string | null;
+}
+
+export const DEFAULT_ANALYTICS_FEEDBACK_DATA: Partial<AnalyticsFeedbackNodeData> =
+  {
+    brandId: null,
+    label: 'Analytics Feedback',
+    status: 'idle',
+    topN: 5,
+    worstN: 5,
+  };
+
+export const analyticsFeedbackNodeDefinition = {
+  category: 'trigger' as const,
+  defaultData: DEFAULT_ANALYTICS_FEEDBACK_DATA,
+  description: 'Read performance analytics to guide content strategy',
+  icon: 'BarChart3',
+  inputs: [],
+  label: 'Analytics Feedback',
+  outputs: [
+    { id: 'topTopics', label: 'Top Topics', type: 'text[]' },
+    { id: 'topHooks', label: 'Top Hooks', type: 'text[]' },
+    { id: 'worstTopics', label: 'Worst Topics', type: 'text[]' },
+    { id: 'bestPlatform', label: 'Best Platform', type: 'text' },
+    { id: 'avgEngagementRate', label: 'Avg Engagement Rate', type: 'number' },
+    {
+      id: 'weekOverWeekDirection',
+      label: 'Week-over-Week Direction',
+      type: 'text',
+    },
+    {
+      id: 'weekOverWeekChange',
+      label: 'Week-over-Week Change %',
+      type: 'number',
+    },
+    { id: 'bestPostingTimes', label: 'Best Posting Times', type: 'json' },
+  ],
+  type: 'analyticsFeedback',
+};

--- a/packages/workflow-saas/src/nodes/index.ts
+++ b/packages/workflow-saas/src/nodes/index.ts
@@ -1,3 +1,4 @@
+export * from './analytics-feedback';
 export * from './beat-analysis';
 export * from './beat-sync-editor';
 export * from './brand';


### PR DESCRIPTION
## Summary

Closes the 3 remaining gaps in the content automation loop (trends → remix → generate → publish → analytics → repeat):

- **Trend Remix Skill** — new `TrendRemixHandler` that takes a trend + brand voice → branded content via LLM, with graceful fallback on LLM failure
- **Analytics Pull-Back for 4 platforms** — LinkedIn, Mastodon (extend existing `analytics-social` processor), Facebook, Threads (new dedicated processors + queues + hourly crons)
- **Closed-Loop Automation** — `CronAnalyticsSyncService` (every 6h with dedup), `AnalyticsFeedbackExecutor` workflow node that reads `PerformanceSummaryService`, content-loop workflow template wiring the full chain

### Files created (10)
- `trend-remix.handler.ts` + `.spec.ts` — skill handler + tests
- `analytics-facebook.processor.ts` + module — Facebook analytics queue processor
- `analytics-threads.processor.ts` + module — Threads analytics queue processor  
- `cron.analytics-facebook.service.ts` — hourly Facebook analytics cron
- `cron.analytics-threads.service.ts` — hourly Threads analytics cron
- `cron.analytics-sync.service.ts` — 6-hourly analytics sync trigger
- `analytics-feedback-executor.ts` — workflow executor with resolver pattern
- `analytics-feedback.ts` (workflow-saas node) — node definition with 8 outputs
- `content-loop.template.ts` — full workflow template

### Files modified (14)
- Skill executor service + module (trend-remix registration)
- Analytics-social processor (LinkedIn/Mastodon branches)
- PostAnalyticsService (4 new process methods)
- Queue registrations (API + Workers queues.module, queue.service)
- ProcessorsModule (Facebook/Threads processors + integration modules)
- CronAnalyticsModule (3 new cron services + 5 integration modules)
- WorkflowEngineAdapterService (analytics-feedback executor wiring)
- Workflow-engine + workflow-saas index exports

## Test plan
- [ ] `bun run test --filter=@genfeedai/api` — trend-remix handler spec passes
- [ ] Type-check passes (no new regressions — pre-existing serializers/helpers issue)
- [ ] Lint passes (no new regressions — pre-existing workflow-ui/tsup issue)
- [ ] Manual: create workflow from content-loop template, verify node graph renders
- [ ] Manual: publish a post on LinkedIn/Mastodon/Facebook/Threads, wait for analytics cron, verify `post_analytics` records created

🤖 Generated with [Claude Code](https://claude.com/claude-code)