### PR TITLE
fix(security): SSRF blocklist, ReDoS guards, unbounded query limit, OAuth redirect allowlist

### DIFF
--- a/apps/server/api/src/collections/workflow-executions/dto/create-workflow-execution.dto.ts
+++ b/apps/server/api/src/collections/workflow-executions/dto/create-workflow-execution.dto.ts
@@ -28,6 +28,8 @@ export class CreateWorkflowExecutionDto {
     description: 'Input values for workflow variables',
     required: false,
   })
+  @IsOptional()
+  @IsObject()
   readonly inputValues?: Record<string, unknown>;
 
   @IsObject()

--- a/apps/server/api/src/collections/workflows/services/adapters/twitter-social.adapter.ts
+++ b/apps/server/api/src/collections/workflows/services/adapters/twitter-social.adapter.ts
@@ -628,9 +628,18 @@ export class TwitterSocialAdapter {
       }
 
       if (matchMode === 'regex') {
+        // ReDoS guard: keyword patterns are user-controlled. Cap pattern
+        // and subject length until RE2 lands (genfeedai/genfeed.ai#475).
+        if (keyword.length > 200) {
+          if (sourceText.includes(keyword)) {
+            return keyword;
+          }
+          continue;
+        }
+
         try {
           const regex = new RegExp(keyword, caseSensitive ? 'g' : 'gi');
-          if (regex.test(text)) {
+          if (regex.test(text.slice(0, 10_000))) {
             return keyword;
           }
         } catch {

--- a/apps/server/api/src/helpers/dto/base-query.dto.ts
+++ b/apps/server/api/src/helpers/dto/base-query.dto.ts
@@ -6,6 +6,7 @@ import {
   IsNumber,
   IsOptional,
   IsString,
+  Max,
   Min,
   ValidateIf,
 } from 'class-validator';
@@ -37,6 +38,7 @@ export class BaseQueryDto {
   @Type(() => Number)
   @IsNumber()
   @Min(1)
+  @Max(100)
   @Transform(({ value }) =>
     value !== undefined && value !== null ? Number(value) : 10,
   )

--- a/apps/server/api/src/helpers/utils/ssrf/ssrf.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/ssrf/ssrf.util.spec.ts
@@ -1,0 +1,54 @@
+import { BadRequestException } from '@nestjs/common';
+import { assertHostNotPrivate, assertUrlNotPrivate } from './ssrf.util';
+
+describe('ssrf.util', () => {
+  describe('assertHostNotPrivate', () => {
+    it.each([
+      'localhost',
+      '127.0.0.1',
+      '0.0.0.0',
+      '::1',
+      'metadata.google.internal',
+      '169.254.169.254',
+      '10.0.0.5',
+      '172.16.1.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      'service.internal',
+      'printer.local',
+    ])('blocks %s', (host) => {
+      expect(() => assertHostNotPrivate(host)).toThrow(BadRequestException);
+    });
+
+    it.each([
+      'genfeed.ai',
+      'api.genfeed.ai',
+      'mastodon.social',
+      '8.8.8.8',
+      '172.32.0.1', // just outside 172.16/12
+      '11.0.0.1', // just outside 10/8
+    ])('allows %s', (host) => {
+      expect(() => assertHostNotPrivate(host)).not.toThrow();
+    });
+  });
+
+  describe('assertUrlNotPrivate', () => {
+    it('blocks the cloud metadata endpoint', () => {
+      expect(() =>
+        assertUrlNotPrivate('http://169.254.169.254/latest/meta-data/'),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects unparseable URLs', () => {
+      expect(() => assertUrlNotPrivate('not a url')).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('allows public URLs', () => {
+      expect(() =>
+        assertUrlNotPrivate('https://example.com/page'),
+      ).not.toThrow();
+    });
+  });
+});

--- a/apps/server/api/src/helpers/utils/ssrf/ssrf.util.ts
+++ b/apps/server/api/src/helpers/utils/ssrf/ssrf.util.ts
@@ -1,0 +1,70 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Hostnames that must never be fetched server-side, regardless of range
+ * checks (cloud metadata endpoints, loopback aliases).
+ */
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  '[::]',
+  '[::1]',
+  'metadata.google.internal',
+  'metadata.google',
+  'instance-data',
+]);
+
+/**
+ * Validate a hostname against SSRF targets: loopback, RFC-1918 private
+ * ranges, link-local/cloud-metadata (169.254.0.0/16), and internal TLDs.
+ * Throws BadRequestException on a blocked host.
+ *
+ * Single source of truth for server-side URL fetching (brand scraper,
+ * Mastodon instance discovery, ...). Extracted from MastodonService.
+ */
+export function assertHostNotPrivate(hostname: string): void {
+  const lowerHost = hostname.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(lowerHost)) {
+    throw new BadRequestException('URL points to a blocked address');
+  }
+
+  const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(
+    lowerHost,
+  );
+  if (ipv4Match) {
+    const [, a, b] = ipv4Match.map(Number);
+    if (
+      a === 10 || // 10.0.0.0/8
+      (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+      (a === 192 && b === 168) || // 192.168.0.0/16
+      (a === 169 && b === 254) || // 169.254.0.0/16 (link-local / cloud metadata)
+      a === 127 || // 127.0.0.0/8
+      a === 0 // 0.0.0.0/8
+    ) {
+      throw new BadRequestException('URL points to a private IP range');
+    }
+  }
+
+  if (lowerHost.endsWith('.internal') || lowerHost.endsWith('.local')) {
+    throw new BadRequestException('URL points to an internal hostname');
+  }
+}
+
+/**
+ * Parse a URL and validate its hostname. Throws BadRequestException for
+ * unparseable URLs or SSRF targets.
+ */
+export function assertUrlNotPrivate(url: string): void {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new BadRequestException('Invalid URL');
+  }
+
+  assertHostNotPrivate(parsed.hostname);
+}

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
@@ -170,6 +170,30 @@ describe('BrandScraperService', () => {
       expect(result.isValid).toBe(false);
     });
 
+    it('rejects the cloud metadata endpoint (SSRF)', () => {
+      const result = service.validateUrl(
+        'http://169.254.169.254/latest/meta-data/',
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('Local URLs are not allowed');
+    });
+
+    it('rejects RFC-1918 private ranges (SSRF)', () => {
+      for (const target of [
+        'http://10.0.0.5',
+        'http://172.16.1.1',
+        'http://192.168.1.1',
+      ]) {
+        expect(service.validateUrl(target).isValid).toBe(false);
+      }
+    });
+
+    it('rejects .internal hostnames (SSRF)', () => {
+      expect(service.validateUrl('http://db.cluster.internal').isValid).toBe(
+        false,
+      );
+    });
+
     it('rejects 0.0.0.0', () => {
       const result = service.validateUrl('http://0.0.0.0');
       expect(result.isValid).toBe(false);

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
@@ -1,3 +1,4 @@
+import { assertHostNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
 import type {
   BrandScrapeSources,
   LinkedInScrapedData,
@@ -902,8 +903,12 @@ export class BrandScraperService {
         return { error: 'Invalid domain', isValid: false };
       }
 
-      const blockedDomains = ['localhost', '127.0.0.1', '0.0.0.0'];
-      if (blockedDomains.some((d) => parsedUrl.hostname.includes(d))) {
+      // Shared SSRF blocklist: loopback, RFC-1918, link-local/cloud
+      // metadata, internal TLDs. The previous three-string check left
+      // 169.254.169.254 and all private ranges fetchable.
+      try {
+        assertHostNotPrivate(parsedUrl.hostname);
+      } catch {
         return { error: 'Local URLs are not allowed', isValid: false };
       }
 

--- a/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.spec.ts
+++ b/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.spec.ts
@@ -26,7 +26,13 @@ describe('MastodonService', () => {
         MastodonService,
         {
           provide: ConfigService,
-          useValue: { get: vi.fn((k: string) => `mock-${k}`) },
+          useValue: {
+            get: vi.fn((k: string) =>
+              // default: no app URL configured → allowlist warn-skips;
+              // the redirectUri allowlist suite overrides per test
+              k === 'GENFEEDAI_APP_URL' ? undefined : `mock-${k}`,
+            ),
+          },
         },
         {
           provide: CredentialsService,
@@ -330,6 +336,38 @@ describe('MastodonService', () => {
         views: 0,
       });
       expect(loggerService.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('redirectUri allowlist', () => {
+    it('rejects redirect URIs outside the configured app origin', () => {
+      configService.get.mockImplementation((k: string) =>
+        k === 'GENFEEDAI_APP_URL' ? 'https://app.genfeed.ai' : `mock-${k}`,
+      );
+
+      expect(() =>
+        service.generateAuthUrl(
+          instanceUrl,
+          'client-id',
+          'https://evil.example.com/callback',
+          'state',
+        ),
+      ).toThrow('redirectUri is not allowed');
+    });
+
+    it('accepts redirect URIs under the configured app origin', () => {
+      configService.get.mockImplementation((k: string) =>
+        k === 'GENFEEDAI_APP_URL' ? 'https://app.genfeed.ai' : `mock-${k}`,
+      );
+
+      expect(() =>
+        service.generateAuthUrl(
+          instanceUrl,
+          'client-id',
+          'https://app.genfeed.ai/integrations/mastodon/callback',
+          'state',
+        ),
+      ).not.toThrow();
     });
   });
 });

--- a/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.ts
+++ b/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.ts
@@ -1,5 +1,6 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { ConfigService } from '@api/config/config.service';
+import { assertHostNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import { CredentialPlatform, OAuthGrantType } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -60,55 +61,36 @@ export class MastodonService {
   ) {}
 
   /**
-   * Blocked hostnames for SSRF prevention
-   */
-  private static readonly BLOCKED_HOSTNAMES = new Set([
-    'localhost',
-    '127.0.0.1',
-    '0.0.0.0',
-    '::1',
-    '[::]',
-    '[::1]',
-    'metadata.google.internal',
-    'metadata.google',
-    'instance-data',
-  ]);
-
-  /**
-   * Validate that a hostname does not resolve to a private/internal address
+   * Validate that a hostname does not resolve to a private/internal address.
+   * Delegates to the shared SSRF util (single fix path for bypasses).
    */
   private validateInstanceHost(hostname: string): void {
-    const lowerHost = hostname.toLowerCase();
+    assertHostNotPrivate(hostname);
+  }
 
-    if (MastodonService.BLOCKED_HOSTNAMES.has(lowerHost)) {
-      throw new BadRequestException('Instance URL points to a blocked address');
-    }
+  /**
+   * Only app-owned redirect URIs may participate in the OAuth flow.
+   * A caller-supplied arbitrary redirectUri turns the API into an open
+   * redirector / token-exfiltration helper.
+   */
+  private assertRedirectUriAllowed(redirectUri: string): void {
+    const appUrl = (
+      this.configService.get('GENFEEDAI_APP_URL') as string | undefined
+    )?.replace(/\/+$/, '');
 
-    // Block private IPv4 ranges
-    const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(
-      lowerHost,
-    );
-    if (ipv4Match) {
-      const [, a, b] = ipv4Match.map(Number);
-      if (
-        a === 10 || // 10.0.0.0/8
-        (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-        (a === 192 && b === 168) || // 192.168.0.0/16
-        (a === 169 && b === 254) || // 169.254.0.0/16 (link-local / cloud metadata)
-        a === 127 || // 127.0.0.0/8
-        a === 0 // 0.0.0.0/8
-      ) {
-        throw new BadRequestException(
-          'Instance URL points to a private IP range',
-        );
-      }
-    }
-
-    // Block .internal and .local TLDs
-    if (lowerHost.endsWith('.internal') || lowerHost.endsWith('.local')) {
-      throw new BadRequestException(
-        'Instance URL points to an internal hostname',
+    if (!appUrl) {
+      this.loggerService.warn(
+        'MastodonService GENFEEDAI_APP_URL not configured — skipping redirectUri allowlist',
       );
+      return;
+    }
+
+    if (
+      redirectUri !== appUrl &&
+      !redirectUri.startsWith(`${appUrl}/`) &&
+      redirectUri !== 'urn:ietf:wg:oauth:2.0:oob'
+    ) {
+      throw new BadRequestException('redirectUri is not allowed');
     }
   }
 
@@ -155,6 +137,7 @@ export class MastodonService {
     instanceUrl: string,
     redirectUri: string,
   ): Promise<MastodonAppRegistration> {
+    this.assertRedirectUriAllowed(redirectUri);
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     const normalizedUrl = this.normalizeInstanceUrl(instanceUrl);
 
@@ -192,6 +175,7 @@ export class MastodonService {
     redirectUri: string,
     state: string,
   ): string {
+    this.assertRedirectUriAllowed(redirectUri);
     const normalizedUrl = this.normalizeInstanceUrl(instanceUrl);
     const params = new URLSearchParams({
       client_id: clientId,
@@ -213,6 +197,7 @@ export class MastodonService {
     code: string,
     redirectUri: string,
   ): Promise<{ accessToken: string }> {
+    this.assertRedirectUriAllowed(redirectUri);
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     const normalizedUrl = this.normalizeInstanceUrl(instanceUrl);
 

--- a/packages/workflow-engine/src/executors/saas/condition-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/condition-executor.spec.ts
@@ -88,6 +88,16 @@ describe('evaluateCondition', () => {
     expect(evaluateCondition('matches', 'hello', '\\d+')).toBe(false);
   });
 
+  it('rejects pathologically long regex patterns without evaluating (ReDoS guard)', () => {
+    const pattern = `(${'a+'.repeat(150)})+$`;
+    const start = Date.now();
+    expect(evaluateCondition('matches', 'a'.repeat(5_000), pattern)).toBe(
+      false,
+    );
+    // must short-circuit, not backtrack
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+
   it('isTrue / isFalse', () => {
     expect(evaluateCondition('isTrue', true, undefined)).toBe(true);
     expect(evaluateCondition('isTrue', 1, undefined)).toBe(true);

--- a/packages/workflow-engine/src/executors/saas/condition-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/condition-executor.ts
@@ -213,9 +213,19 @@ export function evaluateCondition(
       return String(actual).endsWith(String(expected));
 
     case 'matches': {
+      const pattern = String(expected);
+
+      // ReDoS guard: workflow config is user-controlled; a crafted
+      // backtracking pattern against a long string blocks the event loop.
+      // Length caps bound the blowup until a linear-time engine (RE2)
+      // replaces this — tracked in genfeedai/genfeed.ai#475.
+      if (pattern.length > 200) {
+        return false;
+      }
+
       try {
-        const regex = new RegExp(String(expected));
-        return regex.test(String(actual));
+        const regex = new RegExp(pattern);
+        return regex.test(String(actual).slice(0, 10_000));
       } catch {
         return false;
       }


### PR DESCRIPTION
## Problem (P1 — audit-confirmed)

- **SSRF**: brand-scraper `validateUrl` blocked only `localhost`/`127.0.0.1`/`0.0.0.0` — `http://169.254.169.254/latest/meta-data/` and every RFC-1918 range were fetchable from onboarding. Mastodon had the thorough blocklist; brand-scraper didn't.
- **ReDoS**: workflow condition `matches` + twitter-social regex matchMode build `RegExp` from user-controlled config, unbounded.
- **Unbounded queries**: `BaseQueryDto.limit` documented `maximum: 100` in Swagger only — no `@Max`; public.posts/musics/videos/images + mcp controllers pass it through unclamped.
- **Open redirect**: Mastodon register/auth/token accepted arbitrary caller-supplied `redirectUri`.

## Fix

- Shared `ssrf.util` (`assertHostNotPrivate`/`assertUrlNotPrivate`) extracted from Mastodon's implementation; both services now use it — single fix path for bypasses.
- Pattern length cap (200) + subject cap (10k) on both regex sites; linear-time engine tracked in #475.
- `@Max(100)` on `BaseQueryDto.limit`.
- `redirectUri` must be under the configured `GENFEEDAI_APP_URL` origin (or oob); warn-skip when origin unconfigured.
- `inputValues` on workflow-execution DTO gains `@IsObject` (whitelist readiness).

**Deliberately deferred:** flipping the global ValidationPipe to `whitelist: true`. A sweep found **73 DTO fields whose only decorator is `@IsOptional`** (plus undecorated ones) that whitelist would silently strip — that flip needs its own batch with per-field decorators. Follow-up issue incoming.

## Tests

128 specs green: new `ssrf.util.spec` (21 cases), brand-scraper SSRF rejections, ReDoS guard timing spec, Mastodon redirectUri allowlist. Type-check + lint green.

Remediation P1-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)