### PR TITLE
fix(api): unblock localhost boot — articles ESM circular-dep TDZ + cache tsbuildinfo in turbo

### DIFF
--- a/apps/server/api/src/collections/articles/services/articles-content.service.ts
+++ b/apps/server/api/src/collections/articles/services/articles-content.service.ts
@@ -62,7 +62,8 @@ import type {
   GeneratedArticleData,
 } from '@genfeedai/interfaces/content/article.interface';
 import { LoggerService } from '@libs/logger/logger.service';
-import { forwardRef, Inject, Injectable, Optional } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 
 export interface ArticleCycleModelConfig {
   generationModel?: string;
@@ -108,12 +109,10 @@ export class ArticlesContentService {
   constructor(
     private readonly logger: LoggerService,
     private readonly configService: ConfigService,
+    private readonly moduleRef: ModuleRef,
 
     @Optional() private readonly modelsService?: ModelsService,
     @Optional() private readonly promptsService?: PromptsService,
-    @Optional()
-    @Inject(forwardRef(() => ArticlesService))
-    private readonly articlesService?: ArticlesService,
     @Optional() private readonly replicateService?: ReplicateService,
     @Optional() private readonly promptBuilderService?: PromptBuilderService,
     @Optional() private readonly templatesService?: TemplatesService,
@@ -127,6 +126,23 @@ export class ArticlesContentService {
     @Optional()
     private readonly accountPublishingContextService?: AccountPublishingContextService,
   ) {}
+
+  /**
+   * Lazily resolve ArticlesService to break the module-init circular dependency
+   * with articles.service. Resolving via ModuleRef at call time (instead of
+   * constructor injection) keeps ArticlesService out of the emitted
+   * `design:paramtypes` metadata, which otherwise references the class before
+   * it is initialized under ESM (TDZ crash at boot). `strict: false` searches
+   * the whole app context; missing provider yields undefined to preserve the
+   * previous `@Optional()` behavior.
+   */
+  private get articlesService(): ArticlesService | undefined {
+    try {
+      return this.moduleRef.get(ArticlesService, { strict: false });
+    } catch {
+      return undefined;
+    }
+  }
 
   private appendAccountPublishingContextToPrompt(
     prompt: string,

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,7 @@
         ".env.staging",
         ".env.production"
       ],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "*.tsbuildinfo"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

The ESM migration (#396) left **localhost boot broken** — the V1 gate in #184 ("localhost runtime must be reliable"). Two compounding blockers, both fixed here.

### 1. API boot crash — circular-dependency TDZ

```
ReferenceError: Cannot access 'ArticlesService' before initialization
  articles-content.service → articles.service → articles.controller → articles.module → brands.module
```

`ArticlesService` ↔ `ArticlesContentService` form a circular dependency. swc has `decoratorMetadata: true`, so the class is emitted eagerly into `design:paramtypes` at class-decoration (module-eval) time. Under ESM, that's a live binding accessed inside the cycle **before the class is initialized** → TDZ throw. Under the old CommonJS output the same access yielded `undefined`, which Nest tolerated — so the bug only surfaced post-ESM.

History shows this was whack-a-mole: `7dfa90fb1` flipped the import from `import type` back to a value import to fix DI, which reintroduced the boot crash (type import breaks DI; value import breaks boot).

**Fix:** stop injecting `ArticlesService` through the constructor (that's what emits the eager metadata). Inject `ModuleRef` and resolve `ArticlesService` lazily via a getter at call time. The class no longer appears in emitted metadata, the cycle is broken at module-init, and DI + the prior `@Optional()` semantics are preserved. Follows the existing `moduleRef.get(...)` pattern already used in 10 other API sites. The 4 call sites (`this.articlesService?.…`) are unchanged.

### 2. Build silently skipping emit — TS6305

```
error TS6305: Output file 'packages/enums/dist/index.d.ts' has not been built from source
```

`tsc --build` no-op'd against a stale `tsconfig.tsbuildinfo` while `dist/` was missing. Root cause: turbo's build task cached `dist/**` but **not** `tsconfig.tsbuildinfo`, so the incremental state drifted from its output. On a cache restore (or an empty-dist cache entry) tsc trusted the stale tsbuildinfo and emitted nothing → downstream packages failed type-check/build.

**Fix:** add `*.tsbuildinfo` to the build task `outputs` so incremental state is cached and restored **together with** `dist`, keeping them consistent. Also clears the `no output files found for task …` warnings on `@genfeedai/tools` and `@genfeedai/api-types`.

## Verification

- **API boots green** on `:3010` — `Nest application successfully started`, all routes mapped, zero errors
- `build:packages` 25/25 · api `type-check` 15/15 · biome clean
- **Drift test:** delete `dist` + stale `tsbuildinfo` → rebuild cache-hits and restores a complete `dist` (self-heals — the exact broken state this session started in)

## Reviewer notes

- Articles was the *only* circular pair that crashed boot — drove boot fully green, no others surfaced.
- No tests existed for `articles-content.service` / `articles.service`; the live boot (full DI graph + route mapping) is the integration check here.
- `ArticlesService` remains a **value** import (needed as the `moduleRef.get` token) — intentionally not `import type`.