### PR TITLE
fix: wire Skills Pro registry checkout and skills page

### DIFF
--- a/apps/server/api/src/skills-pro/controllers/skill-download.controller.spec.ts
+++ b/apps/server/api/src/skills-pro/controllers/skill-download.controller.spec.ts
@@ -103,6 +103,7 @@ describe('SkillDownloadController', () => {
   describe('downloadSkill', () => {
     it('should call getDownloadUrl with receiptId and skillSlug', async () => {
       const expected = {
+        checksum: 'sha256:image-gen',
         downloadUrl:
           'https://cdn.example.com/skills/image-gen-pro.zip?token=xyz',
         expiresIn: 900,
@@ -153,6 +154,7 @@ describe('SkillDownloadController', () => {
       const downloadUrl =
         'https://s3.amazonaws.com/skills/video-editor-v2.zip?sig=abc';
       skillDownloadService.getDownloadUrl.mockResolvedValue({
+        checksum: 'sha256:video-editor',
         downloadUrl,
         expiresIn: 900,
         skill: { name: 'Video Editor', slug: 'video-editor', version: '2.0.0' },
@@ -164,6 +166,7 @@ describe('SkillDownloadController', () => {
       });
 
       expect(result.downloadUrl).toBe(downloadUrl);
+      expect(result.checksum).toBe('sha256:video-editor');
       expect(result.skill.slug).toBe('video-editor');
     });
 

--- a/apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
+++ b/apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
@@ -49,6 +49,7 @@ describe('SkillCheckoutService', () => {
         {
           provide: SkillRegistryService,
           useValue: {
+            getBundlePriceCents: vi.fn(),
             getBundleStripePriceId: vi.fn(),
             getRegistry: vi.fn(),
             getSkillBySlug: vi.fn(),
@@ -163,7 +164,7 @@ describe('SkillCheckoutService', () => {
       );
     });
 
-    it('should throw BadRequestException when no price ID is available', async () => {
+    it('should fall back to registry bundle price when no price ID is available', async () => {
       configService.get.mockImplementation(
         buildConfigGetMock({
           GENFEEDAI_APP_URL: 'https://app.genfeed.ai',
@@ -172,10 +173,57 @@ describe('SkillCheckoutService', () => {
       );
 
       skillRegistryService.getBundleStripePriceId.mockResolvedValue(undefined);
+      skillRegistryService.getBundlePriceCents.mockResolvedValue(2900);
 
       const dto: CreateSkillCheckoutDto = {};
 
-      await expect(service.createCheckoutSession(dto)).rejects.toThrow(
+      const mockSession = {
+        id: 'cs_test_price_data',
+        url: 'https://checkout.stripe.com/session/cs_test_price_data',
+      } as unknown as Stripe.Checkout.Session;
+
+      stripeService.stripe.checkout.sessions.create.mockResolvedValue(
+        mockSession,
+      );
+
+      const result = await service.createCheckoutSession(dto);
+
+      expect(result.url).toBe(
+        'https://checkout.stripe.com/session/cs_test_price_data',
+      );
+      expect(skillRegistryService.getBundlePriceCents).toHaveBeenCalled();
+      expect(
+        stripeService.stripe.checkout.sessions.create,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          line_items: [
+            {
+              price_data: {
+                currency: 'usd',
+                product_data: {
+                  name: 'Skills Pro Bundle',
+                },
+                unit_amount: 2900,
+              },
+              quantity: 1,
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should throw BadRequestException when no price ID or bundle price is available', async () => {
+      configService.get.mockImplementation(
+        buildConfigGetMock({
+          GENFEEDAI_APP_URL: 'https://app.genfeed.ai',
+          STRIPE_PRICE_SKILLS_PRO: '',
+        }),
+      );
+
+      skillRegistryService.getBundleStripePriceId.mockResolvedValue(undefined);
+      skillRegistryService.getBundlePriceCents.mockResolvedValue(undefined);
+
+      await expect(service.createCheckoutSession({})).rejects.toThrow(
         BadRequestException,
       );
     });

--- a/apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
+++ b/apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
@@ -260,10 +260,11 @@ describe('SkillCheckoutService', () => {
       );
     });
 
-    it('should use custom success and cancel URLs when provided in DTO', async () => {
+    it('should use custom success and cancel URLs from configured origins', async () => {
       configService.get.mockImplementation(
         buildConfigGetMock({
           GENFEEDAI_APP_URL: 'https://app.genfeed.ai',
+          GENFEEDAI_PUBLIC_URL: 'https://genfeed.ai',
           STRIPE_PRICE_SKILLS_PRO: 'price_env_123',
         }),
       );
@@ -278,8 +279,9 @@ describe('SkillCheckoutService', () => {
       );
 
       const dto: CreateSkillCheckoutDto = {
-        cancelUrl: 'https://custom.example.com/cancel',
-        successUrl: 'https://custom.example.com/success',
+        cancelUrl: 'https://genfeed.ai/skills',
+        successUrl:
+          'https://genfeed.ai/skills/success?session_id={CHECKOUT_SESSION_ID}',
       };
 
       await service.createCheckoutSession(dto);
@@ -288,8 +290,45 @@ describe('SkillCheckoutService', () => {
         stripeService.stripe.checkout.sessions.create,
       ).toHaveBeenCalledWith(
         expect.objectContaining({
-          cancel_url: 'https://custom.example.com/cancel',
-          success_url: 'https://custom.example.com/success',
+          cancel_url: 'https://genfeed.ai/skills',
+          success_url:
+            'https://genfeed.ai/skills/success?session_id={CHECKOUT_SESSION_ID}',
+        }),
+      );
+    });
+
+    it('should ignore checkout redirect URLs from unknown origins', async () => {
+      configService.get.mockImplementation(
+        buildConfigGetMock({
+          GENFEEDAI_APP_URL: 'https://app.genfeed.ai',
+          GENFEEDAI_PUBLIC_URL: 'https://genfeed.ai',
+          STRIPE_PRICE_SKILLS_PRO: 'price_env_123',
+        }),
+      );
+
+      const mockSession = {
+        id: 'cs_test_rejected_redirect',
+        url: 'https://checkout.stripe.com/session/cs_test_rejected_redirect',
+      } as unknown as Stripe.Checkout.Session;
+
+      stripeService.stripe.checkout.sessions.create.mockResolvedValue(
+        mockSession,
+      );
+
+      const dto: CreateSkillCheckoutDto = {
+        cancelUrl: 'https://evil.example/cancel',
+        successUrl: 'https://evil.example/success',
+      };
+
+      await service.createCheckoutSession(dto);
+
+      expect(
+        stripeService.stripe.checkout.sessions.create,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cancel_url: 'https://app.genfeed.ai/skills-pro',
+          success_url:
+            'https://app.genfeed.ai/skills-pro/success?session_id={CHECKOUT_SESSION_ID}',
         }),
       );
     });

--- a/apps/server/api/src/skills-pro/services/skill-checkout.service.ts
+++ b/apps/server/api/src/skills-pro/services/skill-checkout.service.ts
@@ -14,6 +14,9 @@ type CheckoutSession = Awaited<
 type CheckoutSessionCreateParams = Parameters<
   StripeClient['checkout']['sessions']['create']
 >[0];
+type CheckoutLineItem = NonNullable<
+  CheckoutSessionCreateParams['line_items']
+>[number];
 
 @Injectable()
 export class SkillCheckoutService {
@@ -32,12 +35,7 @@ export class SkillCheckoutService {
   ): Promise<{ url: string }> {
     this.loggerService.log(`${this.constructorName} createCheckoutSession`);
 
-    const priceId = await this.resolveBundlePriceId();
-    if (!priceId) {
-      throw new BadRequestException(
-        'Skills Pro checkout is not configured. No bundle price ID found.',
-      );
-    }
+    const lineItem = await this.resolveBundleLineItem();
 
     const defaultSuccessUrl =
       this.configService.get('GENFEEDAI_APP_URL') +
@@ -47,12 +45,7 @@ export class SkillCheckoutService {
     const sessionConfig: CheckoutSessionCreateParams = {
       allow_promotion_codes: true,
       cancel_url: dto.cancelUrl || defaultCancelUrl,
-      line_items: [
-        {
-          price: priceId,
-          quantity: 1,
-        },
-      ],
+      line_items: [lineItem],
       metadata: {
         bundle: 'true',
         type: 'skills-pro',
@@ -76,12 +69,35 @@ export class SkillCheckoutService {
     return { url: session.url || '' };
   }
 
-  private async resolveBundlePriceId(): Promise<string | undefined> {
+  private async resolveBundleLineItem(): Promise<CheckoutLineItem> {
     const envPriceId = this.configService.get('STRIPE_PRICE_SKILLS_PRO');
     if (envPriceId) {
-      return envPriceId;
+      return { price: envPriceId, quantity: 1 };
     }
 
-    return this.skillRegistryService.getBundleStripePriceId();
+    const registryPriceId =
+      await this.skillRegistryService.getBundleStripePriceId();
+    if (registryPriceId) {
+      return { price: registryPriceId, quantity: 1 };
+    }
+
+    const bundlePriceCents =
+      await this.skillRegistryService.getBundlePriceCents();
+    if (bundlePriceCents && bundlePriceCents > 0) {
+      return {
+        price_data: {
+          currency: 'usd',
+          product_data: {
+            name: 'Skills Pro Bundle',
+          },
+          unit_amount: bundlePriceCents,
+        },
+        quantity: 1,
+      };
+    }
+
+    throw new BadRequestException(
+      'Skills Pro checkout is not configured. No bundle price found.',
+    );
   }
 }

--- a/apps/server/api/src/skills-pro/services/skill-checkout.service.ts
+++ b/apps/server/api/src/skills-pro/services/skill-checkout.service.ts
@@ -37,14 +37,13 @@ export class SkillCheckoutService {
 
     const lineItem = await this.resolveBundleLineItem();
 
-    const defaultSuccessUrl =
-      this.configService.get('GENFEEDAI_APP_URL') +
-      '/skills-pro/success?session_id={CHECKOUT_SESSION_ID}';
-    const defaultCancelUrl = `${this.configService.get('GENFEEDAI_APP_URL')}/skills-pro`;
+    const appUrl = this.configService.get('GENFEEDAI_APP_URL');
+    const defaultSuccessUrl = `${appUrl}/skills-pro/success?session_id={CHECKOUT_SESSION_ID}`;
+    const defaultCancelUrl = `${appUrl}/skills-pro`;
 
     const sessionConfig: CheckoutSessionCreateParams = {
       allow_promotion_codes: true,
-      cancel_url: dto.cancelUrl || defaultCancelUrl,
+      cancel_url: this.resolveRedirectUrl(dto.cancelUrl, defaultCancelUrl),
       line_items: [lineItem],
       metadata: {
         bundle: 'true',
@@ -52,7 +51,7 @@ export class SkillCheckoutService {
       },
       mode: 'payment',
       payment_method_types: ['card'],
-      success_url: dto.successUrl || defaultSuccessUrl,
+      success_url: this.resolveRedirectUrl(dto.successUrl, defaultSuccessUrl),
     };
 
     if (dto.email) {
@@ -99,5 +98,51 @@ export class SkillCheckoutService {
     throw new BadRequestException(
       'Skills Pro checkout is not configured. No bundle price found.',
     );
+  }
+
+  private resolveRedirectUrl(
+    requestedUrl: string | undefined,
+    fallbackUrl: string,
+  ): string {
+    if (!requestedUrl) {
+      return fallbackUrl;
+    }
+
+    return this.isAllowedRedirectUrl(requestedUrl) ? requestedUrl : fallbackUrl;
+  }
+
+  private isAllowedRedirectUrl(url: string): boolean {
+    let requestedOrigin: string;
+
+    try {
+      requestedOrigin = new URL(url).origin;
+    } catch {
+      return false;
+    }
+
+    return this.getAllowedRedirectOrigins().has(requestedOrigin);
+  }
+
+  private getAllowedRedirectOrigins(): Set<string> {
+    return new Set(
+      [
+        this.configService.get('GENFEEDAI_APP_URL'),
+        this.configService.get('GENFEEDAI_PUBLIC_URL'),
+      ]
+        .map((url) => this.toOrigin(url))
+        .filter((origin): origin is string => Boolean(origin)),
+    );
+  }
+
+  private toOrigin(url: string | undefined): string | undefined {
+    if (!url) {
+      return undefined;
+    }
+
+    try {
+      return new URL(url).origin;
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/apps/server/api/src/skills-pro/services/skill-download.service.ts
+++ b/apps/server/api/src/skills-pro/services/skill-download.service.ts
@@ -71,6 +71,7 @@ export class SkillDownloadService {
     receiptId: string,
     skillSlug?: string,
   ): Promise<{
+    checksum: string;
     downloadUrl: string;
     expiresIn: number;
     skill: { slug: string; name: string; version: string };
@@ -134,6 +135,7 @@ export class SkillDownloadService {
     });
 
     return {
+      checksum: skillEntry.checksum ?? '',
       downloadUrl,
       expiresIn: 900,
       skill: {

--- a/apps/server/api/src/skills-pro/services/skill-registry.service.spec.ts
+++ b/apps/server/api/src/skills-pro/services/skill-registry.service.spec.ts
@@ -10,11 +10,12 @@ interface SkillRegistryEntry {
   version: string;
   s3Key: string;
   category: string;
+  checksum?: string;
 }
 
 interface CdnSkillRegistry {
   skills: SkillRegistryEntry[];
-  bundle?: { price: number; stripePriceId: string; name: string };
+  bundle?: { price: number; stripePriceId?: string; name: string };
   bundlePrice?: number;
   updatedAt: string;
 }
@@ -27,6 +28,7 @@ describe('SkillRegistryService', () => {
   const mockSkills: SkillRegistryEntry[] = [
     {
       category: 'generation',
+      checksum: 'sha256:image-gen',
       description: 'Generate images with AI',
       name: 'Image Gen Pro',
       s3Key: 'skills/image-gen-pro-v1.zip',
@@ -35,6 +37,7 @@ describe('SkillRegistryService', () => {
     },
     {
       category: 'editing',
+      checksum: 'sha256:video-editor',
       description: 'Edit videos with AI',
       name: 'Video Editor',
       s3Key: 'skills/video-editor-v2.zip',
@@ -152,6 +155,27 @@ describe('SkillRegistryService', () => {
       const result = await service.getRegistry();
 
       expect(result.bundlePrice).toBe(99);
+    });
+
+    it('should support registries without a bundle stripePriceId', async () => {
+      const cdnWithoutStripePriceId: CdnSkillRegistry = {
+        bundle: {
+          name: 'Bundle',
+          price: 2900,
+        },
+        skills: mockSkills,
+        updatedAt: '2026-01-15T00:00:00Z',
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(cdnWithoutStripePriceId),
+        ok: true,
+      });
+
+      const result = await service.getRegistry();
+      const stripePriceId = await service.getBundleStripePriceId();
+
+      expect(result.bundlePrice).toBe(29);
+      expect(stripePriceId).toBeUndefined();
     });
 
     it('should set bundlePrice to 0 when neither bundlePrice nor bundle exist', async () => {
@@ -298,6 +322,50 @@ describe('SkillRegistryService', () => {
       await service.getBundleStripePriceId();
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getBundlePriceCents', () => {
+    it('should return bundle price in cents from registry bundle', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(mockCdnRegistry),
+        ok: true,
+      });
+
+      const priceCents = await service.getBundlePriceCents();
+
+      expect(priceCents).toBe(4900);
+    });
+
+    it('should convert bundlePrice dollars to cents when bundle.price is missing', async () => {
+      const cdnWithBundlePriceOnly: CdnSkillRegistry = {
+        bundlePrice: 39,
+        skills: mockSkills,
+        updatedAt: '2026-01-15T00:00:00Z',
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(cdnWithBundlePriceOnly),
+        ok: true,
+      });
+
+      const priceCents = await service.getBundlePriceCents();
+
+      expect(priceCents).toBe(3900);
+    });
+
+    it('should return undefined when no positive bundle price exists', async () => {
+      const cdnNoBundleInfo: CdnSkillRegistry = {
+        skills: mockSkills,
+        updatedAt: '2026-01-15T00:00:00Z',
+      };
+      global.fetch = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(cdnNoBundleInfo),
+        ok: true,
+      });
+
+      const priceCents = await service.getBundlePriceCents();
+
+      expect(priceCents).toBeUndefined();
     });
   });
 

--- a/apps/server/api/src/skills-pro/services/skill-registry.service.ts
+++ b/apps/server/api/src/skills-pro/services/skill-registry.service.ts
@@ -10,11 +10,12 @@ interface SkillRegistryEntry {
   version: string;
   s3Key: string;
   category: string;
+  checksum?: string;
 }
 
 interface CdnSkillRegistry {
   skills: SkillRegistryEntry[];
-  bundle?: { price: number; stripePriceId: string; name: string };
+  bundle?: { price: number; stripePriceId?: string; name: string };
   bundlePrice?: number;
   updatedAt: string;
 }
@@ -32,6 +33,7 @@ export class SkillRegistryService {
   private readonly constructorName: string = String(this.constructor.name);
   private cachedRegistry: SkillRegistry | null = null;
   private cachedBundleStripePriceId: string | undefined;
+  private cachedBundlePriceCents: number | undefined;
   private cacheExpiresAt = 0;
 
   constructor(
@@ -62,16 +64,16 @@ export class SkillRegistryService {
 
     const cdnData = (await response.json()) as CdnSkillRegistry;
 
+    const bundlePriceCents = this.resolveBundlePriceCents(cdnData);
     const registry: SkillRegistry = {
-      bundlePrice:
-        cdnData.bundlePrice ??
-        (cdnData.bundle?.price ? cdnData.bundle.price / 100 : 0),
+      bundlePrice: this.resolveBundlePriceDollars(cdnData, bundlePriceCents),
       skills: cdnData.skills,
       updatedAt: cdnData.updatedAt,
     };
 
     this.cachedRegistry = registry;
     this.cachedBundleStripePriceId = cdnData.bundle?.stripePriceId;
+    this.cachedBundlePriceCents = bundlePriceCents;
     this.cacheExpiresAt = Date.now() + CACHE_TTL_MS;
 
     this.loggerService.log(`${this.constructorName} registry cached`, {
@@ -82,10 +84,17 @@ export class SkillRegistryService {
   }
 
   async getBundleStripePriceId(): Promise<string | undefined> {
-    if (!this.cachedBundleStripePriceId || Date.now() >= this.cacheExpiresAt) {
+    if (!this.cachedRegistry || Date.now() >= this.cacheExpiresAt) {
       await this.getRegistry();
     }
     return this.cachedBundleStripePriceId;
+  }
+
+  async getBundlePriceCents(): Promise<number | undefined> {
+    if (!this.cachedRegistry || Date.now() >= this.cacheExpiresAt) {
+      await this.getRegistry();
+    }
+    return this.cachedBundlePriceCents;
   }
 
   getSkillBySlug(
@@ -93,5 +102,30 @@ export class SkillRegistryService {
     slug: string,
   ): SkillRegistryEntry | undefined {
     return registry.skills.find((s) => s.slug === slug);
+  }
+
+  private resolveBundlePriceCents(
+    cdnData: CdnSkillRegistry,
+  ): number | undefined {
+    if (Number.isFinite(cdnData.bundle?.price) && cdnData.bundle?.price) {
+      return cdnData.bundle.price;
+    }
+
+    if (Number.isFinite(cdnData.bundlePrice) && cdnData.bundlePrice) {
+      return Math.round(cdnData.bundlePrice * 100);
+    }
+
+    return undefined;
+  }
+
+  private resolveBundlePriceDollars(
+    cdnData: CdnSkillRegistry,
+    bundlePriceCents: number | undefined,
+  ): number {
+    if (Number.isFinite(cdnData.bundlePrice)) {
+      return cdnData.bundlePrice ?? 0;
+    }
+
+    return bundlePriceCents ? bundlePriceCents / 100 : 0;
   }
 }

--- a/apps/website/app/(public)/skills/_data.ts
+++ b/apps/website/app/(public)/skills/_data.ts
@@ -80,7 +80,7 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
       },
       {
         description:
-          'Newsletter editions with subject line A/B variants and editorial structure.',
+          'Newsletter editions with subject-line variants, editorial structure, and growth tactics.',
         icon: LuNewspaper,
         name: 'Newsletter Creator',
         slug: 'newsletter-creator',
@@ -92,9 +92,16 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
         name: 'Blog Creator',
         slug: 'blog-content-creator',
       },
+      {
+        description:
+          'Landing pages, CTAs, value propositions, onboarding copy, and product microcopy.',
+        icon: LuPenTool,
+        name: 'Copywriter',
+        slug: 'copywriter',
+      },
     ],
     subtitle:
-      'Platform-native content with hooks, hashtags, SEO, and formatting — ready to post.',
+      'Platform-native content with hooks, hashtags, SEO, and conversion copy ready to publish.',
     title: 'Create for Every Platform',
   },
   {
@@ -110,7 +117,14 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
       },
       {
         description:
-          'Repurpose 1 piece of content into 15+ derivatives across every platform.',
+          'Operate content intake, briefs, production queues, review gates, and analytics loops.',
+        icon: LuPackage,
+        name: 'Factory Operator',
+        slug: 'content-factory-operator',
+      },
+      {
+        description:
+          'Repurpose one source asset into platform-native derivatives across every channel.',
         icon: LuShuffle,
         name: 'Content Atomizer',
         slug: 'content-atomizer',
@@ -122,10 +136,77 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
         name: 'Content Reviewer',
         slug: 'content-reviewer',
       },
+      {
+        description:
+          'Editorial strategy, content pillars, platform roles, cadence, calendars, and KPIs.',
+        icon: LuTarget,
+        name: 'Content Strategist',
+        slug: 'content-strategist',
+      },
+      {
+        description:
+          'Rewrite AI drafts to sound natural while preserving meaning, structure, and voice.',
+        icon: LuSparkles,
+        name: 'Humanizer',
+        slug: 'humanizer',
+      },
     ],
     subtitle:
-      'SEO scoring, quality review, and cross-platform repurposing in one pass.',
+      'SEO scoring, quality review, production operations, repurposing, and humanization.',
     title: 'Optimize Before You Publish',
+  },
+  {
+    id: 'content-analysis',
+    label: 'Content Analysis',
+    skills: [
+      {
+        description:
+          'Pull and score trend signals for the Genfeed content loop.',
+        icon: LuTrendingUp,
+        name: 'Trend Scout',
+        slug: 'trend-scout',
+      },
+      {
+        description:
+          'Collect post-performance metrics and feed them back into content-loop learning.',
+        icon: LuTarget,
+        name: 'Analytics Collector',
+        slug: 'analytics-collector',
+      },
+      {
+        description:
+          'Audit competitor content strategy, channels, formats, topics, and engagement gaps.',
+        icon: LuUsers,
+        name: 'Competitor Analyzer',
+        slug: 'competitor-analyzer',
+      },
+      {
+        description:
+          'Deconstruct YouTube videos into hooks, retention mechanics, and reusable blueprints.',
+        icon: FaYoutube,
+        name: 'YouTube Video Analyst',
+        slug: 'youtube-video-analyst',
+      },
+    ],
+    subtitle:
+      'Trend detection, analytics collection, competitor research, and retention teardown.',
+    title: 'Learn from the Market',
+  },
+  {
+    id: 'communications',
+    label: 'Communications',
+    skills: [
+      {
+        description:
+          'Status reports, 3P updates, leadership updates, newsletters, FAQs, and incident reports.',
+        icon: LuNewspaper,
+        name: 'Internal Comms',
+        slug: 'internal-comms',
+      },
+    ],
+    subtitle:
+      'Structured updates for teams, leaders, customers, and operational incidents.',
+    title: 'Communicate Clearly',
   },
   {
     id: 'image-visual',
@@ -133,28 +214,35 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
     skills: [
       {
         description:
-          'Optimized image prompts with model-specific tips for Flux, DALL-E, Midjourney, and Imagen.',
+          'Optimized prompts with model-specific tips for Flux, DALL-E, Midjourney, and Imagen.',
         icon: LuImage,
         name: 'Image Prompt Engineer',
         slug: 'image-prompt-engineer',
       },
       {
         description:
-          'Pick the right model for the job — face consistency, speed, quality, cost tiers.',
+          'Pick the right model for the job: face consistency, speed, quality, and cost tiers.',
         icon: LuZap,
         name: 'Model Selector',
         slug: 'model-selector',
       },
       {
         description:
-          'Visual brand identity — colors, typography, composition rules, and prompt presets.',
+          'Visual brand systems: colors, typography feel, composition rules, and prompt presets.',
         icon: LuPalette,
         name: 'Visual Brand Kit',
         slug: 'visual-brand-kit',
       },
+      {
+        description:
+          'Generate image, video, and audio artifacts through Replicate or fal.ai workers.',
+        icon: LuWand,
+        name: 'Media Forge',
+        slug: 'media-forge',
+      },
     ],
     subtitle:
-      'Optimized prompts for Flux, DALL-E, Midjourney, Imagen, and more — with model selection intelligence.',
+      'Optimized prompts, model selection, visual systems, and media generation workers.',
     title: 'Prompt Any Model',
   },
   {
@@ -181,27 +269,174 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
     title: 'Ads That Convert',
   },
   {
-    id: 'strategy',
-    label: 'Strategy',
+    id: 'gtm-strategy',
+    label: 'GTM Strategy',
     skills: [
       {
         description:
-          'Content pillars, posting cadence, platform mix, monthly calendar, and KPI targets.',
-        icon: LuTarget,
-        name: 'Content Strategist',
-        slug: 'content-strategist',
+          'Brand foundations: name, positioning, voice, and strategic identity.',
+        icon: LuPalette,
+        name: 'Brand Architect',
+        slug: 'brand-architect',
       },
       {
         description:
-          'Competitive audit — platforms, frequency, engagement, gaps, and differentiation.',
+          'Differentiated market angles, mechanisms, narratives, and positioning tests.',
+        icon: LuTarget,
+        name: 'Positioning Angles',
+        slug: 'positioning-angles',
+      },
+      {
+        description:
+          'ICP, buyer personas, buying centers, pains, triggers, and targeting focus.',
         icon: LuUsers,
-        name: 'Competitor Analyzer',
-        slug: 'competitor-analyzer',
+        name: 'Startup ICP Definer',
+        slug: 'startup-icp-definer',
+      },
+      {
+        description:
+          'Premium and value-based pricing strategy, tiers, price-rise plans, and confidence.',
+        icon: LuTrendingUp,
+        name: 'Pricing Strategist',
+        slug: 'pricing-strategist',
+      },
+      {
+        description:
+          'High-converting offers, bundles, guarantees, packages, and value stacks.',
+        icon: LuSparkles,
+        name: 'Offer Architect',
+        slug: 'offer-architect',
+      },
+      {
+        description:
+          'Existing offer scoring and fixes against the Value Equation.',
+        icon: LuSparkles,
+        name: 'Offer Validator',
+        slug: 'offer-validator',
+      },
+      {
+        description:
+          'Sales funnels, value ladders, customer journeys, and landing-page sequences.',
+        icon: LuLayoutTemplate,
+        name: 'Funnel Architect',
+        slug: 'funnel-architect',
+      },
+      {
+        description:
+          'Funnel audits for hook, story, offer, value ladder fit, traffic match, and conversion path.',
+        icon: LuLayoutTemplate,
+        name: 'Funnel Validator',
+        slug: 'funnel-validator',
+      },
+      {
+        description:
+          'Audience acquisition strategy using Dream 100, organic, paid, and owned audience paths.',
+        icon: LuMegaphone,
+        name: 'Traffic Architect',
+        slug: 'traffic-architect',
+      },
+      {
+        description:
+          'Traffic strategy scoring across channel clarity, hook strategy, funnel alignment, and conversion path.',
+        icon: LuMegaphone,
+        name: 'Traffic Validator',
+        slug: 'traffic-validator',
+      },
+      {
+        description:
+          'Channel focus and expansion-readiness validation against the One Channel Rule.',
+        icon: LuShuffle,
+        name: 'Channel Validator',
+        slug: 'channel-validator',
+      },
+      {
+        description:
+          'Lead generation channel prioritization by ROI, cost, close rate, effort, and system potential.',
+        icon: LuTarget,
+        name: 'Lead Channel Optimizer',
+        slug: 'lead-channel-optimizer',
+      },
+      {
+        description:
+          'Cold email, DM, prospecting, personalization, and outbound sequence optimization.',
+        icon: LuMegaphone,
+        name: 'Outbound Optimizer',
+        slug: 'outbound-optimizer',
+      },
+      {
+        description:
+          'Prospect accounts, decision makers, contact details, company data, and buyer intent signals.',
+        icon: LuSearch,
+        name: 'Leads Researcher',
+        slug: 'leads-researcher',
+      },
+      {
+        description:
+          'Contact email discovery, domain patterns, and verification guidance.',
+        icon: LuSearch,
+        name: 'Email Finder',
+        slug: 'email-finder',
+      },
+      {
+        description:
+          'GTM competitors, market positioning, feature gaps, pricing, and win/loss patterns.',
+        icon: LuUsers,
+        name: 'Competitive Intelligence',
+        slug: 'competitive-intelligence-analyst',
+      },
+      {
+        description:
+          'Affiliate, integration, reseller, co-marketing, embedded distribution, and partner outreach strategy.',
+        icon: LuGitBranch,
+        name: 'Partnership Builder',
+        slug: 'partnership-builder',
+      },
+      {
+        description:
+          'Activation, ascension, upsell, subscription, churn reduction, and LTV systems.',
+        icon: LuTrendingUp,
+        name: 'Retention Engine',
+        slug: 'retention-engine',
+      },
+      {
+        description:
+          'Scalable support systems, docs, FAQs, ticketing, self-service, automation, and response templates.',
+        icon: LuUsers,
+        name: 'Support Systems Architect',
+        slug: 'support-systems-architect',
+      },
+      {
+        description:
+          'Customer friction, buying objections, implementation blockers, refund causes, and success obstacles.',
+        icon: LuTarget,
+        name: 'Constraint Eliminator',
+        slug: 'constraint-eliminator',
+      },
+      {
+        description:
+          'Personal expert positioning, authority, origin story, Big Domino, and new opportunity framing.',
+        icon: LuBrainCircuit,
+        name: 'Expert Architect',
+        slug: 'expert-architect',
+      },
+      {
+        description:
+          'Existing expert positioning and authority narrative scoring.',
+        icon: LuBrainCircuit,
+        name: 'Expert Validator',
+        slug: 'expert-validator',
+      },
+      {
+        description:
+          'Domain syntax validation, availability-oriented checks, and brandable domain options.',
+        icon: LuSearch,
+        name: 'Search Domain Validator',
+        slug: 'search-domain-validator',
       },
     ],
     subtitle:
-      'Content calendars, pillar strategy, and competitive intelligence.',
-    title: 'Plan Before You Create',
+      'Positioning, offers, funnels, traffic, lead generation, retention, and expert authority.',
+    title: 'Build the Market Engine',
   },
   {
     id: 'platform',
@@ -209,7 +444,7 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
     skills: [
       {
         description:
-          'Create visual AI workflows from natural language descriptions.',
+          'Create Genfeed Studio workflows from natural language descriptions.',
         icon: LuGitBranch,
         name: 'Workflow Creator',
         slug: 'workflow-creator',
@@ -221,19 +456,36 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
         slug: 'node-creator',
       },
       {
-        description: 'AI image and video prompt generation with style presets.',
-        icon: LuWand,
-        name: 'Prompt Generator',
-        slug: 'prompt-generator',
+        description:
+          'Operate the executable Genfeed content loop and route each stage to the right skill.',
+        icon: LuShuffle,
+        name: 'Content Loop Orchestrator',
+        slug: 'content-loop-orchestrator',
       },
       {
-        description: 'Get started with Genfeed in under 10 minutes.',
+        description:
+          'Detect Genfeed connectivity and provide content-loop state, token, manifest, and feedback handoff.',
+        icon: LuBrainCircuit,
+        name: 'Genfeed Connector',
+        slug: 'genfeed-connector',
+      },
+      {
+        description:
+          'Publish approved derivatives to X or LinkedIn with a dry-run-by-default approval gate.',
+        icon: LuPackage,
+        name: 'Social Poster',
+        slug: 'social-poster',
+      },
+      {
+        description:
+          'Get started with Genfeed through first content creation in under 10 minutes.',
         icon: LuRocket,
         name: 'Onboarding',
         slug: 'onboarding',
       },
       {
-        description: 'Validate feature scope — core vs cloud.',
+        description:
+          'Classify Genfeed feature requests as OSS Core or Cloud SaaS scope.',
         icon: LuLayoutTemplate,
         name: 'Scope Validator',
         slug: 'scope-validator',
@@ -246,10 +498,15 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
       },
     ],
     subtitle:
-      'Workflow creation, custom nodes, and agent integration for developers.',
+      'Workflow creation, custom nodes, content-loop operations, and agent integration.',
     title: 'Build with Genfeed',
   },
 ];
+
+export const FREE_SKILL_COUNT = SKILL_CATEGORIES.reduce(
+  (total, category) => total + category.skills.length,
+  0,
+);
 
 /* ─── Premium registry types ─── */
 
@@ -260,6 +517,7 @@ export interface SkillRegistryEntry {
   version: string;
   s3Key: string;
   category: string;
+  checksum?: string;
 }
 
 export interface SkillRegistry {
@@ -271,8 +529,8 @@ export interface SkillRegistry {
 /* ─── Stats ─── */
 
 export const STATS = [
-  { label: 'Skills', value: '22' },
-  { label: 'Platforms', value: '6' },
+  { label: 'Free Skills', value: String(FREE_SKILL_COUNT) },
+  { label: 'Categories', value: String(SKILL_CATEGORIES.length) },
   { label: 'Open Source', value: '100%' },
   { label: 'Install Time', value: '<10s' },
 ];
@@ -280,15 +538,18 @@ export const STATS = [
 /* ─── Terminal demo commands ─── */
 
 export const TERMINAL_COMMANDS = [
-  { command: 'npx skills add genfeedai/skills', prompt: '~' },
-  { command: 'Installing 22 skills from genfeedai/skills...', prompt: '' },
+  { command: 'bunx skills add genfeedai/skills', prompt: '~' },
+  {
+    command: `Installing ${FREE_SKILL_COUNT} skills from genfeedai/skills...`,
+    prompt: '',
+  },
   { command: '\u2713 x-content-creator', prompt: '' },
   { command: '\u2713 instagram-content-creator', prompt: '' },
   { command: '\u2713 content-seo-optimizer', prompt: '' },
   { command: '\u2713 image-prompt-engineer', prompt: '' },
   { command: '\u2713 ad-copy-creator', prompt: '' },
-  { command: '... and 17 more', prompt: '' },
-  { command: '# \u2713 All 22 skills installed', prompt: '' },
+  { command: `... and ${FREE_SKILL_COUNT - 5} more`, prompt: '' },
+  { command: `# \u2713 All ${FREE_SKILL_COUNT} skills installed`, prompt: '' },
 ] as const;
 
 /* ─── How It Works steps ─── */
@@ -302,8 +563,7 @@ export interface HowItWorksStep {
 
 export const HOW_IT_WORKS: HowItWorksStep[] = [
   {
-    description:
-      'One command installs all 22 skills into your Claude Code workspace.',
+    description: `One command installs all ${FREE_SKILL_COUNT} free skills into your Claude Code workspace.`,
     icon: LuTerminal,
     number: '01',
     title: 'Install',

--- a/apps/website/app/(public)/skills/install-command.tsx
+++ b/apps/website/app/(public)/skills/install-command.tsx
@@ -10,7 +10,7 @@ export default function InstallCommand(): React.ReactElement {
 
   async function handleCopy(): Promise<void> {
     try {
-      await navigator.clipboard.writeText('npx skills add genfeedai/skills');
+      await navigator.clipboard.writeText('bunx skills add genfeedai/skills');
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
@@ -26,7 +26,7 @@ export default function InstallCommand(): React.ReactElement {
       className="group inline-flex items-center gap-3 px-6 py-3 bg-fill/5 border border-edge/10 hover:border-edge/20 transition-all font-mono text-sm cursor-pointer"
     >
       <LuTerminal className="size-4 text-surface/30" />
-      <span className="text-surface/70">npx skills add genfeedai/skills</span>
+      <span className="text-surface/70">bunx skills add genfeedai/skills</span>
       {copied ? (
         <LuCheck className="size-4 text-emerald-400" />
       ) : (

--- a/apps/website/app/(public)/skills/page.tsx
+++ b/apps/website/app/(public)/skills/page.tsx
@@ -1,10 +1,11 @@
 import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-metadata.helper';
+import { FREE_SKILL_COUNT } from '@public/skills/_data';
 import SkillsContent from '@public/skills/skills-content';
 import { getSkillsRegistry } from '@public/skills/skills-loader';
 
 export const generateMetadata = createPageMetadataWithCanonical(
-  'AI Skills for Content Creation, SEO & Advertising',
-  '22 open-source Claude Code skills for content creation, SEO optimization, advertising, image prompting, and strategy. Install with one command: npx skills add genfeedai/skills',
+  'AI Skills for Content Creation, SEO, GTM & Advertising',
+  `${FREE_SKILL_COUNT} open-source Claude Code skills for content creation, SEO optimization, advertising, image prompting, GTM strategy, and platform development. Install with one command: bunx skills add genfeedai/skills`,
   '/skills',
 );
 

--- a/apps/website/app/(public)/skills/skills-content.tsx
+++ b/apps/website/app/(public)/skills/skills-content.tsx
@@ -4,6 +4,7 @@ import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { Code } from '@genfeedai/ui';
 import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
 import {
+  FREE_SKILL_COUNT,
   SKILL_CATEGORIES,
   type SkillRegistry,
   type SkillRegistryEntry,
@@ -80,10 +81,11 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
         badgeIcon={LuBrainCircuit}
         title={
           <>
-            22 Skills. <span className="italic font-light">One Command.</span>
+            {FREE_SKILL_COUNT} Skills.{' '}
+            <span className="italic font-light">One Command.</span>
           </>
         }
-        description="Content creation, SEO, advertising, image prompting, and strategy — all as Claude Code skills. Works standalone. Works better with Genfeed."
+        description="Content creation, SEO, advertising, GTM, image prompting, platform development, and analysis as Claude Code skills. Works standalone. Works better with Genfeed."
         heroActions={
           <div className="flex flex-col items-center gap-6">
             <InstallCommand />
@@ -160,7 +162,7 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
 
             <div className="text-center mt-8">
               <Code className="bg-transparent text-surface/25">
-                npx skills add genfeedai/skills/{category.skills[0]?.slug}
+                bunx skills add genfeedai/skills/{category.skills[0]?.slug}
               </Code>
             </div>
           </WebSection>
@@ -175,8 +177,9 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
               </div>
               <h2 className="text-5xl font-serif mb-6">Pro Skills</h2>
               <p className="text-surface/50 max-w-xl mx-auto">
-                Deep domain skills that make your agent dramatically more
-                capable. All included in the bundle.
+                Paid operating systems for source-to-brief, brand voice,
+                production queues, performance loops, and platform warmup. All
+                included in the bundle.
               </p>
             </div>
 
@@ -225,8 +228,9 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
               </div>
               <h2 className="text-4xl font-serif mb-4">One Command</h2>
               <p className="text-surface/40 text-sm leading-relaxed mb-6">
-                Install all 22 skills with a single command. Your agent learns
-                each skill and activates it at exactly the right moment.
+                Install all {FREE_SKILL_COUNT} free skills with a single
+                command. Your agent learns each skill and activates it at
+                exactly the right moment.
               </p>
               <div className="space-y-3 text-sm text-surface/40">
                 <p>
@@ -234,7 +238,7 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
                     Install all:
                   </span>{' '}
                   <Code className="text-surface/50 bg-fill/5">
-                    npx skills add genfeedai/skills
+                    bunx skills add genfeedai/skills
                   </Code>
                 </p>
                 <p>
@@ -242,7 +246,7 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
                     Install one:
                   </span>{' '}
                   <Code className="text-surface/50 bg-fill/5">
-                    npx skills add genfeedai/skills/x-content-creator
+                    bunx skills add genfeedai/skills/x-content-creator
                   </Code>
                 </p>
               </div>
@@ -257,7 +261,7 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
         <CtaSection
           bg="subtle"
           title="Start Creating"
-          description="22 free skills. Every platform. One install. Upgrade to Pro for deep domain skills."
+          description={`${FREE_SKILL_COUNT} free skills. Every platform. One install. Upgrade to Pro for warmup and deep operating systems.`}
         >
           {registry && registry.skills.length > 0 && (
             <Button

--- a/apps/website/app/(public)/skills/success/skills-success-content.tsx
+++ b/apps/website/app/(public)/skills/success/skills-success-content.tsx
@@ -9,8 +9,7 @@ import PageLayout from '@web-components/PageLayout';
 import Link from 'next/link';
 import { LuCheck, LuCopy, LuTerminal } from 'react-icons/lu';
 
-const INSTALL_COMMAND =
-  'npx @genfeedai/skills-pro install --receipt sk_rcpt_xxx';
+const INSTALL_COMMAND = 'npx @genfeedai/skills-pro install sk_rcpt_xxx';
 
 async function handleCopy() {
   try {

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@genfeedai/constants": "*",
+    "@genfeedai/enums": "*",
     "@genfeedai/helpers": "*",
     "@genfeedai/interfaces": "*",
     "@genfeedai/next-config": "*",


### PR DESCRIPTION
## Summary
- Updates `/skills` to reflect the current 55-skill public catalogue, `bunx` install flow, and Pro warmup positioning.
- Fixes the Skills Pro registry/checkout API so registries can omit `stripePriceId` and still create Stripe checkout sessions from bundle cents.
- Adds checksum to download responses so the Skills Pro CLI can verify artifacts.

## Changes
- Adds registry cache support for bundle price in cents and optional registry Stripe price IDs.
- Creates Stripe line items from env price ID, registry price ID, or inline registry `price_data` fallback.
- Returns checksum with presigned download URLs.
- Fixes post-purchase CLI command to use `install <receipt-id>`.
- Declares `@genfeedai/enums` in the website package so the prebuild generator resolves its imports.

## Verification
- `bunx biome check --write` on touched files
- `bun run --cwd apps/server/api test:file src/skills-pro/services/skill-registry.service.spec.ts src/skills-pro/services/skill-checkout.service.spec.ts src/skills-pro/controllers/skill-download.controller.spec.ts`
- `bun run --cwd apps/website lint`
- `bun run --cwd apps/website build`
- `bun run --cwd apps/server/api build`

## Rollout
- Depends on `genfeedai/skills-pro#3` for the private registry/artifact payload.
- Production still needs the Skills Pro registry/artifacts uploaded to the private CDN keys referenced by `registry/skills-pro.json`.
