### PR TITLE
fix: install native build tools for server Docker image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -11,14 +11,19 @@
 # ==================================================
 FROM node:24-slim AS base
 
-# Install bun and build dependencies
-RUN apt-get update && apt-get install -y \
+# Install bun and build dependencies. node-pty in @genfeedai/notifications
+# compiles during bun install and expects node-gyp on PATH.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     unzip \
     ffmpeg \
+    python3 \
+    make \
+    g++ \
     && curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.10" \
     && cp /root/.bun/bin/bun /usr/local/bin/bun \
     && chmod +x /usr/local/bin/bun \
+    && npm install -g node-gyp \
     && apt-get purge -y unzip \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
## Summary
- install native build dependencies in the unified server image
- install a global node-gyp binary before bun install so node-pty can compile for @genfeedai/notifications

## Verification
- git diff --check
- Docker build verification is covered by GitHub Actions Build & Boot Check; Docker is not installed in this local workspace.