### PR TITLE
fix(desktop): persist composer controls

### DIFF
--- a/apps/desktop/app/src/renderer/views/useConversationState.test.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationState.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+  IDesktopContentRunDraft,
+  IDesktopWorkspace,
+} from '@genfeedai/desktop-contracts';
+
+import { buildPersistedContentRunDraft } from './useConversationState';
+
+const workspace: IDesktopWorkspace = {
+  createdAt: '2026-06-08T00:00:00.000Z',
+  fileIndex: [],
+  id: 'workspace-1',
+  indexingState: 'idle',
+  lastOpenedAt: '2026-06-08T00:00:00.000Z',
+  linkedProjectId: 'project-2',
+  localDraftCount: 1,
+  name: 'Launch workspace',
+  path: '/Users/example/Launch',
+  pendingSyncCount: 0,
+  syncPolicy: 'metadata-sync',
+  updatedAt: '2026-06-08T00:00:00.000Z',
+};
+
+const selectedDraft: IDesktopContentRunDraft = {
+  createdAt: '2026-06-07T21:00:00.000Z',
+  id: 'draft-1',
+  platform: 'twitter',
+  prompt: 'Old launch hook',
+  publishIntent: 'review',
+  sourceType: 'prompt',
+  status: 'draft',
+  title: 'Old launch hook',
+  type: 'hook',
+  updatedAt: '2026-06-07T21:05:00.000Z',
+  workspaceId: 'workspace-1',
+};
+
+describe('buildPersistedContentRunDraft', () => {
+  it('keeps current composer platform, type, and intent when updating an existing draft', () => {
+    const draft = buildPersistedContentRunDraft({
+      contentType: 'article',
+      input: 'Write the launch positioning as a founder article',
+      now: '2026-06-08T00:15:00.000Z',
+      platform: 'linkedin',
+      publishIntent: 'draft',
+      selectedDraft,
+      workspace,
+      workspaceId: 'workspace-1',
+    });
+
+    expect(draft).toMatchObject({
+      id: 'draft-1',
+      platform: 'linkedin',
+      projectId: 'project-2',
+      prompt: 'Write the launch positioning as a founder article',
+      publishIntent: 'draft',
+      title: 'Write the launch positioning as a founder article',
+      type: 'article',
+      updatedAt: '2026-06-08T00:15:00.000Z',
+    });
+  });
+
+  it('lets send-time generation metadata override the persisted draft status', () => {
+    const draft = buildPersistedContentRunDraft({
+      contentType: 'thread',
+      input: 'Turn the launch into a concise thread',
+      now: '2026-06-08T00:20:00.000Z',
+      overrides: {
+        generatedContent: {
+          content: 'Generated launch thread',
+          id: 'generated-1',
+          platform: 'twitter',
+          type: 'thread',
+        },
+        status: 'generated',
+      },
+      platform: 'twitter',
+      publishIntent: 'review',
+      selectedDraft,
+      workspace: null,
+      workspaceId: 'workspace-1',
+    });
+
+    expect(draft.status).toBe('generated');
+    expect(draft.generatedContent).toMatchObject({
+      content: 'Generated launch thread',
+      platform: 'twitter',
+      type: 'thread',
+    });
+    expect(draft.projectId).toBeUndefined();
+  });
+
+  it('clears a stale draft project link when the workspace is currently unlinked', () => {
+    const draft = buildPersistedContentRunDraft({
+      contentType: 'caption',
+      input: 'Write a launch caption',
+      now: '2026-06-08T00:25:00.000Z',
+      platform: 'instagram',
+      publishIntent: 'review',
+      selectedDraft: {
+        ...selectedDraft,
+        projectId: 'project-1',
+      },
+      workspace: {
+        ...workspace,
+        linkedProjectId: undefined,
+      },
+      workspaceId: 'workspace-1',
+    });
+
+    expect(draft.projectId).toBeUndefined();
+  });
+});

--- a/apps/desktop/app/src/renderer/views/useConversationState.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationState.ts
@@ -32,6 +32,47 @@ export function buildDraftTitle(
   return trimmed.length > 48 ? `${trimmed.slice(0, 48)}…` : trimmed;
 }
 
+type BuildPersistedContentRunDraftParams = {
+  contentType: DesktopContentType;
+  input: string;
+  now: string;
+  overrides?: Partial<IDesktopContentRunDraft>;
+  platform: DesktopContentPlatform;
+  publishIntent: DesktopPublishIntent;
+  selectedDraft: IDesktopContentRunDraft | null;
+  workspace: IDesktopWorkspace | null;
+  workspaceId: string;
+};
+
+export function buildPersistedContentRunDraft({
+  contentType,
+  input,
+  now,
+  overrides,
+  platform,
+  publishIntent,
+  selectedDraft,
+  workspace,
+  workspaceId,
+}: BuildPersistedContentRunDraftParams): IDesktopContentRunDraft {
+  return {
+    ...selectedDraft,
+    createdAt: selectedDraft?.createdAt ?? now,
+    id: selectedDraft?.id ?? createId(),
+    platform,
+    projectId: workspace ? workspace.linkedProjectId : selectedDraft?.projectId,
+    prompt: input.trim(),
+    publishIntent,
+    sourceType: selectedDraft?.sourceType ?? 'prompt',
+    status: selectedDraft?.status ?? 'draft',
+    title: buildDraftTitle(input, contentType),
+    type: contentType,
+    updatedAt: now,
+    workspaceId,
+    ...overrides,
+  };
+}
+
 interface UseConversationStateParams {
   workspaceId: string | null;
   pendingTrend?: {
@@ -210,6 +251,7 @@ export function useConversationState({
         setSelectedDraftId(savedDraft.id);
         setInput(savedDraft.prompt);
         setPlatform(savedDraft.platform);
+        setContentType(savedDraft.type);
         setPublishIntent(savedDraft.publishIntent);
         onTrendConsumed?.();
       })
@@ -232,22 +274,17 @@ export function useConversationState({
       }
 
       const now = new Date().toISOString();
-      const draft: IDesktopContentRunDraft = {
-        createdAt: selectedDraft?.createdAt ?? now,
-        id: selectedDraft?.id ?? createId(),
+      const draft = buildPersistedContentRunDraft({
+        contentType,
+        input,
+        now,
+        overrides,
         platform,
-        projectId: workspace?.linkedProjectId,
-        prompt: input.trim(),
         publishIntent,
-        sourceType: selectedDraft?.sourceType ?? 'prompt',
-        status: selectedDraft?.status ?? 'draft',
-        title: buildDraftTitle(input, contentType),
-        type: contentType,
-        updatedAt: now,
+        selectedDraft,
+        workspace,
         workspaceId,
-        ...selectedDraft,
-        ...overrides,
-      };
+      });
 
       const savedDraft = await window.genfeedDesktop.drafts.save(
         workspaceId,


### PR DESCRIPTION
## Summary
- Fix desktop content-run draft persistence so current composer platform, output type, and publish intent override selected draft values.
- Restore the saved content type when creating a draft from a trend.
- Add focused desktop draft-builder coverage for composer control persistence and stale project links.

## Validation
Local validation intentionally skipped by automation policy. CI/develop GitHub checks are the verification path.

Closes #22