### PR TITLE
feat(trends): add prelaunch corpus backfill

### DIFF
--- a/apps/docs/content/core-loop/_meta.ts
+++ b/apps/docs/content/core-loop/_meta.ts
@@ -2,6 +2,7 @@ export default {
   index: 'Overview',
   'trend-ingestion': 'Trend Ingestion',
   'corpus-health': 'Prelaunch Corpus Health',
+  'prelaunch-corpus-backfill': 'Prelaunch Corpus Backfill',
   'agent-orchestration': 'Agent Orchestration',
   'generation-service': 'Generation Service',
   'analytics-backbone': 'Analytics Backbone',

--- a/apps/docs/content/core-loop/corpus-health.mdx
+++ b/apps/docs/content/core-loop/corpus-health.mdx
@@ -116,7 +116,7 @@ If the corpus is not launch-ready, downstream readers should still use the exist
 
 Follow-up implementation should treat this page as the product contract:
 
-- `#211` should backfill toward the launch-minimum rows.
+- `#211` backfills the first credential-free global source set through `seed:prelaunch-corpus`; it clears the runtime cold-start baseline and starts toward the launch-minimum rows without claiming full launch readiness.
 - `#213` should replace curated topics with public reference ingestion while preserving the platform/content-type targets.
 - `#214` should make paid/creative references classifiable so they do not pollute organic trend slices.
 - `#215` should derive prompt-ready packs only from references that satisfy prompt-ready metadata.

--- a/apps/docs/content/core-loop/index.mdx
+++ b/apps/docs/content/core-loop/index.mdx
@@ -10,6 +10,7 @@ The repo already contains the live server surfaces for this loop. This section m
 
 - **Step 1: Trend Ingestion**: how trend signals enter the platform and end up in `collections/trends`
 - **Prelaunch Corpus Health**: launch-minimum targets, health metrics, and freshness expectations for the global trend/reference corpus
+- **Prelaunch Corpus Backfill**: the credential-free global seed path for launch cold-start coverage
 - **Agent Orchestration**: how the V1 agent runtime should own turn state while campaigns, skills, and content pipelines stay as adapters or deterministic execution layers
 - **Step 3: Generation Service**: how generation-facing modules route into provider-backed media and text paths
 - **Step 5: Analytics Backbone**: how analytics-facing services aggregate activity into dashboard-visible output
@@ -56,6 +57,7 @@ Each v1 area now has one narrow verification path:
 
 - **Trend ingestion**: verify `TrendsService` falls through the cached path into the live-fetch path when cache is empty
 - **Prelaunch corpus health**: verify launch readiness against explicit platform, content-type, freshness, and prompt-ready metadata targets
+- **Prelaunch corpus backfill**: dry-run the global seed plan, then apply it with `seed:prelaunch-corpus` when launch data is needed
 - **Agent orchestration**: verify new agent-facing automation routes through one runtime boundary instead of adding another peer orchestrator
 - **Generation service**: verify dynamic provider-backed model discovery merges into the stable generation-facing model surface
 - **Analytics backbone**: verify provider metrics are stored in `postAnalytics`, visible in publication analytics, and included in content-performance summaries once the data is no longer current-day incomplete
@@ -66,5 +68,6 @@ Each v1 area now has one narrow verification path:
 - `#160` Analytics Backbone
 - `#161` Generation Service
 - `#210` Prelaunch corpus launch targets and health metrics
+- `#211` Prelaunch corpus backfill
 
 Continue with the step-specific pages for the concrete module inventories and smoke-path details.

--- a/apps/docs/content/core-loop/prelaunch-corpus-backfill.mdx
+++ b/apps/docs/content/core-loop/prelaunch-corpus-backfill.mdx
@@ -1,0 +1,112 @@
+# Prelaunch Corpus Backfill
+
+This page documents the credential-free backfill path for `#211`.
+
+## Purpose
+
+The prelaunch reference corpus gives cold-start tenants prompt-ready trend examples before they connect platform credentials or accumulate brand history.
+
+The backfill writes global rows only:
+
+- `organizationId = null`
+- `brandId = null`
+- `requiresAuth = false`
+- `metadata.prelaunchCorpus = true`
+- `metadata.sourceSetVersion = "2026-06-09"`
+
+It is a launch operations path, not a replacement for provider ingestion or the full health automation tracked by `#216`.
+
+## Source Set
+
+The seed source set lives in `apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts`.
+
+It currently generates:
+
+| Slice             | Count |
+| ----------------- | ----- |
+| global trends     | `70`  |
+| source references | `140` |
+| platforms         | `7`   |
+| themes            | `10`  |
+
+Platforms covered:
+
+- TikTok
+- Instagram
+- X / Twitter
+- YouTube
+- Reddit
+- Pinterest
+- LinkedIn
+
+Themes covered:
+
+- AI agent workflows
+- creator ops
+- short-form remix
+- brand voice systems
+- UGC proof hooks
+- launch content sprints
+- analytics feedback loops
+- local-first AI
+- paid creative breakdowns
+- community research
+
+Every source item includes platform, content type, canonical URL, title or text, author handle, published timestamp, and engagement metrics so prompt assembly can use the reference corpus without fetching live provider APIs.
+
+## Write Contract
+
+`TrendsService.backfillPrelaunchReferenceCorpus()` owns the backfill because `TrendsService` owns the trend write boundary.
+
+The method:
+
+1. Builds the deterministic public source set.
+2. Finds existing global prelaunch trend rows by `metadata.prelaunchCorpusKey`.
+3. Creates missing rows or refreshes existing rows.
+4. Stores `metadata.sourcePreviewCache` on each trend row.
+5. Calls `TrendReferenceCorpusService.syncTrendReferences()` to upsert source references, snapshots, and trend-reference links.
+6. Invalidates `trends` and `trends:content` caches.
+
+The operation is idempotent. Re-running it refreshes the same keyed prelaunch rows and does not create duplicate source references for the same canonical URL and platform.
+
+## Operations
+
+Dry-run is the default:
+
+```bash
+bun --cwd apps/server/api run seed:prelaunch-corpus:dry
+```
+
+Apply writes:
+
+```bash
+bun --cwd apps/server/api run seed:prelaunch-corpus
+```
+
+Run against a named env file:
+
+```bash
+bun run apps/server/api/scripts/seeds/prelaunch-reference-corpus.seed.ts --env=production --live
+```
+
+The script loads `.env.local` by default, or `.env.<name>` when `--env=<name>` is provided.
+
+## Verification
+
+After a live run, check the script summary:
+
+- `createdTrends + updatedTrends = 70`
+- `referencesSynced = 140` on first run, or updated references on later runs
+- `links` and `snapshots` are nonzero on first run
+
+Then verify through the existing read surfaces:
+
+- trends can load from the global cached corpus without tenant credentials
+- trend-content reads include `sourcePreviewState = "fallback"` rows
+- reference-corpus reads return prompt-ready source records
+
+Local validation for automation PRs may be skipped when the active policy requires GitHub CI as the verification path.
+
+## Boundary
+
+This backfill clears the existing cold-start baseline and starts the corpus toward the launch-minimum targets in the health contract. It does not claim the full `480` trend and `1,440` reference launch floor, and it does not replace provider-specific ingestion work in `#213` through `#216`.

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -64,6 +64,8 @@
     "lint": "bun run scripts/check-request-context-usage.ts && biome lint --write src --no-errors-on-unmatched",
     "seed:workflows": "bun run scripts/seeds/workflows.seed.ts",
     "seed:workflows:dry": "bun run scripts/seeds/workflows.seed.ts --dry-run",
+    "seed:prelaunch-corpus": "bun run scripts/seeds/prelaunch-reference-corpus.seed.ts --live",
+    "seed:prelaunch-corpus:dry": "bun run scripts/seeds/prelaunch-reference-corpus.seed.ts",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project api-genfeed-ai ../dist",
     "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project api-genfeed-ai ../dist",

--- a/apps/server/api/scripts/seeds/prelaunch-reference-corpus.seed.ts
+++ b/apps/server/api/scripts/seeds/prelaunch-reference-corpus.seed.ts
@@ -1,0 +1,102 @@
+/**
+ * Seed Script: Prelaunch Reference Corpus
+ *
+ * Backfills the global trend/reference corpus with credential-free public
+ * source references. Dry-run is the default. Pass `--live` to apply writes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/prelaunch-reference-corpus.seed.ts
+ *   bun run apps/server/api/scripts/seeds/prelaunch-reference-corpus.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/prelaunch-reference-corpus.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { TrendsService } from '@api/collections/trends/services/trends.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('PrelaunchReferenceCorpusSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+interface SeedArgs {
+  dryRun: boolean;
+  env?: string;
+}
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+
+  const args = parseArgs();
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const trendsService = app.get(TrendsService);
+    const result = await trendsService.backfillPrelaunchReferenceCorpus({
+      dryRun: args.dryRun,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} prelaunch corpus ${args.env ? `for ${args.env} ` : ''}version=${result.version}`,
+    );
+    logger.log(
+      `seedTrends=${result.seedTrends}, seedReferences=${result.seedReferences}, plannedCreates=${result.plannedCreates}, plannedUpdates=${result.plannedUpdates}`,
+    );
+    logger.log(
+      `createdTrends=${result.createdTrends}, updatedTrends=${result.updatedTrends}, referencesSynced=${result.referenceSync.references}, links=${result.referenceSync.links}, snapshots=${result.referenceSync.snapshots}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Prelaunch reference corpus seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts
+++ b/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts
@@ -1,0 +1,239 @@
+import type { TrendSourceItem } from '@api/collections/trends/interfaces/trend.interfaces';
+
+export interface PrelaunchReferenceCorpusSeed {
+  growthRate: number;
+  key: string;
+  mentions: number;
+  metadata: {
+    angle: string;
+    hashtags: string[];
+    launchCorpusSlice: string;
+  };
+  platform: string;
+  sourcePreview: TrendSourceItem[];
+  topic: string;
+  viralityScore: number;
+}
+
+interface CorpusTheme {
+  angle: string;
+  hashtag: string;
+  key: string;
+  shortTitle: string;
+  title: string;
+}
+
+interface CorpusPlatform {
+  accountPrefix: string;
+  contentType: TrendSourceItem['contentType'];
+  key: string;
+  label: string;
+  sourcePath: (theme: CorpusTheme) => string;
+  sourcePathAlt: (theme: CorpusTheme) => string;
+}
+
+export const PRELAUNCH_REFERENCE_CORPUS_VERSION = '2026-06-09';
+
+export const PRELAUNCH_REFERENCE_CORPUS_MINIMUMS = {
+  sourceReferences: 140,
+  trends: 70,
+} as const;
+
+const THEMES: CorpusTheme[] = [
+  {
+    angle: 'AI agents turning repeatable content ops into reusable systems',
+    hashtag: 'aiagents',
+    key: 'ai-agent-workflows',
+    shortTitle: 'AI agent workflows',
+    title: 'AI agent workflow demos',
+  },
+  {
+    angle: 'Creator teams packaging research, briefs, review, and publishing',
+    hashtag: 'creatorops',
+    key: 'creator-ops',
+    shortTitle: 'creator ops',
+    title: 'Creator ops playbooks',
+  },
+  {
+    angle: 'Long-form assets becoming short-form hooks, clips, and captions',
+    hashtag: 'shortformvideo',
+    key: 'short-form-remix',
+    shortTitle: 'short-form remix',
+    title: 'Short-form remix systems',
+  },
+  {
+    angle: 'Approved brand voice becoming reusable prompt and review context',
+    hashtag: 'brandvoice',
+    key: 'brand-voice-systems',
+    shortTitle: 'brand voice systems',
+    title: 'Brand voice systems',
+  },
+  {
+    angle: 'UGC-style examples and proof hooks driving creative testing',
+    hashtag: 'ugccreators',
+    key: 'ugc-proof-hooks',
+    shortTitle: 'UGC proof hooks',
+    title: 'UGC proof hooks',
+  },
+  {
+    angle: 'Launch teams running content sprints from insight to publish',
+    hashtag: 'launchstrategy',
+    key: 'launch-content-sprints',
+    shortTitle: 'launch content sprints',
+    title: 'Launch content sprints',
+  },
+  {
+    angle: 'Performance analytics feeding the next batch of content briefs',
+    hashtag: 'contentanalytics',
+    key: 'analytics-feedback-loops',
+    shortTitle: 'analytics feedback',
+    title: 'Analytics feedback loops',
+  },
+  {
+    angle: 'Local-first AI workspaces balancing privacy, sync, and speed',
+    hashtag: 'localfirst',
+    key: 'local-first-ai',
+    shortTitle: 'local-first AI',
+    title: 'Local-first AI workflows',
+  },
+  {
+    angle: 'Paid creative examples translated into organic content lessons',
+    hashtag: 'creativeanalytics',
+    key: 'paid-creative-breakdowns',
+    shortTitle: 'paid creative breakdowns',
+    title: 'Paid creative breakdowns',
+  },
+  {
+    angle: 'Community research threads surfacing customer language and hooks',
+    hashtag: 'communityledgrowth',
+    key: 'community-research',
+    shortTitle: 'community research',
+    title: 'Community research threads',
+  },
+];
+
+const PLATFORMS: CorpusPlatform[] = [
+  {
+    accountPrefix: 'tiktok',
+    contentType: 'video',
+    key: 'tiktok',
+    label: 'TikTok',
+    sourcePath: (theme) => `https://www.tiktok.com/tag/${theme.hashtag}`,
+    sourcePathAlt: (theme) => `https://www.tiktok.com/tag/${theme.key}`,
+  },
+  {
+    accountPrefix: 'instagram',
+    contentType: 'video',
+    key: 'instagram',
+    label: 'Instagram',
+    sourcePath: (theme) =>
+      `https://www.instagram.com/explore/tags/${theme.hashtag}/`,
+    sourcePathAlt: (theme) =>
+      `https://www.instagram.com/explore/tags/${theme.key}/`,
+  },
+  {
+    accountPrefix: 'x',
+    contentType: 'tweet',
+    key: 'twitter',
+    label: 'X / Twitter',
+    sourcePath: (theme) => `https://x.com/hashtag/${theme.hashtag}`,
+    sourcePathAlt: (theme) => `https://x.com/hashtag/${theme.key}`,
+  },
+  {
+    accountPrefix: 'youtube',
+    contentType: 'video',
+    key: 'youtube',
+    label: 'YouTube',
+    sourcePath: (theme) => `https://www.youtube.com/hashtag/${theme.hashtag}`,
+    sourcePathAlt: (theme) => `https://www.youtube.com/hashtag/${theme.key}`,
+  },
+  {
+    accountPrefix: 'reddit',
+    contentType: 'post',
+    key: 'reddit',
+    label: 'Reddit',
+    sourcePath: (theme) => `https://www.reddit.com/r/${theme.hashtag}/`,
+    sourcePathAlt: (theme) => `https://www.reddit.com/r/${theme.hashtag}/top/`,
+  },
+  {
+    accountPrefix: 'pinterest',
+    contentType: 'image',
+    key: 'pinterest',
+    label: 'Pinterest',
+    sourcePath: (theme) =>
+      `https://www.pinterest.com/search/pins/${theme.hashtag}/`,
+    sourcePathAlt: (theme) =>
+      `https://www.pinterest.com/search/pins/${theme.key}/`,
+  },
+  {
+    accountPrefix: 'linkedin',
+    contentType: 'post',
+    key: 'linkedin',
+    label: 'LinkedIn',
+    sourcePath: (theme) =>
+      `https://www.linkedin.com/feed/hashtag/${theme.hashtag}/`,
+    sourcePathAlt: (theme) =>
+      `https://www.linkedin.com/feed/hashtag/${theme.key}/`,
+  },
+];
+
+export function buildPrelaunchReferenceCorpusSeeds(
+  capturedAt: Date = new Date(),
+): PrelaunchReferenceCorpusSeed[] {
+  return PLATFORMS.flatMap((platform, platformIndex) =>
+    THEMES.map((theme, themeIndex) => {
+      const trendKey = `${platform.key}:${theme.key}`;
+      const publishedAt = new Date(
+        capturedAt.getTime() - (themeIndex + platformIndex + 1) * 86_400_000,
+      ).toISOString();
+
+      return {
+        growthRate: 35 + themeIndex * 3 + platformIndex,
+        key: trendKey,
+        mentions: 18_000 + themeIndex * 2_500 + platformIndex * 1_750,
+        metadata: {
+          angle: theme.angle,
+          hashtags: [`#${theme.hashtag}`, `#${theme.key.replace(/-/g, '')}`],
+          launchCorpusSlice: 'organic-reference',
+        },
+        platform: platform.key,
+        sourcePreview: [
+          {
+            authorHandle: `${platform.accountPrefix}-${theme.key}`,
+            contentType: platform.contentType,
+            id: `${trendKey}:primary`,
+            metrics: {
+              comments: 80 + themeIndex * 12,
+              likes: 1_200 + platformIndex * 140 + themeIndex * 90,
+              shares: 240 + themeIndex * 16,
+              views: 18_000 + platformIndex * 1_500 + themeIndex * 1_100,
+            },
+            platform: platform.key,
+            publishedAt,
+            sourceUrl: platform.sourcePath(theme),
+            text: theme.angle,
+            title: `${theme.shortTitle} on ${platform.label}`,
+          },
+          {
+            authorHandle: `${platform.accountPrefix}-reference-${themeIndex + 1}`,
+            contentType: platform.contentType,
+            id: `${trendKey}:secondary`,
+            metrics: {
+              comments: 45 + platformIndex * 8,
+              likes: 760 + themeIndex * 75,
+              shares: 150 + platformIndex * 18,
+              views: 11_000 + platformIndex * 1_100 + themeIndex * 850,
+            },
+            platform: platform.key,
+            publishedAt,
+            sourceUrl: platform.sourcePathAlt(theme),
+            text: `Reference example for ${theme.title.toLowerCase()} in the ${platform.label} launch corpus.`,
+            title: `${theme.title}: ${platform.label} reference`,
+          },
+        ],
+        topic: `${theme.title} on ${platform.label}`,
+        viralityScore: 58 + themeIndex * 2 + platformIndex,
+      };
+    }),
+  );
+}

--- a/apps/server/api/src/collections/trends/services/trends.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trends.service.spec.ts
@@ -20,11 +20,22 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 
+type MockCacheService = {
+  invalidateByTags: ReturnType<typeof vi.fn>;
+};
+
+type MockTrendReferenceCorpusService = {
+  syncTrendReferences: ReturnType<typeof vi.fn>;
+};
+
 describe('TrendsService', () => {
   let service: TrendsService;
   let trendContentIdeasService: TrendContentIdeasService;
+  let cacheService: MockCacheService;
+  let trendReferenceCorpusService: MockTrendReferenceCorpusService;
   let prisma: {
     trend: {
+      create: ReturnType<typeof vi.fn>;
       findMany: ReturnType<typeof vi.fn>;
       findFirst: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
@@ -86,6 +97,7 @@ describe('TrendsService', () => {
   beforeEach(async () => {
     prisma = {
       trend: {
+        create: vi.fn(),
         findFirst: vi.fn().mockResolvedValue(null),
         findMany: vi.fn().mockResolvedValue([]),
         update: vi.fn().mockResolvedValue({}),
@@ -192,6 +204,10 @@ describe('TrendsService', () => {
     trendContentIdeasService = module.get<TrendContentIdeasService>(
       TrendContentIdeasService,
     );
+    cacheService = module.get(CacheService) as unknown as MockCacheService;
+    trendReferenceCorpusService = module.get(
+      TrendReferenceCorpusService,
+    ) as unknown as MockTrendReferenceCorpusService;
     loggerService = module.get<LoggerService>(LoggerService);
 
     vi.clearAllMocks();
@@ -199,6 +215,107 @@ describe('TrendsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('backfillPrelaunchReferenceCorpus', () => {
+    const fixedNow = new Date('2026-06-09T00:00:00.000Z');
+    const makeSeedTrendDoc = (
+      id: string,
+      data: Record<string, unknown>,
+    ) => ({
+      brandId: null,
+      createdAt: fixedNow,
+      data,
+      id,
+      isDeleted: false,
+      organizationId: null,
+      updatedAt: fixedNow,
+    });
+
+    it('plans the credential-free corpus without writes by default', async () => {
+      prisma.trend.findMany.mockResolvedValue([]);
+
+      const result = await service.backfillPrelaunchReferenceCorpus({
+        now: fixedNow,
+      });
+
+      expect(result).toMatchObject({
+        createdTrends: 0,
+        dryRun: true,
+        plannedCreates: 70,
+        plannedUpdates: 0,
+        seedReferences: 140,
+        seedTrends: 70,
+        updatedTrends: 0,
+      });
+      expect(prisma.trend.create).not.toHaveBeenCalled();
+      expect(prisma.trend.update).not.toHaveBeenCalled();
+      expect(
+        trendReferenceCorpusService.syncTrendReferences,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('creates missing global trends and syncs source references in live mode', async () => {
+      prisma.trend.findMany.mockResolvedValue([]);
+      prisma.trend.create.mockImplementation(async (input: unknown) => {
+        const payload = input as {
+          data: {
+            data: Record<string, unknown>;
+          };
+        };
+
+        return makeSeedTrendDoc(
+          `prelaunch-${prisma.trend.create.mock.calls.length}`,
+          payload.data.data,
+        );
+      });
+      trendReferenceCorpusService.syncTrendReferences.mockResolvedValue({
+        links: 140,
+        references: 140,
+        snapshots: 140,
+      });
+
+      const result = await service.backfillPrelaunchReferenceCorpus({
+        dryRun: false,
+        now: fixedNow,
+      });
+
+      expect(prisma.trend.create).toHaveBeenCalledTimes(70);
+      expect(prisma.trend.update).not.toHaveBeenCalled();
+      expect(
+        trendReferenceCorpusService.syncTrendReferences,
+      ).toHaveBeenCalledTimes(1);
+
+      const syncCall =
+        trendReferenceCorpusService.syncTrendReferences.mock.calls[0];
+      const syncPayload = syncCall?.[0] as Array<{
+        sourcePreview: unknown[];
+        sourcePreviewState: string;
+      }>;
+
+      expect(syncPayload).toHaveLength(70);
+      expect(syncPayload[0]).toMatchObject({
+        sourcePreviewState: 'fallback',
+      });
+      expect(syncPayload[0]?.sourcePreview).toHaveLength(2);
+      expect(cacheService.invalidateByTags).toHaveBeenCalledWith([
+        'trends',
+        'trends:content',
+      ]);
+      expect(result).toMatchObject({
+        createdTrends: 70,
+        dryRun: false,
+        plannedCreates: 70,
+        referenceSync: {
+          links: 140,
+          references: 140,
+          snapshots: 140,
+        },
+        seedReferences: 140,
+        seedTrends: 70,
+        updatedTrends: 0,
+      });
+    });
   });
 
   describe('sanitizeForPrompt', () => {

--- a/apps/server/api/src/collections/trends/services/trends.service.ts
+++ b/apps/server/api/src/collections/trends/services/trends.service.ts
@@ -1,5 +1,11 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import {
+  buildPrelaunchReferenceCorpusSeeds,
+  PRELAUNCH_REFERENCE_CORPUS_MINIMUMS,
+  PRELAUNCH_REFERENCE_CORPUS_VERSION,
+  type PrelaunchReferenceCorpusSeed,
+} from '@api/collections/trends/data/prelaunch-reference-corpus.seed';
 import { TrendIdea } from '@api/collections/trends/dto/trend-ideas.dto';
 import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
 import type {
@@ -41,6 +47,27 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { Timeframe } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
+
+export interface PrelaunchReferenceCorpusBackfillOptions {
+  dryRun?: boolean;
+  now?: Date;
+}
+
+export interface PrelaunchReferenceCorpusBackfillResult {
+  createdTrends: number;
+  dryRun: boolean;
+  plannedCreates: number;
+  plannedUpdates: number;
+  referenceSync: {
+    links: number;
+    references: number;
+    snapshots: number;
+  };
+  seedReferences: number;
+  seedTrends: number;
+  updatedTrends: number;
+  version: string;
+}
 
 @Injectable()
 export class TrendsService {
@@ -369,6 +396,65 @@ export class TrendsService {
       ...doc,
       ...(doc.data as Record<string, unknown>),
     } as unknown as TrendDocument);
+  }
+
+  private async findPrelaunchCorpusDocs(): Promise<
+    Array<{ data: unknown; id: string } & Record<string, unknown>>
+  > {
+    const docs = await this.prisma.trend.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends * 2,
+      where: {
+        brandId: null,
+        isDeleted: false,
+        organizationId: null,
+      } as never,
+    });
+
+    return docs.filter((doc) => this.getPrelaunchCorpusKey(doc) != null);
+  }
+
+  private getPrelaunchCorpusKey(doc: { data: unknown }): string | null {
+    const data = doc.data as Record<string, unknown>;
+    const metadata = data.metadata as Record<string, unknown> | undefined;
+    const key = metadata?.prelaunchCorpusKey;
+
+    return typeof key === 'string' && key.length > 0 ? key : null;
+  }
+
+  private buildPrelaunchTrendData(
+    seed: PrelaunchReferenceCorpusSeed,
+    now: Date,
+  ): Record<string, unknown> {
+    const expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const sourceUrls = seed.sourcePreview.map((item) => item.sourceUrl);
+    const metadata = {
+      ...seed.metadata,
+      prelaunchCorpus: true,
+      prelaunchCorpusKey: seed.key,
+      source: 'curated',
+      sourcePreviewCache: seed.sourcePreview,
+      sourcePreviewCachedAt: now.toISOString(),
+      sourcePreviewState: 'fallback',
+      sourceSetVersion: PRELAUNCH_REFERENCE_CORPUS_VERSION,
+      trendType: seed.sourcePreview.some((item) => item.contentType === 'video')
+        ? 'video'
+        : 'topic',
+      urls: sourceUrls,
+    };
+
+    return {
+      expiresAt: expiresAt.toISOString(),
+      growthRate: seed.growthRate,
+      isCurrent: true,
+      isDeleted: false,
+      mentions: seed.mentions,
+      metadata,
+      platform: seed.platform,
+      requiresAuth: false,
+      topic: seed.topic,
+      viralityScore: seed.viralityScore,
+    };
   }
 
   private async findActiveTrends(filter: {
@@ -713,6 +799,107 @@ export class TrendsService {
     await this.cacheService.invalidateByTags(['trends:content']);
 
     return { processed };
+  }
+
+  async backfillPrelaunchReferenceCorpus(
+    options: PrelaunchReferenceCorpusBackfillOptions = {},
+  ): Promise<PrelaunchReferenceCorpusBackfillResult> {
+    const now = options.now ?? new Date();
+    const dryRun = options.dryRun ?? true;
+    const seeds = buildPrelaunchReferenceCorpusSeeds(now);
+    const seedReferences = seeds.reduce(
+      (total, seed) => total + seed.sourcePreview.length,
+      0,
+    );
+
+    const existingDocs = await this.findPrelaunchCorpusDocs();
+    const existingByKey = new Map(
+      existingDocs.flatMap((doc) => {
+        const key = this.getPrelaunchCorpusKey(doc);
+        return key ? [[key, doc] as const] : [];
+      }),
+    );
+    const plannedCreates = seeds.filter(
+      (seed) => !existingByKey.has(seed.key),
+    ).length;
+    const plannedUpdates = seeds.length - plannedCreates;
+
+    if (dryRun) {
+      return {
+        createdTrends: 0,
+        dryRun,
+        plannedCreates,
+        plannedUpdates,
+        referenceSync: { links: 0, references: 0, snapshots: 0 },
+        seedReferences,
+        seedTrends: seeds.length,
+        updatedTrends: 0,
+        version: PRELAUNCH_REFERENCE_CORPUS_VERSION,
+      };
+    }
+
+    const syncedTrends: TrendEntity[] = [];
+    let createdTrends = 0;
+    let updatedTrends = 0;
+
+    for (const seed of seeds) {
+      const trendData = this.buildPrelaunchTrendData(seed, now);
+      const existing = existingByKey.get(seed.key);
+
+      if (existing) {
+        const updated = await this.prisma.trend.update({
+          data: {
+            data: trendData,
+            isDeleted: false,
+          } as never,
+          where: { id: existing.id },
+        });
+        syncedTrends.push(this.toTrendEntity(updated));
+        updatedTrends += 1;
+        continue;
+      }
+
+      const created = await this.prisma.trend.create({
+        data: {
+          brandId: null,
+          data: trendData,
+          isDeleted: false,
+          organizationId: null,
+        } as never,
+      });
+      syncedTrends.push(this.toTrendEntity(created));
+      createdTrends += 1;
+    }
+
+    const referenceSync =
+      await this.trendReferenceCorpusService.syncTrendReferences(
+        syncedTrends.map((trend) => this.toSyncTrendInput(trend)),
+      );
+
+    await this.cacheService.invalidateByTags(['trends', 'trends:content']);
+
+    if (
+      seeds.length < PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends ||
+      seedReferences < PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.sourceReferences
+    ) {
+      this.loggerService.warn('Prelaunch reference corpus seed is below floor', {
+        minimums: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS,
+        seedReferences,
+        seedTrends: seeds.length,
+      });
+    }
+
+    return {
+      createdTrends,
+      dryRun,
+      plannedCreates,
+      plannedUpdates,
+      referenceSync,
+      seedReferences,
+      seedTrends: seeds.length,
+      updatedTrends,
+      version: PRELAUNCH_REFERENCE_CORPUS_VERSION,
+    };
   }
 
   async getReferenceCorpus(


### PR DESCRIPTION
## Summary

- Add a deterministic credential-free prelaunch reference corpus seed set: 70 global trends and 140 source references across seven platforms.
- Add `TrendsService.backfillPrelaunchReferenceCorpus()` plus dry-run/live API seed scripts for launch operations.
- Document the backfill contract and add focused service coverage for dry-run safety and live reference sync.

## Validation

- Local tests, lint, type-check, builds, Playwright, and heavy validation were intentionally skipped by automation policy.
- Lightweight local checks only: `git diff --cached --check` and staged secret-pattern scan.
- Verification path: GitHub PR/develop checks after this PR is opened.

## Risk

- No schema migration.
- The seed is opt-in and writes only when `seed:prelaunch-corpus` or `--live` is used.

Closes #211
