### PR TITLE
refactor: reuse shared cn helper

### DIFF
--- a/apps/app/src/lib/utils.ts
+++ b/apps/app/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from '@genfeedai/helpers';

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -4,6 +4,7 @@ export * from './brand-completeness.helper';
 export * from './business/pricing/pricing.helper';
 export * from './business/tier-models/tier-models.helper';
 export * from './deserializer.helper';
+export * from './formatting/cn/cn.util';
 export * from './generation-controls.helper';
 export * from './generation-eta.helper';
 export * from './model-capability.helper';


### PR DESCRIPTION
## Summary\n- re-export the app cn helper from @genfeedai/helpers\n- expose the existing shared cn helper from the helpers barrel\n\n## Verification\n- bunx biome check apps/app/src/lib/utils.ts packages/helpers/src/index.ts\n- bunx turbo run type-check --filter=@genfeedai/app\n- git diff --check