### PR TITLE
chore(scripts): one-command prod credential smoke test

### DIFF
--- a/scripts/check-prod-creds.mjs
+++ b/scripts/check-prod-creds.mjs
@@ -1,0 +1,70 @@
+// One-shot prod credential smoke test: AWS S3 + MongoDB + Postgres.
+// Creds are read from env (the companion check-prod-creds.sh pulls them from
+// SSM via substitution, so no secret value is ever printed or stored on disk).
+// READ-ONLY: ListBuckets / Mongo ping / SELECT 1. Prints a PASS/FAIL matrix only.
+//
+// Usage:  bash scripts/check-prod-creds.sh
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { MongoClient } from 'mongodb';
+import { ListBucketsCommand, S3Client } from '@aws-sdk/client-s3';
+
+// pg is bun-isolated (not hoisted) — resolve it from node_modules/.bun directly.
+async function loadPg() {
+  try {
+    const bun = join(process.cwd(), 'node_modules/.bun');
+    const dir = readdirSync(bun).find((d) => d.startsWith('pg@'));
+    if (!dir) return null;
+    const mod = await import(join(bun, dir, 'node_modules/pg/lib/index.js'));
+    return mod.default ?? mod;
+  } catch {
+    return null;
+  }
+}
+
+const out = [];
+
+try {
+  const creds = process.env.__AWS_ID
+    ? { accessKeyId: process.env.__AWS_ID, secretAccessKey: process.env.__AWS_SECRET }
+    : undefined;
+  const s3 = new S3Client({ region: process.env.AWS_REGION || 'us-west-1', credentials: creds });
+  const r = await s3.send(new ListBucketsCommand({}));
+  out.push(['AWS S3', true, `${(r.Buckets ?? []).length} buckets visible`]);
+} catch (e) {
+  out.push(['AWS S3', false, e?.name || e?.message]);
+}
+
+try {
+  if (!process.env.__MONGO) throw new Error('no MONGODB_URL');
+  const m = new MongoClient(process.env.__MONGO, { serverSelectionTimeoutMS: 10000 });
+  await m.connect();
+  await m.db().command({ ping: 1 });
+  const db = m.db().databaseName;
+  await m.close();
+  out.push(['MongoDB', true, `ping ok, db=${db}`]);
+} catch (e) {
+  out.push(['MongoDB', false, e?.codeName || e?.message]);
+}
+
+try {
+  if (!process.env.__PG) throw new Error('no DATABASE_URL');
+  const pg = await loadPg();
+  if (!pg) throw new Error('pg module not found under node_modules/.bun');
+  const u = new URL(process.env.__PG);
+  const sm = u.searchParams.get('sslmode');
+  if (sm && sm !== 'disable' && sm !== 'no-verify') u.searchParams.set('sslmode', 'no-verify');
+  const c = new pg.Client({ connectionString: u.toString(), ssl: { rejectUnauthorized: false }, connectionTimeoutMillis: 10000 });
+  await c.connect();
+  await c.query('select 1 as ok');
+  await c.end();
+  out.push(['Postgres', true, 'connect + select 1 ok']);
+} catch (e) {
+  out.push(['Postgres', false, e?.message]);
+}
+
+console.log('\n=== PROD CREDENTIAL SMOKE TEST (from SSM — no secrets printed) ===');
+for (const [sys, ok, info] of out) console.log(`  ${ok ? '✅' : '❌'} ${sys.padEnd(9)} ${(ok ? 'PASS' : 'FAIL').padEnd(5)} ${info}`);
+const all = out.every((r) => r[1]);
+console.log(all ? '\nALL CREDS GOOD ✅\n' : '\nSOME FAILED ❌\n');
+process.exit(all ? 0 : 1);

--- a/scripts/check-prod-creds.mjs
+++ b/scripts/check-prod-creds.mjs
@@ -26,9 +26,15 @@ const out = [];
 
 try {
   const creds = process.env.__AWS_ID
-    ? { accessKeyId: process.env.__AWS_ID, secretAccessKey: process.env.__AWS_SECRET }
+    ? {
+        accessKeyId: process.env.__AWS_ID,
+        secretAccessKey: process.env.__AWS_SECRET,
+      }
     : undefined;
-  const s3 = new S3Client({ region: process.env.AWS_REGION || 'us-west-1', credentials: creds });
+  const s3 = new S3Client({
+    region: process.env.AWS_REGION || 'us-west-1',
+    credentials: creds,
+  });
   const r = await s3.send(new ListBucketsCommand({}));
   out.push(['AWS S3', true, `${(r.Buckets ?? []).length} buckets visible`]);
 } catch (e) {
@@ -37,7 +43,9 @@ try {
 
 try {
   if (!process.env.__MONGO) throw new Error('no MONGODB_URL');
-  const m = new MongoClient(process.env.__MONGO, { serverSelectionTimeoutMS: 10000 });
+  const m = new MongoClient(process.env.__MONGO, {
+    serverSelectionTimeoutMS: 10000,
+  });
   await m.connect();
   await m.db().command({ ping: 1 });
   const db = m.db().databaseName;
@@ -53,8 +61,13 @@ try {
   if (!pg) throw new Error('pg module not found under node_modules/.bun');
   const u = new URL(process.env.__PG);
   const sm = u.searchParams.get('sslmode');
-  if (sm && sm !== 'disable' && sm !== 'no-verify') u.searchParams.set('sslmode', 'no-verify');
-  const c = new pg.Client({ connectionString: u.toString(), ssl: { rejectUnauthorized: false }, connectionTimeoutMillis: 10000 });
+  if (sm && sm !== 'disable' && sm !== 'no-verify')
+    u.searchParams.set('sslmode', 'no-verify');
+  const c = new pg.Client({
+    connectionString: u.toString(),
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 10000,
+  });
   await c.connect();
   await c.query('select 1 as ok');
   await c.end();
@@ -63,8 +76,13 @@ try {
   out.push(['Postgres', false, e?.message]);
 }
 
-console.log('\n=== PROD CREDENTIAL SMOKE TEST (from SSM — no secrets printed) ===');
-for (const [sys, ok, info] of out) console.log(`  ${ok ? '✅' : '❌'} ${sys.padEnd(9)} ${(ok ? 'PASS' : 'FAIL').padEnd(5)} ${info}`);
+console.log(
+  '\n=== PROD CREDENTIAL SMOKE TEST (from SSM — no secrets printed) ===',
+);
+for (const [sys, ok, info] of out)
+  console.log(
+    `  ${ok ? '✅' : '❌'} ${sys.padEnd(9)} ${(ok ? 'PASS' : 'FAIL').padEnd(5)} ${info}`,
+  );
 const all = out.every((r) => r[1]);
 console.log(all ? '\nALL CREDS GOOD ✅\n' : '\nSOME FAILED ❌\n');
 process.exit(all ? 0 : 1);

--- a/scripts/check-prod-creds.sh
+++ b/scripts/check-prod-creds.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# One-command prod credential smoke test (AWS S3 + MongoDB + Postgres).
+# Pulls each cred from SSM Parameter Store at runtime via command substitution,
+# so no secret value is ever printed, logged, or written to disk. READ-ONLY.
+#
+#   bash scripts/check-prod-creds.sh
+#
+# Requires: awscli authenticated to the genfeed account, node, bun-installed deps.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REGION="${AWS_SSM_REGION:-us-west-1}"
+get() { aws ssm get-parameter --region "$REGION" --name "/genfeed/production/$1" --with-decryption --query Parameter.Value --output text; }
+
+__AWS_ID="$(get AWS_ACCESS_KEY_ID)" \
+__AWS_SECRET="$(get AWS_SECRET_ACCESS_KEY)" \
+AWS_REGION="$(get AWS_REGION)" \
+__MONGO="$(get MONGODB_URL)" \
+__PG="$(get DATABASE_URL)" \
+node scripts/check-prod-creds.mjs


### PR DESCRIPTION
## What
`bash scripts/check-prod-creds.sh` — verifies all three prod credential systems in a single run:

| System | Check | Source |
|---|---|---|
| AWS S3 | `ListBuckets` | SSM `/genfeed/production/AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
| MongoDB | connect + `ping` | SSM `/genfeed/production/MONGODB_URL` |
| Postgres | connect + `SELECT 1` | SSM `/genfeed/production/DATABASE_URL` |

Each cred is pulled from SSM at runtime via command substitution — **no secret is printed, logged, or written to disk**. Output is a PASS/FAIL matrix only. All checks are read-only.

## Why
After the recent AWS + Mongo credential rotations, verifying creds was ad-hoc and one-system-at-a-time. This gives a definitive, repeatable check to run after any rotation.

## Usage
```
bash scripts/check-prod-creds.sh
```
Requires awscli authenticated to the genfeed account.