### PR TITLE
ci(deploy): decouple image build from deploy — build on master-push, pull-only deploy

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -91,8 +91,8 @@ jobs:
       # .turbo (keyed on bun.lock/turbo.json) and retries install on transient
       # CDN failures. The previous inline setup-bun + uncached `bun install`
       # routinely blew past the old 10-min timeout on a cold runner, which
-      # cancelled this job, skipped build-unified-image, and left the deploy
-      # pulling an image tag that was never pushed ("manifest unknown").
+      # cancelled this job; deploy-services is gated on this job's result, so a
+      # cancelled test correctly skips the deploy instead of shipping untested.
       - name: Setup Bun environment
         uses: ./.github/actions/setup-bun-env
         with:
@@ -137,45 +137,11 @@ jobs:
             bun run test --filter=@genfeedai/clips
           fi
 
-  # Build single unified server image containing all 10 services
-  build-unified-image:
-    name: Build Unified Server Image
-    needs: [detect-changes, test-changed]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: |
-      always() &&
-      (needs.test-changed.result == 'success' || needs.test-changed.result == 'skipped') &&
-      (
-        needs.detect-changes.outputs.api_changed == 'true' ||
-        needs.detect-changes.outputs.files_changed == 'true' ||
-        needs.detect-changes.outputs.mcp_changed == 'true' ||
-        needs.detect-changes.outputs.notifications_changed == 'true' ||
-        needs.detect-changes.outputs.telegram_changed == 'true' ||
-        needs.detect-changes.outputs.discord_changed == 'true' ||
-        needs.detect-changes.outputs.slack_changed == 'true' ||
-        needs.detect-changes.outputs.workers_changed == 'true' ||
-        needs.detect-changes.outputs.clips_changed == 'true' ||
-        inputs.force_all == true ||
-        inputs.force_api == true ||
-        inputs.force_bots == true ||
-        inputs.force_workers == true ||
-        inputs.force_redis == true
-      )
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Build unified server image
-        uses: ./.github/actions/build-unified-image
-        with:
-          image_prefix: ${{ env.IMAGE_PREFIX }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          environment: ${{ inputs.environment }}
+  # The unified server image is built+pushed OUT OF BAND by build-server-image.yml
+  # (on master-push, paths-gated). Deploy is pull-only: it pulls server:<sha>,
+  # which is guaranteed present for any committed master SHA. The image-availability
+  # preflight in deploy-services waits briefly in case a just-merged commit's build
+  # is still finishing, then fails fast with a clear message if it never lands.
 
   # --- Single consolidated deploy job ---
   # Deploys all changed services in wave order via one SSH session to EC2
@@ -184,26 +150,16 @@ jobs:
 
   deploy-services:
     name: Deploy Services
-    needs: [detect-changes, resolve-config, test-changed, build-unified-image]
+    needs: [detect-changes, resolve-config, test-changed]
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Guard: only deploy when the server image is actually available. The image
-    # is pushed by build-unified-image; if test-changed failed/was cancelled
-    # (e.g. timeout), build-unified-image skips and NO image is pushed for this
-    # SHA. Without this guard the old condition still ran deploy on a skipped
-    # build and pulled a non-existent tag ("manifest unknown"). build==success
-    # ⇒ image pushed; build==skipped is only legitimate (redis-only deploy, no
-    # server service changed) when tests passed/were skipped — so gate that
-    # branch on test success/skipped too.
+    # Only deploy when pre-deploy tests passed or were skipped (skip_tests). The
+    # server image itself is built out of band by build-server-image.yml; the
+    # "Wait for server image" step below proves server:<sha> exists before any
+    # service is touched, so a missing image fails fast instead of mid-deploy.
     if: |
       always() &&
-      (
-        needs.build-unified-image.result == 'success' ||
-        (
-          needs.build-unified-image.result == 'skipped' &&
-          (needs.test-changed.result == 'success' || needs.test-changed.result == 'skipped')
-        )
-      ) &&
+      (needs.test-changed.result == 'success' || needs.test-changed.result == 'skipped') &&
       (
         needs.detect-changes.outputs.api_changed == 'true' ||
         needs.detect-changes.outputs.files_changed == 'true' ||
@@ -226,6 +182,33 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      # Pull-only deploy: prove the pre-built image exists before touching prod.
+      # build-server-image.yml publishes server:<sha> on master-push; if you
+      # dispatch a deploy seconds after merging, that build may still be running,
+      # so poll briefly before failing. Never builds here — just verifies.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for server image
+        run: |
+          set -euo pipefail
+          IMG="ghcr.io/${{ github.repository }}/server:${{ github.sha }}"
+          echo "Verifying pre-built image: ${IMG}"
+          for i in $(seq 1 30); do
+            if docker manifest inspect "${IMG}" >/dev/null 2>&1; then
+              echo "✅ Image present — proceeding with pull-only deploy."
+              exit 0
+            fi
+            echo "Image not found yet (attempt ${i}/30) — the master-push build may still be running. Sleeping 30s..."
+            sleep 30
+          done
+          echo "::error::${IMG} not found after ~15 min. Run the 'Build Server Image' workflow for this commit, then re-dispatch the deploy."
+          exit 1
 
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
@@ -404,14 +387,13 @@ jobs:
 
   deployment-summary:
     name: Deployment Summary
-    needs: [detect-changes, test-changed, build-unified-image, deploy-services]
+    needs: [detect-changes, test-changed, deploy-services]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Write deployment summary
         env:
           API_CHANGED: ${{ needs.detect-changes.outputs.api_changed }}
-          BUILD_RESULT: ${{ needs.build-unified-image.result }}
           BOTS_CHANGED: ${{ needs.detect-changes.outputs.telegram_changed == 'true' || needs.detect-changes.outputs.discord_changed == 'true' || needs.detect-changes.outputs.slack_changed == 'true' || needs.detect-changes.outputs.clips_changed == 'true' }}
           CHANGED_SERVICES: ${{ needs.deploy-services.outputs.changed_services }}
           DEPLOY_RESULT: ${{ needs.deploy-services.result }}
@@ -441,9 +423,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             if [ "${TEST_RESULT}" = "failure" ]; then
               echo "Backend deploy was skipped because the changed-service test job failed." >> "$GITHUB_STEP_SUMMARY"
-            elif [ "${BUILD_RESULT}" = "failure" ]; then
-              echo "Backend deploy was skipped because the unified server image build failed." >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "Backend deploy was a no-op: no services matched the deploy conditions and no force flag applied." >> "$GITHUB_STEP_SUMMARY"
+              echo "Backend deploy was a no-op: no services matched the deploy conditions and no force flag applied. (The server image is built out of band by build-server-image.yml.)" >> "$GITHUB_STEP_SUMMARY"
             fi
           fi

--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -1,0 +1,71 @@
+# Build Server Image — builds + pushes the unified production server image
+# (docker/Dockerfile.server) so DEPLOYS PULL A PRE-BUILT IMAGE instead of
+# building inline.
+#
+# Why this exists: the deploy used to build the image inside the deploy run, and
+# the shared `server:buildcache` was only written by those deploy builds — so it
+# went stale between deploys and every deploy paid a near-cold ~30-min build.
+# This workflow builds on master-push (async, non-blocking) and writes
+# `server:buildcache` (mode=max) every run via the composite, keeping layers hot
+# so builds drop to ~5-10 min and `server:<sha>` is ready before any deploy.
+#
+# Triggers:
+#   push:master (paths-gated) — publish `server:<sha>` + warm the cache for every
+#     server-affecting commit, making any master SHA instantly deployable.
+#   workflow_dispatch — manual/test rebuild. Pick `environment: staging` when
+#     testing so the run does NOT move the :production/:latest floating tags.
+#   workflow_call — let release/preview callers build on demand.
+
+name: Build Server Image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/server/**'
+      - 'packages/**'
+      - 'ee/**'
+      - 'docker/Dockerfile.server'
+      - 'bun.lock'
+      - 'package.json'
+      - '.github/workflows/build-server-image.yml'
+      - '.github/actions/build-unified-image/**'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Floating-tag scope. production moves :production/:latest; staging moves :staging. server:<sha> is always pushed.'
+        type: choice
+        options: [production, staging]
+        default: production
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: false
+        default: production
+
+concurrency:
+  # Serialize builds for a ref: concurrent runs writing the shared
+  # server:buildcache (mode=max) ref can clobber each other's cache manifest.
+  group: build-server-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & Push Server Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Build & push unified server image
+        uses: ./.github/actions/build-unified-image
+        with:
+          image_prefix: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          environment: ${{ inputs.environment || 'production' }}


### PR DESCRIPTION
## Problem

Every prod deploy built the unified server image **inline** (`build-unified-image` inside `_deploy.yml`), and the shared `server:buildcache` was written **only** by those deploy builds — so it went stale between deploys. After a busy merge window the layer diff is huge → near-cold **~30-min build on every deploy** before it can pull + restart.

## Change: build once on merge, deploy pulls

- **New `build-server-image.yml`** — builds + pushes `server:<sha>` on `push: master` (paths-gated to `apps/server`, `packages`, `ee`, `docker/Dockerfile.server`, lockfile), plus `workflow_dispatch` / `workflow_call`. Reuses the `build-unified-image` composite, which writes `server:buildcache` (mode=max) **every run** → cache stays hot → builds ~5-10 min, async, non-blocking. `concurrency: cancel-in-progress: false` serializes cache writes.
- **`_deploy.yml` → pull-only** — removed the `build-unified-image` job. `deploy-services` gains a **"Wait for server image"** preflight (`docker manifest inspect`, polled ~15 min) that proves `server:<sha>` exists before touching prod and fails fast with a clear message otherwise. Deploy drops **~35 min → ~5 min** (pull + migrate + waves).
- `deploy-services` `if` simplified to the test-result gate; `deployment-summary` no longer references the removed build job.

## Flow

Merge to master → `build-server-image` builds `server:<sha>` (cache-warm) → dispatch Deploy Production → preflight confirms the image → pull + migrate + restart. Dispatch right after merge and the preflight waits out the in-flight build; if the image truly never built, the deploy fails **before** any service is touched.

## Tradeoff (chosen: build on master-push)

Server-affecting merges pay ~5-10 min async build (paths-gated, non-blocking). In exchange any master SHA is instantly deployable and deploys are ~5 min. Floating `:production`/`:latest` move on build (trunk = prod-bound); `:<sha>` is the immutable tag deploy pulls.

## Risk

Workflow-only, no app/runtime code. Validated: YAML parses, actionlint clean (only pre-existing SC2086/SC2029 infos in untouched steps), no dangling job refs. **Tested via `workflow_dispatch` (environment=staging) before merge.**