### PR TITLE
feat(voices): ExternalVoice catalog table + Ingredient FK (PR1/5)

### DIFF
--- a/apps/server/api/src/collections/ingredients/entities/ingredient.entity.ts
+++ b/apps/server/api/src/collections/ingredients/entities/ingredient.entity.ts
@@ -79,6 +79,7 @@ export class IngredientEntity extends BaseEntity implements Ingredient {
   declare readonly voiceSource: Ingredient['voiceSource'];
   declare readonly voiceProvider: Ingredient['voiceProvider'];
   declare readonly externalVoiceId: Ingredient['externalVoiceId'];
+  declare readonly externalVoiceCatalogId: Ingredient['externalVoiceCatalogId'];
   declare readonly cloneStatus: Ingredient['cloneStatus'];
   declare readonly sampleAudioUrl: Ingredient['sampleAudioUrl'];
   declare readonly isCloned: Ingredient['isCloned'];

--- a/packages/models/ingredients/voice.model.ts
+++ b/packages/models/ingredients/voice.model.ts
@@ -11,4 +11,7 @@ export class Voice extends Ingredient {
   public declare providerData?: Record<string, unknown>;
   public declare isFeatured?: boolean;
   public declare voiceSource?: 'catalog' | 'cloned' | 'generated';
+  // FK to the ExternalVoice catalog entry this voice was generated/cloned from.
+  // Catalog entries live in the ExternalVoice table, not in ingredients.
+  public declare externalVoiceCatalogId?: string;
 }

--- a/packages/prisma/prisma/migrations/20260614230201_add_external_voice_catalog/migration.sql
+++ b/packages/prisma/prisma/migrations/20260614230201_add_external_voice_catalog/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "external_voices" (
+    "id" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "externalProvider" "VoiceProvider" NOT NULL,
+    "name" TEXT NOT NULL,
+    "sampleAudioUrl" TEXT,
+    "language" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "isDefaultSelectable" BOOLEAN NOT NULL DEFAULT true,
+    "isFeatured" BOOLEAN NOT NULL DEFAULT false,
+    "providerData" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "external_voices_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "ingredients" ADD COLUMN "externalVoiceCatalogId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "external_voices_provider_external_id_key" ON "external_voices"("externalProvider", "externalId");
+
+-- CreateIndex
+CREATE INDEX "external_voices_provider_active_selectable_idx" ON "external_voices"("externalProvider", "isActive", "isDefaultSelectable");
+
+-- CreateIndex
+CREATE INDEX "ingredients_externalVoiceCatalogId_idx" ON "ingredients"("externalVoiceCatalogId");
+
+-- AddForeignKey
+ALTER TABLE "ingredients" ADD CONSTRAINT "ingredients_externalVoiceCatalogId_fkey" FOREIGN KEY ("externalVoiceCatalogId") REFERENCES "external_voices"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1140,6 +1140,12 @@ model Ingredient {
   providerData        Json?
   isFeatured          Boolean?
 
+  // External voice catalog reference (set on generated/cloned voices that used a
+  // provider catalog voice). Catalog entries themselves live in ExternalVoice,
+  // NOT in ingredients — only generated/cloned voice ASSETS are ingredients.
+  externalVoiceCatalogId String?
+  externalVoiceCatalog   ExternalVoice? @relation("ingredient_external_voice", fields: [externalVoiceCatalogId], references: [id])
+
   // Video discriminator fields
   language String?
 
@@ -1176,7 +1182,32 @@ model Ingredient {
   @@index([personaSlug])
   @@index([isDeleted, personaId, reviewStatus])
   @@index([campaign, isDeleted, personaSlug])
+  @@index([externalVoiceCatalogId])
   @@map("ingredients")
+}
+
+/// Provider voice catalog (ElevenLabs, HeyGen, …). Reference data synced from
+/// provider APIs — NOT user-owned content, so no brand/org/isDeleted. Generated
+/// or cloned voice ingredients reference an entry via Ingredient.externalVoiceCatalogId.
+model ExternalVoice {
+  id                  String        @id @default(cuid())
+  externalId          String
+  externalProvider    VoiceProvider
+  name                String
+  sampleAudioUrl      String?
+  language            String?
+  isActive            Boolean       @default(true)
+  isDefaultSelectable Boolean       @default(true)
+  isFeatured          Boolean       @default(false)
+  providerData        Json?
+  createdAt           DateTime      @default(now())
+  updatedAt           DateTime      @updatedAt
+
+  ingredients Ingredient[] @relation("ingredient_external_voice")
+
+  @@unique([externalProvider, externalId], map: "external_voices_provider_external_id_key")
+  @@index([externalProvider, isActive, isDefaultSelectable], map: "external_voices_provider_active_selectable_idx")
+  @@map("external_voices")
 }
 
 model Metadata {


### PR DESCRIPTION
## What

Foundation PR for separating the **provider voice catalog** from generated/cloned voice **assets**.

Adds a dedicated `ExternalVoice` table for provider voice catalogs (ElevenLabs, HeyGen, …) instead of overloading `ingredients` with `voiceSource='catalog'` rows. That conflation is what produced ~2,300 empty voice "shell" rows in prod (a catalog reference is not a generated asset).

## Changes (pure additive — zero behavior change)

- **`ExternalVoice` model** + `external_voices` migration. Reference data, keyed `@@unique(externalProvider, externalId)`. No brand/org/isDeleted (not user-owned); `isActive` for deactivation.
- **`Ingredient.externalVoiceCatalogId`** nullable FK (`ON DELETE SET NULL`) — generated/cloned voices reference the catalog entry they used.
- **`Voice` model**: `externalVoiceCatalogId` field.
- Migration uses explicit `map:` index names (deterministic, authored without a shadow DB).

## Verification

- `prisma validate` ✓ · `prisma generate` ✓ (model + FK present)
- `tsc --noEmit` on `@genfeedai/models` ✓

## Follows in later PRs

- **PR2**: `ExternalVoiceCatalogService`, async provider import (BullMQ), `GET /voices/catalog`, and the voice-listing/controller field fixes (`type:'voice'` removal, `isActive`→`isVoiceActive`, `provider`→`voiceProvider`).
- **PR3**: frontend catalog split. **PR4**: `metadataId` write-boundary fix. **PR5**: data-migration scripts.

Full plan: `.agents/plans/voice-asset-migration-PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)