### PR TITLE
fix(credits): run balance read/write/ledger inside the Prisma transaction

### DIFF
--- a/apps/server/api/src/collections/credits/services/credit-balance.service.ts
+++ b/apps/server/api/src/collections/credits/services/credit-balance.service.ts
@@ -1,5 +1,6 @@
 import type { CreditBalanceDocument } from '@api/collections/credits/schemas/credit-balance.schema';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
+import type { PrismaTransactionClient } from '@api/helpers/utils/transaction/transaction.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -14,17 +15,21 @@ export class CreditBalanceService {
   ) {}
 
   @HandleErrors('create credit balance', 'credits')
-  async create(data: {
-    balance: number;
-    isDeleted: boolean;
-    organizationId: string;
-  }): Promise<CreditBalanceDocument> {
-    return this.prisma.creditBalance.create({ data });
+  async create(
+    data: {
+      balance: number;
+      isDeleted: boolean;
+      organizationId: string;
+    },
+    tx?: PrismaTransactionClient,
+  ): Promise<CreditBalanceDocument> {
+    return (tx ?? this.prisma).creditBalance.create({ data });
   }
 
   @HandleErrors('find by organization', 'credits')
   async findByOrganization(
     organizationId: string,
+    tx?: PrismaTransactionClient,
   ): Promise<CreditBalanceDocument | null> {
     if (!organizationId) {
       this.logger.warn(`${this.constructorName} findByOrganization failed`, {
@@ -33,7 +38,7 @@ export class CreditBalanceService {
       return null;
     }
 
-    return this.prisma.creditBalance.findFirst({
+    return (tx ?? this.prisma).creditBalance.findFirst({
       where: {
         isDeleted: false,
         organizationId,
@@ -44,15 +49,16 @@ export class CreditBalanceService {
   @HandleErrors('get or create balance', 'credits')
   async getOrCreateBalance(
     organizationId: string,
+    tx?: PrismaTransactionClient,
   ): Promise<CreditBalanceDocument> {
     if (!organizationId) {
       throw new Error(`Invalid organization ID: ${organizationId}`);
     }
 
-    const balance = await this.findByOrganization(organizationId);
+    const balance = await this.findByOrganization(organizationId, tx);
 
     if (!balance) {
-      return this.create({ balance: 0, isDeleted: false, organizationId });
+      return this.create({ balance: 0, isDeleted: false, organizationId }, tx);
     }
 
     return balance;
@@ -62,10 +68,11 @@ export class CreditBalanceService {
   async updateBalance(
     organizationId: string,
     newBalance: number,
+    tx?: PrismaTransactionClient,
   ): Promise<CreditBalanceDocument> {
-    const balance = await this.getOrCreateBalance(organizationId);
+    const balance = await this.getOrCreateBalance(organizationId, tx);
 
-    return this.prisma.creditBalance.update({
+    return (tx ?? this.prisma).creditBalance.update({
       data: { balance: newBalance },
       where: { id: balance.id },
     });

--- a/apps/server/api/src/collections/credits/services/credit-transactions.service.ts
+++ b/apps/server/api/src/collections/credits/services/credit-transactions.service.ts
@@ -3,6 +3,7 @@ import { CreditBalanceService } from '@api/collections/credits/services/credit-b
 import { CACHE_PATTERNS } from '@api/common/constants/cache-patterns.constants';
 import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
 import { BusinessLogicException } from '@api/helpers/exceptions/business/business-logic.exception';
+import type { PrismaTransactionClient } from '@api/helpers/utils/transaction/transaction.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import { CreditTransactionCategory } from '@genfeedai/enums';
@@ -71,6 +72,7 @@ export class CreditTransactionsService extends BaseService<
     source?: string,
     description?: string,
     expiresAt?: Date,
+    tx?: PrismaTransactionClient,
   ): Promise<CreditTransactionsDocument> {
     if (
       !organizationId ||
@@ -101,7 +103,7 @@ export class CreditTransactionsService extends BaseService<
       );
     }
 
-    const result = await this.create({
+    const data = {
       amount,
       balanceAfter,
       category,
@@ -114,7 +116,17 @@ export class CreditTransactionsService extends BaseService<
       },
       organizationId,
       source,
-    } as Record<string, unknown>);
+    } as Record<string, unknown>;
+
+    // When a transaction client is supplied, the ledger entry MUST be written
+    // through it so it commits/rolls back atomically with the balance update.
+    const result = tx
+      ? this.normalizeDocument(
+          await tx.creditTransaction.create({
+            data: data as never,
+          }),
+        )
+      : await this.create(data);
 
     await this.cacheInvalidationService.invalidate(
       CACHE_PATTERNS.CREDITS_USAGE(organizationId),

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
@@ -1,0 +1,241 @@
+import { CreditBalanceService } from '@api/collections/credits/services/credit-balance.service';
+import { CreditTransactionsService } from '@api/collections/credits/services/credit-transactions.service';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
+import { BusinessLogicException } from '@api/helpers/exceptions/business/business-logic.exception';
+import type { PrismaTransactionClient } from '@api/helpers/utils/transaction/transaction.util';
+import { TransactionUtil } from '@api/helpers/utils/transaction/transaction.util';
+import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { EventBusService } from '@api/shared/services/event-bus/event-bus.service';
+import { LoggerService } from '@libs/logger/logger.service';
+
+describe('CreditsUtilsService', () => {
+  const loggerService = { error: vi.fn(), log: vi.fn() };
+  const eventBusService = { emit: vi.fn() };
+  const prisma = {
+    brand: { findFirst: vi.fn() },
+    organization: { findFirst: vi.fn() },
+    subscription: { findFirst: vi.fn() },
+    user: { findFirst: vi.fn() },
+  };
+  const creditBalanceService = {
+    findByOrganization: vi.fn(),
+    updateBalance: vi.fn(),
+  };
+  const creditTransactionsService = {
+    createTransactionEntry: vi.fn(),
+  };
+  const organizationSettingsService = {
+    findOne: vi.fn(),
+    patch: vi.fn(),
+  };
+  const clerkService = { updateUserPublicMetadata: vi.fn() };
+  const websocketService = { emit: vi.fn() };
+  const accessBootstrapCacheService = { invalidateForOrganization: vi.fn() };
+
+  // Marker object standing in for the Prisma transaction client that
+  // runInTransaction injects — assertions check it is threaded through.
+  const txClient = { __tx: true } as unknown as PrismaTransactionClient;
+  const transactionUtil = {
+    runInTransaction: vi.fn(
+      async (fn: (tx: PrismaTransactionClient) => Promise<unknown>) =>
+        fn(txClient),
+    ),
+  };
+
+  function buildService(withTransactionUtil = true): CreditsUtilsService {
+    return new CreditsUtilsService(
+      loggerService as unknown as LoggerService,
+      eventBusService as unknown as EventBusService,
+      prisma as unknown as PrismaService,
+      creditBalanceService as unknown as CreditBalanceService,
+      creditTransactionsService as unknown as CreditTransactionsService,
+      organizationSettingsService as unknown as OrganizationSettingsService,
+      clerkService as unknown as ClerkService,
+      websocketService as unknown as NotificationsPublisherService,
+      accessBootstrapCacheService as unknown as AccessBootstrapCacheService,
+      withTransactionUtil
+        ? (transactionUtil as unknown as TransactionUtil)
+        : undefined,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.organization.findFirst.mockResolvedValue({ id: 'org_1' });
+    prisma.user.findFirst.mockResolvedValue(null);
+    prisma.brand.findFirst.mockResolvedValue(null);
+    prisma.subscription.findFirst.mockResolvedValue(null);
+    creditBalanceService.findByOrganization.mockResolvedValue({ balance: 100 });
+    creditBalanceService.updateBalance.mockResolvedValue({ balance: 60 });
+    creditTransactionsService.createTransactionEntry.mockResolvedValue({});
+    organizationSettingsService.findOne.mockResolvedValue(null);
+  });
+
+  describe('deductCreditsFromOrganization', () => {
+    it('runs balance read + write + ledger entry on the transaction client', async () => {
+      const service = buildService();
+
+      await service.deductCreditsFromOrganization(
+        'org_1',
+        'user_1',
+        40,
+        'test deduct',
+      );
+
+      expect(transactionUtil.runInTransaction).toHaveBeenCalledTimes(1);
+      // Serializable isolation is what actually prevents concurrent double-spend
+      expect(transactionUtil.runInTransaction).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ isolationLevel: 'Serializable' }),
+      );
+      expect(creditBalanceService.findByOrganization).toHaveBeenCalledWith(
+        'org_1',
+        txClient,
+      );
+      expect(creditBalanceService.updateBalance).toHaveBeenCalledWith(
+        'org_1',
+        60,
+        txClient,
+      );
+      expect(
+        creditTransactionsService.createTransactionEntry,
+      ).toHaveBeenCalledWith(
+        'org_1',
+        expect.anything(),
+        40,
+        100,
+        60,
+        expect.anything(),
+        'test deduct',
+        undefined,
+        txClient,
+      );
+    });
+
+    it('throws on insufficient credits without writing', async () => {
+      const service = buildService();
+
+      await expect(
+        service.deductCreditsFromOrganization(
+          'org_1',
+          'user_1',
+          150,
+          'too much',
+        ),
+      ).rejects.toThrow(BusinessLogicException);
+
+      expect(creditBalanceService.updateBalance).not.toHaveBeenCalled();
+      expect(
+        creditTransactionsService.createTransactionEntry,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('falls back to non-transactional path when TransactionUtil is absent', async () => {
+      const service = buildService(false);
+
+      await service.deductCreditsFromOrganization(
+        'org_1',
+        'user_1',
+        40,
+        'fallback deduct',
+      );
+
+      expect(transactionUtil.runInTransaction).not.toHaveBeenCalled();
+      expect(creditBalanceService.updateBalance).toHaveBeenCalledWith(
+        'org_1',
+        60,
+        undefined,
+      );
+    });
+  });
+
+  describe('addOrganizationCreditsWithExpiration', () => {
+    it('threads the transaction client through balance write and ledger entry', async () => {
+      const service = buildService();
+      const expiresAt = new Date('2027-01-01T00:00:00Z');
+
+      await service.addOrganizationCreditsWithExpiration(
+        'org_1',
+        50,
+        'stripe',
+        'renewal credits',
+        expiresAt,
+      );
+
+      expect(transactionUtil.runInTransaction).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ isolationLevel: 'Serializable' }),
+      );
+      expect(creditBalanceService.updateBalance).toHaveBeenCalledWith(
+        'org_1',
+        150,
+        txClient,
+      );
+      expect(
+        creditTransactionsService.createTransactionEntry,
+      ).toHaveBeenCalledWith(
+        'org_1',
+        expect.anything(),
+        50,
+        100,
+        150,
+        'stripe',
+        'renewal credits',
+        expiresAt,
+        txClient,
+      );
+    });
+  });
+
+  describe('refundOrganizationCredits', () => {
+    it('threads the transaction client', async () => {
+      const service = buildService();
+
+      await service.refundOrganizationCredits(
+        'org_1',
+        10,
+        'system',
+        'refund',
+        new Date('2027-01-01T00:00:00Z'),
+      );
+
+      expect(creditBalanceService.updateBalance).toHaveBeenCalledWith(
+        'org_1',
+        110,
+        txClient,
+      );
+    });
+  });
+
+  describe('resetOrganizationCredits', () => {
+    it('threads the transaction client', async () => {
+      const service = buildService();
+
+      await service.resetOrganizationCredits('org_1', 500, 'system', 'reset');
+
+      expect(creditBalanceService.updateBalance).toHaveBeenCalledWith(
+        'org_1',
+        500,
+        txClient,
+      );
+    });
+  });
+
+  describe('removeAllOrganizationCredits', () => {
+    it('threads the transaction client', async () => {
+      const service = buildService();
+
+      await service.removeAllOrganizationCredits('org_1', 'system', 'wipe');
+
+      expect(creditBalanceService.updateBalance).toHaveBeenCalledWith(
+        'org_1',
+        0,
+        txClient,
+      );
+    });
+  });
+});

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.ts
@@ -3,6 +3,7 @@ import { CreditTransactionsService } from '@api/collections/credits/services/cre
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
 import { BusinessLogicException } from '@api/helpers/exceptions/business/business-logic.exception';
+import type { PrismaTransactionClient } from '@api/helpers/utils/transaction/transaction.util';
 import { TransactionUtil } from '@api/helpers/utils/transaction/transaction.util';
 import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -41,6 +42,15 @@ export class CreditsUtilsService implements ICreditsUtilsService {
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
     @Optional() private readonly transactionUtil?: TransactionUtil,
   ) {}
+
+  /**
+   * Serializable isolation is required for the read-modify-write balance
+   * cores: at the default ReadCommitted level two concurrent transactions can
+   * both read the same balance and double-spend.
+   */
+  private static readonly BALANCE_TX_OPTIONS = {
+    isolationLevel: 'Serializable',
+  } as const;
 
   private async markOrganizationAsHavingCredits(
     organizationId: string,
@@ -92,9 +102,11 @@ export class CreditsUtilsService implements ICreditsUtilsService {
       }
 
       // Core deduction logic — runs atomically inside a transaction when available
-      const deductCore = async () => {
-        const currentBalance =
-          await this.getOrganizationCreditsBalance(organizationId);
+      const deductCore = async (tx?: PrismaTransactionClient) => {
+        const currentBalance = await this.getOrganizationCreditsBalance(
+          organizationId,
+          tx,
+        );
 
         const maxOverdraftCredits = Math.max(
           0,
@@ -111,6 +123,7 @@ export class CreditsUtilsService implements ICreditsUtilsService {
         await this.creditBalanceService.updateBalance(
           organizationId,
           newBalance,
+          tx,
         );
         await this.creditTransactionsService.createTransactionEntry(
           organizationId,
@@ -120,14 +133,19 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           newBalance,
           source,
           description,
+          undefined,
+          tx,
         );
 
         return newBalance;
       };
 
-      // Use transaction if available (requires replica set), otherwise fallback
+      // Use transaction if available, otherwise fallback
       const newBalance = this.transactionUtil
-        ? await this.transactionUtil.runInTransaction(() => deductCore())
+        ? await this.transactionUtil.runInTransaction(
+            (tx) => deductCore(tx),
+            CreditsUtilsService.BALANCE_TX_OPTIONS,
+          )
         : await deductCore();
 
       // Side effects outside transaction (idempotent, non-critical)
@@ -190,9 +208,14 @@ export class CreditsUtilsService implements ICreditsUtilsService {
     return currentBalance >= requiredCredits;
   }
 
-  async getOrganizationCreditsBalance(organizationId: string): Promise<number> {
-    const balance =
-      await this.creditBalanceService.findByOrganization(organizationId);
+  async getOrganizationCreditsBalance(
+    organizationId: string,
+    tx?: PrismaTransactionClient,
+  ): Promise<number> {
+    const balance = await this.creditBalanceService.findByOrganization(
+      organizationId,
+      tx,
+    );
     return typeof balance?.balance === 'number' ? balance.balance : 0;
   }
 
@@ -224,15 +247,18 @@ export class CreditsUtilsService implements ICreditsUtilsService {
       }
 
       // Core add logic — runs atomically inside a transaction when available
-      const addCore = async () => {
-        const currentBalance =
-          await this.getOrganizationCreditsBalance(organizationId);
+      const addCore = async (tx?: PrismaTransactionClient) => {
+        const currentBalance = await this.getOrganizationCreditsBalance(
+          organizationId,
+          tx,
+        );
 
         const newBalance = currentBalance + creditsToAdd;
 
         await this.creditBalanceService.updateBalance(
           organizationId,
           newBalance,
+          tx,
         );
         await this.creditTransactionsService.createTransactionEntry(
           organizationId,
@@ -243,14 +269,18 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           source,
           description,
           expiresAt,
+          tx,
         );
 
         return { currentBalance, newBalance };
       };
 
-      // Use transaction if available (requires replica set), otherwise fallback
+      // Use transaction if available, otherwise fallback
       const { currentBalance, newBalance } = this.transactionUtil
-        ? await this.transactionUtil.runInTransaction(() => addCore())
+        ? await this.transactionUtil.runInTransaction(
+            (tx) => addCore(tx),
+            CreditsUtilsService.BALANCE_TX_OPTIONS,
+          )
         : await addCore();
 
       if (creditsToAdd > 0) {
@@ -329,15 +359,18 @@ export class CreditsUtilsService implements ICreditsUtilsService {
       }
 
       // Core refund logic — runs atomically inside a transaction when available
-      const refundCore = async () => {
-        const currentBalance =
-          await this.getOrganizationCreditsBalance(organizationId);
+      const refundCore = async (tx?: PrismaTransactionClient) => {
+        const currentBalance = await this.getOrganizationCreditsBalance(
+          organizationId,
+          tx,
+        );
 
         const newBalance = currentBalance + creditsToRefund;
 
         await this.creditBalanceService.updateBalance(
           organizationId,
           newBalance,
+          tx,
         );
         await this.creditTransactionsService.createTransactionEntry(
           organizationId,
@@ -348,14 +381,18 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           source,
           description,
           expiresAt,
+          tx,
         );
 
         return { currentBalance, newBalance };
       };
 
-      // Use transaction if available (requires replica set), otherwise fallback
+      // Use transaction if available, otherwise fallback
       const { currentBalance, newBalance } = this.transactionUtil
-        ? await this.transactionUtil.runInTransaction(() => refundCore())
+        ? await this.transactionUtil.runInTransaction(
+            (tx) => refundCore(tx),
+            CreditsUtilsService.BALANCE_TX_OPTIONS,
+          )
         : await refundCore();
 
       // Side effects outside transaction (idempotent, non-critical)
@@ -529,13 +566,16 @@ export class CreditsUtilsService implements ICreditsUtilsService {
       }
 
       // Core reset logic — runs atomically inside a transaction when available
-      const resetCore = async () => {
-        const currentBalance =
-          await this.getOrganizationCreditsBalance(organizationId);
+      const resetCore = async (tx?: PrismaTransactionClient) => {
+        const currentBalance = await this.getOrganizationCreditsBalance(
+          organizationId,
+          tx,
+        );
 
         await this.creditBalanceService.updateBalance(
           organizationId,
           newCreditAmount,
+          tx,
         );
         await this.creditTransactionsService.createTransactionEntry(
           organizationId,
@@ -545,14 +585,19 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           newCreditAmount,
           source,
           description,
+          undefined,
+          tx,
         );
 
         return currentBalance;
       };
 
-      // Use transaction if available (requires replica set), otherwise fallback
+      // Use transaction if available, otherwise fallback
       const currentBalance = this.transactionUtil
-        ? await this.transactionUtil.runInTransaction(() => resetCore())
+        ? await this.transactionUtil.runInTransaction(
+            (tx) => resetCore(tx),
+            CreditsUtilsService.BALANCE_TX_OPTIONS,
+          )
         : await resetCore();
 
       if (newCreditAmount > 0) {
@@ -626,11 +671,13 @@ export class CreditsUtilsService implements ICreditsUtilsService {
       }
 
       // Core remove-all logic — runs atomically inside a transaction when available
-      const removeAllCore = async () => {
-        const currentBalance =
-          await this.getOrganizationCreditsBalance(organizationId);
+      const removeAllCore = async (tx?: PrismaTransactionClient) => {
+        const currentBalance = await this.getOrganizationCreditsBalance(
+          organizationId,
+          tx,
+        );
 
-        await this.creditBalanceService.updateBalance(organizationId, 0);
+        await this.creditBalanceService.updateBalance(organizationId, 0, tx);
         await this.creditTransactionsService.createTransactionEntry(
           organizationId,
           CreditTransactionCategory.DEDUCT,
@@ -639,14 +686,19 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           0,
           source,
           description,
+          undefined,
+          tx,
         );
 
         return currentBalance;
       };
 
-      // Use transaction if available (requires replica set), otherwise fallback
+      // Use transaction if available, otherwise fallback
       const currentBalance = this.transactionUtil
-        ? await this.transactionUtil.runInTransaction(() => removeAllCore())
+        ? await this.transactionUtil.runInTransaction(
+            (tx) => removeAllCore(tx),
+            CreditsUtilsService.BALANCE_TX_OPTIONS,
+          )
         : await removeAllCore();
 
       // Side effects outside transaction (idempotent, non-critical)

--- a/apps/server/api/src/helpers/utils/transaction/transaction.util.ts
+++ b/apps/server/api/src/helpers/utils/transaction/transaction.util.ts
@@ -3,7 +3,7 @@ import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
-type PrismaTransactionClient = Omit<
+export type PrismaTransactionClient = Omit<
   PrismaService,
   '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
 >;


### PR DESCRIPTION
## Problem (P0 — billing correctness)

`runInTransaction(() => deductCore())` wrapped zero-arg closures that ignored the injected `tx` client and used `this.prisma` — every credit operation (deduct/add/refund/reset/remove-all) executed **outside** its transaction boundary. Two concurrent deductions read the same balance and double-spend.

## Fix

- Thread `PrismaTransactionClient` through `CreditBalanceService` (find/create/getOrCreate/updateBalance) and `CreditTransactionsService.createTransactionEntry` — ledger entry now commits/rolls back atomically with the balance write.
- All five balance cores run at `Serializable` isolation — ReadCommitted still allows two transactions to read the same balance, so the tx alone was not enough.
- Export `PrismaTransactionClient` from `TransactionUtil` (was module-private; doc comment always promised this usage).
- Fallback path (no TransactionUtil bound) unchanged.

## Tests

New `credits.utils.service.spec.ts` (7 specs): tx threading on all five ops, Serializable option, insufficient-credits guard writes nothing, non-transactional fallback.

`bunx vitest run src/collections/credits` → 31 passed. Type-check + lint green.

Part of the production-readiness audit remediation (P0-A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)