### PR TITLE
fix(server-docker): expose bunx in base image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     && curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.10" \
     && cp /root/.bun/bin/bun /usr/local/bin/bun \
-    && chmod +x /usr/local/bin/bun \
+    && cp /root/.bun/bin/bunx /usr/local/bin/bunx \
+    && chmod +x /usr/local/bin/bun /usr/local/bin/bunx \
     && npm install -g node-gyp \
     && apt-get purge -y unzip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- copy Bun's bunx command into /usr/local/bin in the unified server image
- allow workspace package build scripts such as @genfeedai/serializers to run bunx tsc-alias during Docker builds

## Verification
- git diff --check
- local Docker unavailable in this workspace; GitHub Docker Build will validate