### PR TITLE
refactor(services): type link tracking gtag access

### DIFF
--- a/packages/services/analytics/link-tracking.service.test.ts
+++ b/packages/services/analytics/link-tracking.service.test.ts
@@ -1,5 +1,6 @@
 import { LinkTrackingService } from '@services/analytics/link-tracking.service';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '@services/core/logger.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@services/core/interceptor.service', () => {
   class MockHTTPBaseService {
@@ -32,6 +33,10 @@ describe('LinkTrackingService', () => {
     service = new LinkTrackingService(mockToken);
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('initializes correctly', () => {
     expect(service).toBeInstanceOf(LinkTrackingService);
   });
@@ -56,5 +61,55 @@ describe('LinkTrackingService', () => {
 
   it('has getInstance static method', () => {
     expect(typeof LinkTrackingService.getInstance).toBe('function');
+  });
+
+  it('sends GA events through gtag when available', () => {
+    const gtag = vi.fn();
+    vi.stubGlobal('window', { gtag });
+
+    service.sendGAEvent({
+      eventName: 'link_click',
+      eventParams: {
+        content_id: 'content-123',
+        link_id: 'link-123',
+        session_id: 'session-123',
+      },
+    });
+
+    expect(gtag).toHaveBeenCalledWith('event', 'link_click', {
+      content_id: 'content-123',
+      link_id: 'link-123',
+      session_id: 'session-123',
+    });
+    expect(logger.info).toHaveBeenCalledWith('GA4 event sent', {
+      contentId: 'content-123',
+      eventName: 'link_click',
+    });
+  });
+
+  it('reads the GA client ID through gtag when available', () => {
+    const gtag = vi.fn(
+      (
+        command: string,
+        _measurementId: string,
+        _fieldName: string,
+        callback?: (id: string) => void,
+      ) => {
+        if (command === 'get') {
+          callback?.('client-123');
+        }
+      },
+    );
+    vi.stubGlobal('window', { gtag });
+
+    const result = service.getGAClientId();
+
+    expect(result).toBe('client-123');
+    expect(gtag).toHaveBeenCalledWith(
+      'get',
+      'GA_MEASUREMENT_ID',
+      'client_id',
+      expect.any(Function),
+    );
   });
 });

--- a/packages/services/analytics/link-tracking.service.ts
+++ b/packages/services/analytics/link-tracking.service.ts
@@ -14,6 +14,33 @@ import { EnvironmentService } from '@services/core/environment.service';
 import { HTTPBaseService } from '@services/core/interceptor.service';
 import { logger } from '@services/core/logger.service';
 
+type GoogleTag = {
+  (
+    command: 'event',
+    eventName: string,
+    eventParams: IGoogleAnalyticsEvent['eventParams'],
+  ): void;
+  (
+    command: 'get',
+    measurementId: string,
+    fieldName: 'client_id',
+    callback: (id: string) => void,
+  ): void;
+};
+
+type WindowWithGoogleTag = Window & {
+  gtag?: GoogleTag;
+};
+
+function getGoogleTag(): GoogleTag | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const gtag = (window as WindowWithGoogleTag).gtag;
+  return typeof gtag === 'function' ? gtag : undefined;
+}
+
 export class LinkTrackingService extends HTTPBaseService {
   constructor(token: string) {
     super(`${EnvironmentService.apiEndpoint}/analytics/link-tracking`, token);
@@ -176,24 +203,18 @@ export class LinkTrackingService extends HTTPBaseService {
       return;
     }
 
-    // Check if gtag is available
-    if (
-      'gtag' in window &&
-      typeof (window as unknown as { gtag?: (...args: unknown[]) => void })
-        .gtag === 'function'
-    ) {
-      const gtag = (window as unknown as { gtag: (...args: unknown[]) => void })
-        .gtag;
-
-      gtag('event', event.eventName, event.eventParams);
-
-      logger.info('GA4 event sent', {
-        contentId: event.eventParams.content_id,
-        eventName: event.eventName,
-      });
-    } else {
+    const gtag = getGoogleTag();
+    if (!gtag) {
       logger.error('Google Analytics not available');
+      return;
     }
+
+    gtag('event', event.eventName, event.eventParams);
+
+    logger.info('GA4 event sent', {
+      contentId: event.eventParams.content_id,
+      eventName: event.eventName,
+    });
   }
 
   /**
@@ -294,16 +315,13 @@ export class LinkTrackingService extends HTTPBaseService {
       return undefined;
     }
 
-    // Try to get from gtag
-    if ('gtag' in window) {
-      const gtag = (window as { gtag?: (...args: unknown[]) => void }).gtag;
-      if (typeof gtag === 'function') {
-        let clientId: string | undefined;
-        gtag('get', 'GA_MEASUREMENT_ID', 'client_id', (id: string) => {
-          clientId = id;
-        });
-        return clientId;
-      }
+    const gtag = getGoogleTag();
+    if (gtag) {
+      let clientId: string | undefined;
+      gtag('get', 'GA_MEASUREMENT_ID', 'client_id', (id: string) => {
+        clientId = id;
+      });
+      return clientId;
     }
 
     return undefined;


### PR DESCRIPTION
## Summary
- centralize LinkTrackingService GA access behind a typed local gtag accessor
- remove repeated cast-heavy window.gtag checks from event and client-id flows
- add focused coverage for GA event dispatch and client ID lookup

## Validation
- Mac Studio: `bun run --cwd packages/services test -- analytics/link-tracking.service.test.ts` (7 tests passed)
- Mac Studio: `bunx biome check packages/services/analytics/link-tracking.service.ts packages/services/analytics/link-tracking.service.test.ts`

## Notes
- Local MacBook validation was limited to read-only/static inspection and `git diff --check`; CPU-heavy validation ran on Mac Studio.
