### PR TITLE
ci(e2e): run workflow weekly and manually only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,13 +2,6 @@ name: E2E Tests
 
 on:
   workflow_dispatch:
-  # E2E always runs on develop: on every push to develop and on every PR
-  # targeting it, so the suite is the canonical gate on the integration branch
-  # instead of being run ad-hoc on local machines.
-  push:
-    branches: [develop]
-  pull_request:
-    branches: [develop]
   schedule:
     - cron: "0 6 * * 1" # Weekly Monday 6am UTC
 


### PR DESCRIPTION
Removes the automatic E2E workflow triggers for pushes to develop and PRs targeting develop. Keeps the existing workflow_dispatch and weekly Monday schedule.