### PR TITLE
refactor: reuse shared UI class combiner

### DIFF
--- a/packages/ui/src/dashboard/ActivityRow.tsx
+++ b/packages/ui/src/dashboard/ActivityRow.tsx
@@ -1,8 +1,5 @@
 import type { ComponentType, ReactNode } from 'react';
-
-function cn(...classes: (string | false | undefined | null)[]): string {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '../lib/utils';
 
 interface ActivityRowProps {
   /** Actor display (avatar + name) */

--- a/packages/ui/src/dashboard/MetricCard.tsx
+++ b/packages/ui/src/dashboard/MetricCard.tsx
@@ -1,5 +1,6 @@
 import { ButtonVariant } from '@genfeedai/enums';
 import type { ComponentType, ReactNode } from 'react';
+import { cn } from '../lib/utils';
 import { Button } from '../primitives/button';
 
 interface MetricCardProps {
@@ -15,10 +16,6 @@ interface MetricCardProps {
     onClick?: () => void;
     children: ReactNode;
   }>;
-}
-
-function cn(...classes: (string | false | undefined | null)[]): string {
-  return classes.filter(Boolean).join(' ');
 }
 
 export function MetricCard({

--- a/packages/ui/src/identity/Identity.tsx
+++ b/packages/ui/src/identity/Identity.tsx
@@ -1,6 +1,4 @@
-function cn(...classes: (string | false | undefined | null)[]): string {
-  return classes.filter(Boolean).join(' ');
-}
+import { cn } from '../lib/utils';
 
 type IdentitySize = 'xs' | 'sm' | 'default' | 'lg';
 

--- a/packages/ui/src/sidebar/SidebarNavItem.tsx
+++ b/packages/ui/src/sidebar/SidebarNavItem.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, MouseEvent, ReactNode } from 'react';
+import { cn } from '../lib/utils';
 
 interface SidebarNavItemProps {
   href: string;
@@ -20,10 +21,6 @@ interface SidebarNavItemProps {
     onClick?: (e: MouseEvent) => void;
     children: ReactNode;
   }>;
-}
-
-function cn(...classes: (string | false | undefined | null)[]): string {
-  return classes.filter(Boolean).join(' ');
 }
 
 export function SidebarNavItem({


### PR DESCRIPTION
## Summary
- Replace four local package UI class-name join helpers with the shared cn utility
- Reduce duplicate code by 11 net LOC without changing component APIs

## Verification
- bunx biome check packages/ui/src/dashboard/ActivityRow.tsx packages/ui/src/dashboard/MetricCard.tsx packages/ui/src/identity/Identity.tsx packages/ui/src/sidebar/SidebarNavItem.tsx
- commit hook: secretlint, staged biome, raw HTML lint

## Notes
- bun --filter @genfeedai/ui build is blocked in this fresh worktree because node_modules is absent; it reports existing missing modules/types such as react, react-icons, zod, @shipshitdev/ui/*, and Node globals.