### PR TITLE
fix(deploy): harden Vercel app production path

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,7 +114,7 @@ jobs:
 
   deploy-website:
     name: Deploy genfeed.ai
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ vars.ENABLE_WEBSITE_VERCEL_DEPLOY == 'true' && (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')) }}
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   deploy-docs:
     name: Deploy docs.genfeed.ai
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ vars.ENABLE_DOCS_VERCEL_DEPLOY == 'true' && (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')) }}
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:

--- a/scripts/env-check.ts
+++ b/scripts/env-check.ts
@@ -7,10 +7,22 @@ import { DEPRECATED_ENV_KEYS, ENV_TARGETS } from './env-spec';
 const rootDir = process.cwd();
 
 function listTrackedEnvFiles(): string[] {
-  const stdout = execFileSync('git', ['ls-files'], {
-    cwd: rootDir,
-    encoding: 'utf8',
-  });
+  let stdout: string;
+
+  try {
+    stdout = execFileSync('git', ['ls-files'], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    if (process.env.VERCEL === '1') {
+      console.warn('Skipping tracked env file check outside a git worktree.');
+      return [];
+    }
+
+    throw error;
+  }
 
   return stdout
     .split('\n')


### PR DESCRIPTION
## Summary
- let env:check skip the git-only tracked-env scan when Vercel builds from an archive without .git
- gate website/docs Vercel deploy jobs behind explicit enable vars so the app production path is not blocked by unrelated site/docs build failures

## Verification
- bun run env:check
- VERCEL=1 GIT_DIR=/tmp/genfeed-missing-git-dir bun run env:check
- bunx biome check scripts/env-check.ts
- actionlint .github/workflows/deploy-production.yml
- git diff --check -- scripts/env-check.ts .github/workflows/deploy-production.yml
- bun scripts/run-secretlint.ts --no-glob .github/workflows/deploy-production.yml scripts/env-check.ts
- gitleaks protect --staged --redact

## Production evidence
- Deploy Production run 27340064350 passed backend build/deploy and app env normalization, then app Vercel failed because env:check called git ls-files inside /vercel/path0 without a git worktree.
- Live smoke after env normalization: https://app.genfeed.ai/login returns 200, embeds pk_live_Y2xlcmsuZ2VuZmVlZC5haSQ without trailing newline, and Playwright renders Clerk sign-in with Google/email controls and no console errors.