### PR TITLE
fix(docker): prisma config unresolvable in prod image (isolated installs)

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -248,8 +248,13 @@ COPY --from=builder /usr/src/app/package.json ./package.json
 
 # Prisma schema, migrations, and config — required so `prisma migrate deploy`
 # can run from this image at deploy time (production stage is otherwise dist-only).
+# node_modules too: bun uses isolated installs (symlinks into the root
+# node_modules/.bun store, no hoisting), so prisma.config.mjs can only resolve
+# its `prisma/config` import through packages/prisma/node_modules. The root
+# node_modules copy above brings the store; this brings the symlinks.
 COPY --from=builder /usr/src/app/packages/prisma/prisma ./packages/prisma/prisma
 COPY --from=builder /usr/src/app/packages/prisma/prisma.config.mjs ./packages/prisma/prisma.config.mjs
+COPY --from=builder /usr/src/app/packages/prisma/node_modules ./packages/prisma/node_modules
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY --from=builder /usr/src/app/apps/server/api/package.json ./apps/server/api/package.json


### PR DESCRIPTION
Deploy rung 6 (run 27263841333): `bun x prisma@7.8.0` now runs, but config loading dies with `Cannot find module 'prisma/config'` from `packages/prisma/prisma.config.mjs`.

Root cause: bun **isolated installs** — there is no hoisted root `prisma`; `packages/prisma/node_modules/prisma` is a symlink into the root `node_modules/.bun` store. The production stage copies the store (root node_modules) but not the per-package symlink dir, so module resolution from the config file finds nothing.

Fix: one `COPY` of `packages/prisma/node_modules` into the production stage (symlinks resolve against the already-copied store).

Rung ledger: missing action (#502) → SSH secrets → SSM prefix var → SSM multiline (#506) → bunx entrypoint (#507) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)