### PR TITLE
feat(content): add top performer prompt context

### DIFF
--- a/apps/server/api/src/collections/content-intelligence/content-intelligence.module.ts
+++ b/apps/server/api/src/collections/content-intelligence/content-intelligence.module.ts
@@ -15,6 +15,8 @@ import { CreatorScraperService } from '@api/collections/content-intelligence/ser
 import { PatternAnalyzerService } from '@api/collections/content-intelligence/services/pattern-analyzer.service';
 import { PatternStoreService } from '@api/collections/content-intelligence/services/pattern-store.service';
 import { PlaybookBuilderService } from '@api/collections/content-intelligence/services/playbook-builder.service';
+import { TopPerformerPromptContextService } from '@api/collections/content-intelligence/services/top-performer-prompt-context.service';
+import { ContentPerformanceModule } from '@api/collections/content-performance/content-performance.module';
 import { HarnessProfilesModule } from '@api/collections/harness-profiles/harness-profiles.module';
 import { PersonasModule } from '@api/collections/personas/personas.module';
 import { AgentContextAssemblyModule } from '@api/services/agent-context-assembly/agent-context-assembly.module';
@@ -38,11 +40,13 @@ import { forwardRef, Module } from '@nestjs/common';
     PatternAnalyzerService,
     PatternStoreService,
     PlaybookBuilderService,
+    TopPerformerPromptContextService,
   ],
   imports: [
     forwardRef(() => AgentContextAssemblyModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => ApifyModule),
+    forwardRef(() => ContentPerformanceModule),
     forwardRef(() => ContentHarnessModule),
     forwardRef(() => HarnessProfilesModule),
     forwardRef(() => HttpModule),
@@ -56,6 +60,7 @@ import { forwardRef, Module } from '@nestjs/common';
     PatternAnalyzerService,
     PatternStoreService,
     PlaybookBuilderService,
+    TopPerformerPromptContextService,
   ],
 })
 export class ContentIntelligenceModule {}

--- a/apps/server/api/src/collections/content-intelligence/services/content-generator.service.spec.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/content-generator.service.spec.ts
@@ -1,6 +1,7 @@
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
 import { PatternStoreService } from '@api/collections/content-intelligence/services/pattern-store.service';
 import { PlaybookBuilderService } from '@api/collections/content-intelligence/services/playbook-builder.service';
+import { TopPerformerPromptContextService } from '@api/collections/content-intelligence/services/top-performer-prompt-context.service';
 import { ConfigService } from '@api/config/config.service';
 import { AgentContextAssemblyService } from '@api/services/agent-context-assembly/agent-context-assembly.service';
 import { OpenRouterService } from '@api/services/integrations/openrouter/services/openrouter.service';
@@ -14,6 +15,7 @@ const PATTERN_ID = 'test-object-id';
 const BASE_DTO = {
   hashtags: undefined,
   platform: 'instagram',
+  brandId: 'brand-123',
   topic: 'AI tools for creators',
   variationsCount: 2,
 };
@@ -48,6 +50,9 @@ describe('ContentGeneratorService', () => {
     incrementUsage: ReturnType<typeof vi.fn>;
   };
   let playbookBuilderService: { findOne: ReturnType<typeof vi.fn> };
+  let topPerformerPromptContextService: {
+    assembleContext: ReturnType<typeof vi.fn>;
+  };
   let mockLogger: {
     log: ReturnType<typeof vi.fn>;
     warn: ReturnType<typeof vi.fn>;
@@ -73,6 +78,9 @@ describe('ContentGeneratorService', () => {
       incrementUsage: vi.fn().mockResolvedValue(undefined),
     };
     playbookBuilderService = { findOne: vi.fn().mockResolvedValue(null) };
+    topPerformerPromptContextService = {
+      assembleContext: vi.fn().mockResolvedValue(undefined),
+    };
     mockLogger = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
 
     const module = await Test.createTestingModule({
@@ -87,6 +95,10 @@ describe('ContentGeneratorService', () => {
         { provide: OpenRouterService, useValue: openRouterService },
         { provide: PatternStoreService, useValue: patternStoreService },
         { provide: PlaybookBuilderService, useValue: playbookBuilderService },
+        {
+          provide: TopPerformerPromptContextService,
+          useValue: topPerformerPromptContextService,
+        },
       ],
     }).compile();
 
@@ -220,6 +232,48 @@ describe('ContentGeneratorService', () => {
           expect.objectContaining({ role: 'system' }),
         ]),
       }),
+    );
+  });
+
+  it('adds scoped top-performer context to the generation system prompt', async () => {
+    topPerformerPromptContextService.assembleContext.mockResolvedValue(
+      '## Historical Performance Context\n- Reuse hook structure like "Contrarian opener".',
+    );
+
+    await service.generateContent(ORG_ID, BASE_DTO as any);
+
+    expect(
+      topPerformerPromptContextService.assembleContext,
+    ).toHaveBeenCalledWith({
+      brandId: 'brand-123',
+      organizationId: ORG_ID,
+      platform: 'instagram',
+    });
+    expect(openRouterService.chatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining(
+              '## Historical Performance Context',
+            ),
+            role: 'system',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('continues generation when top-performer context is unavailable', async () => {
+    topPerformerPromptContextService.assembleContext.mockRejectedValue(
+      new Error('analytics unavailable'),
+    );
+
+    const results = await service.generateContent(ORG_ID, BASE_DTO as any);
+
+    expect(results).toHaveLength(2);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Top performer context assembly failed'),
+      expect.any(Error),
     );
   });
 

--- a/apps/server/api/src/collections/content-intelligence/services/content-generator.service.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/content-generator.service.ts
@@ -3,6 +3,7 @@ import { GenerateContentDto } from '@api/collections/content-intelligence/dto/ge
 import { type ContentPatternDocument } from '@api/collections/content-intelligence/schemas/content-pattern.schema';
 import { PatternStoreService } from '@api/collections/content-intelligence/services/pattern-store.service';
 import { PlaybookBuilderService } from '@api/collections/content-intelligence/services/playbook-builder.service';
+import { TopPerformerPromptContextService } from '@api/collections/content-intelligence/services/top-performer-prompt-context.service';
 import { HarnessProfilesService } from '@api/collections/harness-profiles/services/harness-profiles.service';
 import { PersonasService } from '@api/collections/personas/services/personas.service';
 import { ConfigService } from '@api/config/config.service';
@@ -50,6 +51,8 @@ export class ContentGeneratorService {
     private readonly openRouterService: OpenRouterService,
     private readonly patternStoreService: PatternStoreService,
     private readonly playbookBuilderService: PlaybookBuilderService,
+    @Optional()
+    private readonly topPerformerPromptContextService?: TopPerformerPromptContextService,
     @Optional() private readonly brandsService?: BrandsService,
     @Optional() private readonly personasService?: PersonasService,
     @Optional() private readonly contentHarnessService?: ContentHarnessService,
@@ -74,6 +77,7 @@ export class ContentGeneratorService {
         brandGuidance: true,
         brandIdentity: true,
         brandMemory: true,
+        performancePatterns: true,
         ragContext: true,
         recentPosts: true,
       },
@@ -89,9 +93,14 @@ export class ContentGeneratorService {
       organizationId,
       dto,
     );
+    const topPerformerSystemPrompt = await this.buildTopPerformerSystemPrompt(
+      organizationId,
+      dto,
+    );
     const systemPrompt =
-      [baseSystemPrompt, harnessSystemPrompt].filter(Boolean).join('\n\n') ||
-      undefined;
+      [baseSystemPrompt, topPerformerSystemPrompt, harnessSystemPrompt]
+        .filter(Boolean)
+        .join('\n\n') || undefined;
 
     // Get patterns to use
     const patterns = await this.selectPatterns(organizationId, dto);
@@ -236,6 +245,29 @@ export class ContentGeneratorService {
       const formattedBrief = formatHarnessBrief(brief);
       return formattedBrief || undefined;
     } catch {
+      return undefined;
+    }
+  }
+
+  private async buildTopPerformerSystemPrompt(
+    organizationId: string,
+    dto: GenerateContentDto,
+  ): Promise<string | undefined> {
+    if (!this.topPerformerPromptContextService || !dto.brandId) {
+      return undefined;
+    }
+
+    try {
+      return await this.topPerformerPromptContextService.assembleContext({
+        brandId: dto.brandId,
+        organizationId: organizationId.toString(),
+        platform: dto.platform,
+      });
+    } catch (error: unknown) {
+      this.logger.warn(
+        `${this.constructorName}: Top performer context assembly failed`,
+        error,
+      );
       return undefined;
     }
   }

--- a/apps/server/api/src/collections/content-intelligence/services/top-performer-prompt-context.service.spec.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/top-performer-prompt-context.service.spec.ts
@@ -1,0 +1,178 @@
+import { BrandMemoryService } from '@api/collections/brand-memory/services/brand-memory.service';
+import { TopPerformerPromptContextService } from '@api/collections/content-intelligence/services/top-performer-prompt-context.service';
+import {
+  type PerformanceContentItem,
+  PerformanceSummaryService,
+  type WeeklySummary,
+} from '@api/collections/content-performance/services/performance-summary.service';
+import { Test } from '@nestjs/testing';
+import { vi } from 'vitest';
+
+const ORG_ID = 'org-123';
+const BRAND_ID = 'brand-123';
+
+const makePerformanceItem = (
+  overrides: Partial<PerformanceContentItem>,
+): PerformanceContentItem => ({
+  comments: 0,
+  description: '',
+  engagementRate: 0,
+  likes: 0,
+  platform: 'linkedin',
+  postId: 'post-1',
+  saves: 0,
+  shares: 0,
+  title: 'Default post',
+  views: 0,
+  ...overrides,
+});
+
+const makeSummary = (
+  overrides: Partial<WeeklySummary> = {},
+): WeeklySummary => ({
+  avgEngagementByContentType: [],
+  avgEngagementByPlatform: [],
+  bestPostingTimes: [],
+  topHooks: [],
+  topPerformers: [],
+  weekOverWeekTrend: {
+    currentEngagement: 0,
+    direction: 'stable',
+    percentageChange: 0,
+    previousEngagement: 0,
+  },
+  worstPerformers: [],
+  ...overrides,
+});
+
+describe('TopPerformerPromptContextService', () => {
+  let service: TopPerformerPromptContextService;
+  let brandMemoryService: { getInsights: ReturnType<typeof vi.fn> };
+  let performanceSummaryService: { getWeeklySummary: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    brandMemoryService = {
+      getInsights: vi.fn().mockResolvedValue([]),
+    };
+    performanceSummaryService = {
+      getWeeklySummary: vi.fn().mockResolvedValue(makeSummary()),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        TopPerformerPromptContextService,
+        { provide: BrandMemoryService, useValue: brandMemoryService },
+        {
+          provide: PerformanceSummaryService,
+          useValue: performanceSummaryService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(TopPerformerPromptContextService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined when no brand scope is available', async () => {
+    const result = await service.assembleContext({
+      organizationId: ORG_ID,
+      platform: 'linkedin',
+    });
+
+    expect(result).toBeUndefined();
+    expect(performanceSummaryService.getWeeklySummary).not.toHaveBeenCalled();
+    expect(brandMemoryService.getInsights).not.toHaveBeenCalled();
+  });
+
+  it('assembles positive signals, anti-patterns, and brand memory insights', async () => {
+    performanceSummaryService.getWeeklySummary.mockResolvedValue(
+      makeSummary({
+        avgEngagementByContentType: [
+          { avgEngagementRate: 8.4, category: 'thread', totalPosts: 4 },
+        ],
+        bestPostingTimes: [{ avgEngagementRate: 7.2, hour: 9, postCount: 3 }],
+        topHooks: ['Most creators miss this'],
+        topPerformers: [
+          makePerformanceItem({
+            engagementRate: 12.5,
+            platform: 'linkedin',
+            title: 'Contrarian hook that won',
+          }),
+        ],
+        worstPerformers: [
+          makePerformanceItem({
+            engagementRate: 0.8,
+            platform: 'linkedin',
+            title: 'Generic AI tips',
+          }),
+        ],
+      }),
+    );
+    brandMemoryService.getInsights.mockResolvedValue([
+      {
+        category: 'hook',
+        confidence: 0.8,
+        insight: 'Founder-led teardown posts outperform generic tips.',
+      },
+    ]);
+
+    const result = await service.assembleContext({
+      brandId: BRAND_ID,
+      organizationId: ORG_ID,
+      platform: 'linkedin',
+    });
+
+    expect(result).toContain('## Historical Performance Context');
+    expect(result).toContain('Most creators miss this');
+    expect(result).toContain('thread formats');
+    expect(result).toContain('9AM');
+    expect(result).toContain('Contrarian hook that won');
+    expect(result).toContain('Brand memory: [hook]');
+    expect(result).toContain('## Historical Anti-Patterns');
+    expect(result).toContain('Generic AI tips');
+    expect(performanceSummaryService.getWeeklySummary).toHaveBeenCalledWith(
+      ORG_ID,
+      BRAND_ID,
+      { topN: 5, worstN: 5 },
+    );
+    expect(brandMemoryService.getInsights).toHaveBeenCalledWith(
+      ORG_ID,
+      BRAND_ID,
+      8,
+    );
+  });
+
+  it('returns undefined when there is no usable historical context', async () => {
+    const result = await service.assembleContext({
+      brandId: BRAND_ID,
+      organizationId: ORG_ID,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('falls back to all-platform winners when requested platform has no rows', async () => {
+    performanceSummaryService.getWeeklySummary.mockResolvedValue(
+      makeSummary({
+        topPerformers: [
+          makePerformanceItem({
+            engagementRate: 4.1,
+            platform: 'twitter',
+            title: 'Cross-platform winner',
+          }),
+        ],
+      }),
+    );
+
+    const result = await service.assembleContext({
+      brandId: BRAND_ID,
+      organizationId: ORG_ID,
+      platform: 'linkedin',
+    });
+
+    expect(result).toContain('Cross-platform winner');
+  });
+});

--- a/apps/server/api/src/collections/content-intelligence/services/top-performer-prompt-context.service.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/top-performer-prompt-context.service.ts
@@ -1,0 +1,148 @@
+import { BrandMemoryService } from '@api/collections/brand-memory/services/brand-memory.service';
+import {
+  type PerformanceContentItem,
+  PerformanceSummaryService,
+} from '@api/collections/content-performance/services/performance-summary.service';
+import { SecurityUtil } from '@api/helpers/utils/security/security.util';
+import { Injectable } from '@nestjs/common';
+
+export interface TopPerformerPromptContextParams {
+  organizationId: string;
+  brandId?: string;
+  platform?: string;
+  limit?: number;
+}
+
+@Injectable()
+export class TopPerformerPromptContextService {
+  constructor(
+    private readonly brandMemoryService: BrandMemoryService,
+    private readonly performanceSummaryService: PerformanceSummaryService,
+  ) {}
+
+  async assembleContext(
+    params: TopPerformerPromptContextParams,
+  ): Promise<string | undefined> {
+    if (!params.brandId) {
+      return undefined;
+    }
+
+    const limit = params.limit ?? 5;
+    const [summary, memoryInsights] = await Promise.all([
+      this.performanceSummaryService.getWeeklySummary(
+        params.organizationId,
+        params.brandId,
+        { topN: limit, worstN: limit },
+      ),
+      this.brandMemoryService.getInsights(
+        params.organizationId,
+        params.brandId,
+        8,
+      ),
+    ]);
+
+    const topPerformers = this.filterByPlatform(
+      summary.topPerformers,
+      params.platform,
+    );
+    const worstPerformers = this.filterByPlatform(
+      summary.worstPerformers,
+      params.platform,
+    );
+
+    const sections: string[] = [];
+    const positiveSignals = [
+      ...summary.topHooks
+        .slice(0, 3)
+        .map(
+          (hook) =>
+            `Reuse hook structure like "${SecurityUtil.sanitizePromptInput(hook, 120)}".`,
+        ),
+      ...summary.avgEngagementByContentType
+        .slice(0, 2)
+        .map(
+          (item) =>
+            `Favor ${SecurityUtil.sanitizePromptInput(item.category, 80)} formats (${item.avgEngagementRate.toFixed(2)}% avg engagement).`,
+        ),
+      ...summary.bestPostingTimes
+        .slice(0, 2)
+        .map(
+          (item) =>
+            `When timing matters, ${this.formatHour(item.hour)} has historically performed well (${item.avgEngagementRate.toFixed(2)}% avg engagement).`,
+        ),
+    ];
+
+    if (topPerformers.length > 0) {
+      positiveSignals.push(
+        ...topPerformers.slice(0, 3).map((item) => {
+          const label = this.describeContentItem(item);
+          return `Model winning example "${label}" (${item.engagementRate.toFixed(2)}% engagement).`;
+        }),
+      );
+    }
+
+    const memorySignals = memoryInsights
+      .filter((insight) => insight.confidence >= 0.4)
+      .slice(0, 4)
+      .map(
+        (insight) =>
+          `[${SecurityUtil.sanitizePromptInput(insight.category, 40)}] ${SecurityUtil.sanitizePromptInput(insight.insight, 180)}`,
+      );
+
+    if (positiveSignals.length > 0 || memorySignals.length > 0) {
+      sections.push(
+        [
+          '## Historical Performance Context',
+          ...positiveSignals.slice(0, 8).map((signal) => `- ${signal}`),
+          ...memorySignals.map((signal) => `- Brand memory: ${signal}`),
+        ].join('\n'),
+      );
+    }
+
+    if (worstPerformers.length > 0) {
+      const antiPatterns = worstPerformers.slice(0, 3).map((item) => {
+        const label = this.describeContentItem(item);
+        return `Avoid repeating underperforming angle "${label}" (${item.engagementRate.toFixed(2)}% engagement).`;
+      });
+      sections.push(
+        [
+          '## Historical Anti-Patterns',
+          ...antiPatterns.map((signal) => `- ${signal}`),
+        ].join('\n'),
+      );
+    }
+
+    if (sections.length === 0) {
+      return undefined;
+    }
+
+    return sections.join('\n\n');
+  }
+
+  private filterByPlatform(
+    items: PerformanceContentItem[],
+    platform?: string,
+  ): PerformanceContentItem[] {
+    if (!platform) {
+      return items;
+    }
+
+    const normalizedPlatform = platform.toLowerCase();
+    const platformItems = items.filter(
+      (item) => item.platform.toLowerCase() === normalizedPlatform,
+    );
+
+    return platformItems.length > 0 ? platformItems : items;
+  }
+
+  private describeContentItem(item: PerformanceContentItem): string {
+    const rawLabel = item.title || item.description || item.postId;
+    return SecurityUtil.sanitizePromptInput(rawLabel, 140);
+  }
+
+  private formatHour(hour: number): string {
+    const period = hour >= 12 ? 'PM' : 'AM';
+    const displayHour = hour > 12 ? hour - 12 : hour || 12;
+    return `${displayHour}${period}`;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a reusable top-performer prompt context assembler for content generation.
- Injects scoped brand performance winners, anti-patterns, and brand-memory insights into the generation system prompt.
- Enables existing proven creative pattern context during content generation.

Issue: https://github.com/genfeedai/genfeed.ai/issues/181
Closes #181

## Verification
- npx biome check --write apps/server/api/src/collections/content-intelligence/services/top-performer-prompt-context.service.ts apps/server/api/src/collections/content-intelligence/services/top-performer-prompt-context.service.spec.ts apps/server/api/src/collections/content-intelligence/services/content-generator.service.ts apps/server/api/src/collections/content-intelligence/services/content-generator.service.spec.ts apps/server/api/src/collections/content-intelligence/content-intelligence.module.ts
- bun --cwd apps/server/api test:file src/collections/content-intelligence/services/top-performer-prompt-context.service.spec.ts src/collections/content-intelligence/services/content-generator.service.spec.ts
- bunx turbo run type-check --filter=@genfeedai/api
- bunx turbo run lint --filter=@genfeedai/api
- bun run build (from apps/server/api)

## Notes
- Direct raw tsc --noEmit is still noisy in this repo because inherited TS 6/baseUrl and alias-resolution issues fire outside this change; the API Nest build completed successfully.