### PR TITLE
fix(infra): address ECS review follow-ups

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -91,18 +91,26 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: tofu init -input=false
 
+      - name: Register migration task definition
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          tofu apply -input=false -auto-approve \
+            -target=aws_cloudwatch_log_group.migrate \
+            -target=aws_ecs_task_definition.migrate \
+            -var="image_tag=${{ steps.tag.outputs.sha }}"
+
       - name: Run DB migrations (one-off task, gated before services roll)
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
           CLUSTER=$(tofu output -raw cluster_name)
-          FAMILY=$(tofu output -raw migrate_task_family)
+          TASK_DEFINITION=$(tofu output -raw migrate_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
           SG=$(tofu output -raw task_security_group)
-          echo "Running migrate task on $CLUSTER ($FAMILY)..."
+          echo "Running migrate task on $CLUSTER ($TASK_DEFINITION)..."
           # FARGATE — the cluster is Fargate-only (no EC2 capacity); assignPublicIp
           # DISABLED since tasks egress via NAT from the private subnets.
-          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$FAMILY" \
+          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEFINITION" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
             --query 'tasks[0].taskArn' --output text)

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -10,4 +10,3 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
-.terraform.lock.hcl

--- a/infra/terraform/bootstrap/.terraform.lock.hcl
+++ b/infra/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:7/GgVlN+KplSVCuc8qb4ct2R7gotYooPNRd0cnj9GxE=",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:C6eM6fGJVktK2M5vH3Yhv5NnqmegcBDY0EuDHhiXoVY=",
+    "h1:C7yD4Be2zhVdjnilsKPfucYAYMG5UCJYuUSoY6FCtGQ=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:JJ+EJQ+sIN3XRmNmrSUnUQtR8i3P22z+AbtAf8O/cRE=",
+    "h1:Wm5Ofhc15lX1OMMCt7iDV0NY5FDIouQDjX7I1iab55s=",
+    "h1:crKvBCgX6RlMcE6Ewm8o8YVuIg6mkXqKNgt/kSFYTvQ=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -44,16 +44,21 @@ variable "github_repo" {
   default     = "genfeedai/genfeed.ai"
 }
 
-variable "state_bucket_name" {
-  type    = string
-  default = "genfeed-tfstate"
+variable "github_environment" {
+  type        = string
+  description = "GitHub Environment allowed to assume the deploy role"
+  default     = "production"
+}
+
+locals {
+  state_bucket_name = "genfeed-tfstate"
 }
 
 data "aws_caller_identity" "current" {}
 
 # ── Remote state bucket (S3-native locking, no DynamoDB) ──────────────
 resource "aws_s3_bucket" "state" {
-  bucket = var.state_bucket_name
+  bucket = local.state_bucket_name
 }
 
 resource "aws_s3_bucket_versioning" "state" {
@@ -115,12 +120,12 @@ data "aws_iam_policy_document" "gha_trust" {
       variable = "token.actions.githubusercontent.com:aud"
       values   = ["sts.amazonaws.com"]
     }
-    # Restrict to this repo (any branch/PR — tighten to :ref:refs/heads/master
-    # for the deploy role if you want master-only).
+    # Restrict to the repo's protected GitHub Environment instead of every
+    # branch/PR subject in the repository.
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_repo}:*"]
+      values   = ["repo:${var.github_repo}:environment:${var.github_environment}"]
     }
   }
 }
@@ -170,6 +175,11 @@ data "aws_iam_policy_document" "gha_deploy" {
     effect    = "Allow"
     actions   = ["iam:PassRole"]
     resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/genfeed-*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com", "ec2.amazonaws.com"]
+    }
   }
   statement {
     sid    = "TerraformManage"
@@ -184,6 +194,27 @@ data "aws_iam_policy_document" "gha_deploy" {
       "ssm:GetParameter", "ssm:DescribeParameters", "route53:*",
     ]
     resources = ["*"]
+  }
+  statement {
+    sid    = "ManageGenfeedIam"
+    effect = "Allow"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+      "iam:PutRolePolicy",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRole",
+    ]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/genfeed-*"]
   }
   statement {
     sid       = "StateBucket"

--- a/infra/terraform/genfeed-prod/.terraform.lock.hcl
+++ b/infra/terraform/genfeed-prod/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:7/GgVlN+KplSVCuc8qb4ct2R7gotYooPNRd0cnj9GxE=",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:C6eM6fGJVktK2M5vH3Yhv5NnqmegcBDY0EuDHhiXoVY=",
+    "h1:C7yD4Be2zhVdjnilsKPfucYAYMG5UCJYuUSoY6FCtGQ=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:JJ+EJQ+sIN3XRmNmrSUnUQtR8i3P22z+AbtAf8O/cRE=",
+    "h1:Wm5Ofhc15lX1OMMCt7iDV0NY5FDIouQDjX7I1iab55s=",
+    "h1:crKvBCgX6RlMcE6Ewm8o8YVuIg6mkXqKNgt/kSFYTvQ=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/terraform/genfeed-prod/alb.tf
+++ b/infra/terraform/genfeed-prod/alb.tf
@@ -27,11 +27,12 @@ resource "aws_acm_certificate_validation" "api" {
 
 # ── ALB ──────────────────────────────────────────────────────────────
 resource "aws_lb" "main" {
-  name               = "${local.name_prefix}-alb"
-  load_balancer_type = "application"
-  internal           = false
-  security_groups    = [aws_security_group.alb.id]
-  subnets            = local.public_subnet_ids
+  name                       = "${local.name_prefix}-alb"
+  load_balancer_type         = "application"
+  internal                   = false
+  drop_invalid_header_fields = true
+  security_groups            = [aws_security_group.alb.id]
+  subnets                    = local.public_subnet_ids
 }
 
 # api target group — bridge mode static host port 3010 => instance targets.

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -28,6 +28,10 @@ output "migrate_task_family" {
   value = aws_ecs_task_definition.migrate.family
 }
 
+output "migrate_task_definition_arn" {
+  value = aws_ecs_task_definition.migrate.arn
+}
+
 # Network config for `aws ecs run-task` (migrate) in CI — private subnets (NAT egress).
 output "task_subnets" {
   value = local.private_subnet_ids

--- a/infra/terraform/genfeed-prod/providers.tf
+++ b/infra/terraform/genfeed-prod/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.10"
 
   # S3-native state locking (use_lockfile) — no DynamoDB. Bucket created by the
-  # bootstrap stack. `terraform init` this stack after bootstrap has applied.
+  # bootstrap stack and intentionally hard-coded there too.
   backend "s3" {
     bucket       = "genfeed-tfstate"
     key          = "genfeed-prod/terraform.tfstate"

--- a/infra/terraform/genfeed-prod/security.tf
+++ b/infra/terraform/genfeed-prod/security.tf
@@ -83,11 +83,13 @@ resource "aws_security_group" "cache" {
 
 # ── Let ECS tasks reach the existing RDS ─────────────────────────────
 resource "aws_security_group_rule" "rds_from_ecs" {
+  for_each = toset(data.aws_db_instance.genfeed.vpc_security_groups)
+
   type                     = "ingress"
   description              = "genfeed ECS tasks to RDS"
   from_port                = 5432
   to_port                  = 5432
   protocol                 = "tcp"
-  security_group_id        = tolist(data.aws_db_instance.genfeed.vpc_security_groups)[0]
+  security_group_id        = each.value
   source_security_group_id = aws_security_group.ecs.id
 }

--- a/infra/terraform/modules/service/main.tf
+++ b/infra/terraform/modules/service/main.tf
@@ -85,9 +85,9 @@ resource "aws_ecs_service" "this" {
   }
 
   network_configuration {
-    subnets          = var.subnets          # private subnets (NAT egress)
+    subnets          = var.subnets # private subnets (NAT egress)
     security_groups  = var.security_group_ids
-    assign_public_ip = false                # Fargate in private subnets; egress via NAT
+    assign_public_ip = false # Fargate in private subnets; egress via NAT
   }
 
   service_registries {


### PR DESCRIPTION
## Summary
- Register the migration task definition with the selected image before running migrations, then run the exact task definition ARN.
- Commit OpenTofu provider lock files and remove the bootstrap state-bucket override path that could drift from the production backend.
- Tighten the deploy role boundary with GitHub Environment OIDC, `iam:PassedToService`, and scoped genfeed IAM management verbs.
- Enable ALB invalid-header dropping and add RDS ingress rules for every SG attached to the existing DB.

## Deferred Review Follow-ups
- #633 tracks the broader deploy-role wildcard IAM scope reduction.
- #635 tracks Redis transit encryption/auth hardening.
- #636 tracks the single-NAT production availability tradeoff.
- #637 tracks AbortSignal propagation through client services.
- #638 tracks the WorkspaceSwitcher React Doctor reducer refactor.

## Verification
- `tofu fmt -check -recursive` in `infra/terraform`
- `tofu validate -no-color` in `infra/terraform/bootstrap`
- `tofu validate -no-color` in `infra/terraform/genfeed-prod`
- `actionlint .github/workflows/deploy-ecs.yml`
- `git diff --check`
- `gitleaks protect --staged --redact --no-banner`
