### PR TITLE
fix: include CA certificates in server Docker image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -15,6 +15,7 @@ FROM node:24-slim AS base
 # compiles during bun install and expects node-gyp on PATH.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    ca-certificates \
     unzip \
     ffmpeg \
     python3 \


### PR DESCRIPTION
## Summary
- add ca-certificates to the server Docker base stage while using --no-install-recommends
- fixes Bun installer curl failures in the Build & Boot Check

## Verification
- git diff --check
- Docker verification will run in GitHub Actions Build & Boot Check; Docker is not installed locally.