### PR TITLE
refactor: share desktop asset mapper

### DIFF
--- a/apps/desktop/app/package.json
+++ b/apps/desktop/app/package.json
@@ -50,6 +50,7 @@
     "@genfeedai/desktop-core": "workspace:*",
     "@genfeedai/desktop-prisma": "workspace:*",
     "@genfeedai/enums": "workspace:*",
+    "@genfeedai/helpers": "workspace:*",
     "@sentry/browser": "10.53.1",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "6.0.0",

--- a/apps/desktop/app/src/main/desktop-asset.util.ts
+++ b/apps/desktop/app/src/main/desktop-asset.util.ts
@@ -1,0 +1,45 @@
+import type { IDesktopAsset } from '@genfeedai/desktop-contracts';
+
+export type DesktopAssetRow = {
+  brandId: string | null;
+  cloudId: string | null;
+  cloudObjectKey: string | null;
+  createdAt: string;
+  deletedAt: string | null;
+  displayName: string;
+  id: string;
+  kind: string;
+  localPath: string | null;
+  mimeType: string;
+  organizationId: string;
+  origin: string;
+  originalFileName: string;
+  residency: string;
+  sha256: string;
+  sizeBytes: number;
+  updatedAt: string;
+  uploadPolicy: string;
+  workspaceId: string | null;
+};
+
+export const toDesktopAsset = (row: DesktopAssetRow): IDesktopAsset => ({
+  brandId: row.brandId ?? undefined,
+  cloudId: row.cloudId ?? undefined,
+  cloudObjectKey: row.cloudObjectKey ?? undefined,
+  createdAt: row.createdAt,
+  deletedAt: row.deletedAt ?? undefined,
+  displayName: row.displayName,
+  id: row.id,
+  kind: row.kind as IDesktopAsset['kind'],
+  localPath: row.localPath ?? undefined,
+  mimeType: row.mimeType,
+  organizationId: row.organizationId,
+  origin: row.origin as IDesktopAsset['origin'],
+  originalFileName: row.originalFileName,
+  residency: row.residency as IDesktopAsset['residency'],
+  sha256: row.sha256,
+  sizeBytes: row.sizeBytes,
+  updatedAt: row.updatedAt,
+  uploadPolicy: row.uploadPolicy as IDesktopAsset['uploadPolicy'],
+  workspaceId: row.workspaceId ?? undefined,
+});

--- a/apps/desktop/app/src/main/files.service.ts
+++ b/apps/desktop/app/src/main/files.service.ts
@@ -10,6 +10,7 @@ import type {
 import { buildWorkspaceAssetsDir } from '@genfeedai/desktop-core';
 import type { PrismaClient } from '@genfeedai/desktop-prisma';
 import { dialog, shell } from 'electron';
+import { toDesktopAsset } from './desktop-asset.util';
 import { toIso } from './time.util';
 import type { DesktopWorkspaceService } from './workspace.service';
 
@@ -58,48 +59,6 @@ const sanitizeFilenamePart = (value: string): string =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 80) || 'asset';
-
-const toDesktopAsset = (row: {
-  brandId: string | null;
-  cloudId: string | null;
-  cloudObjectKey: string | null;
-  createdAt: string;
-  deletedAt: string | null;
-  displayName: string;
-  id: string;
-  kind: string;
-  localPath: string | null;
-  mimeType: string;
-  organizationId: string;
-  origin: string;
-  originalFileName: string;
-  residency: string;
-  sha256: string;
-  sizeBytes: number;
-  updatedAt: string;
-  uploadPolicy: string;
-  workspaceId: string | null;
-}): IDesktopAsset => ({
-  brandId: row.brandId ?? undefined,
-  cloudId: row.cloudId ?? undefined,
-  cloudObjectKey: row.cloudObjectKey ?? undefined,
-  createdAt: row.createdAt,
-  deletedAt: row.deletedAt ?? undefined,
-  displayName: row.displayName,
-  id: row.id,
-  kind: row.kind as IDesktopAsset['kind'],
-  localPath: row.localPath ?? undefined,
-  mimeType: row.mimeType,
-  organizationId: row.organizationId,
-  origin: row.origin as IDesktopAsset['origin'],
-  originalFileName: row.originalFileName,
-  residency: row.residency as IDesktopAsset['residency'],
-  sha256: row.sha256,
-  sizeBytes: row.sizeBytes,
-  updatedAt: row.updatedAt,
-  uploadPolicy: row.uploadPolicy as IDesktopAsset['uploadPolicy'],
-  workspaceId: row.workspaceId ?? undefined,
-});
 
 export interface GeneratedAssetWriteOptions {
   bytes: Uint8Array;

--- a/apps/desktop/app/src/main/generation.service.ts
+++ b/apps/desktop/app/src/main/generation.service.ts
@@ -10,6 +10,7 @@ import type {
   IDesktopWorkflowGenerationOptions,
   IDesktopWorkflowGenerationResult,
 } from '@genfeedai/desktop-contracts';
+import { sleep } from '@genfeedai/helpers';
 import {
   buildWorkflowGenerationMessages,
   DEFAULT_WORKFLOW_GENERATION_NODE_TYPES,
@@ -105,9 +106,6 @@ type AssetGenerationJobPayload = {
   providerMetadata?: Record<string, unknown>;
   request: IDesktopAssetGenerationRequest;
 };
-
-const sleep = (durationMs: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, durationMs));
 
 const isReplicatePendingStatus = (status: string): boolean =>
   ['queued', 'processing', 'starting'].includes(status.toLowerCase());
@@ -1224,7 +1222,7 @@ export class DesktopGenerationService {
       }
 
       if (attempt > 0) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await sleep(1000);
       }
 
       const statusResponse = await fetch(statusUrl, {
@@ -1341,7 +1339,7 @@ export class DesktopGenerationService {
         );
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(1000);
     }
 
     throw new Error('fal generation timed out waiting for the queued result.');

--- a/apps/desktop/app/src/main/sync.service.ts
+++ b/apps/desktop/app/src/main/sync.service.ts
@@ -14,6 +14,7 @@ import type {
   IDesktopSyncState,
 } from '@genfeedai/desktop-contracts';
 import type { PrismaClient } from '@genfeedai/desktop-prisma';
+import { type DesktopAssetRow, toDesktopAsset } from './desktop-asset.util';
 import { toIso } from './time.util';
 
 const LOCAL_ORGANIZATION_ID = 'local-org';
@@ -91,48 +92,8 @@ export class DesktopSyncService {
     }
   }
 
-  private toAsset(row: {
-    brandId: string | null;
-    cloudId: string | null;
-    cloudObjectKey: string | null;
-    createdAt: string;
-    deletedAt: string | null;
-    displayName: string;
-    id: string;
-    kind: string;
-    localPath: string | null;
-    mimeType: string;
-    organizationId: string;
-    origin: string;
-    originalFileName: string;
-    residency: string;
-    sha256: string;
-    sizeBytes: number;
-    updatedAt: string;
-    uploadPolicy: string;
-    workspaceId: string | null;
-  }): IDesktopAsset {
-    return {
-      brandId: row.brandId ?? undefined,
-      cloudId: row.cloudId ?? undefined,
-      cloudObjectKey: row.cloudObjectKey ?? undefined,
-      createdAt: row.createdAt,
-      deletedAt: row.deletedAt ?? undefined,
-      displayName: row.displayName,
-      id: row.id,
-      kind: row.kind as DesktopAssetKind,
-      localPath: row.localPath ?? undefined,
-      mimeType: row.mimeType,
-      organizationId: row.organizationId,
-      origin: row.origin as DesktopAssetOrigin,
-      originalFileName: row.originalFileName,
-      residency: row.residency as DesktopAssetResidency,
-      sha256: row.sha256,
-      sizeBytes: row.sizeBytes,
-      updatedAt: row.updatedAt,
-      uploadPolicy: row.uploadPolicy as DesktopAssetUploadPolicy,
-      workspaceId: row.workspaceId ?? undefined,
-    };
+  private toAsset(row: DesktopAssetRow): IDesktopAsset {
+    return toDesktopAsset(row);
   }
 
   private toBrand(row: {

--- a/apps/extensions/browser/app/src/services/content-engine.service.ts
+++ b/apps/extensions/browser/app/src/services/content-engine.service.ts
@@ -1,3 +1,4 @@
+import { sleep } from '@genfeedai/helpers';
 import {
   isTerminalRunStatus,
   type RunActionType,
@@ -38,12 +39,6 @@ function getRunId(run: RunRecord): string {
     throw new Error('Run id missing from response.');
   }
   return runId;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 export class ContentEngineService {
@@ -88,7 +83,7 @@ export class ContentEngineService {
       }
 
       pollCount += 1;
-      await delay(pollIntervalMs);
+      await sleep(pollIntervalMs);
 
       const [nextRun, nextEvents] = await Promise.all([
         this.runsService.getRun(runId),

--- a/bun.lock
+++ b/bun.lock
@@ -266,6 +266,7 @@
         "@genfeedai/desktop-core": "workspace:*",
         "@genfeedai/desktop-prisma": "workspace:*",
         "@genfeedai/enums": "workspace:*",
+        "@genfeedai/helpers": "workspace:*",
         "@sentry/browser": "10.53.1",
         "@xterm/addon-fit": "0.11.0",
         "@xterm/xterm": "6.0.0",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -31,11 +31,18 @@
       "types": "./dist/formatting/cn/index.d.ts",
       "import": "./dist/formatting/cn/index.js",
       "default": "./dist/formatting/cn/index.js"
+    },
+    "./async/sleep": {
+      "types": "./dist/async/sleep/index.d.ts",
+      "import": "./dist/async/sleep/index.js",
+      "default": "./dist/async/sleep/index.js"
     }
   },
   "files": [
     "dist",
     "src/index.ts",
+    "src/async/sleep",
+    "src/async/sleep.helper.ts",
     "src/aspect-ratio.helper.ts",
     "src/business/pricing/pricing.helper.ts",
     "src/business/tier-models/tier-models.helper.ts",

--- a/packages/helpers/src/async/sleep.helper.test.ts
+++ b/packages/helpers/src/async/sleep.helper.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sleep } from './sleep.helper';
+
+describe('sleep', () => {
+  it('resolves after the requested duration', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const promise = sleep(250);
+      const resolved = vi.fn();
+      promise.then(resolved);
+
+      vi.advanceTimersByTime(249);
+      await Promise.resolve();
+      expect(resolved).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      await promise;
+      expect(resolved).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/helpers/src/async/sleep.helper.ts
+++ b/packages/helpers/src/async/sleep.helper.ts
@@ -1,0 +1,5 @@
+export function sleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}

--- a/packages/helpers/src/async/sleep/index.ts
+++ b/packages/helpers/src/async/sleep/index.ts
@@ -1,0 +1,1 @@
+export * from '../sleep.helper';

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,4 +1,5 @@
 export * from './aspect-ratio.helper';
+export * from './async/sleep.helper';
 export * from './auth/clerk.helper';
 export * from './brand-completeness.helper';
 export * from './business/pricing/pricing.helper';


### PR DESCRIPTION
## Summary
- extract the desktop asset row mapper into a shared main-process utility
- add a neutral sleep helper to @genfeedai/helpers with a public ./async/sleep export
- reuse the shared sleep helper from desktop generation and browser extension run polling

## Verification
- bunx biome check packages/helpers/package.json packages/helpers/src/index.ts packages/helpers/src/async/sleep.helper.ts packages/helpers/src/async/sleep.helper.test.ts packages/helpers/src/async/sleep/index.ts apps/desktop/app/package.json apps/desktop/app/src/main/generation.service.ts apps/extensions/browser/app/src/services/content-engine.service.ts
- git diff --check
- bun test apps/extensions/browser/app/tests/content-engine.service.test.ts packages/helpers/src/async/sleep.helper.test.ts apps/desktop/app/src/main/generation.service.test.ts
- bunx turbo run build --filter=@genfeedai/helpers
- bunx turbo run type-check --filter=@genfeedai/helpers --filter=@genfeedai/desktop
- bun test apps/desktop/app/src/main/files.service.test.ts apps/desktop/app/src/main/sync.service.test.ts apps/desktop/app/src/main/generation.service.test.ts