### PR TITLE
feat(desktop): add workspace switching and asset import UX

### DIFF
--- a/apps/desktop/app/src/main.ts
+++ b/apps/desktop/app/src/main.ts
@@ -104,6 +104,7 @@ const OFFLINE_MODE_KEY = 'desktop.offline.mode';
 const ONBOARDING_COMPLETED_KEY = 'onboarding.completed';
 const SYNC_THREADS_CURSOR_KEY = 'sync.threads.cursor';
 const LOCAL_CLERK_ID_KEY = 'local.user.clerkId';
+const ACTIVE_WORKSPACE_ID_KEY = 'desktop.workspace.activeId';
 
 function getSyncCursorKey(scope: DesktopSyncCursorScope = 'threads'): string {
   return scope === 'threads' ? SYNC_THREADS_CURSOR_KEY : `sync.${scope}.cursor`;
@@ -112,6 +113,26 @@ function getSyncCursorKey(scope: DesktopSyncCursorScope = 'threads'): string {
 function getClerkId(): string | null {
   return kvService.getValueSync(LOCAL_CLERK_ID_KEY);
 }
+
+const getActiveWorkspaceId = (
+  workspaces = workspaceService.listRecentWorkspaces(),
+): string | null => {
+  const storedWorkspaceId = kvService.getValueSync(ACTIVE_WORKSPACE_ID_KEY);
+
+  if (
+    storedWorkspaceId &&
+    workspaces.some((workspace) => workspace.id === storedWorkspaceId)
+  ) {
+    return storedWorkspaceId;
+  }
+
+  return workspaces[0]?.id ?? null;
+};
+
+const setActiveWorkspaceId = async (workspaceId: string): Promise<void> => {
+  workspaceService.getWorkspace(workspaceId);
+  await kvService.setValue(ACTIVE_WORKSPACE_ID_KEY, workspaceId);
+};
 
 function getDataService(): IDesktopDataService {
   return sessionService.getSession() ? cloudService : localService;
@@ -140,7 +161,9 @@ const getBootstrap = (): IDesktopBootstrap => {
     return bootstrapCache;
   }
 
+  const workspaces = workspaceService.listRecentWorkspaces();
   const bootstrap: IDesktopBootstrap = {
+    activeWorkspaceId: getActiveWorkspaceId(workspaces),
     clerkId: getClerkId(),
     environment: sessionService.getEnvironment(),
     isOfflineMode,
@@ -157,7 +180,7 @@ const getBootstrap = (): IDesktopBootstrap => {
     recents: workspaceService.listRecents(),
     session: sessionService.getSession(),
     syncState: syncService.getState(),
-    workspaces: workspaceService.listRecentWorkspaces(),
+    workspaces,
   };
 
   bootstrapCache = bootstrap;
@@ -291,7 +314,7 @@ const createWindow = async (): Promise<void> => {
   }
 
   buildDesktopMenu(mainWindow, () => {
-    void workspaceService.openWorkspace().then(async (workspace) => {
+    void openAndActivateWorkspace().then(async (workspace) => {
       if (!workspace) {
         return;
       }
@@ -300,6 +323,16 @@ const createWindow = async (): Promise<void> => {
       mainWindow?.webContents.send(DESKTOP_IPC_CHANNELS.toggleSidebar);
     });
   });
+};
+
+const openAndActivateWorkspace = async () => {
+  const workspace = await workspaceService.openWorkspace();
+
+  if (workspace) {
+    await kvService.setValue(ACTIVE_WORKSPACE_ID_KEY, workspace.id);
+  }
+
+  return workspace;
 };
 
 const handleAuthCallback = async (rawUrl: string): Promise<void> => {
@@ -434,7 +467,7 @@ const registerIpcHandlers = (): void => {
       runDataService((service) => service.runWorkflow(params)),
   );
   ipcMain.handle(DESKTOP_IPC_CHANNELS.workspaceOpen, async () => {
-    const workspace = await workspaceService.openWorkspace();
+    const workspace = await openAndActivateWorkspace();
     await emitBootstrap();
     return workspace;
   });
@@ -461,6 +494,14 @@ const registerIpcHandlers = (): void => {
     DESKTOP_IPC_CHANNELS.workspaceReveal,
     async (_event: unknown, workspaceId: string) => {
       await workspaceService.revealInFinder(workspaceId);
+    },
+  );
+  ipcMain.handle(
+    DESKTOP_IPC_CHANNELS.workspaceSelect,
+    async (_event: unknown, workspaceId: string) => {
+      await setActiveWorkspaceId(workspaceId);
+      await emitBootstrap();
+      return workspaceService.getWorkspace(workspaceId);
     },
   );
   ipcMain.handle(
@@ -525,6 +566,12 @@ const registerIpcHandlers = (): void => {
     DESKTOP_IPC_CHANNELS.filesGetAssetUrl,
     async (_event: unknown, assetId: string) =>
       filesService.getAssetUrl(assetId),
+  );
+  ipcMain.handle(
+    DESKTOP_IPC_CHANNELS.filesRevealAsset,
+    async (_event: unknown, assetId: string) => {
+      await filesService.revealAsset(assetId);
+    },
   );
   ipcMain.handle(
     DESKTOP_IPC_CHANNELS.generationEnqueueAssetGeneration,

--- a/apps/desktop/app/src/main/files.service.test.ts
+++ b/apps/desktop/app/src/main/files.service.test.ts
@@ -3,7 +3,10 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { DesktopWorkspaceService } from './workspace.service';
-import './test-support/electron.mock';
+import {
+  electronMockState,
+  resetElectronMockState,
+} from './test-support/electron.mock';
 
 const createPrismaMock = () => {
   const assets = new Map<string, Record<string, unknown>>();
@@ -41,6 +44,7 @@ describe('DesktopFilesService', () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'genfeed-files-'));
+    resetElectronMockState();
   });
 
   afterEach(async () => {
@@ -91,5 +95,60 @@ describe('DesktopFilesService', () => {
     await expect(service.getAssetUrl(asset.id)).resolves.toContain(
       encodeURIComponent(asset.originalFileName),
     );
+  });
+
+  it('imports duplicate filenames without overwriting prior local assets', async () => {
+    const { DesktopFilesService } = await import('./files.service');
+    const prisma = createPrismaMock();
+    const workspaceService = {
+      getWorkspace: () => ({
+        path: tmpDir,
+      }),
+    };
+    const service = new DesktopFilesService(
+      workspaceService as DesktopWorkspaceService,
+      prisma as never,
+    );
+    const sourcePath = path.join(tmpDir, 'source.png');
+    await fs.writeFile(sourcePath, Buffer.from([1, 2, 3]));
+
+    const [firstImport] = await service.importAssets('ws-1', [sourcePath]);
+    const [secondImport] = await service.importAssets('ws-1', [sourcePath]);
+
+    expect(firstImport.localPath).not.toBe(secondImport.localPath);
+    expect(secondImport.displayName).toBe('source-1.png');
+    await expect(fs.readFile(firstImport.localPath ?? '')).resolves.toEqual(
+      Buffer.from([1, 2, 3]),
+    );
+    await expect(fs.readFile(secondImport.localPath ?? '')).resolves.toEqual(
+      Buffer.from([1, 2, 3]),
+    );
+  });
+
+  it('reveals local assets by asset id instead of renderer-provided paths', async () => {
+    const { DesktopFilesService } = await import('./files.service');
+    const prisma = createPrismaMock();
+    const workspaceService = {
+      getWorkspace: () => ({
+        path: tmpDir,
+      }),
+    };
+    const service = new DesktopFilesService(
+      workspaceService as DesktopWorkspaceService,
+      prisma as never,
+    );
+
+    const asset = await service.writeGeneratedAsset({
+      bytes: new Uint8Array([4, 5, 6]),
+      jobId: 'job-2',
+      mimeType: 'image/png',
+      model: 'flux',
+      provider: 'fal',
+      workspaceId: 'ws-1',
+    });
+
+    await service.revealAsset(asset.id);
+
+    expect(electronMockState.shell.revealedPaths).toEqual([asset.localPath]);
   });
 });

--- a/apps/desktop/app/src/main/files.service.test.ts
+++ b/apps/desktop/app/src/main/files.service.test.ts
@@ -2,11 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import type { DesktopWorkspaceService } from './workspace.service';
 import {
   electronMockState,
   resetElectronMockState,
 } from './test-support/electron.mock';
+import type { DesktopWorkspaceService } from './workspace.service';
 
 const createPrismaMock = () => {
   const assets = new Map<string, Record<string, unknown>>();

--- a/apps/desktop/app/src/main/files.service.ts
+++ b/apps/desktop/app/src/main/files.service.ts
@@ -60,6 +60,15 @@ const sanitizeFilenamePart = (value: string): string =>
     .replace(/^-+|-+$/g, '')
     .slice(0, 80) || 'asset';
 
+const pathExists = async (targetPath: string): Promise<boolean> => {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export interface GeneratedAssetWriteOptions {
   bytes: Uint8Array;
   displayName?: string;
@@ -127,11 +136,15 @@ export class DesktopFilesService {
 
     for (const sourceFilePath of selectedFilePaths) {
       const fileName = path.basename(sourceFilePath);
-      const targetPath = path.join(targetDirectory, fileName);
+      const targetPath = await this.resolveAvailableImportPath(
+        targetDirectory,
+        fileName,
+      );
+      const targetFileName = path.basename(targetPath);
       await fs.copyFile(sourceFilePath, targetPath);
       importedAssets.push(
         await this.registerAsset({
-          displayName: fileName,
+          displayName: targetFileName,
           localPath: targetPath,
           mimeType: inferMimeType(targetPath),
           origin: 'local-import',
@@ -143,6 +156,25 @@ export class DesktopFilesService {
     }
 
     return importedAssets;
+  }
+
+  private async resolveAvailableImportPath(
+    targetDirectory: string,
+    fileName: string,
+  ): Promise<string> {
+    const parsed = path.parse(fileName);
+    let candidate = path.join(targetDirectory, fileName);
+    let index = 1;
+
+    while (await pathExists(candidate)) {
+      candidate = path.join(
+        targetDirectory,
+        `${parsed.name}-${String(index)}${parsed.ext}`,
+      );
+      index += 1;
+    }
+
+    return candidate;
   }
 
   async getAssetUrl(assetId: string): Promise<string> {
@@ -199,6 +231,20 @@ export class DesktopFilesService {
 
   async revealPath(targetPath: string): Promise<void> {
     await shell.showItemInFolder(targetPath);
+  }
+
+  async revealAsset(assetId: string): Promise<void> {
+    const asset = await this.prisma.desktopAsset.findUnique({
+      where: {
+        id: assetId,
+      },
+    });
+
+    if (!asset?.localPath) {
+      throw new Error('Local asset file is not available.');
+    }
+
+    await this.revealPath(asset.localPath);
   }
 
   private async registerAsset(params: {

--- a/apps/desktop/app/src/preload.ts
+++ b/apps/desktop/app/src/preload.ts
@@ -103,6 +103,8 @@ const desktopBridge: IGenfeedDesktopBridge = {
       ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.filesListAssets, workspaceId),
     openFileDialog: async () =>
       ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.openFileDialog),
+    revealAsset: async (assetId) =>
+      ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.filesRevealAsset, assetId),
     readFile: async (workspaceId, relativePath) =>
       ipcRenderer.invoke(
         DESKTOP_IPC_CHANNELS.filesRead,
@@ -276,6 +278,8 @@ const desktopBridge: IGenfeedDesktopBridge = {
       ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.workspaceRead, workspaceId),
     revealInFinder: async (workspaceId) =>
       ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.workspaceReveal, workspaceId),
+    selectWorkspace: async (workspaceId) =>
+      ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.workspaceSelect, workspaceId),
   },
 };
 

--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -81,6 +81,7 @@ const emptyBootstrap: IDesktopBootstrap = {
   },
   localUserId: '',
   preferences: { nativeNotificationsEnabled: false },
+  activeWorkspaceId: null,
   brands: [],
   recents: [],
   session: null,
@@ -121,7 +122,13 @@ export const App = () => {
   }, []);
 
   const localUserId = bootstrap.localUserId || null;
-  const selectedWorkspaceId = bootstrap.workspaces[0]?.id ?? null;
+  const selectedWorkspace =
+    bootstrap.workspaces.find(
+      (workspace) => workspace.id === bootstrap.activeWorkspaceId,
+    ) ??
+    bootstrap.workspaces[0] ??
+    null;
+  const selectedWorkspaceId = selectedWorkspace?.id ?? null;
 
   const {
     activeThreadId,
@@ -249,6 +256,10 @@ export const App = () => {
     await window.genfeedDesktop.workspace.openWorkspace();
   }, []);
 
+  const handleSelectWorkspace = useCallback(async (workspaceId: string) => {
+    await window.genfeedDesktop.workspace.selectWorkspace(workspaceId);
+  }, []);
+
   const handleSelectThread = useCallback(
     (threadId: string) => {
       setActiveView('conversation');
@@ -338,7 +349,12 @@ export const App = () => {
       case 'analytics':
         return <AnalyticsView workspaceId={selectedWorkspaceId} />;
       case 'library':
-        return <LibraryView workspaceId={selectedWorkspaceId} />;
+        return (
+          <LibraryView
+            workspace={selectedWorkspace}
+            workspaceId={selectedWorkspaceId}
+          />
+        );
       case 'trends':
         return <TrendsView onGenerateFromTrend={handleGenerateFromTrend} />;
       default:
@@ -362,6 +378,7 @@ export const App = () => {
       )}
       <Sidebar
         activeThreadId={activeThreadId}
+        activeWorkspaceId={selectedWorkspaceId}
         activeView={activeView}
         isCollapsed={isSidebarCollapsed}
         isSyncing={isSyncing}
@@ -371,6 +388,9 @@ export const App = () => {
         onNewThread={handleNewThread}
         onOpenWorkspace={() => void handleOpenWorkspace()}
         onSelectThread={handleSelectThread}
+        onSelectWorkspace={(workspaceId) =>
+          void handleSelectWorkspace(workspaceId)
+        }
         onTriggerSync={triggerSync}
         session={bootstrap.session}
         syncErrors={syncErrors}

--- a/apps/desktop/app/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/app/src/renderer/components/Sidebar.tsx
@@ -88,8 +88,10 @@ interface SidebarProps {
   isCollapsed: boolean;
   isSyncing: boolean;
   lastSyncAt: string | null;
+  activeWorkspaceId: string | null;
   onNavigate: (view: NavView) => void;
   onSelectThread: (threadId: string) => void;
+  onSelectWorkspace: (workspaceId: string) => void;
   onNewThread: () => void;
   onOpenWorkspace: () => void;
   onLogout: () => void;
@@ -104,11 +106,13 @@ interface SidebarProps {
 export const Sidebar = ({
   activeView,
   activeThreadId,
+  activeWorkspaceId,
   isCollapsed,
   isSyncing,
   lastSyncAt,
   onNavigate,
   onSelectThread,
+  onSelectWorkspace,
   onNewThread,
   onOpenWorkspace,
   onLogout,
@@ -177,20 +181,40 @@ export const Sidebar = ({
         </Button>
       )}
 
-      {!isCollapsed && workspaces[0] && (
+      {!isCollapsed && workspaces.length > 0 && (
         <div className="sidebar-workspace-card">
           <span className="sidebar-section-label">Active Workspace</span>
-          <strong>{workspaces[0].name}</strong>
-          <span className="muted-text">{workspaces[0].path}</span>
-          {workspaces[0].linkedProjectId ? (
-            <span className="status-badge status-active">
-              Linked to project
-            </span>
-          ) : (
-            <span className="status-badge status-pending">
-              Project link pending
-            </span>
-          )}
+          <div className="workspace-switch-list">
+            {workspaces.slice(0, 5).map((workspace) => {
+              const isActive = workspace.id === activeWorkspaceId;
+
+              return (
+                <Button
+                  ariaLabel={`Select ${workspace.name}`}
+                  className={`workspace-switch-item ${
+                    isActive ? 'active' : ''
+                  }`}
+                  key={workspace.id}
+                  onClick={() => onSelectWorkspace(workspace.id)}
+                  type="button"
+                  variant={ButtonVariant.UNSTYLED}
+                >
+                  <HiOutlineFolderOpen className="nav-icon-svg" />
+                  <span className="workspace-switch-copy">
+                    <strong>{workspace.name}</strong>
+                    <span className="muted-text">{workspace.path}</span>
+                  </span>
+                  <span
+                    className={`status-dot ${
+                      workspace.linkedProjectId
+                        ? 'status-active'
+                        : 'status-pending'
+                    }`}
+                  />
+                </Button>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/apps/desktop/app/src/renderer/offline/OfflineShell.test.tsx
+++ b/apps/desktop/app/src/renderer/offline/OfflineShell.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import OfflineShell from './OfflineShell';
 
 const bootstrap: IDesktopBootstrap = {
+  activeWorkspaceId: 'workspace-1',
+  brands: [],
   clerkId: null,
   environment: {
     apiEndpoint: '',
@@ -46,6 +48,7 @@ const bootstrap: IDesktopBootstrap = {
       name: 'Workspace One',
       path: '/tmp/workspace-one',
       pendingSyncCount: 0,
+      syncPolicy: 'local-only',
       updatedAt: '2026-04-01T09:00:00.000Z',
     },
   ],

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -1011,6 +1011,13 @@ textarea {
   margin: 0;
 }
 
+.view-header-action {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+  white-space: nowrap;
+}
+
 /* View content wrappers */
 
 .view-library,
@@ -1088,6 +1095,58 @@ textarea {
   gap: 6px;
   margin-bottom: 16px;
   padding: 12px;
+}
+
+.workspace-switch-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workspace-switch-item {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--text);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 18px minmax(0, 1fr) 8px;
+  padding: 8px;
+  text-align: left;
+  width: 100%;
+}
+
+.workspace-switch-item.active,
+.workspace-switch-item:hover {
+  background: var(--accent-soft);
+  border-color: var(--card-border);
+}
+
+.workspace-switch-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.workspace-switch-copy strong,
+.workspace-switch-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-dot {
+  border-radius: 999px;
+  height: 8px;
+  width: 8px;
+}
+
+.status-dot.status-active {
+  background: var(--success);
+}
+
+.status-dot.status-pending {
+  background: var(--warning);
 }
 
 .muted-text {
@@ -1346,6 +1405,15 @@ textarea {
   color: var(--success);
   font-size: 13px;
   font-weight: 700;
+}
+
+.asset-card-action {
+  align-items: center;
+  display: inline-flex;
+  height: 30px;
+  justify-content: center;
+  padding: 0;
+  width: 30px;
 }
 
 .skeleton-grid {

--- a/apps/desktop/app/src/renderer/views/LibraryAssetGrid.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryAssetGrid.tsx
@@ -1,12 +1,17 @@
 import type { IDesktopAsset } from '@genfeedai/desktop-contracts';
+import { ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
 import type { ReactElement } from 'react';
+import { HiOutlineFolderOpen } from 'react-icons/hi2';
 
 type LibraryAssetGridProps = {
   assets: IDesktopAsset[];
+  onRevealAsset: (assetId: string) => void;
 };
 
 export function LibraryAssetGrid({
   assets,
+  onRevealAsset,
 }: LibraryAssetGridProps): ReactElement | null {
   if (assets.length === 0) return null;
 
@@ -25,6 +30,17 @@ export function LibraryAssetGrid({
             <span className="vote-count">
               {Math.round(asset.sizeBytes / 1024)} KB
             </span>
+            {asset.localPath && (
+              <Button
+                ariaLabel={`Show ${asset.displayName} in Finder`}
+                className="asset-card-action"
+                onClick={() => onRevealAsset(asset.id)}
+                type="button"
+                variant={ButtonVariant.GHOST}
+              >
+                <HiOutlineFolderOpen className="nav-icon-svg" />
+              </Button>
+            )}
           </div>
         </div>
       ))}

--- a/apps/desktop/app/src/renderer/views/LibraryView.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryView.tsx
@@ -3,6 +3,7 @@ import type {
   IDesktopGenerationJob,
   IDesktopGenerationProviderPublicConfig,
   IDesktopIngredient,
+  IDesktopWorkspace,
 } from '@genfeedai/desktop-contracts';
 import { DropZone } from '@renderer/components/DropZone';
 import { useCallback, useEffect, useState } from 'react';
@@ -15,15 +16,17 @@ import { LibraryViewHeader } from './LibraryViewHeader';
 type SortBy = 'date' | 'votes';
 
 interface LibraryViewProps {
+  workspace: IDesktopWorkspace | null;
   workspaceId: string | null;
 }
 
-export const LibraryView = ({ workspaceId }: LibraryViewProps) => {
+export const LibraryView = ({ workspace, workspaceId }: LibraryViewProps) => {
   const [assets, setAssets] = useState<IDesktopAsset[]>([]);
   const [assetPrompt, setAssetPrompt] = useState('');
   const [assetJob, setAssetJob] = useState<IDesktopGenerationJob | null>(null);
   const [assetError, setAssetError] = useState<string | null>(null);
   const [isGeneratingAsset, setIsGeneratingAsset] = useState(false);
+  const [isImportingAsset, setIsImportingAsset] = useState(false);
   const [ingredients, setIngredients] = useState<IDesktopIngredient[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -89,14 +92,21 @@ export const LibraryView = ({ workspaceId }: LibraryViewProps) => {
     setTimeout(() => setCopiedId(null), 2000);
   }, []);
 
-  const handleFilesDropped = useCallback(
-    async (paths: string[]) => {
+  const importWorkspaceAssets = useCallback(
+    async (paths?: string[]) => {
       if (!workspaceId) return;
+
+      setIsImportingAsset(true);
+      setError(null);
+
       try {
         const imported = await window.genfeedDesktop.files.importAssets(
           workspaceId,
           paths,
         );
+        if (imported.length === 0) {
+          return;
+        }
         await window.genfeedDesktop.notifications.notify(
           'Import Complete',
           `${String(imported.length)} asset(s) imported to workspace.`,
@@ -104,10 +114,30 @@ export const LibraryView = ({ workspaceId }: LibraryViewProps) => {
         await loadAssets();
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to import files');
+      } finally {
+        setIsImportingAsset(false);
       }
     },
     [loadAssets, workspaceId],
   );
+
+  const handleFilesDropped = useCallback(
+    async (paths: string[]) => {
+      await importWorkspaceAssets(paths);
+    },
+    [importWorkspaceAssets],
+  );
+
+  const handleRevealAsset = useCallback(async (assetId: string) => {
+    try {
+      setAssetError(null);
+      await window.genfeedDesktop.files.revealAsset(assetId);
+    } catch (err) {
+      setAssetError(
+        err instanceof Error ? err.message : 'Failed to reveal asset.',
+      );
+    }
+  }, []);
 
   const handleGenerateAsset = useCallback(async () => {
     if (!workspaceId || !providerConfig) {
@@ -177,7 +207,11 @@ export const LibraryView = ({ workspaceId }: LibraryViewProps) => {
     >
       <LibraryViewHeader
         assetCount={assets.length}
+        canImport={Boolean(workspaceId)}
         ingredientCount={ingredients.length}
+        isImporting={isImportingAsset}
+        onImportAssets={() => void importWorkspaceAssets()}
+        workspaceName={workspace?.name}
       />
 
       <LibraryGeneratePanel
@@ -191,7 +225,10 @@ export const LibraryView = ({ workspaceId }: LibraryViewProps) => {
         workspaceId={workspaceId}
       />
 
-      <LibraryAssetGrid assets={assets} />
+      <LibraryAssetGrid
+        assets={assets}
+        onRevealAsset={(assetId) => void handleRevealAsset(assetId)}
+      />
 
       <LibraryFiltersBar
         onPlatformChange={setPlatformFilter}

--- a/apps/desktop/app/src/renderer/views/LibraryViewHeader.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryViewHeader.tsx
@@ -1,20 +1,44 @@
+import { ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
 import type { ReactElement } from 'react';
+import { HiOutlineArrowUpTray } from 'react-icons/hi2';
 
 type LibraryViewHeaderProps = {
   ingredientCount: number;
   assetCount: number;
+  canImport: boolean;
+  isImporting: boolean;
+  onImportAssets: () => void;
+  workspaceName?: string;
 };
 
 export function LibraryViewHeader({
   ingredientCount,
   assetCount,
+  canImport,
+  isImporting,
+  onImportAssets,
+  workspaceName,
 }: LibraryViewHeaderProps): ReactElement {
   return (
     <div className="view-header">
-      <h2>Library</h2>
-      <span className="muted-text">
-        {ingredientCount} ingredients · {assetCount} assets
-      </span>
+      <div>
+        <h2>Library</h2>
+        <span className="muted-text">
+          {workspaceName ? `${workspaceName} · ` : ''}
+          {ingredientCount} ingredients · {assetCount} assets
+        </span>
+      </div>
+      <Button
+        className="view-header-action"
+        disabled={!canImport || isImporting}
+        onClick={onImportAssets}
+        type="button"
+        variant={ButtonVariant.GHOST}
+      >
+        <HiOutlineArrowUpTray className="nav-icon-svg" />
+        {isImporting ? 'Importing' : 'Import assets'}
+      </Button>
     </div>
   );
 }

--- a/apps/desktop/app/src/shared/desktop-contracts.test.ts
+++ b/apps/desktop/app/src/shared/desktop-contracts.test.ts
@@ -14,6 +14,12 @@ describe('desktop shared packages', () => {
       'desktop:app:openExternalPath',
     );
     expect(DESKTOP_IPC_CHANNELS.workspaceOpen).toBe('desktop:workspace:open');
+    expect(DESKTOP_IPC_CHANNELS.workspaceSelect).toBe(
+      'desktop:workspace:select',
+    );
+    expect(DESKTOP_IPC_CHANNELS.filesRevealAsset).toBe(
+      'desktop:files:revealAsset',
+    );
     expect(DESKTOP_IPC_CHANNELS.draftsSave).toBe('desktop:drafts:save');
     expect(DESKTOP_IPC_CHANNELS.terminalCreate).toBe('desktop:terminal:create');
     expect(DESKTOP_IPC_CHANNELS.terminalData).toBe('desktop:terminal:data');

--- a/packages/desktop-contracts/src/index.ts
+++ b/packages/desktop-contracts/src/index.ts
@@ -30,6 +30,7 @@ export const DESKTOP_IPC_CHANNELS = {
   filesGetAssetUrl: 'desktop:files:getAssetUrl',
   filesImportAssets: 'desktop:files:importAssets',
   filesListAssets: 'desktop:files:listAssets',
+  filesRevealAsset: 'desktop:files:revealAsset',
   filesRead: 'desktop:files:read',
   filesWrite: 'desktop:files:write',
   generationClearProviderConfig: 'desktop:generation:clearProviderConfig',
@@ -71,6 +72,7 @@ export const DESKTOP_IPC_CHANNELS = {
   workspaceRead: 'desktop:workspace:read',
   workspaceRecent: 'desktop:workspace:recent',
   workspaceReveal: 'desktop:workspace:reveal',
+  workspaceSelect: 'desktop:workspace:select',
 } as const;
 
 /* ─── Environment ─── */
@@ -478,6 +480,7 @@ export interface IDesktopPreferences {
 /* ─── Bootstrap ─── */
 
 export interface IDesktopBootstrap {
+  activeWorkspaceId: string | null;
   /** Clerk user ID persisted locally after first cloud sign-in; null if never signed in */
   clerkId: string | null;
   environment: IDesktopEnvironment;
@@ -756,6 +759,7 @@ export interface IGenfeedDesktopBridge {
     ) => Promise<IDesktopAsset[]>;
     listAssets: (workspaceId?: string) => Promise<IDesktopAsset[]>;
     openFileDialog: () => Promise<{ canceled: boolean; filePaths: string[] }>;
+    revealAsset: (assetId: string) => Promise<void>;
     readFile: (workspaceId: string, relativePath: string) => Promise<string>;
     writeFile: (
       workspaceId: string,
@@ -843,6 +847,7 @@ export interface IGenfeedDesktopBridge {
     openWorkspace: () => Promise<IDesktopWorkspace | null>;
     readWorkspace: (workspaceId: string) => Promise<IDesktopWorkspace>;
     revealInFinder: (workspaceId: string) => Promise<void>;
+    selectWorkspace: (workspaceId: string) => Promise<IDesktopWorkspace>;
   };
   onQuickGenerate: (callback: () => void) => () => void;
 }


### PR DESCRIPTION
## Summary

- persist and expose the active desktop workspace through the main-process KV-backed bootstrap
- add sidebar workspace switching so desktop views use the selected workspace instead of implicitly using the most recent one
- improve Library asset import UX with a native import action, duplicate-safe local copies, and safe reveal-by-asset-id IPC

Closes #21

## Validation

Local validation was intentionally skipped by automation policy. PR/develop GitHub checks are the verification path for this change.
