### PR TITLE
refactor(services): type heygen generation response

### DIFF
--- a/packages/services/ingredients/heygen.service.test.ts
+++ b/packages/services/ingredients/heygen.service.test.ts
@@ -1,7 +1,61 @@
+import type { IHeyGen } from '@genfeedai/interfaces';
 import { HeyGenService as HeygenService } from '@services/ingredients/heygen.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@services/core/base.service');
+const { mockDelete, mockGet, mockPatch, mockPost } = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
+  mockGet: vi.fn(),
+  mockPatch: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    apiEndpoint: 'https://api.test.com/v1',
+  },
+}));
+
+vi.mock('@services/core/base.service', () => {
+  const mockInstance = {
+    delete: mockDelete,
+    get: mockGet,
+    patch: mockPatch,
+    post: mockPost,
+  };
+
+  class MockBaseService {
+    public instance = mockInstance;
+
+    async findAll(_params?: unknown) {
+      return [];
+    }
+
+    async findOne(_id: string) {
+      return {};
+    }
+
+    async post(_data: unknown) {
+      return {};
+    }
+
+    async patch(_id: string, _data: unknown) {
+      return {};
+    }
+
+    async delete(_id: string) {
+      return undefined;
+    }
+
+    static getDataServiceInstance<TService>(
+      ServiceClass: new (token: string) => TService,
+      token: string,
+    ): TService {
+      return new ServiceClass(token);
+    }
+  }
+
+  return { BaseService: MockBaseService };
+});
 
 describe('HeygenService', () => {
   let service: HeygenService;
@@ -22,5 +76,35 @@ describe('HeygenService', () => {
     expect(service.post).toBeDefined();
     expect(service.patch).toBeDefined();
     expect(service.delete).toBeDefined();
+  });
+
+  it('generates avatar videos through the videos avatar endpoint', async () => {
+    const response: IHeyGen = {
+      createdAt: '2026-06-08T00:00:00.000Z',
+      id: 'heygen-job-1',
+      isDeleted: false,
+      metadata: { status: 'queued' },
+      provider: 'heygen',
+      updatedAt: '2026-06-08T00:00:00.000Z',
+    };
+    mockPost.mockResolvedValueOnce({ data: response });
+
+    const result = await service.generate({
+      avatarId: 'avatar-1',
+      audioUrl: 'https://cdn.example.com/audio.mp3',
+      text: 'Create a launch video',
+      voiceId: 'voice-1',
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      'https://api.test.com/v1/videos/avatar',
+      {
+        audioUrl: 'https://cdn.example.com/audio.mp3',
+        avatarId: 'avatar-1',
+        elevenlabsVoiceId: 'voice-1',
+        text: 'Create a launch video',
+      },
+    );
+    expect(result).toBe(response);
   });
 });

--- a/packages/services/ingredients/heygen.service.ts
+++ b/packages/services/ingredients/heygen.service.ts
@@ -49,8 +49,11 @@ export class HeyGenService extends BaseService<IHeyGen> {
     // Target: POST /videos/avatar (AvatarVideoController)
     const avatarUrl = `${EnvironmentService.apiEndpoint}${API_ENDPOINTS.VIDEOS}/avatar`;
 
-    const response = await this.instance.post(avatarUrl, backendPayload);
+    const response = await this.instance.post<IHeyGen>(
+      avatarUrl,
+      backendPayload,
+    );
 
-    return response.data as unknown as IHeyGen;
+    return response.data;
   }
 }


### PR DESCRIPTION
## Summary
- type the HeyGen avatar-generation Axios response at the request boundary instead of casting response.data through unknown
- expand the HeyGen service test to cover /videos/avatar URL construction and voiceId -> elevenlabsVoiceId mapping

## Validation
- Mac Studio: `bun install --frozen-lockfile`
- Mac Studio: `bun run --cwd packages/services test -- ingredients/heygen.service.test.ts` (3 tests passed)
- Mac Studio: `bunx biome check packages/services/ingredients/heygen.service.ts packages/services/ingredients/heygen.service.test.ts`
- Mac Studio: `bun run --cwd packages/services type-check`
- Local static only: `git diff --check`, staged diff check, focused secret-value scan

## Notes
- Avoided active PR surfaces: #458 analytics link tracking and #459 desktop release QA.
- No local CPU-heavy lint/test/type-check/build commands were run on the MacBook.