### PR TITLE
fix(ci): make setup-skills.sh set -e safe + skip on Vercel builds

### DIFF
--- a/scripts/setup-skills.sh
+++ b/scripts/setup-skills.sh
@@ -27,10 +27,11 @@ log()  { echo -e "${GREEN}[✓]${NC} $*"; }
 warn() { echo -e "${YELLOW}[!]${NC} $*"; }
 err()  { echo -e "${RED}[✗]${NC} $*" >&2; }
 
-# CI does not need Claude skill symlink generation during install.
-# Keep explicit subcommands available so validation can still run when requested.
-if [[ -z "${1:-}" ]] && [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
-  log "Skipping .claude/skills generation in CI"
+# CI and hosted build environments (Vercel) do not need Claude skill symlink
+# generation during install. Keep explicit subcommands available so validation
+# can still run when requested.
+if [[ -z "${1:-}" ]] && [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" || "${VERCEL:-}" == "1" ]]; then
+  log "Skipping .claude/skills generation in CI/hosted build"
   exit 0
 fi
 
@@ -90,7 +91,7 @@ generate_symlinks() {
     local name
     name=$(basename "$dir")
     ln -sf "../../.agents/skills/${name}" "${CLAUDE_SKILLS}/${name}"
-    ((count++))
+    count=$((count + 1))
   done
 
   log "Generated ${count} symlinks in .claude/skills/"
@@ -110,16 +111,16 @@ sync_from_shipshitdev() {
       # Only sync if source is newer or dest doesn't exist
       if [[ ! -d "${AGENTS_SKILLS}/${skill}" ]]; then
         cp -r "${SHIPSHITDEV_SKILLS}/${skill}" "${AGENTS_SKILLS}/"
-        ((synced++))
+        synced=$((synced + 1))
       else
         # Replace with latest
         rm -rf "${AGENTS_SKILLS}/${skill}"
         cp -r "${SHIPSHITDEV_SKILLS}/${skill}" "${AGENTS_SKILLS}/"
-        ((synced++))
+        synced=$((synced + 1))
       fi
     else
       warn "Not in shipshitdev: ${skill}"
-      ((skipped++))
+      skipped=$((skipped + 1))
     fi
   done
 
@@ -133,7 +134,7 @@ check_integrity() {
   for f in "$AGENTS_SKILLS"/*/SKILL.md; do
     if [[ -f "$f" ]] && ! head -n 1 "$f" | grep -q '^---$'; then
       err "Missing frontmatter: $f"
-      ((errors++))
+      errors=$((errors + 1))
     fi
   done
 
@@ -142,7 +143,7 @@ check_integrity() {
   broken=$(find "$CLAUDE_SKILLS" -maxdepth 1 -type l ! -exec test -e {} \; 2>/dev/null | wc -l | tr -d ' ')
   if [[ "$broken" -gt 0 ]]; then
     err "${broken} broken symlinks in .claude/skills/"
-    ((errors++))
+    errors=$((errors + 1))
   fi
 
   # Check every .agents/skills/ entry has a .claude/skills/ symlink
@@ -151,7 +152,7 @@ check_integrity() {
     name=$(basename "$dir")
     if [[ ! -L "${CLAUDE_SKILLS}/${name}" ]]; then
       err "Missing symlink: .claude/skills/${name}"
-      ((errors++))
+      errors=$((errors + 1))
     fi
   done
 
@@ -162,7 +163,7 @@ check_integrity() {
       target=$(readlink "${link%/}")
       if [[ "$target" == /* ]] || [[ "$target" == ~* ]]; then
         err "External symlink detected: ${link%/} -> ${target}"
-        ((errors++))
+        errors=$((errors + 1))
       fi
     fi
   done


### PR DESCRIPTION
## Problem

`scripts/setup-skills.sh` runs `set -euo pipefail` and uses post-increment arithmetic (`((count++))`, `((errors++))`, `((synced++))`, `((skipped++))`). Post-increment evaluates to the **old** value, so when a counter is `0` the `(( ))` command returns exit status 1 and `set -e` aborts the script.

This made the `postinstall` hook exit 1:
- **Locally**: `bash scripts/setup-skills.sh` exits 1 (first symlink, `count=0`).
- **Vercel**: Vercel sets neither `CI` nor `GITHUB_ACTIONS`, so the existing CI skip-guard never fired → `generate_symlinks` ran → aborted → `Command "bun install" exited with 1`. This is why **docs.genfeed.ai** deploys failed (docs has no `rootDirectory`, so it builds from repo root and runs the root `postinstall`).

## Fix

- Replace every `((x++))` with `set -e`-safe `x=$((x + 1))`.
- Add `VERCEL=1` to the install-time skip guard so hosted builds skip Claude dev-skill symlink generation (they don't need it).

## Verification

```
bash scripts/setup-skills.sh            # exit 0 (Generated 47 symlinks)
bash scripts/setup-skills.sh --check    # exit 0
VERCEL=1 bash scripts/setup-skills.sh   # exit 0 (Skipping … in CI/hosted build)
grep '((.*++' scripts/setup-skills.sh   # none
```

Note: docs also needs its Vercel `rootDirectory` set to `apps/docs` (config, applied separately) so it builds from `apps/docs/vercel.json` like app/website. This PR is the code root-cause so the postinstall can never hard-fail a build again.