### PR TITLE
fix(ci): preserve DNS cutover during ECS deploys

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -99,7 +99,8 @@ jobs:
           tofu apply -input=false -auto-approve \
             -target=aws_cloudwatch_log_group.migrate \
             -target=aws_ecs_task_definition.migrate \
-            -var="image_tag=${{ steps.tag.outputs.sha }}"
+            -var="image_tag=${{ steps.tag.outputs.sha }}" \
+            -var="enable_dns_cutover=true"
 
       - name: Run DB migrations (one-off task, gated before services roll)
         working-directory: ${{ env.TF_DIR }}
@@ -124,7 +125,7 @@ jobs:
 
       - name: Tofu apply (roll services to new image)
         working-directory: ${{ env.TF_DIR }}
-        run: tofu apply -input=false -auto-approve -var="image_tag=${{ steps.tag.outputs.sha }}"
+        run: tofu apply -input=false -auto-approve -var="image_tag=${{ steps.tag.outputs.sha }}" -var="enable_dns_cutover=true"
 
       - name: Wait for services stable
         working-directory: ${{ env.TF_DIR }}

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -191,7 +191,8 @@ data "aws_iam_policy_document" "gha_deploy" {
       "ec2:RevokeSecurityGroup*", "ec2:CreateTags", "ec2:DeleteSecurityGroup",
       "ec2:*LaunchTemplate*", "autoscaling:*", "iam:GetRole", "iam:ListRolePolicies",
       "iam:ListAttachedRolePolicies", "iam:GetRolePolicy", "acm:*", "ssm:GetParameters",
-      "ssm:GetParametersByPath", "ssm:GetParameter", "ssm:DescribeParameters", "route53:*",
+      "ssm:GetParametersByPath", "ssm:GetParameter", "ssm:DescribeParameters",
+      "rds:DescribeDBInstances", "route53:*",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary
- pass enable_dns_cutover=true in Deploy ECS production OpenTofu applies so the API ALB alias remains part of steady-state production config
- add rds:DescribeDBInstances to the GitHub deploy role bootstrap policy

## Live note
- Applied rds:DescribeDBInstances directly to the existing gha-genfeed-deploy role after Deploy ECS run 27758084445 failed at Tofu apply.
- Verified the failed apply did not destroy DNS; api.genfeed.ai still aliases to the ALB and returns 200.

## Validation
- actionlint .github/workflows/deploy-ecs.yml
- tofu fmt -check -diff infra/terraform/bootstrap
- git diff --check
- tofu plan -input=false -detailed-exitcode -var image_tag=dbf06f145a594ba9919d9f6eff96a8e3a7b3dabd -var enable_dns_cutover=true returned No changes
