### PR TITLE
fix(db): build app shell hot-path indexes CONCURRENTLY

### DIFF
--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -20,7 +20,8 @@
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "db:validate": "prisma validate",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "vitest run"
   },
   "version": "0.1.0"
 }

--- a/packages/prisma/prisma/hot-path-indexes.test.ts
+++ b/packages/prisma/prisma/hot-path-indexes.test.ts
@@ -37,6 +37,10 @@ describe('app shell hot-path Prisma indexes', () => {
     hotPathIndexes,
   )('keeps %s in schema and migration source', (indexName) => {
     expect(schemaSource).toContain(`map: "${indexName}"`);
-    expect(migrationSource).toContain(`CREATE INDEX "${indexName}"`);
+    // Built CONCURRENTLY so the deploy never ACCESS EXCLUSIVE-locks these hot
+    // tables. Guardrail: a plain `CREATE INDEX` regression must fail CI.
+    expect(migrationSource).toContain(
+      `CREATE INDEX CONCURRENTLY "${indexName}"`,
+    );
   });
 });

--- a/packages/prisma/prisma/migrations/20260618130000_add_app_shell_hot_path_indexes/migration.sql
+++ b/packages/prisma/prisma/migrations/20260618130000_add_app_shell_hot_path_indexes/migration.sql
@@ -1,54 +1,72 @@
+-- App shell hot-path indexes.
+--
+-- Built with CREATE INDEX CONCURRENTLY so the migration never takes an ACCESS
+-- EXCLUSIVE lock on hot tables (posts, agent_runs, activities, batches,
+-- content_runs) while each index builds — concurrent reads and writes keep
+-- running throughout. A plain CREATE INDEX would block all traffic on those
+-- tables for the duration of the build, which is unacceptable on a live deploy.
+--
+-- CONCURRENTLY must run outside a transaction block. Prisma 7.8.0+ executes each
+-- migration statement without wrapping the migration in a transaction (including
+-- shadow-database replay during `migrate dev`), so this is safe under both
+-- `prisma migrate deploy` (CI / prod) and `prisma migrate dev` (local).
+-- See prisma/prisma#14456 and the Prisma 7.8.0 release notes.
+--
+-- NOTE: if a CONCURRENTLY build fails midway it leaves an INVALID index of the
+-- same name and marks this migration failed. Resolution is to DROP the invalid
+-- index, then `prisma migrate resolve` + re-deploy — do not blindly re-run.
+
 -- Cold protected bootstrap: non-admin membership check.
-CREATE INDEX "members_org_user_deleted_idx"
+CREATE INDEX CONCURRENTLY "members_org_user_deleted_idx"
 ON "members"("organizationId", "userId", "isDeleted");
 
 -- Cold protected bootstrap: organization brand list ordered by label.
-CREATE INDEX "brands_org_deleted_label_idx"
+CREATE INDEX CONCURRENTLY "brands_org_deleted_label_idx"
 ON "brands"("organizationId", "isDeleted", "label");
 
 -- Posts list hot paths: tenant/status/platform filters with created-at ordering.
-CREATE INDEX "posts_org_deleted_status_created_at_idx"
+CREATE INDEX CONCURRENTLY "posts_org_deleted_status_created_at_idx"
 ON "posts"("organizationId", "isDeleted", "status", "createdAt" DESC);
 
-CREATE INDEX "posts_brand_deleted_status_created_at_idx"
+CREATE INDEX CONCURRENTLY "posts_brand_deleted_status_created_at_idx"
 ON "posts"("brandId", "isDeleted", "status", "createdAt" DESC);
 
-CREATE INDEX "posts_brand_credential_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "posts_brand_credential_deleted_created_at_idx"
 ON "posts"("brandId", "credentialId", "isDeleted", "createdAt" DESC);
 
-CREATE INDEX "posts_brand_platform_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "posts_brand_platform_deleted_created_at_idx"
 ON "posts"("brandId", "platform", "isDeleted", "createdAt" DESC);
 
 -- Overview bootstrap: agent-run stats by status/completion window.
-CREATE INDEX "agent_runs_org_deleted_status_completed_at_idx"
+CREATE INDEX CONCURRENTLY "agent_runs_org_deleted_status_completed_at_idx"
 ON "agent_runs"("organizationId", "isDeleted", "status", "completedAt" DESC);
 
 -- Content run list/detail hot paths.
-CREATE INDEX "content_runs_org_brand_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "content_runs_org_brand_deleted_created_at_idx"
 ON "content_runs"("organizationId", "brandId", "isDeleted", "createdAt" DESC);
 
-CREATE INDEX "content_runs_org_brand_deleted_status_created_at_idx"
+CREATE INDEX CONCURRENTLY "content_runs_org_brand_deleted_status_created_at_idx"
 ON "content_runs"("organizationId", "brandId", "isDeleted", "status", "createdAt" DESC);
 
 -- Activity feeds: deleted filter with created-at ordering at platform/org/brand/user scopes.
-CREATE INDEX "activities_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "activities_deleted_created_at_idx"
 ON "activities"("isDeleted", "createdAt" DESC);
 
-CREATE INDEX "activities_org_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "activities_org_deleted_created_at_idx"
 ON "activities"("organizationId", "isDeleted", "createdAt" DESC);
 
-CREATE INDEX "activities_brand_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "activities_brand_deleted_created_at_idx"
 ON "activities"("brandId", "isDeleted", "createdAt" DESC);
 
-CREATE INDEX "activities_user_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "activities_user_deleted_created_at_idx"
 ON "activities"("userId", "isDeleted", "createdAt" DESC);
 
 -- Overview review inbox and batch lists.
-CREATE INDEX "batches_org_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "batches_org_deleted_created_at_idx"
 ON "batches"("organizationId", "isDeleted", "createdAt" DESC);
 
-CREATE INDEX "batches_org_brand_deleted_created_at_idx"
+CREATE INDEX CONCURRENTLY "batches_org_brand_deleted_created_at_idx"
 ON "batches"("organizationId", "brandId", "isDeleted", "createdAt" DESC);
 
-CREATE INDEX "batches_org_deleted_status_created_at_idx"
+CREATE INDEX CONCURRENTLY "batches_org_deleted_status_created_at_idx"
 ON "batches"("organizationId", "isDeleted", "status", "createdAt" DESC);

--- a/packages/prisma/vitest.config.ts
+++ b/packages/prisma/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    // Schema/migration source-integrity guards (e.g. hot-path-indexes.test.ts)
+    // live next to the Prisma schema, not under src/.
+    include: ['prisma/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Why
#680 added 16 app-shell hot-path indexes using plain `CREATE INDEX`. On PostgreSQL that takes an **`ACCESS EXCLUSIVE` lock** on the target table for the entire build, blocking all reads and writes. On the hot tables here — `posts`, `agent_runs`, `activities`, `batches`, `content_runs` — that means a stalled app during the prod migrate. This is the release-blocker called out before cutting `v0.2.6`.

## What
- Convert all 16 indexes to `CREATE INDEX CONCURRENTLY` so reads/writes keep flowing while each index builds.
- `CONCURRENTLY` must run outside a transaction block. **Prisma 7.8.0** (our pinned version) executes migration statements without a transaction wrapper — including shadow-DB replay during `migrate dev` — so this is safe under both `migrate deploy` (CI/prod) and `migrate dev` (local). Refs [prisma/prisma#14456](https://github.com/prisma/prisma/issues/14456) and the [7.8.0 release notes](https://github.com/prisma/prisma/releases/tag/7.8.0).
- Wire `packages/prisma` into the vitest workspace — it shipped `hot-path-indexes.test.ts` but had **no vitest config or `test` script, so the guardrail never ran**. It now runs via `turbo run test` and asserts `CONCURRENTLY`, so a future plain `CREATE INDEX` regression fails CI.

## Safety notes
- Migration `20260618130000` has **not** been applied to staging or prod (last deploys predate the #680 merge), so editing it in place is checksum-safe; `v0.2.6` will be its first apply.
- No `IF NOT EXISTS`: a failed `CONCURRENTLY` build leaves an INVALID index and marks the migration failed (drop + `migrate resolve` + redeploy) — `IF NOT EXISTS` would silently mask that, so it's intentionally omitted. Header comment documents the recovery path.
- Schema unchanged (same end-state indexes); `prisma validate` passes.

## Test
- `@genfeedai/prisma:test` → 16/16 pass (guardrail now live in CI).