### PR TITLE
ci(desktop): add release QA gate

### DIFF
--- a/.github/workflows/desktop-qa.yml
+++ b/.github/workflows/desktop-qa.yml
@@ -1,0 +1,56 @@
+name: Desktop QA
+
+on:
+  pull_request:
+    branches: [develop, staging, master]
+    paths:
+      - 'apps/desktop/**'
+      - 'apps/app/**'
+      - 'packages/desktop-*/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'turbo.json'
+      - '.github/actions/setup-bun-env/**'
+      - '.github/workflows/desktop-qa.yml'
+      - '.github/workflows/desktop-release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-qa-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  GENFEED_DESKTOP_RELEASE: ${{ github.sha }}
+  TZ: UTC
+
+jobs:
+  desktop-release-qa:
+    name: Desktop Release QA
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          node-version: '24.x'
+          bun-version: '1.3.13'
+          install-command: 'bun install --frozen-lockfile'
+
+      - name: Run desktop release QA
+        run: bun run --filter=@genfeedai/desktop qa:release
+
+      - name: QA summary
+        if: always()
+        run: |
+          echo "## Desktop QA" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Checklist: apps/desktop/RELEASE_QA.md" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Command: \`bun run --filter=@genfeedai/desktop qa:release\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Release SHA: \`${GENFEED_DESKTOP_RELEASE}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -107,9 +107,14 @@ downloaded app useful without requiring Redis, BullMQ, or the server repo.
 
 ```bash
 cd apps/desktop/app
-bun run smoke
+bun run qa:release
 bun run release:mac
 ```
+
+`bun run qa:release` is the release-candidate gate for desktop changes. It runs
+desktop lint, type-check, tests, and the Electron smoke boot used by the
+`Desktop QA` workflow. Use the checklist in
+[`apps/desktop/RELEASE_QA.md`](./RELEASE_QA.md) for manual release evidence.
 
 `bun run release:mac` writes macOS artifacts into `apps/desktop/app/release/`
 and creates `genfeed-desktop-release.json` beside them. The manifest records the

--- a/apps/desktop/RELEASE_QA.md
+++ b/apps/desktop/RELEASE_QA.md
@@ -1,0 +1,38 @@
+# Desktop Release QA
+
+Use this checklist for desktop release candidates and PRs that can affect the
+packaged Electron shell.
+
+## Automated Gate
+
+- GitHub Actions workflow: `Desktop QA`.
+- Trigger: pull requests to `develop`, `staging`, or `master` when desktop,
+  embedded app shell, desktop package, root dependency, or workflow files change.
+- Command: `bun run --filter=@genfeedai/desktop qa:release`.
+- Coverage: desktop lint, type-check, Bun/Vitest tests, native rebuild, packaged
+  app-shell build, and Electron `--smoke-test` boot.
+
+## Manual Checklist
+
+- Fresh launch shows the Electron-owned boot screen before the app shell loads.
+- No-API launch enters local/offline mode without requiring a server clone.
+- Browser sign-in deep link preserves a valid session and rejects invalid or
+  replayed callbacks.
+- Workspace selection, recent workspaces, drafts, and content-run handoff survive
+  app restart.
+- Local generation provider setup keeps the API key out of renderer-visible
+  state and shows a recoverable error before a provider is configured.
+- Genfeed Cloud generation and sync are available after sign-in when the API is
+  reachable.
+- Menu, tray, global shortcuts, terminal, library, trends, workflows, agents,
+  and analytics surfaces render without blank states.
+- Packaged artifacts include `GenFeed-*.dmg`, `GenFeed-*.zip`, and
+  `genfeed-desktop-release.json`.
+
+## Release Evidence
+
+- Link the passing `Desktop QA` workflow run for the candidate branch or PR.
+- Link the `Desktop Release` workflow run for the signed macOS artifact.
+- Attach or reference the generated `genfeed-desktop-release.json` manifest.
+- Record macOS runner version, release tag or commit SHA, signing/notarization
+  result, and any deferred manual checklist item.

--- a/apps/desktop/app/package.json
+++ b/apps/desktop/app/package.json
@@ -101,6 +101,7 @@
     "notarize": "node ./scripts/notarize.cjs",
     "pack:mac": "bun run electron:install-binary && bun run native:rebuild && bun run build:release && electron-builder --mac --dir --publish never",
     "prepare:release": "bun run icon:mac",
+    "qa:release": "bun run lint && bun run type-check && bun run test && bun run smoke",
     "release:mac": "bun run electron:install-binary && bun run native:rebuild && bun run build:release && electron-builder --mac dmg zip --publish never && bun run release:manifest",
     "release:manifest": "node ./scripts/write-release-manifest.cjs",
     "smoke": "bun run electron:install-binary && bun run native:rebuild && bun run build && ELECTRON_RUN_AS_NODE= electron dist/main.js --smoke-test",

--- a/apps/desktop/app/src/main/release-qa.test.ts
+++ b/apps/desktop/app/src/main/release-qa.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface DesktopPackageJson {
+  scripts?: Record<string, string>;
+}
+
+const desktopRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+const repoRoot = path.resolve(desktopRoot, '../../..');
+
+const readText = (relativePath: string): string =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+const readPackageJson = (): DesktopPackageJson =>
+  JSON.parse(readText('apps/desktop/app/package.json')) as DesktopPackageJson;
+
+describe('desktop release QA', () => {
+  it('keeps the release-candidate QA script aligned with smoke coverage', () => {
+    const scripts = readPackageJson().scripts;
+
+    expect(scripts?.['qa:release']).toBe(
+      'bun run lint && bun run type-check && bun run test && bun run smoke',
+    );
+    expect(scripts?.smoke).toContain('--smoke-test');
+    expect(scripts?.['release:mac']).toContain('bun run release:manifest');
+  });
+
+  it('runs macOS desktop QA on pull requests that can affect the shell', () => {
+    const workflow = readText('.github/workflows/desktop-qa.yml');
+
+    expect(workflow).toContain('name: Desktop QA');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('runs-on: macos-latest');
+    expect(workflow).toContain("'apps/desktop/**'");
+    expect(workflow).toContain("'apps/app/**'");
+    expect(workflow).toContain("'packages/desktop-*/**'");
+    expect(workflow).toContain(
+      'bun run --filter=@genfeedai/desktop qa:release',
+    );
+  });
+
+  it('documents the manual desktop release evidence checklist', () => {
+    const checklist = readText('apps/desktop/RELEASE_QA.md');
+
+    expect(checklist).toContain('# Desktop Release QA');
+    expect(checklist).toContain('## Automated Gate');
+    expect(checklist).toContain('## Manual Checklist');
+    expect(checklist).toContain('## Release Evidence');
+    expect(checklist).toContain('Desktop QA');
+    expect(checklist).toContain('genfeed-desktop-release.json');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a PR-triggered macOS `Desktop QA` workflow for desktop/app-shell release-critical changes.
- Add `qa:release` to run the desktop release-candidate gate: lint, type-check, tests, and Electron smoke boot.
- Add a desktop release QA checklist plus a static test that keeps the QA script, workflow, and checklist wired.

## Verification
- Not run locally by automation policy: tests, lint, type-check, builds, Playwright, and other heavy validation are intentionally skipped on this MacBook Pro.
- GitHub PR/develop CI checks are the verification path for this change.

## Risk
- The signed/notarized artifact workflow remains separate in `Desktop Release`; this PR adds the PR-level QA gate and checklist only.

Closes #28
