### PR TITLE
fix(api): emit scalar FK keys in folders findAll query (#565)

### DIFF
--- a/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
@@ -112,8 +112,8 @@ describe('FoldersController', () => {
         where: expect.objectContaining({
           isDeleted: false,
           OR: [
-            { user: '507f191e810c19729de860ee' },
-            { organization: '507f191e810c19729de860ee' },
+            { userId: '507f191e810c19729de860ee' },
+            { organizationId: '507f191e810c19729de860ee' },
           ],
         }),
       });
@@ -140,10 +140,10 @@ describe('FoldersController', () => {
         where: expect.objectContaining({
           OR: [
             {
-              brand: null,
-              organization: '507f191e810c19729de860ee',
+              brandId: null,
+              organizationId: '507f191e810c19729de860ee',
             },
-            { brand: 'brand-1' },
+            { brandId: 'brand-1' },
           ],
         }),
       });
@@ -156,9 +156,33 @@ describe('FoldersController', () => {
 
       expect(result).toMatchObject({
         where: expect.objectContaining({
-          OR: [{ organization: 'org-1' }],
+          OR: [{ organizationId: 'org-1' }],
         }),
       });
+    });
+
+    it('should use scalar FK keys and never Prisma relation accessors (#565)', () => {
+      // Relation accessors (brand/organization/user) expect a nested filter
+      // object; emitting them with bare scalars crashed Prisma in prod (#565).
+      // Every branch of every OR clause must use scalar FK keys only.
+      const relationAccessorKeys = ['brand', 'organization', 'user'];
+      const scenarios: Array<BaseQueryDto & Record<string, unknown>> = [
+        {},
+        { brand: 'brand-1' } as BaseQueryDto & { brand: string },
+        { organization: 'org-1' } as BaseQueryDto & { organization: string },
+      ];
+
+      for (const query of scenarios) {
+        const { where } = controller.buildFindAllQuery(mockUser, query);
+        const orClauses = (where as { OR?: Array<Record<string, unknown>> }).OR;
+
+        expect(orClauses).toBeDefined();
+        for (const clause of orClauses ?? []) {
+          for (const key of relationAccessorKeys) {
+            expect(clause).not.toHaveProperty(key);
+          }
+        }
+      }
     });
   });
 

--- a/apps/server/api/src/collections/folders/controllers/folders.controller.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.ts
@@ -71,21 +71,24 @@ export class FoldersController extends BaseCRUDController<
    * - If brand query param: org folders without brand + brand folders
    * - If organization query param (no brand): org folders
    * - Default: user folders + organization folders
+   *
+   * The OR branches are built with scalar foreign-key fields (`brandId`,
+   * `organizationId`, `userId`) rather than Prisma relation accessors
+   * (`brand`, `organization`, `user`). Relation accessors expect a nested
+   * filter object, so emitting `{ brand: null }` reached Prisma as an invalid
+   * relation filter and crashed list queries in production (#565). Scalar FKs
+   * keep this query valid at the source, independent of downstream normalization.
    */
   public buildFindAllQuery(user: User, query: BaseQueryDto) {
     const publicMetadata = getPublicMetadata(user);
     const organizationId = publicMetadata.organization;
 
     // Check if brand or organization query params are provided
-    const brandId = (query as unknown as Record<string, string | undefined>)
-      .brand
-      ? (query as unknown as Record<string, string | undefined>).brand
-      : null;
-    const queryOrganizationId = (
-      query as unknown as Record<string, string | undefined>
-    ).organization
-      ? (query as unknown as Record<string, string | undefined>).organization
-      : null;
+    const requestedBrandId =
+      (query as unknown as Record<string, string | undefined>).brand || null;
+    const requestedOrganizationId =
+      (query as unknown as Record<string, string | undefined>).organization ||
+      null;
 
     const matchStage: Record<string, unknown> & {
       OR?: Array<Record<string, unknown>>;
@@ -93,24 +96,21 @@ export class FoldersController extends BaseCRUDController<
       isDeleted: query.isDeleted ?? false,
     };
 
-    if (brandId) {
+    if (requestedBrandId) {
       // Brand context: show organization folders without brand + brand folders.
       matchStage.OR = [
         {
-          brand: null,
-          organization: queryOrganizationId || organizationId,
+          brandId: null,
+          organizationId: requestedOrganizationId || organizationId,
         }, // Organization folders without brand
-        { brand: brandId }, // Brand folders
+        { brandId: requestedBrandId }, // Brand folders
       ];
-    } else if (queryOrganizationId) {
+    } else if (requestedOrganizationId) {
       // Organization context (no brand): show organization folders.
-      matchStage.OR = [{ organization: queryOrganizationId }];
+      matchStage.OR = [{ organizationId: requestedOrganizationId }];
     } else {
       // Default: user folders + organization folders
-      matchStage.OR = [
-        { user: publicMetadata.user },
-        { organization: organizationId },
-      ];
+      matchStage.OR = [{ userId: publicMetadata.user }, { organizationId }];
     }
 
     return { where: matchStage, orderBy: { createdAt: -1, label: 1 } };


### PR DESCRIPTION
Closes #565

## Problem

`GET /folders` crashed in production with a `PrismaClientValidationError`. `FoldersController.buildFindAllQuery` constructed its `OR` branches using Prisma **relation accessors** (`brand`, `organization`, `user`) instead of the **scalar foreign-key columns** (`brandId`, `organizationId`, `userId`).

Relation accessors expect a nested relation-filter object, so a bare `{ brand: null }` reached Prisma as an invalid relation filter and threw. The brand branch was especially fragile: the downstream `BaseService` normalization only rewrote `brand → brandId` when a runtime model-introspection check succeeded, so the unsafe value could pass straight through to Prisma.

## Fix

Build every `OR` branch with the scalar FK columns directly, so the query is valid **at the source** and no longer depends on downstream where-normalization or runtime model introspection.

- `{ brand: null, organization: … }` → `{ brandId: null, organizationId: … }`
- `{ brand: id }` → `{ brandId: id }`
- `{ organization: id }` → `{ organizationId: id }`
- `{ user: id }, { organization: id }` → `{ userId: id }, { organizationId: id }`

Behaviour is unchanged: the post-normalization query was already scalar, so this only removes the fragile alias hop. Empty-string / undefined query params still collapse to `null` (`|| null`).

## Scope

Strictly folders-scoped per #565. The shared `BaseService.processSearchParams` asymmetry (where `organization`/`user` are in the unconditional `legacyRelationFields` map but `brand` relies on runtime introspection) is left untouched here to keep the blast radius to the crashing endpoint — a defense-in-depth `legacyRelationFields` entry for `brand` belongs in the broader sibling sweep, not this hotfix.

## Verification

- `bunx vitest run … folders.controller.spec.ts` → **15/15 pass** (updated 3 assertions to scalar keys + added a `#565` regression test asserting no relation-accessor key ever appears in an `OR` branch)
- `bunx tsc -p tsconfig.typecheck.json --noEmit` → **0 errors** (api package)
- `bunx biome check` on both touched files → **clean**
- Pre-commit `secretlint` + `lint-staged` → **passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)