### PR TITLE
feat(app): library mood board canvas

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/moodboard/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/moodboard/layout.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import type { LayoutProps } from '@props/layout/layout.props';
+import FeatureGate from '@ui/guards/feature/FeatureGate';
+
+export default function MoodboardLayout({ children }: LayoutProps) {
+  return <FeatureGate flagKey="moodboard">{children}</FeatureGate>;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/moodboard/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/moodboard/page.tsx
@@ -1,0 +1,21 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import { Suspense } from 'react';
+import MoodBoardCanvasClient from '@/features/moodboard/MoodBoardCanvasClient';
+
+export const generateMetadata = createPageMetadata('Mood Board');
+
+function MoodBoardPageFallback() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center bg-background text-sm text-foreground/60">
+      Loading mood board…
+    </div>
+  );
+}
+
+export default function LibraryMoodboardPage() {
+  return (
+    <Suspense fallback={<MoodBoardPageFallback />}>
+      <MoodBoardCanvasClient />
+    </Suspense>
+  );
+}

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -111,6 +111,7 @@ function AppLayoutWithDynamicMenu({
     isFocusedOnboardingRoute,
     isLibraryLandingRoute,
     isLibraryRoute,
+    isMoodboardRoute,
     isOrgRoute,
     isPromptBarRoute,
     isSettingsRoute,
@@ -158,7 +159,7 @@ function AppLayoutWithDynamicMenu({
   );
 
   const menuComponent = useMemo(() => {
-    if (isFocusedOnboardingRoute || isEditorCanvasRoute) {
+    if (isFocusedOnboardingRoute || isEditorCanvasRoute || isMoodboardRoute) {
       return undefined;
     }
 
@@ -208,6 +209,7 @@ function AppLayoutWithDynamicMenu({
     isEditorRoute,
     isFocusedOnboardingRoute,
     isLibraryRoute,
+    isMoodboardRoute,
     isOrgRoute,
     isSettingsRoute,
     isStudioRoute,
@@ -225,7 +227,7 @@ function AppLayoutWithDynamicMenu({
   ]);
 
   const topbarComponent =
-    isEditorCanvasRoute || isFocusedOnboardingRoute
+    isEditorCanvasRoute || isFocusedOnboardingRoute || isMoodboardRoute
       ? undefined
       : isAdminRoute
         ? AdminTopbar
@@ -255,7 +257,7 @@ function AppLayoutWithDynamicMenu({
     </>
   );
 
-  if (isEditorCanvasRoute) {
+  if (isEditorCanvasRoute || isMoodboardRoute) {
     return (
       <CommandPaletteProvider>
         <CommandPaletteInitializer />

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -142,6 +142,7 @@ export function useAppProtectedLayout(
   const hasSecondaryTopbar =
     !isAdminRoute && pathname.startsWith(APP_ROUTE_PREFIXES.STUDIO);
   const isEditorCanvasRoute = isProtectedEditorCanvasRoute(pathname);
+  const isMoodboardRoute = pathname === APP_ROUTES.LIBRARY.MOODBOARD;
   const isWorkflowsRoute =
     pathname.startsWith(APP_ROUTE_PREFIXES.WORKFLOWS) ||
     pathname.startsWith(APP_ROUTE_PREFIXES.ORCHESTRATION);
@@ -167,7 +168,10 @@ export function useAppProtectedLayout(
                   : 'workspace';
 
   const shouldMountAgentPanel =
-    isTerminalDockAvailable() && !isEditorCanvasRoute && !isConversationRoute;
+    isTerminalDockAvailable() &&
+    !isEditorCanvasRoute &&
+    !isMoodboardRoute &&
+    !isConversationRoute;
   const shouldInitAgentApiService =
     shouldMountAgentPanel || isConversationRoute;
 
@@ -490,6 +494,7 @@ export function useAppProtectedLayout(
     isFocusedOnboardingRoute,
     isLibraryLandingRoute,
     isLibraryRoute,
+    isMoodboardRoute,
     isOrgRoute,
     isPromptBarRoute,
     isSettingsRoute,

--- a/apps/app/src/features/moodboard/MediaAssetNode.test.tsx
+++ b/apps/app/src/features/moodboard/MediaAssetNode.test.tsx
@@ -8,10 +8,12 @@ import { MediaAssetNode } from '@/features/moodboard/MediaAssetNode';
 import type { MediaAssetNodeProps } from '@/features/moodboard/moodboard.types';
 
 vi.mock('next/image', () => ({
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    // biome-ignore lint/a11y/useAltText: alt is forwarded via props
+  default: ({
+    alt = '',
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
     // biome-ignore lint/performance/noImgElement: test stub for next/image
-    <img {...props} />
+    <img alt={alt} {...props} />
   ),
 }));
 

--- a/apps/app/src/features/moodboard/MediaAssetNode.test.tsx
+++ b/apps/app/src/features/moodboard/MediaAssetNode.test.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom/vitest';
+import { IngredientCategory } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MediaAssetNode } from '@/features/moodboard/MediaAssetNode';
+import type { MediaAssetNodeProps } from '@/features/moodboard/moodboard.types';
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // biome-ignore lint/a11y/useAltText: alt is forwarded via props
+    // biome-ignore lint/performance/noImgElement: test stub for next/image
+    <img {...props} />
+  ),
+}));
+
+function renderNode(ingredient: IIngredient) {
+  const props = { data: { ingredient } } as unknown as MediaAssetNodeProps;
+  return render(<MediaAssetNode {...props} />);
+}
+
+describe('MediaAssetNode', () => {
+  it('renders an image asset from its ingredientUrl without a play badge', () => {
+    renderNode({
+      id: 'img-1',
+      category: IngredientCategory.IMAGE,
+      ingredientUrl: 'https://cdn/img-1.png',
+      metadataLabel: 'A sunset',
+    } as IIngredient);
+
+    expect(screen.getByAltText('A sunset')).toHaveAttribute(
+      'src',
+      'https://cdn/img-1.png',
+    );
+    expect(screen.queryByTestId('moodboard-play-badge')).toBeNull();
+  });
+
+  it('renders a video poster with a play badge', () => {
+    renderNode({
+      id: 'vid-1',
+      category: IngredientCategory.VIDEO,
+      ingredientUrl: 'https://cdn/vid-1.mp4',
+      thumbnailUrl: 'https://cdn/vid-1.jpg',
+    } as IIngredient);
+
+    expect(screen.getByTestId('moodboard-play-badge')).toBeInTheDocument();
+    // Video tiles show the poster (thumbnailUrl), not the raw media.
+    expect(screen.getByAltText('asset')).toHaveAttribute(
+      'src',
+      'https://cdn/vid-1.jpg',
+    );
+  });
+});

--- a/apps/app/src/features/moodboard/MediaAssetNode.tsx
+++ b/apps/app/src/features/moodboard/MediaAssetNode.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { isVideoIngredient } from '@genfeedai/utils/media/ingredient-type.util';
+import { MOOD_BOARD_TILE_WIDTH } from '@genfeedai/utils/moodboard/mood-board-layout.util';
+import Image from 'next/image';
+import { memo } from 'react';
+import type { MediaAssetNodeProps } from '@/features/moodboard/moodboard.types';
+
+const DEFAULT_ASPECT_RATIO = 4 / 5;
+
+function resolveAspectRatio(width?: number, height?: number): number {
+  if (typeof width === 'number' && typeof height === 'number' && height > 0) {
+    return width / height;
+  }
+  return DEFAULT_ASPECT_RATIO;
+}
+
+function PlayBadge(): React.JSX.Element {
+  return (
+    <div
+      data-testid="moodboard-play-badge"
+      className="absolute right-2 bottom-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/55 text-white backdrop-blur-sm"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        className="h-4 w-4"
+        fill="currentColor"
+        role="img"
+        aria-label="Video"
+      >
+        <title>Video</title>
+        <path d="M8 5v14l11-7z" />
+      </svg>
+    </div>
+  );
+}
+
+function MediaAssetNodeComponent({
+  data,
+}: MediaAssetNodeProps): React.JSX.Element {
+  const { ingredient } = data;
+  const isVideo = isVideoIngredient(ingredient);
+
+  const aspectRatio = resolveAspectRatio(
+    ingredient.metadataWidth,
+    ingredient.metadataHeight,
+  );
+
+  // Videos show their poster on the board; playback happens in the lightbox.
+  const src = isVideo
+    ? ingredient.thumbnailUrl || ingredient.ingredientUrl
+    : ingredient.ingredientUrl || ingredient.thumbnailUrl;
+
+  return (
+    <div
+      className="group relative cursor-pointer overflow-hidden rounded-xl border border-white/[0.08] bg-card shadow-sm transition-colors hover:border-white/[0.18] gen-contact-sheet"
+      style={{ width: MOOD_BOARD_TILE_WIDTH, aspectRatio }}
+    >
+      {src ? (
+        <Image
+          unoptimized
+          src={src}
+          alt={ingredient.metadataLabel || ingredient.promptText || 'asset'}
+          fill
+          sizes={`${MOOD_BOARD_TILE_WIDTH}px`}
+          className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          draggable={false}
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-xs text-foreground/40">
+          No preview
+        </div>
+      )}
+      {isVideo && <PlayBadge />}
+    </div>
+  );
+}
+
+export const MediaAssetNode = memo(MediaAssetNodeComponent);

--- a/apps/app/src/features/moodboard/MoodBoardCanvas.tsx
+++ b/apps/app/src/features/moodboard/MoodBoardCanvas.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import MediaLightbox from '@ui/layouts/lightbox/MediaLightbox';
+import { Button } from '@ui/primitives/button';
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  type NodeChange,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useCallback, useMemo, useState } from 'react';
+import { HiArrowsPointingOut, HiXMark } from 'react-icons/hi2';
+import { MediaAssetNode } from '@/features/moodboard/MediaAssetNode';
+import type { MediaAssetFlowNode } from '@/features/moodboard/moodboard.types';
+
+const NODE_TYPES = { mediaAsset: MediaAssetNode };
+
+export interface MoodBoardCanvasProps {
+  assets: IIngredient[];
+  nodes: MediaAssetFlowNode[];
+  onNodesChange: (changes: NodeChange<MediaAssetFlowNode>[]) => void;
+  onNodeDragStop: () => void;
+  onClose: () => void;
+  isTruncated?: boolean;
+}
+
+function MoodBoardCanvasInner({
+  assets,
+  nodes,
+  onNodesChange,
+  onNodeDragStop,
+  onClose,
+  isTruncated,
+}: MoodBoardCanvasProps): React.JSX.Element {
+  const { fitView } = useReactFlow();
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const assetIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    assets.forEach((asset, index) => {
+      map.set(asset.id, index);
+    });
+    return map;
+  }, [assets]);
+
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: MediaAssetFlowNode) => {
+      const index = assetIndexById.get(node.id);
+      if (index !== undefined) {
+        setLightboxIndex(index);
+      }
+    },
+    [assetIndexById],
+  );
+
+  return (
+    <div className="relative h-full w-full gen-grain gen-vignette">
+      <ReactFlow<MediaAssetFlowNode>
+        nodes={nodes}
+        edges={[]}
+        nodeTypes={NODE_TYPES}
+        onNodesChange={onNodesChange}
+        onNodeDragStop={onNodeDragStop}
+        onNodeClick={handleNodeClick}
+        nodesConnectable={false}
+        nodesFocusable={false}
+        elementsSelectable
+        fitView
+        minZoom={0.05}
+        maxZoom={4}
+        proOptions={{ hideAttribution: true }}
+        onlyRenderVisibleElements={nodes.length > 50}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={24}
+          size={1}
+          color="rgba(255,255,255,0.06)"
+        />
+        <Controls showInteractive={false} />
+        <MiniMap nodeStrokeWidth={0} pannable zoomable />
+      </ReactFlow>
+
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-4">
+        <div className="pointer-events-auto gen-glass flex items-center gap-2 rounded-full px-3 py-1.5">
+          <span className="text-sm font-medium text-foreground/90">
+            Mood board
+          </span>
+          {isTruncated && (
+            <span className="text-xs text-foreground/55">
+              showing first {assets.length}
+            </span>
+          )}
+        </div>
+        <div className="pointer-events-auto flex items-center gap-2">
+          <Button
+            variant={ButtonVariant.GHOST}
+            icon={<HiArrowsPointingOut className="text-lg" />}
+            label="Fit"
+            onClick={() => fitView({ duration: 300 })}
+          />
+          <Button
+            variant={ButtonVariant.GHOST}
+            icon={<HiXMark className="text-lg" />}
+            label="Close"
+            onClick={onClose}
+          />
+        </div>
+      </div>
+
+      {lightboxIndex !== null && (
+        <MediaLightbox
+          items={assets}
+          startIndex={lightboxIndex}
+          open={lightboxIndex !== null}
+          onClose={() => setLightboxIndex(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function MoodBoardCanvas(
+  props: MoodBoardCanvasProps,
+): React.JSX.Element {
+  return (
+    <ReactFlowProvider>
+      <MoodBoardCanvasInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/apps/app/src/features/moodboard/MoodBoardCanvas.tsx
+++ b/apps/app/src/features/moodboard/MoodBoardCanvas.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { ButtonVariant } from '@genfeedai/enums';
-import type { IIngredient } from '@genfeedai/interfaces';
 import MediaLightbox from '@ui/layouts/lightbox/MediaLightbox';
 import { Button } from '@ui/primitives/button';
 import {
@@ -9,7 +8,6 @@ import {
   BackgroundVariant,
   Controls,
   MiniMap,
-  type NodeChange,
   ReactFlow,
   ReactFlowProvider,
   useReactFlow,
@@ -18,18 +16,12 @@ import '@xyflow/react/dist/style.css';
 import { useCallback, useMemo, useState } from 'react';
 import { HiArrowsPointingOut, HiXMark } from 'react-icons/hi2';
 import { MediaAssetNode } from '@/features/moodboard/MediaAssetNode';
-import type { MediaAssetFlowNode } from '@/features/moodboard/moodboard.types';
+import type {
+  MediaAssetFlowNode,
+  MoodBoardCanvasProps,
+} from '@/features/moodboard/moodboard.types';
 
 const NODE_TYPES = { mediaAsset: MediaAssetNode };
-
-export interface MoodBoardCanvasProps {
-  assets: IIngredient[];
-  nodes: MediaAssetFlowNode[];
-  onNodesChange: (changes: NodeChange<MediaAssetFlowNode>[]) => void;
-  onNodeDragStop: () => void;
-  onClose: () => void;
-  isTruncated?: boolean;
-}
 
 function MoodBoardCanvasInner({
   assets,
@@ -42,13 +34,10 @@ function MoodBoardCanvasInner({
   const { fitView } = useReactFlow();
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
-  const assetIndexById = useMemo(() => {
-    const map = new Map<string, number>();
-    assets.forEach((asset, index) => {
-      map.set(asset.id, index);
-    });
-    return map;
-  }, [assets]);
+  const assetIndexById = useMemo(
+    () => new Map(assets.map((asset, index) => [asset.id, index])),
+    [assets],
+  );
 
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: MediaAssetFlowNode) => {
@@ -115,14 +104,12 @@ function MoodBoardCanvasInner({
         </div>
       </div>
 
-      {lightboxIndex !== null && (
-        <MediaLightbox
-          items={assets}
-          startIndex={lightboxIndex}
-          open={lightboxIndex !== null}
-          onClose={() => setLightboxIndex(null)}
-        />
-      )}
+      <MediaLightbox
+        items={assets}
+        startIndex={lightboxIndex ?? 0}
+        open={lightboxIndex !== null}
+        onClose={() => setLightboxIndex(null)}
+      />
     </div>
   );
 }

--- a/apps/app/src/features/moodboard/MoodBoardCanvasClient.test.tsx
+++ b/apps/app/src/features/moodboard/MoodBoardCanvasClient.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom/vitest';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MoodBoardCanvasClient from '@/features/moodboard/MoodBoardCanvasClient';
+
+const assetsState = {
+  assets: [] as IIngredient[],
+  isLoading: false,
+  isTruncated: false,
+  refresh: vi.fn(),
+};
+const boardState = {
+  board: { id: 'board-1', layout: [] },
+  isLoading: false,
+  error: null,
+  refresh: vi.fn(),
+  save: vi.fn(),
+};
+
+vi.mock(
+  '@hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets',
+  () => ({ useBrandMediaAssets: () => assetsState }),
+);
+vi.mock('@hooks/data/content/use-mood-board/use-mood-board', () => ({
+  useMoodBoard: () => boardState,
+}));
+vi.mock('@/features/moodboard/use-mood-board-canvas', () => ({
+  useMoodBoardCanvas: () => ({
+    nodes: [],
+    onNodesChange: vi.fn(),
+    onNodeDragStop: vi.fn(),
+  }),
+}));
+vi.mock('@/features/moodboard/MoodBoardCanvas', () => ({
+  default: ({ assets }: { assets: IIngredient[] }) => (
+    <div data-testid="canvas">{assets.length} assets</div>
+  ),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  useParams: () => ({ orgSlug: 'org', brandSlug: 'brand' }),
+}));
+
+describe('MoodBoardCanvasClient', () => {
+  beforeEach(() => {
+    assetsState.assets = [];
+    assetsState.isLoading = false;
+    boardState.isLoading = false;
+  });
+
+  it('shows a loading message while assets load', () => {
+    assetsState.isLoading = true;
+    render(<MoodBoardCanvasClient />);
+    expect(screen.getByText(/Gathering your assets/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state with no assets', () => {
+    render(<MoodBoardCanvasClient />);
+    expect(screen.getByText(/No assets to arrange yet/i)).toBeInTheDocument();
+  });
+
+  it('renders the canvas once assets are available', () => {
+    assetsState.assets = [
+      { id: 'a' } as IIngredient,
+      { id: 'b' } as IIngredient,
+    ];
+    render(<MoodBoardCanvasClient />);
+    expect(screen.getByTestId('canvas')).toHaveTextContent('2 assets');
+  });
+});

--- a/apps/app/src/features/moodboard/MoodBoardCanvasClient.tsx
+++ b/apps/app/src/features/moodboard/MoodBoardCanvasClient.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import type { IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+import { useMoodBoard } from '@hooks/data/content/use-mood-board/use-mood-board';
+import { useBrandMediaAssets } from '@hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets';
+import { Button } from '@ui/primitives/button';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
+import MoodBoardCanvas from '@/features/moodboard/MoodBoardCanvas';
+import { useMoodBoardCanvas } from '@/features/moodboard/use-mood-board-canvas';
+
+function CanvasMessage({
+  title,
+  children,
+}: {
+  title: string;
+  children?: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-background gen-grain gen-vignette">
+      <p className="text-base font-medium text-foreground/85">{title}</p>
+      {children}
+    </div>
+  );
+}
+
+export default function MoodBoardCanvasClient(): React.JSX.Element {
+  const router = useRouter();
+  const params = useParams<{ orgSlug: string; brandSlug: string }>();
+
+  const {
+    assets,
+    isLoading: isAssetsLoading,
+    isTruncated,
+  } = useBrandMediaAssets();
+  const { board, isLoading: isBoardLoading, save } = useMoodBoard();
+
+  const savedLayout = useMemo<IMoodBoardLayoutItem[]>(
+    () => board?.layout ?? [],
+    [board?.layout],
+  );
+
+  const handlePersist = useCallback(
+    (layout: IMoodBoardLayoutItem[]) => {
+      void save(layout);
+    },
+    [save],
+  );
+
+  const { nodes, onNodesChange, onNodeDragStop } = useMoodBoardCanvas({
+    assets,
+    savedLayout,
+    onPersist: handlePersist,
+  });
+
+  const handleClose = useCallback(() => {
+    const { orgSlug, brandSlug } = params;
+    if (orgSlug && brandSlug) {
+      router.push(`/${orgSlug}/${brandSlug}/library/images`);
+      return;
+    }
+    router.back();
+  }, [params, router]);
+
+  if (isAssetsLoading || isBoardLoading) {
+    return <CanvasMessage title="Gathering your assets…" />;
+  }
+
+  if (assets.length === 0) {
+    return (
+      <CanvasMessage title="No assets to arrange yet">
+        <Button
+          variant={ButtonVariant.OUTLINE}
+          label="Back to library"
+          onClick={handleClose}
+        />
+      </CanvasMessage>
+    );
+  }
+
+  return (
+    <div className="h-screen w-full">
+      <MoodBoardCanvas
+        assets={assets}
+        nodes={nodes}
+        onNodesChange={onNodesChange}
+        onNodeDragStop={onNodeDragStop}
+        onClose={handleClose}
+        isTruncated={isTruncated}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/features/moodboard/MoodBoardCanvasClient.tsx
+++ b/apps/app/src/features/moodboard/MoodBoardCanvasClient.tsx
@@ -8,15 +8,13 @@ import { Button } from '@ui/primitives/button';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 import MoodBoardCanvas from '@/features/moodboard/MoodBoardCanvas';
+import type { CanvasMessageProps } from '@/features/moodboard/moodboard.types';
 import { useMoodBoardCanvas } from '@/features/moodboard/use-mood-board-canvas';
 
 function CanvasMessage({
   title,
   children,
-}: {
-  title: string;
-  children?: React.ReactNode;
-}): React.JSX.Element {
+}: CanvasMessageProps): React.JSX.Element {
   return (
     <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-background gen-grain gen-vignette">
       <p className="text-base font-medium text-foreground/85">{title}</p>

--- a/apps/app/src/features/moodboard/moodboard.types.ts
+++ b/apps/app/src/features/moodboard/moodboard.types.ts
@@ -1,0 +1,10 @@
+import type { IIngredient } from '@genfeedai/interfaces';
+import type { Node, NodeProps } from '@xyflow/react';
+
+export interface MediaAssetNodeData extends Record<string, unknown> {
+  ingredient: IIngredient;
+}
+
+export type MediaAssetFlowNode = Node<MediaAssetNodeData, 'mediaAsset'>;
+
+export type MediaAssetNodeProps = NodeProps<MediaAssetFlowNode>;

--- a/apps/app/src/features/moodboard/moodboard.types.ts
+++ b/apps/app/src/features/moodboard/moodboard.types.ts
@@ -1,5 +1,6 @@
-import type { IIngredient } from '@genfeedai/interfaces';
-import type { Node, NodeProps } from '@xyflow/react';
+import type { IIngredient, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+import type { Node, NodeChange, NodeProps } from '@xyflow/react';
+import type { ReactNode } from 'react';
 
 export interface MediaAssetNodeData extends Record<string, unknown> {
   ingredient: IIngredient;
@@ -8,3 +9,29 @@ export interface MediaAssetNodeData extends Record<string, unknown> {
 export type MediaAssetFlowNode = Node<MediaAssetNodeData, 'mediaAsset'>;
 
 export type MediaAssetNodeProps = NodeProps<MediaAssetFlowNode>;
+
+export interface MoodBoardCanvasProps {
+  assets: IIngredient[];
+  nodes: MediaAssetFlowNode[];
+  onNodesChange: (changes: NodeChange<MediaAssetFlowNode>[]) => void;
+  onNodeDragStop: () => void;
+  onClose: () => void;
+  isTruncated?: boolean;
+}
+
+export interface UseMoodBoardCanvasParams {
+  assets: IIngredient[];
+  savedLayout: IMoodBoardLayoutItem[];
+  onPersist: (layout: IMoodBoardLayoutItem[]) => void;
+}
+
+export interface UseMoodBoardCanvasResult {
+  nodes: MediaAssetFlowNode[];
+  onNodesChange: (changes: NodeChange<MediaAssetFlowNode>[]) => void;
+  onNodeDragStop: () => void;
+}
+
+export interface CanvasMessageProps {
+  title: string;
+  children?: ReactNode;
+}

--- a/apps/app/src/features/moodboard/use-mood-board-canvas.test.ts
+++ b/apps/app/src/features/moodboard/use-mood-board-canvas.test.ts
@@ -1,0 +1,88 @@
+import type { IIngredient, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MOOD_BOARD_AUTOSAVE_DEBOUNCE_MS,
+  useMoodBoardCanvas,
+} from '@/features/moodboard/use-mood-board-canvas';
+
+function asset(id: string): IIngredient {
+  return { id, isDeleted: false } as IIngredient;
+}
+
+// Stable references: the hydration effect keys on assets/savedLayout identity,
+// so inline arrays would re-fire it every render (mirrors real useState/useMemo
+// inputs from the consumer).
+const EMPTY_LAYOUT: IMoodBoardLayoutItem[] = [];
+
+describe('useMoodBoardCanvas', () => {
+  // Only fake the timer functions the debounce uses; faking nextTick/Date as
+  // well leaves the vitest worker unable to terminate cleanly.
+  beforeEach(() =>
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] }),
+  );
+  afterEach(() => vi.useRealTimers());
+
+  it('hydrates one node per asset', () => {
+    const assets = [asset('a'), asset('b')];
+    const { result } = renderHook(() =>
+      useMoodBoardCanvas({
+        assets,
+        savedLayout: EMPTY_LAYOUT,
+        onPersist: vi.fn(),
+      }),
+    );
+
+    expect(result.current.nodes).toHaveLength(2);
+    expect(result.current.nodes[0]).toMatchObject({
+      id: 'a',
+      type: 'mediaAsset',
+    });
+  });
+
+  it('persists the moved layout once after the debounce window', () => {
+    const assets = [asset('a')];
+    const onPersist = vi.fn();
+    const { result } = renderHook(() =>
+      useMoodBoardCanvas({ assets, savedLayout: EMPTY_LAYOUT, onPersist }),
+    );
+
+    act(() => {
+      result.current.onNodesChange([
+        { id: 'a', type: 'position', position: { x: 50, y: 60 } },
+      ]);
+      result.current.onNodeDragStop();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(MOOD_BOARD_AUTOSAVE_DEBOUNCE_MS - 1);
+    });
+    expect(onPersist).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onPersist).toHaveBeenCalledTimes(1);
+    expect(onPersist).toHaveBeenCalledWith([
+      { assetId: 'a', position: { x: 50, y: 60 } },
+    ]);
+  });
+
+  it('coalesces rapid drags into a single persist', () => {
+    const assets = [asset('a')];
+    const onPersist = vi.fn();
+    const { result } = renderHook(() =>
+      useMoodBoardCanvas({ assets, savedLayout: EMPTY_LAYOUT, onPersist }),
+    );
+
+    act(() => {
+      result.current.onNodeDragStop();
+      vi.advanceTimersByTime(500);
+      result.current.onNodeDragStop();
+      vi.advanceTimersByTime(MOOD_BOARD_AUTOSAVE_DEBOUNCE_MS);
+    });
+
+    expect(onPersist).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/features/moodboard/use-mood-board-canvas.ts
+++ b/apps/app/src/features/moodboard/use-mood-board-canvas.ts
@@ -1,28 +1,19 @@
 'use client';
 
-import type { IIngredient, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
 import {
   mergeMoodBoardLayout,
   toMoodBoardLayout,
 } from '@genfeedai/utils/moodboard/mood-board-layout.util';
 import { applyNodeChanges, type NodeChange } from '@xyflow/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { MediaAssetFlowNode } from '@/features/moodboard/moodboard.types';
+import type {
+  MediaAssetFlowNode,
+  UseMoodBoardCanvasParams,
+  UseMoodBoardCanvasResult,
+} from '@/features/moodboard/moodboard.types';
 
 /** Matches the workflow canvas autosave cadence. */
 export const MOOD_BOARD_AUTOSAVE_DEBOUNCE_MS = 2000;
-
-interface UseMoodBoardCanvasParams {
-  assets: IIngredient[];
-  savedLayout: IMoodBoardLayoutItem[];
-  onPersist: (layout: IMoodBoardLayoutItem[]) => void;
-}
-
-interface UseMoodBoardCanvasResult {
-  nodes: MediaAssetFlowNode[];
-  onNodesChange: (changes: NodeChange<MediaAssetFlowNode>[]) => void;
-  onNodeDragStop: () => void;
-}
 
 /**
  * Owns the React Flow node state for the mood board: hydrates nodes from live

--- a/apps/app/src/features/moodboard/use-mood-board-canvas.ts
+++ b/apps/app/src/features/moodboard/use-mood-board-canvas.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import type { IIngredient, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+import {
+  mergeMoodBoardLayout,
+  toMoodBoardLayout,
+} from '@genfeedai/utils/moodboard/mood-board-layout.util';
+import { applyNodeChanges, type NodeChange } from '@xyflow/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MediaAssetFlowNode } from '@/features/moodboard/moodboard.types';
+
+/** Matches the workflow canvas autosave cadence. */
+export const MOOD_BOARD_AUTOSAVE_DEBOUNCE_MS = 2000;
+
+interface UseMoodBoardCanvasParams {
+  assets: IIngredient[];
+  savedLayout: IMoodBoardLayoutItem[];
+  onPersist: (layout: IMoodBoardLayoutItem[]) => void;
+}
+
+interface UseMoodBoardCanvasResult {
+  nodes: MediaAssetFlowNode[];
+  onNodesChange: (changes: NodeChange<MediaAssetFlowNode>[]) => void;
+  onNodeDragStop: () => void;
+}
+
+/**
+ * Owns the React Flow node state for the mood board: hydrates nodes from live
+ * assets merged with the saved layout, applies drag changes, and persists the
+ * arrangement (debounced) whenever a drag completes. Mirrors the workflow
+ * canvas's dirty-then-debounce autosave, minus the execution machinery.
+ */
+export function useMoodBoardCanvas({
+  assets,
+  savedLayout,
+  onPersist,
+}: UseMoodBoardCanvasParams): UseMoodBoardCanvasResult {
+  const [nodes, setNodes] = useState<MediaAssetFlowNode[]>([]);
+
+  const nodesRef = useRef<MediaAssetFlowNode[]>([]);
+  nodesRef.current = nodes;
+
+  const onPersistRef = useRef(onPersist);
+  onPersistRef.current = onPersist;
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const knownIds = useMemo(
+    () => new Set(assets.map((asset) => asset.id)),
+    [assets],
+  );
+
+  useEffect(() => {
+    const { seeds } = mergeMoodBoardLayout(assets, savedLayout);
+    setNodes(
+      seeds.map((seed) => ({
+        id: seed.assetId,
+        type: 'mediaAsset',
+        position: seed.position,
+        data: { ingredient: seed.ingredient },
+      })),
+    );
+  }, [assets, savedLayout]);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange<MediaAssetFlowNode>[]) => {
+      setNodes((current) => applyNodeChanges(changes, current));
+    },
+    [],
+  );
+
+  const onNodeDragStop = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = setTimeout(() => {
+      onPersistRef.current(toMoodBoardLayout(nodesRef.current, knownIds));
+    }, MOOD_BOARD_AUTOSAVE_DEBOUNCE_MS);
+  }, [knownIds]);
+
+  useEffect(
+    () => () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    },
+    [],
+  );
+
+  return { nodes, onNodeDragStop, onNodesChange };
+}

--- a/apps/server/api/src/app.module.ts
+++ b/apps/server/api/src/app.module.ts
@@ -63,6 +63,7 @@ import { LinksModule } from '@api/collections/links/links.module';
 import { MembersModule } from '@api/collections/members/members.module';
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
 import { ModelsModule } from '@api/collections/models/models.module';
+import { MoodBoardsModule } from '@api/collections/mood-boards/mood-boards.module';
 import { MusicsModule } from '@api/collections/musics/musics.module';
 import { NewslettersModule } from '@api/collections/newsletters/newsletters.module';
 import { OptimizersModule } from '@api/collections/optimizers/optimizers.module';
@@ -285,6 +286,7 @@ import { SentryModule } from '@sentry/nestjs/setup';
     MembersModule,
     MetadataModule,
     ModelsModule,
+    MoodBoardsModule,
     MusicsModule,
     NewslettersModule,
     OptimizersModule,

--- a/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.spec.ts
+++ b/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.spec.ts
@@ -1,0 +1,119 @@
+import { MoodBoardsController } from '@api/collections/mood-boards/controllers/mood-boards.controller';
+import { UpdateMoodBoardDto } from '@api/collections/mood-boards/dto/update-mood-board.dto';
+import { MoodBoardsService } from '@api/collections/mood-boards/services/mood-boards.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@genfeedai/serializers', () => ({
+  MoodBoardSerializer: {
+    serialize: vi.fn((data: unknown) => ({ data })),
+  },
+}));
+
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  returnNotFound: vi.fn((name: string, id: string) => ({
+    error: `${name}:${id}`,
+  })),
+  serializeSingle: vi.fn(
+    (_req: unknown, _serializer: unknown, data: unknown) => ({ data }),
+  ),
+}));
+
+const mockMoodBoard = {
+  brandId: 'brand-1',
+  createdAt: new Date(),
+  id: 'mb-1',
+  isDeleted: false,
+  layout: [],
+  metadata: null,
+  organizationId: 'org-1',
+  updatedAt: new Date(),
+};
+
+const mockRequest = {
+  headers: {},
+  protocol: 'http',
+  get: vi.fn().mockReturnValue('localhost'),
+};
+
+describe('MoodBoardsController', () => {
+  let controller: MoodBoardsController;
+  let service: vi.Mocked<MoodBoardsService>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const mockService = {
+      findOne: vi.fn(),
+      findOrCreateByBrand: vi.fn(),
+      patch: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MoodBoardsController],
+      providers: [
+        { provide: MoodBoardsService, useValue: mockService },
+        {
+          provide: LoggerService,
+          useValue: {
+            debug: vi.fn(),
+            error: vi.fn(),
+            log: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<MoodBoardsController>(MoodBoardsController);
+    service = module.get(MoodBoardsService) as vi.Mocked<MoodBoardsService>;
+  });
+
+  describe('findByBrand', () => {
+    it('returns serialized board for valid brandId', async () => {
+      service.findOrCreateByBrand.mockResolvedValueOnce(mockMoodBoard as never);
+
+      const result = await controller.findByBrand(
+        mockRequest as never,
+        'brand-1',
+      );
+
+      expect(service.findOrCreateByBrand).toHaveBeenCalledWith('brand-1');
+      expect(result).toBeDefined();
+    });
+
+    it('throws NotFoundException when brandId missing', async () => {
+      await expect(
+        controller.findByBrand(mockRequest as never, ''),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('patches board when found', async () => {
+      const dto: UpdateMoodBoardDto = { layout: [] };
+      service.findOne.mockResolvedValueOnce(mockMoodBoard as never);
+      service.patch.mockResolvedValueOnce(mockMoodBoard as never);
+
+      const result = await controller.update(mockRequest as never, 'mb-1', dto);
+
+      expect(service.patch).toHaveBeenCalledWith('mb-1', dto);
+      expect(result).toBeDefined();
+    });
+
+    it('returns not-found when board does not exist', async () => {
+      service.findOne.mockResolvedValueOnce(null);
+
+      const result = await controller.update(
+        mockRequest as never,
+        'missing-id',
+        {} as UpdateMoodBoardDto,
+      );
+
+      expect(result).toEqual({ error: 'MoodBoardsController:missing-id' });
+      expect(service.patch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.spec.ts
+++ b/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.spec.ts
@@ -6,6 +6,10 @@ import { NotFoundException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@api/helpers/utils/clerk/clerk.util', () => ({
+  getPublicMetadata: vi.fn(() => ({ organization: 'org-1' })),
+}));
+
 vi.mock('@genfeedai/serializers', () => ({
   MoodBoardSerializer: {
     serialize: vi.fn((data: unknown) => ({ data })),
@@ -92,13 +96,25 @@ describe('MoodBoardsController', () => {
   });
 
   describe('update', () => {
+    const mockUser = { publicMetadata: { organization: 'org-1' } } as never;
+
     it('patches board when found', async () => {
       const dto: UpdateMoodBoardDto = { layout: [] };
       service.findOne.mockResolvedValueOnce(mockMoodBoard as never);
       service.patch.mockResolvedValueOnce(mockMoodBoard as never);
 
-      const result = await controller.update(mockRequest as never, 'mb-1', dto);
+      const result = await controller.update(
+        mockRequest as never,
+        mockUser,
+        'mb-1',
+        dto,
+      );
 
+      expect(service.findOne).toHaveBeenCalledWith({
+        id: 'mb-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      });
       expect(service.patch).toHaveBeenCalledWith('mb-1', dto);
       expect(result).toBeDefined();
     });
@@ -108,6 +124,7 @@ describe('MoodBoardsController', () => {
 
       const result = await controller.update(
         mockRequest as never,
+        mockUser,
         'missing-id',
         {} as UpdateMoodBoardDto,
       );

--- a/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.ts
+++ b/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.ts
@@ -1,10 +1,13 @@
 import type { UpdateMoodBoardDto } from '@api/collections/mood-boards/dto/update-mood-board.dto';
 import { MoodBoardsService } from '@api/collections/mood-boards/services/mood-boards.service';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { getPublicMetadata } from '@api/helpers/utils/clerk/clerk.util';
 import {
   returnNotFound,
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
+import type { User } from '@clerk/backend';
 import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import { MoodBoardSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -46,10 +49,17 @@ export class MoodBoardsController {
   @Patch(':id')
   async update(
     @Req() request: Request,
+    @CurrentUser() user: User,
     @Param('id') id: string,
     @Body() dto: UpdateMoodBoardDto,
   ): Promise<JsonApiSingleResponse> {
-    const existing = await this.service.findOne({ id, isDeleted: false });
+    const { organization: organizationId } = getPublicMetadata(user);
+
+    const existing = await this.service.findOne({
+      id,
+      isDeleted: false,
+      organizationId,
+    });
 
     if (!existing) {
       return returnNotFound(this.constructorName, id);

--- a/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.ts
+++ b/apps/server/api/src/collections/mood-boards/controllers/mood-boards.controller.ts
@@ -1,0 +1,63 @@
+import type { UpdateMoodBoardDto } from '@api/collections/mood-boards/dto/update-mood-board.dto';
+import { MoodBoardsService } from '@api/collections/mood-boards/services/mood-boards.service';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import {
+  returnNotFound,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
+import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
+import { MoodBoardSerializer } from '@genfeedai/serializers';
+import { LoggerService } from '@libs/logger/logger.service';
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Patch,
+  Query,
+  Req,
+} from '@nestjs/common';
+import type { Request } from 'express';
+
+@AutoSwagger()
+@Controller('mood-boards')
+export class MoodBoardsController {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    readonly logger: LoggerService,
+    readonly service: MoodBoardsService,
+  ) {}
+
+  @Get()
+  async findByBrand(
+    @Req() request: Request,
+    @Query('brand') brandId: string,
+  ): Promise<JsonApiSingleResponse> {
+    if (!brandId) {
+      throw new NotFoundException('Query param `brand` is required');
+    }
+
+    const data = await this.service.findOrCreateByBrand(brandId);
+    return serializeSingle(request, MoodBoardSerializer, data);
+  }
+
+  @Patch(':id')
+  async update(
+    @Req() request: Request,
+    @Param('id') id: string,
+    @Body() dto: UpdateMoodBoardDto,
+  ): Promise<JsonApiSingleResponse> {
+    const existing = await this.service.findOne({ id, isDeleted: false });
+
+    if (!existing) {
+      return returnNotFound(this.constructorName, id);
+    }
+
+    const data = await this.service.patch(id, dto);
+    return data
+      ? serializeSingle(request, MoodBoardSerializer, data)
+      : returnNotFound(this.constructorName, id);
+  }
+}

--- a/apps/server/api/src/collections/mood-boards/dto/create-mood-board.dto.ts
+++ b/apps/server/api/src/collections/mood-boards/dto/create-mood-board.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+export class MoodBoardLayoutItemPositionDto {
+  @IsNumber()
+  @ApiProperty({ description: 'X coordinate on canvas' })
+  readonly x!: number;
+
+  @IsNumber()
+  @ApiProperty({ description: 'Y coordinate on canvas' })
+  readonly y!: number;
+}
+
+export class MoodBoardLayoutItemDto {
+  @IsString()
+  @ApiProperty({ description: 'Asset ID placed on the board' })
+  readonly assetId!: string;
+
+  @ValidateNested()
+  @Type(() => MoodBoardLayoutItemPositionDto)
+  @ApiProperty({
+    description: 'Position of the asset on the canvas',
+    type: MoodBoardLayoutItemPositionDto,
+  })
+  readonly position!: MoodBoardLayoutItemPositionDto;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({ description: 'Width of the asset tile', required: false })
+  readonly width?: number;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({ description: 'Z-index layer for stacking', required: false })
+  readonly z?: number;
+}
+
+export class CreateMoodBoardDto {
+  @IsString()
+  @ApiProperty({ description: 'Brand ID this mood board belongs to' })
+  readonly brandId!: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MoodBoardLayoutItemDto)
+  @IsOptional()
+  @ApiProperty({
+    description: 'Canvas layout items',
+    required: false,
+    type: [MoodBoardLayoutItemDto],
+  })
+  readonly layout?: MoodBoardLayoutItemDto[];
+
+  @IsObject()
+  @IsOptional()
+  @ApiProperty({ description: 'Additional metadata', required: false })
+  readonly metadata?: Record<string, unknown>;
+}

--- a/apps/server/api/src/collections/mood-boards/dto/update-mood-board.dto.ts
+++ b/apps/server/api/src/collections/mood-boards/dto/update-mood-board.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateMoodBoardDto } from './create-mood-board.dto';
+
+export class UpdateMoodBoardDto extends PartialType(CreateMoodBoardDto) {}

--- a/apps/server/api/src/collections/mood-boards/dto/update-mood-board.dto.ts
+++ b/apps/server/api/src/collections/mood-boards/dto/update-mood-board.dto.ts
@@ -1,4 +1,4 @@
+import { CreateMoodBoardDto } from '@api/collections/mood-boards/dto/create-mood-board.dto';
 import { PartialType } from '@nestjs/mapped-types';
-import { CreateMoodBoardDto } from './create-mood-board.dto';
 
 export class UpdateMoodBoardDto extends PartialType(CreateMoodBoardDto) {}

--- a/apps/server/api/src/collections/mood-boards/entities/mood-board.entity.ts
+++ b/apps/server/api/src/collections/mood-boards/entities/mood-board.entity.ts
@@ -1,0 +1,18 @@
+import type { MoodBoard } from '@genfeedai/prisma';
+
+export class MoodBoardEntity implements MoodBoard {
+  id!: string;
+  brandId!: string;
+  organizationId!: string;
+  layout!: MoodBoard['layout'];
+  metadata!: MoodBoard['metadata'];
+  isDeleted!: boolean;
+  createdAt!: Date;
+  updatedAt!: Date;
+
+  [key: string]: unknown;
+
+  constructor(partial: Partial<MoodBoard> = {}) {
+    Object.assign(this, partial);
+  }
+}

--- a/apps/server/api/src/collections/mood-boards/mood-boards.module.ts
+++ b/apps/server/api/src/collections/mood-boards/mood-boards.module.ts
@@ -1,0 +1,11 @@
+import { MoodBoardsController } from '@api/collections/mood-boards/controllers/mood-boards.controller';
+import { MoodBoardsService } from '@api/collections/mood-boards/services/mood-boards.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  controllers: [MoodBoardsController],
+  exports: [MoodBoardsService],
+  imports: [],
+  providers: [MoodBoardsService],
+})
+export class MoodBoardsModule {}

--- a/apps/server/api/src/collections/mood-boards/schemas/mood-board.schema.ts
+++ b/apps/server/api/src/collections/mood-boards/schemas/mood-board.schema.ts
@@ -1,0 +1,4 @@
+export type {
+  MoodBoard,
+  MoodBoard as MoodBoardDocument,
+} from '@genfeedai/prisma';

--- a/apps/server/api/src/collections/mood-boards/services/mood-boards.service.spec.ts
+++ b/apps/server/api/src/collections/mood-boards/services/mood-boards.service.spec.ts
@@ -1,0 +1,94 @@
+import { MoodBoardsService } from '@api/collections/mood-boards/services/mood-boards.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockMoodBoard = {
+  brandId: 'brand-1',
+  createdAt: new Date(),
+  id: 'mb-1',
+  isDeleted: false,
+  layout: [],
+  metadata: null,
+  organizationId: 'org-1',
+  updatedAt: new Date(),
+};
+
+const mockPrisma = {
+  brand: {
+    findFirst: vi.fn(),
+  },
+  moodBoard: {
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+};
+
+const mockLogger = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+};
+
+describe('MoodBoardsService', () => {
+  let service: MoodBoardsService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MoodBoardsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: LoggerService, useValue: mockLogger },
+      ],
+    }).compile();
+
+    service = module.get<MoodBoardsService>(MoodBoardsService);
+  });
+
+  describe('findOrCreateByBrand', () => {
+    it('returns existing board when found', async () => {
+      mockPrisma.moodBoard.findFirst.mockResolvedValueOnce(mockMoodBoard);
+
+      const result = await service.findOrCreateByBrand('brand-1');
+
+      expect(result).toEqual(mockMoodBoard);
+      expect(mockPrisma.moodBoard.create).not.toHaveBeenCalled();
+    });
+
+    it('creates board when none exists for brand', async () => {
+      const newBoard = { ...mockMoodBoard, id: 'mb-new' };
+      mockPrisma.moodBoard.findFirst.mockResolvedValueOnce(null);
+      mockPrisma.brand.findFirst.mockResolvedValueOnce({
+        organizationId: 'org-1',
+      });
+      mockPrisma.moodBoard.create.mockResolvedValueOnce(newBoard);
+
+      const result = await service.findOrCreateByBrand('brand-1');
+
+      expect(result).toEqual(newBoard);
+      expect(mockPrisma.moodBoard.create).toHaveBeenCalledWith({
+        data: {
+          brandId: 'brand-1',
+          layout: [],
+          organizationId: 'org-1',
+        },
+      });
+    });
+
+    it('throws NotFoundException when brand not found', async () => {
+      mockPrisma.moodBoard.findFirst.mockResolvedValueOnce(null);
+      mockPrisma.brand.findFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.findOrCreateByBrand('missing-brand'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/server/api/src/collections/mood-boards/services/mood-boards.service.spec.ts
+++ b/apps/server/api/src/collections/mood-boards/services/mood-boards.service.spec.ts
@@ -21,10 +21,9 @@ const mockPrisma = {
     findFirst: vi.fn(),
   },
   moodBoard: {
-    create: vi.fn(),
-    findFirst: vi.fn(),
     findMany: vi.fn(),
     update: vi.fn(),
+    upsert: vi.fn(),
   },
 };
 
@@ -53,37 +52,39 @@ describe('MoodBoardsService', () => {
   });
 
   describe('findOrCreateByBrand', () => {
-    it('returns existing board when found', async () => {
-      mockPrisma.moodBoard.findFirst.mockResolvedValueOnce(mockMoodBoard);
+    it('returns existing board via upsert when brand exists', async () => {
+      mockPrisma.brand.findFirst.mockResolvedValueOnce({
+        organizationId: 'org-1',
+      });
+      mockPrisma.moodBoard.upsert.mockResolvedValueOnce(mockMoodBoard);
 
       const result = await service.findOrCreateByBrand('brand-1');
 
       expect(result).toEqual(mockMoodBoard);
-      expect(mockPrisma.moodBoard.create).not.toHaveBeenCalled();
-    });
-
-    it('creates board when none exists for brand', async () => {
-      const newBoard = { ...mockMoodBoard, id: 'mb-new' };
-      mockPrisma.moodBoard.findFirst.mockResolvedValueOnce(null);
-      mockPrisma.brand.findFirst.mockResolvedValueOnce({
-        organizationId: 'org-1',
-      });
-      mockPrisma.moodBoard.create.mockResolvedValueOnce(newBoard);
-
-      const result = await service.findOrCreateByBrand('brand-1');
-
-      expect(result).toEqual(newBoard);
-      expect(mockPrisma.moodBoard.create).toHaveBeenCalledWith({
-        data: {
+      expect(mockPrisma.moodBoard.upsert).toHaveBeenCalledWith({
+        create: {
           brandId: 'brand-1',
           layout: [],
           organizationId: 'org-1',
         },
+        update: {},
+        where: { brandId: 'brand-1' },
       });
     });
 
+    it('creates board when none exists for brand', async () => {
+      const newBoard = { ...mockMoodBoard, id: 'mb-new' };
+      mockPrisma.brand.findFirst.mockResolvedValueOnce({
+        organizationId: 'org-1',
+      });
+      mockPrisma.moodBoard.upsert.mockResolvedValueOnce(newBoard);
+
+      const result = await service.findOrCreateByBrand('brand-1');
+
+      expect(result).toEqual(newBoard);
+    });
+
     it('throws NotFoundException when brand not found', async () => {
-      mockPrisma.moodBoard.findFirst.mockResolvedValueOnce(null);
       mockPrisma.brand.findFirst.mockResolvedValueOnce(null);
 
       await expect(

--- a/apps/server/api/src/collections/mood-boards/services/mood-boards.service.ts
+++ b/apps/server/api/src/collections/mood-boards/services/mood-boards.service.ts
@@ -1,0 +1,50 @@
+import type { CreateMoodBoardDto } from '@api/collections/mood-boards/dto/create-mood-board.dto';
+import type { UpdateMoodBoardDto } from '@api/collections/mood-boards/dto/update-mood-board.dto';
+import type { MoodBoardDocument } from '@api/collections/mood-boards/schemas/mood-board.schema';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { BaseService } from '@api/shared/services/base/base.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class MoodBoardsService extends BaseService<
+  MoodBoardDocument,
+  CreateMoodBoardDto,
+  UpdateMoodBoardDto
+> {
+  constructor(
+    public readonly prisma: PrismaService,
+    public readonly logger: LoggerService,
+  ) {
+    super(prisma, 'moodBoard', logger);
+  }
+
+  async findOrCreateByBrand(brandId: string): Promise<MoodBoardDocument> {
+    const existing = await this.prisma.moodBoard.findFirst({
+      where: { brandId, isDeleted: false },
+    });
+
+    if (existing) {
+      return existing as MoodBoardDocument;
+    }
+
+    const brand = await this.prisma.brand.findFirst({
+      select: { organizationId: true },
+      where: { id: brandId, isDeleted: false },
+    });
+
+    if (!brand) {
+      throw new NotFoundException(`Brand ${brandId} not found`);
+    }
+
+    const created = await this.prisma.moodBoard.create({
+      data: {
+        brandId,
+        layout: [],
+        organizationId: brand.organizationId,
+      },
+    });
+
+    return created as MoodBoardDocument;
+  }
+}

--- a/apps/server/api/src/collections/mood-boards/services/mood-boards.service.ts
+++ b/apps/server/api/src/collections/mood-boards/services/mood-boards.service.ts
@@ -20,14 +20,6 @@ export class MoodBoardsService extends BaseService<
   }
 
   async findOrCreateByBrand(brandId: string): Promise<MoodBoardDocument> {
-    const existing = await this.prisma.moodBoard.findFirst({
-      where: { brandId, isDeleted: false },
-    });
-
-    if (existing) {
-      return existing as MoodBoardDocument;
-    }
-
     const brand = await this.prisma.brand.findFirst({
       select: { organizationId: true },
       where: { id: brandId, isDeleted: false },
@@ -37,14 +29,16 @@ export class MoodBoardsService extends BaseService<
       throw new NotFoundException(`Brand ${brandId} not found`);
     }
 
-    const created = await this.prisma.moodBoard.create({
-      data: {
+    const record = await this.prisma.moodBoard.upsert({
+      create: {
         brandId,
         layout: [],
         organizationId: brand.organizationId,
       },
+      update: {},
+      where: { brandId },
     });
 
-    return created as MoodBoardDocument;
+    return record as MoodBoardDocument;
   }
 }

--- a/packages/client/src/models/content/index.ts
+++ b/packages/client/src/models/content/index.ts
@@ -3,6 +3,7 @@ export * from './caption.model';
 export * from './ingredient.model';
 export * from './knowledge-base.model';
 export * from './model.model';
+export * from './mood-board.model';
 export * from './newsletter.model';
 export * from './post.model';
 export * from './prompt.model';

--- a/packages/client/src/models/content/mood-board.model.test.ts
+++ b/packages/client/src/models/content/mood-board.model.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@genfeedai/client/models/base/base-entity.model', () => ({
+  BaseEntity: class BaseEntity {
+    public id?: string;
+    public isDeleted?: boolean;
+    public createdAt?: string;
+    public updatedAt?: string;
+    constructor(data: Record<string, unknown> = {}) {
+      Object.assign(this, data);
+    }
+  },
+}));
+
+vi.mock('@genfeedai/interfaces', () => ({}));
+
+import { MoodBoard } from './mood-board.model';
+
+describe('MoodBoard (client model)', () => {
+  it('constructs with empty data', () => {
+    const board = new MoodBoard();
+    expect(board).toBeDefined();
+  });
+
+  it('constructs with partial data', () => {
+    const board = new MoodBoard({ id: 'board-1', brandId: 'brand-1' });
+    expect(board.id).toBe('board-1');
+    expect(board.brandId).toBe('brand-1');
+  });
+
+  it('sets layout from partial', () => {
+    const layout = [{ assetId: 'asset-1', position: { x: 0, y: 0 } }];
+    const board = new MoodBoard({ layout });
+    expect(board.layout).toEqual(layout);
+  });
+});

--- a/packages/client/src/models/content/mood-board.model.ts
+++ b/packages/client/src/models/content/mood-board.model.ts
@@ -1,0 +1,13 @@
+import { BaseEntity } from '@genfeedai/client/models/base/base-entity.model';
+import type { IMoodBoard, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+
+export class MoodBoard extends BaseEntity implements IMoodBoard {
+  public declare brandId: string;
+  public declare organizationId: string;
+  public declare layout: IMoodBoardLayoutItem[];
+  public declare metadata?: Record<string, unknown>;
+
+  constructor(data: Partial<IMoodBoard> = {}) {
+    super(data);
+  }
+}

--- a/packages/constants/src/api.constant.ts
+++ b/packages/constants/src/api.constant.ts
@@ -39,6 +39,7 @@ export const API_ENDPOINTS = {
   MEMBERS: '/members',
   MODELS: '/models',
   MONITORED_ACCOUNTS: '/monitored-accounts',
+  MOOD_BOARDS: '/mood-boards',
   MOODS: '/elements/moods',
   NEWS: '/news',
   ONBOARDING: '/onboarding',

--- a/packages/constants/src/routes.constant.ts
+++ b/packages/constants/src/routes.constant.ts
@@ -99,6 +99,7 @@ export const APP_ROUTES = {
     GIFS: '/library/gifs',
     IMAGES: '/library/images',
     INGREDIENTS: '/library/ingredients',
+    MOODBOARD: '/library/moodboard',
     MUSIC: '/library/music',
     ROOT: '/library/ingredients',
     VIDEOS: '/library/videos',

--- a/packages/hooks/data/content/use-mood-board/index.ts
+++ b/packages/hooks/data/content/use-mood-board/index.ts
@@ -1,0 +1,1 @@
+export * from './use-mood-board';

--- a/packages/hooks/data/content/use-mood-board/use-mood-board.ts
+++ b/packages/hooks/data/content/use-mood-board/use-mood-board.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useAuth } from '@clerk/nextjs';
+import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
+import type { IMoodBoard, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+import { MoodBoardsService } from '@genfeedai/services/content/mood-boards.service';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+export function useMoodBoard() {
+  const { isSignedIn } = useAuth();
+  const { brandId } = useBrand();
+  const queryClient = useQueryClient();
+
+  const getMoodBoardsService = useAuthedService((token: string) =>
+    MoodBoardsService.getInstance(token),
+  );
+
+  const {
+    data: board,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<IMoodBoard | undefined>({
+    queryKey: ['mood-board', brandId],
+    queryFn: async () => {
+      if (!brandId) {
+        return undefined;
+      }
+      const service = await getMoodBoardsService();
+      return service.getByBrand(brandId) as Promise<IMoodBoard>;
+    },
+    enabled: !!isSignedIn && !!brandId,
+  });
+
+  const save = useCallback(
+    async (layout: IMoodBoardLayoutItem[]): Promise<void> => {
+      if (!board?.id) {
+        return;
+      }
+      const service = await getMoodBoardsService();
+      const updated = await service.patch(board.id, { layout });
+      if (updated) {
+        await queryClient.invalidateQueries({
+          queryKey: ['mood-board', brandId],
+        });
+      }
+    },
+    [board?.id, brandId, getMoodBoardsService, queryClient],
+  );
+
+  const refresh = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  return {
+    board,
+    error,
+    isLoading,
+    refresh,
+    save,
+  };
+}

--- a/packages/hooks/data/moodboard/use-brand-media-assets/index.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/index.ts
@@ -1,0 +1,1 @@
+export * from './use-brand-media-assets';

--- a/packages/hooks/data/moodboard/use-brand-media-assets/index.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/index.ts
@@ -1,1 +1,2 @@
 export * from './use-brand-media-assets';
+export * from './use-brand-media-assets.types';

--- a/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.test.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.test.ts
@@ -1,0 +1,87 @@
+import { IngredientCategory } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { useBrandMediaAssets } from '@hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const brandState = { brandId: 'brand-1' };
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => brandState,
+}));
+
+// useAuthedService(factory) -> getter() that resolves the factory with a token.
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: (factory: (token: string) => unknown) => () =>
+    Promise.resolve(factory('test-token')),
+}));
+
+function makeService(items: IIngredient[]) {
+  return { findAll: vi.fn().mockResolvedValue(items) };
+}
+
+const imageItem = {
+  id: 'img-1',
+  category: IngredientCategory.IMAGE,
+  ingredientUrl: 'https://cdn/img-1.png',
+} as IIngredient;
+const videoItem = {
+  id: 'vid-1',
+  category: IngredientCategory.VIDEO,
+  thumbnailUrl: 'https://cdn/vid-1.jpg',
+} as IIngredient;
+const gifItem = {
+  id: 'gif-1',
+  category: IngredientCategory.GIF,
+  ingredientUrl: 'https://cdn/gif-1.gif',
+} as IIngredient;
+const urllessImage = {
+  id: 'img-2',
+  category: IngredientCategory.IMAGE,
+} as IIngredient;
+
+vi.mock('@genfeedai/services/ingredients/images.service', () => ({
+  ImagesService: { getInstance: () => makeService([imageItem, urllessImage]) },
+}));
+vi.mock('@genfeedai/services/ingredients/videos.service', () => ({
+  VideosService: { getInstance: () => makeService([videoItem]) },
+}));
+vi.mock('@genfeedai/services/ingredients/gifs.service', () => ({
+  GIFsService: { getInstance: () => makeService([gifItem]) },
+}));
+vi.mock('@genfeedai/services/ingredients/avatars.service', () => ({
+  AvatarsService: { getInstance: () => makeService([]) },
+}));
+
+describe('useBrandMediaAssets', () => {
+  beforeEach(() => {
+    brandState.brandId = 'brand-1';
+    vi.clearAllMocks();
+  });
+
+  it('merges visual assets across all four types', async () => {
+    const { result } = renderHook(() => useBrandMediaAssets());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const ids = result.current.assets.map((asset) => asset.id).sort();
+    expect(ids).toEqual(['gif-1', 'img-1', 'vid-1']);
+  });
+
+  it('excludes assets without a displayable url', async () => {
+    const { result } = renderHook(() => useBrandMediaAssets());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.assets.find((a) => a.id === 'img-2')).toBeUndefined();
+  });
+
+  it('returns empty and stops loading when no brand is selected', async () => {
+    brandState.brandId = '';
+
+    const { result } = renderHook(() => useBrandMediaAssets());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.assets).toEqual([]);
+  });
+});

--- a/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.ts
@@ -13,6 +13,7 @@ import {
 } from '@genfeedai/utils/media/ingredient-type.util';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { UseBrandMediaAssetsResult } from './use-brand-media-assets.types';
 
 const PAGE_SIZE = 100;
 /** Safety cap so a huge brand can never spin the canvas into thousands of nodes. */
@@ -24,15 +25,6 @@ const DISPLAYABLE_STATUSES = [
 
 interface PageableService {
   findAll(query: Record<string, unknown>): Promise<IIngredient[]>;
-}
-
-export interface UseBrandMediaAssetsResult {
-  assets: IIngredient[];
-  isLoading: boolean;
-  error: Error | null;
-  /** True when the safety cap was hit and not all assets are shown. */
-  isTruncated: boolean;
-  refresh: () => void;
 }
 
 function isVisualMediaIngredient(ingredient: IIngredient): boolean {

--- a/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.ts
@@ -1,0 +1,194 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { IngredientCategory, IngredientStatus } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { AvatarsService } from '@genfeedai/services/ingredients/avatars.service';
+import { GIFsService } from '@genfeedai/services/ingredients/gifs.service';
+import { ImagesService } from '@genfeedai/services/ingredients/images.service';
+import { VideosService } from '@genfeedai/services/ingredients/videos.service';
+import {
+  isAvatarSourceImageIngredient,
+  isAvatarVideoIngredient,
+} from '@genfeedai/utils/media/ingredient-type.util';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const PAGE_SIZE = 100;
+/** Safety cap so a huge brand can never spin the canvas into thousands of nodes. */
+const MAX_ASSETS = 1000;
+const DISPLAYABLE_STATUSES = [
+  IngredientStatus.GENERATED,
+  IngredientStatus.VALIDATED,
+];
+
+interface PageableService {
+  findAll(query: Record<string, unknown>): Promise<IIngredient[]>;
+}
+
+export interface UseBrandMediaAssetsResult {
+  assets: IIngredient[];
+  isLoading: boolean;
+  error: Error | null;
+  /** True when the safety cap was hit and not all assets are shown. */
+  isTruncated: boolean;
+  refresh: () => void;
+}
+
+function isVisualMediaIngredient(ingredient: IIngredient): boolean {
+  const isVisualCategory =
+    ingredient.category === IngredientCategory.IMAGE ||
+    ingredient.category === IngredientCategory.VIDEO ||
+    ingredient.category === IngredientCategory.GIF ||
+    isAvatarSourceImageIngredient(ingredient) ||
+    isAvatarVideoIngredient(ingredient);
+
+  return (
+    isVisualCategory &&
+    Boolean(ingredient.ingredientUrl || ingredient.thumbnailUrl)
+  );
+}
+
+async function fetchAllPages(
+  service: PageableService,
+  brandId: string,
+  signal: AbortSignal,
+): Promise<IIngredient[]> {
+  const collected: IIngredient[] = [];
+
+  for (let page = 1; collected.length < MAX_ASSETS; page += 1) {
+    if (signal.aborted) {
+      break;
+    }
+
+    const batch = await service.findAll({
+      brand: brandId,
+      lightweight: true,
+      status: DISPLAYABLE_STATUSES,
+      limit: PAGE_SIZE,
+      page,
+    });
+
+    collected.push(...batch);
+
+    if (batch.length < PAGE_SIZE) {
+      break;
+    }
+  }
+
+  return collected;
+}
+
+/**
+ * Loads every displayable visual asset (images, videos, gifs, avatars) for the
+ * active brand by fanning out parallel per-type fetches and merging the result.
+ * There is no combined-all endpoint, so this mirrors how the library landing
+ * preview aggregates the per-type ingredient services.
+ */
+export function useBrandMediaAssets(): UseBrandMediaAssetsResult {
+  const { brandId } = useBrand();
+  const [assets, setAssets] = useState<IIngredient[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const getImagesService = useAuthedService((token: string) =>
+    ImagesService.getInstance(token),
+  );
+  const getVideosService = useAuthedService((token: string) =>
+    VideosService.getInstance(token),
+  );
+  const getGifsService = useAuthedService((token: string) =>
+    GIFsService.getInstance(token),
+  );
+  const getAvatarsService = useAuthedService((token: string) =>
+    AvatarsService.getInstance(token),
+  );
+
+  const refresh = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  // useRef keeps the getters stable for the effect dependency array.
+  const serviceGetters = useRef({
+    getAvatarsService,
+    getGifsService,
+    getImagesService,
+    getVideosService,
+  });
+  serviceGetters.current = {
+    getAvatarsService,
+    getGifsService,
+    getImagesService,
+    getVideosService,
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: service getters are read from a ref to keep them out of the deps; reload is driven by brandId + reloadToken.
+  useEffect(() => {
+    if (!brandId) {
+      setAssets([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    async function load() {
+      try {
+        const {
+          getImagesService: images,
+          getVideosService: videos,
+          getGifsService: gifs,
+          getAvatarsService: avatars,
+        } = serviceGetters.current;
+
+        const services = await Promise.all([
+          images(),
+          videos(),
+          gifs(),
+          avatars(),
+        ]);
+
+        const batches = await Promise.all(
+          services.map((service) =>
+            fetchAllPages(
+              service as PageableService,
+              brandId,
+              controller.signal,
+            ),
+          ),
+        );
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const merged = batches.flat().filter(isVisualMediaIngredient);
+        setIsTruncated(merged.length > MAX_ASSETS);
+        setAssets(merged.slice(0, MAX_ASSETS));
+      } catch (caught) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setError(
+          caught instanceof Error ? caught : new Error('Failed to load assets'),
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      controller.abort();
+    };
+  }, [brandId, reloadToken]);
+
+  return { assets, error, isLoading, isTruncated, refresh };
+}

--- a/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.types.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.types.ts
@@ -1,0 +1,10 @@
+import type { IIngredient } from '@genfeedai/interfaces';
+
+export interface UseBrandMediaAssetsResult {
+  assets: IIngredient[];
+  isLoading: boolean;
+  error: Error | null;
+  /** True when the safety cap was hit and not all assets are shown. */
+  isTruncated: boolean;
+  refresh: () => void;
+}

--- a/packages/interfaces/src/content/index.ts
+++ b/packages/interfaces/src/content/index.ts
@@ -7,6 +7,7 @@ export * from './content-run-service.contract';
 export * from './enhancement-response.interface';
 export * from './generation-payload.interface';
 export * from './model.interface';
+export * from './mood-board.interface';
 export * from './persona.interface';
 export * from './post.interface';
 export * from './post-quick-action.interface';

--- a/packages/interfaces/src/content/mood-board.interface.ts
+++ b/packages/interfaces/src/content/mood-board.interface.ts
@@ -1,0 +1,18 @@
+import type { IBaseEntity } from '../core/base.interface';
+
+export interface IMoodBoardLayoutItem {
+  assetId: string;
+  position: {
+    x: number;
+    y: number;
+  };
+  width?: number;
+  z?: number;
+}
+
+export interface IMoodBoard extends IBaseEntity {
+  brandId: string;
+  organizationId: string;
+  layout: IMoodBoardLayoutItem[];
+  metadata?: Record<string, unknown>;
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -80,6 +80,7 @@ export * from './content/content-run-service.contract';
 export * from './content/enhancement-response.interface';
 export * from './content/generation-payload.interface';
 export * from './content/model.interface';
+export * from './content/mood-board.interface';
 export * from './content/persona.interface';
 export * from './content/post.interface';
 export * from './content/post-quick-action.interface';

--- a/packages/models/content/mood-board.model.test.ts
+++ b/packages/models/content/mood-board.model.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@genfeedai/client/models', () => ({
+  MoodBoard: class BaseMoodBoard {
+    public id?: string;
+    public brandId?: string;
+    public organizationId?: string;
+    public layout?: unknown[];
+    public metadata?: Record<string, unknown>;
+    constructor(partial: Record<string, unknown> = {}) {
+      Object.assign(this, partial);
+    }
+  },
+}));
+
+vi.mock('@genfeedai/interfaces', () => ({}));
+
+import { MoodBoard } from './mood-board.model';
+
+describe('MoodBoard (domain model)', () => {
+  it('constructs with partial data', () => {
+    const board = new MoodBoard({ id: 'board-1' });
+    expect(board).toBeDefined();
+    expect(board.id).toBe('board-1');
+  });
+
+  it('assigns layout', () => {
+    const layout = [{ assetId: 'a1', position: { x: 10, y: 20 } }];
+    const board = new MoodBoard({ layout });
+    expect(board.layout).toEqual(layout);
+  });
+
+  it('assigns brandId and organizationId', () => {
+    const board = new MoodBoard({
+      brandId: 'brand-1',
+      organizationId: 'org-1',
+    });
+    expect(board.brandId).toBe('brand-1');
+    expect(board.organizationId).toBe('org-1');
+  });
+});

--- a/packages/models/content/mood-board.model.ts
+++ b/packages/models/content/mood-board.model.ts
@@ -1,8 +1,3 @@
 import { MoodBoard as BaseMoodBoard } from '@genfeedai/client/models';
-import type { IMoodBoard } from '@genfeedai/interfaces';
 
-export class MoodBoard extends BaseMoodBoard {
-  constructor(partial: Partial<IMoodBoard>) {
-    super(partial);
-  }
-}
+export class MoodBoard extends BaseMoodBoard {}

--- a/packages/models/content/mood-board.model.ts
+++ b/packages/models/content/mood-board.model.ts
@@ -1,0 +1,8 @@
+import { MoodBoard as BaseMoodBoard } from '@genfeedai/client/models';
+import type { IMoodBoard } from '@genfeedai/interfaces';
+
+export class MoodBoard extends BaseMoodBoard {
+  constructor(partial: Partial<IMoodBoard>) {
+    super(partial);
+  }
+}

--- a/packages/pages/ingredients/layout/ingredients-layout-toolbar.tsx
+++ b/packages/pages/ingredients/layout/ingredients-layout-toolbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant, PageScope } from '@genfeedai/enums';
 import type {
   IFilters,
@@ -10,7 +11,11 @@ import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
 import FiltersButton from '@ui/content/filters-button/FiltersButton';
 import { Button, Button as PrimitiveButton } from '@ui/primitives/button';
 import Link from 'next/link';
-import { HiArrowTopRightOnSquare, HiArrowUpTray } from 'react-icons/hi2';
+import {
+  HiArrowTopRightOnSquare,
+  HiArrowUpTray,
+  HiOutlineSquares2X2,
+} from 'react-icons/hi2';
 import type { IngredientsLayoutConfig } from './ingredients-layout.config';
 
 type IngredientsLayoutToolbarProps = {
@@ -52,6 +57,19 @@ export default function IngredientsLayoutToolbar({
           variant={ButtonVariant.SECONDARY}
           onClick={onUpload}
         />
+      )}
+
+      {scope === PageScope.BRAND && (
+        <PrimitiveButton
+          asChild
+          tooltip="Mood board"
+          variant={ButtonVariant.SECONDARY}
+        >
+          <Link href={APP_ROUTES.LIBRARY.MOODBOARD}>
+            <HiOutlineSquares2X2 />
+            Mood board
+          </Link>
+        </PrimitiveButton>
       )}
 
       {scope !== PageScope.SUPERADMIN && config.showStudioLink && (

--- a/packages/prisma/prisma/migrations/20260619140000_add_mood_board_model/migration.sql
+++ b/packages/prisma/prisma/migrations/20260619140000_add_mood_board_model/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "mood_boards" (
+    "id" TEXT NOT NULL,
+    "brandId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "layout" JSONB NOT NULL DEFAULT '[]',
+    "metadata" JSONB,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mood_boards_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mood_boards_brandId_key" ON "mood_boards"("brandId");
+
+-- CreateIndex
+CREATE INDEX "mood_boards_organizationId_isDeleted_idx" ON "mood_boards"("organizationId", "isDeleted");
+
+-- AddForeignKey
+ALTER TABLE "mood_boards" ADD CONSTRAINT "mood_boards_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "brands"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mood_boards" ADD CONSTRAINT "mood_boards_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -698,6 +698,7 @@ model Organization {
   activities                    Activity[]
   apiKeys                       ApiKey[]
   creatorAnalyses               CreatorAnalysis[]
+  moodBoards                    MoodBoard[]                    @relation("org_moodboard")
 
   @@index([isDefault])
   @@index([category])
@@ -792,10 +793,30 @@ model Brand {
   contextBases               ContextBase[]              @relation("context_base_source_brand")
   schedules                  Schedule[]
   bookmarks                  Bookmark[]
+  moodBoard                  MoodBoard?                 @relation("brand_moodboard")
 
   @@index([isDefault])
   @@index([organizationId, isDeleted, label], map: "brands_org_deleted_label_idx")
   @@map("brands")
+}
+
+// One mood board per brand. `layout` stores only positions keyed by asset id
+// ([{ assetId, position: { x, y }, width?, z? }]); asset content is fetched
+// live from ingredients and merged by assetId so the board stays self-healing.
+model MoodBoard {
+  id             String       @id @default(cuid())
+  brandId        String       @unique
+  brand          Brand        @relation("brand_moodboard", fields: [brandId], references: [id])
+  organizationId String
+  organization   Organization @relation("org_moodboard", fields: [organizationId], references: [id])
+  layout         Json         @default("[]")
+  metadata       Json?
+  isDeleted      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  @@index([organizationId, isDeleted])
+  @@map("mood_boards")
 }
 
 model Member {

--- a/packages/serializers/src/attributes/content/index.ts
+++ b/packages/serializers/src/attributes/content/index.ts
@@ -22,6 +22,7 @@ export * from '@serializers/attributes/content/fanvue-subscriber.attributes';
 export * from '@serializers/attributes/content/fanvue-sync-log.attributes';
 export * from '@serializers/attributes/content/insight.attributes';
 export * from '@serializers/attributes/content/link.attributes';
+export * from '@serializers/attributes/content/mood-board.attributes';
 export * from '@serializers/attributes/content/news.attributes';
 export * from '@serializers/attributes/content/newsletter.attributes';
 export * from '@serializers/attributes/content/optimization.attributes';

--- a/packages/serializers/src/attributes/content/mood-board.attributes.ts
+++ b/packages/serializers/src/attributes/content/mood-board.attributes.ts
@@ -1,0 +1,6 @@
+import { createEntityAttributes } from '@genfeedai/helpers';
+
+export const moodBoardAttributes = createEntityAttributes([
+  'layout',
+  'metadata',
+]);

--- a/packages/serializers/src/attributes/content/mood-board.attributes.ts
+++ b/packages/serializers/src/attributes/content/mood-board.attributes.ts
@@ -1,6 +1,8 @@
 import { createEntityAttributes } from '@genfeedai/helpers';
 
 export const moodBoardAttributes = createEntityAttributes([
+  'brandId',
+  'organizationId',
   'layout',
   'metadata',
 ]);

--- a/packages/serializers/src/configs/content/index.ts
+++ b/packages/serializers/src/configs/content/index.ts
@@ -23,6 +23,7 @@ export * from '@serializers/configs/content/fanvue-sync-log.config';
 export * from '@serializers/configs/content/ingredient.config';
 export * from '@serializers/configs/content/insight.config';
 export * from '@serializers/configs/content/link.config';
+export * from '@serializers/configs/content/mood-board.config';
 export * from '@serializers/configs/content/news.config';
 export * from '@serializers/configs/content/newsletter.config';
 export * from '@serializers/configs/content/optimization.config';

--- a/packages/serializers/src/configs/content/mood-board.config.ts
+++ b/packages/serializers/src/configs/content/mood-board.config.ts
@@ -1,0 +1,7 @@
+import { moodBoardAttributes } from '@serializers/attributes/content/mood-board.attributes';
+import { simpleConfig } from '@serializers/builders';
+
+export const moodBoardSerializerConfig = simpleConfig(
+  'mood-board',
+  moodBoardAttributes,
+);

--- a/packages/serializers/src/server/content/index.ts
+++ b/packages/serializers/src/server/content/index.ts
@@ -23,6 +23,7 @@ export * from '@serializers/server/content/fanvue-subscriber.serializer';
 export * from '@serializers/server/content/fanvue-sync-log.serializer';
 export * from '@serializers/server/content/insight.serializer';
 export * from '@serializers/server/content/link.serializer';
+export * from '@serializers/server/content/mood-board.serializer';
 export * from '@serializers/server/content/news.serializer';
 export * from '@serializers/server/content/newsletter.serializer';
 export * from '@serializers/server/content/optimization.serializer';

--- a/packages/serializers/src/server/content/mood-board.serializer.ts
+++ b/packages/serializers/src/server/content/mood-board.serializer.ts
@@ -1,0 +1,7 @@
+import { buildSerializer } from '@serializers/builders';
+import { moodBoardSerializerConfig } from '@serializers/configs';
+
+export const { MoodBoardSerializer } = buildSerializer(
+  'server',
+  moodBoardSerializerConfig,
+);

--- a/packages/services/content/mood-boards.service.ts
+++ b/packages/services/content/mood-boards.service.ts
@@ -1,0 +1,36 @@
+import { API_ENDPOINTS } from '@genfeedai/constants';
+import { MoodBoard } from '@genfeedai/models/content/mood-board.model';
+import { MoodBoardSerializer } from '@genfeedai/serializers';
+import {
+  BaseService,
+  type JsonApiResponseDocument,
+} from '@services/core/base.service';
+
+export class MoodBoardsService extends BaseService<MoodBoard> {
+  constructor(token: string) {
+    super(API_ENDPOINTS.MOOD_BOARDS, token, MoodBoard, MoodBoardSerializer);
+  }
+
+  public static getInstance(token: string): MoodBoardsService {
+    return BaseService.getDataServiceInstance(
+      MoodBoardsService,
+      token,
+    ) as MoodBoardsService;
+  }
+
+  /**
+   * Find or create the mood board for a brand via the find-or-create GET
+   * endpoint. The server returns a single resource (creating one when absent)
+   * when queried with `?brand=<brandId>`, so this parses a single document
+   * rather than a collection.
+   */
+  public getByBrand(brandId: string): Promise<MoodBoard> {
+    return this.executeWithErrorHandling(
+      `GET ${API_ENDPOINTS.MOOD_BOARDS}?brand=${brandId}`,
+      this.instance
+        .get<JsonApiResponseDocument>('', { params: { brand: brandId } })
+        .then((res) => res.data)
+        .then((res) => this.mapOne(res)),
+    );
+  }
+}

--- a/packages/services/core/commands.registry.ts
+++ b/packages/services/core/commands.registry.ts
@@ -30,6 +30,7 @@ import {
   HiOutlineMusicalNote,
   HiOutlinePaperAirplane,
   HiOutlinePhoto,
+  HiOutlineSquares2X2,
   HiOutlineUserCircle,
   HiOutlineVideoCamera,
   HiOutlineWrenchScrewdriver,
@@ -108,6 +109,20 @@ export function createNavigationCommands(
       label: 'Go to Library',
       priority: 10,
       shortcut: ['⌘', '3'],
+    },
+    {
+      action: () => {
+        navigate(`${brandPath}/library/moodboard`);
+      },
+      category: 'navigation',
+      condition: () => EnvironmentService.currentApp !== 'app',
+      description: 'Arrange all your generated assets on one canvas',
+      icon: HiOutlineSquares2X2,
+      id: 'nav-moodboard',
+      keywords: ['mood', 'board', 'moodboard', 'canvas', 'gallery', 'assets'],
+      label: 'Go to Mood Board',
+      priority: 9,
+      shortcut: ['⌘', '7'],
     },
     {
       action: () => {

--- a/packages/utils/moodboard/mood-board-layout.util.test.ts
+++ b/packages/utils/moodboard/mood-board-layout.util.test.ts
@@ -1,0 +1,88 @@
+import type { IIngredient, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+import {
+  MOOD_BOARD_TILE_HEIGHT,
+  mergeMoodBoardLayout,
+  toMoodBoardLayout,
+} from '@genfeedai/utils/moodboard/mood-board-layout.util';
+import { describe, expect, it } from 'vitest';
+
+function asset(id: string): IIngredient {
+  return {
+    id,
+    isDeleted: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  } as IIngredient;
+}
+
+function saved(assetId: string, x: number, y: number): IMoodBoardLayoutItem {
+  return { assetId, position: { x, y } };
+}
+
+describe('mergeMoodBoardLayout', () => {
+  it('keeps saved positions for known assets', () => {
+    const { seeds } = mergeMoodBoardLayout(
+      [asset('a'), asset('b')],
+      [saved('a', 100, 200), saved('b', 300, 400)],
+    );
+
+    expect(seeds[0].position).toEqual({ x: 100, y: 200 });
+    expect(seeds[1].position).toEqual({ x: 300, y: 400 });
+  });
+
+  it('auto-places new assets in a grid below saved content', () => {
+    const { seeds } = mergeMoodBoardLayout(
+      [asset('saved'), asset('fresh')],
+      [saved('saved', 0, 0)],
+    );
+
+    const fresh = seeds.find((seed) => seed.assetId === 'fresh');
+    expect(fresh?.position.x).toBe(0);
+    // Placed in a band strictly below the saved tile.
+    expect(fresh?.position.y).toBeGreaterThanOrEqual(MOOD_BOARD_TILE_HEIGHT);
+  });
+
+  it('places all assets from origin when there is no saved layout', () => {
+    const { seeds } = mergeMoodBoardLayout([asset('a'), asset('b')], []);
+
+    expect(seeds[0].position).toEqual({ x: 0, y: 0 });
+    expect(seeds[1].position.x).toBeGreaterThan(0);
+    expect(seeds[1].position.y).toBe(0);
+  });
+
+  it('prunes saved entries for assets that no longer exist', () => {
+    const { layout } = mergeMoodBoardLayout(
+      [asset('a')],
+      [saved('a', 10, 20), saved('ghost', 99, 99)],
+    );
+
+    expect(layout.map((item) => item.assetId)).toEqual(['a']);
+  });
+
+  it('emits a layout entry for every live asset', () => {
+    const { layout } = mergeMoodBoardLayout(
+      [asset('a'), asset('b'), asset('c')],
+      [saved('a', 10, 20)],
+    );
+
+    expect(layout).toHaveLength(3);
+    expect(layout.find((item) => item.assetId === 'a')?.position).toEqual({
+      x: 10,
+      y: 20,
+    });
+  });
+});
+
+describe('toMoodBoardLayout', () => {
+  it('keeps only nodes whose id is a known asset', () => {
+    const layout = toMoodBoardLayout(
+      [
+        { id: 'a', position: { x: 1, y: 2 } },
+        { id: 'unknown', position: { x: 3, y: 4 } },
+      ],
+      new Set(['a']),
+    );
+
+    expect(layout).toEqual([{ assetId: 'a', position: { x: 1, y: 2 } }]);
+  });
+});

--- a/packages/utils/moodboard/mood-board-layout.util.ts
+++ b/packages/utils/moodboard/mood-board-layout.util.ts
@@ -72,16 +72,23 @@ export function mergeMoodBoardLayout(
 
   const liveIds = new Set(assets.map((asset) => asset.id));
 
-  // Band where freshly added (un-positioned) assets start, kept clear of saved tiles.
-  const maxSavedY = savedLayout.reduce((max, item) => {
+  // Band where freshly added (un-positioned) assets start, kept clear of saved
+  // tiles. Tracked as an explicit two-state (presence + value) rather than an
+  // infinity sentinel.
+  let hasSavedLiveItem = false;
+  let maxSavedY = 0;
+  for (const item of savedLayout) {
     if (!liveIds.has(item.assetId)) {
-      return max;
+      continue;
     }
-    return Math.max(max, item.position?.y ?? 0);
-  }, Number.NEGATIVE_INFINITY);
+    const y = item.position?.y ?? 0;
+    if (!hasSavedLiveItem || y > maxSavedY) {
+      maxSavedY = y;
+      hasSavedLiveItem = true;
+    }
+  }
 
-  const hasSaved = Number.isFinite(maxSavedY);
-  const newAssetBaseY = hasSaved
+  const newAssetBaseY = hasSavedLiveItem
     ? maxSavedY + MOOD_BOARD_TILE_HEIGHT + MOOD_BOARD_GRID_GAP
     : 0;
 

--- a/packages/utils/moodboard/mood-board-layout.util.ts
+++ b/packages/utils/moodboard/mood-board-layout.util.ts
@@ -1,0 +1,133 @@
+import type { IIngredient, IMoodBoardLayoutItem } from '@genfeedai/interfaces';
+
+/**
+ * Default tile + grid geometry used when auto-placing assets that do not yet
+ * have a persisted position. Values are canvas units (React Flow coordinates).
+ */
+export const MOOD_BOARD_TILE_WIDTH = 280;
+export const MOOD_BOARD_TILE_HEIGHT = 320;
+export const MOOD_BOARD_GRID_GAP = 32;
+export const MOOD_BOARD_DEFAULT_COLUMNS = 5;
+
+/**
+ * A canvas-ready asset: a live ingredient paired with the position it should
+ * render at. Produced by {@link mergeMoodBoardLayout}.
+ */
+export interface MoodBoardNodeSeed {
+  assetId: string;
+  ingredient: IIngredient;
+  position: { x: number; y: number };
+  width?: number;
+  z?: number;
+}
+
+export interface MergeMoodBoardLayoutResult {
+  /** One seed per live asset, in the same order as `assets`. */
+  seeds: MoodBoardNodeSeed[];
+  /**
+   * The layout to persist: positions for every live asset. Entries for assets
+   * that no longer exist are dropped (pruned), so persisting this keeps the
+   * board self-healing.
+   */
+  layout: IMoodBoardLayoutItem[];
+}
+
+function gridPosition(
+  index: number,
+  columns: number,
+  baseY: number,
+): { x: number; y: number } {
+  const safeColumns = Math.max(1, columns);
+  const column = index % safeColumns;
+  const row = Math.floor(index / safeColumns);
+
+  return {
+    x: column * (MOOD_BOARD_TILE_WIDTH + MOOD_BOARD_GRID_GAP),
+    y: baseY + row * (MOOD_BOARD_TILE_HEIGHT + MOOD_BOARD_GRID_GAP),
+  };
+}
+
+/**
+ * Merge live assets with a brand's saved board layout.
+ *
+ * - Assets with a saved position keep it.
+ * - Assets without one are auto-placed in a grid, in a band below any saved
+ *   content so they never overlap existing tiles.
+ * - Saved entries for assets that no longer exist are pruned.
+ *
+ * Content (urls, dimensions) always comes from the live `assets`; only the
+ * position is sourced from `savedLayout`. This is what keeps the board fresh as
+ * assets are generated or deleted.
+ */
+export function mergeMoodBoardLayout(
+  assets: IIngredient[],
+  savedLayout: IMoodBoardLayoutItem[] = [],
+  columns: number = MOOD_BOARD_DEFAULT_COLUMNS,
+): MergeMoodBoardLayoutResult {
+  const savedById = new Map<string, IMoodBoardLayoutItem>(
+    savedLayout
+      .filter((item) => typeof item?.assetId === 'string')
+      .map((item) => [item.assetId, item]),
+  );
+
+  const liveIds = new Set(assets.map((asset) => asset.id));
+
+  // Band where freshly added (un-positioned) assets start, kept clear of saved tiles.
+  const maxSavedY = savedLayout.reduce((max, item) => {
+    if (!liveIds.has(item.assetId)) {
+      return max;
+    }
+    return Math.max(max, item.position?.y ?? 0);
+  }, Number.NEGATIVE_INFINITY);
+
+  const hasSaved = Number.isFinite(maxSavedY);
+  const newAssetBaseY = hasSaved
+    ? maxSavedY + MOOD_BOARD_TILE_HEIGHT + MOOD_BOARD_GRID_GAP
+    : 0;
+
+  let newAssetIndex = 0;
+
+  const seeds: MoodBoardNodeSeed[] = assets.map((ingredient) => {
+    const saved = savedById.get(ingredient.id);
+
+    if (saved?.position) {
+      return {
+        assetId: ingredient.id,
+        ingredient,
+        position: { x: saved.position.x, y: saved.position.y },
+        width: saved.width,
+        z: saved.z,
+      };
+    }
+
+    const position = gridPosition(newAssetIndex, columns, newAssetBaseY);
+    newAssetIndex += 1;
+
+    return { assetId: ingredient.id, ingredient, position };
+  });
+
+  const layout: IMoodBoardLayoutItem[] = seeds.map((seed) => ({
+    assetId: seed.assetId,
+    position: seed.position,
+    ...(seed.width !== undefined ? { width: seed.width } : {}),
+    ...(seed.z !== undefined ? { z: seed.z } : {}),
+  }));
+
+  return { seeds, layout };
+}
+
+/**
+ * Project the current React Flow node positions back into a persistable layout,
+ * keyed by asset id. Nodes whose id is not a known asset id are ignored.
+ */
+export function toMoodBoardLayout(
+  nodes: Array<{ id: string; position: { x: number; y: number } }>,
+  knownAssetIds: Set<string>,
+): IMoodBoardLayoutItem[] {
+  return nodes
+    .filter((node) => knownAssetIds.has(node.id))
+    .map((node) => ({
+      assetId: node.id,
+      position: { x: node.position.x, y: node.position.y },
+    }));
+}


### PR DESCRIPTION
## What

A fullscreen, pannable/zoomable **mood board** for the library (Google Stitch-style): one big canvas that pulls **all of a brand's generated visual assets** (images, videos, gifs, avatars) together, with the arrangement **persisted per brand**.

## Why

Vincent wanted a single visual surface to see everything generated for a brand at a glance and arrange it freely — distinct from the per-type library list views.

## Approach

- **Canvas** — reuses the workflow editor's canvas tech (`@xyflow/react`) via a *thin, dedicated* canvas rather than the execution-coupled `WorkflowCanvas`/`useWorkflowStore`. A custom `mediaAsset` node bypasses `BaseNode` (same pattern as `BrandAssetNode`); clicking a tile opens the existing `MediaLightbox`.
- **Persistence** — new brand-scoped `MoodBoard` model (one per brand) stores **only `{ assetId, position }` layout**, never asset URLs. Content is fetched live from ingredients and merged by id, so the board self-heals as assets are generated/deleted. Drag autosaves on a 2s debounce (mirrors the workflow canvas).
- **Data** — no combined-all endpoint exists, so assets are loaded by fanning out parallel per-type ingredient fetches (images/videos/gifs/avatars), filtered to visual media.
- **Shell** — fullscreen route strips the app sidebar/topbar via a new `isMoodboardRoute` branch, gated by the `moodboard` feature flag.
- **Entry points** — "Mood board" button on the library toolbar + ⌘K command (*Go to Mood Board*).

## Layers touched

Prisma model + migration · serializer triplet · interfaces · client/domain models · NestJS `mood-boards` collection (find-or-create GET, PATCH layout) · client service + `useMoodBoard` · asset-fetch hook + layout util · canvas/node/autosave · route + shell strip + entry points.

## Verification

- **type-check:** 45/45 packages clean
- **tests:** 30 passing — utils 6, hooks 3, client 3, models 3, app 8, api 7
- **biome / secretlint / no-raw-html:** clean

### Notes for reviewers
- Migration `20260619140000_add_mood_board_model` is hand-authored (no DB in the worktree); CI/`migrate deploy` applies it.
- Requires the `moodboard` feature flag enabled (or `NEXT_PUBLIC_FEATURE_FLAG_DEFAULTS` unset → passthrough in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)