### PR TITLE
Wait for ECS deploy server image

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,7 +1,8 @@
 # ECS production deploy (replaces the SSH-waves path post-cutover).
 # Dispatch-only + gated by the GitHub "production" environment (manual approval).
-# Flow: copy server:<sha> GHCR->ECR -> run migrate task -> terraform apply rolls
-# services (task defs are TF-managed with image_tag) -> wait services-stable.
+# Flow: resolve server:<sha> in GHCR -> copy GHCR->ECR -> run migrate task ->
+# terraform apply rolls services (task defs are TF-managed with image_tag) ->
+# wait services-stable.
 name: Deploy ECS (production)
 
 on:
@@ -37,6 +38,11 @@ jobs:
     environment: production # <- requires reviewer approval (the human gate)
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Needed when HEAD is a non-server commit: the image resolver can walk
+          # recent first-parent ancestors and verify no server-image inputs
+          # changed before reusing an older immutable image tag.
+          fetch-depth: 50
 
       - name: Validate ref is master
         run: |
@@ -78,6 +84,7 @@ jobs:
           fi
           echo "Deploying server image tag: $TAG"
           echo "sha=$TAG" >> "$GITHUB_OUTPUT"
+          echo "explicit=$EXPLICIT_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -92,9 +99,77 @@ jobs:
               "$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_REGION.amazonaws.com"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+      - name: Resolve available server image
+        id: image
+        env:
+          EXPLICIT_TAG: ${{ steps.tag.outputs.explicit }}
+          HEAD_SHA: ${{ github.sha }}
+          REQUESTED_TAG: ${{ steps.tag.outputs.sha }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/${{ github.repository }}/server"
+
+          image_exists() {
+            docker buildx imagetools inspect "${REPO}:$1" >/dev/null 2>&1
+          }
+
+          wait_for_image() {
+            local tag="$1"
+            for i in $(seq 1 20); do
+              if image_exists "$tag"; then
+                echo "Server image ready: ${tag}"
+                return 0
+              fi
+              if [ "$i" = "20" ]; then
+                break
+              fi
+              echo "Server image ${tag} not ready (attempt ${i}/20); waiting 30s..."
+              sleep 30
+            done
+            return 1
+          }
+
+          if wait_for_image "$REQUESTED_TAG"; then
+            echo "sha=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EXPLICIT_TAG" = "true" ]; then
+            echo "::error::Requested server image ${REQUESTED_TAG} was not found in GHCR after waiting. Build it first or choose an existing image tag."
+            exit 1
+          fi
+
+          server_image_paths=(
+            "apps/server/**"
+            "packages/**"
+            "ee/**"
+            "docker/Dockerfile.server"
+            "bun.lock"
+            "package.json"
+            ".github/workflows/build-server-image.yml"
+            ".github/actions/build-unified-image/**"
+          )
+
+          echo "No image for HEAD (${HEAD_SHA}); checking recent first-parent ancestors..."
+          for sha in $(git rev-list --first-parent -n 50 "$HEAD_SHA" | tail -n +2); do
+            if ! image_exists "$sha"; then
+              continue
+            fi
+            if git diff --quiet "${sha}..${HEAD_SHA}" -- "${server_image_paths[@]}"; then
+              echo "::warning::server:${HEAD_SHA} was not built, but server-image inputs are unchanged since ${sha}; deploying ${sha}."
+              echo "sha=$sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::server:${HEAD_SHA} was not found, and server-image inputs changed after newest available ancestor ${sha}. Wait for the Build Server Image workflow for ${HEAD_SHA}, then re-dispatch."
+            exit 1
+          done
+
+          echo "::error::No server image found for HEAD or its recent first-parent ancestors."
+          exit 1
+
       - name: Copy server:<sha> GHCR -> ECR (no rebuild)
         run: |
-          SHA="${{ steps.tag.outputs.sha }}"
+          SHA="${{ steps.image.outputs.sha }}"
           ECR="$(aws ecr describe-repositories --repository-names genfeed/server \
                  --query 'repositories[0].repositoryUri' --output text)"
           docker buildx imagetools create -t "${ECR}:${SHA}" "ghcr.io/genfeedai/genfeed.ai/server:${SHA}"
@@ -116,7 +191,7 @@ jobs:
           tofu apply -input=false -auto-approve \
             -target=aws_cloudwatch_log_group.migrate \
             -target=aws_ecs_task_definition.migrate \
-            -var="image_tag=${{ steps.tag.outputs.sha }}" \
+            -var="image_tag=${{ steps.image.outputs.sha }}" \
             -var="enable_dns_cutover=true"
 
       - name: Run DB migrations (one-off task, gated before services roll)
@@ -142,7 +217,7 @@ jobs:
 
       - name: Tofu apply (roll services to new image)
         working-directory: ${{ env.TF_DIR }}
-        run: tofu apply -input=false -auto-approve -var="image_tag=${{ steps.tag.outputs.sha }}" -var="enable_dns_cutover=true"
+        run: tofu apply -input=false -auto-approve -var="image_tag=${{ steps.image.outputs.sha }}" -var="enable_dns_cutover=true"
 
       - name: Wait for services stable
         working-directory: ${{ env.TF_DIR }}


### PR DESCRIPTION
## Summary
- wait for the requested GHCR server image before copying to ECR
- keep explicit rollback tags strict: explicit tags must exist after the wait window
- allow default deploys to reuse a recent ancestor image only when server-image inputs are unchanged
- feed the resolved immutable image tag into ECR copy and OpenTofu applies

## Validation
- actionlint .github/workflows/deploy-ecs.yml
- git diff --check