### PR TITLE
fix(api): make Clerk webhook user updates idempotent (P2025 race)

### DIFF
--- a/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.spec.ts
@@ -531,6 +531,54 @@ describe('ClerkWebhookService', () => {
       );
     });
 
+    it('should ack (not throw) when the user projection vanishes mid-update (P2025)', async () => {
+      const event = asWebhookEvent({
+        data: { id: 'user_123456' },
+        type: 'user.updated',
+      });
+      const url = 'webhook/clerk';
+
+      // Clerk redelivers/retries: the projection is removed by a concurrent
+      // event between the lookup and the patch, so Prisma throws P2025.
+      const recordNotFound = Object.assign(
+        new Error('No record was found for an update.'),
+        { code: 'P2025', name: 'PrismaClientKnownRequestError' },
+      );
+
+      (clerkService.getUser as vi.Mock).mockResolvedValue(mockClerkUser);
+      (usersService.findOne as vi.Mock).mockResolvedValue(mockUser);
+      (usersService.patch as vi.Mock).mockRejectedValue(recordNotFound);
+
+      // Must resolve cleanly (webhook returns 200) so Clerk stops retrying.
+      await expect(
+        service.handleWebhookEvent(event, url),
+      ).resolves.toBeUndefined();
+
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('user projection no longer exists'),
+        expect.objectContaining({ clerkUserId: 'user_123456' }),
+      );
+      // Bailed before downstream sync — no Clerk metadata write.
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should rethrow non-P2025 database errors during user update', async () => {
+      const event = asWebhookEvent({
+        data: { id: 'user_123456' },
+        type: 'user.updated',
+      });
+      const url = 'webhook/clerk';
+
+      const dbError = new Error('Database connection error');
+      (clerkService.getUser as vi.Mock).mockResolvedValue(mockClerkUser);
+      (usersService.findOne as vi.Mock).mockResolvedValue(mockUser);
+      (usersService.patch as vi.Mock).mockRejectedValue(dbError);
+
+      await expect(service.handleWebhookEvent(event, url)).rejects.toThrow(
+        dbError,
+      );
+    });
+
     it('should reject session.created events', async () => {
       const event = asWebhookEvent({
         data: {

--- a/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.ts
@@ -226,6 +226,46 @@ export class ClerkWebhookService {
     }
   }
 
+  /**
+   * Detect Prisma's "record required but not found" failure (P2025), which
+   * `BaseService.patch`/`update` surfaces when the target row disappeared
+   * between our read and the write.
+   */
+  private isRecordNotFoundError(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'P2025'
+    );
+  }
+
+  /**
+   * Patch a user projection idempotently. Clerk redelivers and retries
+   * webhooks, so the projection can be removed by a concurrent event between
+   * our lookup and this update. A vanished record resolves to `null` (logged)
+   * instead of a P2025 that would 404 the callback and trigger an endless
+   * Clerk retry loop.
+   */
+  private async patchUserProjection(
+    id: string,
+    update: Parameters<UsersService['patch']>[1],
+  ): Promise<UserDocument | null> {
+    try {
+      return await this.usersService.patch(id, update);
+    } catch (error: unknown) {
+      if (this.isRecordNotFoundError(error)) {
+        this.loggerService.warn(
+          `Skipped user projection patch for ${id}; record no longer exists (concurrent Clerk event)`,
+          { id },
+        );
+        return null;
+      }
+
+      throw error;
+    }
+  }
+
   private async findOrganizationProjection(
     clerkOrganizationId: string,
     metadata: ClerkWebhookRecord = {},
@@ -496,8 +536,10 @@ export class ClerkWebhookService {
       });
 
       if (user) {
-        // Update the pre-created user with the real Clerk ID
-        user = await this.usersService.patch(user._id, {
+        // Update the pre-created user with the real Clerk ID. A concurrent
+        // Clerk event may have removed the projection between the lookup above
+        // and this write; tolerate that and fall through to recreation below.
+        user = await this.patchUserProjection(user._id, {
           avatar: avatar ?? user.avatar ?? undefined,
           clerkId: clerkUserId,
           email: email ?? user.email ?? undefined,
@@ -505,9 +547,11 @@ export class ClerkWebhookService {
           lastName: lastName ?? user.lastName ?? undefined,
         });
 
-        this.loggerService.log(
-          `Updated pre-created invited user ${user._id} with Clerk ID ${clerkUserId}`,
-        );
+        if (user) {
+          this.loggerService.log(
+            `Updated pre-created invited user ${user._id} with Clerk ID ${clerkUserId}`,
+          );
+        }
       }
     }
 
@@ -533,13 +577,27 @@ export class ClerkWebhookService {
         }) as Parameters<UsersService['create']>[0],
       );
     } else {
-      // Update existing user profile (for both sign-ins and invitations)
-      user = await this.usersService.patch(user._id, {
+      // Update existing user profile (for both sign-ins and invitations).
+      // Clerk retries and duplicate deliveries mean the projection can vanish
+      // between the lookup above and this write (TOCTOU). Treat a missing
+      // record as an idempotent no-op and ack the webhook so Clerk stops
+      // retrying, instead of surfacing a P2025 that 404s the callback.
+      const patched = await this.patchUserProjection(user._id, {
         avatar,
         email,
         firstName: firstName || undefined,
         lastName: lastName || undefined,
       });
+
+      if (!patched) {
+        this.loggerService.warn(
+          `${url} user projection no longer exists; acking webhook`,
+          { clerkUserId, userId: user._id },
+        );
+        return;
+      }
+
+      user = patched;
 
       if (isInvited) {
         this.loggerService.log(
@@ -556,7 +614,9 @@ export class ClerkWebhookService {
     // For new user creation (not updates), mark onboarding as completed immediately
     // New users skip the wizard — they go to Stripe checkout or explore mode
     if (type === 'user.created' && !isInvited && !isConsumerSignup) {
-      await this.usersService.patch(user._id, { isOnboardingCompleted: true });
+      await this.patchUserProjection(user._id, {
+        isOnboardingCompleted: true,
+      });
     }
 
     // Handle organization membership


### PR DESCRIPTION
## What

Routes all three `usersService.patch(user._id, …)` calls in `ClerkWebhookService.handleUserWebhookEvent` through a new idempotent `patchUserProjection()` helper that tolerates Prisma **P2025** ("record required but not found").

## Why

Clerk redelivers and retries webhooks. A user projection can be removed by a concurrent event between our lookup and the update (TOCTOU). The P2025 then bubbled out of `usersService.patch`, and `DatabaseExceptionFilter` mapped it to a **404** — which makes Clerk **retry the callback indefinitely**.

Surfaced in Sentry as **API-GENFEED-AI-5P** (`POST /v1/webhooks/clerk/callback`). `72f38b628` already stopped the Sentry noise (P2025 excluded from capture), but the retry-storm behavior remained because a 404 is still a delivery failure to Clerk.

## How

- New `patchUserProjection()` + `isRecordNotFoundError()` helpers.
- A vanished projection now resolves to a logged no-op so the webhook acks **200**:
  - pre-created-invited path → falls through to recreation,
  - existing-user path → acks early (nothing left to sync),
  - onboarding flag → best-effort.
- Non-P2025 errors still propagate unchanged.

## Tests

- `should ack (not throw) when the user projection vanishes mid-update (P2025)`
- `should rethrow non-P2025 database errors during user update`

`vitest` 23/23 ✓ · biome ✓ · `@genfeedai/api` type-check ✓

## Context (triage notes — separate owners, not in this PR)

This came out of an inbox/Sentry/PR-review sweep. The other open Sentry issues are **already fixed on master but unshipped** — every event is stamped release `70fc1cf87bba` (May 24):
- `API-GENFEED-AI-60` (FATAL `userSubscriptions` TDZ) → fixed by #575 (Jun 14); needs prod deploy → **#574**.
- `GENFEED-AI-42` / `-3Y` (RSC render errors) → fixed by `8ce04b4f3` (Jun 10).

Also flagged: **PR #609** (`worktree-ecs-hybrid-iac`, still open) has a CodeRabbit 🔴 critical — `deploy-ecs.yml:38` uses `GITHUB_REF_NAME` instead of `GITHUB_REF` (a tag named `master` bypasses the prod-branch gate) + an `image_tag` template injection. Belongs to the ECS owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)