### PR TITLE
fix(workers): validate consumed GENFEEDAI URLs + microservices defaults (#484)

### DIFF
--- a/apps/server/workers/src/config/config.service.spec.ts
+++ b/apps/server/workers/src/config/config.service.spec.ts
@@ -23,6 +23,9 @@ describe('ConfigService (Workers)', () => {
     delete process.env.NODE_ENV;
     delete process.env.PORT;
     delete process.env.GENFEEDAI_CDN_URL;
+    delete process.env.GENFEEDAI_APP_URL;
+    delete process.env.GENFEEDAI_WEBHOOKS_URL;
+    delete process.env.GENFEEDAI_MICROSERVICES_FILES_URL;
   });
 
   describe('constructor', () => {
@@ -86,15 +89,58 @@ describe('ConfigService (Workers)', () => {
   });
 
   describe('ingredientsEndpoint', () => {
-    // GENFEEDAI_CDN_URL is NOT in workers' schema (postgres/redis/sentry only);
-    // the getter reads it via BaseConfigService's allowUnknown passthrough.
-    // This guards that the factory migration preserved that passthrough.
-    it('builds the endpoint from the unschema-d GENFEEDAI_CDN_URL', () => {
+    // GENFEEDAI_CDN_URL is now part of workers' schema (#484): the getter
+    // consumes it, so it is validated at startup instead of silently passing
+    // through whatever (or nothing) is in the environment.
+    it('builds the endpoint from the validated GENFEEDAI_CDN_URL', () => {
       process.env.GENFEEDAI_CDN_URL = 'https://cdn.example.com';
       configService = new ConfigService();
 
       expect(configService.ingredientsEndpoint).toBe(
         'https://cdn.example.com/ingredients',
+      );
+    });
+  });
+
+  describe('consumed env-var validation (#484)', () => {
+    // The workers service consumes these genfeed URLs (ingredientsEndpoint,
+    // the workspace-task webhook fallback, and the trend-summary cron) but
+    // previously validated none of them, so a malformed value silently
+    // produced a broken URL in production. They are validated here as
+    // optional-but-well-formed: absence is tolerated (self-hosted/poll
+    // fallbacks handle it), a malformed value fails fast at boot.
+    it('rejects a malformed GENFEEDAI_CDN_URL at startup', () => {
+      process.env.GENFEEDAI_CDN_URL = 'not-a-url';
+
+      expect(() => new ConfigService()).toThrow(/GENFEEDAI_CDN_URL/);
+    });
+
+    it('rejects a malformed GENFEEDAI_WEBHOOKS_URL at startup', () => {
+      process.env.GENFEEDAI_WEBHOOKS_URL = 'not-a-url';
+
+      expect(() => new ConfigService()).toThrow(/GENFEEDAI_WEBHOOKS_URL/);
+    });
+
+    it('rejects a malformed GENFEEDAI_APP_URL at startup', () => {
+      process.env.GENFEEDAI_APP_URL = 'not-a-url';
+
+      expect(() => new ConfigService()).toThrow(/GENFEEDAI_APP_URL/);
+    });
+
+    it('tolerates absent consumed URL vars (optional in self-hosted)', () => {
+      delete process.env.GENFEEDAI_CDN_URL;
+      delete process.env.GENFEEDAI_APP_URL;
+      delete process.env.GENFEEDAI_WEBHOOKS_URL;
+
+      expect(() => new ConfigService()).not.toThrow();
+    });
+
+    it('defaults GENFEEDAI_MICROSERVICES_FILES_URL to localhost in self-hosted', () => {
+      delete process.env.GENFEEDAI_MICROSERVICES_FILES_URL;
+      configService = new ConfigService();
+
+      expect(configService.get('GENFEEDAI_MICROSERVICES_FILES_URL')).toBe(
+        'http://localhost:3012',
       );
     });
   });

--- a/apps/server/workers/src/config/config.service.ts
+++ b/apps/server/workers/src/config/config.service.ts
@@ -1,6 +1,7 @@
 import {
   createServiceConfig,
   type IEnvConfig,
+  microservicesSchema,
   postgresSchema,
   redisSchema,
   sentryOptionalSchema,
@@ -15,12 +16,29 @@ interface WorkersEnvConfig extends IEnvConfig {
 @Injectable()
 export class ConfigService extends createServiceConfig<WorkersEnvConfig>({
   appName: 'workers',
-  schemas: [postgresSchema, redisSchema, sentryOptionalSchema],
+  schemas: [
+    postgresSchema,
+    redisSchema,
+    sentryOptionalSchema,
+    // #484: workers reaches the files service (clip processors) and the
+    // microservices URLs default to localhost in self-hosted instead of
+    // silently resolving to undefined.
+    microservicesSchema,
+  ],
   extend: {
     GF_DEV_ENABLE_SCHEDULERS: Joi.string()
       .valid('true', 'false')
       .optional()
       .allow(''),
+    // #484: workers consumes these genfeed URLs at runtime — GENFEEDAI_CDN_URL
+    // via ingredientsEndpoint, GENFEEDAI_WEBHOOKS_URL via the workspace-task
+    // processor, GENFEEDAI_APP_URL via the trend-summary cron — but validated
+    // none of them. Optional-but-well-formed: absence is tolerated (self-hosted
+    // poll fallbacks), a malformed value fails fast at boot instead of producing
+    // a broken URL in production.
+    GENFEEDAI_APP_URL: Joi.string().uri().optional().allow(''),
+    GENFEEDAI_CDN_URL: Joi.string().uri().optional().allow(''),
+    GENFEEDAI_WEBHOOKS_URL: Joi.string().uri().optional().allow(''),
   },
 }) {
   public get isDevSchedulersEnabled(): boolean {


### PR DESCRIPTION
Closes #484

## What

Completes the final acceptance criterion of #484 — *"no env var documented in any service schema is missing from any other service that logically needs it"* — for the **workers** service, the only remaining drift after the factory consolidation.

The workers `ConfigService` read four genfeed URLs at runtime but validated none of them, so a malformed value silently produced a broken URL in production:

| Env var | Consumed by |
|---|---|
| `GENFEEDAI_CDN_URL` | `ingredientsEndpoint` getter |
| `GENFEEDAI_WEBHOOKS_URL` | workspace-task processor |
| `GENFEEDAI_APP_URL` | trend-summary cron |
| `GENFEEDAI_MICROSERVICES_FILES_URL` | clip processors (files service) |

## How

- Add the shared `microservicesSchema` to the `schemas` array (FILES/MCP/NOTIFICATIONS URLs → localhost default in self-hosted, optional in cloud) — closes the `GENFEEDAI_MICROSERVICES_FILES_URL` gap the same way clips was fixed in criterion 3.
- Add `GENFEEDAI_APP_URL`, `GENFEEDAI_CDN_URL`, `GENFEEDAI_WEBHOOKS_URL` to `extend` as `Joi.string().uri().optional().allow('')`: absence tolerated (self-hosted / poll fallbacks), a malformed value now fails fast at boot instead of producing a broken URL.

Optional-but-well-formed (not `conditionalRequired`) is deliberate — it matches the notifications/clips precedent and avoids any cloud-boot regression risk.

## Criterion-5 cross-service audit

Every genfeed URL/key each service consumes is now validated by its schema:

- **workers** — CDN/WEBHOOKS/APP/MICROSERVICES_FILES ✅ (this PR)
- **files** — CDN_URL (required), API_URL, API_KEY ✅
- **notifications** — APP_URL, API_URL, API_KEY ✅
- **clips** — MICROSERVICES_FILES_URL, API_URL, API_KEY ✅
- **mcp** — API_URL, API_KEY ✅

Criteria 1–4 landed earlier in 7115183d3 (factory + 5-service migration + clips `microservicesSchema`); this PR completes criterion 5.

## Out of scope

Provider-key drift (`AWS_*`, `REPLICATE_*`, `FAL_*`, `HF_*`, `OPENROUTER_*`) is a distinct cloud-`required` class with different boot-risk characteristics and is intentionally not touched here.

## Verification

- `bun run --cwd apps/server/workers test src/config/config.service.spec.ts` → **16 passed** (4 new: malformed-rejects-at-boot for CDN/WEBHOOKS/APP, absent-tolerated, self-hosted localhost default for files URL).
- `npx biome check` on both touched files → clean.
- `microservicesSchema` barrel export resolution confirmed; no Joi key collision between `schemas` and `extend`.
- CI unit-test job (`build-verify`) does not set `GENFEED_CLOUD`, so the self-hosted localhost-default assertion holds in CI as locally.

Scoped per resource limits: only the touched spec was run; no full suite, turbo, or builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)