### PR TITLE
fix(services): stop posting internal API calls to hardcoded localhost

### DIFF
--- a/apps/server/files/src/processors/youtube.processor.spec.ts
+++ b/apps/server/files/src/processors/youtube.processor.spec.ts
@@ -1,0 +1,82 @@
+import type { ConfigService } from '@files/config/config.service';
+import type { S3Service } from '@files/services/s3/s3.service';
+import type { YoutubeService } from '@files/services/youtube/youtube.service';
+import type { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
+import type { RedisService } from '@libs/redis/redis.service';
+import type { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { YoutubeProcessor } from './youtube.processor';
+
+type ProcessorInternals = {
+  apiBaseUrl: string;
+  updateTranscriptStatus(
+    transcriptId: string,
+    status: string,
+    additionalData?: unknown,
+  ): Promise<void>;
+};
+
+describe('YoutubeProcessor', () => {
+  const configService = { get: vi.fn() };
+  const httpService = {
+    get: vi.fn(),
+    patch: vi.fn().mockReturnValue(of({ data: {} })),
+    post: vi.fn(),
+  };
+
+  function buildProcessor(): ProcessorInternals {
+    return new YoutubeProcessor(
+      configService as unknown as ConfigService,
+      httpService as unknown as HttpService,
+      {} as unknown as RedisService,
+      {} as unknown as S3Service,
+      {} as unknown as YtDlpService,
+      {} as unknown as YoutubeService,
+    ) as unknown as ProcessorInternals;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    httpService.patch.mockReturnValue(of({ data: {} }));
+  });
+
+  describe('apiBaseUrl', () => {
+    it('uses GENFEEDAI_API_URL and appends the /v1 route prefix', () => {
+      configService.get.mockReturnValue('https://api.genfeed.ai');
+
+      expect(buildProcessor().apiBaseUrl).toBe('https://api.genfeed.ai/v1');
+    });
+
+    it('does not double the prefix when the configured URL already has /v1', () => {
+      configService.get.mockReturnValue('https://api.genfeed.ai/v1');
+
+      expect(buildProcessor().apiBaseUrl).toBe('https://api.genfeed.ai/v1');
+    });
+
+    it('strips trailing slashes before appending', () => {
+      configService.get.mockReturnValue('https://api.genfeed.ai/');
+
+      expect(buildProcessor().apiBaseUrl).toBe('https://api.genfeed.ai/v1');
+    });
+
+    it('falls back to localhost for local development', () => {
+      configService.get.mockReturnValue(undefined);
+
+      expect(buildProcessor().apiBaseUrl).toBe('http://localhost:3010/v1');
+    });
+  });
+
+  describe('updateTranscriptStatus', () => {
+    it('PATCHes the configured API host instead of a hardcoded localhost', async () => {
+      configService.get.mockReturnValue('https://api.genfeed.ai');
+      const processor = buildProcessor();
+
+      await processor.updateTranscriptStatus('t_1', 'completed');
+
+      expect(httpService.patch).toHaveBeenCalledWith(
+        'https://api.genfeed.ai/v1/transcripts/t_1',
+        expect.objectContaining({ status: 'completed' }),
+      );
+    });
+  });
+});

--- a/apps/server/files/src/processors/youtube.processor.ts
+++ b/apps/server/files/src/processors/youtube.processor.ts
@@ -59,6 +59,20 @@ export class YoutubeProcessor extends WorkerHost {
     super();
   }
 
+  /**
+   * Base URL for internal calls to the main API. The API serves all routes
+   * under the `v1` global prefix, so it is appended when the configured URL
+   * does not already include it.
+   */
+  private get apiBaseUrl(): string {
+    const base =
+      (this.configService.get('GENFEEDAI_API_URL') as string | undefined) ??
+      'http://localhost:3010';
+    const trimmed = base.replace(/\/+$/, '');
+
+    return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+  }
+
   async process(job: Job): Promise<unknown> {
     this.logger.log(`Processing YouTube job ${job.id}: ${job.name}`);
 
@@ -243,8 +257,7 @@ export class YoutubeProcessor extends WorkerHost {
    * Call Whisper API for transcription
    */
   private async callWhisperAPI(audioPath: string): Promise<string> {
-    // Internal service communication - use localhost
-    const apiUrl = 'http://localhost:3010/speech/transcribe/audio';
+    const apiUrl = `${this.apiBaseUrl}/speech/transcribe/audio`;
 
     try {
       // Read the audio file
@@ -279,8 +292,7 @@ export class YoutubeProcessor extends WorkerHost {
     status: string,
     additionalData: unknown = {},
   ): Promise<void> {
-    // Internal service communication - use localhost
-    const apiUrl = `http://localhost:3010/transcripts/${transcriptId}`;
+    const apiUrl = `${this.apiBaseUrl}/transcripts/${transcriptId}`;
 
     try {
       await firstValueFrom(
@@ -298,7 +310,7 @@ export class YoutubeProcessor extends WorkerHost {
     transcriptId: string,
     update: Record<string, unknown>,
   ): Promise<void> {
-    const apiUrl = `http://localhost:3010/transcripts/${transcriptId}`;
+    const apiUrl = `${this.apiBaseUrl}/transcripts/${transcriptId}`;
 
     try {
       await firstValueFrom(this.httpService.patch(apiUrl, update));
@@ -314,8 +326,7 @@ export class YoutubeProcessor extends WorkerHost {
     transcriptId: string,
     transcriptText: string,
   ): Promise<void> {
-    // Internal service communication - use localhost
-    const apiUrl = `http://localhost:3010/transcripts/${transcriptId}`;
+    const apiUrl = `${this.apiBaseUrl}/transcripts/${transcriptId}`;
 
     try {
       await firstValueFrom(
@@ -353,7 +364,7 @@ export class YoutubeProcessor extends WorkerHost {
   private async fetchVideoMetadata(
     youtubeId: string,
   ): Promise<YoutubeMetadata | null> {
-    const apiUrl = `http://localhost:3010/services/youtube/metadata/${youtubeId}`;
+    const apiUrl = `${this.apiBaseUrl}/services/youtube/metadata/${youtubeId}`;
 
     try {
       const apiKey = this.configService.get('GENFEEDAI_API_KEY');

--- a/apps/server/workers/src/config/config.service.ts
+++ b/apps/server/workers/src/config/config.service.ts
@@ -2,6 +2,7 @@ import {
   BaseConfigService,
   baseSchema,
   type IEnvConfig,
+  microservicesSchema,
   postgresSchema,
   redisSchema,
   sentryOptionalSchema,
@@ -22,6 +23,7 @@ const workersSpecificSchema = {
 
 const workersSchema = Joi.object({
   ...baseSchema,
+  ...microservicesSchema,
   ...postgresSchema,
   ...redisSchema,
   ...sentryOptionalSchema,

--- a/apps/server/workers/src/processors/api/queues/clip-factory/clip-factory.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-factory/clip-factory.processor.spec.ts
@@ -263,4 +263,38 @@ describe('ClipFactoryProcessor', () => {
       expect.objectContaining({ provider: 'heygen' }),
     );
   });
+
+  describe('files service URL resolution', () => {
+    it('fails loud outside development when GENFEEDAI_MICROSERVICES_FILES_URL is unset', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'GENFEEDAI_MICROSERVICES_FILES_URL' ? undefined : 'x',
+      );
+      (configService as { isDevelopment?: boolean }).isDevelopment = false;
+
+      await expect(processor.process(makeJob(makeJobData()))).rejects.toThrow(
+        'GENFEEDAI_MICROSERVICES_FILES_URL is not configured',
+      );
+
+      expect(httpService.post).not.toHaveBeenCalledWith(
+        expect.stringContaining('/v1/files/process/video'),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('keeps the localhost fallback in local development', async () => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'GENFEEDAI_MICROSERVICES_FILES_URL' ? undefined : 'x',
+      );
+      (configService as { isDevelopment?: boolean }).isDevelopment = true;
+
+      await processor.process(makeJob(makeJobData()));
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        'http://localhost:3012/v1/files/process/video',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/apps/server/workers/src/processors/api/queues/clip-factory/clip-factory.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-factory/clip-factory.processor.ts
@@ -222,9 +222,19 @@ export class ClipFactoryProcessor extends WorkerHost {
     organizationId: string,
     userId: string,
   ): Promise<string> {
-    const filesUrl =
-      this.configService.get('GENFEEDAI_MICROSERVICES_FILES_URL') ||
-      'http://localhost:3012';
+    const configuredFilesUrl = this.configService.get(
+      'GENFEEDAI_MICROSERVICES_FILES_URL',
+    ) as string | undefined;
+
+    // Silent localhost fallback posted audio jobs into the void on every
+    // cloud deployment. Fail loud outside local development.
+    if (!configuredFilesUrl && !this.configService.isDevelopment) {
+      throw new Error(
+        'GENFEEDAI_MICROSERVICES_FILES_URL is not configured — clip factory cannot reach the files service',
+      );
+    }
+
+    const filesUrl = configuredFilesUrl || 'http://localhost:3012';
 
     const response = await firstValueFrom(
       this.httpService.post(


### PR DESCRIPTION
## Problem (P0 — pipeline dead in deployed envs)

- `files/youtube.processor.ts` called `http://localhost:3010` for transcript status updates, Whisper transcription, and YouTube metadata — dead in every deployed environment. Worse: the API serves everything under the `v1` global prefix, and these paths had no `/v1`, so the calls 404'd **even locally** (errors swallowed by catch+log).
- `workers/clip-factory.processor.ts` silently fell back to `http://localhost:3012` when `GENFEEDAI_MICROSERVICES_FILES_URL` was unset — audio extraction jobs posted into the void on cloud deploys.

## Fix

- `apiBaseUrl` getter from `GENFEEDAI_API_URL` (already in the files config schema), trailing-slash-safe, appends `/v1` exactly once. All 5 call sites use it.
- clip-factory fails loud outside local development when the files URL is missing; dev keeps the localhost fallback.
- Workers config now declares `microservicesSchema` — the files URL becomes a documented, validated key.

## Tests

- `youtube.processor.spec.ts` (new): base-URL normalization ×4 + PATCH target assertion.
- `clip-factory.processor.spec.ts`: +2 specs (fail-loud, dev fallback); existing 7 still green.

Note: the MCP client + other internal callers have the same `/v1` ambiguity — handled in the webhook-security batch (P1-A) and tracked in #251 (stale API specs).

Part of production-readiness audit remediation (P0-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)