### PR TITLE
docs: define skills memory boundary

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -1,6 +1,7 @@
 # Memory Index
 
 ## Project State
+
 - [Project Overview](project_overview.md) — Genfeed.ai monorepo structure and key context
 - [One API Epic](project_one_api_epic.md) — Epic #95: consolidate self-hosted + cloud into one NestJS API, 20 issues, 8 phases
 - [Fallow Health](project_fallow.md) — Fallow codebase health analysis (#83), weekly CI, score 72/100
@@ -10,6 +11,7 @@
 - [Desktop BYOK Generation](project_desktop_byok_generation.md) — desktop local/BYOK generation works without Clerk; Clerk is sync-only
 
 ## Feedback (user corrections — permanent)
+
 - [Never lose code](feedback_never_lose_code.md) — Always branch+push WIP before destructive git ops
 - [Never commit/push to master](feedback_never_commit_to_master.md) — Feature branches: commit freely. Master: always ask.
 - [proxy.ts is middleware](feedback_proxy_middleware.md) — Next.js 16 renamed middleware.ts → proxy.ts
@@ -24,9 +26,11 @@
 - [GenfeedAI managed provider](feedback_genfeedai_managed_provider.md) — Model Genfeed-managed inference as provider=genfeedai, enabled per customer from console
 
 ## References
+
 - [MongoDB Atlas URI](reference_mongodb_atlas.md) — Atlas connection string for `cloud` DB
 
 ## Context (loaded via CLAUDE.md @import)
+
 - [System Patterns](context/system-patterns.md) — architecture patterns, serializers, multi-tenancy
 - [Project Structure](context/project-structure.md) — directory layout, 12 backend services, 6 frontends
 - [Style Guide](context/project-style-guide.md) — TypeScript, git, formatting, naming conventions
@@ -39,9 +43,11 @@
 - [Tech Context](context/tech-context.md) — technology stack details
 
 ## Features
+
 - [Agent Architecture](features/agent/README.md) — orchestration, threading, collections, tools, frontend
 
 ## System
+
 - [Agent Runtime](system/AGENT-RUNTIME.md) — task loop, verification, completion gate
 - [Critical Never Do](system/CRITICAL-NEVER-DO.md) — production-breaking violations
 - [System Rules](system/SYSTEM-RULES.md) — coding standards
@@ -51,14 +57,18 @@
 - [Self-Hosted Guide](system/SELF-HOSTED-GUIDE.md) — Docker deployment guide
 
 ## Plans (UI design outputs)
+
 - **MergedSwitcher** (2026-05-17) — Merged AppSwitcher + ContentTypeSwitcher. Generate section: 4×2 colored icon grid (GenerationType enum). Navigate section: 2-col grid (Overview, Workflows, Library, Calendar, Analytics). Component: `packages/ui/src/components/shell/merged-switcher/MergedSwitcher.tsx`. HTML mockups gitignored under `.agents/plans/`.
 
 ## Architecture Decisions
+
 - [Dynamic Scheduling](architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md) — scheduling via workflow engine
 - [PLG Boundary](architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md) — OSS vs cloud feature split
 - [Workflow-Backed Agents](architecture/ADR-WORKFLOW-BACKED-RECURRING-AGENT-AUTOMATION.md) — recurring agent automation
+- [Skills, Routines, and Memory Boundary](architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md) — OSS single-player loop vs cloud collaborative governance
 
 ## Rules (symlinked to .claude/rules/)
+
 - [Security](rules/00-security.md) — secret isolation, no outbound HTTP
 - [Backend Services](rules/10-backend-services.md) — soft deletes, service boundaries
 - [Web Apps](rules/20-web-apps.md) — semantic UI, async cancellation

--- a/.agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md
+++ b/.agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md
@@ -6,11 +6,11 @@ Accepted
 
 ## Boundary Spec Version
 
-v1.2.0
+v1.3.0
 
 ## Last Updated
 
-2026-05-03
+2026-06-02
 
 ## Canonical Source
 
@@ -41,6 +41,10 @@ Genfeed follows a hybrid OSS + SaaS model:
 | Social publishing connectors                    | Manual export/upload      | Managed integrations   |
 | Cross-workflow analytics and optimization loops | Limited local insight     | Full managed analytics |
 | Team/org controls, billing, quotas              | Enterprise only (`ee/`)   | Yes                    |
+| Skill model and local attachment                | Yes                       | Yes                    |
+| Personal feedback memory                        | Yes                       | Yes                    |
+| Routine engine and workflow-backed scheduling   | Yes                       | Yes                    |
+| Shared review queue and collaborative memory    | No                        | Yes                    |
 
 ## Non-Negotiables
 
@@ -54,6 +58,13 @@ Genfeed follows a hybrid OSS + SaaS model:
 
 Multi-tenant organization controls are available via `ee/packages/` under commercial license. All multi-tenant data access code must live under `ee/` or import from `ee/packages/`.
 
+## Related ADRs
+
+- `ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md` - canonical boundary for skills,
+  routines, personal feedback memory, shared review, and collaborative learning.
+- `ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md` - workflow-backed scheduling is
+  the canonical scheduling model for new product automation.
+
 ## Version Bump Checklist
 
 1. Update the ADR version and last-updated date.
@@ -66,3 +77,4 @@ Multi-tenant organization controls are available via `ee/packages/` under commer
 | v1.1.0  | 2026-03-11 | Initial accepted version                                                               |
 | v1.1.1  | 2026-03-15 | Added CI check script, revision log                                                    |
 | v1.2.0  | 2026-05-03 | Added V1 execution modes, account-sync contract, and managed inference bridge boundary |
+| v1.3.0  | 2026-06-02 | Added skills, routines, feedback memory, and collaborative learning boundary summary   |

--- a/.agents/memory/architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md
+++ b/.agents/memory/architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md
@@ -1,0 +1,98 @@
+# ADR: Skills, Routines, And Memory Boundary
+
+## Status
+
+Accepted
+
+## Boundary Spec Version
+
+v1.0.0
+
+## Last Updated
+
+2026-06-02
+
+## Canonical Source
+
+This file.
+
+## Decision Summary
+
+Genfeed keeps the single-player skill, routine, and personal memory loop in OSS
+Core. Genfeed Cloud and Enterprise own collaborative governance, team review, and
+shared learning surfaces.
+
+This boundary exists to preserve OSS value without leaking the collaborative moat
+into the open-source package.
+
+## Product Boundary
+
+| Capability                                         | OSS Core                                                              | Genfeed Cloud / Enterprise                                   |
+| -------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Skill model and runtime                            | Define, validate, attach, and execute local skills                    | Managed distribution, governance, and team controls          |
+| Brand/local skill attachment                       | Per-brand local skill library and CRUD                                | Org-wide skill libraries and policy controls                 |
+| Workflow/routine engine                            | Create, edit, execute, import, and export routines locally            | Managed orchestration, hosted execution, and team operations |
+| Workflow-backed local scheduling                   | Recurring routine triggers through the workflow engine                | Hosted scheduled runs, SLAs, and operational monitoring      |
+| Local/personal feedback memory                     | Store user corrections, style preferences, and local learned patterns | Optional promotion into governed org memory                  |
+| Pre-generation feedback retrieval                  | Retrieve local/personal memory before generation                      | Retrieve governed org memory and team-approved patterns      |
+| Shared team review queue                           | No                                                                    | Yes                                                          |
+| Comments, approvals, and requested changes         | No                                                                    | Yes                                                          |
+| Reviewer assignment                                | No                                                                    | Yes                                                          |
+| Org-shared memory and learned pattern governance   | No                                                                    | Yes                                                          |
+| Promotion of feedback into shared skills           | No                                                                    | Yes                                                          |
+| Admin controls, auditability, moderation, rollback | Local-only basics where needed                                        | Yes                                                          |
+
+## Ambiguous Areas
+
+| Area                            | Decision                                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------------------------- |
+| Skill marketplace and discovery | Cloud-only because distribution, moderation, and trust require managed infrastructure    |
+| Skill versioning                | OSS supports local versioning; Cloud adds org-wide version governance                    |
+| Routine templates               | OSS supports local templates; Cloud adds shared org template libraries                   |
+| Cross-brand memory              | OSS is per-brand or personal only; Cloud enables cross-brand memory with org governance  |
+| Feedback export/import          | OSS may export/import local memory; Cloud governs promotion into shared memory or skills |
+
+## Epic #220 Issue Mapping
+
+| Issue                                                                                             | Boundary                   | Rationale                                                               |
+| ------------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------- |
+| #221 `feat(skills): make skills first-class product objects in Genfeed.ai`                        | OSS Core                   | First-class local skills are part of the single-player engine           |
+| #222 `feat(content-engine): build feedback memory adapter from tasks, reviews, and outcome notes` | OSS Core                   | Local feedback ingestion feeds personal memory                          |
+| #223 `feat(agent-orchestrator): retrieve and explain feedback memory before generation`           | OSS Core                   | Pre-generation retrieval is part of the local generation loop           |
+| #224 `feat(workflows): ship productized Daily Trend Loop and Release Loop routines`               | OSS Core                   | Routine authoring and workflow-backed scheduling stay available locally |
+| #225 `feat(ee): collaborative review queue, comments, and approvals for content ops teams`        | Genfeed Cloud / Enterprise | Team review, approvals, and assignments are collaborative governance    |
+| #226 `feat(ee): shared org memory + governance for learned skills and feedback patterns`          | Genfeed Cloud / Enterprise | Org-shared memory and skill promotion require governance controls       |
+
+## Non-Negotiables
+
+1. OSS must have a fully functional single-player skill, routine, and memory loop
+   without Genfeed Cloud.
+2. Collaborative features, including shared review, org memory, reviewer
+   assignment, comments, approvals, and skill promotion, require Enterprise or
+   Genfeed Cloud.
+3. Personal feedback memory never leaves the local deployment unless explicitly
+   promoted by the user.
+4. New recurring product automation must remain workflow-backed, not generic
+   cron scheduling.
+
+## Related ADRs
+
+- `ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md` - workflow-backed scheduling is
+  the canonical direction for recurring automation.
+- `ADR-PLG-BOUNDARY-OSS-CLOUD.md` - parent OSS/Core versus Genfeed Cloud product
+  boundary.
+- `ADR-WORKFLOW-BACKED-RECURRING-AGENT-AUTOMATION.md` - narrow rule for
+  recurring agent automation.
+
+## Version Bump Checklist
+
+1. Update the ADR version and last-updated date.
+2. Update `ADR-PLG-BOUNDARY-OSS-CLOUD.md` if the parent boundary changes.
+3. Update `.agents/memory/system/OPEN-SOURCE-CONTEXT.md` and
+   `docs/architecture.md` if contributor-facing guidance changes.
+
+## Revision Log
+
+| Version | Date       | Summary                                                                                     |
+| ------- | ---------- | ------------------------------------------------------------------------------------------- |
+| v1.0.0  | 2026-06-02 | Initial accepted boundary for skills, routines, feedback memory, and collaborative learning |

--- a/.agents/memory/system/ARCHITECTURE.md
+++ b/.agents/memory/system/ARCHITECTURE.md
@@ -26,6 +26,8 @@ Primary architecture references for planning/reporting.
 
 - Agent runtime: `./AGENT-RUNTIME.md`
 - ADRs: `./architecture/`
-- Critical rules: `./critical/`
+- Skills, routines, and memory boundary:
+  `../architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md`
+- Critical rules: `./CRITICAL-NEVER-DO.md`
 - Open-source context: `./OPEN-SOURCE-CONTEXT.md`
 - Self-hosted guide: `./SELF-HOSTED-GUIDE.md`

--- a/.agents/memory/system/OPEN-SOURCE-CONTEXT.md
+++ b/.agents/memory/system/OPEN-SOURCE-CONTEXT.md
@@ -16,6 +16,7 @@ Multi-tenant organization controls are available under commercial license in `ee
 **Repo invariant:** All multi-tenant data access code must live under `ee/` or import from `ee/packages/`.
 
 This means:
+
 - Organization-scoped query enforcement for data isolation belongs in `ee/`
 - Billing, quotas, and team management belong in `ee/`
 - The core OSS code should work with a single implicit organization
@@ -25,6 +26,7 @@ This means:
 See `CONTRIBUTING.md` at repo root for contribution guidelines.
 
 Key points:
+
 - OSS contributions go to the root codebase (AGPL-3.0)
 - Enterprise features go to `ee/` (commercial license, typically internal)
 - All contributions must follow the coding standards in `CLAUDE.md`
@@ -36,13 +38,19 @@ Key points:
 
 ## What Stays Open vs Enterprise
 
-| Capability | OSS | Enterprise (`ee/`) |
-|---|---|---|
-| Workflow builder + execution | Yes | -- |
-| BYOK model execution | Yes | -- |
-| Agent chat + tools | Yes | -- |
-| Single-tenant deployment | Yes | -- |
-| Multi-tenant org isolation | -- | Yes |
-| Team/role management | -- | Yes |
-| Billing + quotas | -- | Yes |
-| Advanced analytics | -- | Yes |
+| Capability                                  | OSS | Enterprise (`ee/`) |
+| ------------------------------------------- | --- | ------------------ |
+| Workflow builder + execution                | Yes | --                 |
+| BYOK model execution                        | Yes | --                 |
+| Agent chat + tools                          | Yes | --                 |
+| Skill model + local skills                  | Yes | --                 |
+| Routine engine + workflow-backed scheduling | Yes | --                 |
+| Personal feedback memory                    | Yes | --                 |
+| Single-tenant deployment                    | Yes | --                 |
+| Multi-tenant org isolation                  | --  | Yes                |
+| Team/role management                        | --  | Yes                |
+| Shared review queue                         | --  | Yes                |
+| Org-shared memory + governance              | --  | Yes                |
+| Skill promotion from feedback               | --  | Yes                |
+| Billing + quotas                            | --  | Yes                |
+| Advanced analytics                          | --  | Yes                |

--- a/apps/docs/content/core/execution-boundaries.mdx
+++ b/apps/docs/content/core/execution-boundaries.mdx
@@ -6,7 +6,7 @@ Genfeed Core is a self-hosted, single-tenant runtime. Genfeed Cloud is the manag
 
 <Callout type="info">
   This page is the V1 boundary contract for self-hosted Core, BYOK execution, managed Cloud execution, and account
-  handoff.
+  handoff. Boundary spec version: v1.3.0.
 </Callout>
 
 ## Execution Modes
@@ -27,6 +27,8 @@ Core owns the self-hosted runtime:
 - Local object storage or S3-compatible storage owns generated files when configured for the self-hosted deployment.
 - Workflows, brands, prompts, provider settings, generated assets, and content run records are stored in the self-hosted deployment by default.
 - BYOK provider calls are made by the self-hosted API using keys configured on that install or on the active organization.
+- Skills, local routines, workflow-backed scheduling, and personal feedback memory are part of the Core single-player loop.
+- Personal feedback memory stays local unless the user explicitly promotes it into a governed Cloud or Enterprise surface.
 
 ## What Runs in Cloud
 
@@ -35,6 +37,7 @@ Genfeed Cloud owns managed services:
 - Hosted app/API/workers for Cloud workspaces.
 - Managed inference credits and provider billing.
 - Team collaboration, multi-tenant organizations, roles, approvals, quotas, and billing.
+- Shared review queues, reviewer assignment, comments, approvals, org-shared memory, and skill promotion governance.
 - Managed social publishing connectors.
 - Cross-workflow analytics, optimization loops, and managed scheduling.
 - Marketplace and hosted distribution surfaces.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,42 @@
 # Architecture
 
-Genfeed.ai is split into a self-hosted Core runtime and managed Cloud services.
+Genfeed.ai uses a hybrid OSS Core plus Genfeed Cloud model. Core is the
+self-hosted, single-tenant runtime; Cloud is the managed automation,
+collaboration, and governance layer.
 
-- Core is the open-source, single-tenant runtime for local setup, workflow authoring, BYOK execution, server-provider execution, and self-hosted storage.
-- Genfeed Cloud owns managed inference credits, hosted workspaces, team collaboration, publishing connectors, billing, quotas, managed scheduling, and cross-workflow analytics.
-- Enterprise multi-tenancy belongs under `ee/`.
+## Boundary Documents
 
-The V1 execution and account-sync contract is documented in [Core and Cloud Execution Boundaries](./execution-boundaries.md).
+- [Core and Cloud Execution Boundaries](./execution-boundaries.md)
+- [PLG Boundary ADR](../.agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md)
+- [Skills, Routines, and Memory Boundary ADR](../.agents/memory/architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md)
+- [Open-Source and Enterprise Context](../.agents/memory/system/OPEN-SOURCE-CONTEXT.md)
+
+## Boundary Summary
+
+| Capability                                    | OSS Core                           | Genfeed Cloud / Enterprise    |
+| --------------------------------------------- | ---------------------------------- | ----------------------------- |
+| Local setup and self-hosted storage           | Yes                                | N/A                           |
+| Workflow authoring and local/BYOK execution   | Yes                                | Yes                           |
+| Managed inference credits                     | Optional explicit Cloud API bridge | Yes                           |
+| Skill model and local skill attachment        | Yes                                | Yes, with governance          |
+| Routine engine and workflow-backed scheduling | Yes                                | Yes, with hosted operations   |
+| Personal feedback memory and retrieval        | Yes                                | Yes, plus governed org memory |
+| Team review queue, comments, approvals        | No                                 | Yes                           |
+| Skill promotion from feedback                 | No                                 | Yes                           |
+| Social publishing connectors                  | Manual export/upload               | Managed integrations          |
+| Cross-workflow analytics and optimization     | Limited local insight              | Full managed analytics        |
+| Multi-tenant org controls, billing, quotas    | Enterprise only under `ee/`        | Yes                           |
+
+## Core Rules
+
+- Core remains useful without a Cloud account.
+- Personal feedback memory stays local unless the user explicitly promotes it.
+- New recurring product automation is workflow-backed, not generic cron
+  scheduling.
+- Collaborative memory, shared review, approval workflows, and team governance are
+  Cloud or Enterprise surfaces.
+
+## License
+
+The repository root is AGPL-3.0. Enterprise code under `ee/` uses the commercial
+license in `ee/LICENSE`.

--- a/docs/execution-boundaries.md
+++ b/docs/execution-boundaries.md
@@ -2,6 +2,8 @@
 
 This is the repository-level V1 boundary reference. The public docs version lives at `apps/docs/content/core/execution-boundaries.mdx`.
 
+Boundary spec version: v1.3.0.
+
 ## Runtime Modes
 
 | Mode                          | Runtime                            | Provider billing                      | Data owner                                                    | Cloud account |
@@ -33,6 +35,8 @@ Provider calls should persist the execution source so users can distinguish BYOK
 
 - Core remains useful without a Cloud account.
 - Local setup, workflow authoring, provider configuration, and BYOK execution are local Core responsibilities.
+- Skills, local routines, workflow-backed scheduling, and personal feedback memory are local Core responsibilities.
+- Shared review queues, org-shared memory, and skill promotion governance are Cloud or Enterprise responsibilities.
 - Cloud login does not mutate a self-hosted database unless an explicit import, export, or Cloud API action runs.
 - Without a dedicated sync feature, migration is export/import.
 
@@ -42,4 +46,4 @@ Provider calls should persist the execution source so users can distinguish BYOK
 - OSS onboarding: represent `server`, `byok`, and `cloud` access modes truthfully.
 - Managed inference: require an explicit Cloud API key and Cloud-credit authorization.
 - Analytics: Core v1 owns the self-hosted publish -> post analytics -> content-performance loop documented in `apps/docs/content/core-loop/analytics-backbone.mdx`; multi-tenant reporting, billing analytics, and governance remain Cloud/enterprise boundaries.
-- Scheduling, publishing governance, and collaboration: keep Cloud/enterprise boundaries explicit.
+- Scheduling, publishing governance, collaborative learning, and team review: keep Cloud/enterprise boundaries explicit.

--- a/scripts/check-product-boundary-docs.sh
+++ b/scripts/check-product-boundary-docs.sh
@@ -1,41 +1,32 @@
 #!/usr/bin/env bash
 # check-product-boundary-docs.sh
-# Validates that Cloud ADR, Core mirror, and docs all share the same boundary spec version.
+# Validates that the product boundary ADR and public docs share the same boundary spec version.
 # Usage: bash scripts/check-product-boundary-docs.sh
 # Run from repo root.
 set -euo pipefail
 
-CLOUD_ADR=".agents/SYSTEM/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md"
-CORE_ADR="../core/.agents/SYSTEM/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md"
-DOCS_FILE="../docs/content/product/core-cloud-boundary.mdx"
+BOUNDARY_ADR=".agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md"
+DOCS_FILE="apps/docs/content/core/execution-boundaries.mdx"
 
 extract_version() {
-  grep -E "^## Boundary Spec Version" "$1" -A1 | tail -1 | tr -d ' '
+  awk '
+    /^## Boundary Spec Version$/ { in_version = 1; next }
+    in_version && NF { gsub(/[[:space:]]/, ""); print; exit }
+  ' "$1"
 }
 
-CLOUD_VER=$(extract_version "$CLOUD_ADR")
-echo "Cloud ADR version: $CLOUD_VER"
-
-if [ -f "$CORE_ADR" ]; then
-  CORE_VER=$(extract_version "$CORE_ADR")
-  echo "Core mirror version: $CORE_VER"
-  if [ "$CLOUD_VER" != "$CORE_VER" ]; then
-    echo "ERROR: Cloud ($CLOUD_VER) and Core ($CORE_VER) boundary versions are out of sync."
-    exit 1
-  fi
-else
-  echo "WARN: Core mirror ADR not found at $CORE_ADR — skipping cross-repo check."
-fi
+BOUNDARY_VER=$(extract_version "$BOUNDARY_ADR")
+echo "Boundary ADR version: $BOUNDARY_VER"
 
 if [ -f "$DOCS_FILE" ]; then
   DOCS_VER=$(grep -E "boundaryVersion|boundary_version|version:" "$DOCS_FILE" | head -1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
   echo "Docs version: $DOCS_VER"
-  if [ "$DOCS_VER" != "$CLOUD_VER" ] && [ "$DOCS_VER" != "unknown" ]; then
-    echo "ERROR: Cloud ($CLOUD_VER) and docs ($DOCS_VER) boundary versions are out of sync."
+  if [ "$DOCS_VER" != "$BOUNDARY_VER" ] && [ "$DOCS_VER" != "unknown" ]; then
+    echo "ERROR: boundary ADR ($BOUNDARY_VER) and docs ($DOCS_VER) boundary versions are out of sync."
     exit 1
   fi
 else
   echo "WARN: Docs file not found at $DOCS_FILE — skipping docs check."
 fi
 
-echo "OK: Boundary spec versions are in sync ($CLOUD_VER)."
+echo "OK: Boundary spec versions are in sync ($BOUNDARY_VER)."


### PR DESCRIPTION
## Summary

- add the accepted skills, routines, and feedback-memory boundary ADR
- map epic #220 child issues to OSS Core vs Genfeed Cloud / Enterprise
- update the PLG boundary, architecture docs, public docs mirror, and boundary-version validator

## Validation

- scripts/check-product-boundary-docs.sh
- rg scan for stale `.agents/SYSTEM` paths and forbidden cron-backed wording
- git diff --check
- bunx prettier --check on touched Markdown/MDX files
- pre-commit secretlint hook

Closes #227