### PR TITLE
Refactor service operation wrappers

### DIFF
--- a/packages/hooks/utils/service-operation/service-operation.util.test.ts
+++ b/packages/hooks/utils/service-operation/service-operation.util.test.ts
@@ -157,6 +157,33 @@ describe('service-operation utilities', () => {
     expect(endUpdater({ isDeleting: true }).isDeleting).toBe(false);
   });
 
+  it('executeWithActionState resets the specified key after failure', async () => {
+    const operation = vi.fn().mockRejectedValue(new Error('boom'));
+    const setActionStates = vi.fn() as unknown as React.Dispatch<
+      React.SetStateAction<Record<string, boolean>>
+    >;
+
+    const result = await executeWithActionState({
+      errorMessage: 'Delete failed',
+      operation,
+      setActionStates,
+      stateKey: 'isDeleting',
+      successMessage: 'Deleted',
+      url: 'DELETE /items/1',
+    });
+
+    const startUpdater = setActionStates.mock.calls[0][0] as (
+      state: Record<string, boolean>,
+    ) => Record<string, boolean>;
+    const endUpdater = setActionStates.mock.calls[1][0] as (
+      state: Record<string, boolean>,
+    ) => Record<string, boolean>;
+
+    expect(result).toBeUndefined();
+    expect(startUpdater({ isDeleting: false }).isDeleting).toBe(true);
+    expect(endUpdater({ isDeleting: true }).isDeleting).toBe(false);
+  });
+
   it('executeSilentWithActionState toggles state without success notification', async () => {
     const operation = vi.fn().mockResolvedValue('ok');
     const setActionStates = vi.fn() as unknown as React.Dispatch<

--- a/packages/hooks/utils/service-operation/service-operation.util.ts
+++ b/packages/hooks/utils/service-operation/service-operation.util.ts
@@ -17,6 +17,91 @@ export interface ServiceOperationOptions<T> {
   rethrow?: boolean;
 }
 
+type ActionStateOptions<S extends Record<string, boolean>> = {
+  setActionStates: React.Dispatch<React.SetStateAction<S>>;
+  stateKey: keyof S;
+};
+
+type ServiceOperationLogLevel = 'debug' | 'info';
+
+type ServiceOperationRunnerOptions<T> = Omit<
+  ServiceOperationOptions<T>,
+  'successMessage'
+> & {
+  isSuccessNotificationEnabled?: boolean;
+  successLogLevel: ServiceOperationLogLevel;
+  successMessage?: string;
+};
+
+type ActionStateScopeOptions<T, S extends Record<string, boolean>> = {
+  actionState: ActionStateOptions<S>;
+  operation: () => Promise<T | undefined>;
+};
+
+function logServiceOperationSuccess(
+  url: string,
+  level: ServiceOperationLogLevel,
+) {
+  if (level === 'debug') {
+    logger.debug(`${url} success`);
+    return;
+  }
+
+  logger.info(`${url} success`);
+}
+
+async function runServiceOperation<T>({
+  url,
+  operation,
+  successMessage,
+  errorMessage,
+  onSuccess,
+  isSuccessNotificationEnabled = false,
+  successLogLevel,
+  rethrow = false,
+}: ServiceOperationRunnerOptions<T>): Promise<T | undefined> {
+  const notificationsService = NotificationsService.getInstance();
+
+  try {
+    const result = await operation();
+    logServiceOperationSuccess(url, successLogLevel);
+    if (isSuccessNotificationEnabled) {
+      notificationsService.success(successMessage ?? '');
+    }
+    onSuccess?.(result);
+    return result;
+  } catch (error) {
+    logger.error(`${url} failed`, error);
+    notificationsService.error(errorMessage);
+    if (rethrow) {
+      throw error;
+    }
+    return undefined;
+  }
+}
+
+function setActionState<S extends Record<string, boolean>>(
+  { setActionStates, stateKey }: ActionStateOptions<S>,
+  isActive: boolean,
+) {
+  setActionStates((prev) => ({ ...prev, [stateKey]: isActive }));
+}
+
+async function executeWithActionStateScope<
+  T,
+  S extends Record<string, boolean>,
+>({
+  actionState,
+  operation,
+}: ActionStateScopeOptions<T, S>): Promise<T | undefined> {
+  setActionState(actionState, true);
+  try {
+    return await operation();
+  } finally {
+    setActionState(actionState, false);
+  }
+}
+
 /**
  * Wrapper for service operations with consistent logging and notifications
  *
@@ -39,22 +124,16 @@ export async function withServiceOperation<T>({
   onSuccess,
   rethrow = false,
 }: ServiceOperationOptions<T>): Promise<T | undefined> {
-  const notificationsService = NotificationsService.getInstance();
-
-  try {
-    const result = await operation();
-    logger.info(`${url} success`);
-    notificationsService.success(successMessage);
-    onSuccess?.(result);
-    return result;
-  } catch (error) {
-    logger.error(`${url} failed`, error);
-    notificationsService.error(errorMessage);
-    if (rethrow) {
-      throw error;
-    }
-    return undefined;
-  }
+  return runServiceOperation({
+    errorMessage,
+    isSuccessNotificationEnabled: true,
+    onSuccess,
+    operation,
+    rethrow,
+    successLogLevel: 'info',
+    successMessage,
+    url,
+  });
 }
 
 /**
@@ -68,21 +147,14 @@ export async function withSilentOperation<T>({
   onSuccess,
   rethrow = false,
 }: Omit<ServiceOperationOptions<T>, 'successMessage'>): Promise<T | undefined> {
-  const notificationsService = NotificationsService.getInstance();
-
-  try {
-    const result = await operation();
-    logger.debug(`${url} success`);
-    onSuccess?.(result);
-    return result;
-  } catch (error) {
-    logger.error(`${url} failed`, error);
-    notificationsService.error(errorMessage);
-    if (rethrow) {
-      throw error;
-    }
-    return undefined;
-  }
+  return runServiceOperation({
+    errorMessage,
+    onSuccess,
+    operation,
+    rethrow,
+    successLogLevel: 'debug',
+    url,
+  });
 }
 
 /**
@@ -167,20 +239,21 @@ export async function executeWithActionState<
   setActionStates: React.Dispatch<React.SetStateAction<S>>;
   stateKey: keyof S;
 }): Promise<T | undefined> {
-  setActionStates((prev) => ({ ...prev, [stateKey]: true }));
-  try {
-    const result = await withServiceOperation({
-      errorMessage,
-      onSuccess,
-      operation,
-      rethrow,
-      successMessage,
-      url,
-    });
-    return result;
-  } finally {
-    setActionStates((prev) => ({ ...prev, [stateKey]: false }));
-  }
+  return executeWithActionStateScope({
+    actionState: {
+      setActionStates,
+      stateKey,
+    },
+    operation: () =>
+      withServiceOperation({
+        errorMessage,
+        onSuccess,
+        operation,
+        rethrow,
+        successMessage,
+        url,
+      }),
+  });
 }
 
 /**
@@ -202,17 +275,18 @@ export async function executeSilentWithActionState<
   setActionStates: React.Dispatch<React.SetStateAction<S>>;
   stateKey: keyof S;
 }): Promise<T | undefined> {
-  setActionStates((prev) => ({ ...prev, [stateKey]: true }));
-  try {
-    const result = await withSilentOperation({
-      errorMessage,
-      onSuccess,
-      operation,
-      rethrow,
-      url,
-    });
-    return result;
-  } finally {
-    setActionStates((prev) => ({ ...prev, [stateKey]: false }));
-  }
+  return executeWithActionStateScope({
+    actionState: {
+      setActionStates,
+      stateKey,
+    },
+    operation: () =>
+      withSilentOperation({
+        errorMessage,
+        onSuccess,
+        operation,
+        rethrow,
+        url,
+      }),
+  });
 }


### PR DESCRIPTION
## Summary\n- Share service operation success/error handling across normal and silent wrappers\n- Share action-state toggling for normal and silent action helpers\n- Add failure coverage to ensure action state resets after operation errors\n\n## Verification\n- bun run --cwd packages/hooks test utils/service-operation/service-operation.util.test.ts\n- bunx biome check packages/hooks/utils/service-operation/service-operation.util.ts packages/hooks/utils/service-operation/service-operation.util.test.ts\n- bunx jscpd --config .jscpd.json --reporters console packages/hooks/utils/service-operation/service-operation.util.ts\n- bunx tsc --noEmit -p packages/hooks/tsconfig.json