### PR TITLE
fix: scope agent tool hrefs by organization

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -798,6 +798,68 @@ describe('AgentToolExecutorService', () => {
     ]);
   });
 
+  it('scopes organization-level tool hrefs with the active organization slug', async () => {
+    const { organizationsService, service } = createService();
+
+    organizationsService.findOne.mockResolvedValueOnce({
+      _id: '67a123456789012345678901',
+      slug: 'genfeed-ai',
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.INITIATE_OAUTH_CONNECT,
+      {},
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.nextActions?.[0].ctas).toEqual([
+      expect.objectContaining({
+        href: '/genfeed-ai/~/settings/api-keys?returnTo=%2Fagent',
+        label: 'Open integrations',
+      }),
+    ]);
+  });
+
+  it('scopes brand-level tool hrefs with organization and brand slugs', async () => {
+    const { analyticsService, brandsService, organizationsService, service } =
+      createService();
+
+    organizationsService.findOne.mockResolvedValueOnce({
+      _id: '67a123456789012345678901',
+      slug: 'genfeed-ai',
+    });
+    brandsService.findOne.mockResolvedValueOnce({
+      _id: '67a123456789012345678903',
+      slug: 'my-brand',
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.GET_ANALYTICS,
+      { period: '30d' },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(analyticsService.getOverview).toHaveBeenCalled();
+    expect(result.nextActions?.[0].ctas).toEqual([
+      expect.objectContaining({
+        href: '/genfeed-ai/my-brand/analytics/overview',
+        label: 'Open analytics dashboard',
+      }),
+      expect.objectContaining({
+        href: '/genfeed-ai/my-brand/automation/analytics',
+        label: 'Open automation analytics',
+      }),
+    ]);
+  });
+
   it('lists ads research results and returns an ads card', async () => {
     const { adsResearchService, service } = createService();
 
@@ -1998,13 +2060,23 @@ describe('AgentToolExecutorService', () => {
   });
 
   it('should create a workflow directly with graph payload and workflow-created card', async () => {
-    const { brandsService, recurringWorkflowId, service, workflowsService } =
-      createService();
+    const {
+      brandsService,
+      organizationsService,
+      recurringWorkflowId,
+      service,
+      workflowsService,
+    } = createService();
 
     brandsService.findOne.mockResolvedValue({
       _id: '67a1234567890123456789aa',
       isSelected: true,
       label: 'Genfeed',
+      slug: 'genfeed',
+    });
+    organizationsService.findOne.mockResolvedValueOnce({
+      _id: '67a123456789012345678901',
+      slug: 'genfeed-ai',
     });
 
     const result = await service.executeTool(
@@ -2095,15 +2167,24 @@ describe('AgentToolExecutorService', () => {
     );
     expect(result.data).toEqual(
       expect.objectContaining({
-        editorUrl: `/automations/editor/${recurringWorkflowId}`,
+        editorUrl: `/genfeed-ai/genfeed/automations/editor/${recurringWorkflowId}`,
         label: 'Weekly Content Planner',
         nextRunAt: expect.any(Date),
         schedule: '0 9 * * 1',
         timezone: 'Europe/Malta',
       }),
     );
+    expect(result.data?.nextRunAt).toBeInstanceOf(Date);
     expect(result.nextActions?.[0]).toEqual(
       expect.objectContaining({
+        ctas: [
+          expect.objectContaining({
+            href: `/genfeed-ai/genfeed/automations/editor/${recurringWorkflowId}`,
+          }),
+          expect.objectContaining({
+            href: '/genfeed-ai/genfeed/automations/executions',
+          }),
+        ],
         type: 'workflow_created_card',
         workflowId: recurringWorkflowId,
         workflowName: 'Weekly Content Planner',

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -130,6 +130,11 @@ interface ToolExecutionContext {
   streamBatchToUser?: boolean;
 }
 
+interface ToolRouteSlugs {
+  brandSlug?: string;
+  orgSlug: string;
+}
+
 interface DashboardHydrationState {
   status?: 'idle' | 'loading' | 'ready';
   staggerMs?: number;
@@ -177,6 +182,23 @@ const SAVE_BRAND_VOICE_PROFILE_TOOL =
   'save_brand_voice_profile' as AgentToolName;
 const GET_WORKFLOW_INPUTS_TOOL = 'get_workflow_inputs' as AgentToolName;
 const LIVESTREAM_BOT_CATEGORY = 'livestream_chat';
+const ROUTE_HREF_KEYS = new Set(['href', 'ctaHref', 'editorUrl']);
+const ORG_LEVEL_ROUTE_PREFIXES = new Set([
+  'agent',
+  'chat',
+  'overview',
+  'settings',
+]);
+const UNSCOPED_ROUTE_PREFIXES = new Set([
+  'admin',
+  'login',
+  'logout',
+  'oauth',
+  'onboarding',
+  'playwright-ready',
+  'request-access',
+  'sign-up',
+]);
 
 interface AgentLivestreamBotRecord {
   _id: unknown;
@@ -700,6 +722,7 @@ export class AgentToolExecutorService {
 
     try {
       const result = await this.dispatch(toolName, parameters, context);
+      const scopedResult = await this.scopeToolResultHrefs(result, context);
       const durationMs = Date.now() - startTime;
 
       this.loggerService.log(
@@ -707,7 +730,7 @@ export class AgentToolExecutorService {
         this.constructorName,
       );
 
-      return result;
+      return scopedResult;
     } catch (error: unknown) {
       const durationMs = Date.now() - startTime;
       const errorMessage =
@@ -724,6 +747,177 @@ export class AgentToolExecutorService {
         success: false,
       };
     }
+  }
+
+  private async scopeToolResultHrefs(
+    result: AgentToolResult,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.hasScopeableHref(result)) {
+      return result;
+    }
+
+    const routeSlugs = await this.resolveToolRouteSlugs(ctx);
+    if (!routeSlugs) {
+      return result;
+    }
+
+    return this.scopeHrefFields(result, routeSlugs) as AgentToolResult;
+  }
+
+  private async resolveToolRouteSlugs(
+    ctx: ToolExecutionContext,
+  ): Promise<ToolRouteSlugs | null> {
+    if (!this.organizationsService) {
+      return null;
+    }
+
+    try {
+      const organization = await this.organizationsService.findOne({
+        _id: ctx.organizationId,
+        isDeleted: false,
+      });
+      const orgSlug = this.readRecordString(organization, 'slug');
+
+      if (!orgSlug) {
+        return null;
+      }
+
+      const brand = await this.resolveToolRouteBrand(ctx);
+      const brandSlug = this.readRecordString(brand, 'slug');
+
+      return {
+        ...(brandSlug ? { brandSlug } : {}),
+        orgSlug,
+      };
+    } catch (error: unknown) {
+      this.loggerService.warn('Failed to resolve tool route slugs', {
+        error: error instanceof Error ? error.message : String(error),
+        organizationId: ctx.organizationId,
+      });
+      return null;
+    }
+  }
+
+  private async resolveToolRouteBrand(
+    ctx: ToolExecutionContext,
+  ): Promise<Record<string, unknown> | null> {
+    if (ctx.brandId) {
+      return this.brandsService.findOne({
+        _id: ctx.brandId,
+        isDeleted: false,
+        organization: ctx.organizationId,
+      });
+    }
+
+    return this.brandsService.findOne({
+      isDeleted: false,
+      isSelected: true,
+      organization: ctx.organizationId,
+      user: ctx.userId,
+    });
+  }
+
+  private hasScopeableHref(value: unknown): boolean {
+    if (Array.isArray(value)) {
+      return value.some((item) => this.hasScopeableHref(item));
+    }
+
+    if (!this.isPlainRecord(value)) {
+      return false;
+    }
+
+    return Object.entries(value).some(([key, nestedValue]) => {
+      if (
+        ROUTE_HREF_KEYS.has(key) &&
+        typeof nestedValue === 'string' &&
+        this.isScopeableInternalHref(nestedValue)
+      ) {
+        return true;
+      }
+
+      return this.hasScopeableHref(nestedValue);
+    });
+  }
+
+  private scopeHrefFields(value: unknown, slugs: ToolRouteSlugs): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.scopeHrefFields(item, slugs));
+    }
+
+    if (!this.isPlainRecord(value)) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => {
+        if (ROUTE_HREF_KEYS.has(key) && typeof nestedValue === 'string') {
+          return [key, this.scopeInternalHref(nestedValue, slugs)];
+        }
+
+        return [key, this.scopeHrefFields(nestedValue, slugs)];
+      }),
+    );
+  }
+
+  private scopeInternalHref(href: string, slugs: ToolRouteSlugs): string {
+    if (!this.isScopeableInternalHref(href)) {
+      return href;
+    }
+
+    const { path, suffix } = this.splitHrefSuffix(href);
+    const firstSegment = path.split('/').filter(Boolean)[0];
+
+    if (!firstSegment || UNSCOPED_ROUTE_PREFIXES.has(firstSegment)) {
+      return href;
+    }
+
+    if (path.startsWith(`/${slugs.orgSlug}/`)) {
+      return href;
+    }
+
+    if (ORG_LEVEL_ROUTE_PREFIXES.has(firstSegment)) {
+      return `/${slugs.orgSlug}/~${path}${suffix}`;
+    }
+
+    if (slugs.brandSlug) {
+      return `/${slugs.orgSlug}/${slugs.brandSlug}${path}${suffix}`;
+    }
+
+    return `/${slugs.orgSlug}/~${path}${suffix}`;
+  }
+
+  private isScopeableInternalHref(href: string): boolean {
+    return href.startsWith('/') && !href.startsWith('//');
+  }
+
+  private splitHrefSuffix(href: string): { path: string; suffix: string } {
+    const suffixStart = href.search(/[?#]/);
+
+    if (suffixStart === -1) {
+      return { path: href, suffix: '' };
+    }
+
+    return {
+      path: href.slice(0, suffixStart),
+      suffix: href.slice(suffixStart),
+    };
+  }
+
+  private isPlainRecord(value: unknown): value is Record<string, unknown> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  private readRecordString(
+    value: Record<string, unknown> | null | undefined,
+    key: string,
+  ): string | undefined {
+    return value ? this.readOptionalString(value[key]) : undefined;
   }
 
   private async dispatch(


### PR DESCRIPTION
## Summary
- Scope agent tool result href fields with the resolved organization slug before returning UI actions
- Use brand-scoped URLs when an active brand slug is available, and org-level `~` URLs for org routes like settings/chat/agent
- Add executor tests for org-level settings hrefs and brand-level analytics hrefs

Closes #168

## Verification
- `bunx biome check --write apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bunx vitest run --config vitest.config.ts src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts` from `apps/server/api` (66 passed)

## Notes
- `bunx tsc --noEmit -p apps/server/api/tsconfig.json --pretty false` is still blocked by existing repo-wide rootDir/spec typing issues; filtered output showed existing `agent-tool-executor.service.spec.ts` mock/data type errors but no implementation-specific type error from the new helper.