### PR TITLE
fix: resolve lint and type-check errors in app package

### DIFF
--- a/apps/app/app/(public)/oauth/cli/content.tsx
+++ b/apps/app/app/(public)/oauth/cli/content.tsx
@@ -472,8 +472,13 @@ function CliAuthPageContent() {
 
         const state = stateTokenRef.current;
         const callbackUrl = isDesktopMode
-          ? getDesktopCallbackUrl(key, user ?? null, desktopReturnTo)
-          : `http://127.0.0.1:${port ?? 0}/callback?key=${encodeURIComponent(key)}&state=${encodeURIComponent(state)}`;
+          ? getDesktopCallbackUrl(
+              credential,
+              user ?? null,
+              desktopReturnTo,
+              state,
+            )
+          : `http://127.0.0.1:${port ?? 0}/callback?key=${encodeURIComponent(credential)}&state=${encodeURIComponent(state)}`;
 
         redirectToCallback(callbackUrl);
 
@@ -492,8 +497,17 @@ function CliAuthPageContent() {
         setFlowState({ error: message, step: 'error' });
       }
     },
-    // stateTokenRef is a stable ref — no need to list it as a dependency
-    [desktopReturnTo, getToken, isDesktopMode, port, user],
+    [
+      codeChallenge,
+      codeChallengeMethod,
+      desktopReturnTo,
+      desktopState,
+      getToken,
+      hasPkce,
+      isDesktopMode,
+      port,
+      user,
+    ],
   );
 
   useEffect(() => {

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -86,16 +86,6 @@ function canonicalizeFlatProtectedPath(pathname: string): string {
 /** Slug segments must be alphanumeric + hyphens only (no dots, slashes, etc.). */
 const SLUG_RE = /^[a-zA-Z0-9-]+$/;
 
-/**
- * Validate that a slug coming from the API / cookie cannot be used as a
- * cross-origin redirect vector (e.g. `//attacker.example`).
- */
-function assertSafeSlug(slug: string, label: string): void {
-  if (!SLUG_RE.test(slug)) {
-    throw new Error(`Invalid ${label} slug: "${slug}"`);
-  }
-}
-
 function redirectPreservingSearch(req: NextRequest, pathname: string) {
   const url = new URL(pathname, req.url);
   // Guard: the resolved URL must share the same origin as the incoming request.

--- a/apps/server/api/src/services/sync/desktop-sync.service.ts
+++ b/apps/server/api/src/services/sync/desktop-sync.service.ts
@@ -518,7 +518,6 @@ export class DesktopSyncService {
       dto.mimeType ?? asset.mimeType ?? 'application/octet-stream';
     this.assertAllowedMimeType(mimeType);
 
-
     const logicalObjectKey = (
       asset.cloudObjectKey ??
       this.getCloudObjectKey(organizationId, {


### PR DESCRIPTION
## Summary

Fixes lint and type-check errors introduced by the security audit and React Query migration PRs.

- Add missing `useCallback` dependencies in CLI auth flow (biome exhaustive-deps)
- Fix undefined `key` variable → `credential` in callback URL construction (TS2304)
- Add missing `state` param to `getDesktopCallbackUrl` call
- Remove dead `assertSafeSlug` function from `proxy.ts` (unused, `SLUG_RE` used directly)
- Fix trailing whitespace in `desktop-sync.service.ts`

## Verification

- `bunx turbo lint` — 39/39 passed
- `bun type-check` — 42/42 passed

## Test plan

- [ ] CI passes (lint + type-check)
- [ ] CLI auth flow still works (desktop + PKCE paths)