### PR TITLE
fix: exclude desktop packages from server Docker install

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -40,7 +40,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/*']; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows']; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -60,7 +60,26 @@ COPY apps/server/videos/package.json ./apps/server/videos/
 # Match the reduced server-only workspace globs exactly.
 RUN --mount=type=bind,source=.,target=/ctx \
     for f in \
-      /ctx/packages/*/package.json \
+      /ctx/packages/client/package.json \
+      /ctx/packages/config/package.json \
+      /ctx/packages/constants/package.json \
+      /ctx/packages/enums/package.json \
+      /ctx/packages/harness/package.json \
+      /ctx/packages/helpers/package.json \
+      /ctx/packages/integrations/package.json \
+      /ctx/packages/interfaces/package.json \
+      /ctx/packages/models/package.json \
+      /ctx/packages/prisma/package.json \
+      /ctx/packages/props/package.json \
+      /ctx/packages/serializers/package.json \
+      /ctx/packages/services/package.json \
+      /ctx/packages/storage/package.json \
+      /ctx/packages/tools/package.json \
+      /ctx/packages/types/package.json \
+      /ctx/packages/utils/package.json \
+      /ctx/packages/workflow-engine/package.json \
+      /ctx/packages/workflow-saas/package.json \
+      /ctx/packages/workflows/package.json \
       /ctx/apps/server/*/package.json; do \
       [ -f "$f" ] || continue; \
       dir=$(echo "$f" | sed 's|^/ctx/||; s|/package.json$||'); \


### PR DESCRIPTION
## Summary
- narrow the unified server Docker workspace list to server transitive packages
- stop server image bun install from running desktop-only Prisma postinstall scripts

## Verification
- git diff --check
- parsed Dockerfile workspace list locally
- Docker Build & Boot verification must run in GitHub Actions; Docker is not installed locally.