### PR TITLE
feat(desktop): add resilience states

### DIFF
--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -355,22 +355,33 @@ export const App = () => {
       case 'terminal':
         return <TerminalView workspaceId={selectedWorkspaceId} />;
       case 'workflows':
-        return <WorkflowsView />;
+        return <WorkflowsView isOnline={isOnline} />;
       case 'agents':
-        return <AgentsView />;
+        return <AgentsView isOnline={isOnline} />;
       case 'mission-control':
         return <MissionControlView onStartNewThread={handleNewThread} />;
       case 'analytics':
-        return <AnalyticsView workspaceId={selectedWorkspaceId} />;
+        return (
+          <AnalyticsView
+            isOnline={isOnline}
+            workspaceId={selectedWorkspaceId}
+          />
+        );
       case 'library':
         return (
           <LibraryView
+            isOnline={isOnline}
             workspace={selectedWorkspace}
             workspaceId={selectedWorkspaceId}
           />
         );
       case 'trends':
-        return <TrendsView onGenerateFromTrend={handleGenerateFromTrend} />;
+        return (
+          <TrendsView
+            isOnline={isOnline}
+            onGenerateFromTrend={handleGenerateFromTrend}
+          />
+        );
       default:
         return (
           <ConversationView

--- a/apps/desktop/app/src/renderer/components/DesktopResilienceState.test.tsx
+++ b/apps/desktop/app/src/renderer/components/DesktopResilienceState.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DesktopResilienceState } from './DesktopResilienceState';
+
+describe('DesktopResilienceState', () => {
+  it('renders a recoverable desktop state with an action', () => {
+    const onAction = vi.fn();
+
+    render(
+      <DesktopResilienceState
+        actionLabel="Retry"
+        details="Cloud data is unavailable."
+        kind="error"
+        onAction={onAction}
+        title="Unable to load"
+      />,
+    );
+
+    expect(screen.getByText('Unable to load')).toBeInTheDocument();
+    expect(screen.getByText('Cloud data is unavailable.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/app/src/renderer/components/DesktopResilienceState.tsx
+++ b/apps/desktop/app/src/renderer/components/DesktopResilienceState.tsx
@@ -1,0 +1,65 @@
+import { ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
+import type { ReactElement } from 'react';
+import type { IconType } from 'react-icons';
+import {
+  HiOutlineArrowPath,
+  HiOutlineInbox,
+  HiOutlineSignalSlash,
+} from 'react-icons/hi2';
+
+export type DesktopResilienceKind = 'empty' | 'error' | 'offline';
+
+interface DesktopResilienceStateProps {
+  actionLabel?: string;
+  className?: string;
+  details: string;
+  kind: DesktopResilienceKind;
+  onAction?: () => void;
+  title: string;
+}
+
+const RESILIENCE_ICON = {
+  empty: HiOutlineInbox,
+  error: HiOutlineArrowPath,
+  offline: HiOutlineSignalSlash,
+} satisfies Record<DesktopResilienceKind, IconType>;
+
+export function DesktopResilienceState({
+  actionLabel,
+  className = '',
+  details,
+  kind,
+  onAction,
+  title,
+}: DesktopResilienceStateProps): ReactElement {
+  const Icon = RESILIENCE_ICON[kind];
+
+  return (
+    <section
+      className={`desktop-resilience-state desktop-resilience-${kind} ${className}`.trim()}
+      data-resilience-kind={kind}
+    >
+      <div className="desktop-resilience-icon" aria-hidden="true">
+        <Icon className="desktop-resilience-icon-svg" />
+      </div>
+      <div className="desktop-resilience-copy">
+        <h3>{title}</h3>
+        <p>{details}</p>
+      </div>
+      {actionLabel && onAction ? (
+        <Button
+          className="desktop-resilience-action"
+          icon={
+            <HiOutlineArrowPath className="desktop-resilience-action-icon" />
+          }
+          onClick={onAction}
+          type="button"
+          variant={ButtonVariant.GHOST}
+        >
+          {actionLabel}
+        </Button>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -1193,6 +1193,74 @@ textarea {
   padding: 8px 0;
 }
 
+.desktop-resilience-state {
+  align-items: flex-start;
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  margin: 0 0 16px;
+  padding: 16px;
+}
+
+.desktop-resilience-offline {
+  background: color-mix(in srgb, var(--warning) 9%, var(--card));
+  border-color: color-mix(in srgb, var(--warning) 28%, transparent);
+}
+
+.desktop-resilience-error {
+  background: color-mix(in srgb, var(--danger) 9%, var(--card));
+  border-color: color-mix(in srgb, var(--danger) 28%, transparent);
+}
+
+.desktop-resilience-empty {
+  background: color-mix(in srgb, var(--info) 7%, var(--card));
+  border-color: color-mix(in srgb, var(--info) 22%, transparent);
+}
+
+.desktop-resilience-icon {
+  align-items: center;
+  background: var(--accent-soft);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  color: var(--text);
+  display: flex;
+  height: 38px;
+  justify-content: center;
+  width: 38px;
+}
+
+.desktop-resilience-icon-svg,
+.desktop-resilience-action-icon {
+  height: 18px;
+  width: 18px;
+}
+
+.desktop-resilience-copy {
+  min-width: 0;
+}
+
+.desktop-resilience-copy h3 {
+  font-size: 14px;
+  margin: 0 0 4px;
+}
+
+.desktop-resilience-copy p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.desktop-resilience-action {
+  align-self: center;
+  white-space: nowrap;
+}
+
+.desktop-local-stats {
+  margin-top: 16px;
+}
+
 .stack-list {
   display: flex;
   flex-direction: column;
@@ -1886,6 +1954,15 @@ textarea {
 
   .stats-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .desktop-resilience-state {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .desktop-resilience-action {
+    grid-column: 1 / -1;
+    justify-self: start;
   }
 
   .ingredient-grid {

--- a/apps/desktop/app/src/renderer/views/AgentsView.tsx
+++ b/apps/desktop/app/src/renderer/views/AgentsView.tsx
@@ -1,5 +1,6 @@
 import type { IDesktopAgent } from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
+import { DesktopResilienceState } from '@renderer/components/DesktopResilienceState';
 import { Button } from '@ui/primitives/button';
 import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -121,7 +122,11 @@ const AgentCard = ({
   );
 };
 
-export const AgentsView = () => {
+interface AgentsViewProps {
+  isOnline: boolean;
+}
+
+export const AgentsView = ({ isOnline }: AgentsViewProps) => {
   const [agents, setAgents] = useState<IDesktopAgent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -129,6 +134,15 @@ export const AgentsView = () => {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const loadAgents = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    if (!isOnline) {
+      setAgents([]);
+      setLoading(false);
+      return;
+    }
+
     try {
       const result = await window.genfeedDesktop.cloud.listAgents();
       setAgents(result);
@@ -137,7 +151,7 @@ export const AgentsView = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isOnline]);
 
   useEffect(() => {
     void loadAgents();
@@ -166,6 +180,12 @@ export const AgentsView = () => {
       setRunningAgentId(agentId);
       setError(null);
 
+      if (!isOnline) {
+        setError('Reconnect before running cloud agent strategies.');
+        setRunningAgentId(null);
+        return;
+      }
+
       try {
         await window.genfeedDesktop.cloud.runAgent(agentId);
         // Keep polling; it will auto-clear when run completes
@@ -177,7 +197,7 @@ export const AgentsView = () => {
         setRunningAgentId(null);
       }
     },
-    [loadAgents],
+    [isOnline, loadAgents],
   );
 
   return (
@@ -195,25 +215,46 @@ export const AgentsView = () => {
         </Button>
       </div>
 
-      {loading && <p className="muted-text">Loading agents…</p>}
-      {error && <div className="error-banner">{error}</div>}
-
-      {!loading && agents.length === 0 && (
-        <p className="empty-state">
-          No agents configured. Create agent strategies in the GenFeed web app.
-        </p>
+      {loading && <p className="muted-text">Loading agents...</p>}
+      {!loading && !isOnline && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details="Agent strategies sync from Genfeed Cloud. You can keep drafting locally while the desktop app waits for a connection."
+          kind="offline"
+          onAction={() => void loadAgents()}
+          title="Agents are offline"
+        />
+      )}
+      {!loading && isOnline && error && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details={error}
+          kind="error"
+          onAction={() => void loadAgents()}
+          title="Unable to load agents"
+        />
       )}
 
-      <div className="agents-grid">
-        {agents.map((agent) => (
-          <AgentCard
-            agent={agent}
-            key={agent.id}
-            onRun={(id) => void handleRunAgent(id)}
-            runningAgentId={runningAgentId}
-          />
-        ))}
-      </div>
+      {!loading && isOnline && !error && agents.length === 0 && (
+        <DesktopResilienceState
+          details="No agent strategies are available for this account. Create them in the web app, then refresh desktop."
+          kind="empty"
+          title="No agents configured"
+        />
+      )}
+
+      {isOnline && !error && agents.length > 0 ? (
+        <div className="agents-grid">
+          {agents.map((agent) => (
+            <AgentCard
+              agent={agent}
+              key={agent.id}
+              onRun={(id) => void handleRunAgent(id)}
+              runningAgentId={runningAgentId}
+            />
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/app/src/renderer/views/AnalyticsView.tsx
+++ b/apps/desktop/app/src/renderer/views/AnalyticsView.tsx
@@ -1,15 +1,17 @@
 import type { IDesktopAnalytics } from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
+import { DesktopResilienceState } from '@renderer/components/DesktopResilienceState';
 import { Button } from '@ui/primitives/button';
 import { useCallback, useEffect, useState } from 'react';
 
 type DaysRange = 7 | 30 | 90;
 
 interface AnalyticsViewProps {
+  isOnline: boolean;
   workspaceId: string | null;
 }
 
-export const AnalyticsView = ({ workspaceId }: AnalyticsViewProps) => {
+export const AnalyticsView = ({ isOnline, workspaceId }: AnalyticsViewProps) => {
   const [analytics, setAnalytics] = useState<IDesktopAnalytics | null>(null);
   const [draftStats, setDraftStats] = useState({
     generatedCount: 0,
@@ -25,13 +27,10 @@ export const AnalyticsView = ({ workspaceId }: AnalyticsViewProps) => {
     setError(null);
 
     try {
-      const [result, drafts] = await Promise.all([
-        window.genfeedDesktop.cloud.getAnalytics({ days }),
-        workspaceId
-          ? window.genfeedDesktop.drafts.list(workspaceId)
-          : Promise.resolve([]),
-      ]);
-      setAnalytics(result);
+      const drafts = workspaceId
+        ? await window.genfeedDesktop.drafts.list(workspaceId)
+        : [];
+
       setDraftStats({
         generatedCount: drafts.filter((draft) => draft.status === 'generated')
           .length,
@@ -40,12 +39,20 @@ export const AnalyticsView = ({ workspaceId }: AnalyticsViewProps) => {
         reviewCount: drafts.filter((draft) => draft.publishIntent === 'review')
           .length,
       });
+
+      if (!isOnline) {
+        setAnalytics(null);
+        return;
+      }
+
+      const result = await window.genfeedDesktop.cloud.getAnalytics({ days });
+      setAnalytics(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load analytics');
     } finally {
       setLoading(false);
     }
-  }, [days, workspaceId]);
+  }, [days, isOnline, workspaceId]);
 
   useEffect(() => {
     void loadAnalytics();
@@ -70,10 +77,30 @@ export const AnalyticsView = ({ workspaceId }: AnalyticsViewProps) => {
         </div>
       </div>
 
-      {loading && <p className="muted-text">Loading analytics…</p>}
-      {error && <div className="error-banner">{error}</div>}
+      {loading && <p className="muted-text">Loading analytics...</p>}
+      {!loading && !isOnline && (
+        <>
+          <DesktopResilienceState
+            actionLabel="Retry"
+            details="Cloud analytics are unavailable while the desktop app is offline. Local content-run counts are still shown below."
+            kind="offline"
+            onAction={() => void loadAnalytics()}
+            title="Analytics are offline"
+          />
+          <DesktopDraftStatsGrid draftStats={draftStats} />
+        </>
+      )}
+      {!loading && isOnline && error && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details={error}
+          kind="error"
+          onAction={() => void loadAnalytics()}
+          title="Unable to load analytics"
+        />
+      )}
 
-      {!loading && analytics && (
+      {!loading && isOnline && !error && analytics && (
         <>
           <div className="stats-grid">
             <div className="stat-card">
@@ -128,6 +155,41 @@ export const AnalyticsView = ({ workspaceId }: AnalyticsViewProps) => {
           )}
         </>
       )}
+
+      {!loading && isOnline && !error && !analytics && (
+        <DesktopResilienceState
+          details="No cloud analytics are available yet. Publish content or sync recent posts, then refresh this view."
+          kind="empty"
+          title="No analytics yet"
+        />
+      )}
     </div>
   );
 };
+
+function DesktopDraftStatsGrid({
+  draftStats,
+}: {
+  draftStats: {
+    generatedCount: number;
+    publishedCount: number;
+    reviewCount: number;
+  };
+}) {
+  return (
+    <div className="stats-grid desktop-local-stats">
+      <div className="stat-card">
+        <span className="stat-value">{draftStats.generatedCount}</span>
+        <span className="stat-label">Generated Runs</span>
+      </div>
+      <div className="stat-card">
+        <span className="stat-value">{draftStats.publishedCount}</span>
+        <span className="stat-label">Published Runs</span>
+      </div>
+      <div className="stat-card">
+        <span className="stat-value">{draftStats.reviewCount}</span>
+        <span className="stat-label">Review Queue</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/app/src/renderer/views/LibraryIngredientsGrid.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryIngredientsGrid.tsx
@@ -1,5 +1,6 @@
 import type { IDesktopIngredient } from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
+import { DesktopResilienceState } from '@renderer/components/DesktopResilienceState';
 import { Button } from '@ui/primitives/button';
 import type { ReactElement } from 'react';
 
@@ -7,16 +8,20 @@ type LibraryIngredientsGridProps = {
   loading: boolean;
   error: string | null;
   ingredients: IDesktopIngredient[];
+  isOnline: boolean;
   copiedId: string | null;
   onCopy: (ingredient: IDesktopIngredient) => void;
+  onRetry: () => void;
 };
 
 export function LibraryIngredientsGrid({
   loading,
   error,
   ingredients,
+  isOnline,
   copiedId,
   onCopy,
+  onRetry,
 }: LibraryIngredientsGridProps): ReactElement {
   return (
     <>
@@ -28,16 +33,35 @@ export function LibraryIngredientsGrid({
         </div>
       )}
 
-      {error && <div className="error-banner">{error}</div>}
-
-      {!loading && !error && ingredients.length === 0 && (
-        <p className="empty-state">
-          No ingredients found. Try changing your filter or creating content in
-          a conversation.
-        </p>
+      {!loading && !isOnline && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details="Cloud ingredient search needs a connection. Local workspace assets remain available above."
+          kind="offline"
+          onAction={onRetry}
+          title="Ingredient search is offline"
+        />
       )}
 
-      {!loading && ingredients.length > 0 && (
+      {!loading && isOnline && error && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details={error}
+          kind="error"
+          onAction={onRetry}
+          title="Unable to load ingredients"
+        />
+      )}
+
+      {!loading && isOnline && !error && ingredients.length === 0 && (
+        <DesktopResilienceState
+          details="No ingredients matched this filter. Try another platform or create content in a conversation."
+          kind="empty"
+          title="No ingredients found"
+        />
+      )}
+
+      {!loading && isOnline && !error && ingredients.length > 0 && (
         <div className="ingredient-grid">
           {ingredients.map((ingredient) => (
             <div className="ingredient-card panel-card" key={ingredient.id}>

--- a/apps/desktop/app/src/renderer/views/LibraryView.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryView.tsx
@@ -16,11 +16,16 @@ import { LibraryViewHeader } from './LibraryViewHeader';
 type SortBy = 'date' | 'votes';
 
 interface LibraryViewProps {
+  isOnline: boolean;
   workspace: IDesktopWorkspace | null;
   workspaceId: string | null;
 }
 
-export const LibraryView = ({ workspace, workspaceId }: LibraryViewProps) => {
+export const LibraryView = ({
+  isOnline,
+  workspace,
+  workspaceId,
+}: LibraryViewProps) => {
   const [assets, setAssets] = useState<IDesktopAsset[]>([]);
   const [assetPrompt, setAssetPrompt] = useState('');
   const [assetJob, setAssetJob] = useState<IDesktopGenerationJob | null>(null);
@@ -40,6 +45,12 @@ export const LibraryView = ({ workspace, workspaceId }: LibraryViewProps) => {
     setLoading(true);
     setError(null);
 
+    if (!isOnline) {
+      setIngredients([]);
+      setLoading(false);
+      return;
+    }
+
     try {
       const result = await window.genfeedDesktop.cloud.getIngredients({
         limit: 20,
@@ -51,7 +62,7 @@ export const LibraryView = ({ workspace, workspaceId }: LibraryViewProps) => {
     } finally {
       setLoading(false);
     }
-  }, [platformFilter]);
+  }, [isOnline, platformFilter]);
 
   const loadAssets = useCallback(async () => {
     if (!workspaceId) {
@@ -241,7 +252,9 @@ export const LibraryView = ({ workspace, workspaceId }: LibraryViewProps) => {
         copiedId={copiedId}
         error={error}
         ingredients={sortedIngredients}
+        isOnline={isOnline}
         loading={loading}
+        onRetry={() => void loadIngredients()}
         onCopy={(ingredient) => void handleCopy(ingredient)}
       />
     </DropZone>

--- a/apps/desktop/app/src/renderer/views/TrendsView.test.tsx
+++ b/apps/desktop/app/src/renderer/views/TrendsView.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TrendsView } from './TrendsView';
+
+const cloudApi = {
+  getTrends: vi.fn(),
+};
+
+describe('TrendsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cloudApi.getTrends.mockReset();
+
+    Object.defineProperty(window, 'genfeedDesktop', {
+      configurable: true,
+      value: {
+        cloud: cloudApi,
+      },
+    });
+  });
+
+  it('shows an offline state without calling the cloud API', async () => {
+    render(<TrendsView isOnline={false} onGenerateFromTrend={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Trend discovery is offline'),
+      ).toBeInTheDocument(),
+    );
+
+    expect(cloudApi.getTrends).not.toHaveBeenCalled();
+  });
+
+  it('shows a retryable API failure state', async () => {
+    cloudApi.getTrends.mockRejectedValue(new Error('API unavailable'));
+
+    render(<TrendsView isOnline onGenerateFromTrend={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Unable to load trends')).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(cloudApi.getTrends).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an empty state for a successful empty trends response', async () => {
+    cloudApi.getTrends.mockResolvedValue([]);
+
+    render(<TrendsView isOnline onGenerateFromTrend={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No trends found')).toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/desktop/app/src/renderer/views/TrendsView.tsx
+++ b/apps/desktop/app/src/renderer/views/TrendsView.tsx
@@ -4,6 +4,7 @@ import type {
   IDesktopTrendHandoff,
 } from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
+import { DesktopResilienceState } from '@renderer/components/DesktopResilienceState';
 import { Button } from '@ui/primitives/button';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -17,6 +18,7 @@ const PLATFORM_LABELS: Record<string, string> = {
 };
 
 interface TrendsViewProps {
+  isOnline: boolean;
   onGenerateFromTrend: (trend: IDesktopTrendHandoff) => void;
 }
 
@@ -33,7 +35,10 @@ function toDesktopContentPlatform(
   return (nextValue ?? 'twitter') as DesktopContentPlatform;
 }
 
-export const TrendsView = ({ onGenerateFromTrend }: TrendsViewProps) => {
+export const TrendsView = ({
+  isOnline,
+  onGenerateFromTrend,
+}: TrendsViewProps) => {
   const [trends, setTrends] = useState<IDesktopTrend[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -43,6 +48,12 @@ export const TrendsView = ({ onGenerateFromTrend }: TrendsViewProps) => {
     setLoading(true);
     setError(null);
 
+    if (!isOnline) {
+      setTrends([]);
+      setLoading(false);
+      return;
+    }
+
     try {
       const result = await window.genfeedDesktop.cloud.getTrends(platform);
       setTrends(result);
@@ -51,7 +62,7 @@ export const TrendsView = ({ onGenerateFromTrend }: TrendsViewProps) => {
     } finally {
       setLoading(false);
     }
-  }, [platform]);
+  }, [isOnline, platform]);
 
   useEffect(() => {
     void loadTrends();
@@ -80,16 +91,35 @@ export const TrendsView = ({ onGenerateFromTrend }: TrendsViewProps) => {
         ))}
       </div>
 
-      {loading && <p className="muted-text">Loading trends…</p>}
-      {error && <div className="error-banner">{error}</div>}
-
-      {!loading && !error && trends.length === 0 && (
-        <p className="empty-state">
-          No trends found for {PLATFORM_LABELS[platform]}.
-        </p>
+      {loading && <p className="muted-text">Loading trends...</p>}
+      {!loading && !isOnline && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details="Trend discovery needs a cloud connection. Local drafts and desktop generation stay available while the network is down."
+          kind="offline"
+          onAction={() => void loadTrends()}
+          title="Trend discovery is offline"
+        />
+      )}
+      {!loading && isOnline && error && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details={error}
+          kind="error"
+          onAction={() => void loadTrends()}
+          title="Unable to load trends"
+        />
       )}
 
-      {!loading && trends.length > 0 && (
+      {!loading && isOnline && !error && trends.length === 0 && (
+        <DesktopResilienceState
+          details={`No ${PLATFORM_LABELS[platform]} trends are available yet. Try another platform or refresh after the next sync.`}
+          kind="empty"
+          title="No trends found"
+        />
+      )}
+
+      {!loading && isOnline && !error && trends.length > 0 && (
         <div className="trends-list">
           {trends.map((trend) => (
             <div className="trend-card panel-card" key={trend.id}>

--- a/apps/desktop/app/src/renderer/views/WorkflowsView.tsx
+++ b/apps/desktop/app/src/renderer/views/WorkflowsView.tsx
@@ -1,5 +1,6 @@
 import type { IDesktopWorkflow } from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
+import { DesktopResilienceState } from '@renderer/components/DesktopResilienceState';
 import { Button } from '@ui/primitives/button';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -20,13 +21,26 @@ const LIFECYCLE_COLORS: Record<string, string> = {
   published: 'status-active',
 };
 
-export const WorkflowsView = () => {
+interface WorkflowsViewProps {
+  isOnline: boolean;
+}
+
+export const WorkflowsView = ({ isOnline }: WorkflowsViewProps) => {
   const [workflows, setWorkflows] = useState<IDesktopWorkflow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [runningId, setRunningId] = useState<string | null>(null);
 
   const loadWorkflows = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    if (!isOnline) {
+      setWorkflows([]);
+      setLoading(false);
+      return;
+    }
+
     try {
       const result = await window.genfeedDesktop.cloud.listWorkflows();
       setWorkflows(result);
@@ -35,7 +49,7 @@ export const WorkflowsView = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isOnline]);
 
   useEffect(() => {
     void loadWorkflows();
@@ -44,6 +58,12 @@ export const WorkflowsView = () => {
   const handleRun = useCallback(async (workflowId: string, batch?: boolean) => {
     setRunningId(workflowId);
     setError(null);
+
+    if (!isOnline) {
+      setError('Reconnect before running cloud workflows.');
+      setRunningId(null);
+      return;
+    }
 
     try {
       await window.genfeedDesktop.cloud.runWorkflow({ batch, workflowId });
@@ -56,7 +76,7 @@ export const WorkflowsView = () => {
     } finally {
       setRunningId(null);
     }
-  }, []);
+  }, [isOnline]);
 
   return (
     <div className="view-workflows">
@@ -73,74 +93,99 @@ export const WorkflowsView = () => {
         </Button>
       </div>
 
-      {loading && <p className="muted-text">Loading workflows…</p>}
-      {error && <div className="error-banner">{error}</div>}
-
-      {!loading && workflows.length === 0 && (
-        <p className="empty-state">
-          No workflows found. Create workflows in the GenFeed workflow builder.
-        </p>
+      {loading && <p className="muted-text">Loading workflows...</p>}
+      {!loading && !isOnline && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details="Cloud workflows require a network connection. Local drafting remains available until the desktop app reconnects."
+          kind="offline"
+          onAction={() => void loadWorkflows()}
+          title="Workflows are offline"
+        />
+      )}
+      {!loading && isOnline && error && (
+        <DesktopResilienceState
+          actionLabel="Retry"
+          details={error}
+          kind="error"
+          onAction={() => void loadWorkflows()}
+          title="Unable to load workflows"
+        />
       )}
 
-      <div className="workflows-grid">
-        {workflows.map((wf) => (
-          <div className="workflow-card panel-card" key={wf.id}>
-            <div className="workflow-card-header">
-              <div>
-                <strong className="workflow-name">{wf.name}</strong>
-                {wf.description && (
-                  <p className="workflow-desc muted-text">{wf.description}</p>
+      {!loading && isOnline && !error && workflows.length === 0 && (
+        <DesktopResilienceState
+          details="No workflows are available for this workspace. Create workflows in the web builder, then refresh desktop."
+          kind="empty"
+          title="No workflows found"
+        />
+      )}
+
+      {isOnline && !error && workflows.length > 0 ? (
+        <div className="workflows-grid">
+          {workflows.map((wf) => (
+            <div className="workflow-card panel-card" key={wf.id}>
+              <div className="workflow-card-header">
+                <div>
+                  <strong className="workflow-name">{wf.name}</strong>
+                  {wf.description && (
+                    <p className="workflow-desc muted-text">
+                      {wf.description}
+                    </p>
+                  )}
+                </div>
+                <span
+                  className={`status-badge ${LIFECYCLE_COLORS[wf.lifecycle] ?? ''}`}
+                >
+                  {wf.lifecycle}
+                </span>
+              </div>
+
+              <div className="workflow-meta">
+                <span className="node-count-badge">
+                  {String(wf.nodeCount)} node{wf.nodeCount !== 1 ? 's' : ''}
+                </span>
+                {wf.latestRun && (
+                  <span
+                    className={`status-badge status-${wf.latestRun.status}`}
+                  >
+                    {wf.latestRun.mode === 'batch' ? 'Batch' : 'Latest'}:{' '}
+                    {wf.latestRun.status}
+                  </span>
+                )}
+                {wf.lastExecutedAt && (
+                  <span className="muted-text">
+                    Last run: {timeAgo(wf.lastExecutedAt)}
+                  </span>
                 )}
               </div>
-              <span
-                className={`status-badge ${LIFECYCLE_COLORS[wf.lifecycle] ?? ''}`}
-              >
-                {wf.lifecycle}
-              </span>
-            </div>
 
-            <div className="workflow-meta">
-              <span className="node-count-badge">
-                {String(wf.nodeCount)} node{wf.nodeCount !== 1 ? 's' : ''}
-              </span>
-              {wf.latestRun && (
-                <span className={`status-badge status-${wf.latestRun.status}`}>
-                  {wf.latestRun.mode === 'batch' ? 'Batch' : 'Latest'}:{' '}
-                  {wf.latestRun.status}
-                </span>
-              )}
-              {wf.lastExecutedAt && (
-                <span className="muted-text">
-                  Last run: {timeAgo(wf.lastExecutedAt)}
-                </span>
-              )}
-            </div>
-
-            <div className="workflow-card-actions">
-              <Button
-                className="small"
-                disabled={runningId === wf.id}
-                onClick={() => void handleRun(wf.id)}
-                type="button"
-                variant={ButtonVariant.DEFAULT}
-              >
-                {runningId === wf.id ? 'Running…' : '▶ Run'}
-              </Button>
-              {wf.supportsBatch && (
+              <div className="workflow-card-actions">
                 <Button
                   className="small"
                   disabled={runningId === wf.id}
-                  onClick={() => void handleRun(wf.id, true)}
+                  onClick={() => void handleRun(wf.id)}
                   type="button"
-                  variant={ButtonVariant.GHOST}
+                  variant={ButtonVariant.DEFAULT}
                 >
-                  📦 Run Batch
+                  {runningId === wf.id ? 'Running…' : '▶ Run'}
                 </Button>
-              )}
+                {wf.supportsBatch && (
+                  <Button
+                    className="small"
+                    disabled={runningId === wf.id}
+                    onClick={() => void handleRun(wf.id, true)}
+                    type="button"
+                    variant={ButtonVariant.GHOST}
+                  >
+                    📦 Run Batch
+                  </Button>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add a shared desktop resilience state for offline, API failure, and empty data surfaces.
- Wire renderer online state through Trends, Agents, Workflows, Analytics, and Library ingredients so cloud calls are skipped while offline and failures are retryable.
- Keep local draft analytics visible offline and add focused component/view tests documenting the resilience states.

## Validation
- Not run by policy: local tests, lint, type-check, builds, Playwright, and heavy validation are intentionally skipped on this MacBook Pro.
- CI/develop GitHub checks are the verification path for this PR.

## Risk
- Desktop renderer only; no API, schema, serializer, package contract, or environment changes.

Closes #27
