### PR TITLE
fix(app): wire Library section sidebar nav

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -14,7 +14,7 @@
 ## Feedback (user corrections — permanent)
 
 - [Never lose code](feedback_never_lose_code.md) — Always branch+push WIP before destructive git ops
-- [Never commit/push to master](feedback_never_commit_to_master.md) — Feature branches: commit freely. Master: always ask.
+- [Ship autonomously; master is PR-only](feedback_never_commit_to_master.md) — Trunk-based: commit/push/PR freely when work done. Never push direct to master. Secret-scan every commit.
 - [proxy.ts is middleware](feedback_proxy_middleware.md) — Next.js 16 renamed middleware.ts → proxy.ts
 - [Use @ui/primitives](feedback_ui_primitives.md) — Never raw HTML elements — blocked by lint-no-raw-html.sh
 - [Codex adversarial review](feedback_codex_adversarial_review.md) — MANDATORY before ExitPlanMode

--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -18,7 +18,7 @@
 - [proxy.ts is middleware](feedback_proxy_middleware.md) — Next.js 16 renamed middleware.ts → proxy.ts
 - [Use @ui/primitives](feedback_ui_primitives.md) — Never raw HTML elements — blocked by lint-no-raw-html.sh
 - [Codex adversarial review](feedback_codex_adversarial_review.md) — MANDATORY before ExitPlanMode
-- [GitHub issue worktree workflow](feedback_gh_issue_worktree_workflow.md) — Assigned issues use worktrees from develop
+- [GitHub issue worktree workflow](feedback_gh_issue_worktree_workflow.md) — Assigned issues use worktrees from master → PR to master
 - [No external symlinks](feedback_no_external_symlinks.md) — Open source repo. Internal symlinks only.
 - [End-to-end implementation](feedback_end_to_end_implementation.md) — Never ship half-architecture; wire the full user path
 - [P0 status, not label](feedback_p0_status_not_label.md) — P0 is issue status; never create priority labels
@@ -27,9 +27,9 @@
 - [GPU instances off by default](feedback_gpu_instances_off_by_default.md) — Keep Genfeed GPU/Fleet inference instances off unless explicitly needed
 - [Inference servers private boundary](feedback_inference_servers_private_boundary.md) — Keep Genfeed inference server implementations out of the public monorepo
 - [GenfeedAI managed provider](feedback_genfeedai_managed_provider.md) — Model Genfeed-managed inference as provider=genfeedai, enabled per customer from console
-- [Concurrent automation on develop](feedback_concurrent_automation_develop.md) — A background bot commits to HEAD + pushes develop in this shared checkout; path-scope git add, never blind add -u
+- [Concurrent automation in shared checkout](feedback_concurrent_automation_develop.md) — A background bot commits to HEAD + pushes the shared checkout; path-scope git add, never blind add -u
 - [Genfeed project kanban](feedback_genfeed_project_kanban.md) — Use project #12 Genfeed.ai as canonical; never select work from closed Mission Control #11
-- [Production deploys master-only](feedback_production_deploy_master_only.md) — Never deploy develop/staging to production unless Vincent explicitly overrides; production deploys run from GitHub CI on master
+- [Production deploys master-only](feedback_production_deploy_master_only.md) — Never deploy any non-master ref to production unless Vincent explicitly overrides; production deploys run from GitHub CI on master
 
 ## References
 

--- a/.agents/memory/context/e2e-architecture.md
+++ b/.agents/memory/context/e2e-architecture.md
@@ -23,13 +23,14 @@ concurrency:
   cancel-in-progress: true
 ```
 
-- **Manual, per-branch:** Actions → *E2E Tests* → *Run workflow* → choose `develop` / `staging` / `master`.
-  CLI: `gh workflow run e2e.yml --ref <branch>`.
+- **Manual, per-branch:** Actions → *E2E Tests* → *Run workflow* → choose `master` (the trunk) or any
+  short-lived feature branch. CLI: `gh workflow run e2e.yml --ref <branch>`.
   `workflow_dispatch` checks out **that branch** and runs its copy of the workflow + tests.
+  (Trunk-based: `develop`/`staging` branches no longer exist.)
 - **Weekly review:** the `schedule` trigger always runs on the **default branch = `master`**
   (GitHub runs scheduled workflows only from the default branch). This is the weekly master review.
 - **Availability:** the workflow only appears in the Actions UI / runs on schedule when the file
-  exists on `master`. It is present on `master`, `staging`, and `develop`.
+  exists on `master`. `master` is the single trunk.
 - **Free compute:** public repo → unlimited GitHub Actions minutes on `ubuntu-latest`.
 
 Top-level env: `TURBO_TOKEN` (secret) + `TURBO_TEAM` (var) enable Turborepo remote cache in every job.
@@ -216,12 +217,11 @@ Fixtures: `auth.fixture.ts` (`authenticatedPage`, `adminPage`, `automationPage`,
 
 ```bash
 # Trigger per branch
-gh workflow run e2e.yml --ref develop
-gh workflow run e2e.yml --ref staging
 gh workflow run e2e.yml --ref master
+gh workflow run e2e.yml --ref feat/your-branch
 
 # Watch latest
-gh run list --workflow=e2e.yml --branch develop --limit 1
+gh run list --workflow=e2e.yml --branch master --limit 1
 gh run watch <run-id>
 
 # Local

--- a/.agents/memory/context/progress.md
+++ b/.agents/memory/context/progress.md
@@ -27,7 +27,7 @@ author: Claude Code PM System
 - PR #118: Thread context compaction for agent conversations
 - Root `/` redirect loop fixed for authenticated users with org/brand slug resolution; self-hosted onboarding loop tracked separately in issue #141
 - Default local ports regrouped: frontend `300x`, API core `3010-3014`, service/bot apps `3015-3019`, fleet services `3020-3022`
-- GitHub issue implementation workflow standardized on worktrees from `develop` with PRs back to `develop`
+- GitHub issue implementation workflow standardized on worktrees from `master` with PRs back to `master` (trunk-based)
 
 ### Codebase Health
 - Fallow health score: 72/100 (tracked via issue #83)

--- a/.agents/memory/feedback_concurrent_automation_develop.md
+++ b/.agents/memory/feedback_concurrent_automation_develop.md
@@ -1,28 +1,35 @@
 ---
-name: Concurrent automation commits and pushes develop in this shared checkout
-description: A background automation (codex feature-impl + a deps-update bot) commits to HEAD and pushes develop; feature branches do not isolate it
+name: Concurrent automation commits and pushes in this shared checkout
+description: A background automation (codex feature-impl + a deps-update bot) commits to HEAD and pushes the shared checkout; short-lived branches do not isolate it
 type: feedback
+status: active
+last_verified: 2026-06-15
+topics: [workflow, git, automation, shared-checkout]
 ---
 
-**Observed:** 2026-06-03. During an interactive session, a background automation
-repeatedly committed to whatever branch was checked out and pushed `origin/develop`
-without the interactive agent acting. Commits seen interleaved with the agent's:
-`473613a00` (chore deps bump), `f1aa801f0` / `c8e441673` / `6c021339c` (feat UI
-Container integration, settings/sidebar). It also pushed the agent's local-only
-commits to origin as a side effect.
+**Observed:** 2026-06-03 (pre-trunk migration, against the then-`develop` branch).
+During an interactive session, a background automation repeatedly committed to
+whatever branch was checked out and pushed the shared mainline without the
+interactive agent acting. Commits seen interleaved with the agent's: `473613a00`
+(chore deps bump), `f1aa801f0` / `c8e441673` / `6c021339c` (feat UI Container
+integration, settings/sidebar). It also pushed the agent's local-only commits to
+origin as a side effect. The repo is now trunk-based (`master` is the single
+trunk, PR-only), but the shared-checkout contention pattern is durable.
 
 **Why it matters:**
-- `develop` is actively contended. `git status` / `ahead/behind` shifts between
-  tool calls. Treat the working tree + branch tips as moving.
-- A feature branch does NOT isolate you — the automation commits to the current
-  HEAD in the SAME checkout, so it can land commits on your `feat/*` too.
+- The shared checkout is actively contended. `git status` / `ahead/behind` shifts
+  between tool calls. Treat the working tree + branch tips as moving.
+- A short-lived branch does NOT isolate you — the automation commits to the
+  current HEAD in the SAME checkout, so it can land commits on your `feat/*` too.
 - Local-only commits may get pushed to origin by the automation regardless of a
   "no push" instruction.
 
 **How to apply:**
-- NEVER `git add -u` / `git add -A` blindly — path-scope every stage to your own
-  files (e.g. `git add apps/server/api`) so you don't sweep the automation's WIP.
+- NEVER `git add -u` / `git add -A` blindly when sharing a checkout with the
+  automation — path-scope every stage to your own files (e.g. `git add apps/server/api`)
+  so you don't sweep the automation's WIP. (In an isolated worktree of your own,
+  `git add -A` is fine.)
 - Re-check `git log`/`git status` right before committing; don't assume the tip.
 - Before destructive git ops, confirm what's actually in the tree (it may be the
   automation's, not yours).
-- "no push" for develop is best-effort — the automation may push it anyway.
+- "no push" is best-effort in a shared checkout — the automation may push anyway.

--- a/.agents/memory/feedback_gh_issue_worktree_workflow.md
+++ b/.agents/memory/feedback_gh_issue_worktree_workflow.md
@@ -1,23 +1,23 @@
 ---
 name: GitHub issue worktree workflow
-description: Assigned GitHub issues must be implemented in isolated worktrees from develop, then PR to develop, run CI, and merge
+description: Assigned GitHub issues must be implemented in isolated worktrees from master, then PR to master, run CI, and merge
 type: feedback
 status: active
-last_verified: 2026-04-10
+last_verified: 2026-06-15
 topics: [workflow, git, worktrees, github]
 ---
 
-**Rule:** When Vincent assigns a GitHub issue for implementation, create and work in an isolated git worktree branched from `develop`.
+**Rule:** When Vincent assigns a GitHub issue for implementation, create and work in an isolated git worktree branched from `master` (the trunk).
 
-**Why:** Vincent wants up to 5 features in flight at the same time without branch switching, workspace contamination, or cross-feature merge conflicts. The expected delivery path is issue -> worktree -> feature branch -> PR to `develop` -> CI -> merge.
+**Why:** Vincent wants up to 5 features in flight at the same time without branch switching, workspace contamination, or cross-feature merge conflicts. Trunk-based delivery path: issue -> worktree off `master` -> short-lived branch -> PR to `master` -> CI -> merge.
 
 **How to apply:**
-- For every assigned GitHub issue, start from the main repo checkout and create a worktree from the current `develop` branch.
-- Use a feature branch named from the issue, for example `feat/123-short-title` or `fix/123-short-title`.
+- For every assigned GitHub issue, start from the main repo checkout and create a worktree from the current `master` branch.
+- Use a short-lived branch named from the issue, for example `feat/123-short-title` or `fix/123-short-title`.
 - Keep all code edits, tests, commits, and agent/subagent work for that issue inside that worktree.
 - Tell any spawned coding agents to operate inside the issue worktree only and not touch the main checkout or other feature worktrees.
 - Before opening a PR, run the narrowest relevant checks first, then the repo's required pre-push gates when feasible.
-- Open the PR against `develop`, not `staging` or `master`.
+- Open the PR against `master`. There is no `develop`/`staging` branch flow — `master` is the single trunk.
 - After PR creation, inspect CI, fix failures in the same worktree/branch, push updates, and repeat until CI is green.
-- Merge only through the approved GitHub PR path. Never direct-push to `develop`, `staging`, or `master`.
-- Preserve the existing release promotion flow after `develop`: `develop` -> `staging` -> `master`, always via PR.
+- Merge only through the approved GitHub PR path. NEVER direct-push to `master`.
+- Releases are cut from `master` (semver tag + GitHub release); `staging`/`production` are deploy environments driven by CI/tags, not branches.

--- a/.agents/memory/feedback_never_commit_to_master.md
+++ b/.agents/memory/feedback_never_commit_to_master.md
@@ -1,18 +1,18 @@
 ---
-name: Never commit or push to master without explicit approval
-description: Feature branches are fine to commit to freely; master is sacred and was leaked to before
+name: Ship autonomously on short-lived branches; master is PR-only
+description: Trunk-based — commit/push/PR freely when work is done; never push direct to master; always secret-scan before commit
 type: feedback
 ---
 
-**Rule:** Never commit or push to `master` without explicit user approval. On feature branches, worktrees, and any non-master branch, committing is fine and does NOT need per-commit approval — implement the plan and commit as you go.
+**Rule:** This repo is **trunk-based** — `master` is the single trunk. When session work is complete, ship it autonomously: commit, push the short-lived branch, and open a PR to `master`. Per-commit approval is NOT required. The review gate is the PR itself (reviewers + required CI), so opening the PR *is* the handoff.
 
-**Why:** There was a prior incident where `.env.production` secrets were pushed to `master` on this open-source repo. That's why CLAUDE.md's "never commit/push without explicit user approval" rule exists — but the rule's intent is specifically about the branches that matter (master, and by extension staging via PR flow), NOT about the per-commit dance on a throwaway feature branch or worktree. The git workflow in CLAUDE.md explicitly documents: `develop → staging → master` via PR; feature work lives on `feat/xxx` off `develop`. Per-commit approval on feature branches is friction with zero safety value; the real safety gate is at PR-to-staging and PR-to-master.
+**Why:** A prior incident pushed `.env.production` secrets to `master` on this public repo — that's the origin of the old "never commit/push without explicit approval" rule. The real safety gate is (a) never pushing direct to master, and (b) scanning every commit for secrets. Per-commit approval on a throwaway branch is friction with zero safety value, and PR review covers the human gate. The old `develop → staging → master` flow is dead — see CLAUDE.md "Git Workflow".
 
 **How to apply:**
-- Committing on feature branches / worktrees / any branch other than master: just do it. Don't ask.
-- Pushing feature branches to `origin/feat/xxx`: fine without approval (it's just a remote feature branch).
-- Pushing to `origin/develop`: ASK first. That's a shared mainline.
-- Pushing to `origin/staging` or `origin/master`: **always ask**, and also go through PR, never direct push.
-- Force-pushing anywhere other than your own feature branch: ASK.
-- Before ANY commit, regardless of branch: scan staged content for `.env*`, `secrets/`, tokens, private keys, AWS/GCP/Stripe/Clerk/OpenAI/etc. credentials. If found, STOP and flag — do not commit the file even if it was explicitly staged. The worst outcome is leaking secrets to a public repo that's indexed before rotation.
-- When creating worktrees, prefer `git worktree add` off `master` for clean-slate work that isn't tied to current `develop` drift.
+- Committing on short-lived / feature / worktree branches: just do it. Don't ask.
+- Pushing a short-lived branch to its `origin/<branch>`: fine without approval.
+- Opening a PR to `master` when work is done: do it autonomously. Reviewers are on it anyway.
+- Pushing **directly** to `origin/master`: **never** — PR only, no exceptions.
+- Force-pushing anywhere other than your own short-lived branch: ASK. Never force-push master.
+- Before ANY commit, regardless of branch: scan staged content for `.env*`, `secrets/`, tokens, private keys, AWS/GCP/Stripe/Clerk/OpenAI/etc. credentials. If found, STOP and flag — do not commit the file even if it was explicitly staged. Worst outcome is leaking secrets to a public repo indexed before rotation.
+- New worktrees / branches: cut off `master` for clean-slate work (master is the trunk).

--- a/.agents/memory/feedback_production_deploy_master_only.md
+++ b/.agents/memory/feedback_production_deploy_master_only.md
@@ -7,13 +7,13 @@ last_verified: 2026-06-11
 topics: [deployment, production, git, ci]
 ---
 
-**Rule:** Never promote or deploy `develop` or `staging` to production unless Vincent explicitly says to do that exact exception. Production deploys must come from GitHub CI on `master`.
+**Rule:** Never promote or deploy any non-`master` ref to production unless Vincent explicitly says to do that exact exception. Production deploys must come from GitHub CI on `master`.
 
-**Why:** Vincent corrected this after a manual `workflow_dispatch` production deploy was run from `develop`. Genfeed.ai is an open-source app with a clean GitHub CI release flow; production must reflect the release branch, not an arbitrary local or selected dispatch ref.
+**Why:** Vincent corrected this after a manual `workflow_dispatch` production deploy was run from a non-`master` ref. Genfeed.ai is an open-source app with a clean GitHub CI release flow; production must reflect the trunk, not an arbitrary local or selected dispatch ref.
 
 **How to apply:**
-- Default release flow remains `develop` -> `staging` -> `master` -> production deploy.
-- Do not run `Deploy Production` from `develop` or `staging`.
+- Release flow is trunk-based: short-lived branch -> PR -> `master` -> production deploy via GitHub CI. `staging`/`production` are deploy environments driven by CI/tags, NOT branches.
+- Do not run `Deploy Production` from any ref other than `master`.
 - Do not deploy production from local Vercel CLI unless Vincent explicitly asks for that emergency exception.
-- If production needs a hotfix, land or cherry-pick it onto `master`, then deploy from GitHub CI.
+- If production needs a hotfix, land it on `master` via `hotfix/xxx` PR, then deploy from GitHub CI.
 - When touching deployment workflows, preserve or strengthen the master-only production guard.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,9 @@ bun run test --filter=@genfeedai/[name]  # Run specific package tests
 
 ### Files & Git (ALWAYS)
 - **Research the codebase before editing. Never change code you haven't read.**
-- Never commit/push without explicit user approval
+- **When session work is complete, ship it autonomously**: commit, push the short-lived branch, and open a PR to `master`. Review is gated by the PR (reviewers + required CI), not by a per-commit approval dance.
+- **NEVER push directly to `master`** — PR only, always (see Git Workflow above).
+- **Scan staged content for secrets before every commit** (`.env*`, `secrets/`, tokens, private keys, provider credentials). If found, STOP and flag — never commit it even if explicitly staged. This repo is public; a leak is indexed before rotation.
 - Search 3+ similar implementations before writing new code
 - Use conventional commits: `fix:`, `feat:`, `refactor:`, `chore:`
 

--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -3,6 +3,7 @@
 import { ADMIN_LOGO_HREF } from '@app-config/admin-menu-items.config';
 import { ANALYTICS_LOGO_HREF } from '@app-config/analytics-menu-items.config';
 import { COMPOSE_LOGO_HREF } from '@app-config/compose-menu-items.config';
+import { LIBRARY_LOGO_HREF } from '@app-config/library-menu-items.config';
 import { APP_LOGO_HREF } from '@app-config/menu-items.config';
 import { ORG_LOGO_HREF } from '@app-config/org-menu-items.config';
 import { SETTINGS_LOGO_HREF } from '@app-config/settings-menu-items.config';
@@ -35,6 +36,7 @@ type Props = {
   isConversationRoute: boolean;
   isEditorRoute: boolean;
   isFocusedOnboardingRoute: boolean;
+  isLibraryRoute: boolean;
   isOrgRoute: boolean;
   isSettingsRoute: boolean;
   isStudioRoute: boolean;
@@ -42,6 +44,7 @@ type Props = {
   adminMenuItems: MenuItemConfig[];
   analyticsMenuItems: MenuItemConfig[];
   composeMenuItems: MenuItemConfig[];
+  libraryMenuItems: MenuItemConfig[];
   menuItems: MenuItemConfig[];
   orgMenuItems: MenuItemConfig[];
   secondaryMenuItems: MenuItemConfig[];
@@ -63,6 +66,7 @@ export default function AppProtectedLayoutSidebar({
   isConversationRoute,
   isEditorRoute,
   isFocusedOnboardingRoute,
+  isLibraryRoute,
   isOrgRoute,
   isSettingsRoute,
   isStudioRoute,
@@ -70,6 +74,7 @@ export default function AppProtectedLayoutSidebar({
   adminMenuItems,
   analyticsMenuItems,
   composeMenuItems,
+  libraryMenuItems,
   menuItems,
   orgMenuItems,
   secondaryMenuItems,
@@ -84,6 +89,21 @@ export default function AppProtectedLayoutSidebar({
 
   if (isFocusedOnboardingRoute) {
     return null;
+  }
+
+  if (isLibraryRoute) {
+    return (
+      <AppSidebar
+        items={libraryMenuItems}
+        logoHref={withTaskContextHref(
+          buildHref(LIBRARY_LOGO_HREF),
+          taskContextSearchParams,
+        )}
+        currentApp={currentApp}
+        sectionLabel="Library"
+        shellChromeVariant={shellChromeVariant}
+      />
+    );
   }
 
   if (isStudioRoute) {

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -104,6 +104,7 @@ function AppLayoutWithDynamicMenu({
     isEditorRoute,
     isFocusedOnboardingRoute,
     isLibraryLandingRoute,
+    isLibraryRoute,
     isOrgRoute,
     isPromptBarRoute,
     isSettingsRoute,
@@ -121,6 +122,7 @@ function AppLayoutWithDynamicMenu({
     adminMenuItems,
     analyticsMenuItems,
     composeMenuItems,
+    libraryMenuItems,
     menuItems,
     orgMenuItems,
     secondaryMenuItems,
@@ -164,6 +166,7 @@ function AppLayoutWithDynamicMenu({
         isConversationRoute={isConversationRoute}
         isEditorRoute={isEditorRoute}
         isFocusedOnboardingRoute={isFocusedOnboardingRoute}
+        isLibraryRoute={isLibraryRoute}
         isOrgRoute={isOrgRoute}
         isSettingsRoute={isSettingsRoute}
         isStudioRoute={isStudioRoute}
@@ -171,6 +174,7 @@ function AppLayoutWithDynamicMenu({
         adminMenuItems={adminMenuItems}
         analyticsMenuItems={analyticsMenuItems}
         composeMenuItems={composeMenuItems}
+        libraryMenuItems={libraryMenuItems}
         menuItems={menuItems}
         orgMenuItems={orgMenuItems}
         secondaryMenuItems={secondaryMenuItems}
@@ -195,10 +199,12 @@ function AppLayoutWithDynamicMenu({
     isEditorCanvasRoute,
     isEditorRoute,
     isFocusedOnboardingRoute,
+    isLibraryRoute,
     isOrgRoute,
     isSettingsRoute,
     isStudioRoute,
     isWorkflowsRoute,
+    libraryMenuItems,
     menuItems,
     orgMenuItems,
     renderConversations,

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -1,6 +1,7 @@
 import { ADMIN_MENU_ITEMS } from '@app-config/admin-menu-items.config';
 import { ANALYTICS_MENU_ITEMS } from '@app-config/analytics-menu-items.config';
 import { COMPOSE_MENU_ITEMS } from '@app-config/compose-menu-items.config';
+import { LIBRARY_MENU_ITEMS } from '@app-config/library-menu-items.config';
 import {
   APP_MENU_ITEMS,
   getAppSecondaryMenuItems,
@@ -383,6 +384,17 @@ export function useAppProtectedLayout(
     [taskContextSearchParams],
   );
 
+  const libraryMenuItems = useMemo(
+    () =>
+      LIBRARY_MENU_ITEMS.map(
+        (item): MenuItemConfig => ({
+          ...item,
+          href: withTaskContextHref(item.href, taskContextSearchParams),
+        }),
+      ),
+    [taskContextSearchParams],
+  );
+
   const workflowsMenuItems = useMemo(
     () =>
       WORKFLOWS_MENU_ITEMS.map(
@@ -456,6 +468,7 @@ export function useAppProtectedLayout(
     isEditorRoute,
     isFocusedOnboardingRoute,
     isLibraryLandingRoute,
+    isLibraryRoute,
     isOrgRoute,
     isPromptBarRoute,
     isSettingsRoute,
@@ -477,6 +490,7 @@ export function useAppProtectedLayout(
     adminMenuItems,
     analyticsMenuItems,
     composeMenuItems,
+    libraryMenuItems,
     menuItems,
     orgMenuItems,
     secondaryMenuItems,

--- a/apps/app/packages/config/library-menu-items.config.test.ts
+++ b/apps/app/packages/config/library-menu-items.config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LIBRARY_LOGO_HREF,
+  LIBRARY_MENU_ITEMS,
+} from './library-menu-items.config';
+
+describe('LIBRARY_MENU_ITEMS', () => {
+  it('lists every library category route', () => {
+    expect(LIBRARY_MENU_ITEMS.map((item) => item.href)).toEqual([
+      '/library/videos',
+      '/library/images',
+      '/library/gifs',
+      '/library/avatars',
+      '/library/voices',
+      '/library/music',
+      '/library/captions',
+    ]);
+  });
+
+  it('separates visual assets from utility assets with a divider', () => {
+    const voicesItem = LIBRARY_MENU_ITEMS.find(
+      (item) => item.href === '/library/voices',
+    );
+
+    expect(voicesItem).toMatchObject({
+      hasDividerAbove: true,
+      label: 'Voices',
+    });
+  });
+
+  it('points the library logo at the ingredients landing', () => {
+    expect(LIBRARY_LOGO_HREF).toBe('/library/ingredients');
+  });
+});

--- a/apps/app/packages/config/library-menu-items.config.ts
+++ b/apps/app/packages/config/library-menu-items.config.ts
@@ -1,0 +1,79 @@
+import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
+import {
+  HiDocumentText,
+  HiMicrophone,
+  HiMusicalNote,
+  HiOutlineDocumentText,
+  HiOutlineMicrophone,
+  HiOutlineMusicalNote,
+  HiOutlinePhoto,
+  HiOutlinePlayCircle,
+  HiOutlineSparkles,
+  HiOutlineVideoCamera,
+  HiPhoto,
+  HiPlayCircle,
+  HiSparkles,
+  HiVideoCamera,
+} from 'react-icons/hi2';
+
+export const LIBRARY_MENU_ITEMS: MenuItemConfig[] = [
+  {
+    group: '',
+    href: '/library/videos',
+    label: 'Videos',
+    matchPaths: ['/library/videos'],
+    outline: HiOutlineVideoCamera,
+    solid: HiVideoCamera,
+  },
+  {
+    group: '',
+    href: '/library/images',
+    label: 'Images',
+    matchPaths: ['/library/images'],
+    outline: HiOutlinePhoto,
+    solid: HiPhoto,
+  },
+  {
+    group: '',
+    href: '/library/gifs',
+    label: 'GIFs',
+    matchPaths: ['/library/gifs'],
+    outline: HiOutlinePlayCircle,
+    solid: HiPlayCircle,
+  },
+  {
+    group: '',
+    href: '/library/avatars',
+    label: 'Avatars',
+    matchPaths: ['/library/avatars'],
+    outline: HiOutlineSparkles,
+    solid: HiSparkles,
+  },
+  {
+    group: '',
+    hasDividerAbove: true,
+    href: '/library/voices',
+    label: 'Voices',
+    matchPaths: ['/library/voices'],
+    outline: HiOutlineMicrophone,
+    solid: HiMicrophone,
+  },
+  {
+    group: '',
+    href: '/library/music',
+    label: 'Music',
+    matchPaths: ['/library/music'],
+    outline: HiOutlineMusicalNote,
+    solid: HiMusicalNote,
+  },
+  {
+    group: '',
+    href: '/library/captions',
+    label: 'Captions',
+    matchPaths: ['/library/captions'],
+    outline: HiOutlineDocumentText,
+    solid: HiDocumentText,
+  },
+];
+
+export const LIBRARY_LOGO_HREF = '/library/ingredients';


### PR DESCRIPTION
## Problem

On the Library section (e.g. `/[org]/[brand]/library/ingredients`), the **left sidebar** showed the default **workspace** nav (New Task / Dashboard / Inbox / Tasks / Activity) instead of library categories. The top `Library ▾` switcher and the main-content cards already worked — only the sidebar was unwired.

## Root cause

The Library section had no sidebar wiring at all, so `AppProtectedLayoutSidebar` fell through every section branch to the default workspace sidebar.

## Fix (commit 1 — `fix(app)`)

Mirror the existing studio/compose section pattern:

- **`library-menu-items.config.ts`** (new) — 7 categories: Videos, Images, GIFs, Avatars │ Voices, Music, Captions. Divider splits visual vs utility assets. Logo → `/library/ingredients`. Colocated vitest test.
- **`useAppProtectedLayout.ts`** — compute `libraryMenuItems` (task-context-wrapped hrefs) + return `isLibraryRoute`.
- **`AppProtectedLayoutSidebar.tsx`** — `isLibraryRoute` branch renders `AppSidebar` with library items (checked before studio; `/library` vs `/studio` are distinct prefixes, no overlap).
- **`app-protected-layout.tsx`** — thread props + memo deps.

## Docs sweep (commit 2 — `docs(memory)`)

`develop`/`staging` branches no longer exist on origin (trunk-based: `master` is the single trunk). Updated the agent-memory rules/context that still described the dead `develop → staging → master` flow:

- `CLAUDE.md` Files & Git — autonomous ship-on-done + master-is-PR-only + secret-scan gate
- `feedback_never_commit_to_master.md` → ship-autonomously / master-PR-only (+ MEMORY.md index)
- `feedback_gh_issue_worktree_workflow.md` — worktrees + PRs off `master`
- `feedback_concurrent_automation_develop.md` — generalized to shared checkout; develop observation marked historical
- `feedback_production_deploy_master_only.md` — non-`master` ref wording
- `context/progress.md`, `context/e2e-architecture.md` — `master`-only branch refs

Historical mentions (build-regression dates, "old flow is dead" notes, verification provenance) intentionally left as-is.

## Verification

- `biome check` — clean
- `turbo lint --filter=@genfeedai/app` — pass (1259 files)
- `turbo type-check --filter=@genfeedai/app` — pass
- `test --filter=@genfeedai/app` (library-menu-items.config) — 3/3 pass
- pre-commit hooks (secretlint, lint-no-raw-html, biome) — pass on both commits