### PR TITLE
feat(workflow-engine): honor abortSignal cancellation + bound maxConcurrency (#479)

### DIFF
--- a/packages/workflow-engine/src/execution/__tests__/engine.spec.ts
+++ b/packages/workflow-engine/src/execution/__tests__/engine.spec.ts
@@ -597,6 +597,142 @@ describe('WorkflowEngine', () => {
     });
   });
 
+  describe('execute — cancellation', () => {
+    it('should stop dispatching and return cancelled when aborted mid-execution', async () => {
+      const controller = new AbortController();
+      const executed: string[] = [];
+      const abortingExecutor: NodeExecutor = vi.fn(async (node) => {
+        executed.push(node.id);
+        if (node.id === 'n1') {
+          controller.abort();
+        }
+        return { result: node.id };
+      });
+
+      engine.registerExecutor('generate', abortingExecutor);
+      engine.registerExecutor('upscale', abortingExecutor);
+      engine.registerExecutor('publish', abortingExecutor);
+
+      // Sequential chain so the abort lands before n2/n3 are dispatched.
+      const workflow = makeWorkflow(
+        [
+          makeNode('n1', 'generate'),
+          makeNode('n2', 'upscale'),
+          makeNode('n3', 'publish'),
+        ],
+        [makeEdge('n1', 'n2'), makeEdge('n2', 'n3')],
+      );
+
+      const result = await engine.execute(workflow, {
+        abortSignal: controller.signal,
+      });
+
+      expect(result.status).toBe('cancelled');
+      // Only the first node ran; later nodes were never dispatched.
+      expect(executed).toEqual(['n1']);
+      expect(result.nodeResults.has('n2')).toBe(false);
+      expect(result.nodeResults.has('n3')).toBe(false);
+    });
+
+    it('should report cancelled when an in-flight sibling fails after the signal fires', async () => {
+      // maxConcurrency 2 so n1 and n2 fill both slots while n3 is deferred.
+      const cancelEngine = new WorkflowEngine({ maxConcurrency: 2 });
+      const controller = new AbortController();
+
+      // n1 aborts the run the moment it runs, then succeeds immediately.
+      const aborter: NodeExecutor = vi.fn(async (node) => {
+        controller.abort();
+        return { result: node.id };
+      });
+      // n2 is already in flight when the abort fires; it fails during the drain.
+      const failer: NodeExecutor = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        throw new Error('sibling failed during drain');
+      });
+
+      cancelEngine.registerExecutor('generate', aborter);
+      cancelEngine.registerExecutor('upscale', failer);
+      cancelEngine.registerExecutor('publish', aborter);
+
+      // n1 + n2 occupy both slots; n3 is deferred so the dispatch phase re-runs
+      // after n1 settles and observes the abort, then n2 fails during drain.
+      const workflow = makeWorkflow([
+        makeNode('n1', 'generate'),
+        makeNode('n2', 'upscale'),
+        makeNode('n3', 'publish'),
+      ]);
+
+      const result = await cancelEngine.execute(workflow, {
+        abortSignal: controller.signal,
+        maxRetries: 0,
+      });
+
+      // Abort wins over the concurrent in-flight failure.
+      expect(result.status).toBe('cancelled');
+      // n3 was deferred and never dispatched once the abort was observed.
+      expect(result.nodeResults.has('n3')).toBe(false);
+    });
+  });
+
+  describe('execute — concurrency limit', () => {
+    it('should not run more than maxConcurrency nodes simultaneously', async () => {
+      let active = 0;
+      let maxActive = 0;
+      const releases: Array<() => void> = [];
+
+      const gatedExecutor: NodeExecutor = vi.fn(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise<void>((resolve) => {
+          releases.push(() => {
+            active--;
+            resolve();
+          });
+        });
+        return { result: 'ok' };
+      });
+
+      // engine from beforeEach is configured with maxConcurrency: 3.
+      engine.registerExecutor('generate', gatedExecutor);
+
+      // 6 independent branches (no edges) all eligible to run at once.
+      const workflow = makeWorkflow([
+        makeNode('n1', 'generate'),
+        makeNode('n2', 'generate'),
+        makeNode('n3', 'generate'),
+        makeNode('n4', 'generate'),
+        makeNode('n5', 'generate'),
+        makeNode('n6', 'generate'),
+      ]);
+
+      let done = false;
+      const runPromise = engine.execute(workflow).then((r) => {
+        done = true;
+        return r;
+      });
+
+      // Drain: each tick, release every currently-gated node so the scheduler
+      // can dispatch the next batch, until the run resolves.
+      while (!done) {
+        if (releases.length > 0) {
+          const toRelease = releases.splice(0, releases.length);
+          for (const release of toRelease) {
+            release();
+          }
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const result = await runPromise;
+
+      expect(result.status).toBe('completed');
+      expect(result.nodeResults.size).toBe(6);
+      // Never exceeded the limit, and actually reached it (proves parallelism).
+      expect(maxActive).toBeLessThanOrEqual(3);
+      expect(maxActive).toBe(3);
+    });
+  });
+
   describe('estimateCredits', () => {
     it('should return 0 for unknown node types', () => {
       const result = engine.estimateCredits([makeNode('n1', 'generate')]);

--- a/packages/workflow-engine/src/execution/engine.ts
+++ b/packages/workflow-engine/src/execution/engine.ts
@@ -83,6 +83,7 @@ export class WorkflowEngine {
     }
 
     const context: ExecutionContext = {
+      abortSignal: options.abortSignal,
       organizationId: workflow.organizationId,
       runId,
       userId: workflow.userId,
@@ -193,49 +194,107 @@ export class WorkflowEngine {
     const failedNodes = new Set<string>();
     let currentStatus: ExecutionStatus = 'running';
     let lastError: string | undefined;
+    let wasAborted = false;
 
-    for (const nodeId of executionOrder) {
-      if (!nodesToExecute.includes(nodeId)) {
-        continue;
-      }
-      if (completedNodes.has(nodeId)) {
-        continue;
+    // Bounded ready-set scheduler. Dispatches nodes in `executionOrder`
+    // priority, never running more than `maxConcurrency` at once, and only
+    // dispatching a node once `canExecuteNode` confirms its dependencies are
+    // satisfied. A cooperative `abortSignal` halts further dispatch and yields
+    // a `cancelled` status. With `maxConcurrency` of 1 this degrades to the
+    // previous strictly-sequential behavior.
+    const maxConcurrency = Math.max(1, this.config.maxConcurrency);
+    const remaining = executionOrder.filter(
+      (id) => nodesToExecute.includes(id) && !completedNodes.has(id),
+    );
+    const inFlight = new Map<
+      string,
+      Promise<{
+        node: ExecutableNode;
+        nodeId: string;
+        result: NodeExecutionResult;
+      }>
+    >();
+
+    while (inFlight.size > 0 || remaining.length > 0) {
+      // Dispatch phase — fill free slots while running and not aborted.
+      if (currentStatus !== 'failed' && !wasAborted) {
+        let index = 0;
+        while (index < remaining.length && inFlight.size < maxConcurrency) {
+          // Abort is checked before dispatching each node.
+          if (context.abortSignal?.aborted) {
+            wasAborted = true;
+            break;
+          }
+
+          const nodeId = remaining[index];
+          const node = workflow.nodes.find((n) => n.id === nodeId);
+          if (!node) {
+            lastError = `Node ${nodeId} not found`;
+            currentStatus = 'failed';
+            remaining.splice(index, 1);
+            break;
+          }
+
+          if (
+            !canExecuteNode(
+              nodeId,
+              workflow.nodes,
+              workflow.edges,
+              completedNodes,
+              nodeCache,
+            )
+          ) {
+            // Dependency still in flight — defer this node, try the next one.
+            index++;
+            continue;
+          }
+
+          remaining.splice(index, 1);
+          const inputs = this.gatherInputs(node, workflow.edges, nodeCache);
+
+          this.emitNodeStatusChange(options, {
+            newStatus: 'running',
+            nodeId,
+            previousStatus: 'pending',
+            runId,
+            timestamp: new Date(),
+            workflowId: workflow.id,
+          });
+
+          inFlight.set(
+            nodeId,
+            this.executeNode(node, inputs, context, options).then((result) => ({
+              node,
+              nodeId,
+              result,
+            })),
+          );
+        }
       }
 
-      const node = workflow.nodes.find((n) => n.id === nodeId);
-      if (!node) {
-        lastError = `Node ${nodeId} not found`;
+      if (inFlight.size === 0) {
+        if (currentStatus === 'failed' || wasAborted) {
+          break;
+        }
+        if (remaining.length === 0) {
+          break;
+        }
+        // Nothing in flight and nothing dispatchable: a dependency can never be
+        // satisfied. Fail the first stuck node rather than spin forever.
+        const stuckNodeId = remaining[0];
+        lastError = `Dependencies not satisfied for node ${stuckNodeId}`;
+        failedNodes.add(stuckNodeId);
         currentStatus = 'failed';
         break;
       }
 
-      if (
-        !canExecuteNode(
-          nodeId,
-          workflow.nodes,
-          workflow.edges,
-          completedNodes,
-          nodeCache,
-        )
-      ) {
-        lastError = `Dependencies not satisfied for node ${nodeId}`;
-        failedNodes.add(nodeId);
-        currentStatus = 'failed';
-        break;
-      }
+      // Wait for the next in-flight node to settle, then record its result.
+      // Already-dispatched nodes are always drained even after a failure or
+      // abort so their promises never reject unobserved.
+      const settled = await Promise.race(inFlight.values());
+      inFlight.delete(settled.nodeId);
 
-      const inputs = this.gatherInputs(node, workflow.edges, nodeCache);
-
-      this.emitNodeStatusChange(options, {
-        newStatus: 'running',
-        nodeId,
-        previousStatus: 'pending',
-        runId,
-        timestamp: new Date(),
-        workflowId: workflow.id,
-      });
-
-      const result = await this.executeNode(node, inputs, context, options);
+      const { node, nodeId, result } = settled;
       nodeResults.set(nodeId, result);
       totalCreditsUsed += result.creditsUsed;
 
@@ -243,6 +302,39 @@ export class WorkflowEngine {
         completedNodes.add(nodeId);
         if (result.output !== undefined) {
           nodeCache.set(nodeId, result.output);
+        }
+
+        // In-flight siblings drained after a failure or abort are still
+        // recorded in nodeResults/completedNodes (for observability and cache
+        // correctness), but they must not emit user-facing progress/status
+        // events on a run that is no longer healthy.
+        if (currentStatus !== 'failed' && !wasAborted) {
+          const totalNodes = nodesToExecute.length || 1;
+          // Only count completed nodes that are in the execution list for progress
+          const executedCount = nodesToExecute.filter((id) =>
+            completedNodes.has(id),
+          ).length;
+          const progress = Math.round((executedCount / totalNodes) * 100);
+          this.emitProgress(options, {
+            completedNodes: Array.from(completedNodes),
+            currentNodeId: nodeId,
+            currentNodeLabel: node.label,
+            failedNodes: Array.from(failedNodes),
+            progress,
+            runId,
+            timestamp: new Date(),
+            workflowId: workflow.id,
+          });
+
+          this.emitNodeStatusChange(options, {
+            newStatus: result.status,
+            nodeId,
+            output: result.output,
+            previousStatus: 'running',
+            runId,
+            timestamp: new Date(),
+            workflowId: workflow.id,
+          });
         }
       } else if (result.status === 'failed') {
         failedNodes.add(nodeId);
@@ -258,39 +350,15 @@ export class WorkflowEngine {
           timestamp: new Date(),
           workflowId: workflow.id,
         });
-
-        break;
       }
-
-      const totalNodes = nodesToExecute.length || 1;
-      // Only count completed nodes that are in the execution list for progress
-      const executedCount = nodesToExecute.filter((id) =>
-        completedNodes.has(id),
-      ).length;
-      const progress = Math.round((executedCount / totalNodes) * 100);
-      this.emitProgress(options, {
-        completedNodes: Array.from(completedNodes),
-        currentNodeId: nodeId,
-        currentNodeLabel: node.label,
-        failedNodes: Array.from(failedNodes),
-        progress,
-        runId,
-        timestamp: new Date(),
-        workflowId: workflow.id,
-      });
-
-      this.emitNodeStatusChange(options, {
-        newStatus: result.status,
-        nodeId,
-        output: result.output,
-        previousStatus: 'running',
-        runId,
-        timestamp: new Date(),
-        workflowId: workflow.id,
-      });
     }
 
-    if (currentStatus !== 'failed') {
+    // Abort takes priority over a concurrent in-flight failure: a run whose
+    // signal fired must report `cancelled`, even if a sibling node failed while
+    // the already-dispatched work was being drained.
+    if (wasAborted) {
+      currentStatus = 'cancelled';
+    } else if (currentStatus !== 'failed') {
       // Count only nodes that were in the execution list (not pre-skipped locked nodes)
       const executedOrSkipped = nodesToExecute.every((id) =>
         completedNodes.has(id),

--- a/packages/workflow-engine/src/workflows-contracts-shim.ts
+++ b/packages/workflow-engine/src/workflows-contracts-shim.ts
@@ -43,6 +43,11 @@ export interface ExecutionOptions {
   onNodeStatusChange?: (event: NodeStatusChangeEvent) => void;
   availableCredits?: number;
   dryRun?: boolean;
+  /**
+   * Cooperative cancellation signal. When it transitions to aborted, the
+   * engine stops dispatching further nodes and returns a `cancelled` status.
+   */
+  abortSignal?: AbortSignal;
 }
 
 export interface ExecutableNode {

--- a/packages/workflows/src/contracts/execution.ts
+++ b/packages/workflows/src/contracts/execution.ts
@@ -45,6 +45,11 @@ export interface ExecutionOptions {
   onNodeStatusChange?: (event: NodeStatusChangeEvent) => void;
   availableCredits?: number;
   dryRun?: boolean;
+  /**
+   * Cooperative cancellation signal. When it transitions to aborted, the
+   * engine stops dispatching further nodes and returns a `cancelled` status.
+   */
+  abortSignal?: AbortSignal;
 }
 
 export interface ExecutableNode {


### PR DESCRIPTION
## What

Wires up cooperative cancellation and concurrency bounding in the workflow execution engine (issue #479). The engine previously declared `ExecutionContext.abortSignal` and an `ExecutionStatus` of `cancelled`, but never populated the signal and ran every node strictly sequentially regardless of `maxConcurrency`.

## Changes

- **Wire `abortSignal` end-to-end.** `options.abortSignal` now flows into `ExecutionContext`, and is added to the `ExecutionOptions` contract in both `@genfeedai/workflows` (`contracts/execution.ts`) and the workflow-engine shim (the two are kept byte-identical).
- **Bounded ready-set scheduler.** Replaces the sequential `for…of executionOrder` loop. Ready nodes are dispatched in `executionOrder` priority up to `maxConcurrency`; free slots are reclaimed via `Promise.race` over in-flight work; a node whose dependency is still in flight is **deferred, not failed**. At `maxConcurrency: 1` this degrades to the previous strictly-sequential behavior (the telegram-bot caller relies on that).
- **Cancellation semantics.** When the signal fires, dispatch halts and the run returns `cancelled`. Abort takes **priority** over a concurrent in-flight failure during the drain phase — a cancelled run can no longer masquerade as `failed`.
- **No unobserved rejections.** Already-dispatched nodes are always drained on failure/abort; their progress/`onNodeStatusChange` callbacks are suppressed once the run is no longer healthy, so integrators don't see a `completed`/`progress: 100` event on a `failed` run.

## Review

This change was self-reviewed by an adversarial multi-agent pass (find → refute → fix). Three confirmed low-severity findings were folded in before this PR: abort-vs-concurrent-failure status masking, drain-phase callback leakage, and a redundant local alias.

## Verification

- `bun run test` (workflow-engine): **613 passed**. The 4 failing *files* are pre-existing `@genfeedai/enums` entry-resolution errors in unrelated saas-executor specs — 0 test assertions fail and they pre-date this branch.
- New specs: cancellation (sequential + concurrent-failing-sibling) and `maxConcurrency` bounding (never exceeds, actually reaches the limit).
- `tsc` typecheck (workflow-engine + workflows builds): clean.
- Biome check on all changed files: clean.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)