### PR TITLE
refactor(hooks): type topaz enhance payloads

### DIFF
--- a/packages/hooks/ui/ingredient/use-enhance-upscale/use-enhance-upscale.test.ts
+++ b/packages/hooks/ui/ingredient/use-enhance-upscale/use-enhance-upscale.test.ts
@@ -323,7 +323,38 @@ describe('useEnhanceUpscale', () => {
       });
 
       expect(mockGetImagesService).toHaveBeenCalled();
-      expect(mockPostUpscale).toHaveBeenCalled();
+      expect(mockPostUpscale).toHaveBeenCalledWith('img-123', {
+        category: IngredientCategory.IMAGE,
+        model: MODEL_KEYS.REPLICATE_TOPAZ_IMAGE_UPSCALE,
+        parent: 'img-123',
+        prompt: 'Enhance image quality using Topaz AI upscaling',
+      });
+      expect(result.current.enhanceConfirmData).toBeNull();
+    });
+
+    it('executes video enhance with correct parameters', async () => {
+      const ingredient: Partial<IIngredient> = {
+        category: IngredientCategory.VIDEO,
+        id: 'vid-123',
+      };
+
+      const { result } = renderHook(() => useEnhanceUpscale(defaultParams));
+
+      await act(async () => {
+        await result.current.handleEnhance(ingredient as IIngredient);
+      });
+
+      await act(async () => {
+        await result.current.executeEnhance();
+      });
+
+      expect(mockGetVideosService).toHaveBeenCalled();
+      expect(mockPostUpscale).toHaveBeenCalledWith('vid-123', {
+        category: IngredientCategory.VIDEO,
+        model: MODEL_KEYS.REPLICATE_TOPAZ_VIDEO_UPSCALE,
+        parent: 'vid-123',
+        prompt: 'Enhance image quality using Topaz AI upscaling',
+      });
       expect(result.current.enhanceConfirmData).toBeNull();
     });
 

--- a/packages/hooks/ui/ingredient/use-enhance-upscale/use-enhance-upscale.ts
+++ b/packages/hooks/ui/ingredient/use-enhance-upscale/use-enhance-upscale.ts
@@ -1,6 +1,8 @@
 import { MODEL_KEYS } from '@genfeedai/constants';
 import { IngredientCategory } from '@genfeedai/enums';
 import type { IIngredient } from '@genfeedai/interfaces';
+import type { IImageEditParams } from '@genfeedai/interfaces/components/image-edit.interface';
+import type { IVideoEditParams } from '@genfeedai/interfaces/components/video-operations.interface';
 import type { MasonryActionStates } from '@genfeedai/interfaces/hooks/hooks.interface';
 import { NotificationsService } from '@genfeedai/services/core/notifications.service';
 import type { ImagesService } from '@genfeedai/services/ingredients/images.service';
@@ -17,6 +19,18 @@ import {
 } from '@hooks/utils/service-operation/service-operation.util';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+
+const TOPAZ_ENHANCE_PROMPT = 'Enhance image quality using Topaz AI upscaling';
+
+type TopazImageEnhancePayload = IImageEditParams & {
+  category: IngredientCategory.IMAGE;
+  parent: string;
+};
+
+type TopazVideoEnhancePayload = IVideoEditParams & {
+  category: IngredientCategory.VIDEO;
+  parent: string;
+};
 
 export interface UseEnhanceUpscaleParams {
   onRefresh?: () => void | Promise<void>;
@@ -186,24 +200,27 @@ export function useEnhanceUpscale({
       errorMessage: 'Failed to enhance ingredient',
       onSuccess: onRefresh,
       operation: async () => {
-        const service = isVideo
-          ? await getVideosService()
-          : await getImagesService();
+        if (isVideo) {
+          const service = await getVideosService();
+          const payload: TopazVideoEnhancePayload = {
+            category: IngredientCategory.VIDEO,
+            model: modelKey,
+            parent: ingredient.id,
+            prompt: TOPAZ_ENHANCE_PROMPT,
+          };
 
-        const payload: any = {
-          category: isVideo
-            ? IngredientCategory.VIDEO
-            : IngredientCategory.IMAGE,
+          return service.postUpscale(ingredient.id, payload);
+        }
+
+        const service = await getImagesService();
+        const payload: TopazImageEnhancePayload = {
+          category: IngredientCategory.IMAGE,
           model: modelKey,
           parent: ingredient.id,
-          prompt: 'Enhance image quality using Topaz AI upscaling',
+          prompt: TOPAZ_ENHANCE_PROMPT,
         };
 
-        if (isVideo) {
-          return (service as VideosService).postUpscale(ingredient.id, payload);
-        } else {
-          return (service as ImagesService).postUpscale(ingredient.id, payload);
-        }
+        return service.postUpscale(ingredient.id, payload);
       },
       setActionStates,
       stateKey: 'isEnhancing',
@@ -222,19 +239,22 @@ export function useEnhanceUpscale({
     setEnhanceConfirmData(null);
   }, []);
 
-  const formatConfirmMessage = (
-    action: string,
-    data: { ingredient: IIngredient | null; cost: number } | null,
-  ): string => {
-    if (!data) {
-      return '';
-    }
-    const category =
-      data.ingredient?.category === IngredientCategory.VIDEO
-        ? IngredientCategory.VIDEO
-        : IngredientCategory.IMAGE;
-    return `${action} ${category} with Topaz AI?\n\nThis will cost ${formatNumberWithCommas(data.cost)} credits.`;
-  };
+  const formatConfirmMessage = useCallback(
+    (
+      action: string,
+      data: { ingredient: IIngredient | null; cost: number } | null,
+    ): string => {
+      if (!data) {
+        return '';
+      }
+      const category =
+        data.ingredient?.category === IngredientCategory.VIDEO
+          ? IngredientCategory.VIDEO
+          : IngredientCategory.IMAGE;
+      return `${action} ${category} with Topaz AI?\n\nThis will cost ${formatNumberWithCommas(data.cost)} credits.`;
+    },
+    [],
+  );
 
   const enhanceConfirmMessage = useMemo(
     () => formatConfirmMessage('Enhance', enhanceConfirmData),


### PR DESCRIPTION
## Summary
- split Topaz enhance execution by media type so image/video service calls own typed payloads directly
- remove the cast-only `any` payload and service downcasts from `useEnhanceUpscale`
- add exact payload coverage for image and video enhance execution, and stabilize the confirm-message formatter dependency

## Validation
- Mac Studio: `bun run --cwd packages/hooks test -- ui/ingredient/use-enhance-upscale/use-enhance-upscale.test.ts` (20 tests)
- Mac Studio: `bunx biome check packages/hooks/ui/ingredient/use-enhance-upscale/use-enhance-upscale.ts packages/hooks/ui/ingredient/use-enhance-upscale/use-enhance-upscale.test.ts`
- Mac Studio: `bunx turbo run type-check --filter=@genfeedai/hooks`

## Notes
- Local MacBook validation was limited to static `git diff --check` and staged diff/secret scans per the CPU-heavy validation policy.
- Review used the Thermo-Nuclear Code Quality Review rubric: https://www.skills.sh/cursor/plugins/thermo-nuclear-code-quality-review