### PR TITLE
fix(deploy): SSM multiline check false-positives kill every prod deploy

### DIFF
--- a/docker/render-ssm-env.sh
+++ b/docker/render-ssm-env.sh
@@ -195,14 +195,22 @@ fi
 while IFS=$'\t' read -r full_name parameter_value; do
   [ -n "${full_name}" ] || continue
 
+  # A multiline parameter value breaks the tab-separated text framing above:
+  # its continuation lines arrive as rows whose first field is not an SSM
+  # path. (The old `grep -q $'\n'` check could never work — `read` strips
+  # newlines, and GNU grep treats a lone-newline pattern as an empty pattern
+  # that matches every value, which failed the deploy on the first key.)
+  case "${full_name}" in
+    /*) ;;
+    *)
+      log "ERROR: multiline env value detected (row fragment: ${full_name%%=*}) — store single-line values in SSM"
+      exit 1
+      ;;
+  esac
+
   key="${full_name##*/}"
   if [ -z "${key}" ]; then
     log "ERROR: invalid SSM parameter name: ${full_name}"
-    exit 1
-  fi
-
-  if printf '%s' "${parameter_value}" | grep -q $'\n'; then
-    log "ERROR: multiline env values are not supported for ${key}"
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

Deploy rung 4 (run 27261075813, rerun 3): SSM hydration found the parameters but `render-ssm-env.sh` rejected the very first one (`AWS_ACCESS_KEY_ID`) as "multiline".

The check `printf '%s' "$value" | grep -q $'\n'` is broken twice over:
- `read` strips newlines, so the parsed value can never contain one — the check is dead code at best
- on GNU grep (AL2023) a lone-newline pattern degenerates into an empty pattern that matches **every** value → instant false positive on the first key

Real multiline values actually manifest as broken tab-framing in the `aws --output text` rows, so the fix detects that directly: any row whose first field is not an absolute SSM path is a continuation fragment → hard error. Verified: single-line rows parse (2/2), synthetic multiline fragment rejected. Live SSM tree scanned: 0 genuinely multiline values.

Fourth and hopefully last deploy-pipeline rung: missing action (#502) → SSH key/user (secrets) → SSM path prefix (repo var) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)