### PR TITLE
ci: retry inline bun install (3-attempt backoff) to absorb ffmpeg-static CDN flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,29 @@ jobs:
         with:
           bun-version: '1.3.13'
 
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
         if: steps.changed.outputs.files != ''
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
 
       - name: Run secretlint on changed files
         if: steps.changed.outputs.files != ''
@@ -187,7 +208,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run check:architecture
 
   ui-guards:
@@ -209,7 +251,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run check:ui-guards
 
   format:
@@ -231,7 +294,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run format:check
 
   lint:
@@ -260,7 +344,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run lint
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -288,7 +393,28 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - run: bun run design:check
 
   typecheck:
@@ -317,7 +443,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run typecheck
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -387,7 +534,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -422,7 +590,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run server service tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -457,7 +646,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run web, desktop, and mobile tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -492,7 +702,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run extension tests
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -531,7 +762,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Build app workspace
         run: bunx turbo run build --filter='./apps/app...'
       - name: Run app test shard
@@ -569,7 +821,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Build API dependencies
         run: bunx turbo run build --filter=./packages/**
       - name: Run API test shard
@@ -604,7 +877,28 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json', '**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies (retry on transient CDN flake)
+        run: |
+          # ffmpeg-static's postinstall pulls its binary from the GitHub
+          # releases CDN, which flakes intermittently and can take the whole
+          # `bun install` down with it. bun install is idempotent, so retry
+          # with backoff before reddening the gate. Mirrors the wrapper in
+          # .github/actions/setup-bun-env (commit de63db6af).
+          for attempt in 1 2 3; do
+            echo "::group::install attempt ${attempt}/3"
+            if bun install --frozen-lockfile; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "${attempt}" -lt 3 ]; then
+              backoff=$((attempt * 15))
+              echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          echo "::error::install failed after 3 attempts"
+          exit 1
       - name: Run build
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
## What

Wrap the 14 inline `bun install --frozen-lockfile` steps in `ci.yml` with a 3-attempt retry-with-backoff loop.

## Why

`ffmpeg-static`'s postinstall pulls its binary from the GitHub releases CDN, which flakes intermittently and can take the whole `bun install` down with it — reddening the main CI gate at random. `bun install` is idempotent, so a retry only re-attempts the missing download.

The shared composite action `.github/actions/setup-bun-env` already got this same wrapper (de63db6af), but the 14 main-gate jobs use **inline** installs and never adopted it — this PR closes that gap.

## Why inline, not migrate to setup-bun-env

That composite action also installs Node 22.x (absent in these jobs) and defaults to bun 1.3.12 (CI pins 1.3.13), so adopting it would alter the toolchain on the main gate. The wrapper keeps bun/node/cache setup byte-for-byte identical and only adds the retry.

## Risk

Pure additive — success path is byte-identical. No behavior change when install succeeds first try. `actionlint` clean.