### PR TITLE
refactor(props): type image-to-video prompt props

### DIFF
--- a/packages/pages/ingredients/list/ingredients-list.tsx
+++ b/packages/pages/ingredients/list/ingredients-list.tsx
@@ -3,7 +3,6 @@
 import { useIngredientsContext } from '@contexts/content/ingredients-context/ingredients-context';
 import { useIngredientsHeaderContext } from '@contexts/content/ingredients-header-context/ingredients-header-context';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import type { PromptTextareaSchema } from '@genfeedai/client/schemas';
 import {
   AlertCategory,
   ButtonVariant,
@@ -266,16 +265,8 @@ export default function IngredientsList({
             blacklists={blacklists}
             promptData={imageToVideoPromptData || { isValid: false, text: '' }}
             isGenerating={isImageToVideoGenerating || false}
-            onPromptChange={
-              handleImageToVideoPromptChange as (
-                data: Partial<PromptTextareaSchema> & { isValid: boolean },
-              ) => void
-            }
-            onSubmit={
-              handleImageToVideoSubmit as (
-                data: PromptTextareaSchema & { isValid: boolean },
-              ) => void
-            }
+            onPromptChange={handleImageToVideoPromptChange}
+            onSubmit={handleImageToVideoSubmit}
             onClose={handleCloseImageToVideoModal}
           />
         )}

--- a/packages/props/pages/ingredients-list.props.ts
+++ b/packages/props/pages/ingredients-list.props.ts
@@ -1,3 +1,4 @@
+import type { PromptTextareaSchema } from '@genfeedai/client/schemas';
 import type {
   AssetScope,
   IngredientCategory,
@@ -19,6 +20,14 @@ import type {
 } from '@genfeedai/interfaces';
 import type { IngredientsTypeProps } from '@props/content/ingredient.props';
 import type { Dispatch, SetStateAction } from 'react';
+
+export type ImageToVideoPromptDraft = Partial<PromptTextareaSchema> & {
+  isValid: boolean;
+};
+
+export type ImageToVideoPromptSubmit = PromptTextareaSchema & {
+  isValid: boolean;
+};
 
 export interface IngredientsListProps extends IngredientsTypeProps {
   scope?: PageScope.SUPERADMIN | PageScope.ORGANIZATION | PageScope.BRAND;
@@ -158,10 +167,10 @@ export interface UseIngredientsListReturn {
   closeLightbox: () => void;
   handleConvertToVideo?: (ingredient: IIngredient) => void;
   imageToVideoTarget?: IIngredient | null;
-  imageToVideoPromptData?: any;
+  imageToVideoPromptData?: ImageToVideoPromptDraft;
   isImageToVideoGenerating?: boolean;
-  handleImageToVideoPromptChange?: (data: any) => void;
-  handleImageToVideoSubmit?: (data: any) => void;
+  handleImageToVideoPromptChange?: (data: ImageToVideoPromptDraft) => void;
+  handleImageToVideoSubmit?: (data: ImageToVideoPromptSubmit) => void;
   handleCloseImageToVideoModal?: () => void;
   videoModels?: IModel[];
   presets?: IPreset[];


### PR DESCRIPTION
## Summary

- Adds explicit image-to-video prompt draft/submit types to the shared IngredientsList prop contract.
- Removes cast-only PromptTextareaSchema plumbing from the IngredientsList render path.
- Keeps the existing hook and modal behavior unchanged while moving the type boundary to `@genfeedai/props`.

## Validation

Mac Studio worktree: `/Users/decod3rslabs/.codex/automations/thermo-nuclear-review-genfeed/worktrees/thermo-nuclear-review-20260608-221911`

- `bun install --frozen-lockfile`
- `bunx biome check packages/props/pages/ingredients-list.props.ts packages/pages/ingredients/list/ingredients-list.tsx`
- `bunx turbo run type-check --filter=@genfeedai/props`
- `bunx turbo run type-check --filter=@genfeedai/app`

Local MacBook validation was limited to static/staged checks:

- `git diff --check`
- `git diff --cached --check`
- staged secret-pattern scan

## Skipped / Notes

- Full repo tests, full lint, full builds, and Playwright were not run to respect the CPU-heavy validation policy.
- Direct `tsc -p packages/props/tsconfig.json --noEmit` initially failed on baseline unresolved `@genfeedai/helpers` package resolution before dependency builds; the scoped Turbo type-check built dependencies and passed.
- `@genfeedai/pages` has no package test script, and its Vitest config currently includes only `studio/generate/utils/**/*.test.ts`; direct IngredientsList Vitest invocation was therefore not a reliable focused gate.
