### PR TITLE
fix(docker): install ca-certificates for self-hosted image build

### DIFF
--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -8,9 +8,13 @@
 # ==================================================
 FROM node:24-bookworm-slim AS base
 
-# Redis + tini
+# Redis + tini.
+# ca-certificates is required for HTTPS (bun.sh install below): node:*-slim ships
+# no CA bundle, and ca-certificates is only a *Recommends* of curl — so with
+# --no-install-recommends it must be listed explicitly or curl fails with
+# `curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt`.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl redis-server tini && \
+    ca-certificates curl redis-server tini && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.12" && \


### PR DESCRIPTION
## Fix (merging to develop)

Self-hosted Docker image publish failed on v0.1.1 ([run 27402121195](https://github.com/genfeedai/genfeed.ai/actions/runs/27402121195)).

### Root cause
`docker/Dockerfile.selfhosted` runs the bun installer over HTTPS. Base image `node:24-bookworm-slim` ships **no CA bundle**, and `ca-certificates` is only a *Recommends* of `curl` — dropped by `--no-install-recommends`:
```
curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
cp: cannot stat '/root/.bun/bin/bun': No such file or directory
```

### Fix
Add `ca-certificates` to the apt install before the curl. (`Dockerfile.server` already has it — that's why production deploy was unaffected.)

### Scope
- Lands on **develop**; reaches master via normal develop→staging→master promotion.
- **No** image republish, **no** master touch, **no** redeploy (per owner).