### PR TITLE
test(api): expect Prisma UPPERCASE category in query assertions (#564 follow-up)

### DIFF
--- a/apps/server/api/src/collections/trainings/controllers/operations/trainings-operations.controller.spec.ts
+++ b/apps/server/api/src/collections/trainings/controllers/operations/trainings-operations.controller.spec.ts
@@ -170,7 +170,7 @@ describe('TrainingsOperationsController', () => {
 
       const pipelineArg = mockServices.ingredientsService.findAll.mock
         .calls[0][0] as { where: Record<string, unknown> };
-      expect(pipelineArg.where.category).toBe('source');
+      expect(pipelineArg.where.category).toBe('SOURCE');
     });
   });
 });

--- a/apps/server/api/src/endpoints/analytics/analytics.controller.spec.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.controller.spec.ts
@@ -240,10 +240,10 @@ describe('AnalyticsController', () => {
       expect(brandsService.findAll).toHaveBeenCalled();
       expect(ingredientsService.findAll).toHaveBeenCalledTimes(2);
       expect(ingredientsService.findAll.mock.calls[0][0]).toEqual({
-        where: { category: IngredientCategory.VIDEO },
+        where: { category: 'VIDEO' },
       });
       expect(ingredientsService.findAll.mock.calls[1][0]).toEqual({
-        where: { category: IngredientCategory.IMAGE },
+        where: { category: 'IMAGE' },
       });
       expect(result).toBeDefined();
     });

--- a/apps/server/api/src/endpoints/public/controllers/images/public.images.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/images/public.images.controller.spec.ts
@@ -140,7 +140,7 @@ describe('PublicImagesController', () => {
       expect(imagesService.findAll).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            category: IngredientCategory.IMAGE,
+            category: 'IMAGE',
             isDeleted: false,
             scope: AssetScope.PUBLIC,
             status: {
@@ -257,7 +257,7 @@ describe('PublicImagesController', () => {
       expect(imagesService.findOne).toHaveBeenCalledWith(
         {
           _id: imageId,
-          category: IngredientCategory.IMAGE,
+          category: 'IMAGE',
           isDeleted: false,
           scope: AssetScope.PUBLIC,
           status: IngredientStatus.GENERATED,
@@ -323,7 +323,7 @@ describe('PublicImagesController', () => {
 
       expect(imagesService.findOne).toHaveBeenCalledWith({
         _id: imageId,
-        category: IngredientCategory.IMAGE,
+        category: 'IMAGE',
         isDeleted: false,
         scope: AssetScope.PUBLIC,
         status: IngredientStatus.GENERATED,

--- a/apps/server/api/src/endpoints/public/controllers/musics/public.musics.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/musics/public.musics.controller.spec.ts
@@ -117,7 +117,7 @@ describe('PublicMusicsController', () => {
       expect(musicsService.findAll).toHaveBeenCalled();
       expect(musicsService.findAll.mock.calls[0][0]).toMatchObject({
         where: {
-          category: IngredientCategory.MUSIC,
+          category: 'MUSIC',
           scope: AssetScope.PUBLIC,
           status: IngredientStatus.GENERATED,
         },
@@ -182,7 +182,7 @@ describe('PublicMusicsController', () => {
       expect(musicsService.findOne).toHaveBeenCalledWith(
         {
           _id: musicId,
-          category: IngredientCategory.MUSIC,
+          category: 'MUSIC',
           isDeleted: false,
           scope: AssetScope.PUBLIC,
           status: IngredientStatus.GENERATED,
@@ -251,7 +251,7 @@ describe('PublicMusicsController', () => {
 
       expect(musicsService.findOne).toHaveBeenCalledWith({
         _id: musicId,
-        category: IngredientCategory.MUSIC,
+        category: 'MUSIC',
         isDeleted: false,
         scope: AssetScope.PUBLIC,
         status: IngredientStatus.GENERATED,

--- a/apps/server/api/src/endpoints/public/controllers/videos/public.videos.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/videos/public.videos.controller.spec.ts
@@ -117,7 +117,7 @@ describe('PublicVideosController', () => {
       where?: Record<string, unknown>;
     };
     expect(aggregateArg.where).toMatchObject({
-      category: 'video',
+      category: 'VIDEO',
       isDeleted: false,
       scope: 'public',
     });


### PR DESCRIPTION
Fixes the 9 Test API failures: #578's category UPPERCASE conversion is correct (Prisma needs it); the public/analytics/trainings specs still asserted lowercase. Updated expectations to the Prisma value. Verified locally — all 5 specs 54/54 green. Test API skips on develop-base, so this is confirmed on the next staging PR (#589).