### PR TITLE
Refactor browser storage cache helpers

### DIFF
--- a/packages/helpers/src/data/cache/cache.helper.test.ts
+++ b/packages/helpers/src/data/cache/cache.helper.test.ts
@@ -1,7 +1,9 @@
 import {
   clearCache,
   createCacheKey,
+  createLocalStorageCache,
   createMemoryCache,
+  createSessionStorageCache,
   getCacheItem,
   getCacheStats,
   isCacheExpired,
@@ -11,6 +13,44 @@ import {
   setCacheItem,
 } from '@helpers/data/cache/cache.helper';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createStorage(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    removeItem: (key: string) => entries.delete(key),
+    setItem: (key: string, value: string) => entries.set(key, value),
+  } as Storage;
+}
+
+function setBrowserStorage(
+  name: 'localStorage' | 'sessionStorage',
+  storage: Storage,
+): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value: storage,
+    writable: true,
+  });
+}
+
+function restoreBrowserStorage(
+  name: 'localStorage' | 'sessionStorage',
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, name);
+}
 
 // ─── MemoryCache ─────────────────────────────────────────────────────────────
 
@@ -198,6 +238,76 @@ describe('createMemoryCache', () => {
     c.clear();
     expect(c.get('a')).toBeNull();
     expect(c.get('b')).toBeNull();
+  });
+});
+
+// ─── browser storage caches ─────────────────────────────────────────────────
+
+describe('browser storage caches', () => {
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'localStorage',
+  );
+  const originalSessionStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'sessionStorage',
+  );
+
+  afterEach(() => {
+    restoreBrowserStorage('localStorage', originalLocalStorage);
+    restoreBrowserStorage('sessionStorage', originalSessionStorage);
+  });
+
+  it('stores, reads, expires, and removes localStorage entries with callbacks', () => {
+    const storage = createStorage();
+    const onGet = vi.fn();
+    const onRemove = vi.fn();
+    const onSet = vi.fn();
+    setBrowserStorage('localStorage', storage);
+
+    const cache = createLocalStorageCache<string>({ onGet, onRemove, onSet });
+
+    cache.set('key', 'value');
+    expect(cache.get('key')).toBe('value');
+    expect(onSet).toHaveBeenCalledWith('key', 'value');
+    expect(onGet).toHaveBeenCalledWith('key', 'value');
+
+    cache.set('expired', 'stale', -1);
+    expect(cache.get('expired')).toBeNull();
+    expect(storage.getItem('cache:expired')).toBeNull();
+
+    cache.remove('key');
+    expect(onRemove).toHaveBeenCalledWith('key');
+    expect(cache.get('key')).toBeNull();
+  });
+
+  it('clears all localStorage entries only for the default prefix', () => {
+    const storage = createStorage();
+    setBrowserStorage('localStorage', storage);
+    storage.setItem('cache:one', '1');
+    storage.setItem('other:two', '2');
+
+    createLocalStorageCache().clear();
+    expect(storage.length).toBe(0);
+
+    storage.setItem('custom:one', '1');
+    storage.setItem('other:two', '2');
+    createLocalStorageCache({ prefix: 'custom:' }).clear();
+
+    expect(storage.getItem('custom:one')).toBeNull();
+    expect(storage.getItem('other:two')).toBe('2');
+  });
+
+  it('clears only prefixed sessionStorage entries', () => {
+    const storage = createStorage();
+    setBrowserStorage('sessionStorage', storage);
+    storage.setItem('cache:one', '1');
+    storage.setItem('other:two', '2');
+
+    createSessionStorageCache().clear();
+
+    expect(storage.getItem('cache:one')).toBeNull();
+    expect(storage.getItem('other:two')).toBe('2');
   });
 });
 

--- a/packages/helpers/src/data/cache/cache.helper.ts
+++ b/packages/helpers/src/data/cache/cache.helper.ts
@@ -201,38 +201,45 @@ export function createMemoryCache<T = unknown>(
   };
 }
 
-export function createLocalStorageCache<T = unknown>(
-  config?: CacheConfig,
-): {
+type BrowserStorageCache<T> = {
   get: (key: string) => T | null;
   set: (key: string, value: T, ttlMs?: number) => void;
   remove: (key: string) => void;
   clear: () => void;
-} {
+};
+
+function clearStorageByPrefix(storage: Storage, prefix: string): void {
+  const keysToRemove: string[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key?.startsWith(prefix)) {
+      keysToRemove.push(key);
+    }
+  }
+  keysToRemove.forEach((key) => {
+    storage.removeItem(key);
+  });
+}
+
+function createBrowserStorageCache<T = unknown>(
+  storage: Storage,
+  config?: CacheConfig,
+  clearDefaultPrefix = false,
+): BrowserStorageCache<T> {
   const prefix = config?.prefix || 'cache:';
 
   return {
     clear: () => {
-      if (prefix === 'cache:') {
-        // If using default prefix, clear all localStorage
-        localStorage.clear();
-      } else {
-        // Otherwise, only clear items with the specific prefix
-        const keysToRemove: string[] = [];
-        for (let i = 0; i < localStorage.length; i++) {
-          const key = localStorage.key(i);
-          if (key?.startsWith(prefix)) {
-            keysToRemove.push(key);
-          }
-        }
-        keysToRemove.forEach((key) => {
-          localStorage.removeItem(key);
-        });
+      if (clearDefaultPrefix && prefix === 'cache:') {
+        storage.clear();
+        return;
       }
+
+      clearStorageByPrefix(storage, prefix);
     },
     get: (key: string) => {
       try {
-        const stored = localStorage.getItem(`${prefix}${key}`);
+        const stored = storage.getItem(`${prefix}${key}`);
         if (!stored) {
           config?.onGet?.(key, null);
           return null;
@@ -241,7 +248,7 @@ export function createLocalStorageCache<T = unknown>(
         const entry: CacheEntry<T> = JSON.parse(stored);
 
         if (isCacheExpired(entry.expires)) {
-          localStorage.removeItem(`${prefix}${key}`);
+          storage.removeItem(`${prefix}${key}`);
           return null;
         }
 
@@ -252,7 +259,7 @@ export function createLocalStorageCache<T = unknown>(
       }
     },
     remove: (key: string) => {
-      localStorage.removeItem(`${prefix}${key}`);
+      storage.removeItem(`${prefix}${key}`);
       config?.onRemove?.(key);
     },
     set: (key: string, value: T, ttlMs: number = 300000) => {
@@ -261,76 +268,25 @@ export function createLocalStorageCache<T = unknown>(
           data: value,
           expires: Date.now() + ttlMs,
         };
-        localStorage.setItem(`${prefix}${key}`, JSON.stringify(entry));
+        storage.setItem(`${prefix}${key}`, JSON.stringify(entry));
         config?.onSet?.(key, value);
       } catch {
-        // Silently fail if localStorage is unavailable or quota exceeded
+        // Silently fail if browser storage is unavailable or quota exceeded.
       }
     },
   };
 }
 
+export function createLocalStorageCache<T = unknown>(
+  config?: CacheConfig,
+): BrowserStorageCache<T> {
+  return createBrowserStorageCache<T>(localStorage, config, true);
+}
+
 export function createSessionStorageCache<T = unknown>(
   config?: CacheConfig,
-): {
-  get: (key: string) => T | null;
-  set: (key: string, value: T, ttlMs?: number) => void;
-  remove: (key: string) => void;
-  clear: () => void;
-} {
-  const prefix = config?.prefix || 'cache:';
-
-  return {
-    clear: () => {
-      const keysToRemove: string[] = [];
-      for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (key?.startsWith(prefix)) {
-          keysToRemove.push(key);
-        }
-      }
-      keysToRemove.forEach((key) => {
-        sessionStorage.removeItem(key);
-      });
-    },
-    get: (key: string) => {
-      try {
-        const stored = sessionStorage.getItem(`${prefix}${key}`);
-        if (!stored) {
-          config?.onGet?.(key, null);
-          return null;
-        }
-
-        const entry: CacheEntry<T> = JSON.parse(stored);
-
-        if (isCacheExpired(entry.expires)) {
-          sessionStorage.removeItem(`${prefix}${key}`);
-          return null;
-        }
-
-        config?.onGet?.(key, entry.data);
-        return entry.data;
-      } catch {
-        return null;
-      }
-    },
-    remove: (key: string) => {
-      sessionStorage.removeItem(`${prefix}${key}`);
-      config?.onRemove?.(key);
-    },
-    set: (key: string, value: T, ttlMs: number = 300000) => {
-      try {
-        const entry: CacheEntry<T> = {
-          data: value,
-          expires: Date.now() + ttlMs,
-        };
-        sessionStorage.setItem(`${prefix}${key}`, JSON.stringify(entry));
-        config?.onSet?.(key, value);
-      } catch {
-        // Silently fail if sessionStorage is unavailable
-      }
-    },
-  };
+): BrowserStorageCache<T> {
+  return createBrowserStorageCache<T>(sessionStorage, config);
 }
 
 export class RateLimiter {


### PR DESCRIPTION
## Summary
- Extract shared browser storage cache plumbing for localStorage and sessionStorage caches.
- Add focused coverage for callbacks, expiration cleanup, and clear behavior differences.

## Checks
- PASS: bun test packages/helpers/src/data/cache/cache.helper.test.ts
- PASS: bunx biome check packages/helpers/src/data/cache/cache.helper.ts packages/helpers/src/data/cache/cache.helper.test.ts
- PASS: bunx turbo run build --filter=@genfeedai/constants --filter=@genfeedai/enums --filter=@genfeedai/interfaces && bun run --cwd packages/helpers type-check