### PR TITLE
fix(security): spoofable Leonardo IP check, Telegram token leak, billing plan-change gaps

### DIFF
--- a/apps/server/api/src/endpoints/integrations/__tests__/integrations.controller.spec.ts
+++ b/apps/server/api/src/endpoints/integrations/__tests__/integrations.controller.spec.ts
@@ -5,6 +5,7 @@ import { InternalIntegrationsController } from '@api/endpoints/integrations/inte
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { AdminApiKeyGuard } from '@api/helpers/guards/admin-api-key/admin-api-key.guard';
 import { ClerkGuard } from '@api/helpers/guards/clerk/clerk.guard';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import type { User } from '@clerk/backend';
 import { IntegrationPlatform, IntegrationStatus } from '@genfeedai/enums';
 import type { OrgIntegration } from '@genfeedai/prisma';
@@ -54,6 +55,10 @@ describe('OrganizationsIntegrationsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OrganizationsIntegrationsController],
       providers: [
+        {
+          provide: FilesClientService,
+          useValue: { uploadToS3: vi.fn() },
+        },
         {
           provide: IntegrationsService,
           useValue: mockService,
@@ -284,6 +289,10 @@ describe('InternalIntegrationsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [InternalIntegrationsController],
       providers: [
+        {
+          provide: FilesClientService,
+          useValue: { uploadToS3: vi.fn() },
+        },
         {
           provide: IntegrationsService,
           useValue: mockService,

--- a/apps/server/api/src/endpoints/integrations/dto/upload-integration-media.dto.ts
+++ b/apps/server/api/src/endpoints/integrations/dto/upload-integration-media.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+
+export class UploadIntegrationMediaDto {
+  /**
+   * Source URL the files service fetches server-side. May carry transport
+   * credentials (e.g. a Telegram bot-token file URL) — it is never persisted.
+   */
+  @IsUrl()
+  @IsNotEmpty()
+  fileUrl!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  organizationId!: string;
+}

--- a/apps/server/api/src/endpoints/integrations/integrations.controller.spec.ts
+++ b/apps/server/api/src/endpoints/integrations/integrations.controller.spec.ts
@@ -1,6 +1,7 @@
 import { OrganizationsIntegrationsController } from '@api/collections/organizations/controllers/organizations-integrations.controller';
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import type { User } from '@clerk/backend';
 import { Test, type TestingModule } from '@nestjs/testing';
 
@@ -29,6 +30,10 @@ describe('OrganizationsIntegrationsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OrganizationsIntegrationsController],
       providers: [
+        {
+          provide: FilesClientService,
+          useValue: { uploadToS3: vi.fn() },
+        },
         {
           provide: IntegrationsService,
           useValue: integrationsService,

--- a/apps/server/api/src/endpoints/integrations/integrations.controller.ts
+++ b/apps/server/api/src/endpoints/integrations/integrations.controller.ts
@@ -1,17 +1,47 @@
+import { UploadIntegrationMediaDto } from '@api/endpoints/integrations/dto/upload-integration-media.dto';
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { AdminApiKeyGuard } from '@api/helpers/guards/admin-api-key/admin-api-key.guard';
-import { IntegrationPlatform } from '@genfeedai/enums';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import { FileInputType, IntegrationPlatform } from '@genfeedai/enums';
 import type { OrgIntegration } from '@genfeedai/prisma';
 import { Public } from '@libs/decorators/public.decorator';
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiParam } from '@nestjs/swagger';
+import { nanoid } from 'nanoid';
 
 // Internal controller for integration services
 @Controller('internal/integrations')
 @Public()
 @UseGuards(AdminApiKeyGuard)
 export class InternalIntegrationsController {
-  constructor(private readonly integrationsService: IntegrationsService) {}
+  constructor(
+    private readonly integrationsService: IntegrationsService,
+    private readonly filesClientService: FilesClientService,
+  ) {}
+
+  /**
+   * Mirror an external media URL into our storage and return the durable
+   * public URL. Lets channel bots avoid persisting transport URLs that
+   * embed credentials (Telegram file URLs contain the bot token).
+   */
+  @Post(':platform/media')
+  @ApiParam({
+    enum: IntegrationPlatform,
+    enumName: 'IntegrationPlatform',
+    name: 'platform',
+  })
+  async uploadMedia(
+    @Param('platform') platform: IntegrationPlatform,
+    @Body() body: UploadIntegrationMediaDto,
+  ): Promise<{ data: { url: string } }> {
+    const key = `integrations/${platform}/${body.organizationId}/${nanoid()}`;
+    const metadata = await this.filesClientService.uploadToS3(key, 'images', {
+      type: FileInputType.URL,
+      url: body.fileUrl,
+    });
+
+    return { data: { url: String(metadata.publicUrl ?? '') } };
+  }
 
   @Get(':platform')
   @ApiParam({

--- a/apps/server/api/src/endpoints/integrations/integrations.module.ts
+++ b/apps/server/api/src/endpoints/integrations/integrations.module.ts
@@ -1,12 +1,14 @@
 import { InternalIntegrationsController } from '@api/endpoints/integrations/integrations.controller';
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { AdminApiKeyGuard } from '@api/helpers/guards/admin-api-key/admin-api-key.guard';
+import { FilesMicroserviceModule } from '@api/services/files-microservice/files-microservice.module';
 import { CryptoService } from '@libs/crypto/crypto.service';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [InternalIntegrationsController],
   exports: [IntegrationsService],
+  imports: [forwardRef(() => FilesMicroserviceModule)],
   providers: [
     AdminApiKeyGuard,
     IntegrationsService,

--- a/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.controller.ts
+++ b/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.controller.ts
@@ -6,7 +6,14 @@ import { Public } from '@libs/decorators/public.decorator';
 import { LeonardoAIWebhookPayload } from '@libs/interfaces/webhook-payload.interface';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Body, Controller, HttpCode, Post, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
 import type { Request } from 'express';
 
 @AutoSwagger()
@@ -31,10 +38,11 @@ export class LeonardoaiWebhookController {
 
     try {
       this.loggerService.log(`${url} received`, payload);
-      const requestIp: string =
-        request.headers['x-forwarded-for']?.toString().split(',')[0] ||
-        request.ip ||
-        '';
+      // request.ip is derived safely by Express under `trust proxy 1`.
+      // Reading x-forwarded-for directly is spoofable: an attacker sends
+      // 'X-Forwarded-For: <allowed-ip>, <self>' and the first-token split
+      // yields the allowed IP.
+      const requestIp: string = request.ip || '';
 
       // Verify that the request is coming from LeonardoAI's IP addresses
       const allowedIps = [
@@ -50,7 +58,7 @@ export class LeonardoaiWebhookController {
         this.loggerService.warn(
           `Unauthorized webhook request from IP: ${requestIp}`,
         );
-        throw new Error('Unauthorized webhook request');
+        throw new UnauthorizedException('Unauthorized webhook request');
       }
 
       // Handle metadata-based webhook processing if customId is present

--- a/apps/server/telegram/src/services/telegram-bot-manager.service.ts
+++ b/apps/server/telegram/src/services/telegram-bot-manager.service.ts
@@ -441,7 +441,18 @@ export class TelegramBotManager
       const bestPhoto = photos[photos.length - 1];
       const file = await ctx.api.getFile(bestPhoto.file_id);
 
-      const imageUrl = `https://api.telegram.org/file/bot${ctx.api.token}/${file.file_path}`;
+      // The Telegram file URL embeds the bot token — it must never be
+      // persisted. Mirror it into our storage via the internal media
+      // endpoint and store only the durable public URL.
+      const transportUrl = `https://api.telegram.org/file/bot${ctx.api.token}/${file.file_path}`;
+      const imageUrl = session.orgId
+        ? await this.mirrorTelegramFile(transportUrl, session.orgId)
+        : null;
+
+      if (!imageUrl) {
+        await ctx.reply('Failed to process the photo. Please try again.');
+        return;
+      }
 
       session.collectedInputs.set(currentInput.nodeId, imageUrl);
       session.currentInputIndex++;
@@ -573,6 +584,29 @@ export class TelegramBotManager
       .filter(
         (integration): integration is OrgIntegration => integration !== null,
       );
+  }
+
+  private async mirrorTelegramFile(
+    transportUrl: string,
+    organizationId: string,
+  ): Promise<string | null> {
+    try {
+      const apiKey = this.configService.API_KEY;
+      const response = await firstValueFrom(
+        this.httpService.post(
+          `${this.configService.API_URL}/v1/internal/integrations/telegram/media`,
+          { fileUrl: transportUrl, organizationId },
+          {
+            headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+          },
+        ),
+      );
+      const url = response.data?.data?.url;
+      return typeof url === 'string' && url.length > 0 ? url : null;
+    } catch (error) {
+      this.logger.error('Failed to mirror Telegram file:', error);
+      return null;
+    }
   }
 
   private async fetchActiveIntegrations(): Promise<OrgIntegration[]> {

--- a/ee/packages/billing/src/subscriptions/controllers/subscriptions.controller.ts
+++ b/ee/packages/billing/src/subscriptions/controllers/subscriptions.controller.ts
@@ -30,6 +30,7 @@ import {
   Req,
 } from '@nestjs/common';
 import type { Request } from 'express';
+import { ChangePlanDto } from '../dto/change-plan.dto';
 import type { CreateSubscriptionPreviewDto } from '../dto/create-subscription.dto';
 import { SubscriptionsService } from '../services/subscriptions.service';
 
@@ -109,14 +110,18 @@ export class SubscriptionsController {
   @Patch('current')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async changePlan(
+    @Req() request: RequestWithContext,
     @CurrentUser() user: User,
-    @Body() changeData: IChangePriceBodyParams,
+    @Body() changeData: ChangePlanDto,
   ): Promise<SubscriptionMutationResponse> {
-    const publicMetadata = getPublicMetadata(user);
+    // request.context tracks the ACTIVE organization; Clerk publicMetadata
+    // can lag behind an org switch and bill the wrong org.
+    const organizationId =
+      request.context?.organizationId ?? getPublicMetadata(user).organization;
 
     try {
       const result = await this.subscriptionsService.changeSubscriptionPlan(
-        publicMetadata.organization,
+        organizationId,
         changeData.newPriceId,
       );
 

--- a/ee/packages/billing/src/subscriptions/dto/change-plan.dto.ts
+++ b/ee/packages/billing/src/subscriptions/dto/change-plan.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class ChangePlanDto {
+  @IsString()
+  @IsNotEmpty()
+  newPriceId!: string;
+}

--- a/ee/packages/billing/src/subscriptions/services/subscriptions.service.ts
+++ b/ee/packages/billing/src/subscriptions/services/subscriptions.service.ts
@@ -1,3 +1,4 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { CustomersService } from '@api/collections/customers/services/customers.service';
 import type { OrganizationDocument } from '@api/collections/organizations/schemas/organization.schema';
 import { UsersService } from '@api/collections/users/services/users.service';
@@ -16,6 +17,8 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -118,6 +121,8 @@ export class SubscriptionsService
     private readonly stripeService: StripeService,
     private readonly customersService: CustomersService,
     private readonly clerkService: ClerkService,
+    @Inject(forwardRef(() => CreditsUtilsService))
+    private readonly creditsUtilsService: CreditsUtilsService,
   ) {
     super(prisma, 'subscription', logger);
   }
@@ -388,12 +393,12 @@ export class SubscriptionsService
         }
 
         if (creditsForNewPlan > 0) {
-          // await this.creditsUtilsService.resetOrganizationCredits(
-          //   organizationId,
-          //   creditsForNewPlan,
-          //   source,
-          //   `Credits reset due to subscription change from ${subscription.type} to ${newType}`,
-          // );
+          await this.creditsUtilsService.resetOrganizationCredits(
+            organizationId,
+            creditsForNewPlan,
+            source,
+            `Credits reset due to subscription change from ${subscription.type} to ${newType}`,
+          );
 
           this.logger.log(`${url} credits reset for plan change`, {
             newCredits: creditsForNewPlan,
@@ -486,7 +491,9 @@ export class SubscriptionsService
         newPriceId,
         prorationAmount,
         upcomingInvoice: {
-          amount_due: prorationAmount,
+          // Stripe's preview already accounts for billing-cycle position;
+          // the naive price diff over/under-charged mid-cycle changes.
+          amount_due: upcomingInvoice.amount_due,
           currency: upcomingInvoice.currency,
           lines: upcomingInvoice.lines.data,
         },


### PR DESCRIPTION
## Fixes (P1-E, audit-confirmed)

1. **LeonardoAI webhook IP spoof** — controller read raw `x-forwarded-for` first token; `X-Forwarded-For: <allowed-ip>, ...` bypassed the allowlist. Now uses `request.ip` (safe under `trust proxy 1`, main.ts:65) + 401 instead of generic 500.
2. **Telegram bot token leak** — photo uploads stored `api.telegram.org/file/bot<TOKEN>/...` into session inputs → workflow execution records. New `POST /v1/internal/integrations/:platform/media` (AdminApiKeyGuard) mirrors media via `FilesClientService.uploadToS3` and returns the durable URL; bot persists only that.
3. **Plan-change credit reset** was commented out (`subscriptions.service.ts:391`) — restored with proper `CreditsUtilsService` injection.
4. **changePlan**: class-validator DTO (was a plain interface = zero validation) + org from `request.context` (Clerk publicMetadata lags org switches).
5. **previewSubscriptionChange**: returns Stripe's upcoming-invoice `amount_due` (cycle-aware) instead of a naive unit-price diff.

## Verification

- integrations + leonardo specs 51/51 green (both controller spec files updated for the new `FilesClientService` dependency)
- type-check: **0 new errors** (4 pre-existing `newsletters.service.ts` errors on develop from concurrent newsletter work — verified via stash; not addressed here)
- biome + lint green

Remediation P1-E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)