### PR TITLE
perf(api): bound agent and desktop list queries

### DIFF
--- a/apps/server/api/src/collections/agent-messages/services/agent-messages.service.spec.ts
+++ b/apps/server/api/src/collections/agent-messages/services/agent-messages.service.spec.ts
@@ -1,0 +1,101 @@
+import { AgentMessagesService } from '@api/collections/agent-messages/services/agent-messages.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('AgentMessagesService', () => {
+  const agentMessage = {
+    count: vi.fn(),
+    create: vi.fn(),
+    findMany: vi.fn(),
+  };
+
+  let service: AgentMessagesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentMessage.findMany.mockResolvedValue([]);
+
+    service = new AgentMessagesService(
+      { agentMessage } as unknown as PrismaService,
+      {} as LoggerService,
+    );
+  });
+
+  it('uses bounded cursor pagination for room messages', async () => {
+    await service.getMessagesByRoom('thread-1', 'org-1', {
+      cursor: '2026-06-01T10:00:00.000Z',
+      limit: 999,
+    });
+
+    expect(agentMessage.findMany).toHaveBeenCalledWith({
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      skip: undefined,
+      take: 100,
+      where: {
+        createdAt: { lt: new Date('2026-06-01T10:00:00.000Z') },
+        isDeleted: false,
+        organizationId: 'org-1',
+        threadId: 'thread-1',
+      },
+    });
+  });
+
+  it('keeps legacy page support bounded when no cursor is provided', async () => {
+    await service.getMessagesByRoom('thread-1', 'org-1', {
+      limit: 25,
+      page: 3,
+    });
+
+    expect(agentMessage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 50,
+        take: 25,
+      }),
+    );
+  });
+
+  it('bounds compaction backlog reads', async () => {
+    await service.getAllMessages('thread-1');
+    await service.getAllMessagesAfter('thread-1', 'msg-1');
+
+    expect(agentMessage.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ take: 500 }),
+    );
+    expect(agentMessage.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ take: 500 }),
+    );
+  });
+
+  it('copies messages in bounded pages', async () => {
+    agentMessage.findMany
+      .mockResolvedValueOnce(
+        Array.from({ length: 500 }, (_, index) => ({
+          id: `msg-${index}`,
+          organizationId: 'org-1',
+          role: 'user',
+          threadId: 'source',
+        })),
+      )
+      .mockResolvedValueOnce([]);
+    agentMessage.create.mockResolvedValue({});
+
+    await service.copyMessages('source', 'target', 'org-1');
+
+    expect(agentMessage.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ take: 500 }),
+    );
+    expect(agentMessage.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        cursor: { id: 'msg-499' },
+        skip: 1,
+        take: 500,
+      }),
+    );
+    expect(agentMessage.create).toHaveBeenCalledTimes(500);
+  });
+});

--- a/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
+++ b/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
@@ -26,6 +26,16 @@ export interface AddMessageDto {
   metadata?: Record<string, unknown>;
 }
 
+type AgentMessagePageOptions = {
+  cursor?: string;
+  limit?: number;
+  page?: number;
+};
+
+const DEFAULT_AGENT_MESSAGE_LIMIT = 50;
+const MAX_AGENT_MESSAGE_LIMIT = 100;
+const DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT = 500;
+
 @Injectable()
 export class AgentMessagesService extends BaseService<
   AgentMessageDocument,
@@ -52,18 +62,25 @@ export class AgentMessagesService extends BaseService<
   async getMessagesByRoom(
     roomId: string,
     organizationId: string,
-    options: { limit?: number; page?: number } = {},
+    options: AgentMessagePageOptions = {},
   ): Promise<AgentMessageDocument[]> {
-    const { limit = 50, page = 1 } = options;
-    const skip = (page - 1) * limit;
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_AGENT_MESSAGE_LIMIT,
+      MAX_AGENT_MESSAGE_LIMIT,
+    );
+    const page = Math.max(1, options.page ?? 1);
+    const cursorDate = this.parseCursorDate(options.cursor);
+    const skip = cursorDate ? undefined : (page - 1) * limit;
 
     return this.delegate.findMany({
       where: {
+        ...(cursorDate ? { createdAt: { lt: cursorDate } } : {}),
         isDeleted: false,
         organizationId,
         threadId: roomId,
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       skip,
       take: limit,
     }) as Promise<AgentMessageDocument[]>;
@@ -73,13 +90,14 @@ export class AgentMessagesService extends BaseService<
     roomId: string,
     limit = 20,
   ): Promise<AgentMessageDocument[]> {
+    const safeLimit = this.normalizeLimit(limit, 20, MAX_AGENT_MESSAGE_LIMIT);
     const messages = await this.delegate.findMany({
       where: {
         isDeleted: false,
         threadId: roomId,
       },
-      orderBy: { createdAt: 'desc' },
-      take: limit,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: safeLimit,
     });
 
     // Reverse to chronological order for LLM context
@@ -97,6 +115,7 @@ export class AgentMessagesService extends BaseService<
     afterMessageId: string,
     limit = 5,
   ): Promise<AgentMessageDocument[]> {
+    const safeLimit = this.normalizeLimit(limit, 5, MAX_AGENT_MESSAGE_LIMIT);
     // Sort descending to get the LATEST N, then reverse to chronological
     const messages = await this.delegate.findMany({
       where: {
@@ -105,7 +124,7 @@ export class AgentMessagesService extends BaseService<
         threadId: roomId,
       },
       orderBy: { id: 'desc' },
-      take: limit,
+      take: safeLimit,
     });
 
     return (messages as AgentMessageDocument[]).reverse();
@@ -140,27 +159,45 @@ export class AgentMessagesService extends BaseService<
   }
 
   /**
-   * Get ALL non-deleted messages in a thread, in chronological order.
-   * Used by compaction to process the full backlog when no prior state exists.
+   * Get a bounded page of non-deleted messages in a thread, in chronological
+   * order. Used by compaction; callers must pass a cursor or repeat if they
+   * need to process more than DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT messages.
    */
-  async getAllMessages(roomId: string): Promise<AgentMessageDocument[]> {
+  async getAllMessages(
+    roomId: string,
+    options: Pick<AgentMessagePageOptions, 'limit'> = {},
+  ): Promise<AgentMessageDocument[]> {
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT,
+      DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT,
+    );
+
     return this.delegate.findMany({
       where: {
         isDeleted: false,
         threadId: roomId,
       },
       orderBy: { id: 'asc' },
+      take: limit,
     }) as Promise<AgentMessageDocument[]>;
   }
 
   /**
-   * Get ALL non-deleted messages after a boundary, in chronological order.
-   * Used by compaction to process uncompacted messages without a fixed cap.
+   * Get a bounded page of non-deleted messages after a boundary, in
+   * chronological order.
    */
   async getAllMessagesAfter(
     roomId: string,
     afterMessageId: string,
+    options: Pick<AgentMessagePageOptions, 'limit'> = {},
   ): Promise<AgentMessageDocument[]> {
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT,
+      DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT,
+    );
+
     return this.delegate.findMany({
       where: {
         id: { gt: afterMessageId },
@@ -168,6 +205,7 @@ export class AgentMessagesService extends BaseService<
         threadId: roomId,
       },
       orderBy: { id: 'asc' },
+      take: limit,
     }) as Promise<AgentMessageDocument[]>;
   }
 
@@ -176,36 +214,67 @@ export class AgentMessagesService extends BaseService<
     targetRoomId: string,
     organizationId: string,
   ): Promise<void> {
-    const docs = await this.delegate.findMany({
-      where: {
-        isDeleted: false,
-        organizationId,
-        threadId: sourceRoomId,
-      },
-      orderBy: { createdAt: 'asc' },
-    });
+    let cursor: { id: string } | undefined;
 
-    if (!docs || docs.length === 0) {
-      return;
+    while (true) {
+      const docs = (await this.delegate.findMany({
+        ...(cursor ? { cursor, skip: 1 } : {}),
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        take: DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT,
+        where: {
+          isDeleted: false,
+          organizationId,
+          threadId: sourceRoomId,
+        },
+      })) as Array<Record<string, unknown> & { id: string }>;
+
+      if (docs.length === 0) {
+        return;
+      }
+
+      await Promise.all(
+        docs.map((doc) =>
+          this.delegate.create({
+            data: {
+              brandId: doc.brandId,
+              content: doc.content,
+              isDeleted: doc.isDeleted,
+              metadata: doc.metadata,
+              organizationId: doc.organizationId,
+              role: doc.role,
+              threadId: targetRoomId,
+              toolCallId: doc.toolCallId,
+              toolCalls: doc.toolCalls,
+              userId: doc.userId,
+            },
+          }),
+        ),
+      );
+
+      if (docs.length < DEFAULT_AGENT_MESSAGE_BACKLOG_LIMIT) {
+        return;
+      }
+
+      cursor = { id: docs[docs.length - 1].id };
+    }
+  }
+
+  private normalizeLimit(
+    value: number | undefined,
+    defaultLimit: number,
+    maxLimit: number,
+  ): number {
+    if (!Number.isFinite(value) || value == null || value <= 0) {
+      return defaultLimit;
     }
 
-    await Promise.all(
-      docs.map((doc: Record<string, unknown>) =>
-        this.delegate.create({
-          data: {
-            brandId: doc.brandId,
-            content: doc.content,
-            isDeleted: doc.isDeleted,
-            metadata: doc.metadata,
-            organizationId: doc.organizationId,
-            role: doc.role,
-            threadId: targetRoomId,
-            toolCallId: doc.toolCallId,
-            toolCalls: doc.toolCalls,
-            userId: doc.userId,
-          },
-        }),
-      ),
-    );
+    return Math.min(Math.floor(value), maxLimit);
+  }
+
+  private parseCursorDate(cursor: string | undefined): Date | undefined {
+    if (!cursor) return undefined;
+
+    const parsed = new Date(cursor);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   }
 }

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
@@ -260,6 +260,7 @@ describe('AgentRunsController', () => {
 
       expect(mockServiceMethods.getActiveRuns).toHaveBeenCalledWith(
         '507f1f77bcf86cd799439012',
+        { cursor: undefined, limit: undefined },
       );
     });
   });

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
@@ -221,10 +221,19 @@ export class AgentRunsController extends BaseCRUDController<
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Get active agent runs' })
   @ApiResponse({ description: 'Active runs returned', status: 200 })
-  async getActiveRuns(@Req() request: Request, @CurrentUser() user: User) {
+  async getActiveRuns(
+    @Req() request: Request,
+    @CurrentUser() user: User,
+    @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string,
+  ) {
     const publicMetadata = getPublicMetadata(user);
     const runs = await this.agentRunsService.getActiveRuns(
       publicMetadata.organization,
+      {
+        cursor,
+        limit: limit ? Number.parseInt(limit, 10) : undefined,
+      },
     );
     return serializeCollection(request, AgentRunSerializer, { docs: runs });
   }

--- a/apps/server/api/src/collections/agent-runs/controllers/thread-runs.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/thread-runs.controller.spec.ts
@@ -81,6 +81,7 @@ describe('ThreadRunsController', () => {
       expect(agentRunsService.getByThread).toHaveBeenCalledWith(
         threadId,
         orgId,
+        { cursor: undefined, limit: undefined },
       );
       expect(result).toEqual({ data: mockRuns });
     });
@@ -105,6 +106,7 @@ describe('ThreadRunsController', () => {
       expect(agentRunsService.getByThread).toHaveBeenCalledWith(
         expect.any(String),
         orgId,
+        { cursor: undefined, limit: undefined },
       );
     });
 
@@ -116,6 +118,7 @@ describe('ThreadRunsController', () => {
       expect(agentRunsService.getByThread).toHaveBeenCalledWith(
         threadId,
         expect.any(String),
+        { cursor: undefined, limit: undefined },
       );
     });
 
@@ -145,6 +148,7 @@ describe('ThreadRunsController', () => {
       expect(agentRunsService.getByThread).toHaveBeenCalledWith(
         otherThreadId,
         orgId,
+        { cursor: undefined, limit: undefined },
       );
     });
 

--- a/apps/server/api/src/collections/agent-runs/controllers/thread-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/thread-runs.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  Query,
   Req,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -28,11 +29,17 @@ export class ThreadRunsController {
     @Req() request: Request,
     @Param('threadId') threadId: string,
     @CurrentUser() user: User,
+    @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string,
   ) {
     const publicMetadata = getPublicMetadata(user);
     const runs = await this.agentRunsService.getByThread(
       threadId,
       publicMetadata.organization,
+      {
+        cursor,
+        limit: limit ? Number.parseInt(limit, 10) : undefined,
+      },
     );
 
     return serializeCollection(request, AgentRunSerializer, { docs: runs });

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.spec.ts
@@ -26,7 +26,8 @@ describe('AgentRunsService', () => {
     await service.getActiveRuns('org-1');
 
     expect(agentRun.findMany).toHaveBeenCalledWith({
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 50,
       where: {
         isDeleted: false,
         organizationId: 'org-1',
@@ -35,6 +36,22 @@ describe('AgentRunsService', () => {
         },
       },
     });
+  });
+
+  it('caps active runs and applies cursor dates', async () => {
+    await service.getActiveRuns('org-1', {
+      cursor: '2026-06-01T10:00:00.000Z',
+      limit: 999,
+    });
+
+    expect(agentRun.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 200,
+        where: expect.objectContaining({
+          createdAt: { lt: new Date('2026-06-01T10:00:00.000Z') },
+        }),
+      }),
+    );
   });
 
   it('counts run stats with Prisma enum values', async () => {

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
@@ -47,7 +47,16 @@ type AgentRunStatsAggregateResult = {
   trends?: AgentRunTrendAggregateRow[];
 };
 
+type AgentRunPageOptions = {
+  cursor?: string;
+  limit?: number;
+};
+
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_AGENT_RUN_LIMIT = 50;
+const MAX_AGENT_RUN_LIMIT = 200;
+const MAX_AGENT_RUN_BATCH_IDS = 50;
+const MAX_AGENT_RUN_CONTENT_ITEMS = 500;
 
 function getTimeRangeDays(timeRange: AgentRunTimeRange): number {
   switch (timeRange) {
@@ -324,9 +333,10 @@ export class AgentRunsService extends BaseService<
     since: Date,
     take = 200,
   ): Promise<AgentRunDocument[]> {
+    const safeTake = this.normalizeLimit(take, 200, MAX_AGENT_RUN_LIMIT);
     const docs = await this.delegate.findMany({
       orderBy: { createdAt: 'desc' },
-      take,
+      take: safeTake,
       where: {
         createdAt: { gte: since },
         isDeleted: false,
@@ -422,16 +432,28 @@ export class AgentRunsService extends BaseService<
   }
 
   @HandleErrors('get active runs', 'agent-runs')
-  async getActiveRuns(organizationId: string): Promise<AgentRunDocument[]> {
+  async getActiveRuns(
+    organizationId: string,
+    options: AgentRunPageOptions = {},
+  ): Promise<AgentRunDocument[]> {
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_AGENT_RUN_LIMIT,
+      MAX_AGENT_RUN_LIMIT,
+    );
+    const cursorDate = this.parseCursorDate(options.cursor);
+
     return (await this.delegate.findMany({
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit,
       where: {
+        ...(cursorDate ? { createdAt: { lt: cursorDate } } : {}),
         isDeleted: false,
         organizationId,
         status: {
           in: [AgentExecutionStatus.PENDING, AgentExecutionStatus.RUNNING],
         },
       },
-      orderBy: { createdAt: 'desc' },
     })) as AgentRunDocument[];
   }
 
@@ -440,13 +462,14 @@ export class AgentRunsService extends BaseService<
     organizationId: string,
     limit = 20,
   ): Promise<AgentRunDocument[]> {
+    const safeLimit = this.normalizeLimit(limit, 20, MAX_AGENT_RUN_LIMIT);
     return (await this.delegate.findMany({
       where: {
         isDeleted: false,
         organizationId,
       },
-      orderBy: { createdAt: 'desc' },
-      take: limit,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: safeLimit,
     })) as AgentRunDocument[];
   }
 
@@ -454,14 +477,24 @@ export class AgentRunsService extends BaseService<
   async getByThread(
     threadId: string,
     organizationId: string,
+    options: AgentRunPageOptions = {},
   ): Promise<AgentRunDocument[]> {
+    const limit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_AGENT_RUN_LIMIT,
+      MAX_AGENT_RUN_LIMIT,
+    );
+    const cursorDate = this.parseCursorDate(options.cursor);
+
     return (await this.delegate.findMany({
       where: {
+        ...(cursorDate ? { createdAt: { lt: cursorDate } } : {}),
         isDeleted: false,
         organizationId,
         threadId,
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit,
     })) as AgentRunDocument[];
   }
 
@@ -540,20 +573,34 @@ export class AgentRunsService extends BaseService<
     if (ids.length === 0) {
       return [];
     }
+    const boundedIds = ids.slice(0, MAX_AGENT_RUN_BATCH_IDS);
 
     const [runs, postGroups, ingredientGroups] = await Promise.all([
       this.prisma.agentRun.findMany({
         select: { id: true, threadId: true },
-        where: { id: { in: ids }, isDeleted: false, organizationId },
+        take: boundedIds.length,
+        where: { id: { in: boundedIds }, isDeleted: false, organizationId },
       }),
       this.prisma.post.groupBy({
         by: ['agentRunId'],
-        where: { agentRunId: { in: ids }, isDeleted: false, organizationId },
+        orderBy: { agentRunId: 'asc' },
+        take: boundedIds.length,
+        where: {
+          agentRunId: { in: boundedIds },
+          isDeleted: false,
+          organizationId,
+        },
         _count: true,
       }),
       this.prisma.ingredient.groupBy({
         by: ['agentRunId'],
-        where: { agentRunId: { in: ids }, isDeleted: false, organizationId },
+        orderBy: { agentRunId: 'asc' },
+        take: boundedIds.length,
+        where: {
+          agentRunId: { in: boundedIds },
+          isDeleted: false,
+          organizationId,
+        },
         _count: true,
       }),
     ]);
@@ -581,6 +628,7 @@ export class AgentRunsService extends BaseService<
   ): Promise<{ posts: PostDocument[]; ingredients: IngredientDocument[] }> {
     const [posts, ingredients] = await Promise.all([
       this.prisma.post.findMany({
+        take: MAX_AGENT_RUN_CONTENT_ITEMS,
         where: {
           agentRunId: runId,
           isDeleted: false,
@@ -588,6 +636,7 @@ export class AgentRunsService extends BaseService<
         },
       }),
       this.prisma.ingredient.findMany({
+        take: MAX_AGENT_RUN_CONTENT_ITEMS,
         where: {
           agentRunId: runId,
           isDeleted: false,
@@ -600,5 +649,24 @@ export class AgentRunsService extends BaseService<
       ingredients: ingredients as unknown as IngredientDocument[],
       posts: posts as unknown as PostDocument[],
     };
+  }
+
+  private normalizeLimit(
+    value: number | undefined,
+    defaultLimit: number,
+    maxLimit: number,
+  ): number {
+    if (!Number.isFinite(value) || value == null || value <= 0) {
+      return defaultLimit;
+    }
+
+    return Math.min(Math.floor(value), maxLimit);
+  }
+
+  private parseCursorDate(cursor: string | undefined): Date | undefined {
+    if (!cursor) return undefined;
+
+    const parsed = new Date(cursor);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   }
 }

--- a/apps/server/api/src/collections/agent-threads/controllers/agent-threads.controller.ts
+++ b/apps/server/api/src/collections/agent-threads/controllers/agent-threads.controller.ts
@@ -74,6 +74,7 @@ export class AgentThreadsController {
     @Param('threadId') threadId: string,
     @CurrentUser() user: User,
     @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string,
   ) {
     try {
       const organizationId = this.resolveOrganizationId(user);
@@ -82,7 +83,7 @@ export class AgentThreadsController {
       const messages = await this.agentMessagesService.getMessagesByRoom(
         threadId,
         organizationId,
-        { limit: messageLimit },
+        { cursor, limit: messageLimit },
       );
 
       const chronological = [...messages].reverse();

--- a/apps/server/api/src/services/sync/desktop-sync.controller.ts
+++ b/apps/server/api/src/services/sync/desktop-sync.controller.ts
@@ -21,8 +21,15 @@ export class DesktopSyncController {
   async pullThreads(
     @CurrentUser() user: User,
     @Query('cursor') cursor?: string,
+    @Query('limit') limit?: string,
+    @Query('messageLimit') messageLimit?: string,
   ) {
-    return this.desktopSyncService.pullThreads(user, cursor);
+    return this.desktopSyncService.pullThreads(user, cursor, {
+      limit: limit ? Number.parseInt(limit, 10) : undefined,
+      messageLimit: messageLimit
+        ? Number.parseInt(messageLimit, 10)
+        : undefined,
+    });
   }
 
   @Post('threads')

--- a/apps/server/api/src/services/sync/desktop-sync.service.spec.ts
+++ b/apps/server/api/src/services/sync/desktop-sync.service.spec.ts
@@ -60,6 +60,7 @@ function buildService() {
     },
     desktopMessage: {
       createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      findMany: vi.fn().mockResolvedValue([]),
     },
     desktopThread: {
       findMany: vi.fn(),
@@ -127,6 +128,82 @@ describe('DesktopSyncService', () => {
         }),
       }),
     );
+  });
+
+  it('pulls threads with bounded child message queries', async () => {
+    const { prisma, service } = buildService();
+    const threadUpdatedAt = new Date('2026-05-01T11:00:00.000Z');
+    const messageCreatedAt = new Date('2026-05-01T10:30:00.000Z');
+    prisma.desktopThread.findMany.mockResolvedValue([
+      {
+        createdAt: new Date('2026-05-01T10:00:00.000Z'),
+        id: 'thread-local',
+        status: 'idle',
+        title: 'Offline plan',
+        updatedAt: threadUpdatedAt,
+        workspaceId: 'workspace-local',
+      },
+    ]);
+    prisma.desktopMessage.findMany.mockResolvedValue([
+      {
+        content: 'hello',
+        createdAt: messageCreatedAt,
+        draftId: null,
+        generatedContent: null,
+        id: 'message-local',
+        role: 'user',
+      },
+    ]);
+
+    const result = await service.pullThreads(
+      makeUser(),
+      '2026-05-01T09:00:00.000Z',
+      { limit: 999, messageLimit: 999 },
+    );
+
+    expect(prisma.desktopThread.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'asc' },
+      select: {
+        createdAt: true,
+        id: true,
+        status: true,
+        title: true,
+        updatedAt: true,
+        workspaceId: true,
+      },
+      take: 101,
+      where: {
+        organizationId,
+        updatedAt: { gt: new Date('2026-05-01T09:00:00.000Z') },
+        userId,
+      },
+    });
+    expect(prisma.desktopMessage.findMany).toHaveBeenCalledWith({
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      select: {
+        content: true,
+        createdAt: true,
+        draftId: true,
+        generatedContent: true,
+        id: true,
+        role: true,
+      },
+      take: 200,
+      where: { threadId: 'thread-local' },
+    });
+    expect(result.data).toMatchObject({
+      hasMore: false,
+      limits: {
+        messageLimit: 200,
+        threadLimit: 100,
+      },
+      threads: [
+        {
+          id: 'thread-local',
+          messages: [{ id: 'message-local' }],
+        },
+      ],
+    });
   });
 
   it('rejects thread pushes that collide with another owner', async () => {

--- a/apps/server/api/src/services/sync/desktop-sync.service.ts
+++ b/apps/server/api/src/services/sync/desktop-sync.service.ts
@@ -45,6 +45,10 @@ type DesktopSyncOpPushResult = {
 const MAX_DESKTOP_ASSET_BYTES = 500 * 1024 * 1024; // 500 MB
 const MAX_PROXY_UPLOAD_BYTES = 100 * 1024 * 1024; // 100 MB (body-based upload)
 const MAX_ORGANIZATION_DESKTOP_STORAGE_BYTES = 10 * 1024 * 1024 * 1024; // 10 GB
+const DEFAULT_DESKTOP_THREAD_LIMIT = 50;
+const MAX_DESKTOP_THREAD_LIMIT = 100;
+const DEFAULT_DESKTOP_MESSAGE_LIMIT = 100;
+const MAX_DESKTOP_MESSAGE_LIMIT = 200;
 
 const ALLOWED_DESKTOP_MIME_TYPES = new Set([
   'image/jpeg',
@@ -146,27 +150,87 @@ export class DesktopSyncService {
     return `${organizationId}/${asset.sha256}/${safeName}`;
   }
 
+  private normalizeLimit(
+    value: number | undefined,
+    defaultLimit: number,
+    maxLimit: number,
+  ): number {
+    if (!Number.isFinite(value) || value == null || value <= 0) {
+      return defaultLimit;
+    }
+
+    return Math.min(Math.floor(value), maxLimit);
+  }
+
   @LogMethod()
-  async pullThreads(user: User, cursor?: string) {
+  async pullThreads(
+    user: User,
+    cursor?: string,
+    options: { limit?: number; messageLimit?: number } = {},
+  ) {
     const { organizationId, userId } = this.getCloudContext(user);
-    const threads = await this.prisma.desktopThread.findMany({
-      include: { messages: { orderBy: { createdAt: 'asc' } } },
-      orderBy: { updatedAt: 'desc' },
+    const threadLimit = this.normalizeLimit(
+      options.limit,
+      DEFAULT_DESKTOP_THREAD_LIMIT,
+      MAX_DESKTOP_THREAD_LIMIT,
+    );
+    const messageLimit = this.normalizeLimit(
+      options.messageLimit,
+      DEFAULT_DESKTOP_MESSAGE_LIMIT,
+      MAX_DESKTOP_MESSAGE_LIMIT,
+    );
+    const threadPage = await this.prisma.desktopThread.findMany({
+      select: {
+        createdAt: true,
+        id: true,
+        status: true,
+        title: true,
+        updatedAt: true,
+        workspaceId: true,
+      },
+      orderBy: { updatedAt: 'asc' },
+      take: threadLimit + 1,
       where: {
         organizationId,
         userId,
         ...(cursor ? { updatedAt: { gt: new Date(cursor) } } : {}),
       },
     });
+    const hasMore = threadPage.length > threadLimit;
+    const threads = hasMore ? threadPage.slice(0, threadLimit) : threadPage;
 
-    const updatedCursor = new Date().toISOString();
+    const messageEntries = await Promise.all(
+      threads.map(async (thread) => {
+        const messages = await this.prisma.desktopMessage.findMany({
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+          select: {
+            content: true,
+            createdAt: true,
+            draftId: true,
+            generatedContent: true,
+            id: true,
+            role: true,
+          },
+          take: messageLimit,
+          where: { threadId: thread.id },
+        });
+
+        return [thread.id, messages.reverse()] as const;
+      }),
+    );
+    const messagesByThreadId = new Map(messageEntries);
+
+    const updatedCursor =
+      threads[threads.length - 1]?.updatedAt.toISOString() ??
+      new Date().toISOString();
 
     return {
       data: {
+        hasMore,
         threads: threads.map((t) => ({
           createdAt: t.createdAt,
           id: t.id,
-          messages: t.messages.map((m) => ({
+          messages: (messagesByThreadId.get(t.id) ?? []).map((m) => ({
             content: m.content,
             createdAt: m.createdAt,
             draftId: m.draftId,
@@ -179,6 +243,10 @@ export class DesktopSyncService {
           updatedAt: t.updatedAt,
           workspaceId: t.workspaceId,
         })),
+        limits: {
+          messageLimit,
+          threadLimit,
+        },
         updatedCursor,
       },
     };
@@ -284,6 +352,7 @@ export class DesktopSyncService {
       }),
       this.prisma.brand.findMany({
         orderBy: { updatedAt: 'desc' },
+        take: 100,
         select: {
           backgroundColor: true,
           defaultImageModel: true,

--- a/packages/prisma/prisma/migrations/20260618120500_bound_agent_desktop_lists/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618120500_bound_agent_desktop_lists/migration.sql
@@ -1,0 +1,22 @@
+-- Add indexes for bounded agent and desktop list/sync hot paths.
+
+-- CreateIndex
+CREATE INDEX "agent_messages_organizationId_threadId_isDeleted_createdAt_id_idx" ON "agent_messages"("organizationId", "threadId", "isDeleted", "createdAt" DESC, "id");
+
+-- CreateIndex
+CREATE INDEX "agent_messages_threadId_isDeleted_id_idx" ON "agent_messages"("threadId", "isDeleted", "id");
+
+-- CreateIndex
+CREATE INDEX "agent_runs_organizationId_isDeleted_createdAt_idx" ON "agent_runs"("organizationId", "isDeleted", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "agent_runs_organizationId_isDeleted_status_createdAt_idx" ON "agent_runs"("organizationId", "isDeleted", "status", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "agent_runs_organizationId_threadId_isDeleted_createdAt_idx" ON "agent_runs"("organizationId", "threadId", "isDeleted", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "desktop_threads_organization_id_user_id_updatedAt_idx" ON "desktop_threads"("organization_id", "user_id", "updatedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "desktop_messages_threadId_createdAt_id_idx" ON "desktop_messages"("threadId", "createdAt", "id");

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -2133,6 +2133,8 @@ model AgentMessage {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
+  @@index([organizationId, threadId, isDeleted, createdAt(sort: Desc), id])
+  @@index([threadId, isDeleted, id])
   @@map("agent_messages")
 }
 
@@ -2174,6 +2176,9 @@ model AgentRun {
   creditsUsed Int     @default(0)
   durationMs  Int?
 
+  @@index([organizationId, isDeleted, createdAt(sort: Desc)])
+  @@index([organizationId, isDeleted, status, createdAt(sort: Desc)])
+  @@index([organizationId, threadId, isDeleted, createdAt(sort: Desc)])
   @@map("agent_runs")
 }
 
@@ -4019,6 +4024,7 @@ model DesktopThread {
 
   @@index([userId, updatedAt(sort: Desc)])
   @@index([organizationId, updatedAt(sort: Desc)])
+  @@index([organizationId, userId, updatedAt(sort: Desc)])
   @@map("desktop_threads")
 }
 
@@ -4033,5 +4039,6 @@ model DesktopMessage {
   thread           DesktopThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
 
   @@index([threadId, createdAt])
+  @@index([threadId, createdAt, id])
   @@map("desktop_messages")
 }


### PR DESCRIPTION
## Summary

- Adds hard default/max limits and cursor parameters to agent messages, active runs, thread runs, and desktop thread sync.
- Replaces desktop thread sync broad `include` hydration with explicit thread selects plus bounded per-thread message queries.
- Pages internal message copy/compaction reads instead of loading whole threads at once.
- Adds hot-path indexes for agent message, agent run, desktop thread, and desktop message list access.
- Adds focused tests for cursor caps, empty/legacy paging behavior, bounded copy, and desktop child message caps.

Refs #631

## Verification

- `bun install`
- `bunx prisma format --schema packages/prisma/prisma/schema.prisma`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bunx prisma generate --schema packages/prisma/prisma/schema.prisma`
- `bun run --cwd apps/server/api test:file -- src/collections/agent-messages/services/agent-messages.service.spec.ts src/collections/agent-runs/services/agent-runs.service.spec.ts src/collections/agent-runs/controllers/agent-runs.controller.spec.ts src/collections/agent-runs/controllers/thread-runs.controller.spec.ts src/services/sync/desktop-sync.service.spec.ts src/collections/agent-threads/controllers/agent-threads.controller.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bun run --cwd apps/server/api build`
- `bun scripts/api-audit/sql-risk-audit.ts --json`: changed list/include hot paths no longer report unbounded reads or broad include; remaining changed-path findings are the desktop storage aggregate and asset `updateMany`, which are outside #631 and overlap #632.
- `git diff --check`

## Risk / Rollout

- Desktop thread sync is now capped and returns `hasMore` plus limits; `updatedCursor` advances to the last returned thread so capped syncs do not skip remaining rows.
- Message endpoints keep legacy page support when no cursor is supplied, but clamp all limits.
- Production-shaped EXPLAIN should still be captured after migration on real row counts.
