### PR TITLE
fix(ci): restore build-unified-image action — prod deploys broken since migration

### DIFF
--- a/.github/actions/build-unified-image/action.yml
+++ b/.github/actions/build-unified-image/action.yml
@@ -1,0 +1,104 @@
+name: 'Build and Push Unified Server Image'
+description: 'Builds and pushes the single Docker image containing all NestJS server services'
+
+# Restored after the cloud -> genfeed.ai migration dropped this composite
+# action while _deploy.yml kept referencing it (every Deploy Production /
+# Deploy Staging run failed at "Can't find action.yml"). Ported from
+# genfeedai/cloud with three adaptations: GitHub-hosted buildx instead of
+# Blacksmith, a single SENTRY_AUTH_TOKEN secret (matching the current
+# Dockerfile.server secret mount and _deploy.yml input), and a disk-space
+# step (cold builds without the registry cache exhaust ubuntu-latest disks).
+
+inputs:
+  registry:
+    description: 'Container registry'
+    required: false
+    default: 'ghcr.io'
+  image_prefix:
+    description: 'Image name prefix (e.g. genfeedai/cloud)'
+    required: true
+  github_token:
+    description: 'GitHub token for registry authentication'
+    required: true
+  sentry_auth_token:
+    description: 'Sentry auth token for sourcemap injection/upload during build'
+    required: false
+    default: ''
+
+outputs:
+  image_tags:
+    description: 'Generated image tags'
+    value: ${{ steps.meta.outputs.tags }}
+  image_digest:
+    description: 'Image digest'
+    value: ${{ steps.build.outputs.digest }}
+  image_tag:
+    description: 'Immutable image tag for this workflow run'
+    value: ${{ github.sha }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Free runner disk space
+      shell: bash
+      run: |
+        # Uncached unified-image builds need >20 GB; ubuntu-latest ships with
+        # ~14 GB free. Drop preinstalled toolchains we never use.
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+        sudo docker image prune --all --force >/dev/null 2>&1 || true
+        df -h / | tail -1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image_prefix }}/server
+        tags: |
+          type=raw,value=${{ github.sha }}
+          type=sha,prefix={{branch}}-
+          type=raw,value=latest
+          type=raw,value=production
+        labels: |
+          org.opencontainers.image.title=Genfeed Server
+          org.opencontainers.image.description=Unified Genfeed server image (all services)
+          org.opencontainers.image.vendor=GenFeedAI
+
+    - name: Build and push image
+      id: build
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: docker/Dockerfile.server
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        # Shared with build-verify.yml — repopulating this ref also un-breaks
+        # its cache-from (the tag has been missing since the migration).
+        cache-from: type=registry,ref=${{ inputs.registry }}/${{ github.repository }}/server:buildcache
+        cache-to: type=registry,ref=${{ inputs.registry }}/${{ github.repository }}/server:buildcache,mode=max
+        secrets: |
+          SENTRY_AUTH_TOKEN=${{ inputs.sentry_auth_token }}
+        platforms: linux/amd64
+        provenance: true
+        sbom: true
+
+    - name: Generate build summary
+      shell: bash
+      run: |
+        echo "## Unified Server Image Built" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY

--- a/apps/server/clips/package.json
+++ b/apps/server/clips/package.json
@@ -14,7 +14,7 @@
     "dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start clips --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project clips-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project clips-genfeed-ai ../dist",
     "start": "cd .. && nest start clips",
     "start:debug": "cd .. && nest start clips --debug --watch",

--- a/apps/server/files/package.json
+++ b/apps/server/files/package.json
@@ -19,7 +19,7 @@
     "dev:webpack": "cd .. && NODE_OPTIONS=\"--max-old-space-size=4096 --expose-gc\" nest start files --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project files-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project files-genfeed-ai ../dist",
     "start": "cd .. && nest start files",
     "start:debug": "cd .. && nest start files --debug --watch",

--- a/apps/server/images/package.json
+++ b/apps/server/images/package.json
@@ -14,7 +14,7 @@
     "dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start images --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project images-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project images-genfeed-ai ../dist",
     "start": "cd .. && nest start images",
     "start:debug": "cd .. && nest start images --debug --watch",

--- a/apps/server/mcp/package.json
+++ b/apps/server/mcp/package.json
@@ -20,7 +20,7 @@
     "dev:webpack": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start mcp --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project mcp-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project mcp-genfeed-ai ../dist",
     "start": "cd .. && nest start mcp",
     "start:debug": "cd .. && nest start mcp --debug --watch",

--- a/apps/server/notifications/package.json
+++ b/apps/server/notifications/package.json
@@ -22,7 +22,7 @@
     "dev:nest": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start notifications --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project notifications-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project notifications-genfeed-ai ../dist",
     "start": "cd .. && nest start notifications",
     "start:debug": "cd .. && nest start notifications --debug --watch",

--- a/apps/server/slack/package.json
+++ b/apps/server/slack/package.json
@@ -18,7 +18,7 @@
     "dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start slack --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project slack-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project slack-genfeed-ai ../dist",
     "start": "cd .. && nest start slack",
     "start:debug": "cd .. && nest start slack --debug --watch",

--- a/apps/server/telegram/package.json
+++ b/apps/server/telegram/package.json
@@ -19,7 +19,7 @@
     "dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start telegram --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project telegram-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project telegram-genfeed-ai ../dist",
     "start": "cd .. && nest start telegram",
     "start:debug": "cd .. && nest start telegram --debug --watch",

--- a/apps/server/videos/package.json
+++ b/apps/server/videos/package.json
@@ -14,7 +14,7 @@
     "dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start videos --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project videos-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project videos-genfeed-ai ../dist",
     "start": "cd .. && nest start videos",
     "start:debug": "cd .. && nest start videos --debug --watch",

--- a/apps/server/voices/package.json
+++ b/apps/server/voices/package.json
@@ -14,7 +14,7 @@
     "dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start voices --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project voices-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project voices-genfeed-ai ../dist",
     "start": "cd .. && nest start voices",
     "start:debug": "cd .. && nest start voices --debug --watch",

--- a/apps/server/workers/package.json
+++ b/apps/server/workers/package.json
@@ -25,7 +25,7 @@
     "dev:webpack": "cd .. && NODE_OPTIONS=\"--max-old-space-size=4096 --expose-gc\" nest start workers --watch",
     "lint": "biome lint --write src --no-errors-on-unmatched",
     "sentry:inject": "sentry-cli sourcemaps inject --org genfeedai --project workers-genfeed-ai ../dist",
-    "sentry:sourcemaps": "bun run sentry:inject && bun run sentry:upload",
+    "sentry:sourcemaps": "[ -z \"$SENTRY_AUTH_TOKEN\" ] && echo 'Sentry upload skipped (no token)' || (bun run sentry:inject && bun run sentry:upload)",
     "sentry:upload": "sentry-cli sourcemaps upload --org genfeedai --project workers-genfeed-ai ../dist",
     "start": "cd .. && nest start workers",
     "start:debug": "cd .. && nest start workers --debug --watch",


### PR DESCRIPTION
## Summary

**Deploy Production / Deploy Staging have failed on every run since the cloud → genfeed.ai migration**: `_deploy.yml:176` calls the local composite action `./.github/actions/build-unified-image`, which was never migrated (no trace in this repo's history — confirmed via `git log --all`). Yesterday's prod deploy dispatch (run 27224613169) died exactly there: *"Can't find 'action.yml' … under .github/actions/build-unified-image"*.

Ported the action from `genfeedai/cloud` with three adaptations:

1. **GitHub-hosted buildx** instead of the Blacksmith builder, plus a disk-space step — uncached unified builds exhaust `ubuntu-latest` disks (today's Build Verify on staging died on `no space left on device` after the `server:buildcache` registry tags went missing).
2. **Single `SENTRY_AUTH_TOKEN` secret**, matching the current `Dockerfile.server` secret mount and the existing `_deploy.yml` call site (the cloud original used four per-service tokens).
3. **`cache-to` repopulates the shared `server:buildcache` ref** that `build-verify.yml` reads — un-breaks its registry cache (currently `not found` on every run → full cold builds).

Also: guarded `sentry:sourcemaps` behind a `SENTRY_AUTH_TOKEN` check in the 10 server packages missing it (api already had the guard) — without a token they invoked the absent `sentry-cli` and exited 127 under `|| true`.

## Why hotfix → master

The Sentry-fix release (#495) is merged but **cannot reach production** until the deploy pipeline works. CI-only + package-script change; hotfix flow per repo rules, will back-merge into develop after merge.

## After merge

Dispatch **Deploy Production** — `deploy-production.sh` runs `prisma migrate deploy` (includes `reconcile_newsletters`) before the service waves, so one dispatch ships everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)