### PR TITLE
fix(server-docker): skip root postinstall in image deps

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -40,7 +40,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows']; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/


### PR DESCRIPTION
## Summary
- remove the root postinstall from the reduced server Docker manifest before bun install
- keep workspace package postinstall scripts intact for Prisma/native dependency generation

## Verification
- git diff --check
- attempted local Docker base-stage build, but Docker is not installed in this workspace; GitHub Build will validate the image layer