### PR TITLE
ops(prod): per-container mem_limits + redis maxmemory

### DIFF
--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -25,7 +25,11 @@ services:
   redis:
     image: redis:7-alpine
     container_name: genfeed-ai-redis
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
+    # Memory ceilings (added 2026-06): measured steady-state ×~3 with headroom;
+    # sum of all limits ≈5.6G < 7.7G box RAM, so all services can peak at once
+    # without OOM. Caps a single runaway/leak instead of letting it eat the box.
+    mem_limit: 256m
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD} --maxmemory 200mb --maxmemory-policy allkeys-lru
     volumes:
       - redis-data:/data
     restart: unless-stopped
@@ -52,6 +56,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/files", "start:prod"]
     container_name: genfeed-ai-files
+    mem_limit: 512m
     depends_on:
       redis:
         condition: service_healthy
@@ -87,6 +92,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/mcp", "start:prod"]
     container_name: genfeed-ai-mcp
+    mem_limit: 384m
     depends_on:
       redis:
         condition: service_healthy
@@ -122,6 +128,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/notifications", "start:prod"]
     container_name: genfeed-ai-notifications
+    mem_limit: 384m
     depends_on:
       redis:
         condition: service_healthy
@@ -159,6 +166,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/api", "start:prod"]
     container_name: genfeed-ai-api
+    mem_limit: 1280m
     depends_on:
       redis:
         condition: service_healthy
@@ -206,6 +214,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/clips", "start:prod"]
     container_name: genfeed-ai-clips
+    mem_limit: 384m
     depends_on:
       redis:
         condition: service_healthy
@@ -247,6 +256,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/discord", "start:prod"]
     container_name: genfeed-ai-discord
+    mem_limit: 320m
     depends_on:
       redis:
         condition: service_healthy
@@ -285,6 +295,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/slack", "start:prod"]
     container_name: genfeed-ai-slack
+    mem_limit: 320m
     depends_on:
       redis:
         condition: service_healthy
@@ -323,6 +334,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/telegram", "start:prod"]
     container_name: genfeed-ai-telegram
+    mem_limit: 320m
     depends_on:
       redis:
         condition: service_healthy
@@ -363,6 +375,7 @@ services:
     image: ${SERVER_IMAGE:-ghcr.io/genfeedai/genfeed.ai/server:${IMAGE_TAG:-latest}}
     command: ["bun", "--filter", "@genfeedai/workers", "start:prod"]
     container_name: genfeed-ai-workers
+    mem_limit: 1536m
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Why
The prod box (t3a.large, 8GB) runs 10 containers + redis with **no memory limits** — one leak/runaway can starve everything (the 2026-06-10 OOM-thrash). Measured live usage: api 523M, workers 697M, files 179M, redis 12M, bots/mcp/notifications/clips 79-94M each.

## What
Per-service `mem_limit` sized at ~3× steady-state with headroom, + redis internal `maxmemory 200mb` (allkeys-lru):

| svc | limit | | svc | limit |
|---|---|---|---|---|
| api | 1280m | | clips | 384m |
| workers | 1536m | | discord | 320m |
| files | 512m | | slack | 320m |
| mcp | 384m | | telegram | 320m |
| notifications | 384m | | redis | 256m |

**Sum = 5.56G < 7.7G RAM** → all services can peak at once without OOM; each cap only contains a runaway. Applied when the next deploy recreates containers.

## Risk
Compose-only. Limits are generous (3× observed) so normal operation never hits them. Pairs with a 4G swapfile on the box (separate, system-level change).