### PR TITLE
fix(api): centralize article status mapping

### DIFF
--- a/apps/server/api/src/collections/articles/services/articles.service.ts
+++ b/apps/server/api/src/collections/articles/services/articles.service.ts
@@ -36,6 +36,7 @@ import { DEFAULT_TEXT_MODEL } from '@api/constants/default-text-model.constant';
 import { TEXT_GENERATION_LIMITS } from '@api/constants/text-generation-limits.constant';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { InsufficientCreditsException } from '@api/helpers/exceptions/business/business-logic.exception';
+import { ArticleFilterUtil } from '@api/helpers/utils/article-filter/article-filter.util';
 import {
   calculateEstimatedTextCredits,
   getMinimumTextCredits,
@@ -58,10 +59,7 @@ import {
   SystemPromptKey,
 } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
-import {
-  type Prisma,
-  ArticleStatus as PrismaArticleStatus,
-} from '@genfeedai/prisma';
+import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
@@ -130,12 +128,6 @@ export class ArticlesService extends BaseService<
 
   private normalizeArticleScope(value: unknown): ArticleScope | undefined {
     return Object.values(ArticleScope).find((scope) => scope === value);
-  }
-
-  private isPublicArticleStatus(value: unknown): boolean {
-    return (
-      value === ArticleStatus.PUBLIC || value === PrismaArticleStatus.PUBLISHED
-    );
   }
 
   /**
@@ -385,12 +377,12 @@ export class ArticlesService extends BaseService<
       throw new Error('Invalid brandId');
     }
 
-    const articleData = {
+    const articleData = ArticleFilterUtil.toArticlePersistenceData({
       ...createArticleDto,
       brandId,
       organizationId,
       userId,
-    };
+    });
 
     const result = await super.create(articleData);
 
@@ -510,7 +502,9 @@ export class ArticlesService extends BaseService<
         throw new Error('Invalid brandId');
       }
 
-      const updateData: Record<string, unknown> = { ...updateArticleDto };
+      const updateData = ArticleFilterUtil.toArticlePersistenceData({
+        ...updateArticleDto,
+      });
 
       // If status is being changed to PUBLISHED, handle publishing logic
       if (updateArticleDto.status === ArticleStatus.PUBLIC) {
@@ -565,7 +559,7 @@ export class ArticlesService extends BaseService<
         ];
 
         // If article is published, also invalidate public cache (PUBLISHED = public)
-        if (this.isPublicArticleStatus(result.status)) {
+        if (ArticleFilterUtil.isPublicArticleStatus(result.status)) {
           tagsToInvalidate.push('public');
         }
 
@@ -726,7 +720,7 @@ export class ArticlesService extends BaseService<
     const where: Record<string, unknown> = {
       isDeleted: false,
       publishedAt: { not: null },
-      status: PrismaArticleStatus.PUBLISHED,
+      ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
     };
 
     if (search) {
@@ -783,7 +777,7 @@ export class ArticlesService extends BaseService<
     // In normal mode, only show published articles (PUBLISHED = public)
     if (!isPreview) {
       where.publishedAt = { not: null };
-      where.status = PrismaArticleStatus.PUBLISHED;
+      Object.assign(where, ArticleFilterUtil.buildPublicArticleStatusFilter());
     }
 
     const article = await this.delegate.findFirst({ where });

--- a/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.spec.ts
@@ -229,7 +229,7 @@ describe('PublicArticlesController', () => {
         expect.objectContaining({
           _id: id,
           isDeleted: false,
-          status: ArticleStatus.PUBLIC,
+          status: 'PUBLISHED',
         }),
       );
       expect(result).toEqual(mockArticle);

--- a/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.ts
+++ b/apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.ts
@@ -2,6 +2,7 @@ import { ArticlesQueryDto } from '@api/collections/articles/dto/articles-query.d
 import { ArticlesService } from '@api/collections/articles/services/articles.service';
 import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { ArticleFilterUtil } from '@api/helpers/utils/article-filter/article-filter.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
 import {
@@ -9,7 +10,6 @@ import {
   serializeCollection,
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
-import { ArticleStatus } from '@genfeedai/enums';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
@@ -63,7 +63,7 @@ export class PublicArticlesController {
     const matchQuery: PrismaWhereQuery = {
       isDeleted: false,
       publishedAt: { not: null },
-      status: ArticleStatus.PUBLIC,
+      ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
     };
 
     // Add search filter
@@ -145,7 +145,7 @@ export class PublicArticlesController {
       _id: articleId,
       isDeleted: false,
       publishedAt: { not: null },
-      status: ArticleStatus.PUBLIC,
+      ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
     });
 
     if (!article) {

--- a/apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.spec.ts
@@ -18,6 +18,7 @@ import type { Request } from 'express';
 
 describe('PublicBrandsController', () => {
   let controller: PublicBrandsController;
+  let articlesService: vi.Mocked<ArticlesService>;
   let brandsService: vi.Mocked<BrandsService>;
 
   const mockBrand = {
@@ -56,6 +57,7 @@ describe('PublicBrandsController', () => {
       .compile();
 
     controller = module.get<PublicBrandsController>(PublicBrandsController);
+    articlesService = module.get(ArticlesService);
     brandsService = module.get(BrandsService);
   });
 
@@ -94,6 +96,27 @@ describe('PublicBrandsController', () => {
     it('should only access public brand data', () => {
       expect(controller).toBeDefined();
       // Public controller should not expose private data
+    });
+  });
+
+  describe('findBrandArticles', () => {
+    it('queries public brand articles with persisted status values', async () => {
+      brandsService.findOne.mockResolvedValue(
+        mockBrand as unknown as BrandEntity,
+      );
+      articlesService.findAll.mockResolvedValue({
+        docs: [],
+        totalDocs: 0,
+      } as never);
+
+      await controller.findBrandArticles('507f191e810c19729de860ee', mockReq);
+
+      expect(articlesService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'PUBLISHED' }),
+        }),
+        expect.any(Object),
+      );
     });
   });
 });

--- a/apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.spec.ts
@@ -113,7 +113,12 @@ describe('PublicBrandsController', () => {
 
       expect(articlesService.findAll).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ status: 'PUBLISHED' }),
+          where: expect.objectContaining({
+            brand: '507f191e810c19729de860ee',
+            isDeleted: false,
+            scope: AssetScope.PUBLIC,
+            status: 'PUBLISHED',
+          }),
         }),
         expect.any(Object),
       );

--- a/apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.ts
+++ b/apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.ts
@@ -5,6 +5,7 @@ import { LinksService } from '@api/collections/links/services/links.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
 import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { ArticleFilterUtil } from '@api/helpers/utils/article-filter/article-filter.util';
 import { BrandFilterUtil } from '@api/helpers/utils/brand-filter/brand-filter.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import {
@@ -12,7 +13,7 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
-import { ArticleStatus, AssetScope, IngredientStatus } from '@genfeedai/enums';
+import { AssetScope, IngredientStatus } from '@genfeedai/enums';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
@@ -372,7 +373,7 @@ export class PublicBrandsController {
         brand: brandId,
         isDeleted: false,
         scope: AssetScope.PUBLIC,
-        status: ArticleStatus.PUBLIC,
+        ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
       },
       orderBy: { createdAt: -1, publishedAt: -1 },
     };

--- a/apps/server/api/src/endpoints/public/services/rss.service.spec.ts
+++ b/apps/server/api/src/endpoints/public/services/rss.service.spec.ts
@@ -94,7 +94,7 @@ describe('RssService', () => {
           where: {
             isDeleted: false,
             scope: ArticleScope.PUBLIC,
-            status: ArticleStatus.PUBLIC,
+            status: 'PUBLISHED',
           },
         }),
         { pagination: false },

--- a/apps/server/api/src/endpoints/public/services/rss.service.ts
+++ b/apps/server/api/src/endpoints/public/services/rss.service.ts
@@ -1,6 +1,7 @@
 import { ArticlesService } from '@api/collections/articles/services/articles.service';
 import { ConfigService } from '@api/config/config.service';
-import { ArticleScope, ArticleStatus } from '@genfeedai/enums';
+import { ArticleFilterUtil } from '@api/helpers/utils/article-filter/article-filter.util';
+import { ArticleScope } from '@genfeedai/enums';
 import { Injectable } from '@nestjs/common';
 import RSS from 'rss';
 
@@ -46,7 +47,7 @@ export class RssService {
         where: {
           isDeleted: false,
           scope: ArticleScope.PUBLIC,
-          status: ArticleStatus.PUBLIC,
+          ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
         },
         orderBy: { createdAt: -1, publishedAt: -1 },
       },
@@ -89,7 +90,7 @@ export class RssService {
         where: {
           isDeleted: false,
           scope: ArticleScope.PUBLIC,
-          status: ArticleStatus.PUBLIC,
+          ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
           user: userId,
         },
         orderBy: { createdAt: -1, publishedAt: -1 },
@@ -134,7 +135,7 @@ export class RssService {
           brand: brandId,
           isDeleted: false,
           scope: ArticleScope.PUBLIC,
-          status: ArticleStatus.PUBLIC,
+          ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
         },
         orderBy: { createdAt: -1, publishedAt: -1 },
       },
@@ -178,7 +179,7 @@ export class RssService {
           isDeleted: false,
           organization: organizationId,
           scope: ArticleScope.PUBLIC,
-          status: ArticleStatus.PUBLIC,
+          ...ArticleFilterUtil.buildPublicArticleStatusFilter(),
         },
         orderBy: { createdAt: -1, publishedAt: -1 },
       },

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
@@ -10,6 +10,13 @@ const ARTICLE_STATUS_GUARD_ROOTS = [
   join(API_SRC_ROOT, 'endpoints/public'),
 ];
 const PRISMA_ARTICLE_STATUS_MEMBERS = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+const FORBIDDEN_STATUS_FILTER_PATTERNS = [
+  /where\s*:\s*{(?:[^{}]|{[^{}]*})*status\s*:\s*ArticleStatus\./gs,
+  /where\.status\s*=\s*ArticleStatus\./g,
+  /data\s*:\s*{(?:[^{}]|{[^{}]*})*status\s*:\s*ArticleStatus\./gs,
+  /status\s*:\s*PrismaArticleStatus\./g,
+  /where\.status\s*=\s*PrismaArticleStatus\./g,
+];
 
 function walkSourceFiles(dir: string): string[] {
   const results: string[] = [];
@@ -23,6 +30,13 @@ function walkSourceFiles(dir: string): string[] {
     }
   }
   return results;
+}
+
+function hasForbiddenStatusFilter(source: string): boolean {
+  return FORBIDDEN_STATUS_FILTER_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(source);
+  });
 }
 
 describe('ArticleFilterUtil', () => {
@@ -228,26 +242,28 @@ describe('ArticleFilterUtil', () => {
       }
     });
 
+    it('detects direct app status filters after nested where/data filters', () => {
+      expect(
+        hasForbiddenStatusFilter(
+          'where: { publishedAt: { not: null }, status: ArticleStatus.PUBLIC }',
+        ),
+      ).toBe(true);
+      expect(
+        hasForbiddenStatusFilter(
+          'data: { metadata: { source: "rss" }, status: ArticleStatus.PUBLIC }',
+        ),
+      ).toBe(true);
+    });
+
     it('does not use app ArticleStatus values directly in Prisma where/data status filters', () => {
-      const forbiddenPatterns = [
-        /where\s*:\s*{[^}]*status\s*:\s*ArticleStatus\./gs,
-        /where\.status\s*=\s*ArticleStatus\./g,
-        /data\s*:\s*{[^}]*status\s*:\s*ArticleStatus\./gs,
-        /status\s*:\s*PrismaArticleStatus\./g,
-        /where\.status\s*=\s*PrismaArticleStatus\./g,
-      ];
       const violations: string[] = [];
 
       for (const filePath of ARTICLE_STATUS_GUARD_ROOTS.flatMap((root) =>
         walkSourceFiles(root),
       )) {
         const source = readFileSync(filePath, 'utf-8');
-        for (const pattern of forbiddenPatterns) {
-          pattern.lastIndex = 0;
-          if (pattern.test(source)) {
-            violations.push(relative(API_SRC_ROOT, filePath));
-            break;
-          }
+        if (hasForbiddenStatusFilter(source)) {
+          violations.push(relative(API_SRC_ROOT, filePath));
         }
       }
 

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts
@@ -1,7 +1,81 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ArticleFilterUtil } from '@api/helpers/utils/article-filter/article-filter.util';
 import { ArticleStatus } from '@genfeedai/enums';
 
+const API_SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const ARTICLE_STATUS_GUARD_ROOTS = [
+  join(API_SRC_ROOT, 'collections/articles'),
+  join(API_SRC_ROOT, 'endpoints/public'),
+];
+const PRISMA_ARTICLE_STATUS_MEMBERS = ['DRAFT', 'PUBLISHED', 'ARCHIVED'];
+
+function walkSourceFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry === 'dist' || entry === 'node_modules') continue;
+    if (statSync(full).isDirectory()) {
+      results.push(...walkSourceFiles(full));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
 describe('ArticleFilterUtil', () => {
+  describe('toPrismaArticleStatus', () => {
+    it('maps app statuses to persisted Prisma status values', () => {
+      expect(ArticleFilterUtil.toPrismaArticleStatus(ArticleStatus.DRAFT)).toBe(
+        'DRAFT',
+      );
+      expect(
+        ArticleFilterUtil.toPrismaArticleStatus(ArticleStatus.PUBLIC),
+      ).toBe('PUBLISHED');
+      expect(
+        ArticleFilterUtil.toPrismaArticleStatus(ArticleStatus.ARCHIVED),
+      ).toBe('ARCHIVED');
+    });
+
+    it('passes already-persisted Prisma status values through', () => {
+      expect(ArticleFilterUtil.toPrismaArticleStatus('PUBLISHED')).toBe(
+        'PUBLISHED',
+      );
+    });
+
+    it('does not map transient generation statuses to Article.status', () => {
+      expect(
+        ArticleFilterUtil.toPrismaArticleStatus(ArticleStatus.PROCESSING),
+      ).toBeUndefined();
+      expect(
+        ArticleFilterUtil.toPrismaArticleStatus(ArticleStatus.FAILED),
+      ).toBeUndefined();
+    });
+
+    it('rejects transient statuses for persisted write data', () => {
+      expect(() =>
+        ArticleFilterUtil.toPersistedArticleStatus(ArticleStatus.PROCESSING),
+      ).toThrow('cannot be persisted to Article.status');
+    });
+
+    it('maps write data through the same boundary', () => {
+      expect(
+        ArticleFilterUtil.toArticlePersistenceData({
+          label: 'Launch',
+          status: ArticleStatus.PUBLIC,
+        }),
+      ).toEqual({ label: 'Launch', status: 'PUBLISHED' });
+    });
+
+    it('builds the canonical public persisted status filter', () => {
+      expect(ArticleFilterUtil.buildPublicArticleStatusFilter()).toEqual({
+        status: 'PUBLISHED',
+      });
+    });
+  });
+
   describe('buildArticleStatusFilter', () => {
     it('maps draft to Prisma DRAFT', () => {
       const filter = ArticleFilterUtil.buildArticleStatusFilter(
@@ -135,6 +209,49 @@ describe('ArticleFilterUtil', () => {
         { isDeleted: false },
       );
       expect((query.where as Record<string, unknown>).status).toBeUndefined();
+    });
+  });
+
+  describe('guard — ArticleStatus persistence boundary', () => {
+    it('keeps every persisted app status mapped to a valid Prisma ArticleStatus member', () => {
+      const prismaStatusSet = new Set(PRISMA_ARTICLE_STATUS_MEMBERS);
+      for (const status of [
+        ArticleStatus.DRAFT,
+        ArticleStatus.PUBLIC,
+        ArticleStatus.ARCHIVED,
+      ]) {
+        const prismaStatus = ArticleFilterUtil.toPersistedArticleStatus(status);
+        expect(
+          prismaStatusSet.has(prismaStatus),
+          `${status} mapped to ${prismaStatus}, which is not a Prisma ArticleStatus member`,
+        ).toBe(true);
+      }
+    });
+
+    it('does not use app ArticleStatus values directly in Prisma where/data status filters', () => {
+      const forbiddenPatterns = [
+        /where\s*:\s*{[^}]*status\s*:\s*ArticleStatus\./gs,
+        /where\.status\s*=\s*ArticleStatus\./g,
+        /data\s*:\s*{[^}]*status\s*:\s*ArticleStatus\./gs,
+        /status\s*:\s*PrismaArticleStatus\./g,
+        /where\.status\s*=\s*PrismaArticleStatus\./g,
+      ];
+      const violations: string[] = [];
+
+      for (const filePath of ARTICLE_STATUS_GUARD_ROOTS.flatMap((root) =>
+        walkSourceFiles(root),
+      )) {
+        const source = readFileSync(filePath, 'utf-8');
+        for (const pattern of forbiddenPatterns) {
+          pattern.lastIndex = 0;
+          if (pattern.test(source)) {
+            violations.push(relative(API_SRC_ROOT, filePath));
+            break;
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
     });
   });
 });

--- a/apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts
@@ -1,26 +1,98 @@
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ArticleStatus } from '@genfeedai/enums';
+import { BadRequestException } from '@nestjs/common';
 
 /**
  * Maps app-level ArticleStatus values (lowercase) to Prisma enum values (uppercase).
- * processing and failed have no Prisma equivalent and are excluded from the filter.
+ * processing and failed are generation-pipeline states; they never persist to
+ * Article.status and are excluded from persisted filters.
  */
-const APP_TO_PRISMA_STATUS: Partial<Record<ArticleStatus, string>> = {
+export type PrismaArticleStatusValue = 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
+
+const APP_TO_PRISMA_STATUS: Partial<
+  Record<ArticleStatus, PrismaArticleStatusValue>
+> = {
   [ArticleStatus.DRAFT]: 'DRAFT',
   [ArticleStatus.PUBLIC]: 'PUBLISHED',
   [ArticleStatus.ARCHIVED]: 'ARCHIVED',
 };
 
+const PRISMA_ARTICLE_STATUS_VALUES = new Set<string>(
+  Object.values(APP_TO_PRISMA_STATUS),
+);
+
 export class ArticleFilterUtil {
+  static toPrismaArticleStatus(
+    status?: ArticleStatus | PrismaArticleStatusValue | string,
+  ): PrismaArticleStatusValue | undefined {
+    if (status === undefined || status === '') {
+      return undefined;
+    }
+
+    const mapped = APP_TO_PRISMA_STATUS[status as ArticleStatus];
+    if (mapped !== undefined) {
+      return mapped;
+    }
+
+    if (PRISMA_ARTICLE_STATUS_VALUES.has(status)) {
+      return status as PrismaArticleStatusValue;
+    }
+
+    return undefined;
+  }
+
+  static toPersistedArticleStatus(
+    status: ArticleStatus | PrismaArticleStatusValue | string,
+  ): PrismaArticleStatusValue {
+    const mapped = ArticleFilterUtil.toPrismaArticleStatus(status);
+    if (mapped !== undefined) {
+      return mapped;
+    }
+
+    throw new BadRequestException(
+      `ArticleStatus "${status}" cannot be persisted to Article.status`,
+    );
+  }
+
+  static buildPublicArticleStatusFilter(): {
+    status: PrismaArticleStatusValue;
+  } {
+    return {
+      status: ArticleFilterUtil.toPersistedArticleStatus(ArticleStatus.PUBLIC),
+    };
+  }
+
+  static isPublicArticleStatus(status: unknown): boolean {
+    return (
+      ArticleFilterUtil.toPrismaArticleStatus(String(status)) === 'PUBLISHED'
+    );
+  }
+
+  static toArticlePersistenceData<T extends Record<string, unknown>>(
+    data: T,
+  ): T {
+    if (data.status === undefined) {
+      return data;
+    }
+
+    return {
+      ...data,
+      status: ArticleFilterUtil.toPersistedArticleStatus(String(data.status)),
+    };
+  }
+
   static buildArticleStatusFilter(
-    status?: ArticleStatus | ArticleStatus[],
+    status?:
+      | ArticleStatus
+      | PrismaArticleStatusValue
+      | Array<ArticleStatus | PrismaArticleStatusValue>,
   ): Record<string, unknown> {
     if (!status) return {};
 
     const statuses = Array.isArray(status) ? status : [status];
     const mapped = statuses
-      .map((s) => APP_TO_PRISMA_STATUS[s])
-      .filter((s): s is string => s !== undefined);
+      .map((s) => ArticleFilterUtil.toPrismaArticleStatus(s))
+      .filter((s): s is PrismaArticleStatusValue => s !== undefined);
 
     if (mapped.length === 0) return {};
     if (mapped.length === 1) {


### PR DESCRIPTION
## Summary
- Adds an explicit `ArticleFilterUtil` app-to-Prisma `ArticleStatus` boundary for persisted article status values.
- Routes article create/update data and public article/RSS/brand status filters through that boundary instead of direct Prisma enum or app enum filter values.
- Adds focused behavior tests plus a static guard test for article/public source paths so app-level `ArticleStatus` values do not reach Prisma `where.status` / `data.status` filters.

Closes #560

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `npx biome check --write -- apps/server/api/src/helpers/utils/article-filter/article-filter.util.ts apps/server/api/src/helpers/utils/article-filter/article-filter.util.spec.ts apps/server/api/src/collections/articles/services/articles.service.ts apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.ts apps/server/api/src/endpoints/public/controllers/articles/public.articles.controller.spec.ts apps/server/api/src/endpoints/public/services/rss.service.ts apps/server/api/src/endpoints/public/services/rss.service.spec.ts apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.ts apps/server/api/src/endpoints/public/controllers/brands/public.brands.controller.spec.ts`
- `bun run test:file src/helpers/utils/article-filter/article-filter.util.spec.ts src/endpoints/public/controllers/articles/public.articles.controller.spec.ts src/endpoints/public/services/rss.service.spec.ts src/endpoints/public/controllers/brands/public.brands.controller.spec.ts` — 4 files, 42 tests passed
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- Staged sensitive filename/diff-pattern scan — no findings
- `timeout 60s bun scripts/run-secretlint.ts --no-glob $(git diff --cached --name-only)`
- Commit hook: `secretlint`, staged Biome, and `scripts/lint-no-raw-html.sh` passed

## Risk
- No migrations or environment changes.
- Behavior change is limited to article status persistence/filter construction: app `public` now maps explicitly to persisted `PUBLISHED`; transient `processing`/`failed` are rejected for persisted write data and omitted from filters.