### PR TITLE
feat(desktop): add trend brief handoff

### DIFF
--- a/apps/desktop/app/src/main/cloud.service.ts
+++ b/apps/desktop/app/src/main/cloud.service.ts
@@ -97,7 +97,10 @@ export class DesktopCloudService implements IDesktopDataService {
         body: JSON.stringify({
           count: 1,
           platform: params.platform,
-          topic: params.sourceTrendTopic ?? params.prompt,
+          topic:
+            params.brief !== undefined
+              ? params.prompt
+              : (params.sourceTrendTopic ?? params.prompt),
         }),
         method: 'POST',
       },

--- a/apps/desktop/app/src/main/generation.service.test.ts
+++ b/apps/desktop/app/src/main/generation.service.test.ts
@@ -187,6 +187,26 @@ describe('DesktopGenerationService', () => {
     expect(jobs[0]?.type).toBe('generation');
   });
 
+  it('injects saved trend brief context into the local provider prompt', () => {
+    const prompt = __desktopGenerationServiceTestUtils.buildUserPrompt({
+      ...generationParams,
+      brief: {
+        angle: 'Launch teardown posts',
+        channelFit: 'linkedin article adapted from a live trend signal.',
+        evidence: ['Virality score: 86/100'],
+        hypothesis: 'Turn the launch teardown trend into a founder lesson.',
+      },
+      platform: 'linkedin',
+      sourceTrendTopic: 'Launch teardown posts',
+      type: 'article',
+    });
+
+    expect(prompt).toContain('Platform: linkedin');
+    expect(prompt).toContain('Brief angle: Launch teardown posts');
+    expect(prompt).toContain('Evidence: Virality score: 86/100');
+    expect(prompt).not.toContain('Source trend: Launch teardown posts');
+  });
+
   it('marks the local generation job as failed when the provider fails', async () => {
     const database = createDatabaseMock();
     const service = new DesktopGenerationService(

--- a/apps/desktop/app/src/main/generation.service.ts
+++ b/apps/desktop/app/src/main/generation.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type {
   IDesktopAsset,
   IDesktopAssetGenerationRequest,
+  IDesktopContentRunBrief,
   IDesktopGenerationJob,
   IDesktopGenerationOptions,
   IDesktopGenerationProviderConfig,
@@ -230,10 +231,27 @@ const buildSystemPrompt = (): string =>
     'Do not mention that you are a local model or that you lack cloud access.',
   ].join(' ');
 
+const formatBriefForPrompt = (brief: IDesktopContentRunBrief): string =>
+  [
+    brief.angle ? `Brief angle: ${brief.angle}` : undefined,
+    brief.audience ? `Audience: ${brief.audience}` : undefined,
+    brief.channelFit ? `Channel fit: ${brief.channelFit}` : undefined,
+    brief.hypothesis ? `Hypothesis: ${brief.hypothesis}` : undefined,
+    brief.callToAction ? `Call to action: ${brief.callToAction}` : undefined,
+    brief.risk ? `Guardrail: ${brief.risk}` : undefined,
+    brief.evidence?.length
+      ? `Evidence: ${brief.evidence.join(' | ')}`
+      : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n');
+
 const buildUserPrompt = (params: IDesktopGenerationOptions): string => {
-  const source = params.sourceTrendTopic
-    ? `Source trend: ${params.sourceTrendTopic}`
-    : `Prompt: ${params.prompt.trim()}`;
+  const source = params.brief
+    ? formatBriefForPrompt(params.brief)
+    : params.sourceTrendTopic
+      ? `Source trend: ${params.sourceTrendTopic}`
+      : `Prompt: ${params.prompt.trim()}`;
 
   return [
     `Platform: ${params.platform}`,
@@ -331,6 +349,7 @@ const buildGenerationPayload = (params: IDesktopGenerationOptions): string =>
   JSON.stringify({
     platform: params.platform,
     projectId: params.projectId,
+    brief: params.brief,
     prompt: params.prompt,
     publishIntent: params.publishIntent,
     sourceDraftId: params.sourceDraftId,

--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -1,6 +1,7 @@
 import type {
   IDesktopBootstrap,
   IDesktopSession,
+  IDesktopTrendHandoff,
 } from '@genfeedai/desktop-contracts';
 import {
   lazy,
@@ -29,6 +30,11 @@ const AgentsView = lazy(() =>
 const AnalyticsView = lazy(() =>
   import('./views/AnalyticsView').then((module) => ({
     default: module.AnalyticsView,
+  })),
+);
+const ConversationView = lazy(() =>
+  import('./views/ConversationView').then((module) => ({
+    default: module.ConversationView,
   })),
 );
 const LibraryView = lazy(() =>
@@ -105,11 +111,8 @@ export const App = () => {
   const [isOnline, setIsOnline] = useState(
     typeof navigator === 'undefined' ? true : navigator.onLine,
   );
-  const [_pendingTrend, setPendingTrend] = useState<{
-    id: string;
-    platform: 'instagram' | 'linkedin' | 'twitter' | 'tiktok' | 'youtube';
-    topic: string;
-  } | null>(null);
+  const [pendingTrend, setPendingTrend] =
+    useState<IDesktopTrendHandoff | null>(null);
   const [onboardingState, setOnboardingState] = useState<OnboardingState>({
     completed: false,
     loaded: false,
@@ -132,9 +135,11 @@ export const App = () => {
 
   const {
     activeThreadId,
+    activeThread,
     addMessage,
     createThread,
     setActiveThreadId,
+    setThreadStatus,
     threads,
   } = useThreads(selectedWorkspaceId, localUserId);
 
@@ -274,7 +279,7 @@ export const App = () => {
   }, [createThread]);
 
   const handleOpenTerminal = useCallback(() => {
-    setActiveView('conversation');
+    setActiveView('terminal');
   }, []);
 
   const handleOpenSettings = useCallback(() => {
@@ -282,16 +287,12 @@ export const App = () => {
   }, []);
 
   const handleGenerateFromTrend = useCallback(
-    (trend: {
-      id: string;
-      platform: 'instagram' | 'linkedin' | 'twitter' | 'tiktok' | 'youtube';
-      topic: string;
-    }) => {
+    (trend: IDesktopTrendHandoff) => {
       setActiveView('conversation');
       setPendingTrend(trend);
       const thread = createThread();
       const message = {
-        content: `Generate content about: ${trend.topic}`,
+        content: `Draft a ${trend.platform} brief from trend: ${trend.topic}`,
         createdAt: new Date().toISOString(),
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
         role: 'user' as const,
@@ -339,6 +340,18 @@ export const App = () => {
   const renderMainView = () => {
     switch (activeView) {
       case 'conversation':
+        return (
+          <ConversationView
+            onCreateThread={createThread}
+            onSendMessage={addMessage}
+            onSetStatus={setThreadStatus}
+            onTrendConsumed={() => setPendingTrend(null)}
+            pendingTrend={pendingTrend}
+            thread={activeThread}
+            workspaceId={selectedWorkspaceId}
+          />
+        );
+      case 'terminal':
         return <TerminalView workspaceId={selectedWorkspaceId} />;
       case 'workflows':
         return <WorkflowsView />;
@@ -358,7 +371,17 @@ export const App = () => {
       case 'trends':
         return <TrendsView onGenerateFromTrend={handleGenerateFromTrend} />;
       default:
-        return <TerminalView workspaceId={selectedWorkspaceId} />;
+        return (
+          <ConversationView
+            onCreateThread={createThread}
+            onSendMessage={addMessage}
+            onSetStatus={setThreadStatus}
+            onTrendConsumed={() => setPendingTrend(null)}
+            pendingTrend={pendingTrend}
+            thread={activeThread}
+            workspaceId={selectedWorkspaceId}
+          />
+        );
     }
   };
 

--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -111,8 +111,9 @@ export const App = () => {
   const [isOnline, setIsOnline] = useState(
     typeof navigator === 'undefined' ? true : navigator.onLine,
   );
-  const [pendingTrend, setPendingTrend] =
-    useState<IDesktopTrendHandoff | null>(null);
+  const [pendingTrend, setPendingTrend] = useState<IDesktopTrendHandoff | null>(
+    null,
+  );
   const [onboardingState, setOnboardingState] = useState<OnboardingState>({
     completed: false,
     loaded: false,

--- a/apps/desktop/app/src/renderer/nav-view.ts
+++ b/apps/desktop/app/src/renderer/nav-view.ts
@@ -4,5 +4,6 @@ export type NavView =
   | 'conversation'
   | 'library'
   | 'mission-control'
+  | 'terminal'
   | 'trends'
   | 'workflows';

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -763,6 +763,37 @@ textarea {
   padding: 24px;
 }
 
+.brief-handoff-card {
+  background: color-mix(in srgb, var(--accent) 7%, var(--tertiary));
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 18px;
+  max-width: 760px;
+  padding: 14px 16px;
+}
+
+.brief-handoff-header {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.brief-handoff-card h3,
+.brief-handoff-card p {
+  margin: 0;
+}
+
+.brief-evidence-list {
+  color: var(--muted);
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+
 .conversation-empty {
   align-items: center;
   display: flex;

--- a/apps/desktop/app/src/renderer/views/ConversationMessages.tsx
+++ b/apps/desktop/app/src/renderer/views/ConversationMessages.tsx
@@ -1,4 +1,5 @@
 import type {
+  IDesktopContentRunBrief,
   IDesktopContentRunDraft,
   IDesktopThread,
 } from '@genfeedai/desktop-contracts';
@@ -13,6 +14,34 @@ interface ConversationMessagesProps {
   thread: IDesktopThread | null;
 }
 
+function BriefHandoffCard({ brief }: { brief: IDesktopContentRunBrief }) {
+  return (
+    <div className="brief-handoff-card">
+      <div className="brief-handoff-header">
+        <span className="status-badge status-active">Brief</span>
+        {typeof brief.confidence === 'number' && (
+          <span className="muted-text">
+            Confidence {String(Math.round(brief.confidence * 100))}%
+          </span>
+        )}
+      </div>
+      <h3>{brief.angle ?? 'Trend brief'}</h3>
+      {brief.hypothesis && <p>{brief.hypothesis}</p>}
+      {brief.channelFit && (
+        <p className="muted-text">Channel fit: {brief.channelFit}</p>
+      )}
+      {brief.evidence && brief.evidence.length > 0 && (
+        <ul className="brief-evidence-list">
+          {brief.evidence.map((item, index) => (
+            <li key={`${item}-${String(index)}`}>{item}</li>
+          ))}
+        </ul>
+      )}
+      {brief.risk && <p className="muted-text">Guardrail: {brief.risk}</p>}
+    </div>
+  );
+}
+
 export default function ConversationMessages({
   isGenerating,
   messagesEndRef,
@@ -22,6 +51,8 @@ export default function ConversationMessages({
 }: ConversationMessagesProps) {
   return (
     <>
+      {selectedDraft?.brief && <BriefHandoffCard brief={selectedDraft.brief} />}
+
       {(!thread || thread.messages.length === 0) && !isGenerating && (
         <div className="conversation-empty">
           <div className="empty-logo">G</div>

--- a/apps/desktop/app/src/renderer/views/ConversationView.tsx
+++ b/apps/desktop/app/src/renderer/views/ConversationView.tsx
@@ -3,6 +3,7 @@ import type {
   DesktopContentType,
   DesktopPublishIntent,
   IDesktopMessage,
+  IDesktopTrendHandoff,
   IDesktopThread,
 } from '@genfeedai/desktop-contracts';
 import { DropZone } from '@renderer/components/DropZone';
@@ -19,11 +20,7 @@ interface ConversationViewProps {
   onCreateThread: () => IDesktopThread;
   onSendMessage: (threadId: string, message: IDesktopMessage) => void;
   onSetStatus: (threadId: string, status: 'awaiting-response' | 'idle') => void;
-  pendingTrend?: {
-    id: string;
-    platform: DesktopContentPlatform;
-    topic: string;
-  } | null;
+  pendingTrend?: IDesktopTrendHandoff | null;
   onTrendConsumed?: () => void;
   thread: IDesktopThread | null;
   workspaceId: string | null;

--- a/apps/desktop/app/src/renderer/views/ConversationView.tsx
+++ b/apps/desktop/app/src/renderer/views/ConversationView.tsx
@@ -3,8 +3,8 @@ import type {
   DesktopContentType,
   DesktopPublishIntent,
   IDesktopMessage,
-  IDesktopTrendHandoff,
   IDesktopThread,
+  IDesktopTrendHandoff,
 } from '@genfeedai/desktop-contracts';
 import { DropZone } from '@renderer/components/DropZone';
 

--- a/apps/desktop/app/src/renderer/views/TrendsView.tsx
+++ b/apps/desktop/app/src/renderer/views/TrendsView.tsx
@@ -1,4 +1,8 @@
-import type { IDesktopTrend } from '@genfeedai/desktop-contracts';
+import type {
+  DesktopContentPlatform,
+  IDesktopTrend,
+  IDesktopTrendHandoff,
+} from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
 import { Button } from '@ui/primitives/button';
 import { useCallback, useEffect, useState } from 'react';
@@ -13,11 +17,20 @@ const PLATFORM_LABELS: Record<string, string> = {
 };
 
 interface TrendsViewProps {
-  onGenerateFromTrend: (trend: {
-    id: string;
-    platform: 'instagram' | 'linkedin' | 'twitter' | 'tiktok' | 'youtube';
-    topic: string;
-  }) => void;
+  onGenerateFromTrend: (trend: IDesktopTrendHandoff) => void;
+}
+
+function toDesktopContentPlatform(
+  value: string,
+  fallback: string,
+): DesktopContentPlatform {
+  const nextValue = [value, fallback].find((candidate) =>
+    ['instagram', 'linkedin', 'twitter', 'tiktok', 'youtube'].includes(
+      candidate,
+    ),
+  );
+
+  return (nextValue ?? 'twitter') as DesktopContentPlatform;
 }
 
 export const TrendsView = ({ onGenerateFromTrend }: TrendsViewProps) => {
@@ -117,14 +130,15 @@ export const TrendsView = ({ onGenerateFromTrend }: TrendsViewProps) => {
                 className="small"
                 onClick={() =>
                   onGenerateFromTrend({
+                    engagementScore: trend.engagementScore,
                     id: trend.id,
-                    platform: trend.platform as
-                      | 'instagram'
-                      | 'linkedin'
-                      | 'twitter'
-                      | 'tiktok'
-                      | 'youtube',
+                    platform: toDesktopContentPlatform(
+                      trend.platform,
+                      platform,
+                    ),
+                    summary: trend.summary,
                     topic: trend.topic,
+                    viralityScore: trend.viralityScore,
                   })
                 }
                 type="button"

--- a/apps/desktop/app/src/renderer/views/useConversationSend.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationSend.ts
@@ -149,6 +149,7 @@ export function useConversationSend({
 
     try {
       const generated = await window.genfeedDesktop.cloud.generateContent({
+        brief: savedDraft.brief,
         platform,
         projectId: workspace?.linkedProjectId,
         prompt: input.trim(),

--- a/apps/desktop/app/src/renderer/views/useConversationState.test.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationState.test.ts
@@ -4,7 +4,12 @@ import type {
   IDesktopWorkspace,
 } from '@genfeedai/desktop-contracts';
 
-import { buildPersistedContentRunDraft } from './useConversationState';
+import {
+  buildPersistedContentRunDraft,
+  buildTrendBrief,
+  buildTrendBriefPrompt,
+  buildTrendContentRunDraft,
+} from './useConversationState';
 
 const workspace: IDesktopWorkspace = {
   createdAt: '2026-06-08T00:00:00.000Z',
@@ -109,5 +114,86 @@ describe('buildPersistedContentRunDraft', () => {
     });
 
     expect(draft.projectId).toBeUndefined();
+  });
+});
+
+describe('trend brief handoff helpers', () => {
+  it('turns a desktop trend into a scored research brief', () => {
+    const brief = buildTrendBrief(
+      {
+        engagementScore: 70,
+        id: 'trend-1',
+        platform: 'linkedin',
+        summary: 'Founders are sharing launch teardown lessons.',
+        topic: 'Launch teardown posts',
+        viralityScore: 86,
+      },
+      'article',
+    );
+
+    expect(brief).toMatchObject({
+      angle: 'Launch teardown posts',
+      channelFit: 'linkedin article adapted from a live trend signal.',
+      confidence: 0.78,
+      evidence: [
+        'Founders are sharing launch teardown lessons.',
+        'Virality score: 86/100',
+        'Engagement score: 70/100',
+      ],
+      sourceId: 'trend-1',
+    });
+    expect(brief.hypothesis).toContain('brand-fit linkedin article');
+  });
+
+  it('builds a saved content-run draft with brief context and trend evidence', () => {
+    const draft = buildTrendContentRunDraft({
+      contentType: 'thread',
+      now: '2026-06-08T00:30:00.000Z',
+      trend: {
+        engagementScore: 92,
+        id: 'trend-2',
+        platform: 'twitter',
+        summary: 'Teams are posting AI workflow checklists.',
+        topic: 'AI workflow checklists',
+        viralityScore: 88,
+      },
+      workspace,
+      workspaceId: 'workspace-1',
+    });
+
+    expect(draft).toMatchObject({
+      brief: expect.objectContaining({
+        angle: 'AI workflow checklists',
+        evidence: expect.arrayContaining(['Virality score: 88/100']),
+      }),
+      platform: 'twitter',
+      projectId: 'project-2',
+      publishIntent: 'review',
+      sourceTrendId: 'trend-2',
+      sourceTrendTopic: 'AI workflow checklists',
+      sourceType: 'trend',
+      status: 'draft',
+      title: 'Trend brief: AI workflow checklists',
+      type: 'thread',
+      workspaceId: 'workspace-1',
+    });
+    expect(draft.prompt).toContain('Trend: AI workflow checklists');
+    expect(draft.prompt).toContain('Evidence:');
+  });
+
+  it('formats the trend brief prompt for generation handoff', () => {
+    const prompt = buildTrendBriefPrompt(
+      {
+        id: 'trend-3',
+        platform: 'instagram',
+        topic: 'Launch carousel lessons',
+        viralityScore: 64,
+      },
+      'caption',
+    );
+
+    expect(prompt).toContain('Create a instagram caption');
+    expect(prompt).toContain('Trend: Launch carousel lessons');
+    expect(prompt).toContain('no copied source wording');
   });
 });

--- a/apps/desktop/app/src/renderer/views/useConversationState.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationState.ts
@@ -98,9 +98,7 @@ export function buildTrendBriefPrompt(
     'Return a ready-to-edit draft with a clear hook, concrete angle, and no copied source wording.',
   ];
 
-  return lines
-    .filter((line): line is string => line !== undefined)
-    .join('\n');
+  return lines.filter((line): line is string => line !== undefined).join('\n');
 }
 
 export function buildTrendContentRunDraft(params: {

--- a/apps/desktop/app/src/renderer/views/useConversationState.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationState.ts
@@ -4,8 +4,10 @@ import type {
   DesktopGenerationProviderKind,
   DesktopPublishIntent,
   IDesktopCloudProject,
+  IDesktopContentRunBrief,
   IDesktopContentRunDraft,
   IDesktopGenerationProviderPublicConfig,
+  IDesktopTrendHandoff,
   IDesktopWorkspace,
 } from '@genfeedai/desktop-contracts';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -30,6 +32,104 @@ export function buildDraftTitle(
   }
 
   return trimmed.length > 48 ? `${trimmed.slice(0, 48)}…` : trimmed;
+}
+
+function formatTrendScore(label: string, score?: number): string | undefined {
+  if (typeof score !== 'number') {
+    return undefined;
+  }
+
+  return `${label}: ${String(Math.round(score))}/100`;
+}
+
+export function buildTrendBrief(
+  trend: IDesktopTrendHandoff,
+  contentType: DesktopContentType,
+): IDesktopContentRunBrief {
+  const evidence = [
+    trend.summary,
+    formatTrendScore('Virality score', trend.viralityScore),
+    formatTrendScore('Engagement score', trend.engagementScore),
+  ].filter((value): value is string => Boolean(value));
+  const scores = [trend.viralityScore, trend.engagementScore].filter(
+    (score): score is number => typeof score === 'number',
+  );
+  const confidence =
+    scores.length > 0
+      ? Math.min(
+          1,
+          Math.max(
+            0,
+            scores.reduce((total, score) => total + score, 0) /
+              scores.length /
+              100,
+          ),
+        )
+      : undefined;
+
+  return {
+    angle: trend.topic,
+    channelFit: `${trend.platform} ${contentType} adapted from a live trend signal.`,
+    confidence,
+    evidence,
+    hypothesis: `Turn "${trend.topic}" into a brand-fit ${trend.platform} ${contentType} that borrows the trend pattern without copying the source.`,
+    risk: 'Avoid copying source wording; add original perspective and proof.',
+    sourceId: trend.id,
+  };
+}
+
+export function buildTrendBriefPrompt(
+  trend: IDesktopTrendHandoff,
+  contentType: DesktopContentType,
+): string {
+  const brief = buildTrendBrief(trend, contentType);
+  const lines = [
+    `Create a ${trend.platform} ${contentType} from this trend brief.`,
+    '',
+    `Trend: ${trend.topic}`,
+    trend.summary ? `Summary: ${trend.summary}` : undefined,
+    brief.channelFit ? `Channel fit: ${brief.channelFit}` : undefined,
+    brief.hypothesis ? `Hypothesis: ${brief.hypothesis}` : undefined,
+    brief.risk ? `Guardrail: ${brief.risk}` : undefined,
+    brief.evidence?.length
+      ? `Evidence: ${brief.evidence.join(' | ')}`
+      : undefined,
+    '',
+    'Return a ready-to-edit draft with a clear hook, concrete angle, and no copied source wording.',
+  ];
+
+  return lines
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
+}
+
+export function buildTrendContentRunDraft(params: {
+  contentType: DesktopContentType;
+  now: string;
+  trend: IDesktopTrendHandoff;
+  workspace: IDesktopWorkspace | null;
+  workspaceId: string;
+}): IDesktopContentRunDraft {
+  const { contentType, now, trend, workspace, workspaceId } = params;
+  const prompt = buildTrendBriefPrompt(trend, contentType);
+
+  return {
+    brief: buildTrendBrief(trend, contentType),
+    createdAt: now,
+    id: createId(),
+    platform: trend.platform,
+    projectId: workspace?.linkedProjectId,
+    prompt,
+    publishIntent: 'review',
+    sourceTrendId: trend.id,
+    sourceTrendTopic: trend.topic,
+    sourceType: 'trend',
+    status: 'draft',
+    title: buildDraftTitle(`Trend brief: ${trend.topic}`, contentType),
+    type: contentType,
+    updatedAt: now,
+    workspaceId,
+  };
 }
 
 type BuildPersistedContentRunDraftParams = {
@@ -75,11 +175,7 @@ export function buildPersistedContentRunDraft({
 
 interface UseConversationStateParams {
   workspaceId: string | null;
-  pendingTrend?: {
-    id: string;
-    platform: DesktopContentPlatform;
-    topic: string;
-  } | null;
+  pendingTrend?: IDesktopTrendHandoff | null;
   onTrendConsumed?: () => void;
 }
 
@@ -224,25 +320,24 @@ export function useConversationState({
   }, [selectedDraft]);
 
   useEffect(() => {
-    if (!pendingTrend || !workspaceId) {
+    if (!pendingTrend) {
       return;
     }
 
-    const nextDraft: IDesktopContentRunDraft = {
-      createdAt: new Date().toISOString(),
-      id: createId(),
-      platform: pendingTrend.platform,
-      prompt: `Create a ${pendingTrend.platform} ${contentType} from trend: ${pendingTrend.topic}`,
-      publishIntent: 'review',
-      sourceTrendId: pendingTrend.id,
-      sourceTrendTopic: pendingTrend.topic,
-      sourceType: 'trend',
-      status: 'draft',
-      title: buildDraftTitle(pendingTrend.topic, contentType),
-      type: contentType,
-      updatedAt: new Date().toISOString(),
+    if (!workspaceId) {
+      setError('Open a workspace before creating a draft from a trend.');
+      onTrendConsumed?.();
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const nextDraft = buildTrendContentRunDraft({
+      contentType,
+      now,
+      trend: pendingTrend,
+      workspace,
       workspaceId,
-    };
+    });
 
     void window.genfeedDesktop.drafts
       .save(workspaceId, nextDraft)
@@ -262,7 +357,7 @@ export function useConversationState({
             : 'Failed to create draft from trend.',
         );
       });
-  }, [contentType, onTrendConsumed, pendingTrend, workspaceId]);
+  }, [contentType, onTrendConsumed, pendingTrend, workspace, workspaceId]);
 
   const persistDraft = useCallback(
     async (

--- a/packages/desktop-contracts/src/index.ts
+++ b/packages/desktop-contracts/src/index.ts
@@ -108,6 +108,28 @@ export type DesktopContentType =
 
 export type DesktopPublishIntent = 'draft' | 'publish' | 'review';
 
+export interface IDesktopContentRunBrief {
+  angle?: string;
+  audience?: string;
+  callToAction?: string;
+  channelFit?: string;
+  confidence?: number;
+  evidence?: string[];
+  hypothesis?: string;
+  risk?: string;
+  sourceId?: string;
+  sourceUrl?: string;
+}
+
+export interface IDesktopTrendHandoff {
+  engagementScore?: number;
+  id: string;
+  platform: DesktopContentPlatform;
+  summary?: string;
+  topic: string;
+  viralityScore?: number;
+}
+
 /* ─── Session ─── */
 
 export interface IDesktopSession {
@@ -508,6 +530,7 @@ export interface IDesktopGeneratedContent {
 }
 
 export interface IDesktopGenerationOptions {
+  brief?: IDesktopContentRunBrief;
   platform: DesktopContentPlatform;
   projectId?: string;
   prompt: string;
@@ -526,6 +549,7 @@ export interface IDesktopPublishResult {
 }
 
 export interface IDesktopContentRunDraft {
+  brief?: IDesktopContentRunBrief;
   content?: string;
   createdAt: string;
   generatedContent?: IDesktopGeneratedContent;


### PR DESCRIPTION
## Summary
- Wire the desktop conversation route to the real composer while keeping the terminal available as its own view.
- Persist trend brief metadata, evidence, scores, and prompt context when a trend becomes a saved content-run draft.
- Feed saved brief context into cloud/local generation and show the brief above the active run.

## Validation
- Local tests, lint, type-check, builds, Playwright, and heavy validation were intentionally skipped by automation policy on this MacBook Pro.
- CI/develop GitHub checks are the verification path for this PR.

Closes #23