### PR TITLE
Preserve Skills Pro S3 keys for signed downloads

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -36,6 +36,7 @@
 - [MongoDB Atlas URI](reference_mongodb_atlas.md) — Atlas connection string for `cloud` DB
 - [Postgres RDS](reference_postgres_rds.md) — prod `genfeed-data` + dev `local-genfeedai` instances, sslmode gotcha, PrismaService env path
 - [Production EC2](reference_prod_ec2.md) — api.genfeed.ai box: t3a.large, EIP, SSH key, deploy mechanics, never-bulk-restart + Tailscale-DNS gotchas, stale Vercel projects
+- [Skills Source Repos](reference_skills_source_repos.md) — free product skills come from `genfeedai/skills`; paid Skills Pro comes from private `genfeedai/skills-pro`
 
 ## Context (loaded via CLAUDE.md @import)
 

--- a/.agents/memory/reference_skills_source_repos.md
+++ b/.agents/memory/reference_skills_source_repos.md
@@ -1,0 +1,17 @@
+---
+name: skills_source_repos
+description: Source-of-truth repos for free product skills vs paid Skills Pro
+type: reference
+status: active
+last_verified: 2026-06-18
+topics: [skills, skills-pro, cdn, repositories]
+---
+
+Genfeed.ai uses separate source repositories for free and paid skills.
+
+- Free Genfeed product skills come from `genfeedai/skills` and are mirrored into this repo's root `skills/` directory for app usage.
+- Paid Skills Pro content comes from the private `genfeedai/skills-pro` repo, not this repo's root `skills/` directory.
+- `genfeedai/skills-pro` owns the paid `skills/` source, generated `artifacts/skills/v1/**/skill.zip` files, and `registry/skills-pro.json`.
+- Runtime paid access in `genfeed.ai` should use the CDN/S3 registry plus receipt-gated presigned downloads, with `genfeedai/skills-pro` as the source of truth for the published artifacts.
+
+**How to apply:** When debugging or publishing Skills Pro, inspect `genfeedai/skills-pro`. Do not compare the paid CDN registry against this repo's root `skills/` directory; those are the free in-app skills.

--- a/apps/server/files/src/controllers/files-presigned-download-key.spec.ts
+++ b/apps/server/files/src/controllers/files-presigned-download-key.spec.ts
@@ -16,6 +16,17 @@ describe('resolvePresignedDownloadKey', () => {
     expect(generateS3Key).not.toHaveBeenCalled();
   });
 
+  it('rejects Skills Pro keys outside the registry prefix', () => {
+    const generateS3Key = vi.fn(
+      (type: string, key: string) => `ingredients/${type}/${key}`,
+    );
+
+    expect(() =>
+      resolvePresignedDownloadKey('skills', 'private/skill.zip', generateS3Key),
+    ).toThrow('Invalid Skills Pro download key');
+    expect(generateS3Key).not.toHaveBeenCalled();
+  });
+
   it('keeps media downloads on the existing ingredients path', () => {
     const generateS3Key = vi.fn(
       (type: string, key: string) => `ingredients/${type}/${key}`,

--- a/apps/server/files/src/controllers/files-presigned-download-key.spec.ts
+++ b/apps/server/files/src/controllers/files-presigned-download-key.spec.ts
@@ -1,0 +1,33 @@
+import { resolvePresignedDownloadKey } from '@files/controllers/files.controller';
+
+describe('resolvePresignedDownloadKey', () => {
+  it('preserves Skills Pro registry keys', () => {
+    const generateS3Key = vi.fn(
+      (type: string, key: string) => `ingredients/${type}/${key}`,
+    );
+
+    const key = resolvePresignedDownloadKey(
+      'skills',
+      'skills/v1/content-factory-pro/1.0.0/skill.zip',
+      generateS3Key,
+    );
+
+    expect(key).toBe('skills/v1/content-factory-pro/1.0.0/skill.zip');
+    expect(generateS3Key).not.toHaveBeenCalled();
+  });
+
+  it('keeps media downloads on the existing ingredients path', () => {
+    const generateS3Key = vi.fn(
+      (type: string, key: string) => `ingredients/${type}/${key}`,
+    );
+
+    const key = resolvePresignedDownloadKey(
+      'videos',
+      'clip.mp4',
+      generateS3Key,
+    );
+
+    expect(key).toBe('ingredients/videos/clip.mp4');
+    expect(generateS3Key).toHaveBeenCalledWith('videos', 'clip.mp4');
+  });
+});

--- a/apps/server/files/src/controllers/files.controller.spec.ts
+++ b/apps/server/files/src/controllers/files.controller.spec.ts
@@ -1563,6 +1563,21 @@ describe('FilesController', () => {
       expect(result.key).toBe('skills/v1/content-factory-pro/1.0.0/skill.zip');
     });
 
+    it('should reject Skills Pro keys outside the registry prefix', async () => {
+      let caughtError: unknown;
+
+      try {
+        await controller.getPresignedDownloadUrl('skills', 'private/skill.zip');
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(HttpException);
+      expect((caughtError as HttpException).getStatus()).toBe(400);
+      expect(s3Service.generateS3Key).not.toHaveBeenCalled();
+      expect(s3Service.getPresignedDownloadUrl).not.toHaveBeenCalled();
+    });
+
     it('should handle presigned download URL errors', async () => {
       mockS3Service.getPresignedDownloadUrl.mockRejectedValueOnce(
         new Error('Presigned URL error'),

--- a/apps/server/files/src/controllers/files.controller.spec.ts
+++ b/apps/server/files/src/controllers/files.controller.spec.ts
@@ -1549,6 +1549,20 @@ describe('FilesController', () => {
       expect(result.expiresIn).toBe(3600);
     });
 
+    it('should preserve Skills Pro registry keys for presigned downloads', async () => {
+      const result = await controller.getPresignedDownloadUrl(
+        'skills',
+        'skills/v1/content-factory-pro/1.0.0/skill.zip',
+      );
+
+      expect(s3Service.generateS3Key).not.toHaveBeenCalled();
+      expect(s3Service.getPresignedDownloadUrl).toHaveBeenCalledWith(
+        'skills/v1/content-factory-pro/1.0.0/skill.zip',
+        3600,
+      );
+      expect(result.key).toBe('skills/v1/content-factory-pro/1.0.0/skill.zip');
+    });
+
     it('should handle presigned download URL errors', async () => {
       mockS3Service.getPresignedDownloadUrl.mockRejectedValueOnce(
         new Error('Presigned URL error'),

--- a/apps/server/files/src/controllers/files.controller.ts
+++ b/apps/server/files/src/controllers/files.controller.ts
@@ -17,6 +17,7 @@ import { UploadService } from '@files/services/upload/upload.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpService } from '@nestjs/axios';
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -33,12 +34,18 @@ import { firstValueFrom } from 'rxjs';
 
 type S3KeyGenerator = (type: string, key: string) => string;
 
+const SKILLS_PRO_DOWNLOAD_KEY_PREFIX = 'skills/v1/';
+
 export function resolvePresignedDownloadKey(
   type: string,
   key: string,
   generateS3Key: S3KeyGenerator,
 ): string {
   if (type === 'skills') {
+    if (!key.startsWith(SKILLS_PRO_DOWNLOAD_KEY_PREFIX)) {
+      throw new BadRequestException('Invalid Skills Pro download key');
+    }
+
     return key;
   }
 
@@ -1290,6 +1297,10 @@ export class FilesController {
         key: s3Key,
       };
     } catch (error: unknown) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       this.logger.error('Failed to generate presigned download URL:', error);
       throw new HttpException(
         (error as Error)?.message ||

--- a/apps/server/files/src/controllers/files.controller.ts
+++ b/apps/server/files/src/controllers/files.controller.ts
@@ -31,6 +31,20 @@ import {
 import type { Response } from 'express';
 import { firstValueFrom } from 'rxjs';
 
+type S3KeyGenerator = (type: string, key: string) => string;
+
+export function resolvePresignedDownloadKey(
+  type: string,
+  key: string,
+  generateS3Key: S3KeyGenerator,
+): string {
+  if (type === 'skills') {
+    return key;
+  }
+
+  return generateS3Key(type, key);
+}
+
 @Controller('files')
 export class FilesController {
   constructor(
@@ -1260,8 +1274,11 @@ export class FilesController {
     @Param('key') key: string,
   ) {
     try {
-      // Generate S3 key: ingredients/${type}/${key}
-      const s3Key = this.s3Service.generateS3Key(type, key);
+      const s3Key = resolvePresignedDownloadKey(
+        type,
+        key,
+        this.s3Service.generateS3Key.bind(this.s3Service),
+      );
       const downloadUrl = await this.s3Service.getPresignedDownloadUrl(
         s3Key,
         3600,


### PR DESCRIPTION
## Summary
- preserve Skills Pro registry S3 keys when generating presigned download URLs
- keep existing ingredients/{type}/{key} behavior for media downloads
- document the free skills vs paid Skills Pro source repo boundary in project memory

## Verification
- bun run --cwd apps/server/files test
- bun run --cwd apps/server/files build
- bunx biome check --write apps/server/files/src/controllers/files.controller.ts apps/server/files/src/controllers/files.controller.spec.ts apps/server/files/src/controllers/files-presigned-download-key.spec.ts .agents/memory/MEMORY.md .agents/memory/reference_skills_source_repos.md
- git diff --check
- public CDN zip URL returns 403; signed S3 GET returns 206