### PR TITLE
fix(ci): release-triggered builds die on empty {{branch}} tag prefix

### DIFF
--- a/.github/actions/build-unified-image/action.yml
+++ b/.github/actions/build-unified-image/action.yml
@@ -65,9 +65,9 @@ runs:
         images: ${{ inputs.registry }}/${{ inputs.image_prefix }}/server
         tags: |
           type=raw,value=${{ github.sha }}
-          type=sha,prefix={{branch}}-
           type=raw,value=latest
           type=raw,value=production
+          type=ref,event=tag
         labels: |
           org.opencontainers.image.title=Genfeed Server
           org.opencontainers.image.description=Unified Genfeed server image (all services)


### PR DESCRIPTION
v0.1.0 release deploy (run 27270370771) failed at buildx: `invalid tag "ghcr.io/genfeedai/cloud/server:-e4fe9e5"` — `type=sha,prefix={{branch}}-` renders an empty branch on tag refs. Drop it (bare sha tag covers traceability), add `type=ref,event=tag` so releases tag the image with the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)