### PR TITLE
refactor: share yt-dlp command runner

### DIFF
--- a/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, type TestingModule } from '@nestjs/testing';
-import type { Mocked, MockedFunction } from 'vitest';
+import type { Mock, Mocked, MockedFunction } from 'vitest';
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(() => {
@@ -29,6 +29,46 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
 }));
+
+type ProcessHandler = (...args: unknown[]) => void;
+
+type MockProcess = {
+  emit: Mock<(event: string, ...args: unknown[]) => void>;
+  on: Mock<(event: string, cb: ProcessHandler) => void>;
+};
+
+function createMockProcess(): MockProcess {
+  const events: Record<string, ProcessHandler> = {};
+
+  return {
+    emit: vi.fn((event: string, ...args: unknown[]) => {
+      events[event]?.(...args);
+    }),
+    on: vi.fn((event: string, cb: ProcessHandler) => {
+      events[event] = cb;
+    }),
+  };
+}
+
+function useMockProcess(spawnMock: MockedFunction<typeof spawn>): MockProcess {
+  const mockProcess = createMockProcess();
+  spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
+  return mockProcess;
+}
+
+function closeProcess(mockProcess: MockProcess, code: number): void {
+  const closeHandler = mockProcess.on.mock.calls.find(
+    (call) => call[0] === 'close',
+  )?.[1];
+  closeHandler?.(code);
+}
+
+function failProcess(mockProcess: MockProcess, error: Error): void {
+  const errorHandler = mockProcess.on.mock.calls.find(
+    (call) => call[0] === 'error',
+  )?.[1];
+  errorHandler?.(error);
+}
 
 describe('YtDlpService', () => {
   let service: YtDlpService;
@@ -64,21 +104,14 @@ describe('YtDlpService', () => {
   describe('downloadAudio', () => {
     it('should download audio successfully', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const mockProcess = {
-        emit: vi.fn(),
-        on: vi.fn(),
-      };
+      const mockProcess = useMockProcess(spawnMock);
 
-      spawnMock.mockReturnValue(mockProcess);
       fsMock.existsSync.mockReturnValue(true);
 
       const promise = service.downloadAudio(url);
 
       // Simulate successful completion
-      const closeHandler = mockProcess.on.mock.calls.find(
-        (call) => call[0] === 'close',
-      )?.[1];
-      closeHandler?.(0);
+      closeProcess(mockProcess, 0);
 
       const result = await promise;
 
@@ -98,21 +131,14 @@ describe('YtDlpService', () => {
 
     it('should create output directory if it does not exist', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const mockProcess = {
-        emit: vi.fn(),
-        on: vi.fn(),
-      };
+      const mockProcess = useMockProcess(spawnMock);
 
-      spawnMock.mockReturnValue(mockProcess);
       fsMock.existsSync.mockReturnValue(false);
 
       const promise = service.downloadAudio(url);
 
       // Simulate successful completion
-      const closeHandler = mockProcess.on.mock.calls.find(
-        (call) => call[0] === 'close',
-      )?.[1];
-      closeHandler?.(0);
+      closeProcess(mockProcess, 0);
 
       await promise;
 
@@ -124,65 +150,57 @@ describe('YtDlpService', () => {
 
     it('should handle process errors', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const mockProcess = {
-        emit: vi.fn(),
-        on: vi.fn(),
-      };
+      const mockProcess = useMockProcess(spawnMock);
 
-      spawnMock.mockReturnValue(mockProcess);
       fsMock.existsSync.mockReturnValue(true);
 
       const promise = service.downloadAudio(url);
 
       // Simulate process error
-      const errorHandler = mockProcess.on.mock.calls.find(
-        (call) => call[0] === 'error',
-      )?.[1];
       const error = new Error('Process failed');
-      errorHandler?.(error);
+      failProcess(mockProcess, error);
 
       await expect(promise).rejects.toThrow('Process failed');
     });
 
     it('should handle non-zero exit code', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const mockProcess = {
-        emit: vi.fn(),
-        on: vi.fn(),
-      };
+      const mockProcess = useMockProcess(spawnMock);
 
-      spawnMock.mockReturnValue(mockProcess);
       fsMock.existsSync.mockReturnValue(true);
 
       const promise = service.downloadAudio(url);
 
       // Simulate non-zero exit code
-      const closeHandler = mockProcess.on.mock.calls.find(
-        (call) => call[0] === 'close',
-      )?.[1];
-      closeHandler?.(1);
+      closeProcess(mockProcess, 1);
 
       await expect(promise).rejects.toThrow('yt-dlp exited with code 1');
     });
 
     it('should generate unique output filenames with timestamp', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const mockProcess = {
-        emit: vi.fn(),
-        on: vi.fn(),
-      };
+      const firstProcess = createMockProcess();
+      const secondProcess = createMockProcess();
+      const dateNowMock = vi
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(1000)
+        .mockReturnValueOnce(1001);
 
-      spawnMock.mockReturnValue(mockProcess);
+      spawnMock
+        .mockReturnValueOnce(
+          firstProcess as unknown as ReturnType<typeof spawn>,
+        )
+        .mockReturnValueOnce(
+          secondProcess as unknown as ReturnType<typeof spawn>,
+        );
       fsMock.existsSync.mockReturnValue(true);
 
       const promise1 = service.downloadAudio(url);
       const promise2 = service.downloadAudio(url);
 
       // Simulate successful completion for both
-      const closeHandler = mockProcess.on.mock.calls.find(
-        (call) => call[0] === 'close',
-      )?.[1];
-      closeHandler?.(0);
+      closeProcess(firstProcess, 0);
+      closeProcess(secondProcess, 0);
 
       const result1 = await promise1;
       const result2 = await promise2;
@@ -191,34 +209,79 @@ describe('YtDlpService', () => {
       expect(result1).not.toBe(result2);
       expect(result1).toMatch(/\.mp3$/);
       expect(result2).toMatch(/\.mp3$/);
+      dateNowMock.mockRestore();
     });
 
     it('should log the yt-dlp command with correct arguments', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const mockProcess = {
-        emit: vi.fn(),
-        on: vi.fn(),
-      };
+      const mockProcess = useMockProcess(spawnMock);
 
-      spawnMock.mockReturnValue(mockProcess);
       fsMock.existsSync.mockReturnValue(true);
 
       const promise = service.downloadAudio(url);
 
       // Simulate successful completion
-      const closeHandler = mockProcess.on.mock.calls.find(
-        (call) => call[0] === 'close',
-      )?.[1];
-      closeHandler?.(0);
+      closeProcess(mockProcess, 0);
 
       await promise;
 
-      expect(loggerMock.log).toHaveBeenCalledWith(
-        'yt-dlp -x --audio-format mp3 -o ' +
-          expect.stringContaining('public/tmp/clips/') +
-          ' ' +
-          url,
+      const loggedCommand = loggerMock.log.mock.calls[0]?.[0];
+      expect(loggedCommand).toEqual(
+        expect.stringContaining('yt-dlp -x --audio-format mp3 -o '),
       );
+      expect(loggedCommand).toEqual(
+        expect.stringContaining('public/tmp/clips/'),
+      );
+      expect(loggedCommand).toEqual(expect.stringContaining(` ${url}`));
+    });
+  });
+
+  describe('downloadVideo', () => {
+    it('should download a 720p mp4 video to a custom output path', async () => {
+      const url = 'https://youtube.com/watch?v=test';
+      const outputPath = '/tmp/genfeed/video.mp4';
+      const mockProcess = useMockProcess(spawnMock);
+      fsMock.existsSync.mockReturnValue(true);
+
+      const promise = service.downloadVideo(url, outputPath);
+
+      closeProcess(mockProcess, 0);
+
+      await expect(promise).resolves.toBe(outputPath);
+      expect(spawnMock).toHaveBeenCalledWith('yt-dlp', [
+        '-f',
+        'bestvideo[height<=720]+bestaudio/best[height<=720]',
+        '--merge-output-format',
+        'mp4',
+        '-o',
+        outputPath,
+        url,
+      ]);
+    });
+  });
+
+  describe('downloadAudioLowestQuality', () => {
+    it('should download the lowest quality mp3 to the requested output path', async () => {
+      const url = 'https://youtube.com/watch?v=test';
+      const outputPath = '/tmp/genfeed/audio.mp3';
+      const mockProcess = useMockProcess(spawnMock);
+      fsMock.existsSync.mockReturnValue(true);
+
+      const promise = service.downloadAudioLowestQuality(url, outputPath);
+
+      closeProcess(mockProcess, 0);
+
+      await expect(promise).resolves.toBe(outputPath);
+      expect(spawnMock).toHaveBeenCalledWith('yt-dlp', [
+        '-x',
+        '--audio-format',
+        'mp3',
+        '--audio-quality',
+        '9',
+        '-o',
+        outputPath,
+        url,
+      ]);
     });
   });
 });

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -12,9 +12,7 @@ export class YtDlpService {
 
   public downloadAudio(url: string): Promise<string> {
     const outputDir = path.resolve('public', 'tmp', 'clips');
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true });
-    }
+    this.ensureOutputDir(outputDir);
 
     const timestamp = Date.now();
     const outputTemplate = path.join(outputDir, `${timestamp}.%(ext)s`);
@@ -22,28 +20,14 @@ export class YtDlpService {
 
     const args = ['-x', '--audio-format', 'mp3', '-o', outputTemplate, url];
 
-    this.logger.log(`yt-dlp ${args.join(' ')}`);
-
-    return new Promise((resolve, reject) => {
-      const proc = spawn('yt-dlp', args);
-      proc.on('close', (code) => {
-        if (code === 0) {
-          resolve(outputFile);
-        } else {
-          reject(new Error(`yt-dlp exited with code ${code}`));
-        }
-      });
-      proc.on('error', reject);
-    });
+    return this.runYtDlp(args, outputFile);
   }
 
   public downloadVideo(url: string, outputPath?: string): Promise<string> {
     const outputDir = outputPath
       ? path.dirname(outputPath)
       : path.resolve('public', 'tmp', 'clips');
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true });
-    }
+    this.ensureOutputDir(outputDir);
 
     const timestamp = Date.now();
     const outputTemplate =
@@ -61,19 +45,7 @@ export class YtDlpService {
       url,
     ];
 
-    this.logger.log(`yt-dlp ${args.join(' ')}`);
-
-    return new Promise((resolve, reject) => {
-      const proc = spawn('yt-dlp', args);
-      proc.on('close', (code) => {
-        if (code === 0) {
-          resolve(expectedOutput);
-        } else {
-          reject(new Error(`yt-dlp exited with code ${code}`));
-        }
-      });
-      proc.on('error', reject);
-    });
+    return this.runYtDlp(args, expectedOutput);
   }
 
   public downloadAudioLowestQuality(
@@ -81,26 +53,34 @@ export class YtDlpService {
     outputPath: string,
   ): Promise<string> {
     const outputDir = path.dirname(outputPath);
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true });
-    }
+    this.ensureOutputDir(outputDir);
 
     const args = [
-      '-x', // Extract audio
+      '-x',
       '--audio-format',
-      'mp3', // Convert to MP3
+      'mp3',
       '--audio-quality',
-      '9', // Lowest quality (0-9, 9 = worst)
+      '9',
       '-o',
       outputPath,
       url,
     ];
 
+    return this.runYtDlp(args, outputPath);
+  }
+
+  private ensureOutputDir(outputDir: string): void {
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+  }
+
+  private runYtDlp(args: string[], outputPath: string): Promise<string> {
     this.logger.log(`yt-dlp ${args.join(' ')}`);
 
     return new Promise((resolve, reject) => {
       const proc = spawn('yt-dlp', args);
-      proc.on('close', (code) => {
+      proc.on('close', (code: number | null) => {
         if (code === 0) {
           resolve(outputPath);
         } else {


### PR DESCRIPTION
## Summary

- Extract shared YtDlp output-directory setup and process execution into private helpers.
- Keep the existing public download methods and command arguments unchanged.
- Add focused coverage for video and lowest-quality audio command execution, plus a stable timestamp assertion.

## Validation

- `bunx biome check apps/server/files/src/services/ytdlp/ytdlp.service.ts apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts`
- `bunx jscpd --config .jscpd.json --reporters console apps/server/files/src/services/ytdlp/ytdlp.service.ts apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts`
- Mac Studio: `vitest run --config vitest.ytdlp.config.ts` for `src/services/ytdlp/ytdlp.service.spec.ts` (9 tests)

## Notes

- Local package script `bun run --cwd apps/server/files test ...` could not find a package-local `vitest` binary in this checkout.
- Local `bunx tsc --noEmit -p apps/server/files/tsconfig.json --ignoreDeprecations 6.0` remains blocked by existing files-service tsconfig/dependency/test-global issues across the package, unrelated to this refactor.
