### PR TITLE
ci: shards + build-verify on dispatch/release only; deploy dispatch-only

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -4,18 +4,13 @@
 # merge/release. The boot step is the #574 circular-dep regression guard.
 name: Build Verify
 
+# Build + boot verification runs at release/preview time only (dispatch or as a
+# called step in full-suite) — NOT on every PR or master push. Keeps PR/master
+# CI to the fast required checks; heavy compile/boot validation happens when you
+# cut a preview/release.
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'apps/server/**'
-      - 'ee/packages/billing/**'
-      - 'packages/**'
-      - 'configs/**'
-      - 'docker/**'
-      - 'package.json'
-      - 'bun.lock'
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: build-verify-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
     name: Test App (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master'))
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -420,7 +420,7 @@ jobs:
     name: Test API (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && ((github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name != 'pull_request' && github.ref_name == 'master'))
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
     name: Test Scope
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
     outputs:
       app: ${{ steps.scope.outputs.app }}
       api: ${{ steps.scope.outputs.api }}
@@ -312,7 +312,7 @@ jobs:
     name: Test Packages
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -333,7 +333,7 @@ jobs:
     name: Test Server Services
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -354,7 +354,7 @@ jobs:
     name: Test Web, Desktop, Mobile
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -375,7 +375,7 @@ jobs:
     name: Test Extensions
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,13 +1,11 @@
-# Production Deployment — thin caller for the reusable _deploy.yml workflow
-# Triggers on GitHub release (like cal.com). Contributors PR against develop;
-# maintainers merge develop → master, then create a release to deploy.
-# Manual dispatch is also available for hotfixes.
+# Production Deployment — thin caller for the reusable _deploy.yml workflow.
+# Dispatch-only: cutting a release/tag does NOT auto-deploy. A maintainer
+# explicitly dispatches this workflow to ship, so deploys are deliberate and
+# it's always known exactly when prod was shipped.
 
 name: Deploy Production
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       force_all:

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -22,8 +22,13 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
+  build-verify:
+    name: Build & Boot Check
+    uses: ./.github/workflows/build-verify.yml
+    secrets: inherit
+
   e2e:
     name: E2E Suite
-    needs: ci
+    needs: [ci, build-verify]
     uses: ./.github/workflows/e2e.yml
     secrets: inherit


### PR DESCRIPTION
Makes the trunk CI model clean per the intended design:

- **PR → master:** only fast required checks (Format/Typecheck/Lint/Gitleaks/Secretlint). No Test shards, no build-verify → fast merges.
- **push → master:** same fast checks (shards/build-verify no longer fire here).
- **Dispatch a preview/release** (`full-suite` workflow_dispatch): runs the **Test App/API shards + build-verify (compile/boot) + E2E** — i.e. test everything.
- **Deploy (staging + production):** `workflow_dispatch` only. Cutting a release/tag no longer auto-deploys prod — a maintainer dispatches the deploy, so shipping is deliberate + it's known exactly when prod went out.

### Changes
- `ci.yml`: Test App/API shard `if:` → `github.event_name == 'workflow_dispatch'` (was PR-to-master + master-push)
- `build-verify.yml`: `on:` → `workflow_dispatch` + `workflow_call` (was `push: master`)
- `full-suite.yml`: add `build-verify` job so a dispatched preview validates compile/boot too
- `deploy-production.yml`: removed `release: published` → `workflow_dispatch` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)