### PR TITLE
feat(app): prefetch navigation and cache CORS preflights

### DIFF
--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -25,7 +25,7 @@ import { TimeoutInterceptor } from '@api/interceptors/timeout.interceptor';
 import { createBullBoard } from '@bull-board/api';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
-import { getGenfeedCorsOrigins } from '@libs/config/cors.config';
+import { getGenfeedCorsOptions } from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
 import {
   buildBullMQConnection,
@@ -94,14 +94,12 @@ async function main() {
 
     docsService.setGptActionsSpec(gptActionsSpec);
 
-    app.enableCors({
-      credentials: true,
-      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-      origin: getGenfeedCorsOrigins({
+    app.enableCors(
+      getGenfeedCorsOptions({
         chromeExtensionId: configService.get('CHROME_EXTENSION_ID'),
         isDevelopment: nodeEnv === 'development',
       }),
-    });
+    );
 
     app.setGlobalPrefix('v1');
 

--- a/apps/server/files/src/main.ts
+++ b/apps/server/files/src/main.ts
@@ -14,6 +14,10 @@ import path from 'node:path';
 import { AppModule } from '@files/app.module';
 import { ConfigService } from '@files/config/config.service';
 import { IS_SELF_HOSTED } from '@genfeedai/config';
+import {
+  GENFEED_CORS_ALLOWED_METHODS,
+  GENFEED_CORS_PREFLIGHT_MAX_AGE_SECONDS,
+} from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
@@ -48,7 +52,8 @@ async function main() {
 
     app.enableCors({
       credentials: true,
-      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      maxAge: GENFEED_CORS_PREFLIGHT_MAX_AGE_SECONDS,
+      methods: GENFEED_CORS_ALLOWED_METHODS,
       origin: configService.get('GENFEEDAI_API_URL'),
     });
 

--- a/apps/server/mcp/src/main.ts
+++ b/apps/server/mcp/src/main.ts
@@ -4,7 +4,7 @@ import '@mcp/instrument';
 bootstrap({ app: 'mcp' });
 
 import process from 'node:process';
-import { getGenfeedCorsOrigins } from '@libs/config/cors.config';
+import { getGenfeedCorsOptions } from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
 import { AppModule } from '@mcp/app.module';
 import { ConfigService } from '@mcp/config/config.service';
@@ -39,15 +39,13 @@ async function main(): Promise<void> {
 
   const port = configService.get('PORT');
 
-  app.enableCors({
-    credentials: true,
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-    origin: getGenfeedCorsOrigins({
+  app.enableCors(
+    getGenfeedCorsOptions({
       additionalOrigins: ['https://mcp.genfeed.ai'],
       chromeExtensionId: configService.get('CHROME_EXTENSION_ID'),
       isDevelopment: configService.get('NODE_ENV') === 'development',
     }),
-  });
+  );
 
   const expressApp = app.getHttpAdapter().getInstance();
 

--- a/apps/server/notifications/src/main.ts
+++ b/apps/server/notifications/src/main.ts
@@ -7,8 +7,9 @@ import '@notifications/instrument';
 
 bootstrap({ app: 'notifications' });
 
+import process from 'node:process';
 import { RedisIoAdapter } from '@libs/adapters/redis-io.adapter';
-import { getGenfeedCorsOrigins } from '@libs/config/cors.config';
+import { getGenfeedCorsOptions } from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
@@ -44,14 +45,12 @@ async function main() {
     app.setGlobalPrefix('v1');
 
     // Enable CORS for API communication
-    app.enableCors({
-      credentials: true,
-      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-      origin: getGenfeedCorsOrigins({
+    app.enableCors(
+      getGenfeedCorsOptions({
         chromeExtensionId: configService.get('CHROME_EXTENSION_ID'),
         isDevelopment: configService.get('NODE_ENV') === 'development',
       }),
-    });
+    );
 
     await redisIoAdapter.connectToRedis();
     app.useWebSocketAdapter(redisIoAdapter);

--- a/packages/libs/config/cors.config.spec.ts
+++ b/packages/libs/config/cors.config.spec.ts
@@ -1,5 +1,8 @@
 import {
+  GENFEED_CORS_ALLOWED_METHODS,
+  GENFEED_CORS_PREFLIGHT_MAX_AGE_SECONDS,
   GENFEED_SUBDOMAINS,
+  getGenfeedCorsOptions,
   getGenfeedCorsOrigins,
 } from '@libs/config/cors.config';
 
@@ -228,6 +231,21 @@ describe('CORS Configuration', () => {
           false,
         );
       });
+    });
+  });
+
+  describe('getGenfeedCorsOptions', () => {
+    it('adds preflight caching to the shared service CORS options', () => {
+      const options = getGenfeedCorsOptions({
+        isDevelopment: false,
+      });
+
+      expect(options.credentials).toBe(true);
+      expect(options.methods).toBe(GENFEED_CORS_ALLOWED_METHODS);
+      expect(options.maxAge).toBe(GENFEED_CORS_PREFLIGHT_MAX_AGE_SECONDS);
+      expect(options.origin).toEqual(
+        getGenfeedCorsOrigins({ isDevelopment: false }),
+      );
     });
   });
 

--- a/packages/libs/config/cors.config.ts
+++ b/packages/libs/config/cors.config.ts
@@ -25,6 +25,16 @@ export interface CorsOriginConfig {
   additionalOrigins?: (string | RegExp)[];
 }
 
+export const GENFEED_CORS_ALLOWED_METHODS = 'GET,HEAD,PUT,PATCH,POST,DELETE';
+export const GENFEED_CORS_PREFLIGHT_MAX_AGE_SECONDS = 600;
+
+export interface GenfeedCorsOptions {
+  credentials: true;
+  maxAge: number;
+  methods: string;
+  origin: (string | RegExp)[];
+}
+
 /**
  * Get CORS origins configuration for Genfeed.ai services
  *
@@ -86,6 +96,17 @@ export function getGenfeedCorsOrigins(
   // Production without ID = no extension access (fail secure)
 
   return [...productionOrigins, ...additionalOrigins];
+}
+
+export function getGenfeedCorsOptions(
+  config: CorsOriginConfig,
+): GenfeedCorsOptions {
+  return {
+    credentials: true,
+    maxAge: GENFEED_CORS_PREFLIGHT_MAX_AGE_SECONDS,
+    methods: GENFEED_CORS_ALLOWED_METHODS,
+    origin: getGenfeedCorsOrigins(config),
+  };
 }
 
 /**

--- a/packages/ui/src/components/menus/item/MenuItem.tsx
+++ b/packages/ui/src/components/menus/item/MenuItem.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import { ButtonVariant, ComponentSize } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { MenuItemProps } from '@genfeedai/props/navigation/menu.props';
 import ComingSoonBadge from '@ui/badges/ComingSoonBadge';
 import Badge from '@ui/display/badge/Badge';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { Button } from '@ui/primitives/button';
 import { SimpleTooltip } from '@ui/primitives/tooltip';
 import Link from 'next/link';
@@ -23,6 +26,7 @@ export default function MenuItem({
 }: MenuItemProps) {
   const isIconVariant = variant === 'icon';
   const shouldRenderBadge = typeof badgeCount === 'number' && badgeCount > 0;
+  const prefetchHref = useNavigationPrefetch(href);
 
   // Determine layout: horizontal when expanded on desktop, vertical otherwise
   const isHorizontalLayout = isIconVariant && !isCollapsed;
@@ -167,6 +171,8 @@ export default function MenuItem({
       <Link
         href={href}
         onClick={onClick}
+        onFocus={prefetchHref}
+        onMouseEnter={prefetchHref}
         className={contentClasses}
         aria-label={accessibleLabel}
       >

--- a/packages/ui/src/components/menus/shared/DrillDownGroupRow.tsx
+++ b/packages/ui/src/components/menus/shared/DrillDownGroupRow.tsx
@@ -4,6 +4,7 @@ import { ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { Button } from '@ui/primitives/button';
 
 import Link from 'next/link';
@@ -28,6 +29,7 @@ export default function DrillDownGroupRow({
   onEnter: () => void;
 }) {
   const { push } = useRouter();
+  const prefetchDefaultHref = useNavigationPrefetch(defaultHref);
   const firstItem = group.items[0];
   const OutlineIcon =
     DRILL_DOWN_GROUP_ICON_OVERRIDES[
@@ -89,7 +91,13 @@ export default function DrillDownGroupRow({
 
   if (defaultHref) {
     return (
-      <Link href={defaultHref} onClick={handleLinkClick} className={rowClasses}>
+      <Link
+        href={defaultHref}
+        onClick={handleLinkClick}
+        onFocus={prefetchDefaultHref}
+        onMouseEnter={prefetchDefaultHref}
+        className={rowClasses}
+      >
         {content}
       </Link>
     );

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -7,6 +7,7 @@ import { EnvironmentService } from '@genfeedai/services/core/environment.service
 import MenuItem from '@ui/menus/item/MenuItem';
 import SidebarNested from '@ui/menus/sidebar-nested/SidebarNested';
 import WorkspaceSwitcher from '@ui/menus/workspace-switcher/WorkspaceSwitcher';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { Button } from '@ui/primitives/button';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -71,6 +72,10 @@ export default function MenuShared({
     renderAfterNavigation,
     renderFooterSlot,
   });
+  const resolvedBackHref = backHref
+    ? (prefixHref({ href: backHref }) ?? backHref)
+    : undefined;
+  const prefetchBackHref = useNavigationPrefetch(resolvedBackHref);
 
   const secondaryNavigationContent =
     secondaryItems.length > 0 ? (
@@ -114,7 +119,9 @@ export default function MenuShared({
       {backHref && (
         <div className="pb-1">
           <Link
-            href={prefixHref({ href: backHref }) ?? backHref}
+            href={resolvedBackHref ?? backHref}
+            onFocus={prefetchBackHref}
+            onMouseEnter={prefetchBackHref}
             className={cn(
               'group flex h-7 w-full items-center gap-2 rounded px-2.5 py-1 transition-colors duration-150',
               'text-foreground/72 hover:bg-foreground/[0.035] hover:text-foreground',

--- a/packages/ui/src/components/menus/shared/MenuSharedConversations.tsx
+++ b/packages/ui/src/components/menus/shared/MenuSharedConversations.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import { Kbd } from '@genfeedai/ui';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { HiPlus } from 'react-icons/hi2';
@@ -22,6 +23,8 @@ export default function MenuSharedConversations({
   newChatHref,
   onCollapsedChange,
 }: MenuSharedConversationsProps) {
+  const prefetchNewChatHref = useNavigationPrefetch(newChatHref);
+
   return (
     <div
       data-testid="sidebar-conversations-section"
@@ -47,6 +50,8 @@ export default function MenuSharedConversations({
         <div className="pb-1">
           <Link
             href={newChatHref}
+            onFocus={prefetchNewChatHref}
+            onMouseEnter={prefetchNewChatHref}
             className="group flex h-8 w-full items-center gap-3 rounded px-3 py-1.5 text-left text-foreground/72 transition-colors duration-150 cursor-pointer hover:bg-foreground/[0.035] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
           >
             <HiPlus className="size-4 text-foreground/42 group-hover:text-foreground/78" />

--- a/packages/ui/src/components/menus/shared/MenuSharedPrimaryAction.tsx
+++ b/packages/ui/src/components/menus/shared/MenuSharedPrimaryAction.tsx
@@ -5,6 +5,7 @@ import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interf
 import type { MenuShellConfig } from '@genfeedai/props/navigation/menu.props';
 import { Kbd } from '@genfeedai/ui';
 import MenuItem from '@ui/menus/item/MenuItem';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { Button } from '@ui/primitives/button';
 import Link from 'next/link';
 import { HiPlus } from 'react-icons/hi2';
@@ -28,14 +29,21 @@ export default function MenuSharedPrimaryAction({
   isActiveItem,
   handleLinkClick,
 }: MenuSharedPrimaryActionProps) {
+  const primaryActionHref = config.primaryAction?.href
+    ? (prefixHref(config.primaryAction) ?? config.primaryAction.href)
+    : undefined;
+  const prefetchPrimaryActionHref = useNavigationPrefetch(primaryActionHref);
+
   if (config.primaryAction) {
     return (
       <div className="px-3 pt-2 pb-1">
         {config.primaryAction.href ? (
           <Link
             data-testid="sidebar-primary-action"
-            href={prefixHref(config.primaryAction) ?? config.primaryAction.href}
+            href={primaryActionHref ?? config.primaryAction.href}
             onClick={handleLinkClick}
+            onFocus={prefetchPrimaryActionHref}
+            onMouseEnter={prefetchPrimaryActionHref}
             className="flex h-9 w-full items-center gap-3 rounded-md border border-border bg-background-secondary px-3 py-1.5 text-left text-xs font-semibold transition-colors hover:border-border-strong hover:bg-background-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             data-tone="accent"
           >

--- a/packages/ui/src/components/menus/sidebar-back-row/SidebarBackRow.tsx
+++ b/packages/ui/src/components/menus/sidebar-back-row/SidebarBackRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import Link from 'next/link';
 import { HiArrowLeft } from 'react-icons/hi2';
 
@@ -10,10 +11,14 @@ interface SidebarBackRowProps {
 }
 
 export default function SidebarBackRow({ label, href }: SidebarBackRowProps) {
+  const prefetchHref = useNavigationPrefetch(href);
+
   return (
     <div className="px-3 pt-2 pb-1 flex-shrink-0">
       <Link
         href={href}
+        onFocus={prefetchHref}
+        onMouseEnter={prefetchHref}
         className={cn(
           'flex w-full items-center gap-3 px-3 py-2.5 rounded-lg transition-colors duration-200 group',
           'text-foreground/80 hover:bg-foreground/[0.04]',

--- a/packages/ui/src/components/navigation/prefetch/navigation-prefetch-contract.test.ts
+++ b/packages/ui/src/components/navigation/prefetch/navigation-prefetch-contract.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const navigationSurfaces = [
+  'menus/item/MenuItem.tsx',
+  'menus/shared/DrillDownGroupRow.tsx',
+  'menus/shared/MenuShared.tsx',
+  'menus/shared/MenuSharedConversations.tsx',
+  'menus/shared/MenuSharedPrimaryAction.tsx',
+  'menus/sidebar-back-row/SidebarBackRow.tsx',
+  'navigation/tabs/Tabs.tsx',
+] as const;
+
+const componentsRoot = fileURLToPath(new URL('../../', import.meta.url));
+
+describe('navigation prefetch wiring', () => {
+  it.each(navigationSurfaces)('keeps %s wired to route prefetch', (surface) => {
+    const source = readFileSync(join(componentsRoot, surface), 'utf8');
+
+    expect(source).toContain('useNavigationPrefetch');
+    expect(source).toContain('onMouseEnter');
+    expect(source).toContain('onFocus');
+  });
+});

--- a/packages/ui/src/components/navigation/prefetch/useNavigationPrefetch.test.tsx
+++ b/packages/ui/src/components/navigation/prefetch/useNavigationPrefetch.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { prefetchMock } = vi.hoisted(() => ({
+  prefetchMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    prefetch: prefetchMock,
+  }),
+}));
+
+function PrefetchProbe({ href }: { href?: string }) {
+  const prefetchHref = useNavigationPrefetch(href);
+
+  return (
+    <button type="button" onFocus={prefetchHref} onMouseEnter={prefetchHref}>
+      Prefetch
+    </button>
+  );
+}
+
+describe('useNavigationPrefetch', () => {
+  beforeEach(() => {
+    prefetchMock.mockClear();
+  });
+
+  it('prefetches an internal route once on repeated interactions', () => {
+    render(<PrefetchProbe href="/acme/brand/posts" />);
+
+    const button = screen.getByRole('button', { name: 'Prefetch' });
+    fireEvent.mouseEnter(button);
+    fireEvent.focus(button);
+
+    expect(prefetchMock).toHaveBeenCalledTimes(1);
+    expect(prefetchMock).toHaveBeenCalledWith('/acme/brand/posts');
+  });
+
+  it('ignores external, hash-only, and protocol-relative hrefs', () => {
+    const { rerender } = render(<PrefetchProbe href="https://example.com" />);
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Prefetch' }));
+
+    rerender(<PrefetchProbe href="#section" />);
+    fireEvent.focus(screen.getByRole('button', { name: 'Prefetch' }));
+
+    rerender(<PrefetchProbe href="//example.com/path" />);
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Prefetch' }));
+
+    expect(prefetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/navigation/prefetch/useNavigationPrefetch.ts
+++ b/packages/ui/src/components/navigation/prefetch/useNavigationPrefetch.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useRef } from 'react';
+
+function isPrefetchableHref(href?: string): href is string {
+  if (!href || href.startsWith('#')) {
+    return false;
+  }
+
+  if (href.startsWith('/')) {
+    return !href.startsWith('//');
+  }
+
+  return false;
+}
+
+export function useNavigationPrefetch(href?: string) {
+  const router = useRouter();
+  const prefetchedHrefs = useRef(new Set<string>());
+
+  return useCallback(() => {
+    if (!isPrefetchableHref(href) || prefetchedHrefs.current.has(href)) {
+      return;
+    }
+
+    prefetchedHrefs.current.add(href);
+    router.prefetch(href);
+  }, [href, router]);
+}

--- a/packages/ui/src/components/navigation/tabs/Tabs.tsx
+++ b/packages/ui/src/components/navigation/tabs/Tabs.tsx
@@ -8,6 +8,7 @@ import type {
   TabsEnhancedProps,
   TabsItem,
 } from '@genfeedai/props/ui/navigation/tabs.props';
+import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { TabsList, Tabs as TabsRoot, TabsTrigger } from '@ui/primitives/tabs';
 import {
   getTabsListClassName,
@@ -43,6 +44,40 @@ function getRouteParts(href: string) {
     full: search ? `${path}?${search}` : path,
     path,
   };
+}
+
+function NavigationTabLink({
+  children,
+  isActive,
+  itemKey,
+  size,
+  tab,
+  variant,
+}: {
+  children: ReactNode;
+  isActive: boolean;
+  itemKey: string;
+  size: TabsEnhancedProps['size'];
+  tab: RouteTabItem;
+  variant: TabsEnhancedProps['variant'];
+}) {
+  const prefetchHref = useNavigationPrefetch(tab.href);
+
+  return (
+    <Link
+      key={itemKey}
+      href={tab.href}
+      aria-current={isActive ? 'page' : undefined}
+      data-size={size}
+      data-state={isActive ? 'active' : 'inactive'}
+      data-variant={variant}
+      onFocus={prefetchHref}
+      onMouseEnter={prefetchHref}
+      className={getTabsTriggerClassName()}
+    >
+      {children}
+    </Link>
+  );
 }
 
 function TabsContent({
@@ -224,17 +259,16 @@ function TabsContent({
             }
 
             return (
-              <Link
+              <NavigationTabLink
                 key={key}
-                href={tab.href}
-                aria-current={isActive ? 'page' : undefined}
-                data-size={size}
-                data-state={isActive ? 'active' : 'inactive'}
-                data-variant={variant}
-                className={getTabsTriggerClassName()}
+                itemKey={key}
+                isActive={isActive}
+                size={size}
+                tab={tab}
+                variant={variant}
               >
                 {content}
-              </Link>
+              </NavigationTabLink>
             );
           })}
         </div>


### PR DESCRIPTION
## Summary
- Add shared service CORS options with a 10-minute preflight max-age and wire API/MCP/notifications through it.
- Apply the shared CORS methods/max-age constants to the files service.
- Add an interaction-based route prefetch hook for internal navigation hrefs.
- Wire sidebar/menu links and route tabs to prefetch on hover/focus with dedupe and external URL guards.
- Add regression coverage for CORS options and navigation prefetch wiring.

Closes #672

## Verification
- Staged formatting/raw-html lint/secretlint ran via commit hook.
- Not run locally per instruction; CI should run lint, type-check, unit/integration coverage, and e2e.