### PR TITLE
fix(api): convert ingredient category at patch() write boundary (#564)

### DIFF
--- a/apps/server/api/src/collections/ingredients/services/ingredients.service.ts
+++ b/apps/server/api/src/collections/ingredients/services/ingredients.service.ts
@@ -311,9 +311,19 @@ export class IngredientsService extends BaseService<
     try {
       this.logger.debug(`${this.constructorName} patch`, { id, updateDto });
 
+      // Convert the app category enum to its Prisma UPPERCASE form at the write
+      // boundary (#564): patch persists updateDto verbatim and the Prisma 7
+      // adapter does not normalize enum scalars at runtime. toIngredientCategory
+      // is idempotent, so an already-UPPERCASE value passes through unchanged.
+      const data = { ...updateDto } as Record<string, unknown>;
+      if (data.category !== undefined) {
+        data.category = CategoryPrismaUtil.toIngredientCategory(
+          data.category as string,
+        );
+      }
       const updated = await this.prisma.ingredient.update({
         where: { id },
-        data: updateDto as never,
+        data: data as never,
       });
 
       if (!updated) {

--- a/apps/server/api/src/collections/trainings/controllers/operations/trainings-operations.controller.ts
+++ b/apps/server/api/src/collections/trainings/controllers/operations/trainings-operations.controller.ts
@@ -194,9 +194,7 @@ export class TrainingsOperationsController {
       await Promise.all(
         sourceImages.map((img) =>
           this.ingredientsService.patch(img._id, {
-            category: CategoryPrismaUtil.toIngredientCategory(
-              IngredientCategory.SOURCE,
-            ),
+            category: IngredientCategory.SOURCE,
             training: newTraining._id as string,
           }),
         ),

--- a/apps/server/api/src/collections/trainings/controllers/trainings.controller.ts
+++ b/apps/server/api/src/collections/trainings/controllers/trainings.controller.ts
@@ -381,9 +381,7 @@ export class TrainingsController extends BaseCRUDController<
       await Promise.all(
         sourceImages.map((img) =>
           this.ingredientsService.patch(img._id, {
-            category: CategoryPrismaUtil.toIngredientCategory(
-              IngredientCategory.SOURCE,
-            ),
+            category: IngredientCategory.SOURCE,
             training: training._id as string,
           }),
         ),


### PR DESCRIPTION
Fixes the red **Typecheck** on develop/master (TS2322) introduced when #578 merged: trainings controllers fed a Prisma enum value into patch()'s app-enum DTO field. patch() now converts at the write boundary (idempotent), controllers pass the app enum. Also clears master's downstream Test API failures once re-promoted.