### PR TITLE
fix: normalize malformed workflow inputs error

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -34,7 +34,13 @@ interface WorkflowExecution {
 }
 
 function parseInputsOption(value: string): Record<string, unknown> {
-  const parsed = JSON.parse(value) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch {
+    throw new GenfeedError('--inputs must be a JSON object');
+  }
+
   if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
     throw new GenfeedError('--inputs must be a JSON object');
   }

--- a/packages/cli/tests/commands/workflow.test.ts
+++ b/packages/cli/tests/commands/workflow.test.ts
@@ -63,6 +63,19 @@ describe('workflow command', () => {
     expect(mockPost).not.toHaveBeenCalled();
   });
 
+  it('rejects malformed --inputs JSON with a stable CLI error', async () => {
+    await expect(
+      workflowCommand.parseAsync(['run', 'workflow-1', '--inputs', '{bad'], { from: 'user' })
+    ).rejects.toThrow(GenfeedError);
+
+    expect(mockHandleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '--inputs must be a JSON object',
+      })
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
   it('posts object inputs for workflow execution', async () => {
     await workflowCommand.parseAsync(
       ['run', 'workflow-1', '--inputs', '{"topic":"launch"}', '--json'],


### PR DESCRIPTION
## Summary
- Normalize malformed workflow `--inputs` JSON into the existing GenfeedError contract
- Add a focused regression test for malformed `--inputs` input

## Validation
- `bunx biome check packages/cli/src/commands/workflow.ts packages/cli/tests/commands/workflow.test.ts`
- `clawpatch --root . --plain --no-input revalidate --finding fnd_sig-feat-cli-command-012aa40060-_ebfb6f8183` -> fixed
- `bun --filter @genfeedai/cli test tests/commands/workflow.test.ts` did not reach tests because the current isolated test environment cannot resolve `@genfeedai/helpers` via `@genfeedai/serializers`; this appears unrelated to the patch.