### PR TITLE
refactor: share editor time formatting

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorPropertiesPanel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorPropertiesPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
 import { Slider } from '@ui/primitives/slider';
 import { useCallback } from 'react';
+import { formatPreciseFrameTime } from './editor-time-format.util';
 
 interface EditorPropertiesPanelProps {
   tracks: IEditorTrack[];
@@ -13,14 +14,6 @@ interface EditorPropertiesPanelProps {
   selectedTrackId: string | null;
   selectedClipId: string | null;
   onTrackUpdate: (trackId: string, updates: Partial<IEditorTrack>) => void;
-}
-
-function formatFramesAsTime(frames: number, fps: number): string {
-  const totalSeconds = frames / fps;
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = Math.floor(totalSeconds % 60);
-  const ms = Math.round((totalSeconds % 1) * 1000);
-  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${ms.toString().padStart(3, '0')}`;
 }
 
 function EditorPropertiesPanel({
@@ -130,7 +123,7 @@ function EditorPropertiesPanel({
               Start
             </span>
             <div className="text-sm font-mono bg-background border border-white/[0.08] rounded px-2 py-1">
-              {formatFramesAsTime(selectedClip.startFrame, fps)}
+              {formatPreciseFrameTime(selectedClip.startFrame, fps)}
             </div>
           </div>
           <div>
@@ -138,7 +131,7 @@ function EditorPropertiesPanel({
               Duration
             </span>
             <div className="text-sm font-mono bg-background border border-white/[0.08] rounded px-2 py-1">
-              {formatFramesAsTime(selectedClip.durationFrames, fps)}
+              {formatPreciseFrameTime(selectedClip.durationFrames, fps)}
             </div>
           </div>
         </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorTimeline.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorTimeline.tsx
@@ -5,14 +5,7 @@ import type { IEditorClip, IEditorTrack } from '@genfeedai/interfaces';
 import type { EditorTimelineProps } from '@props/studio/editor-timeline.props';
 import { Button } from '@ui/primitives/button';
 import { useCallback, useRef, useState } from 'react';
-
-function formatTime(frames: number, fps: number): string {
-  const totalSeconds = frames / fps;
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = Math.floor(totalSeconds % 60);
-  const frameNum = Math.floor(frames % fps);
-  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}:${frameNum.toString().padStart(2, '0')}`;
-}
+import { formatTimelineFrameTime } from './editor-time-format.util';
 
 function TimeRuler({
   totalFrames,
@@ -33,7 +26,7 @@ function TimeRuler({
   for (let frame = 0; frame <= totalFrames; frame += interval) {
     markers.push({
       frame,
-      label: formatTime(frame, fps),
+      label: formatTimelineFrameTime(frame, fps),
       major: frame % (secondFrames * 5) === 0,
     });
   }
@@ -369,7 +362,7 @@ function EditorTimeline({
       <div className="flex sticky top-0 z-20 bg-background">
         <div className="w-48 shrink-0 border-r border-b border-white/[0.08] bg-card px-3 py-1">
           <span className="text-xs text-muted-foreground">
-            {formatTime(currentFrame, fps)}
+            {formatTimelineFrameTime(currentFrame, fps)}
           </span>
         </div>
         <Button

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorToolbar.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorToolbar.tsx
@@ -20,6 +20,7 @@ import {
   StepForward,
 } from 'lucide-react';
 import { HiOutlineFilm, HiOutlineMusicalNote } from 'react-icons/hi2';
+import { formatPlaybackFrameTime } from './editor-time-format.util';
 
 export interface EditorToolbarProps {
   projectName: string;
@@ -43,14 +44,6 @@ export interface EditorToolbarProps {
   onSave: () => void;
   onRender: () => void;
   onBack: () => void;
-}
-
-function formatTime(frames: number, fps: number): string {
-  const totalSeconds = frames / fps;
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = Math.floor(totalSeconds % 60);
-  const centiseconds = Math.floor((totalSeconds % 1) * 100);
-  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${centiseconds.toString().padStart(2, '0')}`;
 }
 
 const FORMAT_OPTIONS = [
@@ -175,7 +168,8 @@ function EditorToolbar({
 
         {/* Time display */}
         <div className="ml-4 font-mono text-sm text-muted-foreground">
-          {formatTime(currentFrame, fps)} / {formatTime(totalFrames, fps)}
+          {formatPlaybackFrameTime(currentFrame, fps)} /{' '}
+          {formatPlaybackFrameTime(totalFrames, fps)}
         </div>
       </div>
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-time-format.util.test.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-time-format.util.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPlaybackFrameTime,
+  formatPreciseFrameTime,
+  formatTimelineFrameTime,
+} from './editor-time-format.util';
+
+describe('editor time formatting', () => {
+  it('formats timeline ruler time with frame precision', () => {
+    expect(formatTimelineFrameTime(0, 30)).toBe('00:00:00');
+    expect(formatTimelineFrameTime(45, 30)).toBe('00:01:15');
+    expect(formatTimelineFrameTime(1834, 30)).toBe('01:01:04');
+  });
+
+  it('formats playback time with centisecond precision', () => {
+    expect(formatPlaybackFrameTime(0, 30)).toBe('00:00.00');
+    expect(formatPlaybackFrameTime(45, 30)).toBe('00:01.50');
+    expect(formatPlaybackFrameTime(1834, 30)).toBe('01:01.13');
+  });
+
+  it('formats clip property time with millisecond precision', () => {
+    expect(formatPreciseFrameTime(0, 30)).toBe('00:00.000');
+    expect(formatPreciseFrameTime(45, 30)).toBe('00:01.500');
+    expect(formatPreciseFrameTime(1834, 30)).toBe('01:01.133');
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-time-format.util.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-time-format.util.ts
@@ -1,0 +1,34 @@
+function getFrameTimeParts(frames: number, fps: number) {
+  const totalSeconds = frames / fps;
+
+  return {
+    minutes: Math.floor(totalSeconds / 60),
+    seconds: Math.floor(totalSeconds % 60),
+    totalSeconds,
+  };
+}
+
+function padTimePart(value: number, length: number): string {
+  return value.toString().padStart(length, '0');
+}
+
+export function formatTimelineFrameTime(frames: number, fps: number): string {
+  const { minutes, seconds } = getFrameTimeParts(frames, fps);
+  const frameNum = Math.floor(frames % fps);
+
+  return `${padTimePart(minutes, 2)}:${padTimePart(seconds, 2)}:${padTimePart(frameNum, 2)}`;
+}
+
+export function formatPlaybackFrameTime(frames: number, fps: number): string {
+  const { minutes, seconds, totalSeconds } = getFrameTimeParts(frames, fps);
+  const centiseconds = Math.floor((totalSeconds % 1) * 100);
+
+  return `${padTimePart(minutes, 2)}:${padTimePart(seconds, 2)}.${padTimePart(centiseconds, 2)}`;
+}
+
+export function formatPreciseFrameTime(frames: number, fps: number): string {
+  const { minutes, seconds, totalSeconds } = getFrameTimeParts(frames, fps);
+  const ms = Math.round((totalSeconds % 1) * 1000);
+
+  return `${padTimePart(minutes, 2)}:${padTimePart(seconds, 2)}.${padTimePart(ms, 3)}`;
+}


### PR DESCRIPTION
## Summary
- Extract shared editor frame/time formatting helpers for timeline, toolbar playback, and clip properties
- Preserve each existing display precision while removing duplicated frame-to-time math
- Add focused formatter coverage

## Verification
- npx biome check --write apps/app/app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/editor-time-format.util.ts apps/app/app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/editor-time-format.util.test.ts apps/app/app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/EditorTimeline.tsx apps/app/app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/EditorToolbar.tsx apps/app/app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/EditorPropertiesPanel.tsx
- bun vitest run --config ./vitest.config.mts app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/editor-time-format.util.test.ts app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/EditorTimeline.test.tsx app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/EditorToolbar.test.tsx app/\(protected\)/\[orgSlug\]/\[brandSlug\]/editor/\[id\]/EditorPropertiesPanel.test.tsx
- bunx turbo run type-check --filter=@genfeedai/app