### PR TITLE
fix(coverage): repair red unit tests on master (ui/contexts/app)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/published/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/published/page.test.tsx
@@ -1,0 +1,5 @@
+import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+
+assertSourceHasExport(
+  'app/(protected)/[orgSlug]/[brandSlug]/posts/published/page.tsx',
+);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/scheduled/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/scheduled/page.test.tsx
@@ -1,0 +1,5 @@
+import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+
+assertSourceHasExport(
+  'app/(protected)/[orgSlug]/[brandSlug]/posts/scheduled/page.tsx',
+);

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/models/models-layout-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/models/models-layout-content.test.tsx
@@ -6,6 +6,14 @@ import ModelsLayoutContent from './models-layout-content';
 vi.mock('next/navigation', () => ({
   useParams: () => ({ brandSlug: 'brand', orgSlug: 'acme' }),
   usePathname: () => '/acme/~/settings/models/all',
+  useRouter: () => ({
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+    push: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+  }),
   useSearchParams: () => new URLSearchParams(),
 }));
 

--- a/apps/vitest.config.mts
+++ b/apps/vitest.config.mts
@@ -607,6 +607,18 @@ export default defineConfig({
         find: /^@ui\/charts$/,
         replacement: path.resolve(repoRoot, './packages/ui/src/charts.ts'),
       },
+      // Non-component top-level UI sources live at packages/ui/src/<dir>, not
+      // under src/components. tsconfig resolves @ui/* against src/* first, so
+      // these must be enumerated ahead of the src/components catch-all below
+      // (matches the primitives/generators/dashboard/core/semantic entries).
+      {
+        find: /^@ui\/utils$/,
+        replacement: path.resolve(repoRoot, './packages/ui/src/utils'),
+      },
+      {
+        find: /^@ui\/utils\/(.*)$/,
+        replacement: path.resolve(repoRoot, './packages/ui/src/utils/$1'),
+      },
       {
         find: /^@ui\/components\/(.*)$/,
         replacement: path.resolve(repoRoot, './packages/ui/src/components/$1'),

--- a/packages/contexts/vitest.config.ts
+++ b/packages/contexts/vitest.config.ts
@@ -124,6 +124,18 @@ export default defineConfig({
       // src/components — must precede the broad '@ui' -> src/components mapping
       // so @ui/utils/* resolves the way tsconfig (@ui/* -> src/*) does.
       {
+        find: /^@ui\/primitives$/,
+        replacement: path.resolve(__dirname, '../ui/src/primitives'),
+      },
+      {
+        find: /^@ui\/primitives\/(.*)$/,
+        replacement: path.resolve(__dirname, '../ui/src/primitives/$1'),
+      },
+      {
+        find: /^@ui\/utils$/,
+        replacement: path.resolve(__dirname, '../ui/src/utils'),
+      },
+      {
         find: /^@ui\/utils\/(.*)$/,
         replacement: path.resolve(__dirname, '../ui/src/utils/$1'),
       },

--- a/packages/contexts/vitest.config.ts
+++ b/packages/contexts/vitest.config.ts
@@ -120,6 +120,13 @@ export default defineConfig({
         find: '@services',
         replacement: path.resolve(__dirname, '../services'),
       },
+      // Non-component UI sources live at packages/ui/src/<dir>, not under
+      // src/components — must precede the broad '@ui' -> src/components mapping
+      // so @ui/utils/* resolves the way tsconfig (@ui/* -> src/*) does.
+      {
+        find: /^@ui\/utils\/(.*)$/,
+        replacement: path.resolve(__dirname, '../ui/src/utils/$1'),
+      },
       {
         find: '@ui',
         replacement: path.resolve(__dirname, '../ui/src/components'),

--- a/packages/ui/src/components/loading/default/Loading.tsx
+++ b/packages/ui/src/components/loading/default/Loading.tsx
@@ -11,15 +11,15 @@ export default function Loading({
   const label = message ?? 'Loading';
 
   return (
-    <output
+    // Layout container only — the nested <Spinner> is the single status/live
+    // region (role=status + aria-label). Making this wrapper an <output> too
+    // produced two nested status regions with the same label.
+    <div
       className={cn(
         'flex items-center justify-center text-center',
         isFullSize ? 'min-h-screen' : 'min-h-[60vh]',
         className,
       )}
-      aria-busy="true"
-      aria-label={label}
-      aria-live="polite"
     >
       <div className="flex max-w-md flex-col items-center gap-4 px-6">
         <Spinner
@@ -31,6 +31,6 @@ export default function Loading({
           <span className="text-sm text-white/40">{message}</span>
         ) : null}
       </div>
-    </output>
+    </div>
   );
 }

--- a/packages/ui/src/components/navigation/prefetch/navigation-prefetch-contract.test.ts
+++ b/packages/ui/src/components/navigation/prefetch/navigation-prefetch-contract.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const navigationSurfaces = [
@@ -13,7 +12,11 @@ const navigationSurfaces = [
   'navigation/tabs/Tabs.tsx',
 ] as const;
 
-const componentsRoot = fileURLToPath(new URL('../../', import.meta.url));
+// Resolve from cwd (the package root under `cd packages/ui && vitest`) rather
+// than import.meta.url — under --coverage the module URL is not a file: URL,
+// so fileURLToPath() throws ERR_INVALID_URL_SCHEME. Mirrors the cwd-based
+// resolution used by the apps/app protected-pages source contract.
+const componentsRoot = join(process.cwd(), 'src/components');
 
 describe('navigation prefetch wiring', () => {
   it.each(navigationSurfaces)('keeps %s wired to route prefetch', (surface) => {

--- a/packages/ui/src/components/navigation/tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/navigation/tabs/Tabs.test.tsx
@@ -9,6 +9,14 @@ let mockSearch = '';
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
+  useRouter: () => ({
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+    push: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+  }),
   useSearchParams: () => ({
     toString: () => mockSearch,
   }),

--- a/packages/ui/src/components/prompt-bars/base/PromptBar.test.tsx
+++ b/packages/ui/src/components/prompt-bars/base/PromptBar.test.tsx
@@ -215,7 +215,12 @@ vi.mock('@ui-constants/media.constant', () => ({
   }),
 }));
 
-vi.mock('@genfeedai/constants', () => ({
+vi.mock('@genfeedai/constants', async (importOriginal) => ({
+  // Keep the real (pure) route helpers — createBrandAppRoute /
+  // createOrganizationAppRoute are used via useOrgUrl to build the exact
+  // brand-scoped routes these tests assert. Only the model-metadata lookups
+  // are overridden with deterministic test values.
+  ...(await importOriginal<typeof import('@genfeedai/constants')>()),
   getModelDefaultDuration: vi.fn().mockReturnValue(5),
   getModelDurations: vi.fn().mockReturnValue([5, 10]),
   getModelMaxOutputs: vi.fn().mockReturnValue(4),


### PR DESCRIPTION
## Why

The **Coverage** workflow has been red on `master`. The plumbing fix (#600) landed, but it exposed real, failing unit tests underneath. Root cause of *why nobody noticed*: unit tests are `workflow_call`-gated, so **normal PR CI never runs them** — only the nightly Coverage workflow does, and `master` silently accumulated red tests from recent feature PRs (#676–#681).

Empirical Coverage run on master (27817089809) failed with 8 jobs across `apps/app` (4 shards + merge), `packages/ui`, `packages/contexts`, and `apps/server/api`.

## What this fixes (4 independent root causes)

| Area | Cause | Fix |
|---|---|---|
| **`@ui/utils/*` unresolved** (dominant) | contexts + apps base vitest configs alias `@ui` only to `ui/src/components`, but non-component sources live at `ui/src/<dir>` and tsconfig resolves `@ui/*` against `src/*` **first**. `global-modals.provider` (#681) imports `@ui/utils/modal-global-side-effects`, cascading into every protected-layout test. | Added `@ui/utils` alias entries, mirroring the existing `primitives`/`charts`/`generators` entries. |
| **Tabs mock** | `next/navigation` mock missing `useRouter`, which `useNavigationPrefetch` (#679) now calls. | Added `useRouter` to the mock. |
| **PromptBar mock** | Test fully shadowed `@genfeedai/constants`, dropping the real `createBrandAppRoute`/`createOrganizationAppRoute` route helpers that `useOrgUrl` uses to build the asserted brand-scoped routes. | Switched to `importOriginal` — real (pure) route helpers, model lookups still stubbed. |
| **Loading double `role=status`** | `Loading` wrapped the shared `<Spinner>` in another `<output>`, producing two nested `role=status` regions with the same label. | Wrapper is now a plain layout `<div>`; the `<Spinner>` is the single status/live region. |
| **Missing nearby tests** | `posts/published` + `posts/scheduled` pages lacked the nearby page test the protected-pages source contract (#677) requires. | Added both, using the established `assertSourceHasExport` one-liner. |

## Verification

- `packages/ui` — 89 affected-file tests green (was 12 failing)
- `packages/contexts` — full suite 86 green
- `apps/app` — affected files (protected-layout, merged-node-types, source contract, 2 new page tests) 28 green
- `type-check`, `lint`, `biome` — all clean

## Out of scope (separate decision)

`apps/server/api` Coverage stays red on a **pre-existing branch-coverage threshold** (actual 42.92% < 50% global) — all 1112 api test files pass; this is a coverage-policy choice (lower the floor vs. invest in tests), not a broken test. Tracked separately.