### PR TITLE
docs: document ready PR default

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -19,6 +19,7 @@
 - [Use @ui/primitives](feedback_ui_primitives.md) — Never raw HTML elements — blocked by lint-no-raw-html.sh
 - [Codex adversarial review](feedback_codex_adversarial_review.md) — MANDATORY before ExitPlanMode
 - [GitHub issue worktree workflow](feedback_gh_issue_worktree_workflow.md) — Assigned issues use worktrees from master → PR to master
+- [Ready PRs by default](feedback_ready_pr_default.md) — Open normal ready PRs to master by default; draft only by explicit request or blocked WIP
 - [No external symlinks](feedback_no_external_symlinks.md) — Open source repo. Internal symlinks only.
 - [End-to-end implementation](feedback_end_to_end_implementation.md) — Never ship half-architecture; wire the full user path
 - [P0 status, not label](feedback_p0_status_not_label.md) — P0 is issue status; never create priority labels

--- a/.agents/memory/feedback_ready_pr_default.md
+++ b/.agents/memory/feedback_ready_pr_default.md
@@ -1,0 +1,18 @@
+---
+name: Ready PRs by default
+description: Open normal mergeable PRs to master by default; draft PRs are opt-in or blocked WIP only
+type: feedback
+status: active
+last_verified: 2026-06-18
+topics: [workflow, git, github, pull-requests]
+---
+
+**Rule:** For Genfeed.ai, open normal ready-for-review pull requests to `master` by default. PR review and CI are the handoff/gate.
+
+**Why:** Vincent corrected the prior behavior where implementation PRs were opened as drafts because a generic local skill defaulted to draft until CI or production evidence was complete. That is not the Genfeed.ai workflow. A missing CI result, pending review, or missing production EXPLAIN evidence belongs in the PR body as risk/follow-up context; it is not by itself a reason to use draft.
+
+**How to apply:**
+- Use `gh pr create --base master --head <branch> ...` without `--draft` unless Vincent explicitly asks for a draft.
+- Draft PRs are only appropriate for genuinely blocked/WIP work where review should not start yet.
+- Quick fixes still get normal ready PRs; CI and review decide whether they merge.
+- After opening the PR, inspect CI and push fixes on the same short-lived branch until checks pass.


### PR DESCRIPTION
## Summary

- document that Genfeed.ai opens normal ready PRs to master by default
- clarify that draft PRs are only for explicit requests or genuinely blocked/WIP work
- note that CI/review remain the handoff gate, including for quick fixes

## Verification

- git diff --check
- secretlint via commit hook on staged markdown

## Risk

- Documentation-only workflow rule update; no runtime behavior changes.
