### PR TITLE
fix(app): enforce org-root routing invariants

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.test.tsx
@@ -19,6 +19,12 @@ vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
   useAuthedService: () => mocks.getEditorService,
 }));
 
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    href: (path: string) => `/acme/~${path}`,
+  }),
+}));
+
 vi.mock('@services/editor/editor-projects.service', () => ({
   EditorProjectsService: {
     getInstance: vi.fn(),
@@ -149,7 +155,7 @@ describe('EditorProjectsPage', () => {
     expect(await screen.findByText('Create Your First Project')).toBeVisible();
     expect(screen.getByText('Start New Project')).toHaveAttribute(
       'href',
-      '/editor/new',
+      '/acme/~/editor/new',
     );
     expect(screen.getByText('Timeline Editor')).toBeVisible();
     expect(screen.getByText('Effects & Transitions')).toBeVisible();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useBrandId } from '@contexts/user/brand-context/brand-context';
 import { ButtonSize, ButtonVariant, CardVariant } from '@genfeedai/enums';
 import type { IEditorProject } from '@genfeedai/interfaces';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { EditorProjectsService } from '@services/editor/editor-projects.service';
 import Card from '@ui/card/Card';
 import Container from '@ui/layout/container/Container';
@@ -74,7 +74,7 @@ function formatRelativeTime(dateStr: string): string {
 }
 
 export default function EditorProjectsPage() {
-  const _brandId = useBrandId();
+  const { href } = useOrgUrl();
   const [projects, setProjects] = useState<IEditorProject[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -122,7 +122,7 @@ export default function EditorProjectsPage() {
         <div className="space-y-2">
           <div className="flex items-center gap-3">
             <Link
-              href="/studio/video"
+              href={href('/studio/video')}
               className="flex size-8 shrink-0 items-center justify-center rounded-lg text-foreground/40 transition-colors duration-150 hover:bg-white/[0.06] hover:text-foreground"
               aria-label="Back to Studio"
             >
@@ -137,7 +137,7 @@ export default function EditorProjectsPage() {
         </div>
 
         <Link
-          href="/editor/new"
+          href={href('/editor/new')}
           className="inline-flex items-center gap-2 bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           <HiOutlinePlus className="size-4" />
@@ -185,7 +185,7 @@ export default function EditorProjectsPage() {
           </h3>
           <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (
-              <Link key={project.id} href={`/editor/${project.id}`}>
+              <Link key={project.id} href={href(`/editor/${project.id}`)}>
                 <Card
                   variant={CardVariant.DEFAULT}
                   className="group cursor-pointer p-6 transition-all hover:ring-1 hover:ring-primary/30"
@@ -244,7 +244,7 @@ export default function EditorProjectsPage() {
             </p>
 
             <Link
-              href="/editor/new"
+              href={href('/editor/new')}
               className="inline-flex items-center gap-2 bg-primary px-6 py-3 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               <HiOutlinePlus className="size-5" />

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.test.tsx
@@ -1,8 +1,71 @@
-import { describe, expect, it } from 'vitest';
-import Module from './new-editor-project-page.tsx';
+// @vitest-environment jsdom
 
-describe('new-editor-project-page.tsx', () => {
-  it('exports a component', () => {
-    expect(Module).toBeDefined();
+import '@testing-library/jest-dom/vitest';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createProject: vi.fn(),
+  getEditorService: vi.fn(),
+  loggerError: vi.fn(),
+  replace: vi.fn(),
+  searchParamsGet: vi.fn(),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getEditorService,
+}));
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    href: (path: string) => `/acme/~${path}`,
+  }),
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: {
+    error: mocks.loggerError,
+  },
+}));
+
+vi.mock('@services/editor/editor-projects.service', () => ({
+  EditorProjectsService: {
+    getInstance: vi.fn(),
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+  }),
+  useSearchParams: () => ({
+    get: mocks.searchParamsGet,
+  }),
+}));
+
+const { default: NewEditorProjectPage } = await import(
+  './new-editor-project-page'
+);
+
+describe('NewEditorProjectPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createProject.mockResolvedValue({ id: 'project-1' });
+    mocks.getEditorService.mockResolvedValue({
+      create: mocks.createProject,
+    });
+    mocks.searchParamsGet.mockReturnValue(null);
+  });
+
+  it('creates a project and redirects through the current org URL scope', async () => {
+    render(<NewEditorProjectPage />);
+
+    await waitFor(() => {
+      expect(mocks.createProject).toHaveBeenCalledWith({
+        name: 'Untitled Project',
+        sourceVideoId: undefined,
+      });
+    });
+    expect(mocks.replace).toHaveBeenCalledWith('/acme/~/editor/project-1');
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.tsx
@@ -24,21 +24,42 @@ function NewEditorProjectPageContent() {
     }
     creating.current = true;
 
+    const controller = new AbortController();
+
     (async () => {
       try {
         const service = await getEditorService();
+        // Aborting in cleanup runs synchronously before these awaited
+        // microtasks resolve, so a StrictMode-discarded mount bails out here
+        // before creating a project — preserving create-once semantics while
+        // still cancelling on a genuine unmount.
+        if (controller.signal.aborted) {
+          return;
+        }
+
         const project = await service.create({
           name: videoId ? 'Video Edit' : 'Untitled Project',
           sourceVideoId: videoId ?? undefined,
         });
+        if (controller.signal.aborted) {
+          return;
+        }
 
         replace(href(`/editor/${project.id}`));
       } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
         logger.error('Failed to create editor project', error);
         creating.current = false;
         replace(href('/editor'));
       }
     })();
+
+    return () => {
+      controller.abort();
+      creating.current = false;
+    };
   }, [videoId, getEditorService, href, replace]);
 
   return (

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { logger } from '@services/core/logger.service';
 import { EditorProjectsService } from '@services/editor/editor-projects.service';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -8,6 +9,7 @@ import { Suspense, useEffect, useRef } from 'react';
 
 function NewEditorProjectPageContent() {
   const { replace } = useRouter();
+  const { href } = useOrgUrl();
   const searchParams = useSearchParams();
   const videoId = searchParams.get('video') || searchParams.get('videoId');
   const creating = useRef(false);
@@ -30,14 +32,14 @@ function NewEditorProjectPageContent() {
           sourceVideoId: videoId ?? undefined,
         });
 
-        replace(`/editor/${project.id}`);
+        replace(href(`/editor/${project.id}`));
       } catch (error) {
         logger.error('Failed to create editor project', error);
         creating.current = false;
-        replace('/editor');
+        replace(href('/editor'));
       }
     })();
-  }, [videoId, getEditorService, replace]);
+  }, [videoId, getEditorService, href, replace]);
 
   return (
     <div className="flex h-screen items-center justify-center">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/posts-list-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/posts-list-page.tsx
@@ -17,9 +17,11 @@ export type PostsListSearchParams = Promise<{
 
 export async function renderPostsListPage({
   searchParams,
+  scope = PageScope.PUBLISHER,
   statusOverride,
 }: {
   searchParams: PostsListSearchParams;
+  scope?: PageScope;
   statusOverride?: PublisherPostsStatus;
 }) {
   const { page, platform, search, sort, status } = await searchParams;
@@ -32,7 +34,7 @@ export async function renderPostsListPage({
     currentPage,
     platformFilter:
       normalizedPlatform !== 'all' ? normalizedPlatform : undefined,
-    scope: PageScope.PUBLISHER,
+    scope,
     search,
     sort,
     status: normalizedStatus,
@@ -43,7 +45,7 @@ export async function renderPostsListPage({
       initialPostPresets={initialData.postPresets}
       initialPosts={initialData.posts}
       platform={normalizedPlatform}
-      scope={PageScope.PUBLISHER}
+      scope={scope}
       status={normalizedStatus}
     />
   );

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  brandState: {
+    brands: [] as Array<{
+      createdAt?: string;
+      id: string;
+      label: string;
+      logoUrl?: string;
+      slug: string;
+      totalCredentials: number;
+    }>,
+    isReady: true,
+  },
+  replace: vi.fn(),
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => mocks.brandState,
+}));
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    orgHref: (path: string) => `/acme/~${path}`,
+    orgSlug: 'acme',
+  }),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <span aria-label={alt} data-src={src} role="img" />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+  }),
+}));
+
+vi.mock('@/components/ui/client-formatted-date', () => ({
+  ClientFormattedDate: ({ value }: { value: string }) => <span>{value}</span>,
+}));
+
+const { default: OrgLandingContent } = await import('./org-landing-content');
+
+describe('OrgLandingContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.brandState.isReady = true;
+    mocks.brandState.brands = [];
+  });
+
+  it('redirects to onboarding when the organization has no projects', async () => {
+    render(<OrgLandingContent />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/onboarding');
+    });
+  });
+
+  it('redirects into the only project when one project exists', async () => {
+    mocks.brandState.brands = [
+      {
+        id: 'brand_1',
+        label: 'Moonrise',
+        slug: 'moonrise',
+        totalCredentials: 0,
+      },
+    ];
+
+    render(<OrgLandingContent />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith(
+        '/acme/moonrise/workspace/overview',
+      );
+    });
+  });
+
+  it('renders the project picker when multiple projects exist', () => {
+    mocks.brandState.brands = [
+      {
+        id: 'brand_1',
+        label: 'Moonrise',
+        slug: 'moonrise',
+        totalCredentials: 1,
+      },
+      {
+        id: 'brand_2',
+        label: 'Solar',
+        slug: 'solar',
+        totalCredentials: 0,
+      },
+    ];
+
+    render(<OrgLandingContent />);
+
+    expect(screen.getByText('Projects')).toBeVisible();
+    expect(screen.getByRole('link', { name: /moonrise/i })).toHaveAttribute(
+      'href',
+      '/acme/moonrise/workspace/overview',
+    );
+    expect(screen.getByRole('link', { name: /new brand/i })).toHaveAttribute(
+      'href',
+      '/acme/~/settings/brands',
+    );
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -76,6 +76,11 @@ export default function OrgLandingContent() {
       return;
     }
 
+    if (brands.length === 0) {
+      replace('/onboarding');
+      return;
+    }
+
     if (brands.length <= 1 && primaryBrandSlug) {
       replace(`/${orgSlug}/${primaryBrandSlug}/workspace/overview`);
     }

--- a/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx
@@ -1,0 +1,362 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { PageScope, PostStatus } from '@genfeedai/enums';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { notFoundMock, renderPostsListPageMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+  renderPostsListPageMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: notFoundMock,
+}));
+
+vi.mock('@pages/ingredients/layout/ingredients-layout', () => ({
+  default: ({
+    children,
+    defaultType,
+    hideTypeTabs,
+    scope,
+  }: {
+    children: ReactNode;
+    defaultType: string;
+    hideTypeTabs?: boolean;
+    scope: PageScope;
+  }) => (
+    <section
+      data-default-type={defaultType}
+      data-hide-type-tabs={String(Boolean(hideTypeTabs))}
+      data-scope={scope}
+      data-testid="ingredients-layout"
+    >
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@pages/ingredients/list/ingredients-list', () => ({
+  default: ({ scope, type }: { scope: PageScope; type: string }) => (
+    <div data-scope={scope} data-testid="ingredients-list" data-type={type} />
+  ),
+}));
+
+vi.mock('@ui/loading/fallback/LazyLoadingFallback', () => ({
+  default: () => <div data-testid="lazy-loading-fallback" />,
+}));
+
+vi.mock('@ui/loading/skeleton/SkeletonFallbacks', () => ({
+  SkeletonLoadingFallback: () => (
+    <div data-testid="skeleton-loading-fallback" />
+  ),
+}));
+
+vi.mock('@/features/workflows/pages/executions/WorkflowExecutionsPage', () => ({
+  default: () => <div data-testid="workflow-executions-page" />,
+}));
+
+vi.mock('@/features/workflows/pages/library/WorkflowLibraryPage', () => ({
+  default: () => <div data-testid="workflow-library-page" />,
+}));
+
+vi.mock('@/features/workflows/pages/templates/WorkflowTemplatesPage', () => ({
+  default: () => <div data-testid="workflow-templates-page" />,
+}));
+
+vi.mock('../../../[brandSlug]/editor/[id]/page', () => ({
+  default: async ({
+    params,
+  }: {
+    params: Promise<{
+      id: string;
+    }>;
+  }) => {
+    const { id } = await params;
+    return <div data-id={id} data-testid="editor-detail-page" />;
+  },
+}));
+
+vi.mock('../../../[brandSlug]/editor/new/page', () => ({
+  default: () => <div data-testid="editor-new-page" />,
+}));
+
+vi.mock('../../../[brandSlug]/editor/editor-projects-page', () => ({
+  default: () => <div data-testid="editor-projects-page" />,
+}));
+
+vi.mock('../../../[brandSlug]/posts/posts-list-page', () => ({
+  renderPostsListPage: (args: unknown) => {
+    renderPostsListPageMock(args);
+    return <div data-testid="posts-list-page" />;
+  },
+}));
+
+vi.mock('../../../[brandSlug]/workflows/[id]/WorkflowDetailPageClient', () => ({
+  default: ({
+    initialExecutionId,
+    workflowId,
+  }: {
+    initialExecutionId?: string;
+    workflowId: string;
+  }) => (
+    <div
+      data-execution-id={initialExecutionId}
+      data-testid="workflow-detail-page"
+      data-workflow-id={workflowId}
+    />
+  ),
+}));
+
+vi.mock('../../../[brandSlug]/workflows/new/WorkflowNewPageClient', () => ({
+  default: () => <div data-testid="workflow-new-page" />,
+}));
+
+const { default: OrgRootAppPage } = await import('./page');
+
+describe('OrgRootAppPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders org library ingredients by requested type', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'library',
+        orgSlug: 'acme',
+        segments: ['images'],
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('ingredients-layout')).toHaveAttribute(
+      'data-scope',
+      PageScope.ORGANIZATION,
+    );
+    expect(screen.getByTestId('ingredients-layout')).toHaveAttribute(
+      'data-default-type',
+      'images',
+    );
+    expect(screen.getByTestId('ingredients-layout')).toHaveAttribute(
+      'data-hide-type-tabs',
+      'true',
+    );
+    expect(screen.getByTestId('ingredients-list')).toHaveAttribute(
+      'data-type',
+      'images',
+    );
+  });
+
+  it('renders org library with type tabs at the root', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'library',
+        orgSlug: 'acme',
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('ingredients-layout')).toHaveAttribute(
+      'data-default-type',
+      'videos',
+    );
+    expect(screen.getByTestId('ingredients-layout')).toHaveAttribute(
+      'data-hide-type-tabs',
+      'false',
+    );
+  });
+
+  it('renders org studio ingredients by requested type', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'studio',
+        orgSlug: 'acme',
+        segments: ['image'],
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('ingredients-layout')).toHaveAttribute(
+      'data-scope',
+      PageScope.ORGANIZATION,
+    );
+    expect(screen.getByTestId('ingredients-list')).toHaveAttribute(
+      'data-type',
+      'images',
+    );
+  });
+
+  it('renders org posts with published status for /posts/published', async () => {
+    const searchParams = Promise.resolve({ page: '2' });
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'posts',
+        orgSlug: 'acme',
+        segments: ['published'],
+      }),
+      searchParams,
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('posts-list-page')).toBeInTheDocument();
+    expect(renderPostsListPageMock).toHaveBeenCalledWith({
+      scope: PageScope.ORGANIZATION,
+      searchParams,
+      statusOverride: PostStatus.PUBLIC,
+    });
+  });
+
+  it('renders write as the org posts list', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'write',
+        orgSlug: 'acme',
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('posts-list-page')).toBeInTheDocument();
+    expect(renderPostsListPageMock).toHaveBeenCalledWith({
+      scope: PageScope.ORGANIZATION,
+      searchParams: expect.any(Promise),
+      statusOverride: undefined,
+    });
+  });
+
+  it('renders org workflow library by default', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('workflow-library-page')).toBeInTheDocument();
+  });
+
+  it('renders org workflow templates and executions sections', async () => {
+    const templatesElement = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+        segments: ['templates'],
+      }),
+    });
+    const { unmount } = render(templatesElement);
+
+    expect(screen.getByTestId('workflow-templates-page')).toBeInTheDocument();
+
+    unmount();
+
+    const executionsElement = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+        segments: ['executions'],
+      }),
+    });
+    render(executionsElement);
+
+    expect(screen.getByTestId('workflow-executions-page')).toBeInTheDocument();
+  });
+
+  it('renders org workflow new and detail pages', async () => {
+    const newElement = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+        segments: ['new'],
+      }),
+    });
+    const { unmount } = render(newElement);
+
+    expect(screen.getByTestId('workflow-new-page')).toBeInTheDocument();
+
+    unmount();
+
+    const detailElement = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+        segments: ['workflow-1'],
+      }),
+      searchParams: Promise.resolve({ execution: 'execution-1' }),
+    });
+    render(detailElement);
+
+    expect(screen.getByTestId('workflow-detail-page')).toHaveAttribute(
+      'data-workflow-id',
+      'workflow-1',
+    );
+    expect(screen.getByTestId('workflow-detail-page')).toHaveAttribute(
+      'data-execution-id',
+      'execution-1',
+    );
+  });
+
+  it('renders org editor projects', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'editor',
+        orgSlug: 'acme',
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('editor-projects-page')).toBeInTheDocument();
+  });
+
+  it('renders org editor new and detail pages', async () => {
+    const newElement = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'editor',
+        orgSlug: 'acme',
+        segments: ['new'],
+      }),
+    });
+    const { unmount } = render(newElement);
+
+    expect(screen.getByTestId('editor-new-page')).toBeInTheDocument();
+
+    unmount();
+
+    const detailElement = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'editor',
+        orgSlug: 'acme',
+        segments: ['project-1'],
+      }),
+    });
+    render(detailElement);
+
+    expect(screen.getByTestId('editor-detail-page')).toHaveAttribute(
+      'data-id',
+      'project-1',
+    );
+  });
+
+  it('returns not found for unknown org-root routes', async () => {
+    await expect(
+      OrgRootAppPage({
+        params: Promise.resolve({
+          orgRootApp: 'unknown',
+          orgSlug: 'acme',
+        }),
+      }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx
@@ -305,11 +305,39 @@ describe('OrgRootAppPage', () => {
     );
   });
 
+  it('renders org workflow library for the reserved library segment', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+        segments: ['library'],
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('workflow-library-page')).toBeInTheDocument();
+  });
+
   it('renders org editor projects', async () => {
     const element = await OrgRootAppPage({
       params: Promise.resolve({
         orgRootApp: 'editor',
         orgSlug: 'acme',
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('editor-projects-page')).toBeInTheDocument();
+  });
+
+  it('renders org editor projects for the reserved projects segment', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'editor',
+        orgSlug: 'acme',
+        segments: ['projects'],
       }),
     });
 

--- a/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.tsx
@@ -118,6 +118,17 @@ function OrgWorkflowsPage({
     return <WorkflowNewPageClient />;
   }
 
+  // Reserved index segment: /~/workflows/library mirrors the workflows root
+  // (library). Without this guard it would fall into the detail branch below
+  // and request a workflow with id 'library'.
+  if (section === 'library') {
+    return (
+      <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+        <WorkflowLibraryPage />
+      </Suspense>
+    );
+  }
+
   if (section) {
     return (
       <WorkflowDetailPageClient
@@ -183,6 +194,13 @@ export default async function OrgRootAppPage({
 
     if (section === 'new') {
       return <EditorNewPage />;
+    }
+
+    // Reserved index segment: /~/editor/projects mirrors the editor root
+    // (projects). Without this guard it would fall into the detail branch
+    // below and request an editor project with id 'projects'.
+    if (section === 'projects') {
+      return <EditorProjectsPage />;
     }
 
     if (section) {

--- a/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.tsx
@@ -1,0 +1,198 @@
+import { PageScope, PostStatus } from '@genfeedai/enums';
+import IngredientsLayout from '@pages/ingredients/layout/ingredients-layout';
+import IngredientsList from '@pages/ingredients/list/ingredients-list';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import { SkeletonLoadingFallback } from '@ui/loading/skeleton/SkeletonFallbacks';
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import WorkflowExecutionsPage from '@/features/workflows/pages/executions/WorkflowExecutionsPage';
+import WorkflowLibraryPage from '@/features/workflows/pages/library/WorkflowLibraryPage';
+import WorkflowTemplatesPage from '@/features/workflows/pages/templates/WorkflowTemplatesPage';
+import EditorDetailPage from '../../../[brandSlug]/editor/[id]/page';
+import EditorProjectsPage from '../../../[brandSlug]/editor/editor-projects-page';
+import EditorNewPage from '../../../[brandSlug]/editor/new/page';
+import { renderPostsListPage } from '../../../[brandSlug]/posts/posts-list-page';
+import WorkflowDetailPageClient from '../../../[brandSlug]/workflows/[id]/WorkflowDetailPageClient';
+import WorkflowNewPageClient from '../../../[brandSlug]/workflows/new/WorkflowNewPageClient';
+
+const ORG_LIBRARY_TYPE_BY_SEGMENT: Record<string, string> = {
+  avatar: 'avatars',
+  avatars: 'avatars',
+  gif: 'gifs',
+  gifs: 'gifs',
+  image: 'images',
+  images: 'images',
+  ingredients: 'videos',
+  music: 'musics',
+  musics: 'musics',
+  video: 'videos',
+  videos: 'videos',
+  voice: 'voices',
+  voices: 'voices',
+};
+
+type OrgRootAppPageProps = {
+  params: Promise<{
+    orgRootApp: string;
+    orgSlug: string;
+    segments?: string[];
+  }>;
+  searchParams?: Promise<{
+    execution?: string;
+    page?: string;
+    platform?: string;
+    search?: string;
+    sort?: string;
+    status?: string;
+  }>;
+};
+
+function getOrgLibraryType(segments?: string[]): string {
+  return (
+    ORG_LIBRARY_TYPE_BY_SEGMENT[segments?.[0] ?? 'ingredients'] ?? 'videos'
+  );
+}
+
+function OrgIngredientListPage({
+  hideTypeTabs = true,
+  type,
+}: {
+  hideTypeTabs?: boolean;
+  type: string;
+}) {
+  return (
+    <IngredientsLayout
+      scope={PageScope.ORGANIZATION}
+      defaultType={type}
+      hideTypeTabs={hideTypeTabs}
+    >
+      <Suspense
+        fallback={<SkeletonLoadingFallback type="masonry" count={12} />}
+      >
+        <IngredientsList type={type} scope={PageScope.ORGANIZATION} />
+      </Suspense>
+    </IngredientsLayout>
+  );
+}
+
+function getOrgPostsStatusOverride(segments?: string[]) {
+  const segment = segments?.[0];
+
+  if (segment === 'published') {
+    return PostStatus.PUBLIC;
+  }
+
+  if (segment === 'scheduled') {
+    return PostStatus.SCHEDULED;
+  }
+
+  return undefined;
+}
+
+function OrgWorkflowsPage({
+  initialExecutionId,
+  segments,
+}: {
+  initialExecutionId?: string;
+  segments?: string[];
+}) {
+  const section = segments?.[0];
+
+  if (section === 'templates') {
+    return (
+      <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+        <WorkflowTemplatesPage />
+      </Suspense>
+    );
+  }
+
+  if (section === 'executions') {
+    return (
+      <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+        <WorkflowExecutionsPage />
+      </Suspense>
+    );
+  }
+
+  if (section === 'new') {
+    return <WorkflowNewPageClient />;
+  }
+
+  if (section) {
+    return (
+      <WorkflowDetailPageClient
+        workflowId={section}
+        initialExecutionId={initialExecutionId}
+      />
+    );
+  }
+
+  return (
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+      <WorkflowLibraryPage />
+    </Suspense>
+  );
+}
+
+export default async function OrgRootAppPage({
+  params,
+  searchParams,
+}: OrgRootAppPageProps) {
+  const { orgRootApp, segments } = await params;
+
+  if (orgRootApp === 'library') {
+    const type = getOrgLibraryType(segments);
+
+    return (
+      <OrgIngredientListPage
+        type={type}
+        hideTypeTabs={segments?.[0] !== undefined}
+      />
+    );
+  }
+
+  if (orgRootApp === 'studio') {
+    return <OrgIngredientListPage type={getOrgLibraryType(segments)} />;
+  }
+
+  if (
+    orgRootApp === 'posts' ||
+    orgRootApp === 'write' ||
+    orgRootApp === 'compose'
+  ) {
+    return renderPostsListPage({
+      searchParams: searchParams ?? Promise.resolve({}),
+      scope: PageScope.ORGANIZATION,
+      statusOverride: getOrgPostsStatusOverride(segments),
+    });
+  }
+
+  if (orgRootApp === 'workflows') {
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+
+    return (
+      <OrgWorkflowsPage
+        segments={segments}
+        initialExecutionId={resolvedSearchParams?.execution}
+      />
+    );
+  }
+
+  if (orgRootApp === 'editor') {
+    const section = segments?.[0];
+
+    if (section === 'new') {
+      return <EditorNewPage />;
+    }
+
+    if (section) {
+      return EditorDetailPage({
+        params: Promise.resolve({ id: section }),
+      });
+    }
+
+    return <EditorProjectsPage />;
+  }
+
+  notFound();
+}

--- a/apps/app/app/(protected)/root-resolver-client.test.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  accessState: null as { brandId?: string; organizationId?: string } | null,
+  brandState: {
+    brandId: '',
+    brands: [] as Array<{
+      organization?: { slug?: string };
+      slug?: string;
+    }>,
+    organizationId: '',
+    selectedBrand: null as {
+      organization?: { slug?: string };
+      slug?: string;
+    } | null,
+  },
+  isAccessStateLoading: false,
+  replace: vi.fn(),
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => mocks.brandState,
+}));
+
+vi.mock('@providers/access-state/access-state.provider', () => ({
+  useAccessState: () => ({
+    accessState: mocks.accessState,
+    isLoading: mocks.isAccessStateLoading,
+  }),
+}));
+
+vi.mock('@ui/loading/page/PageLoadingState', () => ({
+  default: ({ message }: { message: string }) => (
+    <div data-testid="page-loading-state">{message}</div>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+  }),
+}));
+
+const { default: ProtectedRootResolver } = await import(
+  './root-resolver-client'
+);
+
+describe('ProtectedRootResolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.accessState = null;
+    mocks.isAccessStateLoading = false;
+    mocks.brandState.brandId = '';
+    mocks.brandState.brands = [];
+    mocks.brandState.organizationId = '';
+    mocks.brandState.selectedBrand = null;
+  });
+
+  it('opens the selected brand workspace when org and brand are selected', async () => {
+    mocks.brandState.organizationId = 'org_1';
+    mocks.brandState.brandId = 'brand_1';
+    mocks.brandState.selectedBrand = {
+      organization: { slug: 'acme' },
+      slug: 'moonrise',
+    };
+
+    render(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith(
+        '/acme/moonrise/workspace/overview',
+      );
+    });
+  });
+
+  it('opens org overview when an org exists and no brand is selected', async () => {
+    mocks.brandState.organizationId = 'org_1';
+    mocks.brandState.brands = [
+      {
+        organization: { slug: 'acme' },
+        slug: 'moonrise',
+      },
+    ];
+
+    render(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/acme/~/overview');
+    });
+  });
+
+  it('opens onboarding when no project exists for the organization', async () => {
+    mocks.brandState.organizationId = 'org_1';
+    mocks.brandState.brands = [];
+
+    render(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/onboarding');
+    });
+  });
+});

--- a/apps/app/app/(protected)/root-resolver-client.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.tsx
@@ -66,7 +66,7 @@ export default function ProtectedRootResolver() {
             : 'Opening onboarding...';
         nextUrl =
           hasOrganization && fallbackOrgSlug
-            ? `/${fallbackOrgSlug}/~`
+            ? `/${fallbackOrgSlug}/~/overview`
             : '/onboarding';
       }
     } else {
@@ -77,7 +77,7 @@ export default function ProtectedRootResolver() {
           : 'Opening onboarding...';
       nextUrl =
         hasOrganization && fallbackOrgSlug
-          ? `/${fallbackOrgSlug}/~`
+          ? `/${fallbackOrgSlug}/~/overview`
           : '/onboarding';
     }
 

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -501,6 +501,43 @@ describe('proxy', () => {
     );
   });
 
+  it('does not gate brand-scoped routes through the onboarding bootstrap check', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({ brands: [], currentUser: { id: 'user_1' } }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/acme/moonrise-studio/posts', search: '' },
+        url: 'http://localhost:3000/acme/moonrise-studio/posts',
+      } as never,
+      {} as never,
+    );
+
+    // Brand-scoped paths must fall through, never the org-root (~) onboarding
+    // gate, and must not trigger a bootstrap fetch on every navigation.
+    expect(response.headers.get('location')).not.toBe(
+      'http://localhost:3000/onboarding',
+    );
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).endsWith('/auth/bootstrap'),
+      ),
+    ).toBe(false);
+  });
+
   it('redirects signed-in flat chat to the canonical org-scoped chat path', async () => {
     const { default: proxy } = await import('./proxy');
 

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -140,6 +140,47 @@ describe('proxy', () => {
     );
   });
 
+  it('redirects signed-in root to org overview when no brand is selected', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            access: {},
+            brands: [{ id: 'brand_1', slug: 'moonrise-studio' }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.endsWith('/organizations/mine')) {
+        return new Response(
+          JSON.stringify([{ isActive: true, slug: 'acme' }]),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/' },
+        url: 'http://localhost:3000/',
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/acme/~/overview',
+    );
+  });
+
   it('redirects signed-in root to onboarding when no workspace exists', async () => {
     fetchMock.mockImplementation(async (input: string | URL) => {
       const url = String(input);
@@ -293,6 +334,170 @@ describe('proxy', () => {
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe(
       'http://localhost:3000/acme/moonrise-studio/workspace/overview',
+    );
+  });
+
+  it('redirects signed-in flat protected routes to org views when no brand is selected', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            access: {},
+            brands: [{ id: 'brand_1', slug: 'moonrise-studio' }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.endsWith('/organizations/mine')) {
+        return new Response(
+          JSON.stringify([{ isActive: true, slug: 'acme' }]),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const postsResponse = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/posts', search: '' },
+        url: 'http://localhost:3000/posts',
+      } as never,
+      {} as never,
+    );
+
+    expect(postsResponse.status).toBe(307);
+    expect(postsResponse.headers.get('location')).toBe(
+      'http://localhost:3000/acme/~/posts',
+    );
+
+    const workspaceResponse = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/workspace/overview', search: '' },
+        url: 'http://localhost:3000/workspace/overview',
+      } as never,
+      {} as never,
+    );
+
+    expect(workspaceResponse.status).toBe(307);
+    expect(workspaceResponse.headers.get('location')).toBe(
+      'http://localhost:3000/acme/~/overview',
+    );
+  });
+
+  it('keeps personal settings canonical when no brand is selected', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            access: {},
+            brands: [{ id: 'brand_1', slug: 'moonrise-studio' }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.endsWith('/organizations/mine')) {
+        return new Response(
+          JSON.stringify([{ isActive: true, slug: 'acme' }]),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/settings/personal', search: '' },
+        url: 'http://localhost:3000/settings/personal',
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/settings',
+    );
+  });
+
+  it('redirects signed-in bare protected routes to onboarding when no projects exist', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            brands: [],
+            currentUser: { id: 'user_1' },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/workspace/overview', search: '' },
+        url: 'http://localhost:3000/workspace/overview',
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/onboarding',
+    );
+  });
+
+  it('redirects scoped app routes to onboarding when no projects exist', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            brands: [],
+            currentUser: { id: 'user_1' },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      {
+        cookies: { get: vi.fn() },
+        nextUrl: { pathname: '/acme/~/overview', search: '' },
+        url: 'http://localhost:3000/acme/~/overview',
+      } as never,
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/onboarding',
     );
   });
 

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -146,9 +146,23 @@ function isBareProtectedPath(pathname: string): boolean {
   );
 }
 
+function isScopedWorkspacePath(pathname: string): boolean {
+  const parts = pathname.split('/').filter(Boolean);
+
+  if (parts.length === 0 || parts[0] === 'admin') {
+    return false;
+  }
+
+  if (parts.length === 1) {
+    return !isBareProtectedPath(pathname);
+  }
+
+  return !isBareProtectedPath(pathname);
+}
+
 type WorkspaceSlugs = {
   brandCount: number;
-  brandSlug: string;
+  brandSlug?: string;
   orgSlug: string;
 };
 
@@ -233,9 +247,11 @@ async function decodeSlugCookie(value: string): Promise<WorkspaceSlugs | null> {
       s: WorkspaceSlugs;
     };
     if (parsed.e <= Date.now()) return null;
-    if (!parsed.s?.orgSlug || !parsed.s?.brandSlug) return null;
-    if (!isValidSlug(parsed.s.orgSlug) || !isValidSlug(parsed.s.brandSlug))
+    if (!parsed.s?.orgSlug) return null;
+    if (!isValidSlug(parsed.s.orgSlug)) return null;
+    if (parsed.s.brandSlug !== undefined && !isValidSlug(parsed.s.brandSlug)) {
       return null;
+    }
     return parsed.s;
   } catch {
     return null;
@@ -340,15 +356,22 @@ async function resolveActiveWorkspaceSlugs(
     (await bootstrapResponse.json()) as BootstrapResponse | null;
   const brands = bootstrap?.brands ?? [];
   const activeBrandId = bootstrap?.access?.brandId ?? '';
-  const matchedBrand = brands.find((brand) => {
-    return String(brand.id ?? brand._id ?? '') === activeBrandId;
-  });
+  const matchedBrand = activeBrandId
+    ? brands.find((brand) => {
+        return String(brand.id ?? brand._id ?? '') === activeBrandId;
+      })
+    : undefined;
   const resolvedBrand =
-    (matchedBrand?.slug ? matchedBrand : null) ??
-    brands.find((brand) => Boolean(brand.slug)) ??
-    matchedBrand;
+    activeBrandId && matchedBrand?.slug
+      ? matchedBrand
+      : activeBrandId
+        ? (brands.find((brand) => Boolean(brand.slug)) ?? matchedBrand)
+        : undefined;
   const brandSlug = resolvedBrand?.slug;
-  let orgSlug = resolvedBrand?.organization?.slug;
+  let orgSlug =
+    resolvedBrand?.organization?.slug ??
+    brands.find((brand) => Boolean(brand.organization?.slug))?.organization
+      ?.slug;
 
   if (!orgSlug) {
     let organizationsResponse: Response;
@@ -377,14 +400,14 @@ async function resolveActiveWorkspaceSlugs(
       organizations?.[0]?.slug;
   }
 
-  if (!orgSlug || !brandSlug) {
+  if (!orgSlug) {
     return null;
   }
 
   // Validate slugs before caching and using them in redirect paths.
   // This prevents an attacker-controlled API response from injecting a slug
   // like `//attacker.example` and causing a cross-origin redirect.
-  if (!SLUG_RE.test(orgSlug) || !SLUG_RE.test(brandSlug)) {
+  if (!SLUG_RE.test(orgSlug) || (brandSlug && !SLUG_RE.test(brandSlug))) {
     return null;
   }
 
@@ -418,17 +441,51 @@ async function shouldRedirectSignedInUserToOnboarding(
   const bootstrap =
     (await bootstrapResponse.json()) as BootstrapResponse | null;
 
-  return (
-    Boolean(bootstrap?.currentUser) &&
-    Array.isArray(bootstrap?.brands) &&
-    bootstrap.brands.length === 0
-  );
+  return Array.isArray(bootstrap?.brands) && bootstrap.brands.length === 0;
 }
 
 type CanonicalResolution = {
   cookieValue: string | null;
   path: string;
 };
+
+const ORG_ROOT_APP_PREFIXES = [
+  'analytics',
+  'chat',
+  'compose',
+  'editor',
+  'library',
+  'posts',
+  'settings',
+  'studio',
+  'workflows',
+] as const;
+
+function createOrgScopedCanonicalPath(
+  canonicalPath: string,
+  orgSlug: string,
+): string {
+  const topLevelSegment = getTopLevelSegment(canonicalPath);
+
+  if (topLevelSegment === 'workspace' || topLevelSegment === 'overview') {
+    return `/${orgSlug}/~/overview`;
+  }
+
+  if (topLevelSegment === 'compose') {
+    return `/${orgSlug}/~/posts`;
+  }
+
+  if (
+    topLevelSegment &&
+    ORG_ROOT_APP_PREFIXES.includes(
+      topLevelSegment as (typeof ORG_ROOT_APP_PREFIXES)[number],
+    )
+  ) {
+    return `/${orgSlug}/~${canonicalPath}`;
+  }
+
+  return `/${orgSlug}/~/overview`;
+}
 
 async function resolveCanonicalProtectedPath(
   pathname: string,
@@ -466,6 +523,13 @@ async function resolveCanonicalProtectedPath(
     }
 
     return { cookieValue, path: `/${slugs.orgSlug}/~${canonicalPath}` };
+  }
+
+  if (!slugs.brandSlug) {
+    return {
+      cookieValue,
+      path: createOrgScopedCanonicalPath(canonicalPath, slugs.orgSlug),
+    };
   }
 
   if (
@@ -525,10 +589,10 @@ const clerkProxy = isCloudConnected
               req,
             );
             if (resolution) {
-              const response = redirectPreservingSearch(
-                req,
-                `/${resolution.slugs.orgSlug}/${resolution.slugs.brandSlug}/workspace/overview`,
-              );
+              const destination = resolution.slugs.brandSlug
+                ? `/${resolution.slugs.orgSlug}/${resolution.slugs.brandSlug}/workspace/overview`
+                : `/${resolution.slugs.orgSlug}/~/overview`;
+              const response = redirectPreservingSearch(req, destination);
               if (resolution.cookieValue) {
                 setSlugCookie(response, resolution.cookieValue);
               }
@@ -615,6 +679,13 @@ const clerkProxy = isCloudConnected
             : null;
 
           if (!resolved) {
+            if (
+              token &&
+              (await shouldRedirectSignedInUserToOnboarding(token))
+            ) {
+              return redirectPreservingSearch(req, ONBOARDING_PATH);
+            }
+
             return NextResponse.next();
           }
 
@@ -623,6 +694,14 @@ const clerkProxy = isCloudConnected
             setSlugCookie(response, resolved.cookieValue);
           }
           return response;
+        }
+
+        if (isScopedWorkspacePath(pathname)) {
+          const token = await session.getToken?.();
+
+          if (token && (await shouldRedirectSignedInUserToOnboarding(token))) {
+            return redirectPreservingSearch(req, ONBOARDING_PATH);
+          }
         }
 
         return NextResponse.next();

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -149,15 +149,15 @@ function isBareProtectedPath(pathname: string): boolean {
 function isScopedWorkspacePath(pathname: string): boolean {
   const parts = pathname.split('/').filter(Boolean);
 
-  if (parts.length === 0 || parts[0] === 'admin') {
+  // Only the org-root workspace scope (/:orgSlug/~/...) gates onboarding here.
+  // Brand-scoped (/:orgSlug/:brandSlug/...) and bare protected paths are
+  // handled by their own branches above, so matching them here would fire a
+  // redundant bootstrap fetch on every authenticated navigation.
+  if (parts.length < 2 || parts[0] === 'admin') {
     return false;
   }
 
-  if (parts.length === 1) {
-    return !isBareProtectedPath(pathname);
-  }
-
-  return !isBareProtectedPath(pathname);
+  return parts[1] === '~';
 }
 
 type WorkspaceSlugs = {

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -3,10 +3,19 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockSearchParams = new URLSearchParams();
+const appSwitcherSpy = vi.hoisted(() => vi.fn());
 
 vi.mock('@genfeedai/enums', () => ({
   ButtonSize: { ICON: 'icon' },
   ButtonVariant: { GHOST: 'ghost', UNSTYLED: 'unstyled' },
+}));
+
+vi.mock('@genfeedai/constants', () => ({
+  APP_ROUTES: {
+    WORKSPACE: {
+      OVERVIEW: '/workspace/overview',
+    },
+  },
 }));
 
 vi.mock('@hooks/navigation/use-org-url', () => ({
@@ -42,9 +51,15 @@ vi.mock('@ui/primitives/button', () => ({
 }));
 
 vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
-  AppSwitcher: ({ variant }: { variant?: string }) => (
-    <div data-testid="app-switcher">{variant}</div>
-  ),
+  AppSwitcher: (props: {
+    brandSlug?: string;
+    currentApp?: string;
+    orgSlug: string;
+    variant?: string;
+  }) => {
+    appSwitcherSpy(props);
+    return <div data-testid="app-switcher">{props.variant}</div>;
+  },
 }));
 
 vi.mock('@ui/topbars/credits-bar/TopbarCreditsBar', () => ({
@@ -83,6 +98,7 @@ const { default: AppProtectedTopbar } = await import('./AppProtectedTopbar');
 describe('AppProtectedTopbar', () => {
   beforeEach(() => {
     mockSearchParams = new URLSearchParams();
+    appSwitcherSpy.mockClear();
   });
 
   it('renders the section switcher before the right-side controls', () => {
@@ -96,6 +112,36 @@ describe('AppProtectedTopbar', () => {
       switcher.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it('does not inject the context brand into explicit org-scoped routes', () => {
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="workspace" />);
+
+    expect(appSwitcherSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandSlug: undefined,
+        currentApp: 'workspace',
+        orgSlug: 'acme',
+      }),
+    );
+  });
+
+  it('passes an explicit brand route through to the app switcher', () => {
+    render(
+      <AppProtectedTopbar
+        orgSlug="acme"
+        brandSlug="brand"
+        currentApp="workspace"
+      />,
+    );
+
+    expect(appSwitcherSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandSlug: 'brand',
+        currentApp: 'workspace',
+        orgSlug: 'acme',
+      }),
+    );
   });
 
   it('renders the cloud sync indicator beside the terminal dock control', () => {

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -28,17 +28,19 @@ function AppProtectedTopbarContent({
   brandSlug,
 }: TopbarProps = {}) {
   const searchParams = useSearchParams();
-  // useOrgUrl resolves the brand from the active-brand context when the route has
-  // no [brandSlug] (org-level `/:org/~/...` pages). Use the resolved values so the
-  // app switcher can still link into brand-scoped apps (Library/Posts/Studio/…)
-  // instead of falling back to `/:org/~/overview` and trapping the user there.
+  // Route props are authoritative. Only fall back to useOrgUrl when the shell
+  // is rendered without route context.
   const {
     href,
     brandSlug: resolvedBrandSlug,
     orgSlug: resolvedOrgSlug,
   } = useOrgUrl();
+  const explicitBrandSlug = brandSlug || undefined;
+  const hasExplicitOrgScope = Boolean(orgSlug);
   const effectiveOrgSlug = orgSlug || resolvedOrgSlug;
-  const effectiveBrandSlug = brandSlug || resolvedBrandSlug;
+  const effectiveBrandSlug = hasExplicitOrgScope
+    ? explicitBrandSlug
+    : (explicitBrandSlug ?? resolvedBrandSlug) || undefined;
 
   const taskId = searchParams.get('taskId');
   const taskTitle = searchParams.get('taskTitle');

--- a/packages/hooks/navigation/use-org-url/use-org-url.test.ts
+++ b/packages/hooks/navigation/use-org-url/use-org-url.test.ts
@@ -78,6 +78,18 @@ describe('useOrgUrl', () => {
     );
   });
 
+  it('keeps org-scoped routes brandless when a selected brand exists', () => {
+    mockUseParams.mockReturnValue({ orgSlug: 'genfeed-ai' });
+
+    const { result } = renderHook(() => useOrgUrl());
+
+    expect(result.current.orgSlug).toBe('genfeed-ai');
+    expect(result.current.brandSlug).toBe('');
+    expect(result.current.href('/library/ingredients')).toBe(
+      '/genfeed-ai/~/library/ingredients',
+    );
+  });
+
   it('falls back to org-scoped href when no active brand is available', () => {
     mockUseParams.mockReturnValue({ orgSlug: 'genfeed-ai' });
     mockBrandState.selectedBrand = null;

--- a/packages/hooks/navigation/use-org-url/use-org-url.ts
+++ b/packages/hooks/navigation/use-org-url/use-org-url.ts
@@ -36,8 +36,8 @@ function getBrandOrganizationSlug(brand: IBrand | null | undefined): string {
  * Central navigation utility for org-scoped URLs.
  *
  * Reads `orgSlug` and `brandSlug` from the current route params.
- * Falls back to the active brand slug from context when on org-level
- * pages where `[brandSlug]` is not in the URL (e.g. `/:orgSlug/~/settings`).
+ * Falls back to the active brand from context only when route params are
+ * unavailable. Org-level routes with `/:orgSlug/~/...` stay brandless.
  *
  * @example
  * ```tsx
@@ -51,14 +51,17 @@ export function useOrgUrl(): OrgUrlContext {
   const params = useParams<{ orgSlug: string; brandSlug: string }>();
   const { selectedBrand } = useBrand();
 
-  const orgSlug =
-    params.orgSlug ?? getBrandOrganizationSlug(selectedBrand) ?? '';
-  const brandSlug = params.brandSlug ?? selectedBrand?.slug ?? '';
+  const routeOrgSlug = typeof params.orgSlug === 'string' ? params.orgSlug : '';
+  const routeBrandSlug =
+    typeof params.brandSlug === 'string' ? params.brandSlug : '';
+
+  const orgSlug = routeOrgSlug || getBrandOrganizationSlug(selectedBrand);
+  const brandSlug = routeBrandSlug || (routeOrgSlug ? '' : selectedBrand?.slug);
 
   const orgHref = (path: string) => createOrganizationAppRoute(orgSlug, path);
 
   return {
-    brandSlug,
+    brandSlug: brandSlug ?? '',
     href: (path: string) =>
       brandSlug ? createBrandAppRoute(orgSlug, brandSlug, path) : orgHref(path),
     orgHref,

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -170,12 +170,30 @@ describe('AppSwitcher', () => {
       );
     });
 
-    it('links to org overview for studio when brandSlug is absent', () => {
+    it('links to org studio when brandSlug is absent', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
       expect(screen.getByRole('link', { name: 'Studio' })).toHaveAttribute(
         'href',
-        '/acme/~/overview',
+        '/acme/~/studio/image',
       );
+    });
+
+    it('routes brand apps to org views when brandSlug is absent', () => {
+      render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
+
+      for (const [label, href] of [
+        ['Library', '/acme/~/library'],
+        ['Posts', '/acme/~/posts'],
+        ['Studio', '/acme/~/studio/image'],
+        ['Workflows', '/acme/~/workflows'],
+        ['Editor', '/acme/~/editor'],
+        ['Write', '/acme/~/posts'],
+      ] as const) {
+        expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+          'href',
+          href,
+        );
+      }
     });
 
     it('links to correct route for workspace app', () => {

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -35,14 +35,14 @@ const CONTENT_APPS: AppSwitcherItemConfig[] = [
     id: 'library',
     label: 'Library',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/overview`,
+      brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/library`,
   },
   {
     icon: HiOutlineDocumentText,
     id: 'posts',
     label: 'Posts',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/posts` : `/${org}/~/overview`,
+      brand ? `/${org}/${brand}/posts` : `/${org}/~/posts`,
   },
 ];
 
@@ -65,28 +65,28 @@ const PLATFORM_APPS: AppSwitcherItemConfig[] = [
     id: 'studio',
     label: 'Studio',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/studio/image` : `/${org}/~/overview`,
+      brand ? `/${org}/${brand}/studio/image` : `/${org}/~/studio/image`,
   },
   {
     icon: HiOutlineChartBar,
     id: 'workflows',
     label: 'Workflows',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/workflows` : `/${org}/~/overview`,
+      brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
   },
   {
     icon: HiOutlinePencilSquare,
     id: 'editor',
     label: 'Editor',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/editor` : `/${org}/~/overview`,
+      brand ? `/${org}/${brand}/editor` : `/${org}/~/editor`,
   },
   {
     icon: HiOutlineRectangleGroup,
     id: 'compose',
     label: 'Write',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/compose/post` : `/${org}/~/overview`,
+      brand ? `/${org}/${brand}/compose/post` : `/${org}/~/posts`,
   },
   {
     icon: HiOutlineChartBarSquare,


### PR DESCRIPTION
## Summary

- Enforce the app-shell invariant that an org is required while brand/project selection is optional.
- Route org-without-brand sessions into org-root views instead of borrowing the selected brand or falling back to broken redirects.
- Redirect zero-project workspaces to onboarding so the default project creation flow can run.
- Add org-root app surfaces for library, posts/write, studio, workflows, and editor, including workflow/editor detail/new follow-on routes.

## Verification

- `bunx biome check --write ...`
- `bunx vitest run --config ./vitest.config.mts proxy.test.ts "app/(protected)/root-resolver-client.test.tsx" "app/(protected)/[orgSlug]/org-landing-content.test.tsx" src/components/shell/AppProtectedTopbar.test.tsx "app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx" "app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.test.tsx" "app/(protected)/[orgSlug]/[brandSlug]/editor/new/new-editor-project-page.test.tsx" --maxWorkers=2`
- `bunx vitest run --config packages/hooks/vitest.config.mts packages/hooks/navigation/use-org-url/use-org-url.test.ts`
- `bunx vitest run --config vitest.config.ts src/components/shell/app-switcher/AppSwitcher.test.tsx`
- `bunx tsc --noEmit -p apps/app/tsconfig.json`
- `bunx tsc --noEmit -p packages/hooks/tsconfig.json`

## Known Existing Issue

- `bunx tsc --noEmit -p packages/ui/tsconfig.json` still fails before this change due unresolved local package/build references (`@genfeedai/enums`, stale `packages/helpers/dist`, `packages/client/dist`).
