### PR TITLE
feat(app): add managed credits checkout UX

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
@@ -13,13 +13,17 @@ const {
   getMyOrganizationsMock,
   isEEEnabledMock,
   isSelfHostedMock,
+  managedCreateCheckoutSessionMock,
   resolveClerkTokenMock,
   searchParamsState,
 } = vi.hoisted(() => ({
   createCheckoutSessionMock: vi.fn(),
   currentUserState: {
     currentUser: {
+      email: 'local@example.com',
+      firstName: 'Local',
       id: 'user-123',
+      lastName: 'User',
       onboardingStepsCompleted: [] as string[],
     },
     isLoading: false,
@@ -27,6 +31,7 @@ const {
   getMyOrganizationsMock: vi.fn(),
   isEEEnabledMock: vi.fn(),
   isSelfHostedMock: vi.fn(),
+  managedCreateCheckoutSessionMock: vi.fn(),
   resolveClerkTokenMock: vi.fn(),
   searchParamsState: {
     value: new URLSearchParams(),
@@ -61,6 +66,12 @@ vi.mock('@services/billing/stripe.service', () => ({
     getInstance: vi.fn(() => ({
       createCheckoutSession: createCheckoutSessionMock,
     })),
+  },
+}));
+
+vi.mock('@services/billing/managed-credits.service', () => ({
+  ManagedCreditsService: {
+    createCheckoutSession: managedCreateCheckoutSessionMock,
   },
 }));
 
@@ -136,6 +147,7 @@ describe('PostSignupPage behavior', () => {
 
   beforeEach(() => {
     createCheckoutSessionMock.mockReset();
+    managedCreateCheckoutSessionMock.mockReset();
     getMyOrganizationsMock.mockReset();
     isEEEnabledMock.mockReset();
     isSelfHostedMock.mockReset();
@@ -143,7 +155,10 @@ describe('PostSignupPage behavior', () => {
     localStorageMock.clear();
 
     currentUserState.currentUser = {
+      email: 'local@example.com',
+      firstName: 'Local',
       id: 'user-123',
+      lastName: 'User',
       onboardingStepsCompleted: [],
     };
     currentUserState.isLoading = false;
@@ -153,6 +168,9 @@ describe('PostSignupPage behavior', () => {
     getMyOrganizationsMock.mockResolvedValue([]);
     createCheckoutSessionMock.mockResolvedValue({
       url: 'https://checkout.stripe.test/session',
+    });
+    managedCreateCheckoutSessionMock.mockResolvedValue({
+      url: 'https://checkout.stripe.test/managed-session',
     });
     searchParamsState.value = new URLSearchParams();
 
@@ -230,5 +248,29 @@ describe('PostSignupPage behavior', () => {
     expect(
       localStorage.getItem(ONBOARDING_STORAGE_KEYS.selectedPlan),
     ).toBeNull();
+  });
+
+  it('starts a managed cloud credits checkout for self-hosted credit handoff', async () => {
+    isEEEnabledMock.mockReturnValue(false);
+    isSelfHostedMock.mockReturnValue(true);
+    searchParamsState.value = new URLSearchParams('credits=1000');
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(managedCreateCheckoutSessionMock).toHaveBeenCalledWith({
+        cancelUrl: 'http://localhost/onboarding/providers',
+        email: 'local@example.com',
+        firstName: 'Local',
+        lastName: 'User',
+        quantity: 1000,
+        successUrl:
+          'http://localhost/managed-credits/success?session_id={CHECKOUT_SESSION_ID}',
+      });
+    });
+    expect(createCheckoutSessionMock).not.toHaveBeenCalled();
+    expect(locationState.href).toBe(
+      'https://checkout.stripe.test/managed-session',
+    );
   });
 });

--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.tsx
@@ -8,6 +8,7 @@ import { useAuth, useUser } from '@clerk/nextjs';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
 import { getResumeStep, ONBOARDING_STEPS } from '@genfeedai/constants';
 import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { ManagedCreditsService } from '@services/billing/managed-credits.service';
 import { StripeService } from '@services/billing/stripe.service';
 import { EnvironmentService } from '@services/core/environment.service';
 import { logger } from '@services/core/logger.service';
@@ -30,6 +31,8 @@ function PostSignupPageContent() {
   const [statusMessage, setStatusMessage] = useState(
     'Setting up your workspace...',
   );
+  const checkoutEmail =
+    currentUser?.email || clerkUser?.primaryEmailAddress?.emailAddress || '';
 
   const resolveOnboardingHref = useCallback(async (): Promise<string> => {
     if (clerkUser?.publicMetadata?.proactiveLeadId) {
@@ -152,6 +155,39 @@ function PostSignupPageContent() {
       if (credits) {
         localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedCredits);
 
+        if (isSelfHosted()) {
+          if (!checkoutEmail) {
+            window.location.href = await resolveOnboardingHref();
+            return;
+          }
+
+          setStatusMessage('Preparing your managed credits checkout...');
+
+          try {
+            const result = await ManagedCreditsService.createCheckoutSession({
+              cancelUrl: `${window.location.origin}/onboarding/providers`,
+              email: checkoutEmail,
+              firstName: currentUser?.firstName || undefined,
+              lastName: currentUser?.lastName || undefined,
+              quantity: credits,
+              successUrl: `${window.location.origin}/managed-credits/success?session_id={CHECKOUT_SESSION_ID}`,
+            });
+
+            if (result?.url) {
+              window.location.href = result.url;
+              return;
+            }
+          } catch (error) {
+            logger.error(
+              'Failed to create managed credits checkout from post-signup',
+              error,
+            );
+          }
+
+          window.location.href = await resolveOnboardingHref();
+          return;
+        }
+
         if (!isEEEnabled()) {
           window.location.href = await resolveOnboardingHref();
           return;
@@ -209,6 +245,7 @@ function PostSignupPageContent() {
       window.clearTimeout(fallbackTimeout);
     };
   }, [
+    checkoutEmail,
     clerkUser,
     currentUser,
     getToken,

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   getByokAllProviders: vi.fn(),
   getOrganizationsService: vi.fn(),
   isReady: true,
+  isSelfHosted: false,
   loggerError: vi.fn(),
   notificationsError: vi.fn(),
   notificationsSuccess: vi.fn(),
@@ -108,6 +109,10 @@ vi.mock('@/lib/desktop/runtime', () => ({
   isDesktopShell: () => mocks.desktop,
 }));
 
+vi.mock('@/lib/config/edition', () => ({
+  isSelfHosted: () => mocks.isSelfHosted,
+}));
+
 function providerStatuses() {
   return [
     {
@@ -137,6 +142,7 @@ describe('SettingsApiKeysPage', () => {
     vi.clearAllMocks();
     mocks.desktop = false;
     mocks.isReady = true;
+    mocks.isSelfHosted = false;
     mocks.organizationId = 'org-1';
     mocks.getByokAllProviders.mockResolvedValue(providerStatuses());
     mocks.getOrganizationsService.mockResolvedValue({

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx
@@ -13,7 +13,9 @@ import { Input } from '@ui/primitives/input';
 import { useCallback, useEffect, useState } from 'react';
 import { HiTrash } from 'react-icons/hi2';
 import DesktopLocalProviderSettings from '@/components/desktop/DesktopLocalProviderSettings';
+import { isSelfHosted } from '@/lib/config/edition';
 import { isDesktopShell } from '@/lib/desktop/runtime';
+import ManagedCreditsCheckoutCard from './managed-credits-checkout-card';
 
 export default function SettingsApiKeysPage() {
   const { organizationId, isReady } = useBrand();
@@ -162,6 +164,7 @@ export default function SettingsApiKeysPage() {
   return (
     <div className="space-y-6">
       {desktop ? <DesktopLocalProviderSettings variant="card" /> : null}
+      {isSelfHosted() ? <ManagedCreditsCheckoutCard /> : null}
 
       <div className="mb-6">
         <h2 className="text-lg font-semibold">API Keys</h2>

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ManagedCreditsCheckoutCard from './managed-credits-checkout-card';
+
+const { createCheckoutSessionMock, currentUserState, notificationErrorMock } =
+  vi.hoisted(() => ({
+    createCheckoutSessionMock: vi.fn(),
+    currentUserState: {
+      currentUser: {
+        email: 'local@example.com',
+        firstName: 'Local',
+        lastName: 'User',
+      },
+    },
+    notificationErrorMock: vi.fn(),
+  }));
+
+vi.mock('@contexts/user/user-context/user-context', () => ({
+  useCurrentUser: () => currentUserState,
+}));
+
+vi.mock('@services/billing/managed-credits.service', () => ({
+  ManagedCreditsService: {
+    createCheckoutSession: createCheckoutSessionMock,
+  },
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@services/core/notifications.service', () => ({
+  NotificationsService: {
+    getInstance: () => ({
+      error: notificationErrorMock,
+    }),
+  },
+}));
+
+vi.mock('@ui/card/Card', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    isDisabled,
+    onClick,
+  }: {
+    children: ReactNode;
+    isDisabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button type="button" disabled={isDisabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+describe('ManagedCreditsCheckoutCard', () => {
+  let locationState: { href: string; origin: string };
+
+  beforeEach(() => {
+    createCheckoutSessionMock.mockReset();
+    notificationErrorMock.mockReset();
+    currentUserState.currentUser = {
+      email: 'local@example.com',
+      firstName: 'Local',
+      lastName: 'User',
+    };
+    createCheckoutSessionMock.mockResolvedValue({
+      url: 'https://checkout.stripe.test/session',
+    });
+
+    locationState = {
+      href: 'http://localhost/settings/api-keys',
+      origin: 'http://localhost',
+    };
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: locationState,
+    });
+  });
+
+  it('starts managed checkout using the editable email and quantity', async () => {
+    render(<ManagedCreditsCheckoutCard />);
+
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'buyer@example.com' },
+    });
+    fireEvent.change(screen.getByDisplayValue('1000'), {
+      target: { value: '2500' },
+    });
+    fireEvent.click(screen.getByText('Get Credits'));
+
+    await waitFor(() => {
+      expect(createCheckoutSessionMock).toHaveBeenCalledWith({
+        cancelUrl: 'http://localhost/settings/api-keys',
+        email: 'buyer@example.com',
+        firstName: 'Local',
+        lastName: 'User',
+        quantity: 2500,
+        successUrl:
+          'http://localhost/managed-credits/success?session_id={CHECKOUT_SESSION_ID}',
+      });
+    });
+
+    expect(locationState.href).toBe('https://checkout.stripe.test/session');
+  });
+
+  it('blocks checkout when the email or credit quantity is missing', () => {
+    render(<ManagedCreditsCheckoutCard />);
+
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: '' },
+    });
+    fireEvent.click(screen.getByText('Get Credits'));
+
+    expect(createCheckoutSessionMock).not.toHaveBeenCalled();
+    expect(notificationErrorMock).toHaveBeenCalledWith(
+      'Add a valid email and credit quantity before checkout.',
+    );
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import { ButtonVariant } from '@genfeedai/enums';
+import { ManagedCreditsService } from '@services/billing/managed-credits.service';
+import { logger } from '@services/core/logger.service';
+import { NotificationsService } from '@services/core/notifications.service';
+import Card from '@ui/card/Card';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import { useEffect, useState } from 'react';
+import { HiOutlineCreditCard, HiOutlineKey } from 'react-icons/hi2';
+
+const DEFAULT_CREDIT_PACK = 1000;
+
+function parseCredits(value: string): number | null {
+  const parsed = Number.parseInt(value.trim(), 10);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export default function ManagedCreditsCheckoutCard() {
+  const { currentUser } = useCurrentUser();
+  const [email, setEmail] = useState(currentUser?.email ?? '');
+  const [credits, setCredits] = useState(String(DEFAULT_CREDIT_PACK));
+  const [isStartingCheckout, setIsStartingCheckout] = useState(false);
+
+  useEffect(() => {
+    if (currentUser?.email) {
+      setEmail((previousEmail) => previousEmail || currentUser.email || '');
+    }
+  }, [currentUser?.email]);
+
+  const handleStartCheckout = async () => {
+    const normalizedEmail = email.trim();
+    const quantity = parseCredits(credits);
+
+    if (!normalizedEmail || !quantity) {
+      NotificationsService.getInstance().error(
+        'Add a valid email and credit quantity before checkout.',
+      );
+      return;
+    }
+
+    setIsStartingCheckout(true);
+
+    try {
+      const result = await ManagedCreditsService.createCheckoutSession({
+        cancelUrl: window.location.href,
+        email: normalizedEmail,
+        firstName: currentUser?.firstName || undefined,
+        lastName: currentUser?.lastName || undefined,
+        quantity,
+        successUrl: `${window.location.origin}/managed-credits/success?session_id={CHECKOUT_SESSION_ID}`,
+      });
+
+      window.location.href = result.url;
+    } catch (error) {
+      logger.error('Failed to start managed credits checkout', error);
+      NotificationsService.getInstance().error(
+        'Failed to start managed credits checkout.',
+      );
+      setIsStartingCheckout(false);
+    }
+  };
+
+  return (
+    <Card className="p-5">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="mb-3 flex items-center gap-2">
+            <span className="flex size-8 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/60">
+              <HiOutlineKey className="size-4" />
+            </span>
+            <div>
+              <h3 className="text-sm font-semibold">Genfeed managed credits</h3>
+              <p className="text-xs text-muted-foreground">
+                Buy hosted image-generation credits and copy one managed key
+                into this self-hosted install.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_10rem]">
+            <div>
+              <span className="mb-1 block text-xs text-muted-foreground">
+                Provisioning email
+              </span>
+              <Input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@example.com"
+              />
+            </div>
+            <div>
+              <span className="mb-1 block text-xs text-muted-foreground">
+                Credits
+              </span>
+              <Input
+                type="number"
+                min={1}
+                value={credits}
+                onChange={(event) => setCredits(event.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+
+        <Button
+          variant={ButtonVariant.DEFAULT}
+          onClick={handleStartCheckout}
+          isDisabled={isStartingCheckout}
+          className="w-full shrink-0 lg:mt-8 lg:w-auto"
+        >
+          <HiOutlineCreditCard className="size-4" />
+          {isStartingCheckout ? 'Opening checkout...' : 'Get Credits'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/app/app/(public)/managed-credits/success/page.tsx
+++ b/apps/app/app/(public)/managed-credits/success/page.tsx
@@ -1,0 +1,5 @@
+import ManagedCreditsSuccessContent from './success-content';
+
+export default function ManagedCreditsSuccessPage() {
+  return <ManagedCreditsSuccessContent />;
+}

--- a/apps/app/app/(public)/managed-credits/success/success-content.test.tsx
+++ b/apps/app/app/(public)/managed-credits/success/success-content.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ManagedCreditsSuccessContent from './success-content';
+
+const { getCheckoutResultMock, searchParamsState } = vi.hoisted(() => ({
+  getCheckoutResultMock: vi.fn(),
+  searchParamsState: {
+    value: new URLSearchParams('session_id=cs_test_123'),
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => searchParamsState.value,
+}));
+
+vi.mock('@services/billing/managed-credits.service', () => ({
+  ManagedCreditsService: {
+    apiEndpoint: 'https://api.genfeed.ai/v1',
+    getCheckoutResult: getCheckoutResultMock,
+  },
+}));
+
+vi.mock('@ui/layouts/auth/AuthFormLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/feedback/spinner/Spinner', () => ({
+  default: () => <span>Loading</span>,
+}));
+
+vi.mock('@genfeedai/ui', () => ({
+  Code: ({ children }: { children: ReactNode }) => <code>{children}</code>,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe('ManagedCreditsSuccessContent', () => {
+  beforeEach(() => {
+    getCheckoutResultMock.mockReset();
+    searchParamsState.value = new URLSearchParams('session_id=cs_test_123');
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('loads the checkout result and exposes the managed API key', async () => {
+    getCheckoutResultMock.mockResolvedValue({
+      apiKey: 'gf_managed_secret',
+      apiKeyAlreadyExists: false,
+      brandId: 'brand-1',
+      email: 'buyer@example.com',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+
+    render(<ManagedCreditsSuccessContent />);
+
+    expect(screen.getByText('Provisioning checkout')).toBeVisible();
+
+    await waitFor(() => {
+      expect(screen.getByText('GENFEED_API_KEY')).toBeVisible();
+    });
+
+    expect(screen.getByText('gf_managed_secret')).toBeVisible();
+    expect(
+      screen.getByText(
+        /GENFEED_MANAGED_INFERENCE_URL=https:\/\/api.genfeed.ai/,
+      ),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getAllByText('Copy')[0]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'gf_managed_secret',
+    );
+  });
+
+  it('explains when a key already exists and cannot be shown again', async () => {
+    getCheckoutResultMock.mockResolvedValue({
+      apiKey: null,
+      apiKeyAlreadyExists: true,
+      brandId: 'brand-1',
+      email: 'buyer@example.com',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+
+    render(<ManagedCreditsSuccessContent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Credits added')).toBeVisible();
+    });
+
+    expect(screen.getByText(/secret cannot be shown again/)).toBeVisible();
+  });
+});

--- a/apps/app/app/(public)/managed-credits/success/success-content.tsx
+++ b/apps/app/app/(public)/managed-credits/success/success-content.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { ButtonSize, ButtonVariant, ComponentSize } from '@genfeedai/enums';
+import { Code } from '@genfeedai/ui';
+import {
+  type ManagedCreditsProvisioningResult,
+  ManagedCreditsService,
+} from '@services/billing/managed-credits.service';
+import Spinner from '@ui/feedback/spinner/Spinner';
+import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
+import { Button } from '@ui/primitives/button';
+import { useSearchParams } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import {
+  HiCheckCircle,
+  HiClipboard,
+  HiClipboardDocumentCheck,
+  HiExclamationTriangle,
+  HiKey,
+} from 'react-icons/hi2';
+import { Card, CardContent } from '@/components/ui/card';
+
+type CopyTarget = 'api-key' | 'env';
+
+interface SuccessState {
+  error: string | null;
+  isLoading: boolean;
+  result: ManagedCreditsProvisioningResult | null;
+}
+
+function buildEnvSnippet(apiKey: string): string {
+  return [
+    `GENFEED_API_KEY=${apiKey}`,
+    `GENFEED_MANAGED_INFERENCE_URL=${ManagedCreditsService.apiEndpoint}/managed-inference`,
+  ].join('\n');
+}
+
+function ManagedCreditsSuccessContentInner() {
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('session_id');
+  const [state, setState] = useState<SuccessState>({
+    error: null,
+    isLoading: true,
+    result: null,
+  });
+  const [copiedTarget, setCopiedTarget] = useState<CopyTarget | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setState({
+        error: 'Missing Stripe checkout session.',
+        isLoading: false,
+        result: null,
+      });
+      return;
+    }
+
+    let isMounted = true;
+
+    ManagedCreditsService.getCheckoutResult(sessionId)
+      .then((result) => {
+        if (isMounted) {
+          setState({ error: null, isLoading: false, result });
+        }
+      })
+      .catch((error: unknown) => {
+        if (isMounted) {
+          setState({
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Managed credits checkout result is not ready yet.',
+            isLoading: false,
+            result: null,
+          });
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [sessionId]);
+
+  const copyValue = useCallback(async (target: CopyTarget, value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopiedTarget(target);
+    window.setTimeout(() => setCopiedTarget(null), 2000);
+  }, []);
+
+  const apiKey = state.result?.apiKey ?? '';
+  const envSnippet = apiKey ? buildEnvSnippet(apiKey) : '';
+  const hasRecoverableExistingKey =
+    state.result?.apiKeyAlreadyExists && !state.result.apiKey;
+
+  return (
+    <AuthFormLayout>
+      <div className="mx-auto w-full max-w-xl">
+        <div className="mb-8 text-center">
+          <div className="mb-5 inline-flex size-12 items-center justify-center rounded-xl border border-white/10 bg-white/5">
+            <HiKey className="size-5 text-white/60" />
+          </div>
+          <h1 className="mb-1.5 text-xl font-semibold tracking-tight">
+            Managed credits ready
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Add the managed key to your self-hosted Genfeed install.
+          </p>
+        </div>
+
+        <Card className="border-white/[0.08]">
+          <CardContent className="p-8">
+            {state.isLoading ? (
+              <StepDisplay
+                icon={<Spinner size={ComponentSize.LG} />}
+                title="Provisioning checkout"
+                description="Waiting for Stripe to finish credit and key provisioning..."
+              />
+            ) : null}
+
+            {!state.isLoading && state.error ? (
+              <StepDisplay
+                icon={
+                  <HiExclamationTriangle className="size-8 text-amber-500" />
+                }
+                title="Provisioning result not ready"
+                description={state.error}
+              />
+            ) : null}
+
+            {!state.isLoading && hasRecoverableExistingKey ? (
+              <StepDisplay
+                icon={<HiCheckCircle className="size-8 text-emerald-500" />}
+                title="Credits added"
+                description="This account already has a managed API key, so the secret cannot be shown again. Use your existing key or create a new one in Genfeed Cloud."
+              />
+            ) : null}
+
+            {!state.isLoading && apiKey ? (
+              <div className="space-y-6">
+                <StepDisplay
+                  icon={<HiCheckCircle className="size-8 text-emerald-500" />}
+                  title="Credits added"
+                  description={`Provisioned for ${state.result?.email ?? 'your account'}. Copy this key now and store it in your local environment.`}
+                />
+
+                <KeyBlock
+                  copied={copiedTarget === 'api-key'}
+                  label="GENFEED_API_KEY"
+                  value={apiKey}
+                  onCopy={() => copyValue('api-key', apiKey)}
+                />
+
+                <KeyBlock
+                  copied={copiedTarget === 'env'}
+                  label="Local .env values"
+                  value={envSnippet}
+                  onCopy={() => copyValue('env', envSnippet)}
+                />
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+    </AuthFormLayout>
+  );
+}
+
+function KeyBlock({
+  copied,
+  label,
+  onCopy,
+  value,
+}: {
+  copied: boolean;
+  label: string;
+  onCopy: () => void;
+  value: string;
+}) {
+  return (
+    <div className="border-t border-white/[0.08] pt-5">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          {label}
+        </p>
+        <Button
+          variant={ButtonVariant.SOFT}
+          size={ButtonSize.SM}
+          onClick={onCopy}
+        >
+          {copied ? (
+            <HiClipboardDocumentCheck className="size-4 text-emerald-500" />
+          ) : (
+            <HiClipboard className="size-4" />
+          )}
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+      <Code
+        display="block"
+        size="sm"
+        className="max-h-40 whitespace-pre-wrap break-all border border-white/10 text-white/70"
+      >
+        {value}
+      </Code>
+    </div>
+  );
+}
+
+function StepDisplay({
+  description,
+  icon,
+  title,
+}: {
+  description: string;
+  icon: ReactNode;
+  title: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="mb-1">{icon}</div>
+      <h2 className="text-lg font-medium">{title}</h2>
+      <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export default function ManagedCreditsSuccessContent() {
+  return (
+    <Suspense fallback={null}>
+      <ManagedCreditsSuccessContentInner />
+    </Suspense>
+  );
+}

--- a/apps/server/api/src/services/byok/byok.service.ts
+++ b/apps/server/api/src/services/byok/byok.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import { ByokBillingStatus, ByokProvider } from '@genfeedai/enums';
 import type { IByokKeyEntry, IByokProviderStatus } from '@genfeedai/interfaces';
+import type { Prisma, PrismaClient } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpService } from '@nestjs/axios';
 import { ConflictException, Injectable } from '@nestjs/common';
@@ -443,15 +444,9 @@ export class ByokService {
   }
 
   private async writeByokSettings(
-    tx: {
-      organizationSetting: {
-        updateMany: (
-          args: Record<string, unknown>,
-        ) => Promise<{ count: number }>;
-      };
-    },
+    tx: Pick<PrismaClient, 'organizationSetting'>,
     existing: { id: string; updatedAt: Date },
-    data: Record<string, unknown>,
+    data: Prisma.OrganizationSettingUpdateManyMutationInput,
   ): Promise<void> {
     const result = await tx.organizationSetting.updateMany({
       data,

--- a/packages/enums/src/index.ts
+++ b/packages/enums/src/index.ts
@@ -81,6 +81,7 @@ export * from './reply.enum';
 export * from './reply-bot.enum';
 export * from './review-gate.enum';
 export * from './router.enum';
+// Public automation interfaces import these from the package root.
 export * from './run.enum';
 export * from './scope.enum';
 export * from './severity.enum';

--- a/packages/services/billing/managed-credits.service.test.ts
+++ b/packages/services/billing/managed-credits.service.test.ts
@@ -1,0 +1,73 @@
+import { ManagedCreditsService } from '@services/billing/managed-credits.service';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('ManagedCreditsService', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('creates a public managed checkout session against the cloud API', async () => {
+    vi.stubEnv(
+      'NEXT_PUBLIC_GENFEED_MANAGED_CREDITS_API_ENDPOINT',
+      'https://api.test/v1',
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            attributes: {
+              url: 'https://checkout.stripe.test/session',
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await ManagedCreditsService.createCheckoutSession({
+      email: 'buyer@example.com',
+      quantity: 1000,
+      successUrl:
+        'http://localhost:3000/managed-credits/success?session_id={CHECKOUT_SESSION_ID}',
+    });
+
+    expect(result).toEqual({ url: 'https://checkout.stripe.test/session' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/v1/services/stripe/managed/checkout',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+  });
+
+  it('reads the managed checkout provisioning result by session ID', async () => {
+    vi.stubEnv(
+      'NEXT_PUBLIC_GENFEED_MANAGED_CREDITS_API_ENDPOINT',
+      'https://api.test/v1',
+    );
+    const payload = {
+      apiKey: 'gf_secret',
+      apiKeyAlreadyExists: false,
+      brandId: 'brand-1',
+      email: 'buyer@example.com',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      ManagedCreditsService.getCheckoutResult('cs_test_123'),
+    ).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/v1/services/stripe/managed/sessions/cs_test_123',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});

--- a/packages/services/billing/managed-credits.service.ts
+++ b/packages/services/billing/managed-credits.service.ts
@@ -1,0 +1,124 @@
+import { EnvironmentService } from '@services/core/environment.service';
+
+export interface CreateManagedCreditsCheckoutInput {
+  cancelUrl?: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  quantity?: number;
+  stripePriceId?: string;
+  successUrl?: string;
+}
+
+export interface ManagedCreditsCheckoutResult {
+  url: string;
+}
+
+export interface ManagedCreditsProvisioningResult {
+  apiKey: string | null;
+  apiKeyAlreadyExists: boolean;
+  brandId: string;
+  email: string;
+  organizationId: string;
+  userId: string;
+}
+
+interface JsonApiResource<TAttributes> {
+  attributes?: TAttributes;
+}
+
+interface JsonApiDocument<TAttributes> {
+  data?: JsonApiResource<TAttributes>;
+  errors?: Array<{ detail?: string; title?: string }>;
+}
+
+function joinEndpoint(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/$/, '')}${path}`;
+}
+
+function readErrorMessage(payload: unknown, fallback: string): string {
+  const document = payload as JsonApiDocument<unknown>;
+  const firstError = document.errors?.[0];
+
+  return firstError?.detail || firstError?.title || fallback;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export const ManagedCreditsService = {
+  get apiEndpoint(): string {
+    return EnvironmentService.managedCreditsApiEndpoint;
+  },
+
+  async createCheckoutSession(
+    input: CreateManagedCreditsCheckoutInput,
+  ): Promise<ManagedCreditsCheckoutResult> {
+    const response = await fetch(
+      joinEndpoint(this.apiEndpoint, '/services/stripe/managed/checkout'),
+      {
+        body: JSON.stringify(input),
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      },
+    );
+
+    const payload = await parseJson(response);
+
+    if (!response.ok) {
+      throw new Error(
+        readErrorMessage(payload, 'Failed to create managed credits checkout'),
+      );
+    }
+
+    const document = payload as JsonApiDocument<ManagedCreditsCheckoutResult>;
+    const result = document.data?.attributes;
+
+    if (!result?.url) {
+      throw new Error('Managed credits checkout did not return a Stripe URL');
+    }
+
+    return result;
+  },
+
+  async getCheckoutResult(
+    sessionId: string,
+  ): Promise<ManagedCreditsProvisioningResult> {
+    const response = await fetch(
+      joinEndpoint(
+        this.apiEndpoint,
+        `/services/stripe/managed/sessions/${encodeURIComponent(sessionId)}`,
+      ),
+      {
+        headers: {
+          Accept: 'application/json',
+        },
+        method: 'GET',
+      },
+    );
+
+    const payload = await parseJson(response);
+
+    if (!response.ok) {
+      throw new Error(
+        readErrorMessage(payload, 'Managed credits checkout result not found'),
+      );
+    }
+
+    return payload as ManagedCreditsProvisioningResult;
+  },
+};

--- a/packages/services/core/environment.service.ts
+++ b/packages/services/core/environment.service.ts
@@ -44,6 +44,14 @@ export const EnvironmentService = {
     );
   },
 
+  get managedCreditsApiEndpoint(): string {
+    return (
+      process.env.NEXT_PUBLIC_GENFEED_MANAGED_CREDITS_API_ENDPOINT ||
+      process.env.NEXT_PUBLIC_GENFEED_MANAGED_API_ENDPOINT ||
+      'https://api.genfeed.ai/v1'
+    );
+  },
+
   apps: {
     admin:
       process.env.NEXT_PUBLIC_APPS_ADMIN_ENDPOINT || 'https://admin.genfeed.ai',


### PR DESCRIPTION
## Summary
- Adds a shared managed credits cloud checkout client for self-hosted app flows.
- Routes OSS/self-hosted onboarding credit selection to managed Genfeed Cloud checkout.
- Adds a self-hosted API keys settings card plus checkout success page to retrieve and copy the generated GENFEED_API_KEY/env snippet.

## Verification
- npx biome check packages/services/core/environment.service.ts packages/services/billing/managed-credits.service.ts packages/services/billing/managed-credits.service.test.ts apps/app/app/(onboarding)/onboarding/post-signup/page.tsx apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx apps/app/app/(public)/managed-credits/success/page.tsx apps/app/app/(public)/managed-credits/success/success-content.tsx apps/app/app/(public)/managed-credits/success/success-content.test.tsx apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.tsx apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
- bash scripts/lint-no-raw-html.sh
- bunx vitest run --config packages/services/vitest.config.ts packages/services/billing/managed-credits.service.test.ts
- bunx vitest run --config ./vitest.config.mts app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx app/(public)/managed-credits/success/success-content.test.tsx app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
- bun type-check --filter=@genfeedai/services
- bun type-check --filter=@genfeedai/app

Closes #164 once the image-only V1 scope rewrite is accepted; video support is split into a follow-up issue.