### PR TITLE
chore(release): promote develop to staging

### DIFF
--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -88,6 +88,40 @@ describe('proxy', () => {
     );
   });
 
+  it('redirects signed-in public auth routes to onboarding when no workspace exists', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            brands: [],
+            currentUser: { id: 'user_1' },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/login' },
+        url: 'http://localhost:3000/login',
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/onboarding',
+    );
+  });
+
   it('redirects signed-in root to workspace when single brand', async () => {
     const { default: proxy } = await import('./proxy');
 
@@ -103,6 +137,40 @@ describe('proxy', () => {
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe(
       'http://localhost:3000/acme/moonrise-studio/workspace/overview',
+    );
+  });
+
+  it('redirects signed-in root to onboarding when no workspace exists', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            brands: [],
+            currentUser: { id: 'user_1' },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/' },
+        url: 'http://localhost:3000/',
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/onboarding',
     );
   });
 

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -25,6 +25,7 @@ type BootstrapResponse = {
     brandId?: string;
   };
   brands?: BootstrapBrandSummary[];
+  currentUser?: unknown;
 };
 
 type OrganizationMineResponseItem = {
@@ -36,6 +37,7 @@ const hasClerkKeys =
   Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim()) &&
   Boolean(process.env.CLERK_SECRET_KEY?.trim());
 const isDesktopShell = process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1';
+const ONBOARDING_PATH = '/onboarding';
 const SEEDED_WORKSPACE_PATH = '/default/default/workspace/overview';
 
 /**
@@ -392,6 +394,37 @@ async function resolveActiveWorkspaceSlugs(
   return { cookieValue, slugs };
 }
 
+async function shouldRedirectSignedInUserToOnboarding(
+  token: string,
+): Promise<boolean> {
+  let bootstrapResponse: Response;
+
+  try {
+    bootstrapResponse = await fetch(`${getApiBaseUrl()}/auth/bootstrap`, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch {
+    return false;
+  }
+
+  if (!bootstrapResponse.ok) {
+    return false;
+  }
+
+  const bootstrap =
+    (await bootstrapResponse.json()) as BootstrapResponse | null;
+
+  return (
+    Boolean(bootstrap?.currentUser) &&
+    Array.isArray(bootstrap?.brands) &&
+    bootstrap.brands.length === 0
+  );
+}
+
 type CanonicalResolution = {
   cookieValue: string | null;
   path: string;
@@ -501,6 +534,13 @@ const clerkProxy = isCloudConnected
               }
               return response;
             }
+
+            if (
+              token &&
+              (await shouldRedirectSignedInUserToOnboarding(token))
+            ) {
+              return redirectPreservingSearch(req, ONBOARDING_PATH);
+            }
           }
           return NextResponse.next();
         }
@@ -536,6 +576,13 @@ const clerkProxy = isCloudConnected
                 setSlugCookie(response, resolved.cookieValue);
               }
               return response;
+            }
+
+            if (
+              token &&
+              (await shouldRedirectSignedInUserToOnboarding(token))
+            ) {
+              return redirectPreservingSearch(req, ONBOARDING_PATH);
             }
 
             return NextResponse.next();


### PR DESCRIPTION
Promotes the auth onboarding landing fix from develop to staging.\n\nIncludes:\n- #539: route signed-in users without an accessible workspace to /onboarding instead of leaving them on /login\n\nVerification on source PR:\n- CI passed: format, lint, typecheck, build, focused proxy tests, and guard suites\n