### PR TITLE
test(e2e): real-Clerk authenticated route smoke (storageState)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ apps/desktop/app/release/
 # Agent scratch dirs at any depth (apps/<name>/.agents/, apps/<surface>/<name>/.agents/)
 # Covers apps/app/.agents, apps/mobile/app/.agents, apps/extensions/browser/app/.agents, etc.
 **/apps/**/.agents/
+
+# Clerk E2E storageState (contains real session tokens — never commit)
+playwright/.clerk/

--- a/bun.lock
+++ b/bun.lock
@@ -141,6 +141,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
+        "@clerk/testing": "2.0.35",
         "@clerk/types": "4.101.20",
         "@google/design.md": "0.2.0",
         "@nestjs/cli": "11.0.21",
@@ -1653,7 +1654,9 @@
 
     "@clerk/react": ["@clerk/react@6.7.2", "", { "dependencies": { "@clerk/shared": "^4.14.0", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-tgRWWTfW+ejXj6WiZqx7iMbtvh45h0445uEvbSNVCyJBEOaBlCF0/ZfAfXlWAQNbRZ+bPIphEfNUmatadZgGOQ=="],
 
-    "@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
+    "@clerk/shared": ["@clerk/shared@4.15.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-uX8nfLb69m8mA6KWKWfuPSwoVNDRyUdufeCeTEZsdZxbRUsEYT/c0KWFN28IOQCtK09tpVtzrUHvW44v5Dc5OA=="],
+
+    "@clerk/testing": ["@clerk/testing@2.0.35", "", { "dependencies": { "@clerk/backend": "^3.5.0", "@clerk/shared": "^4.15.0", "dotenv": "17.2.2" }, "peerDependencies": { "@playwright/test": "^1", "cypress": "^13 || ^14" }, "optionalPeers": ["@playwright/test", "cypress"] }, "sha512-VOSyWnmu2ldcUKboMZHDDNCFEFjXmrnbcrMoFb1kw1yAJejqfvIrVD06MJYiWWW9rWi0fWZWaMjwG7Lbm864YQ=="],
 
     "@clerk/themes": ["@clerk/themes@2.4.57", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" } }, "sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w=="],
 
@@ -5655,7 +5658,7 @@
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
-    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-file-download": ["js-file-download@0.4.12", "", {}, "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="],
 
@@ -7907,6 +7910,8 @@
 
     "@clerk/clerk-expo/@clerk/clerk-js": ["@clerk/clerk-js@5.125.10", "", { "dependencies": { "@base-org/account": "2.0.1", "@clerk/localizations": "^3.37.5", "@clerk/shared": "^3.47.5", "@coinbase/wallet-sdk": "4.3.0", "@emotion/cache": "11.11.0", "@emotion/react": "11.11.1", "@floating-ui/react": "0.27.12", "@floating-ui/react-dom": "^2.1.3", "@formkit/auto-animate": "^0.8.2", "@solana/wallet-adapter-base": "0.9.27", "@solana/wallet-adapter-react": "0.15.39", "@solana/wallet-standard": "1.1.4", "@stripe/stripe-js": "5.6.0", "@swc/helpers": "^0.5.17", "@tanstack/query-core": "5.87.4", "@wallet-standard/core": "1.1.1", "@zxcvbn-ts/core": "3.0.4", "@zxcvbn-ts/language-common": "3.0.4", "alien-signals": "2.0.6", "browser-tabs-lock": "1.3.0", "copy-to-clipboard": "3.3.3", "core-js": "3.41.0", "crypto-js": "^4.2.0", "dequal": "2.0.3", "input-otp": "1.4.2", "qrcode.react": "4.2.0", "regenerator-runtime": "0.14.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-R0sZ5n4ND7xnHKkMoSuhcYa5+qcgHeYEsQ8eN0ti5hUgGH3LzQX1vJg0GHTEceJI68SrVETArRR7bxyMwS8QAg=="],
 
+    "@clerk/clerk-expo/@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
+
     "@clerk/clerk-expo/@clerk/types": ["@clerk/types@4.101.23", "", { "dependencies": { "@clerk/shared": "^3.47.5" } }, "sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA=="],
 
     "@clerk/clerk-js/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
@@ -7915,17 +7920,21 @@
 
     "@clerk/clerk-js/core-js": ["core-js@3.47.0", "", {}, "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg=="],
 
+    "@clerk/clerk-react/@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
+
     "@clerk/localizations/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
 
     "@clerk/nextjs/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
 
     "@clerk/react/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
 
-    "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+    "@clerk/testing/@clerk/backend": ["@clerk/backend@3.5.0", "", { "dependencies": { "@clerk/shared": "^4.15.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-g1bjzqj7/mb6rnrQ5zr+ybjpilTIWADaCoHE1HnEAjQfbcdfn3gb9PPX0wJ1KWw8OOQEQYSjzXPzvofEB1j+ww=="],
 
-    "@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "@clerk/testing/dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
 
-    "@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
+    "@clerk/themes/@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
+
+    "@clerk/types/@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
 
     "@clerk/ui/@clerk/shared": ["@clerk/shared@4.14.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-StZCFJ2rg0ITE3fYjIN9CKuKq8ZACW6l2+5qGCFPPYd4hZphA+VDselmh/lHPsF1ex/WRVUSHvquykAHR8cQbQ=="],
 
@@ -9541,11 +9550,7 @@
 
     "@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "@clerk/backend/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
-
     "@clerk/backend/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
-
-    "@clerk/chrome-extension/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "@clerk/chrome-extension/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -9563,23 +9568,45 @@
 
     "@clerk/clerk-expo/@clerk/clerk-js/regenerator-runtime": ["regenerator-runtime@0.14.1", "", {}, "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="],
 
-    "@clerk/clerk-js/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
+    "@clerk/clerk-expo/@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/clerk-expo/@clerk/shared/js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "@clerk/clerk-expo/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@clerk/clerk-expo/@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "@clerk/clerk-js/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "@clerk/localizations/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
+    "@clerk/clerk-react/@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/clerk-react/@clerk/shared/js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "@clerk/clerk-react/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@clerk/clerk-react/@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "@clerk/localizations/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "@clerk/nextjs/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
-
     "@clerk/nextjs/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
-
-    "@clerk/react/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "@clerk/react/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "@clerk/ui/@clerk/shared/js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
+    "@clerk/themes/@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/themes/@clerk/shared/js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "@clerk/themes/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@clerk/themes/@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
+
+    "@clerk/types/@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/types/@clerk/shared/js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
+
+    "@clerk/types/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "@clerk/types/@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "@clerk/ui/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 

--- a/e2e/clerk.setup.ts
+++ b/e2e/clerk.setup.ts
@@ -135,19 +135,17 @@ setup('authenticate clerk sessions', async ({ browser }) => {
     const page = await context.newPage();
 
     await setupClerkTestingToken({ page });
-    await page.goto('/playwright-ready');
-    await clerk.signIn({
-      page,
-      signInParams: {
-        identifier: seed.email,
-        password: testUserPassword,
-        strategy: 'password',
-      },
-    });
+    // Sign in from a real app page so window.Clerk (ClerkProvider) is loaded —
+    // /playwright-ready is a bare readiness route without the provider.
+    await page.goto('/login');
+    // emailAddress mode: @clerk/testing mints a backend sign-in token (ticket
+    // strategy) with the secret key — bypasses password/bot-detection and waits
+    // for window.Clerk.user. Far more reliable than the client password path.
+    await clerk.signIn({ emailAddress: seed.email, page });
 
     // Confirm the session lands somewhere authenticated (not bounced to /login).
     await page.goto('/');
-    await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 });
+    await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 });
 
     await context.storageState({ path: seed.authFile });
     await context.close();

--- a/e2e/clerk.setup.ts
+++ b/e2e/clerk.setup.ts
@@ -1,0 +1,155 @@
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { createClerkClient } from '@clerk/backend';
+import {
+  clerk,
+  clerkSetup,
+  setupClerkTestingToken,
+} from '@clerk/testing/playwright';
+import { expect, test as setup } from '@playwright/test';
+
+/**
+ * Real-Clerk authentication setup for the E2E smoke suite.
+ *
+ * Replaces the legacy fully-mocked auth (fake `__session` cookie + Clerk FAPI
+ * mock + `__playwright_test` bypass) with a REAL Clerk session, so the suite
+ * exercises the genuine `proxy.ts` / clerkMiddleware path instead of relying on
+ * a bypass that is disabled in production builds.
+ *
+ * Flow (per Clerk's Playwright guide):
+ *   1. clerkSetup()                  -> wires the testing token for the instance
+ *   2. @clerk/backend createUser     -> idempotently provisions a `+clerk_test`
+ *      user with the publicMetadata the app's OnboardingGuard expects
+ *   3. clerk.signIn()                -> establishes a real session in the browser
+ *   4. storageState()                -> persisted under playwright/.clerk for reuse
+ *
+ * REQUIRES (no mock fallback):
+ *   - CLERK_SECRET_KEY              real test-instance secret (sk_test_...)
+ *   - CLERK_PUBLISHABLE_KEY (or NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)
+ *   - E2E_CLERK_USER_PASSWORD       password for the provisioned test user
+ * The instance must have email + password sign-in enabled.
+ */
+
+const AUTH_DIR = path.join(process.cwd(), 'playwright', '.clerk');
+const USER_AUTH_FILE = path.join(AUTH_DIR, 'user.json');
+const ADMIN_AUTH_FILE = path.join(AUTH_DIR, 'admin.json');
+
+const MOCK_SECRET = 'test-mock-clerk-key';
+
+const secretKey = process.env.CLERK_SECRET_KEY ?? '';
+const publishableKey =
+  process.env.CLERK_PUBLISHABLE_KEY ??
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??
+  '';
+const testUserPassword = process.env.E2E_CLERK_USER_PASSWORD ?? '';
+
+function assertRealClerkEnv(): void {
+  const problems: string[] = [];
+  if (!secretKey || secretKey === MOCK_SECRET) {
+    problems.push(
+      'CLERK_SECRET_KEY is missing or the mock placeholder — a real test-instance secret (sk_test_...) is required.',
+    );
+  }
+  if (!publishableKey || !publishableKey.startsWith('pk_')) {
+    problems.push(
+      'CLERK_PUBLISHABLE_KEY / NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is missing or not a pk_ key.',
+    );
+  }
+  if (!testUserPassword) {
+    problems.push(
+      'E2E_CLERK_USER_PASSWORD is required to sign the test user in.',
+    );
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `Real Clerk E2E auth cannot run:\n - ${problems.join('\n - ')}\n` +
+        'Set these on the runner (mac-studio / CI) and re-run.',
+    );
+  }
+}
+
+interface SeedUser {
+  authFile: string;
+  email: string;
+  isSuperAdmin: boolean;
+}
+
+const SEED_USERS: SeedUser[] = [
+  {
+    authFile: USER_AUTH_FILE,
+    email: 'e2e.user+clerk_test@genfeed.ai',
+    isSuperAdmin: false,
+  },
+  {
+    authFile: ADMIN_AUTH_FILE,
+    email: 'e2e.admin+clerk_test@genfeed.ai',
+    isSuperAdmin: true,
+  },
+];
+
+/**
+ * Idempotently ensure a `+clerk_test` user exists with the publicMetadata the
+ * app expects (organization / brand / user ids + admin flag), so the
+ * OnboardingGuard lets the session through to the workspace.
+ */
+async function ensureClerkUser(seed: SeedUser): Promise<void> {
+  const client = createClerkClient({ publishableKey, secretKey });
+
+  const existing = await client.users.getUserList({
+    emailAddress: [seed.email],
+  });
+
+  const publicMetadata = {
+    brand: 'brand-1',
+    isOnboardingCompleted: true,
+    isSuperAdmin: seed.isSuperAdmin,
+    organization: 'mock-org-id-e2e-test',
+    user: 'mock-user-id-e2e-test',
+  };
+
+  if (existing.data.length > 0) {
+    await client.users.updateUser(existing.data[0]!.id, { publicMetadata });
+    return;
+  }
+
+  await client.users.createUser({
+    emailAddress: [seed.email],
+    password: testUserPassword,
+    publicMetadata,
+    skipPasswordChecks: true,
+  });
+}
+
+setup.beforeAll(() => {
+  assertRealClerkEnv();
+  mkdirSync(AUTH_DIR, { recursive: true });
+});
+
+setup('authenticate clerk sessions', async ({ browser }) => {
+  await clerkSetup();
+
+  for (const seed of SEED_USERS) {
+    await ensureClerkUser(seed);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await setupClerkTestingToken({ page });
+    await page.goto('/playwright-ready');
+    await clerk.signIn({
+      page,
+      signInParams: {
+        identifier: seed.email,
+        password: testUserPassword,
+        strategy: 'password',
+      },
+    });
+
+    // Confirm the session lands somewhere authenticated (not bounced to /login).
+    await page.goto('/');
+    await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 });
+
+    await context.storageState({ path: seed.authFile });
+    await context.close();
+  }
+});

--- a/e2e/tests/smoke/all-app-pages.authed.spec.ts
+++ b/e2e/tests/smoke/all-app-pages.authed.spec.ts
@@ -1,0 +1,229 @@
+import { createServer, type Server, type ServerResponse } from 'node:http';
+import { expect, type Page, type Response, test } from '@playwright/test';
+
+/**
+ * Real-Clerk authenticated route smoke.
+ *
+ * Unlike all-app-pages.spec.ts (fully-mocked auth via fake cookies + Clerk FAPI
+ * mock + the __playwright_test bypass), this spec runs under a REAL Clerk
+ * session supplied by the `app-authed` project's storageState (written by
+ * e2e/clerk.setup.ts). It exercises the genuine proxy.ts / clerkMiddleware path,
+ * while backend DATA is still served by a local mock API on :3010.
+ *
+ * The mock API binds dual-stack (::) so the app's SSR fetch to `localhost:3010`
+ * (which resolves to IPv6 ::1 first) reaches it.
+ */
+
+function jsonResponse(response: ServerResponse, body: unknown) {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(body));
+}
+
+function collection(type: string) {
+  return { data: [], meta: { page: 1, pageSize: 0, totalCount: 0 }, type };
+}
+
+function bootstrapPayload() {
+  return {
+    access: {
+      brandId: 'brand-1',
+      creditsBalance: 1000,
+      hasEverHadCredits: true,
+      isOnboardingCompleted: true,
+      isSuperAdmin: true,
+      organizationId: 'mock-org-id-e2e-test',
+      subscriptionStatus: 'active',
+      subscriptionTier: 'pro',
+      userId: 'mock-user-id-e2e-test',
+    },
+    brands: [
+      {
+        credentials: [],
+        id: 'brand-1',
+        label: 'Brand 1',
+        name: 'Brand 1',
+        organization: {
+          id: 'mock-org-id-e2e-test',
+          label: 'Test Organization',
+          name: 'Test Organization',
+          slug: 'test-org',
+        },
+        slug: 'brand-1',
+      },
+    ],
+    currentUser: {
+      clerkId: 'mock-user-id-e2e-test',
+      email: 'test@genfeed.ai',
+      firstName: 'Test',
+      id: 'mock-user-id-e2e-test',
+      isOnboardingCompleted: true,
+      lastName: 'User',
+    },
+    darkroomCapabilities: { isByokEnabled: false, isDarkroomAvailable: false },
+    settings: {
+      defaultAvatarIngredientId: null,
+      defaultVoiceId: null,
+      id: 'org-settings-1',
+      isAdvancedMode: false,
+      isDarkroomNsfwVisible: false,
+    },
+    streak: null,
+  };
+}
+
+function installReadinessPayload() {
+  return {
+    access: {
+      byokConfiguredProviders: ['openai'],
+      byokEnabled: true,
+      runtimeMode: 'byok',
+      selectedMode: 'server',
+      serverDefaultsReady: true,
+    },
+    authMode: 'clerk',
+    billingMode: 'oss_local',
+    localTools: {
+      anyDetected: true,
+      claude: true,
+      codex: true,
+      detected: ['Claude Code'],
+    },
+    providers: {
+      anyConfigured: true,
+      configured: ['OpenAI'],
+      imageGenerationReady: true,
+      openai: true,
+      textGenerationReady: true,
+    },
+    ui: {
+      showBilling: false,
+      showCloudUpgradeCta: true,
+      showCredits: false,
+      showPricing: false,
+    },
+    workspace: {
+      brandId: 'brand-1',
+      hasBrand: true,
+      hasOrganization: true,
+      organizationId: 'mock-org-id-e2e-test',
+    },
+  };
+}
+
+function startMockApiServer(): Promise<Server | null> {
+  const server = createServer((request, response) => {
+    const url = request.url ?? '/';
+    if (url.startsWith('/v1/health'))
+      return jsonResponse(response, { status: 'ok' });
+    if (url.startsWith('/v1/auth/bootstrap'))
+      return jsonResponse(response, bootstrapPayload());
+    if (url.startsWith('/v1/onboarding/install-readiness'))
+      return jsonResponse(response, installReadinessPayload());
+    if (url.startsWith('/v1/users/me/brands'))
+      return jsonResponse(response, bootstrapPayload().brands);
+    if (url.startsWith('/v1/users/me/organizations'))
+      return jsonResponse(response, [
+        {
+          brand: { id: 'brand-1', label: 'Brand 1', slug: 'brand-1' },
+          id: 'mock-org-id-e2e-test',
+          isActive: true,
+          label: 'Test Organization',
+          slug: 'test-org',
+        },
+      ]);
+    if (url.startsWith('/v1/users/me'))
+      return jsonResponse(response, bootstrapPayload().currentUser);
+    if (url.includes('/settings'))
+      return jsonResponse(response, {
+        data: { attributes: bootstrapPayload().settings },
+      });
+    if (url.includes('/credits'))
+      return jsonResponse(response, { balance: 1000, modelCosts: {} });
+    return jsonResponse(response, collection('mock'));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE') return resolve(null);
+      reject(error);
+    });
+    // Dual-stack bind so SSR fetch to localhost:3010 (::1) reaches the mock.
+    server.listen(3010, '::', () => resolve(server));
+  });
+}
+
+async function assertRouteLoads(page: Page, route: string): Promise<void> {
+  const response: Response | null = await page.goto(route, {
+    timeout: 30_000,
+    waitUntil: 'domcontentloaded',
+  });
+
+  expect(response?.status() ?? 0, `${route} returned HTTP error`).toBeLessThan(
+    400,
+  );
+  expect(
+    page.url(),
+    `${route} bounced to /login (real session not honored)`,
+  ).not.toMatch(/\/login/);
+  await expect(
+    page.locator('[data-nextjs-dialog]'),
+    `${route} rendered a framework error overlay`,
+  ).toHaveCount(0, { timeout: 1_000 });
+
+  const bodySignal = await page.locator('body').evaluate((body) => ({
+    textLength: body.textContent?.trim().length ?? 0,
+    visibleNodeCount: body.querySelectorAll('*').length,
+  }));
+  expect(
+    bodySignal.textLength + bodySignal.visibleNodeCount,
+    `${route} rendered a blank body`,
+  ).toBeGreaterThan(0);
+}
+
+// Auth-dependent routes that 500'd / bounced to /login under the broken bypass
+// and must now render with a real session. Limited to routes with a direct
+// page.tsx — index-less segments (overview/library/compose) redirect to a
+// data-dependent child and are non-deterministic for a smoke.
+const PROTECTED_ROUTES = [
+  '/',
+  '/settings',
+  '/test-org',
+  '/test-org/brand-1/workflows',
+  '/test-org/brand-1/posts',
+  '/test-org/brand-1/tasks',
+  '/test-org/brand-1/editor',
+  '/test-org/brand-1/workspace',
+];
+
+test.describe('Authenticated route smoke (real Clerk session)', () => {
+  test.setTimeout(180_000);
+
+  let mockApiServer: Server | null = null;
+
+  test.beforeAll(async () => {
+    mockApiServer = await startMockApiServer();
+  });
+
+  test.afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      if (!mockApiServer) return resolve();
+      mockApiServer.close(() => resolve());
+    });
+  });
+
+  test('protected routes render under a real session', async ({ page }) => {
+    const failures: string[] = [];
+    for (const route of PROTECTED_ROUTES) {
+      await test.step(route, async () => {
+        try {
+          await assertRouteLoads(page, route);
+        } catch (error) {
+          failures.push(
+            `${route}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      });
+    }
+    expect(failures, failures.join('\n\n')).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "@clerk/testing": "2.0.35",
     "@clerk/types": "4.101.20",
     "@google/design.md": "0.2.0",
     "@nestjs/cli": "11.0.21",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
     // Requires the real test-instance secret (see e2e/clerk.setup.ts).
     {
       name: 'clerk-setup',
+      testDir: './e2e',
       testMatch: /clerk\.setup\.ts/,
       use: {
         ...devices['Desktop Chrome'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,6 +71,17 @@ export default defineConfig({
 
   // Test project configurations
   projects: [
+    // Real-Clerk auth bootstrap: provisions +clerk_test users and writes
+    // storageState under playwright/.clerk for the authenticated projects.
+    // Requires the real test-instance secret (see e2e/clerk.setup.ts).
+    {
+      name: 'clerk-setup',
+      testMatch: /clerk\.setup\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: appBaseURL,
+      },
+    },
     {
       name: 'app-core',
       testIgnore: [/marketplace\/.+\.spec\.ts/, /website\/.+\.spec\.ts/],
@@ -80,6 +91,19 @@ export default defineConfig({
         launchOptions: {
           args: ['--disable-web-security'], // For API mocking
         },
+      },
+    },
+    // Real-Clerk authenticated smoke: reuses the storageState from clerk-setup
+    // so protected routes hit the genuine clerkMiddleware path (no mock bypass).
+    // Enable once the real secret is wired; see e2e/clerk.setup.ts.
+    {
+      name: 'app-authed',
+      dependencies: ['clerk-setup'],
+      testMatch: /smoke\/.+\.authed\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: appBaseURL,
+        storageState: 'playwright/.clerk/user.json',
       },
     },
   ],


### PR DESCRIPTION
## What

Adds a **real Clerk** authenticated route smoke, replacing the fully-mocked auth path (fake `__session` + Clerk FAPI mock + `__playwright_test` bypass) that `proxy.ts` disables in production builds.

> The integration-coverage + smoke-binding work from this branch (marketplace 0→98%, twitter/stripe/replicate ~93%, threads/youtube/reddit, ratchet floors, CI Prisma migrate, dual-stack `::` smoke bindings) already landed on `develop` via `b8e29973d`. **This PR is the remaining 3 commits** — the real-Clerk auth layer.

## Root cause (the smoke was systemically red)
Three IPv4/IPv6 + auth layers, all fixed:
1. webServer bound `--hostname 127.0.0.1` (IPv4) while `proxy.ts` self-proxies to `localhost` (IPv6 `::1`) → every SSR page 500. → `--hostname ::`
2. spec mock API bound `127.0.0.1:3010`; app SSR-fetches `localhost:3010` (`::1`). → `listen(3010, '::')`
3. `proxy.ts` Clerk bypass gated on `NODE_ENV !== 'production'`, but CI runs `start` (prod) → Clerk handshake on the mock secret → 500.

Rather than weaken the auth bypass, solved properly with real Clerk.

## How
- `@clerk/testing@2.0.35`
- `e2e/clerk.setup.ts` — `clerkSetup()` + idempotent `+clerk_test` user/admin provisioning via `@clerk/backend` + **ticket-strategy** `clerk.signIn({ emailAddress })` (mints a backend sign-in token with the secret, bot-proof) → `storageState`
- `playwright.config.ts` — `clerk-setup` + `app-authed` (storageState) projects
- `e2e/tests/smoke/all-app-pages.authed.spec.ts` — protected-route sweep under the **genuine** `clerkMiddleware` session + dual-stack mock API
- `playwright/.clerk/` gitignored (real session tokens)

## Verified
On mac-studio (Mac13,1): `clerk-setup` + `app-authed` = **2 passed**, real sessions `active`, protected routes render (no 500 / no `/login` bounce).

## Requires for CI
- `CLERK_SECRET_KEY` (test instance) + `E2E_CLERK_USER_PASSWORD` as GitHub secrets
- a build **without** `NEXT_PUBLIC_PLAYWRIGHT_TEST` for the `app-authed` project
- instance: email + password sign-in enabled

## Follow-ups (not in this PR)
- Full route-discovery parity under real auth (current sweep = curated direct-`page.tsx` routes)
- Wire `app-authed` + the secret into `e2e.yml`
- Deep journey specs (generate / compose / schedule / …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)