### PR TITLE
fix(ci): stop Codecov upload from reding the weekly coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v6
         if: always()
+        # Coverage is a best-effort weekly report, not a gate. Without a
+        # CODECOV_TOKEN (public repo / forks) the uploader exits non-zero even
+        # with fail_ci_if_error:false, which reds the job. Never let the upload
+        # fail the workflow.
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ${{ matrix.package }}/coverage
@@ -102,6 +107,11 @@ jobs:
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v6
         if: always()
+        # Coverage is a best-effort weekly report, not a gate. Without a
+        # CODECOV_TOKEN (public repo / forks) the uploader exits non-zero even
+        # with fail_ci_if_error:false, which reds the job. Never let the upload
+        # fail the workflow.
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: packages/hooks/coverage
@@ -184,6 +194,11 @@ jobs:
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v6
         if: always()
+        # Coverage is a best-effort weekly report, not a gate. Without a
+        # CODECOV_TOKEN (public repo / forks) the uploader exits non-zero even
+        # with fail_ci_if_error:false, which reds the job. Never let the upload
+        # fail the workflow.
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: apps/app/coverage
@@ -268,6 +283,11 @@ jobs:
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v6
         if: always()
+        # Coverage is a best-effort weekly report, not a gate. Without a
+        # CODECOV_TOKEN (public repo / forks) the uploader exits non-zero even
+        # with fail_ci_if_error:false, which reds the job. Never let the upload
+        # fail the workflow.
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: apps/server/api/coverage
@@ -330,6 +350,8 @@ jobs:
       - name: Report E2E coverage to Codecov (shard ${{ matrix.shard }})
         uses: codecov/codecov-action@v6
         if: always()
+        # Best-effort upload; never let a missing token / empty report red the job.
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: playwright-report/coverage/lcov.info


### PR DESCRIPTION
## Why
The **Coverage** workflow has failed every run since 2026-04-06. One root cause: with no `CODECOV_TOKEN` (this is a public repo; forks/scheduled runs have an empty token), the Codecov uploader finds zero report files and exits non-zero — and it does so **even though every step already sets `fail_ci_if_error: false`**, reding the upload jobs (`packages/*`, hooks, app-merge, api-merge, e2e).

## What
Mark all **5** `codecov/codecov-action@v6` steps `continue-on-error: true`. Coverage is a best-effort weekly report, not a gate, so a missing token or empty report must never fail the workflow.

## Scope (deliberately narrow)
This fixes only the **Codecov upload** failures. The Coverage workflow is **also** red for a separate reason — the `apps/app` and `apps/server/api` coverage shards exit 1 because some tests fail **only under `--coverage` instrumentation** (plain `vitest run` shards are green; there's no coverage threshold config). That needs local repro to diagnose (the blob reporter hides which tests) and is **intentionally out of scope here** — flagged for a follow-up. So this PR removes the upload-related red but does not by itself turn the whole workflow green.

## Risk
None to product code — CI-only, and only loosens a non-gating weekly report.