### PR TITLE
fix(server-docker): use actual workspace filter names

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -118,13 +118,13 @@ RUN set -e; \
     bun --filter @genfeedai/constants build; \
     bun --filter @genfeedai/interfaces build; \
     bun --filter @genfeedai/client build; \
-    bun --filter @genfeedai/cloud-types build & pid1=$!; \
+    bun --filter @genfeedai/types build & pid1=$!; \
     bun --filter @genfeedai/config build & pid2=$!; \
     bun --filter @genfeedai/workflow-engine build & pid3=$!; \
     wait $pid1 $pid2 $pid3; \
     bun --filter @genfeedai/helpers build; \
     bun --filter @genfeedai/integrations build; \
-    bun --filter @genfeedai/cloud-serializers build; \
+    bun --filter @genfeedai/serializers build; \
     bun --filter @genfeedai/workflow-saas build
 
 # --- Layer 2: Service source code (changes most frequently) ---


### PR DESCRIPTION
## Summary
- replace stale Docker build filters for cloud-types/cloud-serializers with the actual workspace package names
- keep the corrected build ordering from #387

## Verification
- git diff --check
- local Docker unavailable in this workspace; GitHub Docker Build will validate