### PR TITLE
fix(docs): repoint core-loop permalinks develop→master (unblock staging→master)

### DIFF
--- a/apps/docs/content/core-loop/agent-orchestration.mdx
+++ b/apps/docs/content/core-loop/agent-orchestration.mdx
@@ -6,22 +6,22 @@ This page documents the V1 simplification target tracked by `#187`.
 
 The repo has a real agent runtime, but the ownership model is hard to read because several modules still look like competing orchestrators:
 
-- [`apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts)
+- [`apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts)
   - owns the chat entrypoint, tool loop, model selection, stream start, and credit checks
   - imports a broad graph of collections, integrations, workflow modules, and agent helpers through `forwardRef`
-- [`apps/server/api/src/services/agent-threading/agent-threading.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/agent-threading/agent-threading.module.ts)
+- [`apps/server/api/src/services/agent-threading/agent-threading.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/agent-threading/agent-threading.module.ts)
   - owns the event log, projected thread snapshot, runtime session binding, input requests, and per-thread execution lane
-- [`apps/server/api/src/services/agent-spawn/agent-spawn.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/agent-spawn/agent-spawn.module.ts)
+- [`apps/server/api/src/services/agent-spawn/agent-spawn.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/agent-spawn/agent-spawn.module.ts)
   - delegates work to sub-agents by reaching back into the main orchestrator
-- [`apps/server/api/src/services/agent-campaign/agent-campaign-orchestrator.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/agent-campaign/agent-campaign-orchestrator.module.ts)
+- [`apps/server/api/src/services/agent-campaign/agent-campaign-orchestrator.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/agent-campaign/agent-campaign-orchestrator.module.ts)
   - owns recurring campaign queues, trigger evaluation, campaign memory extraction, and an older `ContentEngineService`
-- [`apps/server/api/src/services/content-engine/content-engine.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/content-engine/content-engine.module.ts)
+- [`apps/server/api/src/services/content-engine/content-engine.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/content-engine/content-engine.module.ts)
   - owns content plans, drafts, execution, review, and skill-driven content work
-- [`apps/server/api/src/services/content-orchestration/content-orchestration.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/content-orchestration/content-orchestration.module.ts)
+- [`apps/server/api/src/services/content-orchestration/content-orchestration.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/content-orchestration/content-orchestration.module.ts)
   - owns deterministic media pipeline execution and queueing
-- [`apps/server/api/src/services/workflow-executor/workflow-executor.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/workflow-executor/workflow-executor.module.ts)
+- [`apps/server/api/src/services/workflow-executor/workflow-executor.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/workflow-executor/workflow-executor.module.ts)
   - owns older workflow processors for persona media, sound overlay, and trend inspiration
-- [`apps/server/api/src/services/skill-executor/skill-executor.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/skill-executor/skill-executor.module.ts)
+- [`apps/server/api/src/services/skill-executor/skill-executor.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/skill-executor/skill-executor.module.ts)
   - owns deterministic skill handlers for trend discovery, content writing, and image generation
 
 The pain is not that these modules exist. The pain is that their names and dependencies make it unclear which layer is allowed to own long-running agent state, which layer owns deterministic execution, and which layer is just scheduling or adaptation.

--- a/apps/docs/content/core-loop/analytics-backbone.mdx
+++ b/apps/docs/content/core-loop/analytics-backbone.mdx
@@ -6,36 +6,36 @@ This page documents the OSS v1 analytics surface tracked by `#160`.
 
 The repo currently has these active OSS analytics-facing surfaces that matter for v1:
 
-- [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/app.module.ts)
+- [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/app.module.ts)
   - imports `PostsModule`
   - imports `ContentPerformanceModule`
   - imports `BusinessAnalyticsModule`
   - imports `AnalyticsModule`
 - Provider metric ingestion and publication analytics:
-  - [`apps/server/api/src/collections/posts/posts.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/posts/posts.module.ts)
-  - [`apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.ts)
-  - [`apps/server/api/src/collections/posts/services/post-analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/posts/services/post-analytics.service.ts)
-  - [`apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts)
+  - [`apps/server/api/src/collections/posts/posts.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/posts/posts.module.ts)
+  - [`apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.ts)
+  - [`apps/server/api/src/collections/posts/services/post-analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/posts/services/post-analytics.service.ts)
+  - [`apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts)
 - Brand-facing analytics rollups:
-  - [`apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.ts)
-  - [`apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts)
+  - [`apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.ts)
+  - [`apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts)
 - Content-performance feedback loop:
-  - [`apps/server/api/src/collections/content-performance/content-performance.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/content-performance/content-performance.module.ts)
-  - [`apps/server/api/src/collections/content-performance/controllers/performance-summary.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/content-performance/controllers/performance-summary.controller.ts)
-  - [`apps/server/api/src/collections/content-performance/services/performance-summary.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/content-performance/services/performance-summary.service.ts)
-  - [`apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts)
+  - [`apps/server/api/src/collections/content-performance/content-performance.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/content-performance/content-performance.module.ts)
+  - [`apps/server/api/src/collections/content-performance/controllers/performance-summary.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/content-performance/controllers/performance-summary.controller.ts)
+  - [`apps/server/api/src/collections/content-performance/services/performance-summary.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/content-performance/services/performance-summary.service.ts)
+  - [`apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts)
 - Collection-facing business analytics:
-  - [`apps/server/api/src/collections/business-analytics/business-analytics.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/business-analytics/business-analytics.module.ts)
-  - [`apps/server/api/src/collections/business-analytics/services/business-analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/business-analytics/services/business-analytics.service.ts)
-  - [`apps/server/api/src/collections/business-analytics/controllers/business-analytics.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/business-analytics/controllers/business-analytics.controller.ts)
+  - [`apps/server/api/src/collections/business-analytics/business-analytics.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/business-analytics/business-analytics.module.ts)
+  - [`apps/server/api/src/collections/business-analytics/services/business-analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/business-analytics/services/business-analytics.service.ts)
+  - [`apps/server/api/src/collections/business-analytics/controllers/business-analytics.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/business-analytics/controllers/business-analytics.controller.ts)
 - Endpoint-level organization and brand analytics:
-  - [`apps/server/api/src/endpoints/analytics/analytics.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/endpoints/analytics/analytics.module.ts)
-  - [`apps/server/api/src/endpoints/analytics/analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/endpoints/analytics/analytics.service.ts)
-  - [`apps/server/api/src/endpoints/analytics/analytics.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/endpoints/analytics/analytics.controller.ts)
-  - [`apps/server/api/src/endpoints/analytics/business-analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/endpoints/analytics/business-analytics.service.ts)
+  - [`apps/server/api/src/endpoints/analytics/analytics.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/endpoints/analytics/analytics.module.ts)
+  - [`apps/server/api/src/endpoints/analytics/analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/endpoints/analytics/analytics.service.ts)
+  - [`apps/server/api/src/endpoints/analytics/analytics.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/endpoints/analytics/analytics.controller.ts)
+  - [`apps/server/api/src/endpoints/analytics/business-analytics.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/endpoints/analytics/business-analytics.service.ts)
 - Thin consumers of the same analytics services:
-  - [`apps/server/api/src/endpoints/mcp/mcp.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/endpoints/mcp/mcp.controller.ts)
-  - [`apps/server/api/src/collections/agent-goals/services/agent-goals.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/agent-goals/services/agent-goals.service.ts)
+  - [`apps/server/api/src/endpoints/mcp/mcp.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/endpoints/mcp/mcp.controller.ts)
+  - [`apps/server/api/src/collections/agent-goals/services/agent-goals.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/agent-goals/services/agent-goals.service.ts)
 
 ## Ownership Notes For V1
 
@@ -128,7 +128,7 @@ flowchart LR
 
 The narrow business-analytics verification path for v1 is in:
 
-- [`apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts)
+- [`apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts)
 
 The smoke test proves that representative aggregate inputs are converted into a complete dashboard response with:
 
@@ -143,7 +143,7 @@ That is enough to show the ingestion-to-dashboard contract is still wired withou
 
 The provider-ingestion smoke path for v1 is in:
 
-- [`apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts)
+- [`apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts)
 
 It verifies the representative media analytics path:
 

--- a/apps/docs/content/core-loop/generation-service.mdx
+++ b/apps/docs/content/core-loop/generation-service.mdx
@@ -6,29 +6,29 @@ This page documents the OSS v1 generation surface tracked by `#161`.
 
 The generation story in the current repo spans a small set of stable entrypoints plus provider packages:
 
-- [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/app.module.ts)
+- [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/app.module.ts)
   - imports `BatchGenerationModule`
   - imports the provider-facing integration modules used by generation flows
-- [`apps/server/api/src/services/batch-generation/batch-generation.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/batch-generation/batch-generation.module.ts)
+- [`apps/server/api/src/services/batch-generation/batch-generation.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/batch-generation/batch-generation.module.ts)
   - owns the batch-generation controller/service pair
   - persists batch jobs on the cloud connection
-- [`apps/server/api/src/services/batch-generation/batch-generation.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/batch-generation/batch-generation.controller.ts)
+- [`apps/server/api/src/services/batch-generation/batch-generation.controller.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/batch-generation/batch-generation.controller.ts)
   - exposes the stable batch entrypoints under `batches`
   - routes create/process/review operations into the service layer
-- [`apps/server/api/src/services/batch-generation/batch-generation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/batch-generation/batch-generation.service.ts)
+- [`apps/server/api/src/services/batch-generation/batch-generation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/batch-generation/batch-generation.service.ts)
   - builds batch plans
   - delegates actual generation to `ContentGeneratorService`
-- [`packages/tools/src/registry/source.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/packages/tools/src/registry/source.ts)
+- [`packages/tools/src/registry/source.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/tools/src/registry/source.ts)
   - defines the canonical agent-visible generation tools
-- [`packages/tools/src/registry/tool-registry.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/packages/tools/src/registry/tool-registry.ts)
+- [`packages/tools/src/registry/tool-registry.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/tools/src/registry/tool-registry.ts)
   - assigns generation tool categories and UI action cards
-- [`apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts)
+- [`apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts)
   - dispatches generation tools to the internal media APIs
-- [`packages/services/ai/enhanced-models.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/packages/services/ai/enhanced-models.service.ts)
+- [`packages/services/ai/enhanced-models.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/services/ai/enhanced-models.service.ts)
   - merges base catalog models with provider-discovered models
 - Provider packages:
-  - [`packages/services/ai/providers/fal/fal-provider.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/packages/services/ai/providers/fal/fal-provider.service.ts)
-  - [`packages/services/ai/providers/huggingface/huggingface-provider.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/packages/services/ai/providers/huggingface/huggingface-provider.service.ts)
+  - [`packages/services/ai/providers/fal/fal-provider.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/services/ai/providers/fal/fal-provider.service.ts)
+  - [`packages/services/ai/providers/huggingface/huggingface-provider.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/services/ai/providers/huggingface/huggingface-provider.service.ts)
 
 ## Stable Generation Surface
 
@@ -83,7 +83,7 @@ flowchart LR
 
 The representative media verification path for v1 is in:
 
-- [`apps/server/api/src/services/skill-executor/stable-provider-path.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/skill-executor/stable-provider-path.spec.ts)
+- [`apps/server/api/src/services/skill-executor/stable-provider-path.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/skill-executor/stable-provider-path.spec.ts)
 
 The test uses mocked provider services so it can run in CI without live credentials, but it keeps the production service wiring:
 

--- a/apps/docs/content/core-loop/index.mdx
+++ b/apps/docs/content/core-loop/index.mdx
@@ -25,7 +25,7 @@ The v1 milestone is not blocked on inventing these systems from scratch. It is b
 
 ## Core Module Spine
 
-The main server app already wires the three v1 surfaces directly in [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/app.module.ts):
+The main server app already wires the three v1 surfaces directly in [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/app.module.ts):
 
 - `TrendsModule`
 - `BatchGenerationModule`

--- a/apps/docs/content/core-loop/trend-ingestion.mdx
+++ b/apps/docs/content/core-loop/trend-ingestion.mdx
@@ -6,18 +6,18 @@ This page documents the OSS v1 trend-ingestion surface tracked by `#159`.
 
 The current repo has a real Step 1 ingestion path, not a placeholder:
 
-- [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/app.module.ts)
+- [`apps/server/api/src/app.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/app.module.ts)
   - imports `TrendsModule`
   - imports `TwitterPipelineModule`
-- [`apps/server/api/src/collections/trends/trends.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/trends/trends.module.ts)
+- [`apps/server/api/src/collections/trends/trends.module.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/trends/trends.module.ts)
   - owns the `Trend`, `TrendingVideo`, `TrendingHashtag`, `TrendingSound`, and reference schemas
   - wires `TrendFetchService`, `TrendFilteringService`, `TrendAnalysisService`, `TrendContentIdeasService`, `TrendVideoService`, `TrendReferenceCorpusService`, and `TrendsService`
-- [`apps/server/api/src/collections/trends/services/trends.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/trends/services/trends.service.ts)
+- [`apps/server/api/src/collections/trends/services/trends.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/trends/services/trends.service.ts)
   - provides the canonical cached/live-fetch read path
   - hydrates source previews
   - syncs trend references
   - invalidates trend-content cache after fetch
-- [`apps/server/api/src/services/twitter-pipeline/twitter-pipeline.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/services/twitter-pipeline/twitter-pipeline.service.ts)
+- [`apps/server/api/src/services/twitter-pipeline/twitter-pipeline.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/twitter-pipeline/twitter-pipeline.service.ts)
   - provides a focused Twitter-specific search -> draft -> publish path used by the broader trend workflow
 
 ## Stable OSS Surface
@@ -141,8 +141,8 @@ flowchart LR
 
 The narrow Step 1 verification paths for v1 are in:
 
-- [`apps/server/api/src/collections/trends/services/trends.service.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/trends/services/trends.service.spec.ts)
-- [`apps/server/api/src/collections/trends/services/modules/trend-fetch.service.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/develop/apps/server/api/src/collections/trends/services/modules/trend-fetch.service.spec.ts)
+- [`apps/server/api/src/collections/trends/services/trends.service.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/trends/services/trends.service.spec.ts)
+- [`apps/server/api/src/collections/trends/services/modules/trend-fetch.service.spec.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/collections/trends/services/modules/trend-fetch.service.spec.ts)
 
 The orchestrator smoke test proves the cache-miss path is wired:
 


### PR DESCRIPTION
## Problem

The `staging→master` PR (#568) is blocked by the **"Docs + Markdown Dead Links"** lychee check. 46 links fail with `[404]` because `apps/docs/content/core-loop/*.mdx` contains 48 source permalinks pointing at the `blob/develop/` ref.

The public `genfeed.ai` repo only publishes `master` and `staging` as live heads — **`develop` no longer resolves as a ref** (auto-deleted when #567 `develop→staging` merged). Every `…/blob/develop/<path>` link 404s at the ref level, regardless of whether the target file exists.

## Fix

Repoint all 48 permalinks from `blob/develop/` → `blob/master/`:

- Pure ref swap — 48 insertions / 48 deletions, no content changes.
- All 43 unique referenced source paths exist on the current `master` tree (verified: master-missing = 0).
- `lychee.toml` intentionally does **not** exclude `github.com`, so real blob 404s are caught — repointing (not excluding) is the correct fix.

## Verification

Ran lychee locally over the exact CI scope (`--config lychee.toml 'apps/docs/content/**/*.md' 'apps/docs/content/**/*.mdx' 'README.md' 'apps/website/README.md'`):

```
🔍 251 Total ✅ 124 OK 🚫 0 Errors 👻 127 Excluded 🔀 15 Redirects
EXIT=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
