### PR TITLE
Promote develop to staging: Clerk Vercel key padding fix

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -85,7 +85,7 @@ jobs:
 
           : "${CLERK_SECRET_KEY:?CLERK_SECRET_KEY GitHub secret is required}"
 
-          clerk_publishable_key="pk_live_$(printf '%s$' "${CLERK_FRONTEND_API_DOMAIN}" | base64 | tr -d '\n')"
+          clerk_publishable_key="pk_live_$(printf '%s$' "${CLERK_FRONTEND_API_DOMAIN}" | base64 | tr -d '=\n')"
           update_env CLERK_SECRET_KEY "${CLERK_SECRET_KEY}"
           update_env NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY "${clerk_publishable_key}"
           update_env NEXT_PUBLIC_GENFEED_CLOUD "true"


### PR DESCRIPTION
Promotes the Vercel deploy fix so NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is generated without base64 padding and matches .env.production/SSM.\n\nVerification:\n- generated key matches .env.production\n- generated key is 31 bytes, no '=' padding\n- ruby YAML parse OK\n- git diff --check OK