### PR TITLE
fix(desktop): harden auth callback flow

### DIFF
--- a/apps/desktop/app/src/main/session.service.test.ts
+++ b/apps/desktop/app/src/main/session.service.test.ts
@@ -67,6 +67,12 @@ describe('DesktopSessionService', () => {
 
   it('hydrates a session from the server-minted key', async () => {
     const service = createSessionService(kvService);
+    const loginUrl = new URL(service.getLoginUrl());
+    const state = loginUrl.searchParams.get('state');
+
+    if (!state) {
+      throw new Error('Expected login URL state');
+    }
 
     globalThis.fetch = (async (
       input: RequestInfo | URL,
@@ -97,7 +103,7 @@ describe('DesktopSessionService', () => {
     }) as typeof fetch;
 
     const session = await service.handleCallback(
-      'genfeedai-desktop://auth?key=gf_desktop_key',
+      `genfeedai-desktop://auth?key=gf_desktop_key&state=${state}`,
     );
 
     expect(session).toEqual({
@@ -165,6 +171,111 @@ describe('DesktopSessionService', () => {
     expect(kvService.values.get('desktop.session')).toContain('gf_desktop_key');
   });
 
+  it('rejects browser auth code replays after the pending PKCE state is consumed', async () => {
+    const service = createSessionService(kvService);
+    const loginUrl = new URL(service.getLoginUrl());
+    const state = loginUrl.searchParams.get('state');
+    let exchangeCalls = 0;
+
+    if (!state) {
+      throw new Error('Expected login URL state');
+    }
+
+    globalThis.fetch = (async () => {
+      exchangeCalls += 1;
+      return new Response(
+        JSON.stringify({
+          issuedAt: '2026-05-01T10:00:00.000Z',
+          token: 'gf_desktop_key',
+          userEmail: 'desktop@example.com',
+          userId: 'user-123',
+          userName: 'Desktop User',
+        }),
+        {
+          headers: {
+            'content-type': 'application/json',
+          },
+          status: 200,
+        },
+      );
+    }) as typeof fetch;
+
+    const callbackUrl = `genfeedai-desktop://auth?code=desktop-code&state=${state}`;
+
+    await expect(service.handleCallback(callbackUrl)).resolves.toMatchObject({
+      token: 'gf_desktop_key',
+    });
+    await expect(service.handleCallback(callbackUrl)).resolves.toBeNull();
+    expect(exchangeCalls).toBe(1);
+  });
+
+  it('rejects auth callbacks outside the registered desktop callback target', async () => {
+    const service = createSessionService(kvService);
+
+    globalThis.fetch = (async () => {
+      throw new Error('Unexpected network request');
+    }) as typeof fetch;
+
+    await expect(
+      service.handleCallback('https://evil.example/auth?key=gf_desktop_key'),
+    ).resolves.toBeNull();
+    await expect(
+      service.handleCallback(
+        'genfeedai-desktop://settings?key=gf_desktop_key',
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      service.handleCallback(
+        'genfeedai-desktop://auth/extra?key=gf_desktop_key',
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('rejects OAuth error callbacks and consumes the matching pending auth state', async () => {
+    const service = createSessionService(kvService);
+    const loginUrl = new URL(service.getLoginUrl());
+    const state = loginUrl.searchParams.get('state');
+
+    if (!state) {
+      throw new Error('Expected login URL state');
+    }
+
+    globalThis.fetch = (async () => {
+      throw new Error('Unexpected network request');
+    }) as typeof fetch;
+
+    await expect(
+      service.handleCallback(
+        `genfeedai-desktop://auth?error=access_denied&state=${state}`,
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      service.handleCallback(
+        `genfeedai-desktop://auth?code=desktop-code&state=${state}`,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('rejects ambiguous callbacks without calling either exchange path', async () => {
+    const service = createSessionService(kvService);
+    const loginUrl = new URL(service.getLoginUrl());
+    const state = loginUrl.searchParams.get('state');
+
+    if (!state) {
+      throw new Error('Expected login URL state');
+    }
+
+    globalThis.fetch = (async () => {
+      throw new Error('Unexpected network request');
+    }) as typeof fetch;
+
+    await expect(
+      service.handleCallback(
+        `genfeedai-desktop://auth?code=desktop-code&key=gf_desktop_key&state=${state}`,
+      ),
+    ).resolves.toBeNull();
+  });
+
   it('validates and refreshes an existing desktop session on startup', async () => {
     const service = createSessionService(kvService);
 
@@ -226,6 +337,47 @@ describe('DesktopSessionService', () => {
     await expect(
       service.handleCallback('genfeedai-desktop://auth?token=missing'),
     ).resolves.toBeNull();
+  });
+
+  it('rejects server-minted key callbacks without pending auth state', async () => {
+    const service = createSessionService(kvService);
+
+    globalThis.fetch = (async () => {
+      throw new Error('Unexpected network request');
+    }) as typeof fetch;
+
+    await expect(
+      service.handleCallback('genfeedai-desktop://auth?key=gf_desktop_key'),
+    ).resolves.toBeNull();
+  });
+
+  it('keeps an existing session when a desktop callback exchange fails', async () => {
+    const service = createSessionService(kvService);
+    const loginUrl = new URL(service.getLoginUrl());
+    const state = loginUrl.searchParams.get('state');
+
+    if (!state) {
+      throw new Error('Expected login URL state');
+    }
+
+    await service.setSession({
+      issuedAt: '2026-04-01T09:00:00.000Z',
+      token: 'persisted_desktop_key',
+      userEmail: 'desktop@example.com',
+      userId: 'user-123',
+      userName: 'Desktop User',
+    });
+
+    globalThis.fetch = (async () => {
+      return new Response('invalid code', { status: 400 });
+    }) as typeof fetch;
+
+    await expect(
+      service.handleCallback(
+        `genfeedai-desktop://auth?code=expired-code&state=${state}`,
+      ),
+    ).resolves.toBeNull();
+    expect(service.getSession()?.token).toBe('persisted_desktop_key');
   });
 
   it('clears a stale stored desktop session during startup validation', async () => {

--- a/apps/desktop/app/src/main/session.service.test.ts
+++ b/apps/desktop/app/src/main/session.service.test.ts
@@ -220,9 +220,7 @@ describe('DesktopSessionService', () => {
       service.handleCallback('https://evil.example/auth?key=gf_desktop_key'),
     ).resolves.toBeNull();
     await expect(
-      service.handleCallback(
-        'genfeedai-desktop://settings?key=gf_desktop_key',
-      ),
+      service.handleCallback('genfeedai-desktop://settings?key=gf_desktop_key'),
     ).resolves.toBeNull();
     await expect(
       service.handleCallback(

--- a/apps/desktop/app/src/main/session.service.ts
+++ b/apps/desktop/app/src/main/session.service.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import type {
   IDesktopEnvironment,
   IDesktopSession,
@@ -9,6 +9,8 @@ import type { DesktopKvService } from './kv.service';
 const SESSION_STORAGE_KEY = 'desktop.session';
 const DESKTOP_AUTH_SCHEME = 'genfeedai-desktop';
 const DESKTOP_AUTH_PATH = 'auth';
+const DESKTOP_AUTH_PROTOCOL = `${DESKTOP_AUTH_SCHEME}:`;
+const DESKTOP_AUTH_ALLOWED_PATHS = new Set(['', '/']);
 
 interface AuthWhoamiResponse {
   data?: {
@@ -50,6 +52,20 @@ const createCodeVerifier = (): string => toBase64Url(randomBytes(32));
 const createState = (): string => toBase64Url(randomBytes(24));
 const createCodeChallenge = (verifier: string): string =>
   toBase64Url(createHash('sha256').update(verifier).digest());
+const safeEqual = (left: string, right: string): boolean => {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    timingSafeEqual(leftBuffer, rightBuffer)
+  );
+};
+
+const isExpectedDesktopCallbackUrl = (url: URL): boolean =>
+  url.protocol === DESKTOP_AUTH_PROTOCOL &&
+  url.hostname === DESKTOP_AUTH_PATH &&
+  DESKTOP_AUTH_ALLOWED_PATHS.has(url.pathname);
 
 export class DesktopSessionService {
   private pendingAuth: PendingDesktopAuth | null = null;
@@ -156,7 +172,7 @@ export class DesktopSessionService {
   ): Promise<IDesktopSession | null> {
     const pendingAuth = this.pendingAuth;
 
-    if (!pendingAuth || pendingAuth.state !== state) {
+    if (!pendingAuth || !safeEqual(pendingAuth.state, state)) {
       return null;
     }
 
@@ -200,6 +216,21 @@ export class DesktopSessionService {
     }
   }
 
+  private async exchangeDesktopKey(
+    key: string,
+    state: string,
+  ): Promise<IDesktopSession | null> {
+    const pendingAuth = this.pendingAuth;
+
+    if (!pendingAuth || !safeEqual(pendingAuth.state, state)) {
+      return null;
+    }
+
+    this.pendingAuth = null;
+
+    return this.resolveSessionFromToken(key);
+  }
+
   async validateStoredSession(): Promise<IDesktopSession | null> {
     const session = this.getSession();
 
@@ -222,32 +253,44 @@ export class DesktopSessionService {
   async handleCallback(rawUrl: string): Promise<IDesktopSession | null> {
     try {
       const url = new URL(rawUrl);
-      const code = url.searchParams.get('code');
+
+      if (!isExpectedDesktopCallbackUrl(url)) {
+        return null;
+      }
+
+      const error = url.searchParams.get('error');
       const state = url.searchParams.get('state');
+
+      if (error) {
+        if (
+          state &&
+          this.pendingAuth &&
+          safeEqual(this.pendingAuth.state, state)
+        ) {
+          this.pendingAuth = null;
+        }
+
+        return null;
+      }
+
+      const code = url.searchParams.get('code');
+      const key = url.searchParams.get('key');
+
+      if (code && key) {
+        return null;
+      }
 
       if (code && state) {
         const session = await this.exchangeDesktopCode(code, state);
 
-        if (!session) {
-          await this.clearSession();
-        }
-
         return session;
       }
 
-      const key = url.searchParams.get('key');
-
-      if (!key) {
+      if (!key || !state) {
         return null;
       }
 
-      const session = await this.resolveSessionFromToken(key);
-
-      if (!session) {
-        await this.clearSession();
-      }
-
-      return session;
+      return this.exchangeDesktopKey(key, state);
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- Harden the desktop custom-protocol auth callback to accept only `genfeedai-desktop://auth` URLs.
- Bind legacy `key=` callbacks to the pending in-app auth state and reject ambiguous or OAuth-error callbacks.
- Preserve an existing desktop session when a failed callback arrives, while startup validation still clears stale stored sessions.

Refs #20

## Validation
- Local validation intentionally skipped by automation policy.
- No local tests, lint, type-checks, builds, Playwright, or heavy validation were run.
- GitHub PR/develop checks are the verification path for this change.