### PR TITLE
fix(images): wire direct image resize plumbing

### DIFF
--- a/apps/server/api/src/collections/images/controllers/transformations/images-transformations.controller.spec.ts
+++ b/apps/server/api/src/collections/images/controllers/transformations/images-transformations.controller.spec.ts
@@ -24,7 +24,7 @@ import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { ModelsGuard } from '@api/helpers/guards/models/models.guard';
 import { SubscriptionGuard } from '@api/helpers/guards/subscription/subscription.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
-import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
@@ -43,7 +43,7 @@ describe('ImagesTransformationsController', () => {
   let _imagesService: ImagesService;
   let _metadataService: MetadataService;
   let _sharedService: SharedService;
-  let _fileQueueService: FileQueueService;
+  let _filesClientService: FilesClientService;
   let _replicateService: ReplicateService;
   let _promptBuilderService: PromptBuilderService;
   let _creditsUtilsService: CreditsUtilsService;
@@ -92,9 +92,15 @@ describe('ImagesTransformationsController', () => {
     failedGenerationService: {
       handleFailedImageGeneration: vi.fn(),
     },
-    fileQueueService: {
-      processImage: vi.fn(),
-      waitForJob: vi.fn(),
+    filesClientService: {
+      resizeImageFromUrl: vi.fn().mockResolvedValue(Buffer.from('resized')),
+      uploadToS3: vi.fn().mockResolvedValue({
+        height: 1920,
+        publicUrl: 'https://cdn.example.com/resized.jpg',
+        s3Key: 'ingredients/images/507f1f77bcf86cd799439017',
+        size: 1024 * 1024,
+        width: 1080,
+      }),
     },
     imagesService: {
       findOne: vi.fn(),
@@ -169,8 +175,8 @@ describe('ImagesTransformationsController', () => {
           useValue: mockServices.failedGenerationService,
         },
         {
-          provide: FileQueueService,
-          useValue: mockServices.fileQueueService,
+          provide: FilesClientService,
+          useValue: mockServices.filesClientService,
         },
         { provide: ImagesService, useValue: mockServices.imagesService },
         { provide: LoggerService, useValue: mockServices.loggerService },
@@ -209,7 +215,7 @@ describe('ImagesTransformationsController', () => {
     _imagesService = module.get<ImagesService>(ImagesService);
     _metadataService = module.get<MetadataService>(MetadataService);
     _sharedService = module.get<SharedService>(SharedService);
-    _fileQueueService = module.get<FileQueueService>(FileQueueService);
+    _filesClientService = module.get<FilesClientService>(FilesClientService);
     _replicateService = module.get<ReplicateService>(ReplicateService);
     _promptBuilderService =
       module.get<PromptBuilderService>(PromptBuilderService);
@@ -233,15 +239,9 @@ describe('ImagesTransformationsController', () => {
       };
 
       mockServices.imagesService.findOne.mockResolvedValue(mockImage);
-      mockServices.fileQueueService.processImage.mockResolvedValue({
-        jobId: 'job-123',
-      });
-      mockServices.fileQueueService.waitForJob.mockResolvedValue({
-        metadata: {
-          height: 1920,
-          size: 1024 * 1024,
-          width: 1080,
-        },
+      mockServices.imagesService.patch.mockResolvedValue({
+        _id: '507f1f77bcf86cd799439017',
+        status: 'generated',
       });
 
       const result = await controller.resizeImage(
@@ -253,7 +253,32 @@ describe('ImagesTransformationsController', () => {
 
       expect(mockServices.imagesService.findOne).toHaveBeenCalled();
       expect(mockServices.sharedService.saveDocuments).toHaveBeenCalled();
-      expect(mockServices.fileQueueService.processImage).toHaveBeenCalled();
+      expect(
+        mockServices.filesClientService.resizeImageFromUrl,
+      ).toHaveBeenCalledWith(
+        'https://api.example.com/ingredients/images/507f1f77bcf86cd799439014',
+        {
+          height: 1920,
+          width: 1080,
+        },
+      );
+      expect(mockServices.filesClientService.uploadToS3).toHaveBeenCalledWith(
+        '507f1f77bcf86cd799439017',
+        'images',
+        {
+          contentType: 'image/jpeg',
+          data: Buffer.from('resized'),
+          type: 'buffer',
+        },
+      );
+      expect(mockServices.metadataService.patch).toHaveBeenCalled();
+      expect(mockServices.imagesService.patch).toHaveBeenCalledWith(
+        '507f1f77bcf86cd799439017',
+        expect.objectContaining({
+          status: 'generated',
+          transformations: ['resized'],
+        }),
+      );
       expect(result).toBeDefined();
     });
 
@@ -272,16 +297,6 @@ describe('ImagesTransformationsController', () => {
 
     it('should use default dimensions when not provided', async () => {
       mockServices.imagesService.findOne.mockResolvedValue(mockImage);
-      mockServices.fileQueueService.processImage.mockResolvedValue({
-        jobId: 'job-123',
-      });
-      mockServices.fileQueueService.waitForJob.mockResolvedValue({
-        metadata: {
-          height: 1920,
-          size: 1024 * 1024,
-          width: 1080,
-        },
-      });
 
       await controller.resizeImage(
         mockRequest,
@@ -290,14 +305,14 @@ describe('ImagesTransformationsController', () => {
         {},
       );
 
-      expect(mockServices.fileQueueService.processImage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          params: {
-            height: 1920,
-            sourceId: '507f1f77bcf86cd799439014',
-            width: 1080,
-          },
-        }),
+      expect(
+        mockServices.filesClientService.resizeImageFromUrl,
+      ).toHaveBeenCalledWith(
+        'https://api.example.com/ingredients/images/507f1f77bcf86cd799439014',
+        {
+          height: 1920,
+          width: 1080,
+        },
       );
     });
   });

--- a/apps/server/api/src/collections/images/controllers/transformations/images-transformations.controller.ts
+++ b/apps/server/api/src/collections/images/controllers/transformations/images-transformations.controller.ts
@@ -35,7 +35,7 @@ import {
 } from '@api/helpers/utils/response/response.util';
 import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
-import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
@@ -53,6 +53,7 @@ import {
   ActivityEntityModel,
   ActivityKey,
   ActivitySource,
+  FileInputType,
   IngredientCategory,
   IngredientStatus,
   MetadataExtension,
@@ -98,7 +99,7 @@ export class ImagesTransformationsController {
     private readonly activitiesService: ActivitiesService,
     private readonly configService: ConfigService,
     private readonly failedGenerationService: FailedGenerationService,
-    private readonly fileQueueService: FileQueueService,
+    private readonly filesClientService: FilesClientService,
     private readonly imagesService: ImagesService,
     private readonly loggerService: LoggerService,
     private readonly metadataService: MetadataService,
@@ -144,48 +145,55 @@ export class ImagesTransformationsController {
           status: IngredientStatus.PROCESSING,
         });
 
-      // Queue image resize operation in files.genfeed service
-      const resizeJob = await this.fileQueueService.processImage({
-        clerkUserId: user.id,
-        ingredientId: ingredientData._id.toString(),
-        organizationId: publicMetadata.organization,
-        params: {
-          height: body.height || 1920,
-          sourceId: imageId,
-          width: body.width || 1080,
+      const target = {
+        height: body.height || 1920,
+        width: body.width || 1080,
+      };
+
+      const imageUrl = `${this.configService.ingredientsEndpoint}/images/${imageId}`;
+      const resizedImage = await this.filesClientService.resizeImageFromUrl(
+        imageUrl,
+        target,
+      );
+
+      const uploadMeta = await this.filesClientService.uploadToS3(
+        ingredientData._id.toString(),
+        'images',
+        {
+          contentType: 'image/jpeg',
+          data: resizedImage,
+          type: FileInputType.BUFFER,
         },
-        room: getUserRoomName(user.id),
-        type: 'resize',
-        userId: publicMetadata.user,
-      });
+      );
 
-      // Wait for the resize operation to complete
-      this.fileQueueService
-        .waitForJob(resizeJob.jobId, 30_000)
-        .then(async (result: unknown) => {
-          // The resize operation in files.genfeed should handle S3 upload
-          // Update metadata with the result from the job
-          const meta =
-            (result as { metadata?: Record<string, unknown> }).metadata || {};
+      await this.metadataService.patch(
+        metadataData._id,
+        new MetadataEntity({
+          height: uploadMeta.height ?? target.height,
+          size: uploadMeta.size ?? resizedImage.length,
+          width: uploadMeta.width ?? target.width,
+        }),
+      );
 
-          await this.metadataService.patch(metadataData._id, {
-            height: meta.height,
-            size: meta.size,
-            width: meta.width,
-          });
+      const updatedIngredient = await this.imagesService.patch(
+        ingredientData._id,
+        {
+          cdnUrl:
+            typeof uploadMeta.publicUrl === 'string'
+              ? uploadMeta.publicUrl
+              : undefined,
+          s3Key:
+            typeof uploadMeta.s3Key === 'string' ? uploadMeta.s3Key : undefined,
+          status: IngredientStatus.GENERATED,
+          transformations: [TransformationCategory.RESIZED],
+        },
+      );
 
-          await this.imagesService.patch(ingredientData._id, {
-            status: IngredientStatus.GENERATED,
-            transformations: [TransformationCategory.RESIZED],
-          });
-
-          // Cleanup is handled by files.genfeed service
-        })
-        .catch((error: unknown) => {
-          this.loggerService.error(`${url} resizeImage failed`, error);
-        });
-
-      return serializeSingle(request, IngredientSerializer, ingredientData);
+      return serializeSingle(
+        request,
+        IngredientSerializer,
+        updatedIngredient || ingredientData,
+      );
     } catch (error: unknown) {
       this.loggerService.error(`${url} failed`, error);
       throw error;

--- a/apps/server/api/src/services/files-microservice/client/files-client.service.spec.ts
+++ b/apps/server/api/src/services/files-microservice/client/files-client.service.spec.ts
@@ -362,6 +362,46 @@ describe('FilesClientService', () => {
     });
   });
 
+  describe('resizeImageFromUrl', () => {
+    it('should resize image URL successfully', async () => {
+      const imageUrl = 'https://example.com/image.jpg';
+      const target = { height: 600, width: 800 };
+      const mockResponse = {
+        data: { data: Buffer.from('resized-image').toString('base64') },
+      };
+
+      httpService.post.mockReturnValue(httpResponse(mockResponse.data));
+
+      const result = await service.resizeImageFromUrl(imageUrl, target);
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(httpService.post).toHaveBeenCalledWith(
+        `${mockFilesServiceUrl}/v1/files/processing/resize-image`,
+        {
+          height: target.height,
+          imageUrl,
+          width: target.width,
+        },
+      );
+    });
+
+    it('should handle errors when resizing image URL', async () => {
+      const imageUrl = 'https://example.com/image.jpg';
+      const target = { height: 600, width: 800 };
+      const error = new Error('Processing error');
+
+      httpService.post.mockReturnValue(throwError(() => error));
+
+      await expect(
+        service.resizeImageFromUrl(imageUrl, target),
+      ).rejects.toThrow(error);
+      expect(loggerService.error).toHaveBeenCalledWith(
+        'Failed to resize image from URL',
+        error,
+      );
+    });
+  });
+
   describe('resizeVideo', () => {
     it('should resize video successfully', async () => {
       const inputPath = '/tmp/input.mp4';

--- a/apps/server/api/src/services/files-microservice/client/files-client.service.ts
+++ b/apps/server/api/src/services/files-microservice/client/files-client.service.ts
@@ -193,6 +193,25 @@ export class FilesClientService {
     }
   }
 
+  async resizeImageFromUrl(imageUrl: string, target: IVideoDimensions) {
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(
+          `${this.filesServiceUrl}/v1/files/processing/resize-image`,
+          {
+            height: target.height,
+            imageUrl,
+            width: target.width,
+          },
+        ),
+      );
+      return Buffer.from(response.data.data, 'base64');
+    } catch (error: unknown) {
+      this.loggerService.error('Failed to resize image from URL', error);
+      throw error;
+    }
+  }
+
   async resizeVideo(inputPath: string, target: IVideoDimensions) {
     try {
       const response = await firstValueFrom(

--- a/apps/server/files/src/controllers/files.controller.spec.ts
+++ b/apps/server/files/src/controllers/files.controller.spec.ts
@@ -8,6 +8,7 @@ import { JOB_TYPES } from '@files/queues/queue.constants';
 import { VideoQueueService } from '@files/queues/video-queue.service';
 import { YoutubeQueueService } from '@files/queues/youtube-queue.service';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
+import { FilesService } from '@files/services/files/files.service';
 import { ImagesSplitService } from '@files/services/images/images-split.service';
 import { S3Service } from '@files/services/s3/s3.service';
 import { VideoThumbnailService } from '@files/services/thumbnails/video-thumbnail.service';
@@ -49,6 +50,7 @@ describe('FilesController', () => {
   let uploadService: UploadService;
   let videoThumbnailService: VideoThumbnailService;
   let imagesSplitService: ImagesSplitService;
+  let filesService: FilesService;
   let tempFileCleanupCron: TempFileCleanupCron;
   let ffmpegService: FFmpegService;
 
@@ -180,6 +182,10 @@ describe('FilesController', () => {
     ]),
   };
 
+  const mockFilesService = {
+    resizeImage: vi.fn().mockResolvedValue(Buffer.from('resized-image-data')),
+  };
+
   const mockTempFileCleanupCron = {
     manualCleanup: vi.fn().mockResolvedValue({
       filesDeleted: 5,
@@ -294,6 +300,9 @@ describe('FilesController', () => {
       { buffer: Buffer.from('frame3'), height: 512, width: 512 },
       { buffer: Buffer.from('frame4'), height: 512, width: 512 },
     ]);
+    mockFilesService.resizeImage.mockResolvedValue(
+      Buffer.from('resized-image-data'),
+    );
 
     mockTempFileCleanupCron.manualCleanup.mockResolvedValue({
       filesDeleted: 5,
@@ -315,6 +324,7 @@ describe('FilesController', () => {
         { provide: ConfigService, useValue: mockConfigService },
         { provide: FileQueueService, useValue: mockFileQueueService },
         { provide: FFmpegService, useValue: mockFFmpegService },
+        { provide: FilesService, useValue: mockFilesService },
         { provide: HttpService, useValue: mockHttpService },
         { provide: ImageQueueService, useValue: mockImageQueueService },
         { provide: ImagesSplitService, useValue: mockImagesSplitService },
@@ -339,6 +349,7 @@ describe('FilesController', () => {
       VideoThumbnailService,
     );
     imagesSplitService = module.get<ImagesSplitService>(ImagesSplitService);
+    filesService = module.get<FilesService>(FilesService);
     tempFileCleanupCron = module.get<TempFileCleanupCron>(TempFileCleanupCron);
     ffmpegService = module.get<FFmpegService>(FFmpegService);
   });
@@ -365,6 +376,7 @@ describe('FilesController', () => {
       expect(uploadService).toBeDefined();
       expect(videoThumbnailService).toBeDefined();
       expect(imagesSplitService).toBeDefined();
+      expect(filesService).toBeDefined();
       expect(tempFileCleanupCron).toBeDefined();
       expect(ffmpegService).toBeDefined();
     });
@@ -973,6 +985,78 @@ describe('FilesController', () => {
       await expect(controller.generateThumbnail(body)).rejects.toThrow(
         HttpException,
       );
+    });
+  });
+
+  // ==========================================================================
+  // resizeImage
+  // ==========================================================================
+  describe('resizeImage', () => {
+    it('should resize base64 image data successfully', async () => {
+      const source = Buffer.from('image-data');
+      const result = await controller.resizeImage({
+        height: 600,
+        imageData: source.toString('base64'),
+        width: 800,
+      });
+
+      expect(filesService.resizeImage).toHaveBeenCalledWith(source, {
+        height: 600,
+        width: 800,
+      });
+      expect(result).toEqual({
+        data: Buffer.from('resized-image-data').toString('base64'),
+        height: 600,
+        size: Buffer.from('resized-image-data').length,
+        width: 800,
+      });
+    });
+
+    it('should resize image URL input successfully', async () => {
+      mockHttpService.get.mockReturnValueOnce(
+        of({
+          data: Buffer.from('downloaded-image'),
+          headers: { 'content-type': 'image/png' },
+        }),
+      );
+
+      await controller.resizeImage({
+        height: 600,
+        imageUrl: 'https://example.com/image.png',
+        width: 800,
+      });
+
+      expect(mockHttpService.get).toHaveBeenCalledWith(
+        'https://example.com/image.png',
+        {
+          maxContentLength: 50 * 1024 * 1024,
+          responseType: 'arraybuffer',
+          timeout: 30000,
+        },
+      );
+      expect(filesService.resizeImage).toHaveBeenCalledWith(
+        Buffer.from('downloaded-image'),
+        {
+          height: 600,
+          width: 800,
+        },
+      );
+    });
+
+    it('should reject missing image input', async () => {
+      await expect(
+        controller.resizeImage({ height: 600, width: 800 }),
+      ).rejects.toThrow('imageData or imageUrl is required');
+    });
+
+    it('should reject invalid dimensions', async () => {
+      await expect(
+        controller.resizeImage({
+          height: 600,
+          imageData: Buffer.from('image-data').toString('base64'),
+          width: 0,
+        }),
+      ).rejects.toThrow('width must be a positive number');
     });
   });
 

--- a/apps/server/files/src/controllers/files.controller.ts
+++ b/apps/server/files/src/controllers/files.controller.ts
@@ -8,6 +8,7 @@ import { JOB_PRIORITY, JOB_TYPES } from '@files/queues/queue.constants';
 import { VideoQueueService } from '@files/queues/video-queue.service';
 import { YoutubeQueueService } from '@files/queues/youtube-queue.service';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
+import { FilesService } from '@files/services/files/files.service';
 import type { HookRemixJobData } from '@files/services/hook-remix/hook-remix.interfaces';
 import { HookRemixService } from '@files/services/hook-remix/hook-remix.service';
 import { ImagesSplitService } from '@files/services/images/images-split.service';
@@ -64,6 +65,7 @@ export class FilesController {
     @Inject(HttpService) private readonly httpService: HttpService,
     @Inject(ImageQueueService)
     private readonly imageQueueService: ImageQueueService,
+    @Inject(FilesService) private readonly filesService: FilesService,
     @Inject(ImagesSplitService)
     private readonly imagesSplitService: ImagesSplitService,
     private readonly logger: LoggerService,
@@ -663,6 +665,82 @@ export class FilesController {
       this.logger.error('Failed to generate thumbnail:', error);
       throw new HttpException(
         (error as Error)?.message || 'Failed to generate thumbnail',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * Resize an image from a URL or base64 payload.
+   */
+  @Post('processing/resize-image')
+  async resizeImage(
+    @Body()
+    body: {
+      imageData?: string;
+      imageUrl?: string;
+      width: number;
+      height: number;
+    },
+  ) {
+    try {
+      const { imageData, imageUrl, width, height } = body;
+
+      if (!Number.isFinite(width) || width <= 0) {
+        throw new HttpException(
+          'width must be a positive number',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      if (!Number.isFinite(height) || height <= 0) {
+        throw new HttpException(
+          'height must be a positive number',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      if (!imageData && !imageUrl) {
+        throw new HttpException(
+          'imageData or imageUrl is required',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      let imageBuffer: Buffer;
+
+      if (imageData) {
+        imageBuffer = Buffer.from(imageData, 'base64');
+      } else {
+        const response = await firstValueFrom(
+          this.httpService.get(imageUrl as string, {
+            maxContentLength: 50 * 1024 * 1024,
+            responseType: 'arraybuffer',
+            timeout: 30000,
+          }),
+        );
+        imageBuffer = Buffer.from(response.data);
+      }
+
+      const resizedImage = await this.filesService.resizeImage(imageBuffer, {
+        height,
+        width,
+      });
+
+      return {
+        data: resizedImage.toString('base64'),
+        height,
+        size: resizedImage.length,
+        width,
+      };
+    } catch (error: unknown) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      this.logger.error('Failed to resize image:', error);
+      throw new HttpException(
+        (error as Error)?.message || 'Failed to resize image',
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }


### PR DESCRIPTION
## Summary
- Add the files service `/v1/files/processing/resize-image` endpoint backed by the existing sharp resize implementation
- Route API image resize through the direct files client instead of the stubbed image queue path
- Upload resized image buffers and patch metadata/status synchronously

Refs #480. This is track A for deterministic resize plumbing; model-backed image generation/upscale/reframe remains separate scope.

## Verification
- `npx biome check apps/server/files/src/controllers/files.controller.ts apps/server/files/src/controllers/files.controller.spec.ts apps/server/api/src/services/files-microservice/client/files-client.service.ts apps/server/api/src/services/files-microservice/client/files-client.service.spec.ts apps/server/api/src/collections/images/controllers/transformations/images-transformations.controller.ts apps/server/api/src/collections/images/controllers/transformations/images-transformations.controller.spec.ts`
- `bunx vitest run --config vitest.config.ts src/services/files-microservice/client/files-client.service.spec.ts src/collections/images/controllers/transformations/images-transformations.controller.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bunx turbo run type-check --filter=@genfeedai/files`

Note: `apps/server/files/vitest.config.ts` explicitly excludes `src/controllers/files.controller.spec.ts`, so that focused spec is covered by type-check but not runnable through the normal files Vitest config.