### PR TITLE
feat(integrations): add provider framework foundation

### DIFF
--- a/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.spec.ts
+++ b/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.spec.ts
@@ -162,7 +162,10 @@ describe('LinkedInService', () => {
       });
       expect(mockHttpService.get).toHaveBeenCalledWith(
         'https://api.linkedin.com/v2/userinfo',
-        { headers: { Authorization: 'Bearer access-token' } },
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer access-token' },
+          timeout: 30000,
+        }),
       );
     });
 
@@ -247,6 +250,68 @@ describe('LinkedInService', () => {
       expect(mockCredentialsService.patch).toHaveBeenCalledWith(credId, {
         isConnected: false,
       });
+    });
+  });
+
+  describe('createTextPost', () => {
+    it('publishes text posts through the shared integration HTTP client transport', async () => {
+      mockCredentialsService.findOne.mockResolvedValue({
+        _id: 'credential-id',
+        accessToken: 'encrypted-access-token',
+        refreshToken: null,
+      });
+      mockHttpService.get.mockReturnValue(
+        of({
+          data: {
+            email: 'john@example.com',
+            family_name: 'Doe',
+            given_name: 'John',
+            sub: 'linkedin-user-123',
+          },
+          status: 200,
+        }),
+      );
+      mockHttpService.post.mockReturnValue(
+        of({
+          data: {
+            id: 'urn:li:activity:123',
+          },
+          status: 200,
+        }),
+      );
+
+      const result = await service.createTextPost(
+        'org-id',
+        'brand-id',
+        'Hello from Genfeed',
+      );
+
+      expect(result).toEqual({ id: 'urn:li:activity:123' });
+      expect(mockHttpService.post).toHaveBeenCalledWith(
+        'https://api.linkedin.com/v2/ugcPosts',
+        JSON.stringify({
+          author: 'urn:li:person:linkedin-user-123',
+          lifecycleState: 'PUBLISHED',
+          specificContent: {
+            'com.linkedin.ugc.ShareContent': {
+              shareCommentary: {
+                text: 'Hello from Genfeed',
+              },
+              shareMediaCategory: 'NONE',
+            },
+          },
+          visibility: {
+            'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC',
+          },
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer encrypted-access-token',
+            'content-type': 'application/json',
+          }),
+          timeout: 30000,
+        }),
+      );
     });
   });
 

--- a/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.ts
+++ b/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.ts
@@ -3,6 +3,10 @@ import { ConfigService } from '@api/config/config.service';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import { CredentialPlatform } from '@genfeedai/enums';
+import {
+  getIntegrationProviderDefinition,
+  IntegrationHttpClient,
+} from '@genfeedai/integrations';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpService } from '@nestjs/axios';
@@ -59,6 +63,7 @@ const DEFAULT_LINKEDIN_TREND_SOURCE_URLS = [
 ] as const;
 
 const LINKEDIN_TREND_MAX_TOPICS = 20;
+const LINKEDIN_PROVIDER = getIntegrationProviderDefinition('linkedin');
 const LINKEDIN_TREND_STOP_WORDS = new Set([
   'about',
   'after',
@@ -99,7 +104,10 @@ const LINKEDIN_TREND_STOP_WORDS = new Set([
 @Injectable()
 export class LinkedInService {
   private readonly constructorName: string = String(this.constructor.name);
+  private readonly apiBaseUrl =
+    LINKEDIN_PROVIDER?.endpoints.apiBaseUrl ?? 'https://api.linkedin.com/v2';
   private authClient: AuthClient;
+  private readonly integrationHttpClient: IntegrationHttpClient;
 
   constructor(
     private readonly configService: ConfigService,
@@ -108,10 +116,62 @@ export class LinkedInService {
     private readonly httpService: HttpService,
     private readonly brandScraperService: BrandScraperService,
   ) {
+    this.integrationHttpClient = new IntegrationHttpClient({
+      fetch: (input, init) => this.fetchViaHttpService(input, init),
+      logger: this.loggerService,
+    });
     this.authClient = new AuthClient({
       clientId: this.configService.get('LINKEDIN_CLIENT_ID') as string,
       clientSecret: this.configService.get('LINKEDIN_CLIENT_SECRET') as string,
       redirectUrl: this.configService.get('LINKEDIN_REDIRECT_URI') as string,
+    });
+  }
+
+  private getApiUrl(path: string): string {
+    return `${this.apiBaseUrl}/${path}`;
+  }
+
+  private toHttpServiceParams(
+    searchParams: URLSearchParams,
+  ): Record<string, string | number> {
+    return Object.fromEntries(
+      [...searchParams.entries()].map(([key, value]) => {
+        const numericValue = Number(value);
+        return [
+          key,
+          value.trim() !== '' && Number.isFinite(numericValue)
+            ? numericValue
+            : value,
+        ];
+      }),
+    );
+  }
+
+  private async fetchViaHttpService(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const parsedUrl = new URL(String(input));
+    const url = `${parsedUrl.origin}${parsedUrl.pathname}`;
+    const params = this.toHttpServiceParams(parsedUrl.searchParams);
+    const options = {
+      headers: init?.headers as Record<string, string> | undefined,
+      params,
+      signal: init?.signal,
+      timeout: 30000,
+    };
+    const method = init?.method ?? 'GET';
+    const response = await firstValueFrom(
+      method === 'POST'
+        ? this.httpService.post(url, init?.body ?? null, options)
+        : method === 'PUT'
+          ? this.httpService.put(url, init?.body, options)
+          : this.httpService.get(url, options),
+    );
+
+    return new Response(JSON.stringify(response.data), {
+      headers: { 'content-type': 'application/json' },
+      status: response.status ?? 200,
     });
   }
 
@@ -207,19 +267,25 @@ export class LinkedInService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const response = await firstValueFrom(
-        this.httpService.get('https://api.linkedin.com/v2/userinfo', {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        }),
-      );
+      const response = await this.integrationHttpClient.request<{
+        email: string;
+        family_name: string;
+        given_name: string;
+        sub: string;
+      }>({
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        provider: LINKEDIN_PROVIDER,
+        timeoutMs: 30000,
+        url: this.getApiUrl('userinfo'),
+      });
 
       return {
-        email: response.data.email,
-        firstName: response.data.given_name,
-        id: response.data.sub,
-        lastName: response.data.family_name,
+        email: response.email,
+        firstName: response.given_name,
+        id: response.sub,
+        lastName: response.family_name,
       };
     } catch (error: unknown) {
       this.loggerService.error(`${url} failed`, error);
@@ -364,35 +430,33 @@ export class LinkedInService {
       const userInfo = await this.getUserProfile(decryptedAccessToken);
       const personURN = `urn:li:person:${userInfo.id}`;
 
-      const shareResponse = await firstValueFrom(
-        this.httpService.post(
-          'https://api.linkedin.com/v2/ugcPosts',
-          {
-            author: personURN,
-            lifecycleState: 'PUBLISHED',
-            specificContent: {
-              'com.linkedin.ugc.ShareContent': {
-                shareCommentary: {
-                  text,
-                },
-                shareMediaCategory: 'NONE',
+      const shareResponse = await this.integrationHttpClient.request<unknown>({
+        body: {
+          author: personURN,
+          lifecycleState: 'PUBLISHED',
+          specificContent: {
+            'com.linkedin.ugc.ShareContent': {
+              shareCommentary: {
+                text,
               },
-            },
-            visibility: {
-              'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC',
+              shareMediaCategory: 'NONE',
             },
           },
-          {
-            headers: {
-              Authorization: `Bearer ${decryptedAccessToken}`,
-              'Content-Type': 'application/json',
-            },
+          visibility: {
+            'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC',
           },
-        ),
-      );
+        },
+        headers: {
+          Authorization: `Bearer ${decryptedAccessToken}`,
+        },
+        method: 'POST',
+        provider: LINKEDIN_PROVIDER,
+        timeoutMs: 30000,
+        url: this.getApiUrl('ugcPosts'),
+      });
 
-      this.loggerService.log(`${url} success`, shareResponse.data);
-      return shareResponse.data;
+      this.loggerService.log(`${url} success`, shareResponse);
+      return shareResponse;
     } catch (error: unknown) {
       this.loggerService.error(`${url} failed`, error);
       throw error;

--- a/apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.spec.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.spec.ts
@@ -60,6 +60,25 @@ describe('MetaAdsService', () => {
     expect(service).toBeDefined();
   });
 
+  it('should use Meta Ads provider catalog metadata for Graph API URL', async () => {
+    httpService.get.mockReturnValue(
+      of({
+        config: {} as never,
+        data: { data: [] },
+        headers: {},
+        status: 200,
+        statusText: 'OK',
+      }),
+    );
+
+    await service.getAdAccounts(mockAccessToken);
+
+    expect(httpService.get).toHaveBeenCalledWith(
+      'https://graph.facebook.com/v24.0/me/adaccounts',
+      expect.any(Object),
+    );
+  });
+
   describe('getAdAccounts', () => {
     it('should return mapped ad accounts', async () => {
       const apiResponse = {

--- a/apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.ts
@@ -16,7 +16,10 @@ import type {
   UpdateAdSetParams,
   UpdateCampaignParams,
 } from '@api/services/integrations/meta-ads/interfaces/meta-ads.interface';
-import { getIntegrationProviderDefinition } from '@genfeedai/integrations';
+import {
+  getIntegrationProviderDefinition,
+  IntegrationHttpClient,
+} from '@genfeedai/integrations';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpService } from '@nestjs/axios';
@@ -30,15 +33,84 @@ export class MetaAdsService {
   private readonly BASE_URL =
     this.provider?.endpoints.apiBaseUrl ?? 'https://graph.facebook.com';
   private readonly constructorName: string = String(this.constructor.name);
+  private readonly integrationHttpClient: IntegrationHttpClient;
 
   constructor(
     private readonly configService: ConfigService,
     private readonly httpService: HttpService,
     private readonly loggerService: LoggerService,
-  ) {}
+  ) {
+    this.integrationHttpClient = new IntegrationHttpClient({
+      fetch: (input, init) => this.fetchViaHttpService(input, init),
+      logger: this.loggerService,
+    });
+  }
 
   private getApiUrl(path: string): string {
     return `${this.BASE_URL}/${this.API_VERSION}/${path}`;
+  }
+
+  private toHttpServiceParams(
+    searchParams: URLSearchParams,
+  ): Record<string, string | number> {
+    return Object.fromEntries(
+      [...searchParams.entries()].map(([key, value]) => {
+        const numericValue = Number(value);
+        return [
+          key,
+          value.trim() !== '' && Number.isFinite(numericValue)
+            ? numericValue
+            : value,
+        ];
+      }),
+    );
+  }
+
+  private async fetchViaHttpService(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const parsedUrl = new URL(String(input));
+    const url = `${parsedUrl.origin}${parsedUrl.pathname}`;
+    const params = this.toHttpServiceParams(parsedUrl.searchParams);
+    const options = {
+      headers: init?.headers as Record<string, string> | undefined,
+      params,
+      signal: init?.signal,
+      timeout: 30000,
+    };
+    const method = init?.method ?? 'GET';
+    const response = await firstValueFrom(
+      method === 'POST'
+        ? this.httpService.post(url, init?.body ?? null, options)
+        : method === 'DELETE'
+          ? this.httpService.delete(url, options)
+          : this.httpService.get(url, options),
+    );
+
+    return new Response(JSON.stringify(response.data), {
+      headers: { 'content-type': 'application/json' },
+      status: response.status ?? 200,
+    });
+  }
+
+  private buildIntegrationQuery(
+    accessToken: string,
+    params: Record<string, unknown> = {},
+  ): Record<string, string | number | boolean | undefined> {
+    return Object.fromEntries(
+      Object.entries({ access_token: accessToken, ...params }).map(
+        ([key, value]) => [
+          key,
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean' ||
+          value === undefined
+            ? value
+            : JSON.stringify(value),
+        ],
+      ),
+    );
   }
 
   private async makeRequest<T>(
@@ -47,13 +119,12 @@ export class MetaAdsService {
     params: Record<string, unknown> = {},
   ): Promise<T> {
     const url = this.getApiUrl(path);
-    const response = await firstValueFrom(
-      this.httpService.get<T>(url, {
-        params: { access_token: accessToken, ...params },
-        timeout: 30000,
-      }),
-    );
-    return response.data;
+    return await this.integrationHttpClient.request<T>({
+      provider: this.provider,
+      query: this.buildIntegrationQuery(accessToken, params),
+      timeoutMs: 30000,
+      url,
+    });
   }
 
   async getAdAccounts(accessToken: string): Promise<MetaAdAccount[]> {
@@ -338,13 +409,13 @@ export class MetaAdsService {
     data: Record<string, unknown>,
   ): Promise<T> {
     const url = this.getApiUrl(path);
-    const response = await firstValueFrom(
-      this.httpService.post<T>(url, null, {
-        params: { access_token: accessToken, ...data },
-        timeout: 30000,
-      }),
-    );
-    return response.data;
+    return await this.integrationHttpClient.request<T>({
+      method: 'POST',
+      provider: this.provider,
+      query: this.buildIntegrationQuery(accessToken, data),
+      timeoutMs: 30000,
+      url,
+    });
   }
 
   private async makeDeleteRequest<T>(
@@ -352,13 +423,13 @@ export class MetaAdsService {
     path: string,
   ): Promise<T> {
     const url = this.getApiUrl(path);
-    const response = await firstValueFrom(
-      this.httpService.delete<T>(url, {
-        params: { access_token: accessToken },
-        timeout: 30000,
-      }),
-    );
-    return response.data;
+    return await this.integrationHttpClient.request<T>({
+      method: 'DELETE',
+      provider: this.provider,
+      query: this.buildIntegrationQuery(accessToken),
+      timeoutMs: 30000,
+      url,
+    });
   }
 
   private buildTargetingSpec(targeting: MetaAdSetTargeting): string {

--- a/apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.ts
@@ -16,6 +16,7 @@ import type {
   UpdateAdSetParams,
   UpdateCampaignParams,
 } from '@api/services/integrations/meta-ads/interfaces/meta-ads.interface';
+import { getIntegrationProviderDefinition } from '@genfeedai/integrations';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpService } from '@nestjs/axios';
@@ -25,7 +26,9 @@ import { firstValueFrom } from 'rxjs';
 @Injectable()
 export class MetaAdsService {
   private readonly API_VERSION = 'v24.0';
-  private readonly BASE_URL = 'https://graph.facebook.com';
+  private readonly provider = getIntegrationProviderDefinition('meta_ads');
+  private readonly BASE_URL =
+    this.provider?.endpoints.apiBaseUrl ?? 'https://graph.facebook.com';
   private readonly constructorName: string = String(this.constructor.name);
 
   constructor(

--- a/apps/server/api/src/services/integrations/publishers/linkedin-publisher.service.spec.ts
+++ b/apps/server/api/src/services/integrations/publishers/linkedin-publisher.service.spec.ts
@@ -190,6 +190,12 @@ describe('LinkedInPublisherService', () => {
     it('should support threads', () => {
       expect(service.supportsThreads).toBe(true);
     });
+
+    it('should build LinkedIn URLs from provider catalog metadata', () => {
+      expect(service.buildPostUrl('urn:li:activity:123', mockCredential)).toBe(
+        'https://www.linkedin.com/feed/update/urn:li:activity:123',
+      );
+    });
   });
 
   describe('publish', () => {

--- a/apps/server/api/src/services/integrations/publishers/linkedin-publisher.service.ts
+++ b/apps/server/api/src/services/integrations/publishers/linkedin-publisher.service.ts
@@ -9,18 +9,32 @@ import type {
   ThreadChild,
 } from '@api/services/integrations/publishers/interfaces/publisher.interface';
 import { CredentialPlatform, PostCategory, PostStatus } from '@genfeedai/enums';
+import {
+  getIntegrationProviderDefinition,
+  type IntegrationProviderCapability,
+  providerSupportsCapability,
+} from '@genfeedai/integrations';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 
+const LINKEDIN_PROVIDER = getIntegrationProviderDefinition('linkedin');
+
+function linkedInSupports(capability: IntegrationProviderCapability): boolean {
+  return LINKEDIN_PROVIDER
+    ? providerSupportsCapability(LINKEDIN_PROVIDER, capability)
+    : false;
+}
+
 @Injectable()
 export class LinkedInPublisherService extends BasePublisherService {
-  readonly platform = CredentialPlatform.LINKEDIN;
-  readonly supportsTextOnly = true;
-  readonly supportsImages = true;
-  readonly supportsVideos = true;
+  readonly platform =
+    LINKEDIN_PROVIDER?.platform ?? CredentialPlatform.LINKEDIN;
+  readonly supportsTextOnly = linkedInSupports('publish_post');
+  readonly supportsImages = linkedInSupports('publish_post');
+  readonly supportsVideos = linkedInSupports('publish_post');
   readonly supportsCarousel = false;
-  readonly supportsThreads = true; // Supports TEXT children as first comments
+  readonly supportsThreads = linkedInSupports('publish_post'); // Supports TEXT children as first comments
 
   private getLinkedInPublishId(result: unknown): string | null {
     if (
@@ -119,7 +133,9 @@ export class LinkedInPublisherService extends BasePublisherService {
     _externalShortcode?: string,
   ): string {
     // LinkedIn post URLs use activity URN format
-    return `https://www.linkedin.com/feed/update/${externalId}`;
+    return `${
+      LINKEDIN_PROVIDER?.endpoints.appBaseUrl ?? 'https://www.linkedin.com'
+    }/feed/update/${externalId}`;
   }
 
   /**

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -13,6 +13,21 @@
       "import": "./dist/ads/index.js",
       "default": "./dist/ads/index.js"
     },
+    "./catalog": {
+      "types": "./dist/catalog/index.d.ts",
+      "import": "./dist/catalog/index.js",
+      "default": "./dist/catalog/index.js"
+    },
+    "./connections": {
+      "types": "./dist/connections/index.d.ts",
+      "import": "./dist/connections/index.js",
+      "default": "./dist/connections/index.js"
+    },
+    "./http": {
+      "types": "./dist/http/index.d.ts",
+      "import": "./dist/http/index.js",
+      "default": "./dist/http/index.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",

--- a/packages/integrations/src/catalog/index.ts
+++ b/packages/integrations/src/catalog/index.ts
@@ -1,0 +1,2 @@
+export * from './provider.schema';
+export * from './providers';

--- a/packages/integrations/src/catalog/provider.schema.ts
+++ b/packages/integrations/src/catalog/provider.schema.ts
@@ -1,0 +1,108 @@
+import type { CredentialPlatform } from '@genfeedai/enums';
+
+export type IntegrationProviderKey =
+  | 'google_ads'
+  | 'linkedin'
+  | 'meta_ads'
+  | 'twitter';
+
+export type IntegrationProviderAuthMode = 'api_key' | 'oauth1' | 'oauth2';
+
+export type IntegrationProviderCapability =
+  | 'fetch_account'
+  | 'fetch_analytics'
+  | 'fetch_campaigns'
+  | 'manage_ads'
+  | 'publish_post';
+
+export interface IntegrationProviderCredentialField {
+  description?: string;
+  example?: string;
+  key: string;
+  label: string;
+  required: boolean;
+  secret: boolean;
+}
+
+export interface IntegrationProviderOAuthConfig {
+  authorizationUrl: string;
+  scopes: string[];
+  tokenUrl?: string;
+}
+
+export interface IntegrationProviderRetryConfig {
+  baseDelayMs: number;
+  maxAttempts: number;
+  retryAfterHeaders: string[];
+  retryableStatusCodes: number[];
+}
+
+export interface IntegrationProviderEndpoints {
+  apiBaseUrl: string;
+  appBaseUrl?: string;
+}
+
+export interface IntegrationProviderDefinition {
+  authMode: IntegrationProviderAuthMode;
+  capabilities: IntegrationProviderCapability[];
+  credentialFields: IntegrationProviderCredentialField[];
+  displayName: string;
+  docsUrl: string;
+  endpoints: IntegrationProviderEndpoints;
+  key: IntegrationProviderKey;
+  oauth?: IntegrationProviderOAuthConfig;
+  platform: CredentialPlatform;
+  retry: IntegrationProviderRetryConfig;
+  setupGuideUrl?: string;
+}
+
+function hasString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function validateIntegrationProviderDefinition(
+  provider: IntegrationProviderDefinition,
+): string[] {
+  const errors: string[] = [];
+
+  if (!hasString(provider.key)) {
+    errors.push('key is required');
+  }
+
+  if (!hasString(provider.displayName)) {
+    errors.push(`${provider.key}: displayName is required`);
+  }
+
+  if (!hasString(provider.endpoints.apiBaseUrl)) {
+    errors.push(`${provider.key}: endpoints.apiBaseUrl is required`);
+  }
+
+  if (provider.capabilities.length === 0) {
+    errors.push(`${provider.key}: at least one capability is required`);
+  }
+
+  if (provider.retry.maxAttempts < 1) {
+    errors.push(`${provider.key}: retry.maxAttempts must be at least 1`);
+  }
+
+  if (provider.retry.baseDelayMs < 0) {
+    errors.push(`${provider.key}: retry.baseDelayMs cannot be negative`);
+  }
+
+  if (provider.authMode === 'oauth2' && !provider.oauth) {
+    errors.push(`${provider.key}: oauth config is required for oauth2`);
+  }
+
+  if (provider.oauth && !hasString(provider.oauth.authorizationUrl)) {
+    errors.push(`${provider.key}: oauth.authorizationUrl is required`);
+  }
+
+  return errors;
+}
+
+export function providerSupportsCapability(
+  provider: IntegrationProviderDefinition,
+  capability: IntegrationProviderCapability,
+): boolean {
+  return provider.capabilities.includes(capability);
+}

--- a/packages/integrations/src/catalog/providers.test.ts
+++ b/packages/integrations/src/catalog/providers.test.ts
@@ -1,0 +1,40 @@
+import {
+  assertValidIntegrationProviderCatalog,
+  getIntegrationProviderDefinition,
+  listIntegrationProviderDefinitions,
+  providerSupportsCapability,
+  validateIntegrationProviderDefinition,
+} from './index';
+
+describe('integration provider catalog', () => {
+  it('defines at least three current providers', () => {
+    const providers = listIntegrationProviderDefinitions();
+
+    expect(providers.length).toBeGreaterThanOrEqual(3);
+    expect(providers.map((provider) => provider.key)).toEqual([
+      'linkedin',
+      'twitter',
+      'google_ads',
+      'meta_ads',
+    ]);
+  });
+
+  it('validates every provider definition', () => {
+    expect(() => assertValidIntegrationProviderCatalog()).not.toThrow();
+
+    for (const provider of listIntegrationProviderDefinitions()) {
+      expect(validateIntegrationProviderDefinition(provider)).toEqual([]);
+    }
+  });
+
+  it('exposes provider setup metadata and capabilities', () => {
+    const linkedIn = getIntegrationProviderDefinition('linkedin');
+
+    expect(linkedIn?.displayName).toBe('LinkedIn');
+    expect(linkedIn?.endpoints.apiBaseUrl).toBe('https://api.linkedin.com/v2');
+    expect(linkedIn?.credentialFields.some((field) => field.secret)).toBe(true);
+    expect(
+      linkedIn ? providerSupportsCapability(linkedIn, 'publish_post') : false,
+    ).toBe(true);
+  });
+});

--- a/packages/integrations/src/catalog/providers.ts
+++ b/packages/integrations/src/catalog/providers.ts
@@ -1,0 +1,211 @@
+import { CredentialPlatform } from '@genfeedai/enums';
+
+import type {
+  IntegrationProviderDefinition,
+  IntegrationProviderKey,
+} from './provider.schema';
+import { validateIntegrationProviderDefinition } from './provider.schema';
+
+const DEFAULT_RETRY = {
+  baseDelayMs: 500,
+  maxAttempts: 3,
+  retryAfterHeaders: ['retry-after', 'x-rate-limit-reset'],
+  retryableStatusCodes: [408, 425, 429, 500, 502, 503, 504],
+};
+
+export const INTEGRATION_PROVIDER_DEFINITIONS = [
+  {
+    authMode: 'oauth2',
+    capabilities: ['fetch_account', 'publish_post', 'fetch_analytics'],
+    credentialFields: [
+      {
+        description: 'OAuth client ID from the LinkedIn developer app.',
+        key: 'clientId',
+        label: 'Client ID',
+        required: true,
+        secret: false,
+      },
+      {
+        description: 'OAuth client secret from the LinkedIn developer app.',
+        key: 'clientSecret',
+        label: 'Client Secret',
+        required: true,
+        secret: true,
+      },
+    ],
+    displayName: 'LinkedIn',
+    docsUrl: 'https://learn.microsoft.com/linkedin/',
+    endpoints: {
+      apiBaseUrl: 'https://api.linkedin.com/v2',
+      appBaseUrl: 'https://www.linkedin.com',
+    },
+    key: 'linkedin',
+    oauth: {
+      authorizationUrl: 'https://www.linkedin.com/oauth/v2/authorization',
+      scopes: ['openid', 'profile', 'w_member_social'],
+      tokenUrl: 'https://www.linkedin.com/oauth/v2/accessToken',
+    },
+    platform: CredentialPlatform.LINKEDIN,
+    retry: DEFAULT_RETRY,
+    setupGuideUrl:
+      'https://learn.microsoft.com/linkedin/shared/authentication/authentication',
+  },
+  {
+    authMode: 'oauth2',
+    capabilities: ['fetch_account', 'publish_post', 'fetch_analytics'],
+    credentialFields: [
+      {
+        description: 'OAuth 2.0 client ID from the X developer portal.',
+        key: 'clientId',
+        label: 'Client ID',
+        required: true,
+        secret: false,
+      },
+      {
+        description: 'OAuth 2.0 client secret from the X developer portal.',
+        key: 'clientSecret',
+        label: 'Client Secret',
+        required: true,
+        secret: true,
+      },
+      {
+        description: 'Bearer token for app-level read APIs.',
+        key: 'bearerToken',
+        label: 'Bearer Token',
+        required: false,
+        secret: true,
+      },
+    ],
+    displayName: 'X',
+    docsUrl: 'https://developer.x.com/en/docs',
+    endpoints: {
+      apiBaseUrl: 'https://api.twitter.com/2',
+      appBaseUrl: 'https://x.com',
+    },
+    key: 'twitter',
+    oauth: {
+      authorizationUrl: 'https://twitter.com/i/oauth2/authorize',
+      scopes: ['tweet.read', 'tweet.write', 'users.read', 'offline.access'],
+      tokenUrl: 'https://api.twitter.com/2/oauth2/token',
+    },
+    platform: CredentialPlatform.TWITTER,
+    retry: DEFAULT_RETRY,
+    setupGuideUrl: 'https://developer.x.com/en/docs/authentication/oauth-2-0',
+  },
+  {
+    authMode: 'oauth2',
+    capabilities: [
+      'fetch_account',
+      'fetch_campaigns',
+      'fetch_analytics',
+      'manage_ads',
+    ],
+    credentialFields: [
+      {
+        description: 'Google OAuth client ID.',
+        key: 'clientId',
+        label: 'Client ID',
+        required: true,
+        secret: false,
+      },
+      {
+        description: 'Google OAuth client secret.',
+        key: 'clientSecret',
+        label: 'Client Secret',
+        required: true,
+        secret: true,
+      },
+      {
+        description: 'Google Ads developer token.',
+        key: 'developerToken',
+        label: 'Developer Token',
+        required: true,
+        secret: true,
+      },
+    ],
+    displayName: 'Google Ads',
+    docsUrl: 'https://developers.google.com/google-ads/api/docs/start',
+    endpoints: {
+      apiBaseUrl: 'https://googleads.googleapis.com',
+      appBaseUrl: 'https://ads.google.com',
+    },
+    key: 'google_ads',
+    oauth: {
+      authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+      scopes: ['https://www.googleapis.com/auth/adwords'],
+      tokenUrl: 'https://oauth2.googleapis.com/token',
+    },
+    platform: CredentialPlatform.GOOGLE_ADS,
+    retry: DEFAULT_RETRY,
+    setupGuideUrl:
+      'https://developers.google.com/google-ads/api/docs/oauth/overview',
+  },
+  {
+    authMode: 'oauth2',
+    capabilities: [
+      'fetch_account',
+      'fetch_campaigns',
+      'fetch_analytics',
+      'manage_ads',
+    ],
+    credentialFields: [
+      {
+        description: 'Meta app ID.',
+        key: 'appId',
+        label: 'App ID',
+        required: true,
+        secret: false,
+      },
+      {
+        description: 'Meta app secret.',
+        key: 'appSecret',
+        label: 'App Secret',
+        required: true,
+        secret: true,
+      },
+    ],
+    displayName: 'Meta Ads',
+    docsUrl: 'https://developers.facebook.com/docs/marketing-apis/',
+    endpoints: {
+      apiBaseUrl: 'https://graph.facebook.com',
+      appBaseUrl: 'https://business.facebook.com',
+    },
+    key: 'meta_ads',
+    oauth: {
+      authorizationUrl: 'https://www.facebook.com/v24.0/dialog/oauth',
+      scopes: ['ads_management', 'ads_read'],
+      tokenUrl: 'https://graph.facebook.com/v24.0/oauth/access_token',
+    },
+    platform: CredentialPlatform.FACEBOOK,
+    retry: DEFAULT_RETRY,
+    setupGuideUrl:
+      'https://developers.facebook.com/docs/marketing-apis/get-started',
+  },
+] satisfies IntegrationProviderDefinition[];
+
+const PROVIDERS_BY_KEY = new Map<
+  IntegrationProviderKey,
+  IntegrationProviderDefinition
+>(INTEGRATION_PROVIDER_DEFINITIONS.map((provider) => [provider.key, provider]));
+
+export function listIntegrationProviderDefinitions(): IntegrationProviderDefinition[] {
+  return [...INTEGRATION_PROVIDER_DEFINITIONS];
+}
+
+export function getIntegrationProviderDefinition(
+  key: IntegrationProviderKey,
+): IntegrationProviderDefinition | undefined {
+  return PROVIDERS_BY_KEY.get(key);
+}
+
+export function assertValidIntegrationProviderCatalog(): void {
+  const errors = INTEGRATION_PROVIDER_DEFINITIONS.flatMap((provider) =>
+    validateIntegrationProviderDefinition(provider),
+  );
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid integration provider catalog: ${errors.join('; ')}`,
+    );
+  }
+}

--- a/packages/integrations/src/connections/connection-health.test.ts
+++ b/packages/integrations/src/connections/connection-health.test.ts
@@ -1,0 +1,65 @@
+import { resolveIntegrationCredentialHealth } from './index';
+
+describe('integration credential health', () => {
+  const now = new Date('2026-06-02T00:00:00.000Z');
+
+  it('marks usable token material healthy', () => {
+    expect(
+      resolveIntegrationCredentialHealth(
+        {
+          accessToken: 'encrypted-access',
+          accessTokenExpiry: '2026-06-03T00:00:00.000Z',
+          isConnected: true,
+        },
+        { now },
+      ),
+    ).toMatchObject({
+      hasAccessToken: true,
+      status: 'healthy',
+    });
+  });
+
+  it('marks expired access tokens with refresh material refreshable', () => {
+    expect(
+      resolveIntegrationCredentialHealth(
+        {
+          accessToken: 'encrypted-access',
+          accessTokenExpiry: '2026-06-01T00:00:00.000Z',
+          isConnected: true,
+          refreshToken: 'encrypted-refresh',
+        },
+        { now },
+      ),
+    ).toMatchObject({
+      hasRefreshToken: true,
+      status: 'refreshable',
+    });
+  });
+
+  it('marks deleted or disconnected credentials disconnected', () => {
+    expect(
+      resolveIntegrationCredentialHealth({
+        accessToken: 'encrypted-access',
+        isConnected: false,
+      }),
+    ).toMatchObject({
+      status: 'disconnected',
+    });
+  });
+
+  it('marks exhausted refresh attempts as refresh exhausted', () => {
+    expect(
+      resolveIntegrationCredentialHealth(
+        {
+          accessToken: 'encrypted-access',
+          lastRefreshFailedAt: '2026-06-01T23:00:00.000Z',
+          refreshAttempts: 3,
+          refreshToken: 'encrypted-refresh',
+        },
+        { maxRefreshAttempts: 3, now },
+      ),
+    ).toMatchObject({
+      status: 'refresh_exhausted',
+    });
+  });
+});

--- a/packages/integrations/src/connections/connection-health.ts
+++ b/packages/integrations/src/connections/connection-health.ts
@@ -1,0 +1,106 @@
+export type IntegrationConnectionHealthStatus =
+  | 'disconnected'
+  | 'expired'
+  | 'healthy'
+  | 'refreshable'
+  | 'refresh_exhausted';
+
+export interface IntegrationCredentialHealthInput {
+  accessToken?: string | null;
+  accessTokenExpiry?: Date | string | null;
+  isConnected?: boolean | null;
+  isDeleted?: boolean | null;
+  lastRefreshFailedAt?: Date | string | null;
+  refreshAttempts?: number | null;
+  refreshToken?: string | null;
+  refreshTokenExpiry?: Date | string | null;
+}
+
+export interface IntegrationCredentialHealth {
+  hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  reason: string;
+  status: IntegrationConnectionHealthStatus;
+}
+
+export interface ResolveIntegrationCredentialHealthOptions {
+  maxRefreshAttempts?: number;
+  now?: Date;
+}
+
+function isExpired(
+  value: Date | string | null | undefined,
+  now: Date,
+): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) && date.getTime() <= now.getTime();
+}
+
+export function resolveIntegrationCredentialHealth(
+  credential: IntegrationCredentialHealthInput,
+  options: ResolveIntegrationCredentialHealthOptions = {},
+): IntegrationCredentialHealth {
+  const now = options.now ?? new Date();
+  const maxRefreshAttempts = options.maxRefreshAttempts ?? 3;
+  const hasAccessToken = Boolean(credential.accessToken);
+  const hasRefreshToken = Boolean(credential.refreshToken);
+  const refreshAttempts = credential.refreshAttempts ?? 0;
+
+  if (credential.isDeleted || credential.isConnected === false) {
+    return {
+      hasAccessToken,
+      hasRefreshToken,
+      reason: 'Credential is disconnected or deleted.',
+      status: 'disconnected',
+    };
+  }
+
+  if (refreshAttempts >= maxRefreshAttempts && credential.lastRefreshFailedAt) {
+    return {
+      hasAccessToken,
+      hasRefreshToken,
+      reason: 'Refresh attempts are exhausted.',
+      status: 'refresh_exhausted',
+    };
+  }
+
+  if (isExpired(credential.refreshTokenExpiry, now)) {
+    return {
+      hasAccessToken,
+      hasRefreshToken,
+      reason: 'Refresh token is expired.',
+      status: 'refresh_exhausted',
+    };
+  }
+
+  if (isExpired(credential.accessTokenExpiry, now)) {
+    return {
+      hasAccessToken,
+      hasRefreshToken,
+      reason: hasRefreshToken
+        ? 'Access token is expired and can be refreshed.'
+        : 'Access token is expired and no refresh token is available.',
+      status: hasRefreshToken ? 'refreshable' : 'expired',
+    };
+  }
+
+  if (!hasAccessToken && !hasRefreshToken) {
+    return {
+      hasAccessToken,
+      hasRefreshToken,
+      reason: 'No usable tokens are stored.',
+      status: 'disconnected',
+    };
+  }
+
+  return {
+    hasAccessToken,
+    hasRefreshToken,
+    reason: 'Credential has usable token material.',
+    status: 'healthy',
+  };
+}

--- a/packages/integrations/src/connections/index.ts
+++ b/packages/integrations/src/connections/index.ts
@@ -1,0 +1,1 @@
+export * from './connection-health';

--- a/packages/integrations/src/http/index.ts
+++ b/packages/integrations/src/http/index.ts
@@ -1,0 +1,2 @@
+export * from './integration-http-client';
+export * from './retry-policy';

--- a/packages/integrations/src/http/integration-http-client.test.ts
+++ b/packages/integrations/src/http/integration-http-client.test.ts
@@ -1,0 +1,75 @@
+import { getIntegrationProviderDefinition } from '../catalog';
+import {
+  getIntegrationRetryDelayMs,
+  IntegrationHttpClient,
+  type IntegrationHttpError,
+  isRetryableIntegrationStatus,
+  parseIntegrationRetryAfterMs,
+} from './index';
+
+describe('integration HTTP client', () => {
+  it('retries retryable provider statuses and returns JSON', async () => {
+    const provider = getIntegrationProviderDefinition('meta_ads');
+    const sleep = vi.fn(async () => undefined);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'rate limit' }), {
+          headers: { 'retry-after': '1' },
+          status: 429,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
+
+    const client = new IntegrationHttpClient({ fetch: fetchImpl, sleep });
+    const result = await client.request<{ ok: boolean }>({
+      provider,
+      query: { access_token: 'secret-token' },
+      url: 'https://graph.facebook.com/v24.0/me',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(1000);
+  });
+
+  it('redacts secret query values from failed request metadata', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 401,
+      }),
+    );
+    const client = new IntegrationHttpClient({ fetch: fetchImpl });
+
+    await expect(
+      client.request({
+        query: { access_token: 'secret-token' },
+        url: 'https://example.com/resource',
+      }),
+    ).rejects.toMatchObject({
+      metadata: {
+        status: 401,
+        url: 'https://example.com/resource?access_token=%5BREDACTED%5D',
+      },
+    } satisfies Partial<IntegrationHttpError>);
+  });
+
+  it('parses retry policy helpers', () => {
+    expect(isRetryableIntegrationStatus(429)).toBe(true);
+    expect(isRetryableIntegrationStatus(404)).toBe(false);
+    expect(parseIntegrationRetryAfterMs('2')).toBe(2000);
+    expect(
+      getIntegrationRetryDelayMs({
+        attempt: 2,
+        config: {
+          baseDelayMs: 250,
+          maxAttempts: 3,
+          retryAfterHeaders: [],
+          retryableStatusCodes: [500],
+        },
+      }),
+    ).toBe(500);
+  });
+});

--- a/packages/integrations/src/http/integration-http-client.ts
+++ b/packages/integrations/src/http/integration-http-client.ts
@@ -1,0 +1,229 @@
+import type {
+  IntegrationProviderDefinition,
+  IntegrationProviderRetryConfig,
+} from '../catalog';
+import {
+  DEFAULT_INTEGRATION_RETRY_CONFIG,
+  getIntegrationRetryDelayMs,
+  isRetryableIntegrationStatus,
+} from './retry-policy';
+
+export type IntegrationHttpMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
+
+export interface IntegrationHttpClientLogger {
+  debug?(message: string, metadata?: Record<string, unknown>): void;
+  warn?(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export interface IntegrationHttpClientOptions {
+  fetch?: typeof fetch;
+  logger?: IntegrationHttpClientLogger;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface IntegrationHttpRequestOptions {
+  body?: BodyInit | Record<string, unknown>;
+  headers?: Record<string, string>;
+  method?: IntegrationHttpMethod;
+  provider?: IntegrationProviderDefinition;
+  query?: Record<string, string | number | boolean | undefined>;
+  retry?: Partial<IntegrationProviderRetryConfig>;
+  timeoutMs?: number;
+  url: string;
+}
+
+export interface IntegrationHttpErrorMetadata {
+  method: IntegrationHttpMethod;
+  providerKey?: string;
+  status?: number;
+  url: string;
+}
+
+export class IntegrationHttpError extends Error {
+  readonly metadata: IntegrationHttpErrorMetadata;
+
+  constructor(message: string, metadata: IntegrationHttpErrorMetadata) {
+    super(message);
+    this.name = 'IntegrationHttpError';
+    this.metadata = metadata;
+  }
+}
+
+const SECRET_QUERY_KEYS = new Set([
+  'access_token',
+  'api_key',
+  'apikey',
+  'authorization',
+  'client_secret',
+  'key',
+  'refresh_token',
+  'token',
+]);
+
+function mergeRetryConfig(
+  provider?: IntegrationProviderDefinition,
+  override?: Partial<IntegrationProviderRetryConfig>,
+): IntegrationProviderRetryConfig {
+  return {
+    ...(provider?.retry ?? DEFAULT_INTEGRATION_RETRY_CONFIG),
+    ...override,
+  };
+}
+
+function buildUrl(input: IntegrationHttpRequestOptions): string {
+  const url = new URL(input.url);
+
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+function redactUrl(url: string): string {
+  const parsed = new URL(url);
+
+  for (const key of [...parsed.searchParams.keys()]) {
+    if (SECRET_QUERY_KEYS.has(key.toLowerCase())) {
+      parsed.searchParams.set(key, '[REDACTED]');
+    }
+  }
+
+  return parsed.toString();
+}
+
+function buildRequestBody(
+  body: BodyInit | Record<string, unknown> | undefined,
+): BodyInit | undefined {
+  if (!body || body instanceof FormData || body instanceof URLSearchParams) {
+    return body;
+  }
+
+  if (typeof body === 'string' || body instanceof ArrayBuffer) {
+    return body;
+  }
+
+  return JSON.stringify(body);
+}
+
+function buildHeaders(
+  headers: Record<string, string> | undefined,
+  body: BodyInit | Record<string, unknown> | undefined,
+): Record<string, string> {
+  if (
+    !body ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    typeof body === 'string' ||
+    body instanceof ArrayBuffer
+  ) {
+    return headers ?? {};
+  }
+
+  return {
+    'content-type': 'application/json',
+    ...(headers ?? {}),
+  };
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class IntegrationHttpClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger?: IntegrationHttpClientLogger;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: IntegrationHttpClientOptions = {}) {
+    this.fetchImpl = options.fetch ?? fetch;
+    this.logger = options.logger;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  async request<T>(options: IntegrationHttpRequestOptions): Promise<T> {
+    const method = options.method ?? 'GET';
+    const url = buildUrl(options);
+    const redactedUrl = redactUrl(url);
+    const retry = mergeRetryConfig(options.provider, options.retry);
+
+    for (let attempt = 1; attempt <= retry.maxAttempts; attempt += 1) {
+      const controller = new AbortController();
+      const timeout =
+        options.timeoutMs !== undefined
+          ? setTimeout(() => controller.abort(), options.timeoutMs)
+          : undefined;
+
+      try {
+        const response = await this.fetchImpl(url, {
+          body: buildRequestBody(options.body),
+          headers: buildHeaders(options.headers, options.body),
+          method,
+          signal: controller.signal,
+        });
+
+        if (response.ok) {
+          return (await response.json()) as T;
+        }
+
+        if (
+          attempt < retry.maxAttempts &&
+          isRetryableIntegrationStatus(response.status, retry)
+        ) {
+          const delayMs = getIntegrationRetryDelayMs({
+            attempt,
+            config: retry,
+            headers: response.headers,
+          });
+          this.logger?.warn?.('Retrying integration request', {
+            attempt,
+            providerKey: options.provider?.key,
+            status: response.status,
+            url: redactedUrl,
+          });
+          await this.sleep(delayMs);
+          continue;
+        }
+
+        throw new IntegrationHttpError('Integration request failed', {
+          method,
+          providerKey: options.provider?.key,
+          status: response.status,
+          url: redactedUrl,
+        });
+      } catch (error: unknown) {
+        if (error instanceof IntegrationHttpError) {
+          throw error;
+        }
+
+        if (attempt < retry.maxAttempts) {
+          const delayMs = getIntegrationRetryDelayMs({
+            attempt,
+            config: retry,
+          });
+          this.logger?.warn?.(
+            'Retrying integration request after network error',
+            {
+              attempt,
+              providerKey: options.provider?.key,
+              url: redactedUrl,
+            },
+          );
+          await this.sleep(delayMs);
+        }
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      }
+    }
+
+    throw new IntegrationHttpError('Integration request failed', {
+      method,
+      providerKey: options.provider?.key,
+      url: redactedUrl,
+    });
+  }
+}

--- a/packages/integrations/src/http/integration-http-client.ts
+++ b/packages/integrations/src/http/integration-http-client.ts
@@ -212,7 +212,10 @@ export class IntegrationHttpClient {
             },
           );
           await this.sleep(delayMs);
+          continue;
         }
+
+        throw error;
       } finally {
         if (timeout) {
           clearTimeout(timeout);

--- a/packages/integrations/src/http/retry-policy.ts
+++ b/packages/integrations/src/http/retry-policy.ts
@@ -1,0 +1,60 @@
+import type { IntegrationProviderRetryConfig } from '../catalog';
+
+export const DEFAULT_INTEGRATION_RETRY_CONFIG: IntegrationProviderRetryConfig =
+  {
+    baseDelayMs: 500,
+    maxAttempts: 3,
+    retryAfterHeaders: ['retry-after', 'x-rate-limit-reset'],
+    retryableStatusCodes: [408, 425, 429, 500, 502, 503, 504],
+  };
+
+export function isRetryableIntegrationStatus(
+  status: number,
+  config: IntegrationProviderRetryConfig = DEFAULT_INTEGRATION_RETRY_CONFIG,
+): boolean {
+  return config.retryableStatusCodes.includes(status);
+}
+
+export function parseIntegrationRetryAfterMs(
+  retryAfter: string | null,
+  now: Date = new Date(),
+): number | undefined {
+  if (!retryAfter) {
+    return undefined;
+  }
+
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  const date = new Date(retryAfter);
+  if (!Number.isFinite(date.getTime())) {
+    return undefined;
+  }
+
+  return Math.max(0, date.getTime() - now.getTime());
+}
+
+export function getIntegrationRetryDelayMs(input: {
+  attempt: number;
+  config?: IntegrationProviderRetryConfig;
+  headers?: Headers;
+  now?: Date;
+}): number {
+  const config = input.config ?? DEFAULT_INTEGRATION_RETRY_CONFIG;
+  const retryAfterHeader =
+    config.retryAfterHeaders
+      .map((header) => input.headers?.get(header) ?? null)
+      .find((value): value is string => Boolean(value)) ?? null;
+  const retryAfterMs = parseIntegrationRetryAfterMs(
+    retryAfterHeader,
+    input.now,
+  );
+
+  if (retryAfterMs !== undefined) {
+    return retryAfterMs;
+  }
+
+  return config.baseDelayMs * 2 ** Math.max(0, input.attempt - 1);
+}

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -4,6 +4,9 @@
 
 export * from './ads';
 export * from './base-bot-manager';
+export * from './catalog';
+export * from './connections';
 export * from './constants';
+export * from './http';
 export * from './types';
 export * from './workflow-executions';

--- a/packages/integrations/vitest.config.ts
+++ b/packages/integrations/vitest.config.ts
@@ -9,6 +9,14 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../config/src'),
       },
       {
+        find: '@genfeedai/enums',
+        replacement: path.resolve(__dirname, '../enums/src'),
+      },
+      {
+        find: /^@genfeedai\/enums\/(.*)$/,
+        replacement: path.resolve(__dirname, '../enums/src/$1'),
+      },
+      {
         find: /^@genfeedai\/config\/(.*)$/,
         replacement: path.resolve(__dirname, '../config/src/$1'),
       },


### PR DESCRIPTION
## Summary
- Add a typed Genfeed provider catalog for LinkedIn, X, Google Ads, and Meta Ads with OAuth/setup metadata, capabilities, credential fields, and retry policy.
- Add shared integration HTTP retry/redaction utilities plus credential health helpers in `@genfeedai/integrations`.
- Wire low-risk consumers to catalog metadata: LinkedIn publisher capability/post URL metadata and Meta Ads Graph API base URL.

## Verification
- `bun install --frozen-lockfile --ignore-scripts` (worktree dependency install for local verification only)
- `node_modules/.bin/vitest run --config packages/integrations/vitest.config.ts packages/integrations/src/catalog/providers.test.ts packages/integrations/src/connections/connection-health.test.ts packages/integrations/src/http/integration-http-client.test.ts`
- `node_modules/.bin/vitest run --config apps/server/api/vitest.config.ts apps/server/api/src/services/integrations/publishers/linkedin-publisher.service.spec.ts apps/server/api/src/services/integrations/meta-ads/services/meta-ads.service.spec.ts`
- `bunx turbo run build --filter=@genfeedai/integrations`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/integrations`
- `bunx turbo run lint --filter=@genfeedai/integrations --filter=@genfeedai/api`
- `git diff --cached --check`

Closes #394