### PR TITLE
Fix local self-hosted app boot without Clerk keys

### DIFF
--- a/packages/ui/src/components/providers/AppProviders.test.tsx
+++ b/packages/ui/src/components/providers/AppProviders.test.tsx
@@ -70,7 +70,7 @@ describe('AppProviders', () => {
     );
   });
 
-  it('skips ClerkProvider entirely when Clerk is not configured', async () => {
+  it('mounts ClerkProvider with a local bypass when Clerk is not configured', async () => {
     delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
     vi.resetModules();
 
@@ -80,6 +80,7 @@ describe('AppProviders', () => {
     render(
       <NoClerkAppProviders
         initialTheme="dark"
+        clerkProps={{ signInUrl: '/login' }}
         includeLazyModalErrorDebug={false}
         includeSpeedInsights={false}
         includeToaster={false}
@@ -90,6 +91,11 @@ describe('AppProviders', () => {
     );
 
     expect(screen.getByText('No Clerk content')).toBeInTheDocument();
-    expect(clerkProviderSpy).not.toHaveBeenCalled();
+    expect(clerkProviderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __internal_bypassMissingPublishableKey: true,
+        publishableKey: '',
+      }),
+    );
   });
 });

--- a/packages/ui/src/components/providers/AppProviders.tsx
+++ b/packages/ui/src/components/providers/AppProviders.tsx
@@ -70,21 +70,26 @@ export interface AppProvidersProps {
  * Checked once at module load — NEXT_PUBLIC_ vars are inlined at build time.
  */
 const cloudConnected = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+const hostedCloud = process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true';
 
 function ClerkProviderWithTheme({
   children,
   clerkProps,
+  bypassMissingPublishableKey = false,
 }: {
   children: ReactNode;
   clerkProps?: ClerkProviderProps;
+  bypassMissingPublishableKey?: boolean;
 }) {
   const { resolvedTheme } = useTheme();
   const isPlaywrightTest = process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST === 'true';
+  const shouldBypassMissingPublishableKey =
+    isPlaywrightTest || bypassMissingPublishableKey;
 
   return (
     <ClerkProvider
       {...clerkProps}
-      {...(isPlaywrightTest
+      {...(shouldBypassMissingPublishableKey
         ? {
             __internal_bypassMissingPublishableKey: true,
             publishableKey: '',
@@ -107,12 +112,15 @@ function MaybeClerkProvider({
   children: ReactNode;
   clerkProps?: ClerkProviderProps;
 }) {
-  if (!cloudConnected || !clerkProps) {
+  if ((!cloudConnected && hostedCloud) || !clerkProps) {
     return <>{children}</>;
   }
 
   return (
-    <ClerkProviderWithTheme clerkProps={clerkProps}>
+    <ClerkProviderWithTheme
+      clerkProps={clerkProps}
+      bypassMissingPublishableKey={!cloudConnected}
+    >
       {children}
     </ClerkProviderWithTheme>
   );


### PR DESCRIPTION
## Summary
- mount ClerkProvider with the existing missing-key bypass for local self-hosted app runs
- keep hosted cloud behavior unchanged when Clerk keys are absent
- update provider coverage for local no-key mode

## Verification
- API booted locally on :3010 with self-hosted env and seeded local workspace
- Notifications booted locally on :3011
- curl http://localhost:3010/v1/health -> 200
- curl -I http://localhost:3010/v1/openapi.json -> 200
- curl -I http://localhost:3000/default/default/workspace/overview -> 200
- bunx playwright screenshot --full-page http://localhost:3000/default/default/workspace/overview /tmp/genfeed-app-overview.png
- bunx vitest run 'app/(onboarding)/layout.test.tsx' packages/components/app-protected-layout.test.tsx --config ./vitest.config.mts
- bunx vitest run src/components/providers/AppProviders.test.tsx --config ./vitest.config.ts