### PR TITLE
build: fail loud when tsc --build skips emit (turbo cache poisoning guard)

### DIFF
--- a/ee/packages/harness/package.json
+++ b/ee/packages/harness/package.json
@@ -22,7 +22,7 @@
   "name": "@genfeedai/ee-harness",
   "private": true,
   "scripts": {
-    "build": "tsc --build && if [ -d dist/src ]; then mv dist/src/* dist/ 2>/dev/null && rm -rf dist/src; fi",
+    "build": "tsc --build && if [ -d dist/src ]; then mv dist/src/* dist/ 2>/dev/null && rm -rf dist/src; fi && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "type-check": "tsc --noEmit"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -52,7 +52,7 @@
     "url": "git+https://github.com/genfeedai/packages.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/genfeedai/packages.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/genfeedai/packages.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## Problem

Reproduced this session: `dist/` deleted while `tsconfig.tsbuildinfo` survived → `tsc --build` says up-to-date, emits nothing → turbo caches the **empty** `dist/**` under the current input hash → every cache replay restores nothing → `bun type-check` fails locally for `@genfeedai/cli` (`Cannot find module '@genfeedai/serializers'/'@genfeedai/tools'`). Same failure class as the resolved TS6/Prisma-7 regression.

## Fix

`&& test -f dist/index.js` appended to the build scripts of the four packages that exhibited this (tools, serializers, client, ee-harness). Skipped emit now exits 1 — the poison can't enter the cache.

Verified: simulated the poisoned state (rm -rf dist, keep tsbuildinfo) → build fails; clean build green.

(`*.tsbuildinfo` is already gitignored — local stray artifacts were the trigger, not tracked files.)

Remediation P1-F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)