### PR TITLE
ci(react-doctor): skip on promotion PRs, pin action + drop dead inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -133,7 +134,15 @@ jobs:
     name: React Health Check
     runs-on: ubuntu-latest
     needs: trust
-    if: github.event_name == 'pull_request' && needs.trust.outputs.is-trusted == 'true'
+    # Skip on promotion PRs (base staging/master): their diffs span hundreds of
+    # commits, which defeats react-doctor's changed-file enumeration and forces a
+    # full-monorepo scan that aborts (exit 1, zero findings) → spurious red. The
+    # check already ran green on each underlying feature PR into develop.
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.trust.outputs.is-trusted == 'true'
+      && github.base_ref != 'staging'
+      && github.base_ref != 'master'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
@@ -152,12 +161,12 @@ jobs:
 
       - name: Run React Doctor
         if: steps.react_changes.outputs.changed == 'true'
-        uses: millionco/react-doctor@main
+        uses: millionco/react-doctor@v2.1.0
         with:
           directory: '.'
-          diff: ${{ github.event.pull_request.base.ref }}
-          fail-on: 'error'
-          verbose: 'true'
+          scope: 'changed'
+          blocking: 'error'
+          version: '0.4.2'
 
   architecture-guards:
     name: Architecture Guards


### PR DESCRIPTION
## Why

The **React Health Check** failed spuriously on the develop→staging promotion PR (#451, run 27129330875). Root cause is not a code defect:

- The promotion diff spans **177 commits**. That's too large for react-doctor's changed-file enumeration (`listFiles` via the GitHub API), so it falls back to a **full-monorepo scan**.
- The full scan aborts (~52s, **exit 1, zero findings** — `ERROR_COUNT: 0`, `WARNING_COUNT: 0`, empty `SCORE`), `ensure-json-report.mjs` forces `SCAN_STATUS=1`, gate goes red.
- Proof it's spurious: the same check passed **green on every underlying feature PR** into develop (#443–#446).

While here, the action's input API had drifted — `diff`/`fail-on`/`verbose` are rejected as *"Unexpected input(s)"* by current versions, and `@main` was unpinned.

## Changes

- **Skip on promotion PRs**: guard the job to run only when base is *not* `staging`/`master`. Feature PRs into develop still get the full check.
- **Pin the action**: `millionco/react-doctor@main` → `@v2.1.0`; pin the tool `version: '0.4.2'`.
- **Drop dead inputs** `diff`/`fail-on`/`verbose`; use current `scope: changed` + `blocking: error`.
- **Add `statuses: write`** so the action can publish its commit status (was warning *"could not publish commit status"*).

## Verification

- `actionlint .github/workflows/ci.yml` → clean.
- On this PR (base develop) the check runs normally; on promotion PRs it will now skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)