### PR TITLE
feat: show provider balances in topbar

### DIFF
--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -43,6 +43,10 @@ vi.mock('@ui/topbars/breadcrumbs/TopbarBreadcrumbs', () => ({
   default: () => <div data-testid="breadcrumbs">Breadcrumbs</div>,
 }));
 
+vi.mock('@ui/topbars/credits-bar/TopbarCreditsBar', () => ({
+  default: () => <div data-testid="topbar-credits-bar">Credits</div>,
+}));
+
 vi.mock('@ui/topbars/end/TopbarEnd', () => ({
   default: () => <div data-testid="topbar-end">Topbar End</div>,
 }));
@@ -105,6 +109,18 @@ describe('AppProtectedTopbar', () => {
 
     expect(
       terminalButton.compareDocumentPosition(cloudSyncIndicator) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('renders credit balances before the topbar end slot', () => {
+    render(<AppProtectedTopbar currentApp="workspace" orgSlug="acme" />);
+
+    const credits = screen.getByTestId('topbar-credits-bar');
+    const topbarEnd = screen.getByTestId('topbar-end');
+
+    expect(
+      credits.compareDocumentPosition(topbarEnd) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -6,6 +6,7 @@ import type { TopbarProps } from '@props/navigation/topbar.props';
 import { Button } from '@ui/primitives/button';
 import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
 import TopbarBreadcrumbs from '@ui/topbars/breadcrumbs/TopbarBreadcrumbs';
+import TopbarCreditsBar from '@ui/topbars/credits-bar/TopbarCreditsBar';
 import TopbarEnd from '@ui/topbars/end/TopbarEnd';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
@@ -112,6 +113,8 @@ export default function AppProtectedTopbar({
           ) : null}
 
           <CloudSyncIndicator />
+
+          <TopbarCreditsBar />
 
           <TopbarEnd />
         </div>

--- a/apps/server/api/src/collections/credits/controllers/credits.controller.spec.ts
+++ b/apps/server/api/src/collections/credits/controllers/credits.controller.spec.ts
@@ -1,5 +1,6 @@
 import { CreditsController } from '@api/collections/credits/controllers/credits.controller';
 import { CreditTransactionsService } from '@api/collections/credits/services/credit-transactions.service';
+import { TopbarBalancesService } from '@api/collections/credits/services/topbar-balances.service';
 import { RATE_LIMIT_KEY } from '@api/shared/decorators/rate-limit/rate-limit.decorator';
 import type { User } from '@clerk/backend';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -47,6 +48,21 @@ describe('CreditsController', () => {
       log: vi.fn(),
       warn: vi.fn(),
     },
+    topbarBalancesService: {
+      getTopbarBalances: vi.fn().mockResolvedValue({
+        generatedAt: '2026-05-02T12:00:00.000Z',
+        segments: [
+          {
+            balance: 1000,
+            currencyOrUnit: 'credits',
+            label: 'Genfeed',
+            lastSyncedAt: '2026-05-02T12:00:00.000Z',
+            provider: 'genfeed',
+            status: 'available',
+          },
+        ],
+      }),
+    },
   };
 
   beforeEach(async () => {
@@ -56,6 +72,10 @@ describe('CreditsController', () => {
         {
           provide: CreditTransactionsService,
           useValue: mockServices.creditTransactionsService,
+        },
+        {
+          provide: TopbarBalancesService,
+          useValue: mockServices.topbarBalancesService,
         },
         { provide: LoggerService, useValue: mockServices.loggerService },
       ],
@@ -101,6 +121,14 @@ describe('CreditsController', () => {
     expect(metadata).toEqual({ limit: 20, scope: 'user', windowMs: 60000 });
   });
 
+  it('should have rate limit on getTopbarBalances endpoint', () => {
+    const metadata = Reflect.getMetadata(
+      RATE_LIMIT_KEY,
+      CreditsController.prototype.getTopbarBalances,
+    );
+    expect(metadata).toEqual({ limit: 30, scope: 'user', windowMs: 60000 });
+  });
+
   describe('getUsageMetrics', () => {
     it('should return usage metrics', async () => {
       const result = await controller.getUsageMetrics(mockReq, mockUser);
@@ -138,6 +166,17 @@ describe('CreditsController', () => {
 
       expect(
         mockServices.creditTransactionsService.getLastPurchaseBaseline,
+      ).toHaveBeenCalledWith('507f1f77bcf86cd799439012');
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('getTopbarBalances', () => {
+    it('returns serialized topbar balances for the current organization', async () => {
+      const result = await controller.getTopbarBalances(mockReq, mockUser);
+
+      expect(
+        mockServices.topbarBalancesService.getTopbarBalances,
       ).toHaveBeenCalledWith('507f1f77bcf86cd799439012');
       expect(result).toBeDefined();
     });

--- a/apps/server/api/src/collections/credits/controllers/credits.controller.ts
+++ b/apps/server/api/src/collections/credits/controllers/credits.controller.ts
@@ -1,4 +1,5 @@
 import { CreditTransactionsService } from '@api/collections/credits/services/credit-transactions.service';
+import { TopbarBalancesService } from '@api/collections/credits/services/topbar-balances.service';
 import {
   CACHE_PATTERNS,
   CACHE_TAGS,
@@ -16,6 +17,7 @@ import {
   ByokUsageSummarySerializer,
   CreditUsageSerializer,
   LastPurchaseBaselineSerializer,
+  TopbarBalancesSerializer,
 } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Controller, Get, Optional, Req } from '@nestjs/common';
@@ -26,6 +28,7 @@ import type { Request } from 'express';
 export class CreditsController {
   constructor(
     private readonly creditTransactionsService: CreditTransactionsService,
+    private readonly topbarBalancesService: TopbarBalancesService,
     readonly _loggerService: LoggerService,
     @Optional() private readonly byokBillingService?: ByokBillingService,
   ) {}
@@ -88,6 +91,18 @@ export class CreditsController {
     const data =
       await this.byokBillingService.getByokUsageSummary(organizationId);
     return serializeSingle(req, ByokUsageSummarySerializer, data);
+  }
+
+  @Get('topbar-balances')
+  @RateLimit({ limit: 30, scope: 'user', windowMs: 60000 })
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async getTopbarBalances(@Req() req: Request, @CurrentUser() user: User) {
+    const publicMetadata = getPublicMetadata(user);
+    const organizationId = publicMetadata.organization.toString();
+
+    const data =
+      await this.topbarBalancesService.getTopbarBalances(organizationId);
+    return serializeSingle(req, TopbarBalancesSerializer, data);
   }
 
   @Get('last-purchase-baseline')

--- a/apps/server/api/src/collections/credits/credits.module.ts
+++ b/apps/server/api/src/collections/credits/credits.module.ts
@@ -9,6 +9,7 @@ import { CreditsController } from '@api/collections/credits/controllers/credits.
 import { CreditBalanceService } from '@api/collections/credits/services/credit-balance.service';
 import { CreditTransactionsService } from '@api/collections/credits/services/credit-transactions.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { TopbarBalancesService } from '@api/collections/credits/services/topbar-balances.service';
 import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
 import { OrganizationsModule } from '@api/collections/organizations/organizations.module';
 import { SettingsModule } from '@api/collections/settings/settings.module';
@@ -22,6 +23,7 @@ import { ByokBillingModule } from '@api/services/byok-billing/byok-billing.modul
 import { ClerkModule } from '@api/services/integrations/clerk/clerk.module';
 import { StripeModule } from '@api/services/integrations/stripe/stripe.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
+import { HttpModule } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
@@ -47,6 +49,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => StripeModule),
     forwardRef(() => SubscriptionsModule),
     forwardRef(() => UsersModule),
+    HttpModule,
 
     TransactionModule,
   ],
@@ -54,6 +57,7 @@ import { forwardRef, Module } from '@nestjs/common';
     CreditBalanceService,
     CreditTransactionsService,
     CreditsUtilsService,
+    TopbarBalancesService,
   ],
 })
 export class CreditsModule {}

--- a/apps/server/api/src/collections/credits/services/topbar-balances.service.spec.ts
+++ b/apps/server/api/src/collections/credits/services/topbar-balances.service.spec.ts
@@ -1,0 +1,113 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { TopbarBalancesService } from '@api/collections/credits/services/topbar-balances.service';
+import { ByokService } from '@api/services/byok/byok.service';
+import { ByokProvider } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+
+describe('TopbarBalancesService', () => {
+  const creditsUtilsService = {
+    getOrganizationCreditsBalance: vi.fn(),
+  };
+  const byokService = {
+    resolveApiKey: vi.fn(),
+  };
+  const httpService = {
+    get: vi.fn(),
+  };
+  const loggerService = {
+    warn: vi.fn(),
+  };
+
+  let service: TopbarBalancesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TopbarBalancesService(
+      creditsUtilsService as unknown as CreditsUtilsService,
+      byokService as unknown as ByokService,
+      httpService as unknown as HttpService,
+      loggerService as unknown as LoggerService,
+    );
+    creditsUtilsService.getOrganizationCreditsBalance.mockResolvedValue(840);
+    byokService.resolveApiKey.mockResolvedValue(undefined);
+  });
+
+  it('always includes the Genfeed credit balance', async () => {
+    const result = await service.getTopbarBalances('org_1');
+
+    expect(result.segments).toEqual([
+      expect.objectContaining({
+        balance: 840,
+        currencyOrUnit: 'credits',
+        label: 'Genfeed',
+        provider: 'genfeed',
+        status: 'available',
+      }),
+    ]);
+  });
+
+  it('includes connected fal.ai balances', async () => {
+    byokService.resolveApiKey.mockImplementation(
+      async (_orgId: string, provider: ByokProvider) =>
+        provider === ByokProvider.FAL ? { apiKey: 'fal-key' } : undefined,
+    );
+    httpService.get.mockReturnValue(
+      of({
+        data: {
+          credits: { current_balance: 24.5, currency: 'USD' },
+        },
+      }),
+    );
+
+    const result = await service.getTopbarBalances('org_1');
+
+    expect(httpService.get).toHaveBeenCalledWith(
+      'https://api.fal.ai/v1/account/billing?expand=credits',
+      expect.objectContaining({
+        headers: { Authorization: 'Key fal-key' },
+        timeout: 2500,
+      }),
+    );
+    expect(result.segments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          balance: 24.5,
+          currencyOrUnit: 'USD',
+          label: 'fal.ai',
+          provider: ByokProvider.FAL,
+          status: 'available',
+        }),
+      ]),
+    );
+  });
+
+  it('marks provider segments unavailable without blocking the pill', async () => {
+    byokService.resolveApiKey.mockImplementation(
+      async (_orgId: string, provider: ByokProvider) =>
+        provider === ByokProvider.REPLICATE
+          ? { apiKey: 'replicate-key' }
+          : undefined,
+    );
+    httpService.get.mockReturnValue(throwError(() => new Error('timeout')));
+
+    const result = await service.getTopbarBalances('org_1');
+
+    expect(result.segments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          balance: 840,
+          provider: 'genfeed',
+          status: 'available',
+        }),
+        expect.objectContaining({
+          balance: null,
+          label: 'Replicate',
+          provider: ByokProvider.REPLICATE,
+          status: 'unavailable',
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/server/api/src/collections/credits/services/topbar-balances.service.ts
+++ b/apps/server/api/src/collections/credits/services/topbar-balances.service.ts
@@ -1,0 +1,179 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { ByokService } from '@api/services/byok/byok.service';
+import { ByokProvider } from '@genfeedai/enums';
+import type {
+  ITopbarBalanceSegment,
+  ITopbarBalances,
+} from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+
+const PROVIDER_BALANCE_TIMEOUT_MS = 2500;
+
+@Injectable()
+export class TopbarBalancesService {
+  constructor(
+    private readonly creditsUtilsService: CreditsUtilsService,
+    private readonly byokService: ByokService,
+    private readonly httpService: HttpService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  async getTopbarBalances(organizationId: string): Promise<ITopbarBalances> {
+    const generatedAt = new Date().toISOString();
+    const genfeedBalance =
+      await this.creditsUtilsService.getOrganizationCreditsBalance(
+        organizationId,
+      );
+
+    const providerSegments = await Promise.all([
+      this.getProviderSegment(organizationId, ByokProvider.REPLICATE),
+      this.getProviderSegment(organizationId, ByokProvider.FAL),
+    ]);
+
+    return {
+      generatedAt,
+      segments: [
+        {
+          balance: genfeedBalance,
+          currencyOrUnit: 'credits',
+          label: 'Genfeed',
+          lastSyncedAt: generatedAt,
+          provider: 'genfeed',
+          status: 'available',
+        },
+        ...providerSegments.filter(
+          (segment): segment is ITopbarBalanceSegment => Boolean(segment),
+        ),
+      ],
+    };
+  }
+
+  private async getProviderSegment(
+    organizationId: string,
+    provider: ByokProvider.REPLICATE | ByokProvider.FAL,
+  ): Promise<ITopbarBalanceSegment | null> {
+    const credentials = await this.byokService.resolveApiKey(
+      organizationId,
+      provider,
+    );
+
+    if (!credentials) {
+      return null;
+    }
+
+    try {
+      if (provider === ByokProvider.FAL) {
+        return await this.getFalBalance(credentials.apiKey);
+      }
+
+      return await this.getReplicateBalance(credentials.apiKey);
+    } catch (error: unknown) {
+      this.loggerService.warn('Topbar provider balance lookup failed', {
+        error,
+        provider,
+      });
+
+      return this.unavailableSegment(
+        provider,
+        error instanceof Error ? error.message : 'Balance unavailable',
+      );
+    }
+  }
+
+  private async getFalBalance(apiKey: string): Promise<ITopbarBalanceSegment> {
+    const response = await firstValueFrom(
+      this.httpService.get<{
+        credits?: { current_balance?: number; currency?: string };
+      }>('https://api.fal.ai/v1/account/billing?expand=credits', {
+        headers: { Authorization: `Key ${apiKey}` },
+        timeout: PROVIDER_BALANCE_TIMEOUT_MS,
+      }),
+    );
+    const credits = response.data.credits;
+    const balance = credits?.current_balance;
+
+    if (typeof balance !== 'number') {
+      throw new Error('fal.ai billing response did not include credits');
+    }
+
+    return {
+      balance,
+      currencyOrUnit: credits?.currency ?? 'USD',
+      label: 'fal.ai',
+      lastSyncedAt: new Date().toISOString(),
+      provider: ByokProvider.FAL,
+      status: 'available',
+    };
+  }
+
+  private async getReplicateBalance(
+    apiKey: string,
+  ): Promise<ITopbarBalanceSegment> {
+    const response = await firstValueFrom(
+      this.httpService.get<Record<string, unknown>>(
+        'https://api.replicate.com/v1/account',
+        {
+          headers: { Authorization: `Bearer ${apiKey}` },
+          timeout: PROVIDER_BALANCE_TIMEOUT_MS,
+        },
+      ),
+    );
+    const balance = this.extractNumericBalance(response.data);
+
+    if (typeof balance !== 'number') {
+      throw new Error('Replicate account API did not expose a credit balance');
+    }
+
+    return {
+      balance,
+      currencyOrUnit: 'USD',
+      label: 'Replicate',
+      lastSyncedAt: new Date().toISOString(),
+      provider: ByokProvider.REPLICATE,
+      status: 'available',
+    };
+  }
+
+  private extractNumericBalance(data: Record<string, unknown>): number | null {
+    const directKeys = [
+      'balance',
+      'credit_balance',
+      'creditBalance',
+      'credits',
+    ];
+
+    for (const key of directKeys) {
+      if (typeof data[key] === 'number') {
+        return data[key];
+      }
+    }
+
+    const billing = data.billing as Record<string, unknown> | undefined;
+    const credit = data.credit as Record<string, unknown> | undefined;
+    const nestedBalance =
+      billing?.balance ??
+      billing?.credit_balance ??
+      billing?.creditBalance ??
+      credit?.balance;
+
+    return typeof nestedBalance === 'number' ? nestedBalance : null;
+  }
+
+  private unavailableSegment(
+    provider: ByokProvider.REPLICATE | ByokProvider.FAL,
+    error: string,
+  ): ITopbarBalanceSegment {
+    return {
+      balance: null,
+      currencyOrUnit: provider === ByokProvider.FAL ? 'USD' : 'USD',
+      error,
+      label: provider === ByokProvider.FAL ? 'fal.ai' : 'Replicate',
+      lastSyncedAt: new Date().toISOString(),
+      provider,
+      status: 'unavailable',
+    };
+  }
+}

--- a/packages/interfaces/src/billing/index.ts
+++ b/packages/interfaces/src/billing/index.ts
@@ -2,3 +2,4 @@ export * from './credits.interface';
 export * from './credits-utils.contract';
 export * from './subscription.interface';
 export * from './subscriptions-service.contract';
+export * from './topbar-balance.interface';

--- a/packages/interfaces/src/billing/topbar-balance.interface.ts
+++ b/packages/interfaces/src/billing/topbar-balance.interface.ts
@@ -1,0 +1,16 @@
+export type TopbarBalanceStatus = 'available' | 'unavailable';
+
+export interface ITopbarBalanceSegment {
+  provider: string;
+  label: string;
+  balance: number | null;
+  currencyOrUnit: string;
+  status: TopbarBalanceStatus;
+  lastSyncedAt: string;
+  error?: string;
+}
+
+export interface ITopbarBalances {
+  segments: ITopbarBalanceSegment[];
+  generatedAt: string;
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -47,6 +47,7 @@ export * from './batch/batch.interface';
 export * from './batch/manual-review-batch-item.interface';
 export * from './billing/credits.interface';
 export * from './billing/subscription.interface';
+export * from './billing/topbar-balance.interface';
 export * from './common/content-scope.interface';
 export * from './components/asset-selection.interface';
 export * from './components/background-task.interface';

--- a/packages/serializers/src/attributes/billing/index.ts
+++ b/packages/serializers/src/attributes/billing/index.ts
@@ -5,3 +5,4 @@ export * from '@serializers/attributes/billing/credit-usage.attributes';
 export * from '@serializers/attributes/billing/last-purchase-baseline.attributes';
 export * from '@serializers/attributes/billing/subscription.attributes';
 export * from '@serializers/attributes/billing/subscription-attribution.attributes';
+export * from '@serializers/attributes/billing/topbar-balances.attributes';

--- a/packages/serializers/src/attributes/billing/topbar-balances.attributes.ts
+++ b/packages/serializers/src/attributes/billing/topbar-balances.attributes.ts
@@ -1,0 +1,6 @@
+import { createEntityAttributes } from '@genfeedai/helpers';
+
+export const topbarBalancesAttributes = createEntityAttributes([
+  'generatedAt',
+  'segments',
+]);

--- a/packages/serializers/src/configs/billing/index.ts
+++ b/packages/serializers/src/configs/billing/index.ts
@@ -5,3 +5,4 @@ export * from '@serializers/configs/billing/credit-usage.config';
 export * from '@serializers/configs/billing/last-purchase-baseline.config';
 export * from '@serializers/configs/billing/subscription.config';
 export * from '@serializers/configs/billing/subscription-attribution.config';
+export * from '@serializers/configs/billing/topbar-balances.config';

--- a/packages/serializers/src/configs/billing/topbar-balances.config.ts
+++ b/packages/serializers/src/configs/billing/topbar-balances.config.ts
@@ -1,0 +1,6 @@
+import { topbarBalancesAttributes } from '@serializers/attributes/billing/topbar-balances.attributes';
+
+export const topbarBalancesSerializerConfig = {
+  attributes: topbarBalancesAttributes,
+  type: 'topbar-balances',
+};

--- a/packages/serializers/src/server/billing/index.ts
+++ b/packages/serializers/src/server/billing/index.ts
@@ -5,3 +5,4 @@ export * from '@serializers/server/billing/credit-usage.serializer';
 export * from '@serializers/server/billing/last-purchase-baseline.serializer';
 export * from '@serializers/server/billing/subscription.serializer';
 export * from '@serializers/server/billing/subscription-attribution.serializer';
+export * from '@serializers/server/billing/topbar-balances.serializer';

--- a/packages/serializers/src/server/billing/topbar-balances.serializer.ts
+++ b/packages/serializers/src/server/billing/topbar-balances.serializer.ts
@@ -1,0 +1,7 @@
+import { buildSerializer } from '@serializers/builders';
+import { topbarBalancesSerializerConfig } from '@serializers/configs';
+
+export const { TopbarBalancesSerializer } = buildSerializer(
+  'server',
+  topbarBalancesSerializerConfig,
+);

--- a/packages/services/billing/credits.service.test.ts
+++ b/packages/services/billing/credits.service.test.ts
@@ -103,4 +103,60 @@ describe('CreditsService', () => {
       },
     });
   });
+
+  it('deserializes JSON:API topbar balances', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: {
+          attributes: {
+            generatedAt: '2026-05-02T12:00:00.000Z',
+            segments: [
+              {
+                balance: 420,
+                currencyOrUnit: 'credits',
+                label: 'Genfeed',
+                lastSyncedAt: '2026-05-02T12:00:00.000Z',
+                provider: 'genfeed',
+                status: 'available',
+              },
+            ],
+          },
+          id: 'topbar-balances',
+          type: 'topbar-balances',
+        },
+      },
+    });
+
+    mockDeserializeResource.mockReturnValue({
+      generatedAt: '2026-05-02T12:00:00.000Z',
+      segments: [
+        {
+          balance: 420,
+          currencyOrUnit: 'credits',
+          label: 'Genfeed',
+          lastSyncedAt: '2026-05-02T12:00:00.000Z',
+          provider: 'genfeed',
+          status: 'available',
+        },
+      ],
+    });
+
+    const service = new CreditsService('test-token');
+
+    await expect(service.getTopbarBalances()).resolves.toEqual({
+      generatedAt: '2026-05-02T12:00:00.000Z',
+      segments: [
+        {
+          balance: 420,
+          currencyOrUnit: 'credits',
+          label: 'Genfeed',
+          lastSyncedAt: '2026-05-02T12:00:00.000Z',
+          provider: 'genfeed',
+          status: 'available',
+        },
+      ],
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/topbar-balances');
+  });
 });

--- a/packages/services/billing/credits.service.ts
+++ b/packages/services/billing/credits.service.ts
@@ -2,6 +2,7 @@ import {
   deserializeResource,
   type JsonApiResponseDocument,
 } from '@genfeedai/helpers/data/json-api/json-api.helper';
+import type { ITopbarBalances } from '@genfeedai/interfaces';
 import { EnvironmentService } from '@services/core/environment.service';
 import { HTTPBaseService } from '@services/core/interceptor.service';
 
@@ -35,5 +36,12 @@ export class CreditsService extends HTTPBaseService {
     );
 
     return deserializeResource<ByokUsageSummary>(response.data);
+  }
+
+  async getTopbarBalances(): Promise<ITopbarBalances> {
+    const response =
+      await this.instance.get<JsonApiResponseDocument>('/topbar-balances');
+
+    return deserializeResource<ITopbarBalances>(response.data);
   }
 }

--- a/packages/services/organization/organizations.service.ts
+++ b/packages/services/organization/organizations.service.ts
@@ -440,6 +440,7 @@ export class OrganizationsService extends BaseService<Organization> {
       apiKey,
       apiSecret,
     });
+    this.dispatchTopbarBalanceRefresh();
   }
 
   public async removeByokProviderKey(
@@ -447,6 +448,15 @@ export class OrganizationsService extends BaseService<Organization> {
     provider: string,
   ): Promise<void> {
     await this.instance.delete(`/${orgId}/settings/byok/${provider}`);
+    this.dispatchTopbarBalanceRefresh();
+  }
+
+  private dispatchTopbarBalanceRefresh(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.dispatchEvent(new CustomEvent('genfeed:topbar-balances:refresh'));
   }
 
   public async toggleModel(

--- a/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.tsx
+++ b/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.tsx
@@ -14,10 +14,11 @@ import { useSocketManager } from '@genfeedai/hooks/utils/use-socket-manager/use-
 import type {
   ICreditsEventData,
   IOrganizationEventData,
+  ITopbarBalanceSegment,
 } from '@genfeedai/interfaces';
+import { CreditsService } from '@genfeedai/services/billing/credits.service';
 import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import { logger } from '@genfeedai/services/core/logger.service';
-import { OrganizationsService } from '@genfeedai/services/organization/organizations.service';
 import { Button } from '@ui/primitives/button';
 import {
   Popover,
@@ -33,18 +34,45 @@ export default function TopbarCreditsBar() {
   const { organizationId } = useBrand();
   const { orgHref } = useOrgUrl();
 
-  const getOrganizationsService = useAuthedService((token: string) =>
-    OrganizationsService.getInstance(token),
+  const getCreditsService = useAuthedService((token: string) =>
+    CreditsService.getInstance(token),
   );
 
   const { creditsBreakdown, refreshCreditsBreakdown } = useSubscription();
 
   const [balance, setBalance] = useState<number>(0);
+  const [segments, setSegments] = useState<ITopbarBalanceSegment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
   const refreshBreakdownRef = useRef(refreshCreditsBreakdown);
   refreshBreakdownRef.current = refreshCreditsBreakdown;
   const { subscribe, unsubscribe } = useSocketManager();
+
+  const findTopbarBalances = useCallback(async () => {
+    if (!organizationId) {
+      return setIsLoading(false);
+    }
+
+    try {
+      setIsLoading(true);
+      const service = await getCreditsService();
+      const data = await service.getTopbarBalances();
+      const nextSegments = data.segments ?? [];
+      const genfeedSegment = nextSegments.find(
+        (segment) => segment.provider === 'genfeed',
+      );
+      setSegments(nextSegments);
+      setBalance(
+        typeof genfeedSegment?.balance === 'number'
+          ? genfeedSegment.balance
+          : 0,
+      );
+      setIsLoading(false);
+    } catch (error: unknown) {
+      logger.error('TopbarCreditsBar: failed to fetch balances', error);
+      setIsLoading(false);
+    }
+  }, [organizationId, getCreditsService]);
 
   useEffect(() => {
     if (organizationId) {
@@ -56,6 +84,7 @@ export default function TopbarCreditsBar() {
         if (orgData?.balance !== undefined) {
           setBalance(orgData.balance);
           refreshBreakdownRef.current();
+          void findTopbarBalances();
         }
       };
 
@@ -64,6 +93,7 @@ export default function TopbarCreditsBar() {
         if (creditsData?.balance !== undefined) {
           setBalance(creditsData.balance);
           refreshBreakdownRef.current();
+          void findTopbarBalances();
         }
       };
 
@@ -75,39 +105,37 @@ export default function TopbarCreditsBar() {
         unsubscribe(creditsEvent, creditsHandler);
       };
     }
-  }, [organizationId, subscribe, unsubscribe]);
-
-  const findOrganizationBalance = useCallback(async () => {
-    if (!organizationId) {
-      return setIsLoading(false);
-    }
-
-    try {
-      setIsLoading(true);
-      const service = await getOrganizationsService();
-      const data = await service.findOne(organizationId);
-      setBalance(data?.balance ?? 0);
-      setIsLoading(false);
-    } catch (error: unknown) {
-      logger.error('TopbarCreditsBar: failed to fetch balance', error);
-      setIsLoading(false);
-    }
-  }, [organizationId, getOrganizationsService]);
+  }, [organizationId, subscribe, unsubscribe, findTopbarBalances]);
 
   useEffect(() => {
     if (organizationId) {
       (async () => {
-        await findOrganizationBalance();
+        await findTopbarBalances();
       })();
     }
-  }, [organizationId, findOrganizationBalance]);
+  }, [organizationId, findTopbarBalances]);
+
+  useEffect(() => {
+    const handleRefresh = () => {
+      void findTopbarBalances();
+    };
+
+    window.addEventListener('genfeed:topbar-balances:refresh', handleRefresh);
+
+    return () => {
+      window.removeEventListener(
+        'genfeed:topbar-balances:refresh',
+        handleRefresh,
+      );
+    };
+  }, [findTopbarBalances]);
 
   const handleRefreshBalance = async (e?: ReactMouseEvent) => {
     if (e) {
       e.preventDefault();
       e.stopPropagation();
     }
-    await findOrganizationBalance();
+    await findTopbarBalances();
     await refreshCreditsBreakdown();
   };
 
@@ -138,6 +166,10 @@ export default function TopbarCreditsBar() {
 
   const compactBalance = formatCompactNumber(balance);
   const fullBalance = formatNumberWithCommas(balance);
+  const providerSegments = segments.filter(
+    (segment) => segment.provider !== 'genfeed',
+  );
+  const visibleProviderSegments = providerSegments.slice(0, 2);
 
   // Remaining percentage for the fill bar (how much is left)
   const remainingPercent = planLimit > 0 ? (planBalance / planLimit) * 100 : 0;
@@ -149,7 +181,7 @@ export default function TopbarCreditsBar() {
           withWrapper={false}
           variant={ButtonVariant.UNSTYLED}
           className={cn(
-            'gen-shell-control hidden h-10 items-center gap-3 rounded-md px-3.5 text-left md:flex',
+            'gen-shell-control hidden h-10 max-w-[20rem] items-center gap-2 rounded-md px-3 text-left sm:flex',
           )}
           data-active={isOpen ? 'true' : 'false'}
           title={`${fullBalance} ${EnvironmentService.CREDITS_LABEL}`}
@@ -163,6 +195,33 @@ export default function TopbarCreditsBar() {
               {compactBalance}
             </span>
           </div>
+          {visibleProviderSegments.length > 0 && (
+            <div className="hidden min-w-0 items-center gap-1 border-l border-white/[0.08] pl-2 lg:flex">
+              {visibleProviderSegments.map((segment) => (
+                <span
+                  key={segment.provider}
+                  className={cn(
+                    'inline-flex h-5 max-w-[5.5rem] items-center gap-1 rounded bg-white/[0.04] px-1.5 text-[11px] font-medium text-foreground/62',
+                    segment.status === 'unavailable' && 'text-amber-200/70',
+                  )}
+                  title={`${segment.label}: ${
+                    segment.status === 'available' &&
+                    typeof segment.balance === 'number'
+                      ? `${formatCompactNumber(segment.balance)} ${segment.currencyOrUnit}`
+                      : 'Unavailable'
+                  }`}
+                >
+                  <span className="truncate">{segment.label}</span>
+                  <span className="shrink-0 text-foreground/42">
+                    {segment.status === 'available' &&
+                    typeof segment.balance === 'number'
+                      ? formatCompactNumber(segment.balance)
+                      : '--'}
+                  </span>
+                </span>
+              ))}
+            </div>
+          )}
           {planLimit > 0 && (
             <div className="ml-1 h-1.5 w-14 overflow-hidden rounded-full bg-white/[0.08]">
               <div
@@ -245,6 +304,55 @@ export default function TopbarCreditsBar() {
                 <span className="text-[11px] text-foreground/32">
                   {Math.round(remainingPercent)}% left
                 </span>
+              </div>
+            </div>
+          )}
+
+          {providerSegments.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground/36">
+                  Providers
+                </span>
+                <span className="text-[11px] text-foreground/32">
+                  BYOK balances
+                </span>
+              </div>
+              <div className="space-y-1.5">
+                {providerSegments.map((segment) => (
+                  <div
+                    key={segment.provider}
+                    className="gen-shell-surface flex items-center justify-between gap-3 rounded-md px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-foreground/86">
+                        {segment.label}
+                      </div>
+                      <div className="text-[11px] text-foreground/38">
+                        {segment.status === 'available'
+                          ? 'Connected'
+                          : (segment.error ?? 'Balance unavailable')}
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <div
+                        className={cn(
+                          'text-sm font-semibold text-foreground',
+                          segment.status === 'unavailable' &&
+                            'text-amber-200/80',
+                        )}
+                      >
+                        {segment.status === 'available' &&
+                        typeof segment.balance === 'number'
+                          ? formatCompactNumber(segment.balance)
+                          : '--'}
+                      </div>
+                      <div className="text-[10px] uppercase tracking-[0.14em] text-foreground/32">
+                        {segment.currencyOrUnit}
+                      </div>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- adds a topbar balances endpoint for Genfeed credits plus BYOK provider balances
- surfaces Genfeed, Replicate, and fal.ai balance status in the protected app topbar
- refreshes the topbar after BYOK key save/remove events

Closes #249

## Validation
- npx biome check --write <touched files>
- bun run --cwd apps/server/api test:file src/collections/credits/services/topbar-balances.service.spec.ts src/collections/credits/controllers/credits.controller.spec.ts
- bun run --cwd packages/services test billing/credits.service.test.ts
- bun run --cwd apps/app test src/components/shell/AppProtectedTopbar.test.tsx
- bun run --cwd apps/app type-check
- bun run --cwd apps/server/api build
- bunx turbo run type-check --filter=@genfeedai/services... --filter=@genfeedai/interfaces... --filter=@genfeedai/serializers...
- bunx turbo run build --filter=@genfeedai/ui... --filter=@genfeedai/hooks... --filter=@genfeedai/contexts...
- bunx turbo lint --filter=@genfeedai/api --filter=@genfeedai/app --filter=@genfeedai/ui --filter=@genfeedai/services --filter=@genfeedai/interfaces --filter=@genfeedai/serializers
- git diff --check