### PR TITLE
refactor(hooks): make music playback normalization pure

### DIFF
--- a/packages/hooks/media/use-music-playback/use-music-playback.test.ts
+++ b/packages/hooks/media/use-music-playback/use-music-playback.test.ts
@@ -1,14 +1,61 @@
+import {
+  AssetScope,
+  IngredientCategory,
+  IngredientStatus,
+} from '@genfeedai/enums';
+import type { IIngredient, IMetadata } from '@genfeedai/interfaces';
 import { useMusicPlayback } from '@hooks/media/use-music-playback/use-music-playback';
 import { act, renderHook } from '@testing-library/react';
+import type { SetStateAction } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock useAudioPlayer
+const { mockPlay, mockStop } = vi.hoisted(() => ({
+  mockPlay: vi.fn(),
+  mockStop: vi.fn(),
+}));
+
 vi.mock('@hooks/media/use-audio-player/use-audio-player', () => ({
   useAudioPlayer: () => ({
-    play: vi.fn(),
-    stop: vi.fn(),
+    play: mockPlay,
+    stop: mockStop,
   }),
 }));
+
+const timestamp = '2026-01-01T00:00:00.000Z';
+
+const createSetAssetsMock = () =>
+  vi.fn<(value: SetStateAction<IIngredient[]>) => void>();
+
+const createMetadata = (overrides: Partial<IMetadata> = {}): IMetadata => ({
+  createdAt: timestamp,
+  id: 'metadata-1',
+  isDeleted: false,
+  label: 'Music metadata',
+  updatedAt: timestamp,
+  ...overrides,
+});
+
+const createIngredient = (
+  overrides: Partial<IIngredient> = {},
+): IIngredient => ({
+  category: IngredientCategory.IMAGE,
+  createdAt: timestamp,
+  hasVoted: false,
+  id: 'ingredient-1',
+  isDefault: false,
+  isDeleted: false,
+  isFavorite: false,
+  isHighlighted: false,
+  isVoteAnimating: false,
+  organization: 'organization-1',
+  scope: AssetScope.USER,
+  status: IngredientStatus.GENERATED,
+  totalChildren: 0,
+  totalVotes: 0,
+  updatedAt: timestamp,
+  user: 'user-1',
+  ...overrides,
+});
 
 describe('useMusicPlayback', () => {
   beforeEach(() => {
@@ -16,7 +63,7 @@ describe('useMusicPlayback', () => {
   });
 
   it('returns playback controls', () => {
-    const mockSetAssets = vi.fn();
+    const mockSetAssets = createSetAssetsMock();
     const { result } = renderHook(() =>
       useMusicPlayback({ setAssets: mockSetAssets }),
     );
@@ -30,7 +77,7 @@ describe('useMusicPlayback', () => {
   });
 
   it('stopAll should call setAssets', () => {
-    const mockSetAssets = vi.fn();
+    const mockSetAssets = createSetAssetsMock();
     const { result } = renderHook(() =>
       useMusicPlayback({ setAssets: mockSetAssets }),
     );
@@ -42,18 +89,76 @@ describe('useMusicPlayback', () => {
     expect(mockSetAssets).toHaveBeenCalled();
   });
 
-  it('syncPlaybackState should return marked assets', () => {
-    const mockSetAssets = vi.fn();
+  it('marks music assets without mutating the source objects', () => {
+    const mockSetAssets = createSetAssetsMock();
     const { result } = renderHook(() =>
       useMusicPlayback({ setAssets: mockSetAssets }),
     );
 
     const assets = [
-      { category: 'music', id: '1', isPlaying: false },
-      { category: 'image', id: '2', isPlaying: false },
+      createIngredient({
+        category: IngredientCategory.MUSIC,
+        id: 'music-1',
+        isPlaying: false,
+        metadata: createMetadata({ hasAudio: false }),
+      }),
+      createIngredient({
+        category: IngredientCategory.IMAGE,
+        id: 'image-1',
+        isPlaying: false,
+      }),
     ];
 
-    const syncedAssets = result.current.syncPlaybackState(assets as any);
+    const syncedAssets = result.current.syncPlaybackState(assets);
+
     expect(syncedAssets).toHaveLength(2);
+    expect(syncedAssets[0]).not.toBe(assets[0]);
+    expect(syncedAssets[0]).toMatchObject({
+      hasAudio: true,
+      isPlaying: false,
+      metadata: { hasAudio: true },
+    });
+    expect(syncedAssets[1]).toBe(assets[1]);
+    expect(assets[0]).toMatchObject({
+      isPlaying: false,
+      metadata: { hasAudio: false },
+    });
+  });
+
+  it('marks the active music asset as playing when playback starts', () => {
+    const mockSetAssets = createSetAssetsMock();
+    const { result } = renderHook(() =>
+      useMusicPlayback({ setAssets: mockSetAssets }),
+    );
+
+    const musicAsset = createIngredient({
+      category: IngredientCategory.MUSIC,
+      id: 'music-1',
+      ingredientUrl: 'https://cdn.example.com/music.mp3',
+      metadata: createMetadata(),
+    });
+
+    act(() => {
+      result.current.handlePlay(musicAsset);
+    });
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(mockPlay).toHaveBeenCalledWith(
+      'https://cdn.example.com/music.mp3',
+      expect.any(Function),
+    );
+
+    const update = mockSetAssets.mock.calls[0]?.[0];
+    expect(typeof update).toBe('function');
+    if (typeof update !== 'function') {
+      throw new Error('Expected setAssets to receive an updater function');
+    }
+
+    const updatedAssets = update([musicAsset]);
+    expect(updatedAssets[0]).toMatchObject({
+      hasAudio: true,
+      isPlaying: true,
+      metadata: { hasAudio: true },
+    });
   });
 });

--- a/packages/hooks/media/use-music-playback/use-music-playback.ts
+++ b/packages/hooks/media/use-music-playback/use-music-playback.ts
@@ -1,5 +1,5 @@
 import { IngredientCategory } from '@genfeedai/enums';
-import type { IIngredient } from '@genfeedai/interfaces';
+import type { IIngredient, IMetadata } from '@genfeedai/interfaces';
 import { useAudioPlayer } from '@hooks/media/use-audio-player/use-audio-player';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useRef } from 'react';
@@ -8,18 +8,25 @@ export interface UseMusicPlaybackOptions {
   setAssets: Dispatch<SetStateAction<IIngredient[]>>;
 }
 
-const ensureMusicMetadata = (asset: IIngredient) => {
-  if (asset.category !== IngredientCategory.MUSIC) {
-    return asset;
-  }
+type MusicPlaybackIngredient = IIngredient & { hasAudio: true };
 
-  if (typeof asset.metadata === 'object' && asset.metadata !== null) {
-    (asset.metadata as unknown as Record<string, unknown>).hasAudio = true;
-  }
+const isMetadata = (metadata: IIngredient['metadata']): metadata is IMetadata =>
+  typeof metadata === 'object' && metadata !== null;
 
-  (asset as IIngredient & { hasAudio?: boolean }).hasAudio = true;
+const markMusicAsset = (
+  asset: IIngredient,
+  isPlaying: boolean,
+): MusicPlaybackIngredient => {
+  const metadata = isMetadata(asset.metadata)
+    ? { ...asset.metadata, hasAudio: true }
+    : asset.metadata;
 
-  return asset;
+  return {
+    ...asset,
+    hasAudio: true,
+    isPlaying,
+    metadata,
+  };
 };
 
 const markPlayingState = (
@@ -31,11 +38,7 @@ const markPlayingState = (
       return asset;
     }
 
-    const normalized = ensureMusicMetadata(asset);
-
-    normalized.isPlaying = Boolean(activeId && normalized.id === activeId);
-
-    return normalized;
+    return markMusicAsset(asset, Boolean(activeId && asset.id === activeId));
   });
 
 export function useMusicPlayback({ setAssets }: UseMusicPlaybackOptions) {


### PR DESCRIPTION
## Summary
- replace cast-based music playback normalization with a pure typed helper
- preserve non-music asset references while returning normalized music assets with playback/audio flags
- strengthen the focused hook tests with typed fixtures and active playback coverage

## Validation
- Mac Studio: `bun install --frozen-lockfile` (first attempt hit transient ffmpeg-static 504, retry succeeded)
- Mac Studio: `bun run --cwd packages/hooks test -- media/use-music-playback/use-music-playback.test.ts`
- Mac Studio: `bunx biome check packages/hooks/media/use-music-playback/use-music-playback.ts packages/hooks/media/use-music-playback/use-music-playback.test.ts`
- Mac Studio: `bunx tsc -p packages/hooks/tsconfig.json --noEmit`

## Local CPU policy
- MacBook local checks limited to static git diff checks and staged secret-pattern scan; commit used `HUSKY=0 --no-verify` to avoid local CPU-heavy hooks.