### PR TITLE
feat(build): migrate Next.js builds to Turbopack + pin file-tracing root

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -81,7 +81,7 @@
     "analyze": "ANALYZE=true next build",
     "analyze:browser": "ANALYZE=true BUNDLE_ANALYZE=browser next build",
     "analyze:server": "ANALYZE=true BUNDLE_ANALYZE=server next build",
-    "build": "next build",
+    "build": "next build --turbopack",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "NODE_OPTIONS='--max-old-space-size=4096 --disable-warning=DEP0169' next dev --turbopack",
     "dev:direct": "NODE_OPTIONS='--max-old-space-size=4096 --disable-warning=DEP0169' next dev --turbopack",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,7 +18,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "next build",
+    "build": "next build --turbopack",
     "dev": "next dev --turbopack --port 3001",
     "dev:direct": "next dev --turbopack",
     "dev:portless": "portless run --name docs.genfeed bun run dev:direct",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -29,7 +29,7 @@
     "analyze": "ANALYZE=true next build",
     "analyze:browser": "ANALYZE=true BUNDLE_ANALYZE=browser next build",
     "analyze:server": "ANALYZE=true BUNDLE_ANALYZE=server next build",
-    "build": "next build",
+    "build": "next build --turbopack",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "NODE_OPTIONS='--max-old-space-size=4096 --disable-warning=DEP0169' next dev --turbopack",
     "dev:direct": "NODE_OPTIONS='--max-old-space-size=4096 --disable-warning=DEP0169' next dev --turbopack",

--- a/packages/next-config/next.config.base.ts
+++ b/packages/next-config/next.config.base.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 
@@ -36,6 +37,11 @@ export function createAppNextConfig(options: AppNextConfigOptions): NextConfig {
       'localhost',
     ],
     distDir: process.env.NEXT_DIST_DIR || undefined,
+    // Pin the file-tracing root to the monorepo root so production builds
+    // (standalone / Vercel) trace workspace package files correctly instead of
+    // inferring the root (which warns and can mis-bundle). cwd is the app dir
+    // during `next build` / `next dev`, so two levels up is the repo root.
+    outputFileTracingRoot: path.resolve(process.cwd(), '..', '..'),
     experimental: {
       optimizePackageImports: [
         '@genfeedai/agent',


### PR DESCRIPTION
## Summary

Move the three Next.js apps (`app`, `website`, `docs`) from webpack to **Turbopack** for production builds (`next build --turbopack`). Dev was already on `--turbopack`; this brings prod into parity — faster builds, one bundler across dev and prod.

Also pins `outputFileTracingRoot` to the monorepo root in the shared `next.config.base.ts`.

## Changes

- `apps/{app,website,docs}/package.json` — `build: next build` → `next build --turbopack`
- `packages/next-config/next.config.base.ts` — add `outputFileTracingRoot: path.resolve(process.cwd(), '..', '..')`

## Why Turbopack is safe here

- The only `webpack()` customization in the base config suppresses OpenTelemetry / `require-in-the-middle` / Prisma **dynamic-require warnings**. Turbopack does not emit those, so nothing functional is lost.
- **Sentry** sourcemap upload runs via the `runAfterProductionCompile` hook (prod + auth token only) — verified intact on the website build.
- **bundle-analyzer** is webpack-only and stays behind the opt-in `ANALYZE=true` flag (Turbopack has its own analysis). Default builds are unaffected.
- **NestJS backend** keeps its own webpack (nest-cli, `*/webpack.config.cjs`) — a different bundler Turbopack does not target. Out of scope.

## Why `outputFileTracingRoot`

Different key from `turbopack.root` (dev). It controls **production file-tracing** for standalone / Vercel output. Unset, Next infers the workspace root in a monorepo — warns and can mis-bundle workspace package files. `cwd` is the app dir during `next build`, so two levels up is the repo root.

## Verification — all three build green with Turbopack

| App | Compile | Static pages |
|---|---|---|
| docs | 17.1s | 46/46 |
| website | 11.2s | 89/89 |
| app | 35.0s | 61/61 |

All exit 0. `biome` + `type-check` clean. Sentry post-compile hook ran on website.

## Reviewer notes

- If CI relies on `ANALYZE=true` bundle reports, that path now needs the webpack build (temporarily drop `--turbopack`) — not used in normal CI.
- Build caching unaffected (`*.tsbuildinfo` already in turbo outputs from #398).