### PR TITLE
fix(ci): heavy test jobs gated on a trigger ci.yml never fires (tests never run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,11 +273,17 @@ jobs:
             bun run type-check
           fi
 
+  # Heavy test jobs run only on the on-demand full-suite path. full-suite.yml
+  # invokes this workflow via `uses:` (workflow_call), so the gate must check for
+  # 'workflow_call' — NOT 'workflow_dispatch' (which this workflow never
+  # registers as a trigger; a dispatch gate left every test job permanently
+  # unreachable, including on the full-suite run). Fast PR/master-push checks
+  # (format, lint, typecheck, design, build) stay ungated above.
   test-scope:
     name: Test Scope
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
     outputs:
       app: ${{ steps.scope.outputs.app }}
       api: ${{ steps.scope.outputs.api }}
@@ -312,7 +318,7 @@ jobs:
     name: Test Packages
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -333,7 +339,7 @@ jobs:
     name: Test Server Services
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -354,7 +360,7 @@ jobs:
     name: Test Web, Desktop, Mobile
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -375,7 +381,7 @@ jobs:
     name: Test Extensions
     runs-on: ubuntu-latest
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -396,7 +402,7 @@ jobs:
     name: Test App (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && github.event_name == 'workflow_call'
     strategy:
       fail-fast: false
       matrix:
@@ -420,7 +426,7 @@ jobs:
     name: Test API (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && github.event_name == 'workflow_dispatch'
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && github.event_name == 'workflow_call'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -25,7 +25,9 @@ jobs:
   build-verify:
     name: Build & Boot Check
     uses: ./.github/workflows/build-verify.yml
-    secrets: inherit
+    # No `secrets: inherit` — build-verify.yml only uses GITHUB_TOKEN (GHCR
+    # login), which every called workflow gets automatically. Inheriting the full
+    # secret set here would over-scope it (least-privilege).
 
   e2e:
     name: E2E Suite


### PR DESCRIPTION
## What

All seven test jobs in `ci.yml` (`test-scope`, `test-packages`, `test-server-services`, `test-web-desktop-mobile`, `test-extensions`, `test-app`, `test-api`) gate on `github.event_name == 'workflow_dispatch'`. Switched to `github.event_name == 'workflow_call'`. Also dropped `secrets: inherit` from `full-suite.yml`'s `build-verify` call.

## Why (root cause)

`ci.yml` `on:` registers **push, pull_request, workflow_call** — never `workflow_dispatch`. The on-demand heavy path, `full-suite.yml`, invokes ci.yml via `uses:` (a **workflow_call**). So `github.event_name` inside ci.yml is only ever `push` / `pull_request` / `workflow_call` — **the `workflow_dispatch` gate was false in every path, and the entire unit-test layer never executed in CI.**

CodeRabbit flagged this on **#605**, but only on the two shard jobs (`test-app`, `test-api`). The same dead gate sits on all seven — and the shards `needs: test-scope`, which was equally unreachable, so fixing only the shards would still leave them skipped (empty `test-scope` outputs). This fixes all seven at the root.

## Behavior after

- **PR / master-push** → fast required checks only (format, lint, typecheck, design, build) — unchanged.
- **Full Suite (dispatch → `workflow_call`)** → heavy tests now actually run. Under `workflow_call`, `test-scope` takes its non-PR branch (`app=true`, `api=true`), so all shards execute.

## Least-privilege

`build-verify.yml` only uses `secrets.GITHUB_TOKEN` (GHCR login), which every called workflow receives automatically — so `secrets: inherit` on that call over-scoped it. Removed. `ci.yml` and `e2e.yml` keep `inherit` (they genuinely need the secret set).

## Validation

Both workflows parse (YAML); 7/7 gates swapped, 0 `workflow_dispatch` gates remain; secretlint pre-commit clean. Found during a full PR-comment sweep of #601–610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)