### PR TITLE
docs: correct stack to PostgreSQL/Prisma in monorepo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The web UI will be available at `http://localhost:3000` and the API at `http://l
 
 ## Architecture
 
-Turborepo + Bun monorepo. NestJS backend split into 12 microservices. Next.js frontend. MongoDB for persistence. Redis + BullMQ for queuing and caching.
+Turborepo + Bun monorepo. NestJS backend split into 12 microservices. Next.js frontend. PostgreSQL via Prisma for persistence. Redis + BullMQ for queuing and caching.
 
 ```
 genfeed.ai/
@@ -70,7 +70,7 @@ genfeed.ai/
     extensions/       -- browser and IDE extensions
   packages/           -- shared packages (@genfeedai/*)
     core/             -- domain logic
-    db/               -- database schemas and migrations
+    prisma/           -- Prisma schema and migrations
     workflows/        -- workflow engine and node definitions
     integrations/     -- platform connectors
     ui/               -- shared component library


### PR DESCRIPTION
## What

The public monorepo README still advertised the old stack:

- Architecture paragraph said **MongoDB for persistence**
- Directory tree listed `packages/db/  -- database schemas and migrations`

Persistence is **PostgreSQL via Prisma**, and the schema lives in `packages/prisma/` (there is no `packages/db`).

## Changes

- Architecture line: MongoDB → PostgreSQL via Prisma
- Directory tree: `db/  -- database schemas and migrations` → `prisma/  -- Prisma schema and migrations`

Two-line doc-only change. No code paths touched.

## Note on base branch

Targeted at `master` because `develop` does not exist on the public `genfeedai/genfeed.ai` origin — only `master` is present remotely.