### PR TITLE
refactor: dedupe orchestration skill filters

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillCatalogCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillCatalogCard.tsx
@@ -7,27 +7,12 @@ import Badge from '@ui/display/badge/Badge';
 import InsetSurface from '@ui/display/inset-surface/InsetSurface';
 import { Button } from '@ui/primitives/button';
 import { Switch } from '@ui/primitives/switch';
-
-const MODALITY_FILTERS = [
-  { label: 'All', value: 'all' },
-  { label: 'Text', value: 'text' },
-  { label: 'Image', value: 'image' },
-  { label: 'Video', value: 'video' },
-  { label: 'Audio', value: 'audio' },
-] as const;
-
-const STAGE_FILTERS = [
-  { label: 'All', value: 'all' },
-  { label: 'Research', value: 'research' },
-  { label: 'Planning', value: 'planning' },
-  { label: 'Creation', value: 'creation' },
-  { label: 'Review', value: 'review' },
-  { label: 'Publishing', value: 'publishing' },
-  { label: 'Analysis', value: 'analysis' },
-] as const;
-
-type ModalityFilterValue = (typeof MODALITY_FILTERS)[number]['value'];
-type StageFilterValue = (typeof STAGE_FILTERS)[number]['value'];
+import {
+  MODALITY_FILTERS,
+  type ModalityFilterValue,
+  STAGE_FILTERS,
+  type StageFilterValue,
+} from './skill-filter-options';
 
 function getSourceBadgeVariant(
   source: Skill['source'],

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillsPageHeader.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillsPageHeader.tsx
@@ -5,15 +5,7 @@ import Card from '@ui/card/Card';
 import { Button } from '@ui/primitives/button';
 import Link from 'next/link';
 import { HiOutlineArrowPath, HiOutlineSparkles } from 'react-icons/hi2';
-
-const SOURCE_FILTERS = [
-  { label: 'All', value: 'all' },
-  { label: 'Built-in', value: 'built_in' },
-  { label: 'Imported', value: 'imported' },
-  { label: 'Custom', value: 'custom' },
-] as const;
-
-type SourceFilterValue = (typeof SOURCE_FILTERS)[number]['value'];
+import { SOURCE_FILTERS, type SourceFilterValue } from './skill-filter-options';
 
 type Props = {
   brandLabel: string | undefined;

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
@@ -16,33 +16,11 @@ import {
 import SkillCatalogCard from './SkillCatalogCard';
 import SkillDetailCard from './SkillDetailCard';
 import SkillsPageHeader from './SkillsPageHeader';
-
-const SOURCE_FILTERS = [
-  { label: 'All', value: 'all' },
-  { label: 'Built-in', value: 'built_in' },
-  { label: 'Imported', value: 'imported' },
-  { label: 'Custom', value: 'custom' },
-] as const;
-
-const MODALITY_FILTERS = [
-  { label: 'All', value: 'all' },
-  { label: 'Text', value: 'text' },
-  { label: 'Image', value: 'image' },
-  { label: 'Video', value: 'video' },
-  { label: 'Audio', value: 'audio' },
-] as const;
-
-const STAGE_FILTERS = [
-  { label: 'All', value: 'all' },
-  { label: 'Research', value: 'research' },
-  { label: 'Planning', value: 'planning' },
-  { label: 'Creation', value: 'creation' },
-  { label: 'Review', value: 'review' },
-  { label: 'Publishing', value: 'publishing' },
-  { label: 'Analysis', value: 'analysis' },
-] as const;
-
-type FilterValue<T extends readonly { value: string }[]> = T[number]['value'];
+import type {
+  ModalityFilterValue,
+  SourceFilterValue,
+  StageFilterValue,
+} from './skill-filter-options';
 
 type SkillDraft = {
   defaultInstructions: string;
@@ -63,12 +41,10 @@ export default function OrchestrationSkillsPage() {
   const { enabledSlugs, toggleSkill } = useBrandEnabledSkills();
   const [skills, setSkills] = useState<Skill[]>([]);
   const [selectedSkillId, setSelectedSkillId] = useState<string>('');
-  const [sourceFilter, setSourceFilter] =
-    useState<FilterValue<typeof SOURCE_FILTERS>>('all');
+  const [sourceFilter, setSourceFilter] = useState<SourceFilterValue>('all');
   const [modalityFilter, setModalityFilter] =
-    useState<FilterValue<typeof MODALITY_FILTERS>>('all');
-  const [stageFilter, setStageFilter] =
-    useState<FilterValue<typeof STAGE_FILTERS>>('all');
+    useState<ModalityFilterValue>('all');
+  const [stageFilter, setStageFilter] = useState<StageFilterValue>('all');
   const [loading, setLoading] = useState(true);
   const [savingSkill, setSavingSkill] = useState(false);
   const [customizing, setCustomizing] = useState(false);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/skill-filter-options.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/skill-filter-options.ts
@@ -1,0 +1,28 @@
+export const SOURCE_FILTERS = [
+  { label: 'All', value: 'all' },
+  { label: 'Built-in', value: 'built_in' },
+  { label: 'Imported', value: 'imported' },
+  { label: 'Custom', value: 'custom' },
+] as const;
+
+export const MODALITY_FILTERS = [
+  { label: 'All', value: 'all' },
+  { label: 'Text', value: 'text' },
+  { label: 'Image', value: 'image' },
+  { label: 'Video', value: 'video' },
+  { label: 'Audio', value: 'audio' },
+] as const;
+
+export const STAGE_FILTERS = [
+  { label: 'All', value: 'all' },
+  { label: 'Research', value: 'research' },
+  { label: 'Planning', value: 'planning' },
+  { label: 'Creation', value: 'creation' },
+  { label: 'Review', value: 'review' },
+  { label: 'Publishing', value: 'publishing' },
+  { label: 'Analysis', value: 'analysis' },
+] as const;
+
+export type SourceFilterValue = (typeof SOURCE_FILTERS)[number]['value'];
+export type ModalityFilterValue = (typeof MODALITY_FILTERS)[number]['value'];
+export type StageFilterValue = (typeof STAGE_FILTERS)[number]['value'];


### PR DESCRIPTION
## Summary\n- Extract shared orchestration skill filter options and value types into one local module\n- Remove duplicate source, modality, and stage filter definitions from the page/header/catalog components\n- Net LOC: 43 insertions / 62 deletions (-19)\n\n## Verification\n- bunx biome check --write touched orchestration files\n- pre-commit: secretlint, biome staged check, lint-no-raw-html\n- apps/app type-check could not start in the fresh worktree because Next is not installed/resolved (next: command not found)