### PR TITLE
perf(api): aggregate ad performance benchmarks in SQL

### DIFF
--- a/apps/server/api/src/collections/ad-performance/services/ad-performance.service.ts
+++ b/apps/server/api/src/collections/ad-performance/services/ad-performance.service.ts
@@ -2,6 +2,10 @@ import type {
   AdPerformance,
   AdPerformanceDocument,
 } from '@api/collections/ad-performance/schemas/ad-performance.schema';
+import {
+  type AdPerformanceBenchmarkFields,
+  buildAdPerformanceBenchmarkFields,
+} from '@api/collections/ad-performance/utils/ad-performance-benchmark.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -60,6 +64,7 @@ export class AdPerformanceService {
 
   private toPersistencePayload(data: Record<string, unknown>): {
     brandId: string | null;
+    benchmarkFields: AdPerformanceBenchmarkFields;
     credentialId: string | null;
     data: Record<string, unknown>;
     organizationId: string;
@@ -77,6 +82,7 @@ export class AdPerformanceService {
     }
 
     return {
+      benchmarkFields: buildAdPerformanceBenchmarkFields(normalizedData),
       brandId:
         this.readString(data.brandId) ?? this.readString(data.brand) ?? null,
       credentialId:
@@ -127,6 +133,7 @@ export class AdPerformanceService {
     if (existing) {
       const updated = await this.prisma.adPerformance.update({
         data: {
+          ...payload.benchmarkFields,
           brandId: payload.brandId,
           credentialId: payload.credentialId,
           data: payload.data as never,
@@ -140,6 +147,7 @@ export class AdPerformanceService {
 
     const created = await this.prisma.adPerformance.create({
       data: {
+        ...payload.benchmarkFields,
         brandId: payload.brandId,
         credentialId: payload.credentialId,
         data: payload.data as never,
@@ -294,6 +302,7 @@ export class AdPerformanceService {
               ...this.readObjectRecord(record.data),
               scope: 'organization',
             } as never,
+            scope: 'organization',
           },
           where: { id: record.id },
         }),

--- a/apps/server/api/src/collections/ad-performance/utils/ad-performance-benchmark.util.ts
+++ b/apps/server/api/src/collections/ad-performance/utils/ad-performance-benchmark.util.ts
@@ -1,0 +1,106 @@
+export type AdPerformanceBenchmarkFields = {
+  headlineText: string | null;
+  ctaText: string | null;
+  adPlatform: string | null;
+  industry: string | null;
+  scope: string | null;
+  spend: number | null;
+  ctr: number | null;
+  roas: number | null;
+  cpc: number | null;
+  cpa: number | null;
+  performanceScore: number | null;
+  conversionRate: number | null;
+  dataConfidence: number | null;
+  spendBucket: string | null;
+  headlinePatternCategories: string[];
+  ctaPatternCategories: string[];
+};
+
+export const HEADLINE_PATTERN_CATEGORIES: Record<string, RegExp> = {
+  'benefit-focused': /\b(get|save|earn|boost|improve|increase)\b/i,
+  comparison: /\b(vs\.?|versus|compared|better than|unlike)\b/i,
+  'curiosity-gap': /\b(secret|surprising|you won't believe|revealed)\b/i,
+  'how-to': /^how\s+to\b/i,
+  'number-driven': /\b\d+\b/,
+  'question-based': /\?$/,
+  testimonial: /\b(review|rated|trusted|customers say)\b/i,
+  urgency: /\b(limited|now|today|hurry|last chance|don't miss|ends|expires)\b/i,
+};
+
+export const CTA_PATTERN_CATEGORIES: Record<string, RegExp> = {
+  'book-now': /\b(book|reserve|schedule)\b/i,
+  'contact-us': /\b(contact|call|reach out|get in touch)\b/i,
+  download: /\b(download|install|get the app)\b/i,
+  'get-started': /\b(get started|start|begin|try)\b/i,
+  'learn-more': /\b(learn more|find out|discover|explore)\b/i,
+  'shop-now': /\b(shop|buy|order|purchase)\b/i,
+  'sign-up': /\b(sign up|register|join|subscribe|create account)\b/i,
+  'try-free': /\b(free trial|try free|start free|no cost)\b/i,
+};
+
+export const SPEND_BUCKETS = [
+  { label: '$0-50/day', min: 0, max: 50 },
+  { label: '$50-200/day', min: 50, max: 200 },
+  { label: '$200-500/day', min: 200, max: 500 },
+  { label: '$500-1000/day', min: 500, max: 1000 },
+  { label: '$1000+/day', min: 1000, max: Infinity },
+] as const;
+
+const readString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const readNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const collectMatchingCategories = (
+  value: string | undefined,
+  patterns: Record<string, RegExp>,
+): string[] => {
+  if (!value) return [];
+
+  return Object.entries(patterns)
+    .filter(([, regex]) => regex.test(value))
+    .map(([category]) => category);
+};
+
+const resolveSpendBucket = (spend: number | undefined): string | undefined => {
+  if (spend == null || spend <= 0) return undefined;
+
+  return SPEND_BUCKETS.find(
+    (bucket) => spend >= bucket.min && spend < bucket.max,
+  )?.label;
+};
+
+export const buildAdPerformanceBenchmarkFields = (
+  data: Record<string, unknown>,
+): AdPerformanceBenchmarkFields => {
+  const headlineText = readString(data.headlineText);
+  const ctaText = readString(data.ctaText);
+  const spend = readNumber(data.spend);
+
+  return {
+    adPlatform: readString(data.adPlatform) ?? null,
+    conversionRate: readNumber(data.conversionRate) ?? null,
+    cpa: readNumber(data.cpa) ?? null,
+    cpc: readNumber(data.cpc) ?? null,
+    ctaPatternCategories: collectMatchingCategories(
+      ctaText,
+      CTA_PATTERN_CATEGORIES,
+    ),
+    ctaText: ctaText ?? null,
+    ctr: readNumber(data.ctr) ?? null,
+    dataConfidence: readNumber(data.dataConfidence) ?? null,
+    headlinePatternCategories: collectMatchingCategories(
+      headlineText,
+      HEADLINE_PATTERN_CATEGORIES,
+    ),
+    headlineText: headlineText ?? null,
+    industry: readString(data.industry) ?? null,
+    performanceScore: readNumber(data.performanceScore) ?? null,
+    roas: readNumber(data.roas) ?? null,
+    scope: readString(data.scope) ?? null,
+    spend: spend ?? null,
+    spendBucket: resolveSpendBucket(spend) ?? null,
+  };
+};

--- a/apps/server/api/src/services/ad-aggregation/ad-aggregation.service.spec.ts
+++ b/apps/server/api/src/services/ad-aggregation/ad-aggregation.service.spec.ts
@@ -1,0 +1,213 @@
+import { AdAggregationService } from '@api/services/ad-aggregation/ad-aggregation.service';
+
+describe('AdAggregationService', () => {
+  let service: AdAggregationService;
+  let prisma: {
+    $queryRaw: ReturnType<typeof vi.fn>;
+    adPerformance: { findMany: ReturnType<typeof vi.fn> };
+  };
+
+  beforeEach(() => {
+    prisma = {
+      $queryRaw: vi.fn(),
+      adPerformance: { findMany: vi.fn() },
+    };
+
+    service = new AdAggregationService(
+      prisma as never,
+      {
+        log: vi.fn(),
+      } as never,
+    );
+  });
+
+  it('computes headline pattern benchmarks from SQL aggregate rows', async () => {
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        category: 'benefit-focused',
+        sampleSize: 5,
+        sumCtr: 0.5,
+        sumRoas: 15,
+      },
+    ]);
+
+    const result = await service.computeTopHeadlines('retail');
+
+    expect(prisma.adPerformance.findMany).not.toHaveBeenCalled();
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(result.sampleSize).toBe(5);
+    expect(result.patterns).toContainEqual({
+      avgCtr: 0.1,
+      avgRoas: 3,
+      category: 'benefit-focused',
+      sampleSize: 5,
+    });
+    expect(result.patterns).toContainEqual({
+      avgCtr: 0,
+      avgRoas: 0,
+      category: 'comparison',
+      sampleSize: 0,
+    });
+  });
+
+  it('computes CTA benchmarks from SQL aggregate rows', async () => {
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        category: 'shop-now',
+        sampleSize: 6,
+        sumConversionRate: 0.3,
+        sumCtr: 0.6,
+      },
+    ]);
+
+    const result = await service.computeBestCtas('fashion');
+
+    expect(prisma.adPerformance.findMany).not.toHaveBeenCalled();
+    expect(result.sampleSize).toBe(6);
+    expect(result.patterns).toContainEqual({
+      avgConversionRate: 0.05,
+      avgCtr: 0.1,
+      category: 'shop-now',
+      sampleSize: 6,
+    });
+    expect(result.patterns).toContainEqual({
+      avgConversionRate: 0,
+      avgCtr: 0,
+      category: 'book-now',
+      sampleSize: 0,
+    });
+  });
+
+  it('computes optimal spend buckets from bounded SQL groups', async () => {
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        range: '$50-200/day',
+        sampleSize: 5,
+        sumPerformanceScore: 400,
+        sumRoas: 20,
+      },
+      {
+        range: '$1000+/day',
+        sampleSize: 5,
+        sumPerformanceScore: 300,
+        sumRoas: 10,
+      },
+    ]);
+
+    const result = await service.computeOptimalSpend('meta', 'saas');
+
+    expect(prisma.adPerformance.findMany).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      buckets: [
+        {
+          avgPerformanceScore: 80,
+          avgRoas: 4,
+          range: '$50-200/day',
+          sampleSize: 5,
+        },
+        {
+          avgPerformanceScore: 60,
+          avgRoas: 2,
+          range: '$1000+/day',
+          sampleSize: 5,
+        },
+      ],
+      sampleSize: 10,
+    });
+  });
+
+  it('computes platform benchmarks without hydrating raw ad rows', async () => {
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        avgKey: 'google',
+        sampleSize: 5,
+        sumCpa: 20,
+        sumCpc: 10,
+        sumCtr: 0.5,
+        sumRoas: 15,
+      },
+      {
+        avgKey: 'meta',
+        sampleSize: 5,
+        sumCpa: 25,
+        sumCpc: 5,
+        sumCtr: 1,
+        sumRoas: 10,
+      },
+    ]);
+
+    const result = await service.computePlatformBenchmarks('retail');
+
+    expect(prisma.adPerformance.findMany).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      google: {
+        avgCpa: 4,
+        avgCpc: 2,
+        avgCtr: 0.1,
+        avgRoas: 3,
+        sampleSize: 5,
+      },
+      meta: {
+        avgCpa: 5,
+        avgCpc: 1,
+        avgCtr: 0.2,
+        avgRoas: 2,
+        sampleSize: 5,
+      },
+      sampleSize: 10,
+      tiktok: {
+        avgCpa: 0,
+        avgCpc: 0,
+        avgCtr: 0,
+        avgRoas: 0,
+        sampleSize: 0,
+      },
+    });
+  });
+
+  it('computes industry benchmarks from SQL groups ordered by sample size', async () => {
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        avgKey: 'retail',
+        sampleSize: 7,
+        sumCpa: 28,
+        sumCpc: 14,
+        sumCtr: 0.7,
+        sumRoas: 21,
+      },
+      {
+        avgKey: 'beauty',
+        sampleSize: 5,
+        sumCpa: 10,
+        sumCpc: 5,
+        sumCtr: 0.25,
+        sumRoas: 15,
+      },
+    ]);
+
+    const result = await service.computeIndustryBenchmarks();
+
+    expect(prisma.adPerformance.findMany).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      industries: [
+        {
+          avgCpa: 4,
+          avgCpc: 2,
+          avgCtr: 0.1,
+          avgRoas: 3,
+          industry: 'retail',
+          sampleSize: 7,
+        },
+        {
+          avgCpa: 2,
+          avgCpc: 1,
+          avgCtr: 0.05,
+          avgRoas: 3,
+          industry: 'beauty',
+          sampleSize: 5,
+        },
+      ],
+      sampleSize: 12,
+    });
+  });
+});

--- a/apps/server/api/src/services/ad-aggregation/ad-aggregation.service.ts
+++ b/apps/server/api/src/services/ad-aggregation/ad-aggregation.service.ts
@@ -1,21 +1,35 @@
+import {
+  CTA_PATTERN_CATEGORIES,
+  HEADLINE_PATTERN_CATEGORIES,
+  SPEND_BUCKETS,
+} from '@api/collections/ad-performance/utils/ad-performance-benchmark.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
-type AdPerformanceData = {
-  headlineText?: string;
-  ctaText?: string;
-  ctr?: number;
-  roas?: number;
-  cpc?: number;
-  cpa?: number;
-  spend?: number;
-  performanceScore?: number;
-  adPlatform?: string;
-  industry?: string;
-  scope?: string;
-  conversionRate?: number;
-  dataConfidence?: number;
+type PatternMetricRow = {
+  category: string;
+  sampleSize: number | bigint;
+  sumConversionRate?: number | null;
+  sumCtr: number | null;
+  sumRoas?: number | null;
+};
+
+type SpendBucketMetricRow = {
+  range: string;
+  sampleSize: number | bigint;
+  sumPerformanceScore: number | null;
+  sumRoas: number | null;
+};
+
+type BenchmarkMetricRow = {
+  avgKey: string;
+  sampleSize: number | bigint;
+  sumCpa: number | null;
+  sumCpc: number | null;
+  sumCtr: number | null;
+  sumRoas: number | null;
 };
 
 @Injectable()
@@ -39,71 +53,45 @@ export class AdAggregationService {
   }> {
     this.logger.log(`${this.constructorName}: Computing top headlines`);
 
-    const patternCategories: Record<string, RegExp> = {
-      'benefit-focused': /\b(get|save|earn|boost|improve|increase)\b/i,
-      comparison: /\b(vs\.?|versus|compared|better than|unlike)\b/i,
-      'curiosity-gap': /\b(secret|surprising|you won't believe|revealed)\b/i,
-      'how-to': /^how\s+to\b/i,
-      'number-driven': /\b\d+\b/,
-      'question-based': /\?$/,
-      testimonial: /\b(review|rated|trusted|customers say)\b/i,
-      urgency:
-        /\b(limited|now|today|hurry|last chance|don't miss|ends|expires)\b/i,
-    };
+    const rows = await this.prisma.$queryRaw<PatternMetricRow[]>(
+      Prisma.sql`
+        SELECT
+          pattern.category AS "category",
+          COUNT(*)::integer AS "sampleSize",
+          COALESCE(SUM(COALESCE(ap."ctr", 0) * COALESCE(ap."dataConfidence", 1)), 0)::double precision AS "sumCtr",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."roas", 0) > 0 THEN ap."roas" * COALESCE(ap."dataConfidence", 1) ELSE 0 END), 0)::double precision AS "sumRoas"
+        FROM "ad_performance" ap
+        CROSS JOIN LATERAL unnest(ap."headlinePatternCategories") AS pattern(category)
+        WHERE ap."isDeleted" = false
+          AND ap."scope" = 'public'
+          AND cardinality(ap."headlinePatternCategories") > 0
+          AND ap."headlinePatternCategories" && ${Object.keys(HEADLINE_PATTERN_CATEGORIES)}::text[]
+          ${this.industryClause(industry)}
+        GROUP BY pattern.category
+        HAVING COUNT(DISTINCT ap."organizationId") >= ${this.MIN_ORGS}
+      `,
+    );
 
-    const records = await this.prisma.adPerformance.findMany({
-      select: { data: true, organizationId: true },
-      where: { isDeleted: false },
-    });
-
-    // Filter to public scope + optional industry
-    const eligible = records.filter((r) => {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      if (d.scope !== 'public') return false;
-      if (!d.headlineText) return false;
-      if (industry && d.industry !== industry) return false;
-      return true;
-    });
-
-    const patterns: Array<{
-      category: string;
-      avgCtr: number;
-      avgRoas: number;
-      sampleSize: number;
-    }> = [];
+    const rowsByCategory = new Map(rows.map((row) => [row.category, row]));
     let totalSampleSize = 0;
+    const patterns = Object.keys(HEADLINE_PATTERN_CATEGORIES).map(
+      (category) => {
+        const row = rowsByCategory.get(category);
+        if (!row) {
+          return { avgCtr: 0, avgRoas: 0, category, sampleSize: 0 };
+        }
 
-    for (const [category, regex] of Object.entries(patternCategories)) {
-      const matched = eligible.filter((r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        return regex.test(d.headlineText ?? '');
-      });
+        const sampleSize = this.toNumber(row.sampleSize);
+        totalSampleSize += sampleSize;
 
-      const distinctOrgs = new Set(matched.map((r) => r.organizationId));
-      if (distinctOrgs.size < this.MIN_ORGS) {
-        patterns.push({ avgCtr: 0, avgRoas: 0, category, sampleSize: 0 });
-        continue;
-      }
-
-      const sumCtr = matched.reduce((sum, r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        return sum + (d.ctr ?? 0) * (d.dataConfidence ?? 1);
-      }, 0);
-      const sumRoas = matched.reduce((sum, r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        const roas = d.roas ?? 0;
-        return sum + (roas > 0 ? roas * (d.dataConfidence ?? 1) : 0);
-      }, 0);
-
-      const count = matched.length;
-      patterns.push({
-        avgCtr: Math.round((sumCtr / count) * 10000) / 10000,
-        avgRoas: Math.round((sumRoas / count) * 10000) / 10000,
-        category,
-        sampleSize: count,
-      });
-      totalSampleSize += count;
-    }
+        return {
+          avgCtr: this.round4(this.toNumber(row.sumCtr) / sampleSize),
+          avgRoas: this.round4(this.toNumber(row.sumRoas) / sampleSize),
+          category,
+          sampleSize,
+        };
+      },
+    );
 
     return { patterns, sampleSize: totalSampleSize };
   }
@@ -119,74 +107,50 @@ export class AdAggregationService {
   }> {
     this.logger.log(`${this.constructorName}: Computing best CTAs`);
 
-    const ctaMapping: Record<string, RegExp> = {
-      'book-now': /\b(book|reserve|schedule)\b/i,
-      'contact-us': /\b(contact|call|reach out|get in touch)\b/i,
-      download: /\b(download|install|get the app)\b/i,
-      'get-started': /\b(get started|start|begin|try)\b/i,
-      'learn-more': /\b(learn more|find out|discover|explore)\b/i,
-      'shop-now': /\b(shop|buy|order|purchase)\b/i,
-      'sign-up': /\b(sign up|register|join|subscribe|create account)\b/i,
-      'try-free': /\b(free trial|try free|start free|no cost)\b/i,
-    };
+    const rows = await this.prisma.$queryRaw<PatternMetricRow[]>(
+      Prisma.sql`
+        SELECT
+          pattern.category AS "category",
+          COUNT(*)::integer AS "sampleSize",
+          COALESCE(SUM(COALESCE(ap."ctr", 0)), 0)::double precision AS "sumCtr",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."conversionRate", 0) > 0 THEN ap."conversionRate" ELSE 0 END), 0)::double precision AS "sumConversionRate"
+        FROM "ad_performance" ap
+        CROSS JOIN LATERAL unnest(ap."ctaPatternCategories") AS pattern(category)
+        WHERE ap."isDeleted" = false
+          AND ap."scope" = 'public'
+          AND cardinality(ap."ctaPatternCategories") > 0
+          AND ap."ctaPatternCategories" && ${Object.keys(CTA_PATTERN_CATEGORIES)}::text[]
+          ${this.industryClause(industry)}
+        GROUP BY pattern.category
+        HAVING COUNT(DISTINCT ap."organizationId") >= ${this.MIN_ORGS}
+      `,
+    );
 
-    const records = await this.prisma.adPerformance.findMany({
-      select: { data: true, organizationId: true },
-      where: { isDeleted: false },
-    });
-
-    const eligible = records.filter((r) => {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      if (d.scope !== 'public') return false;
-      if (!d.ctaText) return false;
-      if (industry && d.industry !== industry) return false;
-      return true;
-    });
-
-    const patterns: Array<{
-      category: string;
-      avgCtr: number;
-      avgConversionRate: number;
-      sampleSize: number;
-    }> = [];
+    const rowsByCategory = new Map(rows.map((row) => [row.category, row]));
     let totalSampleSize = 0;
-
-    for (const [category, regex] of Object.entries(ctaMapping)) {
-      const matched = eligible.filter((r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        return regex.test(d.ctaText ?? '');
-      });
-
-      const distinctOrgs = new Set(matched.map((r) => r.organizationId));
-      if (distinctOrgs.size < this.MIN_ORGS) {
-        patterns.push({
+    const patterns = Object.keys(CTA_PATTERN_CATEGORIES).map((category) => {
+      const row = rowsByCategory.get(category);
+      if (!row) {
+        return {
           avgConversionRate: 0,
           avgCtr: 0,
           category,
           sampleSize: 0,
-        });
-        continue;
+        };
       }
 
-      const sumCtr = matched.reduce((sum, r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        return sum + (d.ctr ?? 0);
-      }, 0);
-      const sumConvRate = matched.reduce((sum, r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        const cr = d.conversionRate ?? 0;
-        return sum + (cr > 0 ? cr : 0);
-      }, 0);
+      const sampleSize = this.toNumber(row.sampleSize);
+      totalSampleSize += sampleSize;
 
-      const count = matched.length;
-      patterns.push({
-        avgConversionRate: Math.round((sumConvRate / count) * 10000) / 10000,
-        avgCtr: Math.round((sumCtr / count) * 10000) / 10000,
+      return {
+        avgConversionRate: this.round4(
+          this.toNumber(row.sumConversionRate) / sampleSize,
+        ),
+        avgCtr: this.round4(this.toNumber(row.sumCtr) / sampleSize),
         category,
-        sampleSize: count,
-      });
-      totalSampleSize += count;
-    }
+        sampleSize,
+      };
+    });
 
     return { patterns, sampleSize: totalSampleSize };
   }
@@ -205,66 +169,44 @@ export class AdAggregationService {
   }> {
     this.logger.log(`${this.constructorName}: Computing optimal spend`);
 
-    const records = await this.prisma.adPerformance.findMany({
-      select: { data: true, organizationId: true },
-      where: { isDeleted: false },
-    });
+    const rows = await this.prisma.$queryRaw<SpendBucketMetricRow[]>(
+      Prisma.sql`
+        SELECT
+          ap."spendBucket" AS "range",
+          COUNT(*)::integer AS "sampleSize",
+          COALESCE(SUM(COALESCE(ap."performanceScore", 0)), 0)::double precision AS "sumPerformanceScore",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."roas", 0) > 0 THEN ap."roas" ELSE 0 END), 0)::double precision AS "sumRoas"
+        FROM "ad_performance" ap
+        WHERE ap."isDeleted" = false
+          AND ap."scope" = 'public'
+          AND ap."spendBucket" IS NOT NULL
+          ${this.platformClause(platform)}
+          ${this.industryClause(industry)}
+        GROUP BY ap."spendBucket"
+        HAVING COUNT(DISTINCT ap."organizationId") >= ${this.MIN_ORGS}
+      `,
+    );
 
-    const eligible = records.filter((r) => {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      if (d.scope !== 'public') return false;
-      if ((d.spend ?? 0) <= 0) return false;
-      if (platform && d.adPlatform !== platform) return false;
-      if (industry && d.industry !== industry) return false;
-      return true;
-    });
-
-    const spendBoundaries = [
-      { label: '$0-50/day', min: 0, max: 50 },
-      { label: '$50-200/day', min: 50, max: 200 },
-      { label: '$200-500/day', min: 200, max: 500 },
-      { label: '$500-1000/day', min: 500, max: 1000 },
-      { label: '$1000+/day', min: 1000, max: Infinity },
-    ];
-
-    const buckets: Array<{
-      range: string;
-      avgPerformanceScore: number;
-      avgRoas: number;
-      sampleSize: number;
-    }> = [];
-
+    const rowsByRange = new Map(rows.map((row) => [row.range, row]));
     let totalSampleSize = 0;
+    const buckets = SPEND_BUCKETS.flatMap((bucket) => {
+      const row = rowsByRange.get(bucket.label);
+      if (!row) return [];
 
-    for (const { label, min, max } of spendBoundaries) {
-      const matched = eligible.filter((r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        const s = d.spend ?? 0;
-        return s >= min && s < max;
-      });
+      const sampleSize = this.toNumber(row.sampleSize);
+      totalSampleSize += sampleSize;
 
-      const distinctOrgs = new Set(matched.map((r) => r.organizationId));
-      if (distinctOrgs.size < this.MIN_ORGS) continue;
-
-      const sumPerf = matched.reduce((sum, r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        return sum + (d.performanceScore ?? 0);
-      }, 0);
-      const sumRoas = matched.reduce((sum, r) => {
-        const d = (r.data ?? {}) as AdPerformanceData;
-        const roas = d.roas ?? 0;
-        return sum + (roas > 0 ? roas : 0);
-      }, 0);
-
-      const count = matched.length;
-      buckets.push({
-        avgPerformanceScore: Math.round((sumPerf / count) * 100) / 100,
-        avgRoas: Math.round((sumRoas / count) * 100) / 100,
-        range: label,
-        sampleSize: count,
-      });
-      totalSampleSize += count;
-    }
+      return [
+        {
+          avgPerformanceScore: this.round2(
+            this.toNumber(row.sumPerformanceScore) / sampleSize,
+          ),
+          avgRoas: this.round2(this.toNumber(row.sumRoas) / sampleSize),
+          range: bucket.label,
+          sampleSize,
+        },
+      ];
+    });
 
     return { buckets, sampleSize: totalSampleSize };
   }
@@ -295,80 +237,36 @@ export class AdAggregationService {
   }> {
     this.logger.log(`${this.constructorName}: Computing platform benchmarks`);
 
-    const records = await this.prisma.adPerformance.findMany({
-      select: { data: true, organizationId: true },
-      where: { isDeleted: false },
-    });
+    const rows = await this.prisma.$queryRaw<BenchmarkMetricRow[]>(
+      Prisma.sql`
+        SELECT
+          COALESCE(ap."adPlatform", 'unknown') AS "avgKey",
+          COUNT(*)::integer AS "sampleSize",
+          COALESCE(SUM(COALESCE(ap."ctr", 0)), 0)::double precision AS "sumCtr",
+          COALESCE(SUM(COALESCE(ap."cpc", 0)), 0)::double precision AS "sumCpc",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."cpa", 0) > 0 THEN ap."cpa" ELSE 0 END), 0)::double precision AS "sumCpa",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."roas", 0) > 0 THEN ap."roas" ELSE 0 END), 0)::double precision AS "sumRoas"
+        FROM "ad_performance" ap
+        WHERE ap."isDeleted" = false
+          AND ap."scope" = 'public'
+          ${this.industryClause(industry)}
+        GROUP BY COALESCE(ap."adPlatform", 'unknown')
+        HAVING COUNT(DISTINCT ap."organizationId") >= ${this.MIN_ORGS}
+      `,
+    );
 
-    const eligible = records.filter((r) => {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      if (d.scope !== 'public') return false;
-      if (industry && d.industry !== industry) return false;
-      return true;
-    });
-
-    const emptyBenchmark = {
-      avgCpa: 0,
-      avgCpc: 0,
-      avgCtr: 0,
-      avgRoas: 0,
-      sampleSize: 0,
-    };
-
-    const platformGroups: Record<
-      string,
-      { data: AdPerformanceData; orgId: string }[]
-    > = {};
-    for (const r of eligible) {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      const p = d.adPlatform ?? 'unknown';
-      if (!platformGroups[p]) platformGroups[p] = [];
-      platformGroups[p].push({ data: d, orgId: r.organizationId });
-    }
-
-    const benchmarkMap: Record<
-      string,
-      {
-        avgCtr: number;
-        avgCpc: number;
-        avgCpa: number;
-        avgRoas: number;
-        sampleSize: number;
-      }
-    > = {};
-    let totalSampleSize = 0;
-
-    for (const [platform, rows] of Object.entries(platformGroups)) {
-      const distinctOrgs = new Set(rows.map((r) => r.orgId));
-      if (distinctOrgs.size < this.MIN_ORGS) continue;
-
-      const count = rows.length;
-      const sumCtr = rows.reduce((s, r) => s + (r.data.ctr ?? 0), 0);
-      const sumCpc = rows.reduce((s, r) => s + (r.data.cpc ?? 0), 0);
-      const sumCpa = rows.reduce(
-        (s, r) => s + ((r.data.cpa ?? 0) > 0 ? (r.data.cpa ?? 0) : 0),
-        0,
-      );
-      const sumRoas = rows.reduce(
-        (s, r) => s + ((r.data.roas ?? 0) > 0 ? (r.data.roas ?? 0) : 0),
-        0,
-      );
-
-      benchmarkMap[platform] = {
-        avgCpa: Math.round((sumCpa / count) * 10000) / 10000,
-        avgCpc: Math.round((sumCpc / count) * 10000) / 10000,
-        avgCtr: Math.round((sumCtr / count) * 10000) / 10000,
-        avgRoas: Math.round((sumRoas / count) * 10000) / 10000,
-        sampleSize: count,
-      };
-      totalSampleSize += count;
-    }
+    const benchmarkMap = new Map(
+      rows.map((row) => [row.avgKey, this.toBenchmark(row)]),
+    );
 
     return {
-      google: benchmarkMap.google ?? { ...emptyBenchmark },
-      meta: benchmarkMap.meta ?? { ...emptyBenchmark },
-      sampleSize: totalSampleSize,
-      tiktok: benchmarkMap.tiktok ?? { ...emptyBenchmark },
+      google: benchmarkMap.get('google') ?? this.emptyBenchmark(),
+      meta: benchmarkMap.get('meta') ?? this.emptyBenchmark(),
+      sampleSize: rows.reduce(
+        (sum, row) => sum + this.toNumber(row.sampleSize),
+        0,
+      ),
+      tiktok: benchmarkMap.get('tiktok') ?? this.emptyBenchmark(),
     };
   }
 
@@ -385,66 +283,95 @@ export class AdAggregationService {
   }> {
     this.logger.log(`${this.constructorName}: Computing industry benchmarks`);
 
-    const records = await this.prisma.adPerformance.findMany({
-      select: { data: true, organizationId: true },
-      where: { isDeleted: false },
-    });
+    const rows = await this.prisma.$queryRaw<BenchmarkMetricRow[]>(
+      Prisma.sql`
+        SELECT
+          ap."industry" AS "avgKey",
+          COUNT(*)::integer AS "sampleSize",
+          COALESCE(SUM(COALESCE(ap."ctr", 0)), 0)::double precision AS "sumCtr",
+          COALESCE(SUM(COALESCE(ap."cpc", 0)), 0)::double precision AS "sumCpc",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."cpa", 0) > 0 THEN ap."cpa" ELSE 0 END), 0)::double precision AS "sumCpa",
+          COALESCE(SUM(CASE WHEN COALESCE(ap."roas", 0) > 0 THEN ap."roas" ELSE 0 END), 0)::double precision AS "sumRoas"
+        FROM "ad_performance" ap
+        WHERE ap."isDeleted" = false
+          AND ap."scope" = 'public'
+          AND ap."industry" IS NOT NULL
+        GROUP BY ap."industry"
+        HAVING COUNT(DISTINCT ap."organizationId") >= ${this.MIN_ORGS}
+        ORDER BY "sampleSize" DESC
+      `,
+    );
 
-    const eligible = records.filter((r) => {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      return d.scope === 'public' && Boolean(d.industry);
-    });
-
-    const industryGroups: Record<
-      string,
-      { data: AdPerformanceData; orgId: string }[]
-    > = {};
-    for (const r of eligible) {
-      const d = (r.data ?? {}) as AdPerformanceData;
-      const ind = d.industry!;
-      if (!industryGroups[ind]) industryGroups[ind] = [];
-      industryGroups[ind].push({ data: d, orgId: r.organizationId });
-    }
-
-    const industries: Array<{
-      industry: string;
-      avgCtr: number;
-      avgCpc: number;
-      avgCpa: number;
-      avgRoas: number;
-      sampleSize: number;
-    }> = [];
-    let totalSampleSize = 0;
-
-    for (const [industry, rows] of Object.entries(industryGroups)) {
-      const distinctOrgs = new Set(rows.map((r) => r.orgId));
-      if (distinctOrgs.size < this.MIN_ORGS) continue;
-
-      const count = rows.length;
-      const sumCtr = rows.reduce((s, r) => s + (r.data.ctr ?? 0), 0);
-      const sumCpc = rows.reduce((s, r) => s + (r.data.cpc ?? 0), 0);
-      const sumCpa = rows.reduce(
-        (s, r) => s + ((r.data.cpa ?? 0) > 0 ? (r.data.cpa ?? 0) : 0),
+    return {
+      industries: rows.map((row) => ({
+        ...this.toBenchmark(row),
+        industry: row.avgKey,
+      })),
+      sampleSize: rows.reduce(
+        (sum, row) => sum + this.toNumber(row.sampleSize),
         0,
-      );
-      const sumRoas = rows.reduce(
-        (s, r) => s + ((r.data.roas ?? 0) > 0 ? (r.data.roas ?? 0) : 0),
-        0,
-      );
+      ),
+    };
+  }
 
-      industries.push({
-        avgCpa: Math.round((sumCpa / count) * 10000) / 10000,
-        avgCpc: Math.round((sumCpc / count) * 10000) / 10000,
-        avgCtr: Math.round((sumCtr / count) * 10000) / 10000,
-        avgRoas: Math.round((sumRoas / count) * 10000) / 10000,
-        industry,
-        sampleSize: count,
-      });
-      totalSampleSize += count;
-    }
+  private industryClause(industry?: string) {
+    return industry
+      ? Prisma.sql`AND ap."industry" = ${industry}`
+      : Prisma.empty;
+  }
 
-    industries.sort((a, b) => b.sampleSize - a.sampleSize);
+  private platformClause(platform?: string) {
+    return platform
+      ? Prisma.sql`AND ap."adPlatform" = ${platform}`
+      : Prisma.empty;
+  }
 
-    return { industries, sampleSize: totalSampleSize };
+  private toBenchmark(row: BenchmarkMetricRow): {
+    avgCtr: number;
+    avgCpc: number;
+    avgCpa: number;
+    avgRoas: number;
+    sampleSize: number;
+  } {
+    const sampleSize = this.toNumber(row.sampleSize);
+
+    return {
+      avgCpa: this.round4(this.toNumber(row.sumCpa) / sampleSize),
+      avgCpc: this.round4(this.toNumber(row.sumCpc) / sampleSize),
+      avgCtr: this.round4(this.toNumber(row.sumCtr) / sampleSize),
+      avgRoas: this.round4(this.toNumber(row.sumRoas) / sampleSize),
+      sampleSize,
+    };
+  }
+
+  private emptyBenchmark(): {
+    avgCtr: number;
+    avgCpc: number;
+    avgCpa: number;
+    avgRoas: number;
+    sampleSize: number;
+  } {
+    return {
+      avgCpa: 0,
+      avgCpc: 0,
+      avgCtr: 0,
+      avgRoas: 0,
+      sampleSize: 0,
+    };
+  }
+
+  private toNumber(value: number | bigint | string | null | undefined): number {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') return Number(value);
+    return 0;
+  }
+
+  private round2(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+
+  private round4(value: number): number {
+    return Math.round(value * 10000) / 10000;
   }
 }

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -33,7 +33,19 @@ vi.mock('@genfeedai/prisma', () => {
     HEYGEN: 'HEYGEN',
   } as const;
 
-  return { PrismaClient, VoiceProvider };
+  const Prisma = {
+    empty: '',
+    raw: (value: string) => value,
+    sql: (
+      strings: TemplateStringsArray,
+      ...values: unknown[]
+    ): { strings: TemplateStringsArray; values: unknown[] } => ({
+      strings,
+      values,
+    }),
+  };
+
+  return { Prisma, PrismaClient, VoiceProvider };
 });
 
 // Mock @prisma/adapter-pg so PrismaService constructor doesn't require DATABASE_URL

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -10,6 +10,25 @@ import { vi } from 'vitest';
 
 // Mock @genfeedai/prisma so unit tests never need the generated Prisma client
 vi.mock('@genfeedai/prisma', () => {
+  type MockSql = {
+    sql: string;
+    text: string;
+    values: unknown[];
+  };
+
+  const createSql = (sql: string, values: unknown[] = []): MockSql => ({
+    sql,
+    text: sql,
+    values,
+  });
+
+  const getSqlText = (value: unknown) => {
+    if (typeof value !== 'object' || value === null) return '?';
+    if ('sql' in value) return String(value.sql);
+    if ('text' in value) return String(value.text);
+    return '?';
+  };
+
   class PrismaClient {
     $connect = vi.fn().mockResolvedValue(undefined);
     $disconnect = vi.fn().mockResolvedValue(undefined);
@@ -34,15 +53,16 @@ vi.mock('@genfeedai/prisma', () => {
   } as const;
 
   const Prisma = {
-    empty: '',
-    raw: (value: string) => value,
-    sql: (
-      strings: TemplateStringsArray,
-      ...values: unknown[]
-    ): { strings: TemplateStringsArray; values: unknown[] } => ({
-      strings,
-      values,
-    }),
+    empty: createSql(''),
+    raw: (sql: string) => createSql(sql),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const sql = strings.reduce((acc, part, index) => {
+        const value = index < values.length ? getSqlText(values[index]) : '';
+        return `${acc}${part}${value}`;
+      }, '');
+
+      return createSql(sql, values);
+    },
   };
 
   return { Prisma, PrismaClient, VoiceProvider };

--- a/packages/prisma/prisma/migrations/20260618113000_normalize_ad_performance_benchmarks/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618113000_normalize_ad_performance_benchmarks/migration.sql
@@ -1,0 +1,105 @@
+-- Normalize benchmark hot-path fields out of ad_performance.data so benchmark
+-- endpoints can filter and aggregate in SQL instead of scanning JSON rows.
+
+-- AlterTable
+ALTER TABLE "ad_performance" ADD COLUMN     "headlineText" TEXT,
+ADD COLUMN     "ctaText" TEXT,
+ADD COLUMN     "adPlatform" TEXT,
+ADD COLUMN     "industry" TEXT,
+ADD COLUMN     "scope" TEXT,
+ADD COLUMN     "spend" DOUBLE PRECISION,
+ADD COLUMN     "ctr" DOUBLE PRECISION,
+ADD COLUMN     "roas" DOUBLE PRECISION,
+ADD COLUMN     "cpc" DOUBLE PRECISION,
+ADD COLUMN     "cpa" DOUBLE PRECISION,
+ADD COLUMN     "performanceScore" DOUBLE PRECISION,
+ADD COLUMN     "conversionRate" DOUBLE PRECISION,
+ADD COLUMN     "dataConfidence" DOUBLE PRECISION,
+ADD COLUMN     "spendBucket" TEXT,
+ADD COLUMN     "headlinePatternCategories" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "ctaPatternCategories" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- Backfill scalar mirrors from the legacy JSON payload.
+UPDATE "ad_performance"
+SET
+  "headlineText" = NULLIF("data"->>'headlineText', ''),
+  "ctaText" = NULLIF("data"->>'ctaText', ''),
+  "adPlatform" = NULLIF("data"->>'adPlatform', ''),
+  "industry" = NULLIF("data"->>'industry', ''),
+  "scope" = NULLIF("data"->>'scope', ''),
+  "spend" = CASE
+    WHEN ("data"->>'spend') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'spend')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "ctr" = CASE
+    WHEN ("data"->>'ctr') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'ctr')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "roas" = CASE
+    WHEN ("data"->>'roas') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'roas')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "cpc" = CASE
+    WHEN ("data"->>'cpc') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'cpc')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "cpa" = CASE
+    WHEN ("data"->>'cpa') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'cpa')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "performanceScore" = CASE
+    WHEN ("data"->>'performanceScore') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'performanceScore')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "conversionRate" = CASE
+    WHEN ("data"->>'conversionRate') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'conversionRate')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "dataConfidence" = CASE
+    WHEN ("data"->>'dataConfidence') ~ '^-?[0-9]+(\.[0-9]+)?$' THEN ("data"->>'dataConfidence')::DOUBLE PRECISION
+    ELSE NULL
+  END,
+  "spendBucket" = CASE
+    WHEN ("data"->>'spend') !~ '^-?[0-9]+(\.[0-9]+)?$' THEN NULL
+    WHEN ("data"->>'spend')::DOUBLE PRECISION <= 0 THEN NULL
+    WHEN ("data"->>'spend')::DOUBLE PRECISION < 50 THEN '$0-50/day'
+    WHEN ("data"->>'spend')::DOUBLE PRECISION < 200 THEN '$50-200/day'
+    WHEN ("data"->>'spend')::DOUBLE PRECISION < 500 THEN '$200-500/day'
+    WHEN ("data"->>'spend')::DOUBLE PRECISION < 1000 THEN '$500-1000/day'
+    ELSE '$1000+/day'
+  END,
+  "headlinePatternCategories" = array_remove(ARRAY[
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~* '(^|[^[:alnum:]_])(get|save|earn|boost|improve|increase)([^[:alnum:]_]|$)' THEN 'benefit-focused' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~* '(^|[^[:alnum:]_])(vs\.?|versus|compared|better than|unlike)([^[:alnum:]_]|$)' THEN 'comparison' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~* '(^|[^[:alnum:]_])(secret|surprising|you won''t believe|revealed)([^[:alnum:]_]|$)' THEN 'curiosity-gap' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~* '^how[[:space:]]+to([^[:alnum:]_]|$)' THEN 'how-to' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~ '[0-9]+' THEN 'number-driven' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~ '\?$' THEN 'question-based' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~* '(^|[^[:alnum:]_])(review|rated|trusted|customers say)([^[:alnum:]_]|$)' THEN 'testimonial' END,
+    CASE WHEN COALESCE("data"->>'headlineText', '') ~* '(^|[^[:alnum:]_])(limited|now|today|hurry|last chance|don''t miss|ends|expires)([^[:alnum:]_]|$)' THEN 'urgency' END
+  ], NULL),
+  "ctaPatternCategories" = array_remove(ARRAY[
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(book|reserve|schedule)([^[:alnum:]_]|$)' THEN 'book-now' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(contact|call|reach out|get in touch)([^[:alnum:]_]|$)' THEN 'contact-us' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(download|install|get the app)([^[:alnum:]_]|$)' THEN 'download' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(get started|start|begin|try)([^[:alnum:]_]|$)' THEN 'get-started' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(learn more|find out|discover|explore)([^[:alnum:]_]|$)' THEN 'learn-more' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(shop|buy|order|purchase)([^[:alnum:]_]|$)' THEN 'shop-now' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(sign up|register|join|subscribe|create account)([^[:alnum:]_]|$)' THEN 'sign-up' END,
+    CASE WHEN COALESCE("data"->>'ctaText', '') ~* '(^|[^[:alnum:]_])(free trial|try free|start free|no cost)([^[:alnum:]_]|$)' THEN 'try-free' END
+  ], NULL);
+
+-- CreateIndex
+CREATE INDEX "ad_performance_isDeleted_scope_industry_idx" ON "ad_performance"("isDeleted", "scope", "industry");
+
+-- CreateIndex
+CREATE INDEX "ad_performance_isDeleted_scope_adPlatform_industry_idx" ON "ad_performance"("isDeleted", "scope", "adPlatform", "industry");
+
+-- CreateIndex
+CREATE INDEX "ad_performance_isDeleted_scope_spendBucket_adPlatform_industry_idx" ON "ad_performance"("isDeleted", "scope", "spendBucket", "adPlatform", "industry");
+
+-- CreateIndex
+CREATE INDEX "ad_performance_headlinePatternCategories_gin_idx" ON "ad_performance" USING GIN ("headlinePatternCategories");
+
+-- CreateIndex
+CREATE INDEX "ad_performance_ctaPatternCategories_gin_idx" ON "ad_performance" USING GIN ("ctaPatternCategories");

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -3121,19 +3121,38 @@ model AdOptimizationRecommendation {
 }
 
 model AdPerformance {
-  id             String       @id @default(cuid())
-  mongoId        String?      @unique
-  organizationId String
-  organization   Organization @relation(fields: [organizationId], references: [id])
-  brandId        String?
-  brand          Brand?       @relation(fields: [brandId], references: [id])
-  credentialId   String?
-  credential     Credential?  @relation(fields: [credentialId], references: [id])
-  data           Json         @default("{}")
-  isDeleted      Boolean      @default(false)
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  id                        String       @id @default(cuid())
+  mongoId                   String?      @unique
+  organizationId            String
+  organization              Organization @relation(fields: [organizationId], references: [id])
+  brandId                   String?
+  brand                     Brand?       @relation(fields: [brandId], references: [id])
+  credentialId              String?
+  credential                Credential?  @relation(fields: [credentialId], references: [id])
+  data                      Json         @default("{}")
+  headlineText              String?
+  ctaText                   String?
+  adPlatform                String?
+  industry                  String?
+  scope                     String?
+  spend                     Float?
+  ctr                       Float?
+  roas                      Float?
+  cpc                       Float?
+  cpa                       Float?
+  performanceScore          Float?
+  conversionRate            Float?
+  dataConfidence            Float?
+  spendBucket               String?
+  headlinePatternCategories String[]     @default([])
+  ctaPatternCategories      String[]     @default([])
+  isDeleted                 Boolean      @default(false)
+  createdAt                 DateTime     @default(now())
+  updatedAt                 DateTime     @updatedAt
 
+  @@index([isDeleted, scope, industry])
+  @@index([isDeleted, scope, adPlatform, industry])
+  @@index([isDeleted, scope, spendBucket, adPlatform, industry])
   @@map("ad_performance")
 }
 


### PR DESCRIPTION
## Summary

- Normalizes ad benchmark filter/metric fields out of `ad_performance.data` into scalar columns and pattern category arrays.
- Adds a migration that backfills public benchmark fields, spend buckets, headline/CTA pattern categories, and supporting B-tree/GIN indexes.
- Replaces five benchmark full-row scans with SQL aggregate queries that preserve the minimum distinct-organization threshold.
- Keeps the write path in sync by filling scalar mirrors during ad performance upserts and org-removal scope changes.
- Adds focused coverage for headline, CTA, spend bucket, platform, and industry benchmark behavior.

Refs #630

## Verification

- `bun install`
- `bunx prisma format --schema packages/prisma/prisma/schema.prisma`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bunx prisma generate --schema packages/prisma/prisma/schema.prisma`
- `bun run --cwd apps/server/api test:file -- src/services/ad-aggregation/ad-aggregation.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bun run --cwd apps/server/api build`
- `bunx biome check --write apps/server/api/src/services/ad-aggregation/ad-aggregation.service.ts apps/server/api/src/services/ad-aggregation/ad-aggregation.service.spec.ts apps/server/api/src/collections/ad-performance/services/ad-performance.service.ts apps/server/api/src/collections/ad-performance/utils/ad-performance-benchmark.util.ts apps/server/api/test/setup-unit.ts`
- `git diff --check`
- `bun scripts/api-audit/sql-risk-audit.ts --json`: `ad-aggregation.service.ts` now has 0 unbounded-read findings; remaining entries are raw SQL review items for production EXPLAIN.

## Risk / Rollout

- Migration backfills from existing JSON; nullable scalar mirrors are written on future upserts.
- Headline/CTA aggregates use raw SQL plus array GIN predicates and still need production-shaped `EXPLAIN ANALYZE` before marking the issue fully closed.
- Existing ad-performance collection list/upsert helpers still have separate SQL audit findings outside this benchmark service scope.
