### PR TITLE
chore(config): remove unused Mastodon/Ghost default-endpoint env vars (#90)

### DIFF
--- a/packages/config/__tests__/schemas.test.ts
+++ b/packages/config/__tests__/schemas.test.ts
@@ -38,10 +38,8 @@ import {
   beehiivSchema,
   facebookSchema,
   fanvueSchema,
-  ghostSchema,
   instagramSchema,
   linkedinSchema,
-  mastodonSchema,
   mediumSchema,
   pinterestSchema,
   redditSchema,
@@ -940,46 +938,6 @@ describe('Config Schemas', () => {
     });
   });
 
-  describe('mastodonSchema', () => {
-    it('should be a non-empty object of Joi schemas', () => {
-      expect(typeof mastodonSchema).toBe('object');
-      const keys = Object.keys(mastodonSchema);
-      expect(keys.length).toBeGreaterThan(0);
-      for (const key of keys) {
-        expect(Joi.isSchema((mastodonSchema as any)[key])).toBe(true);
-      }
-    });
-
-    it('should validate with defaults when optional', () => {
-      const schema = Joi.object(mastodonSchema);
-      const { error } = schema.validate({}, { allowUnknown: true });
-      // Some schemas have required fields, so error is acceptable
-      if (error) {
-        expect(error.message).toContain('required');
-      }
-    });
-  });
-
-  describe('ghostSchema', () => {
-    it('should be a non-empty object of Joi schemas', () => {
-      expect(typeof ghostSchema).toBe('object');
-      const keys = Object.keys(ghostSchema);
-      expect(keys.length).toBeGreaterThan(0);
-      for (const key of keys) {
-        expect(Joi.isSchema((ghostSchema as any)[key])).toBe(true);
-      }
-    });
-
-    it('should validate with defaults when optional', () => {
-      const schema = Joi.object(ghostSchema);
-      const { error } = schema.validate({}, { allowUnknown: true });
-      // Some schemas have required fields, so error is acceptable
-      if (error) {
-        expect(error.message).toContain('required');
-      }
-    });
-  });
-
   describe('shopifySchema', () => {
     it('should be a non-empty object of Joi schemas', () => {
       expect(typeof shopifySchema).toBe('object');
@@ -1037,6 +995,16 @@ describe('Config Schemas', () => {
       if (error) {
         expect(error.message).toContain('required');
       }
+    });
+
+    // Regression guard for #90: Mastodon and Ghost are instance-/self-host
+    // specific, so their endpoint is resolved per stored credential, not from
+    // a single global env var. These stale config keys were removed and must
+    // not be reintroduced without a live service consumer.
+    it('should not declare unused per-credential default endpoint keys', () => {
+      const keys = Object.keys(allSocialSchema);
+      expect(keys).not.toContain('MASTODON_DEFAULT_INSTANCE_URL');
+      expect(keys).not.toContain('GHOST_DEFAULT_API_URL');
     });
   });
 

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -228,12 +228,6 @@ export interface IEnvConfig {
   WHATSAPP_TWILIO_AUTH_TOKEN?: string;
   WHATSAPP_TWILIO_PHONE_NUMBER?: string;
 
-  // === Mastodon ===
-  MASTODON_DEFAULT_INSTANCE_URL?: string;
-
-  // === Ghost ===
-  GHOST_DEFAULT_API_URL?: string;
-
   // === Shopify ===
   SHOPIFY_CLIENT_ID?: string;
   SHOPIFY_CLIENT_SECRET?: string;

--- a/packages/config/src/schemas/social.schema.ts
+++ b/packages/config/src/schemas/social.schema.ts
@@ -148,20 +148,6 @@ export const whatsappSchema = {
 };
 
 /**
- * Mastodon API (optional integration — instance-specific)
- */
-export const mastodonSchema = {
-  MASTODON_DEFAULT_INSTANCE_URL: Joi.string().uri().optional().allow(''),
-};
-
-/**
- * Ghost Admin API (optional integration — self-hosted)
- */
-export const ghostSchema = {
-  GHOST_DEFAULT_API_URL: Joi.string().uri().optional().allow(''),
-};
-
-/**
  * Shopify API (optional integration — GraphQL)
  */
 export const shopifySchema = {
@@ -196,8 +182,6 @@ export const allSocialSchema = {
   ...wordpressSchema,
   ...snapchatSchema,
   ...whatsappSchema,
-  ...mastodonSchema,
-  ...ghostSchema,
   ...shopifySchema,
   ...beehiivSchema,
 };


### PR DESCRIPTION
## Summary

Completes the integration env/config audit from #90 for the remaining vars (`MASTODON_DEFAULT_INSTANCE_URL`, `GHOST_DEFAULT_API_URL`, `RUNWAYML_KEY`).

Per the issue's acceptance criteria, every declared integration env var must be **either consumed by live service code or removed** from the active config surface. Audit result:

| Env var | State | Action |
|---|---|---|
| `MASTODON_DEFAULT_INSTANCE_URL` | Declared in interface + Joi schema, **no consumer**. Mastodon is inherently multi-instance — the instance URL is resolved per stored credential (`credential.description`), validated against SSRF in `MastodonService`. A single global default URL does not fit. | **Removed** |
| `GHOST_DEFAULT_API_URL` | Declared in interface + Joi schema, **no consumer**. Ghost URL is per self-hosted site, resolved from `credential.externalHandle` in `GhostService`. | **Removed** |
| `RUNWAYML_KEY` | **Not present** anywhere in the config surface. RunwayML is served indirectly through the Replicate and Fal model providers (`REPLICATE_RUNWAYML_*`, `FAL_RUNWAY_GEN3`), not as a direct integration with its own key. | No change (nothing to wire or remove) |
| `BEEHIIV_API_URL` / `HEDRA_URL` | Already wired (`BeehiivService` / `HedraService`). | Untouched (no regression) |

## Changes

- Removed the now-empty `mastodonSchema` / `ghostSchema` exports and their spreads in `allSocialSchema` (`packages/config/src/schemas/social.schema.ts`).
- Removed the matching fields from `EnvConfig` (`packages/config/src/interfaces/env-config.interface.ts`).
- Updated `packages/config/__tests__/schemas.test.ts`: dropped the two obsolete per-schema describe blocks and their imports, and added a **regression guard** asserting the two stale keys are not reintroduced into `allSocialSchema` without a live consumer.

No `.env*`, docs, or service code referenced the removed keys (verified by repo-wide search).

## Verification

Run on the Mac Studio against `@genfeedai/config`:

- `tsc --noEmit` (type-check): **pass** (exit 0)
- `vitest run` (config package): **133 passed** across 3 files, including `schemas.test.ts` (97 tests) with the new guard.

Closes #90