### PR TITLE
feat(automation): add daily Claude pattern miner

### DIFF
--- a/.github/workflows/claude-pattern-miner.yml
+++ b/.github/workflows/claude-pattern-miner.yml
@@ -1,0 +1,73 @@
+name: Claude Pattern Miner
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: Number of trailing days to analyze
+        required: false
+        default: '1'
+      include_subagents:
+        description: Include subagent transcripts
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: claude-pattern-miner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mine-patterns:
+    name: Mine Claude Session Patterns
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CLAUDE_ROOTS: ${{ vars.CLAUDE_ROOTS || '' }}
+      DAYS: ${{ inputs.days || '1' }}
+      INCLUDE_SUBAGENTS: ${{ inputs.include_subagents || 'false' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          install-command: bun install --frozen-lockfile
+
+      - name: Analyze recent sessions
+        shell: bash
+        run: |
+          args=(
+            --days "$DAYS"
+            --out docs/claude-session-analysis-daily.md
+            --json-out docs/claude-session-analysis-daily.json
+          )
+          if [ "$INCLUDE_SUBAGENTS" = "true" ]; then
+            args+=(--include-subagents)
+          fi
+          if [ -n "$CLAUDE_ROOTS" ]; then
+            IFS=':' read -r -a roots <<< "$CLAUDE_ROOTS"
+            for root in "${roots[@]}"; do
+              args+=(--root "$root")
+            done
+          fi
+          bun run scripts/analyze-claude-sessions.ts -- "${args[@]}"
+
+      - name: Generate pattern report
+        run: |
+          bun run scripts/daily-pattern-miner.ts -- \
+            --input docs/claude-session-analysis-daily.json \
+            --out docs/claude-pattern-miner-report.md
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-pattern-miner-report
+          path: |
+            docs/claude-session-analysis-daily.md
+            docs/claude-session-analysis-daily.json
+            docs/claude-pattern-miner-report.md
+          retention-days: 14

--- a/docs/claude-daily-pattern-miner.md
+++ b/docs/claude-daily-pattern-miner.md
@@ -1,0 +1,40 @@
+# Claude Daily Pattern Miner
+
+The daily pattern miner turns recent Claude session history into ranked candidates for new Genfeed skills, plugins, and autonomous agents.
+
+## Daily Flow
+
+1. `scripts/analyze-claude-sessions.ts` scans Claude JSONL transcripts and writes a scoped Markdown + JSON analysis.
+2. `scripts/daily-pattern-miner.ts` reads the JSON analysis, scores repeated workflows, and writes `docs/claude-pattern-miner-report.md`.
+3. `.github/workflows/claude-pattern-miner.yml` runs the same flow every day and uploads the analysis + report as a workflow artifact.
+
+The workflow does not commit generated reports. Reports can contain local project names or working-directory hints, so they stay in local output or GitHub Actions artifacts.
+
+For hosted GitHub runners, the workflow emits a valid empty report unless Claude history has been synced onto the runner. To point the workflow at explicit transcript roots, set the repository variable `CLAUDE_ROOTS` to a colon-separated list such as `/home/runner/.claude:/mnt/sessions/.claude-genfeedai`.
+
+## Local Commands
+
+```bash
+bun run analyze:claude-sessions
+bun run analyze:claude-sessions -- --previous-day
+bun run analyze:claude-sessions -- --days 7 --include-subagents
+bun run analyze:claude-patterns:daily
+```
+
+The analyzer auto-discovers `~/.claude*/projects` roots. To scope it explicitly:
+
+```bash
+bun run analyze:claude-sessions -- --root ~/.claude --since 2026-06-01 --until 2026-06-02
+```
+
+## Outputs
+
+- `docs/claude-session-analysis.md` - full local analysis for all available history.
+- `docs/claude-session-analysis.json` - machine-readable local analysis.
+- `docs/claude-session-analysis-daily.md` - previous-day daily analysis.
+- `docs/claude-session-analysis-daily.json` - machine-readable daily analysis.
+- `docs/claude-pattern-miner-report.md` - ranked automation candidates and weekly promotion queue.
+
+## Promotion Rule
+
+Promote a candidate to a GitHub issue when the same pattern appears in three or more daily reports in a week. Keep promotion human-reviewed; the miner recommends backlog items but does not create production automations by itself.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "node": ">=24 <25"
   },
   "scripts": {
+    "analyze:claude-patterns": "bun run scripts/daily-pattern-miner.ts",
+    "analyze:claude-patterns:daily": "bun run scripts/analyze-claude-sessions.ts -- --previous-day --out docs/claude-session-analysis-daily.md --json-out docs/claude-session-analysis-daily.json && bun run scripts/daily-pattern-miner.ts -- --input docs/claude-session-analysis-daily.json --out docs/claude-pattern-miner-report.md",
+    "analyze:claude-sessions": "bun run scripts/analyze-claude-sessions.ts",
     "postinstall": "scripts/setup-skills.sh",
     "setup:skills": "scripts/setup-skills.sh",
     "setup:skills:sync": "scripts/setup-skills.sh --sync",

--- a/scripts/analyze-claude-sessions.ts
+++ b/scripts/analyze-claude-sessions.ts
@@ -21,9 +21,12 @@ type CategoryName =
   | 'presentation_media';
 
 interface AnalysisOptions {
+  claudeRoots: string[];
   includeSubagents: boolean;
   jsonOutFile: string | null;
   outFile: string;
+  since: string | null;
+  until: string | null;
 }
 
 interface AnalysisResult {
@@ -197,14 +200,58 @@ const FILTERED_USER_PREFIXES = [
 ];
 
 function parseArgs(argv: string[]): AnalysisOptions {
+  const claudeRoots: string[] = [];
   let includeSubagents = false;
   let jsonOutFile: string | null = DEFAULT_JSON_OUTPUT;
   let outFile = DEFAULT_OUTPUT;
+  let since: string | null = null;
+  let until: string | null = null;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--include-subagents') {
       includeSubagents = true;
+      continue;
+    }
+
+    if (arg === '--root' && argv[i + 1]) {
+      claudeRoots.push(path.resolve(argv[i + 1]));
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--since' && argv[i + 1]) {
+      since = normalizeDateArg(argv[i + 1], 'since');
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--until' && argv[i + 1]) {
+      until = normalizeDateArg(argv[i + 1], 'until');
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--days' && argv[i + 1]) {
+      const days = Number(argv[i + 1]);
+      if (!Number.isFinite(days) || days <= 0) {
+        throw new Error('--days must be a positive number');
+      }
+
+      since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--previous-day') {
+      const now = new Date();
+      const todayUtc = Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate(),
+      );
+      since = new Date(todayUtc - 24 * 60 * 60 * 1000).toISOString();
+      until = new Date(todayUtc).toISOString();
       continue;
     }
 
@@ -228,7 +275,21 @@ function parseArgs(argv: string[]): AnalysisOptions {
     }
   }
 
-  return { includeSubagents, jsonOutFile, outFile };
+  return { claudeRoots, includeSubagents, jsonOutFile, outFile, since, until };
+}
+
+function normalizeDateArg(value: string, mode: 'since' | 'until'): string {
+  if (/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    const suffix = mode === 'since' ? 'T00:00:00.000Z' : 'T23:59:59.999Z';
+    return `${value}${suffix}`;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date for --${mode}: ${value}`);
+  }
+
+  return parsed.toISOString();
 }
 
 function increment(map: CounterMap, key: string, value = 1): void {
@@ -360,6 +421,29 @@ async function walkJsonlFiles(
   return results;
 }
 
+function isRecordInWindow(
+  timestamp: string | undefined,
+  options: AnalysisOptions,
+): boolean {
+  if (!options.since && !options.until) {
+    return true;
+  }
+
+  if (!timestamp) {
+    return false;
+  }
+
+  if (options.since && timestamp < options.since) {
+    return false;
+  }
+
+  if (options.until && timestamp > options.until) {
+    return false;
+  }
+
+  return true;
+}
+
 function parseProjectName(claudeRoot: string, filePath: string): string {
   const projectsPrefix = `${path.join(claudeRoot, 'projects')}${path.sep}`;
   if (!filePath.startsWith(projectsPrefix)) {
@@ -374,11 +458,12 @@ function parseProjectName(claudeRoot: string, filePath: string): string {
 async function analyzeFile(
   filePath: string,
   claudeRoot: string,
+  options: AnalysisOptions,
   result: AnalysisResult,
   sessionIds: Set<string>,
 ): Promise<void> {
   const projectName = parseProjectName(claudeRoot, filePath);
-  increment(result.projectCounts, projectName);
+  let matchedWindow = false;
 
   const rl = createInterface({
     crlfDelay: Number.POSITIVE_INFINITY,
@@ -390,6 +475,12 @@ async function analyzeFile(
     if (!record) {
       continue;
     }
+
+    if (!isRecordInWindow(record.timestamp, options)) {
+      continue;
+    }
+
+    matchedWindow = true;
 
     if (typeof record.sessionId === 'string') {
       sessionIds.add(record.sessionId);
@@ -458,10 +549,17 @@ async function analyzeFile(
       }
     }
   }
+
+  if (matchedWindow) {
+    increment(result.projectCounts, projectName);
+  }
 }
 
 async function runAnalysis(options: AnalysisOptions): Promise<AnalysisResult> {
-  const roots = await discoverClaudeRoots();
+  const roots =
+    options.claudeRoots.length > 0
+      ? options.claudeRoots
+      : await discoverClaudeRoots();
   const result: AnalysisResult = {
     assistantMessages: 0,
     categoryCounts: new Map<CategoryName, number>(),
@@ -486,7 +584,7 @@ async function runAnalysis(options: AnalysisOptions): Promise<AnalysisResult> {
     result.jsonlFiles += files.length;
 
     for (const filePath of files) {
-      await analyzeFile(filePath, root, result, sessionIds);
+      await analyzeFile(filePath, root, options, result, sessionIds);
     }
   }
 
@@ -533,13 +631,17 @@ function buildReportMarkdown(
 ): string {
   const now = new Date().toISOString();
   const includeSubagentsLabel = options.includeSubagents ? 'yes' : 'no';
+  const windowLabel =
+    options.since || options.until
+      ? `${options.since ?? 'beginning'} -> ${options.until ?? 'now'}`
+      : 'all available history';
 
   const categoryRows = Array.from(result.categoryCounts.entries())
     .sort((a, b) => b[1] - a[1])
     .map(([label, count]) => `| ${label} | ${count.toLocaleString()} |`)
     .join('\n');
 
-  return `# Claude Session Analysis\n\nGenerated: ${now}\n\n## Scope\n- Claude roots scanned: ${result.roots.length}\n- Roots:\n${result.roots.map((root) => `  - ${root}`).join('\n')}\n- Included subagent transcripts: ${includeSubagentsLabel}\n- JSONL files scanned: ${result.jsonlFiles.toLocaleString()}\n- Unique sessions: ${result.uniqueSessions.toLocaleString()}\n- Time range: ${result.firstTimestamp ?? 'n/a'} -> ${result.lastTimestamp ?? 'n/a'}\n\n## Event Volume\n- User messages: ${result.userMessages.toLocaleString()}\n- Assistant messages: ${result.assistantMessages.toLocaleString()}\n- Progress events: ${result.progressEvents.toLocaleString()}\n- Other events: ${result.otherEvents.toLocaleString()}\n\n## Top Categories (User Prompt Intent)\n| Category | Count |\n|---|---:|\n${categoryRows || '| (none) | 0 |'}\n\n## Top Models\n| Model | Count |\n|---|---:|\n${formatTopRows(result.modelCounts, 10)}\n\n## Top Tool Uses\n| Tool | Count |\n|---|---:|\n${formatTopRows(result.toolCounts, 15)}\n\n## Top Projects\n| Project | File Count |\n|---|---:|\n${formatTopRows(result.projectCounts, 12)}\n\n## Top Working Directories\n| CWD | Event Count |\n|---|---:|\n${formatTopRows(result.cwdCounts, 12)}\n\n${buildRecommendationsMarkdown(result)}\n\n## How to Run\n\`\`\`bash\nbun run analyze:claude-sessions\nbun run analyze:claude-sessions -- --include-subagents\nbun run analyze:claude-sessions -- --out docs/custom-claude-analysis.md\nbun run analyze:claude-sessions -- --json-out docs/custom-claude-analysis.json\nbun run analyze:claude-sessions -- --no-json\n\`\`\`\n`;
+  return `# Claude Session Analysis\n\nGenerated: ${now}\n\n## Scope\n- Claude roots scanned: ${result.roots.length}\n- Roots:\n${result.roots.map((root) => `  - ${root}`).join('\n')}\n- Included subagent transcripts: ${includeSubagentsLabel}\n- Requested time window: ${windowLabel}\n- JSONL files scanned: ${result.jsonlFiles.toLocaleString()}\n- Unique sessions: ${result.uniqueSessions.toLocaleString()}\n- Time range: ${result.firstTimestamp ?? 'n/a'} -> ${result.lastTimestamp ?? 'n/a'}\n\n## Event Volume\n- User messages: ${result.userMessages.toLocaleString()}\n- Assistant messages: ${result.assistantMessages.toLocaleString()}\n- Progress events: ${result.progressEvents.toLocaleString()}\n- Other events: ${result.otherEvents.toLocaleString()}\n\n## Top Categories (User Prompt Intent)\n| Category | Count |\n|---|---:|\n${categoryRows || '| (none) | 0 |'}\n\n## Top Models\n| Model | Count |\n|---|---:|\n${formatTopRows(result.modelCounts, 10)}\n\n## Top Tool Uses\n| Tool | Count |\n|---|---:|\n${formatTopRows(result.toolCounts, 15)}\n\n## Top Projects\n| Project | File Count |\n|---|---:|\n${formatTopRows(result.projectCounts, 12)}\n\n## Top Working Directories\n| CWD | Event Count |\n|---|---:|\n${formatTopRows(result.cwdCounts, 12)}\n\n${buildRecommendationsMarkdown(result)}\n\n## How to Run\n\`\`\`bash\nbun run analyze:claude-sessions\nbun run analyze:claude-sessions -- --include-subagents\nbun run analyze:claude-sessions -- --previous-day\nbun run analyze:claude-sessions -- --days 7\nbun run analyze:claude-sessions -- --root ~/.claude --since 2026-06-01\nbun run analyze:claude-sessions -- --out docs/custom-claude-analysis.md\nbun run analyze:claude-sessions -- --json-out docs/custom-claude-analysis.json\nbun run analyze:claude-sessions -- --no-json\n\`\`\`\n`;
 }
 
 function topEntries(
@@ -578,9 +680,12 @@ function buildJsonPayload(
     },
     generatedAt: new Date().toISOString(),
     options: {
+      claudeRoots: options.claudeRoots,
       includeSubagents: options.includeSubagents,
       jsonOut: options.jsonOutFile,
       markdownOut: options.outFile,
+      since: options.since,
+      until: options.until,
     },
     scope: {
       firstTimestamp: result.firstTimestamp,

--- a/scripts/daily-pattern-miner.test.ts
+++ b/scripts/daily-pattern-miner.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { buildPatternReport, scoreCandidates } from './daily-pattern-miner';
+
+describe('daily-pattern-miner', () => {
+  it('scores candidates from the current nested analysis JSON shape', () => {
+    const candidates = scoreCandidates({
+      counts: {
+        categories: {
+          agent_skilling: 4,
+          coding_backend: 6,
+          coding_frontend: 2,
+          debugging_testing: 9,
+          docs_content: 3,
+        },
+        projects: {
+          genfeed: 12,
+          shipshit: 2,
+        },
+        tools: {
+          Bash: 300,
+          Task: 20,
+          TaskUpdate: 30,
+        },
+      },
+    });
+
+    expect(candidates[0]?.name).toBe('CI triage-and-fix loop');
+    expect(candidates[0]?.score).toBeGreaterThan(
+      candidates[candidates.length - 1]?.score ?? 0,
+    );
+  });
+
+  it('still supports the previous flat analysis JSON shape', () => {
+    const candidates = scoreCandidates({
+      categoryCounts: {
+        agent_skilling: 8,
+        debugging_testing: 1,
+      },
+      toolCounts: {
+        Bash: 20,
+      },
+    });
+
+    expect(candidates[0]?.name).toBe('Plan-to-execution runbook');
+  });
+
+  it('renders a report with ranked candidates and weekly promotion queue', () => {
+    const report = buildPatternReport(
+      {
+        counts: {
+          categories: {
+            agent_skilling: 5,
+            debugging_testing: 7,
+          },
+          projects: {
+            genfeed: 3,
+          },
+          tools: {
+            Bash: 200,
+            Task: 4,
+          },
+        },
+        events: {
+          userMessages: 20,
+        },
+        generatedAt: '2026-06-01T00:00:00.000Z',
+        options: {
+          since: '2026-05-31T00:00:00.000Z',
+          until: '2026-06-01T00:00:00.000Z',
+        },
+        scope: {
+          uniqueSessions: 4,
+        },
+      },
+      { now: new Date('2026-06-01T09:00:00.000Z') },
+    );
+
+    expect(report).toContain('# Claude Pattern Miner Report');
+    expect(report).toContain(
+      'Window: 2026-05-31T00:00:00.000Z -> 2026-06-01T00:00:00.000Z',
+    );
+    expect(report).toContain('## Ranked Candidates');
+    expect(report).toContain('## Weekly Promotion Queue');
+    expect(report).toContain('CI triage-and-fix loop');
+  });
+});

--- a/scripts/daily-pattern-miner.ts
+++ b/scripts/daily-pattern-miner.ts
@@ -3,76 +3,308 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+type CandidateType = 'agent' | 'plugin' | 'skill';
+
+type CounterRecord = Record<string, number>;
+
 type AnalysisJson = {
-  categoryCounts?: Record<string, number>;
-  cwdCounts?: Record<string, number>;
-  projectCounts?: Record<string, number>;
-  toolCounts?: Record<string, number>;
+  categoryCounts?: CounterRecord;
+  cwdCounts?: CounterRecord;
+  projectCounts?: CounterRecord;
+  toolCounts?: CounterRecord;
+  counts?: {
+    categories?: CounterRecord;
+    cwds?: CounterRecord;
+    projects?: CounterRecord;
+    tools?: CounterRecord;
+  };
+  events?: {
+    userMessages?: number;
+  };
+  generatedAt?: string;
+  options?: {
+    since?: string | null;
+    until?: string | null;
+  };
+  scope?: {
+    firstTimestamp?: string | null;
+    lastTimestamp?: string | null;
+    uniqueSessions?: number;
+  };
 };
 
-function scoreCandidates(analysis: AnalysisJson): Array<{
+type CliOptions = {
+  inputPath: string;
+  minScore: number;
+  outputPath: string;
+  top: number;
+};
+
+export type PatternCandidate = {
+  evidence: string[];
   name: string;
   score: number;
-  type: 'skill' | 'plugin' | 'agent';
+  type: CandidateType;
   rationale: string;
-}> {
-  const toolCounts = analysis.toolCounts ?? {};
-  const categories = analysis.categoryCounts ?? {};
+};
+
+const DEFAULT_INPUT = path.join(
+  process.cwd(),
+  'docs',
+  'claude-session-analysis.json',
+);
+const DEFAULT_OUTPUT = path.join(
+  process.cwd(),
+  'docs',
+  'claude-pattern-miner-report.md',
+);
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    inputPath: DEFAULT_INPUT,
+    minScore: 1,
+    outputPath: DEFAULT_OUTPUT,
+    top: 8,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if ((arg === '--input' || arg === '--json') && argv[i + 1]) {
+      options.inputPath = path.resolve(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if ((arg === '--out' || arg === '--output') && argv[i + 1]) {
+      options.outputPath = path.resolve(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--top' && argv[i + 1]) {
+      options.top = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--min-score' && argv[i + 1]) {
+      options.minScore = Number(argv[i + 1]);
+      i += 1;
+    }
+  }
+
+  if (!Number.isFinite(options.top) || options.top <= 0) {
+    throw new Error('--top must be a positive number');
+  }
+
+  if (!Number.isFinite(options.minScore) || options.minScore < 0) {
+    throw new Error('--min-score must be zero or greater');
+  }
+
+  return options;
+}
+
+function counters(analysis: AnalysisJson): {
+  categories: CounterRecord;
+  cwds: CounterRecord;
+  projects: CounterRecord;
+  tools: CounterRecord;
+} {
+  return {
+    categories: analysis.counts?.categories ?? analysis.categoryCounts ?? {},
+    cwds: analysis.counts?.cwds ?? analysis.cwdCounts ?? {},
+    projects: analysis.counts?.projects ?? analysis.projectCounts ?? {},
+    tools: analysis.counts?.tools ?? analysis.toolCounts ?? {},
+  };
+}
+
+function count(record: CounterRecord, key: string): number {
+  return Number(record[key] ?? 0);
+}
+
+function topCounterRows(record: CounterRecord, limit: number): string[] {
+  return Object.entries(record)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(
+      ([key, value]) => `| ${escapePipe(key)} | ${value.toLocaleString()} |`,
+    );
+}
+
+function escapePipe(value: string): string {
+  return value.replaceAll('|', '\\|');
+}
+
+export function scoreCandidates(analysis: AnalysisJson): PatternCandidate[] {
+  const { categories, projects, tools } = counters(analysis);
+  const bash = count(tools, 'Bash');
+  const task = count(tools, 'Task');
+  const taskUpdate = count(tools, 'TaskUpdate');
+  const debugging = count(categories, 'debugging_testing');
+  const agentSkilling = count(categories, 'agent_skilling');
+  const docs = count(categories, 'docs_content');
+  const security = count(categories, 'security');
+  const content =
+    count(categories, 'marketing_growth') +
+    count(categories, 'presentation_media');
+  const frontend = count(categories, 'coding_frontend');
+  const backend = count(categories, 'coding_backend');
+  const projectBreadth = Object.keys(projects).length;
 
   return [
     {
+      evidence: [
+        `${debugging.toLocaleString()} debugging/testing prompts`,
+        `${bash.toLocaleString()} shell tool calls`,
+      ],
       name: 'Monorepo test-fix loop',
       rationale:
-        'High debugging/testing volume and heavy shell/tool use indicate a repeated deterministic human-in-the-loop workflow.',
-      score:
-        Number(categories.debugging_testing ?? 0) +
-        Number(toolCounts.Bash ?? 0) / 100,
+        'Repeated debugging plus heavy shell usage indicates a deterministic loop worth capturing as a reusable skill.',
+      score: debugging + bash / 100,
       type: 'skill',
     },
     {
+      evidence: [`${agentSkilling.toLocaleString()} agent/skill prompts`],
       name: 'Plan-to-execution runbook',
       rationale:
-        'High agent skilling volume suggests repeated sessions starting from prewritten plans and requiring execution discipline.',
-      score: Number(categories.agent_skilling ?? 0),
+        'Frequent agent and workflow prompts point to recurring plan handoffs that should become a stricter execution checklist.',
+      score: agentSkilling,
       type: 'skill',
     },
     {
+      evidence: [
+        `${debugging.toLocaleString()} debugging/testing prompts`,
+        `${task.toLocaleString()} task dispatches`,
+        `${taskUpdate.toLocaleString()} task updates`,
+      ],
       name: 'CI triage-and-fix loop',
       rationale:
-        'Debugging/testing combined with task orchestration points to repeated CI diagnosis and structured remediation work.',
-      score:
-        Number(categories.debugging_testing ?? 0) +
-        Number(toolCounts.Task ?? 0) / 10 +
-        Number(toolCounts.TaskUpdate ?? 0) / 10,
+        'Debugging/testing combined with task orchestration points to repeated CI diagnosis and remediation.',
+      score: debugging + task / 10 + taskUpdate / 10,
+      type: 'agent',
+    },
+    {
+      evidence: [
+        `${docs.toLocaleString()} docs/handoff prompts`,
+        `${projectBreadth.toLocaleString()} projects touched`,
+      ],
+      name: 'Session handoff summarizer',
+      rationale:
+        'Repeated documentation and cross-project context imply value in a standard daily handoff artifact.',
+      score: docs + projectBreadth / 2,
+      type: 'skill',
+    },
+    {
+      evidence: [`${security.toLocaleString()} security prompts`],
+      name: 'API security preflight',
+      rationale:
+        'Security/auth prompts should become a reusable pre-merge gate for tenancy, serializers, and secret handling.',
+      score: security + backend / 5,
+      type: 'skill',
+    },
+    {
+      evidence: [`${content.toLocaleString()} content/media prompts`],
+      name: 'Content ops workflow',
+      rationale:
+        'Content and media work is repeatable enough to standardize as a brief-to-output workflow.',
+      score: content,
+      type: 'skill',
+    },
+    {
+      evidence: [
+        `${frontend.toLocaleString()} frontend prompts`,
+        `${backend.toLocaleString()} backend prompts`,
+      ],
+      name: 'Full-stack feature QA agent',
+      rationale:
+        'Mixed frontend/backend feature work benefits from a reviewer that checks implementation coverage against acceptance criteria.',
+      score: (frontend + backend) / 2 + debugging / 5,
       type: 'agent',
     },
   ].sort((a, b) => b.score - a.score);
 }
 
-async function main(): Promise<void> {
-  const root = process.cwd();
-  const docsDir = path.join(root, 'docs');
-  const inputPath = path.join(docsDir, 'claude-session-analysis.json');
-  const outputPath = path.join(docsDir, 'claude-pattern-miner-report.md');
+export function buildPatternReport(
+  analysis: AnalysisJson,
+  options: { minScore?: number; now?: Date; top?: number } = {},
+): string {
+  const minScore = options.minScore ?? 1;
+  const top = options.top ?? 8;
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const ranked = scoreCandidates(analysis)
+    .filter((item) => item.score >= minScore)
+    .slice(0, top);
+  const { categories, projects, tools } = counters(analysis);
+  const scope = analysis.scope;
+  const windowLabel = `${analysis.options?.since ?? scope?.firstTimestamp ?? 'beginning'} -> ${
+    analysis.options?.until ?? scope?.lastTimestamp ?? 'now'
+  }`;
+  const categoryRows = topCounterRows(categories, 8);
+  const toolRows = topCounterRows(tools, 8);
+  const projectRows = topCounterRows(projects, 8);
 
-  const analysis = (await Bun.file(inputPath).json()) as AnalysisJson;
-  const ranked = scoreCandidates(analysis);
-
-  const lines = [
+  return [
     '# Claude Pattern Miner Report',
     '',
-    `Generated: ${new Date().toISOString()}`,
+    `Generated: ${generatedAt}`,
+    `Source analysis: ${analysis.generatedAt ?? 'unknown'}`,
+    `Window: ${windowLabel}`,
+    `Unique sessions: ${(scope?.uniqueSessions ?? 0).toLocaleString()}`,
+    `User messages: ${(analysis.events?.userMessages ?? 0).toLocaleString()}`,
     '',
     '## Ranked Candidates',
-    ...ranked.map(
-      (item, index) =>
-        `${index + 1}. **${item.name}** (${item.type}, score ${item.score.toFixed(1)}) — ${item.rationale}`,
-    ),
-  ];
-
-  await mkdir(docsDir, { recursive: true });
-  await writeFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
-  console.log(outputPath);
+    ranked.length === 0
+      ? '- No candidates met the score threshold for this window.'
+      : ranked
+          .map(
+            (item, index) =>
+              `${index + 1}. **${item.name}** (${item.type}, score ${item.score.toFixed(1)}) - ${item.rationale}\n   Evidence: ${item.evidence.join('; ')}`,
+          )
+          .join('\n'),
+    '',
+    '## Weekly Promotion Queue',
+    ranked.length === 0
+      ? '- No weekly backlog promotion recommended yet.'
+      : ranked
+          .slice(0, 3)
+          .map(
+            (item) =>
+              `- [ ] Promote **${item.name}** to a GitHub issue if the pattern repeats in three or more daily reports this week.`,
+          )
+          .join('\n'),
+    '',
+    '## Evidence Summary',
+    '### Categories',
+    '| Category | Count |',
+    '|---|---:|',
+    categoryRows.length > 0 ? categoryRows.join('\n') : '| (none) | 0 |',
+    '',
+    '### Tools',
+    '| Tool | Count |',
+    '|---|---:|',
+    toolRows.length > 0 ? toolRows.join('\n') : '| (none) | 0 |',
+    '',
+    '### Projects',
+    '| Project | File Count |',
+    '|---|---:|',
+    projectRows.length > 0 ? projectRows.join('\n') : '| (none) | 0 |',
+    '',
+  ].join('\n');
 }
 
-await main();
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const analysis = (await Bun.file(options.inputPath).json()) as AnalysisJson;
+  const report = buildPatternReport(analysis, {
+    minScore: options.minScore,
+    top: options.top,
+  });
+
+  await mkdir(path.dirname(options.outputPath), { recursive: true });
+  await writeFile(options.outputPath, `${report}\n`, 'utf8');
+  console.log(options.outputPath);
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- wires the Claude session analyzer into package scripts with recent-window/root filtering for daily runs
- replaces the pattern miner with a report generator that scores skills/plugins/agents from current and legacy analysis JSON shapes
- adds a scheduled/manual GitHub workflow that generates daily analysis and pattern reports as artifacts
- documents the local and workflow paths for the daily miner

Closes #10

## Verification
- `bun test scripts/daily-pattern-miner.test.ts`
- `bun run scripts/analyze-claude-sessions.ts -- --days 1 --out artifacts/verification/issue-10/claude-session-analysis-daily.md --json-out artifacts/verification/issue-10/claude-session-analysis-daily.json`
- `bun run scripts/daily-pattern-miner.ts -- --input artifacts/verification/issue-10/claude-session-analysis-daily.json --out artifacts/verification/issue-10/claude-pattern-miner-report.md`
- `bun run analyze:claude-sessions -- --days 1 --out artifacts/verification/issue-10/package-script-analysis.md --json-out artifacts/verification/issue-10/package-script-analysis.json`
- `bun run analyze:claude-patterns -- --input artifacts/verification/issue-10/claude-session-analysis-daily.json --out artifacts/verification/issue-10/package-script-report.md`
- `bunx biome check --write .github/workflows/claude-pattern-miner.yml docs/claude-daily-pattern-miner.md package.json scripts/analyze-claude-sessions.ts scripts/daily-pattern-miner.ts scripts/daily-pattern-miner.test.ts`
- `actionlint .github/workflows/claude-pattern-miner.yml`

## Visual verification
Skipped: this is backend/automation CLI + GitHub Actions workflow work with no browser-facing UI.

Local verification artifacts are intentionally uncommitted:
- `/Users/decod3rs/.codex/automations/feature-implementation-genfeed/worktrees/codex-feature-20260601-112918-issue-10-daily-claude-session-pattern-miner/artifacts/verification/issue-10/claude-session-analysis-daily.md`
- `/Users/decod3rs/.codex/automations/feature-implementation-genfeed/worktrees/codex-feature-20260601-112918-issue-10-daily-claude-session-pattern-miner/artifacts/verification/issue-10/claude-session-analysis-daily.json`
- `/Users/decod3rs/.codex/automations/feature-implementation-genfeed/worktrees/codex-feature-20260601-112918-issue-10-daily-claude-session-pattern-miner/artifacts/verification/issue-10/claude-pattern-miner-report.md`
