### PR TITLE
feat(content): add weighted campaign rotation

### DIFF
--- a/apps/server/api/src/collections/agent-campaigns/dto/create-agent-campaign.dto.ts
+++ b/apps/server/api/src/collections/agent-campaigns/dto/create-agent-campaign.dto.ts
@@ -33,6 +33,67 @@ export class ContentQuotaConfigDto {
   videos?: number;
 }
 
+export class ContentRotationTargetDto {
+  @IsString()
+  @ApiProperty({ description: 'Stable target key', required: true })
+  key!: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ description: 'Human-readable target label', required: false })
+  label?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ description: 'Optional platform scope', required: false })
+  platform?: string;
+
+  @IsEntityId()
+  @IsOptional()
+  @ApiProperty({ description: 'Optional strategy scope', required: false })
+  strategyId?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ description: 'Optional topic bucket scope', required: false })
+  topic?: string;
+
+  @IsNumber()
+  @Min(0)
+  @ApiProperty({ description: 'Target share weight', required: true })
+  weight!: number;
+}
+
+export class ContentRotationConfigDto {
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Whether weighted content rotation is enabled',
+    required: false,
+  })
+  enabled?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  @Min(1)
+  @ApiProperty({
+    description: 'Recent run lookback window in days',
+    required: false,
+  })
+  lookbackDays?: number;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ContentRotationTargetDto)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Campaign/topic/platform target weights',
+    required: false,
+    type: [ContentRotationTargetDto],
+  })
+  targets?: ContentRotationTargetDto[];
+}
+
 export class CreateAgentCampaignDto {
   @IsString()
   @ApiProperty({ description: 'Campaign label', required: true })
@@ -94,6 +155,16 @@ export class CreateAgentCampaignDto {
     type: ContentQuotaConfigDto,
   })
   contentQuota?: ContentQuotaConfigDto;
+
+  @ValidateNested()
+  @Type(() => ContentRotationConfigDto)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Weighted campaign/topic rotation rules',
+    required: false,
+    type: ContentRotationConfigDto,
+  })
+  contentRotation?: ContentRotationConfigDto;
 
   @IsNumber()
   @IsOptional()

--- a/apps/server/api/src/collections/agent-campaigns/schemas/agent-campaign.schema.ts
+++ b/apps/server/api/src/collections/agent-campaigns/schemas/agent-campaign.schema.ts
@@ -1,4 +1,5 @@
 import type { AgentStrategyDocument } from '@api/collections/agent-strategies/schemas/agent-strategy.schema';
+import type { IAgentCampaignContentRotation } from '@genfeedai/interfaces';
 import type { AgentCampaign } from '@genfeedai/prisma';
 
 export type { AgentCampaign } from '@genfeedai/prisma';
@@ -8,6 +9,7 @@ export interface AgentCampaignDocument extends AgentCampaign {
   agents: Array<string | AgentStrategyDocument>;
   brand?: string | null;
   brief?: string;
+  contentRotation?: IAgentCampaignContentRotation;
   contentQuota?: {
     images?: number;
     posts?: number;

--- a/apps/server/api/src/collections/agent-campaigns/services/agent-campaigns.service.ts
+++ b/apps/server/api/src/collections/agent-campaigns/services/agent-campaigns.service.ts
@@ -3,8 +3,36 @@ import { UpdateAgentCampaignDto } from '@api/collections/agent-campaigns/dto/upd
 import type { AgentCampaignDocument } from '@api/collections/agent-campaigns/schemas/agent-campaign.schema';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import type { PopulateOption } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
+
+type PopulateInput = (string | PopulateOption)[] | 'none';
+
+type AgentCampaignWriteDto = Partial<
+  CreateAgentCampaignDto & UpdateAgentCampaignDto
+> & {
+  brand?: string;
+  config?: unknown;
+  organization?: string;
+  user?: string;
+};
+
+const CONFIG_BACKED_KEYS = [
+  'brief',
+  'contentQuota',
+  'contentRotation',
+  'creditsAllocated',
+  'creditsUsed',
+  'endDate',
+  'lastOrchestratedAt',
+  'lastOrchestrationSummary',
+  'nextOrchestratedAt',
+  'orchestrationEnabled',
+  'orchestrationIntervalHours',
+  'startDate',
+  'status',
+] as const;
 
 @Injectable()
 export class AgentCampaignsService extends BaseService<
@@ -19,6 +47,33 @@ export class AgentCampaignsService extends BaseService<
     super(prisma, 'agentCampaign', logger);
   }
 
+  override async create(
+    createDto: CreateAgentCampaignDto,
+    populate: PopulateInput = [],
+  ): Promise<AgentCampaignDocument> {
+    return await super.create(
+      this.toPrismaWriteData(createDto, 'create'),
+      populate,
+    );
+  }
+
+  override async patch(
+    id: string,
+    updateDto: Partial<UpdateAgentCampaignDto>,
+    populate: PopulateInput = [],
+  ): Promise<AgentCampaignDocument> {
+    const existing = await this.findOne({ _id: id });
+    const existingConfig = this.readRecord(
+      (existing as Record<string, unknown> | null)?.config,
+    );
+
+    return await super.patch(
+      id,
+      this.toPrismaWriteData(updateDto, 'update', existingConfig ?? {}),
+      populate,
+    );
+  }
+
   /**
    * Find campaign by ID and organization
    */
@@ -31,5 +86,63 @@ export class AgentCampaignsService extends BaseService<
       isDeleted: false,
       organizationId,
     });
+  }
+
+  private toPrismaWriteData(
+    dto: AgentCampaignWriteDto,
+    mode: 'create' | 'update',
+    existingConfig: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    const data: Record<string, unknown> = {};
+    const config: Record<string, unknown> = { ...existingConfig };
+
+    if (Object.hasOwn(dto, 'label')) {
+      data.label = dto.label;
+    }
+
+    if (Object.hasOwn(dto, 'brief')) {
+      data.description = dto.brief;
+    }
+
+    if (typeof dto.organization === 'string') {
+      data.organizationId = dto.organization;
+    }
+
+    if (typeof dto.user === 'string') {
+      data.userId = dto.user;
+    }
+
+    if (Object.hasOwn(dto, 'brand')) {
+      data.brandId = dto.brand ?? null;
+    }
+
+    if (Object.hasOwn(dto, 'campaignLeadStrategyId')) {
+      data.campaignLeadStrategyId = dto.campaignLeadStrategyId ?? null;
+    }
+
+    if (Object.hasOwn(dto, 'agents')) {
+      const agents = Array.isArray(dto.agents) ? dto.agents : [];
+      data.agents =
+        mode === 'create'
+          ? { connect: agents.map((id) => ({ id })) }
+          : { set: agents.map((id) => ({ id })) };
+    }
+
+    for (const key of CONFIG_BACKED_KEYS) {
+      if (Object.hasOwn(dto, key)) {
+        config[key] = dto[key];
+      }
+    }
+
+    const suppliedConfig = this.readRecord(dto.config);
+    data.config = suppliedConfig ? { ...config, ...suppliedConfig } : config;
+
+    return data;
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
   }
 }

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
@@ -316,6 +316,25 @@ export class AgentRunsService extends BaseService<
     });
   }
 
+  @HandleErrors('list recent organization agent runs', 'agent-runs')
+  async findRecentByOrganization(
+    organizationId: string,
+    since: Date,
+    take = 200,
+  ): Promise<AgentRunDocument[]> {
+    const docs = await this.delegate.findMany({
+      orderBy: { createdAt: 'desc' },
+      take,
+      where: {
+        createdAt: { gte: since },
+        isDeleted: false,
+        organizationId,
+      },
+    });
+
+    return this.normalizeDocuments(docs) as AgentRunDocument[];
+  }
+
   @HandleErrors('complete agent run', 'agent-runs')
   async complete(
     id: string,

--- a/apps/server/api/src/services/agent-campaign/agent-campaign-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-campaign/agent-campaign-orchestrator.module.ts
@@ -9,6 +9,7 @@ import { AnalyticsModule } from '@api/endpoints/analytics/analytics.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { CampaignMemoryQueueService } from '@api/services/agent-campaign/campaign-memory-queue.service';
 import { ContentEngineService } from '@api/services/agent-campaign/content-engine.service';
+import { ContentRotationService } from '@api/services/agent-campaign/content-rotation.service';
 import {
   CAMPAIGN_MEMORY_EXTRACTION_QUEUE,
   ORCHESTRATOR_RUN_QUEUE,
@@ -25,6 +26,7 @@ import { forwardRef, Module } from '@nestjs/common';
   exports: [
     CampaignMemoryQueueService,
     ContentEngineService,
+    ContentRotationService,
     OrchestratorQueueService,
     TriggerEvaluatorQueueService,
     TriggerEvaluatorService,
@@ -71,6 +73,7 @@ import { forwardRef, Module } from '@nestjs/common';
   providers: [
     CampaignMemoryQueueService,
     ContentEngineService,
+    ContentRotationService,
     OrchestratorQueueService,
     TriggerEvaluatorQueueService,
     TriggerEvaluatorService,

--- a/apps/server/api/src/services/agent-campaign/content-engine.service.spec.ts
+++ b/apps/server/api/src/services/agent-campaign/content-engine.service.spec.ts
@@ -2,6 +2,7 @@ import { AnalyticsMetric } from '@genfeedai/enums';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ContentEngineService } from './content-engine.service';
+import { ContentRotationService } from './content-rotation.service';
 
 describe('ContentEngineService', () => {
   const campaignId = 'test-object-id';
@@ -61,6 +62,7 @@ describe('ContentEngineService', () => {
     };
     const agentRunsService = {
       create: vi.fn(),
+      findRecentByOrganization: vi.fn(),
       mergeMetadata: vi.fn(),
       patch: vi.fn(),
     };
@@ -103,6 +105,7 @@ describe('ContentEngineService', () => {
         agentStrategiesService as never,
         agentGoalsService as never,
         agentRunsService as never,
+        new ContentRotationService(),
         agentRunQueueService as never,
         analyticsService as never,
         agentMemoryCaptureService as never,
@@ -240,6 +243,7 @@ describe('ContentEngineService', () => {
       _id: runId,
       metadata: { existing: true },
     });
+    agentRunsService.findRecentByOrganization.mockResolvedValue([]);
     agentRunsService.mergeMetadata.mockResolvedValue(undefined);
     agentRunsService.patch.mockResolvedValue(undefined);
     agentRunQueueService.queueRun.mockResolvedValue(undefined);
@@ -284,6 +288,107 @@ describe('ContentEngineService', () => {
         metadata: expect.objectContaining({
           campaignId,
           orchestrationSummary: expect.stringContaining('specialist run'),
+        }),
+      }),
+    );
+  });
+
+  it('runOrchestrationCycle favors the underrepresented weighted rotation target', async () => {
+    const {
+      agentCampaignsService,
+      agentGoalsService,
+      agentMemoryCaptureService,
+      agentRunQueueService,
+      agentRunsService,
+      agentStrategiesService,
+      analyticsService,
+      service,
+    } = createService();
+    const launchStrategy = createStrategy({
+      _id: 'launch-strategy',
+      label: 'Launch specialist',
+      platforms: ['linkedin'],
+      topics: ['launch'],
+    });
+    const educationStrategy = createStrategy({
+      _id: 'education-strategy',
+      label: 'Education specialist',
+      platforms: ['linkedin'],
+      topics: ['education'],
+    });
+    const campaign = createCampaign({
+      agents: [launchStrategy._id, educationStrategy._id],
+      contentRotation: {
+        enabled: true,
+        targets: [
+          { key: 'launch', topic: 'launch', weight: 60 },
+          { key: 'education', topic: 'education', weight: 40 },
+        ],
+      },
+    });
+
+    agentCampaignsService.findOne.mockResolvedValue(campaign);
+    agentCampaignsService.patch.mockResolvedValue(undefined);
+    agentStrategiesService.findOneById.mockImplementation((strategyId) =>
+      Promise.resolve(
+        strategyId === 'launch-strategy' ? launchStrategy : educationStrategy,
+      ),
+    );
+    agentGoalsService.getGoalSummary.mockResolvedValue('Increase engagement');
+    analyticsService.getOverview.mockResolvedValue({
+      avgEngagementRate: 7.2,
+      totalPosts: 4,
+      totalViews: 3200,
+    });
+    agentRunsService.findRecentByOrganization.mockResolvedValue([
+      {
+        _id: 'run-1',
+        metadata: { campaignId, contentRotationTargetKey: 'launch' },
+      },
+      {
+        _id: 'run-2',
+        metadata: { campaignId, contentRotationTargetKey: 'launch' },
+      },
+      {
+        _id: 'run-3',
+        metadata: { campaignId, contentRotationTargetKey: 'education' },
+      },
+    ]);
+    agentRunsService.create.mockResolvedValue({
+      _id: 'education-run',
+      metadata: {},
+    });
+    agentRunsService.mergeMetadata.mockResolvedValue(undefined);
+    agentRunsService.patch.mockResolvedValue(undefined);
+    agentRunQueueService.queueRun.mockResolvedValue(undefined);
+    agentMemoryCaptureService.capture.mockResolvedValue({
+      memory: { _id: 'test-object-id' },
+      wroteBrandInsight: false,
+      wroteContextMemory: true,
+    });
+
+    const result = await service.runOrchestrationCycle(
+      campaignId,
+      organizationId,
+    );
+
+    expect(result.dispatchCount).toBe(1);
+    expect(result.dispatchedRuns[0]).toMatchObject({
+      strategyId: 'education-strategy',
+    });
+    expect(result.summary).toContain('Weighted rotation: selected education');
+    expect(agentRunQueueService.queueRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'education-run',
+        strategyId: 'education-strategy',
+      }),
+    );
+    expect(agentRunsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          campaignId,
+          contentRotationTargetKey: 'education',
+          contentRotationTopic: 'education',
         }),
       }),
     );
@@ -542,6 +647,7 @@ describe('ContentEngineService', () => {
       { findOneById: vi.fn() } as never,
       agentGoalsService as never,
       agentRunsService as never,
+      new ContentRotationService(),
       agentRunQueueService as never,
       analyticsService as never,
       agentMemoryCaptureService as never,

--- a/apps/server/api/src/services/agent-campaign/content-engine.service.ts
+++ b/apps/server/api/src/services/agent-campaign/content-engine.service.ts
@@ -13,6 +13,10 @@ import {
 import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
 import { CampaignMemoryQueueService } from '@api/services/agent-campaign/campaign-memory-queue.service';
 import {
+  type ContentRotationSelection,
+  ContentRotationService,
+} from '@api/services/agent-campaign/content-rotation.service';
+import {
   DEFAULT_ORCHESTRATION_INTERVAL_HOURS,
   MAX_ORCHESTRATED_STRATEGIES_PER_RUN,
 } from '@api/services/agent-campaign/orchestrator.constants';
@@ -23,6 +27,7 @@ import {
   type AgentType,
   AnalyticsMetric,
 } from '@genfeedai/enums';
+import type { IAgentCampaignContentRotation } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, NotFoundException } from '@nestjs/common';
 
@@ -102,6 +107,7 @@ export class ContentEngineService {
     private readonly agentStrategiesService: AgentStrategiesService,
     private readonly agentGoalsService: AgentGoalsService,
     private readonly agentRunsService: AgentRunsService,
+    private readonly contentRotationService: ContentRotationService,
     private readonly agentRunQueueService: AgentRunQueueService,
     private readonly analyticsService: AnalyticsService,
     private readonly agentMemoryCaptureService: AgentMemoryCaptureService,
@@ -203,8 +209,25 @@ export class ContentEngineService {
       });
     }
 
+    const contentRotation = this.getCampaignContentRotation(campaign);
+    const recentRotationRuns = contentRotation
+      ? await this.loadRecentRotationRuns(
+          campaign,
+          organizationId,
+          contentRotation,
+        )
+      : [];
+    const rotationResult = this.contentRotationService.selectStrategies({
+      config: contentRotation,
+      recentRuns: recentRotationRuns,
+      strategies: dispatchableStrategies,
+    });
+    const selectedStrategies = rotationResult.selectedStrategies.slice(
+      0,
+      MAX_ORCHESTRATED_STRATEGIES_PER_RUN,
+    );
     const goalSummaries = await this.loadGoalSummaries(
-      dispatchableStrategies,
+      selectedStrategies,
       organizationId,
     );
     const analyticsOverview = await this.loadAnalyticsOverview(campaign);
@@ -231,20 +254,25 @@ export class ContentEngineService {
       remainingCampaignBudget !== null
         ? Math.max(
             1,
-            Math.floor(remainingCampaignBudget / dispatchableStrategies.length),
+            Math.floor(remainingCampaignBudget / selectedStrategies.length),
           )
         : null;
 
     const dispatchedRuns: OrchestrationDispatchPlan[] = [];
     const runRecords: AgentRunDocument[] = [];
 
-    for (const strategy of dispatchableStrategies) {
-      const reason = this.buildDispatchReason(strategy, analyticsOverview);
+    for (const strategy of selectedStrategies) {
+      const reason = this.buildDispatchReason(
+        strategy,
+        analyticsOverview,
+        rotationResult.selection,
+      );
       const objective = this.buildDispatchObjective(
         campaign,
         strategy,
         goalSummaries,
         analyticsOverview,
+        rotationResult.selection,
       );
       const creditBudget =
         perStrategyBudget !== null
@@ -259,6 +287,7 @@ export class ContentEngineService {
         label: `Campaign orchestrator: ${campaign.label} -> ${strategy.label}`,
         metadata: {
           campaignId,
+          ...this.buildRotationMetadata(rotationResult.selection),
           dispatchedBy: 'campaign_orchestrator',
           dispatchedStrategyId: String(strategy._id),
           reason,
@@ -297,6 +326,7 @@ export class ContentEngineService {
     for (const plan of dispatchedRuns) {
       await this.agentRunsService.mergeMetadata(plan.runId, organizationId, {
         campaignId,
+        ...this.buildRotationMetadata(rotationResult.selection),
         orchestrationDispatchReason: plan.reason,
       });
     }
@@ -307,6 +337,7 @@ export class ContentEngineService {
       dispatchedRuns,
       analyticsOverview,
       goalSummaries,
+      rotationResult.selection,
     );
 
     await this.captureDecisionMemory(
@@ -322,6 +353,7 @@ export class ContentEngineService {
         metadata: {
           ...(run.metadata ?? {}),
           campaignId,
+          ...this.buildRotationMetadata(rotationResult.selection),
           orchestrationSummary: summary,
         },
       } as Record<string, unknown>);
@@ -331,6 +363,7 @@ export class ContentEngineService {
       await this.agentRunsService.patch(plan.runId, {
         metadata: {
           campaignId,
+          ...this.buildRotationMetadata(rotationResult.selection),
           orchestrationDispatchReason: plan.reason,
           orchestrationSummary: summary,
         },
@@ -549,6 +582,26 @@ export class ContentEngineService {
       .map((result) => result.value);
   }
 
+  private async loadRecentRotationRuns(
+    campaign: AgentCampaignDocument,
+    organizationId: string,
+    contentRotation: IAgentCampaignContentRotation,
+  ): Promise<AgentRunDocument[]> {
+    const lookbackDays =
+      this.contentRotationService.getLookbackDays(contentRotation);
+    const since = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+    const recentRuns = await this.agentRunsService.findRecentByOrganization(
+      organizationId,
+      since,
+    );
+    const campaignId = String(campaign._id);
+
+    return recentRuns.filter((run) => {
+      const metadata = this.readRunMetadata(run);
+      return metadata?.campaignId === campaignId;
+    });
+  }
+
   private async loadAnalyticsOverview(
     campaign: AgentCampaignDocument,
   ): Promise<AnalyticsOverview> {
@@ -578,6 +631,7 @@ export class ContentEngineService {
   private buildDispatchReason(
     strategy: AgentStrategyDocument,
     analyticsOverview: AnalyticsOverview,
+    rotationSelection?: ContentRotationSelection,
   ): string {
     const engagementRate = Number(
       analyticsOverview.avgEngagementRate ?? 0,
@@ -587,7 +641,13 @@ export class ContentEngineService {
     const topics =
       topicsList.length > 0 ? topicsList.join(', ') : 'campaign priorities';
 
-    return `${strategy.label} is aligned to ${topics} with recent campaign engagement at ${engagementRate}% and ${totalViews} views over the last 7 days.`;
+    const baseReason = `${strategy.label} is aligned to ${topics} with recent campaign engagement at ${engagementRate}% and ${totalViews} views over the last 7 days.`;
+
+    if (!rotationSelection) {
+      return baseReason;
+    }
+
+    return `${baseReason} Weighted content rotation selected ${rotationSelection.label ?? rotationSelection.key} because its recent share is ${(rotationSelection.actualShare * 100).toFixed(1)}% against a ${(rotationSelection.targetShare * 100).toFixed(1)}% target.`;
   }
 
   private buildDispatchObjective(
@@ -595,6 +655,7 @@ export class ContentEngineService {
     strategy: AgentStrategyDocument,
     goalSummaries: string[],
     analyticsOverview: AnalyticsOverview,
+    rotationSelection?: ContentRotationSelection,
   ): string {
     const topics = this.getStrategyTopics(strategy);
     const lines = [
@@ -605,6 +666,12 @@ export class ContentEngineService {
       `Topics: ${topics.join(', ') || 'No topics configured.'}`,
       `Recent 7-day analytics: ${Math.round(analyticsOverview.totalViews ?? 0)} views, ${Math.round(analyticsOverview.totalPosts ?? 0)} tracked posts, ${(analyticsOverview.avgEngagementRate ?? 0).toFixed(2)}% average engagement.`,
     ];
+
+    if (rotationSelection) {
+      lines.push(
+        `Weighted rotation target: ${rotationSelection.label ?? rotationSelection.key}${rotationSelection.topic ? ` topic=${rotationSelection.topic}` : ''}${rotationSelection.platform ? ` platform=${rotationSelection.platform}` : ''}. Recent share ${(rotationSelection.actualShare * 100).toFixed(1)}%; target share ${(rotationSelection.targetShare * 100).toFixed(1)}%.`,
+      );
+    }
 
     if (goalSummaries.length > 0) {
       lines.push(`Goals:\n- ${goalSummaries.join('\n- ')}`);
@@ -669,6 +736,7 @@ export class ContentEngineService {
     dispatchedRuns: OrchestrationDispatchPlan[],
     analyticsOverview: AnalyticsOverview,
     goalSummaries: string[],
+    rotationSelection?: ContentRotationSelection,
   ): string {
     const dispatchLines = dispatchedRuns.map(
       (dispatch) =>
@@ -680,10 +748,18 @@ export class ContentEngineService {
         ? `Goals:\n- ${goalSummaries.join('\n- ')}\n\n`
         : '';
 
+    const rotationSection = rotationSelection
+      ? [
+          '',
+          `Weighted rotation: selected ${rotationSelection.label ?? rotationSelection.key} (${(rotationSelection.actualShare * 100).toFixed(1)}% recent share vs ${(rotationSelection.targetShare * 100).toFixed(1)}% target).`,
+        ]
+      : [];
+
     return [
       `Campaign ${campaign.label} dispatched ${dispatchedRuns.length} specialist run(s).`,
       '',
       `Recent analytics: ${Math.round(analyticsOverview.totalViews ?? 0)} views, ${Math.round(analyticsOverview.totalPosts ?? 0)} posts, ${(analyticsOverview.avgEngagementRate ?? 0).toFixed(2)}% average engagement.`,
+      ...rotationSection,
       '',
       goalSection,
       'Dispatch decisions:',
@@ -724,6 +800,62 @@ export class ContentEngineService {
         tags: [`campaign:${String(campaign._id)}`, 'orchestrator', 'campaign'],
       },
     );
+  }
+
+  private buildRotationMetadata(
+    selection?: ContentRotationSelection,
+  ): Record<string, unknown> {
+    if (!selection) {
+      return {};
+    }
+
+    return {
+      contentRotationActualShare: selection.actualShare,
+      contentRotationPlatform: selection.platform,
+      contentRotationTargetKey: selection.key,
+      contentRotationTargetLabel: selection.label,
+      contentRotationTargetShare: selection.targetShare,
+      contentRotationTopic: selection.topic,
+    };
+  }
+
+  private getCampaignContentRotation(
+    campaign: AgentCampaignDocument,
+  ): IAgentCampaignContentRotation | undefined {
+    if (this.isContentRotation(campaign.contentRotation)) {
+      return campaign.contentRotation;
+    }
+
+    const config = this.readRecord(
+      (campaign as Record<string, unknown>).config,
+    );
+    const contentRotation = config?.contentRotation;
+    return this.isContentRotation(contentRotation)
+      ? contentRotation
+      : undefined;
+  }
+
+  private isContentRotation(
+    value: unknown,
+  ): value is IAgentCampaignContentRotation {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  }
+
+  private readRunMetadata(run: AgentRunDocument): Record<string, unknown> {
+    const record = run as Record<string, unknown>;
+    const metadata = this.readRecord(record.metadata);
+    if (metadata) {
+      return metadata;
+    }
+
+    const config = this.readRecord(record.config);
+    return this.readRecord(config?.metadata) ?? {};
   }
 
   private computeNextRunAt(campaign: AgentCampaignDocument, from: Date): Date {

--- a/apps/server/api/src/services/agent-campaign/content-rotation.service.spec.ts
+++ b/apps/server/api/src/services/agent-campaign/content-rotation.service.spec.ts
@@ -1,0 +1,142 @@
+import type { AgentRunDocument } from '@api/collections/agent-runs/schemas/agent-run.schema';
+import type { AgentStrategyDocument } from '@api/collections/agent-strategies/schemas/agent-strategy.schema';
+import { describe, expect, it } from 'vitest';
+
+import { ContentRotationService } from './content-rotation.service';
+
+describe('ContentRotationService', () => {
+  const service = new ContentRotationService();
+
+  function strategy(
+    overrides: Partial<AgentStrategyDocument>,
+  ): AgentStrategyDocument {
+    return {
+      _id: 'strategy-default',
+      agentType: 'general',
+      creditsUsedThisWeek: 0,
+      dailyCreditBudget: 10,
+      dailyCreditsUsed: 0,
+      isEnabled: true,
+      label: 'Default',
+      monthToDateCreditsUsed: 0,
+      organization: 'org-1',
+      platforms: [],
+      reserveTrendBudgetRemaining: 0,
+      runHistory: [],
+      topics: [],
+      user: 'user-1',
+      weeklyCreditBudget: 0,
+      ...overrides,
+    } as AgentStrategyDocument;
+  }
+
+  function run(targetKey: string): AgentRunDocument {
+    return {
+      _id: `run-${targetKey}`,
+      id: `run-${targetKey}`,
+      isDeleted: false,
+      metadata: { contentRotationTargetKey: targetKey },
+      organization: 'org-1',
+      organizationId: 'org-1',
+      user: 'user-1',
+      userId: 'user-1',
+    } as AgentRunDocument;
+  }
+
+  it('selects the most underrepresented configured topic bucket', () => {
+    const launch = strategy({
+      _id: 'launch-strategy',
+      label: 'Launch',
+      platforms: ['linkedin'],
+      topics: ['launch'],
+    });
+    const education = strategy({
+      _id: 'education-strategy',
+      label: 'Education',
+      platforms: ['linkedin'],
+      topics: ['education'],
+    });
+
+    const result = service.selectStrategies({
+      config: {
+        enabled: true,
+        targets: [
+          { key: 'launch', topic: 'launch', weight: 60 },
+          { key: 'education', topic: 'education', weight: 40 },
+        ],
+      },
+      recentRuns: [run('launch'), run('launch'), run('education')],
+      strategies: [launch, education],
+    });
+
+    expect(result.selection).toMatchObject({
+      key: 'education',
+      recentCount: 1,
+      topic: 'education',
+    });
+    expect(result.selectedStrategies).toEqual([education]);
+  });
+
+  it('scopes rotation targets by platform and strategy when configured', () => {
+    const xStrategy = strategy({
+      _id: 'x-strategy',
+      platforms: ['twitter'],
+      topics: ['launch'],
+    });
+    const linkedinStrategy = strategy({
+      _id: 'linkedin-strategy',
+      platforms: ['linkedin'],
+      topics: ['launch'],
+    });
+
+    const result = service.selectStrategies({
+      config: {
+        targets: [
+          {
+            key: 'linkedin-launch',
+            platform: 'linkedin',
+            strategyId: 'linkedin-strategy',
+            topic: 'launch',
+            weight: 50,
+          },
+          { key: 'x-launch', platform: 'twitter', topic: 'launch', weight: 50 },
+        ],
+      },
+      recentRuns: [run('x-launch')],
+      strategies: [xStrategy, linkedinStrategy],
+    });
+
+    expect(result.selection).toMatchObject({
+      key: 'linkedin-launch',
+      platform: 'linkedin',
+      topic: 'launch',
+    });
+    expect(result.selectedStrategies).toEqual([linkedinStrategy]);
+  });
+
+  it('falls back to original strategies when weights are missing or unusable', () => {
+    const strategies = [
+      strategy({ _id: 'one', topics: ['one'] }),
+      strategy({ _id: 'two', topics: ['two'] }),
+    ];
+
+    expect(
+      service.selectStrategies({
+        config: undefined,
+        recentRuns: [run('one')],
+        strategies,
+      }),
+    ).toEqual({ selectedStrategies: strategies });
+
+    expect(
+      service.selectStrategies({
+        config: {
+          enabled: true,
+          targets: [{ key: 'missing-topic', topic: 'missing', weight: 100 }],
+        },
+        recentRuns: [],
+        strategies,
+      }),
+    ).toEqual({ selectedStrategies: strategies });
+  });
+});

--- a/apps/server/api/src/services/agent-campaign/content-rotation.service.ts
+++ b/apps/server/api/src/services/agent-campaign/content-rotation.service.ts
@@ -1,0 +1,202 @@
+import type { AgentRunDocument } from '@api/collections/agent-runs/schemas/agent-run.schema';
+import type { AgentStrategyDocument } from '@api/collections/agent-strategies/schemas/agent-strategy.schema';
+import type {
+  IAgentCampaignContentRotation,
+  IAgentCampaignRotationTarget,
+} from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+export interface ContentRotationSelection {
+  actualShare: number;
+  key: string;
+  label?: string;
+  platform?: string;
+  recentCount: number;
+  score: number;
+  targetShare: number;
+  topic?: string;
+}
+
+export interface ContentRotationResult {
+  selectedStrategies: AgentStrategyDocument[];
+  selection?: ContentRotationSelection;
+}
+
+interface TargetScore {
+  actualShare: number;
+  eligibleStrategies: AgentStrategyDocument[];
+  recentCount: number;
+  score: number;
+  target: IAgentCampaignRotationTarget;
+  targetShare: number;
+}
+
+const DEFAULT_ROTATION_LOOKBACK_DAYS = 14;
+
+@Injectable()
+export class ContentRotationService {
+  selectStrategies(input: {
+    config?: IAgentCampaignContentRotation | null;
+    recentRuns: AgentRunDocument[];
+    strategies: AgentStrategyDocument[];
+  }): ContentRotationResult {
+    const validTargets = this.normalizeTargets(input.config);
+    if (validTargets.length === 0 || input.strategies.length === 0) {
+      return { selectedStrategies: input.strategies };
+    }
+
+    const totalWeight = validTargets.reduce(
+      (sum, target) => sum + target.weight,
+      0,
+    );
+    const recentCounts = this.countRecentTargets(input.recentRuns);
+    const recentTotal = Array.from(recentCounts.values()).reduce(
+      (sum, count) => sum + count,
+      0,
+    );
+
+    const scoredTargets = validTargets
+      .map((target): TargetScore | null => {
+        const eligibleStrategies = input.strategies.filter((strategy) =>
+          this.matchesTarget(strategy, target),
+        );
+        if (eligibleStrategies.length === 0) {
+          return null;
+        }
+
+        const recentCount = recentCounts.get(target.key) ?? 0;
+        const actualShare = recentTotal > 0 ? recentCount / recentTotal : 0;
+        const targetShare = target.weight / totalWeight;
+
+        return {
+          actualShare,
+          eligibleStrategies,
+          recentCount,
+          score: targetShare - actualShare,
+          target,
+          targetShare,
+        };
+      })
+      .filter((target): target is TargetScore => target !== null)
+      .sort((left, right) => {
+        if (right.score !== left.score) {
+          return right.score - left.score;
+        }
+        if (left.recentCount !== right.recentCount) {
+          return left.recentCount - right.recentCount;
+        }
+        return right.target.weight - left.target.weight;
+      });
+
+    const selected = scoredTargets[0];
+    if (!selected) {
+      return { selectedStrategies: input.strategies };
+    }
+
+    return {
+      selectedStrategies: selected.eligibleStrategies,
+      selection: {
+        actualShare: selected.actualShare,
+        key: selected.target.key,
+        label: selected.target.label,
+        platform: selected.target.platform,
+        recentCount: selected.recentCount,
+        score: selected.score,
+        targetShare: selected.targetShare,
+        topic: selected.target.topic,
+      },
+    };
+  }
+
+  getLookbackDays(config?: IAgentCampaignContentRotation | null): number {
+    return typeof config?.lookbackDays === 'number' && config.lookbackDays > 0
+      ? config.lookbackDays
+      : DEFAULT_ROTATION_LOOKBACK_DAYS;
+  }
+
+  private normalizeTargets(
+    config?: IAgentCampaignContentRotation | null,
+  ): IAgentCampaignRotationTarget[] {
+    if (config?.enabled === false || !Array.isArray(config?.targets)) {
+      return [];
+    }
+
+    return config.targets.filter(
+      (target) =>
+        typeof target.key === 'string' &&
+        target.key.length > 0 &&
+        typeof target.weight === 'number' &&
+        Number.isFinite(target.weight) &&
+        target.weight > 0,
+    );
+  }
+
+  private countRecentTargets(
+    recentRuns: AgentRunDocument[],
+  ): Map<string, number> {
+    const counts = new Map<string, number>();
+
+    for (const run of recentRuns) {
+      const metadata = this.readRunMetadata(run);
+      const targetKey = this.readString(metadata.contentRotationTargetKey);
+      if (!targetKey) {
+        continue;
+      }
+      counts.set(targetKey, (counts.get(targetKey) ?? 0) + 1);
+    }
+
+    return counts;
+  }
+
+  private matchesTarget(
+    strategy: AgentStrategyDocument,
+    target: IAgentCampaignRotationTarget,
+  ): boolean {
+    const strategyId = String(strategy._id ?? strategy.id ?? '');
+    if (target.strategyId && target.strategyId !== strategyId) {
+      return false;
+    }
+
+    if (target.platform) {
+      const platforms = new Set(
+        (strategy.platforms ?? []).map((platform) => platform.toLowerCase()),
+      );
+      if (!platforms.has(target.platform.toLowerCase())) {
+        return false;
+      }
+    }
+
+    if (target.topic) {
+      const topic = target.topic.toLowerCase();
+      const topics = strategy.topics ?? [];
+      if (
+        !topics.some((strategyTopic) => strategyTopic.toLowerCase() === topic)
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private readRunMetadata(run: AgentRunDocument): Record<string, unknown> {
+    const record = run as Record<string, unknown>;
+    const metadata = this.readRecord(record.metadata);
+    if (metadata) {
+      return metadata;
+    }
+
+    const config = this.readRecord(record.config);
+    return this.readRecord(config?.metadata) ?? {};
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  }
+
+  private readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+}

--- a/packages/interfaces/src/ai/agent-campaign.interface.ts
+++ b/packages/interfaces/src/ai/agent-campaign.interface.ts
@@ -1,3 +1,18 @@
+export interface IAgentCampaignRotationTarget {
+  key: string;
+  label?: string;
+  platform?: string;
+  strategyId?: string;
+  topic?: string;
+  weight: number;
+}
+
+export interface IAgentCampaignContentRotation {
+  enabled?: boolean;
+  lookbackDays?: number;
+  targets?: IAgentCampaignRotationTarget[];
+}
+
 export interface IAgentCampaign {
   id: string;
   organization: string;
@@ -9,6 +24,7 @@ export interface IAgentCampaign {
   startDate: string;
   endDate?: string;
   status: 'draft' | 'active' | 'paused' | 'completed';
+  contentRotation?: IAgentCampaignContentRotation;
   contentQuota?: { posts?: number; images?: number; videos?: number };
   creditsAllocated: number;
   creditsUsed: number;
@@ -24,6 +40,7 @@ export interface ICreateAgentCampaignDto {
   startDate: string;
   endDate?: string;
   status?: 'draft' | 'active' | 'paused' | 'completed';
+  contentRotation?: IAgentCampaignContentRotation;
   contentQuota?: { posts?: number; images?: number; videos?: number };
   creditsAllocated?: number;
 }

--- a/packages/serializers/src/attributes/automation/agent-campaign.attributes.ts
+++ b/packages/serializers/src/attributes/automation/agent-campaign.attributes.ts
@@ -5,6 +5,7 @@ export const agentCampaignAttributes = createEntityAttributes([
   'brand',
   'brief',
   'campaignLeadStrategyId',
+  'contentRotation',
   'contentQuota',
   'creditsAllocated',
   'creditsUsed',

--- a/packages/services/automation/agent-campaigns.service.ts
+++ b/packages/services/automation/agent-campaigns.service.ts
@@ -1,6 +1,7 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type {
   IAgentCampaign,
+  IAgentCampaignContentRotation,
   IAgentCampaignStatusResponse,
 } from '@genfeedai/interfaces';
 import type { IServiceSerializer } from '@genfeedai/interfaces/utils/error.interface';
@@ -18,6 +19,7 @@ export interface CreateAgentCampaignInput {
   brief?: string;
   brand?: string;
   campaignLeadStrategyId?: string;
+  contentRotation?: IAgentCampaignContentRotation;
   contentQuota?: { posts?: number; images?: number; videos?: number };
   creditsAllocated?: number;
   endDate?: string;
@@ -38,6 +40,7 @@ export class AgentCampaign implements IAgentCampaign {
   startDate!: string;
   endDate?: string;
   status!: IAgentCampaign['status'];
+  contentRotation?: IAgentCampaignContentRotation;
   contentQuota?: { posts?: number; images?: number; videos?: number };
   creditsAllocated!: number;
   creditsUsed!: number;


### PR DESCRIPTION
## Summary
- add campaign content rotation targets/weights to the API DTO, serializer, shared interfaces, and client service type
- store campaign rotation settings in the existing Prisma config bridge
- select underrepresented campaign/topic/platform targets during scheduled campaign orchestration and stamp run metadata for future balancing

Closes #182

## Verification
- bun run --cwd apps/server/api test:file src/services/agent-campaign/content-rotation.service.spec.ts src/services/agent-campaign/content-engine.service.spec.ts
- npx biome check --write <touched files>
- bunx turbo run type-check --filter=@genfeedai/api
- bunx turbo run lint --filter=@genfeedai/api
- bunx turbo run type-check --filter=@genfeedai/interfaces --filter=@genfeedai/services --filter=@genfeedai/serializers
- git diff --check
- staged secret scan / pre-commit secretlint