### PR TITLE
perf(api): index post analytics SQL paths

### DIFF
--- a/apps/server/api/src/collections/posts/services/posts.service.ts
+++ b/apps/server/api/src/collections/posts/services/posts.service.ts
@@ -499,35 +499,40 @@ export class PostsService extends BaseService<
     populate: PopulateOption[] = [],
     maxDepth: number = 100,
   ): Promise<PostDocument | null> {
+    const requestedMaxDepth = Number.isFinite(maxDepth)
+      ? Math.trunc(maxDepth)
+      : 100;
+    const safeMaxDepth = Math.min(Math.max(requestedMaxDepth, 1), 500);
     const ancestors = await this.prisma.$queryRaw<
-      Array<{ id: string; parentId: string | null }>
+      Array<{ depth: number; id: string; parentId: string | null }>
     >`
       WITH RECURSIVE ancestors AS (
-        SELECT id, "parentId"
+        SELECT id, "parentId", 1 AS depth
         FROM "posts"
         WHERE id = ${postId} AND "isDeleted" = false
         UNION ALL
-        SELECT p.id, p."parentId"
+        SELECT p.id, p."parentId", a.depth + 1
         FROM "posts" p
         INNER JOIN ancestors a ON p.id = a."parentId"
-        WHERE p."isDeleted" = false
+        WHERE p."isDeleted" = false AND a.depth <= ${safeMaxDepth}
       )
-      SELECT id, "parentId" FROM ancestors
-      LIMIT ${maxDepth + 1}
+      SELECT id, "parentId", depth FROM ancestors
+      ORDER BY depth ASC
+      LIMIT ${safeMaxDepth + 1}
     `;
 
     if (!ancestors || ancestors.length === 0) {
       return null;
     }
 
-    if (ancestors.length > maxDepth) {
+    if (ancestors.length > safeMaxDepth) {
       this.logger.error('Max depth exceeded in findRootPost', {
         depth: ancestors.length,
-        maxDepth,
+        maxDepth: safeMaxDepth,
         postId,
       });
       throw new BadRequestException(
-        `Max hierarchy depth (${maxDepth}) exceeded for post ${postId}`,
+        `Max hierarchy depth (${safeMaxDepth}) exceeded for post ${postId}`,
       );
     }
 

--- a/apps/server/api/src/endpoints/analytics/analytics.service.spec.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.service.spec.ts
@@ -1,9 +1,48 @@
 vi.mock('@genfeedai/prisma', () => ({
   Prisma: {
-    raw: (sql: string) => sql,
+    empty: { sql: '', values: [] },
+    raw: (sql: string) => ({ sql, values: [] }),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const parts: string[] = [];
+      const parameters: unknown[] = [];
+
+      strings.forEach((part, index) => {
+        parts.push(part);
+        if (index >= values.length) {
+          return;
+        }
+
+        const value = values[index];
+        if (isSqlFragment(value)) {
+          parts.push(value.sql);
+          parameters.push(...value.values);
+          return;
+        }
+
+        parts.push('?');
+        parameters.push(value);
+      });
+
+      return { sql: parts.join(''), values: parameters };
+    },
   },
   PrismaClient: class {},
 }));
+
+interface SqlFragmentMock {
+  sql: string;
+  values: unknown[];
+}
+
+function isSqlFragment(value: unknown): value is SqlFragmentMock {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'sql' in value &&
+    'values' in value &&
+    Array.isArray((value as { values: unknown }).values)
+  );
+}
 
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
@@ -25,6 +64,41 @@ describe('AnalyticsService', () => {
   const typed = <T>(value: unknown): T => value as T;
 
   let service: AnalyticsService;
+
+  interface CapturedSqlQuery {
+    sql: string;
+    values: unknown[];
+  }
+
+  const captureSqlQuery = (
+    strings: TemplateStringsArray,
+    values: unknown[],
+  ): CapturedSqlQuery => {
+    const parts: string[] = [];
+    const parameters: unknown[] = [];
+
+    strings.forEach((part, index) => {
+      parts.push(part);
+      if (index >= values.length) {
+        return;
+      }
+
+      const value = values[index];
+      if (isSqlFragment(value)) {
+        parts.push(value.sql);
+        parameters.push(...value.values);
+        return;
+      }
+
+      parts.push('?');
+      parameters.push(value);
+    });
+
+    return {
+      sql: parts.join('').replace(/\s+/g, ' ').trim(),
+      values: parameters,
+    };
+  };
 
   // Mock services
   const mockPostsService = {
@@ -90,6 +164,21 @@ describe('AnalyticsService', () => {
     organization: {
       count: vi.fn(),
     },
+  };
+
+  const captureQueryRawCalls = (
+    resultsByCall: unknown[][] = [],
+  ): CapturedSqlQuery[] => {
+    const capturedQueries: CapturedSqlQuery[] = [];
+
+    mockPrismaService.$queryRaw.mockImplementation(
+      (strings: TemplateStringsArray, ...values: unknown[]) => {
+        capturedQueries.push(captureSqlQuery(strings, values));
+        return Promise.resolve(resultsByCall[capturedQueries.length - 1] ?? []);
+      },
+    );
+
+    return capturedQueries;
   };
 
   beforeEach(async () => {
@@ -721,6 +810,23 @@ describe('AnalyticsService', () => {
       expect((result[0].youtube as Record<string, number>).views).toBe(0);
       expect((result[0].tiktok as Record<string, number>).likes).toBe(0);
     });
+
+    it('should parameterize organization and date filters', async () => {
+      const capturedQueries = captureQueryRawCalls();
+      const organizationId = "org-filter-'1";
+
+      await service.getTimeSeriesData(
+        '2025-01-01',
+        '2025-01-31',
+        organizationId,
+      );
+
+      expect(capturedQueries[0].sql).toContain('"date" >= ?');
+      expect(capturedQueries[0].sql).toContain('"date" <= ?');
+      expect(capturedQueries[0].sql).toContain('AND "organizationId" = ?');
+      expect(capturedQueries[0].sql).not.toContain(organizationId);
+      expect(capturedQueries[0].values).toContain(organizationId);
+    });
   });
 
   // ==========================================================================
@@ -791,6 +897,29 @@ describe('AnalyticsService', () => {
           where: expect.objectContaining({ id: orgId }),
         }),
       );
+    });
+
+    it('should parameterize brand and organization filters in overview SQL', async () => {
+      const capturedQueries = captureQueryRawCalls();
+      const brandId = "brand-filter-'1";
+      const organizationId = "org-filter-'1";
+
+      await service.getOverview(
+        '2025-01-01',
+        '2025-01-31',
+        brandId,
+        organizationId,
+      );
+
+      expect(capturedQueries).toHaveLength(2);
+      for (const query of capturedQueries) {
+        expect(query.sql).toContain('AND "brandId" = ?');
+        expect(query.sql).toContain('AND "organizationId" = ?');
+        expect(query.sql).not.toContain(brandId);
+        expect(query.sql).not.toContain(organizationId);
+        expect(query.values).toContain(brandId);
+        expect(query.values).toContain(organizationId);
+      }
     });
   });
 
@@ -886,6 +1015,36 @@ describe('AnalyticsService', () => {
       await service.getTopContent(undefined, undefined, 200);
 
       expect(mockPrismaService.$queryRaw).toHaveBeenCalled();
+    });
+
+    it('should parameterize brand, platform, organization, and date filters', async () => {
+      const capturedQueries = captureQueryRawCalls();
+      const brandId = "brand-filter-'1";
+      const organizationId = "org-filter-'1";
+
+      await service.getTopContent(
+        '2025-01-01',
+        '2025-01-31',
+        10,
+        AnalyticsMetric.ENGAGEMENT,
+        brandId,
+        CredentialPlatform.YOUTUBE,
+        organizationId,
+      );
+
+      expect(capturedQueries[0].sql).toContain('pa."date" >= ?');
+      expect(capturedQueries[0].sql).toContain('pa."date" <= ?');
+      expect(capturedQueries[0].sql).toContain('AND pa."brandId" = ?');
+      expect(capturedQueries[0].sql).toContain('AND pa."platform"::text = ?');
+      expect(capturedQueries[0].sql).toContain('AND pa."organizationId" = ?');
+      expect(capturedQueries[0].sql).toContain(
+        'ORDER BY (pa."totalLikes" + pa."totalComments" + pa."totalShares" + pa."totalSaves") DESC',
+      );
+      expect(capturedQueries[0].sql).not.toContain(brandId);
+      expect(capturedQueries[0].sql).not.toContain(organizationId);
+      expect(capturedQueries[0].values).toContain(brandId);
+      expect(capturedQueries[0].values).toContain(CredentialPlatform.YOUTUBE);
+      expect(capturedQueries[0].values).toContain(organizationId);
     });
   });
 
@@ -1078,7 +1237,7 @@ describe('AnalyticsService', () => {
     });
 
     it('should call $queryRaw when filtering by brand and platform', async () => {
-      mockPrismaService.$queryRaw.mockResolvedValue([]);
+      const capturedQueries = captureQueryRawCalls();
 
       const brandId = 'brand-filter-1';
       await service.getEngagementBreakdown(
@@ -1089,6 +1248,10 @@ describe('AnalyticsService', () => {
       );
 
       expect(mockPrismaService.$queryRaw).toHaveBeenCalled();
+      expect(capturedQueries[0].sql).toContain('AND "brandId" = ?');
+      expect(capturedQueries[0].sql).toContain('AND "platform"::text = ?');
+      expect(capturedQueries[0].values).toContain(brandId);
+      expect(capturedQueries[0].values).toContain(CredentialPlatform.YOUTUBE);
     });
   });
 

--- a/apps/server/api/src/endpoints/analytics/analytics.service.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.service.ts
@@ -35,6 +35,9 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 import * as ExcelJS from 'exceljs';
 
+type PrismaSql = ReturnType<typeof Prisma.sql>;
+type PostAnalyticsTextColumn = 'brandId' | 'organizationId';
+
 interface ExportPostData {
   id: string;
   label: string;
@@ -227,6 +230,55 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     return DateRangeUtil.parseDateRange(startDateStr, endDateStr);
   }
 
+  private postAnalyticsTextColumn(
+    column: PostAnalyticsTextColumn,
+    alias?: 'pa',
+  ): PrismaSql {
+    const prefix = alias ? `${alias}.` : '';
+    return Prisma.raw(`${prefix}"${column}"`);
+  }
+
+  private postAnalyticsOptionalTextFilter(
+    column: PostAnalyticsTextColumn,
+    value?: string,
+    alias?: 'pa',
+  ): PrismaSql {
+    if (!value) {
+      return Prisma.empty;
+    }
+
+    return Prisma.sql`AND ${this.postAnalyticsTextColumn(column, alias)} = ${value}`;
+  }
+
+  private postAnalyticsOptionalPlatformFilter(
+    platform?: CredentialPlatform,
+    alias?: 'pa',
+  ): PrismaSql {
+    if (!platform) {
+      return Prisma.empty;
+    }
+
+    return Prisma.sql`AND ${Prisma.raw(`${alias ? `${alias}.` : ''}"platform"`)}::text = ${String(platform)}`;
+  }
+
+  private postAnalyticsTopContentSortExpression(
+    metric:
+      | AnalyticsMetric.VIEWS
+      | AnalyticsMetric.ENGAGEMENT
+      | AnalyticsMetric.LIKES,
+  ): PrismaSql {
+    switch (metric) {
+      case AnalyticsMetric.ENGAGEMENT:
+        return Prisma.raw(
+          '(pa."totalLikes" + pa."totalComments" + pa."totalShares" + pa."totalSaves") DESC',
+        );
+      case AnalyticsMetric.LIKES:
+        return Prisma.raw('pa."totalLikes" DESC');
+      default:
+        return Prisma.raw('pa."totalViews" DESC');
+    }
+  }
+
   /**
    * Calculate growth percentage between current and previous values
    */
@@ -252,13 +304,12 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       return new Map();
     }
 
-    const column =
-      entityField === 'organizationId' ? '"organizationId"' : '"brandId"';
+    const column = this.postAnalyticsTextColumn(entityField);
 
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
     const results: any[] = await this.prisma.$queryRaw`
       SELECT
-        ${Prisma.raw(column)} AS entity_id,
+        ${column} AS entity_id,
         AVG("engagementRate") AS avg_engagement_rate,
         SUM("totalViews") AS total_views,
         SUM("totalLikes") AS total_likes,
@@ -266,12 +317,12 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
         SUM("totalShares") AS total_shares,
         SUM("totalSaves") AS total_saves,
         COUNT(DISTINCT "postId") AS unique_posts
-        ${includePlatforms ? Prisma.raw(`, ARRAY_AGG(DISTINCT "platform"::text) AS platforms`) : Prisma.raw('')}
+        ${includePlatforms ? Prisma.sql`, ARRAY_AGG(DISTINCT "platform"::text) AS platforms` : Prisma.empty}
       FROM "post_analytics"
-      WHERE ${Prisma.raw(column)} = ANY(${entityIds}::text[])
+      WHERE ${column} = ANY(${entityIds}::text[])
         AND "date" >= ${startDate}
         AND "date" <= ${endDate}
-      GROUP BY ${Prisma.raw(column)}
+      GROUP BY ${column}
     `;
 
     const analyticsMap = new Map<string, IEntityAnalyticsStats>();
@@ -308,19 +359,18 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       return new Map();
     }
 
-    const column =
-      entityField === 'organizationId' ? '"organizationId"' : '"brandId"';
+    const column = this.postAnalyticsTextColumn(entityField);
 
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
     const results: any[] = await this.prisma.$queryRaw`
       SELECT
-        ${Prisma.raw(column)} AS entity_id,
+        ${column} AS entity_id,
         SUM("totalLikes" + "totalComments" + "totalShares" + "totalSaves") AS total_engagement
       FROM "post_analytics"
-      WHERE ${Prisma.raw(column)} = ANY(${entityIds}::text[])
+      WHERE ${column} = ANY(${entityIds}::text[])
         AND "date" >= ${startDate}
         AND "date" <= ${endDate}
-      GROUP BY ${Prisma.raw(column)}
+      GROUP BY ${column}
     `;
 
     const engagementMap = new Map<string, number>();
@@ -944,7 +994,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       FROM "post_analytics"
       WHERE "date" >= ${start}
         AND "date" <= ${end}
-        ${organizationId ? Prisma.raw(`AND "organizationId" = '${organizationId.replace(/'/g, "''")}'`) : Prisma.raw('')}
+        ${this.postAnalyticsOptionalTextFilter('organizationId', organizationId)}
       GROUP BY TO_CHAR("date", 'YYYY-MM-DD'), "platform"
       ORDER BY day ASC
     `;
@@ -1053,14 +1103,14 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       this.parseDateRange(startDateStr, endDateStr);
 
     // Build conditional WHERE fragments
-    const brandFilter = brandId
-      ? Prisma.raw(`AND "brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
-    const orgFilter = organizationId
-      ? Prisma.raw(
-          `AND "organizationId" = '${organizationId.replace(/'/g, "''")}'`,
-        )
-      : Prisma.raw('');
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+    );
+    const orgFilter = this.postAnalyticsOptionalTextFilter(
+      'organizationId',
+      organizationId,
+    );
 
     // Current period metrics
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
@@ -1169,14 +1219,14 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       endDateStr,
     );
 
-    const brandFilter = brandId
-      ? Prisma.raw(`AND "brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
-    const orgFilter = organizationId
-      ? Prisma.raw(
-          `AND "organizationId" = '${organizationId.replace(/'/g, "''")}'`,
-        )
-      : Prisma.raw('');
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+    );
+    const orgFilter = this.postAnalyticsOptionalTextFilter(
+      'organizationId',
+      organizationId,
+    );
 
     // Group by platform and hour, pick the best hour per platform
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
@@ -1241,33 +1291,21 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       endDateStr,
     );
 
-    // Determine sort field based on metric
-    let sortExpr: string;
-    switch (metric) {
-      case AnalyticsMetric.ENGAGEMENT:
-        sortExpr =
-          '(pa."totalLikes" + pa."totalComments" + pa."totalShares" + pa."totalSaves") DESC';
-        break;
-      case AnalyticsMetric.LIKES:
-        sortExpr = 'pa."totalLikes" DESC';
-        break;
-      default:
-        sortExpr = 'pa."totalViews" DESC';
-    }
-
-    const brandFilter = brandId
-      ? Prisma.raw(`AND pa."brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
-    const platformFilter = platform
-      ? Prisma.raw(
-          `AND pa."platform"::text = '${String(platform).replace(/'/g, "''")}'`,
-        )
-      : Prisma.raw('');
-    const orgFilter = organizationId
-      ? Prisma.raw(
-          `AND pa."organizationId" = '${organizationId.replace(/'/g, "''")}'`,
-        )
-      : Prisma.raw('');
+    const sortExpr = this.postAnalyticsTopContentSortExpression(metric);
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+      'pa',
+    );
+    const platformFilter = this.postAnalyticsOptionalPlatformFilter(
+      platform,
+      'pa',
+    );
+    const orgFilter = this.postAnalyticsOptionalTextFilter(
+      'organizationId',
+      organizationId,
+      'pa',
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
     const results: any[] = await this.prisma.$queryRaw`
@@ -1295,7 +1333,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
         ${brandFilter}
         ${platformFilter}
         ${orgFilter}
-      ORDER BY ${Prisma.raw(sortExpr)}
+      ORDER BY ${sortExpr}
       LIMIT ${safeLimit}
     `;
 
@@ -1335,9 +1373,10 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       endDateStr,
     );
 
-    const brandFilter = brandId
-      ? Prisma.raw(`AND "brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+    );
 
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
     const results: any[] = await this.prisma.$queryRaw`
@@ -1408,9 +1447,10 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     const { startDate, endDate, previousStartDate, previousEndDate } =
       this.parseDateRange(startDateStr, endDateStr);
 
-    const brandFilter = brandId
-      ? Prisma.raw(`AND "brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+    );
 
     // Current period: group by day
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
@@ -1516,14 +1556,11 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       endDateStr,
     );
 
-    const brandFilter = brandId
-      ? Prisma.raw(`AND "brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
-    const platformFilter = platform
-      ? Prisma.raw(
-          `AND "platform"::text = '${String(platform).replace(/'/g, "''")}'`,
-        )
-      : Prisma.raw('');
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+    );
+    const platformFilter = this.postAnalyticsOptionalPlatformFilter(platform);
 
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result
     const results: any[] = await this.prisma.$queryRaw`
@@ -1613,14 +1650,16 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
       endDateStr,
     );
 
-    const brandFilter = brandId
-      ? Prisma.raw(`AND pa."brandId" = '${brandId.replace(/'/g, "''")}'`)
-      : Prisma.raw('');
-    const orgFilter = organizationId
-      ? Prisma.raw(
-          `AND pa."organizationId" = '${organizationId.replace(/'/g, "''")}'`,
-        )
-      : Prisma.raw('');
+    const brandFilter = this.postAnalyticsOptionalTextFilter(
+      'brandId',
+      brandId,
+      'pa',
+    );
+    const orgFilter = this.postAnalyticsOptionalTextFilter(
+      'organizationId',
+      organizationId,
+      'pa',
+    );
 
     // Get top performing posts with description data
     // biome-ignore lint/suspicious/noExplicitAny: raw SQL result

--- a/packages/prisma/prisma/migrations/20260618095000_add_post_analytics_performance_indexes/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618095000_add_post_analytics_performance_indexes/migration.sql
@@ -1,0 +1,6 @@
+-- Add dashboard-oriented indexes for post analytics date-window aggregations.
+CREATE INDEX "post_analytics_date_idx" ON "post_analytics"("date" DESC);
+CREATE INDEX "post_analytics_organizationId_date_idx" ON "post_analytics"("organizationId", "date" DESC);
+CREATE INDEX "post_analytics_brandId_date_idx" ON "post_analytics"("brandId", "date" DESC);
+CREATE INDEX "post_analytics_platform_date_idx" ON "post_analytics"("platform", "date" DESC);
+CREATE INDEX "post_analytics_postId_date_idx" ON "post_analytics"("postId", "date" DESC);

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1635,6 +1635,11 @@ model PostAnalytics {
 
   ingredients Ingredient[] @relation("post_analytics_ingredients")
 
+  @@index([date(sort: Desc)])
+  @@index([organizationId, date(sort: Desc)])
+  @@index([brandId, date(sort: Desc)])
+  @@index([platform, date(sort: Desc)])
+  @@index([postId, date(sort: Desc)])
   @@map("post_analytics")
 }
 


### PR DESCRIPTION
## Summary
- Replaces raw interpolated post analytics filters with Prisma SQL fragments so brand, organization, platform, and date values stay parameterized.
- Adds PostAnalytics indexes for dashboard date windows: date, organization/date, brand/date, platform/date, and post/date.
- Bounds the recursive posts ancestor CTE by explicit depth and clamps caller-supplied max depth.
- Adds analytics service tests covering org, brand, platform, and date query-shape branches.

## Verification
- `bun run --cwd apps/server/api test:file -- src/endpoints/analytics/analytics.service.spec.ts`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bunx biome check apps/server/api/src/endpoints/analytics/analytics.service.ts apps/server/api/src/endpoints/analytics/analytics.service.spec.ts apps/server/api/src/collections/posts/services/posts.service.ts`
- `bun scripts/api-audit/sql-risk-audit.ts --json` (253 total findings; 14 `raw-sql-review` findings remain because analytics still intentionally uses raw SQL)
- `bun run --cwd apps/server/api build`
- `bunx turbo run type-check --filter=@genfeedai/api`
- Pre-commit hook: Biome staged check and secretlint

## Not Run
- `EXPLAIN (ANALYZE, BUFFERS)` before/after on production-shaped data. This worktree has no `DATABASE_URL`, so DB-backed plan capture needs to run in staging/prod with representative org/brand/platform/date inputs.

Refs #626
