### PR TITLE
fix(app): restore body interaction after modal cleanup

### DIFF
--- a/packages/contexts/providers/global-modals/global-modals.provider.test.tsx
+++ b/packages/contexts/providers/global-modals/global-modals.provider.test.tsx
@@ -1,6 +1,9 @@
-import { GlobalModalsProvider } from '@providers/global-modals/global-modals.provider';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  GlobalModalsProvider,
+  useConfirmModal,
+} from './global-modals.provider';
 
 vi.mock('@clerk/nextjs', () => ({
   useUser: () => ({
@@ -17,11 +20,13 @@ vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
+  usePathname: () => '/workspace',
   useParams: () => ({ brandSlug: undefined, orgSlug: undefined }),
   useRouter: () => ({
     push: vi.fn(),
     refresh: vi.fn(),
   }),
+  useSearchParams: () => ({ toString: () => '' }),
 }));
 
 vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({
@@ -49,7 +54,49 @@ vi.mock('@ui/modals', () => ({
   ModalUpgradePrompt: () => null,
 }));
 
+function resetBodyState(): void {
+  document.body.removeAttribute('aria-hidden');
+  document.body.removeAttribute('inert');
+  document.body.removeAttribute('data-scroll-locked');
+  document.body.style.cssText = '';
+}
+
+function flushModalCleanup(): void {
+  act(() => {
+    vi.runOnlyPendingTimers();
+  });
+}
+
+function ConfirmHarness() {
+  const { closeConfirm, openConfirm } = useConfirmModal();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          openConfirm({
+            label: 'Delete asset',
+            message: 'This action cannot be undone.',
+            onConfirm: vi.fn(),
+          })
+        }
+      >
+        Open confirm
+      </button>
+      <button type="button" onClick={closeConfirm}>
+        Close confirm
+      </button>
+    </>
+  );
+}
+
 describe('GlobalModalsProvider', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    resetBodyState();
+  });
+
   it('should render without crashing', () => {
     render(
       <GlobalModalsProvider>
@@ -75,5 +122,46 @@ describe('GlobalModalsProvider', () => {
       </GlobalModalsProvider>,
     );
     expect(container).toBeTruthy();
+  });
+
+  it('cleans stale body interaction locks after the last global modal closes', () => {
+    vi.useFakeTimers();
+    render(
+      <GlobalModalsProvider>
+        <ConfirmHarness />
+      </GlobalModalsProvider>,
+    );
+    flushModalCleanup();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open confirm' }));
+    document.body.style.pointerEvents = 'none';
+    document.body.style.overflow = 'hidden';
+    document.body.setAttribute('data-scroll-locked', '1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close confirm' }));
+    flushModalCleanup();
+
+    expect(document.body.style.pointerEvents).toBe('');
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body).not.toHaveAttribute('data-scroll-locked');
+  });
+
+  it('cleans stale body interaction locks when the provider unmounts', () => {
+    vi.useFakeTimers();
+    const { unmount } = render(
+      <GlobalModalsProvider>
+        <div data-testid="provider-child" />
+      </GlobalModalsProvider>,
+    );
+    flushModalCleanup();
+
+    document.body.style.pointerEvents = 'none';
+    document.body.style.overflow = 'hidden';
+
+    unmount();
+    flushModalCleanup();
+
+    expect(document.body.style.pointerEvents).toBe('');
+    expect(document.body.style.overflow).toBe('');
   });
 });

--- a/packages/contexts/providers/global-modals/global-modals.provider.tsx
+++ b/packages/contexts/providers/global-modals/global-modals.provider.tsx
@@ -16,7 +16,18 @@ import type {
   ModalMetadataProps,
   ModalPromptProps,
 } from '@genfeedai/props/modals/modal.props';
-import { createContext, type ReactNode, use, useCallback } from 'react';
+import {
+  scheduleModalGlobalSideEffectCleanup,
+  useRouteModalGlobalSideEffectCleanup,
+} from '@ui/utils/modal-global-side-effects';
+import { usePathname, useSearchParams } from 'next/navigation';
+import {
+  createContext,
+  type ReactNode,
+  use,
+  useCallback,
+  useEffect,
+} from 'react';
 import GlobalModalsRenderer from './GlobalModalsRenderer';
 import { useGlobalModalsState } from './useGlobalModalsState';
 
@@ -388,6 +399,19 @@ export function GlobalModalsProvider({
   children,
 }: GlobalModalsProviderProps): ReactNode {
   const state = useGlobalModalsState();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const routeKey = `${pathname ?? ''}?${searchParams?.toString() ?? ''}`;
+
+  useRouteModalGlobalSideEffectCleanup(routeKey);
+
+  useEffect(() => {
+    if (state.hasOpenGlobalModal) {
+      return;
+    }
+
+    return scheduleModalGlobalSideEffectCleanup();
+  }, [state.hasOpenGlobalModal]);
 
   const contextValue: GlobalModalsContextValue = {
     closeBrandOverlay: state.closeBrandOverlay,

--- a/packages/contexts/providers/global-modals/useGlobalModalsState.ts
+++ b/packages/contexts/providers/global-modals/useGlobalModalsState.ts
@@ -153,6 +153,20 @@ export function useGlobalModalsState() {
   const [postRemixTrigger, setPostRemixTrigger] = useState(0);
 
   const publishIngredient = publishIngredients[0] ?? null;
+  const hasOpenGlobalModal =
+    publishIngredients.length > 0 ||
+    confirmQueue.length > 0 ||
+    uploadConfig != null ||
+    galleryConfig != null ||
+    ingredientOverlayData?.ingredient != null ||
+    exportConfig != null ||
+    credentialData != null ||
+    promptConfig != null ||
+    metadataConfig != null ||
+    brandOverlayData != null ||
+    postMetadataOverlayData?.post != null ||
+    generateIllustrationConfig != null ||
+    postRemixData != null;
 
   const openPostBatchModal = useCallback(
     (ingredient: IIngredient | IIngredient[]) => {
@@ -433,6 +447,7 @@ export function useGlobalModalsState() {
     handleBrandOverlayConfirm,
     handlePostConfirm,
     handlePostCreated,
+    hasOpenGlobalModal,
     ingredientOverlayData,
     ingredientOverlayTrigger,
     metadataConfig,

--- a/packages/ui/src/modals/compound/Modal.tsx
+++ b/packages/ui/src/modals/compound/Modal.tsx
@@ -11,6 +11,7 @@ import {
   useMemo,
 } from 'react';
 import { cn } from '../../lib/utils';
+import { useModalContentGlobalSideEffectCleanup } from '../../utils/modal-global-side-effects';
 
 /**
  * Compound Modal Component
@@ -106,6 +107,7 @@ function ModalContent({
   ...props
 }: ModalContentProps) {
   const modalContextValue = useMemo(() => ({ size }), [size]);
+  useModalContentGlobalSideEffectCleanup();
 
   return (
     <ModalPortal>

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -3,8 +3,6 @@ import {
   DialogClose as ShipDialogClose,
   DialogContent as ShipDialogContent,
   DialogDescription as ShipDialogDescription,
-  DialogFooter as ShipDialogFooter,
-  DialogHeader as ShipDialogHeader,
   DialogOverlay as ShipDialogOverlay,
   DialogPortal as ShipDialogPortal,
   DialogTitle as ShipDialogTitle,
@@ -13,6 +11,7 @@ import {
 import { X } from 'lucide-react';
 import type { ComponentPropsWithRef, HTMLAttributes } from 'react';
 import { cn } from '../lib/utils';
+import { useModalContentGlobalSideEffectCleanup } from '../utils/modal-global-side-effects';
 
 const Dialog = ShipDialog;
 
@@ -49,6 +48,8 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: DialogContentProps) {
+  useModalContentGlobalSideEffectCleanup();
+
   return (
     <ShipDialogContent
       ref={ref}

--- a/packages/ui/src/primitives/drawer.tsx
+++ b/packages/ui/src/primitives/drawer.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps, HTMLAttributes } from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 import { cn } from '../lib/utils';
+import { useModalContentGlobalSideEffectCleanup } from '../utils/modal-global-side-effects';
 
 const Drawer = ({
   shouldScaleBackground = true,
@@ -46,6 +47,8 @@ function DrawerContent({
 }: ComponentProps<typeof DrawerPrimitive.Content> & {
   ref?: React.Ref<React.ComponentRef<typeof DrawerPrimitive.Content>>;
 }) {
+  useModalContentGlobalSideEffectCleanup();
+
   return (
     <DrawerPortal>
       <DrawerOverlay />

--- a/packages/ui/src/primitives/sheet.tsx
+++ b/packages/ui/src/primitives/sheet.tsx
@@ -5,6 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { X } from 'lucide-react';
 import type { ComponentPropsWithRef, HTMLAttributes } from 'react';
 import { cn } from '../lib/utils';
+import { useModalContentGlobalSideEffectCleanup } from '../utils/modal-global-side-effects';
 
 const Sheet = SheetPrimitive.Root;
 
@@ -62,6 +63,8 @@ function SheetContent({
   children,
   ...props
 }: SheetContentProps) {
+  useModalContentGlobalSideEffectCleanup();
+
   return (
     <SheetPortal>
       <SheetOverlay />

--- a/packages/ui/src/utils/modal-global-side-effects.test.tsx
+++ b/packages/ui/src/utils/modal-global-side-effects.test.tsx
@@ -1,0 +1,81 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanupModalGlobalSideEffects,
+  hasActiveModalSurface,
+  useModalContentGlobalSideEffectCleanup,
+} from './modal-global-side-effects';
+
+function resetBodyState(): void {
+  document.body.removeAttribute('aria-hidden');
+  document.body.removeAttribute('inert');
+  document.body.removeAttribute('data-scroll-locked');
+  document.body.style.cssText = '';
+  document.body.replaceChildren();
+}
+
+function CleanupProbe() {
+  useModalContentGlobalSideEffectCleanup();
+  return null;
+}
+
+describe('modal global side effect cleanup', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    resetBodyState();
+  });
+
+  it('cleans stale body and app root locks when no modal is active', () => {
+    const appRoot = document.createElement('div');
+    document.body.appendChild(appRoot);
+
+    document.body.style.pointerEvents = 'none';
+    document.body.style.overflow = 'hidden';
+    document.body.style.touchAction = 'none';
+    document.body.style.paddingRight = '15px';
+    document.body.setAttribute('data-scroll-locked', '1');
+    appRoot.setAttribute('aria-hidden', 'true');
+    appRoot.setAttribute('inert', '');
+
+    cleanupModalGlobalSideEffects();
+
+    expect(document.body.style.pointerEvents).toBe('');
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.touchAction).toBe('');
+    expect(document.body.style.paddingRight).toBe('');
+    expect(document.body).not.toHaveAttribute('data-scroll-locked');
+    expect(appRoot).not.toHaveAttribute('aria-hidden');
+    expect(appRoot).not.toHaveAttribute('inert');
+  });
+
+  it('keeps global locks while an active dialog is still mounted', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('data-state', 'open');
+    document.body.appendChild(dialog);
+    document.body.style.pointerEvents = 'none';
+
+    expect(hasActiveModalSurface()).toBe(true);
+
+    cleanupModalGlobalSideEffects();
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  it('cleans stale locks after abrupt modal content unmount', () => {
+    vi.useFakeTimers();
+    const { unmount } = render(<CleanupProbe />);
+
+    document.body.style.pointerEvents = 'none';
+    document.body.style.overflow = 'hidden';
+
+    unmount();
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(document.body.style.pointerEvents).toBe('');
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/packages/ui/src/utils/modal-global-side-effects.ts
+++ b/packages/ui/src/utils/modal-global-side-effects.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const ACTIVE_MODAL_SELECTOR = [
+  '[role="dialog"][data-state="open"]',
+  '[role="alertdialog"][data-state="open"]',
+  '[data-vaul-drawer][data-state="open"]',
+].join(',');
+
+const NON_APP_BODY_CHILD_SELECTOR = [
+  'script',
+  'style',
+  'link',
+  'meta',
+  '[data-radix-portal]',
+].join(',');
+
+export interface ModalGlobalSideEffectCleanupOptions {
+  force?: boolean;
+}
+
+function getDocument(): Document | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return document;
+}
+
+export function hasActiveModalSurface(
+  doc: Document | null = getDocument(),
+): boolean {
+  if (!doc) {
+    return false;
+  }
+
+  return Boolean(doc.querySelector(ACTIVE_MODAL_SELECTOR));
+}
+
+function cleanupBodyScrollLock(body: HTMLElement): void {
+  if (body.style.pointerEvents === 'none') {
+    body.style.removeProperty('pointer-events');
+  }
+
+  if (body.style.overflow === 'hidden') {
+    body.style.removeProperty('overflow');
+  }
+
+  if (body.style.touchAction === 'none') {
+    body.style.removeProperty('touch-action');
+  }
+
+  if (body.hasAttribute('data-scroll-locked')) {
+    body.removeAttribute('data-scroll-locked');
+    body.style.removeProperty('padding-right');
+    body.style.removeProperty('margin-right');
+  }
+}
+
+function cleanupAppRootLocks(body: HTMLElement): void {
+  for (const child of Array.from(body.children)) {
+    if (!(child instanceof HTMLElement)) {
+      continue;
+    }
+
+    if (child.matches(NON_APP_BODY_CHILD_SELECTOR)) {
+      continue;
+    }
+
+    if (child.getAttribute('aria-hidden') === 'true') {
+      child.removeAttribute('aria-hidden');
+    }
+
+    if (child.hasAttribute('inert')) {
+      child.removeAttribute('inert');
+    }
+  }
+}
+
+export function cleanupModalGlobalSideEffects(
+  options: ModalGlobalSideEffectCleanupOptions = {},
+): void {
+  const doc = getDocument();
+
+  if (!doc?.body) {
+    return;
+  }
+
+  if (!options.force && hasActiveModalSurface(doc)) {
+    return;
+  }
+
+  doc.body.removeAttribute('aria-hidden');
+  doc.body.removeAttribute('inert');
+  cleanupBodyScrollLock(doc.body);
+  cleanupAppRootLocks(doc.body);
+}
+
+export function scheduleModalGlobalSideEffectCleanup(
+  options: ModalGlobalSideEffectCleanupOptions = {},
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  const timeout = window.setTimeout(() => {
+    cleanupModalGlobalSideEffects(options);
+  }, 0);
+
+  return () => {
+    window.clearTimeout(timeout);
+  };
+}
+
+export function useModalContentGlobalSideEffectCleanup(): void {
+  useEffect(
+    () => () => {
+      scheduleModalGlobalSideEffectCleanup();
+    },
+    [],
+  );
+}
+
+export function useRouteModalGlobalSideEffectCleanup(routeKey: string): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: routeKey is the deliberate route-change trigger for stale modal cleanup
+  useEffect(() => scheduleModalGlobalSideEffectCleanup(), [routeKey]);
+
+  useEffect(
+    () => () => {
+      scheduleModalGlobalSideEffectCleanup({ force: true });
+    },
+    [],
+  );
+}

--- a/playwright/e2e/tests/core/modal-cleanup.spec.ts
+++ b/playwright/e2e/tests/core/modal-cleanup.spec.ts
@@ -1,0 +1,78 @@
+import type { Page } from '@playwright/test';
+import { mockActiveSubscription } from '../../fixtures/api-mocks.fixture';
+import { expect, test } from '../../fixtures/auth.fixture';
+
+interface ModalGlobalState {
+  appRootAriaHidden: string | null;
+  appRootInert: boolean;
+  bodyOverflow: string;
+  bodyPointerEvents: string;
+  dataScrollLocked: string | null;
+}
+
+async function setStaleModalGlobalState(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const appRoot = Array.from(document.body.children).find(
+      (element) =>
+        !['SCRIPT', 'STYLE', 'LINK', 'META'].includes(element.tagName),
+    );
+
+    document.body.style.pointerEvents = 'none';
+    document.body.style.overflow = 'hidden';
+    document.body.setAttribute('data-scroll-locked', '1');
+    appRoot?.setAttribute('aria-hidden', 'true');
+    appRoot?.setAttribute('inert', '');
+  });
+}
+
+async function readModalGlobalState(page: Page): Promise<ModalGlobalState> {
+  return page.evaluate(() => {
+    const appRoot = Array.from(document.body.children).find(
+      (element) =>
+        !['SCRIPT', 'STYLE', 'LINK', 'META'].includes(element.tagName),
+    );
+
+    return {
+      appRootAriaHidden: appRoot?.getAttribute('aria-hidden') ?? null,
+      appRootInert: appRoot?.hasAttribute('inert') ?? false,
+      bodyOverflow: document.body.style.overflow,
+      bodyPointerEvents: document.body.style.pointerEvents,
+      dataScrollLocked: document.body.getAttribute('data-scroll-locked'),
+    };
+  });
+}
+
+test.describe('Modal cleanup', () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await mockActiveSubscription(authenticatedPage, {
+      credits: 1000,
+      plan: 'pro',
+    });
+  });
+
+  test('route transitions clear stale modal body and app-root locks', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/workspace/overview');
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Workspace Dashboard' }),
+    ).toBeVisible();
+
+    await setStaleModalGlobalState(authenticatedPage);
+
+    await authenticatedPage
+      .getByRole('link', { name: 'Open Inbox' })
+      .evaluate((link) => (link as HTMLAnchorElement).click());
+
+    await expect(authenticatedPage).toHaveURL(/\/workspace\/inbox\/unread/);
+    await expect
+      .poll(() => readModalGlobalState(authenticatedPage))
+      .toEqual({
+        appRootAriaHidden: null,
+        appRootInert: false,
+        bodyOverflow: '',
+        bodyPointerEvents: '',
+        dataScrollLocked: null,
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared modal global-side-effect cleanup utility for stale body pointer-events, scroll locks, inert, and app-root aria-hidden state.
- Wire cleanup into global modal close/unmount and protected route transitions.
- Harden shared modal/dialog/sheet/drawer content wrappers so abrupt content unmounts schedule defensive cleanup.

## Test Coverage
- Added focused component/unit coverage for stale body/app-root cleanup, active-dialog preservation, modal close cleanup, and provider unmount cleanup.
- Added Playwright coverage for stale modal global state being cleared during a protected route transition.

## Verification
- `bunx biome check --write packages/ui/src/utils/modal-global-side-effects.ts packages/ui/src/utils/modal-global-side-effects.test.tsx packages/ui/src/modals/compound/Modal.tsx packages/ui/src/primitives/dialog.tsx packages/ui/src/primitives/drawer.tsx packages/ui/src/primitives/sheet.tsx packages/contexts/providers/global-modals/useGlobalModalsState.ts packages/contexts/providers/global-modals/global-modals.provider.tsx packages/contexts/providers/global-modals/global-modals.provider.test.tsx playwright/e2e/tests/core/modal-cleanup.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- staged secret-pattern scan
- Commit hook ran staged Biome, raw HTML lint, and secretlint.
- Full unit/integration/e2e suites not run locally per instruction; CI should run them on the PR branch.

Closes #674
