### PR TITLE
ci: trunk-based gates — fast on PR, build-verify on master-push/release

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -1,10 +1,12 @@
-# Build Verification — ensures Docker image builds on PRs
-# Prevents broken images from reaching production (no push, just verify)
+# Build Verification — builds the server image + boots the EE/SaaS bundle.
+# Trunk model: runs on master pushes (post-merge gate) + manual dispatch (used
+# at release cut), NOT on every PR — keeps PRs fast; heavy gates run at
+# merge/release. The boot step is the #574 circular-dep regression guard.
 name: Build Verify
 
 on:
-  pull_request:
-    branches: [staging, master]
+  push:
+    branches: [master]
     paths:
       - 'apps/server/**'
       - 'ee/packages/billing/**'
@@ -13,6 +15,7 @@ on:
       - 'docker/**'
       - 'package.json'
       - 'bun.lock'
+  workflow_dispatch:
 
 concurrency:
   group: build-verify-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, staging]
+    branches: [master]
   pull_request:
-    branches: [master, develop, staging]
+    branches: [master]
   # Allow this gate to be run as a reusable workflow (e.g. by full-suite.yml,
   # which chains CI → E2E on demand). No inputs needed; secrets are inherited.
   workflow_call:
@@ -396,7 +396,7 @@ jobs:
     name: Test App (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && ((github.event_name == 'pull_request' && (github.base_ref == 'staging' || github.base_ref == 'master')) || (github.event_name != 'pull_request' && (github.ref_name == 'staging' || github.ref_name == 'master')))
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master'))
     strategy:
       fail-fast: false
       matrix:
@@ -420,7 +420,7 @@ jobs:
     name: Test API (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && ((github.event_name == 'pull_request' && (github.base_ref == 'staging' || github.base_ref == 'master')) || (github.event_name != 'pull_request' && (github.ref_name == 'staging' || github.ref_name == 'master')))
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master'))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Aligns CI to the trunk model after collapsing to master: PR = fast-5 (required) + unit (informative); build-verify moves off per-PR to master-push + release cut; drops deleted develop/staging from triggers. E2E + deploy stay release-gated.