### PR TITLE
fix: address CodeRabbit review findings across bots, billing, and DTOs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -90,7 +90,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Normalize app Vercel production env
         run: |
           set -euo pipefail
@@ -131,7 +133,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - run: npx vercel deploy --cwd . --archive=tgz --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -143,7 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - run: npx vercel deploy --cwd . --archive=tgz --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -155,7 +161,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-backend
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - run: npx vercel deploy --cwd . --archive=tgz --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}

--- a/apps/server/api/src/collections/assets/dto/assets-query.dto.spec.ts
+++ b/apps/server/api/src/collections/assets/dto/assets-query.dto.spec.ts
@@ -1,0 +1,32 @@
+import { AssetQueryDto } from '@api/collections/assets/dto/assets-query.dto';
+import { plainToInstance } from 'class-transformer';
+
+describe('AssetQueryDto', () => {
+  it('should be defined', () => {
+    expect(AssetQueryDto).toBeDefined();
+  });
+
+  describe('validation', () => {
+    it('should create an instance', () => {
+      const dto = new AssetQueryDto();
+      expect(dto).toBeInstanceOf(AssetQueryDto);
+    });
+  });
+
+  describe('lightweight transform', () => {
+    it.each([
+      [undefined, false],
+      [null, false],
+      ['true', true],
+      [true, true],
+      ['false', false],
+      [false, false],
+      ['0', false],
+      [0, false],
+      ['', false],
+    ])('maps %p → %p', (input, expected) => {
+      const dto = plainToInstance(AssetQueryDto, { lightweight: input });
+      expect(dto.lightweight).toBe(expected);
+    });
+  });
+});

--- a/apps/server/api/src/collections/assets/dto/assets-query.dto.ts
+++ b/apps/server/api/src/collections/assets/dto/assets-query.dto.ts
@@ -52,6 +52,12 @@ export class AssetQueryDto extends BaseQueryDto {
     if (value === 'false' || value === false) {
       return false;
     }
+    if (value === '0' || value === 0) {
+      return false;
+    }
+    if (value === '') {
+      return false;
+    }
     return Boolean(value);
   })
   lightweight?: boolean;

--- a/apps/server/api/src/collections/bots/dto/bot-publishing-settings.dto.spec.ts
+++ b/apps/server/api/src/collections/bots/dto/bot-publishing-settings.dto.spec.ts
@@ -1,4 +1,6 @@
 import { BotPublishingSettingsDto } from '@api/collections/bots/dto/bot-publishing-settings.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
 
 describe('BotPublishingSettingsDto', () => {
   it('should be defined', () => {
@@ -9,6 +11,80 @@ describe('BotPublishingSettingsDto', () => {
     it('should create an instance', () => {
       const dto = new BotPublishingSettingsDto();
       expect(dto).toBeInstanceOf(BotPublishingSettingsDto);
+    });
+
+    describe('scheduledTimes', () => {
+      it('accepts valid HH:mm times', async () => {
+        const dto = plainToInstance(BotPublishingSettingsDto, {
+          scheduledTimes: ['00:00', '09:30', '23:59'],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(0);
+      });
+
+      it('rejects times missing the colon separator', async () => {
+        const dto = plainToInstance(BotPublishingSettingsDto, {
+          scheduledTimes: ['0930'],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(errors)).toContain(
+          'scheduledTimes must be HH:mm (24h)',
+        );
+      });
+
+      it('rejects hours above 23', async () => {
+        const dto = plainToInstance(BotPublishingSettingsDto, {
+          scheduledTimes: ['24:00'],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(errors)).toContain(
+          'scheduledTimes must be HH:mm (24h)',
+        );
+      });
+
+      it('rejects minutes above 59', async () => {
+        const dto = plainToInstance(BotPublishingSettingsDto, {
+          scheduledTimes: ['12:60'],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(errors)).toContain(
+          'scheduledTimes must be HH:mm (24h)',
+        );
+      });
+
+      it('rejects free-form time strings', async () => {
+        const dto = plainToInstance(BotPublishingSettingsDto, {
+          scheduledTimes: ['9am', 'noon', '3:00pm'],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(JSON.stringify(errors)).toContain(
+          'scheduledTimes must be HH:mm (24h)',
+        );
+      });
+
+      it('accepts an empty array', async () => {
+        const dto = plainToInstance(BotPublishingSettingsDto, {
+          scheduledTimes: [],
+        });
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(0);
+      });
     });
   });
 });

--- a/apps/server/api/src/collections/bots/dto/bot-publishing-settings.dto.ts
+++ b/apps/server/api/src/collections/bots/dto/bot-publishing-settings.dto.ts
@@ -6,6 +6,7 @@ import {
   IsInt,
   IsOptional,
   IsString,
+  Matches,
   Max,
   Min,
 } from 'class-validator';
@@ -104,6 +105,10 @@ export class BotPublishingSettingsDto {
 
   @IsArray()
   @IsString({ each: true })
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    each: true,
+    message: 'scheduledTimes must be HH:mm (24h)',
+  })
   @IsOptional()
   @ApiProperty({
     default: [],

--- a/apps/server/api/src/collections/content-intelligence/dto/add-creator.dto.spec.ts
+++ b/apps/server/api/src/collections/content-intelligence/dto/add-creator.dto.spec.ts
@@ -1,0 +1,109 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { AddCreatorDto, ScrapeConfigDto } from './add-creator.dto';
+
+describe('ScrapeConfigDto validation', () => {
+  it('accepts valid scrape config', async () => {
+    const dto = plainToInstance(ScrapeConfigDto, {
+      maxPosts: 100,
+      dateRangeDays: 90,
+      includeReplies: false,
+    });
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects maxPosts below minimum (10)', async () => {
+    const dto = plainToInstance(ScrapeConfigDto, { maxPosts: 5 });
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'maxPosts')).toBe(true);
+  });
+
+  it('rejects maxPosts above maximum (500)', async () => {
+    const dto = plainToInstance(ScrapeConfigDto, { maxPosts: 501 });
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'maxPosts')).toBe(true);
+  });
+
+  it('rejects dateRangeDays below minimum (7)', async () => {
+    const dto = plainToInstance(ScrapeConfigDto, { dateRangeDays: 3 });
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'dateRangeDays')).toBe(true);
+  });
+
+  it('rejects dateRangeDays above maximum (365)', async () => {
+    const dto = plainToInstance(ScrapeConfigDto, { dateRangeDays: 366 });
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'dateRangeDays')).toBe(true);
+  });
+
+  it('rejects non-boolean includeReplies', async () => {
+    const dto = plainToInstance(ScrapeConfigDto, { includeReplies: 'yes' });
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'includeReplies')).toBe(true);
+  });
+});
+
+describe('AddCreatorDto nested scrapeConfig validation', () => {
+  it('propagates nested ScrapeConfigDto constraint violations', async () => {
+    const dto = plainToInstance(AddCreatorDto, {
+      handle: 'testcreator',
+      platform: 'linkedin',
+      scrapeConfig: {
+        dateRangeDays: 400,
+        includeReplies: 'yes',
+        maxPosts: 1,
+      },
+    });
+    const errors = await validate(dto);
+
+    const scrapeConfigError = errors.find((e) => e.property === 'scrapeConfig');
+    expect(scrapeConfigError).toBeDefined();
+    expect(
+      scrapeConfigError?.children?.some((c) => c.property === 'maxPosts'),
+    ).toBe(true);
+    expect(
+      scrapeConfigError?.children?.some((c) => c.property === 'dateRangeDays'),
+    ).toBe(true);
+    expect(
+      scrapeConfigError?.children?.some((c) => c.property === 'includeReplies'),
+    ).toBe(true);
+  });
+
+  it('passes when scrapeConfig is omitted', async () => {
+    const dto = plainToInstance(AddCreatorDto, {
+      handle: 'testcreator',
+      platform: 'linkedin',
+    });
+    const errors = await validate(dto);
+
+    const scrapeConfigErrors = errors.filter(
+      (e) => e.property === 'scrapeConfig',
+    );
+    expect(scrapeConfigErrors).toHaveLength(0);
+  });
+
+  it('passes when scrapeConfig fields are within bounds', async () => {
+    const dto = plainToInstance(AddCreatorDto, {
+      handle: 'testcreator',
+      platform: 'linkedin',
+      scrapeConfig: {
+        dateRangeDays: 30,
+        includeReplies: true,
+        maxPosts: 50,
+      },
+    });
+    const errors = await validate(dto);
+
+    const scrapeConfigErrors = errors.filter(
+      (e) => e.property === 'scrapeConfig',
+    );
+    expect(scrapeConfigErrors).toHaveLength(0);
+  });
+});

--- a/apps/server/api/src/collections/content-intelligence/dto/add-creator.dto.ts
+++ b/apps/server/api/src/collections/content-intelligence/dto/add-creator.dto.ts
@@ -1,5 +1,6 @@
 import { ContentIntelligencePlatform } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -12,6 +13,7 @@ import {
   Max,
   MaxLength,
   Min,
+  ValidateNested,
 } from 'class-validator';
 
 export class ScrapeConfigDto {
@@ -107,6 +109,8 @@ export class AddCreatorDto {
 
   @IsObject()
   @IsOptional()
+  @ValidateNested()
+  @Type(() => ScrapeConfigDto)
   @ApiProperty({
     description: 'Scrape configuration options',
     required: false,

--- a/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.spec.ts
@@ -3,6 +3,7 @@ import { ArticlesService } from '@api/collections/articles/services/articles.ser
 import { PublicArticlesController } from '@api/endpoints/public/controllers/articles/public.articles.controller';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { ArticleCategory, ArticleStatus, AssetScope } from '@genfeedai/enums';
+import { ArticleStatus as PrismaArticleStatus } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
@@ -117,6 +118,14 @@ describe('PublicArticlesController', () => {
 
       expect(articlesService.findAll).toHaveBeenCalled();
       expect(result.data).toEqual(articles);
+
+      // Regression guard (Sentry API-GENFEED-AI-5Z): the Prisma `status`
+      // column is the ArticleStatus enum (DRAFT|PUBLISHED|ARCHIVED). Passing
+      // the app-level ArticleStatus.PUBLIC ('public') triggers
+      // PrismaClientValidationError. Must filter by PUBLISHED.
+      const call = mockArticlesService.findAll.mock.calls[0];
+      const queryArg = call[0] as { where: Record<string, unknown> };
+      expect(queryArg.where.status).toBe(PrismaArticleStatus.PUBLISHED);
     });
 
     it('should filter by search term', async () => {
@@ -229,7 +238,7 @@ describe('PublicArticlesController', () => {
         expect.objectContaining({
           _id: id,
           isDeleted: false,
-          status: ArticleStatus.PUBLIC,
+          status: PrismaArticleStatus.PUBLISHED,
         }),
       );
       expect(result).toEqual(mockArticle);

--- a/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.ts
+++ b/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.ts
@@ -9,11 +9,11 @@ import {
   serializeCollection,
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
-import { ArticleStatus } from '@genfeedai/enums';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
 } from '@genfeedai/interfaces';
+import { ArticleStatus as PrismaArticleStatus } from '@genfeedai/prisma';
 import { ArticleSerializer } from '@genfeedai/serializers';
 import { Public } from '@libs/decorators/public.decorator';
 import { PrismaWhereQuery } from '@libs/interfaces/query.interface';
@@ -63,7 +63,7 @@ export class PublicArticlesController {
     const matchQuery: PrismaWhereQuery = {
       isDeleted: false,
       publishedAt: { not: null },
-      status: ArticleStatus.PUBLIC,
+      status: PrismaArticleStatus.PUBLISHED,
     };
 
     // Add search filter
@@ -145,7 +145,7 @@ export class PublicArticlesController {
       _id: articleId,
       isDeleted: false,
       publishedAt: { not: null },
-      status: ArticleStatus.PUBLIC,
+      status: PrismaArticleStatus.PUBLISHED,
     });
 
     if (!article) {

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
@@ -9,6 +9,18 @@ type InvoiceHandlerAccessor = {
   ): Promise<void>;
 };
 
+type NormalizeObjectIdAccessor = {
+  normalizeObjectId(value: string | undefined): string | null;
+};
+
+type AttributionAccessor = {
+  trackSubscriptionAttributionFromSession(
+    session: unknown,
+    subscription: unknown,
+    url: string,
+  ): Promise<void>;
+};
+
 describe('StripeWebhookService invoice handlers', () => {
   const configService = { get: vi.fn().mockReturnValue(undefined) };
   const loggerService = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
@@ -168,5 +180,185 @@ describe('StripeWebhookService invoice handlers', () => {
 
       expect(subscriptionsService.findOne).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('StripeWebhookService normalizeObjectId', () => {
+  const configService = { get: vi.fn().mockReturnValue(undefined) };
+  const loggerService = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+
+  function buildService(): NormalizeObjectIdAccessor {
+    return new StripeWebhookService(
+      configService as never,
+      loggerService as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    ) as unknown as NormalizeObjectIdAccessor;
+  }
+
+  it('returns null for undefined', () => {
+    expect(buildService().normalizeObjectId(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(buildService().normalizeObjectId('')).toBeNull();
+  });
+
+  it('returns null for the __never__ sentinel', () => {
+    expect(buildService().normalizeObjectId('__never__')).toBeNull();
+  });
+
+  it('returns the string value for a real id', () => {
+    expect(buildService().normalizeObjectId('org_abc123')).toBe('org_abc123');
+  });
+});
+
+describe('StripeWebhookService trackSubscriptionAttributionFromSession', () => {
+  const configService = { get: vi.fn().mockReturnValue(undefined) };
+  const loggerService = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+  const stripeService = { getSubscription: vi.fn() };
+  const subscriptionAttributionsService = { trackSubscription: vi.fn() };
+  const usersService = { findOne: vi.fn() };
+
+  function buildService(): AttributionAccessor {
+    return new StripeWebhookService(
+      configService as never,
+      loggerService as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      usersService as never,
+      {} as never,
+      stripeService as never,
+      {} as never,
+      {} as never,
+      subscriptionAttributionsService as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    ) as unknown as AttributionAccessor;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stripeService.getSubscription.mockResolvedValue({
+      items: {
+        data: [
+          { price: { id: 'price_123', unit_amount: 999, currency: 'usd' } },
+        ],
+      },
+      customer: null,
+    });
+    usersService.findOne.mockResolvedValue(null);
+  });
+
+  it('skips trackSubscription and warns when organizationId resolves to null', async () => {
+    const service = buildService();
+    const session = {
+      subscription: 'sub_stripe_1',
+      customer: 'cus_1',
+      customer_details: { email: 'test@example.com' },
+      metadata: {},
+      id: 'cs_1',
+    };
+    const subscription = {
+      organization: undefined, // falsy → null
+      user: 'user_abc',
+      stripePriceId: 'price_123',
+    };
+
+    await service.trackSubscriptionAttributionFromSession(
+      session,
+      subscription,
+      'test',
+    );
+
+    expect(
+      subscriptionAttributionsService.trackSubscription,
+    ).not.toHaveBeenCalled();
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('skipping attribution'),
+      expect.any(Object),
+    );
+  });
+
+  it('skips trackSubscription and warns when userId resolves to null (__never__ sentinel)', async () => {
+    const service = buildService();
+    const session = {
+      subscription: 'sub_stripe_1',
+      customer: 'cus_1',
+      customer_details: { email: 'test@example.com' },
+      metadata: {},
+      id: 'cs_1',
+    };
+    const subscription = {
+      organization: 'org_abc',
+      user: '__never__', // sentinel → null
+      stripePriceId: 'price_123',
+    };
+
+    await service.trackSubscriptionAttributionFromSession(
+      session,
+      subscription,
+      'test',
+    );
+
+    expect(
+      subscriptionAttributionsService.trackSubscription,
+    ).not.toHaveBeenCalled();
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('skipping attribution'),
+      expect.any(Object),
+    );
+  });
+
+  it('calls trackSubscription when both organizationId and userId are valid', async () => {
+    const service = buildService();
+    const session = {
+      subscription: 'sub_stripe_1',
+      customer: 'cus_1',
+      customer_details: { email: 'test@example.com' },
+      metadata: {},
+      id: 'cs_1',
+    };
+    const subscription = {
+      organization: 'org_abc',
+      user: 'user_abc',
+      stripePriceId: 'price_123',
+    };
+    subscriptionAttributionsService.trackSubscription.mockResolvedValue(
+      undefined,
+    );
+
+    await service.trackSubscriptionAttributionFromSession(
+      session,
+      subscription,
+      'test',
+    );
+
+    expect(
+      subscriptionAttributionsService.trackSubscription,
+    ).toHaveBeenCalledTimes(1);
+    expect(loggerService.warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
@@ -1111,6 +1111,18 @@ export class StripeWebhookService {
       const organizationId = this.normalizeObjectId(subscription.organization);
       const userId = this.normalizeObjectId(subscription.user);
 
+      if (organizationId === null || userId === null) {
+        this.loggerService.warn(
+          `${url} skipping attribution: resolved null org/user id`,
+          {
+            organization: subscription.organization,
+            stripeSubscriptionId: session.subscription,
+            user: subscription.user,
+          },
+        );
+        return;
+      }
+
       const user = await this.usersService.findOne({
         _id: subscription.user,
       });
@@ -1329,13 +1341,9 @@ export class StripeWebhookService {
     });
   }
 
-  private normalizeObjectId(value: string | undefined): string {
-    if (!value) {
-      return 'unknown';
-    }
-
-    if (value === '__never__') {
-      return value.toString();
+  private normalizeObjectId(value: string | undefined): string | null {
+    if (!value || value === '__never__') {
+      return null;
     }
 
     return String(value);

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -897,7 +897,7 @@ describe('AgentOrchestratorService', () => {
         messages: expect.arrayContaining([
           expect.objectContaining({
             content: expect.stringContaining(
-              'Insufficient credits. This tool requires 10 credits.',
+              'Insufficient credits. This tool requires at least 10 credits to start.',
             ),
             role: 'tool',
           }),
@@ -964,7 +964,7 @@ describe('AgentOrchestratorService', () => {
         messages: expect.arrayContaining([
           expect.objectContaining({
             content: expect.stringContaining(
-              'Insufficient credits. This tool requires 50 credits.',
+              'Insufficient credits. This tool requires at least 50 credits to start.',
             ),
             role: 'tool',
           }),

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -1139,7 +1139,7 @@ export class AgentOrchestratorService {
 
               messages.push({
                 content: JSON.stringify({
-                  error: `Insufficient credits. This tool requires ${preflightCreditCost} credits.`,
+                  error: `Insufficient credits. This tool requires at least ${preflightCreditCost} credits to start.`,
                   success: false,
                 }),
                 role: 'tool' as const,
@@ -1908,7 +1908,7 @@ export class AgentOrchestratorService {
 
               messages.push({
                 content: JSON.stringify({
-                  error: `Insufficient credits. This tool requires ${preflightCreditCost} credits.`,
+                  error: `Insufficient credits. This tool requires at least ${preflightCreditCost} credits to start.`,
                   success: false,
                 }),
                 role: 'tool' as const,

--- a/apps/server/api/src/services/byok-billing/byok-billing.service.spec.ts
+++ b/apps/server/api/src/services/byok-billing/byok-billing.service.spec.ts
@@ -1,0 +1,170 @@
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { ConfigService } from '@api/config/config.service';
+import { StripeService } from '@api/services/integrations/stripe/services/stripe.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { SubscriptionsService } from '@genfeedai/ee-billing/subscriptions';
+import { LoggerService } from '@libs/logger/logger.service';
+import { InternalServerErrorException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ByokBillingService } from './byok-billing.service';
+
+const makeConfigService = (
+  overrides: Record<string, string | undefined> = {},
+) => ({
+  get: vi.fn((key: string) => overrides[key]),
+});
+
+const makeLoggerService = () => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+});
+
+describe('ByokBillingService', () => {
+  let service: ByokBillingService;
+  let configService: ReturnType<typeof makeConfigService>;
+  let loggerService: ReturnType<typeof makeLoggerService>;
+  let organizationSettingsService: { findOne: ReturnType<typeof vi.fn> };
+  let prismaService: {
+    creditTransaction: { findMany: ReturnType<typeof vi.fn> };
+  };
+  let subscriptionsService: { findByOrganizationId: ReturnType<typeof vi.fn> };
+  let stripeService: {
+    stripe: {
+      invoices: {
+        list: ReturnType<typeof vi.fn>;
+        create: ReturnType<typeof vi.fn>;
+        finalizeInvoice: ReturnType<typeof vi.fn>;
+      };
+      invoiceItems: {
+        create: ReturnType<typeof vi.fn>;
+        del: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+
+  async function buildModule(
+    configOverrides: Record<string, string | undefined> = {},
+  ) {
+    configService = makeConfigService(configOverrides);
+    loggerService = makeLoggerService();
+    organizationSettingsService = { findOne: vi.fn().mockResolvedValue(null) };
+    prismaService = {
+      creditTransaction: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+    subscriptionsService = {
+      findByOrganizationId: vi.fn().mockResolvedValue(null),
+    };
+    stripeService = {
+      stripe: {
+        invoices: {
+          list: vi.fn().mockResolvedValue({ data: [] }),
+          create: vi.fn(),
+          finalizeInvoice: vi.fn(),
+        },
+        invoiceItems: {
+          create: vi.fn(),
+          del: vi.fn(),
+        },
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ByokBillingService,
+        { provide: ConfigService, useValue: configService },
+        { provide: LoggerService, useValue: loggerService },
+        {
+          provide: OrganizationSettingsService,
+          useValue: organizationSettingsService,
+        },
+        { provide: PrismaService, useValue: prismaService },
+        { provide: SubscriptionsService, useValue: subscriptionsService },
+        { provide: StripeService, useValue: stripeService },
+      ],
+    }).compile();
+
+    service = module.get(ByokBillingService);
+  }
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('should be defined', async () => {
+    await buildModule({
+      STRIPE_BYOK_FEE_PERCENTAGE: '5',
+      STRIPE_BYOK_FREE_THRESHOLD: '10000',
+    });
+    expect(service).toBeDefined();
+  });
+
+  // ── calculateFee ───────────────────────────────────────────────────────────
+
+  describe('calculateFee', () => {
+    beforeEach(() => buildModule());
+
+    it('returns 0 when usage is below the free threshold', () => {
+      expect(service.calculateFee(5000, 10000, 5)).toBe(0);
+    });
+
+    it('computes fee in cents correctly', () => {
+      // 15000 credits - 10000 threshold = 5000 billable
+      // 5000 * $0.01 * 5% = $2.50 → 250 cents
+      expect(service.calculateFee(15000, 10000, 5)).toBe(250);
+    });
+  });
+
+  // ── parseRequiredNumberConfig (via createByokInvoice / getByokUsageSummary) ─
+
+  describe('config validation — malformed env throws InternalServerErrorException', () => {
+    it('createByokInvoice throws when STRIPE_BYOK_FEE_PERCENTAGE is missing', async () => {
+      await buildModule({ STRIPE_BYOK_FREE_THRESHOLD: '10000' }); // FEE_PERCENTAGE missing → undefined → NaN
+      await expect(service.createByokInvoice('org-1')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(loggerService.error).toHaveBeenCalledWith(
+        expect.stringContaining('STRIPE_BYOK_FEE_PERCENTAGE'),
+        expect.objectContaining({ key: 'STRIPE_BYOK_FEE_PERCENTAGE' }),
+      );
+    });
+
+    it('createByokInvoice throws when STRIPE_BYOK_FREE_THRESHOLD is malformed', async () => {
+      await buildModule({
+        STRIPE_BYOK_FEE_PERCENTAGE: '5',
+        STRIPE_BYOK_FREE_THRESHOLD: 'bad',
+      });
+      await expect(service.createByokInvoice('org-1')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(loggerService.error).toHaveBeenCalledWith(
+        expect.stringContaining('STRIPE_BYOK_FREE_THRESHOLD'),
+        expect.objectContaining({ key: 'STRIPE_BYOK_FREE_THRESHOLD' }),
+      );
+    });
+
+    it('getByokUsageSummary throws when STRIPE_BYOK_FEE_PERCENTAGE is missing', async () => {
+      await buildModule({ STRIPE_BYOK_FREE_THRESHOLD: '10000' });
+      await expect(service.getByokUsageSummary('org-1')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(loggerService.error).toHaveBeenCalledWith(
+        expect.stringContaining('STRIPE_BYOK_FEE_PERCENTAGE'),
+        expect.objectContaining({ key: 'STRIPE_BYOK_FEE_PERCENTAGE' }),
+      );
+    });
+
+    it('getByokUsageSummary throws when STRIPE_BYOK_FREE_THRESHOLD is malformed', async () => {
+      await buildModule({
+        STRIPE_BYOK_FEE_PERCENTAGE: '5',
+        STRIPE_BYOK_FREE_THRESHOLD: 'not-a-number',
+      });
+      await expect(service.getByokUsageSummary('org-1')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(loggerService.error).toHaveBeenCalledWith(
+        expect.stringContaining('STRIPE_BYOK_FREE_THRESHOLD'),
+        expect.objectContaining({ key: 'STRIPE_BYOK_FREE_THRESHOLD' }),
+      );
+    });
+  });
+});

--- a/apps/server/api/src/services/byok-billing/byok-billing.service.ts
+++ b/apps/server/api/src/services/byok-billing/byok-billing.service.ts
@@ -6,7 +6,7 @@ import { SubscriptionsService } from '@genfeedai/ee-billing/subscriptions';
 import { ByokBillingStatus, CreditTransactionCategory } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 
 interface ByokInvoiceMetadata {
   billableCredits: string;
@@ -52,6 +52,20 @@ export class ByokBillingService {
     private readonly subscriptionsService: SubscriptionsService,
     private readonly organizationSettingsService: OrganizationSettingsService,
   ) {}
+
+  private parseRequiredNumberConfig(key: string): number {
+    const value = Number(this.configService.get(key));
+    if (Number.isNaN(value)) {
+      this.loggerService.error(
+        `ByokBillingService missing or malformed config key: ${key}`,
+        { key },
+      );
+      throw new InternalServerErrorException(
+        `Configuration error: "${key}" is missing or not a valid number`,
+      );
+    }
+    return value;
+  }
 
   async aggregateByokUsage(
     organizationId: string,
@@ -106,11 +120,11 @@ export class ByokBillingService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const feePercentage = Number(
-        this.configService.get('STRIPE_BYOK_FEE_PERCENTAGE'),
+      const feePercentage = this.parseRequiredNumberConfig(
+        'STRIPE_BYOK_FEE_PERCENTAGE',
       );
-      const globalFreeThreshold = Number(
-        this.configService.get('STRIPE_BYOK_FREE_THRESHOLD'),
+      const globalFreeThreshold = this.parseRequiredNumberConfig(
+        'STRIPE_BYOK_FREE_THRESHOLD',
       );
 
       // Get org settings for rollover and threshold override
@@ -361,11 +375,11 @@ export class ByokBillingService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const feePercentage = Number(
-        this.configService.get('STRIPE_BYOK_FEE_PERCENTAGE'),
+      const feePercentage = this.parseRequiredNumberConfig(
+        'STRIPE_BYOK_FEE_PERCENTAGE',
       );
-      const globalFreeThreshold = Number(
-        this.configService.get('STRIPE_BYOK_FREE_THRESHOLD'),
+      const globalFreeThreshold = this.parseRequiredNumberConfig(
+        'STRIPE_BYOK_FREE_THRESHOLD',
       );
 
       const orgSettings = await this.organizationSettingsService.findOne({

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -5,6 +5,7 @@
  * since unit tests should mock all database operations.
  */
 import 'reflect-metadata';
+import process from 'node:process';
 import { vi } from 'vitest';
 
 // Mock @genfeedai/prisma so unit tests never need the generated Prisma client
@@ -20,7 +21,14 @@ vi.mock('@genfeedai/prisma', () => {
         Array.isArray(arg) ? Promise.all(arg) : arg(new PrismaClient()),
       );
   }
-  return { PrismaClient };
+  return {
+    ArticleStatus: {
+      ARCHIVED: 'ARCHIVED',
+      DRAFT: 'DRAFT',
+      PUBLISHED: 'PUBLISHED',
+    },
+    PrismaClient,
+  };
 });
 
 // Mock @prisma/adapter-pg so PrismaService constructor doesn't require DATABASE_URL

--- a/apps/server/clips/src/config/config.service.ts
+++ b/apps/server/clips/src/config/config.service.ts
@@ -17,6 +17,8 @@ export class ConfigService extends createServiceConfig<IEnvConfig>({
   },
 }) {
   get API_URL(): string {
+    // Self-hosted fallback: GENFEEDAI_API_URL is optional when GENFEED_CLOUD is unset.
+    // In cloud mode the constructor schema validates it as required and throws before this runs.
     return this.get('GENFEEDAI_API_URL') || 'http://localhost:3010';
   }
 

--- a/apps/server/discord/src/services/__tests__/discord-bot-manager.service.spec.ts
+++ b/apps/server/discord/src/services/__tests__/discord-bot-manager.service.spec.ts
@@ -132,13 +132,15 @@ describe('DiscordBotManager', () => {
       );
     });
 
-    it('should subscribe to all three Redis events', async () => {
+    it('should subscribe to the three integration events plus the channel event', async () => {
       (httpService.get as ReturnType<typeof vi.fn>).mockReturnValue(
         of({ data: [] }),
       );
       await service.initialize();
 
-      expect(redisService.subscribe).toHaveBeenCalledTimes(3);
+      // 3 integration events (created/updated/deleted) + the
+      // discord:send-to-channel event = 4 subscriptions.
+      expect(redisService.subscribe).toHaveBeenCalledTimes(4);
       expect(redisService.subscribe).toHaveBeenCalledWith(
         REDIS_EVENTS.INTEGRATION_CREATED,
         expect.any(Function),
@@ -149,6 +151,10 @@ describe('DiscordBotManager', () => {
       );
       expect(redisService.subscribe).toHaveBeenCalledWith(
         REDIS_EVENTS.INTEGRATION_DELETED,
+        expect.any(Function),
+      );
+      expect(redisService.subscribe).toHaveBeenCalledWith(
+        REDIS_EVENTS.DISCORD_SEND_TO_CHANNEL,
         expect.any(Function),
       );
     });
@@ -272,8 +278,8 @@ describe('DiscordBotManager', () => {
 
       await service.destroyBotInstance(mockInstance);
 
-      expect(service.logger.warn).toHaveBeenCalledWith(
-        `Error stopping bot ${mockIntegration.id}:`,
+      expect(service.logger.error).toHaveBeenCalledWith(
+        `Error stopping bot ${mockIntegration.id}`,
         error,
       );
     });

--- a/apps/server/discord/src/services/discord-bot-manager.service.spec.ts
+++ b/apps/server/discord/src/services/discord-bot-manager.service.spec.ts
@@ -9,17 +9,25 @@ vi.mock('discord.js', () => {
     once: vi.fn(),
   };
   return {
-    ActionRowBuilder: vi.fn().mockImplementation(() => ({
-      addComponents: vi.fn().mockReturnThis(),
-    })),
+    // vitest v4 cannot `new` a vi.fn() whose implementation is an arrow
+    // function (arrows have no [[Construct]]). Use normal function expressions
+    // so the mocked discord.js classes are constructable — mirrors the pattern
+    // in __tests__/discord-bot-manager.service.spec.ts.
+    ActionRowBuilder: vi.fn(function () {
+      return { addComponents: vi.fn().mockReturnThis() };
+    }),
     BaseGuildTextChannel: class BaseGuildTextChannel {},
-    ButtonBuilder: vi.fn().mockImplementation(() => ({
-      setCustomId: vi.fn().mockReturnThis(),
-      setLabel: vi.fn().mockReturnThis(),
-      setStyle: vi.fn().mockReturnThis(),
-    })),
+    ButtonBuilder: vi.fn(function () {
+      return {
+        setCustomId: vi.fn().mockReturnThis(),
+        setLabel: vi.fn().mockReturnThis(),
+        setStyle: vi.fn().mockReturnThis(),
+      };
+    }),
     ButtonStyle: { Danger: 4, Primary: 1, Secondary: 2, Success: 3 },
-    Client: vi.fn().mockImplementation(() => mockClient),
+    Client: vi.fn(function () {
+      return mockClient;
+    }),
     Events: { ClientReady: 'ready' },
     GatewayIntentBits: {
       DirectMessages: 8,
@@ -27,22 +35,22 @@ vi.mock('discord.js', () => {
       Guilds: 1,
       MessageContent: 4,
     },
-    REST: vi.fn().mockImplementation(() => ({
-      put: vi.fn().mockResolvedValue(undefined),
-      setToken: vi.fn().mockReturnThis(),
-    })),
+    REST: vi.fn(function () {
+      return {
+        put: vi.fn().mockResolvedValue(undefined),
+        setToken: vi.fn().mockReturnThis(),
+      };
+    }),
     Routes: { applicationCommands: vi.fn().mockReturnValue('/commands') },
-    SlashCommandBuilder: vi.fn().mockImplementation(() => ({
-      setDescription: vi.fn().mockReturnThis(),
-      setName: vi.fn().mockReturnThis(),
-      toJSON: vi.fn().mockReturnValue({}),
-    })),
+    SlashCommandBuilder: vi.fn(function () {
+      return {
+        setDescription: vi.fn().mockReturnThis(),
+        setName: vi.fn().mockReturnThis(),
+        toJSON: vi.fn().mockReturnValue({}),
+      };
+    }),
   };
 });
-
-vi.mock('rxjs', () => ({
-  firstValueFrom: vi.fn(),
-}));
 
 vi.mock('@genfeedai/integrations', () => ({
   BaseBotManager: class {
@@ -101,7 +109,6 @@ vi.mock('@genfeedai/integrations', () => ({
   isWorkflowExecutionTerminalStatus: vi.fn().mockReturnValue(false),
 }));
 
-import { firstValueFrom } from 'rxjs';
 import { DiscordBotManager } from './discord-bot-manager.service';
 
 const mockConfigService = {
@@ -143,9 +150,6 @@ describe('DiscordBotManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (firstValueFrom as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [],
-    });
     manager = createManager();
   });
 
@@ -160,10 +164,17 @@ describe('DiscordBotManager', () => {
 
   it('should fetch active integrations during init', async () => {
     await manager.initialize();
-    // BotInternalApiClient.fetchActiveIntegrations is called internally;
-    // firstValueFrom is no longer invoked directly by the manager.
     expect(mockRedisService.subscribe).toHaveBeenCalled();
     expect(manager.getActiveCount()).toBe(0);
+    expect(
+      (
+        manager as unknown as Record<string, unknown> & {
+          internalApiClient: {
+            fetchActiveIntegrations: ReturnType<typeof vi.fn>;
+          };
+        }
+      ).internalApiClient.fetchActiveIntegrations,
+    ).toHaveBeenCalled();
   });
 
   it('should return 0 active bots initially', () => {
@@ -188,18 +199,36 @@ describe('DiscordBotManager', () => {
   });
 
   it('should handle empty integrations array from API', async () => {
-    (firstValueFrom as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: [],
-    });
+    (
+      manager as unknown as Record<string, unknown> & {
+        internalApiClient: {
+          fetchActiveIntegrations: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).internalApiClient.fetchActiveIntegrations.mockResolvedValue([]);
     await manager.initialize();
     expect(manager.getActiveCount()).toBe(0);
   });
 
-  it('should handle API failure during fetchActiveIntegrations gracefully', async () => {
-    (firstValueFrom as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error('ECONNREFUSED'),
-    );
-    await manager.initialize();
+  it('should log and rethrow when fetchActiveIntegrations fails during init', async () => {
+    // BotInternalApiClient.fetchActiveIntegrations propagates transport errors
+    // (ECONNREFUSED, 401, etc.). initialize() logs the failure and rethrows so
+    // the module-init failure is visible rather than silently swallowed.
+    const error = new Error('ECONNREFUSED');
+    (
+      manager as unknown as Record<string, unknown> & {
+        internalApiClient: {
+          fetchActiveIntegrations: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).internalApiClient.fetchActiveIntegrations.mockRejectedValue(error);
+
+    await expect(manager.initialize()).rejects.toThrow('ECONNREFUSED');
+
+    expect(
+      (manager as unknown as { logger: { error: ReturnType<typeof vi.fn> } })
+        .logger.error,
+    ).toHaveBeenCalledWith('Failed to initialize Discord Bot Manager:', error);
     expect(manager.getActiveCount()).toBe(0);
   });
 

--- a/apps/server/discord/src/services/discord-bot-manager.service.ts
+++ b/apps/server/discord/src/services/discord-bot-manager.service.ts
@@ -1,6 +1,8 @@
 import { ConfigService } from '@discord/config/config.service';
 import {
   BaseBotManager,
+  type BotHttpAdapter,
+  BotInternalApiClient,
   DiscordSendToChannelEvent,
   extractWorkflowExecutionSnapshot,
   extractWorkflowOutputsFromExecution,
@@ -55,6 +57,31 @@ interface WorkflowNode {
   };
 }
 
+/**
+ * Build the BotHttpAdapter that wraps NestJS HttpService + RxJS firstValueFrom
+ * into the framework-agnostic interface BotInternalApiClient expects.
+ */
+function makeBotHttpAdapter(httpService: HttpService): BotHttpAdapter {
+  return {
+    async get<T>(url: string, headers?: Record<string, string>): Promise<T> {
+      const response = await firstValueFrom(
+        httpService.get<T>(url, headers ? { headers } : undefined),
+      );
+      return response.data;
+    },
+    async post<T>(
+      url: string,
+      body: unknown,
+      headers?: Record<string, string>,
+    ): Promise<T> {
+      const response = await firstValueFrom(
+        httpService.post<T>(url, body, headers ? { headers } : undefined),
+      );
+      return response.data;
+    },
+  };
+}
+
 @Injectable()
 export class DiscordBotManager
   extends BaseBotManager<DiscordBotInstance>
@@ -72,6 +99,7 @@ export class DiscordBotManager
   private channelEventSubscribed = false;
   private readonly sessions = new Map<string, WorkflowSession>();
   private readonly userSettings = new Map<string, UserSettings>();
+  private readonly internalApiClient: BotInternalApiClient;
 
   constructor(
     private readonly configService: ConfigService,
@@ -79,6 +107,12 @@ export class DiscordBotManager
     private readonly redisService: RedisService,
   ) {
     super();
+    this.internalApiClient = new BotInternalApiClient({
+      apiUrl: this.configService.API_URL,
+      apiKey: this.configService.API_KEY,
+      platform: this.platform,
+      http: makeBotHttpAdapter(this.httpService),
+    });
   }
 
   async onModuleInit() {
@@ -1191,88 +1225,14 @@ export class DiscordBotManager
 
   // --- API fetch methods ---
 
-  private normalizeIntegration(payload: unknown): OrgIntegration | null {
-    if (!payload || typeof payload !== 'object') {
-      return null;
-    }
-
-    const raw = payload as Record<string, unknown>;
-    const rawId = raw.id ?? raw._id;
-    const rawOrgId = raw.orgId ?? raw.organization;
-    const rawToken = raw.botToken;
-
-    if (!rawId || !rawOrgId || !rawToken) {
-      return null;
-    }
-
-    return {
-      botToken: String(rawToken),
-      config: (raw.config as OrgIntegration['config']) || {},
-      createdAt: raw.createdAt ? new Date(raw.createdAt as string) : new Date(),
-      id: String(rawId),
-      orgId: String(rawOrgId),
-      platform: this.platform,
-      status: (raw.status as OrgIntegration['status'] | undefined) || 'active',
-      updatedAt: raw.updatedAt ? new Date(raw.updatedAt as string) : new Date(),
-    };
-  }
-
-  private normalizeIntegrations(payload: unknown): OrgIntegration[] {
-    if (!Array.isArray(payload)) {
-      return [];
-    }
-
-    return payload
-      .map((integration) => this.normalizeIntegration(integration))
-      .filter(
-        (integration): integration is OrgIntegration => integration !== null,
-      );
-  }
-
   private async fetchActiveIntegrations(): Promise<OrgIntegration[]> {
-    try {
-      const apiKey = this.configService.API_KEY;
-      const response = await firstValueFrom(
-        this.httpService.get(
-          `${this.configService.API_URL}/v1/internal/integrations/discord`,
-          {
-            headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
-          },
-        ),
-      );
-      return this.normalizeIntegrations(response.data);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const status = (error as { response?: { status?: number } })?.response
-        ?.status;
-
-      if (message.includes('ECONNREFUSED')) {
-        this.logger.warn(
-          `API unavailable at ${this.configService.API_URL} — starting with 0 bots. Start the API service first.`,
-        );
-      } else if (status === 401) {
-        this.logger.warn(
-          'API returned 401 — set GENFEEDAI_API_KEY in your .env to authenticate with the API.',
-        );
-      } else {
-        this.logger.error('Failed to fetch integrations:', error);
-      }
-      return [];
-    }
+    return this.internalApiClient.fetchActiveIntegrations();
   }
 
   protected async fetchAndAddIntegration(integrationId: string): Promise<void> {
     try {
-      const apiKey = this.configService.API_KEY;
-      const response = await firstValueFrom(
-        this.httpService.get(
-          `${this.configService.API_URL}/v1/internal/integrations/discord/${integrationId}`,
-          {
-            headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
-          },
-        ),
-      );
-      const integration = this.normalizeIntegration(response.data);
+      const integration =
+        await this.internalApiClient.fetchIntegration(integrationId);
       if (!integration) {
         this.logger.warn(
           `Unable to normalize Discord integration payload: ${integrationId}`,
@@ -1292,16 +1252,8 @@ export class DiscordBotManager
     integrationId: string,
   ): Promise<void> {
     try {
-      const apiKey = this.configService.API_KEY;
-      const response = await firstValueFrom(
-        this.httpService.get(
-          `${this.configService.API_URL}/v1/internal/integrations/discord/${integrationId}`,
-          {
-            headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
-          },
-        ),
-      );
-      const integration = this.normalizeIntegration(response.data);
+      const integration =
+        await this.internalApiClient.fetchIntegration(integrationId);
       if (!integration) {
         this.logger.warn(
           `Unable to normalize Discord integration payload: ${integrationId}`,
@@ -1321,12 +1273,7 @@ export class DiscordBotManager
     orgId: string,
   ): Promise<WorkflowDefinition[]> {
     try {
-      const response = await firstValueFrom(
-        this.httpService.get(
-          `${this.configService.API_URL}/v1/orgs/${orgId}/workflows`,
-        ),
-      );
-      return response.data;
+      return await this.internalApiClient.fetchOrgWorkflows(orgId);
     } catch (error) {
       this.logger.error('Failed to fetch workflows:', error);
       return [];

--- a/apps/server/images/src/services/training.service.spec.ts
+++ b/apps/server/images/src/services/training.service.spec.ts
@@ -457,6 +457,89 @@ describe('TrainingService', () => {
       });
     });
 
+    it('leaves a still-running job in place on module init (process alive)', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Simulate restart: new instance with same Redis, process record still present.
+      // Spy on isProcessAlive so it returns true (process "still alive").
+      const restarted = createService(publisher);
+      const aliveSpy = vi
+        .spyOn(
+          restarted as unknown as { isProcessAlive: (pid: number) => boolean },
+          'isProcessAlive',
+        )
+        .mockReturnValue(true);
+
+      await restarted.onModuleInit();
+      aliveSpy.mockRestore();
+
+      // Process record should still be present (not deleted) — job left running.
+      expect(publisher.store.has(`training:images:process:${jobId}`)).toBe(
+        true,
+      );
+
+      // Job status must NOT have been overwritten to 'failed'.
+      const rawJob = publisher.store.get(`training:images:job:${jobId}`);
+      expect(JSON.parse(rawJob as string)).toMatchObject({ status: 'running' });
+    });
+
+    it('skips overwriting a terminal job on module init', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      const { jobId } = await redisBackedService.startTraining({
+        loraName: 'test-lora',
+        personaSlug: 'test-persona',
+        triggerWord: 'ohwx',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Mark the job completed directly in the store to simulate a terminal state.
+      const rawJob = publisher.store.get(`training:images:job:${jobId}`);
+      const completedJob = {
+        ...JSON.parse(rawJob as string),
+        status: 'completed',
+        stage: 'completed',
+      };
+      publisher.store.set(
+        `training:images:job:${jobId}`,
+        JSON.stringify(completedJob),
+      );
+
+      // Keep a stale process record in the store.
+      publisher.store.set(
+        `training:images:process:${jobId}`,
+        JSON.stringify({
+          jobId,
+          pid: 12345,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+
+      const restarted = createService(publisher);
+      await restarted.onModuleInit();
+
+      // Stale process record must be cleaned up.
+      expect(publisher.store.has(`training:images:process:${jobId}`)).toBe(
+        false,
+      );
+
+      // Job status must NOT have been overwritten — still 'completed'.
+      const afterJob = publisher.store.get(`training:images:job:${jobId}`);
+      expect(JSON.parse(afterJob as string)).toMatchObject({
+        status: 'completed',
+        stage: 'completed',
+      });
+    });
+
     it('loads a job from Redis on getTrainingJob after a restart without init', async () => {
       const mockChild = createMockChildProcess();
       mockSpawn.mockReturnValue(mockChild);

--- a/apps/server/images/src/services/training.service.ts
+++ b/apps/server/images/src/services/training.service.ts
@@ -64,20 +64,35 @@ export class TrainingService implements OnModuleInit {
 
     for (const record of records) {
       const isAlive = this.isProcessAlive(record.pid);
+      const job = this.jobs.get(record.jobId);
+      const isTerminal =
+        job?.status === 'completed' || job?.status === 'failed';
+
       this.loggerService.warn(caller, {
         isAlive,
+        isTerminal,
         jobId: record.jobId,
         message: 'Orphaned training process detected on startup',
         pid: record.pid,
         startedAt: record.startedAt,
       });
-      await this.updateJob(record.jobId, {
-        completedAt: new Date().toISOString(),
-        error: `Process orphaned by service restart (pid ${record.pid}, ${isAlive ? 'still running' : 'no longer running'})`,
-        stage: 'failed',
-        status: 'failed',
-      });
-      await this.trainingStateStore.deleteProcessRecord(record.jobId);
+
+      if (isTerminal) {
+        // Job already reached a terminal state — do not overwrite; just clean up the stale record.
+        await this.trainingStateStore.deleteProcessRecord(record.jobId);
+      } else if (isAlive) {
+        // Process is still running — leave it in its current state; do not mark failed.
+        // The process record remains so a future restart can re-evaluate.
+      } else {
+        // Process is gone and the job is not yet terminal — mark it failed.
+        await this.updateJob(record.jobId, {
+          completedAt: new Date().toISOString(),
+          error: `Process orphaned by service restart (pid ${record.pid}, no longer running)`,
+          stage: 'failed',
+          status: 'failed',
+        });
+        await this.trainingStateStore.deleteProcessRecord(record.jobId);
+      }
     }
   }
 
@@ -295,19 +310,13 @@ export class TrainingService implements OnModuleInit {
           this.handleTrainingComplete(jobId, params).catch((error: unknown) => {
             const errorMessage =
               error instanceof Error ? error.message : String(error);
-            void this.updateJob(jobId, {
-              completedAt: new Date().toISOString(),
-              error: errorMessage,
-              stage: 'failed',
-              status: 'failed',
-            });
             this.loggerService.error(
               `Post-training S3 upload failed for job ${jobId}`,
               error instanceof Error ? error : new Error(errorMessage),
             );
             void this.updateJob(jobId, {
               completedAt: new Date().toISOString(),
-              error: `Post-training upload failed: ${error instanceof Error ? error.message : String(error)}`,
+              error: `Post-training upload failed: ${errorMessage}`,
               stage: 'failed',
               status: 'failed',
             });

--- a/apps/server/workers/src/config/config.service.spec.ts
+++ b/apps/server/workers/src/config/config.service.spec.ts
@@ -86,16 +86,22 @@ describe('ConfigService (Workers)', () => {
   });
 
   describe('ingredientsEndpoint', () => {
-    // GENFEEDAI_CDN_URL is NOT in workers' schema (postgres/redis/sentry only);
-    // the getter reads it via BaseConfigService's allowUnknown passthrough.
-    // This guards that the factory migration preserved that passthrough.
-    it('builds the endpoint from the unschema-d GENFEEDAI_CDN_URL', () => {
+    // GENFEEDAI_CDN_URL is declared in genfeedaiUrlsSchema (added to workers'
+    // schema) so Joi validates it. In self-hosted / test mode it is optional;
+    // in cloud mode (GENFEED_CLOUD set) it is required.
+    it('builds the correct endpoint from GENFEEDAI_CDN_URL', () => {
       process.env.GENFEEDAI_CDN_URL = 'https://cdn.example.com';
       configService = new ConfigService();
 
       expect(configService.ingredientsEndpoint).toBe(
         'https://cdn.example.com/ingredients',
       );
+    });
+
+    it('rejects a non-URI GENFEEDAI_CDN_URL value', () => {
+      process.env.GENFEEDAI_CDN_URL = 'not-a-url';
+
+      expect(() => new ConfigService()).toThrow(/GENFEEDAI_CDN_URL/);
     });
   });
 });

--- a/apps/server/workers/src/config/config.service.ts
+++ b/apps/server/workers/src/config/config.service.ts
@@ -1,5 +1,6 @@
 import {
   createServiceConfig,
+  genfeedaiUrlsSchema,
   type IEnvConfig,
   postgresSchema,
   redisSchema,
@@ -15,7 +16,12 @@ interface WorkersEnvConfig extends IEnvConfig {
 @Injectable()
 export class ConfigService extends createServiceConfig<WorkersEnvConfig>({
   appName: 'workers',
-  schemas: [postgresSchema, redisSchema, sentryOptionalSchema],
+  schemas: [
+    postgresSchema,
+    redisSchema,
+    sentryOptionalSchema,
+    genfeedaiUrlsSchema,
+  ],
   extend: {
     GF_DEV_ENABLE_SCHEDULERS: Joi.string()
       .valid('true', 'false')

--- a/ee/packages/billing/package.json
+++ b/ee/packages/billing/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "build": "echo 'Source-level package — consumed via path aliases, no build needed'",
     "clean": "echo 'Nothing to clean'",
+    "test": "vitest run --config vitest.config.ts",
     "type-check": "tsc --noEmit"
   },
   "sideEffects": false,

--- a/ee/packages/billing/src/subscription-attributions/services/subscription-attributions.service.spec.ts
+++ b/ee/packages/billing/src/subscription-attributions/services/subscription-attributions.service.spec.ts
@@ -1,0 +1,138 @@
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { SubscriptionAttributionsService } from './subscription-attributions.service';
+
+type MockPrisma = {
+  subscriptionAttribution: {
+    create: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+function buildService(): {
+  service: SubscriptionAttributionsService;
+  prisma: MockPrisma;
+} {
+  const prisma: MockPrisma = {
+    subscriptionAttribution: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+
+  // Plain service — instantiate directly with the mocked Prisma. No Nest DI
+  // container needed; the constructor takes a single PrismaService dependency.
+  const service = new SubscriptionAttributionsService(
+    prisma as unknown as PrismaService,
+  );
+
+  return { prisma, service };
+}
+
+describe('SubscriptionAttributionsService', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('updateSubscriptionStatus', () => {
+    it('scopes findMany to the stripeSubscriptionId JSON metadata — never reads all rows', async () => {
+      const { prisma, service } = buildService();
+      prisma.subscriptionAttribution.findMany.mockResolvedValue([]);
+
+      await service.updateSubscriptionStatus('sub_abc123', 'canceled');
+
+      expect(prisma.subscriptionAttribution.findMany).toHaveBeenCalledWith({
+        where: {
+          metadata: {
+            path: ['stripeSubscriptionId'],
+            equals: 'sub_abc123',
+          },
+        },
+      });
+
+      // Critically: no bare findMany() — a non-empty where clause is always present
+      const [call] = prisma.subscriptionAttribution.findMany.mock.calls;
+      expect(call[0]).toHaveProperty('where');
+      expect(call[0].where).not.toEqual({});
+    });
+
+    it('updates only the attributions returned by the scoped query', async () => {
+      const { prisma, service } = buildService();
+      const attribution = {
+        channel: null,
+        createdAt: new Date('2024-01-01'),
+        id: 'attr_1',
+        metadata: { stripeSubscriptionId: 'sub_abc123', status: 'active' },
+        organizationId: 'org_1',
+        referrer: null,
+        sourceContentId: null,
+        sourceLinkId: null,
+        updatedAt: new Date('2024-01-01'),
+        userId: 'user_1',
+      };
+
+      prisma.subscriptionAttribution.findMany.mockResolvedValue([attribution]);
+      prisma.subscriptionAttribution.update.mockResolvedValue(attribution);
+
+      await service.updateSubscriptionStatus('sub_abc123', 'canceled');
+
+      expect(prisma.subscriptionAttribution.update).toHaveBeenCalledTimes(1);
+      expect(prisma.subscriptionAttribution.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            metadata: expect.objectContaining({ status: 'canceled' }),
+          }),
+          where: { id: 'attr_1' },
+        }),
+      );
+    });
+
+    it('does not call update when no attributions match', async () => {
+      const { prisma, service } = buildService();
+      prisma.subscriptionAttribution.findMany.mockResolvedValue([]);
+
+      await service.updateSubscriptionStatus('sub_nonexistent', 'canceled');
+
+      expect(prisma.subscriptionAttribution.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trackSubscription — findMany scopes by organizationId', () => {
+    it('passes organizationId in the where clause', async () => {
+      const { prisma, service } = buildService();
+      prisma.subscriptionAttribution.findMany.mockResolvedValue([]);
+      prisma.subscriptionAttribution.create.mockResolvedValue({
+        channel: null,
+        createdAt: new Date(),
+        id: 'attr_new',
+        metadata: {},
+        organizationId: 'org_1',
+        referrer: null,
+        sourceContentId: null,
+        sourceLinkId: null,
+        updatedAt: new Date(),
+        userId: 'user_1',
+      });
+
+      await service.trackSubscription(
+        {
+          amount: 10,
+          currency: 'usd',
+          email: 'test@example.com',
+          plan: 'pro',
+          stripeCustomerId: 'cus_1',
+          stripeSubscriptionId: 'sub_xyz',
+          userId: 'user_1',
+        },
+        'org_1',
+      );
+
+      expect(prisma.subscriptionAttribution.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: 'org_1' }),
+        }),
+      );
+    });
+  });
+});

--- a/ee/packages/billing/src/subscription-attributions/services/subscription-attributions.service.ts
+++ b/ee/packages/billing/src/subscription-attributions/services/subscription-attributions.service.ts
@@ -393,15 +393,22 @@ export class SubscriptionAttributionsService {
     stripeSubscriptionId: string,
     status: string,
   ): Promise<void> {
-    const attributions = await this.prisma.subscriptionAttribution.findMany();
+    // organizationId is intentionally absent: this method is invoked from a
+    // Stripe webhook keyed only by stripeSubscriptionId, with no org context
+    // available. Scoping by stripeSubscriptionId in the JSON metadata is the
+    // tightest safe filter possible — this model has no isDeleted field.
+    const attributions = await this.prisma.subscriptionAttribution.findMany({
+      where: {
+        metadata: {
+          path: ['stripeSubscriptionId'],
+          equals: stripeSubscriptionId,
+        },
+      },
+    });
 
     await Promise.all(
       attributions
         .map((attribution) => this.normalizeAttribution(attribution))
-        .filter(
-          (attribution) =>
-            attribution.stripeSubscriptionId === stripeSubscriptionId,
-        )
         .map((attribution) =>
           this.prisma.subscriptionAttribution.update({
             data: {

--- a/ee/packages/billing/src/subscriptions/controllers/subscriptions.controller.spec.ts
+++ b/ee/packages/billing/src/subscriptions/controllers/subscriptions.controller.spec.ts
@@ -1,4 +1,5 @@
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import type { RequestWithContext } from '@api/common/middleware/request-context.middleware';
 import { ConfigService } from '@api/config/config.service';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { User } from '@clerk/backend';
@@ -115,7 +116,10 @@ describe('SubscriptionsController', () => {
   });
 
   describe('changePlan', () => {
-    it('should change subscription plan', async () => {
+    it('should change subscription plan using request context organizationId', async () => {
+      const request = {
+        context: { organizationId: mockUser.publicMetadata.organization },
+      } as RequestWithContext;
       const changeData = { newPriceId: 'price_new' };
       const updatedSubscription = {
         ...mockSubscription,
@@ -126,7 +130,7 @@ describe('SubscriptionsController', () => {
         updatedSubscription,
       );
 
-      const result = await controller.changePlan(mockUser, changeData);
+      const result = await controller.changePlan(request, mockUser, changeData);
 
       expect(subscriptionsService.changeSubscriptionPlan).toHaveBeenCalledWith(
         mockUser.publicMetadata.organization,
@@ -134,6 +138,27 @@ describe('SubscriptionsController', () => {
       );
       expect(result.success).toBe(true);
       expect(result.data).toEqual(updatedSubscription);
+    });
+
+    it('falls back to user publicMetadata organization when request context is absent', async () => {
+      const request = {} as RequestWithContext;
+      const changeData = { newPriceId: 'price_new' };
+      const updatedSubscription = {
+        ...mockSubscription,
+        priceId: 'price_new',
+      };
+
+      mockSubscriptionsService.changeSubscriptionPlan.mockResolvedValue(
+        updatedSubscription,
+      );
+
+      const result = await controller.changePlan(request, mockUser, changeData);
+
+      expect(subscriptionsService.changeSubscriptionPlan).toHaveBeenCalledWith(
+        mockUser.publicMetadata.organization,
+        changeData.newPriceId,
+      );
+      expect(result.success).toBe(true);
     });
   });
 

--- a/ee/packages/billing/vitest.config.ts
+++ b/ee/packages/billing/vitest.config.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+const pkgDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(pkgDir, '../../..');
+
+export default defineConfig({
+  oxc: false, // Disable OXC transformer — SWC required for NestJS decorator metadata
+  plugins: [
+    swc.vite({
+      jsc: {
+        parser: { decorators: true, syntax: 'typescript' },
+        transform: { decoratorMetadata: true, legacyDecorator: true },
+      },
+      module: { type: 'es6' },
+    }),
+  ],
+  resolve: {
+    // Mirrors apps/server/api/vitest.config.ts so ee-billing source — which
+    // imports deep into @api services (cache, credits) and shared packages —
+    // resolves identically when its specs are run standalone via turbo.
+    alias: [
+      {
+        find: /^@api\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'apps/server/api/src/$1'),
+      },
+      {
+        find: '@api',
+        replacement: path.resolve(repoRoot, 'apps/server/api/src'),
+      },
+      {
+        find: '@credits',
+        replacement: path.resolve(
+          repoRoot,
+          'apps/server/api/src/collections/credits',
+        ),
+      },
+      {
+        find: '@files',
+        replacement: path.resolve(repoRoot, 'apps/server/files/src'),
+      },
+      {
+        find: /^@libs\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/libs/$1'),
+      },
+      {
+        find: '@libs',
+        replacement: path.resolve(repoRoot, 'packages/libs'),
+      },
+      {
+        find: /^@helpers\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/helpers/src/$1'),
+      },
+      {
+        find: '@helpers',
+        replacement: path.resolve(repoRoot, 'packages/helpers/src'),
+      },
+      {
+        find: /^@serializers\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/serializers/src/$1'),
+      },
+      {
+        find: /^@integrations\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/integrations/src/$1'),
+      },
+      {
+        find: /^@genfeedai\/prisma\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/prisma/src/$1'),
+      },
+      {
+        find: '@genfeedai/prisma',
+        replacement: path.resolve(repoRoot, 'packages/prisma/src'),
+      },
+      {
+        find: /^@genfeedai\/enums\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/enums/src/$1'),
+      },
+      {
+        find: '@genfeedai/enums',
+        replacement: path.resolve(repoRoot, 'packages/enums/src'),
+      },
+      {
+        find: /^@genfeedai\/constants\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/constants/src/$1'),
+      },
+      {
+        find: '@genfeedai/constants',
+        replacement: path.resolve(repoRoot, 'packages/constants/src'),
+      },
+      {
+        find: /^@genfeedai\/types\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/types/src/$1'),
+      },
+      {
+        find: '@genfeedai/types',
+        replacement: path.resolve(repoRoot, 'packages/types/src'),
+      },
+      {
+        find: /^@genfeedai\/config\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/config/src/$1'),
+      },
+      {
+        find: '@genfeedai/config',
+        replacement: path.resolve(repoRoot, 'packages/config/src'),
+      },
+      {
+        find: /^@genfeedai\/helpers\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/helpers/src/$1'),
+      },
+      {
+        find: '@genfeedai/helpers',
+        replacement: path.resolve(repoRoot, 'packages/helpers/src'),
+      },
+      {
+        find: /^@genfeedai\/utils\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/utils/$1'),
+      },
+      {
+        find: '@genfeedai/utils',
+        replacement: path.resolve(repoRoot, 'packages/utils'),
+      },
+      {
+        find: /^@genfeedai\/interfaces\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/interfaces/src/$1'),
+      },
+      {
+        find: '@genfeedai/interfaces',
+        replacement: path.resolve(repoRoot, 'packages/interfaces/src'),
+      },
+      {
+        find: /^@genfeedai\/integrations\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/integrations/src/$1'),
+      },
+      {
+        find: '@genfeedai/integrations',
+        replacement: path.resolve(repoRoot, 'packages/integrations/src'),
+      },
+      {
+        find: /^@genfeedai\/serializers\/(.*)$/,
+        replacement: path.resolve(repoRoot, 'packages/serializers/src/$1'),
+      },
+      {
+        find: '@genfeedai/serializers',
+        replacement: path.resolve(repoRoot, 'packages/serializers/src'),
+      },
+    ],
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.spec.ts'],
+    name: '@genfeedai/ee-billing',
+    passWithNoTests: true,
+    testTimeout: 30000,
+  },
+});

--- a/packages/hooks/storyboard/use-merge-progress/use-merge-progress.test.ts
+++ b/packages/hooks/storyboard/use-merge-progress/use-merge-progress.test.ts
@@ -95,7 +95,7 @@ describe('useMergeProgress', () => {
     expect(result.current.steps[0].label).toBe('Downloading files');
   });
 
-  it('marks steps complete on success event', () => {
+  it('marks steps complete on video-complete event', () => {
     const onComplete = vi.fn();
     const { result } = renderHook(() =>
       useMergeProgress({
@@ -107,7 +107,7 @@ describe('useMergeProgress', () => {
     const completeHandler = subscriptions.get('video-complete');
 
     act(() => {
-      completeHandler?.({ path: '/videos/video-1' });
+      completeHandler?.({});
     });
 
     expect(result.current.overallProgress).toBe(100);
@@ -117,37 +117,27 @@ describe('useMergeProgress', () => {
     expect(onComplete).toHaveBeenCalled();
   });
 
-  it('marks current step as failed on video-complete error events', () => {
-    const onError = vi.fn();
+  it('marks steps complete on video-complete even when event has no path or error fields', () => {
+    const onComplete = vi.fn();
     const { result } = renderHook(() =>
       useMergeProgress({
         ingredientId: 'video-1',
-        onError,
+        onComplete,
       }),
     );
 
-    const pathHandler = subscriptions.get('/videos/video-1');
     const completeHandler = subscriptions.get('video-complete');
 
+    // Simulate the actual channel contract: no path, no error fields
     act(() => {
-      pathHandler?.({
-        progress: {
-          step: 'downloading',
-          stepProgress: 10,
-        },
-        status: 'processing',
-      });
+      completeHandler?.({ result: 'some-url', userId: 'user-1' });
     });
 
-    act(() => {
-      completeHandler?.({
-        error: 'Merge failed',
-        path: '/videos/video-1',
-      });
-    });
-
-    expect(result.current.steps[0].status).toBe('failed');
-    expect(onError).toHaveBeenCalledWith('Merge failed');
+    expect(result.current.overallProgress).toBe(100);
+    expect(
+      result.current.steps.every((step) => step.status === 'completed'),
+    ).toBe(true);
+    expect(onComplete).toHaveBeenCalled();
   });
 
   it('marks current step as failed and calls onError', () => {

--- a/packages/hooks/storyboard/use-merge-progress/use-merge-progress.ts
+++ b/packages/hooks/storyboard/use-merge-progress/use-merge-progress.ts
@@ -32,11 +32,6 @@ interface VideoProgressEvent {
   room?: string;
 }
 
-interface VideoCompleteEvent {
-  path: string;
-  error?: string;
-}
-
 interface PathBasedWebSocketEvent {
   status: 'processing' | 'completed' | 'success' | 'failed';
   progress?: JobProgress;
@@ -308,23 +303,15 @@ export function useMergeProgress({
       },
     );
 
-    // Subscribe to video-complete for success/error
-    const unsubscribeComplete = socketManager.subscribe<VideoCompleteEvent>(
+    // Subscribe to video-complete for success — the channel itself signals completion
+    const unsubscribeComplete = socketManager.subscribe(
       'video-complete',
-      (data) => {
+      () => {
         logger.info('useMergeProgress: Received video-complete event', {
-          eventPath: data.path,
-          hasError: !!data.error,
           websocketPath,
         });
 
-        if (data.path === websocketPath) {
-          if (data.error) {
-            markFailed(data.error);
-          } else {
-            markComplete();
-          }
-        }
+        markComplete();
       },
     );
 

--- a/packages/integrations/src/bot-internal-api-client.test.ts
+++ b/packages/integrations/src/bot-internal-api-client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   type BotHttpAdapter,
@@ -102,6 +102,29 @@ describe('BotInternalApiClient', () => {
       const result = await client.fetchActiveIntegrations();
       expect(result).toHaveLength(1);
     });
+
+    it('propagates transport errors (ECONNREFUSED) to the caller', async () => {
+      const { adapter, get } = makeMockAdapter();
+      get.mockRejectedValue(new Error('ECONNREFUSED'));
+      const client = makeClient('discord', adapter);
+
+      await expect(client.fetchActiveIntegrations()).rejects.toThrow(
+        'ECONNREFUSED',
+      );
+    });
+
+    it('propagates 401 HTTP errors to the caller', async () => {
+      const { adapter, get } = makeMockAdapter();
+      const err = Object.assign(new Error('Unauthorized'), {
+        response: { status: 401 },
+      });
+      get.mockRejectedValue(err);
+      const client = makeClient('discord', adapter);
+
+      await expect(client.fetchActiveIntegrations()).rejects.toThrow(
+        'Unauthorized',
+      );
+    });
   });
 
   describe('fetchIntegration', () => {
@@ -117,7 +140,7 @@ describe('BotInternalApiClient', () => {
         { Authorization: 'Bearer test-key' },
       );
       expect(result).not.toBeNull();
-      expect(result!.id).toBe('int-1');
+      expect(result?.id).toBe('int-1');
     });
 
     it('returns null when payload cannot be normalized', async () => {

--- a/packages/integrations/src/bot-internal-api-client.ts
+++ b/packages/integrations/src/bot-internal-api-client.ts
@@ -50,8 +50,11 @@ export class BotInternalApiClient {
 
   /**
    * Fetch all active integrations for this platform.
-   * Returns an empty array on any error (ECONNREFUSED, 401, etc.) — callers
-   * should handle the "0 bots" case themselves and log appropriately.
+   * Propagates transport errors (ECONNREFUSED, 401, etc.) to the caller — bot
+   * managers wrap this in their own try/catch so the failure is logged with the
+   * underlying error and the manager stays up. Returns `[]` only when the API
+   * responds with a non-array/unnormalizable payload (a genuine "0 bots" state),
+   * mirroring `fetchIntegration` returning `null` on bad payloads.
    */
   async fetchActiveIntegrations(): Promise<OrgIntegration[]> {
     const data = await this.http.get<unknown>(

--- a/packages/integrations/src/bot-normalize.test.ts
+++ b/packages/integrations/src/bot-normalize.test.ts
@@ -32,12 +32,12 @@ describe('normalizeIntegration', () => {
 
     const result = normalizeIntegration(payload, 'discord');
     expect(result).not.toBeNull();
-    expect(result!.id).toBe('int-1');
-    expect(result!.orgId).toBe('org-1');
-    expect(result!.botToken).toBe('tok-abc');
-    expect(result!.platform).toBe('discord');
-    expect(result!.status).toBe('active');
-    expect(result!.config.allowedUserIds).toContain('u1');
+    expect(result?.id).toBe('int-1');
+    expect(result?.orgId).toBe('org-1');
+    expect(result?.botToken).toBe('tok-abc');
+    expect(result?.platform).toBe('discord');
+    expect(result?.status).toBe('active');
+    expect(result?.config.allowedUserIds).toContain('u1');
   });
 
   it('normalizes a MongoDB-style payload with _id and organization', () => {
@@ -51,9 +51,9 @@ describe('normalizeIntegration', () => {
 
     const result = normalizeIntegration(payload, 'telegram');
     expect(result).not.toBeNull();
-    expect(result!.id).toBe('mongo-id-123');
-    expect(result!.orgId).toBe('org-mongo-1');
-    expect(result!.platform).toBe('telegram');
+    expect(result?.id).toBe('mongo-id-123');
+    expect(result?.orgId).toBe('org-mongo-1');
+    expect(result?.platform).toBe('telegram');
   });
 
   it('prefers Prisma id over _id when both present', () => {
@@ -65,7 +65,7 @@ describe('normalizeIntegration', () => {
     };
 
     const result = normalizeIntegration(payload, 'slack');
-    expect(result!.id).toBe('prisma-id');
+    expect(result?.id).toBe('prisma-id');
   });
 
   it('defaults status to "active" when absent', () => {
@@ -76,7 +76,7 @@ describe('normalizeIntegration', () => {
     };
 
     const result = normalizeIntegration(payload, 'slack');
-    expect(result!.status).toBe('active');
+    expect(result?.status).toBe('active');
   });
 
   it('defaults createdAt/updatedAt to now when absent', () => {
@@ -85,14 +85,67 @@ describe('normalizeIntegration', () => {
     const result = normalizeIntegration(payload, 'discord');
     const after = Date.now();
 
-    expect(result!.createdAt.getTime()).toBeGreaterThanOrEqual(before);
-    expect(result!.createdAt.getTime()).toBeLessThanOrEqual(after);
+    expect(result?.createdAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(result?.createdAt.getTime()).toBeLessThanOrEqual(after);
   });
 
   it('defaults config to empty object when absent', () => {
     const payload = { id: 'int-1', orgId: 'org-1', botToken: 'tok' };
     const result = normalizeIntegration(payload, 'telegram');
-    expect(result!.config).toEqual({});
+    expect(result?.config).toEqual({});
+  });
+
+  it('defaults config to {} when raw.config is a primitive (number)', () => {
+    const payload = {
+      id: 'int-1',
+      orgId: 'org-1',
+      botToken: 'tok',
+      config: 42,
+    };
+    const result = normalizeIntegration(payload, 'discord');
+    expect(result?.config).toEqual({});
+  });
+
+  it('defaults config to {} when raw.config is a primitive (string)', () => {
+    const payload = {
+      id: 'int-1',
+      orgId: 'org-1',
+      botToken: 'tok',
+      config: 'bad',
+    };
+    const result = normalizeIntegration(payload, 'discord');
+    expect(result?.config).toEqual({});
+  });
+
+  it('defaults config to {} when raw.config is an array', () => {
+    const payload = {
+      id: 'int-1',
+      orgId: 'org-1',
+      botToken: 'tok',
+      config: ['a', 'b'],
+    };
+    const result = normalizeIntegration(payload, 'discord');
+    expect(result?.config).toEqual({});
+  });
+
+  it('returns a valid Date when createdAt/updatedAt is an unparseable string', () => {
+    const before = Date.now();
+    const payload = {
+      id: 'int-1',
+      orgId: 'org-1',
+      botToken: 'tok',
+      createdAt: 'not-a-date',
+      updatedAt: 'also-not-a-date',
+    };
+    const result = normalizeIntegration(payload, 'slack');
+    const after = Date.now();
+
+    expect(Number.isNaN(result?.createdAt.getTime())).toBe(false);
+    expect(result?.createdAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(result?.createdAt.getTime()).toBeLessThanOrEqual(after);
+    expect(Number.isNaN(result?.updatedAt.getTime())).toBe(false);
+    expect(result?.updatedAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(result?.updatedAt.getTime()).toBeLessThanOrEqual(after);
   });
 
   it('uses the platform argument passed in', () => {
@@ -100,9 +153,9 @@ describe('normalizeIntegration', () => {
     const discord = normalizeIntegration(payload, 'discord');
     const slack = normalizeIntegration(payload, 'slack');
     const telegram = normalizeIntegration(payload, 'telegram');
-    expect(discord!.platform).toBe('discord');
-    expect(slack!.platform).toBe('slack');
-    expect(telegram!.platform).toBe('telegram');
+    expect(discord?.platform).toBe('discord');
+    expect(slack?.platform).toBe('slack');
+    expect(telegram?.platform).toBe('telegram');
   });
 });
 

--- a/packages/integrations/src/bot-normalize.ts
+++ b/packages/integrations/src/bot-normalize.ts
@@ -1,6 +1,20 @@
 import type { IntegrationPlatform } from '@genfeedai/enums';
 import type { OrgIntegration } from './types';
 
+/** Returns a valid Date parsed from value, or new Date() as a fallback. */
+function parseDateOrNow(value: unknown): Date {
+  if (value === undefined || value === null) {
+    return new Date();
+  }
+  const d = new Date(value as string | number);
+  return Number.isNaN(d.getTime()) ? new Date() : d;
+}
+
+/** Returns value only when it is a plain (non-null, non-array) object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * Normalize a raw API payload into an OrgIntegration.
  *
@@ -29,13 +43,15 @@ export function normalizeIntegration(
 
   return {
     botToken: String(rawToken),
-    config: (raw.config as OrgIntegration['config']) || {},
-    createdAt: raw.createdAt ? new Date(raw.createdAt as string) : new Date(),
+    config: isPlainObject(raw.config)
+      ? (raw.config as OrgIntegration['config'])
+      : {},
+    createdAt: parseDateOrNow(raw.createdAt),
     id: String(rawId),
     orgId: String(rawOrgId),
     platform,
     status: (raw.status as OrgIntegration['status'] | undefined) || 'active',
-    updatedAt: raw.updatedAt ? new Date(raw.updatedAt as string) : new Date(),
+    updatedAt: parseDateOrNow(raw.updatedAt),
   };
 }
 

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -27,6 +27,7 @@
     "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
+    "test": "vitest run --config vitest.config.ts",
     "type-check": "tsc --noEmit"
   },
   "sideEffects": false,

--- a/packages/pricing/src/pricing-config.test.ts
+++ b/packages/pricing/src/pricing-config.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getPricingConfig } from './pricing-config';
+
+describe('getPricingConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.GENFEED_BASE_COST_PER_CREDIT;
+    delete process.env.GENFEED_MARGIN_MULTIPLIER;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns the documented defaults when env vars are absent', () => {
+    const config = getPricingConfig();
+    expect(config.baseCostPerCredit).toBe(0.005);
+    expect(config.marginMultiplier).toBe(1.0);
+  });
+
+  it('reads valid numeric env vars', () => {
+    process.env.GENFEED_BASE_COST_PER_CREDIT = '0.01';
+    process.env.GENFEED_MARGIN_MULTIPLIER = '2.5';
+    const config = getPricingConfig();
+    expect(config.baseCostPerCredit).toBe(0.01);
+    expect(config.marginMultiplier).toBe(2.5);
+  });
+
+  it('falls back to default when baseCostPerCredit env var is malformed (NaN)', () => {
+    process.env.GENFEED_BASE_COST_PER_CREDIT = 'not-a-number';
+    const config = getPricingConfig();
+    expect(config.baseCostPerCredit).toBe(0.005);
+  });
+
+  it('falls back to default when marginMultiplier env var is malformed (NaN)', () => {
+    process.env.GENFEED_MARGIN_MULTIPLIER = 'bad';
+    const config = getPricingConfig();
+    expect(config.marginMultiplier).toBe(1.0);
+  });
+
+  it('falls back to default when env var is an empty string', () => {
+    process.env.GENFEED_BASE_COST_PER_CREDIT = '';
+    process.env.GENFEED_MARGIN_MULTIPLIER = '';
+    const config = getPricingConfig();
+    expect(config.baseCostPerCredit).toBe(0.005);
+    expect(config.marginMultiplier).toBe(1.0);
+  });
+
+  it('falls back to default when env var is Infinity', () => {
+    process.env.GENFEED_BASE_COST_PER_CREDIT = 'Infinity';
+    process.env.GENFEED_MARGIN_MULTIPLIER = '-Infinity';
+    const config = getPricingConfig();
+    expect(config.baseCostPerCredit).toBe(0.005);
+    expect(config.marginMultiplier).toBe(1.0);
+  });
+});

--- a/packages/pricing/src/pricing-config.ts
+++ b/packages/pricing/src/pricing-config.ts
@@ -11,13 +11,26 @@ export interface PricingConfig {
   marginMultiplier: number;
 }
 
+const DEFAULT_BASE_COST_PER_CREDIT = 0.005;
+const DEFAULT_MARGIN_MULTIPLIER = 1.0;
+
+function parseFiniteFloat(
+  value: string | undefined,
+  defaultValue: number,
+): number {
+  const parsed = parseFloat(value ?? '');
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}
+
 export function getPricingConfig(): PricingConfig {
   return {
-    baseCostPerCredit: parseFloat(
-      process.env.GENFEED_BASE_COST_PER_CREDIT || '0.005',
+    baseCostPerCredit: parseFiniteFloat(
+      process.env.GENFEED_BASE_COST_PER_CREDIT,
+      DEFAULT_BASE_COST_PER_CREDIT,
     ),
-    marginMultiplier: parseFloat(
-      process.env.GENFEED_MARGIN_MULTIPLIER || '1.0',
+    marginMultiplier: parseFiniteFloat(
+      process.env.GENFEED_MARGIN_MULTIPLIER,
+      DEFAULT_MARGIN_MULTIPLIER,
     ),
   };
 }

--- a/packages/pricing/vitest.config.ts
+++ b/packages/pricing/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/workflow-engine/src/execution/__tests__/engine.spec.ts
+++ b/packages/workflow-engine/src/execution/__tests__/engine.spec.ts
@@ -299,6 +299,52 @@ describe('WorkflowEngine', () => {
 
       expect(result.status).toBe('failed');
     });
+
+    it('should record a failed NodeExecutionResult for the stuck node on deadlock', async () => {
+      // Exercise the deadlock-detection branch: after n1 completes its
+      // executor removes n1 from workflow.nodes so that canExecuteNode('n2')
+      // returns false (n1 dep lookup → undefined → false). With nothing in
+      // flight and n2 still in `remaining`, the engine hits the stuck-node
+      // path. The fix must insert a failed NodeExecutionResult for n2 before
+      // breaking, matching the shape used in every other failure path.
+      const n1Node = makeNode('n1', 'generate');
+      const n2Node = makeNode('n2', 'upscale');
+      const deadlockWorkflow = makeWorkflow(
+        [n1Node, n2Node],
+        [makeEdge('n1', 'n2')],
+      );
+
+      let n1Ran = false;
+      engine.registerExecutor(
+        'generate',
+        vi.fn(async () => {
+          n1Ran = true;
+          // After n1 completes, remove n1 from the nodes array so that when the
+          // engine tries to dispatch n2, canExecuteNode('n2') looks up n1 as a
+          // dependency, finds depNode=undefined (n1 is gone), and returns false.
+          deadlockWorkflow.nodes = deadlockWorkflow.nodes.filter(
+            (n) => n.id !== 'n1',
+          );
+          return 'n1-output';
+        }),
+      );
+
+      const result = await engine.execute(deadlockWorkflow);
+
+      expect(n1Ran).toBe(true);
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Dependencies not satisfied for node n2');
+      // The stuck node MUST have a nodeResults entry (the bug being fixed).
+      expect(result.nodeResults.has('n2')).toBe(true);
+      const stuckResult = result.nodeResults.get('n2');
+      expect(stuckResult?.status).toBe('failed');
+      expect(stuckResult?.error).toContain(
+        'Dependencies not satisfied for node n2',
+      );
+      expect(stuckResult?.creditsUsed).toBe(0);
+      expect(stuckResult?.retryCount).toBe(0);
+      expect(stuckResult?.nodeId).toBe('n2');
+    });
   });
 
   describe('execute — locked nodes', () => {

--- a/packages/workflow-engine/src/execution/engine.ts
+++ b/packages/workflow-engine/src/execution/engine.ts
@@ -285,6 +285,17 @@ export class WorkflowEngine {
         lastError = `Dependencies not satisfied for node ${stuckNodeId}`;
         failedNodes.add(stuckNodeId);
         currentStatus = 'failed';
+        const stuckAt = new Date();
+        const stuckResult: NodeExecutionResult = {
+          completedAt: stuckAt,
+          creditsUsed: 0,
+          error: lastError,
+          nodeId: stuckNodeId,
+          retryCount: 0,
+          startedAt: stuckAt,
+          status: 'failed',
+        };
+        nodeResults.set(stuckNodeId, stuckResult);
         break;
       }
 


### PR DESCRIPTION
## Summary

Implements the still-actionable CodeRabbit review findings surfaced across recent PRs (#558, #559, #563 and related). 31 files changed, +827/−250, every affected package verified green.

> Note: this branch also carries one pre-existing commit (`ed76973f1` refactor article-status handling) that was the base it forked from and is not yet in `develop`. The CodeRabbit fixes are in `d0815f9f9`.

## Changes by area

| Area | Fix |
|---|---|
| `integrations/bot-internal-api-client` + `bot-normalize` (+tests) | Normalize hardening. `fetchActiveIntegrations` now **propagates** transport errors (ECONNREFUSED/401) so bot-manager callers log real outages, matching the other three client methods and both callers — instead of silently swallowing into `[]`. |
| `discord-bot-manager` (.ts + 2 specs) | Dedupe internal-API calls via the shared `BotInternalApiClient`; convert `discord.js` mocks to constructable function expressions (vitest v4 cannot `new` an arrow-fn mock); `initialize()` logs and rethrows on fetch failure. |
| `byok-billing.service` (+spec) | `parseRequiredNumberConfig` throws `InternalServerErrorException` on NaN `STRIPE_BYOK_*` config instead of propagating NaN. |
| `webhooks.stripe.service` (+spec) | Webhook handler hardening + coverage. |
| `agent-orchestrator` (+spec) | Clearer "requires at least N credits to start" message. |
| `assets-query` / `add-creator` / `bot-publishing-settings` DTOs (+specs) | Validation decorators + tests. |
| `images/training`, `workers/config`, `clips/config` | Config + service guards. |
| `ee/billing` (pkg.json, vitest.config, subscription-attributions +spec, subscriptions.controller.spec) | Vitest wiring; org-scoped subscription-attributions query. |
| `pricing` (pkg.json, vitest.config, pricing-config +test) | Config validation + tests. |
| `hooks/use-merge-progress` (+test) | Progress merge fix. |
| `workflow-engine/engine` (+spec) | Execution guard. |
| `.github/workflows/deploy-production.yml` | Workflow hardening. |

## Verification

- `npx biome check` — clean (lint-staged + secretlint passed on commit)
- `bunx turbo run type-check lint --affected` — 64/64
- `bunx turbo run test --affected` — **61/61 packages, exit 0** (`@genfeedai/app` 1632, integrations 142, telegram 36, discord 41, api, ee-billing, workflow-engine, pricing, hooks, clips, workers)

## Notes

A regression introduced mid-implementation (the integrations client swallowing transport errors) was root-caused and reverted before commit; tests now assert the throw-and-let-caller-log contract on all four client methods.