### PR TITLE
ci(deploy): make staging deployment dispatch-only

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,19 +2,11 @@
 
 name: Deploy Staging
 
+# Manual-only: staging API stays down until explicitly dispatched (no
+# auto-deploy on push to staging). Promotions land on the branch without
+# bringing the environment up; deploy on demand via the Actions "Run workflow"
+# button or `gh workflow run deploy-staging.yml`.
 on:
-  push:
-    branches: [staging]
-    paths:
-      - 'apps/server/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'docker/**'
-      - 'scripts/**'
-      - '.github/workflows/deploy-staging.yml'
-      - '.github/workflows/_deploy.yml'
-      - '.github/actions/**'
   workflow_dispatch:
     inputs:
       force_all:


### PR DESCRIPTION
## Why

Staging should stay **down** until a proper client base exists. `deploy-staging.yml` auto-deployed on every push to `staging` (i.e. each develop→staging promotion), bringing the staging API up unintentionally.

## Change

- Remove the `push: branches: [staging]` trigger.
- Keep `workflow_dispatch` (all existing `force_*` / `skip_tests` inputs intact).

Staging now deploys **only on demand** — Actions "Run workflow" or `gh workflow run deploy-staging.yml`. Promotions land commits on `staging` without standing the environment up.

`deploy-production.yml` unaffected (already release/dispatch-only).

## Verification

- `actionlint .github/workflows/deploy-staging.yml` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)