### PR TITLE
fix(docker): include ee billing in server image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -41,7 +41,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -81,6 +81,7 @@ RUN --mount=type=bind,source=.,target=/ctx \
       /ctx/packages/workflow-engine/package.json \
       /ctx/packages/workflow-saas/package.json \
       /ctx/packages/workflows/package.json \
+      /ctx/ee/packages/billing/package.json \
       /ctx/apps/server/*/package.json; do \
       [ -f "$f" ] || continue; \
       dir=$(echo "$f" | sed 's|^/ctx/||; s|/package.json$||'); \
@@ -105,6 +106,7 @@ FROM base AS builder
 COPY tsconfig.json tsconfig.server.decorators.json webpack.base.config.js ./
 COPY configs/ configs/
 COPY packages/ packages/
+COPY ee/packages/billing/ ee/packages/billing/
 
 # Copy server-level configs needed before service source
 COPY apps/server/nest-cli.json apps/server/nest-cli.json


### PR DESCRIPTION
## Summary
- include ee/packages/billing in the reduced server Docker workspace
- copy the ee billing manifest and source into the Docker builder stage so API webpack aliases resolve in CI

## Verification
- git diff --check
- bun --filter @genfeedai/api build:prod
- static Dockerfile check for ee billing workspace/package/source entries

Note: local Docker is unavailable in this workspace (docker: command not found), so Build & Boot CI is the image verification.