### PR TITLE
fix(billing,interfaces,ci): address CodeRabbit nitpicks (#573)

### DIFF
--- a/.github/workflows/build-verify-selfhosted.yml
+++ b/.github/workflows/build-verify-selfhosted.yml
@@ -27,6 +27,9 @@ concurrency:
   group: build-verify-selfhosted-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: genfeed-selfhosted-verify
 
@@ -43,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       # Open-core boundary guard. The self-hosted image is the AGPL community build
       # and must never re-couple to the commercial-licensed ee/ source. Comment
@@ -68,17 +71,17 @@ jobs:
           echo "✅ no active ee/ reference in Dockerfile.selfhosted or entrypoint"
 
       - name: Log in to GHCR (for build cache)
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build self-hosted image (no push)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: docker/Dockerfile.selfhosted

--- a/bun.lock
+++ b/bun.lock
@@ -1021,6 +1021,9 @@
     "packages/pricing": {
       "name": "@genfeedai/pricing",
       "version": "0.1.0",
+      "dependencies": {
+        "@genfeedai/interfaces": "workspace:*",
+      },
       "devDependencies": {
         "@types/node": "25.9.1",
         "typescript": "6.0.2",

--- a/ee/packages/billing/src/subscriptions/dto/create-subscription.dto.spec.ts
+++ b/ee/packages/billing/src/subscriptions/dto/create-subscription.dto.spec.ts
@@ -1,4 +1,9 @@
-import { CreateSubscriptionDto } from './create-subscription.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+  CreateCheckoutSessionDto,
+  CreateSubscriptionDto,
+} from './create-subscription.dto';
 
 describe('CreateSubscriptionDto', () => {
   it('should be defined', () => {
@@ -17,5 +22,49 @@ describe('CreateSubscriptionDto', () => {
     //   const errors = await validate(dto);
     //   expect(errors.length).toBe(0);
     // });
+  });
+});
+
+describe('CreateCheckoutSessionDto — quantity validation', () => {
+  it('should fail validation when quantity (500) is below minimum (1000)', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      stripePriceId: 'price_abc123',
+      quantity: 500,
+    });
+    const errors = await validate(instance);
+    expect(errors.length).toBeGreaterThan(0);
+    const quantityError = errors.find((e) => e.property === 'quantity');
+    expect(quantityError).toBeDefined();
+    expect(Object.keys(quantityError!.constraints ?? {})).toContain('min');
+  });
+
+  it('should pass validation when quantity is at or above minimum (1500)', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      stripePriceId: 'price_abc123',
+      quantity: 1500,
+    });
+    const errors = await validate(instance);
+    const quantityErrors = errors.filter((e) => e.property === 'quantity');
+    expect(quantityErrors.length).toBe(0);
+  });
+
+  it('should pass validation when quantity is omitted (field is optional)', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      stripePriceId: 'price_abc123',
+    });
+    const errors = await validate(instance);
+    const quantityErrors = errors.filter((e) => e.property === 'quantity');
+    expect(quantityErrors.length).toBe(0);
+  });
+
+  it('should coerce string "1500" to number 1500 via @Type(() => Number) and pass validation', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      stripePriceId: 'price_abc123',
+      quantity: '1500',
+    });
+    const errors = await validate(instance);
+    const quantityErrors = errors.filter((e) => e.property === 'quantity');
+    expect(quantityErrors.length).toBe(0);
+    expect(instance.quantity).toBe(1500);
   });
 });

--- a/ee/packages/billing/src/subscriptions/dto/create-subscription.dto.ts
+++ b/ee/packages/billing/src/subscriptions/dto/create-subscription.dto.ts
@@ -1,5 +1,6 @@
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   IsBoolean,
   IsDate,
@@ -8,6 +9,7 @@ import {
   IsOptional,
   IsString,
   Matches,
+  Min,
 } from 'class-validator';
 
 export class CreateSubscriptionPreviewDto {
@@ -36,7 +38,9 @@ export class CreateCheckoutSessionDto {
   readonly stripePriceId!: string;
 
   @IsNumber()
+  @Min(1000)
   @IsOptional()
+  @Type(() => Number)
   @ApiProperty({
     default: 1000,
     description: 'The quantity/amount for the checkout session',

--- a/packages/interfaces/src/billing/index.ts
+++ b/packages/interfaces/src/billing/index.ts
@@ -4,6 +4,7 @@ export * from './credits-utils.contract';
 export * from './isubscription-attributions-service.contract';
 export * from './iuser-subscriptions-service.contract';
 export * from './managed-credits.interface';
+export * from './pricing.interface';
 export * from './subscription.interface';
 export * from './subscriptions-service.contract';
 export type {

--- a/packages/interfaces/src/billing/pricing.interface.ts
+++ b/packages/interfaces/src/billing/pricing.interface.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared pricing-related interfaces.
+ * Concrete pricing values live in @genfeedai/pricing.
+ */
+
+/**
+ * Pricing configuration.
+ *
+ * Margin and credit costs are configurable via admin UI (stored in DB)
+ * with env var fallbacks for self-hosters.
+ */
+export interface PricingConfig {
+  /** Base cost per credit (GPU compute cost) */
+  baseCostPerCredit: number;
+  /** Margin multiplier — 1.0 = no markup, 2.0 = 100% margin */
+  marginMultiplier: number;
+}
+
+export interface ServiceOfferingProps {
+  /** Service name */
+  name: string;
+  /** Short description */
+  description: string;
+  /** What's included */
+  includes: string[];
+  /** How it works — ordered steps */
+  process: { step: string; description: string }[];
+  /** CTA link (Calendly) */
+  ctaHref: string;
+}
+
+export interface TrainingPackageProps {
+  /** Package name */
+  name: string;
+  /** Short description */
+  description: string;
+  /** What's included */
+  includes: string[];
+  /** Price label (e.g. "$499", "Custom") */
+  priceLabel: string;
+  /** CTA link (Calendly) */
+  ctaHref: string;
+}
+
+/**
+ * PAYG Credit Pack tiers
+ * Stripe charges base credits × $0.01. Bonus credits delivered via metadata.
+ * Exchange rate: 1 credit = $0.01
+ */
+export interface CreditPackTier {
+  /** Display label */
+  label: string;
+  /** Number of base credits in pack */
+  credits: number;
+  /** Bonus credits (null = no bonus) */
+  bonus: number | null;
+}

--- a/packages/interfaces/src/billing/subscriptions-service.contract.ts
+++ b/packages/interfaces/src/billing/subscriptions-service.contract.ts
@@ -106,6 +106,13 @@ export interface ISubscriptionFindAllOptions {
  */
 export interface ISubscriptionFindAllResult {
   docs?: ISubscriptionOssReadModel[];
+  /**
+   * Optional, not required: the concrete EE `findAll` returns
+   * `AggregatePaginateResult<SubscriptionDocument>`, which exposes `totalDocs`
+   * rather than a statically-guaranteed `total`, while the OSS no-op returns
+   * `{ total: 0 }`. Keeping this optional lets both producers satisfy the
+   * contract without either lying about its shape; OSS reads it defensively.
+   */
   total?: number;
   [key: string]: unknown;
 }

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -47,6 +47,7 @@ export * from './batch/batch.interface';
 export * from './batch/manual-review-batch-item.interface';
 export * from './billing/credits.interface';
 export * from './billing/managed-credits.interface';
+export * from './billing/pricing.interface';
 export * from './billing/subscription.interface';
 export type {
   ITopbarBalanceSegment,

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "@genfeedai/interfaces": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "25.9.1",
     "typescript": "6.0.2"

--- a/packages/pricing/src/index.ts
+++ b/packages/pricing/src/index.ts
@@ -7,7 +7,7 @@
  * To change a price, edit the files in this package:
  *   - provider-pricing.ts  — AI provider costs, model types, node-type sets, UI option arrays
  *   - plans-pricing.ts     — BYOK constants, credit costs, website plans, credit packs, services
- *   - pricing-config.ts    — PricingConfig interface + getPricingConfig env reader
+ *   - pricing-config.ts    — PricingConfig re-export + getPricingConfig env reader
  *
  * Propagation is verified by:
  *   packages/core/src/pricing.spec.ts

--- a/packages/pricing/src/plans-pricing.ts
+++ b/packages/pricing/src/plans-pricing.ts
@@ -14,6 +14,14 @@
  * @updated 2026-01-21
  */
 
+import type {
+  CreditPackTier,
+  ServiceOfferingProps,
+  TrainingPackageProps,
+} from '@genfeedai/interfaces';
+
+export type { CreditPackTier, ServiceOfferingProps, TrainingPackageProps };
+
 interface PricingOutputsProps {
   /** Video generation in minutes per month */
   videoMinutes?: number;
@@ -48,32 +56,6 @@ interface PricingPlanProps {
   target?: string;
   /** Value proposition one-liner */
   valueProposition?: string;
-}
-
-export interface ServiceOfferingProps {
-  /** Service name */
-  name: string;
-  /** Short description */
-  description: string;
-  /** What's included */
-  includes: string[];
-  /** How it works — ordered steps */
-  process: { step: string; description: string }[];
-  /** CTA link (Calendly) */
-  ctaHref: string;
-}
-
-export interface TrainingPackageProps {
-  /** Package name */
-  name: string;
-  /** Short description */
-  description: string;
-  /** What's included */
-  includes: string[];
-  /** Price label (e.g. "$499", "Custom") */
-  priceLabel: string;
-  /** CTA link (Calendly) */
-  ctaHref: string;
 }
 
 const CALENDLY_URL =
@@ -434,15 +416,6 @@ export const dedicatedServerPlan: PricingPlanProps = {
  * Stripe charges base credits × $0.01. Bonus credits delivered via metadata.
  * Exchange rate: 1 credit = $0.01
  */
-export interface CreditPackTier {
-  /** Display label */
-  label: string;
-  /** Number of base credits in pack */
-  credits: number;
-  /** Bonus credits (null = no bonus) */
-  bonus: number | null;
-}
-
 export const PAYG_CREDIT_PACKS: CreditPackTier[] = [
   { bonus: null, credits: 9_900, label: 'Starter' },
   { bonus: null, credits: 49_900, label: 'Creator' },

--- a/packages/pricing/src/pricing-config.ts
+++ b/packages/pricing/src/pricing-config.ts
@@ -1,15 +1,6 @@
-/**
- * Pricing configuration.
- *
- * Margin and credit costs are configurable via admin UI (stored in DB)
- * with env var fallbacks for self-hosters.
- */
-export interface PricingConfig {
-  /** Base cost per credit (GPU compute cost) */
-  baseCostPerCredit: number;
-  /** Margin multiplier — 1.0 = no markup, 2.0 = 100% margin */
-  marginMultiplier: number;
-}
+import type { PricingConfig } from '@genfeedai/interfaces';
+
+export type { PricingConfig };
 
 export function getPricingConfig(): PricingConfig {
   return {


### PR DESCRIPTION
## What

Resolves the actionable CodeRabbit review items tracked in #573.

### 1. Pricing types → canonical `@genfeedai/interfaces`
Shared pricing shapes were defined inline in `packages/pricing`. Moved the exported ones into `packages/interfaces/src/billing/pricing.interface.ts`:
- `PricingConfig`, `ServiceOfferingProps`, `TrainingPackageProps`, `CreditPackTier`

`packages/pricing` now imports + re-exports these (no public API change for consumers) and gains a `@genfeedai/interfaces` workspace dependency. Package-private shapes (`PricingOutputsProps`, `PricingPlanProps`) stay local.

### 2. `CreateCheckoutSessionDto.quantity` validation
The `@ApiProperty` documented `minimum: 1000`, but nothing enforced it. Added:
```ts
@IsNumber()
@Min(1000)
@IsOptional()
@Type(() => Number)
readonly quantity?: number;
```
`@Type(() => Number)` coerces string query/body values. New spec cases cover: below-min rejection, at/above-min pass, omitted (optional) pass, and string→number coercion. **6/6 tests pass.**

### 3. CI hardening — `build-verify-selfhosted.yml`
- Added top-level least-privilege `permissions: contents: read` (job-level `packages: write` left intact).
- Pinned all third-party actions to full commit SHA (`actions/checkout`, `docker/login-action`, `docker/setup-buildx-action`, `docker/build-push-action`) with `# vN` comments.

## Intentional deviations from the nitpicks

- **`packages/pricing` keeps `private: true`.** Internal margin/cost data must never publish to a registry; no package-field churn.
- **`ISubscriptionFindAllResult.total` kept OPTIONAL** (nitpick asked to make it required). The concrete EE `findAll` returns `AggregatePaginateResult<SubscriptionDocument>`, which exposes `totalDocs` — not a statically-guaranteed `total` — while the OSS no-op returns `{ total: 0 }`. Making it required breaks EE compilation (`TS2420 SubscriptionsService incorrectly implements ISubscriptionsService`) and forces one producer to misrepresent its shape. Kept optional with an explanatory comment; OSS reads it defensively.

## Verification (scoped — no full suite/build)

| Check | Scope | Result |
|---|---|---|
| Type-check | `@genfeedai/interfaces` (dist) | ✅ exit 0 |
| Type-check | `@genfeedai/pricing` (dist) | ✅ exit 0 |
| Type-check | `@genfeedai/config` | ✅ exit 0 |
| Type-check | `@genfeedai/helpers` | ✅ exit 0 |
| Type-check | `@genfeedai/ee-billing` | ✅ exit 0 |
| Unit test | `create-subscription.dto.spec.ts` | ✅ 6/6 pass |
| Format | biome (touched files) | ✅ clean |

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)