### PR TITLE
fix(api): enable validation whitelist

### DIFF
--- a/apps/server/api/src/collections/api-keys/dto/create-api-key.dto.ts
+++ b/apps/server/api/src/collections/api-keys/dto/create-api-key.dto.ts
@@ -5,6 +5,7 @@ import {
   IsDate,
   IsEnum,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   MaxLength,
@@ -85,5 +86,6 @@ export class CreateApiKeyDto {
     required: false,
   })
   @IsOptional()
+  @IsObject()
   readonly metadata?: Record<string, unknown>;
 }

--- a/apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts
@@ -7,6 +7,7 @@ import {
   IsBoolean,
   IsIn,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   Max,
@@ -322,5 +323,7 @@ export class UpdateBrandAgentConfigDto {
     required: false,
     type: Object,
   })
+  @IsOptional()
+  @IsObject()
   platformOverrides?: Record<string, UpdateBrandAgentPlatformOverrideDto>;
 }

--- a/apps/server/api/src/helpers/pipes/validation.pipe.spec.ts
+++ b/apps/server/api/src/helpers/pipes/validation.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { ValidationPipe } from '@api/helpers/pipes/validation.pipe';
 import { type ArgumentMetadata, BadRequestException } from '@nestjs/common';
-import { IsEmail, IsOptional, IsString } from 'class-validator';
+import { IsEmail, IsObject, IsOptional, IsString } from 'class-validator';
 
 class TestDto {
   @IsString()
@@ -17,6 +17,15 @@ class TestDto {
 class PrimitiveDto {
   @IsString()
   value!: string;
+}
+
+class DynamicDto {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsObject()
+  payload?: Record<string, unknown>;
 }
 
 describe('ValidationPipe', () => {
@@ -45,6 +54,26 @@ describe('ValidationPipe', () => {
       const result = await pipe.transform(value, metadata);
 
       expect(result).toEqual(value);
+    });
+
+    it('strips unknown top-level fields while preserving decorated object payloads', async () => {
+      const value = {
+        name: 'workflow',
+        payload: { arbitrary: true, nested: { value: 1 } },
+        unexpected: 'strip me',
+      };
+      const metadata: ArgumentMetadata = {
+        metatype: DynamicDto,
+        type: 'body',
+      };
+
+      const result = await pipe.transform(value, metadata);
+
+      expect(result).toEqual({
+        name: 'workflow',
+        payload: { arbitrary: true, nested: { value: 1 } },
+      });
+      expect(result).not.toHaveProperty('unexpected');
     });
 
     it('should throw BadRequestException for invalid data', async () => {

--- a/apps/server/api/src/helpers/pipes/validation.pipe.ts
+++ b/apps/server/api/src/helpers/pipes/validation.pipe.ts
@@ -87,7 +87,7 @@ export class ValidationPipe implements PipeTransform<unknown> {
       return;
     }
 
-    const errors = await validate(object);
+    const errors = await validate(object, { whitelist: true });
     if (errors.length > 0) {
       const messages = errors.map((error) => ({
         constraints: error.constraints,

--- a/apps/server/api/vitest.config.ts
+++ b/apps/server/api/vitest.config.ts
@@ -184,6 +184,20 @@ export default defineConfig({
         ),
       },
       {
+        find: '@genfeedai/workflows',
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflows/src',
+        ),
+      },
+      {
+        find: /^@genfeedai\/workflows\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflows/src/$1',
+        ),
+      },
+      {
         find: /^@genfeedai\/cloud-serializers\/(.*)$/,
         replacement: path.resolve(
           serviceDir,


### PR DESCRIPTION
## Summary
- Enable API validation whitelisting so unknown DTO fields are stripped instead of passed through.
- Add object validation metadata for dynamic API key metadata and brand agent platform overrides so legitimate Record payloads survive whitelisting.
- Add the missing @genfeedai/workflows Vitest alias used by API tests.

## Verification
- `bunx biome check --write apps/server/api/src/helpers/pipes/validation.pipe.ts apps/server/api/src/helpers/pipes/validation.pipe.spec.ts apps/server/api/src/collections/brands/dto/update-brand-agent-config.dto.ts apps/server/api/src/collections/api-keys/dto/create-api-key.dto.ts apps/server/api/vitest.config.ts`
- `bunx vitest run --config vitest.config.ts src/helpers/pipes/validation.pipe.spec.ts src/collections/credits/services/credits.utils.service.spec.ts src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts src/endpoints/webhooks/stripe/webhooks.stripe.controller.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`

## Risk
- No migrations or env changes.
- Request payloads with undocumented top-level DTO fields will now have those fields stripped by class-validator.
