### PR TITLE
feat(voices): frontend catalog split + executor cleanup (PR3/5)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/voices/library-voices-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/voices/library-voices-page.test.tsx
@@ -196,6 +196,7 @@ import LibraryVoicesPage from './library-voices-page';
 
 function createVoice(overrides: Partial<Voice> = {}): Voice {
   return {
+    externalVoiceCatalogId: 'voice-catalog-1',
     externalVoiceId: 'voice-ext-1',
     id: 'voice-1',
     isCloned: false,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/voices/voice-catalog-row.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/voices/voice-catalog-row.test.tsx
@@ -95,7 +95,7 @@ function createVoice(overrides: Partial<Voice> = {}): Voice {
       index: 4,
     },
     sampleAudioUrl: 'https://example.com/sample.mp3',
-    voiceSource: 'catalog',
+    voiceSource: 'cloned',
     ...overrides,
   } as Voice;
 }
@@ -128,7 +128,7 @@ describe('VoiceCatalogRow', () => {
       'Warm narration voice',
     );
     expect(screen.getByText('secondary:ElevenLabs')).toBeInTheDocument();
-    expect(screen.getByText('ghost:Catalog')).toBeInTheDocument();
+    expect(screen.getByText('ghost:Cloned')).toBeInTheDocument();
     expect(screen.getByText('outline:ready')).toBeInTheDocument();
     expect(screen.getByText('accent:Featured')).toBeInTheDocument();
     expect(screen.getByText('success:Org Default')).toBeInTheDocument();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/voices/voice-catalog-row.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/voices/voice-catalog-row.tsx
@@ -26,11 +26,7 @@ function getVoiceSourceLabel(voice: Voice): string {
     return 'Cloned';
   }
 
-  if (voice.voiceSource === 'generated') {
-    return 'Generated';
-  }
-
-  return 'Catalog';
+  return 'Generated';
 }
 
 function getProviderMeta(voice: Voice): string | null {

--- a/apps/app/app/(protected)/admin/library/voices/voice-catalog-card.tsx
+++ b/apps/app/app/(protected)/admin/library/voices/voice-catalog-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ButtonSize, ButtonVariant, VoiceProvider } from '@genfeedai/enums';
-import type { Voice } from '@models/ingredients/voice.model';
+import type { ExternalVoice } from '@models/elements/external-voice.model';
 import AudioPreviewPlayer from '@ui/audio/preview-player/AudioPreviewPlayer';
 import Card from '@ui/card/Card';
 import Badge from '@ui/display/badge/Badge';
@@ -9,8 +9,8 @@ import InsetSurface from '@ui/display/inset-surface/InsetSurface';
 import { Button } from '@ui/primitives/button';
 import { HiSparkles, HiStar } from 'react-icons/hi2';
 
-function getVoiceName(voice: Voice): string {
-  return voice.metadataLabel || voice.externalVoiceId || voice.id;
+function getVoiceName(voice: ExternalVoice): string {
+  return voice.name || voice.externalId || voice.id;
 }
 
 function getProviderLabel(provider?: string): string {
@@ -26,9 +26,9 @@ function getProviderLabel(provider?: string): string {
 
 type Props = {
   togglingKey: string | null;
-  voice: Voice;
+  voice: ExternalVoice;
   onToggle: (
-    voice: Voice,
+    voice: ExternalVoice,
     field: 'isActive' | 'isDefaultSelectable' | 'isFeatured',
     value: boolean,
   ) => void;
@@ -64,7 +64,7 @@ export default function VoiceCatalogCard({
               {getVoiceName(voice)}
             </h3>
             <p className="truncate text-xs text-foreground/50">
-              {voice.externalVoiceId ?? voice.id}
+              {voice.externalId ?? voice.id}
             </p>
           </div>
         </div>

--- a/apps/app/app/(protected)/admin/library/voices/voice-catalog-card.tsx
+++ b/apps/app/app/(protected)/admin/library/voices/voice-catalog-card.tsx
@@ -10,7 +10,7 @@ import { Button } from '@ui/primitives/button';
 import { HiSparkles, HiStar } from 'react-icons/hi2';
 
 function getVoiceName(voice: ExternalVoice): string {
-  return voice.name || voice.externalId || voice.id;
+  return voice.name || voice.externalVoiceId || voice.id;
 }
 
 function getProviderLabel(provider?: string): string {
@@ -64,7 +64,7 @@ export default function VoiceCatalogCard({
               {getVoiceName(voice)}
             </h3>
             <p className="truncate text-xs text-foreground/50">
-              {voice.externalId ?? voice.id}
+              {voice.externalVoiceId ?? voice.id}
             </p>
           </div>
         </div>

--- a/apps/app/app/(protected)/admin/library/voices/voices-library-page.tsx
+++ b/apps/app/app/(protected)/admin/library/voices/voices-library-page.tsx
@@ -2,7 +2,7 @@
 
 import type { VoiceProvider } from '@genfeedai/enums';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
-import type { Voice } from '@models/ingredients/voice.model';
+import type { ExternalVoice } from '@models/elements/external-voice.model';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
 import { VoicesService } from '@services/ingredients/voices.service';
@@ -31,7 +31,7 @@ export default function VoicesLibraryPage() {
     VoicesService.getInstance(token),
   );
 
-  const [voices, setVoices] = useState<Voice[]>([]);
+  const [voices, setVoices] = useState<ExternalVoice[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSyncingAll, setIsSyncingAll] = useState(false);
   const [syncingProvider, setSyncingProvider] = useState<VoiceProvider | null>(
@@ -46,16 +46,13 @@ export default function VoicesLibraryPage() {
 
     try {
       const service = await getVoicesService();
-      const data = await service.findAll({
-        pagination: false,
-        providers: providerFilter === 'all' ? undefined : [providerFilter],
+      const data = await service.findCatalog({
+        provider: providerFilter === 'all' ? undefined : providerFilter,
         search: search.trim() || undefined,
-        sort: 'provider: 1, metadata.label: 1',
-        voiceSource: ['catalog'],
       });
       setVoices(data);
     } catch (error) {
-      logger.error('GET /voices failed', error);
+      logger.error('GET /voices/catalog failed', error);
       notifications.error('Failed to load voice catalog');
       setVoices([]);
     } finally {
@@ -81,9 +78,11 @@ export default function VoicesLibraryPage() {
 
       try {
         const service = await getVoicesService();
-        const syncedVoices = await service.importCatalogVoices(providers);
-        setVoices(syncedVoices);
-        notifications.success('Voice catalog synced');
+        const result = await service.importCatalogVoices(providers);
+        notifications.success(
+          `Voice catalog synced — ${result.created} created, ${result.updated} updated`,
+        );
+        await loadVoices();
       } catch (error) {
         logger.error('POST /voices/import failed', error);
         notifications.error('Failed to sync voice catalog');
@@ -92,12 +91,12 @@ export default function VoicesLibraryPage() {
         setIsSyncingAll(false);
       }
     },
-    [getVoicesService, notifications],
+    [getVoicesService, loadVoices, notifications],
   );
 
   const handleToggle = useCallback(
     async (
-      voice: Voice,
+      voice: ExternalVoice,
       field: 'isActive' | 'isDefaultSelectable' | 'isFeatured',
       value: boolean,
     ) => {
@@ -105,15 +104,15 @@ export default function VoicesLibraryPage() {
 
       try {
         const service = await getVoicesService();
-        const updatedVoice = await service.patch(voice.id, {
+        const updatedVoice = await service.patchCatalogVoice(voice.id, {
           [field]: value,
-        } as Partial<Voice>);
+        });
 
         setVoices((current) =>
           current.map((item) => (item.id === voice.id ? updatedVoice : item)),
         );
       } catch (error) {
-        logger.error(`PATCH /voices/${voice.id} failed`, error);
+        logger.error(`PATCH /voices/catalog/${voice.id} failed`, error);
         notifications.error('Failed to update voice');
       } finally {
         setTogglingKey(null);

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -7825,8 +7825,7 @@ export class AgentToolExecutorService {
             where: {
               isCloned: true,
               isDeleted: false,
-              organization: ctx.organizationId,
-              type: 'voice',
+              organizationId: ctx.organizationId,
             },
             orderBy: { createdAt: -1 },
           },

--- a/packages/helpers/src/voice/default-voice-ref.helper.test.ts
+++ b/packages/helpers/src/voice/default-voice-ref.helper.test.ts
@@ -10,6 +10,7 @@ describe('default-voice-ref.helper', () => {
   it('builds catalog refs for curated provider voices', () => {
     expect(
       buildDefaultVoiceRefFromVoice({
+        externalVoiceCatalogId: 'voice-catalog-1',
         externalVoiceId: 'voice-ext-1',
         id: 'voice-1',
         metadataLabel: 'Rachel',

--- a/packages/helpers/src/voice/default-voice-ref.helper.ts
+++ b/packages/helpers/src/voice/default-voice-ref.helper.ts
@@ -6,6 +6,7 @@ export interface DefaultVoiceCandidate {
   id: string;
   provider?: string;
   externalVoiceId?: string;
+  externalVoiceCatalogId?: string;
   isCloned?: boolean;
   metadataLabel?: string;
   sampleAudioUrl?: string | null;
@@ -91,6 +92,16 @@ export function buildDefaultVoiceRefFromVoice(
     return null;
   }
 
+  if (voice.externalVoiceCatalogId) {
+    return {
+      externalVoiceId: voice.externalVoiceId,
+      label: voice.metadataLabel ?? voice.externalVoiceId ?? voice.id,
+      preview: voice.sampleAudioUrl ?? null,
+      provider: voice.provider as VoiceProvider | undefined,
+      source: 'catalog',
+    };
+  }
+
   if (
     voice.isCloned ||
     voice.voiceSource === 'cloned' ||
@@ -104,17 +115,7 @@ export function buildDefaultVoiceRefFromVoice(
     };
   }
 
-  if (!voice.provider || !voice.externalVoiceId) {
-    return null;
-  }
-
-  return {
-    externalVoiceId: voice.externalVoiceId,
-    label: voice.metadataLabel ?? voice.externalVoiceId ?? voice.id,
-    preview: voice.sampleAudioUrl ?? null,
-    provider: voice.provider as VoiceProvider,
-    source: 'catalog',
-  };
+  return null;
 }
 
 export function matchesDefaultVoice(

--- a/packages/models/elements/external-voice.model.ts
+++ b/packages/models/elements/external-voice.model.ts
@@ -1,0 +1,18 @@
+export class ExternalVoice {
+  public declare id: string;
+  public declare externalId: string;
+  public declare provider: string;
+  public declare name: string;
+  public declare sampleAudioUrl?: string | null;
+  public declare language?: string | null;
+  public declare isActive: boolean;
+  public declare isDefaultSelectable: boolean;
+  public declare isFeatured: boolean;
+  public declare providerData?: Record<string, unknown> | null;
+  public declare createdAt: string;
+  public declare updatedAt: string;
+
+  constructor(partial: Partial<ExternalVoice>) {
+    Object.assign(this, partial);
+  }
+}

--- a/packages/models/elements/external-voice.model.ts
+++ b/packages/models/elements/external-voice.model.ts
@@ -1,6 +1,8 @@
 export class ExternalVoice {
   public declare id: string;
-  public declare externalId: string;
+  // Wire attribute name is `externalVoiceId` (server toWireFormat maps the
+  // ExternalVoice.externalId Prisma column to this backward-compatible name).
+  public declare externalVoiceId: string;
   public declare provider: string;
   public declare name: string;
   public declare sampleAudioUrl?: string | null;

--- a/packages/pages/library/voices/hooks/use-voice-catalog.test.tsx
+++ b/packages/pages/library/voices/hooks/use-voice-catalog.test.tsx
@@ -37,7 +37,7 @@ describe('useVoiceCatalog', () => {
     );
   });
 
-  it('fetches voices from the db-backed voices service with query options', async () => {
+  it('fetches cloned/generated voices from the ingredients service with query options', async () => {
     const voices = [{ id: 'voice-1', provider: VoiceProvider.ELEVENLABS }];
     mockFindAll.mockResolvedValue(voices);
 
@@ -49,7 +49,6 @@ describe('useVoiceCatalog', () => {
         pagination: true,
         providers: [VoiceProvider.ELEVENLABS],
         search: 'rachel',
-        voiceSource: ['catalog'],
       }),
     );
 
@@ -70,7 +69,6 @@ describe('useVoiceCatalog', () => {
         'failed',
         'completed',
       ],
-      voiceSource: ['catalog'],
     });
     expect(result.current.voices).toEqual(voices);
   });
@@ -112,7 +110,6 @@ describe('useVoiceCatalog', () => {
       providers: undefined,
       search: undefined,
       status: ['completed'],
-      voiceSource: undefined,
     });
     expect(result.current.voices).toEqual([
       { id: 'voice-2' },

--- a/packages/pages/library/voices/hooks/use-voice-catalog.ts
+++ b/packages/pages/library/voices/hooks/use-voice-catalog.ts
@@ -24,7 +24,6 @@ interface UseVoiceCatalogOptions {
   providers?: VoiceProvider[];
   search?: string;
   status?: string[];
-  voiceSource?: Array<'catalog' | 'cloned' | 'generated'>;
 }
 
 export function useVoiceCatalog({
@@ -35,7 +34,6 @@ export function useVoiceCatalog({
   providers,
   search,
   status = DEFAULT_VOICE_CATALOG_STATUS,
-  voiceSource,
 }: UseVoiceCatalogOptions = {}) {
   const getVoicesService = useAuthedService((token: string) =>
     VoicesService.getInstance(token),
@@ -57,7 +55,6 @@ export function useVoiceCatalog({
         providers,
         search,
         status,
-        voiceSource,
       });
       setVoices(nextVoices);
     } catch (error) {
@@ -75,7 +72,6 @@ export function useVoiceCatalog({
     providers,
     search,
     status,
-    voiceSource,
   ]);
 
   useEffect(() => {

--- a/packages/services/ingredients/voices.service.ts
+++ b/packages/services/ingredients/voices.service.ts
@@ -1,10 +1,22 @@
 import type { VoiceProvider } from '@genfeedai/enums';
+import type { ExternalVoice } from '@genfeedai/models/elements/external-voice.model';
 import type { Voice } from '@genfeedai/models/ingredients/voice.model';
 import { IngredientsService } from '@services/content/ingredients.service';
 import type { JsonApiResponseDocument } from '@services/core/base.service';
 import { ServiceInstanceManager } from '@services/core/service-instance-manager';
 
 const voiceInstances = new ServiceInstanceManager<VoicesService>();
+
+export interface CatalogSyncResult {
+  created: number;
+  updated: number;
+  total: number;
+}
+
+export interface CatalogFindParams {
+  provider?: VoiceProvider;
+  search?: string;
+}
 
 export class VoicesService extends IngredientsService<Voice> {
   constructor(token: string) {
@@ -22,9 +34,48 @@ export class VoicesService extends IngredientsService<Voice> {
     return instance;
   }
 
-  async importCatalogVoices(providers?: VoiceProvider[]): Promise<Voice[]> {
-    return await this.instance
-      .post<JsonApiResponseDocument>('/import', providers ? { providers } : {})
-      .then((res) => this.mapMany(res.data));
+  async findCatalog(params: CatalogFindParams = {}): Promise<ExternalVoice[]> {
+    const query: Record<string, unknown> = {};
+    if (params.provider) {
+      query['provider'] = params.provider;
+    }
+    if (params.search) {
+      query['search'] = params.search;
+    }
+
+    return this.executeWithErrorHandling(
+      'GET /voices/catalog',
+      this.instance
+        .get<JsonApiResponseDocument>('/catalog', { params: query })
+        .then((res) => this.extractCollection<ExternalVoice>(res.data)),
+    );
+  }
+
+  async importCatalogVoices(
+    providers?: VoiceProvider[],
+  ): Promise<CatalogSyncResult> {
+    return this.executeWithErrorHandling(
+      'POST /voices/import',
+      this.instance
+        .post<{ data: CatalogSyncResult }>(
+          '/import',
+          providers ? { providers } : {},
+        )
+        .then((res) => res.data.data),
+    );
+  }
+
+  async patchCatalogVoice(
+    id: string,
+    data: Partial<
+      Pick<ExternalVoice, 'isActive' | 'isDefaultSelectable' | 'isFeatured'>
+    >,
+  ): Promise<ExternalVoice> {
+    return this.executeWithErrorHandling(
+      `PATCH /voices/catalog/${id}`,
+      this.instance
+        .patch<ExternalVoice>(`/catalog/${id}`, data)
+        .then((res) => res.data),
+    );
   }
 }

--- a/packages/services/ingredients/voices.service.ts
+++ b/packages/services/ingredients/voices.service.ts
@@ -74,8 +74,8 @@ export class VoicesService extends IngredientsService<Voice> {
     return this.executeWithErrorHandling(
       `PATCH /voices/catalog/${id}`,
       this.instance
-        .patch<ExternalVoice>(`/catalog/${id}`, data)
-        .then((res) => res.data),
+        .patch<JsonApiResponseDocument>(`/catalog/${id}`, data)
+        .then((res) => this.extractResource<ExternalVoice>(res.data)),
     );
   }
 }


### PR DESCRIPTION
**Stacked on #595 (PR2).** Retargets to `master` as the stack merges.

## What
Points every consumer at the new `ExternalVoice` catalog API (PR2) and removes the last `type:'voice'` Mongo discriminator.

- `voices.service`: `findCatalog()` + `patchCatalogVoice()`; `importCatalogVoices()` returns the new `{ created, updated, total }` sync result
- admin `voices-library-page` + `voice-catalog-card`: consume `ExternalVoice` via `findCatalog()`/`patchCatalogVoice()` instead of `findAll({ voiceSource: ['catalog'] })`
- `use-voice-catalog` hook: drop the `voiceSource` option (catalog is its own endpoint)
- `voice-catalog-row`: source label = Cloned/Generated only
- `default-voice-ref.helper`: catalog discriminant = `externalVoiceCatalogId` presence
- `agent-tool-executor`: drop dead `type:'voice'` filter, use `organizationId`
- new `ExternalVoice` frontend model

## Verification
- `tsc --noEmit`: apps/app, packages/services, packages/helpers, packages/models — 0 code errors (only pre-existing `baseUrl` TS6 deprecation)
- raw-HTML lint + biome + secretlint pre-commit hooks pass
- voice-catalog-row + use-voice-catalog tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)