### PR TITLE
fix(auth): remove legacy Clerk publishable env

### DIFF
--- a/.agents/memory/context/e2e-architecture.md
+++ b/.agents/memory/context/e2e-architecture.md
@@ -134,7 +134,7 @@ Primary config highlights:
   ~15 GB → `ENOSPC`). Best-effort; never fails the suite. Respects `PLAYWRIGHT_WEB_APP_PATH`.
 - **clerk.setup.ts** (`clerk-setup` project) — provisions REAL Clerk test users, writes
   `playwright/artifacts/.clerk/{user,admin}.json` storage state for the `app-authed` project.
-  Hard-fails if `CLERK_SECRET_KEY` / `CLERK_PUBLISHABLE_KEY` / `E2E_CLERK_USER_PASSWORD` missing or mock.
+  Hard-fails if `CLERK_SECRET_KEY` / `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` / `E2E_CLERK_USER_PASSWORD` missing or mock.
 
 ### Mock-auth fixtures (`playwright/e2e/fixtures/`)
 Most specs use **3-layer auth bypass** (no real Clerk needed):

--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,6 @@ GENFEEDAI_API_KEY=
 # Shared Auth / Edition
 # --------------------------------------------
 CLERK_SECRET_KEY=sk_test_your_secret_key
-CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key
 CLERK_WEBHOOK_SIGNING_SECRET=whsec_your_webhook_secret
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key
 NEXT_PUBLIC_GENFEED_CLOUD=

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -83,7 +83,10 @@ jobs:
             fi
           }
 
+          : "${CLERK_SECRET_KEY:?CLERK_SECRET_KEY GitHub secret is required}"
+
           clerk_publishable_key="pk_live_$(printf '%s$' "${CLERK_FRONTEND_API_DOMAIN}" | base64 | tr -d '\n')"
+          update_env CLERK_SECRET_KEY "${CLERK_SECRET_KEY}"
           update_env NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY "${clerk_publishable_key}"
           update_env NEXT_PUBLIC_GENFEED_CLOUD "true"
           update_env NEXT_PUBLIC_API_ENDPOINT "https://api.genfeed.ai/v1"
@@ -92,6 +95,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_FRONTEND_API_DOMAIN: clerk.genfeed.ai
       - run: npx vercel deploy --cwd . --archive=tgz --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -243,11 +243,7 @@ jobs:
           CI: true
           APP_BASE_URL: http://localhost:3000
           NEXT_PUBLIC_PLAYWRIGHT_TEST: "false"
-          # clerk.setup.ts reads CLERK_PUBLISHABLE_KEY first, then NEXT_PUBLIC_*.
-          # Set BOTH so the @clerk/backend provisioning client and the app under
-          # test resolve to the SAME Clerk instance as CLERK_SECRET_KEY.
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 'pk_test_ZW5nYWdlZC1wYW50aGVyLTcxLmNsZXJrLmFjY291bnRzLmRldiQ' }}
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 'pk_test_ZW5nYWdlZC1wYW50aGVyLTcxLmNsZXJrLmFjY291bnRzLmRldiQ' }}
           E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
 

--- a/apps/docs/content/core/configuration.mdx
+++ b/apps/docs/content/core/configuration.mdx
@@ -42,7 +42,6 @@ bun run env:sync local
 | ----------------------- | ---------- | ------- | ------------------------------------------------------------ |
 | `JWT_SECRET`            | Yes        | --      | Secret key for signing JWT tokens. Use a long random string. |
 | `CLERK_SECRET_KEY`      | Auth       | --      | Clerk backend secret key for deployments using Clerk auth     |
-| `CLERK_PUBLISHABLE_KEY` | Auth       | --      | Clerk publishable key used by the API Clerk client           |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Auth | --   | Clerk publishable key exposed to the Next.js frontend        |
 
 ---

--- a/apps/server/api/.env.example
+++ b/apps/server/api/.env.example
@@ -162,7 +162,7 @@ DATABASE_URL=postgresql://user:pass@localhost:5432/genfeed
 # --------------------------------------------
 # Clerk Authentication
 # --------------------------------------------
-CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key
+CLERK_SECRET_KEY=sk_test_your_secret_key
 CLERK_WEBHOOK_SIGNING_SECRET=whsec_your_webhook_signing_secret
 
 # --------------------------------------------

--- a/apps/server/api/src/config/config.service.spec.ts
+++ b/apps/server/api/src/config/config.service.spec.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { ConfigService } from '@api/config/config.service';
 
 describe('ConfigService', () => {
@@ -20,7 +21,6 @@ describe('ConfigService', () => {
     env.AWS_SECRET_ACCESS_KEY = 'test-secret';
     delete env.DB_MODE;
     env.PORT = '3010';
-    env.CLERK_PUBLISHABLE_KEY = 'pk_test_test';
     env.CLERK_SECRET_KEY = 'sk_test_test';
     env.CLERK_WEBHOOK_SIGNING_SECRET = 'test-secret';
     env.YOUTUBE_CLIENT_ID = 'test-client-id';

--- a/apps/server/api/src/config/test.prod.env
+++ b/apps/server/api/src/config/test.prod.env
@@ -11,7 +11,6 @@ MDB_DB=test_db
 MDB_URI=mongo.internal:27017
 MDB_PWD=test_password
 MDB_USR=test_user
-CLERK_PUBLISHABLE_KEY=pk_test_mock_key
 CLERK_SECRET_KEY=sk_test_mock_key
 CLERK_WEBHOOK_SIGNING_SECRET=mock_webhook_secret
 SENTRY_ENVIRONMENT=test

--- a/apps/server/api/src/providers/clerk.provider.ts
+++ b/apps/server/api/src/providers/clerk.provider.ts
@@ -9,7 +9,6 @@ export const ClerkClientProvider = {
     if (IS_LOCAL_MODE) return null;
 
     return createClerkClient({
-      publishableKey: configService.get('CLERK_PUBLISHABLE_KEY'),
       secretKey: configService.get('CLERK_SECRET_KEY'),
     });
   },

--- a/apps/server/api/test/test.env
+++ b/apps/server/api/test/test.env
@@ -17,7 +17,6 @@ MDB_URI=mongo.internal:27017
 MDB_PWD=your_db_password
 MDB_USR=your_db_user
 
-CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key
 CLERK_SECRET_KEY=your_clerk_secret_key
 CLERK_WEBHOOK_SIGNING_SECRET=your_clerk_webhook_secret
 

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -47,7 +47,6 @@ export interface IEnvConfig {
   AWS_IMAGE_COMPRESSION?: number;
 
   // === Clerk ===
-  CLERK_PUBLISHABLE_KEY?: string;
   CLERK_SECRET_KEY?: string;
   CLERK_WEBHOOK_SIGNING_SECRET?: string;
 

--- a/packages/config/src/schemas/clerk.schema.ts
+++ b/packages/config/src/schemas/clerk.schema.ts
@@ -5,7 +5,6 @@ import { conditionalRequired } from '../helpers';
  * Optional in self-hosted mode (no auth), required in cloud mode.
  */
 export const clerkSchema = {
-  CLERK_PUBLISHABLE_KEY: conditionalRequired(),
   CLERK_SECRET_KEY: conditionalRequired(),
   CLERK_WEBHOOK_SIGNING_SECRET: conditionalRequired(),
 };

--- a/playwright/e2e/clerk.setup.ts
+++ b/playwright/e2e/clerk.setup.ts
@@ -25,7 +25,7 @@ import { expect, test as setup } from '@playwright/test';
  *
  * REQUIRES (no mock fallback):
  *   - CLERK_SECRET_KEY              real test-instance secret (sk_test_...)
- *   - CLERK_PUBLISHABLE_KEY (or NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)
+ *   - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
  *   - E2E_CLERK_USER_PASSWORD       password for the provisioned test user
  * The instance must have email + password sign-in enabled.
  */
@@ -37,10 +37,7 @@ const ADMIN_AUTH_FILE = path.join(AUTH_DIR, 'admin.json');
 const MOCK_SECRET = 'test-mock-clerk-key';
 
 const secretKey = process.env.CLERK_SECRET_KEY ?? '';
-const publishableKey =
-  process.env.CLERK_PUBLISHABLE_KEY ??
-  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ??
-  '';
+const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
 const testUserPassword = process.env.E2E_CLERK_USER_PASSWORD ?? '';
 
 function assertRealClerkEnv(): void {
@@ -52,7 +49,7 @@ function assertRealClerkEnv(): void {
   }
   if (!publishableKey?.startsWith('pk_')) {
     problems.push(
-      'CLERK_PUBLISHABLE_KEY / NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is missing or not a pk_ key.',
+      'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is missing or not a pk_ key.',
     );
   }
   if (!testUserPassword) {

--- a/scripts/env-spec.ts
+++ b/scripts/env-spec.ts
@@ -48,7 +48,6 @@ const frontendSharedKeys = [
 ] as const;
 
 const backendSharedKeys = [
-  'CLERK_PUBLISHABLE_KEY',
   'CLERK_SECRET_KEY',
   'CLERK_WEBHOOK_SIGNING_SECRET',
   'DATABASE_URL',
@@ -492,7 +491,6 @@ export const ROOT_ENV_SECTIONS: EnvSection[] = [
     title: 'Shared Auth And Edition',
     keys: [
       'CLERK_SECRET_KEY',
-      'CLERK_PUBLISHABLE_KEY',
       'CLERK_WEBHOOK_SIGNING_SECRET',
       'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
       'NEXT_PUBLIC_GENFEED_CLOUD',


### PR DESCRIPTION
## Summary
- remove the legacy bare CLERK_PUBLISHABLE_KEY env from API config, env sync, docs, and real-Clerk Playwright setup
- keep NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY as the canonical browser publishable key
- force production deploy to sync CLERK_SECRET_KEY into the app.genfeed.ai Vercel project before deploy

## Production secret sync already applied
- AWS SSM /genfeed/production now has CLERK_SECRET_KEY and NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY from .env.production
- AWS SSM legacy /genfeed/production/CLERK_PUBLISHABLE_KEY has been deleted
- GitHub Actions secrets CLERK_SECRET_KEY and NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY were refreshed from .env.production
- Vercel app.genfeed.ai production env values were overwritten from .env.production

## Tests
- exact-token scan: no bare CLERK_PUBLISHABLE_KEY remains
- bun run test -- __tests__/schemas.test.ts (packages/config)
- bun run test:file src/config/config.service.spec.ts src/providers/clerk.provider.spec.ts (apps/server/api)
- bunx vitest run --config ./vitest.config.mts proxy.test.ts (apps/app)
- bun run type-check (apps/app)

## Notes
- API tsc direct check is blocked by existing TypeScript 6 baseUrl deprecation in apps/server/api/tsconfig.json, unrelated to this change.
- Local Vercel redeploy of the prior deployment started but remained stuck in Building; production workflow dispatch after merge should be used to produce the replacement deployment.