### PR TITLE
fix(tracked-links): harden redirect/geo SSRF guards and tenant-scope writes

### DIFF
--- a/apps/server/api/src/collections/tracked-links/services/tracked-links.service.spec.ts
+++ b/apps/server/api/src/collections/tracked-links/services/tracked-links.service.spec.ts
@@ -15,6 +15,7 @@ describe('TrackedLinksService', () => {
         create: vi.fn(),
         findFirst: vi.fn(),
         update: vi.fn(),
+        updateMany: vi.fn(),
       },
     };
 
@@ -133,5 +134,128 @@ describe('TrackedLinksService', () => {
     ).rejects.toThrow('Content not found');
 
     expect(prisma.trackedLink.create).not.toHaveBeenCalled();
+  });
+
+  // SSRF / open-redirect: isBlockedRedirectHost must catch IPv6 forms that map
+  // to or expand into loopback / link-local / unique-local ranges.
+  it.each([
+    'https://[::ffff:127.0.0.1]/callback', // IPv4-mapped IPv6 loopback (dotted)
+    'https://[::ffff:7f00:1]/callback', // IPv4-mapped IPv6 loopback (hex)
+    'https://[0:0:0:0:0:0:0:1]/callback', // fully expanded loopback
+    'https://[fe80::1]/callback', // link-local
+    'https://[fc00::1]/callback', // unique-local
+  ])('rejects internal-network IPv6 redirect target %s', async (url) => {
+    const { prisma, service } = makeService();
+    prisma.trackedLink.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.generateTrackingLink({ platform: 'twitter', url }, 'org-1'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.trackedLink.create).not.toHaveBeenCalled();
+  });
+
+  it('allows public IPv6 redirect targets', async () => {
+    const { prisma, service } = makeService();
+    prisma.trackedLink.findFirst.mockResolvedValue(null);
+    prisma.trackedLink.create.mockImplementation(({ data }) =>
+      Promise.resolve({ id: 'link-1', ...data }),
+    );
+
+    const link = await service.generateTrackingLink(
+      { platform: 'twitter', url: 'https://[2606:4700:4700::1111]/page' },
+      'org-1',
+    );
+
+    expect(link.originalUrl).toContain('https://[2606:4700:4700::1111]/page');
+    expect(prisma.trackedLink.create).toHaveBeenCalled();
+  });
+
+  // Cross-tenant write hardening: update()/delete() must scope the mutation by
+  // organizationId, not just a preceding read.
+  it('scopes update writes to the authenticated organization', async () => {
+    const { prisma, service } = makeService();
+    prisma.trackedLink.updateMany.mockResolvedValue({ count: 1 });
+    prisma.trackedLink.findFirst.mockResolvedValue({
+      id: 'link-1',
+      isActive: false,
+      organizationId: 'org-1',
+    });
+
+    await service.update('link-1', 'org-1', { isActive: false });
+
+    expect(prisma.trackedLink.updateMany).toHaveBeenCalledWith({
+      data: { isActive: false },
+      where: { id: 'link-1', isDeleted: false, organizationId: 'org-1' },
+    });
+    expect(prisma.trackedLink.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when an update matches no link in the organization', async () => {
+    const { prisma, service } = makeService();
+    prisma.trackedLink.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      service.update('link-1', 'org-1', { isActive: false }),
+    ).rejects.toThrow('Tracked link not found');
+  });
+
+  it('scopes delete writes to the authenticated organization', async () => {
+    const { prisma, service } = makeService();
+    prisma.trackedLink.updateMany.mockResolvedValue({ count: 1 });
+
+    await service.delete('link-1', 'org-1');
+
+    expect(prisma.trackedLink.updateMany).toHaveBeenCalledWith({
+      data: { isDeleted: true },
+      where: { id: 'link-1', isDeleted: false, organizationId: 'org-1' },
+    });
+    expect(prisma.trackedLink.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when a delete matches no link in the organization', async () => {
+    const { prisma, service } = makeService();
+    prisma.trackedLink.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(service.delete('link-1', 'org-1')).rejects.toThrow(
+      'Tracked link not found',
+    );
+  });
+
+  // SSRF: getCountryFromIP must only interpolate validated IP literals into the
+  // outbound ipapi.co URL.
+  it('does not call the geolocation API for non-IP X-Forwarded-For values', async () => {
+    const { service } = makeService();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('US'));
+    const probe = service as unknown as {
+      getCountryFromIP(ip?: string): Promise<string | undefined>;
+    };
+
+    await expect(
+      probe.getCountryFromIP('1.1.1.1/../v1/admin?x='),
+    ).resolves.toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
+  it('queries the geolocation API for valid public IPs only', async () => {
+    const { service } = makeService();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('US'));
+    const probe = service as unknown as {
+      getCountryFromIP(ip?: string): Promise<string | undefined>;
+    };
+
+    await expect(probe.getCountryFromIP('8.8.8.8')).resolves.toBe('US');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://ipapi.co/8.8.8.8/country/',
+      expect.anything(),
+    );
+
+    fetchSpy.mockRestore();
   });
 });

--- a/apps/server/api/src/collections/tracked-links/services/tracked-links.service.ts
+++ b/apps/server/api/src/collections/tracked-links/services/tracked-links.service.ts
@@ -225,7 +225,11 @@ export class TrackedLinksService {
   }
 
   private isBlockedRedirectHost(hostname: string): boolean {
-    const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    // Strip IPv6 brackets and any zone id before classifying the host.
+    const host = hostname
+      .toLowerCase()
+      .replace(/^\[|\]$/g, '')
+      .split('%')[0];
 
     if (
       host === 'localhost' ||
@@ -236,22 +240,95 @@ export class TrackedLinksService {
     }
 
     if (isIP(host) === 4) {
-      const [a = 0, b = 0] = host.split('.').map((part) => Number(part));
-      return (
-        a === 0 ||
-        a === 10 ||
-        a === 127 ||
-        a === 169 ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168)
-      );
+      return this.isBlockedIPv4(host);
     }
 
     if (isIP(host) === 6) {
-      return host === '::1' || host.startsWith('fc') || host.startsWith('fd');
+      // IPv4-mapped IPv6 in dotted form (e.g. ::ffff:127.0.0.1) — re-check the
+      // embedded IPv4 so loopback/private targets cannot slip through.
+      const dottedV4 = host.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+      if (dottedV4?.[1]) {
+        return this.isBlockedIPv4(dottedV4[1]);
+      }
+
+      const groups = this.expandIPv6(host);
+
+      // IPv4-mapped IPv6 in hex form (e.g. ::ffff:7f00:1).
+      if (
+        groups.slice(0, 5).every((group) => group === '0000') &&
+        groups[5] === 'ffff'
+      ) {
+        const octets = [
+          Number.parseInt(groups[6].slice(0, 2), 16),
+          Number.parseInt(groups[6].slice(2), 16),
+          Number.parseInt(groups[7].slice(0, 2), 16),
+          Number.parseInt(groups[7].slice(2), 16),
+        ];
+        return this.isBlockedIPv4(octets.join('.'));
+      }
+
+      // Unspecified (::) and loopback (::1, including fully expanded forms).
+      if (groups.every((group) => group === '0000')) {
+        return true;
+      }
+      if (
+        groups.slice(0, 7).every((group) => group === '0000') &&
+        groups[7] === '0001'
+      ) {
+        return true;
+      }
+
+      // Unique-local fc00::/7 and link-local fe80::/10.
+      const firstGroup = Number.parseInt(groups[0], 16);
+      if (firstGroup >= 0xfc00 && firstGroup <= 0xfdff) {
+        return true;
+      }
+      if (firstGroup >= 0xfe80 && firstGroup <= 0xfebf) {
+        return true;
+      }
+
+      return false;
     }
 
     return false;
+  }
+
+  private isBlockedIPv4(host: string): boolean {
+    const [a = 0, b = 0] = host.split('.').map((part) => Number(part));
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      a === 169 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && b >= 18 && b <= 19)
+    );
+  }
+
+  /**
+   * Expand an IPv6 literal (without an embedded dotted IPv4 tail) into eight
+   * zero-padded hextets so loopback/link-local/unique-local forms can be
+   * compared regardless of `::` compression.
+   */
+  private expandIPv6(host: string): string[] {
+    const [head, tail] = host.split('::');
+    const headGroups = head ? head.split(':') : [];
+    const tailGroups = tail === undefined ? null : tail ? tail.split(':') : [];
+
+    const groups =
+      tailGroups === null
+        ? headGroups
+        : [
+            ...headGroups,
+            ...Array<string>(
+              Math.max(0, 8 - headGroups.length - tailGroups.length),
+            ).fill('0'),
+            ...tailGroups,
+          ];
+
+    return groups.map((group) => group.padStart(4, '0'));
   }
 
   /**
@@ -648,14 +725,6 @@ export class TrackedLinksService {
     organizationId: string,
     updates: TrackedLinkUpdatePayload,
   ): Promise<TrackedLink> {
-    const existing = await this.prisma.trackedLink.findFirst({
-      where: { id: linkId, isDeleted: false, organizationId },
-    });
-
-    if (!existing) {
-      throw new NotFoundException(`Tracked link not found: ${linkId}`);
-    }
-
     // Allowlist: only safe, user-editable fields are forwarded to the DB.
     // shortCode, organizationId, stats, etc. must never be mutated via this path.
     const safeData: TrackedLinkUpdatePayload = {};
@@ -666,9 +735,20 @@ export class TrackedLinksService {
       ).toString();
     if (updates.title !== undefined) safeData.title = updates.title;
 
-    const result = await this.prisma.trackedLink.update({
+    // Scope the write itself by organizationId so ownership is enforced on the
+    // mutation, not just on a preceding read (defense-in-depth against
+    // cross-tenant writes if the read/write ever drift apart).
+    const { count } = await this.prisma.trackedLink.updateMany({
       data: safeData as never,
-      where: { id: linkId },
+      where: { id: linkId, isDeleted: false, organizationId },
+    });
+
+    if (count !== 1) {
+      throw new NotFoundException(`Tracked link not found: ${linkId}`);
+    }
+
+    const result = await this.prisma.trackedLink.findFirst({
+      where: { id: linkId, isDeleted: false, organizationId },
     });
 
     this.logger.log(`Tracked link updated: ${linkId}`);
@@ -679,18 +759,17 @@ export class TrackedLinksService {
    * Delete tracked link (soft delete)
    */
   async delete(linkId: string, organizationId: string): Promise<void> {
-    const existing = await this.prisma.trackedLink.findFirst({
-      where: { id: linkId, organizationId },
+    // Scope the soft-delete write by organizationId so a tracked link can only
+    // be deleted within its owning tenant (defense-in-depth: no read/write split
+    // that could be bypassed by a future caller or a cross-tenant id leak).
+    const { count } = await this.prisma.trackedLink.updateMany({
+      data: { isDeleted: true } as never,
+      where: { id: linkId, isDeleted: false, organizationId },
     });
 
-    if (!existing) {
+    if (count !== 1) {
       throw new NotFoundException(`Tracked link not found: ${linkId}`);
     }
-
-    await this.prisma.trackedLink.update({
-      data: { isDeleted: true } as never,
-      where: { id: linkId },
-    });
 
     this.logger.log(`Tracked link deleted: ${linkId}`);
   }
@@ -718,8 +797,14 @@ export class TrackedLinksService {
    */
   private async getCountryFromIP(ip?: string): Promise<string | undefined> {
     const normalizedIp = ip?.split(',')[0]?.trim();
+    // Only forward valid IP literals into the outbound geolocation URL. Without
+    // this guard an attacker-controlled X-Forwarded-For value (e.g.
+    // `1.1.1.1/../v1/admin?x=`) would be interpolated into the ipapi.co path
+    // and probe arbitrary endpoints on the third-party host.
+    if (!normalizedIp || isIP(normalizedIp) === 0) {
+      return undefined;
+    }
     if (
-      !normalizedIp ||
       normalizedIp === '::1' ||
       normalizedIp === '127.0.0.1' ||
       normalizedIp.startsWith('192.168.') ||


### PR DESCRIPTION
## Summary

Automated **deepsec** security pass (Vercel deepsec 2.0.8). Findings in `apps/server/api/.../tracked-links/services/tracked-links.service.ts` were re-validated against the current `develop` tip (most earlier findings on this service were already remediated; these three survived revalidation as true-positives). All fixes are small, localized, and backed by unit tests.

### 1. Open-redirect / client-side SSRF — `isBlockedRedirectHost`
The guard only blocked literal `::1` and `fc`/`fd` IPv6 prefixes, so several internal-network forms slipped through:
- IPv4-mapped IPv6 loopback — dotted `::ffff:127.0.0.1` **and** hex `::ffff:7f00:1`
- Fully-expanded loopback `0:0:0:0:0:0:0:1`
- Link-local `fe80::/10`

Now expands/normalizes IPv6, unwraps IPv4-mapped forms back through the IPv4 check, and blocks loopback / unspecified / unique-local (`fc00::/7`) / link-local (`fe80::/10`). The IPv4 check additionally covers CGNAT `100.64.0.0/10` and benchmark `198.18.0.0/15`. (DNS-rebinding via hostnames remains out of scope — documented limitation; redirects are already forced to `https`.)

### 2. SSRF into third-party geolocation URL — `getCountryFromIP`
`req.ip` (attacker-controllable via `X-Forwarded-For` when `trust proxy` is on) was interpolated straight into `https://ipapi.co/<ip>/country/`. A value like `1.1.1.1/../v1/admin?x=` would alter the request path against the third-party host and burn its quota. Now validated with `isIP()` before the fetch.

### 3. Cross-tenant write hardening — `update()` / `delete()`
Both verified ownership with a `findFirst({ id, organizationId })` then wrote with an **unscoped** `update({ where: { id } })`. Replaced the read-then-write split with `updateMany({ where: { id, isDeleted: false, organizationId } })` + `count === 1` check, removing a latent cross-tenant write primitive.

## Test plan
- Added unit tests in `tracked-links.service.spec.ts` for each IPv6 bypass class, a public-IPv6 allow case, the geolocation IP guard (reject non-IP, fetch only for valid public IP), and org-scoped `update`/`delete` writes.
- `bunx vitest run` on the spec — **18 passed**.
- `biome check` on touched files — clean.
- Full `bun type-check` deferred to CI (CPU-heavy; not run on the automation host per local policy). Changes are localized and type-coherent against the repo's `strict` tsconfig.

🤖 Automated deepsec run.