### PR TITLE
fix(infra): overlap ECS service rollouts

### DIFF
--- a/.agents/memory/reference_prod_aws_runtime.md
+++ b/.agents/memory/reference_prod_aws_runtime.md
@@ -12,8 +12,9 @@ Live AWS wins over older AL2023 EC2 migration notes.
 ## Current Runtime Posture
 
 - **Region**: `us-west-1`.
-- **ECS cluster**: `genfeed-production`, Fargate-only. Live services are on
-  Fargate task definition revision `:4` for the current production image.
+- **ECS cluster**: `genfeed-production`, Fargate-only. Task definition
+  revisions change on every deploy; verify live ECS state rather than relying
+  on old EC2-era notes.
 - **Running core services**: `api`, `workers`, `files`, `mcp`, and
   `notifications` are `desired=1`, `running=1`, `pending=0`.
 - **Parked services**: `clips`, `discord`, `slack`, and `telegram` remain
@@ -22,10 +23,10 @@ Live AWS wins over older AL2023 EC2 migration notes.
   internet-facing, active. The API target group uses `targetType=ip`; health is
   green on port `3010`.
 - **Public API DNS**: Route53 `api.genfeed.ai` is now an ALB alias. Public
-  health verification after stopping EC2 returned `200` from ALB IP
-  `52.9.20.128`.
-- **Production image**:
-  `948918267147.dkr.ecr.us-west-1.amazonaws.com/genfeed/server:dbf06f145a594ba9919d9f6eff96a8e3a7b3dabd`.
+  health verification after stopping EC2 returned `200` from ALB IPs.
+- **Last verified ECS deploy**: GitHub Actions run `27759489824` completed on
+  2026-06-18 from `master` and rolled the server image tag
+  `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
 - **Other public backend hostnames**: `mcp.genfeed.ai` and
   `notifications.genfeed.ai` still point to old EIP `52.52.217.255`. They need
   explicit ALB/listener/DNS work or retirement if those public names should
@@ -53,12 +54,14 @@ Live AWS wins over older AL2023 EC2 migration notes.
   deploys. It was the old Tailscale/SSH/Docker Compose path to EC2.
 - `Deploy ECS (production)` is the intended production backend deploy path. It
   is dispatch-only, production-environment gated, and master-only.
-- The 2026-06-18 workflow run copied the GHCR image to ECR but failed before
-  OpenTofu execution because `tofu` was not on PATH. The live cutover was
-  completed locally with OpenTofu 1.12.x.
-- The workflow should use `opentofu/setup-opentofu@v2` with
-  `tofu_wrapper: false`, then run migrations on Fargate, apply OpenTofu, and
-  wait for ECS services to stabilize.
+- The 2026-06-18 cutover was completed locally first, then the GitHub Actions
+  deploy path was fixed and verified green with run `27759489824`.
+- The workflow uses `opentofu/setup-opentofu@v2` with `tofu_wrapper: false`,
+  runs migrations on Fargate, applies OpenTofu with `enable_dns_cutover=true`,
+  and waits for ECS services to stabilize.
+- Keep active services on overlapping deployments (`min_healthy=100`,
+  `max_percent=200`). Workers verify Cloud Map dependency DNS at startup, so
+  stop-then-start rolls can race and temporarily remove internal records.
 
 ## Tailscale
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -17,15 +17,18 @@ is stopped and retained only as a manual rollback host.
   (`registeredContainerInstances=0`, capacity providers `FARGATE` and
   `FARGATE_SPOT`).
 - Running core services: `api`, `workers`, `files`, `mcp`, `notifications`
-  (`desired=1`, `running=1`, `pending=0`), all on task definition revision `:4`
-  for image tag `dbf06f145a594ba9919d9f6eff96a8e3a7b3dabd`.
+  (`desired=1`, `running=1`, `pending=0` at the last verification). Task
+  definition revisions change on every deploy; live AWS is the source of truth.
+- Last verified ECS deploy: GitHub Actions run `27759489824` completed from
+  `master` with server image tag
+  `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
 - Parked services: `clips`, `discord`, `slack`, `telegram`
   (`desired=0`, `running=0`). They are still defined and can be enabled by
   changing `locals.tf`.
 - ALB: `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`, active,
   with a healthy IP target for `api` on port `3010`.
 - Public API DNS: Route53 `api.genfeed.ai` is an ALB alias. Post-stop health
-  verification returned `200` from ALB IP `52.9.20.128`.
+  verification returned `200` from ALB IPs.
 - Other public backend hostnames: `mcp.genfeed.ai` and
   `notifications.genfeed.ai` still point to old EIP `52.52.217.255`. Add public
   ALB/listener/DNS support or retire those records before relying on them after
@@ -95,16 +98,20 @@ tofu apply -var="image_tag=<sha>"
 - `Deploy ECS (production)` is active and is the intended backend deploy path.
   It is dispatch-only, uses the GitHub `production` environment approval, and
   refuses to run from anything except `refs/heads/master`.
-- The 2026-06-18 run copied GHCR `server:dbf06f145...` to ECR but failed before
-  OpenTofu execution because `tofu` was not on PATH. The live cutover was
-  completed locally with OpenTofu.
-- The workflow should use `opentofu/setup-opentofu@v2` with
-  `tofu_wrapper: false`, then:
+- The 2026-06-18 cutover was completed locally first, then the GitHub Actions
+  deploy path was fixed and verified green with run `27759489824`.
+- The workflow uses `opentofu/setup-opentofu@v2` with `tofu_wrapper: false`,
+  then:
 
 1. Copy `ghcr.io/genfeedai/genfeed.ai/server:<sha>` to ECR.
 2. Register/run the Prisma migration task on Fargate in the private subnets.
 3. `tofu apply -var="image_tag=<sha>"` to roll services.
 4. Wait for every ECS service to stabilize.
+
+Active services should roll with `min_healthy=100` and `max_percent=200`.
+Workers verify dependent Cloud Map DNS during startup; stop-then-start deploys
+can temporarily remove `files.genfeed.internal` or
+`notifications.genfeed.internal` and make workers exit.
 
 ## Cutover and Rollback
 
@@ -112,13 +119,16 @@ The API cutover was completed on 2026-06-18:
 
 1. Registered the migration task definition and ran Prisma migrations on
    Fargate. Exit code was `0`; no pending migrations.
-2. Applied OpenTofu with
-   `-var="image_tag=dbf06f145a594ba9919d9f6eff96a8e3a7b3dabd"`
-   and `-var="enable_dns_cutover=true"`.
+2. Applied OpenTofu with `-var="enable_dns_cutover=true"` to move
+   `api.genfeed.ai` to the ALB.
 3. Verified all five core ECS services were stable.
 4. Verified `api.genfeed.ai` resolves to the ALB and `/v1/health` returns `200`
    after stopping EC2.
 5. Stopped, but did not terminate, the old EC2 host.
+
+The CI deploy path was later verified green from `master` with GitHub Actions
+run `27759489824`, using server image tag
+`05f7538e48cad75cbebf7a6405d09fc82d4db868`.
 
 Rollback is manual:
 

--- a/infra/terraform/RESUME.md
+++ b/infra/terraform/RESUME.md
@@ -15,8 +15,9 @@ manual rollback.
 - ALB: `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`.
 - VPC: `vpc-0e7522e453a642bd8`.
 - ECS task SG: `sg-0630fbed0bf8faafc`.
-- Current production image:
-  `948918267147.dkr.ecr.us-west-1.amazonaws.com/genfeed/server:dbf06f145a594ba9919d9f6eff96a8e3a7b3dabd`.
+- Last verified server image tag:
+  `05f7538e48cad75cbebf7a6405d09fc82d4db868`. Live ECS is the source of truth
+  for current task definition revisions.
 - Old EC2 host: `i-0ba4418050d90bd32`, `api.genfeed.ai-al2023`,
   EIP `52.52.217.255`, stopped on 2026-06-18.
 
@@ -33,8 +34,7 @@ manual rollback.
 - ALB target group is healthy for the API target (`targetType=ip`, port `3010`).
 - Route53 `api.genfeed.ai` is an ALB alias.
 - Public health verification after stopping EC2:
-  `curl https://api.genfeed.ai/v1/health` returned `200` from ALB IP
-  `52.9.20.128`.
+  `curl https://api.genfeed.ai/v1/health` returned `200` from ALB IPs.
 - `mcp.genfeed.ai` and `notifications.genfeed.ai` still point to
   `52.52.217.255`. Those public names need explicit ALB/listener/DNS work or
   retirement if they should remain available without EC2.
@@ -43,28 +43,32 @@ manual rollback.
 
 - PR #639, `fix(infra): address ECS review follow-ups`, was merged into
   `master`.
-- GHCR server image `dbf06f145...` was copied to ECR.
+- GHCR server image was copied to ECR.
 - OpenTofu applied the migration task definition, then a Fargate migration task
   ran successfully with exit code `0`.
 - OpenTofu applied the service rollout and `enable_dns_cutover=true`.
-- All five core ECS services stabilized on task definition revision `:4`.
+- All five core ECS services stabilized on Fargate.
 - The old EC2 host was tagged, termination protection was enabled, and the
   instance was stopped.
+- GitHub Actions deploy run `27759489824` later completed green from `master`
+  with server image tag `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
 
 ## CI/Deploy Status
 
 - `Deploy Production` is disabled manually. It was the old EC2 deploy path:
   `_Deploy` -> Tailscale -> SSH -> Docker Compose.
-- `Deploy ECS (production)` is active and should be the normal backend deploy
-  path after the workflow fix is merged.
+- `Deploy ECS (production)` is active and is the normal backend deploy path.
 - Run `27756338031` failed before OpenTofu execution because `tofu` was not on
   PATH after `opentofu/setup-opentofu@v1`.
-- The workflow should use `opentofu/setup-opentofu@v2` with
-  `tofu_wrapper: false`; the live production rollout was completed locally with
-  OpenTofu while the workflow fix was prepared.
+- The workflow now uses `opentofu/setup-opentofu@v2` with
+  `tofu_wrapper: false`, passes `enable_dns_cutover=true`, has the required SSM
+  and RDS IAM reads, and was verified green with run `27759489824`.
 - `Build Server Image` remains active and publishes GHCR server images on
   server-affecting master pushes; ECS receives a new ECR image only when
   `Deploy ECS (production)` copies GHCR to ECR.
+- Active ECS services should roll with `min_healthy=100` and `max_percent=200`.
+  Workers verify Cloud Map dependency DNS at startup, so stop-then-start rolls
+  can race when `files` or `notifications` records briefly disappear.
 
 ## Tailscale Status
 
@@ -102,7 +106,6 @@ ECR, SSM, Route53, RDS, ALB, OpenTofu, or the production VPC.
 
 ## Follow-ups
 
-- Merge and verify the `Deploy ECS (production)` workflow fix.
 - Decide whether `mcp.genfeed.ai` and `notifications.genfeed.ai` should get
   public ALB/listener/DNS support or be retired.
 - Remove broad temporary IAM privileges from the `genfeedai` IAM user after the

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -44,10 +44,10 @@ module "service" {
   target_group_arn = each.value.alb ? aws_lb_target_group.api.arn : ""
   health_grace     = each.value.health_grace
 
-  # api rolls zero-downtime (needs the 2nd box as headroom); single-task
-  # bots/workers tolerate a brief blip on deploy.
-  min_healthy = each.value.alb ? 100 : 0
-  max_percent = each.value.alb ? 200 : 100
+  # Keep internal Cloud Map records present during deployments. Workers verify
+  # dependent service DNS at startup, so stop-then-start rolls can race.
+  min_healthy = 100
+  max_percent = 200
 
   depends_on = [aws_ecs_cluster_capacity_providers.main]
 }


### PR DESCRIPTION
## Summary
- keep ECS service rollouts overlapped with min_healthy=100 and max_percent=200
- document the verified Fargate cutover, green ECS deploy run, and EC2 rollback posture
- avoid stale docs that hard-code task definition revisions as permanent state

## Live changes already applied
- applied the rollout config in us-west-1 with OpenTofu: 0 added, 8 changed, 0 destroyed
- verified core services stable on Fargate with desired=1/running=1/pending=0 and deployment config 100/200

## Validation
- actionlint .github/workflows/deploy-ecs.yml
- tofu fmt -check -diff infra/terraform/genfeed-prod infra/terraform/modules/service
- git diff --check
- Deploy ECS (production) run 27759489824 completed successfully from master
- api.genfeed.ai /v1/health returned 200 via ALB

## Notes
- A post-apply OpenTofu plan showed unrelated SSM drift for VERCEL_DEPLOYMENT_NOTIFICATIONS_ENABLED, which would refresh task definitions on a future apply. I did not apply that drift in this change.