### PR TITLE
perf(api): aggregate business analytics queries

### DIFF
--- a/apps/server/api/src/endpoints/analytics/business-analytics.service.spec.ts
+++ b/apps/server/api/src/endpoints/analytics/business-analytics.service.spec.ts
@@ -1,0 +1,342 @@
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { CreditTransactionCategory } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BusinessAnalyticsService } from './business-analytics.service';
+
+type CreditRow = {
+  amount: number;
+  createdAt: Date;
+  isDeleted: boolean;
+  organizationId: string;
+  source: string;
+};
+
+type IngredientRow = {
+  category: string;
+  createdAt: Date;
+  isDeleted: boolean;
+  organizationId: string | null;
+};
+
+type QueryLike = {
+  sql?: string;
+  text?: string;
+  values?: unknown[];
+};
+
+describe('BusinessAnalyticsService', () => {
+  const now = new Date('2026-06-18T12:00:00.000Z');
+  const organizations = [
+    { id: 'org_a', label: 'Alpha Org' },
+    { id: 'org_b', label: 'Beta Org' },
+  ];
+  const creditRows: CreditRow[] = [
+    {
+      amount: 100,
+      createdAt: new Date('2026-06-18T09:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_a',
+      source: CreditTransactionCategory.ADD,
+    },
+    {
+      amount: 50,
+      createdAt: new Date('2026-06-10T09:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_b',
+      source: CreditTransactionCategory.ADD,
+    },
+    {
+      amount: 30,
+      createdAt: new Date('2026-06-16T09:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_a',
+      source: CreditTransactionCategory.DEDUCT,
+    },
+    {
+      amount: 10,
+      createdAt: new Date('2026-06-10T10:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_b',
+      source: CreditTransactionCategory.DEDUCT,
+    },
+    {
+      amount: 999,
+      createdAt: new Date('2026-06-18T10:00:00.000Z'),
+      isDeleted: true,
+      organizationId: 'org_a',
+      source: CreditTransactionCategory.ADD,
+    },
+  ];
+  const ingredientRows: IngredientRow[] = [
+    {
+      category: 'IMAGE',
+      createdAt: new Date('2026-06-18T08:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_a',
+    },
+    {
+      category: 'VIDEO',
+      createdAt: new Date('2026-06-15T08:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_a',
+    },
+    {
+      category: 'IMAGE',
+      createdAt: new Date('2026-06-10T08:00:00.000Z'),
+      isDeleted: false,
+      organizationId: 'org_b',
+    },
+    {
+      category: 'VOICE',
+      createdAt: new Date('2026-06-18T08:00:00.000Z'),
+      isDeleted: true,
+      organizationId: 'org_b',
+    },
+  ];
+
+  function dateMatches(
+    createdAt: Date,
+    filter?: { gte?: Date; lt?: Date; lte?: Date },
+  ) {
+    if (!filter) return true;
+    if (filter.gte && createdAt < filter.gte) return false;
+    if (filter.lt && createdAt >= filter.lt) return false;
+    if (filter.lte && createdAt > filter.lte) return false;
+    return true;
+  }
+
+  function filterCredits(where: {
+    createdAt?: { gte?: Date; lt?: Date; lte?: Date };
+    isDeleted?: boolean;
+    source?: string;
+  }) {
+    return creditRows.filter(
+      (row) =>
+        (typeof where.isDeleted !== 'boolean' ||
+          row.isDeleted === where.isDeleted) &&
+        (!where.source || row.source === where.source) &&
+        dateMatches(row.createdAt, where.createdAt),
+    );
+  }
+
+  function filterIngredients(where: {
+    createdAt?: { gte?: Date; lt?: Date; lte?: Date };
+    isDeleted?: boolean;
+    organizationId?: { not?: null };
+  }) {
+    return ingredientRows.filter(
+      (row) =>
+        (typeof where.isDeleted !== 'boolean' ||
+          row.isDeleted === where.isDeleted) &&
+        (!where.organizationId || row.organizationId !== null) &&
+        dateMatches(row.createdAt, where.createdAt),
+    );
+  }
+
+  function toDailyAmountRows(rows: CreditRow[]) {
+    const byDay = new Map<string, number>();
+    for (const row of rows) {
+      const date = row.createdAt.toISOString().slice(0, 10);
+      byDay.set(date, (byDay.get(date) ?? 0) + row.amount);
+    }
+    return Array.from(byDay.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([date, amount]) => ({ amount, date }));
+  }
+
+  function toDailyCountRows(rows: IngredientRow[]) {
+    const byDay = new Map<string, number>();
+    for (const row of rows) {
+      const date = row.createdAt.toISOString().slice(0, 10);
+      byDay.set(date, (byDay.get(date) ?? 0) + 1);
+    }
+    return Array.from(byDay.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([date, count]) => ({ count, date }));
+  }
+
+  const prisma = {
+    $queryRaw: vi.fn((query: QueryLike) => {
+      const sql = String(query.sql ?? query.text ?? '');
+      const values = query.values ?? [];
+
+      if (sql.includes('"credit_transactions"')) {
+        const [source, from, to] = values as [string, Date, Date | undefined];
+        const rows = filterCredits({
+          createdAt: {
+            gte: from,
+            ...(sql.includes('"createdAt" <') ? { lt: to } : { lte: to }),
+          },
+          isDeleted: false,
+          source,
+        });
+
+        if (sql.includes('date_trunc')) {
+          return Promise.resolve(toDailyAmountRows(rows));
+        }
+
+        return Promise.resolve([
+          { amount: rows.reduce((total, row) => total + row.amount, 0) },
+        ]);
+      }
+
+      if (sql.includes('"ingredients"')) {
+        const [from, to] = values as [Date, Date];
+        return Promise.resolve(
+          toDailyCountRows(
+            filterIngredients({
+              createdAt: { gte: from, lte: to },
+              isDeleted: false,
+            }),
+          ),
+        );
+      }
+
+      return Promise.resolve([]);
+    }),
+    creditTransaction: {
+      aggregate: vi.fn(({ where }) => {
+        const amount = filterCredits(where).reduce(
+          (total, row) => total + row.amount,
+          0,
+        );
+        return Promise.resolve({ _sum: { amount } });
+      }),
+      findMany: vi.fn(),
+      groupBy: vi.fn(({ take, where }) => {
+        const byOrg = new Map<string, number>();
+        for (const row of filterCredits(where)) {
+          byOrg.set(
+            row.organizationId,
+            (byOrg.get(row.organizationId) ?? 0) + row.amount,
+          );
+        }
+        const rows = Array.from(byOrg.entries())
+          .map(([organizationId, amount]) => ({
+            _sum: { amount },
+            organizationId,
+          }))
+          .sort(
+            (left, right) =>
+              Number(right._sum.amount) - Number(left._sum.amount),
+          );
+        return Promise.resolve(rows.slice(0, take));
+      }),
+    },
+    ingredient: {
+      count: vi.fn(({ where }) =>
+        Promise.resolve(filterIngredients(where).length),
+      ),
+      findMany: vi.fn(),
+      groupBy: vi.fn(({ by, take, where }) => {
+        const rows = filterIngredients(where);
+        const grouped = new Map<string, number>();
+        const keyField = by.includes('category')
+          ? 'category'
+          : 'organizationId';
+        for (const row of rows) {
+          const key = row[keyField];
+          if (!key) continue;
+          grouped.set(key, (grouped.get(key) ?? 0) + 1);
+        }
+        const result = Array.from(grouped.entries())
+          .map(([key, count]) =>
+            keyField === 'category'
+              ? { _count: { _all: count }, category: key }
+              : { _count: { _all: count }, organizationId: key },
+          )
+          .sort(
+            (left, right) =>
+              Number(right._count._all) - Number(left._count._all),
+          );
+        return Promise.resolve(
+          typeof take === 'number' ? result.slice(0, take) : result,
+        );
+      }),
+    },
+    organization: {
+      findMany: vi.fn(({ where }) =>
+        Promise.resolve(
+          organizations.filter((org) => where.id.in.includes(org.id)),
+        ),
+      ),
+    },
+  };
+
+  const loggerService = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes business analytics with database aggregations', async () => {
+    const service = new BusinessAnalyticsService(
+      prisma as unknown as PrismaService,
+      loggerService as unknown as LoggerService,
+    );
+
+    const result = await service.getBusinessAnalytics();
+
+    expect(result.revenue).toMatchObject({
+      last7d: 100,
+      last30d: 150,
+      mtd: 150,
+      today: 100,
+      wowGrowth: 100,
+    });
+    expect(result.credits).toMatchObject({
+      consumed: 40,
+      sold: 150,
+      wowGrowth: 200,
+    });
+    expect(result.ingredients).toMatchObject({
+      categoryBreakdown: [
+        { category: 'IMAGE', count: 2 },
+        { category: 'VIDEO', count: 1 },
+      ],
+      last7d: 2,
+      last30d: 3,
+      today: 1,
+      wowGrowth: 100,
+    });
+    expect(result.leaders).toMatchObject({
+      byCredits: [
+        { amount: 30, organizationId: 'org_a', organizationName: 'Alpha Org' },
+        { amount: 10, organizationId: 'org_b', organizationName: 'Beta Org' },
+      ],
+      byIngredients: [
+        { count: 2, organizationId: 'org_a', organizationName: 'Alpha Org' },
+        { count: 1, organizationId: 'org_b', organizationName: 'Beta Org' },
+      ],
+      byRevenue: [
+        { amount: 100, organizationId: 'org_a', organizationName: 'Alpha Org' },
+        { amount: 50, organizationId: 'org_b', organizationName: 'Beta Org' },
+      ],
+    });
+    expect(result.comparisons).toMatchObject({
+      cashInVsUsageValue: { cashIn: 150, usageValue: 40 },
+      outstandingPrepaid: 110,
+      soldVsConsumed: { consumed: 40, sold: 150 },
+    });
+
+    expect(prisma.creditTransaction.groupBy).toHaveBeenCalled();
+    expect(prisma.ingredient.groupBy).toHaveBeenCalled();
+    expect(prisma.$queryRaw).toHaveBeenCalled();
+    expect(prisma.creditTransaction.findMany).not.toHaveBeenCalled();
+    expect(prisma.ingredient.findMany).not.toHaveBeenCalled();
+    expect(prisma.organization.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 2 }),
+    );
+  });
+});

--- a/apps/server/api/src/endpoints/analytics/business-analytics.service.ts
+++ b/apps/server/api/src/endpoints/analytics/business-analytics.service.ts
@@ -1,6 +1,7 @@
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { CreditTransactionCategory } from '@genfeedai/enums';
+import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
@@ -29,6 +30,31 @@ interface LeaderCountEntry {
   organizationId: string;
   organizationName: string;
   count: number;
+}
+
+interface DailyAmountRow {
+  amount: bigint | number | string | null;
+  date: string;
+}
+
+interface DailyCountRow {
+  count: bigint | number | string;
+  date: string;
+}
+
+interface CreditLeaderRow {
+  _sum?: { amount?: unknown };
+  organizationId?: string;
+}
+
+interface IngredientCategoryRow {
+  _count?: { _all?: unknown };
+  category?: unknown;
+}
+
+interface IngredientLeaderRow {
+  _count?: { _all?: unknown };
+  organizationId?: string | null;
 }
 
 interface BusinessAnalyticsResponse {
@@ -80,6 +106,10 @@ export class BusinessAnalyticsService {
     private readonly prisma: PrismaService,
     private readonly loggerService: LoggerService,
   ) {}
+
+  private readNumber(value: unknown): number {
+    return Number(value ?? 0);
+  }
 
   @LogMethod()
   async getBusinessAnalytics(): Promise<BusinessAnalyticsResponse> {
@@ -257,22 +287,28 @@ export class BusinessAnalyticsService {
     createdAtGte?: Date,
     createdAtLt?: Date,
   ): Promise<number> {
-    const transactions = await this.prisma.creditTransaction.findMany({
-      select: { amount: true },
-      where: {
-        isDeleted: false,
-        source,
-        ...(createdAtGte || createdAtLt
-          ? {
-              createdAt: {
-                ...(createdAtGte ? { gte: createdAtGte } : {}),
-                ...(createdAtLt ? { lt: createdAtLt } : {}),
-              },
-            }
-          : {}),
-      },
-    });
-    return transactions.reduce((sum, t) => sum + (t.amount ?? 0), 0);
+    const rows = createdAtLt
+      ? await this.prisma.$queryRaw<Array<{ amount?: unknown }>>(
+          Prisma.sql`
+            SELECT COALESCE(SUM("amount"), 0) AS amount
+            FROM "credit_transactions"
+            WHERE "isDeleted" = false
+              AND "source" = ${source}
+              AND "createdAt" >= ${createdAtGte ?? new Date(0)}
+              AND "createdAt" < ${createdAtLt}
+          `,
+        )
+      : await this.prisma.$queryRaw<Array<{ amount?: unknown }>>(
+          Prisma.sql`
+            SELECT COALESCE(SUM("amount"), 0) AS amount
+            FROM "credit_transactions"
+            WHERE "isDeleted" = false
+              AND "source" = ${source}
+              AND "createdAt" >= ${createdAtGte ?? new Date(0)}
+          `,
+        );
+
+    return this.readNumber(rows[0]?.amount);
   }
 
   private async getDailyCreditSeries(
@@ -280,24 +316,25 @@ export class BusinessAnalyticsService {
     from: Date,
     to: Date,
   ): Promise<DailyAmountEntry[]> {
-    const transactions = await this.prisma.creditTransaction.findMany({
-      select: { amount: true, createdAt: true },
-      where: {
-        createdAt: { gte: from, lte: to },
-        isDeleted: false,
-        source,
-      },
-    });
+    const rows = await this.prisma.$queryRaw<DailyAmountRow[]>(
+      Prisma.sql`
+        SELECT
+          to_char(date_trunc('day', "createdAt"), 'YYYY-MM-DD') AS date,
+          COALESCE(SUM("amount"), 0) AS amount
+        FROM "credit_transactions"
+        WHERE "isDeleted" = false
+          AND "source" = ${source}
+          AND "createdAt" >= ${from}
+          AND "createdAt" <= ${to}
+        GROUP BY date_trunc('day', "createdAt")
+        ORDER BY date ASC
+      `,
+    );
 
-    const byDay = new Map<string, number>();
-    for (const t of transactions) {
-      const day = t.createdAt.toISOString().slice(0, 10);
-      byDay.set(day, (byDay.get(day) ?? 0) + (t.amount ?? 0));
-    }
-
-    return Array.from(byDay.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, amount]) => ({ amount, date }));
+    return rows.map((row) => ({
+      amount: this.readNumber(row.amount),
+      date: row.date,
+    }));
   }
 
   private async countIngredients(
@@ -323,46 +360,47 @@ export class BusinessAnalyticsService {
     from: Date,
     to: Date,
   ): Promise<DailyCountEntry[]> {
-    const ingredients = await this.prisma.ingredient.findMany({
-      select: { createdAt: true },
-      where: {
-        createdAt: { gte: from, lte: to },
-        isDeleted: false,
-      },
-    });
+    const rows = await this.prisma.$queryRaw<DailyCountRow[]>(
+      Prisma.sql`
+        SELECT
+          to_char(date_trunc('day', "createdAt"), 'YYYY-MM-DD') AS date,
+          COUNT(*) AS count
+        FROM "ingredients"
+        WHERE "isDeleted" = false
+          AND "createdAt" >= ${from}
+          AND "createdAt" <= ${to}
+        GROUP BY date_trunc('day', "createdAt")
+        ORDER BY date ASC
+      `,
+    );
 
-    const byDay = new Map<string, number>();
-    for (const i of ingredients) {
-      const day = i.createdAt.toISOString().slice(0, 10);
-      byDay.set(day, (byDay.get(day) ?? 0) + 1);
-    }
-
-    return Array.from(byDay.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, count]) => ({ count, date }));
+    return rows.map((row) => ({
+      count: this.readNumber(row.count),
+      date: row.date,
+    }));
   }
 
   private async getIngredientCategoryBreakdown(
     from: Date,
     to: Date,
   ): Promise<CategoryBreakdownEntry[]> {
-    const ingredients = await this.prisma.ingredient.findMany({
-      select: { category: true },
+    const rows = await this.prisma.ingredient.groupBy({
+      _count: { _all: true },
+      by: ['category'],
+      orderBy: { _count: { category: 'desc' } },
+      take: 20,
       where: {
         createdAt: { gte: from, lte: to },
         isDeleted: false,
       },
-    });
+    } as never);
 
-    const byCat = new Map<string, number>();
-    for (const i of ingredients) {
-      const cat = String(i.category ?? 'UNKNOWN');
-      byCat.set(cat, (byCat.get(cat) ?? 0) + 1);
-    }
-
-    return Array.from(byCat.entries())
-      .sort(([, a], [, b]) => b - a)
-      .map(([category, count]) => ({ category, count }));
+    return (rows as IngredientCategoryRow[])
+      .map((row) => ({
+        category: String(row.category ?? 'UNKNOWN'),
+        count: this.readNumber(row._count?._all),
+      }))
+      .sort((a, b) => b.count - a.count);
   }
 
   private async getLeadersByCredits(
@@ -370,39 +408,34 @@ export class BusinessAnalyticsService {
     from: Date,
     to: Date,
   ): Promise<LeaderEntry[]> {
-    const transactions = await this.prisma.creditTransaction.findMany({
-      select: { amount: true, organizationId: true },
+    const rows = await this.prisma.creditTransaction.groupBy({
+      _sum: { amount: true },
+      by: ['organizationId'],
+      orderBy: { _sum: { amount: 'desc' } },
+      take: 10,
       where: {
         createdAt: { gte: from, lte: to },
         isDeleted: false,
         source,
       },
-    });
+    } as never);
 
-    // Aggregate in-memory by organizationId
-    const byOrg = new Map<string, number>();
-    for (const t of transactions) {
-      byOrg.set(
-        t.organizationId,
-        (byOrg.get(t.organizationId) ?? 0) + (t.amount ?? 0),
-      );
-    }
-
-    const top10 = Array.from(byOrg.entries())
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 10);
-
-    if (top10.length === 0) return [];
+    const leaders = (rows as CreditLeaderRow[]).map((row) => ({
+      amount: this.readNumber(row._sum?.amount),
+      organizationId: String(row.organizationId),
+    }));
+    if (leaders.length === 0) return [];
 
     // Resolve org names
-    const orgIds = top10.map(([id]) => id);
+    const orgIds = leaders.map((leader) => leader.organizationId);
     const orgs = await this.prisma.organization.findMany({
       select: { id: true, label: true },
+      take: orgIds.length,
       where: { id: { in: orgIds }, isDeleted: false },
     });
     const orgNameMap = new Map(orgs.map((o) => [o.id, o.label ?? 'Unknown']));
 
-    return top10.map(([organizationId, amount]) => ({
+    return leaders.map(({ amount, organizationId }) => ({
       amount,
       organizationId,
       organizationName: orgNameMap.get(organizationId) ?? 'Unknown',
@@ -413,37 +446,36 @@ export class BusinessAnalyticsService {
     from: Date,
     to: Date,
   ): Promise<LeaderCountEntry[]> {
-    const ingredients = await this.prisma.ingredient.findMany({
-      select: { organizationId: true },
+    const rows = await this.prisma.ingredient.groupBy({
+      _count: { _all: true },
+      by: ['organizationId'],
+      orderBy: { _count: { organizationId: 'desc' } },
+      take: 10,
       where: {
         createdAt: { gte: from, lte: to },
         isDeleted: false,
         organizationId: { not: null },
       },
-    });
+    } as never);
 
-    // Aggregate in-memory by organizationId
-    const byOrg = new Map<string, number>();
-    for (const i of ingredients) {
-      if (!i.organizationId) continue;
-      byOrg.set(i.organizationId, (byOrg.get(i.organizationId) ?? 0) + 1);
-    }
-
-    const top10 = Array.from(byOrg.entries())
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 10);
-
-    if (top10.length === 0) return [];
+    const leaders = (rows as IngredientLeaderRow[])
+      .filter((row) => row.organizationId)
+      .map((row) => ({
+        count: this.readNumber(row._count?._all),
+        organizationId: String(row.organizationId),
+      }));
+    if (leaders.length === 0) return [];
 
     // Resolve organization names
-    const orgIds = top10.map(([id]) => id);
+    const orgIds = leaders.map((leader) => leader.organizationId);
     const orgs = await this.prisma.organization.findMany({
       select: { id: true, label: true },
+      take: orgIds.length,
       where: { id: { in: orgIds }, isDeleted: false },
     });
     const orgNameMap = new Map(orgs.map((o) => [o.id, o.label ?? 'Unknown']));
 
-    return top10.map(([organizationId, count]) => ({
+    return leaders.map(({ count, organizationId }) => ({
       count,
       organizationId,
       organizationName: orgNameMap.get(organizationId) ?? 'Unknown',

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -10,6 +10,25 @@ import { vi } from 'vitest';
 
 // Mock @genfeedai/prisma so unit tests never need the generated Prisma client
 vi.mock('@genfeedai/prisma', () => {
+  type MockSql = {
+    sql: string;
+    text: string;
+    values: unknown[];
+  };
+
+  const createSql = (sql: string, values: unknown[] = []): MockSql => ({
+    sql,
+    text: sql,
+    values,
+  });
+
+  const getSqlText = (value: unknown) => {
+    if (typeof value !== 'object' || value === null) return '?';
+    if ('sql' in value) return String(value.sql);
+    if ('text' in value) return String(value.text);
+    return '?';
+  };
+
   class PrismaClient {
     $connect = vi.fn().mockResolvedValue(undefined);
     $disconnect = vi.fn().mockResolvedValue(undefined);
@@ -33,7 +52,20 @@ vi.mock('@genfeedai/prisma', () => {
     HEYGEN: 'HEYGEN',
   } as const;
 
-  return { PrismaClient, VoiceProvider };
+  const Prisma = {
+    empty: createSql(''),
+    raw: (sql: string) => createSql(sql),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const sql = strings.reduce((acc, part, index) => {
+        const value = index < values.length ? getSqlText(values[index]) : '';
+        return `${acc}${part}${value}`;
+      }, '');
+
+      return createSql(sql, values);
+    },
+  };
+
+  return { Prisma, PrismaClient, VoiceProvider };
 });
 
 // Mock @prisma/adapter-pg so PrismaService constructor doesn't require DATABASE_URL

--- a/packages/prisma/prisma/migrations/20260618102000_add_business_analytics_performance_indexes/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618102000_add_business_analytics_performance_indexes/migration.sql
@@ -1,0 +1,19 @@
+-- Business analytics credit totals and daily/source reporting.
+CREATE INDEX "credit_transactions_source_deleted_created_at_idx"
+ON "credit_transactions"("source", "isDeleted", "createdAt" DESC);
+
+-- Business analytics credit leaderboards grouped by organization.
+CREATE INDEX "credit_transactions_source_deleted_org_created_at_idx"
+ON "credit_transactions"("source", "isDeleted", "organizationId", "createdAt" DESC);
+
+-- Business analytics ingredient totals and daily reporting.
+CREATE INDEX "ingredients_deleted_created_at_idx"
+ON "ingredients"("isDeleted", "createdAt" DESC);
+
+-- Business analytics ingredient category breakdowns.
+CREATE INDEX "ingredients_deleted_category_created_at_idx"
+ON "ingredients"("isDeleted", "category", "createdAt" DESC);
+
+-- Business analytics ingredient leaderboards grouped by organization.
+CREATE INDEX "ingredients_deleted_org_created_at_idx"
+ON "ingredients"("isDeleted", "organizationId", "createdAt" DESC);

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1183,6 +1183,9 @@ model Ingredient {
   @@index([isDeleted, personaId, reviewStatus])
   @@index([campaign, isDeleted, personaSlug])
   @@index([externalVoiceCatalogId])
+  @@index([isDeleted, createdAt(sort: Desc)], map: "ingredients_deleted_created_at_idx")
+  @@index([isDeleted, category, createdAt(sort: Desc)], map: "ingredients_deleted_category_created_at_idx")
+  @@index([isDeleted, organizationId, createdAt(sort: Desc)], map: "ingredients_deleted_org_created_at_idx")
   @@map("ingredients")
 }
 
@@ -1844,6 +1847,8 @@ model CreditTransaction {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
+  @@index([source, isDeleted, createdAt(sort: Desc)], map: "credit_transactions_source_deleted_created_at_idx")
+  @@index([source, isDeleted, organizationId, createdAt(sort: Desc)], map: "credit_transactions_source_deleted_org_created_at_idx")
   @@map("credit_transactions")
 }
 


### PR DESCRIPTION
Refs #628

## Summary
- Replaced business analytics row materialization with database-side sums, daily date buckets, category grouping, and top-10 leaderboards.
- Added hard bounds on leaderboard/category grouping and bounded organization lookups by the top result set.
- Added Prisma indexes and migration for the credit transaction and ingredient query shapes used by the dashboard.
- Added a focused service spec covering totals, daily series, category breakdowns, leaderboards, and the absence of old `findMany` aggregation paths.

## Verification
- `bun run --cwd apps/server/api test:file -- src/endpoints/analytics/business-analytics.service.spec.ts`
- `bunx biome check --write apps/server/api/src/endpoints/analytics/business-analytics.service.ts apps/server/api/src/endpoints/analytics/business-analytics.service.spec.ts apps/server/api/test/setup-unit.ts packages/prisma/prisma/schema.prisma packages/prisma/prisma/migrations/20260618102000_add_business_analytics_performance_indexes/migration.sql`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bun scripts/api-audit/sql-risk-audit.ts --json` (business analytics unbounded-read cluster removed; remaining entries are raw-sql-review for the new aggregate/date-bucket SQL)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bun run --cwd apps/server/api build`
- `git diff --check`

## Not Run
- `EXPLAIN (ANALYZE, BUFFERS)` before/after on production-shaped data. This worktree does not have a reachable populated `DATABASE_URL`, so this PR references rather than closes the issue.