### PR TITLE
fix(server-docker): preserve build order before parallel batch

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -113,18 +113,18 @@ COPY apps/server/tsconfig.json apps/server/tsconfig.json
 # This layer is cached when only apps/server/* source changes
 # Some workspace packages export dist paths, so build those before packages that
 # compile against their package exports.
-RUN set -e && \
-    bun --filter @genfeedai/enums build && \
-    bun --filter @genfeedai/constants build && \
-    bun --filter @genfeedai/interfaces build && \
-    bun --filter @genfeedai/client build && \
-    bun --filter @genfeedai/cloud-types build & pid1=$! && \
-    bun --filter @genfeedai/config build & pid2=$! && \
-    bun --filter @genfeedai/workflow-engine build & pid3=$! && \
-    wait $pid1 $pid2 $pid3 && \
-    bun --filter @genfeedai/helpers build && \
-    bun --filter @genfeedai/integrations build && \
-    bun --filter @genfeedai/cloud-serializers build && \
+RUN set -e; \
+    bun --filter @genfeedai/enums build; \
+    bun --filter @genfeedai/constants build; \
+    bun --filter @genfeedai/interfaces build; \
+    bun --filter @genfeedai/client build; \
+    bun --filter @genfeedai/cloud-types build & pid1=$!; \
+    bun --filter @genfeedai/config build & pid2=$!; \
+    bun --filter @genfeedai/workflow-engine build & pid3=$!; \
+    wait $pid1 $pid2 $pid3; \
+    bun --filter @genfeedai/helpers build; \
+    bun --filter @genfeedai/integrations build; \
+    bun --filter @genfeedai/cloud-serializers build; \
     bun --filter @genfeedai/workflow-saas build
 
 # --- Layer 2: Service source code (changes most frequently) ---


### PR DESCRIPTION
## Summary
- replace the shared package build chain with explicit semicolon-separated commands
- keep the independent cloud-types/config/workflow-engine builds parallel, after dist-exporting dependencies finish

## Verification
- git diff --check
- local Docker unavailable in this workspace; GitHub Docker Build will validate