### PR TITLE
fix(docker): ship RDS CA bundle — new image fails all Prisma TLS connections

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -326,6 +326,13 @@ RUN mkdir -p /usr/src/app/public/tmp \
         /usr/src/app/apps/server/workers \
         /usr/src/app/public
 
+# RDS CA bundle — DATABASE_URL uses TLS against RDS and the runtime env sets
+# NODE_EXTRA_CA_CERTS=/certs/rds-ca.pem; without the file every Prisma query
+# fails with "self-signed certificate in certificate chain".
+RUN mkdir -p /certs && \
+    curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /certs/rds-ca.pem && \
+    chmod 444 /certs/rds-ca.pem
+
 # Switch to non-root user
 USER appuser
 ENV HOME=/home/appuser


### PR DESCRIPTION
Post-deploy: all 10 services healthy but every Prisma query failed with `self-signed certificate in certificate chain`. SSM sets `NODE_EXTRA_CA_CERTS=/certs/rds-ca.pem`; the file was never in this repo's image (lost in migration). Bakes the AWS RDS global trust bundle into the production stage. Containers were hot-patched on the box (docker cp + restart) to restore service immediately; this makes it permanent for the next recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)