### PR TITLE
ci: retry inline bun install with backoff to absorb ffmpeg-static CDN flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,29 @@ jobs:
         with:
           bun-version: '1.3.13'
 
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
         if: steps.changed.outputs.files != ''
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
 
       - name: Run secretlint on changed files
         if: steps.changed.outputs.files != ''
@@ -178,7 +199,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run check:architecture
 
   ui-guards:
@@ -200,7 +242,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run check:ui-guards
 
   format:
@@ -222,7 +285,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run format:check
 
   lint:
@@ -251,7 +335,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run lint
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -279,7 +384,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run design:check
 
   typecheck:
@@ -308,7 +434,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run typecheck
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -378,7 +525,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -413,7 +581,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run server service tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -448,7 +637,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run web, desktop, and mobile tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -483,7 +693,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run extension tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -522,7 +753,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Build app workspace
         run: bunx turbo run build --filter='./apps/app...'
       - name: Run app test shard
@@ -560,7 +812,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Build API dependencies
         run: bunx turbo run build --filter=./packages/**
       - name: Run API test shard
@@ -595,7 +868,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run build
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
## Problem

The main CI gate (`.github/workflows/ci.yml`) ran `bun install --frozen-lockfile` **inline in 14 jobs** with no retry. The root dependency `ffmpeg-static@5.3.0` (bun.lock:87) runs a postinstall that downloads its binary from the GitHub releases CDN (`https://github.com/eugeneware/ffmpeg-static/releases/download/...`). That CDN flakes intermittently and fails the whole `bun install`, reddening the gate at random.

The shared composite action `.github/actions/setup-bun-env` already wraps its install in a 3-attempt backoff loop (de63db6af) — but ci.yml does **not** use that action.

## Fix

Wrapped each of the 14 inline install steps in the same 3-attempt retry-with-backoff loop (15s / 30s). `bun install` is idempotent, so a retry only re-attempts the missing download. A flaky CDN becomes a self-healing step.

## Why replicate instead of migrate to `setup-bun-env` (option b, not a)

Migrating was rejected because the inline jobs' toolchain does **not** match the action's:

- The action runs `actions/setup-node@v5` (Node 22.x); the inline jobs install **no** Node.
- The action defaults to bun **1.3.12**; CI pins **1.3.13**.
- Several jobs (secretlint, architecture-guards, ui-guards, format, design) don't cache Turbo, which the action enables by default.

Adopting the action would alter the toolchain on the highest-blast-radius workflow (or require per-job overrides that re-add most of the boilerplate). The inline wrapper keeps bun / node / cache setup **byte-for-byte identical** and only adds the retry. The action is left untouched — it's still used by `coverage.yml`, `e2e.yml`, and `claude-pattern-miner.yml`.

## Notes

- secretlint's `if: steps.changed.outputs.files != ''` guard is preserved on its install step.
- Default `run` shell on Linux runners is `bash -e`; `if`-conditions are exempt from `set -e`, so a failed attempt falls through to the retry instead of aborting the step.

## Validation

- `actionlint .github/workflows/ci.yml` → **PASS**
- 0 bare `bun install` lines remain; 14 retry wrappers present.
- Pre-commit secretlint hook passed.