### PR TITLE
fix(website): build workspace deps before next build (Vercel)

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "alias": ["genfeed.ai", "www.genfeed.ai"],
-  "buildCommand": "bunx next build",
+  "buildCommand": "cd ../../ && sh scripts/sh/vercel-bun.sh run build:website",
   "git": {
     "deploymentEnabled": {
       "*": false,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build:packages": "bunx turbo run build --filter='./packages/*'",
     "build:web:parallel": "bunx turbo run build --filter=@genfeedai/app --filter=@genfeedai/website --filter=@genfeedai/docs",
     "build:web:sequential": "bunx turbo run build --filter=@genfeedai/app --filter=@genfeedai/website --filter=@genfeedai/docs --concurrency=1",
+    "build:website": "bunx turbo run build --filter=@genfeedai/website",
     "check:architecture": "bun run scripts/check-architecture.ts",
     "check:import-cycles": "bun run scripts/check-import-cycles.ts",
     "check:ui-guards": "bun run scripts/ui/check-ui-guards.ts",


### PR DESCRIPTION
## Why the website is failing / stale

`apps/website/vercel.json` ran **`buildCommand: "bunx next build"`** — Next builds in `apps/website` *without* compiling the monorepo workspace packages first. The app aliases `@genfeedai/*` to **`packages/*/dist/index`** (built output, via tsconfig paths), so every build died on:

```
Module not found: Can't resolve '@genfeedai/enums'
  > 1 | import { ErrorCode } from '@genfeedai/enums';
```

Since `vercel.json` has `git.deploymentEnabled.master: true`, Vercel's Git integration has been **failing every website production build** since this config landed (~May 24) — freezing genfeed.ai on the last good build and leaving the (already code-fixed) RSC Sentry errors **GENFEED-AI-3Y / -42** looking stale.

`app.genfeed.ai` deploys fine because its buildCommand builds from the repo root (`build:app` → turbo), compiling deps first.

## Fix

Mirror the app config:
- add root `build:website` → `bunx turbo run build --filter=@genfeedai/website` (turbo builds workspace deps via `^build`, same as `build:app`)
- point the website `buildCommand` at it through `vercel-bun.sh`

After merge, Vercel's master git-deploy rebuilds the website green → genfeed.ai ships current → 3Y/42 clear.

## Note

`apps/docs/vercel.json` has the same `next build`-without-deps shape, but lacks the root `installCommand` and git auto-deploy that the website has — left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)