### PR TITLE
refactor: share analytics date range formatting

### DIFF
--- a/packages/helpers/src/utils/date-range.util.test.ts
+++ b/packages/helpers/src/utils/date-range.util.test.ts
@@ -1,4 +1,7 @@
 import {
+  formatApiDate,
+  formatOptionalApiDate,
+  getDateRangeKeys,
   getDateRangeWithDefaults,
   getDefaultDateRange,
 } from '@helpers/utils/date-range.util';
@@ -48,6 +51,50 @@ describe('date-range.util', () => {
       );
 
       expect(diffDays).toBe(6); // 6 days difference = 7 day range (inclusive)
+    });
+  });
+
+  describe('formatApiDate', () => {
+    it('should format string dates for API query params', () => {
+      expect(formatApiDate('2024-01-15T10:30:00Z')).toBe('2024-01-15');
+    });
+
+    it('should format Date objects for API query params', () => {
+      expect(formatApiDate(new Date('2024-02-20T15:45:00Z'))).toBe(
+        '2024-02-20',
+      );
+    });
+  });
+
+  describe('formatOptionalApiDate', () => {
+    it('should return null for empty dates', () => {
+      expect(formatOptionalApiDate(null)).toBeNull();
+      expect(formatOptionalApiDate(undefined)).toBeNull();
+    });
+
+    it('should format provided dates', () => {
+      expect(formatOptionalApiDate(new Date('2024-03-10'))).toBe('2024-03-10');
+    });
+  });
+
+  describe('getDateRangeKeys', () => {
+    it('should return formatted keys for present dates', () => {
+      expect(
+        getDateRangeKeys({
+          endDate: new Date('2024-01-07'),
+          startDate: new Date('2024-01-01'),
+        }),
+      ).toEqual({
+        endDateKey: '2024-01-07',
+        startDateKey: '2024-01-01',
+      });
+    });
+
+    it('should return null keys for missing dates', () => {
+      expect(getDateRangeKeys({ endDate: null, startDate: null })).toEqual({
+        endDateKey: null,
+        startDateKey: null,
+      });
     });
   });
 

--- a/packages/helpers/src/utils/date-range.util.ts
+++ b/packages/helpers/src/utils/date-range.util.ts
@@ -1,12 +1,39 @@
 import { format, subDays } from 'date-fns';
 
+const API_DATE_FORMAT = 'yyyy-MM-dd';
+
+type DateRangeInput = {
+  endDate?: Date | string | null;
+  startDate?: Date | string | null;
+};
+
+export function formatApiDate(date: Date | string): string {
+  return format(new Date(date), API_DATE_FORMAT);
+}
+
+export function formatOptionalApiDate(
+  date?: Date | string | null,
+): string | null {
+  return date ? formatApiDate(date) : null;
+}
+
+export function getDateRangeKeys(dateRange: DateRangeInput): {
+  endDateKey: string | null;
+  startDateKey: string | null;
+} {
+  return {
+    endDateKey: formatOptionalApiDate(dateRange.endDate),
+    startDateKey: formatOptionalApiDate(dateRange.startDate),
+  };
+}
+
 export function getDefaultDateRange(): { startDate: string; endDate: string } {
   const yesterday = subDays(new Date(), 1);
   const sevenDaysAgo = subDays(yesterday, 6);
 
   return {
-    endDate: format(yesterday, 'yyyy-MM-dd'),
-    startDate: format(sevenDaysAgo, 'yyyy-MM-dd'),
+    endDate: formatApiDate(yesterday),
+    startDate: formatApiDate(sevenDaysAgo),
   };
 }
 
@@ -15,15 +42,12 @@ export function getDateRangeWithDefaults(
   endDate?: string | Date,
 ): { startDate: string; endDate: string } {
   const defaults = getDefaultDateRange();
-  const dateFormat = 'yyyy-MM-dd';
 
   const formattedStartDate = startDate
-    ? format(new Date(startDate), dateFormat)
+    ? formatApiDate(startDate)
     : defaults.startDate;
 
-  const formattedEndDate = endDate
-    ? format(new Date(endDate), dateFormat)
-    : defaults.endDate;
+  const formattedEndDate = endDate ? formatApiDate(endDate) : defaults.endDate;
 
   return {
     endDate: formattedEndDate,

--- a/packages/hooks/data/analytics/use-leaderboards/use-leaderboards.ts
+++ b/packages/hooks/data/analytics/use-leaderboards/use-leaderboards.ts
@@ -13,8 +13,8 @@ import {
   createCacheKey,
   createLocalStorageCache,
 } from '@helpers/data/cache/cache.helper';
+import { getDateRangeKeys } from '@helpers/utils/date-range.util';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
-import { format } from 'date-fns';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const LEADERBOARD_CACHE_TTL_MS = 15 * 60 * 1000;
@@ -89,14 +89,9 @@ export function useLeaderboards(
   );
   const [isLeaderboardUsingCache, setIsLeaderboardUsingCache] = useState(false);
 
-  const startDateKey = useMemo(
-    () =>
-      dateRange.startDate ? format(dateRange.startDate, 'yyyy-MM-dd') : null,
-    [dateRange.startDate],
-  );
-  const endDateKey = useMemo(
-    () => (dateRange.endDate ? format(dateRange.endDate, 'yyyy-MM-dd') : null),
-    [dateRange.endDate],
+  const { endDateKey, startDateKey } = useMemo(
+    () => getDateRangeKeys(dateRange),
+    [dateRange],
   );
 
   const orgsCacheKey = useMemo(
@@ -122,7 +117,7 @@ export function useLeaderboards(
   );
 
   const fetchLeaderboards = useCallback(async () => {
-    if (!dateRange.startDate || !dateRange.endDate) {
+    if (!startDateKey || !endDateKey) {
       return;
     }
 
@@ -131,10 +126,10 @@ export function useLeaderboards(
 
       const service = await getAnalyticsService();
       const query: ILeaderboardQueryParams = {
-        endDate: format(dateRange.endDate, 'yyyy-MM-dd'),
+        endDate: endDateKey,
         limit: 5,
         sort: AnalyticsMetric.ENGAGEMENT,
-        startDate: format(dateRange.startDate, 'yyyy-MM-dd'),
+        startDate: startDateKey,
       };
 
       const [orgsData, brandsData] = await Promise.all([
@@ -197,7 +192,14 @@ export function useLeaderboards(
     } finally {
       setIsLeaderboardLoading(false);
     }
-  }, [brandsCacheKey, dateRange, getAnalyticsService, orgsCacheKey, scope]);
+  }, [
+    brandsCacheKey,
+    endDateKey,
+    getAnalyticsService,
+    orgsCacheKey,
+    scope,
+    startDateKey,
+  ]);
 
   useEffect(() => {
     if (

--- a/packages/hooks/data/analytics/use-timeseries/use-timeseries.ts
+++ b/packages/hooks/data/analytics/use-timeseries/use-timeseries.ts
@@ -9,9 +9,11 @@ import {
   createCacheKey,
   createLocalStorageCache,
 } from '@helpers/data/cache/cache.helper';
-import { getDateRangeWithDefaults } from '@helpers/utils/date-range.util';
+import {
+  getDateRangeKeys,
+  getDateRangeWithDefaults,
+} from '@helpers/utils/date-range.util';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
-import { format } from 'date-fns';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const TIMESERIES_CACHE_TTL_MS = 15 * 60 * 1000;
@@ -67,14 +69,9 @@ export function useTimeseries(
   );
   const [isTimeseriesUsingCache, setIsTimeseriesUsingCache] = useState(false);
 
-  const startDateKey = useMemo(
-    () =>
-      dateRange.startDate ? format(dateRange.startDate, 'yyyy-MM-dd') : null,
-    [dateRange.startDate],
-  );
-  const endDateKey = useMemo(
-    () => (dateRange.endDate ? format(dateRange.endDate, 'yyyy-MM-dd') : null),
-    [dateRange.endDate],
+  const { endDateKey, startDateKey } = useMemo(
+    () => getDateRangeKeys(dateRange),
+    [dateRange],
   );
 
   const timeseriesCacheKey = useMemo(

--- a/packages/hooks/data/analytics/use-top-posts/use-top-posts.ts
+++ b/packages/hooks/data/analytics/use-top-posts/use-top-posts.ts
@@ -5,9 +5,9 @@ import {
   createCacheKey,
   createLocalStorageCache,
 } from '@helpers/data/cache/cache.helper';
+import { getDateRangeKeys } from '@helpers/utils/date-range.util';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useQuery } from '@tanstack/react-query';
-import { format } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 export interface TopPostData {
@@ -71,12 +71,10 @@ export function useTopPosts(options: UseTopPostsOptions = {}) {
     };
   }, []);
 
-  const startDateKey = dateRange.startDate
-    ? format(dateRange.startDate, 'yyyy-MM-dd')
-    : null;
-  const endDateKey = dateRange.endDate
-    ? format(dateRange.endDate, 'yyyy-MM-dd')
-    : null;
+  const { endDateKey, startDateKey } = useMemo(
+    () => getDateRangeKeys(dateRange),
+    [dateRange],
+  );
 
   const cacheKey = useMemo(
     () =>
@@ -125,13 +123,17 @@ export function useTopPosts(options: UseTopPostsOptions = {}) {
       refreshTrigger,
     ],
     queryFn: async () => {
+      if (!startDateKey || !endDateKey) {
+        return [];
+      }
+
       try {
         const service = await getAnalyticsService();
         const fetchedData = (await service.getTopContent({
-          endDate: endDateKey!,
+          endDate: endDateKey,
           limit,
           metric,
-          startDate: startDateKey!,
+          startDate: startDateKey,
           ...(brandId && { brand: brandId }),
           ...(platform && { platform }),
         })) as TopPostData[];


### PR DESCRIPTION
## Summary
- add shared API date formatting helpers in `date-range.util`
- use shared date-range keys in analytics leaderboard, timeseries, and top-post hooks
- cover the shared helper with focused unit tests

## Verification
- `bun vitest run --config vitest.config.ts src/utils/date-range.util.test.ts` from `packages/helpers`
- `bun vitest run --config packages/hooks/vitest.config.mts packages/hooks/data/analytics/use-top-posts/use-top-posts.test.ts`
- `npx biome check --write packages/helpers/src/utils/date-range.util.ts packages/helpers/src/utils/date-range.util.test.ts packages/hooks/data/analytics/use-leaderboards/use-leaderboards.ts packages/hooks/data/analytics/use-timeseries/use-timeseries.ts packages/hooks/data/analytics/use-top-posts/use-top-posts.ts`

## Notes
- `bunx turbo run type-check --filter=@genfeedai/helpers --filter=@genfeedai/hooks` is currently blocked by existing `@genfeedai/helpers` package errors around missing `@genfeedai/constants` exports and stale `interfaces/dist` TS6305 diagnostics.
