### PR TITLE
perf(api): index trend reference corpus lookups

### DIFF
--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
@@ -349,6 +349,22 @@ describe('TrendReferenceCorpusService', () => {
     );
   });
 
+  it('caps reference lookup limits before querying', async () => {
+    await service.getReferenceCorpus('org_1', 'brand_1', { limit: 999 });
+    await service.getTopReferenceAccounts('org_1', 'brand_1', { limit: 999 });
+
+    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 100,
+      }),
+    );
+    expect(prisma.trendSourceReference.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 100,
+      }),
+    );
+  });
+
   it('resolves metadata source URLs before creating org-scoped remix lineage', async () => {
     await service.recordDraftRemixLineage({
       brandId: 'brand_1',

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
@@ -1,0 +1,385 @@
+import type { TrendSourceItem } from '@api/collections/trends/interfaces/trend.interfaces';
+import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+
+type ReferenceRow = {
+  authorHandle: string | null;
+  canonicalUrl: string;
+  createdAt: Date;
+  currentEngagementTotal: number;
+  data: Record<string, unknown>;
+  id: string;
+  isDeleted: boolean;
+  lastSeenAt: Date | null;
+  latestTrendViralityScore: number;
+  platform: string | null;
+};
+
+type QueryLike = {
+  sql?: string;
+  text?: string;
+};
+
+describe('TrendReferenceCorpusService', () => {
+  const referenceRows: ReferenceRow[] = [
+    {
+      authorHandle: 'creator',
+      canonicalUrl: 'https://example.com/a',
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      currentEngagementTotal: 1200,
+      data: {
+        authorHandle: 'creator',
+        canonicalUrl: 'https://example.com/a',
+        contentType: 'video',
+        currentEngagementTotal: 1200,
+        firstSeenAt: '2026-06-01T00:00:00.000Z',
+        lastSeenAt: '2026-06-12T00:00:00.000Z',
+        latestTrendMentions: 300,
+        latestTrendViralityScore: 91,
+        matchedTrendTopics: ['ai tools'],
+        platform: 'tiktok',
+        sourcePreviewState: 'live',
+        title: 'AI tools clip',
+      },
+      id: 'ref_tiktok',
+      isDeleted: false,
+      lastSeenAt: new Date('2026-06-12T00:00:00.000Z'),
+      latestTrendViralityScore: 91,
+      platform: 'tiktok',
+    },
+    {
+      authorHandle: 'creator',
+      canonicalUrl: 'https://example.com/b',
+      createdAt: new Date('2026-06-02T00:00:00.000Z'),
+      currentEngagementTotal: 400,
+      data: {
+        authorHandle: 'creator',
+        canonicalUrl: 'https://example.com/b',
+        contentType: 'post',
+        currentEngagementTotal: 400,
+        firstSeenAt: '2026-06-02T00:00:00.000Z',
+        lastSeenAt: '2026-06-10T00:00:00.000Z',
+        latestTrendMentions: 100,
+        latestTrendViralityScore: 35,
+        matchedTrendTopics: ['design'],
+        platform: 'instagram',
+        sourcePreviewState: 'live',
+        title: 'Design post',
+      },
+      id: 'ref_instagram',
+      isDeleted: false,
+      lastSeenAt: new Date('2026-06-10T00:00:00.000Z'),
+      latestTrendViralityScore: 35,
+      platform: 'instagram',
+    },
+  ];
+
+  function filterReferences(where: {
+    authorHandle?: string;
+    canonicalUrl?: { in: string[] };
+    id?: { in: string[] };
+    isDeleted?: boolean;
+    platform?: string | { not: null };
+  }) {
+    return referenceRows.filter((row) => {
+      if (
+        typeof where.isDeleted === 'boolean' &&
+        row.isDeleted !== where.isDeleted
+      ) {
+        return false;
+      }
+      if (
+        where.canonicalUrl?.in &&
+        !where.canonicalUrl.in.includes(row.canonicalUrl)
+      ) {
+        return false;
+      }
+      if (where.id?.in && !where.id.in.includes(row.id)) {
+        return false;
+      }
+      if (
+        typeof where.platform === 'string' &&
+        row.platform !== where.platform
+      ) {
+        return false;
+      }
+      if (
+        typeof where.authorHandle === 'string' &&
+        row.authorHandle !== where.authorHandle
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  const prisma = {
+    $queryRaw: vi.fn((query: QueryLike) => {
+      const sql = String(query.sql ?? query.text ?? '');
+      if (sql.includes('source_reference_id')) {
+        return Promise.resolve([
+          { remix_count: 2, source_reference_id: 'ref_tiktok' },
+        ]);
+      }
+      if (sql.includes('author_handle')) {
+        return Promise.resolve([
+          {
+            author_handle: 'creator',
+            platform: 'tiktok',
+            remix_count: 2,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    }),
+    trend: {
+      findFirst: vi.fn(({ where }) =>
+        Promise.resolve(
+          where.id === 'trend_1' && where.organizationId === 'org_1'
+            ? { id: 'trend_1' }
+            : null,
+        ),
+      ),
+      findMany: vi.fn(({ where }) =>
+        Promise.resolve(
+          where.id.in.includes('trend_1') && where.organizationId === 'org_1'
+            ? [{ id: 'trend_1' }]
+            : [],
+        ),
+      ),
+    },
+    trendRemixLineage: {
+      create: vi.fn().mockResolvedValue({ id: 'lineage_1' }),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+    },
+    trendSourceReference: {
+      create: vi.fn(),
+      findFirst: vi.fn(({ where }) =>
+        Promise.resolve(
+          referenceRows.find(
+            (row) =>
+              row.canonicalUrl === where.canonicalUrl &&
+              row.platform === where.platform &&
+              row.isDeleted === where.isDeleted,
+          ) ?? null,
+        ),
+      ),
+      findMany: vi.fn(({ orderBy, take, where }) => {
+        let rows = filterReferences(where);
+        if (orderBy) {
+          rows = [...rows].sort(
+            (left, right) =>
+              right.currentEngagementTotal - left.currentEngagementTotal ||
+              right.latestTrendViralityScore - left.latestTrendViralityScore,
+          );
+        }
+        return Promise.resolve(
+          typeof take === 'number' ? rows.slice(0, take) : rows,
+        );
+      }),
+      groupBy: vi.fn(({ take, where }) => {
+        const rows = filterReferences(where).filter(
+          (row) => row.platform && row.authorHandle,
+        );
+        const groups = new Map<string, ReferenceRow[]>();
+        for (const row of rows) {
+          groups.set(`${row.platform}:${row.authorHandle}`, [
+            ...(groups.get(`${row.platform}:${row.authorHandle}`) ?? []),
+            row,
+          ]);
+        }
+        const result = Array.from(groups.entries())
+          .map(([key, groupRows]) => {
+            const [platform, authorHandle] = key.split(':');
+            const engagement = groupRows.reduce(
+              (total, row) => total + row.currentEngagementTotal,
+              0,
+            );
+            const virality = groupRows.reduce(
+              (total, row) => total + row.latestTrendViralityScore,
+              0,
+            );
+            return {
+              _avg: {
+                latestTrendViralityScore: virality / groupRows.length,
+              },
+              _count: { _all: groupRows.length },
+              _max: {
+                lastSeenAt: groupRows.reduce<Date | null>(
+                  (latest, row) =>
+                    !latest || (row.lastSeenAt && row.lastSeenAt > latest)
+                      ? row.lastSeenAt
+                      : latest,
+                  null,
+                ),
+              },
+              _sum: { currentEngagementTotal: engagement },
+              authorHandle,
+              platform,
+            };
+          })
+          .sort(
+            (left, right) =>
+              Number(right._avg.latestTrendViralityScore) -
+              Number(left._avg.latestTrendViralityScore),
+          );
+        return Promise.resolve(
+          typeof take === 'number' ? result.slice(0, take) : result,
+        );
+      }),
+      update: vi.fn().mockResolvedValue({ id: 'ref_tiktok' }),
+    },
+    trendSourceReferenceLink: {
+      create: vi.fn(),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn(({ where }) =>
+        Promise.resolve(
+          where.trendId === 'trend_1'
+            ? [{ sourceReferenceId: 'ref_tiktok' }]
+            : [],
+        ),
+      ),
+    },
+    trendSourceReferenceSnapshot: {
+      create: vi.fn(),
+      findFirst: vi.fn().mockResolvedValue(null),
+      update: vi.fn(),
+    },
+  };
+
+  const loggerService = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  let service: TrendReferenceCorpusService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TrendReferenceCorpusService(
+      prisma as unknown as PrismaService,
+      loggerService as unknown as LoggerService,
+    );
+  });
+
+  it('filters reference corpus by trend, platform, and author without scanning recent references', async () => {
+    const result = await service.getReferenceCorpus('org_1', 'brand_1', {
+      authorHandle: 'creator',
+      limit: 5,
+      platform: 'tiktok',
+      trendId: 'trend_1',
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      id: 'ref_tiktok',
+      platform: 'tiktok',
+      remixCount: 2,
+    });
+    expect(prisma.trendSourceReferenceLink.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { sourceReferenceId: true },
+        take: 100,
+      }),
+    );
+    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 5,
+        where: expect.objectContaining({
+          authorHandle: 'creator',
+          id: { in: ['ref_tiktok'] },
+          platform: 'tiktok',
+        }),
+      }),
+    );
+  });
+
+  it('annotates source items through indexed canonical URL lookup', async () => {
+    const items: TrendSourceItem[] = [
+      {
+        contentType: 'video',
+        id: 'source_1',
+        platform: 'tiktok',
+        sourceUrl: 'https://example.com/a?utm=1',
+      },
+    ];
+
+    const result = await service.annotateSourceItemsWithReferenceIds(items);
+
+    expect(result[0].sourceReferenceId).toBe('ref_tiktok');
+    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 1,
+        where: {
+          canonicalUrl: { in: ['https://example.com/a'] },
+          isDeleted: false,
+        },
+      }),
+    );
+  });
+
+  it('groups top reference accounts with scalar columns and brand remix counts', async () => {
+    const result = await service.getTopReferenceAccounts('org_1', 'brand_1', {
+      limit: 10,
+      platform: 'tiktok',
+    });
+
+    expect(result.accounts).toEqual([
+      {
+        authorHandle: 'creator',
+        avgTrendViralityScore: 91,
+        brandRemixCount: 2,
+        lastSeenAt: '2026-06-12T00:00:00.000Z',
+        platform: 'tiktok',
+        referenceCount: 1,
+        totalEngagement: 1200,
+      },
+    ]);
+    expect(prisma.trendSourceReference.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        by: ['platform', 'authorHandle'],
+        take: 10,
+        where: expect.objectContaining({ platform: 'tiktok' }),
+      }),
+    );
+  });
+
+  it('resolves metadata source URLs before creating org-scoped remix lineage', async () => {
+    await service.recordDraftRemixLineage({
+      brandId: 'brand_1',
+      contentDraftId: 'draft_1',
+      generatedBy: 'test',
+      metadata: {
+        sourceUrl: 'https://example.com/a?utm=1',
+        trendId: 'trend_1',
+      },
+      organizationId: 'org_1',
+      platforms: ['tiktok'],
+    });
+
+    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 1,
+        where: {
+          canonicalUrl: { in: ['https://example.com/a'] },
+          isDeleted: false,
+        },
+      }),
+    );
+    expect(prisma.trendRemixLineage.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          brandId: 'brand_1',
+          organizationId: 'org_1',
+          sourceReferences: { connect: [{ id: 'ref_tiktok' }] },
+          trends: { connect: [{ id: 'trend_1' }] },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -59,6 +59,10 @@ interface ReferenceRecordData {
   title?: string;
 }
 
+const DEFAULT_REFERENCE_CORPUS_LIMIT = 30;
+const DEFAULT_REFERENCE_ACCOUNT_LIMIT = 20;
+const MAX_REFERENCE_QUERY_LIMIT = 100;
+
 @Injectable()
 export class TrendReferenceCorpusService {
   constructor(
@@ -409,7 +413,10 @@ export class TrendReferenceCorpusService {
     brandId: string | undefined,
     options: ReferenceQueryOptions = {},
   ): Promise<TrendSourceReferenceResult> {
-    const limit = options.limit ?? 30;
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_REFERENCE_CORPUS_LIMIT,
+    );
 
     let sourceReferenceIds: string[] | undefined;
     if (options.trendId) {
@@ -490,7 +497,10 @@ export class TrendReferenceCorpusService {
       platform?: string;
     } = {},
   ): Promise<TrendSourceAccountResult> {
-    const limit = options.limit ?? 20;
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_REFERENCE_ACCOUNT_LIMIT,
+    );
 
     type AccountKey = string; // `${platform}:${authorHandle}`
     const accountRows = await this.prisma.trendSourceReference.groupBy({
@@ -616,6 +626,17 @@ export class TrendReferenceCorpusService {
       });
       return url.replace(/[?#].*$/, '').replace(/\/$/, '');
     }
+  }
+
+  private normalizeLimit(
+    value: number | undefined,
+    defaultLimit: number,
+  ): number {
+    if (!Number.isFinite(value) || value == null || value <= 0) {
+      return defaultLimit;
+    }
+
+    return Math.min(Math.floor(value), MAX_REFERENCE_QUERY_LIMIT);
   }
 
   private getEngagementTotal(metrics?: TrendSourceItem['metrics']): number {

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -6,6 +6,7 @@ import type {
   TrendSourceReferenceResult,
 } from '@api/collections/trends/interfaces/trend.interfaces';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
 
@@ -80,28 +81,12 @@ export class TrendReferenceCorpusService {
 
         const canonicalUrl = this.normalizeSourceUrl(sourceItem.sourceUrl);
 
-        // Upsert the source reference
-        const existingRef = await this.prisma.trendSourceReference.findFirst({
+        const matchedRef = await this.prisma.trendSourceReference.findFirst({
           where: {
+            canonicalUrl,
             isDeleted: false,
-            // match canonicalUrl + platform stored in data JSON — in-memory
+            platform: sourceItem.platform,
           },
-        });
-
-        // In-memory approach since canonicalUrl/platform live in JSON `data`
-        const allRefs = await this.prisma.trendSourceReference.findMany({
-          orderBy: { createdAt: 'desc' },
-          take: 5000,
-          where: { isDeleted: false },
-        });
-        void existingRef;
-
-        const matchedRef = allRefs.find((doc) => {
-          const d = doc.data as unknown as Record<string, unknown>;
-          return (
-            d.canonicalUrl === canonicalUrl &&
-            d.platform === sourceItem.platform
-          );
         });
 
         const engagementTotal = this.getEngagementTotal(sourceItem.metrics);
@@ -121,9 +106,13 @@ export class TrendReferenceCorpusService {
 
           await this.prisma.trendSourceReference.update({
             data: {
+              authorHandle: sourceItem.authorHandle,
+              canonicalUrl,
+              currentEngagementTotal: engagementTotal,
               data: {
                 ...existingData,
                 authorHandle: sourceItem.authorHandle,
+                canonicalUrl,
                 contentType: sourceItem.contentType,
                 currentEngagementTotal: engagementTotal,
                 currentMetrics: sourceItem.metrics || {},
@@ -141,6 +130,9 @@ export class TrendReferenceCorpusService {
                 thumbnailUrl: sourceItem.thumbnailUrl,
                 title: sourceItem.title,
               } as never,
+              lastSeenAt: now,
+              latestTrendViralityScore: trend.viralityScore,
+              platform: sourceItem.platform,
             },
             where: { id: matchedRef.id },
           });
@@ -148,6 +140,9 @@ export class TrendReferenceCorpusService {
         } else {
           const created = await this.prisma.trendSourceReference.create({
             data: {
+              authorHandle: sourceItem.authorHandle,
+              canonicalUrl,
+              currentEngagementTotal: engagementTotal,
               data: {
                 authorHandle: sourceItem.authorHandle,
                 canonicalUrl,
@@ -171,6 +166,9 @@ export class TrendReferenceCorpusService {
                 title: sourceItem.title,
               } as never,
               isDeleted: false,
+              lastSeenAt: now,
+              latestTrendViralityScore: trend.viralityScore,
+              platform: sourceItem.platform,
             },
           });
           referenceId = created.id;
@@ -179,27 +177,14 @@ export class TrendReferenceCorpusService {
 
         // Upsert snapshot for today
         const snapshotDate = this.toSnapshotDate();
-        const existingSnapshot =
+        const matchedSnapshot =
           await this.prisma.trendSourceReferenceSnapshot.findFirst({
             where: {
               isDeleted: false,
+              snapshotDate,
               sourceReferenceId: referenceId,
             },
           });
-
-        // Find snapshot matching snapshotDate (stored in data)
-        const snapshotDocs =
-          await this.prisma.trendSourceReferenceSnapshot.findMany({
-            where: {
-              isDeleted: false,
-              sourceReferenceId: referenceId,
-            },
-          });
-        const matchedSnapshot = snapshotDocs.find((doc) => {
-          const d = doc.data as unknown as Record<string, unknown>;
-          return d.snapshotDate === snapshotDate.toISOString();
-        });
-        void existingSnapshot;
 
         if (!matchedSnapshot) {
           await this.prisma.trendSourceReferenceSnapshot.create({
@@ -212,6 +197,7 @@ export class TrendReferenceCorpusService {
                 trendViralityScore: trend.viralityScore,
               } as never,
               isDeleted: false,
+              snapshotDate,
               sourceReferenceId: referenceId,
             },
           });
@@ -226,6 +212,7 @@ export class TrendReferenceCorpusService {
                 trendMentions: trend.mentions,
                 trendViralityScore: trend.viralityScore,
               } as never,
+              snapshotDate,
             },
             where: { id: matchedSnapshot.id },
           });
@@ -389,15 +376,13 @@ export class TrendReferenceCorpusService {
       ),
     );
 
-    const allRefs = await this.prisma.trendSourceReference.findMany({
+    const matchedRefs = await this.prisma.trendSourceReference.findMany({
       orderBy: { createdAt: 'desc' },
-      take: 5000,
-      where: { isDeleted: false },
-    });
-
-    const matchedRefs = allRefs.filter((doc) => {
-      const d = doc.data as unknown as Record<string, unknown>;
-      return canonicalUrls.includes(d.canonicalUrl as string);
+      take: canonicalUrls.length,
+      where: {
+        canonicalUrl: { in: canonicalUrls },
+        isDeleted: false,
+      },
     });
 
     if (matchedRefs.length === 0) {
@@ -406,8 +391,8 @@ export class TrendReferenceCorpusService {
 
     const referenceMap = new Map(
       matchedRefs.map((doc) => {
-        const d = doc.data as unknown as Record<string, unknown>;
-        return [d.canonicalUrl as string, doc.id];
+        const d = doc.data as unknown as ReferenceRecordData;
+        return [doc.canonicalUrl ?? d.canonicalUrl, doc.id];
       }),
     );
 
@@ -449,6 +434,8 @@ export class TrendReferenceCorpusService {
       }
 
       const links = await this.prisma.trendSourceReferenceLink.findMany({
+        select: { sourceReferenceId: true },
+        take: Math.max(limit * 10, 100),
         where: {
           isDeleted: false,
           trendId: options.trendId,
@@ -459,40 +446,22 @@ export class TrendReferenceCorpusService {
         .filter((id): id is string => id != null);
     }
 
-    const allRefs = await this.prisma.trendSourceReference.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: limit * 10,
+    const docs = await this.prisma.trendSourceReference.findMany({
+      orderBy: [
+        { currentEngagementTotal: 'desc' },
+        { latestTrendViralityScore: 'desc' },
+        { lastSeenAt: 'desc' },
+      ],
+      take: limit,
       where: {
+        ...(options.authorHandle ? { authorHandle: options.authorHandle } : {}),
+        ...(options.platform ? { platform: options.platform } : {}),
         ...(sourceReferenceIds != null
           ? { id: { in: sourceReferenceIds } }
           : {}),
         isDeleted: false,
       },
     });
-
-    // In-memory filter on JSON data fields
-    let docs = allRefs.filter((doc) => {
-      const d = doc.data as unknown as Record<string, unknown>;
-      if (options.platform && d.platform !== options.platform) return false;
-      if (options.authorHandle && d.authorHandle !== options.authorHandle)
-        return false;
-      return true;
-    });
-
-    // Sort by engagement, lastSeenAt, viralityScore
-    docs = docs
-      .sort((a, b) => {
-        const ad = a.data as unknown as Record<string, number>;
-        const bd = b.data as unknown as Record<string, number>;
-        const engDiff =
-          (bd.currentEngagementTotal ?? 0) - (ad.currentEngagementTotal ?? 0);
-        if (engDiff !== 0) return engDiff;
-        const virDiff =
-          (bd.latestTrendViralityScore ?? 0) -
-          (ad.latestTrendViralityScore ?? 0);
-        return virDiff;
-      })
-      .slice(0, limit);
 
     const remixCounts = await this.getRemixCounts(
       docs.map((doc) => doc.id),
@@ -523,60 +492,25 @@ export class TrendReferenceCorpusService {
   ): Promise<TrendSourceAccountResult> {
     const limit = options.limit ?? 20;
 
-    const allRefs = await this.prisma.trendSourceReference.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: 10000,
-      where: { isDeleted: false },
-    });
-
-    // In-memory grouping by authorHandle + platform (data fields)
     type AccountKey = string; // `${platform}:${authorHandle}`
-    const accountMap = new Map<
-      AccountKey,
-      {
-        authorHandle: string;
-        platform: string;
-        referenceCount: number;
-        totalEngagement: number;
-        totalViralityScore: number;
-        lastSeenAt?: Date;
-      }
-    >();
-
-    for (const doc of allRefs) {
-      const d = doc.data as unknown as Record<string, unknown>;
-      const authorHandle = d.authorHandle as string | undefined;
-      const platform = d.platform as string | undefined;
-      if (!authorHandle || !platform) continue;
-      if (options.platform && platform !== options.platform) continue;
-
-      const key: AccountKey = `${platform}:${authorHandle}`;
-      const existing = accountMap.get(key);
-      const lastSeenAtStr = d.lastSeenAt as string | undefined;
-      const lastSeenAt = lastSeenAtStr ? new Date(lastSeenAtStr) : undefined;
-
-      if (existing) {
-        existing.referenceCount += 1;
-        existing.totalEngagement += (d.currentEngagementTotal as number) ?? 0;
-        existing.totalViralityScore +=
-          (d.latestTrendViralityScore as number) ?? 0;
-        if (
-          lastSeenAt &&
-          (!existing.lastSeenAt || lastSeenAt > existing.lastSeenAt)
-        ) {
-          existing.lastSeenAt = lastSeenAt;
-        }
-      } else {
-        accountMap.set(key, {
-          authorHandle,
-          lastSeenAt,
-          platform,
-          referenceCount: 1,
-          totalEngagement: (d.currentEngagementTotal as number) ?? 0,
-          totalViralityScore: (d.latestTrendViralityScore as number) ?? 0,
-        });
-      }
-    }
+    const accountRows = await this.prisma.trendSourceReference.groupBy({
+      _avg: { latestTrendViralityScore: true },
+      _count: { _all: true },
+      _max: { lastSeenAt: true },
+      _sum: { currentEngagementTotal: true },
+      by: ['platform', 'authorHandle'],
+      orderBy: [
+        { _avg: { latestTrendViralityScore: 'desc' } },
+        { _count: { authorHandle: 'desc' } },
+        { _sum: { currentEngagementTotal: 'desc' } },
+      ],
+      take: limit,
+      where: {
+        authorHandle: { not: null },
+        isDeleted: false,
+        platform: options.platform ? options.platform : { not: null },
+      },
+    } as never);
 
     const brandRemixCounts = await this.getBrandRemixCountsByAccount(
       organizationId,
@@ -584,29 +518,31 @@ export class TrendReferenceCorpusService {
       options.platform,
     );
 
-    const accounts: TrendSourceAccountSummary[] = Array.from(
-      accountMap.entries(),
+    const accounts: TrendSourceAccountSummary[] = (
+      accountRows as Array<{
+        _avg?: { latestTrendViralityScore?: unknown };
+        _count?: { _all?: unknown };
+        _max?: { lastSeenAt?: Date | null };
+        _sum?: { currentEngagementTotal?: unknown };
+        authorHandle?: string | null;
+        platform?: string | null;
+      }>
     )
-      .map(([key, stats]) => ({
-        authorHandle: stats.authorHandle,
-        avgTrendViralityScore: Math.round(
-          stats.referenceCount > 0
-            ? stats.totalViralityScore / stats.referenceCount
-            : 0,
-        ),
-        brandRemixCount: brandRemixCounts.get(key) || 0,
-        lastSeenAt: stats.lastSeenAt?.toISOString(),
-        platform: stats.platform,
-        referenceCount: stats.referenceCount,
-        totalEngagement: stats.totalEngagement,
-      }))
-      .sort(
-        (a, b) =>
-          b.avgTrendViralityScore - a.avgTrendViralityScore ||
-          b.referenceCount - a.referenceCount ||
-          b.totalEngagement - a.totalEngagement,
-      )
-      .slice(0, limit);
+      .filter((row) => row.platform && row.authorHandle)
+      .map((row) => {
+        const key: AccountKey = `${row.platform}:${row.authorHandle}`;
+        return {
+          authorHandle: String(row.authorHandle),
+          avgTrendViralityScore: Math.round(
+            Number(row._avg?.latestTrendViralityScore ?? 0),
+          ),
+          brandRemixCount: brandRemixCounts.get(key) || 0,
+          lastSeenAt: row._max?.lastSeenAt?.toISOString(),
+          platform: String(row.platform),
+          referenceCount: Number(row._count?._all ?? 0),
+          totalEngagement: Number(row._sum?.currentEngagementTotal ?? 0),
+        };
+      });
 
     return {
       accounts,
@@ -637,17 +573,16 @@ export class TrendReferenceCorpusService {
       this.normalizeSourceUrl(url),
     );
 
-    const allRefs = await this.prisma.trendSourceReference.findMany({
-      take: 5000,
-      where: { isDeleted: false },
+    const refs = await this.prisma.trendSourceReference.findMany({
+      select: { id: true },
+      take: normalizedUrls.length,
+      where: {
+        canonicalUrl: { in: normalizedUrls },
+        isDeleted: false,
+      },
     });
 
-    return allRefs
-      .filter((doc) => {
-        const d = doc.data as unknown as Record<string, unknown>;
-        return normalizedUrls.includes(d.canonicalUrl as string);
-      })
-      .map((doc) => doc.id);
+    return refs.map((doc) => doc.id);
   }
 
   private parseOptionalString(value: unknown): string[] {
@@ -707,26 +642,32 @@ export class TrendReferenceCorpusService {
       return new Map();
     }
 
-    // Fetch remix lineages for this org+brand, then count source reference occurrences
-    const lineages = await this.prisma.trendRemixLineage.findMany({
-      include: { sourceReferences: { select: { id: true } } },
-      where: {
-        brandId,
-        isDeleted: false,
-        organizationId,
-      },
-    });
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        remix_count: bigint | number | string;
+        source_reference_id: string;
+      }>
+    >(
+      Prisma.sql`
+        SELECT
+          refs."B" AS source_reference_id,
+          COUNT(*) AS remix_count
+        FROM "_remix_lineage_source_refs" refs
+        INNER JOIN "trend_remix_lineages" lineage ON lineage."id" = refs."A"
+        WHERE refs."B" = ANY(${sourceReferenceIds}::text[])
+          AND lineage."organizationId" = ${organizationId}
+          AND lineage."brandId" = ${brandId}
+          AND lineage."isDeleted" = false
+        GROUP BY refs."B"
+      `,
+    );
 
-    const countMap = new Map<string, number>();
-    for (const lineage of lineages) {
-      for (const ref of lineage.sourceReferences) {
-        if (sourceReferenceIds.includes(ref.id)) {
-          countMap.set(ref.id, (countMap.get(ref.id) ?? 0) + 1);
-        }
-      }
-    }
-
-    return countMap;
+    return new Map(
+      rows.map((row) => [
+        row.source_reference_id,
+        Number(row.remix_count ?? 0),
+      ]),
+    );
   }
 
   private async getBrandRemixCountsByAccount(
@@ -738,31 +679,41 @@ export class TrendReferenceCorpusService {
       return new Map();
     }
 
-    const lineages = await this.prisma.trendRemixLineage.findMany({
-      include: {
-        sourceReferences: { select: { data: true, id: true } },
-      },
-      where: {
-        brandId,
-        isDeleted: false,
-        organizationId,
-      },
-    });
+    const platformFilter = platform
+      ? Prisma.sql`AND source_ref."platform" = ${platform}`
+      : Prisma.empty;
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        author_handle: string;
+        platform: string;
+        remix_count: bigint | number | string;
+      }>
+    >(
+      Prisma.sql`
+        SELECT
+          source_ref."platform" AS platform,
+          source_ref."authorHandle" AS author_handle,
+          COUNT(*) AS remix_count
+        FROM "_remix_lineage_source_refs" refs
+        INNER JOIN "trend_remix_lineages" lineage ON lineage."id" = refs."A"
+        INNER JOIN "trend_source_references" source_ref ON source_ref."id" = refs."B"
+        WHERE lineage."organizationId" = ${organizationId}
+          AND lineage."brandId" = ${brandId}
+          AND lineage."isDeleted" = false
+          AND source_ref."isDeleted" = false
+          AND source_ref."platform" IS NOT NULL
+          AND source_ref."authorHandle" IS NOT NULL
+          ${platformFilter}
+        GROUP BY source_ref."platform", source_ref."authorHandle"
+      `,
+    );
 
-    const countMap = new Map<string, number>();
-    for (const lineage of lineages) {
-      for (const ref of lineage.sourceReferences) {
-        const d = ref.data as unknown as Record<string, unknown>;
-        const authorHandle = d.authorHandle as string | undefined;
-        const refPlatform = d.platform as string | undefined;
-        if (!authorHandle || !refPlatform) continue;
-        if (platform && refPlatform !== platform) continue;
-        const key = `${refPlatform}:${authorHandle}`;
-        countMap.set(key, (countMap.get(key) ?? 0) + 1);
-      }
-    }
-
-    return countMap;
+    return new Map(
+      rows.map((row) => [
+        `${row.platform}:${row.author_handle}`,
+        Number(row.remix_count ?? 0),
+      ]),
+    );
   }
 
   private toReferenceRecord(

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -10,6 +10,25 @@ import { vi } from 'vitest';
 
 // Mock @genfeedai/prisma so unit tests never need the generated Prisma client
 vi.mock('@genfeedai/prisma', () => {
+  type MockSql = {
+    sql: string;
+    text: string;
+    values: unknown[];
+  };
+
+  const createSql = (sql: string, values: unknown[] = []): MockSql => ({
+    sql,
+    text: sql,
+    values,
+  });
+
+  const getSqlText = (value: unknown) => {
+    if (typeof value !== 'object' || value === null) return '?';
+    if ('sql' in value) return String(value.sql);
+    if ('text' in value) return String(value.text);
+    return '?';
+  };
+
   class PrismaClient {
     $connect = vi.fn().mockResolvedValue(undefined);
     $disconnect = vi.fn().mockResolvedValue(undefined);
@@ -33,7 +52,20 @@ vi.mock('@genfeedai/prisma', () => {
     HEYGEN: 'HEYGEN',
   } as const;
 
-  return { PrismaClient, VoiceProvider };
+  const Prisma = {
+    empty: createSql(''),
+    raw: (sql: string) => createSql(sql),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const sql = strings.reduce((acc, part, index) => {
+        const value = index < values.length ? getSqlText(values[index]) : '';
+        return `${acc}${part}${value}`;
+      }, '');
+
+      return createSql(sql, values);
+    },
+  };
+
+  return { Prisma, PrismaClient, VoiceProvider };
 });
 
 // Mock @prisma/adapter-pg so PrismaService constructor doesn't require DATABASE_URL

--- a/packages/prisma/prisma/migrations/20260618104000_normalize_trend_reference_corpus/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618104000_normalize_trend_reference_corpus/migration.sql
@@ -1,0 +1,65 @@
+ALTER TABLE "trend_source_references"
+ADD COLUMN "canonicalUrl" TEXT,
+ADD COLUMN "platform" TEXT,
+ADD COLUMN "authorHandle" TEXT,
+ADD COLUMN "currentEngagementTotal" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "latestTrendViralityScore" DOUBLE PRECISION NOT NULL DEFAULT 0,
+ADD COLUMN "lastSeenAt" TIMESTAMP(3);
+
+ALTER TABLE "trend_source_reference_snapshots"
+ADD COLUMN "snapshotDate" TIMESTAMP(3);
+
+UPDATE "trend_source_references"
+SET
+  "canonicalUrl" = NULLIF("data"->>'canonicalUrl', ''),
+  "platform" = NULLIF("data"->>'platform', ''),
+  "authorHandle" = NULLIF("data"->>'authorHandle', ''),
+  "currentEngagementTotal" = CASE
+    WHEN ("data"->>'currentEngagementTotal') ~ '^-?[0-9]+(\.[0-9]+)?$'
+      THEN FLOOR(("data"->>'currentEngagementTotal')::numeric)::integer
+    ELSE 0
+  END,
+  "latestTrendViralityScore" = CASE
+    WHEN ("data"->>'latestTrendViralityScore') ~ '^-?[0-9]+(\.[0-9]+)?$'
+      THEN ("data"->>'latestTrendViralityScore')::double precision
+    ELSE 0
+  END,
+  "lastSeenAt" = CASE
+    WHEN ("data"->>'lastSeenAt') ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+      THEN ("data"->>'lastSeenAt')::timestamp(3)
+    ELSE NULL
+  END;
+
+UPDATE "trend_source_reference_snapshots"
+SET "snapshotDate" = CASE
+  WHEN ("data"->>'snapshotDate') ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+    THEN ("data"->>'snapshotDate')::timestamp(3)
+  ELSE NULL
+END;
+
+CREATE INDEX "trend_remix_lineages_org_brand_deleted_idx"
+ON "trend_remix_lineages"("organizationId", "brandId", "isDeleted");
+
+CREATE INDEX "trend_remix_lineages_content_draft_deleted_idx"
+ON "trend_remix_lineages"("contentDraftId", "isDeleted");
+
+CREATE INDEX "trend_remix_lineages_post_deleted_idx"
+ON "trend_remix_lineages"("postId", "isDeleted");
+
+CREATE INDEX "trend_source_refs_url_platform_deleted_idx"
+ON "trend_source_references"("canonicalUrl", "platform", "isDeleted");
+
+CREATE INDEX "trend_source_refs_account_lookup_idx"
+ON "trend_source_references"("isDeleted", "platform", "authorHandle", "lastSeenAt" DESC);
+
+CREATE INDEX "trend_source_refs_rank_idx"
+ON "trend_source_references"("isDeleted", "currentEngagementTotal" DESC, "latestTrendViralityScore" DESC);
+
+CREATE INDEX "trend_source_reference_links_trend_deleted_idx"
+ON "trend_source_reference_links"("trendId", "isDeleted");
+
+CREATE INDEX "trend_source_reference_links_ref_deleted_idx"
+ON "trend_source_reference_links"("sourceReferenceId", "isDeleted");
+
+CREATE INDEX "trend_source_reference_snapshots_ref_date_deleted_idx"
+ON "trend_source_reference_snapshots"("sourceReferenceId", "snapshotDate", "isDeleted");

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -3232,21 +3232,33 @@ model TrendRemixLineage {
   trends           Trend[]                @relation("remix_lineage_trends")
   sourceReferences TrendSourceReference[] @relation("remix_lineage_source_refs")
 
+  @@index([organizationId, brandId, isDeleted], map: "trend_remix_lineages_org_brand_deleted_idx")
+  @@index([contentDraftId, isDeleted], map: "trend_remix_lineages_content_draft_deleted_idx")
+  @@index([postId, isDeleted], map: "trend_remix_lineages_post_deleted_idx")
   @@map("trend_remix_lineages")
 }
 
 model TrendSourceReference {
-  id        String   @id @default(cuid())
-  mongoId   String?  @unique
-  data      Json     @default("{}")
-  isDeleted Boolean  @default(false)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                       String    @id @default(cuid())
+  mongoId                  String?   @unique
+  canonicalUrl             String?
+  platform                 String?
+  authorHandle             String?
+  currentEngagementTotal   Int       @default(0)
+  latestTrendViralityScore Float     @default(0)
+  lastSeenAt               DateTime?
+  data                     Json      @default("{}")
+  isDeleted                Boolean   @default(false)
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
 
   links         TrendSourceReferenceLink[]
   snapshots     TrendSourceReferenceSnapshot[]
   remixLineages TrendRemixLineage[]            @relation("remix_lineage_source_refs")
 
+  @@index([canonicalUrl, platform, isDeleted], map: "trend_source_refs_url_platform_deleted_idx")
+  @@index([isDeleted, platform, authorHandle, lastSeenAt(sort: Desc)], map: "trend_source_refs_account_lookup_idx")
+  @@index([isDeleted, currentEngagementTotal(sort: Desc), latestTrendViralityScore(sort: Desc)], map: "trend_source_refs_rank_idx")
   @@map("trend_source_references")
 }
 
@@ -3261,6 +3273,8 @@ model TrendSourceReferenceLink {
   createdAt         DateTime              @default(now())
   updatedAt         DateTime              @updatedAt
 
+  @@index([trendId, isDeleted], map: "trend_source_reference_links_trend_deleted_idx")
+  @@index([sourceReferenceId, isDeleted], map: "trend_source_reference_links_ref_deleted_idx")
   @@map("trend_source_reference_links")
 }
 
@@ -3269,11 +3283,13 @@ model TrendSourceReferenceSnapshot {
   mongoId           String?               @unique
   sourceReferenceId String?
   sourceReference   TrendSourceReference? @relation(fields: [sourceReferenceId], references: [id])
+  snapshotDate      DateTime?
   data              Json                  @default("{}")
   isDeleted         Boolean               @default(false)
   createdAt         DateTime              @default(now())
   updatedAt         DateTime              @updatedAt
 
+  @@index([sourceReferenceId, snapshotDate, isDeleted], map: "trend_source_reference_snapshots_ref_date_deleted_idx")
   @@map("trend_source_reference_snapshots")
 }
 


### PR DESCRIPTION
## Summary

- Normalizes trend source reference lookup fields out of JSON into indexed scalar columns.
- Adds a Prisma migration to backfill canonical URL, platform, author handle, engagement, virality, and snapshot dates.
- Reworks reference corpus reads/grouping/remix counts to use indexed Prisma filters, `groupBy`, bounded selects, and focused raw SQL joins for the implicit remix relation.
- Adds focused unit coverage for indexed corpus filters, URL annotation, account grouping, and remix lineage creation.

Refs #629

## Verification

- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bunx prisma generate --schema packages/prisma/prisma/schema.prisma`
- `bun run --cwd apps/server/api test:file -- src/collections/trends/services/trend-reference-corpus.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bun run --cwd apps/server/api build`
- `bunx biome check --write apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts apps/server/api/test/setup-unit.ts`
- `git diff --check`
- SQL audit rerun: #629 scan cluster removed from the trend reference service; remaining raw SQL review entries need production EXPLAIN once real corpus volume is available. The branch is independent from #628, so older business analytics findings still appear until PR #643 lands.

## Risk / Rollout

- Adds nullable scalar mirror columns plus bounded backfill for existing JSON values.
- New indexes target canonical URL/platform matching, author/platform corpus filters, engagement sorting, link lookups, and snapshot-date lookups.
- Raw SQL is limited to remix counts over the implicit Prisma many-to-many join table and keeps org/brand/isDeleted filters.
