### PR TITLE
feat(agent): non-zero creditCost floors for generation tools (#482)

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -842,6 +842,269 @@ describe('AgentOrchestratorService', () => {
     );
   });
 
+  it('should block a generation tool call when the org cannot afford its flat credit cost', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+    creditsUtilsService.checkOrganizationCreditsAvailable
+      .mockResolvedValueOnce(true) // turn-cost pre-check
+      .mockResolvedValueOnce(false); // generate_music flat-cost gate
+
+    llmDispatcher.chatCompletion
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  function: {
+                    arguments: '{"prompt":"lofi beat"}',
+                    name: 'generate_music',
+                  },
+                  id: 'call-music-1',
+                },
+              ],
+            },
+          },
+        ],
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 10,
+          total_tokens: 20,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'Done!' } }],
+        usage: {
+          completion_tokens: 5,
+          prompt_tokens: 15,
+          total_tokens: 20,
+        },
+      } as never);
+
+    await service.chat(
+      { content: 'Make me a song' },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    expect(
+      creditsUtilsService.checkOrganizationCreditsAvailable,
+    ).toHaveBeenCalledWith(ORG_ID, 10);
+    expect(toolExecutorService.executeTool).not.toHaveBeenCalled();
+    expect(llmDispatcher.chatCompletion).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining(
+              'Insufficient credits. This tool requires 10 credits.',
+            ),
+            role: 'tool',
+          }),
+        ]),
+      }),
+      ORG_ID,
+    );
+  });
+
+  it('should gate on the requested tool cost when the call is remapped to prepare_generation', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+    creditsUtilsService.checkOrganizationCreditsAvailable
+      .mockResolvedValueOnce(true) // turn-cost pre-check
+      .mockResolvedValueOnce(false); // generate_image pre-remap flat-cost gate
+
+    llmDispatcher.chatCompletion
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  function: {
+                    arguments: '{"prompt":"a red fox"}',
+                    name: 'generate_image',
+                  },
+                  id: 'call-image-1',
+                },
+              ],
+            },
+          },
+        ],
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 10,
+          total_tokens: 20,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'Done!' } }],
+        usage: {
+          completion_tokens: 5,
+          prompt_tokens: 15,
+          total_tokens: 20,
+        },
+      } as never);
+
+    await service.chat(
+      { content: 'Make me an image' },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    // generate_image is remapped to prepare_generation (cost 0); the gate
+    // must still use the requested tool's cost of 50.
+    expect(
+      creditsUtilsService.checkOrganizationCreditsAvailable,
+    ).toHaveBeenCalledWith(ORG_ID, 50);
+    expect(toolExecutorService.executeTool).not.toHaveBeenCalled();
+    expect(llmDispatcher.chatCompletion).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining(
+              'Insufficient credits. This tool requires 50 credits.',
+            ),
+            role: 'tool',
+          }),
+        ]),
+      }),
+      ORG_ID,
+    );
+  });
+
+  it('should not deduct the flat credit cost when the tool delegates billing to its endpoint', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+
+    llmDispatcher.chatCompletion
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  function: {
+                    arguments: '{"prompt":"lofi beat"}',
+                    name: 'generate_music',
+                  },
+                  id: 'call-music-2',
+                },
+              ],
+            },
+          },
+        ],
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 10,
+          total_tokens: 20,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'Done!' } }],
+        usage: {
+          completion_tokens: 5,
+          prompt_tokens: 15,
+          total_tokens: 20,
+        },
+      } as never);
+
+    toolExecutorService.executeTool.mockResolvedValue({
+      creditsUsed: 0,
+      data: { id: 'music-1' },
+      isBillingDelegated: true,
+      success: true,
+    });
+
+    const result = await service.chat(
+      { content: 'Make me a song' },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    // Only the base turn cost is deducted; the endpoint bills the generation.
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).not.toHaveBeenCalledWith(
+      ORG_ID,
+      USER_ID,
+      expect.anything(),
+      'Agent tool: generate_music',
+      expect.anything(),
+    );
+    expect(result.creditsUsed).toBe(1);
+  });
+
+  it('should deduct the flat credit cost exactly once when billing is not delegated', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+
+    llmDispatcher.chatCompletion
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  function: {
+                    arguments: '{"prompt":"lofi beat"}',
+                    name: 'generate_music',
+                  },
+                  id: 'call-music-3',
+                },
+              ],
+            },
+          },
+        ],
+        usage: {
+          completion_tokens: 10,
+          prompt_tokens: 10,
+          total_tokens: 20,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: 'Done!' } }],
+        usage: {
+          completion_tokens: 5,
+          prompt_tokens: 15,
+          total_tokens: 20,
+        },
+      } as never);
+
+    toolExecutorService.executeTool.mockResolvedValue({
+      creditsUsed: 0,
+      data: { id: 'music-1' },
+      success: true,
+    });
+
+    const result = await service.chat(
+      { content: 'Make me a song' },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).toHaveBeenCalledWith(
+      ORG_ID,
+      USER_ID,
+      10,
+      'Agent tool: generate_music',
+      expect.anything(),
+    );
+    // Base turn cost + the generate_music flat cost.
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).toHaveBeenCalledTimes(2);
+    expect(result.creditsUsed).toBe(11);
+  });
+
   it('should apply org agent policy defaults for strategy-driven runs', async () => {
     const strategyBrandId = 'test-object-id';
     organizationsService.findOne.mockResolvedValue({

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -1068,6 +1068,7 @@ export class AgentOrchestratorService {
             }
           }
 
+          const preRemapToolName = toolName;
           const directGenerationOverride =
             this.getGenerationPreparationOverride(toolName, allowedToolNames);
           if (directGenerationOverride) {
@@ -1099,16 +1100,23 @@ export class AgentOrchestratorService {
           });
 
           const creditCost = AGENT_CREDIT_COSTS[toolName] ?? 0;
-          if (creditCost > 0) {
+          // Gate affordability on the tool the model asked for: the
+          // prepare_generation remap above would otherwise resolve a zero
+          // cost and skip the check entirely (#482).
+          const preflightCreditCost = Math.max(
+            creditCost,
+            AGENT_CREDIT_COSTS[preRemapToolName] ?? 0,
+          );
+          if (preflightCreditCost > 0) {
             const canAfford =
               await this.creditsUtilsService.checkOrganizationCreditsAvailable(
                 context.organizationId,
-                creditCost,
+                preflightCreditCost,
               );
 
             if (!canAfford) {
               const durationMs = Date.now() - startTime;
-              const error = `Insufficient credits (need ${creditCost})`;
+              const error = `Insufficient credits (need ${preflightCreditCost})`;
               const summary: ToolCallSummary = {
                 creditsUsed: 0,
                 durationMs,
@@ -1131,7 +1139,7 @@ export class AgentOrchestratorService {
 
               messages.push({
                 content: JSON.stringify({
-                  error: `Insufficient credits. This tool requires ${creditCost} credits.`,
+                  error: `Insufficient credits. This tool requires ${preflightCreditCost} credits.`,
                   success: false,
                 }),
                 role: 'tool' as const,
@@ -1181,7 +1189,11 @@ export class AgentOrchestratorService {
             highestRiskLevel = 'medium';
           }
 
-          if (result.success && creditCost > 0) {
+          // Generation tools delegate billing to their endpoint (dynamic
+          // amount); deducting the flat creditCost here would double-charge.
+          const isOrchestratorBilled =
+            result.success && creditCost > 0 && !result.isBillingDelegated;
+          if (isOrchestratorBilled) {
             await this.creditsUtilsService.deductCreditsFromOrganization(
               context.organizationId,
               context.userId,
@@ -1193,7 +1205,7 @@ export class AgentOrchestratorService {
           }
 
           const summary: ToolCallSummary = {
-            creditsUsed: result.success ? creditCost : 0,
+            creditsUsed: isOrchestratorBilled ? creditCost : 0,
             durationMs,
             error: result.error,
             parameters: toolParams,
@@ -1761,6 +1773,7 @@ export class AgentOrchestratorService {
             }
           }
 
+          const preRemapToolName = toolName;
           const directGenerationOverride =
             this.getGenerationPreparationOverride(toolName, allowedToolNames);
           if (directGenerationOverride) {
@@ -1783,6 +1796,13 @@ export class AgentOrchestratorService {
           }
 
           const creditCost = AGENT_CREDIT_COSTS[toolName] ?? 0;
+          // Gate affordability on the tool the model asked for: the
+          // prepare_generation remap above would otherwise resolve a zero
+          // cost and skip the check entirely (#482).
+          const preflightCreditCost = Math.max(
+            creditCost,
+            AGENT_CREDIT_COSTS[preRemapToolName] ?? 0,
+          );
           const startTime = Date.now();
 
           await runEffectPromise(
@@ -1853,18 +1873,18 @@ export class AgentOrchestratorService {
           }
 
           // Check credits
-          if (creditCost > 0) {
+          if (preflightCreditCost > 0) {
             const canAfford =
               await this.creditsUtilsService.checkOrganizationCreditsAvailable(
                 context.organizationId,
-                creditCost,
+                preflightCreditCost,
               );
 
             if (!canAfford) {
               const summary: ToolCallSummary = {
                 creditsUsed: 0,
                 durationMs: Date.now() - startTime,
-                error: `Insufficient credits (need ${creditCost})`,
+                error: `Insufficient credits (need ${preflightCreditCost})`,
                 status: 'failed',
                 toolName,
               };
@@ -1888,7 +1908,7 @@ export class AgentOrchestratorService {
 
               messages.push({
                 content: JSON.stringify({
-                  error: `Insufficient credits. This tool requires ${creditCost} credits.`,
+                  error: `Insufficient credits. This tool requires ${preflightCreditCost} credits.`,
                   success: false,
                 }),
                 role: 'tool' as const,
@@ -1945,7 +1965,11 @@ export class AgentOrchestratorService {
             highestRiskLevel = 'medium';
           }
 
-          if (result.success && creditCost > 0) {
+          // Generation tools delegate billing to their endpoint (dynamic
+          // amount); deducting the flat creditCost here would double-charge.
+          const isOrchestratorBilled =
+            result.success && creditCost > 0 && !result.isBillingDelegated;
+          if (isOrchestratorBilled) {
             await this.creditsUtilsService.deductCreditsFromOrganization(
               context.organizationId,
               context.userId,
@@ -1957,7 +1981,7 @@ export class AgentOrchestratorService {
           }
 
           const summary: ToolCallSummary = {
-            creditsUsed: result.success ? creditCost : 0,
+            creditsUsed: isOrchestratorBilled ? creditCost : 0,
             durationMs,
             error: result.error,
             parameters: toolParams,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -5764,6 +5764,7 @@ export class AgentToolExecutorService {
       return {
         creditsUsed: 0,
         data: { status: Status.PROCESSING },
+        isBillingDelegated: true,
         nextActions: [
           {
             ctas: [{ href: '/library/images', label: 'Check gallery' }],
@@ -5804,6 +5805,7 @@ export class AgentToolExecutorService {
     return {
       creditsUsed: 0, // endpoint handles credits via CreditsInterceptor
       data: { id, status: Status.GENERATED, url: cdnUrl },
+      isBillingDelegated: true,
       nextActions: id
         ? [
             {
@@ -5998,6 +6000,7 @@ export class AgentToolExecutorService {
     return {
       creditsUsed: 0,
       data: { id, status: Status.GENERATED, url: cdnUrl },
+      isBillingDelegated: true,
       nextActions: id
         ? [
             {
@@ -6047,6 +6050,7 @@ export class AgentToolExecutorService {
     return {
       creditsUsed: 0,
       data: { id, status: Status.GENERATED, url: cdnUrl },
+      isBillingDelegated: true,
       nextActions: id
         ? [
             {
@@ -6095,6 +6099,7 @@ export class AgentToolExecutorService {
     return {
       creditsUsed: 0,
       data: { id, status: Status.GENERATED, url: cdnUrl },
+      isBillingDelegated: true,
       nextActions: id
         ? [
             {
@@ -7319,6 +7324,7 @@ export class AgentToolExecutorService {
           'Avatar video generation started using your identity (avatar + cloned voice).',
         status: 'processing',
       },
+      isBillingDelegated: true,
       nextActions: id
         ? [
             {

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-registry.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-registry.spec.ts
@@ -35,6 +35,14 @@ describe('agent-tool-registry', () => {
     expect(uniqueNames.size).toBe(names.length);
   });
 
+  it('should set non-zero credit costs for generation tools', () => {
+    expect(AGENT_CREDIT_COSTS[AgentToolName.GENERATE_IMAGE]).toBe(50);
+    expect(AGENT_CREDIT_COSTS[AgentToolName.GENERATE_VIDEO]).toBe(300);
+    expect(AGENT_CREDIT_COSTS[AgentToolName.GENERATE_MUSIC]).toBe(10);
+    expect(AGENT_CREDIT_COSTS[AgentToolName.GENERATE_VOICE]).toBe(17);
+    expect(AGENT_CREDIT_COSTS[AgentToolName.GENERATE_AS_IDENTITY]).toBe(100);
+  });
+
   it('should set onboarding tool costs to zero', () => {
     expect(AGENT_CREDIT_COSTS[AgentToolName.CREATE_BRAND]).toBe(0);
     expect(AGENT_CREDIT_COSTS[AgentToolName.CHECK_ONBOARDING_STATUS]).toBe(0);

--- a/packages/interfaces/src/ai/agent-tool.interface.ts
+++ b/packages/interfaces/src/ai/agent-tool.interface.ts
@@ -99,6 +99,12 @@ export interface AgentToolResult {
   data?: Record<string, unknown>;
   error?: string;
   creditsUsed: number;
+  /**
+   * True when the downstream generation endpoint bills the call itself
+   * (dynamic amount). The orchestrator must not deduct its flat creditCost
+   * again for these results.
+   */
+  isBillingDelegated?: boolean;
   riskLevel?: 'low' | 'medium' | 'high';
   requiresConfirmation?: boolean;
   nextActions?: AgentUiAction[];

--- a/packages/tools/src/registry/source.ts
+++ b/packages/tools/src/registry/source.ts
@@ -257,7 +257,9 @@ const OVERLAP_TOOLS: SourceTool[] = [
   },
   // generate_image: mcp params (4 props) > agent params (2 props); mcp desc longer
   {
-    creditCost: 0,
+    // Minimum charge per call (standard image; 4k costs more). Actual amount
+    // is billed dynamically by the generation endpoint (issue #482).
+    creditCost: 50,
     description:
       'Generate AI images with custom prompts, styles, and dimensions. Perfect for social media, blogs, and marketing materials.',
     name: 'generate_image',
@@ -308,7 +310,9 @@ const OVERLAP_TOOLS: SourceTool[] = [
   },
   // generate_music: mcp params (4 props) = agent params (2 props) → mcp wins; agent desc longer
   {
-    creditCost: 0,
+    // Minimum charge per call (cheapest music model). Actual amount is billed
+    // dynamically by the generation endpoint per model cost (issue #482).
+    creditCost: 10,
     description:
       'Generate music or audio using AI. Describe the desired music style, mood, instruments, and genre. Returns the audio URL.',
     name: 'generate_music',
@@ -360,7 +364,9 @@ const OVERLAP_TOOLS: SourceTool[] = [
   },
   // generate_video: agent and mcp both have 5 props → agent wins (equal, a is chosen); agent desc longer
   {
-    creditCost: 0,
+    // Minimum charge per call (shortest 4s clip). Actual amount is billed
+    // dynamically by the generation endpoint per duration (issue #482).
+    creditCost: 300,
     description:
       'Generate a video using AI. Provide a detailed prompt describing the desired video. For talking avatar videos, provide imageUrl (portrait image) and audioUrl (audio file) — the model will lip-sync the portrait to the audio. Returns the video URL.',
     name: 'generate_video',
@@ -1074,7 +1080,9 @@ const AGENT_ONLY_TOOLS: SourceTool[] = [
     surfaces: { agent: true, cliAgentVisible: true, mcp: false },
   },
   {
-    creditCost: 0,
+    // Minimum charge per call (one minute of speech). Actual amount is billed
+    // dynamically by the generation endpoint per audio length (issue #482).
+    creditCost: 17,
     description:
       'Generate speech audio from text using text-to-speech. Requires a voice ID from ElevenLabs. Returns the audio URL.',
     name: 'generate_voice',
@@ -1326,9 +1334,11 @@ const AGENT_ONLY_TOOLS: SourceTool[] = [
     surfaces: { agent: true, cliAgentVisible: true, mcp: false },
   },
   {
-    creditCost: 0,
+    // Minimum charge per call. Actual amount is billed dynamically by the
+    // generation endpoint per avatar video duration (issue #482).
+    creditCost: 100,
     description:
-      "Generate an avatar video using the user's identity (default avatar photo + cloned voice from org settings). Provide text for the voice to speak. Uses HeyGen photo avatar API. Credits handled by the endpoint's CreditsInterceptor.",
+      "Generate an avatar video using the user's identity (default avatar photo + cloned voice from org settings). Provide text for the voice to speak. Uses HeyGen photo avatar API. Credits are billed by the avatar video generation endpoint.",
     name: 'generate_as_identity',
     parameters: {
       properties: {


### PR DESCRIPTION
Closes #482

## What

All five agent generation tools now carry a non-zero `creditCost` (minimum-charge floor), and the orchestrator no longer double-charges or silently skips the affordability gate.

### Credit cost decision (floors, 1 credit = $0.01)

| Tool | Floor | Basis |
|------|-------|-------|
| `generate_image` | 50 | `INTERNAL_CREDIT_COSTS.image` (4k variant bills 100 at the endpoint) |
| `generate_video` | 300 | `VIDEO_CREDIT_COSTS` minimum (4s clip) |
| `generate_music` | 10 | Conservative floor; actual = DB `Model.cost` per model |
| `generate_voice` | 17 | `INTERNAL_CREDIT_COSTS.voicePerMinute` |
| `generate_as_identity` | 100 | `INTERNAL_CREDIT_COSTS.avatarPerSecond` |

These are **floors for the pre-flight affordability gate**, not the billed amount. The downstream generation endpoints bill the real dynamic amount (CreditsGuard/CreditsInterceptor or direct deduction), so the orchestrator must not also deduct its flat cost.

### Changes

- **`packages/tools/src/registry/source.ts`**: the five generation tools get non-zero `creditCost` floors with comments documenting the basis.
- **`packages/interfaces`**: new optional `AgentToolResult.isBillingDelegated` flag.
- **`agent-tool-executor.service.ts`**: the six generation success paths (image incl. timeout fallback, video, music, voice, as_identity) return `isBillingDelegated: true`.
- **`agent-orchestrator.service.ts`** (both chat and stream paths):
  - Deduction guard: flat `creditCost` is only deducted when `result.success && creditCost > 0 && !result.isBillingDelegated`, preventing double-charging delegated generations.
  - **Gate bypass fix**: the `prepare_generation` remap mutated `toolName` *before* the `AGENT_CREDIT_COSTS` lookup, so `generate_image`/`generate_video`/`generate_as_identity` resolved a cost of 0 and skipped the affordability check entirely. The gate now uses `max(effective cost, requested tool's pre-remap cost)`; the deduction still uses the effective tool's cost (so the free prep card is never billed).

### Tests

- `agent-tool-registry.spec.ts`: asserts the five non-zero costs.
- `agent-orchestrator.service.spec.ts` (4 new integration tests):
  - blocks a generation tool call when the org cannot afford the flat cost (asserts `checkOrganizationCreditsAvailable(orgId, 10)`, no execution, tool error message)
  - gates on the requested tool's cost (50) when the call is remapped to `prepare_generation`
  - skips the flat deduction when the result is `isBillingDelegated` (turn cost only, `creditsUsed === 1`)
  - deducts the flat cost exactly once when billing is not delegated (`deduct(orgId, userId, 10, 'Agent tool: generate_music', …)`, `creditsUsed === 11`)

## Verification

- `bunx vitest run src/services/agent-orchestrator/tools/agent-tool-registry.spec.ts` — 4/4 pass
- `bunx vitest run src/services/agent-orchestrator/agent-orchestrator.service.spec.ts` — 38/38 pass
- `bunx biome check` on all 6 changed files — clean
- `packages/tools` and `packages/interfaces` `tsc --build` — clean (scoped typecheck)

## Out of scope (pre-existing, noted for follow-up)

- `generate_video`/`generate_music`/`generate_voice`/`generate_as_identity` executor handlers lack `generate_image`'s timeout fallback (try/catch returning `PROCESSING`). No wrong deduction is possible (the guard requires `success: true`), only reporting accuracy differs on timeout.
- `reframe_image` / `upscale_image` still have `creditCost: 0` while hitting paid endpoints.
- `videos.controller.ts` generate endpoint has a pre-existing double-deduct path; avatar endpoint deducts a hardcoded 1 credit (`avatar-video-generation.service.ts:173`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)