### PR TITLE
infra(ecs): genfeed.ai ECS-hybrid migration — Terraform + ECS deploy

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -82,25 +82,29 @@ jobs:
                  --query 'repositories[0].repositoryUri' --output text)"
           docker buildx imagetools create -t "${ECR}:${SHA}" "ghcr.io/genfeedai/genfeed.ai/server:${SHA}"
 
-      - uses: hashicorp/setup-terraform@v3
-        with: { terraform_version: "1.10.5" }
+      # OpenTofu, not Terraform — state is tofu in S3; mixing the two risks a
+      # state-version mismatch.
+      - uses: opentofu/setup-opentofu@v1
+        with: { tofu_version: "1.12.2" }
 
-      - name: Terraform init
+      - name: Tofu init
         working-directory: ${{ env.TF_DIR }}
-        run: terraform init -input=false
+        run: tofu init -input=false
 
       - name: Run DB migrations (one-off task, gated before services roll)
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
-          CLUSTER=$(terraform output -raw cluster_name)
-          FAMILY=$(terraform output -raw migrate_task_family)
-          SUBNETS=$(terraform output -json task_subnets | jq -r 'join(",")')
-          SG=$(terraform output -raw task_security_group)
+          CLUSTER=$(tofu output -raw cluster_name)
+          FAMILY=$(tofu output -raw migrate_task_family)
+          SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
+          SG=$(tofu output -raw task_security_group)
           echo "Running migrate task on $CLUSTER ($FAMILY)..."
+          # FARGATE — the cluster is Fargate-only (no EC2 capacity); assignPublicIp
+          # DISABLED since tasks egress via NAT from the private subnets.
           TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$FAMILY" \
-            --launch-type EC2 \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG]}" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
             --query 'tasks[0].taskArn' --output text)
           aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
           CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
@@ -108,16 +112,16 @@ jobs:
           echo "migrate exit code: $CODE"
           [ "$CODE" = "0" ] || { echo "::error::migration failed"; exit 1; }
 
-      - name: Terraform apply (roll services to new image)
+      - name: Tofu apply (roll services to new image)
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -input=false -auto-approve -var="image_tag=${{ steps.tag.outputs.sha }}"
+        run: tofu apply -input=false -auto-approve -var="image_tag=${{ steps.tag.outputs.sha }}"
 
       - name: Wait for services stable
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
-          CLUSTER=$(terraform output -raw cluster_name)
-          for svc in $(terraform output -json service_names | jq -r '.[]'); do
+          CLUSTER=$(tofu output -raw cluster_name)
+          for svc in $(tofu output -json service_names | jq -r '.[]'); do
             echo "waiting: $svc"
             aws ecs wait services-stable --cluster "$CLUSTER" --services "$svc"
           done

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,0 +1,105 @@
+# ECS production deploy (replaces the SSH-waves path post-cutover).
+# Dispatch-only + gated by the GitHub "production" environment (manual approval).
+# Flow: copy server:<sha> GHCR->ECR -> run migrate task -> terraform apply rolls
+# services (task defs are TF-managed with image_tag) -> wait services-stable.
+name: Deploy ECS (production)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'server image tag to deploy (default: current SHA)'
+        required: false
+        default: ''
+
+concurrency:
+  group: deploy-ecs-production
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  TF_DIR: infra/terraform/genfeed-prod
+
+jobs:
+  deploy:
+    name: Deploy ECS
+    runs-on: ubuntu-latest
+    environment: production # <- requires reviewer approval (the human gate)
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate ref is master
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "master" ]; then
+            echo "::error::Production deploy must run from master (got ${GITHUB_REF_NAME})"; exit 1
+          fi
+
+      - name: Resolve image tag
+        id: tag
+        run: echo "sha=${{ inputs.image_tag != '' && inputs.image_tag || github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR + GHCR
+        run: |
+          aws ecr get-login-password --region "$AWS_REGION" \
+            | docker login --username AWS --password-stdin \
+              "$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_REGION.amazonaws.com"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Copy server:<sha> GHCR -> ECR (no rebuild)
+        run: |
+          SHA="${{ steps.tag.outputs.sha }}"
+          ECR="$(aws ecr describe-repositories --repository-names genfeed/server \
+                 --query 'repositories[0].repositoryUri' --output text)"
+          docker buildx imagetools create -t "${ECR}:${SHA}" "ghcr.io/genfeedai/genfeed.ai/server:${SHA}"
+
+      - uses: hashicorp/setup-terraform@v3
+        with: { terraform_version: "1.10.5" }
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform init -input=false
+
+      - name: Run DB migrations (one-off task, gated before services roll)
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          set -euo pipefail
+          CLUSTER=$(terraform output -raw cluster_name)
+          FAMILY=$(terraform output -raw migrate_task_family)
+          SUBNETS=$(terraform output -json task_subnets | jq -r 'join(",")')
+          SG=$(terraform output -raw task_security_group)
+          echo "Running migrate task on $CLUSTER ($FAMILY)..."
+          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$FAMILY" \
+            --launch-type EC2 \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG]}" \
+            --query 'tasks[0].taskArn' --output text)
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
+          CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          echo "migrate exit code: $CODE"
+          [ "$CODE" = "0" ] || { echo "::error::migration failed"; exit 1; }
+
+      - name: Terraform apply (roll services to new image)
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform apply -input=false -auto-approve -var="image_tag=${{ steps.tag.outputs.sha }}"
+
+      - name: Wait for services stable
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          set -euo pipefail
+          CLUSTER=$(terraform output -raw cluster_name)
+          for svc in $(terraform output -json service_names | jq -r '.[]'); do
+            echo "waiting: $svc"
+            aws ecs wait services-stable --cluster "$CLUSTER" --services "$svc"
+          done
+          echo "All services stable."

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -35,13 +35,32 @@ jobs:
 
       - name: Validate ref is master
         run: |
-          if [ "${GITHUB_REF_NAME}" != "master" ]; then
-            echo "::error::Production deploy must run from master (got ${GITHUB_REF_NAME})"; exit 1
+          # Check the FULL ref, not GITHUB_REF_NAME: the short name strips the
+          # refs/heads vs refs/tags prefix, so a tag literally named "master"
+          # would satisfy a name-only check and bypass the production gate.
+          if [ "${GITHUB_REF}" != "refs/heads/master" ]; then
+            echo "::error::Production deploy must run from refs/heads/master (got ${GITHUB_REF})"; exit 1
           fi
 
       - name: Resolve image tag
         id: tag
-        run: echo "sha=${{ inputs.image_tag != '' && inputs.image_tag || github.sha }}" >> "$GITHUB_OUTPUT"
+        env:
+          # Read the dispatch input via env (never interpolate ${{ inputs }}
+          # directly into a run script — that is a template-injection sink).
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_IMAGE_TAG:-}"
+          [ -z "$TAG" ] && TAG="$DEFAULT_SHA"
+          # The tag flows into `docker buildx imagetools` and a terraform -var;
+          # restrict it to a conservative image-tag charset so a crafted input
+          # cannot inject shell or terraform. (The image must also exist in GHCR,
+          # which imagetools enforces downstream.)
+          if ! printf '%s' "$TAG" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "::error::Invalid image_tag '$TAG' (allowed chars: A-Za-z0-9 . _ -)"; exit 1
+          fi
+          echo "sha=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,13 @@
+# Local Terraform state (bootstrap uses local state — never commit it)
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+*.tfvars
+*.tfvars.json
+!example.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraform.lock.hcl

--- a/infra/terraform/PREVIEW.md
+++ b/infra/terraform/PREVIEW.md
@@ -1,0 +1,44 @@
+# Per-PR preview environments (Fargate) — design for the next PR
+
+Steady-state ECS (this PR) ships first. Previews are the immediate follow-up;
+they share the same cluster's **Fargate** capacity provider (scale-to-zero, $0
+when no PR is open) and the same ALB.
+
+## Shape
+
+On `pull_request: opened|synchronize`:
+1. Build the PR image → ECR tag `pr-<n>` (reuse `build-server-image` + the
+   GHCR→ECR copy from `deploy-ecs.yml`).
+2. `module "preview-env"` (Fargate, awsvpc, `assign_public_ip` for ECR pull):
+   a Fargate **api** task (+ the deps it needs — see open decision) registered to
+   a per-PR ALB target group + a host-rule on the prod ALB HTTPS listener
+   (`pr-<n>.preview.genfeed.ai`).
+3. Route53 `pr-<n>.preview.genfeed.ai` → ALB; comment the URL on the PR.
+
+On `pull_request: closed`: destroy the PR's Fargate service, target group,
+listener rule, DNS record, ECR `pr-<n>` tag, and its DB schema.
+
+## Prereqs to add
+
+- **Wildcard cert**: add `*.preview.genfeed.ai` as a SAN on the ACM cert (or a
+  second cert) attached to the HTTPS listener.
+- **Listener rules**: host-based rule per PR (priority = PR number offset).
+- **Fargate**: previews run on `FARGATE` capacity provider (already attached to
+  the cluster), so they never consume the EC2 boxes.
+
+## OPEN DECISION — preview database (pick before building)
+
+A preview needs a DB. Options:
+1. **Schema-per-PR on the existing dev RDS (`local-genfeedai`)** — cheapest. The
+   preview's migrate task runs `prisma migrate deploy` into `pr_<n>` schema
+   (search_path); dropped on close. Recommended.
+2. **Dedicated preview RDS** — cleaner isolation, ~$15-30/mo extra, slower spin-up.
+3. **Point previews at staging DB read-mostly** — risky (writes pollute staging).
+
+Default if unspecified: **Option 1** (schema-per-PR on dev RDS).
+
+## Why it's a separate PR
+
+It needs the wildcard cert + listener-rule wiring + the DB-schema lifecycle, and
+the DB decision above. Keeping it out of the steady-state migration PR keeps that
+PR reviewable and lets the core cutover land first.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,63 @@
+# genfeed.ai — ECS-hybrid Terraform
+
+Replaces the SSH-waves deploy with **AWS ECS** (EC2 capacity for steady services
++ Fargate for per-PR previews). genfeed.ai only.
+
+## Layout
+
+- `bootstrap/` — run ONCE locally with admin creds. Creates the S3 state bucket
+  (S3-native locking, no DynamoDB) + GitHub OIDC provider + `gha-genfeed-deploy`
+  role. Uses local state.
+- `genfeed-prod/` — the cluster, ALB, ECR, IAM, ElastiCache, Cloud Map, and the
+  9 ECS services. S3 backend.
+- `modules/service/` — reusable task-def + ECS service + logs + Cloud Map (+ optional ALB).
+
+## One-time setup
+
+```bash
+# 1. Bootstrap (admin creds)
+cd infra/terraform/bootstrap
+terraform init && terraform apply
+#  -> note outputs: state_bucket, gha_deploy_role_arn
+#  -> add gha_deploy_role_arn as the GitHub Actions variable AWS_DEPLOY_ROLE_ARN
+
+# 2. Main stack
+cd ../genfeed-prod
+terraform init
+terraform plan            # review carefully (first plan surfaces VPC/zone specifics)
+terraform apply           # gated — human approves
+
+# 3. Push the server image to ECR (first time), then re-apply with the tag
+#    (CI does this on every deploy; first time can be manual):
+#    docker buildx imagetools create -t <ecr_url>:<sha> ghcr.io/genfeedai/genfeed.ai/server:<sha>
+terraform apply -var="image_tag=<sha>"
+
+# 4. Point REDIS at ElastiCache (one-time):
+#    set SSM /genfeed/production/REDIS_URL = redis://<redis_primary_endpoint>:6379
+
+# 5. Smoke-test via the ALB DNS BEFORE flipping DNS:
+#    curl https://<alb_dns_name>/v1/health   (Host header api.genfeed.ai if needed)
+```
+
+## Assumptions to verify on first `plan`
+
+- VPC: defaults to the **default VPC** + all its subnets. Override `vpc_id` /
+  `public_subnet_ids` / `private_subnet_ids` if genfeed runs elsewhere.
+- DNS: assumes `genfeed.ai` is a **Route53** hosted zone (cert validation + the
+  `api` A-alias). If DNS is at a registrar, set `route53_zone_id` or move the
+  zone / handle ACM validation manually.
+- RDS: looks up `genfeed-data` by identifier and opens its SG to the ECS tasks SG.
+- Secrets: every SSM param under `/genfeed/production/*` is injected as a task
+  secret (env var = last path segment). Ensure `REDIS_URL` points at ElastiCache
+  (step 4) and the provider keys are valid.
+
+## Cutover (in-place)
+
+1. Apply the stack; services come up at desired_count, api registered to the ALB.
+2. Smoke-test via ALB DNS.
+3. Flip `api.genfeed.ai` A record → ALB (Terraform manages this record; it
+   happens on apply once the zone is correct).
+4. Keep the old EC2 box **stopped, not terminated**, for ~1 week (snapshot first)
+   as a one-flip rollback.
+5. Remove the SSH deploy (`docker/deploy-common.sh`, `deploy-*.sh`,
+   `render-ssm-env.sh`, Tailscale steps) in a follow-up PR.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -53,11 +53,17 @@ terraform apply -var="image_tag=<sha>"
 
 ## Cutover (in-place)
 
-1. Apply the stack; services come up at desired_count, api registered to the ALB.
-2. Smoke-test via ALB DNS.
-3. Flip `api.genfeed.ai` A record → ALB (Terraform manages this record; it
-   happens on apply once the zone is correct).
-4. Keep the old EC2 box **stopped, not terminated**, for ~1 week (snapshot first)
-   as a one-flip rollback.
+1. `terraform apply` (enable_dns_cutover=false, the default) — builds the cluster,
+   ALB, ECR, ElastiCache, services. Does NOT touch api.genfeed.ai DNS, so the old
+   box keeps serving traffic. (Services crash-loop until the image is pushed — fine,
+   no traffic.)
+2. Push the image to ECR + `terraform apply -var="image_tag=<sha>"` → services
+   go healthy.
+3. Smoke-test via the **ALB DNS name** (`terraform output alb_dns_name`):
+   `curl -H 'Host: api.genfeed.ai' https://<alb_dns>/v1/health`.
+4. **Cutover:** `terraform apply -var="image_tag=<sha>" -var="enable_dns_cutover=true"`
+   → creates the api.genfeed.ai A-record → ALB. (Lower the record TTL beforehand.)
+5. Keep the old EC2 box **stopped, not terminated**, for ~1 week (snapshot first).
+   Rollback = re-point api.genfeed.ai at the box's EIP / `enable_dns_cutover=false`.
 5. Remove the SSH deploy (`docker/deploy-common.sh`, `deploy-*.sh`,
    `render-ssm-env.sh`, Tailscale steps) in a follow-up PR.

--- a/infra/terraform/RESUME.md
+++ b/infra/terraform/RESUME.md
@@ -1,0 +1,81 @@
+# RESUME — genfeed.ai ECS/Fargate migration (PR #609)
+
+Hand-off state for continuing in a new session. **PROD IS UNTOUCHED + LIVE** —
+`api.genfeed.ai` → `52.52.217.255` (old EC2 box). No cutover happened. Zero user
+impact. Everything below is the *parallel* ECS platform being stood up.
+
+## Tooling / facts (read first)
+- Run with **OpenTofu (`tofu`)**, NOT terraform — state is tofu 1.12 in S3
+  (`genfeed-tfstate`, native lockfile). CI's deploy-ecs.yml still uses
+  `terraform` 1.10.5 → **must switch to opentofu/setup-opentofu** before that
+  workflow runs (state-version mismatch risk).
+- Always `export AWS_DEFAULT_REGION=us-west-1`.
+- AWS account `948918267147`, IAM user `genfeedai` (has TEMPORARY
+  AdministratorAccess — **detach after migration is done**).
+- Apply dir: `infra/terraform/genfeed-prod`. Always pass
+  `-var="image_tag=66f97e5a116d7aa3cabea80cae97fb69705c58f6"` (master image in ECR).
+- ECR image: `948918267147.dkr.ecr.us-west-1.amazonaws.com/genfeed/server:66f97e5a116d7aa3cabea80cae97fb69705c58f6`
+- ALB DNS: `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`
+- Cluster `genfeed-production`; private subnets `subnet-09ddda2bcf4a385c2`,
+  `subnet-058e42079550dd81f`; ECS SG `sg-0630fbed0bf8faafc`.
+- Old box to stop (NOT terminate) after cutover: `i-0ba4418050d90bd32` / EIP `52.52.217.255`.
+
+## Done
+- Bootstrap applied (S3 state bucket + GitHub OIDC + `gha-genfeed-deploy` role).
+  Repo vars set: `AWS_DEPLOY_ROLE_ARN`, `AWS_REGION`.
+- genfeed-prod applied: ECS cluster (**Fargate-only** — t3a.medium can't ENI-trunk,
+  so EC2 capacity was torn down: CP deleted manually, ASG deleted), ALB + ACM +
+  (gated) Route53, NAT gateway, **2 private subnets** (10.0.11/12.0/24) in
+  genfeedai-vpc `vpc-0e7522e453a642bd8`, ElastiCache `cache.t4g.micro`, Cloud Map
+  `genfeed.internal`, IAM exec/task roles, ECR (image pushed).
+- 9 ECS services exist: **core 5 desired=1** (api, workers, files, mcp,
+  notifications); **bots/clips desired=0 (parked** — code stays, flip on by
+  setting `desired=1` in `locals.tf` + apply).
+- Prod RDS `genfeed-data` schema already current (migrations ran via the old-box
+  deploy earlier) — Fargate services point at it via SSM `DATABASE_URL`.
+- Wiring fixes already applied: REDIS_URL→ElastiCache + REDIS_PASSWORD filtered
+  from secrets; env-overridden SSM keys filtered from secrets; ALB target_type=ip;
+  awsvpc + NAT egress; DNS cutover gated behind `enable_dns_cutover` (default false).
+
+## ⛔ CURRENT BLOCKER (resume here)
+The **5 core Fargate tasks won't start — running=0, IN_PROGRESS.** Even `files`
+(which has no dependency check) is at 0, so it's almost certainly **infra**, not
+the app boot-ordering. Diagnose first:
+
+```bash
+export AWS_DEFAULT_REGION=us-west-1
+CL=genfeed-production
+T=$(aws ecs list-tasks --cluster $CL --service-name files --desired-status STOPPED --query 'taskArns[0]' --output text)
+aws ecs describe-tasks --cluster $CL --tasks "$T" \
+  --query 'tasks[0].{stopped:stoppedReason,reason:containers[0].reason,exit:containers[0].exitCode}'
+aws logs tail /ecs/genfeed-production/files --since 15m --format short | tail -20
+```
+
+Most likely causes (in order):
+1. **`CannotPullContainerError`** → Fargate can't reach ECR. Check NAT egress from
+   the private subnets (route table 0.0.0.0/0 → NAT), or add ECR/S3/logs VPC
+   endpoints. (Fargate pulls via the task ENI, which is in the private subnets.)
+2. **Secrets/exec-role** → execution role `genfeed-production-task-execution` must
+   have `ssm:GetParameters` on `/genfeed/production/*` + `kms:Decrypt` (added in
+   iam.tf — verify it actually attached) + `AmazonECSTaskExecutionRolePolicy`.
+   A `ResourceInitializationError` about SSM = this.
+3. **ENI / subnet IP** → unlikely (Fargate, /24 subnets).
+
+Fix the root cause, then `tofu apply -var="image_tag=66f97e5a116d7aa3cabea80cae97fb69705c58f6"`
+(or just let ECS retry once infra is fixed).
+
+## Then (finish line)
+1. Confirm core 5 healthy: `aws ecs describe-services --cluster genfeed-production --services api workers files mcp notifications --query 'services[].{n:serviceName,run:runningCount}'`
+2. **Smoke-test (no DNS flip):** `curl -H 'Host: api.genfeed.ai' https://genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com/v1/health`
+3. **Cutover:** `tofu apply -var="image_tag=66f97e5a116d7aa3cabea80cae97fb69705c58f6" -var="enable_dns_cutover=true"` → flips api.genfeed.ai → ALB.
+4. **Stop** (not terminate) the old box `i-0ba4418050d90bd32` for ~1 week (rollback = re-point DNS to its EIP / `enable_dns_cutover=false`).
+5. Detach AdministratorAccess from `genfeedai`.
+
+## Follow-ups (separate)
+- Fix `deploy-ecs.yml`: migrate run-task `--launch-type FARGATE` (+ awsvpc network
+  config), and switch setup-terraform → setup-opentofu (state-tool consistency).
+- Per-PR Fargate previews (design in `PREVIEW.md`) — pick preview-DB approach.
+- Voice catalog reseed — BLOCKED: ElevenLabs + HeyGen system keys in SSM are
+  invalid (both 401). Set valid keys in `/genfeed/production/*`, then run
+  `scripts/migrations/reseed-voice-catalog.incontainer.mjs` (or the endpoint).
+- cdnUrl/s3Key backfill on migrated assets.

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -1,0 +1,209 @@
+# Bootstrap stack — run ONCE, locally, with admin AWS creds.
+#
+#   cd infra/terraform/bootstrap
+#   terraform init && terraform apply
+#
+# Creates the prerequisites the rest of the IaC assumes:
+#   1. S3 bucket for remote Terraform state (with native S3 locking — no DynamoDB)
+#   2. GitHub OIDC provider + the gha-genfeed-deploy role CI assumes (no static keys)
+#
+# This stack uses LOCAL state (chicken-and-egg: it creates the very bucket the
+# other stacks use as their backend). Its own state is tiny and rarely changes;
+# keep terraform.tfstate here out of git (see .gitignore) or migrate it into the
+# bucket afterwards if you prefer.
+
+terraform {
+  required_version = ">= 1.10"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      Project   = "genfeed"
+      ManagedBy = "terraform"
+      Stack     = "bootstrap"
+    }
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "us-west-1"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "owner/name of the repo allowed to assume the deploy role"
+  default     = "genfeedai/genfeed.ai"
+}
+
+variable "state_bucket_name" {
+  type    = string
+  default = "genfeed-tfstate"
+}
+
+data "aws_caller_identity" "current" {}
+
+# ── Remote state bucket (S3-native locking, no DynamoDB) ──────────────
+resource "aws_s3_bucket" "state" {
+  bucket = var.state_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket                  = aws_s3_bucket.state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    id     = "expire-old-state-versions"
+    status = "Enabled"
+    filter {}
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}
+
+# ── GitHub OIDC provider ─────────────────────────────────────────────
+# AWS now trusts GitHub's OIDC thumbprints natively; thumbprint_list is no
+# longer strictly required but kept for older AWS-provider compatibility.
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# ── CI deploy role ───────────────────────────────────────────────────
+data "aws_iam_policy_document" "gha_trust" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    # Restrict to this repo (any branch/PR — tighten to :ref:refs/heads/master
+    # for the deploy role if you want master-only).
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "gha_deploy" {
+  name               = "gha-genfeed-deploy"
+  assume_role_policy = data.aws_iam_policy_document.gha_trust.json
+}
+
+# Permissions CI needs: build/push ECR, run terraform (manage ECS/ALB/IAM/
+# ElastiCache/logs/cloudmap), update/run ECS, pass task roles, read state bucket.
+# Broad on purpose for plan/apply; tighten per-action once stable.
+data "aws_iam_policy_document" "gha_deploy" {
+  statement {
+    sid    = "EcrPushPull"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "EcsDeploy"
+    effect = "Allow"
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTasks",
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+      "ecs:DeregisterTaskDefinition",
+      "ecs:UpdateService",
+      "ecs:RunTask",
+      "ecs:ListTasks",
+      "ecs:TagResource",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "PassTaskRoles"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/genfeed-*"]
+  }
+  statement {
+    sid    = "TerraformManage"
+    effect = "Allow"
+    actions = [
+      "ecs:*", "elasticloadbalancing:*", "application-autoscaling:*",
+      "servicediscovery:*", "elasticache:*", "logs:*", "ecr:*",
+      "ec2:Describe*", "ec2:CreateSecurityGroup", "ec2:AuthorizeSecurityGroup*",
+      "ec2:RevokeSecurityGroup*", "ec2:CreateTags", "ec2:DeleteSecurityGroup",
+      "ec2:*LaunchTemplate*", "autoscaling:*", "iam:GetRole", "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies", "iam:GetRolePolicy", "acm:*", "ssm:GetParameters",
+      "ssm:GetParameter", "ssm:DescribeParameters", "route53:*",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "StateBucket"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:ListBucket", "s3:DeleteObject"]
+    resources = [aws_s3_bucket.state.arn, "${aws_s3_bucket.state.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "gha_deploy" {
+  name   = "gha-genfeed-deploy"
+  role   = aws_iam_role.gha_deploy.id
+  policy = data.aws_iam_policy_document.gha_deploy.json
+}
+
+output "state_bucket" {
+  value = aws_s3_bucket.state.id
+}
+
+output "gha_deploy_role_arn" {
+  description = "Set this as the AWS_DEPLOY_ROLE_ARN GitHub Actions variable."
+  value       = aws_iam_role.gha_deploy.arn
+}

--- a/infra/terraform/genfeed-prod/alb.tf
+++ b/infra/terraform/genfeed-prod/alb.tf
@@ -82,8 +82,11 @@ resource "aws_lb_listener" "http_redirect" {
   }
 }
 
-# ── api.genfeed.ai -> ALB ────────────────────────────────────────────
+# ── api.genfeed.ai -> ALB (gated: the actual traffic cutover) ────────
+# Only created when enable_dns_cutover=true, so the first apply builds the ALB
+# without stealing live traffic from the old box before services are healthy.
 resource "aws_route53_record" "api" {
+  count   = var.enable_dns_cutover ? 1 : 0
   zone_id = local.zone_id
   name    = local.fqdn
   type    = "A"

--- a/infra/terraform/genfeed-prod/alb.tf
+++ b/infra/terraform/genfeed-prod/alb.tf
@@ -36,11 +36,11 @@ resource "aws_lb" "main" {
 
 # api target group — bridge mode static host port 3010 => instance targets.
 resource "aws_lb_target_group" "api" {
-  name                 = "${local.name_prefix}-api"
+  name_prefix          = "gpapi" # <=6 chars; create_before_destroy needs unique names on replace
   port                 = local.services.api.port
   protocol             = "HTTP"
   vpc_id               = local.vpc_id
-  target_type          = "instance"
+  target_type          = "ip" # awsvpc tasks register their ENI IP, not the instance
   deregistration_delay = 30
 
   health_check {

--- a/infra/terraform/genfeed-prod/alb.tf
+++ b/infra/terraform/genfeed-prod/alb.tf
@@ -86,10 +86,13 @@ resource "aws_lb_listener" "http_redirect" {
 # Only created when enable_dns_cutover=true, so the first apply builds the ALB
 # without stealing live traffic from the old box before services are healthy.
 resource "aws_route53_record" "api" {
-  count   = var.enable_dns_cutover ? 1 : 0
-  zone_id = local.zone_id
-  name    = local.fqdn
-  type    = "A"
+  count = var.enable_dns_cutover ? 1 : 0
+  # Overwrite the pre-existing manual A record (old EC2 box) on cutover instead
+  # of failing with "record already exists".
+  allow_overwrite = true
+  zone_id         = local.zone_id
+  name            = local.fqdn
+  type            = "A"
   alias {
     name                   = aws_lb.main.dns_name
     zone_id                = aws_lb.main.zone_id

--- a/infra/terraform/genfeed-prod/alb.tf
+++ b/infra/terraform/genfeed-prod/alb.tf
@@ -1,0 +1,95 @@
+# ── ACM cert for api.genfeed.ai (DNS-validated via Route53) ──────────
+resource "aws_acm_certificate" "api" {
+  domain_name       = local.fqdn
+  validation_method = "DNS"
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_route53_record" "api_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.api.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+  zone_id = local.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "api" {
+  certificate_arn         = aws_acm_certificate.api.arn
+  validation_record_fqdns = [for r in aws_route53_record.api_cert_validation : r.fqdn]
+}
+
+# ── ALB ──────────────────────────────────────────────────────────────
+resource "aws_lb" "main" {
+  name               = "${local.name_prefix}-alb"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = local.public_subnet_ids
+}
+
+# api target group — bridge mode static host port 3010 => instance targets.
+resource "aws_lb_target_group" "api" {
+  name                 = "${local.name_prefix}-api"
+  port                 = local.services.api.port
+  protocol             = "HTTP"
+  vpc_id               = local.vpc_id
+  target_type          = "instance"
+  deregistration_delay = 30
+
+  health_check {
+    path                = "/v1/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 15
+    timeout             = 5
+    matcher             = "200"
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate_validation.api.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# ── api.genfeed.ai -> ALB ────────────────────────────────────────────
+resource "aws_route53_record" "api" {
+  zone_id = local.zone_id
+  name    = local.fqdn
+  type    = "A"
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infra/terraform/genfeed-prod/cluster.tf
+++ b/infra/terraform/genfeed-prod/cluster.tf
@@ -6,86 +6,16 @@ resource "aws_ecs_cluster" "main" {
   }
 }
 
-# awsvpc network mode gives each task its own ENI/IP, so Cloud Map A records
-# resolve to the task (matching the app's fixed http://files:3012 calls). ENI
-# trunking raises the per-instance ENI cap so ~5 awsvpc tasks fit on a
-# t3a.medium (base limit is ~3). Account-wide, must precede instance launch.
-resource "aws_ecs_account_setting_default" "awsvpc_trunking" {
-  name  = "awsvpcTrunking"
-  value = "enabled"
-}
-
-# ── EC2 capacity (ASG of ECS-optimized instances) ────────────────────
-resource "aws_launch_template" "ecs" {
-  name_prefix   = "${local.name_prefix}-"
-  image_id      = data.aws_ssm_parameter.ecs_ami.value
-  instance_type = var.instance_type
-
-  iam_instance_profile {
-    arn = aws_iam_instance_profile.ecs_instance.arn
-  }
-  vpc_security_group_ids = [aws_security_group.ecs.id]
-
-  # Register the instance with this cluster.
-  user_data = base64encode(<<-EOF
-    #!/bin/bash
-    echo "ECS_CLUSTER=${aws_ecs_cluster.main.name}" >> /etc/ecs/ecs.config
-    echo "ECS_ENABLE_SPOT_INSTANCE_DRAINING=true" >> /etc/ecs/ecs.config
-  EOF
-  )
-
-  tag_specifications {
-    resource_type = "instance"
-    tags          = { Name = "${local.name_prefix}-ecs" }
-  }
-  lifecycle { create_before_destroy = true }
-}
-
-resource "aws_autoscaling_group" "ecs" {
-  # Instances must launch AFTER awsvpcTrunking is enabled, or the ECS agent
-  # registers them without the eni-trunking capability and each t3a.medium caps
-  # at ~2 awsvpc tasks (can't fit all 9 services). If instances predate the
-  # setting, terminate them so the ASG relaunches trunking-capable ones.
-  depends_on          = [aws_ecs_account_setting_default.awsvpc_trunking]
-  name_prefix         = "${local.name_prefix}-"
-  vpc_zone_identifier = local.private_subnet_ids
-  min_size            = var.asg_min
-  max_size            = var.asg_max
-  desired_capacity    = var.asg_desired
-
-  launch_template {
-    id      = aws_launch_template.ecs.id
-    version = "$Latest"
-  }
-
-  # Required for ECS managed scaling to manage this ASG.
-  tag {
-    key                 = "AmazonECSManaged"
-    value               = "true"
-    propagate_at_launch = true
-  }
-  lifecycle { create_before_destroy = true }
-}
-
-resource "aws_ecs_capacity_provider" "ec2" {
-  name = "${local.name_prefix}-ec2"
-  auto_scaling_group_provider {
-    auto_scaling_group_arn         = aws_autoscaling_group.ecs.arn
-    managed_termination_protection = "DISABLED"
-    managed_scaling {
-      status          = "ENABLED"
-      target_capacity = 100
-    }
-  }
-}
-
+# Fargate-only capacity. Each task gets its own ENI from the private subnets
+# (NAT egress) — no EC2 instances to manage and no per-instance ENI cap (the
+# reason t3a.medium EC2 capacity couldn't fit all 9 awsvpc services).
 resource "aws_ecs_cluster_capacity_providers" "main" {
   cluster_name       = aws_ecs_cluster.main.name
-  capacity_providers = [aws_ecs_capacity_provider.ec2.name, "FARGATE", "FARGATE_SPOT"]
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
 
   default_capacity_provider_strategy {
-    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    capacity_provider = "FARGATE"
     weight            = 1
-    base              = 1
+    base              = 0
   }
 }

--- a/infra/terraform/genfeed-prod/cluster.tf
+++ b/infra/terraform/genfeed-prod/cluster.tf
@@ -43,7 +43,7 @@ resource "aws_launch_template" "ecs" {
 
 resource "aws_autoscaling_group" "ecs" {
   name_prefix         = "${local.name_prefix}-"
-  vpc_zone_identifier = local.public_subnet_ids
+  vpc_zone_identifier = local.private_subnet_ids
   min_size            = var.asg_min
   max_size            = var.asg_max
   desired_capacity    = var.asg_desired

--- a/infra/terraform/genfeed-prod/cluster.tf
+++ b/infra/terraform/genfeed-prod/cluster.tf
@@ -1,0 +1,86 @@
+resource "aws_ecs_cluster" "main" {
+  name = local.name_prefix
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+# awsvpc network mode gives each task its own ENI/IP, so Cloud Map A records
+# resolve to the task (matching the app's fixed http://files:3012 calls). ENI
+# trunking raises the per-instance ENI cap so ~5 awsvpc tasks fit on a
+# t3a.medium (base limit is ~3). Account-wide, must precede instance launch.
+resource "aws_ecs_account_setting_default" "awsvpc_trunking" {
+  name  = "awsvpcTrunking"
+  value = "enabled"
+}
+
+# ── EC2 capacity (ASG of ECS-optimized instances) ────────────────────
+resource "aws_launch_template" "ecs" {
+  name_prefix   = "${local.name_prefix}-"
+  image_id      = data.aws_ssm_parameter.ecs_ami.value
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.ecs_instance.arn
+  }
+  vpc_security_group_ids = [aws_security_group.ecs.id]
+
+  # Register the instance with this cluster.
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    echo "ECS_CLUSTER=${aws_ecs_cluster.main.name}" >> /etc/ecs/ecs.config
+    echo "ECS_ENABLE_SPOT_INSTANCE_DRAINING=true" >> /etc/ecs/ecs.config
+  EOF
+  )
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = { Name = "${local.name_prefix}-ecs" }
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_autoscaling_group" "ecs" {
+  name_prefix         = "${local.name_prefix}-"
+  vpc_zone_identifier = local.public_subnet_ids
+  min_size            = var.asg_min
+  max_size            = var.asg_max
+  desired_capacity    = var.asg_desired
+
+  launch_template {
+    id      = aws_launch_template.ecs.id
+    version = "$Latest"
+  }
+
+  # Required for ECS managed scaling to manage this ASG.
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = "true"
+    propagate_at_launch = true
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_ecs_capacity_provider" "ec2" {
+  name = "${local.name_prefix}-ec2"
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.ecs.arn
+    managed_termination_protection = "DISABLED"
+    managed_scaling {
+      status          = "ENABLED"
+      target_capacity = 100
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = [aws_ecs_capacity_provider.ec2.name, "FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 1
+    base              = 1
+  }
+}

--- a/infra/terraform/genfeed-prod/cluster.tf
+++ b/infra/terraform/genfeed-prod/cluster.tf
@@ -42,6 +42,11 @@ resource "aws_launch_template" "ecs" {
 }
 
 resource "aws_autoscaling_group" "ecs" {
+  # Instances must launch AFTER awsvpcTrunking is enabled, or the ECS agent
+  # registers them without the eni-trunking capability and each t3a.medium caps
+  # at ~2 awsvpc tasks (can't fit all 9 services). If instances predate the
+  # setting, terminate them so the ASG relaunches trunking-capable ones.
+  depends_on          = [aws_ecs_account_setting_default.awsvpc_trunking]
   name_prefix         = "${local.name_prefix}-"
   vpc_zone_identifier = local.private_subnet_ids
   min_size            = var.asg_min

--- a/infra/terraform/genfeed-prod/data.tf
+++ b/infra/terraform/genfeed-prod/data.tf
@@ -1,0 +1,42 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# ── Network (default VPC unless overridden) ──────────────────────────
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+}
+
+# ── Existing RDS — to wire the ECS tasks SG into its security group ───
+data "aws_db_instance" "genfeed" {
+  db_instance_identifier = "genfeed-data"
+}
+
+# ── Route53 zone for genfeed.ai (assumes zone is in Route53) ─────────
+data "aws_route53_zone" "main" {
+  count        = var.route53_zone_id == "" ? 1 : 0
+  name         = "${var.domain}."
+  private_zone = false
+}
+
+locals {
+  zone_id = var.route53_zone_id != "" ? var.route53_zone_id : data.aws_route53_zone.main[0].zone_id
+}
+
+# ── ECS-optimized AMI (Amazon Linux 2023) via SSM public parameter ──
+data "aws_ssm_parameter" "ecs_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}
+
+# ── App secrets under the SSM path (names + ARNs only; no decryption) ─
+data "aws_ssm_parameters_by_path" "prod" {
+  path            = var.ssm_path
+  recursive       = true
+  with_decryption = false
+}

--- a/infra/terraform/genfeed-prod/data.tf
+++ b/infra/terraform/genfeed-prod/data.tf
@@ -1,18 +1,6 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-# ── Network (default VPC unless overridden) ──────────────────────────
-data "aws_vpc" "default" {
-  default = true
-}
-
-data "aws_subnets" "all" {
-  filter {
-    name   = "vpc-id"
-    values = [local.vpc_id]
-  }
-}
-
 # ── Existing RDS — to wire the ECS tasks SG into its security group ───
 data "aws_db_instance" "genfeed" {
   db_instance_identifier = "genfeed-data"

--- a/infra/terraform/genfeed-prod/data.tf
+++ b/infra/terraform/genfeed-prod/data.tf
@@ -17,11 +17,6 @@ locals {
   zone_id = var.route53_zone_id != "" ? var.route53_zone_id : data.aws_route53_zone.main[0].zone_id
 }
 
-# ── ECS-optimized AMI (Amazon Linux 2023) via SSM public parameter ──
-data "aws_ssm_parameter" "ecs_ami" {
-  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
-}
-
 # ── App secrets under the SSM path (names + ARNs only; no decryption) ─
 data "aws_ssm_parameters_by_path" "prod" {
   path            = var.ssm_path

--- a/infra/terraform/genfeed-prod/discovery.tf
+++ b/infra/terraform/genfeed-prod/discovery.tf
@@ -1,0 +1,8 @@
+# Private DNS namespace for internal service-to-service resolution.
+# Each service registers as <name>.genfeed.internal (Cloud Map A records ->
+# container-instance IP). api reaches files at http://files.genfeed.internal:3012,
+# clips/bots reach api at http://api.genfeed.internal:3010, etc.
+resource "aws_service_discovery_private_dns_namespace" "internal" {
+  name = "genfeed.internal"
+  vpc  = local.vpc_id
+}

--- a/infra/terraform/genfeed-prod/ecr.tf
+++ b/infra/terraform/genfeed-prod/ecr.tf
@@ -1,0 +1,23 @@
+resource "aws_ecr_repository" "server" {
+  name                 = "${var.project}/server"
+  image_tag_mutability = "MUTABLE"
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "server" {
+  repository = aws_ecr_repository.server.name
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "keep last 20 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 20
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/infra/terraform/genfeed-prod/elasticache.tf
+++ b/infra/terraform/genfeed-prod/elasticache.tf
@@ -1,0 +1,28 @@
+# Managed redis, off the app instances (state must not live on ephemeral tasks).
+# Single t4g.micro node (~$12/mo). SG-restricted to ECS only.
+#
+# NOTE: after apply, set the SSM param /genfeed/production/REDIS_URL to
+#   redis://<primary_endpoint_address>:6379
+# (no AUTH — access is gated by the cache SG). The app reads REDIS_URL from SSM,
+# so no code change is needed; just repoint the param.
+
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "${local.name_prefix}-redis"
+  subnet_ids = local.private_subnet_ids
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id       = "${local.name_prefix}-redis"
+  description                = "genfeed production redis"
+  engine                     = "redis"
+  engine_version             = "7.1"
+  node_type                  = "cache.t4g.micro"
+  num_cache_clusters         = 1
+  port                       = 6379
+  parameter_group_name       = "default.redis7"
+  subnet_group_name          = aws_elasticache_subnet_group.redis.name
+  security_group_ids         = [aws_security_group.cache.id]
+  automatic_failover_enabled = false
+  at_rest_encryption_enabled = true
+  apply_immediately          = true
+}

--- a/infra/terraform/genfeed-prod/iam.tf
+++ b/infra/terraform/genfeed-prod/iam.tf
@@ -1,0 +1,105 @@
+# ── EC2 container-instance role ──────────────────────────────────────
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_instance" {
+  name               = "${local.name_prefix}-ecs-instance"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ssm" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance" {
+  name = "${local.name_prefix}-ecs-instance"
+  role = aws_iam_role.ecs_instance.name
+}
+
+# ── Task execution role (pull image, read secrets, write logs) ───────
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${local.name_prefix}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Read the SSM app params (injected as task secrets) + decrypt with the default
+# SSM KMS key.
+data "aws_iam_policy_document" "execution_secrets" {
+  statement {
+    sid       = "ReadAppSsm"
+    effect    = "Allow"
+    actions   = ["ssm:GetParameters", "ssm:GetParameter", "ssm:GetParametersByPath"]
+    resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_path}/*"]
+  }
+  statement {
+    sid       = "DecryptSsm"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${data.aws_region.current.name}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  name   = "read-app-ssm"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.execution_secrets.json
+}
+
+# ── Task role (app runtime perms) ────────────────────────────────────
+resource "aws_iam_role" "task" {
+  name               = "${local.name_prefix}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+data "aws_iam_policy_document" "task" {
+  statement {
+    sid    = "CdnBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::cdn.genfeed.ai",
+      "arn:aws:s3:::cdn.genfeed.ai/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "task" {
+  name   = "app-runtime"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.task.json
+}

--- a/infra/terraform/genfeed-prod/iam.tf
+++ b/infra/terraform/genfeed-prod/iam.tf
@@ -1,34 +1,3 @@
-# ── EC2 container-instance role ──────────────────────────────────────
-data "aws_iam_policy_document" "ec2_assume" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "ecs_instance" {
-  name               = "${local.name_prefix}-ecs-instance"
-  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_instance" {
-  role       = aws_iam_role.ecs_instance.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_instance_ssm" {
-  role       = aws_iam_role.ecs_instance.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_instance_profile" "ecs_instance" {
-  name = "${local.name_prefix}-ecs-instance"
-  role = aws_iam_role.ecs_instance.name
-}
-
 # ── Task execution role (pull image, read secrets, write logs) ───────
 data "aws_iam_policy_document" "ecs_assume" {
   statement {

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -3,8 +3,8 @@ locals {
   fqdn        = "${var.api_subdomain}.${var.domain}" # api.genfeed.ai
 
   vpc_id             = var.vpc_id
-  public_subnet_ids  = var.public_subnet_ids                  # ALB (internet-facing)
-  private_subnet_ids = [for s in aws_subnet.private : s.id]   # ECS tasks/instances + cache (NAT egress)
+  public_subnet_ids  = var.public_subnet_ids                # ALB (internet-facing)
+  private_subnet_ids = [for s in aws_subnet.private : s.id] # ECS tasks/instances + cache (NAT egress)
 
   image = "${aws_ecr_repository.server.repository_url}:${var.image_tag}"
 

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -2,12 +2,9 @@ locals {
   name_prefix = "${var.project}-${var.environment}"
   fqdn        = "${var.api_subdomain}.${var.domain}" # api.genfeed.ai
 
-  vpc_id = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default.id
-
-  public_subnet_ids = length(var.public_subnet_ids) > 0 ? var.public_subnet_ids : data.aws_subnets.all.ids
-  private_subnet_ids = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : (
-    length(var.public_subnet_ids) > 0 ? var.public_subnet_ids : data.aws_subnets.all.ids
-  )
+  vpc_id             = var.vpc_id
+  public_subnet_ids  = var.public_subnet_ids                  # ALB (internet-facing)
+  private_subnet_ids = [for s in aws_subnet.private : s.id]   # ECS tasks/instances + cache (NAT egress)
 
   image = "${aws_ecr_repository.server.repository_url}:${var.image_tag}"
 

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -10,15 +10,21 @@ locals {
 
   # SSM params under ssm_path injected as task secrets: env var name = last path
   # segment (e.g. /genfeed/production/DATABASE_URL -> DATABASE_URL).
-  # Exclude REDIS_PASSWORD: ElastiCache here is no-auth (private subnet, SG-locked),
-  # and redis-connection.utils.ts falls back to REDIS_PASSWORD as the AUTH password
-  # even when the URL has none — which a no-auth server rejects. REDIS_URL (below)
-  # carries the connection instead.
+  # ECS forbids a `secrets` entry sharing a name with an `environment` entry, so
+  # any SSM param we also set as a container env var (the Cloud Map inter-service
+  # URLs, REDIS_URL, NODE_ENV, VERSION, PORT, SERVICE_NAME) must be filtered out
+  # of the injected secrets — the env value wins. REDIS_PASSWORD is dropped too:
+  # ElastiCache is no-auth (private + SG-locked) and redis-connection.utils.ts
+  # would otherwise send AUTH (which a no-auth server rejects).
+  reserved_env_names = toset(concat(
+    [for e in local.internal_env : e.name],
+    ["PORT", "SERVICE_NAME", "REDIS_PASSWORD"],
+  ))
   task_secrets = [
     for i, name in data.aws_ssm_parameters_by_path.prod.names : {
       name      = element(reverse(split("/", name)), 0)
       valueFrom = data.aws_ssm_parameters_by_path.prod.arns[i]
-    } if element(reverse(split("/", name)), 0) != "REDIS_PASSWORD"
+    } if !contains(local.reserved_env_names, element(reverse(split("/", name)), 0))
   ]
 
   # ── Service catalogue (mirrors docker-compose.production.yml) ─────────

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -1,0 +1,39 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+  fqdn        = "${var.api_subdomain}.${var.domain}" # api.genfeed.ai
+
+  vpc_id = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default.id
+
+  public_subnet_ids = length(var.public_subnet_ids) > 0 ? var.public_subnet_ids : data.aws_subnets.all.ids
+  private_subnet_ids = length(var.private_subnet_ids) > 0 ? var.private_subnet_ids : (
+    length(var.public_subnet_ids) > 0 ? var.public_subnet_ids : data.aws_subnets.all.ids
+  )
+
+  image = "${aws_ecr_repository.server.repository_url}:${var.image_tag}"
+
+  # SSM params under ssm_path injected as task secrets: env var name = last path
+  # segment (e.g. /genfeed/production/DATABASE_URL -> DATABASE_URL).
+  task_secrets = [
+    for i, name in data.aws_ssm_parameters_by_path.prod.names : {
+      name      = element(reverse(split("/", name)), 0)
+      valueFrom = data.aws_ssm_parameters_by_path.prod.arns[i]
+    }
+  ]
+
+  # ── Service catalogue (mirrors docker-compose.production.yml) ─────────
+  # mem = hard memory MB (matches the mem_limits in compose); cpu = CPU shares
+  # (1024 = 1 vCPU; kept modest so ~9 tasks bin-pack across 2× t3a.medium).
+  # Every service registers in Cloud Map for internal name resolution; only api
+  # is also placed behind the public ALB.
+  services = {
+    api           = { filter = "@genfeedai/api", port = 3010, mem = 1280, cpu = 512, alb = true, health_grace = 90 }
+    workers       = { filter = "@genfeedai/workers", port = 3013, mem = 1536, cpu = 512, alb = false, health_grace = 40 }
+    files         = { filter = "@genfeedai/files", port = 3012, mem = 512, cpu = 256, alb = false, health_grace = 40 }
+    mcp           = { filter = "@genfeedai/mcp", port = 3014, mem = 384, cpu = 128, alb = false, health_grace = 40 }
+    notifications = { filter = "@genfeedai/notifications", port = 3011, mem = 384, cpu = 128, alb = false, health_grace = 40 }
+    clips         = { filter = "@genfeedai/clips", port = 3015, mem = 384, cpu = 128, alb = false, health_grace = 40 }
+    discord       = { filter = "@genfeedai/discord", port = 3016, mem = 320, cpu = 128, alb = false, health_grace = 40 }
+    slack         = { filter = "@genfeedai/slack", port = 3018, mem = 320, cpu = 128, alb = false, health_grace = 40 }
+    telegram      = { filter = "@genfeedai/telegram", port = 3019, mem = 320, cpu = 128, alb = false, health_grace = 40 }
+  }
+}

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -28,19 +28,20 @@ locals {
   ]
 
   # ── Service catalogue (mirrors docker-compose.production.yml) ─────────
-  # mem = hard memory MB (matches the mem_limits in compose); cpu = CPU shares
-  # (1024 = 1 vCPU; kept modest so ~9 tasks bin-pack across 2× t3a.medium).
-  # Every service registers in Cloud Map for internal name resolution; only api
-  # is also placed behind the public ALB.
+  # Fargate launch type: cpu/mem MUST be valid Fargate task pairs (256→512-2048,
+  # 512→1024-4096, 1024→2048-8192). Each task gets its own ENI from the private
+  # subnets (NAT egress) — no per-instance ENI cap. Every service registers in
+  # Cloud Map for internal DNS; only api is behind the public ALB. (Tune api/
+  # workers cpu up if boot/throughput needs it — these are lean starting points.)
   services = {
-    api           = { filter = "@genfeedai/api", port = 3010, mem = 1280, cpu = 512, alb = true, health_grace = 90 }
-    workers       = { filter = "@genfeedai/workers", port = 3013, mem = 1536, cpu = 512, alb = false, health_grace = 40 }
-    files         = { filter = "@genfeedai/files", port = 3012, mem = 512, cpu = 256, alb = false, health_grace = 40 }
-    mcp           = { filter = "@genfeedai/mcp", port = 3014, mem = 384, cpu = 128, alb = false, health_grace = 40 }
-    notifications = { filter = "@genfeedai/notifications", port = 3011, mem = 384, cpu = 128, alb = false, health_grace = 40 }
-    clips         = { filter = "@genfeedai/clips", port = 3015, mem = 384, cpu = 128, alb = false, health_grace = 40 }
-    discord       = { filter = "@genfeedai/discord", port = 3016, mem = 320, cpu = 128, alb = false, health_grace = 40 }
-    slack         = { filter = "@genfeedai/slack", port = 3018, mem = 320, cpu = 128, alb = false, health_grace = 40 }
-    telegram      = { filter = "@genfeedai/telegram", port = 3019, mem = 320, cpu = 128, alb = false, health_grace = 40 }
+    api           = { filter = "@genfeedai/api", port = 3010, cpu = 1024, mem = 2048, alb = true, health_grace = 120 }
+    workers       = { filter = "@genfeedai/workers", port = 3013, cpu = 512, mem = 2048, alb = false, health_grace = 60 }
+    files         = { filter = "@genfeedai/files", port = 3012, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    mcp           = { filter = "@genfeedai/mcp", port = 3014, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    notifications = { filter = "@genfeedai/notifications", port = 3011, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    clips         = { filter = "@genfeedai/clips", port = 3015, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    discord       = { filter = "@genfeedai/discord", port = 3016, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    slack         = { filter = "@genfeedai/slack", port = 3018, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    telegram      = { filter = "@genfeedai/telegram", port = 3019, cpu = 256, mem = 512, alb = false, health_grace = 60 }
   }
 }

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -33,15 +33,19 @@ locals {
   # subnets (NAT egress) — no per-instance ENI cap. Every service registers in
   # Cloud Map for internal DNS; only api is behind the public ALB. (Tune api/
   # workers cpu up if boot/throughput needs it — these are lean starting points.)
+  # desired=0 keeps the service + task def defined (code stays, flip on anytime)
+  # but runs zero tasks => ~$0. Bots/clips are built but unused, so they're parked
+  # at 0. Core set (api + its boot-required deps files/mcp/notifications, +
+  # workers) runs at 1.
   services = {
-    api           = { filter = "@genfeedai/api", port = 3010, cpu = 1024, mem = 2048, alb = true, health_grace = 120 }
-    workers       = { filter = "@genfeedai/workers", port = 3013, cpu = 512, mem = 2048, alb = false, health_grace = 60 }
-    files         = { filter = "@genfeedai/files", port = 3012, cpu = 256, mem = 512, alb = false, health_grace = 60 }
-    mcp           = { filter = "@genfeedai/mcp", port = 3014, cpu = 256, mem = 512, alb = false, health_grace = 60 }
-    notifications = { filter = "@genfeedai/notifications", port = 3011, cpu = 256, mem = 512, alb = false, health_grace = 60 }
-    clips         = { filter = "@genfeedai/clips", port = 3015, cpu = 256, mem = 512, alb = false, health_grace = 60 }
-    discord       = { filter = "@genfeedai/discord", port = 3016, cpu = 256, mem = 512, alb = false, health_grace = 60 }
-    slack         = { filter = "@genfeedai/slack", port = 3018, cpu = 256, mem = 512, alb = false, health_grace = 60 }
-    telegram      = { filter = "@genfeedai/telegram", port = 3019, cpu = 256, mem = 512, alb = false, health_grace = 60 }
+    api           = { filter = "@genfeedai/api", port = 3010, cpu = 1024, mem = 2048, alb = true, health_grace = 120, desired = 1 }
+    workers       = { filter = "@genfeedai/workers", port = 3013, cpu = 512, mem = 2048, alb = false, health_grace = 60, desired = 1 }
+    files         = { filter = "@genfeedai/files", port = 3012, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
+    mcp           = { filter = "@genfeedai/mcp", port = 3014, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
+    notifications = { filter = "@genfeedai/notifications", port = 3011, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
+    clips         = { filter = "@genfeedai/clips", port = 3015, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }
+    discord       = { filter = "@genfeedai/discord", port = 3016, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }
+    slack         = { filter = "@genfeedai/slack", port = 3018, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }
+    telegram      = { filter = "@genfeedai/telegram", port = 3019, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }
   }
 }

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -10,11 +10,15 @@ locals {
 
   # SSM params under ssm_path injected as task secrets: env var name = last path
   # segment (e.g. /genfeed/production/DATABASE_URL -> DATABASE_URL).
+  # Exclude REDIS_PASSWORD: ElastiCache here is no-auth (private subnet, SG-locked),
+  # and redis-connection.utils.ts falls back to REDIS_PASSWORD as the AUTH password
+  # even when the URL has none — which a no-auth server rejects. REDIS_URL (below)
+  # carries the connection instead.
   task_secrets = [
     for i, name in data.aws_ssm_parameters_by_path.prod.names : {
       name      = element(reverse(split("/", name)), 0)
       valueFrom = data.aws_ssm_parameters_by_path.prod.arns[i]
-    }
+    } if element(reverse(split("/", name)), 0) != "REDIS_PASSWORD"
   ]
 
   # ── Service catalogue (mirrors docker-compose.production.yml) ─────────

--- a/infra/terraform/genfeed-prod/network.tf
+++ b/infra/terraform/genfeed-prod/network.tf
@@ -1,0 +1,36 @@
+# Private subnets (2 AZ) for ECS instances + awsvpc task ENIs + ElastiCache.
+# awsvpc-on-EC2 task ENIs get no public IP, so they egress (ECR pull, ElevenLabs/
+# Clerk/Stripe/etc.) via a NAT gateway. ALB stays in the existing public subnets.
+resource "aws_subnet" "private" {
+  for_each          = var.private_subnet_cidrs
+  vpc_id            = var.vpc_id
+  availability_zone = each.key
+  cidr_block        = each.value
+  tags              = { Name = "${local.name_prefix}-private-${each.key}" }
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+  tags   = { Name = "${local.name_prefix}-nat" }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = var.nat_public_subnet_id
+  tags          = { Name = "${local.name_prefix}-nat" }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = var.vpc_id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+  tags = { Name = "${local.name_prefix}-private" }
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = aws_subnet.private
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -28,9 +28,9 @@ output "migrate_task_family" {
   value = aws_ecs_task_definition.migrate.family
 }
 
-# Network config for `aws ecs run-task` (migrate) in CI.
+# Network config for `aws ecs run-task` (migrate) in CI — private subnets (NAT egress).
 output "task_subnets" {
-  value = local.public_subnet_ids
+  value = local.private_subnet_ids
 }
 
 output "task_security_group" {

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -1,0 +1,38 @@
+output "cluster_name" {
+  value = aws_ecs_cluster.main.name
+}
+
+output "ecr_repository_url" {
+  value = aws_ecr_repository.server.repository_url
+}
+
+output "alb_dns_name" {
+  description = "Smoke-test here before flipping api.genfeed.ai DNS."
+  value       = aws_lb.main.dns_name
+}
+
+output "api_url" {
+  value = "https://${local.fqdn}"
+}
+
+output "redis_primary_endpoint" {
+  description = "Set SSM /genfeed/production/REDIS_URL to redis://<this>:6379 after apply."
+  value       = aws_elasticache_replication_group.redis.primary_endpoint_address
+}
+
+output "service_names" {
+  value = [for k, m in module.service : m.service_name]
+}
+
+output "migrate_task_family" {
+  value = aws_ecs_task_definition.migrate.family
+}
+
+# Network config for `aws ecs run-task` (migrate) in CI.
+output "task_subnets" {
+  value = local.public_subnet_ids
+}
+
+output "task_security_group" {
+  value = aws_security_group.ecs.id
+}

--- a/infra/terraform/genfeed-prod/providers.tf
+++ b/infra/terraform/genfeed-prod/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = ">= 1.10"
+
+  # S3-native state locking (use_lockfile) — no DynamoDB. Bucket created by the
+  # bootstrap stack. `terraform init` this stack after bootstrap has applied.
+  backend "s3" {
+    bucket       = "genfeed-tfstate"
+    key          = "genfeed-prod/terraform.tfstate"
+    region       = "us-west-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      Project   = "genfeed"
+      ManagedBy = "terraform"
+      Stack     = "genfeed-prod"
+    }
+  }
+}

--- a/infra/terraform/genfeed-prod/providers.tf
+++ b/infra/terraform/genfeed-prod/providers.tf
@@ -23,9 +23,10 @@ provider "aws" {
   region = var.region
   default_tags {
     tags = {
-      Project   = "genfeed"
-      ManagedBy = "terraform"
-      Stack     = "genfeed-prod"
+      Project     = "genfeed"
+      Environment = "production"
+      ManagedBy   = "terraform"
+      Stack       = "genfeed-prod"
     }
   }
 }

--- a/infra/terraform/genfeed-prod/security.tf
+++ b/infra/terraform/genfeed-prod/security.tf
@@ -1,0 +1,93 @@
+# ── ALB SG: public 80/443 ────────────────────────────────────────────
+resource "aws_security_group" "alb" {
+  name_prefix = "${local.name_prefix}-alb-"
+  vpc_id      = local.vpc_id
+  description = "genfeed ALB"
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+# ── ECS container-instance / task SG ─────────────────────────────────
+# Bridge mode + static host ports: the ALB reaches api on its host port, and
+# services reach each other host-IP:port (Cloud Map A record -> host IP), so
+# allow the ALB and self on the service port range.
+resource "aws_security_group" "ecs" {
+  name_prefix = "${local.name_prefix}-ecs-"
+  vpc_id      = local.vpc_id
+  description = "genfeed ECS container instances"
+
+  ingress {
+    description     = "ALB to service ports"
+    from_port       = 3010
+    to_port         = 3019
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+  ingress {
+    description = "intra-cluster service-to-service"
+    from_port   = 3010
+    to_port     = 3019
+    protocol    = "tcp"
+    self        = true
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+# ── ElastiCache SG: 6379 from ECS only ───────────────────────────────
+resource "aws_security_group" "cache" {
+  name_prefix = "${local.name_prefix}-cache-"
+  vpc_id      = local.vpc_id
+  description = "genfeed ElastiCache redis"
+
+  ingress {
+    description     = "redis from ECS"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+# ── Let ECS tasks reach the existing RDS ─────────────────────────────
+resource "aws_security_group_rule" "rds_from_ecs" {
+  type                     = "ingress"
+  description              = "genfeed ECS tasks to RDS"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = tolist(data.aws_db_instance.genfeed.vpc_security_groups)[0]
+  source_security_group_id = aws_security_group.ecs.id
+}

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -5,6 +5,7 @@ locals {
     { name = "GENFEEDAI_MICROSERVICES_MCP_URL", value = "http://mcp.genfeed.internal:${local.services.mcp.port}" },
     { name = "GENFEEDAI_MICROSERVICES_NOTIFICATIONS_URL", value = "http://notifications.genfeed.internal:${local.services.notifications.port}" },
     { name = "GENFEEDAI_API_URL", value = "http://api.genfeed.internal:${local.services.api.port}" },
+    { name = "REDIS_URL", value = "redis://${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379" },
     { name = "NODE_ENV", value = "production" },
     { name = "VERSION", value = "1.0.0" },
   ]

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -28,7 +28,7 @@ module "service" {
   execution_role_arn = aws_iam_role.execution.arn
   task_role_arn      = aws_iam_role.task.arn
 
-  subnets            = local.public_subnet_ids
+  subnets            = local.private_subnet_ids
   security_group_ids = [aws_security_group.ecs.id]
   namespace_id       = aws_service_discovery_private_dns_namespace.internal.id
 

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -72,9 +72,13 @@ resource "aws_ecs_task_definition" "migrate" {
     image            = local.image
     essential        = true
     workingDirectory = "/usr/src/app/packages/prisma"
-    command          = ["bunx", "prisma", "migrate", "deploy"]
-    secrets          = local.task_secrets
-    environment      = [{ name = "NODE_ENV", value = "production" }]
+    # Use `bun x` (the bun subcommand), NOT `bunx` — the server image ships the
+    # `bun` binary but not a standalone `bunx`, so `["bunx", ...]` fell through to
+    # the node entrypoint (`Cannot find module .../packages/prisma/bunx`) and the
+    # migrate task exited 1. Matches the services' `["bun", ...]` invocation.
+    command     = ["bun", "x", "prisma", "migrate", "deploy"]
+    secrets     = local.task_secrets
+    environment = [{ name = "NODE_ENV", value = "production" }]
     logConfiguration = {
       logDriver = "awslogs"
       options = {

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -18,7 +18,7 @@ module "service" {
   name              = each.key
   name_prefix       = local.name_prefix
   cluster_id        = aws_ecs_cluster.main.id
-  capacity_provider = aws_ecs_capacity_provider.ec2.name
+  capacity_provider = "FARGATE"
   image             = local.image
   command           = ["bun", "--filter", each.value.filter, "start:prod"]
   cpu               = each.value.cpu
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_log_group" "migrate" {
 resource "aws_ecs_task_definition" "migrate" {
   family                   = "${local.name_prefix}-migrate"
   network_mode             = "awsvpc"
-  requires_compatibilities = ["EC2"]
+  requires_compatibilities = ["FARGATE"]
   cpu                      = 512
   memory                   = 1024
   execution_role_arn       = aws_iam_role.execution.arn

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -39,6 +39,7 @@ module "service" {
     { name = "SERVICE_NAME", value = each.key },
   ])
 
+  desired_count    = each.value.desired
   register_alb     = each.value.alb
   target_group_arn = each.value.alb ? aws_lb_target_group.api.arn : ""
   health_grace     = each.value.health_grace

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -1,0 +1,85 @@
+locals {
+  # Internal service URLs via Cloud Map (replace docker-compose http://files:3012).
+  internal_env = [
+    { name = "GENFEEDAI_MICROSERVICES_FILES_URL", value = "http://files.genfeed.internal:${local.services.files.port}" },
+    { name = "GENFEEDAI_MICROSERVICES_MCP_URL", value = "http://mcp.genfeed.internal:${local.services.mcp.port}" },
+    { name = "GENFEEDAI_MICROSERVICES_NOTIFICATIONS_URL", value = "http://notifications.genfeed.internal:${local.services.notifications.port}" },
+    { name = "GENFEEDAI_API_URL", value = "http://api.genfeed.internal:${local.services.api.port}" },
+    { name = "NODE_ENV", value = "production" },
+    { name = "VERSION", value = "1.0.0" },
+  ]
+}
+
+module "service" {
+  source   = "../modules/service"
+  for_each = local.services
+
+  name              = each.key
+  name_prefix       = local.name_prefix
+  cluster_id        = aws_ecs_cluster.main.id
+  capacity_provider = aws_ecs_capacity_provider.ec2.name
+  image             = local.image
+  command           = ["bun", "--filter", each.value.filter, "start:prod"]
+  cpu               = each.value.cpu
+  memory            = each.value.mem
+  port              = each.value.port
+  region            = var.region
+
+  execution_role_arn = aws_iam_role.execution.arn
+  task_role_arn      = aws_iam_role.task.arn
+
+  subnets            = local.public_subnet_ids
+  security_group_ids = [aws_security_group.ecs.id]
+  namespace_id       = aws_service_discovery_private_dns_namespace.internal.id
+
+  secrets = local.task_secrets
+  environment = concat(local.internal_env, [
+    { name = "PORT", value = tostring(each.value.port) },
+    { name = "SERVICE_NAME", value = each.key },
+  ])
+
+  register_alb     = each.value.alb
+  target_group_arn = each.value.alb ? aws_lb_target_group.api.arn : ""
+  health_grace     = each.value.health_grace
+
+  # api rolls zero-downtime (needs the 2nd box as headroom); single-task
+  # bots/workers tolerate a brief blip on deploy.
+  min_healthy = each.value.alb ? 100 : 0
+  max_percent = each.value.alb ? 200 : 100
+
+  depends_on = [aws_ecs_cluster_capacity_providers.main]
+}
+
+# ── One-off migration task (run via `aws ecs run-task` before api rolls) ─
+resource "aws_cloudwatch_log_group" "migrate" {
+  name              = "/ecs/${local.name_prefix}/migrate"
+  retention_in_days = 30
+}
+
+resource "aws_ecs_task_definition" "migrate" {
+  family                   = "${local.name_prefix}-migrate"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([{
+    name             = "migrate"
+    image            = local.image
+    essential        = true
+    workingDirectory = "/usr/src/app/packages/prisma"
+    command          = ["bunx", "prisma", "migrate", "deploy"]
+    secrets          = local.task_secrets
+    environment      = [{ name = "NODE_ENV", value = "production" }]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.migrate.name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "migrate"
+      }
+    }
+  }])
+}

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -50,6 +50,15 @@ variable "route53_zone_id" {
   description = "Hosted zone for genfeed.ai. Empty = look up by name (assumes the zone is in Route53)."
 }
 
+# DNS cutover gate. FALSE (default): build everything EXCEPT the api.genfeed.ai
+# A-record, so the first apply never repoints live traffic at an empty ALB. Push
+# the image, get services healthy, smoke-test the ALB DNS, THEN apply with
+# enable_dns_cutover=true to flip api.genfeed.ai onto the ALB.
+variable "enable_dns_cutover" {
+  type    = bool
+  default = false
+}
+
 # ── Capacity ─────────────────────────────────────────────────────────
 variable "instance_type" {
   type    = string

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -1,0 +1,86 @@
+variable "region" {
+  type    = string
+  default = "us-west-1"
+}
+
+variable "project" {
+  type    = string
+  default = "genfeed"
+}
+
+variable "environment" {
+  type    = string
+  default = "production"
+}
+
+# ── Network ──────────────────────────────────────────────────────────
+# Leave empty to auto-discover the default VPC + its subnets (the box + RDS
+# live there today). Override if genfeed runs in a non-default VPC.
+variable "vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "public_subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "Public subnets for the ALB + ECS container instances. Empty = all subnets in the VPC."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "Private subnets for ElastiCache. Empty = same as public (default-VPC has only public subnets)."
+}
+
+# ── DNS / TLS ────────────────────────────────────────────────────────
+variable "domain" {
+  type    = string
+  default = "genfeed.ai"
+}
+
+variable "api_subdomain" {
+  type    = string
+  default = "api"
+}
+
+variable "route53_zone_id" {
+  type        = string
+  default     = ""
+  description = "Hosted zone for genfeed.ai. Empty = look up by name (assumes the zone is in Route53)."
+}
+
+# ── Capacity ─────────────────────────────────────────────────────────
+variable "instance_type" {
+  type    = string
+  default = "t3a.medium"
+}
+
+variable "asg_min" {
+  type    = number
+  default = 2
+}
+
+variable "asg_max" {
+  type    = number
+  default = 3
+}
+
+variable "asg_desired" {
+  type    = number
+  default = 2
+}
+
+# ── Image ────────────────────────────────────────────────────────────
+variable "image_tag" {
+  type        = string
+  default     = "latest"
+  description = "ECR tag of genfeed/server to deploy (CI passes the commit SHA via TF_VAR_image_tag)."
+}
+
+# ── Secrets ──────────────────────────────────────────────────────────
+variable "ssm_path" {
+  type        = string
+  default     = "/genfeed/production"
+  description = "SSM path whose params are injected as task secrets (one env var per param)."
+}

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -13,24 +13,33 @@ variable "environment" {
   default = "production"
 }
 
-# ── Network ──────────────────────────────────────────────────────────
-# Leave empty to auto-discover the default VPC + its subnets (the box + RDS
-# live there today). Override if genfeed runs in a non-default VPC.
+# ── Network (genfeedai-vpc; no default VPC in this account) ──────────
 variable "vpc_id" {
   type    = string
-  default = ""
+  default = "vpc-0e7522e453a642bd8" # genfeedai-vpc (10.0.8.0/21)
 }
 
+# Existing public subnets (IGW route) — used for the internet-facing ALB + NAT.
 variable "public_subnet_ids" {
-  type        = list(string)
-  default     = []
-  description = "Public subnets for the ALB + ECS container instances. Empty = all subnets in the VPC."
+  type    = list(string)
+  default = ["subnet-04dfe8480e85f0a47", "subnet-07aec43af6ded15f0"] # 1b, 1c
 }
 
-variable "private_subnet_ids" {
-  type        = list(string)
-  default     = []
-  description = "Private subnets for ElastiCache. Empty = same as public (default-VPC has only public subnets)."
+# NAT lives in this public subnet (1b).
+variable "nat_public_subnet_id" {
+  type    = string
+  default = "subnet-04dfe8480e85f0a47"
+}
+
+# New private subnets created by this stack for ECS tasks/instances + cache
+# (existing private subnets are 1b-only; we need 2 AZs). CIDRs are free space in
+# the VPC (10.0.11/12 .0/24).
+variable "private_subnet_cidrs" {
+  type = map(string)
+  default = {
+    "us-west-1b" = "10.0.11.0/24"
+    "us-west-1c" = "10.0.12.0/24"
+  }
 }
 
 # ── DNS / TLS ────────────────────────────────────────────────────────

--- a/infra/terraform/modules/service/main.tf
+++ b/infra/terraform/modules/service/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.60" }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name_prefix}/${var.name}"
+  retention_in_days = var.log_retention_days
+}
+
+# Internal DNS: <name>.genfeed.internal -> task IP (awsvpc A record).
+resource "aws_service_discovery_service" "this" {
+  name = var.name
+  dns_config {
+    namespace_id = var.namespace_id
+    dns_records {
+      type = "A"
+      ttl  = 10
+    }
+    routing_policy = "MULTIVALUE"
+  }
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${var.name_prefix}-${var.name}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([{
+    name        = var.name
+    image       = var.image
+    command     = var.command
+    essential   = true
+    environment = var.environment
+    secrets     = var.secrets
+    portMappings = [{
+      containerPort = var.port
+      hostPort      = var.port
+      protocol      = "tcp"
+    }]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.this.name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = var.name
+      }
+    }
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:${var.port}${var.health_path} || exit 1"]
+      interval    = 30
+      timeout     = 10
+      retries     = 5
+      startPeriod = var.health_grace > 0 ? var.health_grace : 40
+    }
+  }])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+
+  capacity_provider_strategy {
+    capacity_provider = var.capacity_provider
+    weight            = 1
+    base              = 0
+  }
+
+  deployment_minimum_healthy_percent = var.min_healthy
+  deployment_maximum_percent         = var.max_percent
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = var.security_group_ids
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.this.arn
+  }
+
+  # Spread tasks across instances + AZs so one box dying never takes all of a
+  # service, and so api can roll onto the other box (zero-downtime).
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.register_alb ? [1] : []
+    content {
+      target_group_arn = var.target_group_arn
+      container_name   = var.name
+      container_port   = var.port
+    }
+  }
+
+  health_check_grace_period_seconds = var.register_alb ? var.health_grace : null
+
+  lifecycle {
+    ignore_changes = [desired_count] # allow manual/auto scaling without TF drift
+  }
+}

--- a/infra/terraform/modules/service/main.tf
+++ b/infra/terraform/modules/service/main.tf
@@ -28,7 +28,7 @@ resource "aws_service_discovery_service" "this" {
 resource "aws_ecs_task_definition" "this" {
   family                   = "${var.name_prefix}-${var.name}"
   network_mode             = "awsvpc"
-  requires_compatibilities = ["EC2"]
+  requires_compatibilities = ["FARGATE"]
   cpu                      = var.cpu
   memory                   = var.memory
   execution_role_arn       = var.execution_role_arn
@@ -85,24 +85,17 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    subnets         = var.subnets
-    security_groups = var.security_group_ids
+    subnets          = var.subnets          # private subnets (NAT egress)
+    security_groups  = var.security_group_ids
+    assign_public_ip = false                # Fargate in private subnets; egress via NAT
   }
 
   service_registries {
     registry_arn = aws_service_discovery_service.this.arn
   }
 
-  # Spread tasks across instances + AZs so one box dying never takes all of a
-  # service, and so api can roll onto the other box (zero-downtime).
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "attribute:ecs.availability-zone"
-  }
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
-  }
+  # No placement strategy: Fargate doesn't support them and auto-spreads tasks
+  # across the AZs of the configured subnets.
 
   dynamic "load_balancer" {
     for_each = var.register_alb ? [1] : []

--- a/infra/terraform/modules/service/main.tf
+++ b/infra/terraform/modules/service/main.tf
@@ -107,8 +107,4 @@ resource "aws_ecs_service" "this" {
   }
 
   health_check_grace_period_seconds = var.register_alb ? var.health_grace : null
-
-  lifecycle {
-    ignore_changes = [desired_count] # allow manual/auto scaling without TF drift
-  }
 }

--- a/infra/terraform/modules/service/outputs.tf
+++ b/infra/terraform/modules/service/outputs.tf
@@ -1,0 +1,11 @@
+output "service_name" {
+  value = aws_ecs_service.this.name
+}
+
+output "task_definition_arn" {
+  value = aws_ecs_task_definition.this.arn
+}
+
+output "log_group" {
+  value = aws_cloudwatch_log_group.this.name
+}

--- a/infra/terraform/modules/service/variables.tf
+++ b/infra/terraform/modules/service/variables.tf
@@ -1,0 +1,57 @@
+variable "name" { type = string }
+variable "name_prefix" { type = string }
+variable "cluster_id" { type = string }
+variable "capacity_provider" { type = string }
+variable "image" { type = string }
+variable "command" { type = list(string) }
+variable "cpu" { type = number }
+variable "memory" { type = number }
+variable "port" { type = number }
+variable "region" { type = string }
+variable "execution_role_arn" { type = string }
+variable "task_role_arn" { type = string }
+variable "subnets" { type = list(string) }
+variable "security_group_ids" { type = list(string) }
+variable "namespace_id" { type = string }
+
+variable "secrets" {
+  type    = list(object({ name = string, valueFrom = string }))
+  default = []
+}
+variable "environment" {
+  type    = list(object({ name = string, value = string }))
+  default = []
+}
+
+variable "desired_count" {
+  type    = number
+  default = 1
+}
+variable "register_alb" {
+  type    = bool
+  default = false
+}
+variable "target_group_arn" {
+  type    = string
+  default = ""
+}
+variable "health_grace" {
+  type    = number
+  default = 0
+}
+variable "health_path" {
+  type    = string
+  default = "/v1/health"
+}
+variable "min_healthy" {
+  type    = number
+  default = 100
+}
+variable "max_percent" {
+  type    = number
+  default = 200
+}
+variable "log_retention_days" {
+  type    = number
+  default = 30
+}


### PR DESCRIPTION
Replaces the SSH-waves deploy (`docker/deploy-common.sh`) with **AWS ECS under Terraform**: EC2 capacity for steady services + Fargate wired for per-PR previews. **genfeed.ai only** (per plan). Nothing is applied — `terraform apply` stays human-gated.

## What's here

**`infra/terraform/`**
- `bootstrap/` — S3 state bucket (**S3-native locking, no DynamoDB**) + GitHub OIDC provider + `gha-genfeed-deploy` role. Run once, locally.
- `genfeed-prod/` — ECS cluster + EC2 capacity provider (**ASG 2× t3a.medium**) + Fargate provider; ALB + ACM (`api.genfeed.ai`) + Route53; ECR; IAM exec/task/instance roles; **ElastiCache t4g.micro** (redis off the app boxes); Cloud Map (`genfeed.internal`); **9 ECS services** via `modules/service`; one-off **migrate** task.
- `modules/service/` — task def + service + CloudWatch logs + Cloud Map (+ optional ALB).

**`.github/workflows/deploy-ecs.yml`** — dispatch-only, gated by the GitHub **`production` environment**. OIDC → copy `server:<sha>` GHCR→ECR (no rebuild) → run **migrate** task (gated, before services roll) → `terraform apply` rolls services → `wait services-stable`.

## Key design decisions

- **awsvpc + ENI trunking** so Cloud Map A-records match the app's fixed `http://files:3012` calls, and ~5 tasks fit a t3a.medium.
- **Secrets**: every `/genfeed/production/*` SSM param → task secret (env = last path segment). Replaces `render-ssm-env.sh`.
- **Redis → ElastiCache** (state can't live on ephemeral tasks). Post-apply: set SSM `REDIS_URL` to the ElastiCache endpoint (one-time; documented).
- **api zero-downtime** (min 100 / max 200 across 2 boxes); bots tolerate a brief blip. Circuit-breaker auto-rollback on all.
- ECR push handled by the deploy-time GHCR→ECR copy (no `build-server-image` change needed).

## Validation

`tofu validate` passes for **bootstrap + genfeed-prod + the service module**; `tofu fmt` clean; deploy workflow YAML parses. The first `terraform plan` with real creds will surface env-specific values — see **Assumptions** in `README.md` (default VPC; Route53 zone for genfeed.ai; RDS `genfeed-data`).

## NOT in this PR (next, scoped)

- **Per-PR Fargate previews** — design + open preview-DB decision captured in `infra/terraform/PREVIEW.md`. The cluster already has the Fargate provider; the preview module + open/close workflows + wildcard cert land next, once you pick the preview-DB approach.
- Decommissioning the SSH deploy (`deploy-common.sh` etc.) — happens at cutover (README step 5).

## How to drive it (README has full steps)

1. `bootstrap/` apply (you, admin creds) → add `AWS_DEPLOY_ROLE_ARN` repo var.
2. `genfeed-prod/` `terraform plan` → review → `apply`.
3. Repoint SSM `REDIS_URL`; smoke-test via ALB DNS; flip `api.genfeed.ai`.
4. Keep old box **stopped** ~1 week as rollback.