### PR TITLE
fix(app): Vercel install --ignore-scripts (root postinstall kills app builds)

### DIFF
--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -9,6 +9,6 @@
       "staging": true
     }
   },
-  "installCommand": "cd ../../ && sh scripts/sh/vercel-bun.sh install",
+  "installCommand": "cd ../../ && sh scripts/sh/vercel-bun.sh install --ignore-scripts",
   "outputDirectory": ".next"
 }


### PR DESCRIPTION
app.genfeed.ai Vercel builds die in the root postinstall (scripts/setup-skills.sh exits 1 in the build container). website/docs already install with --ignore-scripts; the app needs no install-time scripts (no prisma dependency in its graph). Project-side blockers already fixed via API: root dir apps/web/app→apps/app, git link cloud→genfeed.ai, ignore-command 'exit 0' cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)