### PR TITLE
feat(ci): self-hosted release E2E against the shipped image

### DIFF
--- a/.github/workflows/e2e-selfhosted-release.yml
+++ b/.github/workflows/e2e-selfhosted-release.yml
@@ -1,0 +1,215 @@
+name: Self-Hosted Release E2E
+
+# Tests the RELEASED self-hosted image — the exact artifact users `docker run`,
+# produced by "Docker Publish (Self-Hosted)" on release (ghcr :latest). Boots it
+# against a throwaway Postgres in LOCAL mode (no Clerk, no secrets), then drives
+# Playwright critical-path specs through the live API + frontend + DB stack.
+#
+# This is the only suite that proves real API ↔ frontend ↔ Postgres integration.
+# The weekly e2e.yml runs the frontend against a MOCKED backend; this runs the
+# shipped container end to end.
+
+on:
+  # Run right after a publish so :latest is the freshly-released artifact.
+  workflow_run:
+    workflows: ["Docker Publish (Self-Hosted)"]
+    types: [completed]
+  # Every 3 days, 05:23 UTC (off-:00 hygiene; */3 resets at month boundaries).
+  schedule:
+    - cron: "23 5 */3 * *"
+  # Manual / CI dry-run against an explicit tag.
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Published image tag to test (e.g. latest, v0.1.2)"
+        required: false
+        default: "latest"
+
+concurrency:
+  group: e2e-selfhosted-release
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+  issues: write
+
+env:
+  COMPOSE_FILE: docker/docker-compose.selfhosted.yml
+  # workflow_dispatch supplies image_tag; schedule/workflow_run fall back to latest.
+  IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
+  APP_BASE_URL: http://localhost:3000
+  API_BASE_URL: http://localhost:3010
+
+jobs:
+  release-e2e:
+    name: Release E2E (LOCAL mode)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # On a workflow_run trigger, only proceed if the publish actually succeeded.
+    # schedule / workflow_dispatch always proceed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Boot released image + Postgres
+        run: |
+          echo "Testing image tag: ${IMAGE_TAG}"
+          GENFEED_IMAGE_TAG="${IMAGE_TAG}" docker compose -f "${COMPOSE_FILE}" up -d --quiet-pull
+
+      # Readiness gate — the #1 false-green risk. Migrate + seed run async on
+      # boot, so liveness can be green before the DB is usable. Fail loud on
+      # timeout; never let the specs run against a half-booted stack.
+      - name: Readiness — stage 1 (liveness, <=120s)
+        run: |
+          deadline=$((SECONDS + 120))
+          until curl -fsS "${API_BASE_URL}/v1/health/ready" >/dev/null \
+             && curl -fsS "${APP_BASE_URL}/playwright-ready" >/dev/null; do
+            if (( SECONDS >= deadline )); then
+              echo "::error::Liveness gate timed out after 120s — processes not answering"
+              exit 1
+            fi
+            sleep 3
+          done
+          echo "Liveness OK — API + app processes answering."
+
+      - name: Readiness — stage 2 (DB + seed + auth gate, <=180s)
+        run: |
+          # Poll bootstrap until it returns the SEEDED admin. This drives
+          # LOCAL-mode auth injection -> Prisma -> SelfHostedSeedService rows,
+          # so it only greens once DB + migrations + seed + auth are ALL live.
+          deadline=$((SECONDS + 180))
+          until curl -fsS "${API_BASE_URL}/v1/auth/bootstrap" | grep -q 'admin@localhost'; do
+            if (( SECONDS >= deadline )); then
+              echo "::error::Bootstrap/seed gate timed out after 180s — DB + migrate + seed + auth not all ready"
+              exit 1
+            fi
+            sleep 3
+          done
+          echo "Bootstrap + seed OK — seeded admin@localhost reachable."
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: "1.3.14"
+          install-command: "bun install"
+          cache-playwright: "true"
+
+      - name: Run release E2E specs
+        run: bun run test:e2e:release
+        env:
+          CI: true
+
+      - name: Dump container logs (on failure)
+        if: failure()
+        run: |
+          docker compose -f "${COMPOSE_FILE}" logs --no-color > compose-logs.txt 2>&1 || true
+          echo "===== compose logs (tail) ====="
+          tail -n 200 compose-logs.txt || true
+
+      - name: Upload container logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-e2e-compose-logs
+          path: compose-logs.txt
+          retention-days: 14
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-e2e-playwright-report
+          path: playwright/artifacts/report/
+          retention-days: 14
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f "${COMPOSE_FILE}" down -v
+
+  # File a deduped tracking issue when the release E2E fails, so a broken
+  # shipped image is visible without watching the Actions tab.
+  report-failure:
+    name: Report failure
+    runs-on: ubuntu-latest
+    needs: [release-e2e]
+    if: failure()
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@v8
+        env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        with:
+          script: |
+            const label = 'release-e2e';
+            const imageTag = process.env.IMAGE_TAG || 'latest';
+            const date = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `**Self-hosted release E2E failed** on \`${date}\`.`,
+              ``,
+              `- Image tag under test: \`ghcr.io/genfeedai/genfeed.ai:${imageTag}\``,
+              `- Failed run: ${runUrl}`,
+              `- Artifacts: \`release-e2e-playwright-report\`, \`release-e2e-compose-logs\``,
+              ``,
+              `This means the shipped container does not boot + serve cleanly in LOCAL mode.`,
+              `Triage to **P0 status** on the project board (P0 is a status, not a label).`,
+            ].join('\n');
+
+            // Dedupe: comment on the existing open issue if one exists.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 1,
+            });
+
+            if (existing.data.length > 0) {
+              const number = existing.data[0].number;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                body,
+              });
+              core.info(`Commented on existing issue #${number}`);
+              return;
+            }
+
+            // Ensure the label exists before creating the issue.
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'b60205',
+                  description: 'Self-hosted release E2E failures',
+                });
+              } else {
+                throw error;
+              }
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚦 Self-hosted release E2E failed — ${date}`,
+              body,
+              labels: [label],
+            });
+            core.info(`Created issue #${created.data.number}`);

--- a/docker/docker-compose.selfhosted.yml
+++ b/docker/docker-compose.selfhosted.yml
@@ -17,13 +17,17 @@ services:
       start_period: 30s
 
   genfeed:
-    image: ghcr.io/genfeedai/genfeed.ai:latest
+    # Default :latest for real self-host users. The release E2E workflow overrides
+    # GENFEED_IMAGE_TAG to pin the exact published tag under test.
+    image: ghcr.io/genfeedai/genfeed.ai:${GENFEED_IMAGE_TAG:-latest}
     depends_on:
       postgres:
         condition: service_healthy
     ports:
-      - "${SELFHOSTED_APP_PORT:-3000}:${SELFHOSTED_APP_PORT:-3000}"  # Web UI
-      - "${SELFHOSTED_API_PORT:-3010}:${SELFHOSTED_API_PORT:-3010}"  # API
+      # Host side overridable; container side is FIXED — the entrypoint always
+      # starts the app on 3000 and the API on 3010 regardless of these vars.
+      - "${SELFHOSTED_APP_PORT:-3000}:3000"  # Web UI
+      - "${SELFHOSTED_API_PORT:-3010}:3010"  # API
     volumes:
       - genfeed_data:/data
 

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "test:e2e:full": "bunx playwright test --config=playwright/configs/playwright-full.config.ts",
     "test:e2e:coverage": "E2E_COVERAGE=1 bunx playwright test --config=playwright/configs/playwright-coverage.config.ts",
     "test:e2e:routes": "node scripts/e2e-route-coverage.mjs",
+    "test:e2e:release": "bunx playwright test --config=playwright/configs/playwright-release-e2e.config.ts",
     "type-check": "bunx turbo run type-check",
     "type-check:cli": "bunx turbo run type-check --filter=@genfeedai/cli",
     "secretlint": "secretlint '**/*'"

--- a/playwright/configs/playwright-release-e2e.config.ts
+++ b/playwright/configs/playwright-release-e2e.config.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Self-Hosted Release E2E config — drives the LIVE released container.
+ *
+ * Unlike every other config here, this one talks to a REAL backend: the
+ * `e2e-selfhosted-release.yml` workflow boots the published self-hosted image
+ * (`ghcr.io/genfeedai/genfeed.ai:<tag>`) + Postgres via docker compose in LOCAL
+ * mode, then points these specs at it. So, deliberately:
+ *   - NO `webServer` — compose owns the stack; Playwright must not spawn its own.
+ *   - NO `globalSetup`/`globalTeardown` — the shared ones force
+ *     `PLAYWRIGHT_TEST=true` (mock/bypass mode) and prune a Turbopack dev cache
+ *     that does not exist against a container. Neither applies here.
+ *   - NO mock fixtures, NO network guard — the whole point is the real API.
+ *
+ * Base URLs come from the workflow (APP_BASE_URL / API_BASE_URL), defaulting to
+ * the compose-published localhost ports for local runs.
+ */
+
+const isCI = !!process.env.CI;
+const appBaseURL = process.env.APP_BASE_URL || 'http://localhost:3000';
+const playwrightRoot = path.resolve(process.cwd(), 'playwright');
+const artifactsRoot = path.join(playwrightRoot, 'artifacts');
+const e2eRoot = path.join(playwrightRoot, 'e2e');
+
+export default defineConfig({
+  forbidOnly: isCI,
+  fullyParallel: false,
+  outputDir: path.join(artifactsRoot, 'results', 'release'),
+  projects: [
+    {
+      name: 'release',
+      use: { ...devices['Desktop Chrome'], baseURL: appBaseURL },
+    },
+  ],
+  reporter: [
+    ['list'],
+    [
+      'html',
+      {
+        open: 'never',
+        outputFolder: path.join(artifactsRoot, 'report'),
+      },
+    ],
+    ...(isCI ? [['github'] as const] : []),
+  ],
+  retries: 1,
+  testDir: path.join(e2eRoot, 'tests', 'release'),
+  timeout: 60000,
+  use: {
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+    viewport: { height: 720, width: 1280 },
+  },
+  workers: 1,
+});

--- a/playwright/e2e/tests/release/api-integration.spec.ts
+++ b/playwright/e2e/tests/release/api-integration.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Core integration proof — the spec that actually justifies this whole suite.
+ *
+ * Hits the LIVE released container's API in LOCAL mode (no Clerk, no secrets).
+ * A single `GET /v1/auth/bootstrap` exercises the entire boot chain:
+ *   CombinedAuthGuard injects local-admin (combined-auth.guard.ts) →
+ *   Prisma reads the rows SelfHostedSeedService wrote on boot
+ *   (self-hosted-seed.service.ts: admin@localhost, org/brand slug "default") →
+ *   AuthBootstrapService assembles the payload.
+ * So a 200 here with the seeded identity proves auth + DB + migrations + seed
+ * are ALL live and wired together — not just that a process is answering.
+ *
+ * Talks to the API directly on API_BASE_URL (3010), independent of the web app.
+ */
+
+const apiBaseURL = process.env.API_BASE_URL || 'http://localhost:3010';
+
+interface BootstrapBrand {
+  slug?: string;
+}
+
+interface BootstrapBody {
+  brands?: BootstrapBrand[];
+  currentUser?: { email?: string };
+}
+
+test.describe('Released image — API integration (LOCAL mode)', () => {
+  test('GET /v1/auth/bootstrap returns the seeded local-admin identity', async ({
+    request,
+  }) => {
+    const response = await request.get(`${apiBaseURL}/v1/auth/bootstrap`);
+
+    expect(
+      response.status(),
+      'bootstrap must 200 — auth injection + DB + seed all live',
+    ).toBe(200);
+
+    const body = (await response.json()) as BootstrapBody;
+
+    // Seeded user proves the guard injected local-admin AND Prisma read the seed.
+    expect(
+      body.currentUser?.email,
+      'bootstrap currentUser must be the seeded admin@localhost',
+    ).toBe('admin@localhost');
+
+    // Seeded brand proves the default org/brand rows exist and serialize.
+    const brandSlugs = (body.brands ?? []).map((brand) => brand.slug);
+
+    expect(
+      brandSlugs,
+      'bootstrap must include the seeded default brand',
+    ).toContain('default');
+  });
+
+  test('GET /v1/auth/bootstrap/overview returns 200', async ({ request }) => {
+    const response = await request.get(
+      `${apiBaseURL}/v1/auth/bootstrap/overview`,
+    );
+
+    expect(response.status(), 'bootstrap/overview must 200 in LOCAL mode').toBe(
+      200,
+    );
+  });
+});

--- a/playwright/e2e/tests/release/app-loads.spec.ts
+++ b/playwright/e2e/tests/release/app-loads.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Root entry — the released web app boots and routes a fresh visitor.
+ *
+ * In LOCAL mode the app has no Clerk, so proxy.ts redirects `/` straight to the
+ * seeded workspace (SEEDED_WORKSPACE_PATH = /default/default/workspace/overview)
+ * rather than to /login. Landing there proves the Next.js server is up AND the
+ * LOCAL-mode routing path is active.
+ *
+ * SCOPE: routing/liveness ONLY. That redirect target is a hardcoded constant in
+ * proxy.ts — it does NOT consult the API/DB/seed, so this spec must not be read
+ * as integration proof. The real proofs are api-integration.spec.ts (bootstrap)
+ * and workspace-loads.spec.ts (seeded label in the live shell).
+ */
+
+const SEEDED_WORKSPACE_PATH = '/default/default/workspace/overview';
+
+test.describe('Released image — app entry', () => {
+  test('GET / redirects into the seeded workspace, not login', async ({
+    page,
+  }) => {
+    const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    expect(
+      response?.status() ?? 0,
+      'root must not return an HTTP error',
+    ).toBeLessThan(400);
+
+    expect(page.url(), 'LOCAL mode must not redirect to login').not.toMatch(
+      /\/login/,
+    );
+    expect(page.url(), 'root must land on the seeded workspace').toContain(
+      SEEDED_WORKSPACE_PATH,
+    );
+
+    await expect(page.locator('body')).not.toBeEmpty();
+  });
+});

--- a/playwright/e2e/tests/release/health.spec.ts
+++ b/playwright/e2e/tests/release/health.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Liveness — secondary, documented as liveness-ONLY.
+ *
+ * `/v1/health/ready` is a STATIC `{ status }` body (health.controller.ts); it
+ * proves the API process answers but says NOTHING about DB/seed/auth. The real
+ * integration gate is api-integration.spec.ts (bootstrap). This spec only
+ * guards against the API process being entirely absent.
+ */
+
+const apiBaseURL = process.env.API_BASE_URL || 'http://localhost:3010';
+
+test.describe('Released image — liveness', () => {
+  test('GET /v1/health/ready reports ready', async ({ request }) => {
+    const response = await request.get(`${apiBaseURL}/v1/health/ready`);
+
+    expect(response.status(), 'health endpoint must answer').toBe(200);
+
+    const body = (await response.json()) as { status?: string };
+
+    expect(body.status, 'health body must carry a status').toBe('ready');
+  });
+});

--- a/playwright/e2e/tests/release/workspace-loads.spec.ts
+++ b/playwright/e2e/tests/release/workspace-loads.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Frontend ↔ API integration — the workspace shell renders SEEDED data.
+ *
+ * This is deliberately stronger than "Next served HTML". The overview server
+ * loader swallows API failures into empty UI (overview-page-data.server.ts), so
+ * a shell-only assertion would go green even with the API down. Instead we bind
+ * to the protected layout's bootstrap result: the workspace switcher trigger
+ * only shows the seeded label ("Default Workspace" / "Default Brand") once
+ * AuthBootstrapService returned the seeded org/brand. So requiring that label
+ * proves the web app fetched live data from the real API.
+ */
+
+const SEEDED_WORKSPACE_PATH = '/default/default/workspace/overview';
+
+test.describe('Released image — workspace shell', () => {
+  test('seeded workspace renders with live brand/org data', async ({
+    page,
+  }) => {
+    const response = await page.goto(SEEDED_WORKSPACE_PATH, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    expect(
+      response?.status() ?? 0,
+      'workspace must not return an HTTP error',
+    ).toBeLessThan(400);
+
+    // Middleware accepted the seeded slugs — no auth bounce.
+    expect(page.url(), 'must not redirect to login').not.toMatch(/\/login/);
+    expect(page.url(), 'must not redirect to onboarding').not.toMatch(
+      /\/onboarding/,
+    );
+
+    // No framework error overlay.
+    await expect(
+      page.locator('[data-nextjs-dialog]'),
+      'workspace rendered a framework error overlay',
+    ).toHaveCount(0);
+
+    // Shell chrome mounted (protected layout resolved).
+    const switcher = page.getByTestId('workspace-switcher-trigger');
+    await expect(switcher, 'workspace switcher must mount').toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Seed-bound: the switcher label is the seeded "Default …" workspace/brand,
+    // which only appears when bootstrap returned the seeded org/brand from the
+    // live API. This is the assertion that proves real integration.
+    await expect(
+      switcher,
+      'switcher must show the seeded "Default" workspace label',
+    ).toContainText(/default/i, { timeout: 30_000 });
+  });
+});


### PR DESCRIPTION
## What

Scheduled GitHub Action that tests the **RELEASED** self-hosted image — the exact artifact users `docker run`, produced by **Docker Publish (Self-Hosted)** on release (`ghcr.io/genfeedai/genfeed.ai:latest`). Boots it against a throwaway Postgres in **LOCAL mode** (no Clerk, no secrets) and drives Playwright critical-path specs through the live API + frontend + DB stack.

This is the **only** suite proving real **API ↔ frontend ↔ Postgres** integration. The existing `e2e.yml` runs the frontend against a **mocked** backend (`NEXT_PUBLIC_PLAYWRIGHT_TEST=true`), so it never verifies the shipped container actually boots and serves.

## Triggers

- **`schedule`** — every 3 days, `cron: "23 5 */3 * *"` (off-`:00` hygiene)
- **`workflow_run`** — right after each Docker publish, guarded on `conclusion == 'success'`, so `:latest` is the freshly-released artifact
- **`workflow_dispatch`** — manual/CI dry-run with an `image_tag` input (default `latest`)

## How it avoids a false green

Migrate + seed run **async on boot**, so liveness can be green before the DB is usable. Two-stage readiness gate closes that window:

- **Stage 1 (≤120s)** — static liveness: `/v1/health/ready` + `/playwright-ready`. Proves processes answer.
- **Stage 2 (≤180s)** — the one that matters: poll `/v1/auth/bootstrap` until the body contains `admin@localhost`. Drives LOCAL-mode auth injection → Prisma → `SelfHostedSeedService` rows, so it only greens once **DB + migrations + seed + auth** are all live.

Both fail loud (`::error::` + `exit 1`) on timeout — specs never run against a half-booted stack.

## Specs (`playwright/e2e/tests/release/`)

| Spec | Proves |
|------|--------|
| **`api-integration.spec.ts`** (core proof) | `GET /v1/auth/bootstrap` → 200 with seeded `admin@localhost` + `default` brand. Auth injection → Prisma → seed in one call. |
| `workspace-loads.spec.ts` | Seeded workspace renders; switcher label is fed from the bootstrap brand/org (seed-bound, not URL) → real frontend↔API integration. |
| `app-loads.spec.ts` | `GET /` redirects into the seeded workspace, not `/login` (routing/liveness scope — documented as not integration proof). |
| `health.spec.ts` | `/v1/health/ready` liveness (secondary). |

Every assertion targets **positive seeded data**, never mere chrome — the overview/bootstrap server loaders swallow API failures into empty UI, so a shell-only assertion would false-green when the API is down.

## On failure

`report-failure` job files a **deduped** `release-e2e`-labeled issue (comments on the existing open one if present) with the run URL, image tag, and artifact names. Body says triage to **P0 status** on the board — **no P0 label** (P0 is a board status, not a label).

## Also in this PR

- **Compose:** image tag overridable via `${GENFEED_IMAGE_TAG:-latest}` (default unchanged for real users).
- **Compose port-mapping fix:** was `${VAR}:${VAR}` (host:host) — a custom host port broke because the container always listens on fixed `3000`/`3010`. Now `${VAR}:3000` / `${VAR}:3010`.
- **`package.json`:** `test:e2e:release` script.

## ⚠️ Hard prerequisite before this can pass

`ghcr.io/genfeedai/genfeed.ai:latest` **currently 404s** — the historical `v0.1.1` publish predates the ca-certs fix (`474062245`) and bun `1.3.14` (`eab4fd8a7`). The E2E cannot pass until `:latest` is republished (cut a release, or re-run `docker-publish.yml` from master). Master-gated; not done in this PR.

## Notes

- Workflow goes live only once on **master** (`workflow_run` + `schedule` fire from the default branch). Normal promotion: develop → staging → master.
- `turbo lint` + `type-check` were deferred to CI (worktree had no `node_modules`); biome + actionlint passed locally; codex adversarial review done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)