### PR TITLE
fix: harden managed credits checkout flow

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
@@ -131,4 +131,23 @@ describe('ManagedCreditsCheckoutCard', () => {
       'Add a valid email and credit quantity before checkout.',
     );
   });
+
+  it('rejects partial and non-whole credit quantities', () => {
+    render(<ManagedCreditsCheckoutCard />);
+
+    const creditsInput = screen.getByDisplayValue('1000');
+
+    fireEvent.change(creditsInput, {
+      target: { value: '1e3' },
+    });
+    fireEvent.click(screen.getByText('Get Credits'));
+
+    fireEvent.change(creditsInput, {
+      target: { value: '1.9' },
+    });
+    fireEvent.click(screen.getByText('Get Credits'));
+
+    expect(createCheckoutSessionMock).not.toHaveBeenCalled();
+    expect(notificationErrorMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.tsx
@@ -14,13 +14,13 @@ import { HiOutlineCreditCard, HiOutlineKey } from 'react-icons/hi2';
 const DEFAULT_CREDIT_PACK = 1000;
 
 function parseCredits(value: string): number | null {
-  const parsed = Number.parseInt(value.trim(), 10);
-
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  const normalized = value.trim();
+  if (!/^[1-9]\d*$/.test(normalized)) {
     return null;
   }
 
-  return parsed;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 export default function ManagedCreditsCheckoutCard() {

--- a/apps/app/app/(public)/managed-credits/success/success-content.test.tsx
+++ b/apps/app/app/(public)/managed-credits/success/success-content.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ManagedCreditsSuccessContent from './success-content';
 
 const { getCheckoutResultMock, searchParamsState } = vi.hoisted(() => ({
@@ -56,6 +62,10 @@ vi.mock('@/components/ui/card', () => ({
 }));
 
 describe('ManagedCreditsSuccessContent', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     getCheckoutResultMock.mockReset();
     searchParamsState.value = new URLSearchParams('session_id=cs_test_123');
@@ -116,5 +126,37 @@ describe('ManagedCreditsSuccessContent', () => {
     });
 
     expect(screen.getByText(/secret cannot be shown again/)).toBeVisible();
+  });
+
+  it('polls while checkout provisioning is not ready yet', async () => {
+    vi.useFakeTimers();
+
+    getCheckoutResultMock
+      .mockRejectedValueOnce(
+        new Error('Managed credits checkout result not found'),
+      )
+      .mockResolvedValue({
+        apiKey: 'gf_managed_secret',
+        apiKeyAlreadyExists: false,
+        brandId: 'brand-1',
+        email: 'buyer@example.com',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      });
+
+    render(<ManagedCreditsSuccessContent />);
+
+    expect(getCheckoutResultMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(getCheckoutResultMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('gf_managed_secret')).toBeVisible();
+    expect(getCheckoutResultMock).toHaveBeenCalledWith(
+      'cs_test_123',
+      expect.any(AbortSignal),
+    );
   });
 });

--- a/apps/app/app/(public)/managed-credits/success/success-content.tsx
+++ b/apps/app/app/(public)/managed-credits/success/success-content.tsx
@@ -23,6 +23,8 @@ import { Card, CardContent } from '@/components/ui/card';
 
 type CopyTarget = 'api-key' | 'env';
 
+const CHECKOUT_RESULT_POLL_DELAYS_MS = [1000, 2000, 3000, 5000, 8000];
+
 interface SuccessState {
   error: string | null;
   isLoading: boolean;
@@ -34,6 +36,32 @@ function buildEnvSnippet(apiKey: string): string {
     `GENFEED_API_KEY=${apiKey}`,
     `GENFEED_MANAGED_INFERENCE_URL=${ManagedCreditsService.apiEndpoint}/managed-inference`,
   ].join('\n');
+}
+
+function readProvisioningError(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : 'Managed credits checkout result is not ready yet.';
+}
+
+function waitForPollDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(resolve, delayMs);
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        window.clearTimeout(timeoutId);
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }
 
 function ManagedCreditsSuccessContentInner() {
@@ -56,29 +84,60 @@ function ManagedCreditsSuccessContentInner() {
       return;
     }
 
-    let isMounted = true;
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    const checkoutSessionId = sessionId;
 
-    ManagedCreditsService.getCheckoutResult(sessionId)
-      .then((result) => {
-        if (isMounted) {
-          setState({ error: null, isLoading: false, result });
+    setState({ error: null, isLoading: true, result: null });
+
+    async function loadCheckoutResult() {
+      let lastError: unknown = null;
+
+      for (
+        let attempt = 0;
+        attempt <= CHECKOUT_RESULT_POLL_DELAYS_MS.length;
+        attempt += 1
+      ) {
+        try {
+          const result = await ManagedCreditsService.getCheckoutResult(
+            checkoutSessionId,
+            signal,
+          );
+
+          if (!signal.aborted) {
+            setState({ error: null, isLoading: false, result });
+          }
+
+          return;
+        } catch (error) {
+          if (signal.aborted) {
+            return;
+          }
+
+          lastError = error;
+
+          const nextDelay = CHECKOUT_RESULT_POLL_DELAYS_MS[attempt];
+          if (nextDelay === undefined) {
+            break;
+          }
+
+          await waitForPollDelay(nextDelay, signal);
         }
-      })
-      .catch((error: unknown) => {
-        if (isMounted) {
-          setState({
-            error:
-              error instanceof Error
-                ? error.message
-                : 'Managed credits checkout result is not ready yet.',
-            isLoading: false,
-            result: null,
-          });
-        }
-      });
+      }
+
+      if (!signal.aborted) {
+        setState({
+          error: readProvisioningError(lastError),
+          isLoading: false,
+          result: null,
+        });
+      }
+    }
+
+    void loadCheckoutResult();
 
     return () => {
-      isMounted = false;
+      abortController.abort();
     };
   }, [sessionId]);
 

--- a/packages/services/billing/managed-credits.service.test.ts
+++ b/packages/services/billing/managed-credits.service.test.ts
@@ -61,13 +61,14 @@ describe('ManagedCreditsService', () => {
         new Response(JSON.stringify(payload), { status: 200 }),
       );
     vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
 
     await expect(
-      ManagedCreditsService.getCheckoutResult('cs_test_123'),
+      ManagedCreditsService.getCheckoutResult('cs_test_123', controller.signal),
     ).resolves.toEqual(payload);
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.test/v1/services/stripe/managed/sessions/cs_test_123',
-      expect.objectContaining({ method: 'GET' }),
+      expect.objectContaining({ method: 'GET', signal: controller.signal }),
     );
   });
 });

--- a/packages/services/billing/managed-credits.service.ts
+++ b/packages/services/billing/managed-credits.service.ts
@@ -97,6 +97,7 @@ export const ManagedCreditsService = {
 
   async getCheckoutResult(
     sessionId: string,
+    signal?: AbortSignal,
   ): Promise<ManagedCreditsProvisioningResult> {
     const response = await fetch(
       joinEndpoint(
@@ -108,6 +109,7 @@ export const ManagedCreditsService = {
           Accept: 'application/json',
         },
         method: 'GET',
+        signal,
       },
     );
 


### PR DESCRIPTION
## Summary
- poll managed checkout success results so webhook provisioning races resolve without manual refresh
- pass AbortSignal through the managed credits result fetch and abort on unmount
- validate checkout credit quantities as strict positive safe integers

## Review comments handled
- Implemented: checkout result polling / async readiness
- Implemented: strict credit quantity parsing
- Implemented as part of polling: AbortController support
- Skipped: shared-interface moves; too much release-path churn for local flow types
- Skipped: CodeRabbit import reordering; Biome enforces the repo's current import order

## Verification
- npx biome check --write on changed files
- bunx vitest run --config packages/services/vitest.config.ts packages/services/billing/managed-credits.service.test.ts
- bunx vitest run --config vitest.config.mjs app/(public)/managed-credits/success/success-content.test.tsx app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/managed-credits-checkout-card.test.tsx
- bun type-check --filter=@genfeedai/services
- bun type-check --filter=@genfeedai/app