### PR TITLE
feat(reply-bot): prefilter candidate opportunities

### DIFF
--- a/apps/server/api/src/collections/reply-bot-configs/dto/create-reply-bot-config.dto.ts
+++ b/apps/server/api/src/collections/reply-bot-configs/dto/create-reply-bot-config.dto.ts
@@ -46,6 +46,39 @@ export class ReplyBotFiltersDto {
   })
   excludeKeywords?: string[];
 
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  @ApiProperty({
+    default: [],
+    description: 'Skip candidates from these author usernames',
+    required: false,
+    type: [String],
+  })
+  excludeAuthors?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  @ApiProperty({
+    default: [],
+    description: 'Skip candidates from these platform author IDs',
+    required: false,
+    type: [String],
+  })
+  excludeAuthorIds?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  @ApiProperty({
+    default: [],
+    description: 'Skip candidates whose canonical URL contains these values',
+    required: false,
+    type: [String],
+  })
+  excludeUrls?: string[];
+
   @IsNumber()
   @Min(0)
   @IsOptional()
@@ -56,6 +89,36 @@ export class ReplyBotFiltersDto {
     required: false,
   })
   minFollowers?: number;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Maximum follower count for candidate author',
+    minimum: 0,
+    required: false,
+  })
+  maxFollowers?: number;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Skip candidates older than this many hours',
+    minimum: 0,
+    required: false,
+  })
+  maxAgeHours?: number;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Minimum candidate text length before drafting',
+    minimum: 0,
+    required: false,
+  })
+  minTextLength?: number;
 }
 
 export class CreateReplyBotConfigDto {

--- a/apps/server/api/src/collections/reply-bot-configs/schemas/reply-bot-config.schema.ts
+++ b/apps/server/api/src/collections/reply-bot-configs/schemas/reply-bot-config.schema.ts
@@ -44,7 +44,19 @@ export interface ReplyBotSchedule {
 }
 
 export interface ReplyBotFilters {
+  excludeAccountIds?: string[];
+  excludeAccounts?: string[];
+  excludeAuthorIds?: string[];
+  excludeAuthors?: string[];
   excludeKeywords?: string[];
+  excludeUrls?: string[];
+  excludedAccountIds?: string[];
+  excludedAccounts?: string[];
+  excludedAuthorIds?: string[];
+  excludedAuthors?: string[];
+  excludedAuthorUsernames?: string[];
+  excludedDomains?: string[];
+  excludedUrls?: string[];
   filters?: string[];
   hashtags?: {
     exclude?: string[];
@@ -57,14 +69,18 @@ export interface ReplyBotFilters {
     include?: string[];
     [key: string]: unknown;
   };
+  maxAgeHours?: number;
+  maxFollowers?: number;
   mediaType?: string;
   minEngagement?: {
     minLikes?: number;
     minReplies?: number;
     minRetweets?: number;
+    minViews?: number;
     [key: string]: unknown;
   };
   minFollowers?: number;
+  minTextLength?: number;
   [key: string]: unknown;
 }
 

--- a/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.spec.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@api/config/config.service';
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import { RateLimitService } from '@api/services/reply-bot/rate-limit.service';
 import { ReplyBotOrchestratorService } from '@api/services/reply-bot/reply-bot-orchestrator.service';
+import { ReplyCandidatePrefilterService } from '@api/services/reply-bot/reply-candidate-prefilter.service';
 import { ReplyGenerationService } from '@api/services/reply-bot/reply-generation.service';
 import { SocialMonitorService } from '@api/services/reply-bot/social-monitor.service';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -51,6 +52,14 @@ describe('ReplyBotOrchestratorService', () => {
     isWithinSchedule: vi.fn(),
   };
 
+  const mockReplyCandidatePrefilterService = {
+    prefilter: vi.fn((content) => ({
+      candidates: content,
+      skipped: 0,
+      skipCounts: {},
+    })),
+  };
+
   const mockReplyBotConfigsService = {
     findActive: vi.fn(),
     findOneById: vi.fn(),
@@ -86,6 +95,10 @@ describe('ReplyBotOrchestratorService', () => {
           useValue: mockBotActionExecutorService,
         },
         { provide: RateLimitService, useValue: mockRateLimitService },
+        {
+          provide: ReplyCandidatePrefilterService,
+          useValue: mockReplyCandidatePrefilterService,
+        },
         {
           provide: ReplyBotConfigsService,
           useValue: mockReplyBotConfigsService,
@@ -202,6 +215,7 @@ describe('ReplyBotOrchestratorService', () => {
       await service.processSingleBot(botConfig as never, orgId, credential);
 
       expect(mockSocialMonitorService.getUserMentions).toHaveBeenCalled();
+      expect(mockReplyCandidatePrefilterService.prefilter).toHaveBeenCalled();
     });
 
     it('should fetch monitored account content for ACCOUNT_MONITOR bot type', async () => {
@@ -260,6 +274,41 @@ describe('ReplyBotOrchestratorService', () => {
       expect(result.repliesSent).toBe(0);
     });
 
+    it('should skip candidates removed by the deterministic prefilter', async () => {
+      const botConfig = makeBotConfig();
+      const contentItem = {
+        authorId: 'author-1',
+        authorUsername: 'author',
+        contentType: 'tweet',
+        createdAt: new Date(),
+        id: 'tweet-1',
+        platform: 'twitter',
+        text: 'Hello',
+      };
+
+      mockRateLimitService.isWithinSchedule.mockReturnValue(true);
+      mockSocialMonitorService.getUserMentions.mockResolvedValue([contentItem]);
+      mockSocialMonitorService.filterUnprocessedContent.mockResolvedValue([
+        contentItem,
+      ]);
+      mockReplyCandidatePrefilterService.prefilter.mockReturnValueOnce({
+        candidates: [],
+        skipped: 1,
+        skipCounts: { excluded_keyword: 1 },
+      });
+
+      const result = await service.processSingleBot(
+        botConfig as never,
+        orgId,
+        credential,
+      );
+
+      expect(result.skipped).toBe(1);
+      expect(result.contentProcessed).toBe(0);
+      expect(mockReplyGenerationService.generateReply).not.toHaveBeenCalled();
+      expect(mockRateLimitService.checkRateLimit).not.toHaveBeenCalled();
+    });
+
     it('should increment repliesSent on successful reply post', async () => {
       const botConfig = makeBotConfig({ actionType: 'reply_only' });
       const contentItem = {
@@ -306,6 +355,52 @@ describe('ReplyBotOrchestratorService', () => {
         orgId,
         'reply_guy',
         botConfig._id.toString(),
+      );
+    });
+
+    it('should pass enriched candidate context into reply generation', async () => {
+      const botConfig = makeBotConfig({ actionType: 'reply_only' });
+      const contentItem = {
+        authorId: 'author-1',
+        authorUsername: 'author',
+        contentType: 'tweet',
+        createdAt: new Date(),
+        id: 'tweet-1',
+        platform: 'twitter',
+        replyContext: 'Parent content ID: parent-1',
+        text: 'Hello',
+      };
+
+      mockRateLimitService.isWithinSchedule.mockReturnValue(true);
+      mockSocialMonitorService.getUserMentions.mockResolvedValue([contentItem]);
+      mockSocialMonitorService.filterUnprocessedContent.mockResolvedValue([
+        contentItem,
+      ]);
+      mockReplyCandidatePrefilterService.prefilter.mockReturnValueOnce({
+        candidates: [contentItem],
+        skipped: 0,
+        skipCounts: {},
+      });
+      mockRateLimitService.checkRateLimit.mockResolvedValue({ allowed: true });
+      mockBotActivitiesService.create.mockResolvedValue({
+        _id: 'test-object-id',
+      });
+      mockReplyGenerationService.generateReply.mockResolvedValue(
+        'Generated reply text',
+      );
+      mockBotActionExecutorService.postReply.mockResolvedValue({
+        contentId: 'reply-1',
+        success: true,
+      });
+      mockBotActivitiesService.updateStatus.mockResolvedValue(undefined);
+      mockProcessedTweetsService.markAsProcessed.mockResolvedValue(undefined);
+
+      await service.processSingleBot(botConfig as never, orgId, credential);
+
+      expect(mockReplyGenerationService.generateReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: 'test context\n\nParent content ID: parent-1',
+        }),
       );
     });
 

--- a/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts
+++ b/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts
@@ -17,6 +17,10 @@ import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/servi
 import { ConfigService } from '@api/config/config.service';
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import { RateLimitService } from '@api/services/reply-bot/rate-limit.service';
+import {
+  type ReplyCandidate,
+  ReplyCandidatePrefilterService,
+} from '@api/services/reply-bot/reply-candidate-prefilter.service';
 import { ReplyGenerationService } from '@api/services/reply-bot/reply-generation.service';
 import {
   type SocialContentData,
@@ -60,6 +64,7 @@ export class ReplyBotOrchestratorService {
     private readonly replyGenerationService: ReplyGenerationService,
     private readonly botActionExecutorService: BotActionExecutorService,
     private readonly rateLimitService: RateLimitService,
+    private readonly replyCandidatePrefilterService: ReplyCandidatePrefilterService,
     private readonly replyBotConfigsService: ReplyBotConfigsService,
     private readonly monitoredAccountsService: MonitoredAccountsService,
     private readonly botActivitiesService: BotActivitiesService,
@@ -170,6 +175,28 @@ export class ReplyBotOrchestratorService {
         botType: botConfig.type,
         contentCount: content.length,
         platform,
+      });
+
+      const prefilterResult = this.replyCandidatePrefilterService.prefilter(
+        content,
+        {
+          botConfig,
+          botType: (botConfig.type ?? ReplyBotType.REPLY_GUY) as ReplyBotType,
+          credential,
+          organizationId,
+          platform,
+        },
+      );
+      content = prefilterResult.candidates;
+      result.skipped += prefilterResult.skipped;
+
+      this.loggerService.log(`${url} prefiltered candidates`, {
+        acceptedCount: content.length,
+        botConfigId,
+        fetchedCount: content.length + prefilterResult.skipped,
+        platform,
+        skippedCount: prefilterResult.skipped,
+        skipCounts: prefilterResult.skipCounts,
       });
 
       // Process each content item
@@ -393,7 +420,7 @@ export class ReplyBotOrchestratorService {
    */
   private async processContent(
     botConfig: ReplyBotConfigDocument,
-    content: SocialContentData,
+    content: ReplyCandidate,
     organizationId: string,
     credential: IReplyBotCredentialData,
   ): Promise<{
@@ -451,7 +478,10 @@ export class ReplyBotOrchestratorService {
     try {
       // Generate AI reply
       const replyText = await this.replyGenerationService.generateReply({
-        context: botConfig.context,
+        context: this.mergeReplyContext(
+          botConfig.context,
+          content.replyContext,
+        ),
         customInstructions: botConfig.customInstructions,
         length: (botConfig.replyLength as ReplyLength) || ReplyLength.MEDIUM,
         organizationId,
@@ -616,6 +646,14 @@ export class ReplyBotOrchestratorService {
    */
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private mergeReplyContext(
+    botContext: string | undefined,
+    candidateContext: string | undefined,
+  ): string | undefined {
+    const context = [botContext, candidateContext].filter(Boolean).join('\n\n');
+    return context || undefined;
   }
 
   /**

--- a/apps/server/api/src/services/reply-bot/reply-bot.module.ts
+++ b/apps/server/api/src/services/reply-bot/reply-bot.module.ts
@@ -27,6 +27,7 @@ import { PromptBuilderModule } from '@api/services/prompt-builder/prompt-builder
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import { RateLimitService } from '@api/services/reply-bot/rate-limit.service';
 import { ReplyBotOrchestratorService } from '@api/services/reply-bot/reply-bot-orchestrator.service';
+import { ReplyCandidatePrefilterService } from '@api/services/reply-bot/reply-candidate-prefilter.service';
 import { ReplyGenerationService } from '@api/services/reply-bot/reply-generation.service';
 import { SocialMonitorService } from '@api/services/reply-bot/social-monitor.service';
 import { LoggerModule } from '@libs/logger/logger.module';
@@ -39,6 +40,7 @@ import { forwardRef, Module } from '@nestjs/common';
 
     BotActionExecutorService,
     RateLimitService,
+    ReplyCandidatePrefilterService,
     ReplyGenerationService,
     // Export individual services for testing and direct access
     SocialMonitorService,
@@ -70,6 +72,7 @@ import { forwardRef, Module } from '@nestjs/common';
   providers: [
     BotActionExecutorService,
     RateLimitService,
+    ReplyCandidatePrefilterService,
     ReplyGenerationService,
     // Core services
     SocialMonitorService,

--- a/apps/server/api/src/services/reply-bot/reply-candidate-prefilter.service.spec.ts
+++ b/apps/server/api/src/services/reply-bot/reply-candidate-prefilter.service.spec.ts
@@ -1,0 +1,149 @@
+import type { ReplyBotConfigDocument } from '@api/collections/reply-bot-configs/schemas/reply-bot-config.schema';
+import { ReplyCandidatePrefilterService } from '@api/services/reply-bot/reply-candidate-prefilter.service';
+import type { SocialContentData } from '@api/services/reply-bot/social-monitor.service';
+import {
+  ReplyBotPlatform,
+  ReplyBotType,
+  SocialContentType,
+} from '@genfeedai/enums';
+
+const makeContent = (
+  overrides: Partial<SocialContentData> = {},
+): SocialContentData => ({
+  authorFollowersCount: 100,
+  authorId: 'author-1',
+  authorUsername: 'alice',
+  contentType: SocialContentType.TWEET,
+  contentUrl: 'https://x.com/alice/status/tweet-1',
+  createdAt: new Date('2026-06-01T00:00:00.000Z'),
+  hashtags: ['ai'],
+  id: 'tweet-1',
+  metrics: { comments: 3, likes: 10, shares: 2, views: 1000 },
+  platform: ReplyBotPlatform.TWITTER,
+  text: 'Useful AI workflow discussion',
+  ...overrides,
+});
+
+const makeConfig = (
+  filters: ReplyBotConfigDocument['filters'] = {},
+): ReplyBotConfigDocument =>
+  ({
+    _id: 'bot-1',
+    filters,
+    organization: 'org-1',
+    type: ReplyBotType.REPLY_GUY,
+  }) as ReplyBotConfigDocument;
+
+describe('ReplyCandidatePrefilterService', () => {
+  let service: ReplyCandidatePrefilterService;
+
+  beforeEach(() => {
+    service = new ReplyCandidatePrefilterService();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-01T01:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('deduplicates candidates by canonical target before generation', () => {
+    const result = service.prefilter(
+      [
+        makeContent({ id: 'tweet-1' }),
+        makeContent({ id: 'tweet-1' }),
+        makeContent({
+          contentUrl: 'https://x.com/bob/status/tweet-3',
+          id: 'tweet-3',
+        }),
+      ],
+      {
+        botConfig: makeConfig(),
+        botType: ReplyBotType.REPLY_GUY,
+        credential: { accessToken: 'token', username: 'brand' },
+        organizationId: 'org-1',
+        platform: ReplyBotPlatform.TWITTER,
+      },
+    );
+
+    expect(result.candidates).toHaveLength(2);
+    expect(result.skipped).toBe(1);
+    expect(result.skipCounts.duplicate).toBe(1);
+  });
+
+  it('applies author, URL, keyword, freshness, and quality exclusions', () => {
+    const result = service.prefilter(
+      [
+        makeContent({ authorUsername: 'blocked' }),
+        makeContent({
+          contentUrl: 'https://spam.test/post',
+          id: 'tweet-2',
+        }),
+        makeContent({ id: 'tweet-3', text: 'Crypto workflow spam' }),
+        makeContent({
+          createdAt: new Date('2026-05-31T00:00:00.000Z'),
+          id: 'tweet-4',
+        }),
+        makeContent({ authorFollowersCount: 3, id: 'tweet-5' }),
+        makeContent({
+          contentUrl: 'https://x.com/alice/status/tweet-6',
+          id: 'tweet-6',
+          text: 'Thoughtful AI launch workflow breakdown',
+        }),
+      ],
+      {
+        botConfig: makeConfig({
+          excludeAuthors: ['blocked'],
+          excludeKeywords: ['crypto'],
+          excludeUrls: ['spam.test'],
+          includeKeywords: ['workflow'],
+          maxAgeHours: 2,
+          minFollowers: 10,
+          minTextLength: 10,
+        }),
+        botType: ReplyBotType.REPLY_GUY,
+        credential: { accessToken: 'token', username: 'brand' },
+        organizationId: 'org-1',
+        platform: ReplyBotPlatform.TWITTER,
+      },
+    );
+
+    expect(result.candidates.map((candidate) => candidate.id)).toEqual([
+      'tweet-6',
+    ]);
+    expect(result.skipCounts.excluded_author).toBe(1);
+    expect(result.skipCounts.excluded_url).toBe(1);
+    expect(result.skipCounts.excluded_keyword).toBe(1);
+    expect(result.skipCounts.too_old).toBe(1);
+    expect(result.skipCounts.followers_too_low).toBe(1);
+  });
+
+  it('adds available thread and engagement context to accepted candidates', () => {
+    const result = service.prefilter(
+      [
+        makeContent({
+          inReplyToId: 'parent-1',
+          parentContentId: 'thread-1',
+        }),
+      ],
+      {
+        botConfig: makeConfig(),
+        botType: ReplyBotType.COMMENT_RESPONDER,
+        credential: { accessToken: 'token', username: 'brand' },
+        organizationId: 'org-1',
+        platform: ReplyBotPlatform.TWITTER,
+      },
+    );
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0].replyContext).toContain(
+      'Parent content ID: thread-1',
+    );
+    expect(result.candidates[0].replyContext).toContain(
+      'In reply to ID: parent-1',
+    );
+    expect(result.candidates[0].replyContext).toContain(
+      'Engagement: likes 10, comments 3, shares 2, views 1000',
+    );
+  });
+});

--- a/apps/server/api/src/services/reply-bot/reply-candidate-prefilter.service.ts
+++ b/apps/server/api/src/services/reply-bot/reply-candidate-prefilter.service.ts
@@ -1,0 +1,322 @@
+import type { ReplyBotConfigDocument } from '@api/collections/reply-bot-configs/schemas/reply-bot-config.schema';
+import type { SocialContentData } from '@api/services/reply-bot/social-monitor.service';
+import type { ReplyBotPlatform, ReplyBotType } from '@genfeedai/enums';
+import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+export interface ReplyCandidate extends SocialContentData {
+  replyContext?: string;
+}
+
+export interface ReplyCandidatePrefilterOptions {
+  botConfig: ReplyBotConfigDocument;
+  botType: ReplyBotType;
+  credential: IReplyBotCredentialData;
+  organizationId: string;
+  platform: ReplyBotPlatform;
+}
+
+export interface ReplyCandidatePrefilterResult {
+  candidates: ReplyCandidate[];
+  skipped: number;
+  skipCounts: Record<string, number>;
+}
+
+type ReplyCandidateSkipReason =
+  | 'duplicate'
+  | 'excluded_author'
+  | 'excluded_author_id'
+  | 'excluded_url'
+  | 'excluded_keyword'
+  | 'missing_include_keyword'
+  | 'too_old'
+  | 'text_too_short'
+  | 'followers_too_low'
+  | 'followers_too_high'
+  | 'engagement_too_low';
+
+interface NormalizedReplyFilters {
+  excludedAuthorIds: Set<string>;
+  excludedAuthors: Set<string>;
+  excludedKeywords: string[];
+  excludedUrls: string[];
+  includeKeywords: string[];
+  maxAgeHours?: number;
+  maxFollowers?: number;
+  minComments?: number;
+  minFollowers?: number;
+  minLikes?: number;
+  minShares?: number;
+  minTextLength?: number;
+  minViews?: number;
+}
+
+@Injectable()
+export class ReplyCandidatePrefilterService {
+  prefilter(
+    candidates: SocialContentData[],
+    options: ReplyCandidatePrefilterOptions,
+  ): ReplyCandidatePrefilterResult {
+    const filters = this.normalizeFilters(options);
+    const seenTargets = new Set<string>();
+    const accepted: ReplyCandidate[] = [];
+    const skipCounts: Record<string, number> = {};
+
+    for (const candidate of candidates) {
+      const skipReason = this.getSkipReason(candidate, filters);
+      if (skipReason) {
+        this.incrementSkip(skipCounts, skipReason);
+        continue;
+      }
+
+      const duplicateKey = this.getCandidateKey(candidate);
+      if (seenTargets.has(duplicateKey)) {
+        this.incrementSkip(skipCounts, 'duplicate');
+        continue;
+      }
+      seenTargets.add(duplicateKey);
+
+      accepted.push({
+        ...candidate,
+        replyContext: this.buildReplyContext(candidate),
+      });
+    }
+
+    const skipped = Object.values(skipCounts).reduce(
+      (sum, count) => sum + count,
+      0,
+    );
+
+    return { candidates: accepted, skipped, skipCounts };
+  }
+
+  private normalizeFilters(
+    options: ReplyCandidatePrefilterOptions,
+  ): NormalizedReplyFilters {
+    const filters = options.botConfig.filters ?? {};
+    const keywords =
+      typeof filters.keywords === 'object' && filters.keywords
+        ? filters.keywords
+        : {};
+    const minEngagement =
+      typeof filters.minEngagement === 'object' && filters.minEngagement
+        ? filters.minEngagement
+        : {};
+    const ownUsername = this.normalize(options.credential.username);
+
+    return {
+      excludedAuthorIds: this.toNormalizedSet([
+        ...this.asStringArray(filters.excludedAuthorIds),
+        ...this.asStringArray(filters.excludeAuthorIds),
+        ...this.asStringArray(filters.excludedAccountIds),
+        ...this.asStringArray(filters.excludeAccountIds),
+        this.normalize(options.credential.externalId),
+      ]),
+      excludedAuthors: this.toNormalizedSet([
+        ...this.asStringArray(filters.excludedAuthors),
+        ...this.asStringArray(filters.excludeAuthors),
+        ...this.asStringArray(filters.excludedAuthorUsernames),
+        ...this.asStringArray(filters.excludeAuthorUsernames),
+        ...this.asStringArray(filters.excludedAccounts),
+        ...this.asStringArray(filters.excludeAccounts),
+        ownUsername,
+      ]),
+      excludedKeywords: [
+        ...this.asStringArray(filters.excludeKeywords),
+        ...this.asStringArray(keywords.exclude),
+      ].map((value) => value.toLowerCase()),
+      excludedUrls: [
+        ...this.asStringArray(filters.excludedUrls),
+        ...this.asStringArray(filters.excludeUrls),
+        ...this.asStringArray(filters.excludedDomains),
+        ...this.asStringArray(filters.excludeDomains),
+      ].map((value) => value.toLowerCase()),
+      includeKeywords: [
+        ...this.asStringArray(filters.includeKeywords),
+        ...this.asStringArray(keywords.include),
+      ].map((value) => value.toLowerCase()),
+      maxAgeHours: this.asPositiveNumber(filters.maxAgeHours),
+      maxFollowers: this.asPositiveNumber(filters.maxFollowers),
+      minComments: this.asPositiveNumber(minEngagement.minReplies),
+      minFollowers: this.asPositiveNumber(filters.minFollowers),
+      minLikes: this.asPositiveNumber(minEngagement.minLikes),
+      minShares: this.asPositiveNumber(minEngagement.minRetweets),
+      minTextLength: this.asPositiveNumber(filters.minTextLength),
+      minViews: this.asPositiveNumber(minEngagement.minViews),
+    };
+  }
+
+  private getSkipReason(
+    candidate: SocialContentData,
+    filters: NormalizedReplyFilters,
+  ): ReplyCandidateSkipReason | undefined {
+    const authorUsername = this.normalize(candidate.authorUsername);
+    const authorId = this.normalize(candidate.authorId);
+    const text = candidate.text.toLowerCase();
+    const contentUrl = (candidate.contentUrl ?? '').toLowerCase();
+
+    if (filters.excludedAuthors.has(authorUsername)) {
+      return 'excluded_author';
+    }
+
+    if (filters.excludedAuthorIds.has(authorId)) {
+      return 'excluded_author_id';
+    }
+
+    if (
+      contentUrl &&
+      filters.excludedUrls.some((excludedUrl) =>
+        contentUrl.includes(excludedUrl),
+      )
+    ) {
+      return 'excluded_url';
+    }
+
+    if (
+      filters.includeKeywords.length > 0 &&
+      !filters.includeKeywords.some((keyword) => text.includes(keyword))
+    ) {
+      return 'missing_include_keyword';
+    }
+
+    if (filters.excludedKeywords.some((keyword) => text.includes(keyword))) {
+      return 'excluded_keyword';
+    }
+
+    if (
+      filters.maxAgeHours &&
+      Date.now() - candidate.createdAt.getTime() >
+        filters.maxAgeHours * 60 * 60 * 1000
+    ) {
+      return 'too_old';
+    }
+
+    if (
+      filters.minTextLength &&
+      candidate.text.trim().length < filters.minTextLength
+    ) {
+      return 'text_too_short';
+    }
+
+    if (
+      filters.minFollowers &&
+      (candidate.authorFollowersCount ?? 0) < filters.minFollowers
+    ) {
+      return 'followers_too_low';
+    }
+
+    if (
+      filters.maxFollowers &&
+      (candidate.authorFollowersCount ?? 0) > filters.maxFollowers
+    ) {
+      return 'followers_too_high';
+    }
+
+    if (
+      filters.minLikes &&
+      (candidate.metrics?.likes ?? 0) < filters.minLikes
+    ) {
+      return 'engagement_too_low';
+    }
+
+    if (
+      filters.minComments &&
+      (candidate.metrics?.comments ?? 0) < filters.minComments
+    ) {
+      return 'engagement_too_low';
+    }
+
+    if (
+      filters.minShares &&
+      (candidate.metrics?.shares ?? 0) < filters.minShares
+    ) {
+      return 'engagement_too_low';
+    }
+
+    if (
+      filters.minViews &&
+      (candidate.metrics?.views ?? 0) < filters.minViews
+    ) {
+      return 'engagement_too_low';
+    }
+
+    return undefined;
+  }
+
+  private buildReplyContext(candidate: SocialContentData): string {
+    const contextParts = [
+      `Platform: ${candidate.platform}`,
+      `Content type: ${candidate.contentType}`,
+      candidate.contentUrl ? `URL: ${candidate.contentUrl}` : undefined,
+      candidate.parentContentId
+        ? `Parent content ID: ${candidate.parentContentId}`
+        : undefined,
+      candidate.inReplyToId
+        ? `In reply to ID: ${candidate.inReplyToId}`
+        : undefined,
+      typeof candidate.authorFollowersCount === 'number'
+        ? `Author followers: ${candidate.authorFollowersCount}`
+        : undefined,
+      candidate.metrics
+        ? `Engagement: ${[
+            `likes ${candidate.metrics.likes}`,
+            typeof candidate.metrics.comments === 'number'
+              ? `comments ${candidate.metrics.comments}`
+              : undefined,
+            typeof candidate.metrics.shares === 'number'
+              ? `shares ${candidate.metrics.shares}`
+              : undefined,
+            typeof candidate.metrics.views === 'number'
+              ? `views ${candidate.metrics.views}`
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join(', ')}`
+        : undefined,
+      candidate.hashtags?.length
+        ? `Hashtags: ${candidate.hashtags.join(', ')}`
+        : undefined,
+    ];
+
+    return contextParts.filter(Boolean).join('\n');
+  }
+
+  private getCandidateKey(candidate: SocialContentData): string {
+    const target =
+      this.normalize(candidate.id) ||
+      this.normalize(candidate.contentUrl) ||
+      this.normalize(candidate.parentContentId) ||
+      this.normalize(candidate.inReplyToId);
+
+    return `${candidate.platform}:${target}`;
+  }
+
+  private incrementSkip(
+    skipCounts: Record<string, number>,
+    reason: ReplyCandidateSkipReason,
+  ): void {
+    skipCounts[reason] = (skipCounts[reason] ?? 0) + 1;
+  }
+
+  private toNormalizedSet(values: string[]): Set<string> {
+    return new Set(
+      values.map((value) => this.normalize(value)).filter(Boolean),
+    );
+  }
+
+  private normalize(value: unknown): string {
+    return typeof value === 'string'
+      ? value.trim().replace(/^@/, '').toLowerCase()
+      : '';
+  }
+
+  private asStringArray(value: unknown): string[] {
+    return Array.isArray(value)
+      ? value.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+  }
+
+  private asPositiveNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && value > 0 ? value : undefined;
+  }
+}

--- a/packages/client/src/schemas/automation/reply-bot-config.schema.ts
+++ b/packages/client/src/schemas/automation/reply-bot-config.schema.ts
@@ -32,11 +32,16 @@ export const replyBotScheduleSchema = z.object({
 });
 
 export const replyBotFiltersSchema = z.object({
+  excludeAuthorIds: z.array(z.string()).default([]),
+  excludeAuthors: z.array(z.string()).default([]),
   excludeKeywords: z.array(z.string()).default([]),
+  excludeUrls: z.array(z.string()).default([]),
   includeKeywords: z.array(z.string()).default([]),
   languageFilter: z.array(z.string()).default([]),
+  maxAgeHours: z.number().min(0).optional(),
   maxFollowers: z.number().min(0).optional(),
   minFollowers: z.number().min(0).default(0),
+  minTextLength: z.number().min(0).optional(),
   mustHaveBio: z.boolean().default(false),
 });
 

--- a/packages/interfaces/src/services/reply-bot.interface.ts
+++ b/packages/interfaces/src/services/reply-bot.interface.ts
@@ -75,12 +75,18 @@ export interface IReplyBotSchedule {
 }
 
 export interface IReplyBotFilters {
+  excludeAuthorIds?: string[];
+  excludeAuthors?: string[];
   keywords: string[];
   hashtags: string[];
   excludeKeywords: string[];
+  excludeUrls?: string[];
   minFollowers?: number;
   maxFollowers?: number;
+  maxAgeHours?: number;
+  minTextLength?: number;
   requireVerified?: boolean;
+  excludedUrls?: string[];
 }
 
 export interface IReplyBotConfig {

--- a/packages/ui/src/components/modals/automation/useModalReplyBot.ts
+++ b/packages/ui/src/components/modals/automation/useModalReplyBot.ts
@@ -107,16 +107,26 @@ export function useModalReplyBot({
           minFollowers?: number;
           maxFollowers?: number;
           mustHaveBio?: boolean;
+          excludeAuthorIds?: string[];
+          excludeAuthors?: string[];
           excludeKeywords?: string[];
+          excludeUrls?: string[];
           includeKeywords?: string[];
           languageFilter?: string[];
+          maxAgeHours?: number;
+          minTextLength?: number;
         };
         form.setValue('filters', {
+          excludeAuthorIds: filters.excludeAuthorIds ?? [],
+          excludeAuthors: filters.excludeAuthors ?? [],
           excludeKeywords: filters.excludeKeywords ?? [],
+          excludeUrls: filters.excludeUrls ?? [],
           includeKeywords: filters.includeKeywords ?? [],
           languageFilter: filters.languageFilter ?? [],
+          maxAgeHours: filters.maxAgeHours,
           maxFollowers: filters.maxFollowers,
           minFollowers: filters.minFollowers ?? 0,
+          minTextLength: filters.minTextLength,
           mustHaveBio: filters.mustHaveBio ?? false,
         });
       }


### PR DESCRIPTION
## Summary
- add a deterministic reply candidate prefilter before reply-bot generation/action execution
- support duplicate suppression, author/account/URL/keyword/freshness/quality filters, and enriched candidate context
- expose new reply-bot filter config fields through API DTOs and shared client/interface schemas

Closes #183

## Verification
- npx biome check apps/server/api/src/services/reply-bot/reply-candidate-prefilter.service.ts apps/server/api/src/services/reply-bot/reply-candidate-prefilter.service.spec.ts apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.spec.ts apps/server/api/src/services/reply-bot/reply-bot.module.ts apps/server/api/src/collections/reply-bot-configs/dto/create-reply-bot-config.dto.ts apps/server/api/src/collections/reply-bot-configs/schemas/reply-bot-config.schema.ts packages/interfaces/src/services/reply-bot.interface.ts packages/client/src/schemas/automation/reply-bot-config.schema.ts
- bun run --cwd apps/server/api test:file src/services/reply-bot/reply-candidate-prefilter.service.spec.ts src/services/reply-bot/reply-bot-orchestrator.service.spec.ts src/services/reply-bot/social-monitor.service.spec.ts
- bunx turbo run type-check --filter=@genfeedai/api

## Notes
- The first direct `bun test` invocation failed because it does not load the API package alias config; the configured Vitest command above was used for verification.
