### PR TITLE
ci: move release gates off pull requests

### DIFF
--- a/.github/workflows/build-verify-selfhosted.yml
+++ b/.github/workflows/build-verify-selfhosted.yml
@@ -1,27 +1,18 @@
-# Build Verify (Self-Hosted) — ensures the community all-in-one image builds on PRs
+# Build Verify (Self-Hosted) — ensures the community all-in-one image builds
+# before release/full-suite runs, without slowing every pull request.
 # Mirror of build-verify.yml, but targets docker/Dockerfile.selfhosted (Redis +
 # NestJS services + Next.js in one container) instead of the microservice image.
 #
 # Why this exists: the self-hosted image is published ONLY on `release: published`
-# (see docker-publish.yml) — there is no per-PR build of it anywhere else. A break
-# in Dockerfile.selfhosted (e.g. a missing apt package, a failed `bun.sh` install)
-# is therefore invisible until a GitHub Release fails mid-publish. This guard builds
-# it on every staging/master PR (no push, just verify) so the community `docker run`
-# image can never silently break a release.
+# (see docker-publish.yml). A break in Dockerfile.selfhosted (e.g. a missing apt
+# package, a failed `bun.sh` install) should be caught while cutting a release,
+# but not paid on every PR. This guard is manual/reusable so Full Suite and
+# release prep can run it explicitly before publishing.
 name: Build Verify (Self-Hosted)
 
 on:
-  pull_request:
-    branches: [staging, master]
-    paths:
-      - 'apps/server/**'
-      - 'apps/app/**'
-      - 'packages/**'
-      - 'configs/**'
-      - 'docker/Dockerfile.selfhosted'
-      - 'docker/selfhosted-entrypoint.sh'
-      - 'package.json'
-      - 'bun.lock'
+  workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: build-verify-selfhosted-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/desktop-qa.yml
+++ b/.github/workflows/desktop-qa.yml
@@ -1,19 +1,8 @@
 name: Desktop QA
 
 on:
-  pull_request:
-    branches: [develop, staging, master]
-    paths:
-      - 'apps/desktop/**'
-      - 'apps/app/**'
-      - 'packages/desktop-*/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'turbo.json'
-      - '.github/actions/setup-bun-env/**'
-      - '.github/workflows/desktop-qa.yml'
-      - '.github/workflows/desktop-release.yml'
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
@@ -49,8 +38,10 @@ jobs:
       - name: QA summary
         if: always()
         run: |
-          echo "## Desktop QA" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Checklist: apps/desktop/RELEASE_QA.md" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Command: \`bun run --filter=@genfeedai/desktop qa:release\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Release SHA: \`${GENFEED_DESKTOP_RELEASE}\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Desktop QA"
+            echo ""
+            echo "- Checklist: apps/desktop/RELEASE_QA.md"
+            echo "- Command: \`bun run --filter=@genfeedai/desktop qa:release\`"
+            echo "- Release SHA: \`${GENFEED_DESKTOP_RELEASE}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -10,7 +10,12 @@ permissions:
   contents: read
 
 jobs:
+  desktop-release-qa:
+    name: Desktop Release QA
+    uses: ./.github/workflows/desktop-qa.yml
+
   desktop-macos:
+    needs: desktop-release-qa
     runs-on: macos-latest
     env:
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -1,13 +1,14 @@
-# Full Suite — on-demand caller that runs the CI gate, then the E2E suite.
+# Full Suite — on-demand caller for CI, heavy build verification, then E2E.
 #
-# Dispatch from any branch: Actions → "Full Suite (CI + E2E)" → Run workflow →
-# pick the branch. E2E runs only if the CI gate (format, lint, typecheck,
-# design, unit tests, build) passes first.
+# Dispatch from any branch: Actions → "Full Suite (CI + Release Gates + E2E)"
+# → Run workflow → pick the branch. E2E runs only if the CI gate (format, lint,
+# typecheck, design, unit tests, build) and release-time build verification pass
+# first.
 #
-# Reuses ci.yml and e2e.yml unchanged via workflow_call — no job logic is
-# duplicated here; this file only orders the two existing workflows.
+# Reuses existing workflows via workflow_call — no job logic is duplicated here;
+# this file only orders the release-prep gates.
 
-name: Full Suite (CI + E2E)
+name: Full Suite (CI + Release Gates + E2E)
 
 on:
   workflow_dispatch:
@@ -29,8 +30,14 @@ jobs:
     # login), which every called workflow gets automatically. Inheriting the full
     # secret set here would over-scope it (least-privilege).
 
+  selfhosted-build-verify:
+    name: Self-Hosted Build & Boot Check
+    uses: ./.github/workflows/build-verify-selfhosted.yml
+    # Release-time self-hosted image validation. Kept out of normal PR CI so
+    # routine pull requests stay fast; run through Full Suite before release.
+
   e2e:
     name: E2E Suite
-    needs: [ci, build-verify]
+    needs: [ci, build-verify, selfhosted-build-verify]
     uses: ./.github/workflows/e2e.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- remove self-hosted Docker build/boot verification from pull_request triggers and keep it as manual/reusable release-prep validation
- add the self-hosted verification workflow to Full Suite before E2E runs
- remove Desktop QA from pull_request triggers and call it from Desktop Release before building macOS artifacts

## Verification
- actionlint .github/workflows/build-verify-selfhosted.yml .github/workflows/full-suite.yml .github/workflows/desktop-qa.yml .github/workflows/desktop-release.yml
- git diff --check
- ruby -e "require \"yaml\"; ARGV.each { |f| YAML.load_file(f); puts \"ok #{f}\" }" .github/workflows/build-verify-selfhosted.yml .github/workflows/full-suite.yml .github/workflows/desktop-qa.yml .github/workflows/desktop-release.yml
- pre-commit secretlint on staged workflow files