### PR TITLE
feat(desktop): add agent run handoff surface

### DIFF
--- a/apps/desktop/app/src/main/cloud.service.test.ts
+++ b/apps/desktop/app/src/main/cloud.service.test.ts
@@ -172,6 +172,114 @@ describe('DesktopCloudService', () => {
     });
   });
 
+  it('maps agent run output and queued manual run responses', async () => {
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      expect(init?.headers).toMatchObject({
+        Authorization: 'Bearer gf_desktop_key',
+      });
+
+      if (String(input).endsWith('/agent-strategies')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                attributes: {
+                  isActive: true,
+                  label: 'Trend Scout',
+                  platforms: ['linkedin'],
+                  runHistory: [
+                    {
+                      completedAt: '2026-06-11T06:02:00.000Z',
+                      contentGenerated: 3,
+                      creditsUsed: 12,
+                      id: 'run-1',
+                      startedAt: '2026-06-11T06:00:00.000Z',
+                      status: 'completed',
+                      summary:
+                        'Generated three LinkedIn hooks for the launch angle.',
+                      threadId: 'thread-1',
+                    },
+                  ],
+                },
+                id: 'agent-1',
+              },
+            ],
+          }),
+          {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          },
+        );
+      }
+
+      expect(String(input)).toBe(
+        'https://api.genfeed.ai/v1/agent-strategies/agent-1/run-now',
+      );
+      expect(init?.method).toBe('POST');
+      return new Response(
+        JSON.stringify({
+          message: 'Proactive run queued. It will execute shortly.',
+        }),
+        {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
+      );
+    }) as typeof fetch;
+
+    const service = new DesktopCloudService(environment, () => session);
+
+    await expect(service.listAgents()).resolves.toEqual({
+      data: [
+        {
+          id: 'agent-1',
+          isActive: true,
+          lastRunAt: '2026-06-11T06:02:00.000Z',
+          latestRun: {
+            completedAt: '2026-06-11T06:02:00.000Z',
+            contentGenerated: 3,
+            creditsUsed: 12,
+            id: 'run-1',
+            outputSummary:
+              'Generated three LinkedIn hooks for the launch angle.',
+            startedAt: '2026-06-11T06:00:00.000Z',
+            status: 'completed',
+            threadId: 'thread-1',
+          },
+          name: 'Trend Scout',
+          platforms: ['linkedin'],
+          recentRuns: [
+            {
+              completedAt: '2026-06-11T06:02:00.000Z',
+              contentGenerated: 3,
+              creditsUsed: 12,
+              id: 'run-1',
+              outputSummary:
+                'Generated three LinkedIn hooks for the launch angle.',
+              startedAt: '2026-06-11T06:00:00.000Z',
+              status: 'completed',
+              threadId: 'thread-1',
+            },
+          ],
+          status: 'active',
+        },
+      ],
+      status: 'success',
+    });
+
+    await expect(service.runAgent('agent-1')).resolves.toEqual({
+      data: {
+        message: 'Proactive run queued. It will execute shortly.',
+        runId: '',
+        status: 'pending',
+      },
+      status: 'success',
+    });
+  });
+
   it('rejects cloud calls without a session', async () => {
     const service = new DesktopCloudService(environment, () => null);
 

--- a/apps/desktop/app/src/main/cloud.service.ts
+++ b/apps/desktop/app/src/main/cloud.service.ts
@@ -1,5 +1,6 @@
 import type {
   IDesktopAgent,
+  IDesktopAgentRun,
   IDesktopAgentRunResult,
   IDesktopAnalytics,
   IDesktopCloudProject,
@@ -15,6 +16,75 @@ import type {
   IDesktopWorkflow,
   IDesktopWorkflowRunResult,
 } from '@genfeedai/desktop-contracts';
+
+const AGENT_RUN_STATUSES = new Set<IDesktopAgentRun['status']>([
+  'completed',
+  'failed',
+  'pending',
+  'queued',
+  'running',
+]);
+
+function maybeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function maybeNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+
+  const nextValue = Number(value);
+  return Number.isFinite(nextValue) ? nextValue : undefined;
+}
+
+function normalizeAgentRunStatus(value: unknown): IDesktopAgentRun['status'] {
+  const status = typeof value === 'string' ? value.toLowerCase() : '';
+  return AGENT_RUN_STATUSES.has(status as IDesktopAgentRun['status'])
+    ? (status as IDesktopAgentRun['status'])
+    : 'pending';
+}
+
+function runTimestamp(run: IDesktopAgentRun): number {
+  const timestamp = new Date(run.completedAt ?? run.startedAt).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function mapAgentRun(
+  run: Record<string, unknown>,
+  fallbackId: string,
+): IDesktopAgentRun {
+  const completedAt = maybeString(run.completedAt ?? run.endedAt);
+  const contentGenerated = maybeNumber(
+    run.contentGenerated ?? run.generatedCount ?? run.outputCount,
+  );
+  const creditsUsed = maybeNumber(run.creditsUsed ?? run.creditCost);
+  const message = maybeString(run.message);
+  const outputSummary = maybeString(run.summary ?? run.outputSummary);
+  const threadId = maybeString(run.threadId);
+  const startedAt =
+    maybeString(run.startedAt ?? run.createdAt) ??
+    completedAt ??
+    new Date(0).toISOString();
+
+  return {
+    ...(completedAt ? { completedAt } : {}),
+    ...(contentGenerated !== undefined ? { contentGenerated } : {}),
+    ...(creditsUsed !== undefined ? { creditsUsed } : {}),
+    id: maybeString(run.id ?? run._id ?? run.runId) ?? fallbackId,
+    ...(message ? { message } : {}),
+    ...(outputSummary ? { outputSummary } : {}),
+    startedAt,
+    status: normalizeAgentRunStatus(
+      run.status ?? (completedAt ? 'completed' : undefined),
+    ),
+    ...(threadId ? { threadId } : {}),
+  };
+}
 
 export class DesktopCloudService implements IDesktopDataService {
   constructor(
@@ -280,25 +350,23 @@ export class DesktopCloudService implements IDesktopDataService {
         const runHistory = Array.isArray(attrs.runHistory)
           ? (attrs.runHistory as Array<Record<string, unknown>>)
           : [];
-        const recentRuns = runHistory.slice(0, 5).map((run) => ({
-          completedAt: run.endedAt ? String(run.endedAt) : undefined,
-          id: String(run._id ?? run.id ?? ''),
-          startedAt: String(run.startedAt ?? ''),
-          status: String(run.status ?? 'completed') as
-            | 'completed'
-            | 'failed'
-            | 'pending'
-            | 'running',
-        }));
+        const agentId = String(item.id ?? '');
+        const recentRuns = runHistory
+          .map((run, index) => mapAgentRun(run, `${agentId}-run-${index}`))
+          .sort((left, right) => runTimestamp(right) - runTimestamp(left))
+          .slice(0, 5);
 
         const isActive = Boolean(attrs.isActive ?? attrs.enabled ?? false);
         return {
           avatar: attrs.avatar ? String(attrs.avatar) : undefined,
-          id: String(item.id ?? ''),
+          id: agentId,
           isActive,
-          lastRunAt: recentRuns[0]?.startedAt,
+          lastRunAt:
+            (attrs.lastRunAt ? String(attrs.lastRunAt) : undefined) ??
+            recentRuns[0]?.completedAt ??
+            recentRuns[0]?.startedAt,
           latestRun: recentRuns[0],
-          name: String(attrs.name ?? 'Unnamed Agent'),
+          name: String(attrs.label ?? attrs.name ?? 'Unnamed Agent'),
           platforms: Array.isArray(attrs.platforms)
             ? (attrs.platforms as string[])
             : [],
@@ -314,17 +382,23 @@ export class DesktopCloudService implements IDesktopDataService {
     agentId: string,
   ): Promise<IDesktopDataResult<IDesktopAgentRunResult>> {
     const response = await this.fetchJson<{
+      agentRunId?: string;
       data?: { id?: string; attributes?: Record<string, unknown> };
+      message?: string;
+      runId?: string;
+      status?: string;
     }>(`/agent-strategies/${agentId}/run-now`, {
       method: 'POST',
     });
+    const attributes = response.data?.attributes ?? {};
 
     return {
       data: {
-        runId: String(response.data?.id ?? ''),
-        status: String(response.data?.attributes?.status ?? 'pending') as
-          | 'pending'
-          | 'running',
+        ...(response.message ? { message: response.message } : {}),
+        runId: String(
+          response.data?.id ?? response.agentRunId ?? response.runId ?? '',
+        ),
+        status: normalizeAgentRunStatus(attributes.status ?? response.status),
       },
       status: 'success',
     };

--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -21,6 +21,7 @@ import type { NavView } from './nav-view';
 import OfflineShell from './offline/OfflineShell';
 import { useSyncEngine } from './sync/useSyncEngine';
 import { initializeRendererTelemetry } from './telemetry';
+import type { DesktopAgentRunHandoff } from './views/AgentsView';
 
 const AgentsView = lazy(() =>
   import('./views/AgentsView').then((module) => ({
@@ -303,6 +304,37 @@ export const App = () => {
     [createThread, addMessage],
   );
 
+  const handleAgentRunHandoff = useCallback(
+    ({ agentName, run }: DesktopAgentRunHandoff) => {
+      setActiveView('conversation');
+      const thread = createThread();
+      const outputParts = [
+        run.outputSummary,
+        run.contentGenerated !== undefined
+          ? `${String(run.contentGenerated)} generated output${
+              run.contentGenerated === 1 ? '' : 's'
+            }`
+          : undefined,
+        run.creditsUsed !== undefined
+          ? `${String(run.creditsUsed)} credits used`
+          : undefined,
+        run.threadId ? `Cloud thread: ${run.threadId}` : undefined,
+      ].filter((part): part is string => Boolean(part));
+      const content =
+        outputParts.length > 0
+          ? `Review and turn this ${agentName} run into a content-ready follow-up:\n\n${outputParts.join('\n')}`
+          : `Review the latest ${agentName} run and prepare the next content handoff.`;
+
+      addMessage(thread.id, {
+        content,
+        createdAt: new Date().toISOString(),
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        role: 'user',
+      });
+    },
+    [addMessage, createThread],
+  );
+
   /* ─── Derived state ─── */
 
   const shouldShowWizard =
@@ -357,7 +389,12 @@ export const App = () => {
       case 'workflows':
         return <WorkflowsView isOnline={isOnline} />;
       case 'agents':
-        return <AgentsView isOnline={isOnline} />;
+        return (
+          <AgentsView
+            isOnline={isOnline}
+            onRunHandoff={handleAgentRunHandoff}
+          />
+        );
       case 'mission-control':
         return <MissionControlView onStartNewThread={handleNewThread} />;
       case 'analytics':

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -1350,6 +1350,11 @@ textarea {
   color: var(--warning);
 }
 
+.status-queued {
+  background: color-mix(in srgb, var(--info) 14%, transparent);
+  color: var(--info);
+}
+
 .status-running {
   animation: pulse 1.5s infinite;
   background: color-mix(in srgb, var(--agent) 14%, transparent);
@@ -1666,6 +1671,52 @@ textarea {
   font-size: 12px;
 }
 
+.agent-manual-run-panel {
+  border-color: rgba(74, 144, 226, 0.34);
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.agent-manual-run-header,
+.agent-run-output-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.agent-manual-run-header h3 {
+  font-size: 14px;
+  margin: 0 0 4px;
+}
+
+.agent-run-output {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+
+.agent-run-metrics,
+.agent-run-summary,
+.agent-run-handoff-note {
+  font-size: 12px;
+  margin: 0;
+}
+
+.agent-run-summary {
+  line-height: 1.5;
+}
+
+.agent-run-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .agent-runs-section {
   margin-top: 4px;
 }
@@ -1681,6 +1732,7 @@ textarea {
 .agent-run-row {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
 }
 

--- a/apps/desktop/app/src/renderer/views/AgentsView.test.tsx
+++ b/apps/desktop/app/src/renderer/views/AgentsView.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentsView } from './AgentsView';
+
+const cloudApi = {
+  listAgents: vi.fn(),
+  runAgent: vi.fn(),
+};
+
+const notificationsApi = {
+  notify: vi.fn(),
+};
+
+const agent = {
+  id: 'agent-1',
+  isActive: true,
+  lastRunAt: '2026-06-11T06:00:00.000Z',
+  latestRun: {
+    completedAt: '2026-06-11T06:02:00.000Z',
+    contentGenerated: 3,
+    creditsUsed: 12,
+    id: 'run-1',
+    outputSummary: 'Generated three LinkedIn hooks for the launch angle.',
+    startedAt: '2026-06-11T06:00:00.000Z',
+    status: 'completed' as const,
+    threadId: 'thread-1',
+  },
+  name: 'Trend Scout',
+  platforms: ['linkedin'],
+  recentRuns: [
+    {
+      completedAt: '2026-06-11T06:02:00.000Z',
+      contentGenerated: 3,
+      creditsUsed: 12,
+      id: 'run-1',
+      outputSummary: 'Generated three LinkedIn hooks for the launch angle.',
+      startedAt: '2026-06-11T06:00:00.000Z',
+      status: 'completed' as const,
+      threadId: 'thread-1',
+    },
+  ],
+  status: 'active' as const,
+};
+
+describe('AgentsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cloudApi.listAgents.mockReset();
+    cloudApi.runAgent.mockReset();
+    notificationsApi.notify.mockReset();
+    cloudApi.listAgents.mockResolvedValue([agent]);
+    notificationsApi.notify.mockResolvedValue(undefined);
+
+    Object.defineProperty(window, 'genfeedDesktop', {
+      configurable: true,
+      value: {
+        cloud: cloudApi,
+        notifications: notificationsApi,
+      },
+    });
+  });
+
+  it('shows latest run output and hands it to the composer', async () => {
+    const onRunHandoff = vi.fn();
+
+    render(<AgentsView isOnline onRunHandoff={onRunHandoff} />);
+
+    expect(
+      await screen.findByText(
+        'Generated three LinkedIn hooks for the launch angle.',
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send to composer' }));
+
+    expect(onRunHandoff).toHaveBeenCalledWith({
+      agentName: 'Trend Scout',
+      run: expect.objectContaining({
+        contentGenerated: 3,
+        threadId: 'thread-1',
+      }),
+    });
+  });
+
+  it('shows a manual run status after triggering an agent', async () => {
+    cloudApi.runAgent.mockResolvedValue({
+      message: 'Proactive run queued. It will execute on the next minute cycle.',
+      runId: '',
+      status: 'pending',
+    });
+
+    render(<AgentsView isOnline />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '▶ Run' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Manual run status')).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Pending')).toBeInTheDocument(),
+    );
+    expect(notificationsApi.notify).toHaveBeenCalledWith(
+      'Agent run queued',
+      'Proactive run queued. It will execute on the next minute cycle.',
+    );
+  });
+});

--- a/apps/desktop/app/src/renderer/views/AgentsView.tsx
+++ b/apps/desktop/app/src/renderer/views/AgentsView.tsx
@@ -1,9 +1,27 @@
-import type { IDesktopAgent } from '@genfeedai/desktop-contracts';
+import type {
+  IDesktopAgent,
+  IDesktopAgentRun,
+  IDesktopAgentRunResult,
+} from '@genfeedai/desktop-contracts';
 import { ButtonVariant } from '@genfeedai/enums';
 import { DesktopResilienceState } from '@renderer/components/DesktopResilienceState';
 import { Button } from '@ui/primitives/button';
 import Image from 'next/image';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+type ManualRunState = {
+  agentId: string;
+  agentName: string;
+  message?: string;
+  runId?: string;
+  startedAt: string;
+  status: IDesktopAgentRunResult['status'];
+};
+
+export interface DesktopAgentRunHandoff {
+  agentName: string;
+  run: IDesktopAgentRun;
+}
 
 function timeAgo(dateStr: string): string {
   const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
@@ -16,12 +34,155 @@ function timeAgo(dateStr: string): string {
   return `${String(days)}d ago`;
 }
 
+function runStatusLabel(status: IDesktopAgentRun['status']): string {
+  switch (status) {
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+      return 'Failed';
+    case 'queued':
+      return 'Queued';
+    case 'running':
+      return 'Running';
+    case 'pending':
+      return 'Pending';
+  }
+}
+
+function formatRunOutput(run: IDesktopAgentRun): string {
+  const parts: string[] = [];
+
+  if (run.contentGenerated !== undefined) {
+    parts.push(
+      `${String(run.contentGenerated)} output${run.contentGenerated === 1 ? '' : 's'}`,
+    );
+  }
+
+  if (run.creditsUsed !== undefined) {
+    parts.push(`${String(run.creditsUsed)} credits`);
+  }
+
+  if (run.threadId) {
+    parts.push('thread linked');
+  }
+
+  return parts.join(' / ');
+}
+
+function canHandoffRun(run: IDesktopAgentRun): boolean {
+  return Boolean(run.contentGenerated || run.outputSummary || run.threadId);
+}
+
+function runTime(run: IDesktopAgentRun): number {
+  const timestamp = new Date(run.completedAt ?? run.startedAt).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function isManualRunInFlight(manualRun: ManualRunState | null): boolean {
+  return (
+    manualRun !== null &&
+    ['pending', 'queued', 'running'].includes(manualRun.status)
+  );
+}
+
+function isMatchingManualRun(
+  manualRun: ManualRunState,
+  run: IDesktopAgentRun,
+): boolean {
+  if (manualRun.runId) {
+    return manualRun.runId === run.id;
+  }
+
+  return runTime(run) >= new Date(manualRun.startedAt).getTime();
+}
+
+function AgentManualRunPanel({
+  manualRun,
+}: {
+  manualRun: ManualRunState | null;
+}) {
+  if (!manualRun) {
+    return null;
+  }
+
+  return (
+    <section className="agent-manual-run-panel panel-card">
+      <div className="agent-manual-run-header">
+        <div>
+          <h3>Manual run status</h3>
+          <p className="muted-text">
+            {manualRun.agentName} run started {timeAgo(manualRun.startedAt)}.
+          </p>
+        </div>
+        <span className={`status-badge status-${manualRun.status}`}>
+          {runStatusLabel(manualRun.status)}
+        </span>
+      </div>
+      {manualRun.message && (
+        <p className="agent-run-summary muted-text">{manualRun.message}</p>
+      )}
+      {manualRun.runId && (
+        <p className="muted-text agent-run-handoff-note">
+          Cloud run: {manualRun.runId}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function AgentRunOutput({
+  agentName,
+  onRunHandoff,
+  run,
+}: {
+  agentName: string;
+  onRunHandoff?: (handoff: DesktopAgentRunHandoff) => void;
+  run: IDesktopAgentRun;
+}) {
+  const output = formatRunOutput(run);
+  const canHandoff = canHandoffRun(run) && onRunHandoff !== undefined;
+
+  return (
+    <div className="agent-run-output">
+      <div className="agent-run-output-header">
+        <span className={`status-badge status-${run.status}`}>
+          {runStatusLabel(run.status)}
+        </span>
+        <span className="muted-text">
+          Started {timeAgo(run.startedAt)}
+          {run.completedAt ? ` / finished ${timeAgo(run.completedAt)}` : ''}
+        </span>
+      </div>
+
+      {output && <p className="agent-run-metrics muted-text">{output}</p>}
+      {run.outputSummary && (
+        <p className="agent-run-summary muted-text">{run.outputSummary}</p>
+      )}
+
+      {canHandoff && (
+        <div className="agent-run-actions">
+          <Button
+            className="small"
+            onClick={() => onRunHandoff?.({ agentName, run })}
+            type="button"
+            variant={ButtonVariant.GHOST}
+          >
+            Send to composer
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 const AgentCard = ({
   agent,
+  onRunHandoff,
   onRun,
   runningAgentId,
 }: {
   agent: IDesktopAgent;
+  onRunHandoff?: (handoff: DesktopAgentRunHandoff) => void;
   onRun: (id: string) => void;
   runningAgentId: string | null;
 }) => {
@@ -92,6 +253,14 @@ const AgentCard = ({
         </span>
       )}
 
+      {agent.latestRun && (
+        <AgentRunOutput
+          agentName={agent.name}
+          onRunHandoff={onRunHandoff}
+          run={agent.latestRun}
+        />
+      )}
+
       {agent.recentRuns.length > 0 && (
         <div className="agent-runs-section">
           <Button
@@ -109,9 +278,24 @@ const AgentCard = ({
               {agent.recentRuns.map((run) => (
                 <div className="agent-run-row" key={run.id}>
                   <span className={`status-badge status-${run.status}`}>
-                    {run.status}
+                    {runStatusLabel(run.status)}
                   </span>
                   <span className="muted-text">{timeAgo(run.startedAt)}</span>
+                  {formatRunOutput(run) && (
+                    <span className="muted-text">{formatRunOutput(run)}</span>
+                  )}
+                  {canHandoffRun(run) && onRunHandoff && (
+                    <Button
+                      className="small"
+                      onClick={() =>
+                        onRunHandoff({ agentName: agent.name, run })
+                      }
+                      type="button"
+                      variant={ButtonVariant.GHOST}
+                    >
+                      Handoff
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>
@@ -124,22 +308,28 @@ const AgentCard = ({
 
 interface AgentsViewProps {
   isOnline: boolean;
+  onRunHandoff?: (handoff: DesktopAgentRunHandoff) => void;
 }
 
-export const AgentsView = ({ isOnline }: AgentsViewProps) => {
+export const AgentsView = ({ isOnline, onRunHandoff }: AgentsViewProps) => {
   const [agents, setAgents] = useState<IDesktopAgent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [manualRun, setManualRun] = useState<ManualRunState | null>(null);
   const [runningAgentId, setRunningAgentId] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const loadAgents = useCallback(async () => {
-    setLoading(true);
+  const loadAgents = useCallback(async (options?: { silent?: boolean }) => {
+    if (!options?.silent) {
+      setLoading(true);
+    }
     setError(null);
 
     if (!isOnline) {
       setAgents([]);
-      setLoading(false);
+      if (!options?.silent) {
+        setLoading(false);
+      }
       return;
     }
 
@@ -149,7 +339,9 @@ export const AgentsView = ({ isOnline }: AgentsViewProps) => {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load agents');
     } finally {
-      setLoading(false);
+      if (!options?.silent) {
+        setLoading(false);
+      }
     }
   }, [isOnline]);
 
@@ -157,11 +349,11 @@ export const AgentsView = ({ isOnline }: AgentsViewProps) => {
     void loadAgents();
   }, [loadAgents]);
 
-  // Poll every 5s while a run is in progress
+  // Poll every 5s while a manually triggered run is waiting on cloud history.
   useEffect(() => {
-    if (runningAgentId) {
+    if (isManualRunInFlight(manualRun)) {
       pollRef.current = setInterval(() => {
-        void loadAgents();
+        void loadAgents({ silent: true });
       }, 5000);
     } else if (pollRef.current) {
       clearInterval(pollRef.current);
@@ -173,31 +365,81 @@ export const AgentsView = ({ isOnline }: AgentsViewProps) => {
         clearInterval(pollRef.current);
       }
     };
-  }, [runningAgentId, loadAgents]);
+  }, [manualRun, loadAgents]);
+
+  useEffect(() => {
+    if (!isManualRunInFlight(manualRun)) {
+      return;
+    }
+
+    const agent = agents.find((item) => item.id === manualRun.agentId);
+    const latestRun = agent?.latestRun;
+
+    if (
+      !latestRun ||
+      !isMatchingManualRun(manualRun, latestRun) ||
+      ['pending', 'queued', 'running'].includes(latestRun.status)
+    ) {
+      return;
+    }
+
+    setManualRun({
+      ...manualRun,
+      ...(latestRun.outputSummary ? { message: latestRun.outputSummary } : {}),
+      runId: latestRun.id,
+      status: latestRun.status,
+    });
+  }, [agents, manualRun]);
 
   const handleRunAgent = useCallback(
     async (agentId: string) => {
+      const agent = agents.find((item) => item.id === agentId);
+      const startedAt = new Date().toISOString();
       setRunningAgentId(agentId);
+      setManualRun({
+        agentId,
+        agentName: agent?.name ?? 'Agent',
+        startedAt,
+        status: 'queued',
+      });
       setError(null);
 
       if (!isOnline) {
         setError('Reconnect before running cloud agent strategies.');
         setRunningAgentId(null);
+        setManualRun(null);
         return;
       }
 
       try {
-        await window.genfeedDesktop.cloud.runAgent(agentId);
-        // Keep polling; it will auto-clear when run completes
-        setTimeout(() => {
-          void loadAgents().then(() => setRunningAgentId(null));
-        }, 10000);
+        const result = await window.genfeedDesktop.cloud.runAgent(agentId);
+        setManualRun({
+          agentId,
+          agentName: agent?.name ?? 'Agent',
+          ...(result.message ? { message: result.message } : {}),
+          ...(result.runId ? { runId: result.runId } : {}),
+          startedAt,
+          status: result.status,
+        });
+        await window.genfeedDesktop.notifications.notify(
+          'Agent run queued',
+          result.message ?? `${agent?.name ?? 'Agent'} will run shortly.`,
+        );
+        await loadAgents({ silent: true });
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to run agent');
+        setManualRun({
+          agentId,
+          agentName: agent?.name ?? 'Agent',
+          message: err instanceof Error ? err.message : 'Failed to run agent',
+          startedAt,
+          status: 'failed',
+        });
+      } finally {
         setRunningAgentId(null);
       }
     },
-    [isOnline, loadAgents],
+    [agents, isOnline, loadAgents],
   );
 
   return (
@@ -216,6 +458,9 @@ export const AgentsView = ({ isOnline }: AgentsViewProps) => {
       </div>
 
       {loading && <p className="muted-text">Loading agents...</p>}
+      {!loading && isOnline && !error && (
+        <AgentManualRunPanel manualRun={manualRun} />
+      )}
       {!loading && !isOnline && (
         <DesktopResilienceState
           actionLabel="Retry"
@@ -249,6 +494,7 @@ export const AgentsView = ({ isOnline }: AgentsViewProps) => {
             <AgentCard
               agent={agent}
               key={agent.id}
+              onRunHandoff={onRunHandoff}
               onRun={(id) => void handleRunAgent(id)}
               runningAgentId={runningAgentId}
             />

--- a/packages/desktop-contracts/src/index.ts
+++ b/packages/desktop-contracts/src/index.ts
@@ -660,11 +660,23 @@ export interface IDesktopTerminalExitEvent {
 
 /* ─── Agents ─── */
 
+export type DesktopAgentRunStatus =
+  | 'completed'
+  | 'failed'
+  | 'pending'
+  | 'queued'
+  | 'running';
+
 export interface IDesktopAgentRun {
   completedAt?: string;
+  contentGenerated?: number;
+  creditsUsed?: number;
   id: string;
+  message?: string;
+  outputSummary?: string;
   startedAt: string;
-  status: 'completed' | 'failed' | 'pending' | 'running';
+  status: DesktopAgentRunStatus;
+  threadId?: string;
 }
 
 export interface IDesktopAgent {
@@ -680,8 +692,9 @@ export interface IDesktopAgent {
 }
 
 export interface IDesktopAgentRunResult {
+  message?: string;
   runId: string;
-  status: 'pending' | 'running';
+  status: DesktopAgentRunStatus;
 }
 
 /* ─── Workflows ─── */


### PR DESCRIPTION
## Summary
- Map agent run output metadata and queued manual-run responses through the desktop contracts and cloud service.
- Show latest run status, output summary, metrics, and manual run status on the desktop agents surface.
- Add handoff actions that send agent run output into the desktop composer.

## Validation
- Local validation intentionally skipped by automation policy for this MacBook Pro.
- GitHub PR/develop checks are the verification path.

Closes genfeedai/genfeed.ai#24