### PR TITLE
fix(infra): allow deploy role to read SSM path

### DIFF
--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "gha_deploy" {
       "ec2:RevokeSecurityGroup*", "ec2:CreateTags", "ec2:DeleteSecurityGroup",
       "ec2:*LaunchTemplate*", "autoscaling:*", "iam:GetRole", "iam:ListRolePolicies",
       "iam:ListAttachedRolePolicies", "iam:GetRolePolicy", "acm:*", "ssm:GetParameters",
-      "ssm:GetParameter", "ssm:DescribeParameters", "route53:*",
+      "ssm:GetParametersByPath", "ssm:GetParameter", "ssm:DescribeParameters", "route53:*",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary
- add ssm:GetParametersByPath to the GitHub deploy role bootstrap policy
- persist the live IAM permission needed by data.aws_ssm_parameters_by_path.prod

## Live note
- Applied the same permission directly to the existing gha-genfeed-deploy role after Deploy ECS run 27757726917 failed at Register migration task definition with AccessDenied on ssm:GetParametersByPath.

## Validation
- tofu fmt -check -diff infra/terraform/bootstrap
- git diff --check
- AWS IAM role policy now includes ssm:GetParametersByPath
