### PR TITLE
docs: migrate git workflow to trunk-based

### DIFF
--- a/.agents/memory/context/progress.md
+++ b/.agents/memory/context/progress.md
@@ -19,7 +19,7 @@ author: Claude Code PM System
 - GitHub Actions configured for CI/CD pipeline
 - Blacksmith runners removed — using standard GitHub Actions runners
 - Secret scanning set up
-- Branch flow: `develop` -> `staging` -> `master` via PR
+- Branch flow: trunk-based — short-lived branches off `master` → PR → `master`
 
 ### Recent Milestones
 - PR #116: Migrated raw HTML to UI primitives across the codebase

--- a/.agents/memory/context/project-overview.md
+++ b/.agents/memory/context/project-overview.md
@@ -29,4 +29,4 @@ Genfeed.ai is an open-source AI operating system for content creation — a self
 
 ## Current State
 
-Migrated and consolidated from separate cloud + core repositories into this single monorepo. CI/CD runs on GitHub Actions. Branch flow: `develop` -> `staging` -> `master`. Assigned GitHub issue work should use isolated worktrees branched from `develop`, then PR back to `develop`.
+Migrated and consolidated from separate cloud + core repositories into this single monorepo. CI/CD runs on GitHub Actions. Branch flow: trunk-based — `master` is the single trunk. Assigned GitHub issue work should use isolated worktrees branched from `master`, then PR back to `master`.

--- a/.agents/memory/context/project-style-guide.md
+++ b/.agents/memory/context/project-style-guide.md
@@ -25,8 +25,8 @@ author: Claude Code PM System
 ## Git Conventions
 
 - **Conventional commits**: `fix:`, `feat:`, `refactor:`, `chore:`, `test:`, `build:`
-- **Branch flow**: `develop` -> `staging` -> `master` via PR
-- **Feature branches**: `feat/xxx` off `develop`
+- **Branch flow**: trunk-based — short-lived branches off `master` → PR → `master`
+- **Feature branches**: `feat/xxx` off `master`
 - **Never commit secrets**
 
 ## Formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,20 +11,20 @@ Stack: Next.js + NestJS + PostgreSQL (Prisma) + Redis + BullMQ
 
 ## Git Workflow
 
-**Branch flow: `develop` → `staging` → `master`. Always via PR. No exceptions.**
+**Trunk-based: `master` is the single trunk. Short-lived branches → PR → `master`. Always via PR. No exceptions.**
 
 ### Rules
-- **NEVER push directly to staging or master** — always create a PR
-- **NEVER merge to staging until develop CI is green**
-- **NEVER merge to master until staging CI is green**
-- **Hotfix flow**: `hotfix/xxx` off `master` → fix → PR to `master` → merge back into `develop`
-- **Feature work**: `feat/xxx` off `develop` → work → PR to `develop`
+- **NEVER push directly to `master`** — always create a PR
+- **NEVER merge until `master`'s required CI checks are green**
+- **Feature work**: `feat/xxx` off `master` → work → PR to `master`
+- **Hotfix**: `hotfix/xxx` off `master` → fix → PR to `master`
+- **Releases** are cut from `master` (semver tag + GitHub release via `/release`); `staging`/`production` are deploy environments driven by CI/tags, not branches
 - **bun.lock is `merge=binary`** — on conflicts: `rm bun.lock && bun install`
 
 ### Pre-Push Checklist (MANDATORY)
 
 ```bash
-npx biome check --write .
+bunx biome check --write .
 bunx turbo lint
 bun type-check
 bun run test --filter=@genfeedai/[changed-package]
@@ -48,7 +48,7 @@ bunx turbo run build --filter=@genfeedai/[name]      # Build specific app/packag
 # Quality
 bun type-check                           # Type-check all packages
 bunx turbo lint                          # Lint all packages
-npx biome check --write .                # Format all files
+bunx biome check --write .               # Format all files
 
 # Testing
 bun run test --filter=@genfeedai/[name]  # Run specific package tests


### PR DESCRIPTION
`develop → staging → master` promotion is deprecated — the repo is now **trunk-based**: `master` is the single trunk, short-lived branches → PR → `master`, releases are tags cut from `master` (via the `/release` skill), and `staging`/`production` are deploy environments driven by CI/tags, not branches.

## Changed
- `CLAUDE.md` — rewrote the **Git Workflow** section (branch flow + rules), fixed `npx biome` → `bunx biome` in pre-push + quality commands.
- `.agents/memory/context/progress.md`, `project-overview.md`, `project-style-guide.md` — updated the branch-flow lines these `@`-import into the agent context.

Docs only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)