### PR TITLE
chore: promote deploy remediation to staging

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,7 +114,7 @@ jobs:
 
   deploy-website:
     name: Deploy genfeed.ai
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ vars.ENABLE_WEBSITE_VERCEL_DEPLOY == 'true' && (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')) }}
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   deploy-docs:
     name: Deploy docs.genfeed.ai
-    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
+    if: ${{ vars.ENABLE_DOCS_VERCEL_DEPLOY == 'true' && (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v')) }}
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:

--- a/scripts/env-check.ts
+++ b/scripts/env-check.ts
@@ -7,10 +7,22 @@ import { DEPRECATED_ENV_KEYS, ENV_TARGETS } from './env-spec';
 const rootDir = process.cwd();
 
 function listTrackedEnvFiles(): string[] {
-  const stdout = execFileSync('git', ['ls-files'], {
-    cwd: rootDir,
-    encoding: 'utf8',
-  });
+  let stdout: string;
+
+  try {
+    stdout = execFileSync('git', ['ls-files'], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    if (process.env.VERCEL === '1') {
+      console.warn('Skipping tracked env file check outside a git worktree.');
+      return [];
+    }
+
+    throw error;
+  }
 
   return stdout
     .split('\n')


### PR DESCRIPTION
## Summary
- Promote production deploy remediation from develop to staging.
- Includes app Vercel root deploy fix and Vercel env-check hardening.
- Keeps website/docs/admin deploys gated unless explicitly enabled.

## Validation
- #536 CI passed before merge into develop.
- Follow-up production deploy will run from master after staging -> master promotion.