### PR TITLE
fix(app): render protected shell before bootstrap

### DIFF
--- a/apps/app/app/(protected)/layout.test.tsx
+++ b/apps/app/app/(protected)/layout.test.tsx
@@ -10,4 +10,14 @@ describe('app/(protected)/layout.tsx', () => {
     );
     expect(source).toContain('export ');
   });
+
+  it('does not block the protected shell on the server bootstrap payload', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'app/(protected)/layout.tsx'),
+      'utf8',
+    );
+
+    expect(source).not.toContain('loadProtectedBootstrap');
+    expect(source).toContain('initialBootstrap={null}');
+  });
 });

--- a/apps/app/app/(protected)/layout.tsx
+++ b/apps/app/app/(protected)/layout.tsx
@@ -1,12 +1,9 @@
 import ProtectedLayoutClient from '@app/(protected)/protected-layout-client';
-import { loadProtectedBootstrap } from '@app-server/protected-bootstrap.server';
 import type { LayoutProps } from '@props/layout/layout.props';
 
-export default async function ProtectedLayout({ children }: LayoutProps) {
-  const initialBootstrap = await loadProtectedBootstrap();
-
+export default function ProtectedLayout({ children }: LayoutProps) {
   return (
-    <ProtectedLayoutClient initialBootstrap={initialBootstrap}>
+    <ProtectedLayoutClient initialBootstrap={null}>
       {children}
     </ProtectedLayoutClient>
   );


### PR DESCRIPTION
## Summary
- Make the protected root layout render synchronously without awaiting the bootstrap payload.
- Keep client bootstrap/cache behavior by passing `initialBootstrap={null}` into the protected shell.
- Add a regression test that prevents the server layout from reintroducing blocking bootstrap work.

Closes #669

## Verification
- Not run locally per instruction; CI should run lint, type-check, unit/integration coverage, and e2e.