### PR TITLE
feat(media): persist job state across restarts via Redis (#478)

### DIFF
--- a/apps/server/images/src/app.module.ts
+++ b/apps/server/images/src/app.module.ts
@@ -13,6 +13,7 @@ import { JobService } from '@images/services/job.service';
 import { LoraService } from '@images/services/lora.service';
 import { TrainingService } from '@images/services/training.service';
 import { LoggerModule } from '@libs/logger/logger.module';
+import { RedisModule } from '@libs/redis/redis.module';
 import { S3Module } from '@libs/s3/s3.module';
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
@@ -30,6 +31,10 @@ import { Module } from '@nestjs/common';
     ConfigModule,
     HttpModule,
     LoggerModule,
+    RedisModule.forRoot({
+      configModule: ConfigModule,
+      configService: ConfigService,
+    }),
     S3Module.forRoot({
       configModule: ConfigModule,
       configService: ConfigService,

--- a/apps/server/images/src/controllers/health.controller.spec.ts
+++ b/apps/server/images/src/controllers/health.controller.spec.ts
@@ -34,18 +34,18 @@ describe('HealthController (images)', () => {
   });
 
   describe('getHealth', () => {
-    it('returns status ok', () => {
-      const result = controller.getHealth();
+    it('returns status ok', async () => {
+      const result = await controller.getHealth();
       expect(result.status).toBe('ok');
     });
 
-    it('returns service name as images', () => {
-      const result = controller.getHealth();
+    it('returns service name as images', async () => {
+      const result = await controller.getHealth();
       expect(result.service).toBe('images');
     });
 
-    it('includes job stats from JobService', () => {
-      const result = controller.getHealth();
+    it('includes job stats from JobService', async () => {
+      const result = await controller.getHealth();
       expect(result.jobs).toEqual({
         active: 1,
         completed: 5,
@@ -56,31 +56,31 @@ describe('HealthController (images)', () => {
       expect(jobService.getStats).toHaveBeenCalledTimes(1);
     });
 
-    it('includes memory usage fields', () => {
-      const result = controller.getHealth();
+    it('includes memory usage fields', async () => {
+      const result = await controller.getHealth();
       expect(result.memory).toHaveProperty('heapUsed');
       expect(result.memory).toHaveProperty('heapTotal');
       expect(result.memory).toHaveProperty('rss');
     });
 
-    it('includes a valid ISO timestamp', () => {
-      const result = controller.getHealth();
+    it('includes a valid ISO timestamp', async () => {
+      const result = await controller.getHealth();
       expect(() => new Date(result.timestamp)).not.toThrow();
       expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
     });
 
-    it('includes uptime as a number', () => {
-      const result = controller.getHealth();
+    it('includes uptime as a number', async () => {
+      const result = await controller.getHealth();
       expect(typeof result.uptime).toBe('number');
       expect(result.uptime).toBeGreaterThanOrEqual(0);
     });
 
-    it('calls getStats exactly once per request', () => {
-      controller.getHealth();
+    it('calls getStats exactly once per request', async () => {
+      await controller.getHealth();
       expect(jobService.getStats).toHaveBeenCalledTimes(1);
     });
 
-    it('reflects updated stats on subsequent calls', () => {
+    it('reflects updated stats on subsequent calls', async () => {
       jobService.getStats.mockReturnValueOnce({
         active: 0,
         completed: 10,
@@ -88,7 +88,7 @@ describe('HealthController (images)', () => {
         queued: 0,
         total: 11,
       });
-      const result = controller.getHealth();
+      const result = await controller.getHealth();
       expect(result.jobs.completed).toBe(10);
     });
   });

--- a/apps/server/images/src/controllers/health.controller.ts
+++ b/apps/server/images/src/controllers/health.controller.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { JobService } from '@images/services/job.service';
 import { Controller, Get } from '@nestjs/common';
 
@@ -6,11 +7,11 @@ export class HealthController {
   constructor(private readonly jobService: JobService) {}
 
   @Get()
-  getHealth() {
+  async getHealth() {
     const mem = process.memoryUsage();
 
     return {
-      jobs: this.jobService.getStats(),
+      jobs: await this.jobService.getStats(),
       memory: {
         heapTotal: mem.heapTotal,
         heapUsed: mem.heapUsed,

--- a/apps/server/images/src/services/job.service.spec.ts
+++ b/apps/server/images/src/services/job.service.spec.ts
@@ -1,5 +1,6 @@
 import { JobService } from '@images/services/job.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
 import { Test, TestingModule } from '@nestjs/testing';
 
 vi.mock('@libs/utils/caller/caller.util', () => ({
@@ -113,8 +114,8 @@ describe('JobService', () => {
   });
 
   describe('getStats', () => {
-    it('returns zero counts when no jobs exist', () => {
-      const stats = service.getStats();
+    it('returns zero counts when no jobs exist', async () => {
+      const stats = await service.getStats();
       expect(stats).toEqual({
         active: 0,
         completed: 0,
@@ -127,7 +128,7 @@ describe('JobService', () => {
     it('counts queued jobs correctly', async () => {
       await service.createJob({ params: {}, type: 'test' });
       await service.createJob({ params: {}, type: 'test' });
-      const stats = service.getStats();
+      const stats = await service.getStats();
       expect(stats.queued).toBe(2);
       expect(stats.total).toBe(2);
     });
@@ -140,12 +141,36 @@ describe('JobService', () => {
       await service.updateJob(j1.jobId, { status: 'processing' });
       await service.updateJob(j2.jobId, { status: 'completed' });
       await service.updateJob(j3.jobId, { status: 'failed' });
-      const stats = service.getStats();
+      const stats = await service.getStats();
       expect(stats.active).toBe(1);
       expect(stats.completed).toBe(1);
       expect(stats.failed).toBe(1);
       expect(stats.queued).toBe(1);
       expect(stats.total).toBe(4);
+    });
+  });
+
+  describe('Redis persistence', () => {
+    it('persists jobs under the images namespace', async () => {
+      const setEx = vi.fn(async () => undefined);
+      const redisService = {
+        getPublisher: vi.fn(() => ({ setEx })),
+      } as unknown as RedisService;
+      const redisBackedService = new JobService(
+        logger as unknown as LoggerService,
+        redisService,
+      );
+
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'image-gen',
+      });
+
+      expect(setEx).toHaveBeenCalledWith(
+        `jobs:images:${job.jobId}`,
+        86400,
+        JSON.stringify(job),
+      );
     });
   });
 });

--- a/apps/server/images/src/services/job.service.ts
+++ b/apps/server/images/src/services/job.service.ts
@@ -1,6 +1,17 @@
 import type { GenerationJob } from '@images/interfaces/images.interfaces';
 import { BaseJobService } from '@libs/jobs/base-job.service';
-import { Injectable } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
+import { Injectable, Optional } from '@nestjs/common';
 
 @Injectable()
-export class JobService extends BaseJobService<GenerationJob> {}
+export class JobService extends BaseJobService<GenerationJob> {
+  constructor(
+    loggerService: LoggerService,
+    @Optional() redisService?: RedisService,
+  ) {
+    super(loggerService, 'images', redisService);
+  }
+}

--- a/apps/server/images/src/services/training.service.spec.ts
+++ b/apps/server/images/src/services/training.service.spec.ts
@@ -4,6 +4,8 @@ import { Readable } from 'node:stream';
 import { ConfigService } from '@images/config/config.service';
 import { TrainingService } from '@images/services/training.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
+import { S3Service } from '@libs/s3/s3.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -12,6 +14,40 @@ const mockSpawn = vi.fn();
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
+
+/** In-memory fake of the node-redis publisher surface used by the store. */
+function createMockPublisher() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    scanIterator: vi.fn(({ MATCH }: { COUNT: number; MATCH: string }) => {
+      const prefix = MATCH.slice(0, -1);
+      return (async function* () {
+        for (const key of store.keys()) {
+          if (key.startsWith(prefix)) {
+            yield key;
+          }
+        }
+      })();
+    }),
+    setEx: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+    }),
+    store,
+    unlink: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+type MockPublisher = ReturnType<typeof createMockPublisher>;
+
+function createMockRedisService(publisher: MockPublisher | null): RedisService {
+  return {
+    getPublisher: vi.fn(() => publisher),
+  } as unknown as RedisService;
+}
 
 describe('TrainingService', () => {
   let service: TrainingService;
@@ -25,6 +61,13 @@ describe('TrainingService', () => {
     COMFYUI_LORAS_PATH: '/comfyui/models/loras',
     DATASETS_PATH: '/datasets',
     TRAINING_BINARY_PATH: '/usr/local/bin/accelerate',
+  };
+
+  const mockS3Service = {
+    uploadSafetensors: vi.fn().mockResolvedValue({
+      s3Key: 'loras/test-lora.safetensors',
+      sizeBytes: 1024,
+    }),
   };
 
   function createMockChildProcess(): ChildProcess & EventEmitter {
@@ -50,6 +93,7 @@ describe('TrainingService', () => {
         TrainingService,
         { provide: ConfigService, useValue: mockConfigService },
         { provide: LoggerService, useValue: mockLoggerService },
+        { provide: S3Service, useValue: mockS3Service },
       ],
     }).compile();
 
@@ -279,6 +323,174 @@ describe('TrainingService', () => {
       expect(result.args).toContain('32');
       expect(result.args).toContain('--learning_rate');
       expect(result.args).toContain('0.00005');
+    });
+  });
+
+  describe('Redis persistence', () => {
+    let publisher: MockPublisher;
+    let redisBackedService: TrainingService;
+
+    function createService(
+      targetPublisher: MockPublisher | null,
+    ): TrainingService {
+      return new TrainingService(
+        mockConfigService as unknown as ConfigService,
+        mockLoggerService as unknown as LoggerService,
+        mockS3Service as unknown as S3Service,
+        createMockRedisService(targetPublisher),
+      );
+    }
+
+    beforeEach(() => {
+      publisher = createMockPublisher();
+      redisBackedService = createService(publisher);
+    });
+
+    it('persists the job and process record when training starts', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const rawJob = publisher.store.get(`training:images:job:${jobId}`);
+      expect(rawJob).toBeDefined();
+      expect(JSON.parse(rawJob as string)).toMatchObject({
+        jobId,
+        personaSlug: 'test-persona',
+      });
+
+      const rawRecord = publisher.store.get(`training:images:process:${jobId}`);
+      expect(rawRecord).toBeDefined();
+      expect(JSON.parse(rawRecord as string)).toMatchObject({
+        jobId,
+        pid: 12345,
+      });
+    });
+
+    it('removes the process record when the process exits', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      mockChild.emit('close', 0);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(publisher.store.has(`training:images:process:${jobId}`)).toBe(
+        false,
+      );
+      const rawJob = publisher.store.get(`training:images:job:${jobId}`);
+      expect(JSON.parse(rawJob as string)).toMatchObject({
+        status: 'completed',
+      });
+    });
+
+    it('removes the process record when the process emits an error', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      mockChild.emit('error', new Error('spawn ENOENT'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(publisher.store.has(`training:images:process:${jobId}`)).toBe(
+        false,
+      );
+      const rawJob = publisher.store.get(`training:images:job:${jobId}`);
+      expect(JSON.parse(rawJob as string)).toMatchObject({
+        status: 'failed',
+      });
+    });
+
+    it('recovers orphaned jobs and process records on module init', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Simulate a service restart while the process record is still present.
+      const restarted = createService(publisher);
+      await restarted.onModuleInit();
+
+      expect(mockLoggerService.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          jobId,
+          message: 'Orphaned training process detected on startup',
+          pid: 12345,
+        }),
+      );
+
+      const job = await restarted.getTrainingJob(jobId);
+      expect(job.status).toBe('failed');
+      expect(job.stage).toBe('failed');
+      expect(job.error).toContain('orphaned by service restart');
+      expect(publisher.store.has(`training:images:process:${jobId}`)).toBe(
+        false,
+      );
+
+      const persistedJob = publisher.store.get(`training:images:job:${jobId}`);
+      expect(JSON.parse(persistedJob as string)).toMatchObject({
+        stage: 'failed',
+        status: 'failed',
+      });
+    });
+
+    it('loads a job from Redis on getTrainingJob after a restart without init', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Fresh instance, same Redis store, onModuleInit not run.
+      const restarted = createService(publisher);
+      const job = await restarted.getTrainingJob(jobId);
+
+      expect(job.jobId).toBe(jobId);
+      expect(job.personaSlug).toBe('test-persona');
+    });
+
+    it('starts cleanly when Redis is unavailable', async () => {
+      const offlineService = createService(null);
+      await offlineService.onModuleInit();
+
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await offlineService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+
+      const job = await offlineService.getTrainingJob(jobId);
+      expect(job.jobId).toBe(jobId);
     });
   });
 });

--- a/apps/server/images/src/services/training.service.ts
+++ b/apps/server/images/src/services/training.service.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import process from 'node:process';
 import { ConfigService } from '@images/config/config.service';
 import type {
   TrainingJob,
@@ -8,13 +9,19 @@ import type {
   TrainingParams,
   TrainingRequest,
 } from '@images/interfaces/training.interfaces';
+import { TrainingStateStore } from '@libs/jobs/training-state.store';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { S3Service } from '@libs/s3/s3.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  type OnModuleInit,
+  Optional,
 } from '@nestjs/common';
 
 const DEFAULT_LORA_RANK = 16;
@@ -22,16 +29,57 @@ const DEFAULT_STEPS = 1500;
 const DEFAULT_LEARNING_RATE = 1e-4;
 
 @Injectable()
-export class TrainingService {
+export class TrainingService implements OnModuleInit {
   private readonly constructorName: string = String(this.constructor.name);
   private readonly jobs: Map<string, TrainingJob> = new Map();
   private readonly processes: Map<string, ChildProcess> = new Map();
+  private readonly trainingStateStore: TrainingStateStore<TrainingJob>;
 
   constructor(
     private readonly configService: ConfigService,
     private readonly loggerService: LoggerService,
     private readonly s3Service: S3Service,
-  ) {}
+    @Optional() private readonly redisService?: RedisService,
+  ) {
+    this.trainingStateStore = new TrainingStateStore<TrainingJob>(
+      'images',
+      loggerService,
+      redisService,
+    );
+  }
+
+  async onModuleInit(): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+
+    const [jobs, records] = await Promise.all([
+      this.trainingStateStore.loadJobs(),
+      this.trainingStateStore.loadProcessRecords(),
+    ]);
+
+    for (const job of jobs) {
+      if (!this.jobs.has(job.jobId)) {
+        this.jobs.set(job.jobId, job);
+      }
+    }
+
+    for (const record of records) {
+      const isAlive = this.isProcessAlive(record.pid);
+      this.loggerService.warn(caller, {
+        isAlive,
+        jobId: record.jobId,
+        message: 'Orphaned training process detected on startup',
+        pid: record.pid,
+        startedAt: record.startedAt,
+      });
+      await this.updateJob(record.jobId, {
+        completedAt: new Date().toISOString(),
+        error: `Process orphaned by service restart (pid ${record.pid}, ${isAlive ? 'still running' : 'no longer running'})`,
+        stage: 'failed',
+        status: 'failed',
+      });
+      await this.trainingStateStore.deleteProcessRecord(record.jobId);
+    }
+  }
 
   async startTraining(request: TrainingRequest): Promise<{ jobId: string }> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
@@ -68,6 +116,7 @@ export class TrainingService {
     };
 
     this.jobs.set(jobId, job);
+    await this.trainingStateStore.persistJob(job);
 
     this.loggerService.log(caller, {
       jobId,
@@ -83,7 +132,15 @@ export class TrainingService {
   async getTrainingJob(jobId: string): Promise<TrainingJob> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
-    const job = this.jobs.get(jobId);
+    let job = this.jobs.get(jobId);
+    if (!job) {
+      const persisted = await this.trainingStateStore.loadJob(jobId);
+      if (persisted) {
+        this.jobs.set(jobId, persisted);
+        job = persisted;
+      }
+    }
+
     if (!job) {
       throw new NotFoundException(`Training job "${jobId}" not found`);
     }
@@ -192,8 +249,15 @@ export class TrainingService {
       });
 
       this.processes.set(jobId, child);
+      if (typeof child.pid === 'number') {
+        void this.trainingStateStore.persistProcessRecord({
+          jobId,
+          pid: child.pid,
+          startedAt: new Date().toISOString(),
+        });
+      }
 
-      this.updateJob(jobId, { progress: 5, stage: 'training' });
+      void this.updateJob(jobId, { progress: 5, stage: 'training' });
 
       child.stdout?.on('data', (data: Buffer) => {
         const output = data.toString();
@@ -209,7 +273,7 @@ export class TrainingService {
           const total = Number(progressMatch[2] || params.steps);
           if (total > 0) {
             const progress = Math.min(95, Math.round((current / total) * 100));
-            this.updateJob(jobId, { progress });
+            void this.updateJob(jobId, { progress });
           }
         }
       });
@@ -225,12 +289,13 @@ export class TrainingService {
 
       child.on('close', (code: number | null) => {
         this.processes.delete(jobId);
+        void this.trainingStateStore.deleteProcessRecord(jobId);
 
         if (code === 0) {
           this.handleTrainingComplete(jobId, params).catch((error: unknown) => {
             const errorMessage =
               error instanceof Error ? error.message : String(error);
-            this.updateJob(jobId, {
+            void this.updateJob(jobId, {
               completedAt: new Date().toISOString(),
               error: errorMessage,
               stage: 'failed',
@@ -240,7 +305,7 @@ export class TrainingService {
               `Post-training S3 upload failed for job ${jobId}`,
               error instanceof Error ? error : new Error(errorMessage),
             );
-            this.updateJob(jobId, {
+            void this.updateJob(jobId, {
               completedAt: new Date().toISOString(),
               error: `Post-training upload failed: ${error instanceof Error ? error.message : String(error)}`,
               stage: 'failed',
@@ -248,7 +313,7 @@ export class TrainingService {
             });
           });
         } else {
-          this.updateJob(jobId, {
+          void this.updateJob(jobId, {
             completedAt: new Date().toISOString(),
             error: `Training process exited with code ${code}`,
             stage: 'failed',
@@ -263,7 +328,8 @@ export class TrainingService {
 
       child.on('error', (error: Error) => {
         this.processes.delete(jobId);
-        this.updateJob(jobId, {
+        void this.trainingStateStore.deleteProcessRecord(jobId);
+        void this.updateJob(jobId, {
           completedAt: new Date().toISOString(),
           error: error.message,
           stage: 'failed',
@@ -277,7 +343,7 @@ export class TrainingService {
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      this.updateJob(jobId, {
+      void this.updateJob(jobId, {
         completedAt: new Date().toISOString(),
         error: errorMessage,
         stage: 'failed',
@@ -301,7 +367,7 @@ export class TrainingService {
     const lorasPath = this.configService.COMFYUI_LORAS_PATH;
     const localPath = `${lorasPath}/${params.loraName}.safetensors`;
 
-    this.updateJob(jobId, { progress: 96, stage: 'uploading' });
+    await this.updateJob(jobId, { progress: 96, stage: 'uploading' });
 
     this.loggerService.log(caller, {
       jobId,
@@ -333,7 +399,7 @@ export class TrainingService {
       });
     }
 
-    this.updateJob(jobId, {
+    await this.updateJob(jobId, {
       completedAt: new Date().toISOString(),
       progress: 100,
       stage: 'completed',
@@ -346,7 +412,10 @@ export class TrainingService {
     });
   }
 
-  private updateJob(jobId: string, updates: Partial<TrainingJob>): void {
+  private async updateJob(
+    jobId: string,
+    updates: Partial<TrainingJob>,
+  ): Promise<void> {
     const job = this.jobs.get(jobId);
     if (job) {
       const updated: TrainingJob = {
@@ -355,6 +424,16 @@ export class TrainingService {
         updatedAt: new Date().toISOString(),
       };
       this.jobs.set(jobId, updated);
+      await this.trainingStateStore.persistJob(updated);
+    }
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
     }
   }
 }

--- a/apps/server/videos/src/app.module.ts
+++ b/apps/server/videos/src/app.module.ts
@@ -1,4 +1,5 @@
 import { LoggerModule } from '@libs/logger/logger.module';
+import { RedisModule } from '@libs/redis/redis.module';
 import { S3Module } from '@libs/s3/s3.module';
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
@@ -18,6 +19,10 @@ import { WorkflowService } from '@videos/services/workflow.service';
     ConfigModule,
     HttpModule,
     LoggerModule,
+    RedisModule.forRoot({
+      configModule: ConfigModule,
+      configService: ConfigService,
+    }),
     S3Module.forRoot({
       configModule: ConfigModule,
       configService: ConfigService,

--- a/apps/server/videos/src/controllers/health.controller.spec.ts
+++ b/apps/server/videos/src/controllers/health.controller.spec.ts
@@ -34,18 +34,18 @@ describe('HealthController (videos)', () => {
   });
 
   describe('getHealth', () => {
-    it('returns status ok', () => {
-      const result = controller.getHealth();
+    it('returns status ok', async () => {
+      const result = await controller.getHealth();
       expect(result.status).toBe('ok');
     });
 
-    it('returns service name as videos', () => {
-      const result = controller.getHealth();
+    it('returns service name as videos', async () => {
+      const result = await controller.getHealth();
       expect(result.service).toBe('videos');
     });
 
-    it('includes job stats from JobService', () => {
-      const result = controller.getHealth();
+    it('includes job stats from JobService', async () => {
+      const result = await controller.getHealth();
       expect(result.jobs).toEqual({
         active: 2,
         completed: 7,
@@ -55,30 +55,30 @@ describe('HealthController (videos)', () => {
       });
     });
 
-    it('calls getStats once per request', () => {
-      controller.getHealth();
+    it('calls getStats once per request', async () => {
+      await controller.getHealth();
       expect(jobService.getStats).toHaveBeenCalledTimes(1);
     });
 
-    it('includes memory usage fields', () => {
-      const result = controller.getHealth();
+    it('includes memory usage fields', async () => {
+      const result = await controller.getHealth();
       expect(result.memory).toHaveProperty('heapUsed');
       expect(result.memory).toHaveProperty('heapTotal');
       expect(result.memory).toHaveProperty('rss');
     });
 
-    it('includes a valid ISO timestamp', () => {
-      const result = controller.getHealth();
+    it('includes a valid ISO timestamp', async () => {
+      const result = await controller.getHealth();
       expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
     });
 
-    it('includes uptime as a non-negative number', () => {
-      const result = controller.getHealth();
+    it('includes uptime as a non-negative number', async () => {
+      const result = await controller.getHealth();
       expect(typeof result.uptime).toBe('number');
       expect(result.uptime).toBeGreaterThanOrEqual(0);
     });
 
-    it('reflects updated stats on subsequent calls', () => {
+    it('reflects updated stats on subsequent calls', async () => {
       jobService.getStats.mockReturnValueOnce({
         active: 0,
         completed: 20,
@@ -86,7 +86,7 @@ describe('HealthController (videos)', () => {
         queued: 0,
         total: 20,
       });
-      const result = controller.getHealth();
+      const result = await controller.getHealth();
       expect(result.jobs.total).toBe(20);
     });
   });

--- a/apps/server/videos/src/controllers/health.controller.ts
+++ b/apps/server/videos/src/controllers/health.controller.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { Controller, Get } from '@nestjs/common';
 import { JobService } from '@videos/services/job.service';
 
@@ -6,11 +7,11 @@ export class HealthController {
   constructor(private readonly jobService: JobService) {}
 
   @Get()
-  getHealth() {
+  async getHealth() {
     const mem = process.memoryUsage();
 
     return {
-      jobs: this.jobService.getStats(),
+      jobs: await this.jobService.getStats(),
       memory: {
         heapTotal: mem.heapTotal,
         heapUsed: mem.heapUsed,

--- a/apps/server/videos/src/services/job.service.spec.ts
+++ b/apps/server/videos/src/services/job.service.spec.ts
@@ -1,4 +1,5 @@
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { JobService } from '@videos/services/job.service';
 
@@ -130,8 +131,8 @@ describe('JobService (videos)', () => {
   });
 
   describe('getStats', () => {
-    it('should return zeroed stats when no jobs exist', () => {
-      const stats = service.getStats();
+    it('should return zeroed stats when no jobs exist', async () => {
+      const stats = await service.getStats();
 
       expect(stats).toEqual({
         active: 0,
@@ -146,7 +147,7 @@ describe('JobService (videos)', () => {
       await service.createJob({ params: {}, type: 'render' });
       await service.createJob({ params: {}, type: 'encode' });
 
-      const stats = service.getStats();
+      const stats = await service.getStats();
 
       expect(stats.queued).toBe(2);
       expect(stats.total).toBe(2);
@@ -156,7 +157,7 @@ describe('JobService (videos)', () => {
       const job = await service.createJob({ params: {}, type: 'render' });
       await service.updateJob(job.jobId, { status: 'processing' });
 
-      const stats = service.getStats();
+      const stats = await service.getStats();
 
       expect(stats.active).toBe(1);
       expect(stats.queued).toBe(0);
@@ -170,12 +171,36 @@ describe('JobService (videos)', () => {
       await service.updateJob(j1.jobId, { status: 'completed' });
       await service.updateJob(j2.jobId, { status: 'failed' });
 
-      const stats = service.getStats();
+      const stats = await service.getStats();
 
       expect(stats.completed).toBe(1);
       expect(stats.failed).toBe(1);
       expect(stats.queued).toBe(1);
       expect(stats.total).toBe(3);
+    });
+  });
+
+  describe('Redis persistence', () => {
+    it('persists jobs under the videos namespace', async () => {
+      const setEx = vi.fn(async () => undefined);
+      const redisService = {
+        getPublisher: vi.fn(() => ({ setEx })),
+      } as unknown as RedisService;
+      const redisBackedService = new JobService(
+        mockLoggerService as unknown as LoggerService,
+        redisService,
+      );
+
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'render',
+      });
+
+      expect(setEx).toHaveBeenCalledWith(
+        `jobs:videos:${job.jobId}`,
+        86400,
+        JSON.stringify(job),
+      );
     });
   });
 });

--- a/apps/server/videos/src/services/job.service.ts
+++ b/apps/server/videos/src/services/job.service.ts
@@ -1,6 +1,17 @@
 import { BaseJobService } from '@libs/jobs/base-job.service';
-import { Injectable } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
+import { Injectable, Optional } from '@nestjs/common';
 import type { VideoGenerationJob } from '@videos/interfaces/videos.interfaces';
 
 @Injectable()
-export class JobService extends BaseJobService<VideoGenerationJob> {}
+export class JobService extends BaseJobService<VideoGenerationJob> {
+  constructor(
+    loggerService: LoggerService,
+    @Optional() redisService?: RedisService,
+  ) {
+    super(loggerService, 'videos', redisService);
+  }
+}

--- a/apps/server/voices/src/app.module.ts
+++ b/apps/server/voices/src/app.module.ts
@@ -1,4 +1,5 @@
 import { LoggerModule } from '@libs/logger/logger.module';
+import { RedisModule } from '@libs/redis/redis.module';
 import { S3Module } from '@libs/s3/s3.module';
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
@@ -31,6 +32,10 @@ import { VoiceTrainingService } from '@voices/services/voice-training.service';
     ConfigModule,
     HttpModule,
     LoggerModule,
+    RedisModule.forRoot({
+      configModule: ConfigModule,
+      configService: ConfigService,
+    }),
     S3Module.forRoot({
       configModule: ConfigModule,
       configService: ConfigService,

--- a/apps/server/voices/src/controllers/health.controller.spec.ts
+++ b/apps/server/voices/src/controllers/health.controller.spec.ts
@@ -44,27 +44,27 @@ describe('HealthController', () => {
   });
 
   describe('getHealth', () => {
-    it('returns service name as "voices"', () => {
-      const result = controller.getHealth();
+    it('returns service name as "voices"', async () => {
+      const result = await controller.getHealth();
 
       expect(result.service).toBe('voices');
     });
 
-    it('returns status "ok"', () => {
-      const result = controller.getHealth();
+    it('returns status "ok"', async () => {
+      const result = await controller.getHealth();
 
       expect(result.status).toBe('ok');
     });
 
-    it('includes job stats from JobService', () => {
-      const result = controller.getHealth();
+    it('includes job stats from JobService', async () => {
+      const result = await controller.getHealth();
 
       expect(mockJobService.getStats).toHaveBeenCalled();
       expect(result.jobs).toEqual(mockJobStats);
     });
 
-    it('includes memory usage fields', () => {
-      const result = controller.getHealth();
+    it('includes memory usage fields', async () => {
+      const result = await controller.getHealth();
 
       expect(result.memory).toHaveProperty('heapTotal');
       expect(result.memory).toHaveProperty('heapUsed');
@@ -74,14 +74,14 @@ describe('HealthController', () => {
       expect(typeof result.memory.rss).toBe('number');
     });
 
-    it('includes uptime as a number', () => {
-      const result = controller.getHealth();
+    it('includes uptime as a number', async () => {
+      const result = await controller.getHealth();
 
       expect(typeof result.uptime).toBe('number');
     });
 
-    it('includes timestamp as ISO string', () => {
-      const result = controller.getHealth();
+    it('includes timestamp as ISO string', async () => {
+      const result = await controller.getHealth();
 
       expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });

--- a/apps/server/voices/src/controllers/health.controller.ts
+++ b/apps/server/voices/src/controllers/health.controller.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JobService } from '@voices/services/job.service';
@@ -13,11 +14,11 @@ export class HealthController {
 
   @Get()
   @ApiOperation({ summary: 'Voices service health' })
-  getHealth() {
+  async getHealth() {
     const mem = process.memoryUsage();
 
     return {
-      jobs: this.jobService.getStats(),
+      jobs: await this.jobService.getStats(),
       memory: {
         heapTotal: mem.heapTotal,
         heapUsed: mem.heapUsed,

--- a/apps/server/voices/src/services/job.service.spec.ts
+++ b/apps/server/voices/src/services/job.service.spec.ts
@@ -1,4 +1,5 @@
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { JobService } from '@voices/services/job.service';
 
@@ -63,8 +64,12 @@ describe('JobService', () => {
       const job = await service.createJob({ params: {}, type: 'tts' });
       const after = new Date().toISOString();
 
-      expect(job.createdAt).toBeGreaterThanOrEqual(before);
-      expect(job.createdAt).toBeLessThanOrEqual(after);
+      expect(new Date(job.createdAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(before).getTime(),
+      );
+      expect(new Date(job.createdAt).getTime()).toBeLessThanOrEqual(
+        new Date(after).getTime(),
+      );
     });
 
     it('should log job creation', async () => {
@@ -131,8 +136,8 @@ describe('JobService', () => {
   });
 
   describe('getStats', () => {
-    it('should return zeroes when no jobs exist', () => {
-      const stats = service.getStats();
+    it('should return zeroes when no jobs exist', async () => {
+      const stats = await service.getStats();
 
       expect(stats).toEqual({
         active: 0,
@@ -147,7 +152,7 @@ describe('JobService', () => {
       await service.createJob({ params: {}, type: 'tts' });
       await service.createJob({ params: {}, type: 'tts' });
 
-      const stats = service.getStats();
+      const stats = await service.getStats();
 
       expect(stats.queued).toBe(2);
       expect(stats.total).toBe(2);
@@ -157,7 +162,7 @@ describe('JobService', () => {
       const job = await service.createJob({ params: {}, type: 'tts' });
       await service.updateJob(job.jobId, { status: 'processing' });
 
-      const stats = service.getStats();
+      const stats = await service.getStats();
 
       expect(stats.active).toBe(1);
       expect(stats.queued).toBe(0);
@@ -171,12 +176,36 @@ describe('JobService', () => {
       await service.updateJob(j1.jobId, { status: 'completed' });
       await service.updateJob(j2.jobId, { status: 'failed' });
 
-      const stats = service.getStats();
+      const stats = await service.getStats();
 
       expect(stats.completed).toBe(1);
       expect(stats.failed).toBe(1);
       expect(stats.queued).toBe(1);
       expect(stats.total).toBe(3);
+    });
+  });
+
+  describe('Redis persistence', () => {
+    it('persists jobs under the voices namespace', async () => {
+      const setEx = vi.fn(async () => undefined);
+      const redisService = {
+        getPublisher: vi.fn(() => ({ setEx })),
+      } as unknown as RedisService;
+      const redisBackedService = new JobService(
+        loggerService as unknown as LoggerService,
+        redisService,
+      );
+
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'tts',
+      });
+
+      expect(setEx).toHaveBeenCalledWith(
+        `jobs:voices:${job.jobId}`,
+        86400,
+        JSON.stringify(job),
+      );
     });
   });
 });

--- a/apps/server/voices/src/services/job.service.ts
+++ b/apps/server/voices/src/services/job.service.ts
@@ -1,6 +1,17 @@
 import { BaseJobService } from '@libs/jobs/base-job.service';
-import { Injectable } from '@nestjs/common';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
+import { Injectable, Optional } from '@nestjs/common';
 import type { TTSJob } from '@voices/interfaces/voices.interfaces';
 
 @Injectable()
-export class JobService extends BaseJobService<TTSJob> {}
+export class JobService extends BaseJobService<TTSJob> {
+  constructor(
+    loggerService: LoggerService,
+    @Optional() redisService?: RedisService,
+  ) {
+    super(loggerService, 'voices', redisService);
+  }
+}

--- a/apps/server/voices/src/services/voice-profiles.service.spec.ts
+++ b/apps/server/voices/src/services/voice-profiles.service.spec.ts
@@ -1,10 +1,32 @@
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TTSInferenceService } from '@voices/services/tts-inference.service';
 import { VoiceProfilesService } from '@voices/services/voice-profiles.service';
 import type { Mocked } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** In-memory fake of the node-redis publisher surface used by the service. */
+function createMockPublisher() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    store,
+  };
+}
+
+type MockPublisher = ReturnType<typeof createMockPublisher>;
+
+function createMockRedisService(publisher: MockPublisher | null): RedisService {
+  return {
+    getPublisher: vi.fn(() => publisher),
+  } as unknown as RedisService;
+}
 
 describe('VoiceProfilesService', () => {
   let service: VoiceProfilesService;
@@ -175,6 +197,141 @@ describe('VoiceProfilesService', () => {
       await expect(service.getVoice('unknown-handle')).rejects.toThrow(
         '"unknown-handle" not found',
       );
+    });
+  });
+
+  describe('Redis persistence', () => {
+    let publisher: MockPublisher;
+    let redisBackedService: VoiceProfilesService;
+
+    beforeEach(() => {
+      publisher = createMockPublisher();
+      redisBackedService = new VoiceProfilesService(
+        loggerService,
+        ttsInferenceService,
+        createMockRedisService(publisher),
+      );
+    });
+
+    it('persists profiles to Redis when a voice is cloned', async () => {
+      ttsInferenceService.getStatus = vi
+        .fn()
+        .mockResolvedValue({ modelLoaded: true, status: 'online' });
+
+      await redisBackedService.cloneVoice({
+        audioUrl: 'https://cdn.example.com/grace.wav',
+        handle: 'grace',
+      });
+
+      const raw = publisher.store.get('voices:profiles');
+      expect(raw).toBeDefined();
+      const persisted = JSON.parse(raw as string) as Record<
+        string,
+        { handle: string }
+      >;
+      expect(persisted.grace?.handle).toBe('grace');
+    });
+
+    it('persists the status transition after validation settles', async () => {
+      ttsInferenceService.getStatus = vi
+        .fn()
+        .mockResolvedValue({ modelLoaded: true, status: 'online' });
+
+      await redisBackedService.cloneVoice({
+        audioUrl: 'https://cdn.example.com/henry.wav',
+        handle: 'henry',
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      const persisted = JSON.parse(
+        publisher.store.get('voices:profiles') as string,
+      ) as Record<string, { status: string }>;
+      expect(persisted.henry?.status).toBe('ready');
+    });
+
+    it('restores profiles from Redis on module init', async () => {
+      ttsInferenceService.getStatus = vi
+        .fn()
+        .mockResolvedValue({ modelLoaded: true, status: 'online' });
+
+      await redisBackedService.cloneVoice({
+        audioUrl: 'https://cdn.example.com/iris.wav',
+        handle: 'iris',
+      });
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Simulate a service restart: fresh instance, same Redis store.
+      const restarted = new VoiceProfilesService(
+        loggerService,
+        ttsInferenceService,
+        createMockRedisService(publisher),
+      );
+      await restarted.onModuleInit();
+
+      const profile = await restarted.getVoice('iris');
+      expect(profile.handle).toBe('iris');
+      expect(profile.status).toBe('ready');
+    });
+
+    it('skips restore and works in-memory when Redis is unavailable', async () => {
+      ttsInferenceService.getStatus = vi
+        .fn()
+        .mockResolvedValue({ modelLoaded: true, status: 'online' });
+
+      const offlineService = new VoiceProfilesService(
+        loggerService,
+        ttsInferenceService,
+        createMockRedisService(null),
+      );
+      await offlineService.onModuleInit();
+
+      const result = await offlineService.cloneVoice({
+        audioUrl: 'https://cdn.example.com/jack.wav',
+        handle: 'jack',
+      });
+
+      expect(result.status).toBe('cloning');
+      expect(await offlineService.listVoices()).toHaveLength(1);
+    });
+
+    it('warns instead of throwing when persistence fails', async () => {
+      ttsInferenceService.getStatus = vi
+        .fn()
+        .mockResolvedValue({ modelLoaded: true, status: 'online' });
+      publisher.set.mockRejectedValueOnce(new Error('redis down'));
+
+      const result = await redisBackedService.cloneVoice({
+        audioUrl: 'https://cdn.example.com/kate.wav',
+        handle: 'kate',
+      });
+
+      expect(result.handle).toBe('kate');
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: 'Failed to persist voice profiles to Redis',
+        }),
+      );
+    });
+
+    it('warns instead of throwing when restore fails', async () => {
+      publisher.get.mockRejectedValueOnce(new Error('redis down'));
+
+      const restarted = new VoiceProfilesService(
+        loggerService,
+        ttsInferenceService,
+        createMockRedisService(publisher),
+      );
+      await restarted.onModuleInit();
+
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: 'Failed to restore voice profiles from Redis',
+        }),
+      );
+      expect(await restarted.listVoices()).toEqual([]);
     });
   });
 });

--- a/apps/server/voices/src/services/voice-profiles.service.ts
+++ b/apps/server/voices/src/services/voice-profiles.service.ts
@@ -1,18 +1,60 @@
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  type OnModuleInit,
+  Optional,
+} from '@nestjs/common';
 import type { VoiceProfile } from '@voices/interfaces/voices.interfaces';
 import { TTSInferenceService } from '@voices/services/tts-inference.service';
 
+/** Voice profiles are durable user data: persisted as one JSON blob, no TTL. */
+const VOICE_PROFILES_KEY = 'voices:profiles';
+
 @Injectable()
-export class VoiceProfilesService {
+export class VoiceProfilesService implements OnModuleInit {
   private readonly constructorName: string = String(this.constructor.name);
   private readonly profiles: Map<string, VoiceProfile> = new Map();
 
   constructor(
     private readonly loggerService: LoggerService,
     private readonly ttsInferenceService: TTSInferenceService,
+    @Optional() private readonly redisService?: RedisService,
   ) {}
+
+  async onModuleInit(): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return;
+    }
+
+    try {
+      const raw = await publisher.get(VOICE_PROFILES_KEY);
+      if (!raw) {
+        return;
+      }
+
+      const persisted = JSON.parse(raw) as Record<string, VoiceProfile>;
+      for (const [handle, profile] of Object.entries(persisted)) {
+        this.profiles.set(handle, profile);
+      }
+
+      this.loggerService.log(caller, {
+        count: this.profiles.size,
+        message: 'Voice profiles restored from Redis',
+      });
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        message: 'Failed to restore voice profiles from Redis',
+      });
+    }
+  }
 
   async cloneVoice(params: {
     handle: string;
@@ -31,6 +73,7 @@ export class VoiceProfilesService {
     };
 
     this.profiles.set(params.handle, profile);
+    await this.persistProfiles();
 
     // Validate inference container is available
     this.validateClone(params.handle).catch((error) => {
@@ -41,7 +84,8 @@ export class VoiceProfilesService {
       });
     });
 
-    return profile;
+    // Snapshot so async validation cannot mutate the returned status
+    return { ...profile };
   }
 
   private async validateClone(handle: string): Promise<void> {
@@ -57,6 +101,7 @@ export class VoiceProfilesService {
         if (profile) {
           profile.status = 'ready';
           this.profiles.set(handle, profile);
+          await this.persistProfiles();
           this.loggerService.log(caller, {
             handle,
             message: 'Voice profile ready',
@@ -70,6 +115,7 @@ export class VoiceProfilesService {
       if (profile) {
         profile.status = 'failed';
         this.profiles.set(handle, profile);
+        await this.persistProfiles();
       }
       throw error;
     }
@@ -85,5 +131,25 @@ export class VoiceProfilesService {
       throw new NotFoundException(`Voice profile "${handle}" not found`);
     }
     return profile;
+  }
+
+  private async persistProfiles(): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return;
+    }
+
+    try {
+      await publisher.set(
+        VOICE_PROFILES_KEY,
+        JSON.stringify(Object.fromEntries(this.profiles)),
+      );
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        message: 'Failed to persist voice profiles to Redis',
+      });
+    }
   }
 }

--- a/apps/server/voices/src/services/voice-training.service.spec.ts
+++ b/apps/server/voices/src/services/voice-training.service.spec.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@voices/config/config.service';
@@ -12,6 +13,40 @@ const mockSpawn = vi.fn();
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
+
+/** In-memory fake of the node-redis publisher surface used by the store. */
+function createMockPublisher() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    scanIterator: vi.fn(({ MATCH }: { COUNT: number; MATCH: string }) => {
+      const prefix = MATCH.slice(0, -1);
+      return (async function* () {
+        for (const key of store.keys()) {
+          if (key.startsWith(prefix)) {
+            yield key;
+          }
+        }
+      })();
+    }),
+    setEx: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+    }),
+    store,
+    unlink: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+type MockPublisher = ReturnType<typeof createMockPublisher>;
+
+function createMockRedisService(publisher: MockPublisher | null): RedisService {
+  return {
+    getPublisher: vi.fn(() => publisher),
+  } as unknown as RedisService;
+}
 
 describe('VoiceTrainingService', () => {
   let service: VoiceTrainingService;
@@ -244,6 +279,161 @@ describe('VoiceTrainingService', () => {
       expect(result.args).toContain('200');
       expect(result.args).toContain('--batch_size');
       expect(result.args).toContain('16');
+    });
+  });
+
+  describe('Redis persistence', () => {
+    let publisher: MockPublisher;
+    let redisBackedService: VoiceTrainingService;
+
+    function createService(
+      targetPublisher: MockPublisher | null,
+    ): VoiceTrainingService {
+      return new VoiceTrainingService(
+        mockConfigService as unknown as ConfigService,
+        mockLoggerService as unknown as LoggerService,
+        createMockRedisService(targetPublisher),
+      );
+    }
+
+    beforeEach(() => {
+      publisher = createMockPublisher();
+      redisBackedService = createService(publisher);
+    });
+
+    it('persists the job and process record when training starts', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        voiceId: 'test-voice',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const rawJob = publisher.store.get(`training:voices:job:${jobId}`);
+      expect(rawJob).toBeDefined();
+      expect(JSON.parse(rawJob as string)).toMatchObject({
+        jobId,
+        voiceId: 'test-voice',
+      });
+
+      const rawRecord = publisher.store.get(`training:voices:process:${jobId}`);
+      expect(rawRecord).toBeDefined();
+      expect(JSON.parse(rawRecord as string)).toMatchObject({
+        jobId,
+        pid: 12345,
+      });
+    });
+
+    it('removes the process record when the process exits', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        voiceId: 'test-voice',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      mockChild.emit('close', 0);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(publisher.store.has(`training:voices:process:${jobId}`)).toBe(
+        false,
+      );
+      const rawJob = publisher.store.get(`training:voices:job:${jobId}`);
+      expect(JSON.parse(rawJob as string)).toMatchObject({
+        status: 'completed',
+      });
+    });
+
+    it('removes the process record when the process emits an error', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        voiceId: 'test-voice',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      mockChild.emit('error', new Error('spawn ENOENT'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(publisher.store.has(`training:voices:process:${jobId}`)).toBe(
+        false,
+      );
+      const rawJob = publisher.store.get(`training:voices:job:${jobId}`);
+      expect(JSON.parse(rawJob as string)).toMatchObject({
+        status: 'failed',
+      });
+    });
+
+    it('recovers orphaned jobs and process records on module init', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        voiceId: 'test-voice',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Simulate a service restart while the process record is still present.
+      const restarted = createService(publisher);
+      await restarted.onModuleInit();
+
+      expect(mockLoggerService.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          jobId,
+          message: 'Orphaned voice training process detected on startup',
+          pid: 12345,
+        }),
+      );
+
+      const job = await restarted.getJob(jobId);
+      expect(job.status).toBe('failed');
+      expect(job.stage).toBe('failed');
+      expect(job.error).toContain('orphaned by service restart');
+      expect(publisher.store.has(`training:voices:process:${jobId}`)).toBe(
+        false,
+      );
+
+      const persistedJob = publisher.store.get(`training:voices:job:${jobId}`);
+      expect(JSON.parse(persistedJob as string)).toMatchObject({
+        stage: 'failed',
+        status: 'failed',
+      });
+    });
+
+    it('loads a job from Redis on getJob after a restart without init', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        voiceId: 'test-voice',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Fresh instance, same Redis store, onModuleInit not run.
+      const restarted = createService(publisher);
+      const job = await restarted.getJob(jobId);
+
+      expect(job.jobId).toBe(jobId);
+      expect(job.voiceId).toBe('test-voice');
+    });
+
+    it('starts cleanly when Redis is unavailable', async () => {
+      const offlineService = createService(null);
+      await offlineService.onModuleInit();
+
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await offlineService.startTraining({
+        voiceId: 'test-voice',
+      });
+
+      const job = await offlineService.getJob(jobId);
+      expect(job.jobId).toBe(jobId);
     });
   });
 });

--- a/apps/server/voices/src/services/voice-training.service.ts
+++ b/apps/server/voices/src/services/voice-training.service.ts
@@ -1,12 +1,19 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import process from 'node:process';
+import { TrainingStateStore } from '@libs/jobs/training-state.store';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  type OnModuleInit,
+  Optional,
 } from '@nestjs/common';
 import { ConfigService } from '@voices/config/config.service';
 import type {
@@ -21,15 +28,56 @@ const DEFAULT_EPOCHS = 100;
 const DEFAULT_BATCH_SIZE = 8;
 
 @Injectable()
-export class VoiceTrainingService {
+export class VoiceTrainingService implements OnModuleInit {
   private readonly constructorName: string = String(this.constructor.name);
   private readonly jobs: Map<string, VoiceTrainingJob> = new Map();
   private readonly processes: Map<string, ChildProcess> = new Map();
+  private readonly trainingStateStore: TrainingStateStore<VoiceTrainingJob>;
 
   constructor(
     private readonly configService: ConfigService,
     private readonly loggerService: LoggerService,
-  ) {}
+    @Optional() private readonly redisService?: RedisService,
+  ) {
+    this.trainingStateStore = new TrainingStateStore<VoiceTrainingJob>(
+      'voices',
+      loggerService,
+      redisService,
+    );
+  }
+
+  async onModuleInit(): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+
+    const [jobs, records] = await Promise.all([
+      this.trainingStateStore.loadJobs(),
+      this.trainingStateStore.loadProcessRecords(),
+    ]);
+
+    for (const job of jobs) {
+      if (!this.jobs.has(job.jobId)) {
+        this.jobs.set(job.jobId, job);
+      }
+    }
+
+    for (const record of records) {
+      const isAlive = this.isProcessAlive(record.pid);
+      this.loggerService.warn(caller, {
+        isAlive,
+        jobId: record.jobId,
+        message: 'Orphaned voice training process detected on startup',
+        pid: record.pid,
+        startedAt: record.startedAt,
+      });
+      await this.updateJob(record.jobId, {
+        completedAt: new Date().toISOString(),
+        error: `Process orphaned by service restart (pid ${record.pid}, ${isAlive ? 'still running' : 'no longer running'})`,
+        stage: 'failed',
+        status: 'failed',
+      });
+      await this.trainingStateStore.deleteProcessRecord(record.jobId);
+    }
+  }
 
   async startTraining(
     request: VoiceTrainingRequest,
@@ -62,6 +110,7 @@ export class VoiceTrainingService {
     };
 
     this.jobs.set(jobId, job);
+    await this.trainingStateStore.persistJob(job);
 
     this.loggerService.log(caller, {
       jobId,
@@ -77,7 +126,15 @@ export class VoiceTrainingService {
   async getJob(jobId: string): Promise<VoiceTrainingJob> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
-    const job = this.jobs.get(jobId);
+    let job = this.jobs.get(jobId);
+    if (!job) {
+      const persisted = await this.trainingStateStore.loadJob(jobId);
+      if (persisted) {
+        this.jobs.set(jobId, persisted);
+        job = persisted;
+      }
+    }
+
     if (!job) {
       throw new NotFoundException(`Voice training job "${jobId}" not found`);
     }
@@ -162,8 +219,15 @@ export class VoiceTrainingService {
       });
 
       this.processes.set(jobId, child);
+      if (typeof child.pid === 'number') {
+        void this.trainingStateStore.persistProcessRecord({
+          jobId,
+          pid: child.pid,
+          startedAt: new Date().toISOString(),
+        });
+      }
 
-      this.updateJob(jobId, {
+      void this.updateJob(jobId, {
         progress: 5,
         stage: 'training',
         status: 'running',
@@ -187,7 +251,7 @@ export class VoiceTrainingService {
           );
           if (total > 0) {
             const progress = Math.min(95, Math.round((current / total) * 100));
-            this.updateJob(jobId, { progress });
+            void this.updateJob(jobId, { progress });
           }
         }
       });
@@ -203,9 +267,10 @@ export class VoiceTrainingService {
 
       child.on('close', (code: number | null) => {
         this.processes.delete(jobId);
+        void this.trainingStateStore.deleteProcessRecord(jobId);
 
         if (code === 0) {
-          this.updateJob(jobId, {
+          void this.updateJob(jobId, {
             completedAt: new Date().toISOString(),
             progress: 100,
             stage: 'completed',
@@ -216,7 +281,7 @@ export class VoiceTrainingService {
             message: 'Voice training completed successfully',
           });
         } else {
-          this.updateJob(jobId, {
+          void this.updateJob(jobId, {
             completedAt: new Date().toISOString(),
             error: `Training process exited with code ${code}`,
             stage: 'failed',
@@ -231,7 +296,8 @@ export class VoiceTrainingService {
 
       child.on('error', (error: Error) => {
         this.processes.delete(jobId);
-        this.updateJob(jobId, {
+        void this.trainingStateStore.deleteProcessRecord(jobId);
+        void this.updateJob(jobId, {
           completedAt: new Date().toISOString(),
           error: error.message,
           stage: 'failed',
@@ -245,7 +311,7 @@ export class VoiceTrainingService {
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      this.updateJob(jobId, {
+      void this.updateJob(jobId, {
         completedAt: new Date().toISOString(),
         error: errorMessage,
         stage: 'failed',
@@ -258,7 +324,10 @@ export class VoiceTrainingService {
     }
   }
 
-  private updateJob(jobId: string, updates: Partial<VoiceTrainingJob>): void {
+  private async updateJob(
+    jobId: string,
+    updates: Partial<VoiceTrainingJob>,
+  ): Promise<void> {
     const job = this.jobs.get(jobId);
     if (job) {
       const updated: VoiceTrainingJob = {
@@ -267,6 +336,16 @@ export class VoiceTrainingService {
         updatedAt: new Date().toISOString(),
       };
       this.jobs.set(jobId, updated);
+      await this.trainingStateStore.persistJob(updated);
+    }
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
     }
   }
 }

--- a/packages/libs/jobs/base-job.service.spec.ts
+++ b/packages/libs/jobs/base-job.service.spec.ts
@@ -1,6 +1,7 @@
 import { type BaseJob, BaseJobService } from '@libs/jobs/base-job.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import type { RedisService } from '@libs/redis/redis.service';
+import { Injectable, Optional } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 vi.mock('@libs/utils/caller/caller.util', () => ({
@@ -14,19 +15,66 @@ interface TestJob extends BaseJob {
 
 /** Concrete injectable subclass for DI in tests. */
 @Injectable()
-class TestJobService extends BaseJobService<TestJob> {}
+class TestJobService extends BaseJobService<TestJob> {
+  constructor(
+    loggerService: LoggerService,
+    @Optional() redisService?: RedisService,
+  ) {
+    super(loggerService, 'test', redisService);
+  }
+}
+
+type MockLogger = {
+  log: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+};
+
+function createMockLogger(): MockLogger {
+  return { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+}
+
+/** In-memory fake of the node-redis publisher surface used by the service. */
+function createMockPublisher() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    scanIterator: vi.fn(({ MATCH }: { COUNT: number; MATCH: string }) => {
+      const prefix = MATCH.slice(0, -1);
+      return (async function* () {
+        for (const key of store.keys()) {
+          if (key.startsWith(prefix)) {
+            yield key;
+          }
+        }
+      })();
+    }),
+    setEx: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+    }),
+    store,
+    unlink: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+type MockPublisher = ReturnType<typeof createMockPublisher>;
+
+function createMockRedisService(publisher: MockPublisher | null): RedisService {
+  return {
+    getPublisher: vi.fn(() => publisher),
+  } as unknown as RedisService;
+}
 
 describe('BaseJobService', () => {
   let service: TestJobService;
-  let logger: {
-    log: ReturnType<typeof vi.fn>;
-    error: ReturnType<typeof vi.fn>;
-    warn: ReturnType<typeof vi.fn>;
-  };
+  let logger: MockLogger;
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    logger = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+    logger = createMockLogger();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [TestJobService, { provide: LoggerService, useValue: logger }],
@@ -132,8 +180,8 @@ describe('BaseJobService', () => {
   });
 
   describe('getStats', () => {
-    it('returns zero counts when no jobs exist', () => {
-      const stats = service.getStats();
+    it('returns zero counts when no jobs exist', async () => {
+      const stats = await service.getStats();
       expect(stats).toEqual({
         active: 0,
         completed: 0,
@@ -146,7 +194,7 @@ describe('BaseJobService', () => {
     it('counts queued jobs correctly', async () => {
       await service.createJob({ params: {}, type: 'gen' });
       await service.createJob({ params: {}, type: 'gen' });
-      const stats = service.getStats();
+      const stats = await service.getStats();
       expect(stats.queued).toBe(2);
       expect(stats.total).toBe(2);
     });
@@ -159,12 +207,200 @@ describe('BaseJobService', () => {
       await service.updateJob(j1.jobId, { status: 'processing' });
       await service.updateJob(j2.jobId, { status: 'completed' });
       await service.updateJob(j3.jobId, { status: 'failed' });
-      const stats = service.getStats();
+      const stats = await service.getStats();
       expect(stats.active).toBe(1);
       expect(stats.completed).toBe(1);
       expect(stats.failed).toBe(1);
       expect(stats.queued).toBe(1);
       expect(stats.total).toBe(4);
+      expect(j4.status).toBe('queued');
+    });
+  });
+
+  describe('Redis persistence', () => {
+    let publisher: MockPublisher;
+    let redisService: RedisService;
+    let redisBackedService: TestJobService;
+
+    beforeEach(() => {
+      publisher = createMockPublisher();
+      redisService = createMockRedisService(publisher);
+      redisBackedService = new TestJobService(
+        logger as unknown as LoggerService,
+        redisService,
+      );
+    });
+
+    it('persists created jobs to Redis under the namespaced key', async () => {
+      const job = await redisBackedService.createJob({
+        params: { prompt: 'persist me' },
+        type: 'gen',
+      });
+
+      expect(publisher.setEx).toHaveBeenCalledWith(
+        `jobs:test:${job.jobId}`,
+        86400,
+        JSON.stringify(job),
+      );
+    });
+
+    it('persists job updates to Redis', async () => {
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'gen',
+      });
+      const updated = await redisBackedService.updateJob(job.jobId, {
+        status: 'completed',
+      });
+
+      expect(publisher.store.get(`jobs:test:${job.jobId}`)).toBe(
+        JSON.stringify(updated),
+      );
+    });
+
+    it('reads a job from Redis when not in the in-memory cache', async () => {
+      const job = await redisBackedService.createJob({
+        params: { prompt: 'survive' },
+        type: 'gen',
+      });
+
+      // Simulate a service restart: fresh instance, same Redis store.
+      const restarted = new TestJobService(
+        logger as unknown as LoggerService,
+        redisService,
+      );
+      const recovered = await restarted.getJob(job.jobId);
+
+      expect(recovered).toEqual(job);
+    });
+
+    it('updates a job recovered from Redis after a restart', async () => {
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'gen',
+      });
+
+      const restarted = new TestJobService(
+        logger as unknown as LoggerService,
+        redisService,
+      );
+      const updated = await restarted.updateJob(job.jobId, {
+        resultUrl: 'https://cdn.example.com/after-restart.jpg',
+        status: 'completed',
+      });
+
+      expect(updated?.status).toBe('completed');
+      expect(updated?.resultUrl).toBe(
+        'https://cdn.example.com/after-restart.jpg',
+      );
+    });
+
+    it('computes stats from Redis after a restart', async () => {
+      const j1 = await redisBackedService.createJob({
+        params: {},
+        type: 'gen',
+      });
+      await redisBackedService.createJob({ params: {}, type: 'gen' });
+      await redisBackedService.updateJob(j1.jobId, { status: 'completed' });
+
+      const restarted = new TestJobService(
+        logger as unknown as LoggerService,
+        redisService,
+      );
+      const stats = await restarted.getStats();
+
+      expect(stats.completed).toBe(1);
+      expect(stats.queued).toBe(1);
+      expect(stats.total).toBe(2);
+    });
+
+    it('falls back to memory and warns when Redis writes fail', async () => {
+      publisher.setEx.mockRejectedValueOnce(new Error('redis down'));
+
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'gen',
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: 'Failed to persist job to Redis' }),
+      );
+      expect(await redisBackedService.getJob(job.jobId)).toEqual(job);
+    });
+
+    it('falls back to memory stats when the publisher is unavailable', async () => {
+      const offlineService = new TestJobService(
+        logger as unknown as LoggerService,
+        createMockRedisService(null),
+      );
+      await offlineService.createJob({ params: {}, type: 'gen' });
+
+      const stats = await offlineService.getStats();
+
+      expect(stats.queued).toBe(1);
+      expect(stats.total).toBe(1);
+    });
+
+    it('returns null from getJob when Redis reads fail', async () => {
+      publisher.get.mockRejectedValueOnce(new Error('read error'));
+
+      const result = await redisBackedService.getJob('unknown-id');
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: 'Failed to read job from Redis' }),
+      );
+    });
+
+    it('keeps the 24h TTL when persisting job updates', async () => {
+      const job = await redisBackedService.createJob({
+        params: {},
+        type: 'gen',
+      });
+      const updated = await redisBackedService.updateJob(job.jobId, {
+        status: 'completed',
+      });
+
+      expect(publisher.setEx).toHaveBeenLastCalledWith(
+        `jobs:test:${job.jobId}`,
+        86400,
+        JSON.stringify(updated),
+      );
+    });
+
+    it('skips corrupt job entries and keeps valid ones in stats', async () => {
+      await redisBackedService.createJob({ params: {}, type: 'gen' });
+      publisher.store.set('jobs:test:corrupt', 'not-json{');
+
+      const stats = await redisBackedService.getStats();
+
+      expect(stats.queued).toBe(1);
+      expect(stats.total).toBe(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          key: 'jobs:test:corrupt',
+          message: 'Skipping corrupt job entry in Redis',
+        }),
+      );
+    });
+
+    it('falls back to memory stats and warns when the Redis scan fails', async () => {
+      await redisBackedService.createJob({ params: {}, type: 'gen' });
+      publisher.scanIterator.mockImplementationOnce(() => {
+        throw new Error('scan failed');
+      });
+
+      const stats = await redisBackedService.getStats();
+
+      expect(stats.queued).toBe(1);
+      expect(stats.total).toBe(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: 'Failed to read jobs from Redis' }),
+      );
     });
   });
 });

--- a/packages/libs/jobs/base-job.service.ts
+++ b/packages/libs/jobs/base-job.service.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto';
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
+import type { RedisClientType } from 'redis';
 
 /** Minimum required fields for any job tracked by BaseJobService. */
 export interface BaseJob {
@@ -23,22 +25,30 @@ export type JobStats = {
   total: number;
 };
 
+/** Jobs are transient operational state: expire after 24 hours. */
+export const JOB_TTL_SECONDS = 86400;
+
 /**
- * Generic in-memory job store for GPU/inference micro-services.
+ * Generic Redis-backed job store for GPU/inference micro-services.
  *
  * Each media service (images, videos, voices) extends this with its own
  * typed job interface that adds domain-specific result fields (resultUrl,
- * videoUrl, audioUrl, etc.).
+ * videoUrl, audioUrl, etc.) and passes a unique key namespace.
  *
- * TODO(#478): Replace the in-memory Map with Redis-backed persistence.
+ * Jobs are written through to Redis (`jobs:{namespace}:{jobId}`) so state
+ * survives a service restart. The in-memory Map serves as a fast-path cache
+ * and as the sole store when Redis is unavailable.
  */
 @Injectable()
 export class BaseJobService<T extends BaseJob> {
   private readonly constructorName: string = String(this.constructor.name);
-  // TODO(#478): replace with Redis-backed persistence
   private readonly jobs: Map<string, T> = new Map();
 
-  constructor(protected readonly loggerService: LoggerService) {}
+  constructor(
+    protected readonly loggerService: LoggerService,
+    private readonly namespace: string,
+    private readonly redisService?: RedisService,
+  ) {}
 
   async createJob(params: {
     type: string;
@@ -56,33 +66,48 @@ export class BaseJobService<T extends BaseJob> {
     } as T;
 
     this.jobs.set(jobId, job);
+    await this.persistJob(job);
     this.loggerService.log(caller, { jobId, message: 'Job created' });
 
     return job;
   }
 
   async getJob(jobId: string): Promise<T | null> {
-    return this.jobs.get(jobId) ?? null;
+    const cached = this.jobs.get(jobId);
+    if (cached) {
+      return cached;
+    }
+
+    const persisted = await this.readJob(jobId);
+    if (persisted) {
+      this.jobs.set(jobId, persisted);
+    }
+
+    return persisted;
   }
 
   async updateJob(jobId: string, updates: Partial<T>): Promise<T | null> {
-    const job = this.jobs.get(jobId);
+    const job = await this.getJob(jobId);
     if (!job) {
       return null;
     }
 
     const updated = { ...job, ...updates };
     this.jobs.set(jobId, updated);
+    await this.persistJob(updated);
     return updated;
   }
 
-  getStats(): JobStats {
+  async getStats(): Promise<JobStats> {
+    const persisted = await this.readAllJobs();
+    const jobs = persisted ?? Array.from(this.jobs.values());
+
     let active = 0;
     let queued = 0;
     let completed = 0;
     let failed = 0;
 
-    for (const job of this.jobs.values()) {
+    for (const job of jobs) {
       switch (job.status) {
         case 'processing':
           active++;
@@ -99,6 +124,111 @@ export class BaseJobService<T extends BaseJob> {
       }
     }
 
-    return { active, completed, failed, queued, total: this.jobs.size };
+    return { active, completed, failed, queued, total: jobs.length };
+  }
+
+  private buildJobKey(jobId: string): string {
+    return `jobs:${this.namespace}:${jobId}`;
+  }
+
+  private async persistJob(job: T): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return;
+    }
+
+    try {
+      await publisher.setEx(
+        this.buildJobKey(job.jobId),
+        JOB_TTL_SECONDS,
+        JSON.stringify(job),
+      );
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        jobId: job.jobId,
+        message: 'Failed to persist job to Redis',
+      });
+    }
+  }
+
+  private async readJob(jobId: string): Promise<T | null> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return null;
+    }
+
+    try {
+      const raw = await publisher.get(this.buildJobKey(jobId));
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        jobId,
+        message: 'Failed to read job from Redis',
+      });
+      return null;
+    }
+  }
+
+  /** Returns null when Redis is unavailable so callers can fall back to memory. */
+  private async readAllJobs(): Promise<T[] | null> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return null;
+    }
+
+    try {
+      const keys = await this.collectJobKeys(publisher);
+      const rawJobs = await Promise.all(keys.map((key) => publisher.get(key)));
+      const jobs: T[] = [];
+
+      for (const [index, raw] of rawJobs.entries()) {
+        if (!raw) {
+          continue;
+        }
+
+        try {
+          jobs.push(JSON.parse(raw) as T);
+        } catch (error) {
+          this.loggerService.warn(caller, {
+            error: error instanceof Error ? error.message : String(error),
+            key: keys[index],
+            message: 'Skipping corrupt job entry in Redis',
+          });
+        }
+      }
+
+      return jobs;
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        message: 'Failed to read jobs from Redis',
+      });
+      return null;
+    }
+  }
+
+  private async collectJobKeys(publisher: RedisClientType): Promise<string[]> {
+    const keys: string[] = [];
+
+    for await (const key of publisher.scanIterator({
+      COUNT: 100,
+      MATCH: `jobs:${this.namespace}:*`,
+    })) {
+      if (Array.isArray(key)) {
+        keys.push(...key);
+      } else {
+        keys.push(key);
+      }
+    }
+
+    return keys;
   }
 }

--- a/packages/libs/jobs/training-state.store.spec.ts
+++ b/packages/libs/jobs/training-state.store.spec.ts
@@ -1,0 +1,303 @@
+import {
+  type TrainingProcessRecord,
+  TrainingStateStore,
+} from '@libs/jobs/training-state.store';
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
+
+vi.mock('@libs/utils/caller/caller.util', () => ({
+  CallerUtil: { getCallerName: vi.fn().mockReturnValue('test-caller') },
+}));
+
+interface TestTrainingJob {
+  jobId: string;
+  status: string;
+}
+
+type MockLogger = {
+  log: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+};
+
+function createMockLogger(): MockLogger {
+  return { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+}
+
+/** In-memory fake of the node-redis publisher surface used by the store. */
+function createMockPublisher() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    scanIterator: vi.fn(({ MATCH }: { COUNT: number; MATCH: string }) => {
+      const prefix = MATCH.slice(0, -1);
+      return (async function* () {
+        for (const key of store.keys()) {
+          if (key.startsWith(prefix)) {
+            yield key;
+          }
+        }
+      })();
+    }),
+    setEx: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+    }),
+    store,
+    unlink: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+type MockPublisher = ReturnType<typeof createMockPublisher>;
+
+function createMockRedisService(publisher: MockPublisher | null): RedisService {
+  return {
+    getPublisher: vi.fn(() => publisher),
+  } as unknown as RedisService;
+}
+
+describe('TrainingStateStore', () => {
+  let logger: MockLogger;
+  let publisher: MockPublisher;
+  let store: TrainingStateStore<TestTrainingJob>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+    publisher = createMockPublisher();
+    store = new TrainingStateStore<TestTrainingJob>(
+      'voices',
+      logger as unknown as LoggerService,
+      createMockRedisService(publisher),
+    );
+  });
+
+  describe('persistJob', () => {
+    it('writes the job under the namespaced job key with a TTL', async () => {
+      const job: TestTrainingJob = { jobId: 'job-1', status: 'running' };
+
+      await store.persistJob(job);
+
+      expect(publisher.setEx).toHaveBeenCalledWith(
+        'training:voices:job:job-1',
+        86400,
+        JSON.stringify(job),
+      );
+    });
+
+    it('is a no-op when Redis is unavailable', async () => {
+      const offlineStore = new TrainingStateStore<TestTrainingJob>(
+        'voices',
+        logger as unknown as LoggerService,
+        createMockRedisService(null),
+      );
+
+      await expect(
+        offlineStore.persistJob({ jobId: 'job-1', status: 'running' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('warns instead of throwing when the write fails', async () => {
+      publisher.setEx.mockRejectedValueOnce(new Error('redis down'));
+
+      await store.persistJob({ jobId: 'job-1', status: 'running' });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: 'Failed to persist training state to Redis',
+        }),
+      );
+    });
+  });
+
+  describe('persistProcessRecord', () => {
+    it('writes the process record under the namespaced process key', async () => {
+      const record: TrainingProcessRecord = {
+        jobId: 'job-1',
+        pid: 12345,
+        startedAt: '2026-06-11T00:00:00.000Z',
+      };
+
+      await store.persistProcessRecord(record);
+
+      expect(publisher.setEx).toHaveBeenCalledWith(
+        'training:voices:process:job-1',
+        86400,
+        JSON.stringify(record),
+      );
+    });
+  });
+
+  describe('deleteProcessRecord', () => {
+    it('removes the process record key', async () => {
+      await store.persistProcessRecord({
+        jobId: 'job-1',
+        pid: 12345,
+        startedAt: '2026-06-11T00:00:00.000Z',
+      });
+
+      await store.deleteProcessRecord('job-1');
+
+      expect(publisher.unlink).toHaveBeenCalledWith(
+        'training:voices:process:job-1',
+      );
+      expect(publisher.store.has('training:voices:process:job-1')).toBe(false);
+    });
+
+    it('warns instead of throwing when the delete fails', async () => {
+      publisher.unlink.mockRejectedValueOnce(new Error('redis down'));
+
+      await store.deleteProcessRecord('job-1');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: 'Failed to delete training process record from Redis',
+        }),
+      );
+    });
+  });
+
+  describe('loadJobs', () => {
+    it('returns all persisted jobs for the namespace', async () => {
+      await store.persistJob({ jobId: 'job-1', status: 'running' });
+      await store.persistJob({ jobId: 'job-2', status: 'completed' });
+
+      const jobs = await store.loadJobs();
+
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((job) => job.jobId).sort()).toEqual(['job-1', 'job-2']);
+    });
+
+    it('does not return process records or other namespaces', async () => {
+      await store.persistJob({ jobId: 'job-1', status: 'running' });
+      await store.persistProcessRecord({
+        jobId: 'job-1',
+        pid: 12345,
+        startedAt: '2026-06-11T00:00:00.000Z',
+      });
+      publisher.store.set(
+        'training:images:job:other',
+        JSON.stringify({ jobId: 'other', status: 'running' }),
+      );
+
+      const jobs = await store.loadJobs();
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]?.jobId).toBe('job-1');
+    });
+
+    it('returns an empty array when Redis is unavailable', async () => {
+      const offlineStore = new TrainingStateStore<TestTrainingJob>(
+        'voices',
+        logger as unknown as LoggerService,
+        createMockRedisService(null),
+      );
+
+      expect(await offlineStore.loadJobs()).toEqual([]);
+    });
+
+    it('returns an empty array and warns when the read fails', async () => {
+      publisher.scanIterator.mockImplementationOnce(() => {
+        throw new Error('scan failed');
+      });
+
+      const jobs = await store.loadJobs();
+
+      expect(jobs).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: 'Failed to load training state from Redis',
+        }),
+      );
+    });
+
+    it('skips corrupt entries and keeps valid ones', async () => {
+      await store.persistJob({ jobId: 'job-1', status: 'running' });
+      publisher.store.set('training:voices:job:corrupt', 'not-json{');
+
+      const jobs = await store.loadJobs();
+
+      expect(jobs).toEqual([{ jobId: 'job-1', status: 'running' }]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          key: 'training:voices:job:corrupt',
+          message: 'Skipping corrupt training state entry in Redis',
+        }),
+      );
+    });
+  });
+
+  describe('loadProcessRecords', () => {
+    it('returns all persisted process records for the namespace', async () => {
+      const record: TrainingProcessRecord = {
+        jobId: 'job-1',
+        pid: 12345,
+        startedAt: '2026-06-11T00:00:00.000Z',
+      };
+      await store.persistProcessRecord(record);
+      await store.persistJob({ jobId: 'job-1', status: 'running' });
+
+      const records = await store.loadProcessRecords();
+
+      expect(records).toEqual([record]);
+    });
+
+    it('survives a simulated restart with a fresh store instance', async () => {
+      const record: TrainingProcessRecord = {
+        jobId: 'job-1',
+        pid: 12345,
+        startedAt: '2026-06-11T00:00:00.000Z',
+      };
+      await store.persistProcessRecord(record);
+
+      const restartedStore = new TrainingStateStore<TestTrainingJob>(
+        'voices',
+        logger as unknown as LoggerService,
+        createMockRedisService(publisher),
+      );
+
+      expect(await restartedStore.loadProcessRecords()).toEqual([record]);
+    });
+  });
+
+  describe('loadJob', () => {
+    it('returns a persisted job by id', async () => {
+      const job: TestTrainingJob = { jobId: 'job-1', status: 'running' };
+      await store.persistJob(job);
+
+      expect(await store.loadJob('job-1')).toEqual(job);
+    });
+
+    it('returns null for an unknown job id', async () => {
+      expect(await store.loadJob('missing')).toBeNull();
+    });
+
+    it('returns null when Redis is unavailable', async () => {
+      const offlineStore = new TrainingStateStore<TestTrainingJob>(
+        'voices',
+        logger as unknown as LoggerService,
+        createMockRedisService(null),
+      );
+
+      expect(await offlineStore.loadJob('job-1')).toBeNull();
+    });
+
+    it('returns null and warns when the read fails', async () => {
+      publisher.get.mockRejectedValueOnce(new Error('read failed'));
+
+      expect(await store.loadJob('job-1')).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: 'Failed to load training job from Redis',
+        }),
+      );
+    });
+  });
+});

--- a/packages/libs/jobs/training-state.store.ts
+++ b/packages/libs/jobs/training-state.store.ts
@@ -1,0 +1,182 @@
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { RedisService } from '@libs/redis/redis.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import type { RedisClientType } from 'redis';
+
+/** Redis record linking a training job to its spawned OS process. */
+export interface TrainingProcessRecord {
+  jobId: string;
+  pid: number;
+  startedAt: string;
+}
+
+/** Training state is transient operational state: expire after 24 hours. */
+export const TRAINING_STATE_TTL_SECONDS = 86400;
+
+/**
+ * Redis persistence for ChildProcess-based training services.
+ *
+ * Persists job state (`training:{namespace}:job:{jobId}`) and live process
+ * records (`training:{namespace}:process:{jobId}`) so a restarted service can
+ * restore job history and detect orphaned training processes. All operations
+ * degrade to no-ops when Redis is unavailable.
+ */
+export class TrainingStateStore<TJob extends { jobId: string }> {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly namespace: string,
+    private readonly loggerService: LoggerService,
+    private readonly redisService?: RedisService,
+  ) {}
+
+  async persistJob(job: TJob): Promise<void> {
+    await this.persist(this.buildJobKey(job.jobId), job);
+  }
+
+  async persistProcessRecord(record: TrainingProcessRecord): Promise<void> {
+    await this.persist(this.buildProcessKey(record.jobId), record);
+  }
+
+  async deleteProcessRecord(jobId: string): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return;
+    }
+
+    try {
+      await publisher.unlink(this.buildProcessKey(jobId));
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        jobId,
+        message: 'Failed to delete training process record from Redis',
+      });
+    }
+  }
+
+  async loadJobs(): Promise<TJob[]> {
+    return this.loadByPattern<TJob>(`training:${this.namespace}:job:*`);
+  }
+
+  async loadProcessRecords(): Promise<TrainingProcessRecord[]> {
+    return this.loadByPattern<TrainingProcessRecord>(
+      `training:${this.namespace}:process:*`,
+    );
+  }
+
+  async loadJob(jobId: string): Promise<TJob | null> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return null;
+    }
+
+    try {
+      const raw = await publisher.get(this.buildJobKey(jobId));
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw) as TJob;
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        jobId,
+        message: 'Failed to load training job from Redis',
+      });
+      return null;
+    }
+  }
+
+  private buildJobKey(jobId: string): string {
+    return `training:${this.namespace}:job:${jobId}`;
+  }
+
+  private buildProcessKey(jobId: string): string {
+    return `training:${this.namespace}:process:${jobId}`;
+  }
+
+  private async persist(key: string, value: unknown): Promise<void> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return;
+    }
+
+    try {
+      await publisher.setEx(
+        key,
+        TRAINING_STATE_TTL_SECONDS,
+        JSON.stringify(value),
+      );
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        key,
+        message: 'Failed to persist training state to Redis',
+      });
+    }
+  }
+
+  private async loadByPattern<TValue>(pattern: string): Promise<TValue[]> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const publisher = this.redisService?.getPublisher();
+    if (!publisher) {
+      return [];
+    }
+
+    try {
+      const keys = await this.collectKeys(publisher, pattern);
+      const rawValues = await Promise.all(
+        keys.map((key) => publisher.get(key)),
+      );
+      const values: TValue[] = [];
+
+      for (const [index, raw] of rawValues.entries()) {
+        if (!raw) {
+          continue;
+        }
+
+        try {
+          values.push(JSON.parse(raw) as TValue);
+        } catch (error) {
+          this.loggerService.warn(caller, {
+            error: error instanceof Error ? error.message : String(error),
+            key: keys[index],
+            message: 'Skipping corrupt training state entry in Redis',
+          });
+        }
+      }
+
+      return values;
+    } catch (error) {
+      this.loggerService.warn(caller, {
+        error: error instanceof Error ? error.message : String(error),
+        message: 'Failed to load training state from Redis',
+        pattern,
+      });
+      return [];
+    }
+  }
+
+  private async collectKeys(
+    publisher: RedisClientType,
+    pattern: string,
+  ): Promise<string[]> {
+    const keys: string[] = [];
+
+    for await (const key of publisher.scanIterator({
+      COUNT: 100,
+      MATCH: pattern,
+    })) {
+      if (Array.isArray(key)) {
+        keys.push(...key);
+      } else {
+        keys.push(key);
+      }
+    }
+
+    return keys;
+  }
+}


### PR DESCRIPTION
Closes #478

## What

Redis-backed persistence for the media services (images / videos / voices) so in-flight job state survives container restarts.

- **`BaseJobService`** (`packages/libs/jobs`): shared Redis-backed job store for the three `JobService` subclasses. Jobs persist under `jobs:<namespace>:<jobId>` with a 24h TTL on create and update; `getJob` falls back to Redis and rehydrates the in-memory cache; `getStats` scans the namespace and falls back to memory if the scan fails.
- **`TrainingStateStore`** (`packages/libs/jobs`): persistence for the ChildProcess-backed training services (images `TrainingService`, voices `VoiceTrainingService`). Jobs persist under `training:<namespace>:job:<jobId>` and process records (pid, startedAt) under `training:<namespace>:process:<jobId>`. On `onModuleInit`, persisted jobs are restored, orphaned process records are logged (with a pid liveness probe via `process.kill(pid, 0)`), their jobs are marked failed, and the stale records are deleted.
- **`VoiceProfilesService`**: profile map persists as a durable JSON blob under `voices:profiles` (no TTL) and is restored on module init; clone-state transitions persist as they happen.
- **Graceful degradation everywhere**: when `RedisService` is absent or the publisher is offline, every path logs a warning and falls back to in-memory behavior; Redis errors never propagate to callers. Corrupt entries are skipped per-item during scans instead of aborting the batch.
- `RedisModule.forRoot` wired into the three app modules; health controllers report job stats via the async `getStats` path.

## Design deviation from the issue

The issue sketch proposed `HSET`/`HGET`. This repo's established Redis style is **string keys + `JSON.stringify`** (`setEx`/`get`/`unlink`/`scanIterator`) and hash commands are not used anywhere; the implementation follows house style instead.

## Adversarial review

Ran a 15-agent multi-stage adversarial review of the diff; 9 confirmed findings, all fixed: write-ordering races between fire-and-forget persists and awaited deletes (orphan recovery + voice clone), per-item JSON.parse guards in scan batches, Redis read-through fallback for training-job lookups, namespace-wiring tests, error-event process-record cleanup tests, persisted-failed-state assertions, scan-failure fallback test, and TTL-on-update assertion.

## Pre-existing test fixes (required to get suites green)

- images `training.service.spec.ts`: missing `S3Service` provider in the testing module
- voices `voice-profiles.service.spec.ts`: clone-validation microtask race (assert against a returned snapshot)
- voices `job.service.spec.ts`: `createdAt` matcher compared ISO strings with numeric matchers

## Verification

- `packages/libs/jobs/base-job.service.spec.ts` — 27 passed
- `packages/libs/jobs/training-state.store.spec.ts` — 17 passed
- voices: `job.service.spec.ts` 18, `voice-training.service.spec.ts` 19, `voice-profiles.service.spec.ts` 16, `health.controller.spec.ts` 11 — all passed
- images: `job.service.spec.ts` 15, `training.service.spec.ts` 18, `health.controller.spec.ts` 9 — all passed
- videos: `job.service.spec.ts` 16, `health.controller.spec.ts` 9 — all passed
- `biome check` clean on all changed paths (one pre-existing warning in untouched `redis.module.ts`)
- `nest build images` / `videos` / `voices` all compile

Restart survival is covered by unit tests that simulate a restart (fresh service instance against the same Redis store, `onModuleInit` recovery); a docker-compose restart smoke test was not run on this machine per resource limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)