### PR TITLE
fix(infra): route public backend services to Fargate

### DIFF
--- a/.agents/memory/reference_prod_aws_runtime.md
+++ b/.agents/memory/reference_prod_aws_runtime.md
@@ -20,17 +20,18 @@ Live AWS wins over older AL2023 EC2 migration notes.
 - **Parked services**: `clips`, `discord`, `slack`, and `telegram` remain
   defined ECS services with `desired=0`, `running=0`.
 - **ALB**: `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`,
-  internet-facing, active. The API target group uses `targetType=ip`; health is
-  green on port `3010`.
-- **Public API DNS**: Route53 `api.genfeed.ai` is now an ALB alias. Public
-  health verification after stopping EC2 returned `200` from ALB IPs.
+  internet-facing, active. Public target groups use `targetType=ip`; health is
+  green for `api` on port `3010`, `mcp` on port `3014`, and `notifications` on
+  port `3011`.
+- **Public backend DNS**: Route53 `api.genfeed.ai`, `mcp.genfeed.ai`, and
+  `notifications.genfeed.ai` are ALB aliases. Public health verification after
+  stopping EC2 returned `200` for all three `/v1/health` endpoints.
 - **Last verified ECS deploy**: GitHub Actions run `27759489824` completed on
   2026-06-18 from `master` and rolled the server image tag
   `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
-- **Other public backend hostnames**: `mcp.genfeed.ai` and
-  `notifications.genfeed.ai` still point to old EIP `52.52.217.255`. They need
-  explicit ALB/listener/DNS work or retirement if those public names should
-  survive the EC2 shutdown.
+- **Public backend follow-up**: `mcp.genfeed.ai` and
+  `notifications.genfeed.ai` were moved from stale A records on EIP
+  `52.52.217.255` to ALB aliases on 2026-06-18.
 
 ## Legacy EC2 Host
 
@@ -38,12 +39,13 @@ Live AWS wins over older AL2023 EC2 migration notes.
   Amazon Linux 2023, `t3a.large`, EIP `52.52.217.255`.
 - **State**: stopped on 2026-06-18 after the API DNS cutover. It was not
   terminated.
-- **Guards**: `Deploy Production` is disabled manually in GitHub Actions;
-  instance termination protection is enabled; instance and root volume are
-  tagged `DoNotStart=true`, `StoppedFor=fargate-cutover-2026-06-18`, and
+- **Guards**: `Deploy Production` is disabled manually in GitHub Actions; its
+  legacy backend job is a repo-level no-op; instance termination protection is
+  enabled; instance and root volume are tagged `DoNotStart=true`,
+  `StoppedFor=fargate-cutover-2026-06-18`, and
   `CutoverSnapshot=snap-0232fb7b41809e8e0`.
-- **Rollback role only**: rollback means manually re-pointing Route53
-  `api.genfeed.ai` to `52.52.217.255` and starting the instance. Do not treat
+- **Rollback role only**: rollback means manually re-pointing affected public
+  backend hostnames to `52.52.217.255` and starting the instance. Do not treat
   it as the intended managed production platform.
 - **Historical access**: previous SSH path used Tailscale IP
   `100.101.125.109`; verify current access details before any rollback work.
@@ -51,7 +53,8 @@ Live AWS wins over older AL2023 EC2 migration notes.
 ## Deployment Path
 
 - `Deploy Production` is disabled and should not be used for normal backend
-  deploys. It was the old Tailscale/SSH/Docker Compose path to EC2.
+  deploys. Its backend job is a no-op so it cannot call the old
+  Tailscale/SSH/Docker Compose path to EC2 if the workflow is re-enabled.
 - `Deploy ECS (production)` is the intended production backend deploy path. It
   is dispatch-only, production-environment gated, and master-only.
 - The 2026-06-18 cutover was completed locally first, then the GitHub Actions

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -65,19 +65,15 @@ jobs:
           RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish || '' }}
 
   deploy-backend:
+    name: Legacy EC2 backend disabled
     if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
     needs: validate-production-ref
-    uses: ./.github/workflows/_deploy.yml
-    with:
-      environment: production
-      workers_follow_api: true
-      force_all: ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) || inputs.force_all || false }}
-      force_api: ${{ inputs.force_api || false }}
-      force_bots: ${{ inputs.force_bots || false }}
-      force_workers: ${{ inputs.force_workers || false }}
-      force_redis: ${{ inputs.force_redis || false }}
-      skip_tests: ${{ inputs.skip_tests || false }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip legacy Tailscale/SSH backend deploy
+        run: |
+          echo "::warning::The legacy EC2/Tailscale/Docker Compose backend deploy is disabled after the ECS/Fargate cutover."
+          echo "::warning::Use the Deploy ECS (production) workflow for managed backend deploys."
 
   # Deploy all Vercel frontend apps in parallel after backend is up.
   # Secret: VERCEL_TOKEN (auth)

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,6 +1,7 @@
 # genfeed.ai - ECS/Fargate Terraform
 
-Last verified against live AWS: 2026-06-18, after the production API cutover.
+Last verified against live AWS: 2026-06-18, after the public ALB cutover for
+API, MCP, and notifications.
 
 Managed production infrastructure for genfeed.ai only. Community self-hosting
 stays on the Docker path in `docker/Dockerfile.selfhosted` and
@@ -19,20 +20,17 @@ is stopped and retained only as a manual rollback host.
 - Running core services: `api`, `workers`, `files`, `mcp`, `notifications`
   (`desired=1`, `running=1`, `pending=0` at the last verification). Task
   definition revisions change on every deploy; live AWS is the source of truth.
-- Last verified ECS deploy: GitHub Actions run `27759489824` completed from
-  `master` with server image tag
-  `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
+- Last verified ECS deploy path: GitHub Actions run `27759489824` completed
+  from `master`. Live ECS is the source of truth for current task definitions.
 - Parked services: `clips`, `discord`, `slack`, `telegram`
   (`desired=0`, `running=0`). They are still defined and can be enabled by
   changing `locals.tf`.
 - ALB: `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`, active,
-  with a healthy IP target for `api` on port `3010`.
-- Public API DNS: Route53 `api.genfeed.ai` is an ALB alias. Post-stop health
-  verification returned `200` from ALB IPs.
-- Other public backend hostnames: `mcp.genfeed.ai` and
-  `notifications.genfeed.ai` still point to old EIP `52.52.217.255`. Add public
-  ALB/listener/DNS support or retire those records before relying on them after
-  the EC2 stop.
+  with healthy IP targets for `api` on port `3010`, `mcp` on port `3014`, and
+  `notifications` on port `3011`.
+- Public backend DNS: Route53 `api.genfeed.ai`, `mcp.genfeed.ai`, and
+  `notifications.genfeed.ai` are ALB aliases. Public health verification for
+  all three `/v1/health` endpoints returned `200` from ALB IPs.
 - Legacy EC2 host: `i-0ba4418050d90bd32` / EIP `52.52.217.255` is stopped, not
   terminated. Termination protection is enabled, and the instance/root volume
   are tagged `DoNotStart=true`, `StoppedFor=fargate-cutover-2026-06-18`, and
@@ -92,9 +90,9 @@ tofu apply -var="image_tag=<sha>"
 
 ## Production Deploy Paths
 
-- `Deploy Production` is disabled manually. It was the old Tailscale + SSH +
-  Docker Compose deploy path to the AL2023 EC2 host and should not be used for
-  normal backend deploys.
+- `Deploy Production` is disabled manually. Its legacy backend job is also a
+  no-op in repo so it cannot call the old Tailscale + SSH + Docker Compose path
+  to the AL2023 EC2 host if the workflow is re-enabled.
 - `Deploy ECS (production)` is active and is the intended backend deploy path.
   It is dispatch-only, uses the GitHub `production` environment approval, and
   refuses to run from anything except `refs/heads/master`.
@@ -105,7 +103,8 @@ tofu apply -var="image_tag=<sha>"
 
 1. Copy `ghcr.io/genfeedai/genfeed.ai/server:<sha>` to ECR.
 2. Register/run the Prisma migration task on Fargate in the private subnets.
-3. `tofu apply -var="image_tag=<sha>"` to roll services.
+3. `tofu apply -var="image_tag=<sha>" -var="enable_dns_cutover=true"` to roll
+   services and preserve public ALB aliases.
 4. Wait for every ECS service to stabilize.
 
 Active services should roll with `min_healthy=100` and `max_percent=200`.
@@ -126,6 +125,19 @@ The API cutover was completed on 2026-06-18:
    after stopping EC2.
 5. Stopped, but did not terminate, the old EC2 host.
 
+The public backend follow-up was completed on 2026-06-18:
+
+1. Attached `mcp` and `notifications` Fargate services to dedicated ALB target
+   groups with host-header HTTPS listener rules.
+2. Added ACM SNI coverage for `mcp.genfeed.ai` and
+   `notifications.genfeed.ai`.
+3. Replaced the stale Route53 A records for `mcp.genfeed.ai` and
+   `notifications.genfeed.ai`, which pointed at `52.52.217.255`, with ALB
+   aliases.
+4. Verified `api.genfeed.ai`, `mcp.genfeed.ai`, and
+   `notifications.genfeed.ai` all resolve to ALB IPs and return `200` on
+   `/v1/health`.
+
 The CI deploy path was later verified green from `master` with GitHub Actions
 run `27759489824`, using server image tag
 `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
@@ -133,7 +145,9 @@ run `27759489824`, using server image tag
 Rollback is manual:
 
 1. Start EC2 instance `i-0ba4418050d90bd32`.
-2. Re-point Route53 `api.genfeed.ai` to EIP `52.52.217.255`.
+2. Re-point any public backend hostnames being rolled back
+   (`api.genfeed.ai`, `mcp.genfeed.ai`, `notifications.genfeed.ai`) to EIP
+   `52.52.217.255`.
 3. Verify the old nginx/Docker path before sending user traffic.
 
 `enable_dns_cutover=false` only removes the Terraform-managed ALB alias record;

--- a/infra/terraform/RESUME.md
+++ b/infra/terraform/RESUME.md
@@ -1,8 +1,9 @@
 # RESUME - genfeed.ai ECS/Fargate migration
 
-Last verified against live AWS: 2026-06-18, after the production API cutover.
+Last verified against live AWS: 2026-06-18, after the public ALB cutover for
+API, MCP, and notifications.
 
-The managed production API is now on ECS/Fargate behind the production ALB.
+The managed production backend is now on ECS/Fargate behind the production ALB.
 The old AL2023 EC2 host is stopped, not terminated, and retained only for
 manual rollback.
 
@@ -15,9 +16,8 @@ manual rollback.
 - ALB: `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`.
 - VPC: `vpc-0e7522e453a642bd8`.
 - ECS task SG: `sg-0630fbed0bf8faafc`.
-- Last verified server image tag:
-  `05f7538e48cad75cbebf7a6405d09fc82d4db868`. Live ECS is the source of truth
-  for current task definition revisions.
+- Live ECS is the source of truth for current task definition revisions and
+  image tags.
 - Old EC2 host: `i-0ba4418050d90bd32`, `api.genfeed.ai-al2023`,
   EIP `52.52.217.255`, stopped on 2026-06-18.
 
@@ -31,13 +31,13 @@ manual rollback.
   (`desired=1`, `running=1`, `pending=0`, rollout `COMPLETED`).
 - Parked services: `clips`, `discord`, `slack`, `telegram`
   (`desired=0`, `running=0`).
-- ALB target group is healthy for the API target (`targetType=ip`, port `3010`).
-- Route53 `api.genfeed.ai` is an ALB alias.
-- Public health verification after stopping EC2:
-  `curl https://api.genfeed.ai/v1/health` returned `200` from ALB IPs.
-- `mcp.genfeed.ai` and `notifications.genfeed.ai` still point to
-  `52.52.217.255`. Those public names need explicit ALB/listener/DNS work or
-  retirement if they should remain available without EC2.
+- ALB target groups are healthy for `api` (`targetType=ip`, port `3010`),
+  `mcp` (port `3014`), and `notifications` (port `3011`).
+- Route53 `api.genfeed.ai`, `mcp.genfeed.ai`, and
+  `notifications.genfeed.ai` are ALB aliases.
+- Public health verification after stopping EC2 returned `200` for:
+  `https://api.genfeed.ai/v1/health`, `https://mcp.genfeed.ai/v1/health`, and
+  `https://notifications.genfeed.ai/v1/health`.
 
 ## Cutover Completed
 
@@ -52,11 +52,14 @@ manual rollback.
   instance was stopped.
 - GitHub Actions deploy run `27759489824` later completed green from `master`
   with server image tag `05f7538e48cad75cbebf7a6405d09fc82d4db868`.
+- Public `mcp.genfeed.ai` and `notifications.genfeed.ai` ALB/listener/DNS
+  support was added in the follow-up cutover on 2026-06-18.
 
 ## CI/Deploy Status
 
-- `Deploy Production` is disabled manually. It was the old EC2 deploy path:
-  `_Deploy` -> Tailscale -> SSH -> Docker Compose.
+- `Deploy Production` is disabled manually. Its legacy backend job is also a
+  repo-level no-op so it cannot call `_Deploy` -> Tailscale -> SSH -> Docker
+  Compose if the workflow is re-enabled.
 - `Deploy ECS (production)` is active and is the normal backend deploy path.
 - Run `27756338031` failed before OpenTofu execution because `tofu` was not on
   PATH after `opentofu/setup-opentofu@v1`.
@@ -91,11 +94,13 @@ manual rollback.
 Rollback is manual:
 
 1. Start EC2 instance `i-0ba4418050d90bd32`.
-2. Re-point Route53 `api.genfeed.ai` to EIP `52.52.217.255`.
+2. Re-point any public backend hostnames being rolled back
+   (`api.genfeed.ai`, `mcp.genfeed.ai`, `notifications.genfeed.ai`) to EIP
+   `52.52.217.255`.
 3. Verify the old nginx/Docker API path before sending user traffic.
 
-`enable_dns_cutover=false` only destroys the Terraform-managed ALB alias record;
-it does not recreate the old manual A record.
+`enable_dns_cutover=false` only destroys Terraform-managed ALB alias records; it
+does not recreate old manual A records.
 
 ## Community Deployment Impact
 
@@ -106,8 +111,6 @@ ECR, SSM, Route53, RDS, ALB, OpenTofu, or the production VPC.
 
 ## Follow-ups
 
-- Decide whether `mcp.genfeed.ai` and `notifications.genfeed.ai` should get
-  public ALB/listener/DNS support or be retired.
 - Remove broad temporary IAM privileges from the `genfeedai` IAM user after the
   migration work is complete.
 - Per-PR Fargate previews (design in `PREVIEW.md`).

--- a/infra/terraform/genfeed-prod/alb.tf
+++ b/infra/terraform/genfeed-prod/alb.tf
@@ -25,6 +25,33 @@ resource "aws_acm_certificate_validation" "api" {
   validation_record_fqdns = [for r in aws_route53_record.api_cert_validation : r.fqdn]
 }
 
+resource "aws_acm_certificate" "public_backend" {
+  domain_name               = local.public_service_hostnames["mcp"]
+  subject_alternative_names = [local.public_service_hostnames["notifications"]]
+  validation_method         = "DNS"
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_route53_record" "public_backend_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.public_backend.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+  zone_id = local.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "public_backend" {
+  certificate_arn         = aws_acm_certificate.public_backend.arn
+  validation_record_fqdns = [for r in aws_route53_record.public_backend_cert_validation : r.fqdn]
+}
+
 # ── ALB ──────────────────────────────────────────────────────────────
 resource "aws_lb" "main" {
   name                       = "${local.name_prefix}-alb"
@@ -35,13 +62,36 @@ resource "aws_lb" "main" {
   subnets                    = local.public_subnet_ids
 }
 
-# api target group — bridge mode static host port 3010 => instance targets.
+# api target group.
 resource "aws_lb_target_group" "api" {
   name_prefix          = "gpapi" # <=6 chars; create_before_destroy needs unique names on replace
   port                 = local.services.api.port
   protocol             = "HTTP"
   vpc_id               = local.vpc_id
   target_type          = "ip" # awsvpc tasks register their ENI IP, not the instance
+  deregistration_delay = 30
+
+  health_check {
+    path                = "/v1/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 15
+    timeout             = 5
+    matcher             = "200"
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_lb_target_group" "public_backend" {
+  for_each = {
+    for name in local.public_backend_service_names : name => local.services[name]
+  }
+
+  name_prefix          = local.public_target_group_prefixes[each.key]
+  port                 = each.value.port
+  protocol             = "HTTP"
+  vpc_id               = local.vpc_id
+  target_type          = "ip"
   deregistration_delay = 30
 
   health_check {
@@ -68,6 +118,31 @@ resource "aws_lb_listener" "https" {
   }
 }
 
+resource "aws_lb_listener_certificate" "public_backend" {
+  listener_arn    = aws_lb_listener.https.arn
+  certificate_arn = aws_acm_certificate_validation.public_backend.certificate_arn
+}
+
+resource "aws_lb_listener_rule" "public_backend" {
+  for_each = {
+    for name in local.public_backend_service_names : name => local.services[name]
+  }
+
+  listener_arn = aws_lb_listener.https.arn
+  priority     = local.public_listener_priorities[each.key]
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.public_backend[each.key].arn
+  }
+
+  condition {
+    host_header {
+      values = [local.public_service_hostnames[each.key]]
+    }
+  }
+}
+
 resource "aws_lb_listener" "http_redirect" {
   load_balancer_arn = aws_lb.main.arn
   port              = 80
@@ -83,7 +158,7 @@ resource "aws_lb_listener" "http_redirect" {
   }
 }
 
-# ── api.genfeed.ai -> ALB (gated: the actual traffic cutover) ────────
+# ── Public service DNS -> ALB (gated: the actual traffic cutover) ─────
 # Only created when enable_dns_cutover=true, so the first apply builds the ALB
 # without stealing live traffic from the old box before services are healthy.
 resource "aws_route53_record" "api" {
@@ -93,6 +168,23 @@ resource "aws_route53_record" "api" {
   allow_overwrite = true
   zone_id         = local.zone_id
   name            = local.fqdn
+  type            = "A"
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "public_backend" {
+  for_each = var.enable_dns_cutover ? {
+    for name in local.public_backend_service_names : name => local.public_service_hostnames[name]
+  } : {}
+
+  # Overwrite the pre-existing manual A records (old EC2 box) on cutover.
+  allow_overwrite = true
+  zone_id         = local.zone_id
+  name            = each.value
   type            = "A"
   alias {
     name                   = aws_lb.main.dns_name

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -2,6 +2,20 @@ locals {
   name_prefix = "${var.project}-${var.environment}"
   fqdn        = "${var.api_subdomain}.${var.domain}" # api.genfeed.ai
 
+  public_backend_service_names = ["mcp", "notifications"]
+  public_service_hostnames = merge(
+    { api = local.fqdn },
+    { for name in local.public_backend_service_names : name => "${name}.${var.domain}" },
+  )
+  public_target_group_prefixes = {
+    mcp           = "gpmcp"
+    notifications = "gpntf"
+  }
+  public_listener_priorities = {
+    mcp           = 20
+    notifications = 30
+  }
+
   vpc_id             = var.vpc_id
   public_subnet_ids  = var.public_subnet_ids                # ALB (internet-facing)
   private_subnet_ids = [for s in aws_subnet.private : s.id] # ECS tasks/instances + cache (NAT egress)
@@ -31,8 +45,9 @@ locals {
   # Fargate launch type: cpu/mem MUST be valid Fargate task pairs (256→512-2048,
   # 512→1024-4096, 1024→2048-8192). Each task gets its own ENI from the private
   # subnets (NAT egress) — no per-instance ENI cap. Every service registers in
-  # Cloud Map for internal DNS; only api is behind the public ALB. (Tune api/
-  # workers cpu up if boot/throughput needs it — these are lean starting points.)
+  # Cloud Map for internal DNS; api/mcp/notifications are also behind the public
+  # ALB. (Tune api/workers cpu up if boot/throughput needs it — these are lean
+  # starting points.)
   # desired=0 keeps the service + task def defined (code stays, flip on anytime)
   # but runs zero tasks => ~$0. Bots/clips are built but unused, so they're parked
   # at 0. Core set (api + its boot-required deps files/mcp/notifications, +
@@ -41,8 +56,8 @@ locals {
     api           = { filter = "@genfeedai/api", port = 3010, cpu = 1024, mem = 2048, alb = true, health_grace = 120, desired = 1 }
     workers       = { filter = "@genfeedai/workers", port = 3013, cpu = 512, mem = 2048, alb = false, health_grace = 60, desired = 1 }
     files         = { filter = "@genfeedai/files", port = 3012, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
-    mcp           = { filter = "@genfeedai/mcp", port = 3014, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
-    notifications = { filter = "@genfeedai/notifications", port = 3011, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
+    mcp           = { filter = "@genfeedai/mcp", port = 3014, cpu = 256, mem = 512, alb = true, health_grace = 60, desired = 1 }
+    notifications = { filter = "@genfeedai/notifications", port = 3011, cpu = 256, mem = 512, alb = true, health_grace = 60, desired = 1 }
     clips         = { filter = "@genfeedai/clips", port = 3015, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }
     discord       = { filter = "@genfeedai/discord", port = 3016, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }
     slack         = { filter = "@genfeedai/slack", port = 3018, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 0 }

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -7,12 +7,19 @@ output "ecr_repository_url" {
 }
 
 output "alb_dns_name" {
-  description = "Smoke-test here before flipping api.genfeed.ai DNS."
+  description = "Smoke-test here before flipping public service DNS."
   value       = aws_lb.main.dns_name
 }
 
 output "api_url" {
   value = "https://${local.fqdn}"
+}
+
+output "public_backend_urls" {
+  description = "Public HTTPS URLs routed through the production ALB."
+  value = {
+    for name, hostname in local.public_service_hostnames : name => "https://${hostname}"
+  }
 }
 
 output "redis_primary_endpoint" {

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -41,7 +41,7 @@ module "service" {
 
   desired_count    = each.value.desired
   register_alb     = each.value.alb
-  target_group_arn = each.value.alb ? aws_lb_target_group.api.arn : ""
+  target_group_arn = each.value.alb ? (each.key == "api" ? aws_lb_target_group.api.arn : aws_lb_target_group.public_backend[each.key].arn) : ""
   health_grace     = each.value.health_grace
 
   # Keep internal Cloud Map records present during deployments. Workers verify

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -59,10 +59,10 @@ variable "route53_zone_id" {
   description = "Hosted zone for genfeed.ai. Empty = look up by name (assumes the zone is in Route53)."
 }
 
-# DNS cutover gate. FALSE (default): build everything EXCEPT the api.genfeed.ai
-# A-record, so the first apply never repoints live traffic at an empty ALB. Push
-# the image, get services healthy, smoke-test the ALB DNS, THEN apply with
-# enable_dns_cutover=true to flip api.genfeed.ai onto the ALB.
+# DNS cutover gate. FALSE (default): build everything EXCEPT public service
+# A-records, so the first apply never repoints live traffic at an empty ALB.
+# Push the image, get services healthy, smoke-test the ALB DNS, THEN apply with
+# enable_dns_cutover=true to flip api/mcp/notifications hostnames onto the ALB.
 variable "enable_dns_cutover" {
   type    = bool
   default = false


### PR DESCRIPTION
## Summary
- route `mcp.genfeed.ai` and `notifications.genfeed.ai` through the production ALB to their Fargate services
- add ACM SNI coverage, host-header listener rules, target groups, and Route53 aliases for the two public backend hostnames
- document the post-cutover AWS source of truth and make the legacy `Deploy Production` backend job a no-op so it cannot call the old Tailscale/SSH/EC2 path

## Live production verification
- Applied the public backend ALB resources and Route53 aliases in `us-west-1`.
- Restored missing SSM parameter `/genfeed/production/VERCEL_DEPLOYMENT_NOTIFICATIONS_ENABLED=false`; replacement Fargate tasks could not start while that key was absent.
- Refreshed OpenTofu state after manual ECS attachment.
- `tofu plan -var='image_tag=763f7a07c5105e4c43cc1f4c45e13ee47e3fc667' -var='enable_dns_cutover=true'` now returns no changes.
- Route53 now aliases all public backend names to `genfeed-production-alb-774183965.us-west-1.elb.amazonaws.com`.
- Public health checks returned 200:
  - `https://api.genfeed.ai/v1/health`
  - `https://mcp.genfeed.ai/v1/health`
  - `https://notifications.genfeed.ai/v1/health`
- ECS services `api`, `mcp`, and `notifications` are desired/running `1/1`, pending `0`, rollout `COMPLETED`.
- Target groups are healthy for `mcp` on port 3014 and `notifications` on port 3011.
- Old EC2 `i-0ba4418050d90bd32` remains stopped, not terminated, with termination protection enabled and `DoNotStart=true`.

## Checks
- `tofu fmt -check -diff infra/terraform/genfeed-prod infra/terraform/modules/service`
- `git diff --check origin/master..HEAD`
- `actionlint .github/workflows/deploy-ecs.yml .github/workflows/deploy-production.yml`
- `tofu plan -input=false -detailed-exitcode -var='image_tag=763f7a07c5105e4c43cc1f4c45e13ee47e3fc667' -var='enable_dns_cutover=true'`
