### PR TITLE
fix(cli): workflow list --json empty output + whoami spinner cleanup (clawpatch)

### DIFF
--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -16,8 +16,14 @@ export const whoamiCommand = new Command('whoami')
       await requireAuth();
 
       const spinner = ora('Fetching user info...').start();
-      const info = await whoami();
-      spinner.stop();
+      let info: Awaited<ReturnType<typeof whoami>>;
+      try {
+        info = await whoami();
+        spinner.stop();
+      } catch (error) {
+        spinner.fail('Failed to fetch user info');
+        throw error;
+      }
 
       const activeBrandId = await getActiveBrand();
       let activeBrand = null;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -72,13 +72,13 @@ export const workflowCommand = new Command('workflow')
             const workflows = flattenCollection<Workflow>(response);
             spinner.stop();
 
-            if (workflows.length === 0) {
-              print(chalk.dim('No workflows found.'));
+            if (options.json) {
+              printJson(workflows);
               return;
             }
 
-            if (options.json) {
-              printJson(workflows);
+            if (workflows.length === 0) {
+              print(chalk.dim('No workflows found.'));
               return;
             }
 

--- a/packages/cli/tests/commands/whoami.test.ts
+++ b/packages/cli/tests/commands/whoami.test.ts
@@ -8,6 +8,8 @@ const {
   mockHandleError,
   mockPrintJson,
   mockRequireAuth,
+  mockSpinnerFail,
+  mockSpinnerStop,
   mockWhoami,
 } = vi.hoisted(() => ({
   mockGetActiveBrand: vi.fn(),
@@ -17,8 +19,19 @@ const {
   }),
   mockPrintJson: vi.fn(),
   mockRequireAuth: vi.fn(),
+  mockSpinnerFail: vi.fn(),
+  mockSpinnerStop: vi.fn(),
   mockWhoami: vi.fn(),
 }));
+
+vi.mock('ora', () => {
+  const spinner = {
+    fail: (...args: unknown[]) => mockSpinnerFail(...args),
+    start: () => spinner,
+    stop: (...args: unknown[]) => mockSpinnerStop(...args),
+  };
+  return { default: () => spinner };
+});
 
 vi.mock('../../src/api/auth', () => ({
   whoami: () => mockWhoami(),
@@ -62,6 +75,18 @@ describe('whoami command', () => {
     });
     mockGetActiveBrand.mockResolvedValue('brand-1');
     mockGetBrand.mockResolvedValue({ id: 'brand-1', label: 'Brand' });
+  });
+
+  it('fails the spinner when the whoami request rejects', async () => {
+    const error = new Error('whoami request failed');
+    mockWhoami.mockRejectedValue(error);
+
+    await expect(whoamiCommand.parseAsync(['--json'], { from: 'user' })).rejects.toThrow(error);
+
+    expect(mockSpinnerFail).toHaveBeenCalled();
+    expect(mockSpinnerStop).not.toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalledWith(error);
+    expect(mockPrintJson).not.toHaveBeenCalled();
   });
 
   it('does not hide non-404 active brand lookup failures', async () => {

--- a/packages/cli/tests/commands/workflow.test.ts
+++ b/packages/cli/tests/commands/workflow.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { workflowCommand } from '../../src/commands/workflow';
 import { GenfeedError } from '../../src/utils/errors';
 
-const { mockHandleError, mockPost, mockPrintJson, mockRequireAuth } = vi.hoisted(() => ({
+const { mockGet, mockHandleError, mockPost, mockPrintJson, mockRequireAuth } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
   mockHandleError: vi.fn((error: unknown) => {
     throw error;
   }),
@@ -12,7 +13,7 @@ const { mockHandleError, mockPost, mockPrintJson, mockRequireAuth } = vi.hoisted
 }));
 
 vi.mock('../../src/api/client', () => ({
-  get: vi.fn(),
+  get: (...args: unknown[]) => mockGet(...args),
   post: (...args: unknown[]) => mockPost(...args),
   requireAuth: () => mockRequireAuth(),
 }));
@@ -74,6 +75,14 @@ describe('workflow command', () => {
       })
     );
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('emits a JSON array for list --json when no workflows exist', async () => {
+    mockGet.mockResolvedValue({ data: [] });
+
+    await workflowCommand.parseAsync(['list', '--json'], { from: 'user' });
+
+    expect(mockPrintJson).toHaveBeenCalledWith([]);
   });
 
   it('posts object inputs for workflow execution', async () => {


### PR DESCRIPTION
## Summary

Automated clawpatch review of `origin/develop` surfaced two real, verified CLI bugs. Both fixes are small and behavior-correct, with focused regression tests.

### 1. `workflow list --json` emitted non-JSON on empty result (medium, api-contract)
The empty-result branch ran **before** the `--json` branch, so `gf workflow list --json` printed `No workflows found.` (human text) instead of `[]` whenever the API returned an empty collection — breaking any caller parsing stdout as JSON. Moved the `--json` branch ahead of the empty-state branch so it always emits the flattened array, including `[]`.

### 2. `whoami` left the spinner running on request failure (low, bug)
The ora spinner was only stopped after `whoami()` resolved. On rejection, control jumped to the outer catch without stopping the spinner, leaving it spinning and potentially corrupting error output. Wrapped the spinner-backed call in `try/catch` that fails the spinner before rethrowing — matching the existing `workflow` command pattern.

## Tests
- `workflow list --json` with an empty collection asserts `printJson([])`.
- `whoami` rejection asserts the spinner is failed (not stopped) before `handleError`.
- `packages/cli` touched specs: **10/10 passing**. Biome clean.

## Findings reviewed but intentionally NOT landed
- **IPv4-mapped IPv6 SSRF (webhook-endpoint.validator)** — the reported reproduction (`http://[::ffff:172.16.0.1]/` accepted) does **not** reproduce. Node's `URL.hostname` returns IPv6 literals **with brackets** (`[::ffff:ac10:1]`) and normalizes the embedded IPv4 to hex, so `isIP(hostname)===0`; the literal-IP classifier never runs and such endpoints are already rejected via DNS `ENOTFOUND`. There is a deeper latent defect (brackets are never stripped, so IPv6-literal classification is effectively dead and public IPv6 webhooks are wrongly rejected), but fixing it **changes behavior** for public-IPv6 endpoints and is out of scope for an autonomous, behavior-preserving patch. Flagged here for human review.
- **Webhook validator test-gap** — a `webhook-endpoint.validator.spec.ts` already exists; deferred alongside the item above.

## Validation notes
Per local CPU policy, only lightweight/narrow checks were run locally (Biome + the touched `packages/cli` specs). Full suite, monorepo type-check, and e2e are left to CI. Pre-existing type errors from unbuilt workspace `dist` (`@genfeedai/serializers`, `@genfeedai/tools`) are unrelated to these changes.

🤖 Generated by clawpatch automation