### PR TITLE
fix(api): reconcile list-filter fields with Prisma schema + additive migration

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/layout.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import type { LayoutProps } from '@props/layout/layout.props';
+import Container from '@ui/layout/container/Container';
 import Tabs from '@ui/navigation/tabs/Tabs';
 import { useParams } from 'next/navigation';
+import { HiOutlineCog6Tooth } from 'react-icons/hi2';
 
 export default function BrandSettingsLayout({ children }: LayoutProps) {
   const params = useParams<{ brandSlug?: string; orgSlug?: string }>();
@@ -45,9 +47,15 @@ export default function BrandSettingsLayout({ children }: LayoutProps) {
   ];
 
   return (
-    <div className="space-y-6">
-      <Tabs items={items} variant="underline" fullWidth={false} />
-      {children}
-    </div>
+    <Container
+      label="Brand Settings"
+      description="Manage voice, harness, publishing, and agent defaults for this brand"
+      icon={HiOutlineCog6Tooth}
+    >
+      <div className="space-y-6">
+        <Tabs items={items} variant="underline" fullWidth={false} />
+        {children}
+      </div>
+    </Container>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/~/overview/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/overview/layout.tsx
@@ -3,11 +3,14 @@
 import { AnalyticsProvider } from '@contexts/analytics/analytics-context';
 import type { LayoutProps } from '@props/layout/layout.props';
 import FeatureGate from '@ui/guards/feature/FeatureGate';
+import Container from '@ui/layout/container/Container';
 
 export default function OrgOverviewLayout({ children }: LayoutProps) {
   return (
     <FeatureGate flagKey="analytics">
-      <AnalyticsProvider>{children}</AnalyticsProvider>
+      <AnalyticsProvider>
+        <Container>{children}</Container>
+      </AnalyticsProvider>
     </FeatureGate>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/elements/scenes/scenes-list.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/elements/scenes/scenes-list.tsx
@@ -9,6 +9,7 @@ import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
 import { ScenesService } from '@services/elements/scenes.service';
 import AppTable from '@ui/display/table/Table';
+import Container from '@ui/layout/container/Container';
 import AutoPagination from '@ui/navigation/pagination/auto-pagination/AutoPagination';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useState } from 'react';
@@ -61,7 +62,10 @@ function ScenesListContent() {
   }, [findAllScenes]);
 
   return (
-    <>
+    <Container
+      label="Scenes"
+      description="Reusable scene elements for generation"
+    >
       <AppTable<ElementScene>
         items={scenes}
         columns={columns}
@@ -74,7 +78,7 @@ function ScenesListContent() {
       <div className="mt-4">
         <AutoPagination showTotal totalLabel="scenes" />
       </div>
-    </>
+    </Container>
   );
 }
 

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -41,8 +41,10 @@ vi.mock('@ui/primitives/button', () => ({
   ),
 }));
 
-vi.mock('@ui/topbars/breadcrumbs/TopbarBreadcrumbs', () => ({
-  default: () => <div data-testid="breadcrumbs">Breadcrumbs</div>,
+vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
+  AppSwitcher: ({ variant }: { variant?: string }) => (
+    <div data-testid="app-switcher">{variant}</div>
+  ),
 }));
 
 vi.mock('@ui/topbars/credits-bar/TopbarCreditsBar', () => ({
@@ -83,15 +85,15 @@ describe('AppProtectedTopbar', () => {
     mockSearchParams = new URLSearchParams();
   });
 
-  it('renders breadcrumbs before the right-side controls', () => {
-    render(<AppProtectedTopbar />);
+  it('renders the section switcher before the right-side controls', () => {
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
 
-    const breadcrumbs = screen.getByTestId('breadcrumbs');
+    const switcher = screen.getByTestId('app-switcher');
     const cloudSyncIndicator = screen.getByTestId('cloud-sync-indicator');
 
-    expect(breadcrumbs).toBeInTheDocument();
+    expect(switcher).toBeInTheDocument();
     expect(
-      breadcrumbs.compareDocumentPosition(cloudSyncIndicator) &
+      switcher.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -4,7 +4,7 @@ import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { TopbarProps } from '@props/navigation/topbar.props';
 import { Button } from '@ui/primitives/button';
-import TopbarBreadcrumbs from '@ui/topbars/breadcrumbs/TopbarBreadcrumbs';
+import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
 import TopbarCreditsBar from '@ui/topbars/credits-bar/TopbarCreditsBar';
 import TopbarEnd from '@ui/topbars/end/TopbarEnd';
 import Link from 'next/link';
@@ -22,6 +22,9 @@ function AppProtectedTopbarContent({
   onSidebarToggle,
   isAgentCollapsed,
   onAgentToggle,
+  currentApp,
+  orgSlug,
+  brandSlug,
 }: TopbarProps = {}) {
   const searchParams = useSearchParams();
   const { href } = useOrgUrl();
@@ -71,9 +74,16 @@ function AppProtectedTopbarContent({
             </Button>
           ) : null}
 
-          <div className="min-w-0">
-            <TopbarBreadcrumbs />
-          </div>
+          {orgSlug ? (
+            <div className="min-w-0">
+              <AppSwitcher
+                variant="labeled"
+                currentApp={currentApp ?? 'workspace'}
+                orgSlug={orgSlug}
+                brandSlug={brandSlug}
+              />
+            </div>
+          ) : null}
         </div>
 
         <div className="flex min-w-0 items-center gap-1.5">

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
@@ -81,6 +81,147 @@ describe('AgentRunsController', () => {
         },
       });
     });
+
+    it('should filter routingPolicy using Prisma JSON path syntax', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          routingPolicy: 'cost-optimized',
+        } as any,
+      );
+
+      expect(query.where).toMatchObject({
+        metadata: { path: ['routingPolicy'], equals: 'cost-optimized' },
+      });
+      expect(query.where).not.toHaveProperty('metadata.routingPolicy');
+    });
+
+    it('should filter webSearchEnabled using Prisma JSON path syntax', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          webSearchEnabled: true,
+        } as any,
+      );
+
+      expect(query.where).toMatchObject({
+        metadata: { path: ['webSearchEnabled'], equals: true },
+      });
+      expect(query.where).not.toHaveProperty('metadata.webSearchEnabled');
+    });
+
+    it('should combine routingPolicy and webSearchEnabled via AND when both present', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          routingPolicy: 'cost-optimized',
+          webSearchEnabled: false,
+        } as any,
+      );
+
+      expect(Array.isArray(query.where.AND)).toBe(true);
+      expect(query.where.AND).toContainEqual({
+        metadata: { path: ['routingPolicy'], equals: 'cost-optimized' },
+      });
+      expect(query.where.AND).toContainEqual({
+        metadata: { path: ['webSearchEnabled'], equals: false },
+      });
+    });
+
+    it('should filter by model using Prisma JSON path string_contains', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          model: 'gpt-4o',
+        } as any,
+      );
+
+      expect(query.where.OR).toEqual([
+        { metadata: { path: ['actualModel'], string_contains: 'gpt-4o' } },
+        { metadata: { path: ['requestedModel'], string_contains: 'gpt-4o' } },
+      ]);
+    });
+
+    it('should build search OR with real column contains and JSON path string_contains', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          q: 'test search',
+        } as any,
+      );
+
+      expect(Array.isArray(query.where.OR)).toBe(true);
+      const orConditions = query.where.OR as unknown[];
+      expect(orConditions).toContainEqual({
+        label: { contains: 'test search', mode: 'insensitive' },
+      });
+      expect(orConditions).toContainEqual({
+        objective: { contains: 'test search', mode: 'insensitive' },
+      });
+      expect(orConditions).toContainEqual({
+        metadata: { path: ['actualModel'], string_contains: 'test search' },
+      });
+      expect(orConditions).toContainEqual({
+        metadata: { path: ['requestedModel'], string_contains: 'test search' },
+      });
+      expect(orConditions).toContainEqual({
+        metadata: { path: ['routingPolicy'], string_contains: 'test search' },
+      });
+      // Must NOT use dotted key syntax
+      expect(
+        orConditions.some((c) => 'metadata.actualModel' in (c as object)),
+      ).toBe(false);
+    });
+
+    it('should wrap both model OR and search OR inside AND when both are present', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          model: 'gpt-4o',
+          q: 'hello',
+        } as any,
+      );
+
+      expect(Array.isArray(query.where.AND)).toBe(true);
+      const andConditions = query.where.AND as Array<{ OR: unknown[] }>;
+      expect(andConditions).toHaveLength(2);
+      expect(andConditions[0]).toHaveProperty('OR');
+      expect(andConditions[1]).toHaveProperty('OR');
+      expect(query.where).not.toHaveProperty('OR');
+    });
+
+    it('should apply credits sortMode', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          sortMode: 'credits',
+        } as any,
+      );
+
+      expect(query.orderBy).toEqual({ createdAt: -1, creditsUsed: -1 });
+    });
+
+    it('should apply duration sortMode', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          sortMode: 'duration',
+        } as any,
+      );
+
+      expect(query.orderBy).toEqual({ createdAt: -1, durationMs: -1 });
+    });
+
+    it('should filter by trigger column directly', () => {
+      const query = controller.buildFindAllQuery(
+        mockUser as any,
+        {
+          trigger: 'manual',
+        } as any,
+      );
+
+      expect(query.where).toMatchObject({ trigger: 'manual' });
+    });
   });
 
   describe('canUserModifyEntity', () => {

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
@@ -112,34 +112,55 @@ export class AgentRunsController extends BaseCRUDController<
       match.trigger = query.trigger;
     }
 
+    const metadataFilters: Record<string, unknown>[] = [];
+
     if (query.routingPolicy) {
-      match['metadata.routingPolicy'] = query.routingPolicy;
+      metadataFilters.push({
+        metadata: { path: ['routingPolicy'], equals: query.routingPolicy },
+      });
     }
 
     if (query.webSearchEnabled !== undefined) {
-      match['metadata.webSearchEnabled'] = query.webSearchEnabled;
+      metadataFilters.push({
+        metadata: {
+          path: ['webSearchEnabled'],
+          equals: query.webSearchEnabled,
+        },
+      });
+    }
+
+    if (metadataFilters.length === 1) {
+      Object.assign(match, metadataFilters[0]);
+    } else if (metadataFilters.length > 1) {
+      const existingAnd = Array.isArray(match.AND) ? match.AND : [];
+      match.AND = [...existingAnd, ...metadataFilters];
     }
 
     if (query.model) {
       match.OR = [
-        { 'metadata.actualModel': query.model },
-        { 'metadata.requestedModel': query.model },
+        { metadata: { path: ['actualModel'], string_contains: query.model } },
+        {
+          metadata: { path: ['requestedModel'], string_contains: query.model },
+        },
       ];
     }
 
     if (query.q) {
-      const escapedQuery = query.q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const searchRegex = new RegExp(escapedQuery, 'i');
       const searchConditions = [
-        { label: searchRegex },
-        { objective: searchRegex },
-        { 'metadata.actualModel': searchRegex },
-        { 'metadata.requestedModel': searchRegex },
-        { 'metadata.routingPolicy': searchRegex },
+        { label: { contains: query.q, mode: 'insensitive' } },
+        { objective: { contains: query.q, mode: 'insensitive' } },
+        { metadata: { path: ['actualModel'], string_contains: query.q } },
+        { metadata: { path: ['requestedModel'], string_contains: query.q } },
+        { metadata: { path: ['routingPolicy'], string_contains: query.q } },
       ];
 
       if (Array.isArray(match.OR)) {
-        match.AND = [{ OR: [...match.OR] }, { OR: searchConditions }];
+        const existingAnd = Array.isArray(match.AND) ? match.AND : [];
+        match.AND = [
+          ...existingAnd,
+          { OR: [...(match.OR as unknown[])] },
+          { OR: searchConditions },
+        ];
         delete match.OR;
       } else {
         match.OR = searchConditions;

--- a/apps/server/api/src/collections/font-families/controllers/font-families.controller.spec.ts
+++ b/apps/server/api/src/collections/font-families/controllers/font-families.controller.spec.ts
@@ -145,29 +145,44 @@ describe('FontFamiliesController', () => {
   });
 
   describe('buildFindAllQuery', () => {
-    it('should build query with organization filter', () => {
+    it('should build query with organization filter and include global items', () => {
       const inputQuery = {};
-      const query = controller.buildFindAllQuery(mockUser, inputQuery, false);
+      const query = controller.buildFindAllQuery(mockUser, inputQuery as never);
 
       expect(query).toBeDefined();
       expect(Array.isArray(query)).toBe(false);
+      // global condition must be organization: null only (no user field)
+      expect(query.where.OR).toContainEqual({ organization: null });
+      // user's org condition must be present
+      expect(query.where.OR).toContainEqual({
+        organization: '507f1f77bcf86cd799439012',
+      });
+      // no { user: ... } condition — FontFamilyRecord has no user column
+      expect(
+        query.where.OR.some((c: Record<string, unknown>) => 'user' in c),
+      ).toBe(false);
     });
 
-    it('should load defaults when no organization', () => {
+    it('should return only global items when no organization', () => {
       const userWithoutOrg: User = {
-        publicMetadata: {
-          user: '507f1f77bcf86cd799439011',
-        },
+        publicMetadata: {},
       } as unknown as User;
 
       const inputQuery = {};
       const query = controller.buildFindAllQuery(
         userWithoutOrg,
-        inputQuery,
-        false,
+        inputQuery as never,
       );
 
       expect(query).toBeDefined();
+      expect(query.where.OR).toEqual([{ organization: null }]);
+    });
+
+    it('should use default orderBy with label when no sort provided', () => {
+      const inputQuery = {};
+      const query = controller.buildFindAllQuery(mockUser, inputQuery as never);
+
+      expect(query.orderBy).toEqual({ createdAt: -1, label: 1 });
     });
   });
 });

--- a/apps/server/api/src/collections/font-families/controllers/font-families.controller.ts
+++ b/apps/server/api/src/collections/font-families/controllers/font-families.controller.ts
@@ -101,24 +101,20 @@ export class FontFamiliesController extends BaseCRUDController<
 
   /**
    * Override the base pipeline to load font families
-   * Load items with: (no org AND no user) OR (user's org) OR (user's user)
+   * Load items with: (no org) OR (user's org)
    */
   public buildFindAllQuery(user: User, query: BaseQueryDto) {
     const publicMetadata = getPublicMetadata(user);
 
-    // Build OR conditions: global items OR user's org items OR user's items
+    // Build OR conditions: global items OR user's org items
     const orConditions: Record<string, unknown>[] = [
-      { organization: null, user: null }, // global items
+      { organization: null }, // global items
     ];
 
     if (publicMetadata.organization) {
       orConditions.push({
         organization: publicMetadata.organization,
       });
-    }
-
-    if (publicMetadata.user) {
-      orConditions.push({ user: publicMetadata.user });
     }
 
     return {

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
@@ -196,6 +196,28 @@ describe('MusicsController', () => {
       expect(musicsService.findAll).toHaveBeenCalled();
     });
 
+    it('should exclude training-associated musics using trainingId: null', async () => {
+      const user = createMockUser();
+      const request = createMockRequest();
+      musicsService.findAll.mockResolvedValue({
+        docs: [],
+        hasNextPage: false,
+        hasPrevPage: false,
+        limit: 10,
+        page: 1,
+        totalDocs: 0,
+        totalPages: 1,
+      });
+
+      await controller.findLatest(request as never, user as never, 10);
+
+      const callArgs = musicsService.findAll.mock.calls[0];
+      const aggregate = callArgs[0];
+      const userBranch = aggregate.where.OR[0];
+      expect(userBranch).toHaveProperty('trainingId', null);
+      expect(userBranch).not.toHaveProperty('training');
+    });
+
     it('should cap limit at 50', async () => {
       const user = createMockUser();
       const request = createMockRequest();

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.ts
@@ -118,7 +118,7 @@ export class MusicsController extends BaseCRUDController<
             category: IngredientCategory.MUSIC,
             isDeleted,
             // Exclude training source musics by default
-            training: { not: false },
+            trainingId: null,
             user: publicMetadata.user,
           },
           {

--- a/apps/server/api/src/collections/posts/controllers/posts.controller.spec.ts
+++ b/apps/server/api/src/collections/posts/controllers/posts.controller.spec.ts
@@ -1,0 +1,67 @@
+import { PostsController } from '@api/collections/posts/controllers/posts.controller';
+import type { User } from '@clerk/backend';
+import type { PostsQueryDto } from '../dto/posts-query.dto';
+
+const makeUser = (overrides: Partial<User['publicMetadata']> = {}): User =>
+  ({
+    publicMetadata: {
+      organization: 'org-1',
+      brand: 'brand-1',
+      user: 'user-1',
+      role: 'member',
+      ...overrides,
+    },
+  }) as unknown as User;
+
+describe('PostsController.buildFindAllQuery', () => {
+  let controller: PostsController;
+
+  beforeEach(() => {
+    // Minimal stub — only buildFindAllQuery is under test here
+    controller = {
+      buildFindAllQuery: PostsController.prototype.buildFindAllQuery,
+    } as unknown as PostsController;
+  });
+
+  it('uses parentId (scalar FK) not parent (relation alias) in OR filter', () => {
+    const query: PostsQueryDto = {} as PostsQueryDto;
+    const result = controller.buildFindAllQuery(makeUser(), query);
+
+    const orFilter = (result.where as Record<string, unknown>).OR as Record<
+      string,
+      unknown
+    >[];
+
+    expect(orFilter).toBeDefined();
+
+    const keys = orFilter.flatMap((branch) => Object.keys(branch));
+    expect(keys).not.toContain('parent');
+    expect(keys.filter((k) => k === 'parentId').length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  it('includes { parentId: null } branch for top-level posts', () => {
+    const query: PostsQueryDto = {} as PostsQueryDto;
+    const result = controller.buildFindAllQuery(makeUser(), query);
+
+    const orFilter = (result.where as Record<string, unknown>).OR as Record<
+      string,
+      unknown
+    >[];
+
+    expect(orFilter).toContainEqual({ parentId: null });
+  });
+
+  it('includes { parentId: { not: null } } branch (has parent)', () => {
+    const query: PostsQueryDto = {} as PostsQueryDto;
+    const result = controller.buildFindAllQuery(makeUser(), query);
+
+    const orFilter = (result.where as Record<string, unknown>).OR as Record<
+      string,
+      unknown
+    >[];
+
+    expect(orFilter).toContainEqual({ parentId: { not: null } });
+  });
+});

--- a/apps/server/api/src/collections/posts/controllers/posts.controller.ts
+++ b/apps/server/api/src/collections/posts/controllers/posts.controller.ts
@@ -393,7 +393,7 @@ export class PostsController extends BaseCRUDController<
       ...dateFilter,
       // Only show parent posts (not children/replies)
       // Handle both null and undefined (undefined fields aren't stored in MongoDB)
-      OR: [{ parent: null }, { parent: { not: false } }],
+      OR: [{ parentId: null }, { parentId: { not: null } }],
     };
 
     if (query.platform) {

--- a/apps/server/api/src/collections/presets/controllers/presets.controller.spec.ts
+++ b/apps/server/api/src/collections/presets/controllers/presets.controller.spec.ts
@@ -84,6 +84,12 @@ describe('PresetsController', () => {
       expect(Array.isArray(query)).toBe(false);
     });
 
+    it('should default orderBy to { createdAt: -1 } when no sort provided', () => {
+      const query = controller.buildFindAllQuery(mockUser, {}, false);
+
+      expect(query.orderBy).toEqual({ createdAt: -1 });
+    });
+
     it('should filter by category', () => {
       const inputQuery = { category: 'image' };
       const query = controller.buildFindAllQuery(mockUser, inputQuery, false);

--- a/apps/server/api/src/collections/presets/controllers/presets.controller.ts
+++ b/apps/server/api/src/collections/presets/controllers/presets.controller.ts
@@ -76,7 +76,7 @@ export class PresetsController extends BaseCRUDController<
       where: matchStage,
       orderBy: query.sort
         ? handleQuerySort(query.sort)
-        : ({ createdAt: -1, key: 1, label: 1, type: 1 } as SortObject),
+        : ({ createdAt: -1 } as SortObject),
     };
   }
 

--- a/apps/server/api/src/collections/tags/controllers/tags.controller.spec.ts
+++ b/apps/server/api/src/collections/tags/controllers/tags.controller.spec.ts
@@ -97,6 +97,25 @@ describe('TagsController', () => {
       expect(query.where.AND).toBeDefined();
     });
 
+    it('should not include category in search OR conditions (enum field does not support contains)', () => {
+      const inputQuery = {
+        isDeleted: false,
+        search: 'trending',
+      } as unknown as TagsQueryDto;
+      const query = controller.buildFindAllQuery(mockUser, inputQuery);
+
+      const andBlock = query.where.AND as Array<{
+        OR: Array<Record<string, unknown>>;
+      }>;
+      const searchOrFields = andBlock[0].OR.map(
+        (entry) => Object.keys(entry)[0],
+      );
+      expect(searchOrFields).not.toContain('category');
+      expect(searchOrFields).toEqual(
+        expect.arrayContaining(['label', 'key', 'description']),
+      );
+    });
+
     it('should use label filter when search is not provided but label is', () => {
       const inputQuery = {
         isDeleted: false,

--- a/apps/server/api/src/collections/tags/controllers/tags.controller.ts
+++ b/apps/server/api/src/collections/tags/controllers/tags.controller.ts
@@ -64,8 +64,9 @@ export class TagsController extends BaseCRUDController<
       OR: orConditions,
     };
 
-    // Add search condition (searches across label, key, description, category)
+    // Add search condition (searches across label, key, description)
     // If both search and label are provided, search takes precedence
+    // Note: category is a TagCategory enum — Prisma does not support `contains` on enum fields
     if (query.search) {
       // Add search OR condition - MongoDB will AND it with the organization OR
       matchConditions.AND = [
@@ -74,7 +75,6 @@ export class TagsController extends BaseCRUDController<
             { label: { mode: 'insensitive', contains: query.search } },
             { key: { mode: 'insensitive', contains: query.search } },
             { description: { mode: 'insensitive', contains: query.search } },
-            { category: { mode: 'insensitive', contains: query.search } },
           ],
         },
       ];

--- a/apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts
+++ b/apps/server/api/src/collections/trainings/controllers/trainings.controller.spec.ts
@@ -193,7 +193,7 @@ describe('TrainingsController', () => {
       expect(result).toBeDefined();
     });
 
-    it('should filter by status when provided', async () => {
+    it('should map status=completed to stage=READY in the filter', async () => {
       const mockTrainings = {
         docs: [],
         hasNextPage: false,
@@ -211,14 +211,14 @@ describe('TrainingsController', () => {
         mockTrainings as unknown as AggregatePaginateResult<TrainingDocument>,
       );
 
-      const query = createTrainingsQuery({
-        status: [IngredientStatus.GENERATED] as unknown as IngredientStatus[],
-      });
+      const query = createTrainingsQuery({ status: ['completed'] });
       await controller.findAll(mockRequest, mockUser, query);
 
       const pipeline = controller.buildFindAllPipeline(mockUser, query);
       const matchStage = asMatchStage(pipeline[0]);
-      expect(matchStage.$match.status).toEqual(IngredientStatus.GENERATED);
+      // Training has no `status` column — app-vocab is mapped to `stage`.
+      expect(matchStage.$match.status).toBeUndefined();
+      expect(matchStage.$match.stage).toEqual('READY');
     });
 
     it('should apply sorting when sort parameter is provided', () => {
@@ -416,14 +416,54 @@ describe('TrainingsController', () => {
       expect(matchStage.$match.isDeleted).toBe(false);
     });
 
-    it('should include status filter when provided', () => {
+    it('should map app-vocab status values to TrainingStage enum values', () => {
+      const query = createTrainingsQuery({ status: ['completed'] });
+      const pipeline = controller.buildFindAllPipeline(mockUser, query);
+
+      const matchStage = asMatchStage(pipeline[0]);
+      // Training has no `status` column — app-vocab is mapped to `stage`.
+      expect(matchStage.$match.status).toBeUndefined();
+      expect(matchStage.$match.stage).toEqual('READY');
+    });
+
+    it('should map multiple status values to multiple TrainingStage values', () => {
       const query = createTrainingsQuery({
-        status: [IngredientStatus.GENERATED] as unknown as IngredientStatus[],
+        status: ['completed', 'failed'],
       });
       const pipeline = controller.buildFindAllPipeline(mockUser, query);
 
       const matchStage = asMatchStage(pipeline[0]);
-      expect(matchStage.$match.status).toEqual(IngredientStatus.GENERATED);
+      expect(matchStage.$match.status).toBeUndefined();
+      expect(matchStage.$match.stage).toEqual({ in: ['READY', 'FAILED'] });
+    });
+
+    it('should map processing to TRAINING stage', () => {
+      const query = createTrainingsQuery({ status: ['processing'] });
+      const pipeline = controller.buildFindAllPipeline(mockUser, query);
+
+      const matchStage = asMatchStage(pipeline[0]);
+      expect(matchStage.$match.stage).toEqual('TRAINING');
+    });
+
+    it('should drop unknown status values silently', () => {
+      const query = createTrainingsQuery({ status: ['unknown-value'] });
+      const pipeline = controller.buildFindAllPipeline(mockUser, query);
+
+      const matchStage = asMatchStage(pipeline[0]);
+      expect(matchStage.$match.status).toBeUndefined();
+      expect(matchStage.$match.stage).toBeUndefined();
+    });
+
+    it('should deduplicate stage values when multiple inputs map to the same stage', () => {
+      // completed and ready both map to READY
+      const query = createTrainingsQuery({
+        status: ['completed', 'ready'],
+      });
+      const pipeline = controller.buildFindAllPipeline(mockUser, query);
+
+      const matchStage = asMatchStage(pipeline[0]);
+      // Deduplication means single value, not { in: ['READY', 'READY'] }
+      expect(matchStage.$match.stage).toEqual('READY');
     });
 
     it('should handle isDeleted parameter', () => {

--- a/apps/server/api/src/collections/trainings/controllers/trainings.controller.ts
+++ b/apps/server/api/src/collections/trainings/controllers/trainings.controller.ts
@@ -92,6 +92,27 @@ export class TrainingsController extends BaseCRUDController<
   }
 
   /**
+   * Maps studio/app-level status vocabulary to the Training `stage` enum.
+   *
+   * Training has NO `status` column — the schema uses `stage: TrainingStage`
+   * with values PENDING | UPLOADING | TRAINING | READY | FAILED | CANCELLED.
+   *
+   * The studio sends lowercase app-vocab values (e.g. ?status=completed).
+   * NOTE for review: `completed` → READY and `processing` → TRAINING are
+   * semantic assumptions — confirm with Vincent before shipping to production.
+   */
+  private static readonly STATUS_TO_STAGE: Record<string, string> = {
+    cancelled: 'CANCELLED',
+    completed: 'READY',
+    failed: 'FAILED',
+    pending: 'PENDING',
+    processing: 'TRAINING',
+    ready: 'READY',
+    training: 'TRAINING',
+    uploading: 'UPLOADING',
+  };
+
+  /**
    * Override buildFindAllQuery to support both user and organization filtering
    */
   public buildFindAllQuery(user: User, query: TrainingsQueryDto) {
@@ -116,9 +137,22 @@ export class TrainingsController extends BaseCRUDController<
       isDeleted: query.isDeleted ?? false,
     };
 
-    const statusFilter = CollectionFilterUtil.buildStatusFilter(query.status);
-    if (Object.keys(statusFilter).length > 0) {
-      Object.assign(where, statusFilter);
+    // Map app-vocab status values to the TrainingStage enum; drop unknowns.
+    if (query.status && query.status.length > 0) {
+      const mappedStages = [
+        ...new Set(
+          query.status
+            .map((s) => TrainingsController.STATUS_TO_STAGE[s.toLowerCase()])
+            .filter(Boolean),
+        ),
+      ];
+
+      if (mappedStages.length === 1) {
+        where.stage = mappedStages[0];
+      } else if (mappedStages.length > 1) {
+        where.stage = { in: mappedStages };
+      }
+      // If all values were unknown, no stage filter is applied.
     }
 
     return {

--- a/apps/server/api/src/collections/trainings/dto/trainings-query.dto.ts
+++ b/apps/server/api/src/collections/trainings/dto/trainings-query.dto.ts
@@ -6,8 +6,21 @@ import { IsArray, IsOptional, IsString } from 'class-validator';
 export class TrainingsQueryDto extends BaseQueryDto {
   @ApiProperty({
     description:
-      'Filter trainings by status using repeated query keys (e.g., ?status=completed&status=failed).',
-    enum: ['processing', 'completed', 'failed'],
+      'Filter trainings by status using repeated query keys (e.g., ?status=completed&status=failed). ' +
+      'Values are mapped to the TrainingStage enum: ' +
+      'pending→PENDING, uploading→UPLOADING, processing→TRAINING, training→TRAINING, ' +
+      'completed→READY, ready→READY, failed→FAILED, cancelled→CANCELLED. ' +
+      'Unknown values are silently dropped.',
+    enum: [
+      'pending',
+      'uploading',
+      'processing',
+      'training',
+      'completed',
+      'ready',
+      'failed',
+      'cancelled',
+    ],
     required: false,
     type: [String],
   })

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
@@ -28,10 +28,10 @@ describe('ArticleFilterUtil', () => {
   });
 
   describe('buildTagFilter', () => {
-    it('returns ObjectId for valid tag', () => {
+    it('returns Prisma m2m relation filter for valid tag', () => {
       const tagId = '507f191e810c19729de860ee';
       const filter = ArticleFilterUtil.buildTagFilter(tagId);
-      expect(filter.tags).toBe(tagId);
+      expect(filter).toEqual({ tags: { some: { id: tagId } } });
     });
 
     it('returns empty object for invalid tag', () => {
@@ -44,7 +44,7 @@ describe('ArticleFilterUtil', () => {
       const filter = ArticleFilterUtil.buildContentSearchFilter(' marketing ');
       expect(filter.OR as unknown[]).toHaveLength(3);
       expect(
-        (filter.OR as Array<{ label?: { contains: string } }>)[0].label
+        (filter.OR as Array<{ title?: { contains: string } }>)[0].title
           ?.contains,
       ).toBe('marketing');
     });
@@ -85,7 +85,7 @@ describe('ArticleFilterUtil', () => {
           isDeleted: false,
           organization: '507f191e810c19729de860ee',
           scope: 'organization',
-          tags: tag,
+          tags: { some: { id: tag } },
         },
       });
       expect((query.where as { AND: unknown[] }).AND).toHaveLength(1);

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
@@ -3,27 +3,64 @@ import { ArticleStatus } from '@genfeedai/enums';
 
 describe('ArticleFilterUtil', () => {
   describe('buildArticleStatusFilter', () => {
-    it('expands draft to include processing', () => {
+    it('maps draft to Prisma DRAFT', () => {
       const filter = ArticleFilterUtil.buildArticleStatusFilter(
         ArticleStatus.DRAFT,
       );
-      expect(filter).toEqual({
-        status: { in: [ArticleStatus.DRAFT, ArticleStatus.PROCESSING] },
-      });
+      expect(filter).toEqual({ status: 'DRAFT' });
     });
 
-    it('accepts multiple statuses', () => {
+    it('maps public to Prisma PUBLISHED', () => {
+      const filter = ArticleFilterUtil.buildArticleStatusFilter(
+        ArticleStatus.PUBLIC,
+      );
+      expect(filter).toEqual({ status: 'PUBLISHED' });
+    });
+
+    it('maps archived to Prisma ARCHIVED', () => {
+      const filter = ArticleFilterUtil.buildArticleStatusFilter(
+        ArticleStatus.ARCHIVED,
+      );
+      expect(filter).toEqual({ status: 'ARCHIVED' });
+    });
+
+    it('drops processing (no Prisma equivalent)', () => {
+      const filter = ArticleFilterUtil.buildArticleStatusFilter(
+        ArticleStatus.PROCESSING,
+      );
+      expect(filter).toEqual({});
+    });
+
+    it('drops failed (no Prisma equivalent)', () => {
+      const filter = ArticleFilterUtil.buildArticleStatusFilter(
+        ArticleStatus.FAILED,
+      );
+      expect(filter).toEqual({});
+    });
+
+    it('accepts multiple statuses and maps each', () => {
       const filter = ArticleFilterUtil.buildArticleStatusFilter([
         ArticleStatus.PUBLIC,
         ArticleStatus.DRAFT,
       ]);
-      expect((filter.status as { in: ArticleStatus[] }).in).toEqual(
-        expect.arrayContaining([
-          ArticleStatus.DRAFT,
-          ArticleStatus.PROCESSING,
-          ArticleStatus.PUBLIC,
-        ]),
-      );
+      expect(filter).toEqual({ status: { in: ['PUBLISHED', 'DRAFT'] } });
+    });
+
+    it('excludes unmappable values when mixed with valid ones', () => {
+      const filter = ArticleFilterUtil.buildArticleStatusFilter([
+        ArticleStatus.DRAFT,
+        ArticleStatus.PROCESSING,
+      ]);
+      // processing has no Prisma equivalent — only DRAFT survives
+      expect(filter).toEqual({ status: 'DRAFT' });
+    });
+
+    it('returns empty object when all statuses are unmappable', () => {
+      const filter = ArticleFilterUtil.buildArticleStatusFilter([
+        ArticleStatus.PROCESSING,
+        ArticleStatus.FAILED,
+      ]);
+      expect(filter).toEqual({});
     });
   });
 
@@ -85,10 +122,19 @@ describe('ArticleFilterUtil', () => {
           isDeleted: false,
           organization: '507f191e810c19729de860ee',
           scope: 'organization',
+          status: 'DRAFT',
           tags: { some: { id: tag } },
         },
       });
       expect((query.where as { AND: unknown[] }).AND).toHaveLength(1);
+    });
+
+    it('omits status filter when all provided statuses are unmappable', () => {
+      const query = ArticleFilterUtil.buildArticlequery(
+        { status: ArticleStatus.PROCESSING },
+        { isDeleted: false },
+      );
+      expect((query.where as Record<string, unknown>).status).toBeUndefined();
     });
   });
 });

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts
@@ -32,7 +32,7 @@ export class ArticleFilterUtil {
   }
 
   static buildTagFilter(tagId?: string): Record<string, unknown> {
-    return tagId && isEntityId(tagId) ? { tags: tagId } : {};
+    return tagId && isEntityId(tagId) ? { tags: { some: { id: tagId } } } : {};
   }
 
   static buildContentSearchFilter(search?: string): Record<string, unknown> {
@@ -41,8 +41,8 @@ export class ArticleFilterUtil {
     const searchFilter = { contains: search.trim(), mode: 'insensitive' };
     return {
       OR: [
-        { label: searchFilter },
-        { summary: searchFilter },
+        { title: searchFilter },
+        { excerpt: searchFilter },
         { content: searchFilter },
       ],
     };

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts
@@ -1,6 +1,16 @@
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ArticleStatus } from '@genfeedai/enums';
 
+/**
+ * Maps app-level ArticleStatus values (lowercase) to Prisma enum values (uppercase).
+ * processing and failed have no Prisma equivalent and are excluded from the filter.
+ */
+const APP_TO_PRISMA_STATUS: Partial<Record<ArticleStatus, string>> = {
+  [ArticleStatus.DRAFT]: 'DRAFT',
+  [ArticleStatus.PUBLIC]: 'PUBLISHED',
+  [ArticleStatus.ARCHIVED]: 'ARCHIVED',
+};
+
 export class ArticleFilterUtil {
   static buildArticleStatusFilter(
     status?: ArticleStatus | ArticleStatus[],
@@ -8,23 +18,16 @@ export class ArticleFilterUtil {
     if (!status) return {};
 
     const statuses = Array.isArray(status) ? status : [status];
-    const expandedStatuses = new Set<ArticleStatus>();
+    const mapped = statuses
+      .map((s) => APP_TO_PRISMA_STATUS[s])
+      .filter((s): s is string => s !== undefined);
 
-    for (const item of statuses) {
-      if (item === ArticleStatus.DRAFT) {
-        expandedStatuses.add(ArticleStatus.DRAFT);
-        expandedStatuses.add(ArticleStatus.PROCESSING);
-      } else {
-        expandedStatuses.add(item);
-      }
+    if (mapped.length === 0) return {};
+    if (mapped.length === 1) {
+      return { status: mapped[0] };
     }
 
-    if (expandedStatuses.size === 0) return {};
-    if (expandedStatuses.size === 1) {
-      return { status: Array.from(expandedStatuses)[0] };
-    }
-
-    return { status: { in: Array.from(expandedStatuses) } };
+    return { status: { in: mapped } };
   }
 
   static buildCategoryFilter(category?: string): Record<string, unknown> {

--- a/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.spec.ts
@@ -67,9 +67,9 @@ describe('IngredientFilterUtil', () => {
       expect(result).toEqual(brandId);
     });
 
-    it('should filter for any existing brand when no ID provided', () => {
+    it('should assert brandId is set (not null) when no ID provided', () => {
       const result = IngredientFilterUtil.buildBrandFilter(undefined);
-      expect(result).toEqual({ not: true });
+      expect(result).toEqual({ not: null });
     });
   });
 

--- a/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.ts
@@ -116,11 +116,11 @@ export class IngredientFilterUtil {
    */
   static buildBrandFilter(
     brand: string | undefined,
-  ): string | Record<string, boolean> {
+  ): string | Record<string, unknown> {
     if (isEntityId(brand)) {
       return brand;
     }
-    return { not: true };
+    return { not: null };
   }
 
   /**

--- a/apps/server/api/src/helpers/utils/training-filter/training-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/training-filter/training-filter.util.spec.ts
@@ -41,7 +41,7 @@ describe('TrainingFilterUtil', () => {
       expect(filter).toEqual({
         category: 'IMAGE',
         isDeleted: false,
-        metadata: { in: ['metadata-1', 'metadata-2'] },
+        metadataId: { in: ['metadata-1', 'metadata-2'] },
       });
     });
   });

--- a/apps/server/api/src/helpers/utils/training-filter/training-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/training-filter/training-filter.util.ts
@@ -20,7 +20,7 @@ export class TrainingFilterUtil {
     return {
       category: 'IMAGE',
       isDeleted: false,
-      metadata: { in: options.metadataIds },
+      metadataId: { in: options.metadataIds },
     };
   }
 }

--- a/packages/agent/src/components/AgentCliTerminal.tsx
+++ b/packages/agent/src/components/AgentCliTerminal.tsx
@@ -869,7 +869,7 @@ export function AgentCliTerminalControls({
             >
               <Button
                 className={cn(
-                  'h-5 rounded-sm border border-border/60 px-2 text-[10px] text-foreground/50 transition-colors hover:border-emerald-300/40 hover:text-emerald-200',
+                  'h-6 rounded-sm border border-border/60 px-2 text-[10px] text-foreground/50 transition-colors hover:border-emerald-300/40 hover:text-emerald-200',
                   activeSessionId === session.id &&
                     'border-emerald-300/50 text-emerald-200',
                 )}
@@ -884,7 +884,7 @@ export function AgentCliTerminalControls({
               />
               <Button
                 aria-label={`Close ${session.kind} session`}
-                className="h-5 rounded-sm border border-border/60 px-1 text-[10px] text-foreground/35 transition-colors hover:border-red-400/50 hover:text-red-300"
+                className="h-6 rounded-sm border border-border/60 px-1 text-[10px] text-foreground/35 transition-colors hover:border-red-400/50 hover:text-red-300"
                 label="×"
                 onClick={(event) => {
                   event.stopPropagation();
@@ -898,7 +898,7 @@ export function AgentCliTerminalControls({
           ))}
           <Button
             aria-label="Open new terminal session"
-            className="h-5 rounded-sm border border-border/60 px-1.5 text-[10px] text-foreground/35 transition-colors hover:border-emerald-300/40 hover:text-emerald-200"
+            className="h-6 rounded-sm border border-border/60 px-1.5 text-[10px] text-foreground/35 transition-colors hover:border-emerald-300/40 hover:text-emerald-200"
             label="+"
             onClick={(event) => {
               event.stopPropagation();

--- a/packages/agent/src/components/AgentRuntimeSelector.tsx
+++ b/packages/agent/src/components/AgentRuntimeSelector.tsx
@@ -89,7 +89,7 @@ export function AgentRuntimeSelector({
           </span>
           <HiChevronDown
             className={cn(
-              'size-3 text-foreground/42 transition-transform',
+              'size-3.5 text-foreground/42 transition-transform',
               open && 'rotate-180',
             )}
           />

--- a/packages/agent/src/components/AgentTerminalHeader.tsx
+++ b/packages/agent/src/components/AgentTerminalHeader.tsx
@@ -33,7 +33,7 @@ export function AgentTerminalHeader({
         )}
       />
       <span className="sr-only">{catalog.environmentLabel}</span>
-      <p className="shrink-0 truncate text-[11px] text-foreground/55">
+      <p className="shrink-0 self-center truncate text-[11px] leading-none text-foreground/55">
         {threadLabel || 'New session'}
       </p>
 

--- a/packages/pages/agents/library/LivestreamChatBotPage.tsx
+++ b/packages/pages/agents/library/LivestreamChatBotPage.tsx
@@ -2,6 +2,7 @@
 
 import { ButtonVariant } from '@genfeedai/enums';
 import Textarea from '@ui/inputs/textarea/Textarea';
+import Container from '@ui/layout/container/Container';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
 import LivestreamBotConfigCard from './LivestreamBotConfigCard';
@@ -59,140 +60,137 @@ export default function LivestreamChatBotPage({
   );
 
   return (
-    <div className="space-y-6 p-6">
-      <div className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold">Livestream Chat Bot</h1>
-        <p className="text-sm text-muted-foreground">
-          YouTube is treated as the primary platform. Save the bot, connect the
-          channel targets, then control the live session from the same screen.
-        </p>
-      </div>
+    <Container
+      label="Livestream Chat Bot"
+      description="YouTube is treated as the primary platform. Save the bot, connect the channel targets, then control the live session from the same screen."
+    >
+      <div className="space-y-6">
+        <LivestreamBotConfigCard
+          form={form}
+          isSaving={isSaving}
+          onFormChange={(patch) =>
+            setForm((current) => ({ ...current, ...patch }))
+          }
+          onSave={() => void handleSave()}
+        />
 
-      <LivestreamBotConfigCard
-        form={form}
-        isSaving={isSaving}
-        onFormChange={(patch) =>
-          setForm((current) => ({ ...current, ...patch }))
-        }
-        onSave={() => void handleSave()}
-      />
+        <LivestreamPlatformTargets
+          form={form}
+          onFormChange={(patch) =>
+            setForm((current) => ({ ...current, ...patch }))
+          }
+          youtubeLastPostedAt={youtubeFirstStatus?.lastPostedAt}
+          twitchLastPostedAt={twitchStatus?.lastPostedAt}
+        />
 
-      <LivestreamPlatformTargets
-        form={form}
-        onFormChange={(patch) =>
-          setForm((current) => ({ ...current, ...patch }))
-        }
-        youtubeLastPostedAt={youtubeFirstStatus?.lastPostedAt}
-        twitchLastPostedAt={twitchStatus?.lastPostedAt}
-      />
-
-      <div className="gen-glass rounded-xl p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold">Runtime Controls</h2>
-            <p className="text-sm text-muted-foreground">
-              Session status: {session?.status || 'stopped'}
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              label="Start"
-              variant={ButtonVariant.DEFAULT}
-              onClick={() => void handleSessionAction('start')}
-            />
-            <Button
-              label="Pause"
-              variant={ButtonVariant.SECONDARY}
-              onClick={() => void handleSessionAction('pause')}
-            />
-            <Button
-              label="Resume"
-              variant={ButtonVariant.SECONDARY}
-              onClick={() => void handleSessionAction('resume')}
-            />
-            <Button
-              label="Stop"
-              variant={ButtonVariant.DESTRUCTIVE}
-              onClick={() => void handleSessionAction('stop')}
-            />
-          </div>
-        </div>
-
-        <div className="mt-6 grid gap-6 lg:grid-cols-3">
-          <div className="space-y-4">
-            <h3 className="font-medium">Manual Override</h3>
-            <Input
-              label="Current Topic"
-              value={manualTopic}
-              onChange={(event) => setManualTopic(event.target.value)}
-            />
-            <Input
-              label="Promotion Angle"
-              value={promotionAngle}
-              onChange={(event) => setPromotionAngle(event.target.value)}
-            />
-            <Button
-              label="Apply Override"
-              variant={ButtonVariant.SECONDARY}
-              onClick={() => void handleApplyOverride()}
-            />
-          </div>
-
-          <div className="space-y-4">
-            <h3 className="font-medium">Transcript Ingestion</h3>
-            <Textarea
-              label="Transcript Chunk"
-              value={transcriptChunk}
-              onChange={(event) => setTranscriptChunk(event.target.value)}
-            />
-            <Button
-              label="Process Transcript"
-              variant={ButtonVariant.SECONDARY}
-              onClick={() => void handleIngestTranscript()}
-            />
-          </div>
-
-          <div className="space-y-4">
-            <h3 className="font-medium">Send One-Off Message</h3>
-            <div className="flex gap-2">
+        <div className="gen-glass rounded-xl p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Runtime Controls</h2>
+              <p className="text-sm text-muted-foreground">
+                Session status: {session?.status || 'stopped'}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
               <Button
-                label="YouTube"
-                variant={
-                  selectedPlatform === 'youtube'
-                    ? ButtonVariant.DEFAULT
-                    : ButtonVariant.SECONDARY
-                }
-                onClick={() => setSelectedPlatform('youtube')}
+                label="Start"
+                variant={ButtonVariant.DEFAULT}
+                onClick={() => void handleSessionAction('start')}
               />
               <Button
-                label="Twitch"
-                variant={
-                  selectedPlatform === 'twitch'
-                    ? ButtonVariant.DEFAULT
-                    : ButtonVariant.SECONDARY
-                }
-                onClick={() => setSelectedPlatform('twitch')}
+                label="Pause"
+                variant={ButtonVariant.SECONDARY}
+                onClick={() => void handleSessionAction('pause')}
+              />
+              <Button
+                label="Resume"
+                variant={ButtonVariant.SECONDARY}
+                onClick={() => void handleSessionAction('resume')}
+              />
+              <Button
+                label="Stop"
+                variant={ButtonVariant.DESTRUCTIVE}
+                onClick={() => void handleSessionAction('stop')}
               />
             </div>
-            <Textarea
-              label="Message"
-              placeholder="Leave blank to let the bot generate the next prompt."
-              value={sendNowMessage}
-              onChange={(event) => setSendNowMessage(event.target.value)}
-            />
-            <Button
-              label="Send Now"
-              variant={ButtonVariant.DEFAULT}
-              onClick={() => void handleSendNow()}
-            />
+          </div>
+
+          <div className="mt-6 grid gap-6 lg:grid-cols-3">
+            <div className="space-y-4">
+              <h3 className="font-medium">Manual Override</h3>
+              <Input
+                label="Current Topic"
+                value={manualTopic}
+                onChange={(event) => setManualTopic(event.target.value)}
+              />
+              <Input
+                label="Promotion Angle"
+                value={promotionAngle}
+                onChange={(event) => setPromotionAngle(event.target.value)}
+              />
+              <Button
+                label="Apply Override"
+                variant={ButtonVariant.SECONDARY}
+                onClick={() => void handleApplyOverride()}
+              />
+            </div>
+
+            <div className="space-y-4">
+              <h3 className="font-medium">Transcript Ingestion</h3>
+              <Textarea
+                label="Transcript Chunk"
+                value={transcriptChunk}
+                onChange={(event) => setTranscriptChunk(event.target.value)}
+              />
+              <Button
+                label="Process Transcript"
+                variant={ButtonVariant.SECONDARY}
+                onClick={() => void handleIngestTranscript()}
+              />
+            </div>
+
+            <div className="space-y-4">
+              <h3 className="font-medium">Send One-Off Message</h3>
+              <div className="flex gap-2">
+                <Button
+                  label="YouTube"
+                  variant={
+                    selectedPlatform === 'youtube'
+                      ? ButtonVariant.DEFAULT
+                      : ButtonVariant.SECONDARY
+                  }
+                  onClick={() => setSelectedPlatform('youtube')}
+                />
+                <Button
+                  label="Twitch"
+                  variant={
+                    selectedPlatform === 'twitch'
+                      ? ButtonVariant.DEFAULT
+                      : ButtonVariant.SECONDARY
+                  }
+                  onClick={() => setSelectedPlatform('twitch')}
+                />
+              </div>
+              <Textarea
+                label="Message"
+                placeholder="Leave blank to let the bot generate the next prompt."
+                value={sendNowMessage}
+                onChange={(event) => setSendNowMessage(event.target.value)}
+              />
+              <Button
+                label="Send Now"
+                variant={ButtonVariant.DEFAULT}
+                onClick={() => void handleSendNow()}
+              />
+            </div>
           </div>
         </div>
-      </div>
 
-      <LivestreamSessionPanels
-        recentDeliveries={recentDeliveries}
-        session={session}
-      />
-    </div>
+        <LivestreamSessionPanels
+          recentDeliveries={recentDeliveries}
+          session={session}
+        />
+      </div>
+    </Container>
   );
 }

--- a/packages/prisma/prisma/migrations/20260603083913_reconcile_filter_fields/migration.sql
+++ b/packages/prisma/prisma/migrations/20260603083913_reconcile_filter_fields/migration.sql
@@ -1,0 +1,76 @@
+-- AlterTable
+ALTER TABLE "articles" ADD COLUMN     "category" TEXT,
+ADD COLUMN     "scope" TEXT;
+
+-- AlterTable
+ALTER TABLE "models" ADD COLUMN     "category" TEXT;
+
+-- AlterTable
+ALTER TABLE "agent_runs" ADD COLUMN     "creditsUsed" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "durationMs" INTEGER,
+ADD COLUMN     "label" TEXT,
+ADD COLUMN     "metadata" JSONB NOT NULL DEFAULT '{}',
+ADD COLUMN     "objective" TEXT,
+ADD COLUMN     "trigger" TEXT;
+
+-- AlterTable
+ALTER TABLE "agent_strategies" ADD COLUMN     "agentType" TEXT,
+ADD COLUMN     "platforms" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "agent_campaigns" ADD COLUMN     "status" TEXT DEFAULT 'draft';
+
+-- AlterTable
+ALTER TABLE "workflow_executions" ADD COLUMN     "trigger" TEXT;
+
+-- AlterTable
+ALTER TABLE "tasks" ADD COLUMN     "assigneeAgentId" TEXT,
+ADD COLUMN     "assigneeUserId" TEXT,
+ADD COLUMN     "goalId" TEXT,
+ADD COLUMN     "projectId" TEXT,
+ADD COLUMN     "reviewState" TEXT NOT NULL DEFAULT 'none';
+
+-- AlterTable
+ALTER TABLE "bots" ADD COLUMN     "category" TEXT,
+ADD COLUMN     "platforms" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "reply_bot_configs" ADD COLUMN     "actionType" TEXT,
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "type" TEXT;
+
+-- AlterTable
+ALTER TABLE "monitored_accounts" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "outreach_campaigns" ADD COLUMN     "campaignType" TEXT,
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "platform" TEXT;
+
+-- AlterTable
+ALTER TABLE "elements_blacklists" ADD COLUMN     "category" TEXT;
+
+-- AlterTable
+ALTER TABLE "elements_scenes" ADD COLUMN     "isFavorite" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "elements_sounds" ADD COLUMN     "isFavorite" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "presets" ADD COLUMN     "category" TEXT,
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "isFavorite" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "templates" ADD COLUMN     "categories" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "industries" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "isFeatured" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "key" TEXT,
+ADD COLUMN     "platforms" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "purpose" TEXT,
+ADD COLUMN     "scope" TEXT;
+
+-- AlterTable
+ALTER TABLE "goals" ADD COLUMN     "level" TEXT,
+ADD COLUMN     "status" TEXT;
+

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -501,88 +501,88 @@ enum BatchStatus {
 // ═══════════════════════════════════════════════════════════════
 
 model User {
-  id                      String          @id @default(cuid())
-  mongoId                 String?         @unique
-  clerkId                 String?         @unique
-  handle                  String          @unique
-  firstName               String?
-  lastName                String?
-  email                   String?
-  avatar                  String?
-  isDefault               Boolean         @default(false)
-  isDeleted               Boolean         @default(false)
-  isInvited               Boolean         @default(false)
-  isOnboardingCompleted   Boolean         @default(false)
-  onboardingStartedAt     DateTime?
-  onboardingCompletedAt   DateTime?
-  onboardingType          OnboardingType?
-  onboardingStepsCompleted String[]       @default([])
-  appSource               AppSource       @default(GENFEED)
-  stripeCustomerId        String?
-  createdAt               DateTime        @default(now())
-  updatedAt               DateTime        @updatedAt
+  id                       String          @id @default(cuid())
+  mongoId                  String?         @unique
+  clerkId                  String?         @unique
+  handle                   String          @unique
+  firstName                String?
+  lastName                 String?
+  email                    String?
+  avatar                   String?
+  isDefault                Boolean         @default(false)
+  isDeleted                Boolean         @default(false)
+  isInvited                Boolean         @default(false)
+  isOnboardingCompleted    Boolean         @default(false)
+  onboardingStartedAt      DateTime?
+  onboardingCompletedAt    DateTime?
+  onboardingType           OnboardingType?
+  onboardingStepsCompleted String[]        @default([])
+  appSource                AppSource       @default(GENFEED)
+  stripeCustomerId         String?
+  createdAt                DateTime        @default(now())
+  updatedAt                DateTime        @updatedAt
 
   // Ownership relations (what this user owns)
-  organizations       Organization[]
-  brands              Brand[]
-  members             Member[]
-  settings            Setting?
-  credentials         Credential[]
-  apiKeys             ApiKey[]
-  ingredients         Ingredient[]
-  posts               Post[]
-  postAnalytics       PostAnalytics[]
-  prompts             Prompt[]
-  folders             Folder[]
-  bookmarks           Bookmark[]
-  articles            Article[]
-  articleAnalytics    ArticleAnalytics[]
-  newsletters         Newsletter[]         @relation("newsletter_user")
-  newsletterApprovals Newsletter[]         @relation("newsletter_approved_by")
-  newsletterPublishes Newsletter[]         @relation("newsletter_published_by")
-  transcripts         Transcript[]
-  trainings           Training[]
-  personas            Persona[]
-  agentRuns           AgentRun[]
-  agentStrategies     AgentStrategy[]
-  agentCampaigns      AgentCampaign[]
-  agentGoals          AgentGoal[]
-  agentMemories       AgentMemory[]
-  agentThreads        AgentThread[]
-  agentMessages       AgentMessage[]
-  agentWorkflows      AgentWorkflow[]
-  workflows           Workflow[]
-  workflowExecutions  WorkflowExecution[]
-  cronJobs            CronJob[]
-  cronRuns            CronRun[]
-  bots                Bot[]
-  botActivities       BotActivity[]
-  replyBotConfigs     ReplyBotConfig[]
-  monitoredAccounts   MonitoredAccount[]
-  votes               Vote[]
-  watchlists          Watchlist[]
-  streaks             Streak[]
-  forecasts           Forecast[]
-  tasks               Task[]
-  contentPlans        ContentPlan[]
-  evaluations         Evaluation[]
-  editorProjects      EditorProject[]
-  batches             Batch[]
-  assets              Asset[]
-  subscriptions       Subscription[]
-  userSubscription    UserSubscription?
+  organizations            Organization[]
+  brands                   Brand[]
+  members                  Member[]
+  settings                 Setting?
+  credentials              Credential[]
+  apiKeys                  ApiKey[]
+  ingredients              Ingredient[]
+  posts                    Post[]
+  postAnalytics            PostAnalytics[]
+  prompts                  Prompt[]
+  folders                  Folder[]
+  bookmarks                Bookmark[]
+  articles                 Article[]
+  articleAnalytics         ArticleAnalytics[]
+  newsletters              Newsletter[]              @relation("newsletter_user")
+  newsletterApprovals      Newsletter[]              @relation("newsletter_approved_by")
+  newsletterPublishes      Newsletter[]              @relation("newsletter_published_by")
+  transcripts              Transcript[]
+  trainings                Training[]
+  personas                 Persona[]
+  agentRuns                AgentRun[]
+  agentStrategies          AgentStrategy[]
+  agentCampaigns           AgentCampaign[]
+  agentGoals               AgentGoal[]
+  agentMemories            AgentMemory[]
+  agentThreads             AgentThread[]
+  agentMessages            AgentMessage[]
+  agentWorkflows           AgentWorkflow[]
+  workflows                Workflow[]
+  workflowExecutions       WorkflowExecution[]
+  cronJobs                 CronJob[]
+  cronRuns                 CronRun[]
+  bots                     Bot[]
+  botActivities            BotActivity[]
+  replyBotConfigs          ReplyBotConfig[]
+  monitoredAccounts        MonitoredAccount[]
+  votes                    Vote[]
+  watchlists               Watchlist[]
+  streaks                  Streak[]
+  forecasts                Forecast[]
+  tasks                    Task[]
+  contentPlans             ContentPlan[]
+  evaluations              Evaluation[]
+  editorProjects           EditorProject[]
+  batches                  Batch[]
+  assets                   Asset[]
+  subscriptions            Subscription[]
+  userSubscription         UserSubscription?
   subscriptionAttributions SubscriptionAttribution[]
-  distributions       Distribution[]
-  repurposingJobs     RepurposingJob[]
-  contentDrafts       ContentDraft[]       @relation("content_draft_approved_by")
-  creatorAnalyses     CreatorAnalysis[]
-  profiles            Profile[]
-  contextBases        ContextBase[]
-  optimizations       Optimization[]
-  leads               Lead[]               @relation("lead_user")
-  outreachCampaigns   OutreachCampaign[]
-  captions            Caption[]
-  personaAssignments  Persona[]            @relation("persona_assigned_members")
+  distributions            Distribution[]
+  repurposingJobs          RepurposingJob[]
+  contentDrafts            ContentDraft[]            @relation("content_draft_approved_by")
+  creatorAnalyses          CreatorAnalysis[]
+  profiles                 Profile[]
+  contextBases             ContextBase[]
+  optimizations            Optimization[]
+  leads                    Lead[]                    @relation("lead_user")
+  outreachCampaigns        OutreachCampaign[]
+  captions                 Caption[]
+  personaAssignments       Persona[]                 @relation("persona_assigned_members")
 
   @@index([isDefault])
   @@index([appSource])
@@ -591,129 +591,129 @@ model User {
 }
 
 model Organization {
-  id                       String               @id @default(cuid())
-  mongoId                 String?         @unique
-  clerkOrganizationId      String?              @unique
-  userId                   String
-  user                     User                 @relation(fields: [userId], references: [id])
-  label                    String
-  slug                     String               @unique
-  prefix                   String?
-  isSelected               Boolean              @default(false)
-  isDefault                Boolean              @default(false)
-  isDeleted                Boolean              @default(false)
-  category                 OrganizationCategory @default(BUSINESS)
-  accountType              OrganizationCategory?
-  onboardingCompleted      Boolean              @default(false)
-  isProactiveOnboarding    Boolean              @default(false)
-  proactiveWelcomeDismissed Boolean             @default(false)
-  createdAt                DateTime             @default(now())
-  updatedAt                DateTime             @updatedAt
+  id                        String                @id @default(cuid())
+  mongoId                   String?               @unique
+  clerkOrganizationId       String?               @unique
+  userId                    String
+  user                      User                  @relation(fields: [userId], references: [id])
+  label                     String
+  slug                      String                @unique
+  prefix                    String?
+  isSelected                Boolean               @default(false)
+  isDefault                 Boolean               @default(false)
+  isDeleted                 Boolean               @default(false)
+  category                  OrganizationCategory  @default(BUSINESS)
+  accountType               OrganizationCategory?
+  onboardingCompleted       Boolean               @default(false)
+  isProactiveOnboarding     Boolean               @default(false)
+  proactiveWelcomeDismissed Boolean               @default(false)
+  createdAt                 DateTime              @default(now())
+  updatedAt                 DateTime              @updatedAt
 
   // Ownership relations
-  brands               Brand[]
-  members              Member[]
-  settings             OrganizationSetting?
-  credentials          Credential[]
-  orgIntegrations      OrgIntegration[]
-  ingredients          Ingredient[]
-  posts                Post[]
-  postAnalytics        PostAnalytics[]
-  prompts              Prompt[]
-  folders              Folder[]
-  bookmarks            Bookmark[]
-  tags                 Tag[]
-  articles             Article[]
-  articleAnalytics     ArticleAnalytics[]
-  newsletters          Newsletter[]
-  transcripts          Transcript[]
-  trainings            Training[]
-  models               Model[]
-  personas             Persona[]
-  agentRuns            AgentRun[]
-  agentStrategies      AgentStrategy[]
-  agentCampaigns       AgentCampaign[]
-  agentGoals           AgentGoal[]
-  agentMemories        AgentMemory[]
-  agentThreads         AgentThread[]
-  agentMessages        AgentMessage[]
-  agentThreadEvents    AgentThreadEvent[]
-  agentThreadSnapshots AgentThreadSnapshot[]
-  threadContextStates  ThreadContextState[]
-  agentWorkflows       AgentWorkflow[]
-  agentStrategyOpportunities AgentStrategyOpportunity[]
-  agentStrategyReports AgentStrategyReport[]
-  workflows            Workflow[]
-  workflowExecutions   WorkflowExecution[]
-  batchWorkflowJobs    BatchWorkflowJob[]
-  contentRuns          ContentRun[]
-  cronJobs             CronJob[]
-  cronRuns             CronRun[]
-  bots                 Bot[]
-  botActivities        BotActivity[]
-  replyBotConfigs      ReplyBotConfig[]
-  monitoredAccounts    MonitoredAccount[]
-  processedTweets      ProcessedTweet[]
-  trackedLinks         TrackedLink[]
-  schedules            Schedule[]
-  contentSchedules     ContentSchedule[]
-  distributions        Distribution[]
-  repurposingJobs      RepurposingJob[]
-  votes                Vote[]
-  watchlists           Watchlist[]
-  goals                Goal[]
-  streaks              Streak[]
-  presets              Preset[]
-  captions             Caption[]
-  clipProjects         ClipProject[]
-  clipResults          ClipResult[]
-  editorProjects       EditorProject[]
-  projects             Project[]
-  forecasts            Forecast[]
-  insights             Insight[]
-  contentScores        ContentScore[]
-  optimizations        Optimization[]
-  evaluations          Evaluation[]
-  tasks                Task[]
-  taskComments         TaskComment[]
-  taskCounters         TaskCounter[]
-  contentPlans         ContentPlan[]
-  contentPlanItems     ContentPlanItem[]
-  contentPerformances  ContentPerformance[]
-  contentDrafts        ContentDraft[]
-  contentPatterns      ContentPattern[]
-  creativePatterns     CreativePattern[]
-  patternPlaybooks     PatternPlaybook[]
-  trends               Trend[]
-  trendPreferences     TrendPreferences[]
-  trendRemixLineages   TrendRemixLineage[]
-  adBulkUploadJobs     AdBulkUploadJob[]
-  adCreativeMappings   AdCreativeMapping[]
-  adOptimizationConfigs      AdOptimizationConfig[]
-  adOptimizationAuditLogs    AdOptimizationAuditLog[]
+  brands                        Brand[]
+  members                       Member[]
+  settings                      OrganizationSetting?
+  credentials                   Credential[]
+  orgIntegrations               OrgIntegration[]
+  ingredients                   Ingredient[]
+  posts                         Post[]
+  postAnalytics                 PostAnalytics[]
+  prompts                       Prompt[]
+  folders                       Folder[]
+  bookmarks                     Bookmark[]
+  tags                          Tag[]
+  articles                      Article[]
+  articleAnalytics              ArticleAnalytics[]
+  newsletters                   Newsletter[]
+  transcripts                   Transcript[]
+  trainings                     Training[]
+  models                        Model[]
+  personas                      Persona[]
+  agentRuns                     AgentRun[]
+  agentStrategies               AgentStrategy[]
+  agentCampaigns                AgentCampaign[]
+  agentGoals                    AgentGoal[]
+  agentMemories                 AgentMemory[]
+  agentThreads                  AgentThread[]
+  agentMessages                 AgentMessage[]
+  agentThreadEvents             AgentThreadEvent[]
+  agentThreadSnapshots          AgentThreadSnapshot[]
+  threadContextStates           ThreadContextState[]
+  agentWorkflows                AgentWorkflow[]
+  agentStrategyOpportunities    AgentStrategyOpportunity[]
+  agentStrategyReports          AgentStrategyReport[]
+  workflows                     Workflow[]
+  workflowExecutions            WorkflowExecution[]
+  batchWorkflowJobs             BatchWorkflowJob[]
+  contentRuns                   ContentRun[]
+  cronJobs                      CronJob[]
+  cronRuns                      CronRun[]
+  bots                          Bot[]
+  botActivities                 BotActivity[]
+  replyBotConfigs               ReplyBotConfig[]
+  monitoredAccounts             MonitoredAccount[]
+  processedTweets               ProcessedTweet[]
+  trackedLinks                  TrackedLink[]
+  schedules                     Schedule[]
+  contentSchedules              ContentSchedule[]
+  distributions                 Distribution[]
+  repurposingJobs               RepurposingJob[]
+  votes                         Vote[]
+  watchlists                    Watchlist[]
+  goals                         Goal[]
+  streaks                       Streak[]
+  presets                       Preset[]
+  captions                      Caption[]
+  clipProjects                  ClipProject[]
+  clipResults                   ClipResult[]
+  editorProjects                EditorProject[]
+  projects                      Project[]
+  forecasts                     Forecast[]
+  insights                      Insight[]
+  contentScores                 ContentScore[]
+  optimizations                 Optimization[]
+  evaluations                   Evaluation[]
+  tasks                         Task[]
+  taskComments                  TaskComment[]
+  taskCounters                  TaskCounter[]
+  contentPlans                  ContentPlan[]
+  contentPlanItems              ContentPlanItem[]
+  contentPerformances           ContentPerformance[]
+  contentDrafts                 ContentDraft[]
+  contentPatterns               ContentPattern[]
+  creativePatterns              CreativePattern[]
+  patternPlaybooks              PatternPlaybook[]
+  trends                        Trend[]
+  trendPreferences              TrendPreferences[]
+  trendRemixLineages            TrendRemixLineage[]
+  adBulkUploadJobs              AdBulkUploadJob[]
+  adCreativeMappings            AdCreativeMapping[]
+  adOptimizationConfigs         AdOptimizationConfig[]
+  adOptimizationAuditLogs       AdOptimizationAuditLog[]
   adOptimizationRecommendations AdOptimizationRecommendation[]
-  adPerformances       AdPerformance[]
-  outreachCampaigns    OutreachCampaign[]
-  campaignTargets      CampaignTarget[]
-  customers            Customer[]
-  subscriptions        Subscription[]
-  creditBalances       CreditBalance[]
-  creditTransactions   CreditTransaction[]
-  subscriptionAttributions SubscriptionAttribution[]
-  announcements        Announcement[]
-  leads                Lead[]              @relation("lead_org")
-  proactiveLeads       Lead[]              @relation("lead_proactive_org")
-  brandMemories        BrandMemory[]
-  contextBases         ContextBase[]
-  contextEntries       ContextEntry[]
-  skills               Skill[]
-  templates            Template[]
-  templateUsages       TemplateUsage[]
-  batches              Batch[]
-  profiles             Profile[]
-  activities           Activity[]
-  apiKeys              ApiKey[]
-  creatorAnalyses      CreatorAnalysis[]
+  adPerformances                AdPerformance[]
+  outreachCampaigns             OutreachCampaign[]
+  campaignTargets               CampaignTarget[]
+  customers                     Customer[]
+  subscriptions                 Subscription[]
+  creditBalances                CreditBalance[]
+  creditTransactions            CreditTransaction[]
+  subscriptionAttributions      SubscriptionAttribution[]
+  announcements                 Announcement[]
+  leads                         Lead[]                         @relation("lead_org")
+  proactiveLeads                Lead[]                         @relation("lead_proactive_org")
+  brandMemories                 BrandMemory[]
+  contextBases                  ContextBase[]
+  contextEntries                ContextEntry[]
+  skills                        Skill[]
+  templates                     Template[]
+  templateUsages                TemplateUsage[]
+  batches                       Batch[]
+  profiles                      Profile[]
+  activities                    Activity[]
+  apiKeys                       ApiKey[]
+  creatorAnalyses               CreatorAnalysis[]
 
   @@index([isDefault])
   @@index([category])
@@ -722,121 +722,121 @@ model Organization {
 }
 
 model Brand {
-  id                     String     @id @default(cuid())
-  mongoId                 String?         @unique
-  userId                 String?
-  user                   User?      @relation(fields: [userId], references: [id])
-  organizationId         String
-  organization           Organization @relation(fields: [organizationId], references: [id])
-  voiceIngredientId      String?
-  voiceIngredient        Ingredient?  @relation("brand_voice", fields: [voiceIngredientId], references: [id])
-  musicIngredientId      String?
-  musicIngredient        Ingredient?  @relation("brand_music", fields: [musicIngredientId], references: [id])
-  slug                   String     @unique
-  label                  String
-  description            String?
-  text                   String?
-  fontFamily             FontFamily @default(MONTSERRAT_BLACK)
-  primaryColor           String     @default("#000000")
-  secondaryColor         String     @default("#FFFFFF")
-  backgroundColor        String     @default("transparent")
-  referenceImages        Json       @default("[]")
-  isSelected             Boolean
-  scope                  AssetScope @default(USER)
-  isActive               Boolean    @default(true)
-  isDefault              Boolean    @default(false)
-  isDeleted              Boolean    @default(false)
-  isHighlighted          Boolean    @default(false)
-  isDarkroomEnabled      Boolean    @default(false)
-  defaultVideoModel      String?
-  defaultImageModel      String?
+  id                       String       @id @default(cuid())
+  mongoId                  String?      @unique
+  userId                   String?
+  user                     User?        @relation(fields: [userId], references: [id])
+  organizationId           String
+  organization             Organization @relation(fields: [organizationId], references: [id])
+  voiceIngredientId        String?
+  voiceIngredient          Ingredient?  @relation("brand_voice", fields: [voiceIngredientId], references: [id])
+  musicIngredientId        String?
+  musicIngredient          Ingredient?  @relation("brand_music", fields: [musicIngredientId], references: [id])
+  slug                     String       @unique
+  label                    String
+  description              String?
+  text                     String?
+  fontFamily               FontFamily   @default(MONTSERRAT_BLACK)
+  primaryColor             String       @default("#000000")
+  secondaryColor           String       @default("#FFFFFF")
+  backgroundColor          String       @default("transparent")
+  referenceImages          Json         @default("[]")
+  isSelected               Boolean
+  scope                    AssetScope   @default(USER)
+  isActive                 Boolean      @default(true)
+  isDefault                Boolean      @default(false)
+  isDeleted                Boolean      @default(false)
+  isHighlighted            Boolean      @default(false)
+  isDarkroomEnabled        Boolean      @default(false)
+  defaultVideoModel        String?
+  defaultImageModel        String?
   defaultImageToVideoModel String?
-  defaultMusicModel      String?
-  agentConfig            Json       @default("{}")
-  createdAt              DateTime   @default(now())
-  updatedAt              DateTime   @updatedAt
+  defaultMusicModel        String?
+  agentConfig              Json         @default("{}")
+  createdAt                DateTime     @default(now())
+  updatedAt                DateTime     @updatedAt
 
   // Ownership relations
-  members            Member[]         @relation("member_brands")
-  lastUsedByMembers  Member[]         @relation("member_last_used_brand")
-  credentials        Credential[]
-  ingredients        Ingredient[]     @relation("ingredient_brand")
-  posts              Post[]
-  postAnalytics      PostAnalytics[]
-  prompts            Prompt[]
-  folders            Folder[]
-  tags               Tag[]
-  articles           Article[]
-  articleAnalytics   ArticleAnalytics[]
-  newsletters        Newsletter[]
-  trainings          Training[]
-  personas           Persona[]
-  agentStrategies    AgentStrategy[]
-  agentCampaigns     AgentCampaign[]
-  agentGoals         AgentGoal[]
-  agentMemories      AgentMemory[]
-  agentMessages      AgentMessage[]
+  members                    Member[]                   @relation("member_brands")
+  lastUsedByMembers          Member[]                   @relation("member_last_used_brand")
+  credentials                Credential[]
+  ingredients                Ingredient[]               @relation("ingredient_brand")
+  posts                      Post[]
+  postAnalytics              PostAnalytics[]
+  prompts                    Prompt[]
+  folders                    Folder[]
+  tags                       Tag[]
+  articles                   Article[]
+  articleAnalytics           ArticleAnalytics[]
+  newsletters                Newsletter[]
+  trainings                  Training[]
+  personas                   Persona[]
+  agentStrategies            AgentStrategy[]
+  agentCampaigns             AgentCampaign[]
+  agentGoals                 AgentGoal[]
+  agentMemories              AgentMemory[]
+  agentMessages              AgentMessage[]
   agentStrategyOpportunities AgentStrategyOpportunity[]
-  agentStrategyReports AgentStrategyReport[]
-  workflows          Workflow[]       @relation("workflow_brands")
-  contentRuns        ContentRun[]
-  contentSchedules   ContentSchedule[]
-  distributions      Distribution[]
-  watchlists         Watchlist[]
-  presets            Preset[]
-  clipProjects       ClipProject[]
-  editorProjects     EditorProject[]
-  contentPerformances ContentPerformance[]
-  contentDrafts      ContentDraft[]
-  contentPlanItems   ContentPlanItem[]
-  creativePatterns   CreativePattern[]
-  trends             Trend[]
-  trendPreferences   TrendPreferences[]
-  trendRemixLineages TrendRemixLineage[]
-  adBulkUploadJobs   AdBulkUploadJob[]
-  adCreativeMappings AdCreativeMapping[]
-  adPerformances     AdPerformance[]
-  botActivities      BotActivity[]
-  monitoredAccounts  MonitoredAccount[]
-  brandMemories      BrandMemory[]
-  links              Link[]
-  trackedLinks       TrackedLink[]
-  proactiveLeads     Lead[]           @relation("lead_proactive_brand")
-  contentPlans       ContentPlan[]
-  batches            Batch[]
-  activities         Activity[]
-  contextBases       ContextBase[]    @relation("context_base_source_brand")
-  schedules          Schedule[]
-  bookmarks          Bookmark[]
+  agentStrategyReports       AgentStrategyReport[]
+  workflows                  Workflow[]                 @relation("workflow_brands")
+  contentRuns                ContentRun[]
+  contentSchedules           ContentSchedule[]
+  distributions              Distribution[]
+  watchlists                 Watchlist[]
+  presets                    Preset[]
+  clipProjects               ClipProject[]
+  editorProjects             EditorProject[]
+  contentPerformances        ContentPerformance[]
+  contentDrafts              ContentDraft[]
+  contentPlanItems           ContentPlanItem[]
+  creativePatterns           CreativePattern[]
+  trends                     Trend[]
+  trendPreferences           TrendPreferences[]
+  trendRemixLineages         TrendRemixLineage[]
+  adBulkUploadJobs           AdBulkUploadJob[]
+  adCreativeMappings         AdCreativeMapping[]
+  adPerformances             AdPerformance[]
+  botActivities              BotActivity[]
+  monitoredAccounts          MonitoredAccount[]
+  brandMemories              BrandMemory[]
+  links                      Link[]
+  trackedLinks               TrackedLink[]
+  proactiveLeads             Lead[]                     @relation("lead_proactive_brand")
+  contentPlans               ContentPlan[]
+  batches                    Batch[]
+  activities                 Activity[]
+  contextBases               ContextBase[]              @relation("context_base_source_brand")
+  schedules                  Schedule[]
+  bookmarks                  Bookmark[]
 
   @@index([isDefault])
   @@map("brands")
 }
 
 model Member {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
+  id                String       @id @default(cuid())
+  mongoId           String?      @unique
   clerkMembershipId String?      @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  roleId          String
-  role            Role         @relation(fields: [roleId], references: [id])
-  brands          Brand[]      @relation("member_brands")
-  lastUsedBrandId String?
-  lastUsedBrand   Brand?       @relation("member_last_used_brand", fields: [lastUsedBrandId], references: [id])
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  organizationId    String
+  organization      Organization @relation(fields: [organizationId], references: [id])
+  userId            String
+  user              User         @relation(fields: [userId], references: [id])
+  roleId            String
+  role              Role         @relation(fields: [roleId], references: [id])
+  brands            Brand[]      @relation("member_brands")
+  lastUsedBrandId   String?
+  lastUsedBrand     Brand?       @relation("member_last_used_brand", fields: [lastUsedBrandId], references: [id])
+  isActive          Boolean      @default(true)
+  isDeleted         Boolean      @default(false)
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
 
   @@map("members")
 }
 
 model Role {
   id           String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId      String?  @unique
   label        String
   key          String   @unique
   primaryColor String?
@@ -854,80 +854,80 @@ model Role {
 // ══════��════════════════════════════════════════════════════════
 
 model Setting {
-  id                             String                     @id @default(cuid())
-  mongoId                 String?         @unique
-  userId                         String                     @unique
-  user                           User                       @relation(fields: [userId], references: [id])
-  theme                          String                     @default("dark")
-  isVerified                     Boolean                    @default(false)
-  isFirstLogin                   Boolean                    @default(true)
-  isMenuCollapsed                Boolean                    @default(false)
-  isSidebarProgressVisible       Boolean                    @default(true)
-  isSidebarProgressCollapsed     Boolean                    @default(false)
-  isAdvancedMode                 Boolean                    @default(true)
-  isTrendNotificationsInApp      Boolean                    @default(true)
-  isTrendNotificationsTelegram   Boolean                    @default(false)
-  isTrendNotificationsEmail      Boolean                    @default(false)
-  isWorkflowNotificationsEmail   Boolean                    @default(false)
-  isVideoNotificationsEmail      Boolean                    @default(false)
+  id                               String                     @id @default(cuid())
+  mongoId                          String?                    @unique
+  userId                           String                     @unique
+  user                             User                       @relation(fields: [userId], references: [id])
+  theme                            String                     @default("dark")
+  isVerified                       Boolean                    @default(false)
+  isFirstLogin                     Boolean                    @default(true)
+  isMenuCollapsed                  Boolean                    @default(false)
+  isSidebarProgressVisible         Boolean                    @default(true)
+  isSidebarProgressCollapsed       Boolean                    @default(false)
+  isAdvancedMode                   Boolean                    @default(true)
+  isTrendNotificationsInApp        Boolean                    @default(true)
+  isTrendNotificationsTelegram     Boolean                    @default(false)
+  isTrendNotificationsEmail        Boolean                    @default(false)
+  isWorkflowNotificationsEmail     Boolean                    @default(false)
+  isVideoNotificationsEmail        Boolean                    @default(false)
   trendNotificationsTelegramChatId String?
-  trendNotificationsEmailAddress String?
-  trendNotificationsFrequency    TrendNotificationFrequency @default(DAILY)
-  trendNotificationsMinViralScore Int                       @default(70)
-  contentPreferences             String[]                   @default([])
-  favoriteModelKeys              String[]                   @default([])
-  defaultAgentModel              String                     @default("deepseek/deepseek-chat")
-  isAgentAssetsPanelOpen         Boolean                    @default(false)
-  generationPriority             GenerationPriority         @default(QUALITY)
-  dashboardPreferences           Json                       @default("{\"scopes\":{}}")
-  isDeleted                      Boolean                    @default(false)
-  createdAt                      DateTime                   @default(now())
-  updatedAt                      DateTime                   @updatedAt
+  trendNotificationsEmailAddress   String?
+  trendNotificationsFrequency      TrendNotificationFrequency @default(DAILY)
+  trendNotificationsMinViralScore  Int                        @default(70)
+  contentPreferences               String[]                   @default([])
+  favoriteModelKeys                String[]                   @default([])
+  defaultAgentModel                String                     @default("deepseek/deepseek-chat")
+  isAgentAssetsPanelOpen           Boolean                    @default(false)
+  generationPriority               GenerationPriority         @default(QUALITY)
+  dashboardPreferences             Json                       @default("{\"scopes\":{}}")
+  isDeleted                        Boolean                    @default(false)
+  createdAt                        DateTime                   @default(now())
+  updatedAt                        DateTime                   @updatedAt
 
   @@map("settings")
 }
 
 model OrganizationSetting {
-  id                            String               @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId                String               @unique
-  organization                  Organization         @relation(fields: [organizationId], references: [id])
-  isFirstLogin                  Boolean              @default(true)
-  isWhitelabelEnabled           Boolean              @default(false)
-  isVoiceControlEnabled         Boolean              @default(false)
-  isNotificationsDiscordEnabled Boolean              @default(false)
-  isNotificationsEmailEnabled   Boolean              @default(true)
-  isDarkroomNsfwVisible         Boolean              @default(false)
-  isWatermarkEnabled            Boolean              @default(true)
-  isVerifyScriptEnabled         Boolean              @default(true)
-  isVerifyIngredientEnabled     Boolean              @default(true)
-  isVerifyVideoEnabled          Boolean              @default(true)
-  isGenerateVideosEnabled       Boolean              @default(true)
-  isGenerateArticlesEnabled     Boolean              @default(false)
-  isGenerateImagesEnabled       Boolean              @default(true)
-  isGenerateMusicEnabled        Boolean              @default(true)
-  isAutoEvaluateEnabled         Boolean              @default(false)
-  seatsLimit                    Int                  @default(3)
-  brandsLimit                   Int                  @default(5)
-  timezone                      String               @default("UTC")
-  isWebhookEnabled              Boolean              @default(false)
+  id                            String            @id @default(cuid())
+  mongoId                       String?           @unique
+  organizationId                String            @unique
+  organization                  Organization      @relation(fields: [organizationId], references: [id])
+  isFirstLogin                  Boolean           @default(true)
+  isWhitelabelEnabled           Boolean           @default(false)
+  isVoiceControlEnabled         Boolean           @default(false)
+  isNotificationsDiscordEnabled Boolean           @default(false)
+  isNotificationsEmailEnabled   Boolean           @default(true)
+  isDarkroomNsfwVisible         Boolean           @default(false)
+  isWatermarkEnabled            Boolean           @default(true)
+  isVerifyScriptEnabled         Boolean           @default(true)
+  isVerifyIngredientEnabled     Boolean           @default(true)
+  isVerifyVideoEnabled          Boolean           @default(true)
+  isGenerateVideosEnabled       Boolean           @default(true)
+  isGenerateArticlesEnabled     Boolean           @default(false)
+  isGenerateImagesEnabled       Boolean           @default(true)
+  isGenerateMusicEnabled        Boolean           @default(true)
+  isAutoEvaluateEnabled         Boolean           @default(false)
+  seatsLimit                    Int               @default(3)
+  brandsLimit                   Int               @default(5)
+  timezone                      String            @default("UTC")
+  isWebhookEnabled              Boolean           @default(false)
   webhookEndpoint               String?
   webhookSecret                 String?
-  quotaYoutube                  Int                  @default(5)
-  quotaTiktok                   Int                  @default(1)
-  quotaTwitter                  Int                  @default(5)
-  quotaInstagram                Int                  @default(5)
-  enabledModelIds               String[]             @default([])
+  quotaYoutube                  Int               @default(5)
+  quotaTiktok                   Int               @default(1)
+  quotaTwitter                  Int               @default(5)
+  quotaInstagram                Int               @default(5)
+  enabledModelIds               String[]          @default([])
   subscriptionTier              String?
-  isByokEnabled                 Boolean              @default(false)
-  hasEverHadCredits             Boolean              @default(false)
-  onboardingJourneyMissions     Json                 @default("[]")
+  isByokEnabled                 Boolean           @default(false)
+  hasEverHadCredits             Boolean           @default(false)
+  onboardingJourneyMissions     Json              @default("[]")
   onboardingJourneyCompletedAt  DateTime?
-  isAdvancedMode                Boolean              @default(false)
-  agentReplyStyle               AgentReplyStyle      @default(CONCISE)
+  isAdvancedMode                Boolean           @default(false)
+  agentReplyStyle               AgentReplyStyle   @default(CONCISE)
   byokOpenrouterApiKey          String?
-  byokBillingRollover           Float                @default(0)
-  byokBillingStatus             ByokBillingStatus    @default(ACTIVE)
+  byokBillingRollover           Float             @default(0)
+  byokBillingStatus             ByokBillingStatus @default(ACTIVE)
   byokFreeThresholdOverride     Float?
   defaultAvatarPhotoUrl         String?
   defaultAvatarIngredientId     String?
@@ -941,10 +941,10 @@ model OrganizationSetting {
   defaultVideoModel             String?
   defaultImageToVideoModel      String?
   defaultMusicModel             String?
-  agentPolicy                   Json                 @default("{}")
-  byokKeys                      Json                 @default("{}")
-  createdAt                     DateTime             @default(now())
-  updatedAt                     DateTime             @updatedAt
+  agentPolicy                   Json              @default("{}")
+  byokKeys                      Json              @default("{}")
+  createdAt                     DateTime          @default(now())
+  updatedAt                     DateTime          @updatedAt
 
   @@map("organization_settings")
 }
@@ -955,7 +955,7 @@ model OrganizationSetting {
 
 model Credential {
   id                 String             @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId            String?            @unique
   organizationId     String?
   organization       Organization?      @relation(fields: [organizationId], references: [id])
   brandId            String?
@@ -985,12 +985,12 @@ model Credential {
   updatedAt          DateTime           @updatedAt
 
   // Relations
-  tags               Tag[]              @relation("credential_tags")
-  posts              Post[]
-  adBulkUploadJobs   AdBulkUploadJob[]
-  adPerformances     AdPerformance[]
-  monitoredAccounts  MonitoredAccount[]
-  personas           Persona[]          @relation("persona_credentials")
+  tags              Tag[]              @relation("credential_tags")
+  posts             Post[]
+  adBulkUploadJobs  AdBulkUploadJob[]
+  adPerformances    AdPerformance[]
+  monitoredAccounts MonitoredAccount[]
+  personas          Persona[]          @relation("persona_credentials")
 
   @@index([oauthTokenHash])
   @@map("credentials")
@@ -998,7 +998,7 @@ model Credential {
 
 model ApiKey {
   id             String         @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId        String?        @unique
   userId         String
   user           User           @relation(fields: [userId], references: [id])
   organizationId String
@@ -1049,7 +1049,7 @@ model DesktopAuthCode {
 
 model OrgIntegration {
   id               String              @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId          String?             @unique
   organizationId   String
   organization     Organization        @relation(fields: [organizationId], references: [id])
   platform         IntegrationPlatform
@@ -1070,46 +1070,46 @@ model OrgIntegration {
 // ═══════════════════════════════════════════════════════════════
 
 model Ingredient {
-  id                    String               @id @default(cuid())
-  mongoId                 String?         @unique
-  userId                String?
-  user                  User?                @relation(fields: [userId], references: [id])
-  organizationId        String?
-  organization          Organization?        @relation(fields: [organizationId], references: [id])
-  brandId               String?
-  brand                 Brand?               @relation("ingredient_brand", fields: [brandId], references: [id])
-  folderId              String?
-  folder                Folder?              @relation(fields: [folderId], references: [id])
-  parentId              String?
-  parent                Ingredient?          @relation("ingredient_parent", fields: [parentId], references: [id])
-  children              Ingredient[]         @relation("ingredient_parent")
-  metadataId            String?
-  metadata              Metadata?            @relation(fields: [metadataId], references: [id])
-  promptId              String?
-  prompt                Prompt?              @relation("ingredient_prompt", fields: [promptId], references: [id])
-  trainingId            String?
-  training              Training?            @relation("ingredient_training", fields: [trainingId], references: [id])
-  bookmarkId            String?
-  bookmark              Bookmark?            @relation(fields: [bookmarkId], references: [id])
-  personaId             String?
-  persona               Persona?             @relation(fields: [personaId], references: [id])
-  agentRunId            String?
-  agentRun              AgentRun?            @relation("ingredient_agent_run", fields: [agentRunId], references: [id])
-  agentStrategyId       String?
-  agentStrategy         AgentStrategy?       @relation("ingredient_agent_strategy", fields: [agentStrategyId], references: [id])
+  id              String         @id @default(cuid())
+  mongoId         String?        @unique
+  userId          String?
+  user            User?          @relation(fields: [userId], references: [id])
+  organizationId  String?
+  organization    Organization?  @relation(fields: [organizationId], references: [id])
+  brandId         String?
+  brand           Brand?         @relation("ingredient_brand", fields: [brandId], references: [id])
+  folderId        String?
+  folder          Folder?        @relation(fields: [folderId], references: [id])
+  parentId        String?
+  parent          Ingredient?    @relation("ingredient_parent", fields: [parentId], references: [id])
+  children        Ingredient[]   @relation("ingredient_parent")
+  metadataId      String?
+  metadata        Metadata?      @relation(fields: [metadataId], references: [id])
+  promptId        String?
+  prompt          Prompt?        @relation("ingredient_prompt", fields: [promptId], references: [id])
+  trainingId      String?
+  training        Training?      @relation("ingredient_training", fields: [trainingId], references: [id])
+  bookmarkId      String?
+  bookmark        Bookmark?      @relation(fields: [bookmarkId], references: [id])
+  personaId       String?
+  persona         Persona?       @relation(fields: [personaId], references: [id])
+  agentRunId      String?
+  agentRun        AgentRun?      @relation("ingredient_agent_run", fields: [agentRunId], references: [id])
+  agentStrategyId String?
+  agentStrategy   AgentStrategy? @relation("ingredient_agent_strategy", fields: [agentStrategyId], references: [id])
 
   // Discriminator: single table for Image, Video, Music, GIF, Avatar, Voice, etc.
-  category              IngredientCategory   @default(IMAGE)
-  status                IngredientStatus     @default(DRAFT)
+  category              IngredientCategory       @default(IMAGE)
+  status                IngredientStatus         @default(DRAFT)
   transformations       TransformationCategory[] @default([])
-  order                 Int                  @default(0)
-  version               Int                  @default(1)
-  isHighlighted         Boolean              @default(false)
-  isDefault             Boolean              @default(false)
-  scope                 AssetScope           @default(USER)
-  isDeleted             Boolean              @default(false)
-  isFavorite            Boolean              @default(false)
-  isPublic              Boolean              @default(false)
+  order                 Int                      @default(0)
+  version               Int                      @default(1)
+  isHighlighted         Boolean                  @default(false)
+  isDefault             Boolean                  @default(false)
+  scope                 AssetScope               @default(USER)
+  isDeleted             Boolean                  @default(false)
+  isFavorite            Boolean                  @default(false)
+  isPublic              Boolean                  @default(false)
   groupId               String?
   groupIndex            Int?
   isMergeEnabled        Boolean?
@@ -1139,50 +1139,50 @@ model Ingredient {
   generationCompletedAt DateTime?
   fileSize              Int?
   mimeType              String?
-  postedTo              String[]             @default([])
+  postedTo              String[]                 @default([])
   qualityScore          Float?
-  qualityFeedback       String[]             @default([])
-  qualityStatus         QualityStatus        @default(UNRATED)
+  qualityFeedback       String[]                 @default([])
+  qualityStatus         QualityStatus            @default(UNRATED)
 
   // Voice discriminator fields (only populated when category = VOICE)
-  voiceSource           String?
-  voiceProvider         VoiceProvider?
-  externalVoiceId       String?
-  cloneStatus           VoiceCloneStatus?
-  sampleAudioUrl        String?
-  isCloned              Boolean?
-  isVoiceActive         Boolean?
-  isDefaultSelectable   Boolean?
-  providerData          Json?
-  isFeatured            Boolean?
+  voiceSource         String?
+  voiceProvider       VoiceProvider?
+  externalVoiceId     String?
+  cloneStatus         VoiceCloneStatus?
+  sampleAudioUrl      String?
+  isCloned            Boolean?
+  isVoiceActive       Boolean?
+  isDefaultSelectable Boolean?
+  providerData        Json?
+  isFeatured          Boolean?
 
   // Video discriminator fields
-  language              String?
+  language String?
 
-  createdAt             DateTime             @default(now())
-  updatedAt             DateTime             @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   // Self-referential many-to-many (sources)
-  sourceOf              Ingredient[]         @relation("ingredient_sources")
-  sources               Ingredient[]         @relation("ingredient_sources")
+  sourceOf Ingredient[] @relation("ingredient_sources")
+  sources  Ingredient[] @relation("ingredient_sources")
 
   // Relations where this ingredient is referenced
-  tags                  Tag[]                @relation("ingredient_tags")
-  brandVoices           Brand[]              @relation("brand_voice")
-  brandMusics           Brand[]              @relation("brand_music")
-  postEntities          Post[]               @relation("post_entity_ingredient")
-  postIngredients       Post[]               @relation("post_ingredients")
-  postAnalyticsIngredients PostAnalytics[]   @relation("post_analytics_ingredients")
-  bookmarkExtracted     Bookmark[]           @relation("bookmark_extracted")
-  bookmarkGenerated     Bookmark[]           @relation("bookmark_generated")
-  trainingSources       Training[]           @relation("training_sources")
-  personaAvatars        Persona[]            @relation("persona_avatar")
-  personaVoices         Persona[]            @relation("persona_voice")
-  captions              Caption[]
-  editorProjectVideos   EditorProject[]      @relation("editor_project_video")
-  trackedLinkContent    TrackedLink[]
-  taskLinkedOutputs     Task[]           @relation("task_linked_outputs")
-  taskApprovedOutputs   Task[]           @relation("task_approved_outputs")
+  tags                     Tag[]           @relation("ingredient_tags")
+  brandVoices              Brand[]         @relation("brand_voice")
+  brandMusics              Brand[]         @relation("brand_music")
+  postEntities             Post[]          @relation("post_entity_ingredient")
+  postIngredients          Post[]          @relation("post_ingredients")
+  postAnalyticsIngredients PostAnalytics[] @relation("post_analytics_ingredients")
+  bookmarkExtracted        Bookmark[]      @relation("bookmark_extracted")
+  bookmarkGenerated        Bookmark[]      @relation("bookmark_generated")
+  trainingSources          Training[]      @relation("training_sources")
+  personaAvatars           Persona[]       @relation("persona_avatar")
+  personaVoices            Persona[]       @relation("persona_voice")
+  captions                 Caption[]
+  editorProjectVideos      EditorProject[] @relation("editor_project_video")
+  trackedLinkContent       TrackedLink[]
+  taskLinkedOutputs        Task[]          @relation("task_linked_outputs")
+  taskApprovedOutputs      Task[]          @relation("task_approved_outputs")
 
   @@index([groupId])
   @@index([scope])
@@ -1196,36 +1196,36 @@ model Ingredient {
 }
 
 model Metadata {
-  id               String             @id @default(cuid())
-  mongoId                 String?         @unique
+  id               String            @id @default(cuid())
+  mongoId          String?           @unique
   label            String
-  description      String             @default("Default Description")
+  description      String            @default("Default Description")
   promptId         String?
-  prompt           Prompt?            @relation(fields: [promptId], references: [id])
+  prompt           Prompt?           @relation(fields: [promptId], references: [id])
   model            String?
   style            String?
   extension        MetadataExtension
   assistant        String?
-  result           String             @default("")
+  result           String            @default("")
   error            String?
   externalId       String?
   externalProvider String?
-  width            Int                @default(0)
-  height           Int                @default(0)
-  duration         Float              @default(0)
-  size             Int                @default(0)
-  hasAudio         Boolean            @default(false)
+  width            Int               @default(0)
+  height           Int               @default(0)
+  duration         Float             @default(0)
+  size             Int               @default(0)
+  hasAudio         Boolean           @default(false)
   fps              Float?
   resolution       String?
   seed             Int?
   promptTemplate   String?
   templateVersion  Int?
-  isDeleted        Boolean            @default(false)
-  createdAt        DateTime           @default(now())
-  updatedAt        DateTime           @updatedAt
+  isDeleted        Boolean           @default(false)
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
 
-  tags             Tag[]              @relation("metadata_tags")
-  ingredients      Ingredient[]
+  tags        Tag[]        @relation("metadata_tags")
+  ingredients Ingredient[]
 
   @@index([externalId])
   @@index([externalProvider])
@@ -1233,68 +1233,68 @@ model Metadata {
 }
 
 model Prompt {
-  id               String          @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId   String?
-  organization     Organization?   @relation(fields: [organizationId], references: [id])
-  brandId          String?
-  brand            Brand?          @relation(fields: [brandId], references: [id])
-  userId           String
-  user             User            @relation(fields: [userId], references: [id])
-  ingredientId     String?
-  articleId        String?
-  article          Article?        @relation(fields: [articleId], references: [id])
-  category         PromptCategory?
-  original         String
-  enhanced         String?
-  status           PromptStatus    @default(DRAFT)
-  style            String?
-  mood             String?
-  camera           String?
-  scene            String?
-  fontFamily       String?
-  blacklists       String[]        @default([])
-  sounds           String[]        @default([])
-  model            String?
-  duration         Float?
-  ratio            String?
-  resolution       String?
-  seed             Int?
-  reference        String?
-  isSkipEnhancement Boolean        @default(false)
-  scope            AssetScope      @default(USER)
-  isDeleted        Boolean         @default(false)
-  isFavorite       Boolean         @default(false)
-  speech           String?
-  createdAt        DateTime        @default(now())
-  updatedAt        DateTime        @updatedAt
+  id                String          @id @default(cuid())
+  mongoId           String?         @unique
+  organizationId    String?
+  organization      Organization?   @relation(fields: [organizationId], references: [id])
+  brandId           String?
+  brand             Brand?          @relation(fields: [brandId], references: [id])
+  userId            String
+  user              User            @relation(fields: [userId], references: [id])
+  ingredientId      String?
+  articleId         String?
+  article           Article?        @relation(fields: [articleId], references: [id])
+  category          PromptCategory?
+  original          String
+  enhanced          String?
+  status            PromptStatus    @default(DRAFT)
+  style             String?
+  mood              String?
+  camera            String?
+  scene             String?
+  fontFamily        String?
+  blacklists        String[]        @default([])
+  sounds            String[]        @default([])
+  model             String?
+  duration          Float?
+  ratio             String?
+  resolution        String?
+  seed              Int?
+  reference         String?
+  isSkipEnhancement Boolean         @default(false)
+  scope             AssetScope      @default(USER)
+  isDeleted         Boolean         @default(false)
+  isFavorite        Boolean         @default(false)
+  speech            String?
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
 
-  tags             Tag[]           @relation("prompt_tags")
-  ingredients      Ingredient[]    @relation("ingredient_prompt")
-  metadata         Metadata[]
+  tags        Tag[]        @relation("prompt_tags")
+  ingredients Ingredient[] @relation("ingredient_prompt")
+  metadata    Metadata[]
 
   @@map("prompts")
 }
 
 model Folder {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  label           String
-  description     String?
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  label          String
+  description    String?
+  isActive       Boolean      @default(true)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  tags            Tag[]        @relation("folder_tags")
-  ingredients     Ingredient[]
-  bookmarks       Bookmark[]
+  tags        Tag[]        @relation("folder_tags")
+  ingredients Ingredient[]
+  bookmarks   Bookmark[]
 
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@index([brandId, isDeleted, createdAt(sort: Desc)])
@@ -1303,7 +1303,7 @@ model Folder {
 
 model Tag {
   id              String        @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId         String?       @unique
   userId          String?
   organizationId  String?
   organization    Organization? @relation(fields: [organizationId], references: [id])
@@ -1321,16 +1321,16 @@ model Tag {
   updatedAt       DateTime      @updatedAt
 
   // Many-to-many relations
-  ingredients     Ingredient[]  @relation("ingredient_tags")
-  metadata        Metadata[]    @relation("metadata_tags")
-  prompts         Prompt[]      @relation("prompt_tags")
-  folders         Folder[]      @relation("folder_tags")
-  credentials     Credential[]  @relation("credential_tags")
-  posts           Post[]        @relation("post_tags")
-  articles        Article[]     @relation("article_tags")
-  personas        Persona[]     @relation("persona_tags")
-  workflows       Workflow[]    @relation("workflow_tags")
-  bookmarks       Bookmark[]    @relation("bookmark_tags")
+  ingredients Ingredient[] @relation("ingredient_tags")
+  metadata    Metadata[]   @relation("metadata_tags")
+  prompts     Prompt[]     @relation("prompt_tags")
+  folders     Folder[]     @relation("folder_tags")
+  credentials Credential[] @relation("credential_tags")
+  posts       Post[]       @relation("post_tags")
+  articles    Article[]    @relation("article_tags")
+  personas    Persona[]    @relation("persona_tags")
+  workflows   Workflow[]   @relation("workflow_tags")
+  bookmarks   Bookmark[]   @relation("bookmark_tags")
 
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@index([brandId, isDeleted, createdAt(sort: Desc)])
@@ -1338,69 +1338,69 @@ model Tag {
 }
 
 model Bookmark {
-  id                    String           @id @default(cuid())
-  mongoId                 String?         @unique
-  userId                String
-  user                  User             @relation(fields: [userId], references: [id])
-  organizationId        String
-  organization          Organization     @relation(fields: [organizationId], references: [id])
-  brandId               String?
-  brand                 Brand?           @relation(fields: [brandId], references: [id])
-  folderId              String?
-  folder                Folder?          @relation(fields: [folderId], references: [id])
-  category              BookmarkCategory @default(URL)
-  url                   String
-  platform              BookmarkPlatform @default(WEB)
-  title                 String?
-  content               String
-  description           String?
-  author                String?
-  authorHandle          String?
-  thumbnailUrl          String?
-  mediaUrls             String[]         @default([])
-  platformData          Json             @default("{}")
-  intent                BookmarkIntent   @default(INSPIRATION)
-  savedAt               DateTime         @default(now())
-  processedAt           DateTime?
-  isDeleted             Boolean          @default(false)
-  createdAt             DateTime         @default(now())
-  updatedAt             DateTime         @updatedAt
+  id             String           @id @default(cuid())
+  mongoId        String?          @unique
+  userId         String
+  user           User             @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization     @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?           @relation(fields: [brandId], references: [id])
+  folderId       String?
+  folder         Folder?          @relation(fields: [folderId], references: [id])
+  category       BookmarkCategory @default(URL)
+  url            String
+  platform       BookmarkPlatform @default(WEB)
+  title          String?
+  content        String
+  description    String?
+  author         String?
+  authorHandle   String?
+  thumbnailUrl   String?
+  mediaUrls      String[]         @default([])
+  platformData   Json             @default("{}")
+  intent         BookmarkIntent   @default(INSPIRATION)
+  savedAt        DateTime         @default(now())
+  processedAt    DateTime?
+  isDeleted      Boolean          @default(false)
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
 
-  tags                  Tag[]            @relation("bookmark_tags")
-  extractedIngredients  Ingredient[]     @relation("bookmark_extracted")
-  generatedIngredients  Ingredient[]     @relation("bookmark_generated")
-  ingredients           Ingredient[]
+  tags                 Tag[]        @relation("bookmark_tags")
+  extractedIngredients Ingredient[] @relation("bookmark_extracted")
+  generatedIngredients Ingredient[] @relation("bookmark_generated")
+  ingredients          Ingredient[]
 
   @@map("bookmarks")
 }
 
 model Asset {
-  id            String        @id @default(cuid())
-  mongoId                 String?         @unique
-  userId        String
-  user          User          @relation(fields: [userId], references: [id])
-  parentType    AssetParent
-  parentOrgId   String?
-  parentBrandId String?
+  id                 String        @id @default(cuid())
+  mongoId            String?       @unique
+  userId             String
+  user               User          @relation(fields: [userId], references: [id])
+  parentType         AssetParent
+  parentOrgId        String?
+  parentBrandId      String?
   parentIngredientId String?
-  parentArticleId String?
-  category      AssetCategory
-  externalId    String?
-  localAssetId  String?
-  cloudObjectKey String?
-  sha256        String?
-  sizeBytes     Int?
-  mimeType      String?
-  kind          String?
-  origin        String?
-  residency     String?
-  uploadPolicy  String?
-  originalFileName String?
-  displayName   String?
-  deletedAt     DateTime?
-  isDeleted     Boolean       @default(false)
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
+  parentArticleId    String?
+  category           AssetCategory
+  externalId         String?
+  localAssetId       String?
+  cloudObjectKey     String?
+  sha256             String?
+  sizeBytes          Int?
+  mimeType           String?
+  kind               String?
+  origin             String?
+  residency          String?
+  uploadPolicy       String?
+  originalFileName   String?
+  displayName        String?
+  deletedAt          DateTime?
+  isDeleted          Boolean       @default(false)
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
 
   @@index([parentOrgId, parentBrandId, updatedAt(sort: Desc)])
   @@index([sha256, sizeBytes])
@@ -1409,23 +1409,23 @@ model Asset {
 }
 
 model Link {
-  id         String       @id @default(cuid())
-  mongoId                 String?         @unique
-  brandId    String
-  brand      Brand        @relation(fields: [brandId], references: [id])
-  label      String
-  category   LinkCategory
-  url        String
-  isDeleted  Boolean      @default(false)
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
+  id        String       @id @default(cuid())
+  mongoId   String?      @unique
+  brandId   String
+  brand     Brand        @relation(fields: [brandId], references: [id])
+  label     String
+  category  LinkCategory
+  url       String
+  isDeleted Boolean      @default(false)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
 
   @@map("links")
 }
 
 model TrackedLink {
   id             String       @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId        String?      @unique
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id])
   brandId        String?
@@ -1447,27 +1447,27 @@ model TrackedLink {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
-  linkClicks     LinkClick[]
+  linkClicks               LinkClick[]
   subscriptionAttributions SubscriptionAttribution[] @relation("attribution_link")
 
   @@map("tracked_links")
 }
 
 model LinkClick {
-  id         String     @id @default(cuid())
-  mongoId                 String?         @unique
+  id         String      @id @default(cuid())
+  mongoId    String?     @unique
   linkId     String
   link       TrackedLink @relation(fields: [linkId], references: [id])
-  timestamp  DateTime   @default(now())
+  timestamp  DateTime    @default(now())
   sessionId  String
-  isUnique   Boolean    @default(false)
+  isUnique   Boolean     @default(false)
   referrer   String?
   userAgent  String?
   country    String?
   device     String?
   gaClientId String?
-  createdAt  DateTime   @default(now())
-  updatedAt  DateTime   @updatedAt
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @updatedAt
 
   @@map("link_clicks")
 }
@@ -1477,66 +1477,66 @@ model LinkClick {
 // ═══════════════════════════════════════════════════════════════
 
 model Post {
-  id                    String             @id @default(cuid())
-  mongoId                 String?         @unique
+  id                  String             @id @default(cuid())
+  mongoId             String?            @unique
   // Polymorphic entity: either an Ingredient or an Article
-  entityIngredientId    String?
-  entityIngredient      Ingredient?        @relation("post_entity_ingredient", fields: [entityIngredientId], references: [id])
-  entityArticleId       String?
-  entityArticle         Article?           @relation("post_entity_article", fields: [entityArticleId], references: [id])
-  entityModel           PostEntityModel?
-  credentialId          String
-  credential            Credential         @relation(fields: [credentialId], references: [id])
-  platform              CredentialPlatform
-  userId                String
-  user                  User               @relation(fields: [userId], references: [id])
-  organizationId        String
-  organization          Organization       @relation(fields: [organizationId], references: [id])
-  brandId               String
-  brand                 Brand              @relation(fields: [brandId], references: [id])
-  parentId              String?
-  parent                Post?              @relation("post_thread", fields: [parentId], references: [id])
-  children              Post[]             @relation("post_thread")
-  originalPostId        String?
-  originalPost          Post?              @relation("post_variant", fields: [originalPostId], references: [id])
-  variants              Post[]             @relation("post_variant")
-  personaId             String?
-  persona               Persona?           @relation(fields: [personaId], references: [id])
-  contentRunId          String?
-  contentRun            ContentRun?        @relation(fields: [contentRunId], references: [id])
-  workflowExecutionId   String?
-  workflowExecution     WorkflowExecution? @relation(fields: [workflowExecutionId], references: [id])
-  agentRunId            String?
-  agentRun              AgentRun?          @relation("post_agent_run", fields: [agentRunId], references: [id])
-  agentStrategyId       String?
-  agentStrategy         AgentStrategy?     @relation("post_agent_strategy", fields: [agentStrategyId], references: [id])
+  entityIngredientId  String?
+  entityIngredient    Ingredient?        @relation("post_entity_ingredient", fields: [entityIngredientId], references: [id])
+  entityArticleId     String?
+  entityArticle       Article?           @relation("post_entity_article", fields: [entityArticleId], references: [id])
+  entityModel         PostEntityModel?
+  credentialId        String
+  credential          Credential         @relation(fields: [credentialId], references: [id])
+  platform            CredentialPlatform
+  userId              String
+  user                User               @relation(fields: [userId], references: [id])
+  organizationId      String
+  organization        Organization       @relation(fields: [organizationId], references: [id])
+  brandId             String
+  brand               Brand              @relation(fields: [brandId], references: [id])
+  parentId            String?
+  parent              Post?              @relation("post_thread", fields: [parentId], references: [id])
+  children            Post[]             @relation("post_thread")
+  originalPostId      String?
+  originalPost        Post?              @relation("post_variant", fields: [originalPostId], references: [id])
+  variants            Post[]             @relation("post_variant")
+  personaId           String?
+  persona             Persona?           @relation(fields: [personaId], references: [id])
+  contentRunId        String?
+  contentRun          ContentRun?        @relation(fields: [contentRunId], references: [id])
+  workflowExecutionId String?
+  workflowExecution   WorkflowExecution? @relation(fields: [workflowExecutionId], references: [id])
+  agentRunId          String?
+  agentRun            AgentRun?          @relation("post_agent_run", fields: [agentRunId], references: [id])
+  agentStrategyId     String?
+  agentStrategy       AgentStrategy?     @relation("post_agent_strategy", fields: [agentStrategyId], references: [id])
 
-  order                 Int                @default(0)
+  order                 Int             @default(0)
   externalId            String?
   externalShortcode     String?
   quoteTweetId          String?
   groupId               String?
   url                   String?
-  status                PostStatus         @default(SCHEDULED)
+  status                PostStatus      @default(SCHEDULED)
   label                 String?
   description           String
-  category              PostCategory       @default(TEXT)
+  category              PostCategory    @default(TEXT)
   scheduledDate         DateTime?
-  timezone              String             @default("UTC")
+  timezone              String          @default("UTC")
   publicationDate       DateTime?
   publishedAt           DateTime?
   uploadedAt            DateTime?
   nextScheduledDate     DateTime?
-  isRepeat              Boolean            @default(false)
+  isRepeat              Boolean         @default(false)
   repeatFrequency       String?
   repeatInterval        Int?
   repeatEndDate         DateTime?
   maxRepeats            Int?
   repeatCount           Int?
-  repeatDaysOfWeek      Int[]              @default([])
-  isShareToFeedSelected Boolean            @default(true)
-  isAnalyticsEnabled    Boolean            @default(true)
-  retryCount            Int                @default(0)
+  repeatDaysOfWeek      Int[]           @default([])
+  isShareToFeedSelected Boolean         @default(true)
+  isAnalyticsEnabled    Boolean         @default(true)
+  retryCount            Int             @default(0)
   lastAttemptAt         DateTime?
   variantId             String?
   hookVersion           String?
@@ -1550,22 +1550,22 @@ model Post {
   reviewDecision        ReviewDecision?
   reviewFeedback        String?
   reviewedAt            DateTime?
-  reviewEvents          Json               @default("[]")
+  reviewEvents          Json            @default("[]")
   sourceActionId        String?
   sourceWorkflowId      String?
   sourceWorkflowName    String?
-  isDeleted             Boolean            @default(false)
-  createdAt             DateTime           @default(now())
-  updatedAt             DateTime           @updatedAt
+  isDeleted             Boolean         @default(false)
+  createdAt             DateTime        @default(now())
+  updatedAt             DateTime        @updatedAt
 
   // Many-to-many
-  ingredients           Ingredient[]       @relation("post_ingredients")
-  tags                  Tag[]              @relation("post_tags")
+  ingredients Ingredient[] @relation("post_ingredients")
+  tags        Tag[]        @relation("post_tags")
 
   // Reverse relations
-  postAnalytics         PostAnalytics[]
-  contentPerformances   ContentPerformance[]
-  trendRemixLineages    TrendRemixLineage[]
+  postAnalytics            PostAnalytics[]
+  contentPerformances      ContentPerformance[]
+  trendRemixLineages       TrendRemixLineage[]
   subscriptionAttributions SubscriptionAttribution[] @relation("attribution_content")
 
   @@index([externalId])
@@ -1586,104 +1586,104 @@ model Post {
 }
 
 model PostAnalytics {
-  id                    String             @id @default(cuid())
-  mongoId                 String?         @unique
-  postId                String
-  post                  Post               @relation(fields: [postId], references: [id])
-  userId                String
-  user                  User               @relation(fields: [userId], references: [id])
-  organizationId        String
-  organization          Organization       @relation(fields: [organizationId], references: [id])
-  brandId               String
-  brand                 Brand              @relation(fields: [brandId], references: [id])
-  platform              CredentialPlatform
-  date                  DateTime
-  totalViews            Int                @default(0)
-  totalLikes            Int                @default(0)
-  totalComments         Int                @default(0)
-  totalShares           Int                @default(0)
-  totalSaves            Int                @default(0)
-  totalViewsIncrement   Int                @default(0)
-  totalLikesIncrement   Int                @default(0)
-  totalCommentsIncrement Int               @default(0)
-  totalSharesIncrement  Int                @default(0)
-  totalSavesIncrement   Int                @default(0)
-  engagementRate        Float              @default(0)
-  createdAt             DateTime           @default(now())
-  updatedAt             DateTime           @updatedAt
+  id                     String             @id @default(cuid())
+  mongoId                String?            @unique
+  postId                 String
+  post                   Post               @relation(fields: [postId], references: [id])
+  userId                 String
+  user                   User               @relation(fields: [userId], references: [id])
+  organizationId         String
+  organization           Organization       @relation(fields: [organizationId], references: [id])
+  brandId                String
+  brand                  Brand              @relation(fields: [brandId], references: [id])
+  platform               CredentialPlatform
+  date                   DateTime
+  totalViews             Int                @default(0)
+  totalLikes             Int                @default(0)
+  totalComments          Int                @default(0)
+  totalShares            Int                @default(0)
+  totalSaves             Int                @default(0)
+  totalViewsIncrement    Int                @default(0)
+  totalLikesIncrement    Int                @default(0)
+  totalCommentsIncrement Int                @default(0)
+  totalSharesIncrement   Int                @default(0)
+  totalSavesIncrement    Int                @default(0)
+  engagementRate         Float              @default(0)
+  createdAt              DateTime           @default(now())
+  updatedAt              DateTime           @updatedAt
 
-  ingredients           Ingredient[]       @relation("post_analytics_ingredients")
+  ingredients Ingredient[] @relation("post_analytics_ingredients")
 
   @@map("post_analytics")
 }
 
 model Schedule {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  label           String?
-  platform        CredentialPlatform?
-  timezone        String       @default("UTC")
-  slots           Json         @default("[]")
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String              @id @default(cuid())
+  mongoId        String?             @unique
+  organizationId String
+  organization   Organization        @relation(fields: [organizationId], references: [id])
+  userId         String
+  brandId        String?
+  brand          Brand?              @relation(fields: [brandId], references: [id])
+  label          String?
+  platform       CredentialPlatform?
+  timezone       String              @default("UTC")
+  slots          Json                @default("[]")
+  isActive       Boolean             @default(true)
+  isDeleted      Boolean             @default(false)
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
 
   @@map("schedules")
 }
 
 model ContentSchedule {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  config          Json         @default("{}")
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  config         Json         @default("{}")
+  isActive       Boolean      @default(true)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("content_schedules")
 }
 
 model Distribution {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  config          Json         @default("{}")
-  status          String?
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  config         Json         @default("{}")
+  status         String?
+  isActive       Boolean      @default(true)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("distributions")
 }
 
 model RepurposingJob {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  config          Json         @default("{}")
-  status          String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  config         Json         @default("{}")
+  status         String?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("repurposing_jobs")
 }
@@ -1693,65 +1693,65 @@ model RepurposingJob {
 // ═══════════════════════════════════════════════════════════════
 
 model Customer {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
+  id               String       @id @default(cuid())
+  mongoId          String?      @unique
+  organizationId   String
+  organization     Organization @relation(fields: [organizationId], references: [id])
   stripeCustomerId String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  isDeleted        Boolean      @default(false)
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
 
-  subscriptions   Subscription[]
+  subscriptions Subscription[]
 
   @@map("customers")
 }
 
 model Subscription {
-  id              String             @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization       @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User               @relation(fields: [userId], references: [id])
-  customerId      String?
-  customer        Customer?          @relation(fields: [customerId], references: [id])
+  id                   String             @id @default(cuid())
+  mongoId              String?            @unique
+  organizationId       String
+  organization         Organization       @relation(fields: [organizationId], references: [id])
+  userId               String
+  user                 User               @relation(fields: [userId], references: [id])
+  customerId           String?
+  customer             Customer?          @relation(fields: [customerId], references: [id])
   stripeSubscriptionId String?
-  stripePriceId   String?
-  status          SubscriptionStatus @default(ACTIVE)
-  plan            String?
-  currentPeriodStart DateTime?
-  currentPeriodEnd   DateTime?
-  cancelAtPeriodEnd  Boolean         @default(false)
-  isDeleted       Boolean            @default(false)
-  createdAt       DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
+  stripePriceId        String?
+  status               SubscriptionStatus @default(ACTIVE)
+  plan                 String?
+  currentPeriodStart   DateTime?
+  currentPeriodEnd     DateTime?
+  cancelAtPeriodEnd    Boolean            @default(false)
+  isDeleted            Boolean            @default(false)
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
   @@map("subscriptions")
 }
 
 model UserSubscription {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String       @unique
-  user            User         @relation(fields: [userId], references: [id])
+  id                   String             @id @default(cuid())
+  mongoId              String?            @unique
+  userId               String             @unique
+  user                 User               @relation(fields: [userId], references: [id])
   stripeSubscriptionId String?
-  stripePriceId   String?
-  status          SubscriptionStatus @default(ACTIVE)
-  plan            String?
-  currentPeriodStart DateTime?
-  currentPeriodEnd   DateTime?
-  cancelAtPeriodEnd  Boolean    @default(false)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  stripePriceId        String?
+  status               SubscriptionStatus @default(ACTIVE)
+  plan                 String?
+  currentPeriodStart   DateTime?
+  currentPeriodEnd     DateTime?
+  cancelAtPeriodEnd    Boolean            @default(false)
+  isDeleted            Boolean            @default(false)
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
 
   @@map("user_subscriptions")
 }
 
 model SubscriptionAttribution {
   id              String       @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId         String?      @unique
   organizationId  String
   organization    Organization @relation(fields: [organizationId], references: [id])
   userId          String
@@ -1770,46 +1770,46 @@ model SubscriptionAttribution {
 }
 
 model CreditBalance {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String       @unique
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  balance         Float        @default(0)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String       @unique
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  balance        Float        @default(0)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("credit_balances")
 }
 
 model CreditTransaction {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  amount          Float
-  balanceAfter    Float?
-  source          String?
-  description     String?
-  referenceId     String?
-  referenceType   String?
-  metadata        Json?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  amount         Float
+  balanceAfter   Float?
+  source         String?
+  description    String?
+  referenceId    String?
+  referenceType  String?
+  metadata       Json?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("credit_transactions")
 }
 
 model CustomerInstance {
-  id              String   @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String?
-  config          Json     @default("{}")
-  status          String?
-  isDeleted       Boolean  @default(false)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String?
+  config         Json     @default("{}")
+  status         String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("customer_instances")
 }
@@ -1819,55 +1819,58 @@ model CustomerInstance {
 // ═══════════════════════════════════════════════════════════════
 
 model Article {
-  id              String        @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User          @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization  @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?        @relation(fields: [brandId], references: [id])
-  title           String
-  slug            String?
-  content         String?
-  excerpt         String?
-  coverImageUrl   String?
-  status          ArticleStatus @default(DRAFT)
-  publishedAt     DateTime?
-  isDeleted       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  userId         String
+  user           User          @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  title          String
+  slug           String?
+  content        String?
+  excerpt        String?
+  coverImageUrl  String?
+  status         ArticleStatus @default(DRAFT)
+  publishedAt    DateTime?
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
-  tags            Tag[]         @relation("article_tags")
-  prompts         Prompt[]
-  postEntities    Post[]        @relation("post_entity_article")
+  tags             Tag[]              @relation("article_tags")
+  prompts          Prompt[]
+  postEntities     Post[]             @relation("post_entity_article")
   articleAnalytics ArticleAnalytics[]
-  transcripts     Transcript[]
-  newsletters     Newsletter[]  @relation("newsletter_articles")
+  transcripts      Transcript[]
+  newsletters      Newsletter[]       @relation("newsletter_articles")
+
+  category String?
+  scope    String?
 
   @@map("articles")
 }
 
 model ArticleAnalytics {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  articleId       String
-  article         Article      @relation(fields: [articleId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  date            DateTime
-  totalViews      Int          @default(0)
-  totalLikes      Int          @default(0)
-  totalComments   Int          @default(0)
-  totalShares     Int          @default(0)
-  engagementRate  Float        @default(0)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  articleId      String
+  article        Article      @relation(fields: [articleId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  date           DateTime
+  totalViews     Int          @default(0)
+  totalLikes     Int          @default(0)
+  totalComments  Int          @default(0)
+  totalShares    Int          @default(0)
+  engagementRate Float        @default(0)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@unique([articleId, date])
   @@index([organizationId, date(sort: Desc)])
@@ -1877,7 +1880,7 @@ model ArticleAnalytics {
 
 model Newsletter {
   id                String           @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId           String?          @unique
   userId            String
   user              User             @relation("newsletter_user", fields: [userId], references: [id])
   organizationId    String
@@ -1899,27 +1902,27 @@ model Newsletter {
   createdAt         DateTime         @default(now())
   updatedAt         DateTime         @updatedAt
 
-  articles          Article[]        @relation("newsletter_articles")
-  contextNewsletters Newsletter[]    @relation("newsletter_context")
-  contextOf         Newsletter[]     @relation("newsletter_context")
+  articles           Article[]    @relation("newsletter_articles")
+  contextNewsletters Newsletter[] @relation("newsletter_context")
+  contextOf          Newsletter[] @relation("newsletter_context")
 
   @@map("newsletters")
 }
 
 model Transcript {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  articleId       String?
-  article         Article?     @relation(fields: [articleId], references: [id])
-  content         String?
-  language        String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  articleId      String?
+  article        Article?     @relation(fields: [articleId], references: [id])
+  content        String?
+  language       String?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("transcripts")
 }
@@ -1929,28 +1932,28 @@ model Transcript {
 // ═══════════════════════════════════════════════════════════════
 
 model Training {
-  id              String        @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User          @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization  @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?        @relation(fields: [brandId], references: [id])
-  personaId       String?
-  persona         Persona?      @relation(fields: [personaId], references: [id])
-  label           String?
-  description     String?
-  externalId      String?
-  stage           TrainingStage @default(PENDING)
-  config          Json          @default("{}")
-  isDeleted       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  userId         String
+  user           User          @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  personaId      String?
+  persona        Persona?      @relation(fields: [personaId], references: [id])
+  label          String?
+  description    String?
+  externalId     String?
+  stage          TrainingStage @default(PENDING)
+  config         Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
-  sources         Ingredient[]  @relation("training_sources")
-  ingredients     Ingredient[]  @relation("ingredient_training")
-  models          Model[]
+  sources     Ingredient[] @relation("training_sources")
+  ingredients Ingredient[] @relation("ingredient_training")
+  models      Model[]
 
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@index([brandId, isDeleted, createdAt(sort: Desc)])
@@ -1959,22 +1962,24 @@ model Training {
 }
 
 model Model {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String?
-  organization    Organization? @relation(fields: [organizationId], references: [id])
-  trainingId      String?
-  training        Training?    @relation(fields: [trainingId], references: [id])
-  parentModelId   String?
-  parentModel     Model?       @relation("model_parent", fields: [parentModelId], references: [id])
-  childModels     Model[]      @relation("model_parent")
-  label           String?
-  externalId      String?
-  config          Json         @default("{}")
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  trainingId     String?
+  training       Training?     @relation(fields: [trainingId], references: [id])
+  parentModelId  String?
+  parentModel    Model?        @relation("model_parent", fields: [parentModelId], references: [id])
+  childModels    Model[]       @relation("model_parent")
+  label          String?
+  externalId     String?
+  config         Json          @default("{}")
+  isActive       Boolean       @default(true)
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  category String?
 
   @@index([organizationId, isActive, isDeleted])
   @@map("models")
@@ -1985,35 +1990,35 @@ model Model {
 // ═══════════════════════════════════════════════════════════════
 
 model Persona {
-  id                     String        @id @default(cuid())
-  mongoId                 String?         @unique
-  userId                 String
-  user                   User          @relation(fields: [userId], references: [id])
-  organizationId         String
-  organization           Organization  @relation(fields: [organizationId], references: [id])
-  brandId                String?
-  brand                  Brand?        @relation(fields: [brandId], references: [id])
-  avatarIngredientId     String?
-  avatarIngredient       Ingredient?   @relation("persona_avatar", fields: [avatarIngredientId], references: [id])
-  voiceIngredientId      String?
-  voiceIngredient        Ingredient?   @relation("persona_voice", fields: [voiceIngredientId], references: [id])
-  label                  String
-  slug                   String?
-  description            String?
-  status                 PersonaStatus @default(ACTIVE)
-  config                 Json          @default("{}")
-  isAutopilotEnabled     Boolean       @default(false)
-  nextAutopilotRunAt     DateTime?
-  isDeleted              Boolean       @default(false)
-  createdAt              DateTime      @default(now())
-  updatedAt              DateTime      @updatedAt
+  id                 String        @id @default(cuid())
+  mongoId            String?       @unique
+  userId             String
+  user               User          @relation(fields: [userId], references: [id])
+  organizationId     String
+  organization       Organization  @relation(fields: [organizationId], references: [id])
+  brandId            String?
+  brand              Brand?        @relation(fields: [brandId], references: [id])
+  avatarIngredientId String?
+  avatarIngredient   Ingredient?   @relation("persona_avatar", fields: [avatarIngredientId], references: [id])
+  voiceIngredientId  String?
+  voiceIngredient    Ingredient?   @relation("persona_voice", fields: [voiceIngredientId], references: [id])
+  label              String
+  slug               String?
+  description        String?
+  status             PersonaStatus @default(ACTIVE)
+  config             Json          @default("{}")
+  isAutopilotEnabled Boolean       @default(false)
+  nextAutopilotRunAt DateTime?
+  isDeleted          Boolean       @default(false)
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
 
-  tags                   Tag[]         @relation("persona_tags")
-  credentials            Credential[]  @relation("persona_credentials")
-  assignedMembers        User[]        @relation("persona_assigned_members")
-  ingredients            Ingredient[]
-  posts                  Post[]
-  trainings              Training[]
+  tags            Tag[]        @relation("persona_tags")
+  credentials     Credential[] @relation("persona_credentials")
+  assignedMembers User[]       @relation("persona_assigned_members")
+  ingredients     Ingredient[]
+  posts           Post[]
+  trainings       Training[]
 
   @@index([organizationId, isDeleted, status])
   @@index([brandId, organizationId, isDeleted])
@@ -2026,231 +2031,243 @@ model Persona {
 // ═══════════════════════════════════════════════════════════════
 
 model AgentThread {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  title           String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  title          String?
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  messages        AgentMessage[]
-  runs            AgentRun[]
-  events          AgentThreadEvent[]
-  snapshots       AgentThreadSnapshot[]
-  contextStates   ThreadContextState[]
-  tasks           Task[]       @relation("task_planning_thread")
+  messages      AgentMessage[]
+  runs          AgentRun[]
+  events        AgentThreadEvent[]
+  snapshots     AgentThreadSnapshot[]
+  contextStates ThreadContextState[]
+  tasks         Task[]                @relation("task_planning_thread")
 
   @@map("agent_threads")
 }
 
 model AgentMessage {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  threadId        String
-  thread          AgentThread  @relation(fields: [threadId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String?
-  user            User?        @relation(fields: [userId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  role            String
-  content         String?
-  toolCalls       Json?
-  toolResults     Json?
-  metadata        Json?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  threadId       String
+  thread         AgentThread  @relation(fields: [threadId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String?
+  user           User?        @relation(fields: [userId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  role           String
+  content        String?
+  toolCalls      Json?
+  toolResults    Json?
+  metadata       Json?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("agent_messages")
 }
 
 model AgentRun {
-  id              String        @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization  @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User          @relation(fields: [userId], references: [id])
-  strategyId      String?
-  strategy        AgentStrategy? @relation(fields: [strategyId], references: [id])
-  threadId        String?
-  thread          AgentThread?  @relation(fields: [threadId], references: [id])
-  parentRunId     String?
-  parentRun       AgentRun?     @relation("agent_run_parent", fields: [parentRunId], references: [id])
-  childRuns       AgentRun[]    @relation("agent_run_parent")
-  status          AgentRunStatus @default(PENDING)
-  type            String?
-  config          Json          @default("{}")
-  result          Json?
-  error           String?
-  startedAt       DateTime?
-  completedAt     DateTime?
-  isDeleted       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  id             String         @id @default(cuid())
+  mongoId        String?        @unique
+  organizationId String
+  organization   Organization   @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User           @relation(fields: [userId], references: [id])
+  strategyId     String?
+  strategy       AgentStrategy? @relation(fields: [strategyId], references: [id])
+  threadId       String?
+  thread         AgentThread?   @relation(fields: [threadId], references: [id])
+  parentRunId    String?
+  parentRun      AgentRun?      @relation("agent_run_parent", fields: [parentRunId], references: [id])
+  childRuns      AgentRun[]     @relation("agent_run_parent")
+  status         AgentRunStatus @default(PENDING)
+  type           String?
+  config         Json           @default("{}")
+  result         Json?
+  error          String?
+  startedAt      DateTime?
+  completedAt    DateTime?
+  isDeleted      Boolean        @default(false)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
 
-  ingredients     Ingredient[]  @relation("ingredient_agent_run")
-  posts           Post[]        @relation("post_agent_run")
-  newsletters     Newsletter[]
-  captions        Caption[]
-  tasks           Task[]        @relation("task_linked_runs")
+  ingredients Ingredient[] @relation("ingredient_agent_run")
+  posts       Post[]       @relation("post_agent_run")
+  newsletters Newsletter[]
+  captions    Caption[]
+  tasks       Task[]       @relation("task_linked_runs")
+
+  metadata    Json    @default("{}")
+  label       String?
+  objective   String?
+  trigger     String?
+  creditsUsed Int     @default(0)
+  durationMs  Int?
 
   @@map("agent_runs")
 }
 
 model AgentStrategy {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  goalId          String?
-  goal            AgentGoal?   @relation(fields: [goalId], references: [id])
-  label           String?
-  description     String?
-  config          Json         @default("{}")
-  policies        Json         @default("{}")
-  isActive        Boolean      @default(true)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  goalId         String?
+  goal           AgentGoal?   @relation(fields: [goalId], references: [id])
+  label          String?
+  description    String?
+  config         Json         @default("{}")
+  policies       Json         @default("{}")
+  isActive       Boolean      @default(true)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  runs            AgentRun[]
-  ingredients     Ingredient[] @relation("ingredient_agent_strategy")
-  posts           Post[]       @relation("post_agent_strategy")
-  opportunities   AgentStrategyOpportunity[]
-  reports         AgentStrategyReport[]
-  campaigns       AgentCampaign[] @relation("campaign_agents")
-  campaignLeads   AgentCampaign[] @relation("campaign_lead")
-  batches         Batch[]
+  runs          AgentRun[]
+  ingredients   Ingredient[]               @relation("ingredient_agent_strategy")
+  posts         Post[]                     @relation("post_agent_strategy")
+  opportunities AgentStrategyOpportunity[]
+  reports       AgentStrategyReport[]
+  campaigns     AgentCampaign[]            @relation("campaign_agents")
+  campaignLeads AgentCampaign[]            @relation("campaign_lead")
+  batches       Batch[]
+
+  agentType String?
+  platforms String[] @default([])
 
   @@map("agent_strategies")
 }
 
 model AgentStrategyOpportunity {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  strategyId      String
-  strategy        AgentStrategy @relation(fields: [strategyId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  strategyId     String
+  strategy       AgentStrategy @relation(fields: [strategyId], references: [id])
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  data           Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("agent_strategy_opportunities")
 }
 
 model AgentStrategyReport {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  strategyId      String
-  strategy        AgentStrategy @relation(fields: [strategyId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  strategyId     String
+  strategy       AgentStrategy @relation(fields: [strategyId], references: [id])
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  data           Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("agent_strategy_reports")
 }
 
 model AgentCampaign {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
+  id                     String         @id @default(cuid())
+  mongoId                String?        @unique
+  organizationId         String
+  organization           Organization   @relation(fields: [organizationId], references: [id])
+  userId                 String
+  user                   User           @relation(fields: [userId], references: [id])
+  brandId                String?
+  brand                  Brand?         @relation(fields: [brandId], references: [id])
   campaignLeadStrategyId String?
   campaignLeadStrategy   AgentStrategy? @relation("campaign_lead", fields: [campaignLeadStrategyId], references: [id])
-  label           String?
-  description     String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  label                  String?
+  description            String?
+  config                 Json           @default("{}")
+  isDeleted              Boolean        @default(false)
+  createdAt              DateTime       @default(now())
+  updatedAt              DateTime       @updatedAt
 
-  agents          AgentStrategy[] @relation("campaign_agents")
-  memories        AgentMemory[]
+  agents   AgentStrategy[] @relation("campaign_agents")
+  memories AgentMemory[]
+
+  status String? @default("draft")
 
   @@map("agent_campaigns")
 }
 
 model AgentGoal {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  label           String?
-  description     String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  label          String?
+  description    String?
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  strategies      AgentStrategy[]
+  strategies AgentStrategy[]
 
   @@map("agent_goals")
 }
 
 model AgentMemory {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  campaignId      String?
-  campaign        AgentCampaign? @relation(fields: [campaignId], references: [id])
-  content         String?
-  type            String?
-  metadata        Json?
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String         @id @default(cuid())
+  mongoId        String?        @unique
+  organizationId String
+  organization   Organization   @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User           @relation(fields: [userId], references: [id])
+  brandId        String?
+  brand          Brand?         @relation(fields: [brandId], references: [id])
+  campaignId     String?
+  campaign       AgentCampaign? @relation(fields: [campaignId], references: [id])
+  content        String?
+  type           String?
+  metadata       Json?
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
 
   @@map("agent_memories")
 }
 
 model AgentThreadEvent {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  threadId        String
-  thread          AgentThread  @relation(fields: [threadId], references: [id])
-  sequence        Int
-  commandId       String?
-  runId           String?
-  type            String?
-  data            Json?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  threadId       String
+  thread         AgentThread  @relation(fields: [threadId], references: [id])
+  sequence       Int
+  commandId      String?
+  runId          String?
+  type           String?
+  data           Json?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@unique([organizationId, threadId, sequence])
   @@index([organizationId, threadId, commandId])
@@ -2259,50 +2276,50 @@ model AgentThreadEvent {
 }
 
 model AgentThreadSnapshot {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  threadId        String
-  thread          AgentThread  @relation(fields: [threadId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  threadId       String
+  thread         AgentThread  @relation(fields: [threadId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@unique([organizationId, threadId])
   @@map("agent_thread_snapshots")
 }
 
 model ThreadContextState {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  threadId        String
-  thread          AgentThread  @relation(fields: [threadId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  threadId       String
+  thread         AgentThread  @relation(fields: [threadId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@unique([organizationId, threadId])
   @@map("thread_context_states")
 }
 
 model AgentWorkflow {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  label           String?
-  description     String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  label          String?
+  description    String?
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("agent_workflows")
 }
@@ -2312,68 +2329,70 @@ model AgentWorkflow {
 // ═══════════════════════════════════════════════════════════════
 
 model Workflow {
-  id              String         @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User           @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization   @relation(fields: [organizationId], references: [id])
-  label           String?
-  description     String?
-  steps           Json           @default("[]")
-  nodes           Json           @default("[]")
-  edges           Json           @default("[]")
-  inputVariables  Json           @default("[]")
-  config          Json           @default("{}")
-  status          WorkflowStatus @default(DRAFT)
-  isDeleted       Boolean        @default(false)
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  id             String         @id @default(cuid())
+  mongoId        String?        @unique
+  userId         String
+  user           User           @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization   @relation(fields: [organizationId], references: [id])
+  label          String?
+  description    String?
+  steps          Json           @default("[]")
+  nodes          Json           @default("[]")
+  edges          Json           @default("[]")
+  inputVariables Json           @default("[]")
+  config         Json           @default("{}")
+  status         WorkflowStatus @default(DRAFT)
+  isDeleted      Boolean        @default(false)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
 
-  tags            Tag[]          @relation("workflow_tags")
-  brands          Brand[]        @relation("workflow_brands")
-  executions      WorkflowExecution[]
-  batchJobs       BatchWorkflowJob[]
+  tags       Tag[]               @relation("workflow_tags")
+  brands     Brand[]             @relation("workflow_brands")
+  executions WorkflowExecution[]
+  batchJobs  BatchWorkflowJob[]
 
   @@map("workflows")
 }
 
 model WorkflowExecution {
-  id              String                  @id @default(cuid())
-  mongoId                 String?         @unique
-  workflowId      String
-  workflow        Workflow                @relation(fields: [workflowId], references: [id])
-  userId          String
-  user            User                    @relation(fields: [userId], references: [id])
-  organizationId  String
-  organization    Organization            @relation(fields: [organizationId], references: [id])
-  status          WorkflowExecutionStatus @default(PENDING)
-  result          Json?
-  error           String?
-  startedAt       DateTime?
-  completedAt     DateTime?
-  isDeleted       Boolean                 @default(false)
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  id             String                  @id @default(cuid())
+  mongoId        String?                 @unique
+  workflowId     String
+  workflow       Workflow                @relation(fields: [workflowId], references: [id])
+  userId         String
+  user           User                    @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization            @relation(fields: [organizationId], references: [id])
+  status         WorkflowExecutionStatus @default(PENDING)
+  result         Json?
+  error          String?
+  startedAt      DateTime?
+  completedAt    DateTime?
+  isDeleted      Boolean                 @default(false)
+  createdAt      DateTime                @default(now())
+  updatedAt      DateTime                @updatedAt
 
-  posts           Post[]
+  posts Post[]
+
+  trigger String?
 
   @@map("workflow_executions")
 }
 
 model BatchWorkflowJob {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  workflowId      String
-  workflow        Workflow     @relation(fields: [workflowId], references: [id])
-  items           Json         @default("[]")
-  status          BatchStatus  @default(PENDING)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  workflowId     String
+  workflow       Workflow     @relation(fields: [workflowId], references: [id])
+  items          Json         @default("[]")
+  status         BatchStatus  @default(PENDING)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@index([organizationId, status])
   @@index([workflowId])
@@ -2381,64 +2400,64 @@ model BatchWorkflowJob {
 }
 
 model ContentRun {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  config          Json         @default("{}")
-  status          String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  config         Json         @default("{}")
+  status         String?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  posts           Post[]
+  posts               Post[]
   contentPerformances ContentPerformance[]
-  contentDrafts   ContentDraft[]
+  contentDrafts       ContentDraft[]
 
   @@map("content_runs")
 }
 
 model CronJob {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  label           String?
-  expression      String?
-  config          Json         @default("{}")
-  status          CronJobStatus @default(ACTIVE)
-  lastRunAt       DateTime?
-  nextRunAt       DateTime?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User          @relation(fields: [userId], references: [id])
+  label          String?
+  expression     String?
+  config         Json          @default("{}")
+  status         CronJobStatus @default(ACTIVE)
+  lastRunAt      DateTime?
+  nextRunAt      DateTime?
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
-  runs            CronRun[]
+  runs CronRun[]
 
   @@map("cron_jobs")
 }
 
 model CronRun {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  cronJobId       String
-  cronJob         CronJob      @relation(fields: [cronJobId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  status          CronRunStatus @default(PENDING)
-  result          Json?
-  error           String?
-  startedAt       DateTime?
-  completedAt     DateTime?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  cronJobId      String
+  cronJob        CronJob       @relation(fields: [cronJobId], references: [id])
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User          @relation(fields: [userId], references: [id])
+  status         CronRunStatus @default(PENDING)
+  result         Json?
+  error          String?
+  startedAt      DateTime?
+  completedAt    DateTime?
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("cron_runs")
 }
@@ -2448,63 +2467,69 @@ model CronRun {
 // ��══════════════════════════════════════════════════════════════
 
 model Task {
-  id                  String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId      String
-  organization        Organization @relation(fields: [organizationId], references: [id])
-  brandId             String?
-  userId              String?
-  user                User?        @relation(fields: [userId], references: [id])
-  parentId            String?
-  parent              Task?        @relation("task_parent", fields: [parentId], references: [id])
-  children            Task[]       @relation("task_parent")
-  planningThreadId    String?
-  planningThread      AgentThread? @relation("task_planning_thread", fields: [planningThreadId], references: [id])
-  title               String?
-  description         String?
-  status              TaskStatus   @default(TODO)
-  priority            TaskPriority @default(MEDIUM)
-  config              Json         @default("{}")
-  eventStream         Json         @default("[]")
-  decomposition       Json?
-  progress            Json?
-  isDeleted           Boolean      @default(false)
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
+  id               String       @id @default(cuid())
+  mongoId          String?      @unique
+  organizationId   String
+  organization     Organization @relation(fields: [organizationId], references: [id])
+  brandId          String?
+  userId           String?
+  user             User?        @relation(fields: [userId], references: [id])
+  parentId         String?
+  parent           Task?        @relation("task_parent", fields: [parentId], references: [id])
+  children         Task[]       @relation("task_parent")
+  planningThreadId String?
+  planningThread   AgentThread? @relation("task_planning_thread", fields: [planningThreadId], references: [id])
+  title            String?
+  description      String?
+  status           TaskStatus   @default(TODO)
+  priority         TaskPriority @default(MEDIUM)
+  config           Json         @default("{}")
+  eventStream      Json         @default("[]")
+  decomposition    Json?
+  progress         Json?
+  isDeleted        Boolean      @default(false)
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
 
-  comments            TaskComment[]
-  linkedRuns          AgentRun[]   @relation("task_linked_runs")
-  linkedOutputs       Ingredient[] @relation("task_linked_outputs")
-  approvedOutputs     Ingredient[] @relation("task_approved_outputs")
+  comments        TaskComment[]
+  linkedRuns      AgentRun[]    @relation("task_linked_runs")
+  linkedOutputs   Ingredient[]  @relation("task_linked_outputs")
+  approvedOutputs Ingredient[]  @relation("task_approved_outputs")
+
+  assigneeUserId  String?
+  assigneeAgentId String?
+  projectId       String?
+  goalId          String?
+  reviewState     String  @default("none")
 
   @@map("tasks")
 }
 
 model TaskComment {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  taskId          String
-  task            Task         @relation(fields: [taskId], references: [id])
-  content         String?
-  authorId        String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  taskId         String
+  task           Task         @relation(fields: [taskId], references: [id])
+  content        String?
+  authorId       String?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("task_comments")
 }
 
 model TaskCounter {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String       @unique
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  counter         Int          @default(0)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String       @unique
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  counter        Int          @default(0)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("task_counters")
 }
@@ -2514,105 +2539,114 @@ model TaskCounter {
 // ═══════════════════════════════════════════════════════════════
 
 model Bot {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  label           String?
-  config          Json         @default("{}")
-  targets         Json         @default("[]")
-  settings        Json         @default("{}")
-  status          BotStatus    @default(ACTIVE)
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  label          String?
+  config         Json         @default("{}")
+  targets        Json         @default("[]")
+  settings       Json         @default("{}")
+  status         BotStatus    @default(ACTIVE)
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  platforms String[] @default([])
+  category  String?
 
   @@map("bots")
 }
 
 model BotActivity {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  replyBotConfigId String?
-  replyBotConfig  ReplyBotConfig? @relation(fields: [replyBotConfigId], references: [id])
+  id                 String            @id @default(cuid())
+  mongoId            String?           @unique
+  organizationId     String
+  organization       Organization      @relation(fields: [organizationId], references: [id])
+  brandId            String?
+  brand              Brand?            @relation(fields: [brandId], references: [id])
+  userId             String
+  user               User              @relation(fields: [userId], references: [id])
+  replyBotConfigId   String?
+  replyBotConfig     ReplyBotConfig?   @relation(fields: [replyBotConfigId], references: [id])
   monitoredAccountId String?
-  monitoredAccount MonitoredAccount? @relation(fields: [monitoredAccountId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  monitoredAccount   MonitoredAccount? @relation(fields: [monitoredAccountId], references: [id])
+  data               Json              @default("{}")
+  isDeleted          Boolean           @default(false)
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
 
   @@map("bot_activities")
 }
 
 model ReplyBotConfig {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  botActivities   BotActivity[]
+  botActivities     BotActivity[]
   monitoredAccounts MonitoredAccount[]
-  processedTweets ProcessedTweet[]
+  processedTweets   ProcessedTweet[]
+
+  type       String?
+  actionType String?
+  isActive   Boolean @default(true)
 
   @@map("reply_bot_configs")
 }
 
 model MonitoredAccount {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  credentialId    String?
-  credential      Credential?  @relation(fields: [credentialId], references: [id])
-  botConfigId     String?
-  botConfig       ReplyBotConfig? @relation(fields: [botConfigId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String          @id @default(cuid())
+  mongoId        String?         @unique
+  organizationId String
+  organization   Organization    @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?          @relation(fields: [brandId], references: [id])
+  userId         String
+  user           User            @relation(fields: [userId], references: [id])
+  credentialId   String?
+  credential     Credential?     @relation(fields: [credentialId], references: [id])
+  botConfigId    String?
+  botConfig      ReplyBotConfig? @relation(fields: [botConfigId], references: [id])
+  config         Json            @default("{}")
+  isDeleted      Boolean         @default(false)
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
   botActivities   BotActivity[]
   processedTweets ProcessedTweet[]
+
+  isActive Boolean @default(true)
 
   @@map("monitored_accounts")
 }
 
 model ProcessedTweet {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  replyBotConfigId String?
-  replyBotConfig  ReplyBotConfig? @relation(fields: [replyBotConfigId], references: [id])
-  botActivityId   String?
+  id                 String            @id @default(cuid())
+  mongoId            String?           @unique
+  organizationId     String
+  organization       Organization      @relation(fields: [organizationId], references: [id])
+  replyBotConfigId   String?
+  replyBotConfig     ReplyBotConfig?   @relation(fields: [replyBotConfigId], references: [id])
+  botActivityId      String?
   monitoredAccountId String?
-  monitoredAccount MonitoredAccount? @relation(fields: [monitoredAccountId], references: [id])
-  tweetId         String
-  processedBy     String?
-  processedAt     DateTime     @default(now())
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  monitoredAccount   MonitoredAccount? @relation(fields: [monitoredAccountId], references: [id])
+  tweetId            String
+  processedBy        String?
+  processedAt        DateTime          @default(now())
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
 
   @@unique([organizationId, tweetId, processedBy])
   @@map("processed_tweets")
@@ -2624,7 +2658,7 @@ model ProcessedTweet {
 
 model ContentPerformance {
   id                  String       @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId             String?      @unique
   organizationId      String
   organization        Organization @relation(fields: [organizationId], references: [id])
   brandId             String?
@@ -2653,85 +2687,85 @@ model ContentPerformance {
 }
 
 model ContentPattern {
-  id                String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId    String
-  organization      Organization @relation(fields: [organizationId], references: [id])
-  sourceCreatorId   String?
-  sourceCreator     CreatorAnalysis? @relation(fields: [sourceCreatorId], references: [id])
-  data              Json         @default("{}")
-  isDeleted         Boolean      @default(false)
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  id              String           @id @default(cuid())
+  mongoId         String?          @unique
+  organizationId  String
+  organization    Organization     @relation(fields: [organizationId], references: [id])
+  sourceCreatorId String?
+  sourceCreator   CreatorAnalysis? @relation(fields: [sourceCreatorId], references: [id])
+  data            Json             @default("{}")
+  isDeleted       Boolean          @default(false)
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
 
   @@map("content_patterns")
 }
 
 model CreatorAnalysis {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  createdById     String?
-  createdBy       User?        @relation(fields: [createdById], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  createdById    String?
+  createdBy      User?        @relation(fields: [createdById], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  contentPatterns ContentPattern[]
+  contentPatterns  ContentPattern[]
   patternPlaybooks PatternPlaybook[]
 
   @@map("creator_analyses")
 }
 
 model PatternPlaybook {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  createdById     String?
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  createdById    String?
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  sourceCreators  CreatorAnalysis[]
+  sourceCreators CreatorAnalysis[]
 
   @@map("pattern_playbooks")
 }
 
 model CreativePattern {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("creative_patterns")
 }
 
 model ContentDraft {
-  id              String            @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization      @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?            @relation(fields: [brandId], references: [id])
-  contentRunId    String?
-  contentRun      ContentRun?       @relation(fields: [contentRunId], references: [id])
-  approvedById    String?
-  approvedBy      User?             @relation("content_draft_approved_by", fields: [approvedById], references: [id])
-  status          ContentDraftStatus @default(DRAFT)
-  data            Json              @default("{}")
-  isDeleted       Boolean           @default(false)
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
+  id             String             @id @default(cuid())
+  mongoId        String?            @unique
+  organizationId String
+  organization   Organization       @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?             @relation(fields: [brandId], references: [id])
+  contentRunId   String?
+  contentRun     ContentRun?        @relation(fields: [contentRunId], references: [id])
+  approvedById   String?
+  approvedBy     User?              @relation("content_draft_approved_by", fields: [approvedById], references: [id])
+  status         ContentDraftStatus @default(DRAFT)
+  data           Json               @default("{}")
+  isDeleted      Boolean            @default(false)
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
 
   trendRemixLineages TrendRemixLineage[]
 
@@ -2739,134 +2773,134 @@ model ContentDraft {
 }
 
 model ContentPlan {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  createdById     String?
-  createdBy       User?        @relation(fields: [createdById], references: [id])
-  label           String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  createdById    String?
+  createdBy      User?        @relation(fields: [createdById], references: [id])
+  label          String?
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  items           ContentPlanItem[]
+  items ContentPlanItem[]
 
   @@map("content_plans")
 }
 
 model ContentPlanItem {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  planId          String
-  plan            ContentPlan  @relation(fields: [planId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  planId         String
+  plan           ContentPlan  @relation(fields: [planId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("content_plan_items")
 }
 
 model ContentScore {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  optimizations   Optimization[]
+  optimizations Optimization[]
 
   @@map("content_scores")
 }
 
 model Optimization {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  scoreId         String?
-  score           ContentScore? @relation(fields: [scoreId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User          @relation(fields: [userId], references: [id])
+  scoreId        String?
+  score          ContentScore? @relation(fields: [scoreId], references: [id])
+  data           Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("optimizations")
 }
 
 model Evaluation {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  contentType     String?
-  contentId       String?
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  contentType    String?
+  contentId      String?
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("evaluations")
 }
 
 model Activity {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String?
-  organizationId  String?
-  organization    Organization? @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  entityId        String?
-  entityModel     String?
-  action          String?
-  data            Json?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  userId         String?
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  entityId       String?
+  entityModel    String?
+  action         String?
+  data           Json?
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("activities")
 }
 
 model Insight {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("insights")
 }
 
 model Forecast {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("forecasts")
 }
@@ -2876,40 +2910,40 @@ model Forecast {
 // ═══════════════════════════════════════════════════════════════
 
 model AdBulkUploadJob {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  credentialId    String?
-  credential      Credential?  @relation(fields: [credentialId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  credentialId   String?
+  credential     Credential?  @relation(fields: [credentialId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("ad_bulk_upload_jobs")
 }
 
 model AdCreativeMapping {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("ad_creative_mappings")
 }
 
 model AdInsights {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -2919,57 +2953,57 @@ model AdInsights {
 }
 
 model AdOptimizationAuditLog {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("ad_optimization_audit_logs")
 }
 
 model AdOptimizationConfig {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String       @unique
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String       @unique
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("ad_optimization_configs")
 }
 
 model AdOptimizationRecommendation {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("ad_optimization_recommendations")
 }
 
 model AdPerformance {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  credentialId    String?
-  credential      Credential?  @relation(fields: [credentialId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  credentialId   String?
+  credential     Credential?  @relation(fields: [credentialId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("ad_performance")
 }
@@ -2979,26 +3013,26 @@ model AdPerformance {
 // ═══════════════════════════════════════════════════════════════
 
 model Trend {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   sourceReferenceLinks TrendSourceReferenceLink[]
-  remixLineages   TrendRemixLineage[] @relation("remix_lineage_trends")
+  remixLineages        TrendRemixLineage[]        @relation("remix_lineage_trends")
 
   @@map("trends")
 }
 
 model TrendingHashtag {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -3009,7 +3043,7 @@ model TrendingHashtag {
 
 model TrendingSound {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -3020,7 +3054,7 @@ model TrendingSound {
 
 model TrendingVideo {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -3030,37 +3064,37 @@ model TrendingVideo {
 }
 
 model TrendPreferences {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("trend_preferences")
 }
 
 model TrendRemixLineage {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  contentDraftId  String?
-  contentDraft    ContentDraft? @relation(fields: [contentDraftId], references: [id])
-  postId          String?
-  post            Post?        @relation(fields: [postId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  contentDraftId String?
+  contentDraft   ContentDraft? @relation(fields: [contentDraftId], references: [id])
+  postId         String?
+  post           Post?         @relation(fields: [postId], references: [id])
+  data           Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
-  trends          Trend[]      @relation("remix_lineage_trends")
+  trends           Trend[]                @relation("remix_lineage_trends")
   sourceReferences TrendSourceReference[] @relation("remix_lineage_source_refs")
 
   @@map("trend_remix_lineages")
@@ -3068,42 +3102,42 @@ model TrendRemixLineage {
 
 model TrendSourceReference {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  links           TrendSourceReferenceLink[]
-  snapshots       TrendSourceReferenceSnapshot[]
-  remixLineages   TrendRemixLineage[] @relation("remix_lineage_source_refs")
+  links         TrendSourceReferenceLink[]
+  snapshots     TrendSourceReferenceSnapshot[]
+  remixLineages TrendRemixLineage[]            @relation("remix_lineage_source_refs")
 
   @@map("trend_source_references")
 }
 
 model TrendSourceReferenceLink {
-  id                String               @id @default(cuid())
-  mongoId                 String?         @unique
+  id                String                @id @default(cuid())
+  mongoId           String?               @unique
   trendId           String?
-  trend             Trend?               @relation(fields: [trendId], references: [id])
+  trend             Trend?                @relation(fields: [trendId], references: [id])
   sourceReferenceId String?
   sourceReference   TrendSourceReference? @relation(fields: [sourceReferenceId], references: [id])
-  isDeleted         Boolean              @default(false)
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
+  isDeleted         Boolean               @default(false)
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
 
   @@map("trend_source_reference_links")
 }
 
 model TrendSourceReferenceSnapshot {
-  id                String               @id @default(cuid())
-  mongoId                 String?         @unique
+  id                String                @id @default(cuid())
+  mongoId           String?               @unique
   sourceReferenceId String?
   sourceReference   TrendSourceReference? @relation(fields: [sourceReferenceId], references: [id])
-  data              Json                 @default("{}")
-  isDeleted         Boolean              @default(false)
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
+  data              Json                  @default("{}")
+  isDeleted         Boolean               @default(false)
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
 
   @@map("trend_source_reference_snapshots")
 }
@@ -3113,36 +3147,40 @@ model TrendSourceReferenceSnapshot {
 // ═══════════════════════════════════════════════════════════════
 
 model OutreachCampaign {
-  id              String                 @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization           @relation(fields: [organizationId], references: [id])
-  userId          String?
-  user            User?                  @relation(fields: [userId], references: [id])
-  brandId         String?
-  status          OutreachCampaignStatus @default(DRAFT)
-  config          Json                   @default("{}")
-  isDeleted       Boolean                @default(false)
-  createdAt       DateTime               @default(now())
-  updatedAt       DateTime               @updatedAt
+  id             String                 @id @default(cuid())
+  mongoId        String?                @unique
+  organizationId String
+  organization   Organization           @relation(fields: [organizationId], references: [id])
+  userId         String?
+  user           User?                  @relation(fields: [userId], references: [id])
+  brandId        String?
+  status         OutreachCampaignStatus @default(DRAFT)
+  config         Json                   @default("{}")
+  isDeleted      Boolean                @default(false)
+  createdAt      DateTime               @default(now())
+  updatedAt      DateTime               @updatedAt
 
-  targets         CampaignTarget[]
+  targets CampaignTarget[]
+
+  platform     String?
+  campaignType String?
+  isActive     Boolean @default(true)
 
   @@map("outreach_campaigns")
 }
 
 model CampaignTarget {
-  id              String               @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization         @relation(fields: [organizationId], references: [id])
-  campaignId      String
-  campaign        OutreachCampaign     @relation(fields: [campaignId], references: [id])
-  status          CampaignTargetStatus @default(PENDING)
-  data            Json                 @default("{}")
-  isDeleted       Boolean              @default(false)
-  createdAt       DateTime             @default(now())
-  updatedAt       DateTime             @updatedAt
+  id             String               @id @default(cuid())
+  mongoId        String?              @unique
+  organizationId String
+  organization   Organization         @relation(fields: [organizationId], references: [id])
+  campaignId     String
+  campaign       OutreachCampaign     @relation(fields: [campaignId], references: [id])
+  status         CampaignTargetStatus @default(PENDING)
+  data           Json                 @default("{}")
+  isDeleted      Boolean              @default(false)
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
 
   @@map("campaign_targets")
 }
@@ -3152,212 +3190,222 @@ model CampaignTarget {
 // ═══════════════════════════════════════════════════════════════
 
 model ElementBlacklist {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  category String?
 
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@map("elements_blacklists")
 }
 
 model ElementCamera {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@map("elements_cameras")
 }
 
 model ElementCameraMovement {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("elements_camera_movements")
 }
 
 model ElementLens {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("elements_lenses")
 }
 
 model ElementLighting {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("elements_lightings")
 }
 
 model ElementMood {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("elements_moods")
 }
 
 model ElementScene {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  isFavorite Boolean @default(false)
 
   @@map("elements_scenes")
 }
 
 model ElementSound {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  isFavorite Boolean @default(false)
 
   @@map("elements_sounds")
 }
 
 model ElementStyle {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("elements_styles")
 }
 
 model FontFamilyRecord {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String?
-  key             String?
-  label           String?
-  description     String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String?
+  key            String?
+  label          String?
+  description    String?
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("font_families")
 }
 
 model Preset {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String?
-  organization    Organization? @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?        @relation(fields: [brandId], references: [id])
+  config         Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  category   String?
+  isActive   Boolean @default(true)
+  isFavorite Boolean @default(false)
 
   @@map("presets")
 }
 
 model Caption {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  ingredientId    String?
-  ingredient      Ingredient?  @relation(fields: [ingredientId], references: [id])
-  agentRunId      String?
-  agentRun        AgentRun?    @relation(fields: [agentRunId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  content         String?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  ingredientId   String?
+  ingredient     Ingredient?  @relation(fields: [ingredientId], references: [id])
+  agentRunId     String?
+  agentRun       AgentRun?    @relation(fields: [agentRunId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  content        String?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("captions")
 }
 
 model ClipProject {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("clip_projects")
 }
 
 model ClipResult {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("clip_results")
 }
 
 model EditorProject {
   id              String       @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId         String?      @unique
   organizationId  String
   organization    Organization @relation(fields: [organizationId], references: [id])
   brandId         String?
@@ -3376,89 +3424,89 @@ model EditorProject {
 }
 
 model Project {
-  id              String        @id @default(cuid())
-  mongoId         String?       @unique
-  organizationId  String
-  organization    Organization  @relation(fields: [organizationId], references: [id])
-  label           String
-  description     String?
-  status          String        @default("active")
-  isDeleted       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  label          String
+  description    String?
+  status         String       @default("active")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@index([organizationId, isDeleted])
   @@map("projects")
 }
 
 model BrandMemory {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  content         String?
-  type            String?
-  metadata        Json?
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  content        String?
+  type           String?
+  metadata       Json?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("brand_memories")
 }
 
 model ContextBase {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  createdById     String?
-  createdBy       User?        @relation(fields: [createdById], references: [id])
-  sourceBrandId   String?
-  sourceBrand     Brand?       @relation("context_base_source_brand", fields: [sourceBrandId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  createdById    String?
+  createdBy      User?        @relation(fields: [createdById], references: [id])
+  sourceBrandId  String?
+  sourceBrand    Brand?       @relation("context_base_source_brand", fields: [sourceBrandId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
-  entries         ContextEntry[]
+  entries ContextEntry[]
 
   @@map("context_bases")
 }
 
 model ContextEntry {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  contextBaseId   String
-  contextBase     ContextBase  @relation(fields: [contextBaseId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  contextBaseId  String
+  contextBase    ContextBase  @relation(fields: [contextBaseId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("context_entries")
 }
 
 model Skill {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  label           String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  label          String?
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("skills")
 }
 
 model SkillReceipt {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -3468,25 +3516,33 @@ model SkillReceipt {
 }
 
 model Template {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String?
-  organization    Organization? @relation(fields: [organizationId], references: [id])
-  label           String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  label          String?
+  config         Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
-  metadata        TemplateMetadata?
-  usages          TemplateUsage[]
+  metadata TemplateMetadata?
+  usages   TemplateUsage[]
+
+  purpose    String?
+  key        String?
+  scope      String?
+  categories String[] @default([])
+  industries String[] @default([])
+  platforms  String[] @default([])
+  isFeatured Boolean  @default(false)
 
   @@map("templates")
 }
 
 model TemplateMetadata {
   id         String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId    String?  @unique
   templateId String   @unique
   template   Template @relation(fields: [templateId], references: [id])
   data       Json     @default("{}")
@@ -3498,152 +3554,155 @@ model TemplateMetadata {
 }
 
 model TemplateUsage {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  templateId      String
-  template        Template     @relation(fields: [templateId], references: [id])
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  templateId     String
+  template       Template     @relation(fields: [templateId], references: [id])
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("template_usages")
 }
 
 model Vote {
-  id              String        @id @default(cuid())
-  mongoId                 String?         @unique
-  userId          String
-  user            User          @relation(fields: [userId], references: [id])
-  organizationId  String?
-  organization    Organization? @relation(fields: [organizationId], references: [id])
-  entityId        String?
-  entityModel     String?
-  isDeleted       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  userId         String
+  user           User          @relation(fields: [userId], references: [id])
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  entityId       String?
+  entityModel    String?
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("votes")
 }
 
 model Watchlist {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  brandId         String?
-  brand           Brand?       @relation(fields: [brandId], references: [id])
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  brandId        String?
+  brand          Brand?       @relation(fields: [brandId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("watchlists")
 }
 
 model Goal {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  parentId        String?
-  parent          Goal?        @relation("goal_parent", fields: [parentId], references: [id])
-  children        Goal[]       @relation("goal_parent")
-  label           String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  parentId       String?
+  parent         Goal?        @relation("goal_parent", fields: [parentId], references: [id])
+  children       Goal[]       @relation("goal_parent")
+  label          String?
+  config         Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  status String?
+  level  String?
 
   @@map("goals")
 }
 
 model Streak {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  userId          String
-  user            User         @relation(fields: [userId], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("streaks")
 }
 
 model Announcement {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String?
-  organization    Organization? @relation(fields: [organizationId], references: [id])
-  title           String?
-  content         String?
-  config          Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String        @id @default(cuid())
+  mongoId        String?       @unique
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id])
+  title          String?
+  content        String?
+  config         Json          @default("{}")
+  isDeleted      Boolean       @default(false)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@map("announcements")
 }
 
 model Lead {
-  id                    String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId        String?
-  organization          Organization? @relation("lead_org", fields: [organizationId], references: [id])
-  userId                String?
-  user                  User?        @relation("lead_user", fields: [userId], references: [id])
+  id                      String        @id @default(cuid())
+  mongoId                 String?       @unique
+  organizationId          String?
+  organization            Organization? @relation("lead_org", fields: [organizationId], references: [id])
+  userId                  String?
+  user                    User?         @relation("lead_user", fields: [userId], references: [id])
   proactiveOrganizationId String?
-  proactiveOrganization Organization? @relation("lead_proactive_org", fields: [proactiveOrganizationId], references: [id])
-  proactiveBrandId      String?
-  proactiveBrand        Brand?       @relation("lead_proactive_brand", fields: [proactiveBrandId], references: [id])
-  status                LeadStatus   @default(NEW)
-  data                  Json         @default("{}")
-  isDeleted             Boolean      @default(false)
-  createdAt             DateTime     @default(now())
-  updatedAt             DateTime     @updatedAt
+  proactiveOrganization   Organization? @relation("lead_proactive_org", fields: [proactiveOrganizationId], references: [id])
+  proactiveBrandId        String?
+  proactiveBrand          Brand?        @relation("lead_proactive_brand", fields: [proactiveBrandId], references: [id])
+  status                  LeadStatus    @default(NEW)
+  data                    Json          @default("{}")
+  isDeleted               Boolean       @default(false)
+  createdAt               DateTime      @default(now())
+  updatedAt               DateTime      @updatedAt
 
   @@index([organizationId, isDeleted, status])
   @@map("leads")
 }
 
 model Profile {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  organization    Organization @relation(fields: [organizationId], references: [id])
-  createdById     String?
-  createdBy       User?        @relation(fields: [createdById], references: [id])
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String       @id @default(cuid())
+  mongoId        String?      @unique
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  createdById    String?
+  createdBy      User?        @relation(fields: [createdById], references: [id])
+  data           Json         @default("{}")
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 
   @@map("profiles")
 }
 
 model Batch {
-  id              String        @id @default(cuid())
-  mongoId                 String?         @unique
+  id              String         @id @default(cuid())
+  mongoId         String?        @unique
   organizationId  String
-  organization    Organization  @relation(fields: [organizationId], references: [id])
+  organization    Organization   @relation(fields: [organizationId], references: [id])
   userId          String
-  user            User          @relation(fields: [userId], references: [id])
+  user            User           @relation(fields: [userId], references: [id])
   brandId         String?
-  brand           Brand?        @relation(fields: [brandId], references: [id])
+  brand           Brand?         @relation(fields: [brandId], references: [id])
   agentStrategyId String?
   agentStrategy   AgentStrategy? @relation(fields: [agentStrategyId], references: [id])
-  items           Json          @default("[]")
-  status          BatchStatus   @default(PENDING)
-  config          Json          @default("{}")
-  isDeleted       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  items           Json           @default("[]")
+  status          BatchStatus    @default(PENDING)
+  config          Json           @default("{}")
+  isDeleted       Boolean        @default(false)
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
 
   @@map("batches")
 }
@@ -3653,18 +3712,18 @@ model Batch {
 // ═══════════════════════════════════════════════════════════════
 
 model FanvueContent {
-  id              String   @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  userId          String
-  status          String?
-  data            Json     @default("{}")
-  publishedAt     DateTime?
-  isDeleted       Boolean  @default(false)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String    @id @default(cuid())
+  mongoId        String?   @unique
+  organizationId String
+  userId         String
+  status         String?
+  data           Json      @default("{}")
+  publishedAt    DateTime?
+  isDeleted      Boolean   @default(false)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
-  schedules       FanvueSchedule[]
+  schedules FanvueSchedule[]
 
   @@index([organizationId, isDeleted, status])
   @@index([organizationId, publishedAt(sort: Desc)])
@@ -3672,16 +3731,16 @@ model FanvueContent {
 }
 
 model FanvueEarnings {
-  id              String   @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  userId          String
-  type            String?
-  data            Json     @default("{}")
-  earnedAt        DateTime?
-  isDeleted       Boolean  @default(false)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String    @id @default(cuid())
+  mongoId        String?   @unique
+  organizationId String
+  userId         String
+  type           String?
+  data           Json      @default("{}")
+  earnedAt       DateTime?
+  isDeleted      Boolean   @default(false)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   @@index([organizationId, isDeleted, type])
   @@index([organizationId, earnedAt(sort: Desc)])
@@ -3689,18 +3748,18 @@ model FanvueEarnings {
 }
 
 model FanvueSchedule {
-  id              String   @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  userId          String
-  contentId       String?
-  content         FanvueContent? @relation(fields: [contentId], references: [id])
-  status          String?
-  scheduledAt     DateTime?
-  data            Json     @default("{}")
-  isDeleted       Boolean  @default(false)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String         @id @default(cuid())
+  mongoId        String?        @unique
+  organizationId String
+  userId         String
+  contentId      String?
+  content        FanvueContent? @relation(fields: [contentId], references: [id])
+  status         String?
+  scheduledAt    DateTime?
+  data           Json           @default("{}")
+  isDeleted      Boolean        @default(false)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
 
   @@index([organizationId, isDeleted, status])
   @@index([scheduledAt, status])
@@ -3708,16 +3767,16 @@ model FanvueSchedule {
 }
 
 model FanvueSubscriber {
-  id              String   @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  userId          String
-  externalId      String?
-  status          String?
-  data            Json     @default("{}")
-  isDeleted       Boolean  @default(false)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  userId         String
+  externalId     String?
+  status         String?
+  data           Json     @default("{}")
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@unique([organizationId, externalId])
   @@index([organizationId, isDeleted, status])
@@ -3726,7 +3785,7 @@ model FanvueSubscriber {
 
 model LivestreamBotSession {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   isDeleted Boolean  @default(false)
   createdAt DateTime @default(now())
@@ -3736,21 +3795,21 @@ model LivestreamBotSession {
 }
 
 model Run {
-  id              String       @id @default(cuid())
-  mongoId                 String?         @unique
-  organizationId  String
-  brandId         String?
-  data            Json         @default("{}")
-  isDeleted       Boolean      @default(false)
-  createdAt       DateTime     @default(now())
-  updatedAt       DateTime     @updatedAt
+  id             String   @id @default(cuid())
+  mongoId        String?  @unique
+  organizationId String
+  brandId        String?
+  data           Json     @default("{}")
+  isDeleted      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@map("runs")
 }
 
 model Analytic {
   id        String   @id @default(cuid())
-  mongoId                 String?         @unique
+  mongoId   String?  @unique
   data      Json     @default("{}")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/packages/props/ui/app-switcher.props.ts
+++ b/packages/props/ui/app-switcher.props.ts
@@ -5,4 +5,6 @@ export interface AppSwitcherProps {
   currentApp: AppContext;
   orgSlug: string;
   preservedSearch?: string;
+  /** Trigger style: compact grid icon (sidebar) or labeled section pill (topbar) */
+  variant?: 'icon' | 'labeled';
 }

--- a/packages/ui/src/components/agent-panel/AgentPanelShell.tsx
+++ b/packages/ui/src/components/agent-panel/AgentPanelShell.tsx
@@ -101,7 +101,7 @@ function AgentPanelShell({
               variant={ButtonVariant.UNSTYLED}
               withWrapper={false}
               onClick={onExpand}
-              className="gen-shell-control size-7 rounded-md"
+              className="gen-shell-control flex items-center justify-center size-7 rounded-md"
               ariaLabel="Open full chat workspace"
             >
               <HiArrowsPointingOut className="size-3.5" />
@@ -112,7 +112,7 @@ function AgentPanelShell({
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
             onClick={onToggle}
-            className="gen-shell-control size-7 rounded-md"
+            className="gen-shell-control flex items-center justify-center size-7 rounded-md"
             data-active={isOpen ? 'true' : 'false'}
             ariaLabel={isOpen ? 'Collapse terminal' : 'Expand terminal'}
           >

--- a/packages/ui/src/components/layout/container-title/ContainerTitle.tsx
+++ b/packages/ui/src/components/layout/container-title/ContainerTitle.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSidebarNavigation } from '@genfeedai/contexts/ui/sidebar-navigation-context';
 import type { ContainerTitleProps } from '@genfeedai/props/layout/container-title.props';
 import CardIcon from '@ui/card/icon/CardIcon';
 
@@ -8,6 +9,9 @@ export default function ContainerTitle({
   description,
   icon,
 }: ContainerTitleProps) {
+  const { activeGroupId, activePageLabel } = useSidebarNavigation();
+  const hasBreadcrumb = Boolean(activeGroupId || activePageLabel);
+
   const isTextDescription =
     typeof description === 'number' || typeof description === 'string';
   const DescriptionTag = isTextDescription ? 'p' : 'div';
@@ -17,6 +21,26 @@ export default function ContainerTitle({
       <h1 className="text-base font-semibold tracking-[-0.01em] text-foreground">
         {title}
       </h1>
+      {hasBreadcrumb ? (
+        <nav
+          aria-label="Breadcrumb"
+          className="mt-1 flex items-center gap-1.5 text-xs text-foreground/45"
+        >
+          {activeGroupId ? (
+            <span className="truncate">{activeGroupId}</span>
+          ) : null}
+          {activeGroupId && activePageLabel ? (
+            <span aria-hidden="true" className="select-none text-foreground/25">
+              ›
+            </span>
+          ) : null}
+          {activePageLabel ? (
+            <span className="truncate text-foreground/65">
+              {activePageLabel}
+            </span>
+          ) : null}
+        </nav>
+      ) : null}
       {description ? (
         <DescriptionTag className="mt-1 max-w-3xl text-xs leading-snug text-foreground/55">
           {description}

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -8,7 +8,6 @@ import MenuItem from '@ui/menus/item/MenuItem';
 import SidebarNested from '@ui/menus/sidebar-nested/SidebarNested';
 import WorkspaceSwitcher from '@ui/menus/workspace-switcher/WorkspaceSwitcher';
 import { Button } from '@ui/primitives/button';
-import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -25,7 +24,6 @@ const SIDEBAR_WIDTH = 240;
 
 export default function MenuShared({
   config,
-  currentApp,
   onClose,
   renderTopSlot,
   renderBody,
@@ -46,8 +44,6 @@ export default function MenuShared({
     logoUrl,
     href,
     orgHref,
-    orgSlug,
-    brandSlug,
     isConversationsCollapsed,
     setIsConversationsCollapsed,
     nestedGroupId,
@@ -207,13 +203,6 @@ export default function MenuShared({
         >
           {sharedCollapseControl}
           <WorkspaceSwitcher />
-          {currentApp && orgSlug && (
-            <AppSwitcher
-              currentApp={currentApp}
-              orgSlug={orgSlug}
-              brandSlug={brandSlug}
-            />
-          )}
         </div>
 
         {/* Body — fades out when collapsed, pointer-events disabled */}

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -6,6 +6,7 @@ import type { AppSwitcherItemConfig } from '@genfeedai/interfaces';
 import type { AppSwitcherProps } from '@genfeedai/props/ui/app-switcher.props';
 import Link from 'next/link';
 import {
+  HiChevronDown,
   HiOutlineChartBar,
   HiOutlineChartBarSquare,
   HiOutlineChatBubbleLeftRight,
@@ -97,6 +98,8 @@ const PLATFORM_APPS: AppSwitcherItemConfig[] = [
   },
 ];
 
+const ALL_APPS: AppSwitcherItemConfig[] = [...PLATFORM_APPS, ...CONTENT_APPS];
+
 function withPreservedSearch(path: string, preservedSearch?: string): string {
   if (!preservedSearch) {
     return path;
@@ -165,23 +168,43 @@ export function AppSwitcher({
   currentApp,
   orgSlug,
   preservedSearch,
+  variant = 'icon',
 }: AppSwitcherProps) {
   function getAppHref(app: AppSwitcherItemConfig) {
     return withPreservedSearch(app.route(orgSlug, brandSlug), preservedSearch);
   }
 
+  const activeApp = ALL_APPS.find((app) => app.id === currentApp);
+  const ActiveIcon = activeApp?.icon ?? HiOutlineSquares2X2;
+  const activeLabel = activeApp?.label ?? 'Workspace';
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant={ButtonVariant.GHOST}
-          size={ButtonSize.ICON}
-          className="size-7"
-          ariaLabel="Switch app"
-        >
-          <TbGridDots className="size-4" />
-        </Button>
+        {variant === 'labeled' ? (
+          <Button
+            type="button"
+            variant={ButtonVariant.GHOST}
+            className="flex h-7 items-center gap-2 rounded-md px-2"
+            ariaLabel="Switch section"
+          >
+            <ActiveIcon className="size-4 shrink-0 text-foreground/70" />
+            <span className="max-w-[12rem] truncate text-[13px] font-semibold text-foreground">
+              {activeLabel}
+            </span>
+            <HiChevronDown className="size-3.5 shrink-0 text-foreground/45" />
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant={ButtonVariant.GHOST}
+            size={ButtonSize.ICON}
+            className="size-7"
+            ariaLabel="Switch app"
+          >
+            <TbGridDots className="size-4" />
+          </Button>
+        )}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={8} className="w-48">
         <DropdownMenuLabel>Content</DropdownMenuLabel>


### PR DESCRIPTION
## What
Resolves the `PrismaClientValidationError` 500s on API list endpoints (font-families, tags, presets, trainings, agent-runs, articles, …) caused by an incomplete Mongo→Prisma migration: controllers filtered/sorted by fields the Prisma schema no longer had.

## Changes
- **Stage 3 schema** (`d765dc58f`): additive Prisma migration — **42 `ADD COLUMN`, 0 drops, all nullable/defaulted** (zero data loss). Plain String/Boolean/Int/String[]/Json columns matching the app's lowercase values (no new enums → no canonicalization layer). 17 models (AgentCampaign.status, Task.{assignee*,projectId,goalId,reviewState}, AgentRun.{metadata,label,objective,trigger,creditsUsed,durationMs}, Goal.{status,level}, …).
- **Stage 3 wiring** (`09ee13713`): the 3 filters needing code beyond the columns — agent-runs `metadata.*`→Prisma JSON-path, trainings `status`→`stage` map, article status app→Prisma enum map. 84 tests pass.
- (Stage 1 filter code-fixes + the 3 central normalizer fixes already on develop.)

## ⚠️ Required after merge
- **Apply the migration**: `DATABASE_URL=… bun run --filter=@genfeedai/prisma db:migrate` (additive, safe). Until applied, the new-column filters return "column does not exist".

## Notes / follow-ups
- **Semantic mapping to confirm**: trainings `completed→READY`, `processing→TRAINING`; articles drops `processing`/`failed` (no Prisma `ArticleStatus` equivalent).
- **Pre-existing build bug** (separate, from the Prisma-7/TS deps bump): package build script `tsc --build && mv dist/src/* dist/` breaks `tsc --build` project references (TS6305 on helpers/constants). Blocks local typecheck + the planned Stage 4 typed-generics. To be fixed on develop next.
- Includes one prior automation UI commit (`6c021339c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)