### PR TITLE
fix(billing): allocate renewal credits on invoice.paid + atomic webhook idempotency

### DIFF
--- a/apps/server/api/src/collections/subscriptions/services/subscriptions.service.spec.ts
+++ b/apps/server/api/src/collections/subscriptions/services/subscriptions.service.spec.ts
@@ -1,0 +1,84 @@
+import { SubscriptionsService } from '@api/collections/subscriptions/services/subscriptions.service';
+import type { SubscriptionDocument } from '@genfeedai/ee-billing/subscriptions';
+
+type NormalizeAccessor = {
+  normalizeDocument(document: unknown): SubscriptionDocument;
+};
+
+describe('SubscriptionsService', () => {
+  const prisma = {
+    customer: { findUnique: vi.fn() },
+    subscription: { findFirst: vi.fn() },
+  };
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  function buildService(): NormalizeAccessor {
+    return new SubscriptionsService(
+      prisma as never,
+      logger as never,
+      { get: vi.fn() } as never,
+      { findOne: vi.fn() } as never,
+      {} as never,
+      { findByStripeCustomerId: vi.fn() } as never,
+      { updateUserPublicMetadata: vi.fn() } as never,
+    ) as unknown as NormalizeAccessor;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('normalizeDocument', () => {
+    it('maps the persisted plan column onto the in-memory type field', () => {
+      const service = buildService();
+
+      const normalized = service.normalizeDocument({
+        customerId: 'cus_local_1',
+        id: 'sub_db_1',
+        isDeleted: false,
+        organizationId: 'org_1',
+        plan: 'monthly',
+        status: 'active',
+        stripeSubscriptionId: 'sub_stripe_1',
+        userId: 'user_1',
+      });
+
+      // type drives credit allocation in the Stripe invoice.paid handler —
+      // every BaseService read path (findOne/findAll/patch) must populate it
+      expect(normalized.type).toBe('monthly');
+      expect(normalized.customer).toBe('cus_local_1');
+      expect(normalized.organization).toBe('org_1');
+    });
+
+    it('keeps an explicit type value over the plan fallback', () => {
+      const service = buildService();
+
+      const normalized = service.normalizeDocument({
+        id: 'sub_db_2',
+        organizationId: 'org_1',
+        plan: 'monthly',
+        type: 'yearly',
+        userId: 'user_1',
+      });
+
+      expect(normalized.type).toBe('yearly');
+    });
+
+    it('leaves type undefined when neither type nor plan is present', () => {
+      const service = buildService();
+
+      const normalized = service.normalizeDocument({
+        id: 'sub_db_3',
+        organizationId: 'org_1',
+        userId: 'user_1',
+      });
+
+      expect(normalized.type).toBeUndefined();
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.controller.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.controller.spec.ts
@@ -25,8 +25,7 @@ describe('StripeWebhookController', () => {
   let configService: vi.Mocked<ConfigService>;
 
   const mockPublisher = {
-    get: vi.fn().mockResolvedValue(null),
-    setEx: vi.fn().mockResolvedValue('OK'),
+    set: vi.fn().mockResolvedValue('OK'),
   };
 
   beforeEach(async () => {
@@ -121,6 +120,51 @@ describe('StripeWebhookController', () => {
         mockEvent,
         expect.stringContaining('StripeWebhookController'),
       );
+      expect(result).toEqual({ success: true });
+    });
+
+    it('acquires the idempotency key atomically (SET NX) before processing', async () => {
+      const rawBody = Buffer.from('{"type":"invoice.paid"}');
+      const mockEvent = {
+        data: { object: { id: 'in_1' } },
+        id: 'evt_nx',
+        type: 'invoice.paid',
+      };
+      const request = mockRequest(rawBody, 'valid-signature');
+
+      stripeService.stripe.webhooks.constructEventAsync.mockResolvedValue(
+        mockEvent,
+      );
+      mockPublisher.set.mockResolvedValueOnce('OK');
+
+      await controller.handleStripe(request);
+
+      expect(mockPublisher.set).toHaveBeenCalledWith(
+        'stripe:webhook:evt_nx',
+        expect.any(String),
+        expect.objectContaining({ NX: true, EX: expect.any(Number) }),
+      );
+      expect(stripeWebhookService.handleWebhookEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips processing when another delivery already holds the idempotency key', async () => {
+      const rawBody = Buffer.from('{"type":"invoice.paid"}');
+      const mockEvent = {
+        data: { object: { id: 'in_1' } },
+        id: 'evt_dup',
+        type: 'invoice.paid',
+      };
+      const request = mockRequest(rawBody, 'valid-signature');
+
+      stripeService.stripe.webhooks.constructEventAsync.mockResolvedValue(
+        mockEvent,
+      );
+      // SET NX returns null when the key already exists — concurrent duplicate
+      mockPublisher.set.mockResolvedValueOnce(null);
+
+      const result = await controller.handleStripe(request);
+
+      expect(stripeWebhookService.handleWebhookEvent).not.toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.controller.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.controller.ts
@@ -73,22 +73,21 @@ export class StripeWebhookController {
       const publisher = this.redisService.getPublisher();
 
       if (publisher) {
-        const alreadyProcessed = await publisher.get(idempotencyKey);
+        // Atomic SET NX: GET-then-SETEX was a TOCTOU race — two concurrent
+        // deliveries of the same event both saw null and both processed.
+        const acquired = await publisher.set(
+          idempotencyKey,
+          new Date().toISOString(),
+          { EX: WEBHOOK_IDEMPOTENCY_TTL, NX: true },
+        );
 
-        if (alreadyProcessed) {
+        if (!acquired) {
           this.loggerService.log(`${url} duplicate event skipped`, {
             id: event.id,
             type: event.type,
           });
           return { success: true };
         }
-
-        // Mark as processing before handling (set-if-not-exists with TTL)
-        await publisher.setEx(
-          idempotencyKey,
-          WEBHOOK_IDEMPOTENCY_TTL,
-          new Date().toISOString(),
-        );
       }
 
       await this.stripeWebhookService.handleWebhookEvent(event, url);

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
@@ -1,0 +1,172 @@
+import { StripeWebhookService } from '@api/endpoints/webhooks/stripe/webhooks.stripe.service';
+import type Stripe from 'stripe';
+
+type InvoiceHandlerAccessor = {
+  handleInvoicePaid(invoice: Stripe.Invoice, url: string): Promise<void>;
+  handleInvoicePaymentFailed(
+    invoice: Stripe.Invoice,
+    url: string,
+  ): Promise<void>;
+};
+
+describe('StripeWebhookService invoice handlers', () => {
+  const configService = { get: vi.fn().mockReturnValue(undefined) };
+  const loggerService = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+  const subscriptionsService = {
+    findOne: vi.fn(),
+    patch: vi.fn(),
+    syncSubscriptionToClerkMetadata: vi.fn(),
+  };
+  const creditsUtilsService = {
+    addOrganizationCreditsWithExpiration: vi.fn(),
+    getOrganizationCreditsBalance: vi.fn().mockResolvedValue(35_000),
+    resetOrganizationCredits: vi.fn(),
+  };
+  const activitiesService = { create: vi.fn() };
+
+  function buildService(): InvoiceHandlerAccessor {
+    return new StripeWebhookService(
+      configService as never,
+      loggerService as never,
+      {} as never, // apiKeysService
+      {} as never, // brandsService
+      subscriptionsService as never,
+      creditsUtilsService as never,
+      activitiesService as never,
+      {} as never, // usersService
+      {} as never, // clerkService
+      {} as never, // stripeService
+      {} as never, // managedStripeCheckoutService
+      {} as never, // organizationsService
+      {} as never, // subscriptionAttributionsService
+      {} as never, // userSubscriptionsService
+      {} as never, // organizationSettingsService
+      {} as never, // prisma
+      {} as never, // requestContextCacheService
+      {} as never, // accessBootstrapCacheService
+      {} as never, // userSetupService
+    ) as unknown as InvoiceHandlerAccessor;
+  }
+
+  function invoiceWith(overrides: Record<string, unknown>): Stripe.Invoice {
+    return {
+      billing_reason: 'subscription_cycle',
+      id: 'in_123',
+      metadata: {},
+      ...overrides,
+    } as unknown as Stripe.Invoice;
+  }
+
+  const monthlySubscription = {
+    _id: 'sub_db_1',
+    organization: 'org_1',
+    status: 'active',
+    stripeSubscriptionId: 'sub_stripe_1',
+    type: 'monthly',
+    user: 'user_1',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configService.get.mockReturnValue(undefined);
+    creditsUtilsService.getOrganizationCreditsBalance.mockResolvedValue(35_000);
+    subscriptionsService.findOne.mockResolvedValue(monthlySubscription);
+    subscriptionsService.patch.mockResolvedValue(monthlySubscription);
+  });
+
+  describe('handleInvoicePaid', () => {
+    it('allocates monthly credits on a subscription_cycle invoice', async () => {
+      const service = buildService();
+
+      await service.handleInvoicePaid(
+        invoiceWith({
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(subscriptionsService.findOne).toHaveBeenCalledWith({
+        stripeSubscriptionId: 'sub_stripe_1',
+      });
+      expect(
+        creditsUtilsService.addOrganizationCreditsWithExpiration,
+      ).toHaveBeenCalledWith(
+        'org_1',
+        35_000,
+        'monthly',
+        expect.stringContaining('monthly'),
+        expect.any(Date),
+      );
+    });
+
+    it('resets credits for yearly subscriptions', async () => {
+      subscriptionsService.findOne.mockResolvedValue({
+        ...monthlySubscription,
+        type: 'yearly',
+      });
+      subscriptionsService.patch.mockResolvedValue({
+        ...monthlySubscription,
+        type: 'yearly',
+      });
+      const service = buildService();
+
+      await service.handleInvoicePaid(
+        invoiceWith({
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(creditsUtilsService.resetOrganizationCredits).toHaveBeenCalledWith(
+        'org_1',
+        500_000,
+        'yearly',
+        expect.stringContaining('yearly'),
+      );
+    });
+
+    it('does not query subscriptions when the invoice carries no subscription id', async () => {
+      const service = buildService();
+
+      await service.handleInvoicePaid(invoiceWith({}), 'test');
+
+      expect(subscriptionsService.findOne).not.toHaveBeenCalled();
+      expect(loggerService.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleInvoicePaymentFailed', () => {
+    it('reads the subscription id from the v22 parent path and marks past_due', async () => {
+      const service = buildService();
+
+      await service.handleInvoicePaymentFailed(
+        invoiceWith({
+          billing_reason: 'subscription_cycle',
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(subscriptionsService.findOne).toHaveBeenCalledWith({
+        stripeSubscriptionId: 'sub_stripe_1',
+      });
+      expect(subscriptionsService.patch).toHaveBeenCalledWith('sub_db_1', {
+        status: 'past_due',
+      });
+    });
+
+    it('does not query subscriptions when the invoice carries no subscription id', async () => {
+      const service = buildService();
+
+      await service.handleInvoicePaymentFailed(invoiceWith({}), 'test');
+
+      expect(subscriptionsService.findOne).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
@@ -1456,6 +1456,39 @@ export class StripeWebhookService {
     }
   }
 
+  /**
+   * Stripe SDK v22 moved the invoice→subscription link to
+   * `invoice.parent.subscription_details.subscription`; the pre-v22
+   * top-level `invoice.subscription` is kept as a fallback for replayed
+   * historical events. The value may also arrive as an expanded object.
+   */
+  private extractInvoiceSubscriptionId(
+    invoice: StripeInvoice,
+  ): string | undefined {
+    const parentPath = (
+      invoice as unknown as {
+        parent?: {
+          subscription_details?: { subscription?: string | { id?: string } };
+        };
+      }
+    ).parent?.subscription_details?.subscription;
+    const legacyPath = (
+      invoice as unknown as { subscription?: string | { id?: string } }
+    ).subscription;
+
+    const candidate = parentPath ?? legacyPath;
+
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+
+    if (candidate && typeof candidate === 'object' && candidate.id) {
+      return candidate.id;
+    }
+
+    return undefined;
+  }
+
   private async handleInvoicePaid(invoice: StripeInvoice, url: string) {
     try {
       // Handle BYOK platform fee invoices
@@ -1468,11 +1501,14 @@ export class StripeWebhookService {
         invoice.billing_reason === 'subscription_cycle' ||
         invoice.billing_reason === 'subscription_create'
       ) {
-        const stripeSubscriptionId = (
-          invoice as unknown as {
-            parent?: { subscription_details?: { subscription?: string } };
-          }
-        ).parent?.subscription_details?.subscription;
+        const stripeSubscriptionId = this.extractInvoiceSubscriptionId(invoice);
+
+        if (!stripeSubscriptionId) {
+          return this.loggerService.warn(
+            `${url} invoice carries no subscription id, skipping`,
+            { billingReason: invoice.billing_reason, invoiceId: invoice.id },
+          );
+        }
 
         const subscription = await this.subscriptionsService.findOne({
           stripeSubscriptionId: stripeSubscriptionId,
@@ -1668,9 +1704,15 @@ export class StripeWebhookService {
         return;
       }
 
-      const stripeSubscriptionId = (
-        invoice as unknown as { subscription?: string }
-      ).subscription as string;
+      const stripeSubscriptionId = this.extractInvoiceSubscriptionId(invoice);
+
+      if (!stripeSubscriptionId) {
+        return this.loggerService.warn(
+          `${url} failed invoice carries no subscription id, skipping`,
+          { invoiceId: invoice.id },
+        );
+      }
+
       const subscription = await this.subscriptionsService.findOne({
         stripeSubscriptionId: stripeSubscriptionId,
       });

--- a/ee/packages/billing/src/subscriptions/services/subscriptions.service.ts
+++ b/ee/packages/billing/src/subscriptions/services/subscriptions.service.ts
@@ -87,14 +87,41 @@ export class SubscriptionsService
     return customer?.stripeCustomerId ?? undefined;
   }
 
-  private async normalizeSubscriptionDocument(
+  /**
+   * The DB column is `plan`; the in-memory field consumers branch on
+   * (Stripe invoice.paid credit allocation, Clerk sync, tier resolution)
+   * is `type`. Overriding here guarantees EVERY BaseService read path
+   * (findOne/findAll/patch/create) populates it — previously only
+   * findByOrganizationId/findByStripeCustomerId did, so webhook handlers
+   * using findOne({stripeSubscriptionId}) saw type=undefined and silently
+   * skipped credit allocation.
+   */
+  protected override normalizeDocument(
     document: unknown,
-  ): Promise<SubscriptionDocument> {
-    const normalized = this.normalizeDocument(
+  ): SubscriptionDocument {
+    const normalized = super.normalizeDocument(
       document,
     ) as SubscriptionDocument & {
       plan?: string | null;
     };
+
+    if (typeof normalized !== 'object' || normalized === null) {
+      return normalized;
+    }
+
+    return {
+      ...normalized,
+      customer:
+        normalized.customer ??
+        (normalized.customerId ? String(normalized.customerId) : undefined),
+      type: normalized.type ?? normalized.plan ?? undefined,
+    };
+  }
+
+  private async normalizeSubscriptionDocument(
+    document: unknown,
+  ): Promise<SubscriptionDocument> {
+    const normalized = this.normalizeDocument(document);
 
     const stripeCustomerId =
       normalized.stripeCustomerId ??
@@ -102,11 +129,7 @@ export class SubscriptionsService
 
     return {
       ...normalized,
-      customer:
-        normalized.customer ??
-        (normalized.customerId ? String(normalized.customerId) : undefined),
       stripeCustomerId,
-      type: normalized.type ?? normalized.plan ?? undefined,
     };
   }
 


### PR DESCRIPTION
## Problem (P0 — every paying subscriber affected)

`handleInvoicePaid` loads the subscription via `findOne({stripeSubscriptionId})` → `BaseService.normalizeDocument` — which never mapped the persisted `plan` column onto the in-memory `type` field (only `findByOrganizationId`/`findByStripeCustomerId` did, via a private helper). `subscription.type` was `undefined`, both MONTHLY/YEARLY branches evaluated false, and **renewal credits were never allocated on any billing cycle**.

## Fix

- **Root cause:** override `normalizeDocument()` in `SubscriptionsService` so every BaseService read path (findOne/findAll/patch/create) maps `plan`→`type` + `customerId`→`customer`. Also un-no-ops the other webhook handlers that silently skipped on `type=undefined` (subscription updated/deleted → Clerk sync, tier resolution).
- **Guard:** invoices with no subscription id no longer reach `findOne({stripeSubscriptionId: undefined})` (which matched an arbitrary row).
- **SDK 22 field path:** `handleInvoicePaymentFailed` read the removed top-level `invoice.subscription`; now uses `parent.subscription_details.subscription` with legacy fallback + expanded-object support (shared `extractInvoiceSubscriptionId`).
- **Idempotency TOCTOU:** GET-then-SETEX → atomic `SET NX EX`; concurrent duplicate deliveries short-circuit.

## Tests

- `subscriptions.service.spec.ts` (new): plan→type via normalizeDocument, explicit-type precedence, undefined passthrough.
- `webhooks.stripe.service.spec.ts` (new): monthly allocation, yearly reset, no-subscription-id guard, payment-failed v22 path.
- Controller spec: atomic SET NX acquisition + duplicate skip.

`bunx vitest run src/collections/subscriptions src/endpoints/webhooks/stripe` → 32 passed. Type-check + lint green.

Part of production-readiness audit remediation (P0-B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)