### PR TITLE
fix(app): app switcher traps users on org-level (/~/) pages

### DIFF
--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -27,7 +27,17 @@ function AppProtectedTopbarContent({
   brandSlug,
 }: TopbarProps = {}) {
   const searchParams = useSearchParams();
-  const { href } = useOrgUrl();
+  // useOrgUrl resolves the brand from the active-brand context when the route has
+  // no [brandSlug] (org-level `/:org/~/...` pages). Use the resolved values so the
+  // app switcher can still link into brand-scoped apps (Library/Posts/Studio/…)
+  // instead of falling back to `/:org/~/overview` and trapping the user there.
+  const {
+    href,
+    brandSlug: resolvedBrandSlug,
+    orgSlug: resolvedOrgSlug,
+  } = useOrgUrl();
+  const effectiveOrgSlug = orgSlug || resolvedOrgSlug;
+  const effectiveBrandSlug = brandSlug || resolvedBrandSlug;
 
   const taskId = searchParams.get('taskId');
   const taskTitle = searchParams.get('taskTitle');
@@ -74,13 +84,13 @@ function AppProtectedTopbarContent({
             </Button>
           ) : null}
 
-          {orgSlug ? (
+          {effectiveOrgSlug ? (
             <div className="min-w-0">
               <AppSwitcher
                 variant="labeled"
                 currentApp={currentApp ?? 'workspace'}
-                orgSlug={orgSlug}
-                brandSlug={brandSlug}
+                orgSlug={effectiveOrgSlug}
+                brandSlug={effectiveBrandSlug}
               />
             </div>
           ) : null}


### PR DESCRIPTION
## Symptom
On org-level pages (`/:org/~/overview`, `/~/settings`, etc.) the top-bar **app switcher** doesn't navigate — clicking Library / Posts / Studio / Workflows / … just lands on the org overview. Users had to type the brand URL directly (e.g. `/genfeed/<brand>/library/avatars`), and the library "wasn't loading" because navigation never reached it.

## Root cause
`AppSwitcher` route builders fall back to `/:org/~/overview` whenever `brand` is falsy:
```ts
route: (org, brand) => brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/overview`
```
`AppProtectedTopbar` passed the **raw route-param `brandSlug`**, which is `undefined` on `/~/` pages → every switcher link collapsed to the org overview.

## Fix
Use the brand resolved by `useOrgUrl()`, which already falls back to the **active-brand context** (`selectedBrand`) when `[brandSlug]` is absent from the route. The switcher now links into the current brand's apps from org-level pages too. (`orgSlug` resolved the same way for robustness.)

## Not included (separate, larger task)
The **slow first load on `/~/`** is a perf investigation — the org-level redirect chain (next.config rewrites + proxy.ts Clerk auth + HMAC slug-cookie) plus the org page's own RSC data fetching, now also subject to single-task Fargate cold-start. Needs profiling, not a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)