### PR TITLE
feat(db): add app shell hot-path indexes

### DIFF
--- a/packages/prisma/prisma/hot-path-indexes.test.ts
+++ b/packages/prisma/prisma/hot-path-indexes.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const prismaDir = fileURLToPath(new URL('./', import.meta.url));
+const schemaSource = readFileSync(join(prismaDir, 'schema.prisma'), 'utf8');
+const migrationSource = readFileSync(
+  join(
+    prismaDir,
+    'migrations/20260618130000_add_app_shell_hot_path_indexes/migration.sql',
+  ),
+  'utf8',
+);
+
+const hotPathIndexes = [
+  'members_org_user_deleted_idx',
+  'brands_org_deleted_label_idx',
+  'posts_org_deleted_status_created_at_idx',
+  'posts_brand_deleted_status_created_at_idx',
+  'posts_brand_credential_deleted_created_at_idx',
+  'posts_brand_platform_deleted_created_at_idx',
+  'agent_runs_org_deleted_status_completed_at_idx',
+  'content_runs_org_brand_deleted_created_at_idx',
+  'content_runs_org_brand_deleted_status_created_at_idx',
+  'activities_deleted_created_at_idx',
+  'activities_org_deleted_created_at_idx',
+  'activities_brand_deleted_created_at_idx',
+  'activities_user_deleted_created_at_idx',
+  'batches_org_deleted_created_at_idx',
+  'batches_org_brand_deleted_created_at_idx',
+  'batches_org_deleted_status_created_at_idx',
+] as const;
+
+describe('app shell hot-path Prisma indexes', () => {
+  it.each(
+    hotPathIndexes,
+  )('keeps %s in schema and migration source', (indexName) => {
+    expect(schemaSource).toContain(`map: "${indexName}"`);
+    expect(migrationSource).toContain(`CREATE INDEX "${indexName}"`);
+  });
+});

--- a/packages/prisma/prisma/migrations/20260618130000_add_app_shell_hot_path_indexes/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618130000_add_app_shell_hot_path_indexes/migration.sql
@@ -1,0 +1,54 @@
+-- Cold protected bootstrap: non-admin membership check.
+CREATE INDEX "members_org_user_deleted_idx"
+ON "members"("organizationId", "userId", "isDeleted");
+
+-- Cold protected bootstrap: organization brand list ordered by label.
+CREATE INDEX "brands_org_deleted_label_idx"
+ON "brands"("organizationId", "isDeleted", "label");
+
+-- Posts list hot paths: tenant/status/platform filters with created-at ordering.
+CREATE INDEX "posts_org_deleted_status_created_at_idx"
+ON "posts"("organizationId", "isDeleted", "status", "createdAt" DESC);
+
+CREATE INDEX "posts_brand_deleted_status_created_at_idx"
+ON "posts"("brandId", "isDeleted", "status", "createdAt" DESC);
+
+CREATE INDEX "posts_brand_credential_deleted_created_at_idx"
+ON "posts"("brandId", "credentialId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX "posts_brand_platform_deleted_created_at_idx"
+ON "posts"("brandId", "platform", "isDeleted", "createdAt" DESC);
+
+-- Overview bootstrap: agent-run stats by status/completion window.
+CREATE INDEX "agent_runs_org_deleted_status_completed_at_idx"
+ON "agent_runs"("organizationId", "isDeleted", "status", "completedAt" DESC);
+
+-- Content run list/detail hot paths.
+CREATE INDEX "content_runs_org_brand_deleted_created_at_idx"
+ON "content_runs"("organizationId", "brandId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX "content_runs_org_brand_deleted_status_created_at_idx"
+ON "content_runs"("organizationId", "brandId", "isDeleted", "status", "createdAt" DESC);
+
+-- Activity feeds: deleted filter with created-at ordering at platform/org/brand/user scopes.
+CREATE INDEX "activities_deleted_created_at_idx"
+ON "activities"("isDeleted", "createdAt" DESC);
+
+CREATE INDEX "activities_org_deleted_created_at_idx"
+ON "activities"("organizationId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX "activities_brand_deleted_created_at_idx"
+ON "activities"("brandId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX "activities_user_deleted_created_at_idx"
+ON "activities"("userId", "isDeleted", "createdAt" DESC);
+
+-- Overview review inbox and batch lists.
+CREATE INDEX "batches_org_deleted_created_at_idx"
+ON "batches"("organizationId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX "batches_org_brand_deleted_created_at_idx"
+ON "batches"("organizationId", "brandId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX "batches_org_deleted_status_created_at_idx"
+ON "batches"("organizationId", "isDeleted", "status", "createdAt" DESC);

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -794,6 +794,7 @@ model Brand {
   bookmarks                  Bookmark[]
 
   @@index([isDefault])
+  @@index([organizationId, isDeleted, label], map: "brands_org_deleted_label_idx")
   @@map("brands")
 }
 
@@ -815,6 +816,7 @@ model Member {
   createdAt         DateTime     @default(now())
   updatedAt         DateTime     @updatedAt
 
+  @@index([organizationId, userId, isDeleted], map: "members_org_user_deleted_idx")
   @@map("members")
 }
 
@@ -1606,6 +1608,10 @@ model Post {
   @@index([isDeleted, nextScheduledDate, status])
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@index([brandId, isDeleted, createdAt(sort: Desc)])
+  @@index([organizationId, isDeleted, status, createdAt(sort: Desc)], map: "posts_org_deleted_status_created_at_idx")
+  @@index([brandId, isDeleted, status, createdAt(sort: Desc)], map: "posts_brand_deleted_status_created_at_idx")
+  @@index([brandId, credentialId, isDeleted, createdAt(sort: Desc)], map: "posts_brand_credential_deleted_created_at_idx")
+  @@index([brandId, platform, isDeleted, createdAt(sort: Desc)], map: "posts_brand_platform_deleted_created_at_idx")
   @@map("posts")
 }
 
@@ -2189,6 +2195,7 @@ model AgentRun {
   @@index([organizationId, isDeleted, createdAt(sort: Desc)])
   @@index([organizationId, isDeleted, status, createdAt(sort: Desc)])
   @@index([organizationId, threadId, isDeleted, createdAt(sort: Desc)])
+  @@index([organizationId, isDeleted, status, completedAt(sort: Desc)], map: "agent_runs_org_deleted_status_completed_at_idx")
   @@map("agent_runs")
 }
 
@@ -2519,6 +2526,8 @@ model ContentRun {
   contentPerformances ContentPerformance[]
   contentDrafts       ContentDraft[]
 
+  @@index([organizationId, brandId, isDeleted, createdAt(sort: Desc)], map: "content_runs_org_brand_deleted_created_at_idx")
+  @@index([organizationId, brandId, isDeleted, status, createdAt(sort: Desc)], map: "content_runs_org_brand_deleted_status_created_at_idx")
   @@map("content_runs")
 }
 
@@ -3018,6 +3027,10 @@ model Activity {
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
 
+  @@index([isDeleted, createdAt(sort: Desc)], map: "activities_deleted_created_at_idx")
+  @@index([organizationId, isDeleted, createdAt(sort: Desc)], map: "activities_org_deleted_created_at_idx")
+  @@index([brandId, isDeleted, createdAt(sort: Desc)], map: "activities_brand_deleted_created_at_idx")
+  @@index([userId, isDeleted, createdAt(sort: Desc)], map: "activities_user_deleted_created_at_idx")
   @@map("activities")
 }
 
@@ -3924,6 +3937,9 @@ model Batch {
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
 
+  @@index([organizationId, isDeleted, createdAt(sort: Desc)], map: "batches_org_deleted_created_at_idx")
+  @@index([organizationId, brandId, isDeleted, createdAt(sort: Desc)], map: "batches_org_brand_deleted_created_at_idx")
+  @@index([organizationId, isDeleted, status, createdAt(sort: Desc)], map: "batches_org_deleted_status_created_at_idx")
   @@map("batches")
 }
 


### PR DESCRIPTION
## Summary
- Add Prisma schema indexes and a matching PostgreSQL migration for cold protected bootstrap and overview/dashboard hot paths.
- Cover member access checks, organization brand lists, posts list filters, agent-run completion stats, content-run lists, activity feeds, and review inbox batch queries.
- Add a source-level regression test that keeps schema and migration index names in sync.

Closes #673

## Verification
- Staged formatting/secretlint ran via commit hook.
- Not run locally per instruction; CI should run Prisma validation/migrations, lint, type-check, unit/integration coverage, and e2e.