### PR TITLE
fix(deploy): prisma migrate container used bunx, which the image doesn't ship

### DIFF
--- a/docker/deploy-production.sh
+++ b/docker/deploy-production.sh
@@ -295,13 +295,16 @@ run_db_migrations() {
   # and egress to the public RDS endpoint (default bridge network provides it).
   # Run as root + HOME=/tmp so the schema engine can write its cache regardless
   # of the image's non-root runtime user.
+  # `bun x` (not `bunx`): the image only ships the bun binary, and the
+  # node:24-slim entrypoint rewrites an unknown first arg into `node bunx ...`
+  # -> MODULE_NOT_FOUND. Pin the prisma version to match packages/prisma.
   if docker run --rm \
       --user root \
       -e HOME=/tmp \
       --env-file "$ENV_FILE" \
       -w /usr/src/app/packages/prisma \
       "$DEFAULT_SERVER_IMAGE" \
-      bunx prisma migrate deploy; then
+      bun x prisma@7.8.0 migrate deploy; then
     log "Prisma migrations applied (or already up to date)"
     return 0
   fi


### PR DESCRIPTION
Deploy rung 5 (run 27262689381): everything through SSM render + image pull now works; the one-shot migration container died with `Cannot find module '/usr/src/app/packages/prisma/bunx'` — node:24-slim's entrypoint turns the unknown `bunx` first-arg into `node bunx …`. The image only ships the raw `bun` binary.

Fix: `bun x prisma@7.8.0 migrate deploy` (version pinned to packages/prisma). Schema + migrations are in the image (`packages/prisma/prisma/` copied at build), network + writable HOME already handled by the script.

Rung ledger: missing action (#502) → SSH secrets → SSM prefix var → SSM multiline check (#506) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)