### PR TITLE
fix(app): stabilize switchers and posts queries

### DIFF
--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -489,6 +489,7 @@ describe('AppProtectedLayout', () => {
     expect(appSidebarSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         collapsedSidebarWidth: 0,
+        currentApp: 'workspace',
         mobileSidebarWidth: 304,
         renderTopSlot: expect.any(Function),
         secondaryItems: [

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -14,13 +14,19 @@ import OnboardingGuard from '@ui/guards/onboarding/OnboardingGuard';
 import AppLayout from '@ui/layouts/app/AppLayout';
 import AdminTopbar from '@ui/shell/topbars/AdminTopbar';
 import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
 import { type ReactNode, Suspense, useCallback, useMemo } from 'react';
 
 import AppProtectedTopbar from '@/components/shell/AppProtectedTopbar';
 import { isEEEnabled } from '@/lib/config/edition';
+import { normalizeProtectedPathname } from '@/lib/navigation/operator-shell';
 
 import AppProtectedLayoutSidebar from './AppProtectedLayoutSidebar';
-import { useAppProtectedLayout } from './useAppProtectedLayout';
+import {
+  isProtectedEditorCanvasRoute,
+  isProtectedWorkspaceRoute,
+  useAppProtectedLayout,
+} from './useAppProtectedLayout';
 
 type AgentPanelProps = {
   apiService: AgentApiService;
@@ -160,6 +166,7 @@ function AppLayoutWithDynamicMenu({
       <AppProtectedLayoutSidebar
         shellChromeVariant={shellChromeVariant}
         taskContextSearchParams={taskContextSearchParams}
+        currentApp={currentApp}
         isAdminRoute={isAdminRoute}
         isAnalyticsRoute={isAnalyticsRoute}
         isComposeRoute={isComposeRoute}
@@ -190,6 +197,7 @@ function AppLayoutWithDynamicMenu({
     adminMenuItems,
     analyticsMenuItems,
     composeMenuItems,
+    currentApp,
     conversationActions,
     handleOpenCommandPalette,
     isAdminRoute,
@@ -307,8 +315,13 @@ function AppProtectedLayoutContent({
   children,
   initialBootstrap,
 }: AppProtectedLayoutProps) {
-  const { isEditorCanvasRoute, isWorkspaceRoute } =
-    useAppProtectedLayout(initialBootstrap);
+  const rawPathname = usePathname();
+  const pathname = useMemo(
+    () => normalizeProtectedPathname(rawPathname),
+    [rawPathname],
+  );
+  const isEditorCanvasRoute = isProtectedEditorCanvasRoute(pathname);
+  const isWorkspaceRoute = isProtectedWorkspaceRoute(pathname);
 
   return (
     <ProtectedProviders

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -65,6 +65,24 @@ const WORKFLOWS_NAMED_ROUTES = new Set([
   'skills',
 ]);
 
+export function isProtectedEditorCanvasRoute(pathname: string): boolean {
+  return (
+    pathname === '/editor/new' ||
+    /^\/editor\/[^/]+$/.test(pathname) ||
+    pathname === '/workflows/new' ||
+    (/^\/workflows\/([^/]+)$/.test(pathname) &&
+      !WORKFLOWS_NAMED_ROUTES.has(pathname.split('/')[2] ?? ''))
+  );
+}
+
+export function isProtectedWorkspaceRoute(pathname: string): boolean {
+  return (
+    pathname === '/workspace' ||
+    pathname === '/overview' ||
+    pathname.startsWith('/workspace/')
+  );
+}
+
 function isTerminalDockAvailable(): boolean {
   return (
     process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1' ||
@@ -113,12 +131,7 @@ export function useAppProtectedLayout(
   })();
   const isSettingsRoute = pathname.startsWith('/settings');
   const hasSecondaryTopbar = !isAdminRoute && pathname.startsWith('/studio');
-  const isEditorCanvasRoute =
-    pathname === '/editor/new' ||
-    /^\/editor\/[^/]+$/.test(pathname) ||
-    pathname === '/workflows/new' ||
-    (/^\/workflows\/([^/]+)$/.test(pathname) &&
-      !WORKFLOWS_NAMED_ROUTES.has(pathname.split('/')[2] ?? ''));
+  const isEditorCanvasRoute = isProtectedEditorCanvasRoute(pathname);
   const isWorkflowsRoute =
     pathname.startsWith('/workflows') || pathname.startsWith('/orchestration');
   const isEditorRoute = pathname.startsWith('/editor');
@@ -450,10 +463,7 @@ export function useAppProtectedLayout(
     [taskContextSearchParams],
   );
 
-  const isWorkspaceRoute =
-    pathname === '/workspace' ||
-    pathname === '/overview' ||
-    pathname.startsWith('/workspace/');
+  const isWorkspaceRoute = isProtectedWorkspaceRoute(pathname);
 
   const isLowCreditsBannerEnabled = useFeatureFlag('low_credits_banner');
   const isDesktopShell = process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1';

--- a/apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.spec.ts
+++ b/apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.spec.ts
@@ -146,6 +146,30 @@ describe('BrandsRelationshipsController', () => {
     });
   });
 
+  describe('findAllPosts', () => {
+    it('uses a Prisma-safe root-post filter', async () => {
+      await controller.findAllPosts(
+        {} as Request,
+        '507f1f77bcf86cd799439013',
+        mockUser,
+        { status: 'draft' } as never,
+      );
+
+      expect(mockServices.postsService.findAll).toHaveBeenCalledWith(
+        {
+          orderBy: { createdAt: -1 },
+          where: {
+            brand: '507f1f77bcf86cd799439013',
+            isDeleted: false,
+            parentId: null,
+            status: 'draft',
+          },
+        },
+        expect.objectContaining({ limit: 10, page: 1 }),
+      );
+    });
+  });
+
   describe('findBrandAnalytics', () => {
     it('should return brand analytics', async () => {
       const result = await controller.findBrandAnalytics(

--- a/apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/relationships/brands-relationships.controller.ts
@@ -373,11 +373,9 @@ export class BrandsRelationshipsController {
 
     // Build match filter
     const matchFilter: Record<string, unknown> = {
-      // Only show parent posts (not children/replies)
-      // Handle both null and undefined (undefined fields aren't stored in MongoDB)
-      OR: [{ parent: null }, { parent: { not: false } }],
       brand: brandId,
       isDeleted,
+      parentId: null,
     };
 
     // Add platform filter if provided

--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
@@ -69,7 +69,6 @@ export class GifsController {
   ): Promise<JsonApiCollectionResponse> {
     const publicMetadata = getPublicMetadata(user);
     const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const scope = { not: null };
     const brand = publicMetadata.brand;
 
     const aggregate = {
@@ -83,7 +82,6 @@ export class GifsController {
                     brand,
                     category: IngredientCategory.GIF,
                     isDeleted,
-                    scope,
                     user: publicMetadata.user,
                   },
                 ],
@@ -96,7 +94,6 @@ export class GifsController {
                     category: IngredientCategory.GIF,
                     isDefault: true,
                     isDeleted,
-                    scope,
                   },
                 ],
               },
@@ -170,7 +167,7 @@ export class GifsController {
                     brand,
                     category: IngredientCategory.GIF,
                     isDeleted,
-                    scope,
+                    ...(scope !== undefined ? { scope } : {}),
                     status,
                   },
                   folderConditions,

--- a/apps/server/api/src/collections/images/controllers/images.controller.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.ts
@@ -66,7 +66,6 @@ export class ImagesController {
   ): Promise<JsonApiCollectionResponse> {
     const publicMetadata = getPublicMetadata(user);
     const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const scope = { not: null };
     const brand = publicMetadata.brand;
 
     const aggregate = {
@@ -80,7 +79,6 @@ export class ImagesController {
                     brand,
                     category: IngredientCategory.IMAGE,
                     isDeleted,
-                    scope,
                     // Exclude training source images by default
                     training: { not: false },
                     user: publicMetadata.user,
@@ -95,7 +93,6 @@ export class ImagesController {
                     category: IngredientCategory.IMAGE,
                     isDefault: true,
                     isDeleted,
-                    scope,
                   },
                 ],
               },
@@ -194,7 +191,9 @@ export class ImagesController {
                     ],
                     category: IngredientCategory.IMAGE,
                     isDeleted,
-                    ...(query.isPublic === undefined ? { scope } : {}),
+                    ...(query.isPublic === undefined && scope !== undefined
+                      ? { scope }
+                      : {}),
                     brand,
                     status,
                     ...isPublicFilter,

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
@@ -104,7 +104,7 @@ describe('MusicsController', () => {
       expect(query.where.OR).toHaveLength(2);
     });
 
-    it('should keep the default music branch scoped', () => {
+    it('should not add a required-scope not-null filter to the default music branch', () => {
       const user = createMockUser();
       const inputQuery = {};
       const query = controller.buildFindAllQuery(
@@ -114,8 +114,8 @@ describe('MusicsController', () => {
 
       expect(query.where.OR[1]).toMatchObject({
         isDefault: { not: null },
-        scope: { not: null },
       });
+      expect(query.where.OR[1]).not.toHaveProperty('scope');
     });
 
     it('should add status filters when provided', () => {

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.ts
@@ -81,7 +81,7 @@ export class MusicsController extends BaseCRUDController<
             category: IngredientCategory.MUSIC,
             isDefault,
             isDeleted: query.isDeleted ?? false,
-            scope,
+            ...(scope !== undefined ? { scope } : {}),
             status,
             // Filter default musics by brand when brand is specified
             ...(query.brand && isEntityId(query.brand) ? { brand } : {}),
@@ -107,7 +107,6 @@ export class MusicsController extends BaseCRUDController<
   ): Promise<JsonApiCollectionResponse> {
     const publicMetadata = getPublicMetadata(user);
     const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const scope = { not: null };
     const brand = publicMetadata.brand;
 
     const aggregate = {
@@ -127,7 +126,6 @@ export class MusicsController extends BaseCRUDController<
             category: IngredientCategory.MUSIC,
             isDefault: true,
             isDeleted,
-            scope,
           },
         ],
       },

--- a/apps/server/api/src/collections/organizations/controllers/organizations-relationships.controller.spec.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-relationships.controller.spec.ts
@@ -67,7 +67,9 @@ describe('OrganizationsRelationshipsController', () => {
       findAll: vi.fn().mockResolvedValue({ docs: [], total: 0 }),
     },
     loggerService: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
-    membersService: {},
+    membersService: {
+      findOne: vi.fn().mockResolvedValue(null),
+    },
     organizationsService: {
       findOne: vi.fn().mockResolvedValue({
         _id: '507f1f77bcf86cd799439012',
@@ -131,6 +133,30 @@ describe('OrganizationsRelationshipsController', () => {
     );
     _organizationsService =
       module.get<OrganizationsService>(OrganizationsService);
+  });
+
+  describe('findAllPosts', () => {
+    it('uses a Prisma-safe root-post filter', async () => {
+      await controller.findAllPosts(
+        {} as never,
+        '507f1f77bcf86cd799439012',
+        mockUser,
+        { status: 'draft' } as never,
+      );
+
+      expect(mockServices.postsService.findAll).toHaveBeenCalledWith(
+        {
+          orderBy: { createdAt: -1 },
+          where: {
+            isDeleted: false,
+            organization: '507f1f77bcf86cd799439012',
+            parentId: null,
+            status: 'draft',
+          },
+        },
+        expect.objectContaining({ limit: 10, page: 1 }),
+      );
+    });
   });
 
   afterEach(() => {

--- a/apps/server/api/src/collections/organizations/controllers/organizations-relationships.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-relationships.controller.ts
@@ -503,11 +503,9 @@ export class OrganizationsRelationshipsController {
 
     // Build match filter
     const matchFilter: MatchConditions = {
-      // Only show parent posts (not children/replies)
-      // Handle both null and undefined (undefined fields aren't stored in MongoDB)
-      OR: [{ parent: null }, { parent: { not: false } }],
       isDeleted,
       organization: organizationId,
+      parentId: null,
     };
 
     // Add platform filter if provided

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.ts
@@ -177,7 +177,6 @@ export class VideosController {
   ): Promise<JsonApiCollectionResponse> {
     const publicMetadata = getPublicMetadata(user);
     const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const scope = { not: null };
     const brand = publicMetadata.brand;
 
     const aggregate = {
@@ -189,7 +188,6 @@ export class VideosController {
               IngredientCategory.VIDEO,
             ),
             isDeleted,
-            scope,
             // Exclude training source videos by default
             training: { not: false },
             user: publicMetadata.user,
@@ -279,7 +277,7 @@ export class VideosController {
               IngredientCategory.VIDEO,
             ),
             isDeleted,
-            scope,
+            ...(scope !== undefined ? { scope } : {}),
             status,
             // ...(isEntityId(query.references)
             //   ? { references: query.references }

--- a/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.spec.ts
@@ -51,9 +51,9 @@ describe('CollectionFilterUtil', () => {
       expect(result).toBe(AssetScope.PUBLIC);
     });
 
-    it('returns not-null filter when scope missing', () => {
+    it('omits the scope filter when scope missing', () => {
       const result = CollectionFilterUtil.buildScopeFilter(undefined);
-      expect(result).toEqual({ not: null });
+      expect(result).toBeUndefined();
     });
   });
 

--- a/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.ts
@@ -132,7 +132,7 @@ export class CollectionFilterUtil {
    *
    * Handles filtering by asset scope (public/private/organization):
    * - specific scope → that scope value
-   * - undefined → any scope (not null)
+   * - undefined → no scope filter
    *
    * @param scope - Scope from query params
    * @returns Filter value for scope field
@@ -143,14 +143,12 @@ export class CollectionFilterUtil {
    * // Returns: 'public'
    *
    * @example
-   * // Default - any scope
+   * // Default - no filter
    * CollectionFilterUtil.buildScopeFilter(undefined)
-   * // Returns: { not: null }
+   * // Returns: undefined
    */
-  static buildScopeFilter(
-    scope?: AssetScope,
-  ): AssetScope | Record<string, unknown> {
-    return scope ? scope : { not: null };
+  static buildScopeFilter(scope?: AssetScope): AssetScope | undefined {
+    return scope;
   }
 
   /**

--- a/apps/server/api/src/helpers/utils/query-defaults/query-defaults.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/query-defaults/query-defaults.util.spec.ts
@@ -42,6 +42,27 @@ describe('QueryDefaultsUtil', () => {
       const result = QueryDefaultsUtil.getPaginationDefaults(query);
       expect(result.pagination).toBe(true);
     });
+
+    it('should coerce string limit and page values to numbers', () => {
+      const result = QueryDefaultsUtil.getPaginationDefaults({
+        limit: '30' as never,
+        page: '2' as never,
+      });
+
+      expect(result).toEqual({
+        limit: 30,
+        page: 2,
+        pagination: true,
+      });
+    });
+
+    it('should clamp oversized string limits to the DTO max', () => {
+      const result = QueryDefaultsUtil.getPaginationDefaults({
+        limit: '500' as never,
+      });
+
+      expect(result.limit).toBe(100);
+    });
   });
 
   describe('getIsDeletedDefault', () => {
@@ -120,6 +141,16 @@ describe('QueryDefaultsUtil', () => {
         pagination: true,
         sort: 'updatedAt',
       });
+    });
+
+    it('should coerce runtime string pagination values', () => {
+      const result = QueryDefaultsUtil.applyDefaults({
+        limit: '25' as never,
+        page: '4' as never,
+      });
+
+      expect(result.limit).toBe(25);
+      expect(result.page).toBe(4);
     });
   });
 

--- a/apps/server/api/src/helpers/utils/query-defaults/query-defaults.util.ts
+++ b/apps/server/api/src/helpers/utils/query-defaults/query-defaults.util.ts
@@ -5,6 +5,27 @@ import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
  */
 export class QueryDefaultsUtil {
   private static readonly defaults = new BaseQueryDto();
+  private static readonly maxLimit = 100;
+
+  private static parsePositiveInteger(
+    value: unknown,
+    fallback: number,
+    max?: number,
+  ): number {
+    const numericValue =
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string' && value.trim() !== ''
+          ? Number(value)
+          : Number.NaN;
+
+    if (!Number.isFinite(numericValue) || numericValue < 1) {
+      return fallback;
+    }
+
+    const integerValue = Math.floor(numericValue);
+    return max ? Math.min(integerValue, max) : integerValue;
+  }
 
   /**
    * Get default pagination options from BaseQueryDto
@@ -20,8 +41,15 @@ export class QueryDefaultsUtil {
     }
 
     return {
-      limit: query.limit ?? QueryDefaultsUtil.defaults.limit,
-      page: query.page ?? QueryDefaultsUtil.defaults.page,
+      limit: QueryDefaultsUtil.parsePositiveInteger(
+        query.limit,
+        QueryDefaultsUtil.defaults.limit,
+        QueryDefaultsUtil.maxLimit,
+      ),
+      page: QueryDefaultsUtil.parsePositiveInteger(
+        query.page,
+        QueryDefaultsUtil.defaults.page,
+      ),
       pagination: paginationValue,
     };
   }
@@ -51,8 +79,15 @@ export class QueryDefaultsUtil {
     return {
       ...query,
       isDeleted: query.isDeleted ?? QueryDefaultsUtil.defaults.isDeleted,
-      limit: query.limit ?? QueryDefaultsUtil.defaults.limit,
-      page: query.page ?? QueryDefaultsUtil.defaults.page,
+      limit: QueryDefaultsUtil.parsePositiveInteger(
+        query.limit,
+        QueryDefaultsUtil.defaults.limit,
+        QueryDefaultsUtil.maxLimit,
+      ),
+      page: QueryDefaultsUtil.parsePositiveInteger(
+        query.page,
+        QueryDefaultsUtil.defaults.page,
+      ),
       pagination: query.pagination ?? QueryDefaultsUtil.defaults.pagination,
       sort: query.sort ?? QueryDefaultsUtil.defaults.sort,
     } as T & BaseQueryDto;

--- a/apps/website/app/(content)/articles/[slug]/page.spec.tsx
+++ b/apps/website/app/(content)/articles/[slug]/page.spec.tsx
@@ -1,7 +1,12 @@
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import { expect, it } from 'vitest';
 import * as PageModule from './page';
 
 runPageModuleTests(
   'apps/website/app/(content)/articles/[slug]/page',
   PageModule,
 );
+
+it('opts into dynamic rendering for preview query support', () => {
+  expect(PageModule.dynamic).toBe('force-dynamic');
+});

--- a/apps/website/app/(content)/articles/[slug]/page.tsx
+++ b/apps/website/app/(content)/articles/[slug]/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from 'next';
 import ArticleDetailContent from './article-detail';
 import { getPublicArticleBySlugCached } from './article-loader';
 
+export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {

--- a/packages/ui/src/components/menus/workspace-switcher/WorkspaceSwitcher.tsx
+++ b/packages/ui/src/components/menus/workspace-switcher/WorkspaceSwitcher.tsx
@@ -3,6 +3,11 @@
 import { useUser } from '@clerk/nextjs';
 import { useBrandOverlay } from '@genfeedai/contexts/providers/global-modals/global-modals.provider';
 import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
+import {
+  getBrandEntityId,
+  getBrandOrganizationId,
+  getBrandOrganizationSlug,
+} from '@genfeedai/contexts/user/brand-context/brand-context.helpers';
 import { useAuthedService } from '@genfeedai/hooks/auth/use-authed-service/use-authed-service';
 import { useOrgUrl } from '@genfeedai/hooks/navigation/use-org-url';
 import { logger } from '@genfeedai/services/core/logger.service';
@@ -13,7 +18,7 @@ import {
   PopoverPanelContent,
   PopoverTrigger,
 } from '@ui/primitives/popover';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CreateOrgModal } from './CreateOrgModal';
 import { WorkspaceSwitcherPanel } from './WorkspaceSwitcherPanel';
@@ -26,11 +31,22 @@ type OrganizationEntry = {
   brand: { id: string; label: string } | null;
 };
 
+function getCurrentBrandScopedPath(pathname: string): string {
+  const parts = pathname.split('/').filter(Boolean);
+
+  if (parts.length >= 3 && parts[1] !== '~') {
+    return `/${parts.slice(2).join('/')}`;
+  }
+
+  return '/workspace/overview';
+}
+
 export default function WorkspaceSwitcher() {
   const { user } = useUser();
-  const { brands, brandId } = useBrand();
+  const { brands, brandId, setBrandId, setOrganizationId } = useBrand();
   const { openBrandOverlay } = useBrandOverlay();
   const { push, refresh } = useRouter();
+  const pathname = usePathname();
   const { href, orgSlug, orgHref } = useOrgUrl();
 
   const getOrganizationsService = useAuthedService((token: string) =>
@@ -87,7 +103,7 @@ export default function WorkspaceSwitcher() {
     [organizations],
   );
   const selectedBrand = useMemo(
-    () => brands.find((b) => b.id === brandId),
+    () => brands.find((brand) => getBrandEntityId(brand) === brandId),
     [brands, brandId],
   );
 
@@ -126,13 +142,31 @@ export default function WorkspaceSwitcher() {
       try {
         setIsSwitchingBrand(true);
         const service = await getUsersService();
-        await service.patchMeBrand(id, { isSelected: true });
+        const updatedBrand = await service.patchMeBrand(id, {
+          isSelected: true,
+        });
         logger.info(`${url} success`);
-        await user?.reload();
 
-        const newBrand = brands.find((b) => b.id === id);
+        const newBrand =
+          brands.find((brand) => getBrandEntityId(brand) === id) ??
+          updatedBrand;
         if (newBrand?.slug) {
-          push(`/${orgSlug}/${newBrand.slug}/workspace/overview`);
+          const nextBrandId = getBrandEntityId(newBrand) || id;
+          const nextOrganizationId = getBrandOrganizationId(newBrand);
+          const nextOrgSlug = getBrandOrganizationSlug(newBrand) || orgSlug;
+
+          setBrandId(nextBrandId);
+          if (nextOrganizationId) {
+            setOrganizationId(nextOrganizationId);
+          }
+          setIsOpen(false);
+          push(
+            `/${nextOrgSlug}/${newBrand.slug}${getCurrentBrandScopedPath(pathname)}`,
+          );
+          const reloadPromise = user?.reload();
+          void reloadPromise?.catch((error) => {
+            logger.error('Failed to reload user after brand switch', error);
+          });
         } else {
           refresh();
         }
@@ -142,7 +176,18 @@ export default function WorkspaceSwitcher() {
         setIsSwitchingBrand(false);
       }
     },
-    [getUsersService, user, brands, orgSlug, push, refresh, isSwitchingBrand],
+    [
+      getUsersService,
+      user,
+      brands,
+      orgSlug,
+      pathname,
+      push,
+      refresh,
+      setBrandId,
+      setOrganizationId,
+      isSwitchingBrand,
+    ],
   );
 
   const close = useCallback(() => {

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -5,6 +5,7 @@ import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { AppSwitcherItemConfig } from '@genfeedai/interfaces';
 import type { AppSwitcherProps } from '@genfeedai/props/ui/app-switcher.props';
 import Link from 'next/link';
+import { useRef } from 'react';
 import {
   HiChevronDown,
   HiOutlineChartBar,
@@ -130,10 +131,12 @@ function AppDropdownItem({
   app,
   isActive,
   href,
+  onNavigateStart,
 }: {
   app: AppSwitcherItemConfig;
   isActive: boolean;
   href: string;
+  onNavigateStart: () => void;
 }) {
   const Icon = app.icon;
 
@@ -142,6 +145,7 @@ function AppDropdownItem({
       <Link
         href={href}
         aria-current={isActive ? 'page' : undefined}
+        onClick={onNavigateStart}
         className={cn(
           'flex items-center gap-2.5 px-3 py-1.5 text-[13px]',
           isActive && 'bg-foreground/[0.06] font-medium',
@@ -170,9 +174,15 @@ export function AppSwitcher({
   preservedSearch,
   variant = 'icon',
 }: AppSwitcherProps) {
+  const preventTriggerAutoFocusRef = useRef(false);
+
   function getAppHref(app: AppSwitcherItemConfig) {
     return withPreservedSearch(app.route(orgSlug, brandSlug), preservedSearch);
   }
+
+  const handleNavigateStart = () => {
+    preventTriggerAutoFocusRef.current = true;
+  };
 
   const activeApp = ALL_APPS.find((app) => app.id === currentApp);
   const ActiveIcon = activeApp?.icon ?? HiOutlineSquares2X2;
@@ -185,7 +195,7 @@ export function AppSwitcher({
           <Button
             type="button"
             variant={ButtonVariant.GHOST}
-            className="flex h-7 items-center gap-2 rounded-md px-2"
+            className="flex h-7 items-center gap-2 rounded-md px-2 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0"
             ariaLabel="Switch section"
           >
             <ActiveIcon className="size-4 shrink-0 text-foreground/70" />
@@ -199,14 +209,26 @@ export function AppSwitcher({
             type="button"
             variant={ButtonVariant.GHOST}
             size={ButtonSize.ICON}
-            className="size-7"
+            className="size-7 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0"
             ariaLabel="Switch app"
           >
             <TbGridDots className="size-4" />
           </Button>
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={8} className="w-48">
+      <DropdownMenuContent
+        align="start"
+        sideOffset={8}
+        className="w-48"
+        onCloseAutoFocus={(event) => {
+          if (!preventTriggerAutoFocusRef.current) {
+            return;
+          }
+
+          event.preventDefault();
+          preventTriggerAutoFocusRef.current = false;
+        }}
+      >
         <DropdownMenuLabel>Content</DropdownMenuLabel>
         {CONTENT_APPS.map((app) => (
           <AppDropdownItem
@@ -214,6 +236,7 @@ export function AppSwitcher({
             app={app}
             isActive={app.id === currentApp}
             href={getAppHref(app)}
+            onNavigateStart={handleNavigateStart}
           />
         ))}
 
@@ -226,6 +249,7 @@ export function AppSwitcher({
             app={app}
             isActive={app.id === currentApp}
             href={getAppHref(app)}
+            onNavigateStart={handleNavigateStart}
           />
         ))}
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary

Fixes the Sentry crashes and UI regressions behind the app switcher, brand switcher, and posts reload path.

## Changes

- Coerce pagination defaults to numbers and cap API page size to avoid invalid Prisma `take` values.
- Stop emitting invalid Prisma filters for nullable `scope` and root posts.
- Remove the duplicated protected-layout bootstrap call that was re-querying the app on reload.
- Keep sidebar/menu state in sync when switching apps and brands.
- Prevent Radix focus restoration from leaving the app switcher trigger outlined after navigation.
- Mark article slug rendering dynamic for preview-query support.

## Verification

- `bunx biome check --write <touched files>`
- `bun vitest run --config vitest.config.ts src/helpers/utils/query-defaults/query-defaults.util.spec.ts src/helpers/utils/collection-filter/collection-filter.util.spec.ts src/collections/musics/controllers/musics.controller.spec.ts src/collections/brands/controllers/relationships/brands-relationships.controller.spec.ts src/collections/organizations/controllers/organizations-relationships.controller.spec.ts`
- `bun vitest run --config ./vitest.config.mts packages/components/app-protected-layout.test.tsx`
- `bun vitest run --config vitest.config.ts src/components/shell/app-switcher/AppSwitcher.test.tsx`
- `bun vitest run --config ../vitest.config.mts 'app/(content)/articles/[slug]/page.spec.tsx'`
- `bun run type-check` in `apps/app`
- `git diff --check`

## Risk

- No migrations or env changes.
- Cross-organization brand selection still follows the existing organization switch path; this patch fixes same-organization brand selection immediately in the client.
