### PR TITLE
fix(billing): break EE billing circular-dep TDZ crashing api on boot (#574)

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -90,9 +90,38 @@ jobs:
               done
             '
 
+      - name: Boot-check EE/SaaS api bundle (#574 circular-dep regression guard)
+        run: |
+          echo "Booting the EE/SaaS api bundle to prove the module graph initializes..."
+          # The bundle-exists check above never RUNS the bundle. The EE billing
+          # decouple (#563) introduced an ESM eval-time circular dependency that
+          # crashed api on boot with a TDZ ("Cannot access 'userSubscriptions'
+          # before initialization") — invisible to typecheck/lint/vitest (which
+          # resolve @billing-providers to the OSS stub) and to the self-hosted E2E
+          # (community image). This boots the actual EE bundle that prod runs.
+          docker run --rm -e NODE_ENV=production ${{ env.IMAGE_NAME }}:test \
+            sh -c '
+              set +e
+              # It will fail shortly after on missing PORT/DB/Redis env — that is
+              # EXPECTED and proves the module graph (DI container) initialized.
+              OUT=$(timeout 40 node apps/server/dist/apps/api/main.js 2>&1)
+              echo "----- boot output (tail) -----"
+              echo "$OUT" | tail -n 60
+              echo "------------------------------"
+              if echo "$OUT" | grep -qiE "Cannot access .* before initialization|ReferenceError"; then
+                echo "❌ #574 regression: EE api bundle crashed at module init (circular-dep TDZ)"
+                exit 1
+              fi
+              if [ -z "$OUT" ]; then
+                echo "❌ EE api bundle produced no output — cannot confirm module init"
+                exit 1
+              fi
+              echo "✅ EE api bundle initialized past the module graph (no TDZ)"
+            '
+
       - name: Build summary
         if: success()
         run: |
           echo "## ✅ Build Verification Passed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Docker image built successfully. All 12 service bundles verified." >> $GITHUB_STEP_SUMMARY
+          echo "Docker image built + all 12 bundles verified; EE api bundle booted past module init (#574 guard)." >> $GITHUB_STEP_SUMMARY

--- a/ee/packages/billing/src/billing.providers.ee.ts
+++ b/ee/packages/billing/src/billing.providers.ee.ts
@@ -32,7 +32,6 @@ import { OssSubscriptionAttributionsService } from '@api/common/subscriptions/os
 import { OssSubscriptionsService } from '@api/common/subscriptions/oss-subscriptions.service';
 import { OssUserSubscriptionsService } from '@api/common/subscriptions/oss-user-subscriptions.service';
 import { ClerkModule } from '@api/services/integrations/clerk/clerk.module';
-import { StripeModule } from '@api/services/integrations/stripe/stripe.module';
 import { isEEEnabled } from '@genfeedai/config';
 import {
   SUBSCRIPTION_ATTRIBUTIONS_SERVICE,
@@ -54,7 +53,21 @@ export const subscriptions: BillingProviderFragment = {
     forwardRef(() => CreditsModule),
     forwardRef(() => CustomersModule),
     forwardRef(() => OrganizationsModule),
-    forwardRef(() => StripeModule),
+    // StripeModule is resolved lazily (NOT a top-level import) to break an ESM
+    // eval-time circular dependency that crashes the EE/SaaS bundle on boot:
+    //   billing.providers.ee → stripe.module → user-subscriptions.module
+    //   → @Module(userSubscriptions) reads this file's exports before its body
+    //   has run → TDZ "Cannot access 'userSubscriptions' before initialization".
+    // A lazy require defers stripe.module's evaluation to DI-resolution time,
+    // after this module body has fully initialized. See issue #574.
+    // Do NOT convert back to a top-level `import { StripeModule }` — it
+    // reintroduces the boot crash (community/OSS bundle is unaffected either way).
+    forwardRef(
+      () =>
+        (
+          require('@api/services/integrations/stripe/stripe.module') as typeof import('@api/services/integrations/stripe/stripe.module')
+        ).StripeModule,
+    ),
     forwardRef(() => UsersModule),
   ],
   providers: [


### PR DESCRIPTION
Fixes #574.

## Root cause
`billing.providers.ee.ts:35` eager-imported `StripeModule` at the top level, creating an ESM eval-time cycle:
```
billing.providers.ee → stripe.module → user-subscriptions.module
  → @Module(userSubscriptions) reads this file's exports before its body runs
  → TDZ: "Cannot access 'userSubscriptions' before initialization"
```
The EE/SaaS api bundle crashed on boot; the `v0.1.2` deploy health-check auto-rolled api back to `v0.1.1` (prod left split-version). The `forwardRef` at :57 wrapped the *reference* but the top-level `import` statement itself is eager — ESM hoists + fully evaluates imports before the module body, so const ordering is irrelevant.

## Fix
1. **Break the cycle** — resolve `StripeModule` lazily inside the `forwardRef` closure via `require` (not a top-level import), deferring `stripe.module` evaluation to DI-resolution time, after this module body has fully initialized. The community/OSS bundle was never affected (its `@billing-providers` stub has no `StripeModule`).
2. **CI gate** — `build-verify` now BOOTS the EE api bundle (`node apps/server/dist/apps/api/main.js`) and fails on a module-init TDZ/`ReferenceError`. The job previously only checked bundles *exist* (`test -f main.js`) and never ran them, so all three promotion gates (develop→staging→master) were blind to a runtime-only cycle.

## Verification (local)
Built the EE api bundle and booted it:
- ✅ Initializes past the module graph — logs provider wiring (`WorkflowEngineAdapterService social executors wired…`, deep in Nest DI).
- ✅ Stops only on `Config validation error: "PORT" is required` (env), **not** the TDZ.
- ✅ No `ReferenceError` / "before initialization".

## Follow-up (per issue)
After this lands: re-promote develop→staging→master → release `v0.1.3` → redeploy (full backend waves + frontends).