### PR TITLE
fix(api): enable validation whitelist and protect DTO fields (#493)

### DIFF
--- a/apps/server/api/src/collections/agent-goals/dto/create-agent-goal.dto.ts
+++ b/apps/server/api/src/collections/agent-goals/dto/create-agent-goal.dto.ts
@@ -7,6 +7,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
+  IsDate,
   IsEnum,
   IsNumber,
   IsOptional,
@@ -48,11 +49,13 @@ export class CreateAgentGoalDto {
   @ApiProperty({ description: 'Target metric value' })
   targetValue!: number;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Optional start date', required: false })
   startDate?: Date;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Optional end date', required: false })

--- a/apps/server/api/src/collections/agent-goals/dto/update-agent-goal.dto.ts
+++ b/apps/server/api/src/collections/agent-goals/dto/update-agent-goal.dto.ts
@@ -6,6 +6,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
+  IsDate,
   IsEnum,
   IsNumber,
   IsOptional,
@@ -35,11 +36,13 @@ export class UpdateAgentGoalDto {
   @ApiProperty({ description: 'Target metric value', required: false })
   targetValue?: number;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Optional start date', required: false })
   startDate?: Date;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Optional end date', required: false })

--- a/apps/server/api/src/collections/agent-strategies/dto/create-agent-strategy.dto.ts
+++ b/apps/server/api/src/collections/agent-strategies/dto/create-agent-strategy.dto.ts
@@ -15,6 +15,7 @@ import { Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
+  IsDate,
   IsEnum,
   IsIn,
   IsNumber,
@@ -498,16 +499,19 @@ export class CreateAgentStrategyDto {
   })
   rankingPolicy?: RankingPolicyDto;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Next scheduled run time', required: false })
   nextRunAt?: Date;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Daily reset timestamp', required: false })
   dailyResetAt?: Date;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({
@@ -516,6 +520,7 @@ export class CreateAgentStrategyDto {
   })
   dailyCreditResetAt?: Date;
 
+  @IsDate()
   @Type(() => Date)
   @IsOptional()
   @ApiProperty({ description: 'Monthly reset timestamp', required: false })

--- a/apps/server/api/src/collections/api-keys/controllers/api-keys.controller.ts
+++ b/apps/server/api/src/collections/api-keys/controllers/api-keys.controller.ts
@@ -1,10 +1,10 @@
+import { ApiKeysQueryDto } from '@api/collections/api-keys/dto/api-keys-query.dto';
 import { CreateApiKeyDto } from '@api/collections/api-keys/dto/create-api-key.dto';
 import { UpdateApiKeyDto } from '@api/collections/api-keys/dto/update-api-key.dto';
 import { ApiKeysService } from '@api/collections/api-keys/services/api-keys.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
-import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { getPublicMetadata } from '@api/helpers/utils/clerk/clerk.util';
 import {
   serializeCollection,
@@ -105,21 +105,20 @@ export class ApiKeysController {
   async findAll(
     @Req() request: Request,
     @CurrentUser() user: User,
-    @Query() query: BaseQueryDto,
+    @Query() query: ApiKeysQueryDto,
   ) {
     const publicMetadata = getPublicMetadata(user);
-    const queryAny = query as unknown as Record<string, string | undefined>;
 
     const findAllQuery = {
       orderBy: { createdAt: -1 },
       where: {
         isRevoked: false,
         userId: publicMetadata.user,
-        ...(queryAny.label && {
-          label: { mode: 'insensitive', contains: queryAny.label },
+        ...(query.label && {
+          label: { mode: 'insensitive', contains: query.label },
         }),
-        ...(queryAny.description && {
-          description: { mode: 'insensitive', contains: queryAny.description },
+        ...(query.description && {
+          description: { mode: 'insensitive', contains: query.description },
         }),
       },
     };

--- a/apps/server/api/src/collections/api-keys/dto/api-keys-query.dto.ts
+++ b/apps/server/api/src/collections/api-keys/dto/api-keys-query.dto.ts
@@ -1,0 +1,21 @@
+import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class ApiKeysQueryDto extends BaseQueryDto {
+  @ApiProperty({
+    description: 'Filter by label (case-insensitive contains)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @ApiProperty({
+    description: 'Filter by description (case-insensitive contains)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/apps/server/api/src/collections/api-keys/dto/create-api-key.dto.ts
+++ b/apps/server/api/src/collections/api-keys/dto/create-api-key.dto.ts
@@ -5,6 +5,7 @@ import {
   IsDate,
   IsEnum,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   MaxLength,
@@ -84,6 +85,7 @@ export class CreateApiKeyDto {
     description: 'Optional metadata for managed/system-created keys',
     required: false,
   })
+  @IsObject()
   @IsOptional()
   readonly metadata?: Record<string, unknown>;
 }

--- a/apps/server/api/src/collections/assets/dto/assets-query.dto.ts
+++ b/apps/server/api/src/collections/assets/dto/assets-query.dto.ts
@@ -3,7 +3,7 @@ import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { AssetCategory, AssetParent } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEnum, IsOptional } from 'class-validator';
+import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
 
 export class AssetQueryDto extends BaseQueryDto {
   @ApiProperty({
@@ -40,6 +40,7 @@ export class AssetQueryDto extends BaseQueryDto {
       'Use lightweight mode (skip expensive lookups for gallery views)',
     required: false,
   })
+  @IsBoolean()
   @IsOptional()
   @Transform(({ value }) => {
     if (value === undefined || value === null) {

--- a/apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts
@@ -7,6 +7,7 @@ import {
   IsBoolean,
   IsIn,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   Max,
@@ -312,6 +313,7 @@ export class UpdateBrandAgentConfigDto {
   })
   persona?: string;
 
+  @IsObject()
   @IsOptional()
   @ApiProperty({
     additionalProperties: {

--- a/apps/server/api/src/collections/brands/dto/update-brand.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/update-brand.dto.ts
@@ -5,7 +5,7 @@ import type {
 } from '@api/collections/brands/schemas/brand.schema';
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty, PartialType } from '@nestjs/swagger';
-import { IsArray, IsBoolean, IsOptional } from 'class-validator';
+import { IsArray, IsBoolean, IsObject, IsOptional } from 'class-validator';
 
 export class UpdateBrandDto extends PartialType(CreateBrandDto) {
   @IsBoolean()
@@ -16,6 +16,7 @@ export class UpdateBrandDto extends PartialType(CreateBrandDto) {
   })
   readonly isDeleted?: boolean;
 
+  @IsObject()
   @IsOptional()
   @ApiProperty({
     description: 'Agent configuration overrides for the brand',

--- a/apps/server/api/src/collections/content-intelligence/dto/add-creator.dto.ts
+++ b/apps/server/api/src/collections/content-intelligence/dto/add-creator.dto.ts
@@ -5,6 +5,7 @@ import {
   IsBoolean,
   IsEnum,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   IsUrl,
@@ -104,6 +105,7 @@ export class AddCreatorDto {
   })
   niche?: string;
 
+  @IsObject()
   @IsOptional()
   @ApiProperty({
     description: 'Scrape configuration options',

--- a/apps/server/api/src/collections/contexts/dto/create-context.dto.ts
+++ b/apps/server/api/src/collections/contexts/dto/create-context.dto.ts
@@ -1,6 +1,6 @@
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { Allow, IsEnum, IsOptional, IsString } from 'class-validator';
 
 export class CreateContextDto {
   @ApiProperty({
@@ -47,6 +47,7 @@ export class CreateContextDto {
   @IsEntityId()
   sourceBrand?: string;
 
+  @Allow()
   @ApiProperty({
     description: 'Last analyzed timestamp',
     required: false,

--- a/apps/server/api/src/collections/gifs/dto/gifs-query.dto.ts
+++ b/apps/server/api/src/collections/gifs/dto/gifs-query.dto.ts
@@ -3,7 +3,13 @@ import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { AssetScope } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class GifsQueryDto extends BaseQueryDto {
   @ApiProperty({
@@ -92,6 +98,7 @@ export class GifsQueryDto extends BaseQueryDto {
       'Use lightweight mode (skip expensive lookups for gallery views)',
     required: false,
   })
+  @IsBoolean()
   @IsOptional()
   @Transform(({ value }) => {
     if (value === undefined || value === null) {

--- a/apps/server/api/src/collections/images/dto/images-query.dto.ts
+++ b/apps/server/api/src/collections/images/dto/images-query.dto.ts
@@ -3,7 +3,13 @@ import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { AssetScope } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class ImagesQueryDto extends BaseQueryDto {
   @ApiProperty({
@@ -100,6 +106,7 @@ export class ImagesQueryDto extends BaseQueryDto {
       'Use lightweight mode (skip expensive lookups for gallery views)',
     required: false,
   })
+  @IsBoolean()
   @IsOptional()
   @Transform(({ value }) => {
     if (value === undefined || value === null) {
@@ -126,6 +133,7 @@ export class ImagesQueryDto extends BaseQueryDto {
     description: 'Filter by public gallery visibility (for getshareable.app)',
     required: false,
   })
+  @IsBoolean()
   @IsOptional()
   @Transform(({ value }) => {
     if (value === undefined || value === null) {

--- a/apps/server/api/src/collections/ingredients/dto/create-ingredient.dto.ts
+++ b/apps/server/api/src/collections/ingredients/dto/create-ingredient.dto.ts
@@ -1,7 +1,7 @@
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import {
   AssetScope,
-  type ContentRating,
+  ContentRating,
   DarkroomReviewStatus,
   IngredientAvatarCategory,
   IngredientCategory,
@@ -212,6 +212,7 @@ export class CreateIngredientDto {
   })
   readonly qualityStatus?: string;
 
+  @IsEnum(ContentRating)
   @IsOptional()
   @ApiProperty({
     description: 'Moderation content rating for darkroom assets',

--- a/apps/server/api/src/collections/ingredients/dto/update-ingredient.dto.ts
+++ b/apps/server/api/src/collections/ingredients/dto/update-ingredient.dto.ts
@@ -1,7 +1,13 @@
 import { CreateIngredientDto } from '@api/collections/ingredients/dto/create-ingredient.dto';
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty, PartialType } from '@nestjs/swagger';
-import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  Allow,
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class UpdateIngredientDto extends PartialType(CreateIngredientDto) {
   @IsBoolean()
@@ -53,6 +59,7 @@ export class UpdateIngredientDto extends PartialType(CreateIngredientDto) {
   })
   readonly generationStage?: string;
 
+  @Allow()
   @IsOptional()
   @ApiProperty({
     description: 'Timestamp when generation completed',

--- a/apps/server/api/src/collections/metadata/dto/create-metadata.dto.ts
+++ b/apps/server/api/src/collections/metadata/dto/create-metadata.dto.ts
@@ -4,6 +4,7 @@ import { MetadataExtension, MetadataStyle } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import {
+  IsArray,
   IsBoolean,
   IsEnum,
   IsNumber,
@@ -112,6 +113,8 @@ export class CreateMetadataDto {
   @IsOptional()
   readonly hasAudio?: boolean;
 
+  @IsArray()
+  @IsString({ each: true })
   @IsOptional()
   readonly tags?: string[];
 }

--- a/apps/server/api/src/collections/organization-settings/dto/create-organization-setting.dto.ts
+++ b/apps/server/api/src/collections/organization-settings/dto/create-organization-setting.dto.ts
@@ -12,6 +12,7 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
+  Allow,
   IsBoolean,
   IsEnum,
   IsIn,
@@ -144,6 +145,7 @@ export class OnboardingJourneyMissionStateDto {
   @ApiProperty({ required: true })
   readonly rewardCredits!: number;
 
+  @Allow()
   @IsOptional()
   @ApiProperty({ required: false })
   readonly completedAt?: Date | string | null;
@@ -162,6 +164,7 @@ export class CreateOrganizationSettingDto {
   })
   readonly onboardingJourneyMissions?: OnboardingJourneyMissionStateDto[];
 
+  @Allow()
   @IsOptional()
   @ApiProperty({
     description: 'Timestamp when the onboarding journey was fully completed',

--- a/apps/server/api/src/collections/posts/dto/create-post.dto.ts
+++ b/apps/server/api/src/collections/posts/dto/create-post.dto.ts
@@ -115,6 +115,7 @@ export class CreatePostDto {
     description: 'Whether this post should repeat on a schedule',
     required: false,
   })
+  @IsBoolean()
   @IsOptional()
   readonly isRepeat?: boolean;
 

--- a/apps/server/api/src/collections/transcripts/dto/update-transcript.dto.ts
+++ b/apps/server/api/src/collections/transcripts/dto/update-transcript.dto.ts
@@ -75,6 +75,7 @@ export class UpdateTranscriptDto {
   audioFileUrl?: string;
 
   @IsOptional()
+  @IsString()
   article?: string;
 
   @IsOptional()

--- a/apps/server/api/src/collections/videos/dto/videos-query.dto.ts
+++ b/apps/server/api/src/collections/videos/dto/videos-query.dto.ts
@@ -3,7 +3,13 @@ import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { AssetScope } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class VideosQueryDto extends BaseQueryDto {
   @ApiProperty({
@@ -100,6 +106,7 @@ export class VideosQueryDto extends BaseQueryDto {
       'Use lightweight mode (skip expensive lookups for masonry/gallery views)',
     required: false,
   })
+  @IsBoolean()
   @IsOptional()
   @Transform(({ value }) => {
     if (value === undefined || value === null) {

--- a/apps/server/api/src/collections/workflows/dto/create-workflow.dto.ts
+++ b/apps/server/api/src/collections/workflows/dto/create-workflow.dto.ts
@@ -9,6 +9,7 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
+  Allow,
   IsArray,
   IsBoolean,
   IsDate,
@@ -161,6 +162,7 @@ export class WorkflowInputVariableDto {
   @ApiProperty({ description: 'Help text', required: false })
   readonly description?: string;
 
+  @Allow()
   @IsOptional()
   @ApiProperty({ description: 'Default value', required: false })
   readonly defaultValue?: unknown;
@@ -308,6 +310,7 @@ export class CreateWorkflowDto extends LabeledCreateDto {
   })
   readonly status?: WorkflowStatus;
 
+  @IsNumber()
   @IsOptional()
   @ApiProperty({
     description: 'Workflow progress percentage',
@@ -315,6 +318,7 @@ export class CreateWorkflowDto extends LabeledCreateDto {
   })
   readonly progress?: number;
 
+  @IsNumber()
   @IsOptional()
   @ApiProperty({
     description: 'Number of times this workflow has been executed',
@@ -322,6 +326,7 @@ export class CreateWorkflowDto extends LabeledCreateDto {
   })
   readonly executionCount?: number;
 
+  @Allow()
   @IsOptional()
   @ApiProperty({
     description: 'Last execution timestamp',
@@ -329,6 +334,7 @@ export class CreateWorkflowDto extends LabeledCreateDto {
   })
   readonly lastExecutedAt?: Date;
 
+  @Allow()
   @IsOptional()
   @ApiProperty({
     description: 'Workflow start timestamp',
@@ -336,6 +342,7 @@ export class CreateWorkflowDto extends LabeledCreateDto {
   })
   readonly startedAt?: Date;
 
+  @Allow()
   @IsOptional()
   @ApiProperty({
     description: 'Workflow completion timestamp',

--- a/apps/server/api/src/helpers/pipes/validation.pipe.spec.ts
+++ b/apps/server/api/src/helpers/pipes/validation.pipe.spec.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe } from '@api/helpers/pipes/validation.pipe';
 import { type ArgumentMetadata, BadRequestException } from '@nestjs/common';
-import { IsEmail, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { Allow, IsDate, IsEmail, IsOptional, IsString } from 'class-validator';
 
 class TestDto {
   @IsString()
@@ -12,6 +13,30 @@ class TestDto {
   @IsOptional()
   @IsString()
   description?: string;
+}
+
+class WhitelistDto {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  validatedOptional?: string;
+
+  @Allow()
+  @IsOptional()
+  allowedField?: unknown;
+
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  scheduledAt?: Date;
+
+  // class-validator 0.15 keeps @IsOptional-only properties under
+  // whitelist (0.13/0.14 stripped them). Pinned here so a future
+  // class-validator bump that reverts this surfaces as a test failure.
+  @IsOptional()
+  optionalOnly?: string;
 }
 
 class PrimitiveDto {
@@ -209,6 +234,118 @@ describe('ValidationPipe', () => {
           email: 'john@example.com',
           name: 'John Doe',
         }),
+      );
+    });
+  });
+
+  describe('whitelist stripping', () => {
+    const metadata: ArgumentMetadata = {
+      metatype: WhitelistDto,
+      type: 'body',
+    };
+
+    it('should strip properties that are not declared on the DTO', async () => {
+      const value = {
+        injectedField: 'malicious',
+        name: 'John Doe',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.name).toBe('John Doe');
+      expect(result).not.toHaveProperty('injectedField');
+    });
+
+    it('should keep properties decorated with @IsOptional alone', async () => {
+      const value = {
+        name: 'John Doe',
+        optionalOnly: 'sent by client',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.optionalOnly).toBe('sent by client');
+    });
+
+    it('should keep properties protected by @Allow', async () => {
+      const value = {
+        allowedField: { anything: true },
+        name: 'John Doe',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.allowedField).toEqual({ anything: true });
+    });
+
+    it('should keep optional properties that have a real validator', async () => {
+      const value = {
+        name: 'John Doe',
+        validatedOptional: 'kept',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.validatedOptional).toBe('kept');
+    });
+
+    it('should keep @Type(() => Date) properties validated with @IsDate', async () => {
+      const value = {
+        name: 'John Doe',
+        scheduledAt: '2026-01-15T10:00:00.000Z',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.scheduledAt).toBeInstanceOf(Date);
+      expect((result.scheduledAt as Date).toISOString()).toBe(
+        '2026-01-15T10:00:00.000Z',
+      );
+    });
+
+    it('should strip unknown properties in JSON:API format payloads', async () => {
+      const value = {
+        data: {
+          attributes: {
+            injectedField: 'malicious',
+            name: 'John Doe',
+          },
+          type: 'test',
+        },
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.name).toBe('John Doe');
+      expect(result).not.toHaveProperty('injectedField');
+    });
+
+    it('should still reject invalid values for declared properties', async () => {
+      const value = {
+        name: 'John Doe',
+        validatedOptional: 123,
+      };
+
+      await expect(pipe.transform(value, metadata)).rejects.toThrow(
+        BadRequestException,
       );
     });
   });

--- a/apps/server/api/src/helpers/pipes/validation.pipe.ts
+++ b/apps/server/api/src/helpers/pipes/validation.pipe.ts
@@ -87,7 +87,7 @@ export class ValidationPipe implements PipeTransform<unknown> {
       return;
     }
 
-    const errors = await validate(object);
+    const errors = await validate(object, { whitelist: true });
     if (errors.length > 0) {
       const messages = errors.map((error) => ({
         constraints: error.constraints,


### PR DESCRIPTION
Closes #493

## What

Flips the API's custom global `ValidationPipe` to `validate(object, { whitelist: true })` so undeclared payload properties are stripped before reaching services, and hardens 31 DTO fields plus one query DTO so every previously-accepted payload keeps working.

## Key decisions

- **class-validator 0.15 semantics discovery**: the issue's premise (`@IsOptional`-only fields get stripped) held for 0.13/0.14 but **not** for the pinned 0.15.1 — `@IsOptional`-only properties now survive whitelist. Verified empirically and pinned in a spec test so a future class-validator bump that reverts this fails loudly. The decorator additions are therefore belt-and-braces plus genuine validation hardening, not strictly required for whitelist survival.
- **Decorator policy** (prime directive: payloads accepted before must still be accepted):
  - `@IsDate()` on `@Type(() => Date)` fields (agent-goals, agent-strategies incl. the issue-named `nextRunAt`/`dailyResetAt`/`dailyCreditResetAt`/`monthlyResetAt`)
  - `@IsBoolean()` only where the existing `@Transform` provably always returns a boolean (assets/gifs/images/videos query DTOs, posts `isRepeat`)
  - `@IsObject()`/`@IsString()`/`@IsNumber()`/`@IsArray()+@IsString({each:true})`/`@IsEnum()` where the wire type is unambiguous
  - `@Allow()` where the wire format differs from the declared type (Date fields without `@Type` arrive as strings, unions, `unknown`) — whitelists without over-constraining
  - No `@ValidateNested` added anywhere; no existing decorators removed
- **api-keys regression found by adversarial review**: `GET /api-keys` read `label`/`description` off an untyped cast of `BaseQueryDto` — whitelist would have silently dropped both and broken search. Fixed with a dedicated `ApiKeysQueryDto extends BaseQueryDto` (mirrors `AssetQueryDto` pattern) and removed the cast.
- **Intentionally not changed**: `UploadPostDto` (never imported by any controller — dead code), `RunEventEnvelopeDto` (swagger `@ApiResponse` only), `CreateWorkspaceTaskDto` (service-only, no controller). All three are unreachable from any controller param. Also `BaseCRUDController` generic bodies erase to `Object` at runtime so the pipe never validated them — pre-existing, unaffected by this PR.
- `forbidNonWhitelisted` deliberately **not** set: unknown keys strip silently rather than 400, keeping lenient behavior for existing clients.

## Verification

- `validation.pipe.spec.ts`: 20/20 pass, incl. new 7-test whitelist suite (unknown props stripped in plain + JSON:API paths, `@Allow`/`@IsOptional`-only/validated-optional kept, `@Type(() => Date)` converts, invalid values still 400)
- Biome clean on all 23 changed files
- Typecheck zero-delta vs develop baseline (stash-diff proof: sorted tsc output identical before/after, 0 changed lines; the 862 pre-existing errors are module-resolution noise from unbuilt workspace package dists)
- Deterministic AST sweep over `apps/server/api/src`: 0 controller-reachable DTO fields left without validation metadata (was 26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)