### PR TITLE
fix(analytics): resolve GA client id from async gtag callback

### DIFF
--- a/packages/interfaces/src/analytics/link-tracking.interface.ts
+++ b/packages/interfaces/src/analytics/link-tracking.interface.ts
@@ -107,6 +107,24 @@ export interface IGoogleAnalyticsEvent {
   };
 }
 
+export type GoogleTag = {
+  (
+    command: 'event',
+    eventName: string,
+    eventParams: IGoogleAnalyticsEvent['eventParams'],
+  ): void;
+  (
+    command: 'get',
+    measurementId: string,
+    fieldName: 'client_id',
+    callback: (id: string) => void,
+  ): void;
+};
+
+export type WindowWithGoogleTag = Window & {
+  gtag?: GoogleTag;
+};
+
 export interface IContentCTAStats {
   contentId: string;
   contentType: string;

--- a/packages/services/analytics/link-tracking.service.test.ts
+++ b/packages/services/analytics/link-tracking.service.test.ts
@@ -17,7 +17,10 @@ vi.mock('@services/core/interceptor.service', () => {
 });
 
 vi.mock('@services/core/environment.service', () => ({
-  EnvironmentService: { apiEndpoint: 'https://api.genfeed.ai' },
+  EnvironmentService: {
+    GA_ID: 'G-TESTID0001',
+    apiEndpoint: 'https://api.genfeed.ai',
+  },
 }));
 
 vi.mock('@services/core/logger.service', () => ({
@@ -87,7 +90,7 @@ describe('LinkTrackingService', () => {
     });
   });
 
-  it('reads the GA client ID through gtag when available', () => {
+  it('reads the GA client ID through gtag when available', async () => {
     const gtag = vi.fn(
       (
         command: string,
@@ -96,18 +99,19 @@ describe('LinkTrackingService', () => {
         callback?: (id: string) => void,
       ) => {
         if (command === 'get') {
-          callback?.('client-123');
+          // GA invokes the callback asynchronously in production.
+          setTimeout(() => callback?.('client-123'), 0);
         }
       },
     );
     vi.stubGlobal('window', { gtag });
 
-    const result = service.getGAClientId();
+    const result = await service.getGAClientId();
 
     expect(result).toBe('client-123');
     expect(gtag).toHaveBeenCalledWith(
       'get',
-      'GA_MEASUREMENT_ID',
+      'G-TESTID0001',
       'client_id',
       expect.any(Function),
     );

--- a/packages/services/analytics/link-tracking.service.ts
+++ b/packages/services/analytics/link-tracking.service.ts
@@ -4,33 +4,17 @@
  */
 
 import type {
+  GoogleTag,
   IContentCTAStats,
   IGoogleAnalyticsEvent,
   ILinkPerformance,
   ITrackedLink,
   IUTMBuilder,
+  WindowWithGoogleTag,
 } from '@genfeedai/interfaces/analytics/link-tracking.interface';
 import { EnvironmentService } from '@services/core/environment.service';
 import { HTTPBaseService } from '@services/core/interceptor.service';
 import { logger } from '@services/core/logger.service';
-
-type GoogleTag = {
-  (
-    command: 'event',
-    eventName: string,
-    eventParams: IGoogleAnalyticsEvent['eventParams'],
-  ): void;
-  (
-    command: 'get',
-    measurementId: string,
-    fieldName: 'client_id',
-    callback: (id: string) => void,
-  ): void;
-};
-
-type WindowWithGoogleTag = Window & {
-  gtag?: GoogleTag;
-};
 
 function getGoogleTag(): GoogleTag | undefined {
   if (typeof window === 'undefined') {
@@ -309,21 +293,25 @@ export class LinkTrackingService extends HTTPBaseService {
 
   /**
    * Get Google Analytics Client ID (for GA4 integration)
+   *
+   * `gtag('get', ...)` resolves its value through an asynchronous callback, so
+   * this must return a Promise — reading the result synchronously always yields
+   * `undefined`.
    */
-  public getGAClientId(): string | undefined {
+  public async getGAClientId(): Promise<string | undefined> {
     if (typeof window === 'undefined') {
       return undefined;
     }
 
     const gtag = getGoogleTag();
-    if (gtag) {
-      let clientId: string | undefined;
-      gtag('get', 'GA_MEASUREMENT_ID', 'client_id', (id: string) => {
-        clientId = id;
-      });
-      return clientId;
+    if (!gtag) {
+      return undefined;
     }
 
-    return undefined;
+    return new Promise<string | undefined>((resolve) => {
+      gtag('get', EnvironmentService.GA_ID, 'client_id', (id: string) => {
+        resolve(id);
+      });
+    });
   }
 }


### PR DESCRIPTION
## What

`getGAClientId()` read `gtag('get', ...)` synchronously, which always returned `undefined` — GA resolves the value through an async callback.

## Changes

- `getGAClientId()` now returns `Promise<string | undefined>`, resolving from the gtag callback
- Use `EnvironmentService.GA_ID` for the measurement id instead of a hardcoded/missing value
- Moved `GoogleTag` / `WindowWithGoogleTag` inline types into `@genfeedai/interfaces/analytics/link-tracking.interface`
- Updated test to await the async client id and assert the gtag `get` call shape

## Why

Resolves CodeRabbit review finding on #443. Reading the client id synchronously was a real bug — callers never got a value.

## Verification

- `bun run test --filter=@genfeedai/services` — 7 pass
- `bun type-check` — green
- `bunx turbo lint` (services + interfaces) — green
- `npx biome check` — clean