### PR TITLE
fix(app): unblock workspace reloads and loaders

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -23,4 +23,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: millionco/react-doctor@v2
+      - uses: millionco/react-doctor@v2.1.0
+        with:
+          directory: '.'
+          scope: 'changed'
+          blocking: 'error'
+          version: '0.4.2'

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/[view]/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/[view]/page.test.tsx
@@ -2,17 +2,6 @@ import { runPageModuleTests } from '@shared/pages/pageTestUtils';
 import { render, screen } from '@testing-library/react';
 import WorkspaceInboxViewPage, * as PageModule from './page';
 
-vi.mock('@app-server/overview-page-data.server', () => ({
-  loadOverviewPageData: vi.fn(async () => ({
-    activeRuns: [],
-    analytics: null,
-    reviewInbox: [],
-    runs: [],
-    stats: null,
-    timeSeriesData: [],
-  })),
-}));
-
 vi.mock('next/navigation', () => ({
   notFound: vi.fn(() => {
     throw new Error('not-found');

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/[view]/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/[view]/page.tsx
@@ -1,4 +1,3 @@
-import { loadOverviewPageData } from '@app-server/overview-page-data.server';
 import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
 import ErrorBoundary from '@ui/display/error-boundary/ErrorBoundary';
 import { notFound } from 'next/navigation';
@@ -19,18 +18,10 @@ export default async function WorkspaceInboxViewPage({
     notFound();
   }
 
-  const initialData = await loadOverviewPageData();
-
   return (
     <ErrorBoundary>
       <WorkspacePageContent
         defaultInboxView={view as 'all' | 'recent' | 'unread'}
-        initialActiveRuns={initialData.activeRuns}
-        initialAnalytics={initialData.analytics}
-        initialReviewInbox={initialData.reviewInbox}
-        initialRuns={initialData.runs}
-        initialStats={initialData.stats}
-        initialTimeSeriesData={initialData.timeSeriesData}
         section="inbox"
       />
     </ErrorBoundary>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.tsx
@@ -1,23 +1,13 @@
-import { loadOverviewPageData } from '@app-server/overview-page-data.server';
 import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
 import ErrorBoundary from '@ui/display/error-boundary/ErrorBoundary';
 import WorkspacePageContent from '../workspace-page';
 
 export const generateMetadata = createPageMetadata('Workspace Dashboard');
 
-export default async function WorkspaceOverviewPage() {
-  const initialData = await loadOverviewPageData();
-
+export default function WorkspaceOverviewPage() {
   return (
     <ErrorBoundary>
-      <WorkspacePageContent
-        initialActiveRuns={initialData.activeRuns}
-        initialAnalytics={initialData.analytics}
-        initialReviewInbox={initialData.reviewInbox}
-        initialRuns={initialData.runs}
-        initialStats={initialData.stats}
-        initialTimeSeriesData={initialData.timeSeriesData}
-      />
+      <WorkspacePageContent />
     </ErrorBoundary>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
@@ -7,6 +7,7 @@ import type { AgentRunStats } from '@genfeedai/types';
 import { resolveClerkToken } from '@helpers/auth/clerk.helper';
 import { useSocketManager } from '@hooks/utils/use-socket-manager/use-socket-manager';
 import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props';
+import { AgentRunsService } from '@services/ai/agent-runs.service';
 import { Task, TasksService } from '@services/management/tasks.service';
 import { WebSocketPaths } from '@utils/network/websocket.util';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -72,6 +73,11 @@ export function useWorkspacePageContent({
   const [isWorkspaceRefreshing, setWorkspaceRefreshing] = useState(false);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [activeRuns, setActiveRuns] = useState<IAgentRun[]>(initialActiveRuns);
+  const [agentRuns, setAgentRuns] = useState<IAgentRun[]>(initialRuns);
+  const [agentStats, setAgentStats] = useState<AgentRunStats | null>(
+    initialStats,
+  );
   const [workspaceTasks, setWorkspaceTasks] = useState<Task[]>([]);
 
   const reviewInboxTasks = useMemo(
@@ -185,20 +191,20 @@ export function useWorkspacePageContent({
       },
       {
         label: 'In Progress',
-        value: String(inProgressTasks.length + initialActiveRuns.length),
+        value: String(inProgressTasks.length + activeRuns.length),
       },
       {
         label: 'Completed Today',
-        value: String(initialStats?.completedToday ?? 0),
+        value: String(agentStats?.completedToday ?? 0),
       },
       {
         label: 'Failed Today',
-        value: String(initialStats?.failedToday ?? 0),
+        value: String(agentStats?.failedToday ?? 0),
       },
     ],
     [
-      initialActiveRuns.length,
-      initialStats,
+      activeRuns.length,
+      agentStats,
       inProgressTasks.length,
       unreadInboxTasks.length,
     ],
@@ -251,6 +257,51 @@ export function useWorkspacePageContent({
       controller.abort();
     };
   }, [getToken]);
+
+  useEffect(() => {
+    if (section !== 'overview') {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadWorkspaceRuns = async () => {
+      const token = await resolveClerkToken(getToken);
+      if (!token || !isMounted) {
+        return;
+      }
+
+      const service = AgentRunsService.getInstance(token);
+      const [runsResult, activeRunsResult, statsResult] =
+        await Promise.allSettled([
+          service.list({ page: 1 }),
+          service.getActive(),
+          service.getStats(),
+        ]);
+
+      if (!isMounted) {
+        return;
+      }
+
+      startTransition(() => {
+        if (runsResult.status === 'fulfilled') {
+          setAgentRuns(runsResult.value);
+        }
+        if (activeRunsResult.status === 'fulfilled') {
+          setActiveRuns(activeRunsResult.value);
+        }
+        if (statsResult.status === 'fulfilled') {
+          setAgentStats(statsResult.value);
+        }
+      });
+    };
+
+    void loadWorkspaceRuns();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [getToken, section]);
 
   useEffect(() => {
     if (!organizationId) {
@@ -394,10 +445,10 @@ export function useWorkspacePageContent({
     defaultInboxView,
     historyPreviewItems,
     inProgressTasks,
-    initialActiveRuns,
+    initialActiveRuns: activeRuns,
     initialReviewInbox,
-    initialRuns,
-    initialStats,
+    initialRuns: agentRuns,
+    initialStats: agentStats,
     isInboxSection,
     isOverviewSection,
     isTaskComposerOpen,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -18,9 +18,12 @@ import WorkspacePageContent from './workspace-page';
 
 const getTokenMock = vi.fn();
 const listMock = vi.fn();
+const listAgentRunsMock = vi.fn();
 const createTaskMock = vi.fn();
 const ensurePlanningThreadMock = vi.fn();
+const getActiveRunsMock = vi.fn();
 const getBatchMock = vi.fn();
+const getRunStatsMock = vi.fn();
 const findIngredientsByIdsMock = vi.fn();
 const findIssueMock = vi.fn();
 const routerPushMock = vi.fn();
@@ -221,6 +224,9 @@ describe('WorkspacePageContent', () => {
       id: 'issue-1',
       identifier: 'GEN-42',
     });
+    listAgentRunsMock.mockResolvedValue([]);
+    getActiveRunsMock.mockResolvedValue([]);
+    getRunStatsMock.mockResolvedValue(null);
     vi.mocked(TasksService.getInstance).mockReturnValue({
       approve: vi.fn(),
       createChildTasks: vi.fn(),
@@ -232,7 +238,10 @@ describe('WorkspacePageContent', () => {
       requestChanges: vi.fn(),
     } as unknown as ReturnType<typeof TasksService.getInstance>);
     vi.mocked(AgentRunsService.getInstance).mockReturnValue({
+      getActive: getActiveRunsMock,
       getBatch: getBatchMock,
+      getStats: getRunStatsMock,
+      list: listAgentRunsMock,
     } as unknown as ReturnType<typeof AgentRunsService.getInstance>);
     vi.mocked(IngredientsService.getInstance).mockReturnValue({
       findByIds: findIngredientsByIdsMock,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -4,12 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import WorkspacePageContent from './workspace-page';
 
 const mocks = vi.hoisted(() => ({
+  agentRunsList: vi.fn(),
   approve: vi.fn(),
   dismiss: vi.fn(),
   ensurePlanningThread: vi.fn(),
   findByIds: vi.fn(),
   findOne: vi.fn(),
+  getActiveRuns: vi.fn(),
   getBatch: vi.fn(),
+  getRunStats: vi.fn(),
   getToken: vi.fn(),
   keepOutput: vi.fn(),
   list: vi.fn(),
@@ -48,7 +51,10 @@ vi.mock('@hooks/utils/use-socket-manager/use-socket-manager', () => ({
 vi.mock('@services/ai/agent-runs.service', () => ({
   AgentRunsService: {
     getInstance: () => ({
+      getActive: mocks.getActiveRuns,
       getBatch: mocks.getBatch,
+      getStats: mocks.getRunStats,
+      list: mocks.agentRunsList,
     }),
   },
 }));
@@ -160,6 +166,9 @@ describe('WorkspacePageContent', () => {
     vi.clearAllMocks();
     mocks.resolveClerkToken.mockResolvedValue('token-1');
     mocks.subscribe.mockReturnValue(vi.fn());
+    mocks.agentRunsList.mockResolvedValue([]);
+    mocks.getActiveRuns.mockResolvedValue([]);
+    mocks.getRunStats.mockResolvedValue(null);
     mocks.list.mockResolvedValue([
       makeInspectorTask(),
       makeTask({
@@ -252,6 +261,7 @@ describe('WorkspacePageContent', () => {
     render(<WorkspacePageContent section="inbox" defaultInboxView="unread" />);
 
     expect(await screen.findByText('Campaign image')).toBeVisible();
+    expect(mocks.agentRunsList).not.toHaveBeenCalled();
     expect(screen.getByText('Workspace at a glance')).toBeVisible();
     expect(mocks.subscribe).toHaveBeenCalled();
 
@@ -372,6 +382,9 @@ describe('WorkspacePageContent', () => {
     );
 
     expect(await screen.findByText('Workspace Dashboard')).toBeVisible();
+    await waitFor(() =>
+      expect(mocks.agentRunsList).toHaveBeenCalledWith({ page: 1 }),
+    );
     expect(screen.getByTestId('workspace-in-progress')).toBeVisible();
     expect(screen.getAllByText('Campaign image').length).toBeGreaterThan(0);
     expect(screen.getByText('Live runs')).toBeVisible();

--- a/apps/server/api/src/auth/controllers/auth-bootstrap.controller.spec.ts
+++ b/apps/server/api/src/auth/controllers/auth-bootstrap.controller.spec.ts
@@ -24,7 +24,7 @@ const mockShellBootstrapPayload = {
 
 const mockOverviewBootstrapPayload = {
   activeRuns: [{ id: 'run_2' }],
-  analytics: { totalPosts: 12 },
+  analytics: {},
   reviewInbox: {
     approvedCount: 0,
     changesRequestedCount: 0,
@@ -49,7 +49,7 @@ const mockOverviewBootstrapPayload = {
     trends: [],
     webEnabledRuns: 1,
   },
-  timeSeries: [{ date: '2026-03-17', instagram: 10 }],
+  timeSeries: [],
 };
 
 const mockAuthBootstrapService = {

--- a/apps/server/api/src/auth/services/auth-bootstrap.service.spec.ts
+++ b/apps/server/api/src/auth/services/auth-bootstrap.service.spec.ts
@@ -40,10 +40,6 @@ vi.mock('@api/collections/brands/services/brands.service', () => ({
   BrandsService: class BrandsService {},
 }));
 
-vi.mock('@api/collections/credentials/services/credentials.service', () => ({
-  CredentialsService: class CredentialsService {},
-}));
-
 vi.mock('@api/collections/credits/services/credits.utils.service', () => ({
   CreditsUtilsService: class CreditsUtilsService {},
 }));
@@ -56,13 +52,6 @@ vi.mock(
   '@api/collections/organization-settings/services/organization-settings.service',
   () => ({
     OrganizationSettingsService: class OrganizationSettingsService {},
-  }),
-);
-
-vi.mock(
-  '@api/collections/posts/services/analytics-aggregation.service',
-  () => ({
-    AnalyticsAggregationService: class AnalyticsAggregationService {},
   }),
 );
 
@@ -111,10 +100,6 @@ describe('AuthBootstrapService', () => {
     getStats: vi.fn(),
     listRecentRuns: vi.fn(),
   };
-  const analyticsAggregationService = {
-    getOverviewMetrics: vi.fn(),
-    getTimeSeriesDataWithPlatforms: vi.fn(),
-  };
   const brandsService = {
     findForOrganization: vi.fn(),
   };
@@ -123,9 +108,6 @@ describe('AuthBootstrapService', () => {
   };
   const creditsUtilsService = {
     getOrganizationCreditsBalance: vi.fn(),
-  };
-  const credentialsService = {
-    countConnected: vi.fn(),
   };
   const batchGenerationService = {
     getReviewInboxSummary: vi.fn(),
@@ -154,11 +136,9 @@ describe('AuthBootstrapService', () => {
     service = new AuthBootstrapService(
       accessBootstrapCacheService as never,
       agentRunsService as never,
-      analyticsAggregationService as never,
       brandsService as never,
       configService as never,
       creditsUtilsService as never,
-      credentialsService as never,
       batchGenerationService as never,
       fleetService as never,
       membersService as never,
@@ -172,16 +152,9 @@ describe('AuthBootstrapService', () => {
     agentRunsService.getActiveRuns.mockResolvedValue([]);
     agentRunsService.getStats.mockResolvedValue(null);
     agentRunsService.listRecentRuns.mockResolvedValue([]);
-    analyticsAggregationService.getOverviewMetrics.mockResolvedValue({
-      totalPosts: 12,
-    });
-    analyticsAggregationService.getTimeSeriesDataWithPlatforms.mockResolvedValue(
-      [],
-    );
     brandsService.findForOrganization.mockResolvedValue([]);
     configService.get.mockReturnValue('');
     creditsUtilsService.getOrganizationCreditsBalance.mockResolvedValue(0);
-    credentialsService.countConnected.mockResolvedValue(0);
     batchGenerationService.getReviewInboxSummary.mockResolvedValue({
       approvedCount: 1,
       changesRequestedCount: 0,
@@ -517,7 +490,7 @@ describe('AuthBootstrapService', () => {
     expect(result.darkroomCapabilities).toBeNull();
   });
 
-  it('aggregates overview data through the single overview bootstrap path', async () => {
+  it('loads workspace overview data without unused analytics work', async () => {
     const organizationId = 'test-object-id';
     const brandId = 'test-object-id';
     const userId = 'test-object-id';
@@ -561,14 +534,6 @@ describe('AuthBootstrapService', () => {
       trends: [],
       webEnabledRuns: 1,
     });
-    analyticsAggregationService.getOverviewMetrics.mockResolvedValue({
-      totalPosts: 12,
-    });
-    analyticsAggregationService.getTimeSeriesDataWithPlatforms.mockResolvedValue(
-      [{ date: '2026-03-17', instagram: 10 }],
-    );
-    credentialsService.countConnected.mockResolvedValue(3);
-
     const result = await service.getOverviewBootstrap({
       context: {
         brandId,
@@ -587,12 +552,6 @@ describe('AuthBootstrapService', () => {
 
     expect(getBootstrapSpy).not.toHaveBeenCalled();
     expect(usersService.findOne).not.toHaveBeenCalled();
-    expect(analyticsAggregationService.getOverviewMetrics).toHaveBeenCalledWith(
-      organizationId,
-      brandId,
-      expect.any(String),
-      expect.any(String),
-    );
     expect(agentRunsService.listRecentRuns).toHaveBeenCalledWith(
       organizationId,
       20,
@@ -602,16 +561,9 @@ describe('AuthBootstrapService', () => {
       brandId,
       5,
     );
-    expect(credentialsService.countConnected).toHaveBeenCalledWith(
-      organizationId,
-      brandId,
-    );
     expect(result).toEqual({
       activeRuns: [{ id: 'run_2' }],
-      analytics: {
-        totalCredentialsConnected: 3,
-        totalPosts: 12,
-      },
+      analytics: {},
       reviewInbox: {
         approvedCount: 1,
         changesRequestedCount: 0,
@@ -649,7 +601,7 @@ describe('AuthBootstrapService', () => {
         trends: [],
         webEnabledRuns: 1,
       },
-      timeSeries: [{ date: '2026-03-17', instagram: 10 }],
+      timeSeries: [],
     });
   });
 
@@ -675,8 +627,6 @@ describe('AuthBootstrapService', () => {
       settings: null,
       streak: null,
     } satisfies AccessBootstrapCachePayload);
-    credentialsService.countConnected.mockResolvedValue(3);
-
     const request = {
       context: {
         brandId,
@@ -697,13 +647,6 @@ describe('AuthBootstrapService', () => {
     const result2 = await service.getOverviewBootstrap(request);
 
     expect(result1).toEqual(result2);
-    expect(
-      analyticsAggregationService.getOverviewMetrics,
-    ).toHaveBeenCalledTimes(1);
-    expect(
-      analyticsAggregationService.getTimeSeriesDataWithPlatforms,
-    ).toHaveBeenCalledTimes(1);
-    expect(credentialsService.countConnected).toHaveBeenCalledTimes(1);
     expect(batchGenerationService.getReviewInboxSummary).toHaveBeenCalledTimes(
       1,
     );

--- a/apps/server/api/src/auth/services/auth-bootstrap.service.ts
+++ b/apps/server/api/src/auth/services/auth-bootstrap.service.ts
@@ -1,10 +1,8 @@
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
-import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
-import { AnalyticsAggregationService } from '@api/collections/posts/services/analytics-aggregation.service';
 import { StreaksService } from '@api/collections/streaks/services/streaks.service';
 import { UsersService } from '@api/collections/users/services/users.service';
 import type { RequestWithContext } from '@api/common/middleware/request-context.middleware';
@@ -85,11 +83,9 @@ export class AuthBootstrapService {
   constructor(
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
     private readonly agentRunsService: AgentRunsService,
-    private readonly analyticsAggregationService: AnalyticsAggregationService,
     private readonly brandsService: BrandsService,
     private readonly configService: ConfigService,
     private readonly creditsUtilsService: CreditsUtilsService,
-    private readonly credentialsService: CredentialsService,
     private readonly batchGenerationService: BatchGenerationService,
     private readonly fleetService: FleetService,
     private readonly membersService: MembersService,
@@ -426,40 +422,11 @@ export class AuthBootstrapService {
       return cached;
     }
 
-    const endDate = new Date();
-    const startDate = new Date();
-    startDate.setDate(endDate.getDate() - 13);
-
-    const startDateIso = startDate.toISOString().split('T')[0] ?? '';
-    const endDateIso = endDate.toISOString().split('T')[0] ?? '';
-
-    const [
-      analyticsMetrics,
-      totalCredentialsConnected,
-      reviewInbox,
-      timeSeries,
-      runs,
-      activeRuns,
-      stats,
-    ] = await Promise.all([
-      this.analyticsAggregationService.getOverviewMetrics(
-        organizationId,
-        brandId,
-        startDateIso,
-        endDateIso,
-      ),
-      this.credentialsService.countConnected(organizationId, brandId),
+    const [reviewInbox, runs, activeRuns, stats] = await Promise.all([
       this.batchGenerationService.getReviewInboxSummary(
         organizationId,
         brandId || undefined,
         5,
-      ),
-      this.analyticsAggregationService.getTimeSeriesDataWithPlatforms(
-        organizationId,
-        brandId,
-        startDateIso,
-        endDateIso,
-        'day',
       ),
       this.agentRunsService.listRecentRuns(organizationId, 20),
       this.agentRunsService.getActiveRuns(organizationId),
@@ -468,14 +435,11 @@ export class AuthBootstrapService {
 
     const payload: OverviewBootstrapPayload = {
       activeRuns: toPlainJson(activeRuns),
-      analytics: {
-        ...analyticsMetrics,
-        totalCredentialsConnected,
-      },
+      analytics: {},
       reviewInbox: toPlainJson(reviewInbox),
       runs: toPlainJson(runs),
       stats,
-      timeSeries: toPlainJson(timeSeries),
+      timeSeries: [],
     };
 
     this.setCachedOverviewBootstrap(cacheKey, payload);

--- a/packages/services/billing/credits.service.test.ts
+++ b/packages/services/billing/credits.service.test.ts
@@ -208,6 +208,8 @@ describe('CreditsService', () => {
       ],
     });
 
-    expect(mockGet).toHaveBeenCalledWith('/topbar-balances');
+    expect(mockGet).toHaveBeenCalledWith('/topbar-balances', {
+      timeout: 5_000,
+    });
   });
 });

--- a/packages/services/billing/credits.service.ts
+++ b/packages/services/billing/credits.service.ts
@@ -6,6 +6,8 @@ import {
   type JsonApiResponseDocument,
 } from '@services/core/json-api';
 
+const TOPBAR_BALANCES_TIMEOUT_MS = 5_000;
+
 export interface ByokUsageSummary {
   totalUsage: number;
   freeThreshold: number;
@@ -39,8 +41,10 @@ export class CreditsService extends HTTPBaseService {
   }
 
   public async getTopbarBalances(): Promise<ITopbarBalances> {
-    const response =
-      await this.instance.get<JsonApiResponseDocument>('/topbar-balances');
+    const response = await this.instance.get<JsonApiResponseDocument>(
+      '/topbar-balances',
+      { timeout: TOPBAR_BALANCES_TIMEOUT_MS },
+    );
 
     return deserializeResource<ITopbarBalances>(response.data);
   }

--- a/packages/ui/src/components/loading/default/Loading.stories.tsx
+++ b/packages/ui/src/components/loading/default/Loading.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Full-page or partial loading indicator with infinity animation.',
+          'Full-page or partial loading indicator using the shared spinner.',
       },
     },
     layout: 'fullscreen',

--- a/packages/ui/src/components/loading/default/Loading.test.tsx
+++ b/packages/ui/src/components/loading/default/Loading.test.tsx
@@ -1,21 +1,34 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Loading from '@ui/loading/default/Loading';
 import { describe, expect, it } from 'vitest';
 
 describe('Loading', () => {
-  it('should render without crashing', () => {
+  it('renders the shared spinner loader', () => {
     const { container } = render(<Loading />);
-    expect(container.firstChild).toBeInTheDocument();
-  });
 
-  it('should handle user interactions correctly', () => {
-    const { container } = render(<Loading />);
-    expect(container.firstChild).toBeInTheDocument();
-  });
-
-  it('should apply correct styles and classes', () => {
-    const { container } = render(<Loading />);
     const rootElement = container.firstChild as HTMLElement;
-    expect(rootElement).toBeInTheDocument();
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+
+    expect(rootElement).toHaveClass('min-h-screen');
+    expect(spinner).toHaveClass('animate-spin', 'size-6');
+    expect(container.querySelector('.animate-pulse')).not.toBeInTheDocument();
+  });
+
+  it('renders a partial loader with a message', () => {
+    const { container } = render(
+      <Loading
+        className="custom-loader"
+        isFullSize={false}
+        message="Loading posts"
+      />,
+    );
+
+    const rootElement = container.firstChild as HTMLElement;
+
+    expect(rootElement).toHaveClass('min-h-[60vh]', 'custom-loader');
+    expect(screen.getByRole('status', { name: 'Loading posts' })).toHaveClass(
+      'animate-spin',
+    );
+    expect(screen.getByText('Loading posts')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/loading/default/Loading.tsx
+++ b/packages/ui/src/components/loading/default/Loading.tsx
@@ -1,19 +1,35 @@
+import { ComponentSize } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { LoadingProps } from '@genfeedai/props/ui/feedback/loading.props';
+import Spinner from '@ui/feedback/spinner/Spinner';
 
-export default function Loading({ isFullSize = true }: LoadingProps) {
+export default function Loading({
+  className = '',
+  isFullSize = true,
+  message,
+}: LoadingProps) {
+  const label = message ?? 'Loading';
+
   return (
     <div
       className={cn(
-        'flex flex-col text-center justify-center items-center py-10',
-        isFullSize ? 'min-h-screen' : 'min-h-full',
+        'flex items-center justify-center text-center',
+        isFullSize ? 'min-h-screen' : 'min-h-[60vh]',
+        className,
       )}
       aria-busy="true"
-      role="status"
       aria-live="polite"
-      aria-label="Loading"
     >
-      <span className="animate-pulse size-12 rounded-full bg-primary/30" />
+      <div className="flex max-w-md flex-col items-center gap-4 px-6">
+        <Spinner
+          ariaLabel={label}
+          className="text-white/80"
+          size={ComponentSize.LG}
+        />
+        {message ? (
+          <output className="text-sm text-white/40">{message}</output>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/loading/fallback/LazyLoadingFallback.test.tsx
+++ b/packages/ui/src/components/loading/fallback/LazyLoadingFallback.test.tsx
@@ -1,21 +1,32 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
 import { describe, expect, it } from 'vitest';
 
 describe('LazyLoadingFallback', () => {
-  it('should render without crashing', () => {
+  it('renders the skeleton fallback by default', () => {
     const { container } = render(<LazyLoadingFallback />);
-    expect(container.firstChild).toBeInTheDocument();
+
+    expect(container.firstChild).toHaveAttribute(
+      'aria-label',
+      'Loading content',
+    );
   });
 
-  it('should handle user interactions correctly', () => {
-    const { container } = render(<LazyLoadingFallback />);
-    expect(container.firstChild).toBeInTheDocument();
+  it('uses the shared spinner for minimal fallbacks', () => {
+    const { container } = render(<LazyLoadingFallback variant="minimal" />);
+
+    expect(container.firstChild).toHaveClass('min-h-[60vh]');
+    expect(screen.getByRole('status', { name: 'Loading' })).toHaveClass(
+      'animate-spin',
+    );
   });
 
-  it('should apply correct styles and classes', () => {
-    const { container } = render(<LazyLoadingFallback />);
-    const rootElement = container.firstChild as HTMLElement;
-    expect(rootElement).toBeInTheDocument();
+  it('uses the shared spinner for full-page fallbacks', () => {
+    const { container } = render(<LazyLoadingFallback variant="full" />);
+
+    expect(container.firstChild).toHaveClass('min-h-screen');
+    expect(screen.getByRole('status', { name: 'Loading' })).toHaveClass(
+      'animate-spin',
+    );
   });
 });

--- a/packages/ui/src/components/loading/overlay/LoadingOverlay.test.tsx
+++ b/packages/ui/src/components/loading/overlay/LoadingOverlay.test.tsx
@@ -1,21 +1,16 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import LoadingOverlay from '@ui/loading/overlay/LoadingOverlay';
 import { describe, expect, it } from 'vitest';
 
 describe('LoadingOverlay', () => {
-  it('should render without crashing', () => {
-    const { container } = render(<LoadingOverlay />);
-    expect(container.firstChild).toBeInTheDocument();
-  });
+  it('renders an accessible overlay status', () => {
+    render(<LoadingOverlay message="Rendering" />);
 
-  it('should handle user interactions correctly', () => {
-    const { container } = render(<LoadingOverlay />);
-    expect(container.firstChild).toBeInTheDocument();
-  });
+    const overlay = screen.getByRole('alert');
+    const spinner = screen.getByRole('status', { name: 'Rendering' });
 
-  it('should apply correct styles and classes', () => {
-    const { container } = render(<LoadingOverlay />);
-    const rootElement = container.firstChild as HTMLElement;
-    expect(rootElement).toBeInTheDocument();
+    expect(overlay).toHaveAttribute('aria-busy', 'true');
+    expect(spinner).toHaveClass('animate-spin');
+    expect(screen.getByText('Rendering')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/loading/overlay/LoadingOverlay.tsx
+++ b/packages/ui/src/components/loading/overlay/LoadingOverlay.tsx
@@ -1,5 +1,7 @@
+import { ComponentSize } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { LoadingOverlayProps } from '@genfeedai/props/ui/feedback/loading.props';
+import Spinner from '@ui/feedback/spinner/Spinner';
 
 export default function LoadingOverlay({
   message = 'Loading…',
@@ -15,8 +17,13 @@ export default function LoadingOverlay({
         className,
       )}
     >
-      <div className="absolute bg-primary/5 inset-0 backdrop-blur-sm"></div>
-      <span className="relative bg-black/10 w-full text-center text-white px-2 py-1 animate-pulse">
+      <div className="absolute inset-0 bg-background/70 backdrop-blur-sm" />
+      <span className="relative flex items-center gap-3 rounded-md border border-border/60 bg-background/90 px-3 py-2 text-sm text-foreground shadow-lg">
+        <Spinner
+          ariaLabel={message}
+          className="text-white/80"
+          size={ComponentSize.SM}
+        />
         {message}
       </span>
     </div>

--- a/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.test.tsx
+++ b/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import TopbarCreditsBar from '@ui/topbars/credits-bar/TopbarCreditsBar';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetCreditsService,
+  mockGetTopbarBalances,
+  mockLoggerError,
+  mockLoggerWarn,
+  mockRefreshCreditsBreakdown,
+  mockSubscribe,
+  mockUnsubscribe,
+} = vi.hoisted(() => ({
+  mockGetCreditsService: vi.fn(),
+  mockGetTopbarBalances: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockRefreshCreditsBreakdown: vi.fn(),
+  mockSubscribe: vi.fn(),
+  mockUnsubscribe: vi.fn(),
+}));
+
+vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({ organizationId: 'org_1' }),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mockGetCreditsService,
+}));
+
+vi.mock(
+  '@genfeedai/hooks/data/subscription/use-subscription/use-subscription',
+  () => ({
+    useSubscription: () => ({
+      creditsBreakdown: null,
+      refreshCreditsBreakdown: mockRefreshCreditsBreakdown,
+    }),
+  }),
+);
+
+vi.mock('@genfeedai/hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({ orgHref: (path: string) => `/genfeed${path}` }),
+}));
+
+vi.mock('@genfeedai/hooks/utils/use-socket-manager/use-socket-manager', () => ({
+  useSocketManager: () => ({
+    subscribe: mockSubscribe,
+    unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+vi.mock('@genfeedai/services/core/logger.service', () => ({
+  logger: {
+    error: mockLoggerError,
+    warn: mockLoggerWarn,
+  },
+}));
+
+vi.mock('@ui/primitives/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('./CreditsBarTrigger', () => ({
+  default: ({ fullBalance }: { fullBalance: string }) => (
+    <button type="button">Credits {fullBalance}</button>
+  ),
+}));
+
+vi.mock('./CreditsBarPanel', () => ({
+  default: ({ isLoading }: { isLoading: boolean }) => (
+    <div data-loading={String(isLoading)} data-testid="credits-panel" />
+  ),
+}));
+
+describe('TopbarCreditsBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCreditsService.mockResolvedValue({
+      getTopbarBalances: mockGetTopbarBalances,
+    });
+    mockGetTopbarBalances.mockResolvedValue({
+      generatedAt: '2026-06-17T00:00:00.000Z',
+      segments: [
+        {
+          balance: 42,
+          currencyOrUnit: 'credits',
+          label: 'Genfeed',
+          lastSyncedAt: '2026-06-17T00:00:00.000Z',
+          provider: 'genfeed',
+          status: 'available',
+        },
+      ],
+    });
+  });
+
+  it('loads topbar balances without logging an error', async () => {
+    render(<TopbarCreditsBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Credits 42')).toBeInTheDocument();
+    });
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('treats balance timeouts as non-critical topbar warnings', async () => {
+    const timeoutError = new Error('Request timed out') as Error & {
+      isTimeout: boolean;
+    };
+    timeoutError.isTimeout = true;
+    mockGetTopbarBalances.mockRejectedValue(timeoutError);
+
+    render(<TopbarCreditsBar />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('credits-panel')).toHaveAttribute(
+        'data-loading',
+        'false',
+      );
+    });
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'TopbarCreditsBar: failed to fetch balances',
+      {
+        error: timeoutError,
+        reportToSentry: false,
+      },
+    );
+  });
+});

--- a/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.tsx
+++ b/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.tsx
@@ -22,6 +22,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CreditsBarPanel from './CreditsBarPanel';
 import CreditsBarTrigger from './CreditsBarTrigger';
 
+interface OptionalBalanceRequestError {
+  isCancelled?: boolean;
+  silent?: boolean;
+}
+
 export default function TopbarCreditsBar() {
   const { organizationId } = useBrand();
   const { orgHref } = useOrgUrl();
@@ -64,7 +69,13 @@ export default function TopbarCreditsBar() {
       );
       setIsLoading(false);
     } catch (error: unknown) {
-      logger.error('TopbarCreditsBar: failed to fetch balances', error);
+      const requestError = error as OptionalBalanceRequestError;
+      if (!requestError.isCancelled && !requestError.silent) {
+        logger.warn('TopbarCreditsBar: failed to fetch balances', {
+          error,
+          reportToSentry: false,
+        });
+      }
       setIsLoading(false);
     }
   }, [organizationId, getCreditsService]);

--- a/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.tsx
+++ b/packages/ui/src/components/topbars/credits-bar/TopbarCreditsBar.tsx
@@ -48,6 +48,14 @@ export default function TopbarCreditsBar() {
   refreshBreakdownRef.current = refreshCreditsBreakdown;
   const { subscribe, unsubscribe } = useSocketManager();
 
+  const clearTopbarBalanceRefreshTimeout = useCallback(() => {
+    const timeout = balanceRefreshTimeoutRef.current;
+    if (timeout) {
+      clearTimeout(timeout);
+      balanceRefreshTimeoutRef.current = null;
+    }
+  }, []);
+
   const findTopbarBalances = useCallback(async () => {
     if (!organizationId) {
       return setIsLoading(false);
@@ -81,15 +89,13 @@ export default function TopbarCreditsBar() {
   }, [organizationId, getCreditsService]);
 
   const scheduleTopbarBalanceRefresh = useCallback(() => {
-    if (balanceRefreshTimeoutRef.current) {
-      clearTimeout(balanceRefreshTimeoutRef.current);
-    }
+    clearTopbarBalanceRefreshTimeout();
 
     balanceRefreshTimeoutRef.current = setTimeout(() => {
       balanceRefreshTimeoutRef.current = null;
       void findTopbarBalances();
     }, 1500);
-  }, [findTopbarBalances]);
+  }, [clearTopbarBalanceRefreshTimeout, findTopbarBalances]);
 
   useEffect(() => {
     if (organizationId) {
@@ -124,13 +130,10 @@ export default function TopbarCreditsBar() {
     }
   }, [organizationId, subscribe, unsubscribe, scheduleTopbarBalanceRefresh]);
 
-  useEffect(() => {
-    return () => {
-      if (balanceRefreshTimeoutRef.current) {
-        clearTimeout(balanceRefreshTimeoutRef.current);
-      }
-    };
-  }, []);
+  useEffect(
+    () => clearTopbarBalanceRefreshTimeout,
+    [clearTopbarBalanceRefreshTimeout],
+  );
 
   useEffect(() => {
     if (organizationId) {


### PR DESCRIPTION
## Summary

- standardize default and overlay loading states on the shared spinner
- make topbar balance loading optional/non-blocking with a shorter request timeout and no Sentry noise
- stop workspace overview/inbox routes from blocking on the heavy overview bootstrap request
- trim `/auth/bootstrap/overview` to the data that is still used and load run data via split component-level calls only on overview

## Verification

- `bun vitest run --config vitest.config.mts app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.spec.tsx app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/[view]/page.test.tsx app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx`
- `bun vitest run --config vitest.config.ts src/components/loading/default/Loading.test.tsx src/components/loading/fallback/LazyLoadingFallback.test.tsx src/components/loading/overlay/LoadingOverlay.test.tsx src/components/topbars/credits-bar/TopbarCreditsBar.test.tsx`
- `bun vitest run --config vitest.config.ts billing/credits.service.test.ts`
- `bun vitest run --config vitest.config.ts src/auth/services/auth-bootstrap.service.spec.ts src/auth/controllers/auth-bootstrap.controller.spec.ts`
- `bunx biome check --write <touched files>`
- `bun run build` in `packages/ui`
- local API timings: overview 200 ~50ms warm, bootstrap 200 ~16ms, runs 200 ~10ms, runs/active 200 ~6ms, runs/stats 200 ~6ms, topbar balances 200 ~22ms

## Risk

- No database migration or env changes.
