### PR TITLE
fix(docker): include pricing workspace in server image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -41,7 +41,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -70,6 +70,7 @@ RUN --mount=type=bind,source=.,target=/ctx \
       /ctx/packages/integrations/package.json \
       /ctx/packages/interfaces/package.json \
       /ctx/packages/models/package.json \
+      /ctx/packages/pricing/package.json \
       /ctx/packages/prisma/package.json \
       /ctx/packages/props/package.json \
       /ctx/packages/serializers/package.json \
@@ -126,6 +127,7 @@ RUN set -e; \
     bun --filter @genfeedai/enums build; \
     bun --filter @genfeedai/constants build; \
     bun --filter @genfeedai/interfaces build; \
+    bun --filter @genfeedai/pricing build; \
     bun --filter @genfeedai/client build; \
     bun --filter @genfeedai/types build & pid1=$!; \
     bun --filter @genfeedai/config build & pid2=$!; \
@@ -234,6 +236,7 @@ RUN mkdir -p apps/server/api \
              packages/integrations \
              packages/interfaces \
              packages/models \
+             packages/pricing \
              packages/prisma \
              packages/props \
              packages/serializers \
@@ -281,6 +284,7 @@ COPY --from=builder /usr/src/app/packages/helpers/package.json ./packages/helper
 COPY --from=builder /usr/src/app/packages/integrations/package.json ./packages/integrations/package.json
 COPY --from=builder /usr/src/app/packages/interfaces/package.json ./packages/interfaces/package.json
 COPY --from=builder /usr/src/app/packages/models/package.json ./packages/models/package.json
+COPY --from=builder /usr/src/app/packages/pricing/package.json ./packages/pricing/package.json
 COPY --from=builder /usr/src/app/packages/prisma/package.json ./packages/prisma/package.json
 COPY --from=builder /usr/src/app/packages/props/package.json ./packages/props/package.json
 COPY --from=builder /usr/src/app/packages/serializers/package.json ./packages/serializers/package.json


### PR DESCRIPTION
Fixes the staging promotion Build & Boot Check failure by adding @genfeedai/pricing to the reduced server Docker workspace graph.\n\nValidation:\n- bun --filter @genfeedai/pricing build\n- git diff --check\n\nLocal Docker is unavailable in this desktop environment, so GitHub Build & Boot Check is the Docker validation.