### PR TITLE
feat(app): add protected route loading coverage

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/research/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/research/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="minimal" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/~/chat/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/chat/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="minimal" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/~/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/~/overview/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/overview/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/admin/loading.tsx
+++ b/apps/app/app/(protected)/admin/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/protected-route-loading-coverage.test.tsx
+++ b/apps/app/app/(protected)/protected-route-loading-coverage.test.tsx
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const protectedLoadingRoutes = [
+  { route: 'loading.tsx', variant: 'minimal' },
+  { route: 'settings/loading.tsx', variant: 'grid' },
+  { route: 'admin/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/loading.tsx', variant: 'minimal' },
+  { route: '[orgSlug]/~/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/~/chat/loading.tsx', variant: 'minimal' },
+  { route: '[orgSlug]/~/overview/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/~/settings/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/analytics/loading.tsx', variant: 'grid' },
+  {
+    route: '[orgSlug]/[brandSlug]/analytics/overview/loading.tsx',
+    variant: 'grid',
+  },
+  { route: '[orgSlug]/[brandSlug]/compose/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/editor/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/library/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/orchestration/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/overview/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/posts/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/research/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/settings/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/studio/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/tasks/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/workflows/loading.tsx', variant: 'grid' },
+  { route: '[orgSlug]/[brandSlug]/workspace/loading.tsx', variant: 'grid' },
+] as const;
+
+describe('protected route loading coverage', () => {
+  it.each(protectedLoadingRoutes)('keeps $route skeleton-first', ({
+    route,
+    variant,
+  }) => {
+    const routePath = join(process.cwd(), 'app/(protected)', route);
+
+    expect(existsSync(routePath)).toBe(true);
+
+    const source = readFileSync(routePath, 'utf8');
+
+    expect(source).toContain(
+      "import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback'",
+    );
+    expect(source).toContain(`variant="${variant}"`);
+  });
+});

--- a/apps/app/app/(protected)/settings/loading.tsx
+++ b/apps/app/app/(protected)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}


### PR DESCRIPTION
## Summary
- Add route-level skeleton loading fallbacks for protected admin, org, brand, and hot brand section routes.
- Keep chat/org routes on the minimal fallback and data-heavy sections on the grid fallback.
- Add a source-level regression test enumerating protected loading coverage.

Closes #670

## Verification
- Not run locally per instruction; CI should run lint, type-check, unit/integration coverage, and e2e.