### PR TITLE
fix(ci): verify current server bundle list

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -7,6 +7,7 @@ on:
     branches: [staging, master]
     paths:
       - 'apps/server/**'
+      - 'ee/packages/billing/**'
       - 'packages/**'
       - 'configs/**'
       - 'docker/**'
@@ -71,17 +72,15 @@ jobs:
               test -f apps/server/dist/apps/telegram/main.js && echo "✅ Telegram bundle" || (echo "❌ Telegram bundle missing" && exit 1)
               test -f apps/server/dist/apps/discord/main.js && echo "✅ Discord bundle" || (echo "❌ Discord bundle missing" && exit 1)
               test -f apps/server/dist/apps/slack/main.js && echo "✅ Slack bundle" || (echo "❌ Slack bundle missing" && exit 1)
-              test -f apps/server/dist/apps/fanvue/main.js && echo "✅ Fanvue bundle" || (echo "❌ Fanvue bundle missing" && exit 1)
               test -f apps/server/dist/apps/clips/main.js && echo "✅ Clips bundle" || (echo "❌ Clips bundle missing" && exit 1)
               test -f apps/server/dist/apps/images/main.js && echo "✅ Images bundle" || (echo "❌ Images bundle missing" && exit 1)
               test -f apps/server/dist/apps/voices/main.js && echo "✅ Voices bundle" || (echo "❌ Voices bundle missing" && exit 1)
               test -f apps/server/dist/apps/videos/main.js && echo "✅ Videos bundle" || (echo "❌ Videos bundle missing" && exit 1)
-              test -f apps/server/dist/apps/llm/main.js && echo "✅ LLM bundle" || (echo "❌ LLM bundle missing" && exit 1)
               echo ""
-              echo "All 14 service bundles verified ✅"
+              echo "All 12 service bundles verified ✅"
 
               # Check bundle sizes (catch empty/broken bundles)
-              for svc in api workers files mcp notifications telegram discord slack fanvue clips images voices videos llm; do
+              for svc in api workers files mcp notifications telegram discord slack clips images voices videos; do
                 SIZE=$(stat -c%s "apps/server/dist/apps/$svc/main.js" 2>/dev/null || echo "0")
                 if [ "$SIZE" -lt 10000 ]; then
                   echo "❌ $svc bundle suspiciously small (${SIZE} bytes)"
@@ -96,4 +95,4 @@ jobs:
         run: |
           echo "## ✅ Build Verification Passed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Docker image built successfully. All 14 service bundles verified." >> $GITHUB_STEP_SUMMARY
+          echo "Docker image built successfully. All 12 service bundles verified." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- update Build Verify to check the current 12-service server image bundle list
- remove stale fanvue/llm bundle checks
- include ee/packages/billing changes in Build Verify path triggers

## Verification
- git diff --check
- static workflow assertion that fanvue/llm checks are gone and 12-service list is present