### PR TITLE
Ignore retired production SSM flag

### DIFF
--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -20,11 +20,17 @@ locals {
     [for e in local.internal_env : e.name],
     ["PORT", "SERVICE_NAME", "REDIS_PASSWORD"],
   ))
+  ignored_ssm_secret_names = toset([
+    # Retired Vercel deployment-notification gate. Keep it out of task definitions
+    # even if a stale temporary parameter is present under the production path.
+    "VERCEL_DEPLOYMENT_NOTIFICATIONS_ENABLED",
+  ])
+  excluded_ssm_secret_names = setunion(local.reserved_env_names, local.ignored_ssm_secret_names)
   task_secrets = [
     for i, name in data.aws_ssm_parameters_by_path.prod.names : {
       name      = element(reverse(split("/", name)), 0)
       valueFrom = data.aws_ssm_parameters_by_path.prod.arns[i]
-    } if !contains(local.reserved_env_names, element(reverse(split("/", name)), 0))
+    } if !contains(local.excluded_ssm_secret_names, element(reverse(split("/", name)), 0))
   ]
 
   # ── Service catalogue (mirrors docker-compose.production.yml) ─────────


### PR DESCRIPTION
## Summary
- exclude the retired VERCEL_DEPLOYMENT_NOTIFICATIONS_ENABLED SSM parameter from ECS task secrets
- keep task definitions from depending on that temporary parameter if it exists or is later deleted

## Verification
- tofu -chdir=infra/terraform/genfeed-prod fmt -check
- tofu -chdir=infra/terraform/genfeed-prod init -input=false
- tofu -chdir=infra/terraform/genfeed-prod validate
- git diff --check