### PR TITLE
test(e2e): scope release workspace switcher selector

### DIFF
--- a/playwright/e2e/tests/release/workspace-loads.spec.ts
+++ b/playwright/e2e/tests/release/workspace-loads.spec.ts
@@ -40,7 +40,9 @@ test.describe('Released image — workspace shell', () => {
     ).toHaveCount(0);
 
     // Shell chrome mounted (protected layout resolved).
-    const switcher = page.getByTestId('workspace-switcher-trigger');
+    const switcher = page
+      .getByTestId('desktop-sidebar-rail')
+      .getByTestId('workspace-switcher-trigger');
     await expect(switcher, 'workspace switcher must mount').toBeVisible({
       timeout: 30_000,
     });


### PR DESCRIPTION
## Summary
- scope the release workspace switcher assertion to the desktop sidebar rail
- avoid Playwright strict-mode failure when duplicate shell switchers are mounted

## Verification
- ./node_modules/.bin/biome check playwright/e2e/tests/release/workspace-loads.spec.ts
- git diff --check
- commit hook: secretlint + staged Biome

## Context
Post-release Self-Hosted Release E2E for v0.2.5 failed because getByTestId('workspace-switcher-trigger') resolved to two elements. The released image loaded and 4/5 release specs passed; this is a selector ambiguity in the test.