### PR TITLE
fix: Z-Image Turbo split loading (#58)

### DIFF
--- a/packages/workflows/src/comfyui/prompt-builder.test.ts
+++ b/packages/workflows/src/comfyui/prompt-builder.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildFlux2DevPrompt,
+  buildFlux2KleinPrompt,
+  buildFluxDevPrompt,
+  buildZImageTurboLoraPrompt,
+  buildZImageTurboPrompt,
+} from './prompt-builder';
+
+describe('buildZImageTurboPrompt', () => {
+  const prompt = buildZImageTurboPrompt({ prompt: 'a red car', seed: 42 });
+
+  it('uses UNETLoader instead of CheckpointLoaderSimple', () => {
+    const node1 = prompt['1'];
+    expect(node1.class_type).toBe('UNETLoader');
+    expect(node1.inputs).toEqual({
+      unet_name: 'z_image_turbo_bf16.safetensors',
+      weight_dtype: 'default',
+    });
+  });
+
+  it('uses CLIPLoader with lumina2 type for Qwen encoder', () => {
+    const node2 = prompt['2'];
+    expect(node2.class_type).toBe('CLIPLoader');
+    expect(node2.inputs).toEqual({
+      clip_name: 'qwen_3_4b.safetensors',
+      type: 'lumina2',
+    });
+  });
+
+  it('references CLIPLoader output (node 2) for text encoding', () => {
+    expect(prompt['3'].inputs.clip).toEqual(['2', 0]);
+    expect(prompt['4'].inputs.clip).toEqual(['2', 0]);
+  });
+
+  it('uses separate VAELoader instead of checkpoint VAE output', () => {
+    const vaeNode = prompt['7'];
+    expect(vaeNode.class_type).toBe('VAELoader');
+    expect(vaeNode.inputs).toEqual({ vae_name: 'ae.safetensors' });
+  });
+
+  it('VAEDecode references VAELoader output', () => {
+    const decodeNode = prompt['8'];
+    expect(decodeNode.class_type).toBe('VAEDecode');
+    expect(decodeNode.inputs.vae).toEqual(['7', 0]);
+  });
+
+  it('uses euler_ancestral sampler', () => {
+    expect(prompt['6'].inputs.sampler_name).toBe('euler_ancestral');
+  });
+
+  it('does not contain CheckpointLoaderSimple anywhere', () => {
+    const classTypes = Object.values(prompt).map((n) => n.class_type);
+    expect(classTypes).not.toContain('CheckpointLoaderSimple');
+  });
+});
+
+describe('buildZImageTurboLoraPrompt', () => {
+  const prompt = buildZImageTurboLoraPrompt({
+    loraPath: 'test_lora.safetensors',
+    prompt: 'a blue sky',
+    seed: 99,
+  });
+
+  it('uses UNETLoader for split loading', () => {
+    expect(prompt['1'].class_type).toBe('UNETLoader');
+  });
+
+  it('uses CLIPLoader with lumina2 type', () => {
+    expect(prompt['2'].class_type).toBe('CLIPLoader');
+    expect(prompt['2'].inputs.type).toBe('lumina2');
+  });
+
+  it('applies LoRA after split loaders', () => {
+    expect(prompt['3'].class_type).toBe('LoraLoader');
+    expect(prompt['3'].inputs.model).toEqual(['1', 0]);
+    expect(prompt['3'].inputs.clip).toEqual(['2', 0]);
+  });
+});
+
+describe('buildFlux2DevPrompt', () => {
+  const prompt = buildFlux2DevPrompt({ prompt: 'sunset', seed: 1 });
+
+  it('uses UNETLoader for split loading', () => {
+    expect(prompt['1'].class_type).toBe('UNETLoader');
+  });
+
+  it('uses CLIPLoader with flux2 type', () => {
+    expect(prompt['2'].class_type).toBe('CLIPLoader');
+    expect(prompt['2'].inputs.type).toBe('flux2');
+  });
+
+  it('uses separate VAELoader', () => {
+    expect(prompt['6'].class_type).toBe('VAELoader');
+  });
+});
+
+describe('buildFlux2KleinPrompt', () => {
+  const prompt = buildFlux2KleinPrompt({ prompt: 'mountain', seed: 7 });
+
+  it('uses UNETLoader for split loading', () => {
+    expect(prompt['1'].class_type).toBe('UNETLoader');
+  });
+
+  it('uses separate VAELoader', () => {
+    expect(prompt['6'].class_type).toBe('VAELoader');
+  });
+});
+
+describe('buildFluxDevPrompt (legacy Flux 1)', () => {
+  const prompt = buildFluxDevPrompt({ prompt: 'hello', seed: 5 });
+
+  it('still uses CheckpointLoaderSimple (Flux 1 single checkpoint)', () => {
+    expect(prompt['1'].class_type).toBe('CheckpointLoaderSimple');
+  });
+});

--- a/packages/workflows/src/comfyui/prompt-builder.test.ts
+++ b/packages/workflows/src/comfyui/prompt-builder.test.ts
@@ -49,6 +49,13 @@ describe('buildZImageTurboPrompt', () => {
     expect(prompt['6'].inputs.sampler_name).toBe('euler_ancestral');
   });
 
+  it('wires KSampler to the split loader outputs', () => {
+    const ksampler = prompt['6'];
+    expect(ksampler.inputs.model).toEqual(['1', 0]);
+    expect(ksampler.inputs.positive).toEqual(['3', 0]);
+    expect(ksampler.inputs.negative).toEqual(['4', 0]);
+  });
+
   it('does not contain CheckpointLoaderSimple anywhere', () => {
     const classTypes = Object.values(prompt).map((n) => n.class_type);
     expect(classTypes).not.toContain('CheckpointLoaderSimple');

--- a/packages/workflows/src/comfyui/prompt-builder.ts
+++ b/packages/workflows/src/comfyui/prompt-builder.ts
@@ -235,26 +235,34 @@ export function buildZImageTurboPrompt(
 
   return {
     '1': {
-      class_type: 'CheckpointLoaderSimple',
+      class_type: 'UNETLoader',
       inputs: {
-        ckpt_name: 'z-image-turbo.safetensors',
+        unet_name: 'z_image_turbo_bf16.safetensors',
+        weight_dtype: 'default',
       },
     },
     '2': {
-      class_type: 'CLIPTextEncode',
+      class_type: 'CLIPLoader',
       inputs: {
-        clip: ['1', 1],
-        text: prompt,
+        clip_name: 'qwen_3_4b.safetensors',
+        type: 'lumina2',
       },
     },
     '3': {
       class_type: 'CLIPTextEncode',
       inputs: {
-        clip: ['1', 1],
-        text: '',
+        clip: ['2', 0],
+        text: prompt,
       },
     },
     '4': {
+      class_type: 'CLIPTextEncode',
+      inputs: {
+        clip: ['2', 0],
+        text: '',
+      },
+    },
+    '5': {
       class_type: 'EmptyLatentImage',
       inputs: {
         batch_size: 1,
@@ -262,33 +270,39 @@ export function buildZImageTurboPrompt(
         width,
       },
     },
-    '5': {
+    '6': {
       class_type: 'KSampler',
       inputs: {
         cfg: 1.0,
         denoise: 1.0,
-        latent_image: ['4', 0],
+        latent_image: ['5', 0],
         model: ['1', 0],
-        negative: ['3', 0],
-        positive: ['2', 0],
+        negative: ['4', 0],
+        positive: ['3', 0],
         sampler_name: 'euler_ancestral',
         scheduler: 'normal',
         seed,
         steps,
       },
     },
-    '6': {
-      class_type: 'VAEDecode',
+    '7': {
+      class_type: 'VAELoader',
       inputs: {
-        samples: ['5', 0],
-        vae: ['1', 2],
+        vae_name: 'ae.safetensors',
       },
     },
-    '7': {
+    '8': {
+      class_type: 'VAEDecode',
+      inputs: {
+        samples: ['6', 0],
+        vae: ['7', 0],
+      },
+    },
+    '9': {
       class_type: 'SaveImage',
       inputs: {
         filename_prefix: 'genfeed-z-turbo',
-        images: ['6', 0],
+        images: ['8', 0],
       },
     },
   };


### PR DESCRIPTION
## Summary
- Replace `CheckpointLoaderSimple` with `UNETLoader` + `CLIPLoader` + `VAELoader` in `buildZImageTurboPrompt`
- Z-Image is Lumina2-based (Qwen text encoder), not a single Flux checkpoint — `CheckpointLoaderSimple` only found `flux1-dev-fp8.safetensors`, never the Z-Image model
- Split loading now matches the pattern already used by `buildZImageTurboLoraPrompt`
- Added comprehensive prompt-builder unit tests covering all builder functions

## Test plan
- [x] `bun test packages/workflows/src/comfyui/prompt-builder.test.ts` — 16 tests pass
- [x] `bun test packages/workflows/src/generation.test.ts` — existing tests still pass
- [x] Biome check clean
- [ ] Queue test image generation through Z-Image Turbo pipeline on GPU instance

Closes #58