### PR TITLE
fix(ci): ship deploy-common.sh to EC2 (script split in #498)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -355,6 +355,7 @@ jobs:
           scp $SSH_OPTS docker/${COMPOSE_FILE} ${EC2_USER}@${API_IP}:./cloud/docker/${COMPOSE_FILE}
           scp $SSH_OPTS docker/${DEPLOY_SCRIPT} ${EC2_USER}@${API_IP}:./cloud/docker/${DEPLOY_SCRIPT}
           scp $SSH_OPTS docker/render-ssm-env.sh ${EC2_USER}@${API_IP}:./cloud/docker/render-ssm-env.sh
+          scp $SSH_OPTS docker/deploy-common.sh ${EC2_USER}@${API_IP}:./cloud/docker/deploy-common.sh
           ssh $SSH_OPTS ${EC2_USER}@${API_IP} "chmod +x ./cloud/docker/${DEPLOY_SCRIPT}"
           ssh $SSH_OPTS ${EC2_USER}@${API_IP} "chmod +x ./cloud/docker/render-ssm-env.sh"
 


### PR DESCRIPTION
Deploy run 27270574673: `deploy-production.sh: line 30: deploy-common.sh: No such file or directory` — the #498 dedup split the script but the workflow's scp list never learned about the new file. One-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)