### PR TITLE
fix(api): quiet invalid Clerk webhook signatures

### DIFF
--- a/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.controller.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.controller.spec.ts
@@ -42,6 +42,7 @@ describe('ClerkWebhookController', () => {
           useValue: {
             error: vi.fn(),
             log: vi.fn(),
+            warn: vi.fn(),
           },
         },
         {
@@ -155,17 +156,20 @@ describe('ClerkWebhookController', () => {
         return { verify: mockVerify };
       });
 
-      // A failed verification is expected hostile/replayed traffic — it must
-      // surface as a 400 HttpException (suppressed from Sentry), never as the
-      // raw svix error (which the catch-all filter reports as a 500).
+      // A failed verification is expected hostile/replayed traffic: return a
+      // 400 and keep it out of error-level logs/Sentry noise.
       await expect(controller.handleClerk(request)).rejects.toThrow(
         BadRequestException,
       );
 
-      expect(loggerService.error).toHaveBeenCalledWith(
+      expect(loggerService.warn).toHaveBeenCalledWith(
         'ClerkWebhookController createClerk invalid signature',
-        verificationError,
+        {
+          error: 'No matching signature found',
+          svixId: 'test-id',
+        },
       );
+      expect(loggerService.error).not.toHaveBeenCalled();
     });
 
     it('should propagate errors from webhook service', async () => {

--- a/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.controller.ts
+++ b/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.controller.ts
@@ -75,7 +75,10 @@ export class ClerkWebhookController {
           'svix-timestamp': svixTimestamp,
         }) as WebhookEvent;
       } catch (error: unknown) {
-        this.loggerService.error(`${url} invalid signature`, error);
+        this.loggerService.warn(`${url} invalid signature`, {
+          error: error instanceof Error ? error.message : String(error),
+          svixId,
+        });
         throw new BadRequestException('Invalid Clerk webhook signature');
       }
 
@@ -88,6 +91,10 @@ export class ClerkWebhookController {
 
       return { message: 'Webhook processed successfully', success: true };
     } catch (error: unknown) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+
       this.loggerService.error(`${url} failed`, error);
       throw error;
     }


### PR DESCRIPTION
## Summary
- Treat invalid Clerk webhook signatures as expected 400 traffic with warn-level logging.
- Avoid the outer controller catch re-logging those BadRequestExceptions as failures.
- Keep real webhook service failures logged at error level.

Fixes #562.

## Verification
- npx biome check apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.controller.ts apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.controller.spec.ts
- bunx vitest run --config vitest.config.ts src/endpoints/webhooks/clerk/webhooks.clerk.controller.spec.ts (from apps/server/api)
- bunx turbo run type-check --filter=@genfeedai/api
- staged secretlint via commit hook