### PR TITLE
fix(storage): namespace lora/voice-clone/video uploads under ingredients/ prefix

### DIFF
--- a/apps/server/images/src/controllers/lora.controller.spec.ts
+++ b/apps/server/images/src/controllers/lora.controller.spec.ts
@@ -44,7 +44,7 @@ describe('LoraController', () => {
 
       const result: LoraUploadResult = {
         loraName: 'my-lora',
-        s3Key: 'trainings/loras/my-lora.safetensors',
+        s3Key: 'ingredients/trainings/loras/my-lora.safetensors',
         uploaded: true,
       };
 
@@ -64,7 +64,7 @@ describe('LoraController', () => {
 
       mockLoraService.uploadLora.mockResolvedValue({
         loraName: 'lora-v2',
-        s3Key: 'trainings/loras/lora-v2.safetensors',
+        s3Key: 'ingredients/trainings/loras/lora-v2.safetensors',
         uploaded: true,
       });
 
@@ -131,7 +131,7 @@ describe('LoraController', () => {
           {
             filename: 's3-lora.safetensors',
             name: 's3-lora',
-            s3Key: 'trainings/loras/s3-lora.safetensors',
+            s3Key: 'ingredients/trainings/loras/s3-lora.safetensors',
             source: 's3',
           },
         ],

--- a/apps/server/images/src/services/lora.service.spec.ts
+++ b/apps/server/images/src/services/lora.service.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from '@images/config/config.service';
 import { LoraService } from '@images/services/lora.service';
-import { S3Service } from '@images/services/s3.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { S3Service } from '@libs/s3/s3.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -69,11 +69,13 @@ describe('LoraService', () => {
       });
 
       expect(result.loraName).toBe('my-lora');
-      expect(result.s3Key).toBe('trainings/loras/my-lora.safetensors');
+      expect(result.s3Key).toBe(
+        'ingredients/trainings/loras/my-lora.safetensors',
+      );
       expect(result.uploaded).toBe(true);
       expect(mockS3Service.uploadFile).toHaveBeenCalledWith(
         'test-bucket',
-        'trainings/loras/my-lora.safetensors',
+        'ingredients/trainings/loras/my-lora.safetensors',
         '/comfyui/models/loras/my-lora.safetensors',
       );
     });
@@ -141,7 +143,7 @@ describe('LoraService', () => {
       mockReaddir.mockResolvedValue([]);
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/loras/s3-model.safetensors',
+          key: 'ingredients/trainings/loras/s3-model.safetensors',
           lastModified: '2024-02-01T00:00:00.000Z',
           size: 2048,
         },
@@ -153,7 +155,7 @@ describe('LoraService', () => {
       expect(result.loras[0].name).toBe('s3-model');
       expect(result.loras[0].source).toBe('s3');
       expect(result.loras[0].s3Key).toBe(
-        'trainings/loras/s3-model.safetensors',
+        'ingredients/trainings/loras/s3-model.safetensors',
       );
     });
 
@@ -165,7 +167,7 @@ describe('LoraService', () => {
       });
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/loras/shared-model.safetensors',
+          key: 'ingredients/trainings/loras/shared-model.safetensors',
           lastModified: '2024-02-01T00:00:00.000Z',
           size: 2048,
         },
@@ -181,7 +183,7 @@ describe('LoraService', () => {
       mockReaddir.mockRejectedValue(new Error('ENOENT'));
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/loras/s3-model.safetensors',
+          key: 'ingredients/trainings/loras/s3-model.safetensors',
           lastModified: '2024-02-01T00:00:00.000Z',
           size: 2048,
         },

--- a/apps/server/images/src/services/lora.service.ts
+++ b/apps/server/images/src/services/lora.service.ts
@@ -17,7 +17,7 @@ import {
 } from '@nestjs/common';
 
 const SAFETENSORS_EXT = '.safetensors';
-const S3_LORA_PREFIX = 'trainings/loras/';
+const S3_LORA_PREFIX = 'ingredients/trainings/loras/';
 
 @Injectable()
 export class LoraService {

--- a/apps/server/videos/src/services/generation.service.spec.ts
+++ b/apps/server/videos/src/services/generation.service.spec.ts
@@ -1,11 +1,11 @@
 import { LoggerService } from '@libs/logger/logger.service';
+import { S3Service } from '@libs/s3/s3.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@videos/config/config.service';
 import type { GenerateVideoRequest } from '@videos/interfaces/videos.interfaces';
 import { ComfyUIService } from '@videos/services/comfyui.service';
 import { GenerationService } from '@videos/services/generation.service';
 import { JobService } from '@videos/services/job.service';
-import { S3Service } from '@videos/services/s3.service';
 import { WorkflowService } from '@videos/services/workflow.service';
 
 describe('GenerationService', () => {
@@ -159,7 +159,7 @@ describe('GenerationService', () => {
 
       expect(s3Service.uploadFile).toHaveBeenCalledWith(
         'test-bucket',
-        expect.stringContaining('videos/generated/job-abc-123'),
+        expect.stringContaining('ingredients/videos/generated/job-abc-123'),
         expect.stringContaining('output-video.mp4'),
         'video/mp4',
       );

--- a/apps/server/videos/src/services/generation.service.ts
+++ b/apps/server/videos/src/services/generation.service.ts
@@ -100,7 +100,7 @@ export class GenerationService {
 
       if (outputFilename) {
         // Upload to S3 and build CDN URL
-        const s3Key = `videos/generated/${jobId}/${outputFilename}`;
+        const s3Key = `ingredients/videos/generated/${jobId}/${outputFilename}`;
         const localPath = join(
           this.configService.COMFYUI_OUTPUT_PATH,
           outputFilename,

--- a/apps/server/voices/src/services/voice-clone.service.spec.ts
+++ b/apps/server/voices/src/services/voice-clone.service.spec.ts
@@ -1,8 +1,8 @@
 import { LoggerService } from '@libs/logger/logger.service';
+import { S3Service } from '@libs/s3/s3.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@voices/config/config.service';
-import { S3Service } from '@voices/services/s3.service';
 import { VoiceCloneService } from '@voices/services/voice-clone.service';
 
 // Mock node:fs/promises
@@ -69,11 +69,13 @@ describe('VoiceCloneService', () => {
       });
 
       expect(result.voiceId).toBe('my-voice');
-      expect(result.s3Key).toBe('trainings/voice-clones/my-voice/model.pth');
+      expect(result.s3Key).toBe(
+        'ingredients/trainings/voice-clones/my-voice/model.pth',
+      );
       expect(result.uploaded).toBe(true);
       expect(mockS3Service.uploadFile).toHaveBeenCalledWith(
         'test-bucket',
-        'trainings/voice-clones/my-voice/model.pth',
+        'ingredients/trainings/voice-clones/my-voice/model.pth',
         '/models/voices/my-voice/model.pth',
       );
     });
@@ -121,7 +123,7 @@ describe('VoiceCloneService', () => {
     it('should download clone files from S3', async () => {
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/voice-clones/my-voice/model.pth',
+          key: 'ingredients/trainings/voice-clones/my-voice/model.pth',
           lastModified: '2024-01-01T00:00:00.000Z',
           size: 1024,
         },
@@ -173,7 +175,7 @@ describe('VoiceCloneService', () => {
       mockReaddir.mockResolvedValue([]);
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/voice-clones/s3-voice/model.pth',
+          key: 'ingredients/trainings/voice-clones/s3-voice/model.pth',
           lastModified: '2024-02-01T00:00:00.000Z',
           size: 2048,
         },
@@ -195,7 +197,7 @@ describe('VoiceCloneService', () => {
         .mockResolvedValueOnce({ mtime: new Date('2024-01-01'), size: 1024 });
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/voice-clones/shared-voice/model.pth',
+          key: 'ingredients/trainings/voice-clones/shared-voice/model.pth',
           lastModified: '2024-02-01T00:00:00.000Z',
           size: 2048,
         },
@@ -211,7 +213,7 @@ describe('VoiceCloneService', () => {
       mockReaddir.mockRejectedValue(new Error('ENOENT'));
       mockS3Service.listObjects.mockResolvedValue([
         {
-          key: 'trainings/voice-clones/s3-voice/model.pth',
+          key: 'ingredients/trainings/voice-clones/s3-voice/model.pth',
           lastModified: '2024-02-01T00:00:00.000Z',
           size: 2048,
         },

--- a/apps/server/voices/src/services/voice-clone.service.ts
+++ b/apps/server/voices/src/services/voice-clone.service.ts
@@ -16,7 +16,7 @@ import type {
   VoiceCloneUploadResult,
 } from '@voices/interfaces/voice-clone.interfaces';
 
-const S3_VOICE_CLONE_PREFIX = 'trainings/voice-clones/';
+const S3_VOICE_CLONE_PREFIX = 'ingredients/trainings/voice-clones/';
 const MODEL_EXTENSIONS = new Set(['.pth', '.onnx', '.bin', '.safetensors']);
 
 @Injectable()

--- a/packages/libs/s3/s3.service.spec.ts
+++ b/packages/libs/s3/s3.service.spec.ts
@@ -177,7 +177,9 @@ describe('S3Service (shared @libs/s3)', () => {
         '/tmp/my-lora.safetensors',
       );
 
-      expect(result.s3Key).toBe('trainings/loras/my-lora.safetensors');
+      expect(result.s3Key).toBe(
+        'ingredients/trainings/loras/my-lora.safetensors',
+      );
       expect(result.sizeBytes).toBe(9);
       expect(mockSend).toHaveBeenCalledTimes(1);
       expect(mockLoggerService.log).toHaveBeenCalledTimes(2);
@@ -189,12 +191,12 @@ describe('S3Service (shared @libs/s3)', () => {
       mockSend.mockResolvedValue({
         Contents: [
           {
-            Key: 'trainings/loras/model-a.safetensors',
+            Key: 'ingredients/trainings/loras/model-a.safetensors',
             LastModified: new Date('2024-01-01'),
             Size: 1024,
           },
           {
-            Key: 'trainings/loras/model-b.safetensors',
+            Key: 'ingredients/trainings/loras/model-b.safetensors',
             LastModified: new Date('2024-01-02'),
             Size: 2048,
           },
@@ -204,11 +206,13 @@ describe('S3Service (shared @libs/s3)', () => {
 
       const result = await service.listObjects(
         'test-bucket',
-        'trainings/loras/',
+        'ingredients/trainings/loras/',
       );
 
       expect(result).toHaveLength(2);
-      expect(result[0].key).toBe('trainings/loras/model-a.safetensors');
+      expect(result[0].key).toBe(
+        'ingredients/trainings/loras/model-a.safetensors',
+      );
       expect(result[0].size).toBe(1024);
     });
 

--- a/packages/libs/s3/s3.service.ts
+++ b/packages/libs/s3/s3.service.ts
@@ -162,7 +162,7 @@ export class S3Service {
     localPath: string,
   ): Promise<{ s3Key: string; sizeBytes: number }> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    const s3Key = `trainings/loras/${loraName}.safetensors`;
+    const s3Key = `ingredients/trainings/loras/${loraName}.safetensors`;
 
     this.loggerService.log(caller, {
       bucket,


### PR DESCRIPTION
## Why
While fixing prod SSM `AWS_S3_BUCKET` (was `ingredients.genfeed.ai`, a non-existent bucket → 404; corrected to `cdn.genfeed.ai`), audited every S3 upload path. Three services build object keys at the **bucket root** instead of under the `ingredients/` namespace. Since `cdn.genfeed.ai` also holds `assets/`, `skills/`, and unrelated content, those uploads would dump at root.

A bucket name can't carry a path (`cdn.genfeed.ai/ingredients` is invalid), so the `ingredients/` prefix must live in the **object key**.

## What
Aligned the 3 stray paths with the files-service convention (`generateS3Key` → `ingredients/<type>/<id>`) and the existing `cdn.genfeed.ai/ingredients/` layout:

| Service | Before | After |
|---|---|---|
| videos `generation.service` | `videos/generated/…` | `ingredients/videos/generated/…` |
| voices `voice-clone.service` | `trainings/voice-clones/…` | `ingredients/trainings/voice-clones/…` |
| images `lora.service` + `libs/s3 uploadSafetensors` | `trainings/loras/…` | `ingredients/trainings/loras/…` |

Each writer's prefix kept in sync with its reader/lister.

Also repaired stale spec imports (`@x/services/s3.service` → `@libs/s3/s3.service`) that had broken these specs on load since the cloud migration — they execute again now.

## Tests
55 pass — images 19, voices 14, videos 11, libs 11.

## ⚠️ Deploy ordering
This must reach `master` **before** the next Deploy Production that re-renders the corrected `AWS_S3_BUCKET=cdn.genfeed.ai` from SSM. Otherwise the window between bucket-fix-live and this-code-live = root dumps.