### PR TITLE
feat(pages): Fastlane studio page package

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/fastlane/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/fastlane/page.tsx
@@ -1,0 +1,14 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import FastlanePageContent from '@pages/studio/fastlane';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import { Suspense } from 'react';
+
+export const generateMetadata = createPageMetadata('Fastlane');
+
+export default function StudioFastlanePage() {
+  return (
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+      <FastlanePageContent />
+    </Suspense>
+  );
+}

--- a/apps/app/app/(protected)/admin/organization/components/organization-settings-table.tsx
+++ b/apps/app/app/(protected)/admin/organization/components/organization-settings-table.tsx
@@ -64,6 +64,11 @@ const SETTING_GROUPS: SettingGroup[] = [
         label: 'Auto Evaluation',
         type: 'boolean',
       },
+      {
+        key: 'isFastlaneEnabled',
+        label: 'Fastlane',
+        type: 'boolean',
+      },
     ],
   },
   {

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -30,6 +30,7 @@ import {
   STUDIO_CATEGORY_CONFIG,
   useEnabledCategories,
 } from '@hooks/data/organization/use-enabled-categories/use-enabled-categories';
+import { useFastlaneEnabled } from '@hooks/data/organization/use-fastlane-enabled/use-fastlane-enabled';
 import { useFeatureFlag } from '@hooks/feature-flags/use-feature-flag';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { useMenuItems } from '@hooks/ui/use-menu-items';
@@ -321,6 +322,8 @@ export function useAppProtectedLayout(
   const role = useUserRole();
   const { enabledCategories, isLoading: isEnabledCategoriesLoading } =
     useEnabledCategories();
+  const { isEnabled: isFastlaneEnabled, isLoading: isFastlaneLoading } =
+    useFastlaneEnabled();
 
   // Sync route context into the agent store
   useAgentPageContext(role);
@@ -376,6 +379,15 @@ export function useAppProtectedLayout(
       const studioCategory = categoryByHref.get(item.href);
 
       if (!studioCategory) {
+        // Fastlane is not a generation category — gate it on its own org flag.
+        // Hide while the flag is still loading to avoid a flash of the item.
+        if (
+          item.href === APP_ROUTES.STUDIO.FASTLANE &&
+          (!isFastlaneEnabled || isFastlaneLoading)
+        ) {
+          return items;
+        }
+
         items.push({
           ...item,
           href: withTaskContextHref(item.href, taskContextSearchParams),
@@ -395,7 +407,13 @@ export function useAppProtectedLayout(
 
       return items;
     }, []);
-  }, [enabledCategories, isEnabledCategoriesLoading, taskContextSearchParams]);
+  }, [
+    enabledCategories,
+    isEnabledCategoriesLoading,
+    isFastlaneEnabled,
+    isFastlaneLoading,
+    taskContextSearchParams,
+  ]);
 
   const composeMenuItems = useMemo(
     () =>

--- a/apps/app/packages/config/studio-menu-items.config.ts
+++ b/apps/app/packages/config/studio-menu-items.config.ts
@@ -1,7 +1,9 @@
 import { APP_ROUTES } from '@genfeedai/constants';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import {
+  HiBolt,
   HiMusicalNote,
+  HiOutlineBolt,
   HiOutlineMusicalNote,
   HiOutlinePhoto,
   HiOutlinePlayCircle,
@@ -54,6 +56,14 @@ export const STUDIO_MENU_ITEMS: MenuItemConfig[] = [
     matchPaths: [APP_ROUTES.STUDIO.BATCH],
     outline: HiOutlineRectangleStack,
     solid: HiRectangleStack,
+  },
+  {
+    group: '',
+    href: APP_ROUTES.STUDIO.FASTLANE,
+    label: 'Fastlane',
+    matchPaths: [APP_ROUTES.STUDIO.FASTLANE],
+    outline: HiOutlineBolt,
+    solid: HiBolt,
   },
 ];
 

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -3,6 +3,7 @@ import { ArticlesService } from '@api/collections/articles/services/articles.ser
 import { STRATEGY_TEMPLATES } from '@api/collections/brands/constants/strategy-templates.constant';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
 import { GenerateBrandVoiceDto } from '@api/collections/brands/dto/generate-brand-voice.dto';
+import { GenerateFastlaneIdeasDto } from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
 import { ToggleBrandSkillDto } from '@api/collections/brands/dto/toggle-brand-skill.dto';
 import { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
 import { UpdateBrandAgentConfigDto } from '@api/collections/brands/dto/update-brand-agent-config.dto';
@@ -387,6 +388,53 @@ export class BrandsController extends BaseCRUDController<
     );
 
     return { data: voice };
+  }
+
+  @Post(':id/fastlane/ideas')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async generateFastlaneIdeas(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() generateFastlaneIdeasDto: GenerateFastlaneIdeasDto,
+  ) {
+    const publicMetadata = getPublicMetadata(user);
+    const organizationId = publicMetadata.organization?.toString();
+
+    if (!organizationId) {
+      throw new HttpException(
+        {
+          detail: 'Organization context is required',
+          title: 'Forbidden',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    // Backend flag guard: the studio `studio` FeatureGate does NOT enforce
+    // isFastlaneEnabled, so a direct call here must be rejected when the org
+    // flag is off — before any LLM work is metered.
+    const settings = await this.organizationSettingsService.findOne({
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!settings?.isFastlaneEnabled) {
+      throw new HttpException(
+        {
+          detail: 'Fastlane is not enabled for this organization',
+          title: 'Forbidden',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    const ideas = await this.brandsService.generateFastlaneIdeas(
+      id,
+      generateFastlaneIdeasDto,
+      organizationId,
+    );
+
+    return { data: ideas };
   }
 
   @Patch(':id/agent-config/enabled-skills')

--- a/apps/server/api/src/collections/brands/dto/generate-fastlane-ideas.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/generate-fastlane-ideas.dto.ts
@@ -1,0 +1,50 @@
+import type { FastlaneFormat } from '@genfeedai/interfaces';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/** Canonical set of formats Fastlane can fan generation across. */
+export const FASTLANE_FORMATS: readonly FastlaneFormat[] = [
+  'image',
+  'video',
+  'avatar',
+] as const;
+
+export class GenerateFastlaneIdeasDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsIn([...FASTLANE_FORMATS], { each: true })
+  @ApiProperty({
+    description: 'Content formats to distribute the idea batch across',
+    enum: FASTLANE_FORMATS,
+    isArray: true,
+  })
+  readonly formats!: FastlaneFormat[];
+
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  @ApiProperty({
+    default: 6,
+    description: 'Number of ideas to generate (1-12)',
+  })
+  readonly count!: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(300)
+  @ApiPropertyOptional({
+    description: 'Optional creative angle or theme to steer the batch',
+    example: 'Black Friday launch',
+  })
+  readonly angle?: string;
+}

--- a/apps/server/api/src/collections/brands/services/brands.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.spec.ts
@@ -8,13 +8,17 @@ import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.s
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { FastlaneFormat } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 
 describe('BrandsService', () => {
   let service: BrandsService;
   let delegate: Record<string, ReturnType<typeof vi.fn>>;
+  let llmDispatcher: { chatCompletion: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    llmDispatcher = { chatCompletion: vi.fn() };
     delegate = {
       count: vi.fn(),
       create: vi.fn(),
@@ -53,7 +57,7 @@ describe('BrandsService', () => {
       } as unknown as LoggerService,
       {} as CacheService,
       {} as BrandScraperService,
-      {} as LlmDispatcherService,
+      llmDispatcher as unknown as LlmDispatcherService,
       {
         invalidate: vi.fn(),
         invalidatePattern: vi.fn(),
@@ -124,5 +128,113 @@ describe('BrandsService', () => {
       ),
     ).rejects.toThrow(NotFoundException);
     expect(delegate.updateMany).not.toHaveBeenCalled();
+  });
+
+  describe('generateFastlaneIdeas', () => {
+    const organizationId = 'org_1';
+    const brandId = 'brand_1';
+
+    it('returns normalized ideas with unique generated ids for a configured brand', async () => {
+      delegate.findFirst.mockResolvedValue({
+        agentConfig: { voice: { tone: 'bold' } },
+        description: 'A bold brand',
+        id: brandId,
+        isDeleted: false,
+        label: 'Acme',
+        organizationId,
+      });
+      llmDispatcher.chatCompletion.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify([
+                {
+                  caption: 'cap',
+                  format: 'image',
+                  hook: 'hook',
+                  platformHints: ['tiktok'],
+                  visualPrompt: 'a scene',
+                },
+                {
+                  caption: 'cap2',
+                  format: 'avatar',
+                  hook: 'hook2',
+                  platformHints: ['instagram'],
+                  speechText: 'hello there',
+                  visualPrompt: '',
+                },
+              ]),
+            },
+          },
+        ],
+      });
+
+      const result = await service.generateFastlaneIdeas(
+        brandId,
+        { count: 2, formats: ['image', 'avatar'] as FastlaneFormat[] },
+        organizationId,
+      );
+
+      expect(llmDispatcher.chatCompletion).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBeTruthy();
+      expect(result[1].id).toBeTruthy();
+      expect(result[0].id).not.toEqual(result[1].id);
+      expect(result[0].format).toBe('image');
+      expect(result[1].speechText).toBe('hello there');
+    });
+
+    it('throws NotFoundException when the brand is not found', async () => {
+      delegate.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.generateFastlaneIdeas(
+          brandId,
+          { count: 2, formats: ['image'] as FastlaneFormat[] },
+          organizationId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(llmDispatcher.chatCompletion).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the brand voice is not configured', async () => {
+      delegate.findFirst.mockResolvedValue({
+        agentConfig: {},
+        id: brandId,
+        isDeleted: false,
+        label: 'Acme',
+        organizationId,
+      });
+
+      await expect(
+        service.generateFastlaneIdeas(
+          brandId,
+          { count: 2, formats: ['image'] as FastlaneFormat[] },
+          organizationId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(llmDispatcher.chatCompletion).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty array when the LLM response is not valid JSON', async () => {
+      delegate.findFirst.mockResolvedValue({
+        agentConfig: { voice: { tone: 'bold' } },
+        id: brandId,
+        isDeleted: false,
+        label: 'Acme',
+        organizationId,
+      });
+      llmDispatcher.chatCompletion.mockResolvedValue({
+        choices: [{ message: { content: 'not json at all' } }],
+      });
+
+      const result = await service.generateFastlaneIdeas(
+        brandId,
+        { count: 2, formats: ['image'] as FastlaneFormat[] },
+        organizationId,
+      );
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -1,11 +1,17 @@
+import { randomUUID } from 'node:crypto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
 import type {
   GenerateBrandVoiceDto,
   GeneratedBrandVoice,
 } from '@api/collections/brands/dto/generate-brand-voice.dto';
+import {
+  FASTLANE_FORMATS,
+  type GenerateFastlaneIdeasDto,
+} from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
 import { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
 import { UpdateBrandAgentConfigDto } from '@api/collections/brands/dto/update-brand-agent-config.dto';
 import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
+import { buildPromptBrandingFromBrand } from '@api/collections/brands/utils/brand-context.util';
 import {
   CACHE_PATTERNS,
   CACHE_TAGS,
@@ -17,6 +23,7 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import type { FastlaneFormat, FastlaneIdea } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -306,6 +313,145 @@ Respond ONLY with the JSON object, no markdown fences or extra text.`;
         tone: 'professional',
         values: [],
       };
+    }
+  }
+
+  /**
+   * Turns structured brand data into a batch of ready-to-produce short-form
+   * content ideas distributed across the requested formats. This is the
+   * brand-data-driven core of Fastlane — the user never writes a prompt.
+   *
+   * Org-scoped: the brand is loaded with the caller's organizationId so a brand
+   * from another org cannot be targeted. Requires a configured brand voice.
+   */
+  async generateFastlaneIdeas(
+    brandId: string,
+    dto: GenerateFastlaneIdeasDto,
+    organizationId: string,
+  ): Promise<FastlaneIdea[]> {
+    this.logger.debug('Generating fastlane ideas', {
+      brandId,
+      count: dto.count,
+      formats: dto.formats,
+      operation: 'generateFastlaneIdeas',
+      service: this.constructorName,
+    });
+
+    const brand = await this.findOne({
+      id: brandId,
+      isDeleted: false,
+      organizationId,
+    });
+    if (!brand) {
+      throw new NotFoundException('Brand not found');
+    }
+
+    const branding = buildPromptBrandingFromBrand(brand);
+    if (!branding) {
+      throw new BadRequestException('Brand voice not configured');
+    }
+
+    const brandParts = [
+      brand.label && `Brand name: ${brand.label}`,
+      brand.description && `Description: ${brand.description}`,
+      branding.tone && `Tone: ${branding.tone}`,
+      branding.voice && `Style: ${branding.voice}`,
+      branding.audience && `Audience: ${branding.audience}`,
+      Array.isArray(branding.values) &&
+        branding.values.length > 0 &&
+        `Values: ${branding.values.join(', ')}`,
+      Array.isArray(branding.messagingPillars) &&
+        branding.messagingPillars.length > 0 &&
+        `Messaging pillars: ${branding.messagingPillars.join(', ')}`,
+      Array.isArray(branding.taglines) &&
+        branding.taglines.length > 0 &&
+        `Taglines: ${branding.taglines.join(' | ')}`,
+      Array.isArray(branding.hashtags) &&
+        branding.hashtags.length > 0 &&
+        `Hashtags: ${branding.hashtags.join(' ')}`,
+      Array.isArray(branding.doNotSoundLike) &&
+        branding.doNotSoundLike.length > 0 &&
+        `Avoid sounding like: ${branding.doNotSoundLike.join(', ')}`,
+      branding.sampleOutput && `Sample voice: ${branding.sampleOutput}`,
+    ].filter(Boolean);
+
+    const angleContext = dto.angle ? `\nCreative angle: ${dto.angle}` : '';
+    const formatsList = dto.formats.join(', ');
+
+    const prompt = `You are a short-form content strategist. Using ONLY the brand profile below, generate ${dto.count} distinct, ready-to-produce short-form content ideas distributed as evenly as possible across these formats: ${formatsList}.
+
+Format meanings:
+- image: a single scroll-stopping still or slideshow frame
+- video: a short b-roll or hook-and-demo style clip
+- avatar: a UGC-style talking-avatar clip with a spoken script
+
+Return ONLY a JSON array (no markdown fences). Each element must be an object with these exact fields:
+- format: one of ${formatsList}
+- hook: a short scroll-stopping hook line (max ~12 words)
+- caption: a ready-to-publish caption with a clear call to action
+- visualPrompt: a vivid visual/scene description to feed an image or video generator
+- platformHints: array of 1-3 platforms from ["tiktok","instagram","youtube"] this idea suits
+- speechText: ONLY for format "avatar" — the spoken script (2-4 sentences); omit for other formats
+
+Brand profile:
+${brandParts.join('\n')}${angleContext}
+
+Respond ONLY with the JSON array.`;
+
+    const completion = await this.llmDispatcherService.chatCompletion(
+      {
+        max_tokens: 2000,
+        messages: [{ content: prompt, role: 'user' }],
+        model: 'anthropic/claude-sonnet-4-5-20250514',
+        temperature: 0.8,
+      },
+      organizationId,
+    );
+
+    const rawContent = completion.choices?.[0]?.message?.content?.trim() ?? '';
+
+    try {
+      const parsed = JSON.parse(rawContent) as unknown;
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .filter(
+          (item): item is Partial<FastlaneIdea> =>
+            Boolean(item) && typeof item === 'object',
+        )
+        .map((item) => {
+          const format: FastlaneFormat = FASTLANE_FORMATS.includes(
+            item.format as FastlaneFormat,
+          )
+            ? (item.format as FastlaneFormat)
+            : dto.formats[0];
+
+          return {
+            caption: typeof item.caption === 'string' ? item.caption : '',
+            format,
+            hook: typeof item.hook === 'string' ? item.hook : '',
+            id: randomUUID(),
+            platformHints: Array.isArray(item.platformHints)
+              ? item.platformHints.filter(
+                  (platform): platform is string =>
+                    typeof platform === 'string',
+                )
+              : [],
+            speechText:
+              typeof item.speechText === 'string' ? item.speechText : undefined,
+            visualPrompt:
+              typeof item.visualPrompt === 'string' ? item.visualPrompt : '',
+          } satisfies FastlaneIdea;
+        })
+        .filter((idea) => idea.hook || idea.caption || idea.visualPrompt);
+    } catch {
+      this.logger.warn('Failed to parse fastlane ideas LLM response', {
+        rawContent,
+        service: this.constructorName,
+      });
+      return [];
     }
   }
 

--- a/apps/server/api/src/collections/organization-settings/dto/create-organization-setting.dto.ts
+++ b/apps/server/api/src/collections/organization-settings/dto/create-organization-setting.dto.ts
@@ -283,6 +283,16 @@ export class CreateOrganizationSettingDto {
   })
   readonly isAutoEvaluateEnabled!: boolean;
 
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    default: false,
+    description:
+      'Whether Fastlane (brand-data-driven batch content) is enabled for the organization',
+    required: false,
+  })
+  readonly isFastlaneEnabled?: boolean;
+
   @IsNumber()
   @IsOptional()
   @Min(0)

--- a/apps/server/api/src/collections/organization-settings/entities/organization-setting.entity.ts
+++ b/apps/server/api/src/collections/organization-settings/entities/organization-setting.entity.ts
@@ -18,6 +18,7 @@ export class OrganizationSettingEntity extends BaseEntity {
   declare readonly isGenerateMusicEnabled: boolean;
 
   declare readonly isAutoEvaluateEnabled: boolean;
+  declare readonly isFastlaneEnabled: boolean;
 
   declare readonly isWebhookEnabled: boolean;
   declare readonly webhookEndpoint: string | undefined;

--- a/apps/server/api/src/collections/posts/dto/create-post.dto.ts
+++ b/apps/server/api/src/collections/posts/dto/create-post.dto.ts
@@ -301,4 +301,13 @@ export class CreatePostDto {
   @IsOptional()
   @IsString()
   readonly publishIntent?: string;
+
+  @ApiProperty({
+    description:
+      'Origin label for the post (e.g. agent, fastlane, manual). Free-form string.',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  readonly source?: string;
 }

--- a/apps/server/api/src/collections/users/services/user-setup.service.ts
+++ b/apps/server/api/src/collections/users/services/user-setup.service.ts
@@ -228,6 +228,7 @@ export class UserSetupService {
       brandsLimit: 5,
       enabledModels: enabledModelIds,
       isAutoEvaluateEnabled: false,
+      isFastlaneEnabled: false,
       isGenerateArticlesEnabled: false,
       isGenerateImagesEnabled: true,
       isGenerateMusicEnabled: true,

--- a/apps/server/api/test/e2e/e2e-test.utils.ts
+++ b/apps/server/api/test/e2e/e2e-test.utils.ts
@@ -423,6 +423,7 @@ export const createTestOrganizationSetting = (
   createdAt: new Date(),
   enabledModels: [],
   isDeleted: false,
+  isFastlaneEnabled: false,
   isGenerateArticlesEnabled: true,
   isGenerateImagesEnabled: true,
   isGenerateMusicEnabled: true,

--- a/bun.lock
+++ b/bun.lock
@@ -1017,6 +1017,9 @@
         "@genfeedai/constants": "workspace:*",
         "@tanstack/react-query": "5.101.0",
       },
+      "devDependencies": {
+        "@testing-library/react": "16.3.2",
+      },
     },
     "packages/pricing": {
       "name": "@genfeedai/pricing",

--- a/packages/api-types/src/contracts/posts.contract.ts
+++ b/packages/api-types/src/contracts/posts.contract.ts
@@ -71,6 +71,7 @@ export const createPostSchema = z.object({
   repeatFrequency: z.nativeEnum(PostFrequency).optional(),
   repeatInterval: z.number().int().positive().optional(),
   scheduledDate: dateStringSchema.optional(),
+  source: optionalStringSchema,
   status: z.nativeEnum(PostStatus),
   tags: objectIdArraySchema().optional(),
   timezone: timezoneSchema.optional(),

--- a/packages/api-types/src/generated/api.d.ts
+++ b/packages/api-types/src/generated/api.d.ts
@@ -24,6 +24,7 @@ export interface components {
       creativeVersion?: string;
       scheduleSlot?: string;
       publishIntent?: string;
+      source?: string;
       publicationDate?: string;
       quoteTweetId?: string;
       repeatDaysOfWeek?: number[];

--- a/packages/client/src/models/organization/organization-setting.model.ts
+++ b/packages/client/src/models/organization/organization-setting.model.ts
@@ -26,6 +26,7 @@ export class OrganizationSetting
   public declare isGenerateImagesEnabled: boolean;
   public declare isGenerateMusicEnabled: boolean;
   public declare isAutoEvaluateEnabled: boolean;
+  public declare isFastlaneEnabled: boolean;
   public declare isDarkroomNsfwVisible: boolean;
 
   public declare isAdvancedMode: boolean;

--- a/packages/constants/src/routes.constant.ts
+++ b/packages/constants/src/routes.constant.ts
@@ -167,6 +167,7 @@ export const APP_ROUTES = {
     AVATAR: '/studio/avatar',
     BATCH: '/studio/batch',
     CLIPS: '/studio/clips',
+    FASTLANE: '/studio/fastlane',
     IMAGE: '/studio/image',
     MUSIC: '/studio/music',
     ROOT: '/studio',

--- a/packages/hooks/data/organization/use-fastlane-enabled/use-fastlane-enabled.ts
+++ b/packages/hooks/data/organization/use-fastlane-enabled/use-fastlane-enabled.ts
@@ -1,0 +1,23 @@
+import { useOrganization } from '@hooks/data/organization/use-organization/use-organization';
+
+export interface UseFastlaneEnabledReturn {
+  /** Whether Fastlane is enabled for the current organization. Defaults to false. */
+  isEnabled: boolean;
+  /** Whether the organization settings are still loading. */
+  isLoading: boolean;
+}
+
+/**
+ * Reads the org-level `isFastlaneEnabled` flag. Default OFF.
+ *
+ * Consumers must respect `isLoading` to avoid nav flicker / rendering gated
+ * content before the flag resolves.
+ */
+export function useFastlaneEnabled(): UseFastlaneEnabledReturn {
+  const { settings, isLoading } = useOrganization();
+
+  return {
+    isEnabled: settings?.isFastlaneEnabled ?? false,
+    isLoading,
+  };
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -188,6 +188,7 @@ export * from './social/link.interface';
 export * from './studio/camera-movement.interface';
 export * from './studio/conversation-canvas.interface';
 export * from './studio/conversation-sidebar.interface';
+export * from './studio/fastlane.interface';
 export * from './studio/recent-asset.interface';
 export * from './studio/studio-edit.interface';
 export * from './studio/studio-edit-layout.interface';

--- a/packages/interfaces/src/organization/organization-setting.interface.ts
+++ b/packages/interfaces/src/organization/organization-setting.interface.ts
@@ -35,6 +35,7 @@ export interface IOrganizationSetting extends IBaseEntity {
   isGenerateImagesEnabled: boolean;
   isGenerateMusicEnabled: boolean;
   isAutoEvaluateEnabled: boolean;
+  isFastlaneEnabled: boolean;
   isDarkroomNsfwVisible: boolean;
 
   isWebhookEnabled: boolean;

--- a/packages/interfaces/src/studio/fastlane.interface.ts
+++ b/packages/interfaces/src/studio/fastlane.interface.ts
@@ -1,0 +1,74 @@
+/**
+ * Fastlane — brand-data-driven studio mode.
+ *
+ * The user never writes prompts: brand data is turned into a batch of content
+ * ideas (one LLM call), each idea is generated across image/video/avatar
+ * pipelines, reviewed in a Tinder-style "Blitz" swipe, and the keepers are
+ * scheduled to connected short-form socials.
+ */
+
+/** Content formats Fastlane can fan generation across. */
+export type FastlaneFormat = 'image' | 'video' | 'avatar';
+
+/** A single brand-derived content brief produced by the ideas endpoint. */
+export interface FastlaneIdea {
+  /** Client/server-assigned stable id (UUID). */
+  id: string;
+  /** Which generation pipeline this idea targets. */
+  format: FastlaneFormat;
+  /** Short scroll-stopping hook line (also used as the post label). */
+  hook: string;
+  /** Ready-to-publish caption copy. */
+  caption: string;
+  /** Visual/scene prompt fed to the image/video pipeline. */
+  visualPrompt: string;
+  /** Platforms this idea suits best (e.g. tiktok, instagram, youtube). */
+  platformHints: string[];
+  /** Spoken script for avatar ideas (UGC voiceover). */
+  speechText?: string;
+}
+
+/** Request body for the brand → ideas endpoint. */
+export interface FastlaneGenerateIdeasRequest {
+  /** Formats the batch should be distributed across. */
+  formats: FastlaneFormat[];
+  /** How many ideas to generate (1–12). */
+  count: number;
+  /** Optional creative angle/theme to steer the batch. */
+  angle?: string;
+}
+
+/** Lifecycle of a single generated asset through the Fastlane flow. */
+export type FastlaneAssetStatus =
+  | 'pending'
+  | 'generating'
+  | 'ready'
+  | 'failed'
+  | 'approved'
+  | 'rejected';
+
+/** An idea paired with its generation/review state in the session. */
+export interface FastlaneAssetItem {
+  /** The originating brief. */
+  idea: FastlaneIdea;
+  /** Resolved ingredient id once generation lands (null until ready). */
+  ingredientId: string | null;
+  /** Public URL of the generated media when ready. */
+  ingredientUrl?: string;
+  /** Thumbnail/preview URL when available. */
+  thumbnailUrl?: string;
+  /** Current lifecycle status. */
+  status: FastlaneAssetStatus;
+  /** Failure detail when status is 'failed'. */
+  errorMessage?: string;
+}
+
+/** A scheduling destination for an approved asset. */
+export interface FastlaneScheduleTarget {
+  /** Credential id of the connected social account. */
+  credentialId: string;
+  /** Canonical lowercase platform value (tiktok, instagram, youtube). */
+  platform: string;
+  /** When to publish; omit/undefined means publish now. */
+  scheduledDate?: string;
+}

--- a/packages/interfaces/src/studio/index.ts
+++ b/packages/interfaces/src/studio/index.ts
@@ -1,6 +1,7 @@
 export * from './camera-movement.interface';
 export * from './conversation-canvas.interface';
 export * from './conversation-sidebar.interface';
+export * from './fastlane.interface';
 export * from './recent-asset.interface';
 export * from './studio-edit.interface';
 export * from './studio-edit-layout.interface';

--- a/packages/models/organization/organization.model.test.ts
+++ b/packages/models/organization/organization.model.test.ts
@@ -84,6 +84,7 @@ const createOrganizationSetting = (
   brandsLimit: 1,
   isAdvancedMode: false,
   isAutoEvaluateEnabled: false,
+  isFastlaneEnabled: false,
   isDarkroomNsfwVisible: false,
   isGenerateArticlesEnabled: true,
   isGenerateImagesEnabled: true,

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -4,6 +4,9 @@
     "@tanstack/react-query": "5.101.0"
   },
   "description": "Shared page-level compositions for Genfeed applications",
+  "devDependencies": {
+    "@testing-library/react": "16.3.2"
+  },
   "exports": {
     "./*": "./*"
   },

--- a/packages/pages/studio/fastlane/FastlaneLayout.tsx
+++ b/packages/pages/studio/fastlane/FastlaneLayout.tsx
@@ -39,9 +39,11 @@ export default function FastlaneLayout() {
     [selectedBrand, credentials, selectedFormats],
   );
 
-  const isAvatarConfigured =
-    Boolean(selectedBrand?.agentConfig?.defaultAvatarIngredientId) ||
-    Boolean(selectedBrand?.agentConfig?.defaultAvatarPhotoUrl);
+  // Avatar generation needs a default avatar *ingredient* (a photo-url-only
+  // config can't drive HeyGen generation here), matching brand-readiness.
+  const isAvatarConfigured = Boolean(
+    selectedBrand?.agentConfig?.defaultAvatarIngredientId,
+  );
 
   const avatarIngredientId =
     selectedBrand?.agentConfig?.defaultAvatarIngredientId ?? null;
@@ -58,7 +60,6 @@ export default function FastlaneLayout() {
     isLoading: isIdeasLoading,
     error,
     generateIdeas,
-    reset,
   } = useFastlaneIdeas(brandId);
 
   const { assets, isGenerating, startGeneration, failedCount } =
@@ -79,34 +80,20 @@ export default function FastlaneLayout() {
     await startGeneration(ideas);
   }, [ideas, startGeneration]);
 
+  // useFastlaneGeneration owns the asset list + generation status. Approval is a
+  // review-time concern, so it is tracked here as an overlay map and merged into
+  // the asset list for display + scheduling (see enrichedAssets below).
+  const [approvalMap, setApprovalMap] = useState<
+    Record<string, 'approved' | 'rejected'>
+  >({});
+
   const handleApprove = useCallback((ideaId: string) => {
-    // Update the asset's status — generation hook owns asset state; blitz
-    // calls back to parent so layout can drive the state update.
-    // We surface this via the generation hook's setAssets (not exposed), so
-    // we track approved/rejected via a separate local map here.
-    // DESIGN CHOICE: useFastlaneGeneration owns the asset list including status;
-    // to keep it as single source of truth, we proxy approve/reject back into it
-    // via startGeneration's returned mutators. However, since the generation hook
-    // doesn't expose setAssets directly, we achieve this by re-reading the assets
-    // array and identifying which got approved. The Blitz component calls onApprove
-    // so we need to apply the status update.
-    //
-    // Since the hook's update function is internal, we replicate the mutation here
-    // by rebuilding the asset list. The generation hook provides `assets` as state —
-    // to mutate it from outside we need to either lift the state or expose a mutator.
-    //
-    // IMPLEMENTATION: We'll lift approval/rejection state to this layout component
-    // as a separate overlay, applied when rendering.
     setApprovalMap((prev) => ({ ...prev, [ideaId]: 'approved' }));
   }, []);
 
   const handleReject = useCallback((ideaId: string) => {
     setApprovalMap((prev) => ({ ...prev, [ideaId]: 'rejected' }));
   }, []);
-
-  const [approvalMap, setApprovalMap] = useState<
-    Record<string, 'approved' | 'rejected'>
-  >({});
 
   // Merge approval status into assets for display / scheduling
   const enrichedAssets = useMemo(

--- a/packages/pages/studio/fastlane/FastlaneLayout.tsx
+++ b/packages/pages/studio/fastlane/FastlaneLayout.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { useFastlaneEnabled } from '@hooks/data/organization/use-fastlane-enabled/use-fastlane-enabled';
+import { useCallback, useMemo, useState } from 'react';
+import FastlaneBlitz from './components/FastlaneBlitz';
+import FastlaneBrandGate from './components/FastlaneBrandGate';
+import FastlaneIdeaSelector from './components/FastlaneIdeaSelector';
+import FastlaneSchedulePanel from './components/FastlaneSchedulePanel';
+import { useFastlaneGeneration } from './hooks/useFastlaneGeneration';
+import { useFastlaneIdeas } from './hooks/useFastlaneIdeas';
+import { useFastlaneSchedule } from './hooks/useFastlaneSchedule';
+import type {
+  FastlaneFormat,
+  FastlaneStep,
+  ScheduleApprovedParams,
+} from './types';
+import { isBrandReadyForFastlane } from './utils/brand-readiness';
+
+const STEPS: { id: FastlaneStep; label: string }[] = [
+  { id: 'ideas', label: '1. Ideas' },
+  { id: 'review', label: '2. Review' },
+  { id: 'schedule', label: '3. Schedule' },
+];
+
+export default function FastlaneLayout() {
+  const { isEnabled, isLoading: isFastlaneLoading } = useFastlaneEnabled();
+  const { brandId, selectedBrand, credentials, isReady } = useBrand();
+
+  const [step, setStep] = useState<FastlaneStep>('ideas');
+  const [selectedFormats, setSelectedFormats] = useState<FastlaneFormat[]>([
+    'image',
+    'video',
+  ]);
+
+  // Derive brand readiness — recomputed whenever selectedFormats changes
+  const readiness = useMemo(
+    () => isBrandReadyForFastlane(selectedBrand, credentials, selectedFormats),
+    [selectedBrand, credentials, selectedFormats],
+  );
+
+  const isAvatarConfigured =
+    Boolean(selectedBrand?.agentConfig?.defaultAvatarIngredientId) ||
+    Boolean(selectedBrand?.agentConfig?.defaultAvatarPhotoUrl);
+
+  const avatarIngredientId =
+    selectedBrand?.agentConfig?.defaultAvatarIngredientId ?? null;
+  const voiceId = selectedBrand?.agentConfig?.defaultVoiceId ?? null;
+
+  // Extract reference IDs from the brand
+  const references = useMemo(
+    () => selectedBrand?.references?.map((r: { id: string }) => r.id) ?? [],
+    [selectedBrand?.references],
+  );
+
+  const {
+    ideas,
+    isLoading: isIdeasLoading,
+    error,
+    generateIdeas,
+    reset,
+  } = useFastlaneIdeas(brandId);
+
+  const { assets, isGenerating, startGeneration, failedCount } =
+    useFastlaneGeneration({ brandId, avatarIngredientId, voiceId, references });
+
+  const { isScheduling, scheduleApproved } = useFastlaneSchedule();
+
+  const handleGenerate = useCallback(
+    async (formats: FastlaneFormat[], count: number, angle?: string) => {
+      setSelectedFormats(formats);
+      await generateIdeas(formats, count, angle);
+    },
+    [generateIdeas],
+  );
+
+  const handleStartGeneration = useCallback(async () => {
+    setStep('review');
+    await startGeneration(ideas);
+  }, [ideas, startGeneration]);
+
+  const handleApprove = useCallback((ideaId: string) => {
+    // Update the asset's status — generation hook owns asset state; blitz
+    // calls back to parent so layout can drive the state update.
+    // We surface this via the generation hook's setAssets (not exposed), so
+    // we track approved/rejected via a separate local map here.
+    // DESIGN CHOICE: useFastlaneGeneration owns the asset list including status;
+    // to keep it as single source of truth, we proxy approve/reject back into it
+    // via startGeneration's returned mutators. However, since the generation hook
+    // doesn't expose setAssets directly, we achieve this by re-reading the assets
+    // array and identifying which got approved. The Blitz component calls onApprove
+    // so we need to apply the status update.
+    //
+    // Since the hook's update function is internal, we replicate the mutation here
+    // by rebuilding the asset list. The generation hook provides `assets` as state —
+    // to mutate it from outside we need to either lift the state or expose a mutator.
+    //
+    // IMPLEMENTATION: We'll lift approval/rejection state to this layout component
+    // as a separate overlay, applied when rendering.
+    setApprovalMap((prev) => ({ ...prev, [ideaId]: 'approved' }));
+  }, []);
+
+  const handleReject = useCallback((ideaId: string) => {
+    setApprovalMap((prev) => ({ ...prev, [ideaId]: 'rejected' }));
+  }, []);
+
+  const [approvalMap, setApprovalMap] = useState<
+    Record<string, 'approved' | 'rejected'>
+  >({});
+
+  // Merge approval status into assets for display / scheduling
+  const enrichedAssets = useMemo(
+    () =>
+      assets.map((a) => {
+        const override = approvalMap[a.idea.id];
+        return override ? { ...a, status: override } : a;
+      }),
+    [assets, approvalMap],
+  );
+
+  const handleSchedule = useCallback(
+    (params: ScheduleApprovedParams) => {
+      void scheduleApproved(params);
+    },
+    [scheduleApproved],
+  );
+
+  // ─────────────────────────────────────────────────────────
+  // Guard: Fastlane feature flag
+  // ─────────────────────────────────────────────────────────
+  if (isFastlaneLoading || !isReady) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <span className="gen-dot gen-dot-processing" />
+      </div>
+    );
+  }
+
+  if (!isEnabled) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+        <h2 className="gen-heading-lg">Fastlane is not available</h2>
+        <p className="text-sm text-muted-foreground">
+          Contact your organization admin to enable Fastlane.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <FastlaneBrandGate readiness={readiness}>
+      <div className="flex flex-col gap-8">
+        {/* Step indicator */}
+        <div className="flex items-center gap-2">
+          {STEPS.map((s, i) => (
+            <div key={s.id} className="flex items-center gap-2">
+              <span
+                className={
+                  step === s.id
+                    ? 'gen-label text-foreground'
+                    : 'gen-label-sm text-muted-foreground'
+                }
+              >
+                {s.label}
+              </span>
+              {i < STEPS.length - 1 && (
+                <span className="gen-divider-vertical h-4 mx-1" />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="gen-divider" />
+
+        {/* Step content */}
+        {step === 'ideas' && (
+          <FastlaneIdeaSelector
+            isAvatarConfigured={isAvatarConfigured}
+            isLoading={isIdeasLoading}
+            ideas={ideas}
+            error={error}
+            onGenerate={handleGenerate}
+            onStartGeneration={handleStartGeneration}
+          />
+        )}
+
+        {step === 'review' && (
+          <FastlaneBlitz
+            assets={enrichedAssets}
+            failedCount={failedCount}
+            isGenerating={isGenerating}
+            onApprove={handleApprove}
+            onReject={handleReject}
+            onDone={() => setStep('schedule')}
+          />
+        )}
+
+        {step === 'schedule' && (
+          <FastlaneSchedulePanel
+            assets={enrichedAssets}
+            credentials={credentials}
+            isScheduling={isScheduling}
+            timezone={Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC'}
+            onSchedule={handleSchedule}
+          />
+        )}
+      </div>
+    </FastlaneBrandGate>
+  );
+}

--- a/packages/pages/studio/fastlane/components/FastlaneBlitz.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneBlitz.tsx
@@ -70,6 +70,24 @@ export default function FastlaneBlitz({
     );
   }
 
+  if (isExhausted && isGenerating) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+        <div className="gen-dot gen-dot-processing" />
+        <p className="text-sm text-muted-foreground">
+          You're caught up — more assets are still generating…
+        </p>
+        <div className="flex gap-4 text-sm text-muted-foreground">
+          <span>{approvedCount} approved</span>
+          <span>{rejectedCount} rejected</span>
+          {failedCount > 0 && (
+            <Badge variant="destructive">{failedCount} failed</Badge>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   if (isExhausted) {
     return (
       <div className="flex flex-col items-center justify-center gap-6 py-16 text-center">

--- a/packages/pages/studio/fastlane/components/FastlaneBlitz.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneBlitz.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import type { FastlaneAssetItem } from '@genfeedai/interfaces';
+import { Badge } from '@ui/primitives/badge';
+import { Button } from '@ui/primitives/button';
+import { useEffect, useState } from 'react';
+
+interface FastlaneBlitzProps {
+  assets: FastlaneAssetItem[];
+  failedCount: number;
+  isGenerating: boolean;
+  onApprove: (ideaId: string) => void;
+  onReject: (ideaId: string) => void;
+  onDone: () => void;
+}
+
+export default function FastlaneBlitz({
+  assets,
+  failedCount,
+  isGenerating,
+  onApprove,
+  onReject,
+  onDone,
+}: FastlaneBlitzProps) {
+  const readyAssets = assets.filter((a) => a.status === 'ready');
+  const approvedCount = assets.filter((a) => a.status === 'approved').length;
+  const rejectedCount = assets.filter((a) => a.status === 'rejected').length;
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [swipeDir, setSwipeDir] = useState<'left' | 'right' | null>(null);
+
+  const currentAsset = readyAssets[currentIndex] ?? null;
+  const isExhausted = currentIndex >= readyAssets.length;
+
+  function triggerSwipe(dir: 'left' | 'right') {
+    if (!currentAsset || swipeDir) return;
+    setSwipeDir(dir);
+    setTimeout(() => {
+      if (dir === 'right') {
+        onApprove(currentAsset.idea.id);
+      } else {
+        onReject(currentAsset.idea.id);
+      }
+      setCurrentIndex((i) => i + 1);
+      setSwipeDir(null);
+    }, 250);
+  }
+
+  // Keyboard left/right arrow support
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'ArrowRight') triggerSwipe('right');
+      if (e.key === 'ArrowLeft') triggerSwipe('left');
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentAsset, swipeDir]);
+
+  if (isGenerating && readyAssets.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-16">
+        <div className="gen-dot gen-dot-processing" />
+        <p className="text-sm text-muted-foreground">Generating your assets…</p>
+        {failedCount > 0 && (
+          <Badge variant="destructive">{failedCount} failed</Badge>
+        )}
+      </div>
+    );
+  }
+
+  if (isExhausted) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 py-16 text-center">
+        <h3 className="gen-heading-md">Review complete</h3>
+        <div className="flex gap-4 text-sm text-muted-foreground">
+          <span>{approvedCount} approved</span>
+          <span>{rejectedCount} rejected</span>
+          {failedCount > 0 && (
+            <Badge variant="destructive">{failedCount} failed</Badge>
+          )}
+        </div>
+        {approvedCount > 0 ? (
+          <Button
+            variant={ButtonVariant.DEFAULT}
+            label="Schedule approved"
+            onClick={onDone}
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No assets approved. Go back to generate more ideas.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  const swipeStyle: React.CSSProperties =
+    swipeDir === 'right'
+      ? {
+          transform: 'translateX(120%) rotate(15deg)',
+          opacity: 0,
+          transition: 'transform 250ms ease, opacity 250ms ease',
+        }
+      : swipeDir === 'left'
+        ? {
+            transform: 'translateX(-120%) rotate(-15deg)',
+            opacity: 0,
+            transition: 'transform 250ms ease, opacity 250ms ease',
+          }
+        : {
+            transform: 'translateX(0) rotate(0deg)',
+            opacity: 1,
+            transition: 'transform 250ms ease, opacity 250ms ease',
+          };
+
+  return (
+    <div className="flex flex-col items-center gap-6 w-full max-w-sm mx-auto">
+      {failedCount > 0 && (
+        <Badge variant="destructive">{failedCount} failed</Badge>
+      )}
+
+      <p className="gen-label-sm text-muted-foreground">
+        {currentIndex + 1} / {readyAssets.length} — ← reject · approve →
+      </p>
+
+      {/* Card */}
+      <div className="relative w-full" style={{ minHeight: 420 }}>
+        <div
+          className="gen-glass rounded-2xl overflow-hidden w-full absolute inset-0"
+          style={swipeStyle}
+        >
+          {currentAsset?.thumbnailUrl || currentAsset?.ingredientUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={currentAsset.thumbnailUrl ?? currentAsset.ingredientUrl}
+              alt={currentAsset.idea.hook}
+              className="w-full h-64 object-cover"
+            />
+          ) : (
+            <div className="w-full h-64 bg-muted flex items-center justify-center">
+              <Badge variant="secondary">
+                {currentAsset?.idea.format ?? 'asset'}
+              </Badge>
+            </div>
+          )}
+
+          <div className="p-4 flex flex-col gap-2">
+            <div className="flex gap-2 flex-wrap">
+              <Badge variant="secondary">{currentAsset?.idea.format}</Badge>
+              {currentAsset?.idea.platformHints.map((hint: string) => (
+                <Badge key={hint} variant="outline" className="text-xs">
+                  {hint}
+                </Badge>
+              ))}
+            </div>
+            <p className="text-sm font-semibold">{currentAsset?.idea.hook}</p>
+            <p className="text-xs text-muted-foreground line-clamp-3">
+              {currentAsset?.idea.caption}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex gap-4 mt-4" style={{ paddingTop: 420 }}>
+        <Button
+          variant={ButtonVariant.OUTLINE}
+          size={ButtonSize.LG}
+          label="✕ Reject"
+          onClick={() => triggerSwipe('left')}
+          isDisabled={!!swipeDir}
+        />
+        <Button
+          variant={ButtonVariant.DEFAULT}
+          size={ButtonSize.LG}
+          label="✓ Approve"
+          onClick={() => triggerSwipe('right')}
+          isDisabled={!!swipeDir}
+        />
+      </div>
+
+      {isGenerating && (
+        <p className="text-xs text-muted-foreground">
+          More assets still generating…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/pages/studio/fastlane/components/FastlaneBrandGate.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneBrandGate.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import type { ReactNode } from 'react';
+import type { BrandReadinessResult } from '../utils/brand-readiness';
+
+interface FastlaneBrandGateProps {
+  readiness: BrandReadinessResult;
+  children: ReactNode;
+}
+
+export default function FastlaneBrandGate({
+  readiness,
+  children,
+}: FastlaneBrandGateProps) {
+  const params = useParams<{ orgSlug: string; brandSlug: string }>();
+
+  if (readiness.ready) {
+    return <>{children}</>;
+  }
+
+  const settingsHref =
+    params?.orgSlug && params?.brandSlug
+      ? `/${params.orgSlug}/${params.brandSlug}/settings`
+      : '/settings';
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 py-16 px-4 text-center">
+      <div className="flex flex-col gap-2 max-w-md">
+        <h2 className="gen-heading-lg">Brand not ready for Fastlane</h2>
+        <p className="text-sm text-muted-foreground">
+          Complete the following before using Fastlane:
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-2 text-left w-full max-w-sm">
+        {readiness.reasons.map((reason) => (
+          <li
+            key={reason}
+            className="flex items-start gap-2 text-sm text-muted-foreground"
+          >
+            <span className="gen-dot gen-dot-warning mt-1 shrink-0" />
+            {reason}
+          </li>
+        ))}
+      </ul>
+
+      <Link href={settingsHref}>
+        <Button variant={ButtonVariant.DEFAULT} label="Go to Brand Settings" />
+      </Link>
+    </div>
+  );
+}

--- a/packages/pages/studio/fastlane/components/FastlaneIdeaSelector.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneIdeaSelector.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { Badge } from '@ui/primitives/badge';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import { SimpleTooltip } from '@ui/primitives/tooltip';
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+import { FASTLANE_CREDIT_COSTS } from '../hooks/useFastlaneGeneration';
+import type { FastlaneFormat, FastlaneIdea } from '../types';
+
+const ALL_FORMATS: FastlaneFormat[] = ['image', 'video', 'avatar'];
+
+const FORMAT_LABELS: Record<FastlaneFormat, string> = {
+  image: 'Image',
+  video: 'Video',
+  avatar: 'Avatar',
+};
+
+const MIN_COUNT = 3;
+const MAX_COUNT = 9;
+
+interface FastlaneIdeaSelectorProps {
+  isAvatarConfigured: boolean;
+  isLoading: boolean;
+  ideas: FastlaneIdea[];
+  error: string | null;
+  onGenerate: (
+    formats: FastlaneFormat[],
+    count: number,
+    angle?: string,
+  ) => void;
+  onStartGeneration: () => void;
+}
+
+export default function FastlaneIdeaSelector({
+  isAvatarConfigured,
+  isLoading,
+  ideas,
+  error,
+  onGenerate,
+  onStartGeneration,
+}: FastlaneIdeaSelectorProps) {
+  const [selectedFormats, setSelectedFormats] = useState<FastlaneFormat[]>([
+    'image',
+    'video',
+  ]);
+  const [count, setCount] = useState(6);
+  const [angle, setAngle] = useState('');
+
+  const creditEstimate = selectedFormats.reduce(
+    (sum, fmt) => sum + FASTLANE_CREDIT_COSTS[fmt] * count,
+    0,
+  );
+
+  function toggleFormat(format: FastlaneFormat) {
+    setSelectedFormats((prev) =>
+      prev.includes(format)
+        ? prev.filter((f) => f !== format)
+        : [...prev, format],
+    );
+  }
+
+  function handleCountChange(delta: number) {
+    setCount((c) => Math.min(MAX_COUNT, Math.max(MIN_COUNT, c + delta)));
+  }
+
+  function handleAngleChange(e: ChangeEvent<HTMLInputElement>) {
+    setAngle(e.target.value);
+  }
+
+  function handleGenerate() {
+    if (selectedFormats.length === 0) return;
+    onGenerate(selectedFormats, count, angle.trim() || undefined);
+  }
+
+  const hasIdeas = ideas.length > 0;
+
+  return (
+    <div className="flex flex-col gap-6 max-w-xl mx-auto w-full">
+      <div className="flex flex-col gap-3">
+        <p className="gen-label-sm text-muted-foreground">Content formats</p>
+        <div className="flex gap-2">
+          {ALL_FORMATS.map((fmt) => {
+            const isAvatar = fmt === 'avatar';
+            const isDisabled = isAvatar && !isAvatarConfigured;
+            const isSelected = selectedFormats.includes(fmt);
+
+            const toggle = (
+              <Button
+                key={fmt}
+                variant={
+                  isSelected ? ButtonVariant.DEFAULT : ButtonVariant.OUTLINE
+                }
+                size={ButtonSize.SM}
+                label={FORMAT_LABELS[fmt]}
+                isDisabled={isDisabled}
+                onClick={() => !isDisabled && toggleFormat(fmt)}
+              />
+            );
+
+            if (isDisabled) {
+              return (
+                <SimpleTooltip
+                  key={fmt}
+                  label="Configure a default avatar in brand settings to unlock avatar generation"
+                >
+                  {toggle}
+                </SimpleTooltip>
+              );
+            }
+
+            return toggle;
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="gen-label-sm text-muted-foreground">Ideas per format</p>
+        <div className="flex items-center gap-3">
+          <Button
+            variant={ButtonVariant.OUTLINE}
+            size={ButtonSize.SM}
+            label="-"
+            isDisabled={count <= MIN_COUNT}
+            onClick={() => handleCountChange(-1)}
+          />
+          <span className="text-lg font-semibold w-6 text-center">{count}</span>
+          <Button
+            variant={ButtonVariant.OUTLINE}
+            size={ButtonSize.SM}
+            label="+"
+            isDisabled={count >= MAX_COUNT}
+            onClick={() => handleCountChange(1)}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="gen-label-sm text-muted-foreground">
+          Angle <span className="text-xs font-normal">(optional)</span>
+        </p>
+        <Input
+          label="e.g. Focus on summer vibes"
+          value={angle}
+          onChange={handleAngleChange}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="gen-label-sm text-muted-foreground">
+            Estimated cost
+          </span>
+          <Badge variant="secondary">{creditEstimate} credits</Badge>
+        </div>
+        <Button
+          variant={ButtonVariant.GENERATE}
+          label="Generate ideas"
+          isDisabled={selectedFormats.length === 0}
+          isLoading={isLoading}
+          onClick={handleGenerate}
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive bg-destructive/10 rounded-md p-3">
+          {error}
+        </p>
+      )}
+
+      {hasIdeas && !isLoading && (
+        <div className="flex flex-col gap-4 mt-2">
+          <div className="gen-divider" />
+          <p className="gen-label text-muted-foreground">
+            {ideas.length} idea{ideas.length !== 1 ? 's' : ''} generated
+          </p>
+          <div className="flex flex-col gap-3">
+            {ideas.map((idea) => (
+              <div
+                key={idea.id}
+                className="gen-glass rounded-lg p-4 flex flex-col gap-1"
+              >
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary">
+                    {FORMAT_LABELS[idea.format]}
+                  </Badge>
+                  {idea.platformHints.map((hint: string) => (
+                    <Badge key={hint} variant="outline" className="text-xs">
+                      {hint}
+                    </Badge>
+                  ))}
+                </div>
+                <p className="text-sm font-medium">{idea.hook}</p>
+                <p className="text-xs text-muted-foreground line-clamp-2">
+                  {idea.caption}
+                </p>
+              </div>
+            ))}
+          </div>
+          <Button
+            variant={ButtonVariant.DEFAULT}
+            label="Start generating"
+            onClick={onStartGeneration}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/pages/studio/fastlane/components/FastlaneSchedulePanel.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneSchedulePanel.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import type {
+  FastlaneAssetItem,
+  FastlaneScheduleTarget,
+  ICredential,
+} from '@genfeedai/interfaces';
+import { Badge } from '@ui/primitives/badge';
+import { Button } from '@ui/primitives/button';
+import DateTimePicker from '@ui/primitives/date-time-picker';
+import { Textarea } from '@ui/primitives/textarea';
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+import type { ScheduleApprovedParams } from '../types';
+
+const SHORT_FORM_PLATFORMS = ['tiktok', 'instagram', 'youtube'];
+
+interface FastlaneSchedulePanelProps {
+  assets: FastlaneAssetItem[];
+  credentials: ICredential[];
+  isScheduling: boolean;
+  timezone: string;
+  onSchedule: (params: ScheduleApprovedParams) => void;
+}
+
+interface CredentialTarget {
+  credentialId: string;
+  platform: string;
+  isSelected: boolean;
+  scheduledDate: string | undefined;
+}
+
+export default function FastlaneSchedulePanel({
+  assets,
+  credentials,
+  isScheduling,
+  timezone,
+  onSchedule,
+}: FastlaneSchedulePanelProps) {
+  const approved = assets.filter(
+    (a) => a.status === 'approved' && a.ingredientId,
+  );
+
+  const shortFormCreds = credentials.filter((c) =>
+    SHORT_FORM_PLATFORMS.includes((c.platform as string).toLowerCase()),
+  );
+
+  // Caption edits keyed by ideaId
+  const [captions, setCaptions] = useState<Record<string, string>>(() =>
+    Object.fromEntries(approved.map((a) => [a.idea.id, a.idea.caption])),
+  );
+
+  // Credential targets: all selected by default, no scheduledDate = post now
+  const [credTargets, setCredTargets] = useState<CredentialTarget[]>(() =>
+    shortFormCreds.map((c) => ({
+      credentialId: c.id,
+      platform: (c.platform as string).toLowerCase(),
+      isSelected: true,
+      scheduledDate: undefined,
+    })),
+  );
+
+  function updateCaption(ideaId: string, value: string) {
+    setCaptions((prev) => ({ ...prev, [ideaId]: value }));
+  }
+
+  function toggleCredential(credentialId: string) {
+    setCredTargets((prev) =>
+      prev.map((t) =>
+        t.credentialId === credentialId
+          ? { ...t, isSelected: !t.isSelected }
+          : t,
+      ),
+    );
+  }
+
+  function setScheduledDate(credentialId: string, date: Date | null) {
+    setCredTargets((prev) =>
+      prev.map((t) =>
+        t.credentialId === credentialId
+          ? { ...t, scheduledDate: date?.toISOString() ?? undefined }
+          : t,
+      ),
+    );
+  }
+
+  function handleScheduleAll() {
+    const selectedTargets: FastlaneScheduleTarget[] = credTargets
+      .filter((t) => t.isSelected)
+      .map((t) => ({
+        credentialId: t.credentialId,
+        platform: t.platform,
+        scheduledDate: t.scheduledDate,
+      }));
+
+    if (selectedTargets.length === 0) return;
+
+    onSchedule({
+      assets: approved,
+      targets: selectedTargets,
+      captions,
+      timezone,
+    });
+  }
+
+  const selectedCredCount = credTargets.filter((t) => t.isSelected).length;
+
+  if (approved.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+        <p className="text-sm text-muted-foreground">
+          No approved assets to schedule.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 max-w-2xl mx-auto w-full">
+      {/* Platform selection */}
+      <div className="flex flex-col gap-3">
+        <p className="gen-label">Publish to</p>
+        {shortFormCreds.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No short-form social accounts connected (TikTok, Instagram,
+            YouTube).
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {credTargets.map((target) => {
+              const cred = shortFormCreds.find(
+                (c) => c.id === target.credentialId,
+              );
+              return (
+                <div
+                  key={target.credentialId}
+                  className="gen-glass rounded-lg p-4 flex flex-col gap-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        variant={target.isSelected ? 'default' : 'outline'}
+                      >
+                        {target.platform}
+                      </Badge>
+                      <span className="text-sm">
+                        {cred?.externalHandle ?? target.credentialId}
+                      </span>
+                    </div>
+                    <Button
+                      variant={
+                        target.isSelected
+                          ? ButtonVariant.DEFAULT
+                          : ButtonVariant.OUTLINE
+                      }
+                      size={ButtonSize.SM}
+                      label={target.isSelected ? 'Selected' : 'Select'}
+                      onClick={() => toggleCredential(target.credentialId)}
+                    />
+                  </div>
+                  {target.isSelected && (
+                    <DateTimePicker
+                      label="Schedule date (leave empty to post now)"
+                      value={target.scheduledDate}
+                      onChange={(date) =>
+                        setScheduledDate(target.credentialId, date)
+                      }
+                      minDate={new Date()}
+                      timezone={timezone}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Per-asset captions */}
+      <div className="flex flex-col gap-4">
+        <p className="gen-label">Review captions</p>
+        {approved.map((asset) => (
+          <div
+            key={asset.idea.id}
+            className="gen-glass rounded-lg p-4 flex flex-col gap-3"
+          >
+            <div className="flex items-center gap-2">
+              {(asset.thumbnailUrl ?? asset.ingredientUrl) && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={asset.thumbnailUrl ?? asset.ingredientUrl}
+                  alt={asset.idea.hook}
+                  className="w-12 h-12 rounded-md object-cover shrink-0"
+                />
+              )}
+              <div className="flex flex-col gap-1 min-w-0">
+                <Badge variant="secondary">{asset.idea.format}</Badge>
+                <p className="text-sm font-medium truncate">
+                  {asset.idea.hook}
+                </p>
+              </div>
+            </div>
+            <label className="gen-label-sm text-muted-foreground">
+              Caption
+            </label>
+            <Textarea
+              value={captions[asset.idea.id] ?? asset.idea.caption}
+              rows={3}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                updateCaption(asset.idea.id, e.target.value)
+              }
+            />
+          </div>
+        ))}
+      </div>
+
+      <Button
+        variant={ButtonVariant.DEFAULT}
+        label={`Schedule ${approved.length} post${approved.length !== 1 ? 's' : ''} to ${selectedCredCount} account${selectedCredCount !== 1 ? 's' : ''}`}
+        isDisabled={selectedCredCount === 0}
+        isLoading={isScheduling}
+        onClick={handleScheduleAll}
+      />
+    </div>
+  );
+}

--- a/packages/pages/studio/fastlane/hooks/useFastlaneGeneration.test.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneGeneration.test.ts
@@ -1,0 +1,260 @@
+import type { FastlaneIdea } from '@genfeedai/interfaces';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ────────────────────────────────────────────────────────────
+// Mock dependencies before importing the hook
+// ────────────────────────────────────────────────────────────
+
+const mockSubscribe = vi.fn();
+const mockUnsubscribe = vi.fn();
+
+vi.mock('@hooks/utils/use-socket-manager/use-socket-manager', () => ({
+  useSocketManager: () => ({ subscribe: mockSubscribe }),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: (factory: (token: string) => unknown) => {
+    // Return an async getter that calls factory with a stub token
+    return async () => factory('stub-token');
+  },
+}));
+
+const mockImagesPost = vi.fn();
+const mockImagesFindOne = vi.fn();
+vi.mock('@services/ingredients/images.service', () => ({
+  ImagesService: {
+    getInstance: () => ({
+      post: mockImagesPost,
+      findOne: mockImagesFindOne,
+    }),
+  },
+}));
+
+const mockVideosPost = vi.fn();
+const mockVideosFindOne = vi.fn();
+vi.mock('@services/ingredients/videos.service', () => ({
+  VideosService: {
+    getInstance: () => ({
+      post: mockVideosPost,
+      findOne: mockVideosFindOne,
+    }),
+  },
+}));
+
+const mockHeyGenGenerate = vi.fn();
+vi.mock('@services/ingredients/heygen.service', () => ({
+  HeyGenService: {
+    getInstance: () => ({
+      generate: mockHeyGenGenerate,
+    }),
+  },
+}));
+
+const mockIngredientsFindOne = vi.fn();
+vi.mock('@services/content/ingredients.service', () => ({
+  IngredientsService: {
+    getInstance: () => ({
+      findOne: mockIngredientsFindOne,
+    }),
+  },
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockNotificationsError = vi.fn();
+vi.mock('@services/core/notifications.service', () => ({
+  NotificationsService: {
+    getInstance: () => ({ error: mockNotificationsError }),
+  },
+}));
+
+vi.mock('@services/core/socket-manager.service', () => ({
+  createMediaHandler: (
+    onSuccess: (r: unknown) => void,
+    onFailed: (e: string) => void,
+  ) => ({ onSuccess, onFailed }),
+}));
+
+vi.mock('@pages/studio/generate/utils/generation-payloads', () => ({
+  buildBaseGenerationPayload: vi.fn(() => ({})),
+  buildImagePayload: vi.fn(() => ({})),
+  buildVideoPayload: vi.fn(() => ({})),
+  buildAvatarPayload: vi.fn(() => ({
+    text: 'test',
+    speech: '',
+    avatarId: undefined,
+    voiceId: undefined,
+  })),
+}));
+
+vi.mock('@utils/network/generation.util', () => ({
+  resolvePendingIds: (response: unknown) => {
+    const r = response as { pendingIngredientIds?: string[]; id?: string };
+    if (r?.pendingIngredientIds?.length) return r.pendingIngredientIds;
+    if (r?.id) return [r.id];
+    throw new Error('No valid ingredient IDs found');
+  },
+}));
+
+// Import hook after all mocks
+import { useFastlaneGeneration } from './useFastlaneGeneration';
+
+// ────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────
+
+function makeIdea(
+  format: 'image' | 'video' | 'avatar',
+  id = `idea-${format}`,
+): FastlaneIdea {
+  return {
+    id,
+    format,
+    hook: 'Test hook',
+    caption: 'Test caption',
+    visualPrompt: 'A beautiful scene',
+    platformHints: ['tiktok'],
+  };
+}
+
+const DEFAULT_PARAMS = {
+  brandId: 'brand-1',
+  avatarIngredientId: 'avatar-1',
+  voiceId: 'voice-1',
+  references: [],
+};
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe('useFastlaneGeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubscribe.mockReturnValue(mockUnsubscribe);
+    mockImagesPost.mockResolvedValue({ id: 'img-pending-1' });
+    mockVideosPost.mockResolvedValue({ id: 'vid-pending-1' });
+    mockHeyGenGenerate.mockResolvedValue({ id: 'avatar-pending-1' });
+    mockImagesFindOne.mockResolvedValue({
+      id: 'img-1',
+      url: 'https://img.url',
+      thumbnailUrl: 'https://thumb.url',
+    });
+    mockVideosFindOne.mockResolvedValue({
+      id: 'vid-1',
+      url: 'https://vid.url',
+      thumbnailUrl: 'https://thumb.url',
+    });
+    mockIngredientsFindOne.mockResolvedValue({
+      id: 'avatar-1',
+      url: 'https://avatar.url',
+    });
+  });
+
+  it('dispatches to the correct service for each format', async () => {
+    const ideas = [
+      makeIdea('image', 'idea-img'),
+      makeIdea('video', 'idea-vid'),
+      makeIdea('avatar', 'idea-avatar'),
+    ];
+
+    const { result } = renderHook(() => useFastlaneGeneration(DEFAULT_PARAMS));
+
+    await act(async () => {
+      await result.current.startGeneration(ideas);
+    });
+
+    expect(mockImagesPost).toHaveBeenCalledTimes(1);
+    expect(mockVideosPost).toHaveBeenCalledTimes(1);
+    expect(mockHeyGenGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks asset as failed when resolvePendingIds throws (no id in response)', async () => {
+    // Post returns an empty object — resolvePendingIds will throw
+    mockImagesPost.mockResolvedValue({});
+
+    const { result } = renderHook(() => useFastlaneGeneration(DEFAULT_PARAMS));
+
+    await act(async () => {
+      await result.current.startGeneration([makeIdea('image', 'idea-bad')]);
+    });
+
+    const asset = result.current.assets.find((a) => a.idea.id === 'idea-bad');
+    expect(asset?.status).toBe('failed');
+  });
+
+  it('marks asset as ready when WS success fires and findOne resolves', async () => {
+    let capturedHandler: { onSuccess: (r: unknown) => void } | undefined;
+    mockSubscribe.mockImplementation(
+      (_url: string, handler: { onSuccess: (r: unknown) => void }) => {
+        capturedHandler = handler;
+        return mockUnsubscribe;
+      },
+    );
+
+    const { result } = renderHook(() => useFastlaneGeneration(DEFAULT_PARAMS));
+
+    await act(async () => {
+      await result.current.startGeneration([makeIdea('image', 'idea-ws')]);
+    });
+
+    // Simulate WS success event
+    await act(async () => {
+      await capturedHandler?.onSuccess({ id: 'img-resolved-1' });
+    });
+
+    const asset = result.current.assets.find((a) => a.idea.id === 'idea-ws');
+    expect(asset?.status).toBe('ready');
+    expect(asset?.ingredientId).toBe('img-resolved-1');
+    expect(mockImagesFindOne).toHaveBeenCalledWith('img-resolved-1');
+  });
+
+  it('marks asset as failed when WS error fires', async () => {
+    let capturedHandler: { onFailed: (e: string) => void } | undefined;
+    mockSubscribe.mockImplementation(
+      (_url: string, handler: { onFailed: (e: string) => void }) => {
+        capturedHandler = handler;
+        return mockUnsubscribe;
+      },
+    );
+
+    const { result } = renderHook(() => useFastlaneGeneration(DEFAULT_PARAMS));
+
+    await act(async () => {
+      await result.current.startGeneration([makeIdea('image', 'idea-err')]);
+    });
+
+    await act(async () => {
+      capturedHandler?.onFailed('GPU timeout');
+    });
+
+    const asset = result.current.assets.find((a) => a.idea.id === 'idea-err');
+    expect(asset?.status).toBe('failed');
+    expect(asset?.errorMessage).toBe('GPU timeout');
+  });
+
+  it('calls every unsubscribe on unmount', async () => {
+    const unsub1 = vi.fn();
+    const unsub2 = vi.fn();
+    let call = 0;
+    mockSubscribe.mockImplementation(() => (call++ === 0 ? unsub1 : unsub2));
+
+    const ideas = [makeIdea('image', 'idea-1'), makeIdea('video', 'idea-2')];
+
+    const { result, unmount } = renderHook(() =>
+      useFastlaneGeneration(DEFAULT_PARAMS),
+    );
+
+    await act(async () => {
+      await result.current.startGeneration(ideas);
+    });
+
+    unmount();
+
+    expect(unsub1).toHaveBeenCalledTimes(1);
+    expect(unsub2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/pages/studio/fastlane/hooks/useFastlaneGeneration.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneGeneration.ts
@@ -1,0 +1,339 @@
+'use client';
+
+import type { PromptTextareaSchema } from '@genfeedai/client/schemas';
+import { IngredientFormat } from '@genfeedai/enums';
+import type {
+  FastlaneAssetItem,
+  FastlaneIdea,
+  IImage,
+  IVideo,
+} from '@genfeedai/interfaces';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useSocketManager } from '@hooks/utils/use-socket-manager/use-socket-manager';
+import {
+  buildAvatarPayload,
+  buildBaseGenerationPayload,
+  buildImagePayload,
+  buildVideoPayload,
+} from '@pages/studio/generate/utils/generation-payloads';
+import { IngredientsService } from '@services/content/ingredients.service';
+import { logger } from '@services/core/logger.service';
+import { NotificationsService } from '@services/core/notifications.service';
+import { createMediaHandler } from '@services/core/socket-manager.service';
+import { HeyGenService } from '@services/ingredients/heygen.service';
+import { ImagesService } from '@services/ingredients/images.service';
+import { VideosService } from '@services/ingredients/videos.service';
+import { resolvePendingIds } from '@utils/network/generation.util';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  FastlaneAssetUpdate,
+  UseFastlaneGenerationParams,
+  UseFastlaneGenerationReturn,
+} from '../types';
+
+// Credit-weight constants (visible in idea selector)
+export const FASTLANE_CREDIT_COSTS: Record<string, number> = {
+  image: 2,
+  video: 5,
+  avatar: 8,
+};
+
+type SocketResult = { id?: string } | string;
+
+function buildPromptData(
+  idea: FastlaneIdea,
+  brandId: string,
+  avatarIngredientId?: string | null,
+  voiceId?: string | null,
+  references?: string[],
+): PromptTextareaSchema & { isValid: boolean } {
+  const baseText = (
+    idea.visualPrompt?.trim() ||
+    idea.hook?.trim() ||
+    ''
+  ).trim();
+  const text = baseText.length > 0 ? baseText : idea.caption;
+
+  const base: PromptTextareaSchema & { isValid: boolean } = {
+    autoSelectModel: true,
+    blacklist: [],
+    brand: brandId,
+    category: idea.format,
+    fontFamily: '',
+    format: IngredientFormat.PORTRAIT,
+    height: 1920,
+    isValid: true,
+    models: [],
+    outputs: 1,
+    quality: 'premium',
+    references: references ?? [],
+    sounds: [],
+    style: '',
+    tags: [],
+    text,
+    width: 1080,
+  };
+
+  if (idea.format === 'avatar') {
+    return {
+      ...base,
+      avatarId: avatarIngredientId ?? undefined,
+      voiceId: voiceId ?? undefined,
+      speech: (idea.speechText ?? idea.caption ?? '').trim(),
+      text: (idea.speechText ?? idea.caption ?? '').trim() || text,
+    };
+  }
+
+  return base;
+}
+
+export function useFastlaneGeneration({
+  brandId,
+  avatarIngredientId,
+  voiceId,
+  references,
+}: UseFastlaneGenerationParams): UseFastlaneGenerationReturn {
+  const [assets, setAssets] = useState<FastlaneAssetItem[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const socketSubscriptionsRef = useRef<Array<() => void>>([]);
+
+  const { subscribe } = useSocketManager();
+  const notificationsService = NotificationsService.getInstance();
+
+  const getImagesService = useAuthedService((token: string) =>
+    ImagesService.getInstance(token),
+  );
+  const getVideosService = useAuthedService((token: string) =>
+    VideosService.getInstance(token),
+  );
+  const getHeyGenService = useAuthedService((token: string) =>
+    HeyGenService.getInstance(token),
+  );
+  const getIngredientsService = useAuthedService((token: string) =>
+    IngredientsService.getInstance(token),
+  );
+
+  // Cleanup all WS subscriptions on unmount
+  useEffect(() => {
+    return () => {
+      for (const unsub of socketSubscriptionsRef.current) {
+        try {
+          unsub();
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+      socketSubscriptionsRef.current = [];
+    };
+  }, []);
+
+  const updateAsset = useCallback(
+    (ideaId: string, update: FastlaneAssetUpdate) => {
+      setAssets((prev) =>
+        prev.map((a) => (a.idea.id === ideaId ? { ...a, ...update } : a)),
+      );
+    },
+    [],
+  );
+
+  const subscribeToAsset = useCallback(
+    (idea: FastlaneIdea, pendingId: string) => {
+      const url = `/${idea.format}s/${pendingId}`;
+      let unsubscribe: (() => void) | null = null;
+
+      const cleanupSubscription = () => {
+        if (unsubscribe) {
+          unsubscribe();
+          socketSubscriptionsRef.current =
+            socketSubscriptionsRef.current.filter((fn) => fn !== unsubscribe);
+          unsubscribe = null;
+        }
+      };
+
+      const handler = createMediaHandler<SocketResult>(
+        async (result) => {
+          const resolvedId =
+            typeof result === 'string'
+              ? result
+              : typeof result?.id === 'string'
+                ? result.id
+                : pendingId;
+
+          try {
+            let ingredientUrl: string | undefined;
+            let thumbnailUrl: string | undefined;
+
+            if (idea.format === 'video') {
+              const service = await getVideosService();
+              const ingredient = await service.findOne(resolvedId);
+              ingredientUrl = (ingredient as { url?: string }).url;
+              thumbnailUrl = (ingredient as { thumbnailUrl?: string })
+                .thumbnailUrl;
+            } else if (idea.format === 'image') {
+              const service = await getImagesService();
+              const ingredient = await service.findOne(resolvedId);
+              ingredientUrl = (ingredient as { url?: string }).url;
+              thumbnailUrl = (ingredient as { thumbnailUrl?: string })
+                .thumbnailUrl;
+            } else {
+              // avatar — use IngredientsService
+              const service = await getIngredientsService();
+              const ingredient = await service.findOne(resolvedId);
+              ingredientUrl = (ingredient as { url?: string }).url;
+              thumbnailUrl = (ingredient as { thumbnailUrl?: string })
+                .thumbnailUrl;
+            }
+
+            updateAsset(idea.id, {
+              status: 'ready',
+              ingredientId: resolvedId,
+              ingredientUrl,
+              thumbnailUrl,
+            });
+          } catch (err) {
+            logger.error(
+              'Fastlane: failed to fetch ingredient after WS event',
+              err,
+            );
+            updateAsset(idea.id, {
+              status: 'failed',
+              errorMessage: 'Failed to load generated asset',
+            });
+          } finally {
+            cleanupSubscription();
+          }
+        },
+        (errorMessage: string) => {
+          updateAsset(idea.id, {
+            status: 'failed',
+            errorMessage: errorMessage || `${idea.format} generation failed`,
+          });
+          notificationsService.error(
+            errorMessage || `${idea.format} generation failed`,
+          );
+          cleanupSubscription();
+        },
+      );
+
+      unsubscribe = subscribe(url, handler);
+      // unsubscribe is non-null here since subscribe() always returns a function
+      socketSubscriptionsRef.current.push(unsubscribe as () => void);
+    },
+    [
+      getImagesService,
+      getVideosService,
+      getIngredientsService,
+      notificationsService,
+      subscribe,
+      updateAsset,
+    ],
+  );
+
+  const dispatchIdea = useCallback(
+    async (idea: FastlaneIdea): Promise<void> => {
+      const promptData = buildPromptData(
+        idea,
+        brandId,
+        avatarIngredientId,
+        voiceId,
+        references,
+      );
+
+      let response: unknown;
+
+      try {
+        if (idea.format === 'image') {
+          const service = await getImagesService();
+          const base = buildBaseGenerationPayload(promptData, '', brandId);
+          const imagePayload = buildImagePayload(base, promptData);
+          // Mirror useSocketGeneration: re-apply blacklist as string[] and cast
+          const servicePayload = {
+            ...imagePayload,
+            blacklist: promptData.blacklist || [],
+          };
+          response = await service.post(
+            servicePayload as unknown as Partial<IImage>,
+          );
+        } else if (idea.format === 'video') {
+          const service = await getVideosService();
+          const base = buildBaseGenerationPayload(promptData, '', brandId);
+          const videoPayload = buildVideoPayload(base, promptData);
+          const servicePayload = {
+            ...videoPayload,
+            blacklist: promptData.blacklist || [],
+          };
+          response = await service.post(
+            servicePayload as unknown as Partial<IVideo>,
+          );
+        } else {
+          // avatar
+          const service = await getHeyGenService();
+          const payload = buildAvatarPayload(promptData);
+          response = await service.generate(payload);
+        }
+      } catch (err) {
+        logger.error('Fastlane: dispatch failed for idea', {
+          ideaId: idea.id,
+          err,
+        });
+        updateAsset(idea.id, {
+          status: 'failed',
+          errorMessage:
+            err instanceof Error ? err.message : 'Generation request failed',
+        });
+        return;
+      }
+
+      let pendingIds: string[];
+      try {
+        pendingIds = resolvePendingIds(response);
+      } catch {
+        updateAsset(idea.id, {
+          status: 'failed',
+          errorMessage: 'No pending ID returned from generation service',
+        });
+        return;
+      }
+
+      // Subscribe to all pending IDs (usually 1, but batch is possible)
+      for (const pendingId of pendingIds) {
+        subscribeToAsset(idea, pendingId);
+      }
+    },
+    [
+      brandId,
+      avatarIngredientId,
+      voiceId,
+      references,
+      getImagesService,
+      getVideosService,
+      getHeyGenService,
+      updateAsset,
+      subscribeToAsset,
+    ],
+  );
+
+  const startGeneration = useCallback(
+    async (ideas: FastlaneIdea[]): Promise<void> => {
+      // Initialize all assets as generating
+      const initial: FastlaneAssetItem[] = ideas.map((idea) => ({
+        idea,
+        ingredientId: null,
+        status: 'generating',
+      }));
+      setAssets(initial);
+      setIsGenerating(true);
+
+      await Promise.allSettled(ideas.map((idea) => dispatchIdea(idea)));
+
+      setIsGenerating(false);
+    },
+    [dispatchIdea],
+  );
+
+  const failedCount = assets.filter((a) => a.status === 'failed').length;
+  const readyCount = assets.filter((a) => a.status === 'ready').length;
+
+  return { assets, isGenerating, startGeneration, failedCount, readyCount };
+}

--- a/packages/pages/studio/fastlane/hooks/useFastlaneGeneration.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneGeneration.ts
@@ -94,9 +94,9 @@ export function useFastlaneGeneration({
   references,
 }: UseFastlaneGenerationParams): UseFastlaneGenerationReturn {
   const [assets, setAssets] = useState<FastlaneAssetItem[]>([]);
-  const [isGenerating, setIsGenerating] = useState(false);
 
   const socketSubscriptionsRef = useRef<Array<() => void>>([]);
+  const isMountedRef = useRef(true);
 
   const { subscribe } = useSocketManager();
   const notificationsService = NotificationsService.getInstance();
@@ -117,6 +117,7 @@ export function useFastlaneGeneration({
   // Cleanup all WS subscriptions on unmount
   useEffect(() => {
     return () => {
+      isMountedRef.current = false;
       for (const unsub of socketSubscriptionsRef.current) {
         try {
           unsub();
@@ -185,6 +186,11 @@ export function useFastlaneGeneration({
                 .thumbnailUrl;
             }
 
+            // The component may have unmounted while findOne was in flight.
+            if (!isMountedRef.current) {
+              return;
+            }
+
             updateAsset(idea.id, {
               status: 'ready',
               ingredientId: resolvedId,
@@ -196,6 +202,9 @@ export function useFastlaneGeneration({
               'Fastlane: failed to fetch ingredient after WS event',
               err,
             );
+            if (!isMountedRef.current) {
+              return;
+            }
             updateAsset(idea.id, {
               status: 'failed',
               errorMessage: 'Failed to load generated asset',
@@ -323,15 +332,16 @@ export function useFastlaneGeneration({
         status: 'generating',
       }));
       setAssets(initial);
-      setIsGenerating(true);
 
       await Promise.allSettled(ideas.map((idea) => dispatchIdea(idea)));
-
-      setIsGenerating(false);
     },
     [dispatchIdea],
   );
 
+  // Derived: still generating while any asset has not reached a terminal state
+  // (ready/failed). This stays true through the WebSocket phase — not just the
+  // dispatch requests — so the UI cannot advance to scheduling prematurely.
+  const isGenerating = assets.some((a) => a.status === 'generating');
   const failedCount = assets.filter((a) => a.status === 'failed').length;
   const readyCount = assets.filter((a) => a.status === 'ready').length;
 

--- a/packages/pages/studio/fastlane/hooks/useFastlaneIdeas.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneIdeas.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { logger } from '@services/core/logger.service';
+import { BrandsService } from '@services/social/brands.service';
+import { useCallback, useRef, useState } from 'react';
+import type {
+  FastlaneFormat,
+  FastlaneIdea,
+  UseFastlaneIdeasReturn,
+} from '../types';
+
+export function useFastlaneIdeas(brandId: string): UseFastlaneIdeasReturn {
+  const [ideas, setIdeas] = useState<FastlaneIdea[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getBrandsService = useAuthedService((token: string) =>
+    BrandsService.getInstance(token),
+  );
+
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const generateIdeas = useCallback(
+    async (
+      formats: FastlaneFormat[],
+      count: number,
+      angle?: string,
+    ): Promise<void> => {
+      // Cancel any in-flight request
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      setIsLoading(true);
+      setError(null);
+      setIdeas([]);
+
+      try {
+        const service = await getBrandsService();
+        const result = await service.generateFastlaneIdeas(brandId, {
+          formats,
+          count,
+          angle,
+        });
+
+        if (!controller.signal.aborted) {
+          setIdeas(result);
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+
+        logger.error('Fastlane: failed to generate ideas', err);
+
+        // Surface 400 (brand voice not configured) as a user-readable message
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Failed to generate ideas. Check that your brand voice is configured.';
+
+        setError(message);
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [brandId, getBrandsService],
+  );
+
+  const reset = useCallback(() => {
+    controllerRef.current?.abort();
+    setIdeas([]);
+    setIsLoading(false);
+    setError(null);
+  }, []);
+
+  return { ideas, isLoading, error, generateIdeas, reset };
+}

--- a/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.test.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.test.ts
@@ -1,0 +1,247 @@
+import { PostCategory, PostStatus } from '@genfeedai/enums';
+import type {
+  FastlaneAssetItem,
+  FastlaneScheduleTarget,
+} from '@genfeedai/interfaces';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ────────────────────────────────────────────────────────────
+// Mocks
+// ────────────────────────────────────────────────────────────
+
+const mockPost = vi.fn();
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: (factory: (token: string) => unknown) => async () =>
+    factory('stub-token'),
+}));
+
+vi.mock('@services/content/posts.service', () => ({
+  PostsService: {
+    getInstance: () => ({ post: mockPost }),
+  },
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockError = vi.fn();
+const mockSuccess = vi.fn();
+vi.mock('@services/core/notifications.service', () => ({
+  NotificationsService: {
+    getInstance: () => ({ error: mockError, success: mockSuccess }),
+  },
+}));
+
+// Stable crypto.randomUUID shim
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: () => 'test-group-id' },
+  writable: true,
+});
+
+import { useFastlaneSchedule } from './useFastlaneSchedule';
+
+// ────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────
+
+function makeAsset(
+  id: string,
+  format: 'image' | 'video' = 'image',
+): FastlaneAssetItem {
+  return {
+    idea: {
+      id,
+      format,
+      hook: `Hook for ${id}`,
+      caption: `Caption for ${id}`,
+      visualPrompt: 'prompt',
+      platformHints: ['tiktok'],
+    },
+    ingredientId: `ingredient-${id}`,
+    status: 'approved',
+  };
+}
+
+function makeTarget(
+  credentialId: string,
+  scheduledDate?: string,
+): FastlaneScheduleTarget {
+  return { credentialId, platform: 'tiktok', scheduledDate };
+}
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe('useFastlaneSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ id: 'post-1' });
+  });
+
+  it('creates one post per asset × credential (2 × 2 = 4 posts)', async () => {
+    const assets = [makeAsset('asset-1'), makeAsset('asset-2')];
+    const targets = [makeTarget('cred-a'), makeTarget('cred-b')];
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(4);
+  });
+
+  it('uses the same groupId for all posts in the batch', async () => {
+    const assets = [makeAsset('asset-1'), makeAsset('asset-2')];
+    const targets = [makeTarget('cred-a'), makeTarget('cred-b')];
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    const calls = mockPost.mock.calls;
+    const groupIds = calls.map((c) => (c[0] as { groupId?: string }).groupId);
+    expect(new Set(groupIds).size).toBe(1);
+    expect(groupIds[0]).toBe('test-group-id');
+  });
+
+  it('sets source to "fastlane" on every post', async () => {
+    const assets = [makeAsset('asset-1')];
+    const targets = [makeTarget('cred-a')];
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    const payload = mockPost.mock.calls[0][0] as { source?: string };
+    expect(payload.source).toBe('fastlane');
+  });
+
+  it('uses SCHEDULED status when scheduledDate is provided', async () => {
+    const assets = [makeAsset('asset-1')];
+    const targets = [makeTarget('cred-a', '2026-12-01T10:00:00Z')];
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    const payload = mockPost.mock.calls[0][0] as {
+      status: string;
+      scheduledDate?: string;
+    };
+    expect(payload.status).toBe(PostStatus.SCHEDULED);
+    expect(payload.scheduledDate).toBe('2026-12-01T10:00:00Z');
+  });
+
+  it('uses PENDING status when no scheduledDate is provided', async () => {
+    const assets = [makeAsset('asset-1')];
+    const targets = [makeTarget('cred-a')]; // no scheduledDate
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    const payload = mockPost.mock.calls[0][0] as { status: string };
+    expect(payload.status).toBe(PostStatus.PENDING);
+  });
+
+  it('surfaces partial failures without throwing', async () => {
+    const assets = [makeAsset('asset-1'), makeAsset('asset-2')];
+    const targets = [makeTarget('cred-a')];
+
+    // First succeeds, second fails
+    mockPost
+      .mockResolvedValueOnce({ id: 'post-1' })
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    // Should surface error notification, not throw
+    expect(mockError).toHaveBeenCalledTimes(1);
+    expect(result.current.isScheduling).toBe(false);
+  });
+
+  it('uses edited caption when provided', async () => {
+    const assets = [makeAsset('asset-1')];
+    const targets = [makeTarget('cred-a')];
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: { 'asset-1': 'My custom caption' },
+        timezone: 'UTC',
+      });
+    });
+
+    const payload = mockPost.mock.calls[0][0] as { description: string };
+    expect(payload.description).toBe('My custom caption');
+  });
+
+  it('sets correct category for image format', async () => {
+    const assets = [makeAsset('asset-1', 'image')];
+    const targets = [makeTarget('cred-a')];
+
+    const { result } = renderHook(() => useFastlaneSchedule());
+
+    await act(async () => {
+      await result.current.scheduleApproved({
+        assets,
+        targets,
+        captions: {},
+        timezone: 'UTC',
+      });
+    });
+
+    const payload = mockPost.mock.calls[0][0] as { category: string };
+    expect(payload.category).toBe(PostCategory.IMAGE);
+  });
+});

--- a/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.test.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.test.ts
@@ -163,9 +163,9 @@ describe('useFastlaneSchedule', () => {
     expect(payload.scheduledDate).toBe('2026-12-01T10:00:00Z');
   });
 
-  it('uses PENDING status when no scheduledDate is provided', async () => {
+  it('uses SCHEDULED with an immediate scheduledDate for "post now"', async () => {
     const assets = [makeAsset('asset-1')];
-    const targets = [makeTarget('cred-a')]; // no scheduledDate
+    const targets = [makeTarget('cred-a')]; // no scheduledDate → post now
 
     const { result } = renderHook(() => useFastlaneSchedule());
 
@@ -178,8 +178,15 @@ describe('useFastlaneSchedule', () => {
       });
     });
 
-    const payload = mockPost.mock.calls[0][0] as { status: string };
-    expect(payload.status).toBe(PostStatus.PENDING);
+    // "Post now" must still be SCHEDULED (the publisher cron ignores PENDING for
+    // Instagram/YouTube) with scheduledDate set to now so it publishes immediately.
+    const payload = mockPost.mock.calls[0][0] as {
+      status: string;
+      scheduledDate?: string;
+    };
+    expect(payload.status).toBe(PostStatus.SCHEDULED);
+    expect(typeof payload.scheduledDate).toBe('string');
+    expect((payload.scheduledDate ?? '').length).toBeGreaterThan(0);
   });
 
   it('surfaces partial failures without throwing', async () => {

--- a/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.ts
@@ -45,6 +45,12 @@ export function useFastlaneSchedule(): UseFastlaneScheduleReturn {
       try {
         const service = await getPostsService();
 
+        // "Post now" must use SCHEDULED with scheduledDate = now: the publisher
+        // cron only picks up posts with status in [SCHEDULED, PROCESSING] whose
+        // scheduledDate <= now (PENDING is a TikTok-specific intermediate state,
+        // so PENDING immediate posts would never publish on Instagram/YouTube).
+        const nowIso = new Date().toISOString();
+
         const posts = approved.flatMap((asset) =>
           targets.map((target: FastlaneScheduleTarget) => {
             const editedCaption = captions[asset.idea.id] ?? asset.idea.caption;
@@ -52,10 +58,6 @@ export function useFastlaneSchedule(): UseFastlaneScheduleReturn {
               asset.idea.format === 'image'
                 ? PostCategory.IMAGE
                 : PostCategory.VIDEO;
-
-            const status = target.scheduledDate
-              ? PostStatus.SCHEDULED
-              : PostStatus.PENDING;
 
             // PostsService extends BaseService<Post> with TCreate = Partial<Post>.
             // We cast via unknown to include the 'source' field that is part of
@@ -66,8 +68,8 @@ export function useFastlaneSchedule(): UseFastlaneScheduleReturn {
               label: asset.idea.hook.slice(0, 100),
               description: editedCaption,
               category,
-              status,
-              scheduledDate: target.scheduledDate ?? undefined,
+              status: PostStatus.SCHEDULED,
+              scheduledDate: target.scheduledDate ?? nowIso,
               timezone,
               groupId,
               source: 'fastlane',

--- a/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.ts
+++ b/packages/pages/studio/fastlane/hooks/useFastlaneSchedule.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { PostCategory, PostStatus } from '@genfeedai/enums';
+import type { FastlaneScheduleTarget } from '@genfeedai/interfaces';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import type { Post } from '@models/content/post.model';
+import { PostsService } from '@services/content/posts.service';
+import { logger } from '@services/core/logger.service';
+import { NotificationsService } from '@services/core/notifications.service';
+import { useCallback, useState } from 'react';
+import type {
+  ScheduleApprovedParams,
+  UseFastlaneScheduleReturn,
+} from '../types';
+
+export function useFastlaneSchedule(): UseFastlaneScheduleReturn {
+  const [isScheduling, setIsScheduling] = useState(false);
+
+  const getPostsService = useAuthedService((token: string) =>
+    PostsService.getInstance(token),
+  );
+
+  const notificationsService = NotificationsService.getInstance();
+
+  const scheduleApproved = useCallback(
+    async ({
+      assets,
+      targets,
+      captions,
+      timezone,
+    }: ScheduleApprovedParams): Promise<void> => {
+      const approved = assets.filter(
+        (a) => a.status === 'approved' && a.ingredientId,
+      );
+
+      if (approved.length === 0 || targets.length === 0) {
+        return;
+      }
+
+      setIsScheduling(true);
+
+      // Single shared groupId for this Fastlane batch
+      const groupId = crypto.randomUUID();
+
+      try {
+        const service = await getPostsService();
+
+        const posts = approved.flatMap((asset) =>
+          targets.map((target: FastlaneScheduleTarget) => {
+            const editedCaption = captions[asset.idea.id] ?? asset.idea.caption;
+            const category =
+              asset.idea.format === 'image'
+                ? PostCategory.IMAGE
+                : PostCategory.VIDEO;
+
+            const status = target.scheduledDate
+              ? PostStatus.SCHEDULED
+              : PostStatus.PENDING;
+
+            // PostsService extends BaseService<Post> with TCreate = Partial<Post>.
+            // We cast via unknown to include the 'source' field that is part of
+            // CreatePostDto but not reflected on the IPost read model.
+            const payload = {
+              credential: target.credentialId,
+              ingredients: [asset.ingredientId as string],
+              label: asset.idea.hook.slice(0, 100),
+              description: editedCaption,
+              category,
+              status,
+              scheduledDate: target.scheduledDate ?? undefined,
+              timezone,
+              groupId,
+              source: 'fastlane',
+              isShareToFeedSelected: true,
+            } as unknown as Partial<Post>;
+
+            return { asset, target, payload };
+          }),
+        );
+
+        const results = await Promise.allSettled(
+          posts.map(({ payload }) => service.post(payload)),
+        );
+
+        const failedCount = results.filter(
+          (r) => r.status === 'rejected',
+        ).length;
+
+        if (failedCount > 0) {
+          const successCount = results.length - failedCount;
+          logger.warn('Fastlane: partial schedule failure', {
+            failedCount,
+            successCount,
+          });
+          notificationsService.error(
+            `${successCount} post${successCount !== 1 ? 's' : ''} scheduled, ${failedCount} failed. Check your connected accounts.`,
+          );
+        } else {
+          notificationsService.success?.(
+            `${results.length} post${results.length !== 1 ? 's' : ''} scheduled successfully`,
+          );
+        }
+      } catch (err) {
+        logger.error('Fastlane: scheduleApproved failed', err);
+        notificationsService.error(
+          'Failed to schedule posts. Please try again.',
+        );
+      } finally {
+        setIsScheduling(false);
+      }
+    },
+    [getPostsService, notificationsService],
+  );
+
+  return { isScheduling, scheduleApproved };
+}

--- a/packages/pages/studio/fastlane/index.ts
+++ b/packages/pages/studio/fastlane/index.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from './FastlaneLayout';

--- a/packages/pages/studio/fastlane/types.ts
+++ b/packages/pages/studio/fastlane/types.ts
@@ -1,0 +1,82 @@
+import type {
+  FastlaneAssetItem,
+  FastlaneAssetStatus,
+  FastlaneFormat,
+  FastlaneIdea,
+  FastlaneScheduleTarget,
+} from '@genfeedai/interfaces';
+
+// ────────────────────────────────────────────────────────────
+// Hook param / return interfaces
+// ────────────────────────────────────────────────────────────
+
+export interface UseFastlaneIdeasParams {
+  brandId: string;
+  isReady: boolean;
+}
+
+export interface UseFastlaneIdeasReturn {
+  ideas: FastlaneIdea[];
+  isLoading: boolean;
+  error: string | null;
+  generateIdeas: (
+    formats: FastlaneFormat[],
+    count: number,
+    angle?: string,
+  ) => Promise<void>;
+  reset: () => void;
+}
+
+export interface UseFastlaneGenerationParams {
+  brandId: string;
+  avatarIngredientId?: string | null;
+  voiceId?: string | null;
+  references?: string[];
+}
+
+export interface FastlaneAssetUpdate {
+  status: FastlaneAssetStatus;
+  ingredientId?: string | null;
+  ingredientUrl?: string;
+  thumbnailUrl?: string;
+  errorMessage?: string;
+}
+
+export interface UseFastlaneGenerationReturn {
+  assets: FastlaneAssetItem[];
+  isGenerating: boolean;
+  startGeneration: (ideas: FastlaneIdea[]) => Promise<void>;
+  failedCount: number;
+  readyCount: number;
+}
+
+export interface UseFastlaneScheduleParams {
+  brandId: string;
+}
+
+export interface ScheduleApprovedParams {
+  assets: FastlaneAssetItem[];
+  targets: FastlaneScheduleTarget[];
+  captions: Record<string, string>;
+  timezone: string;
+}
+
+export interface UseFastlaneScheduleReturn {
+  isScheduling: boolean;
+  scheduleApproved: (params: ScheduleApprovedParams) => Promise<void>;
+}
+
+// ────────────────────────────────────────────────────────────
+// Wizard state
+// ────────────────────────────────────────────────────────────
+
+export type FastlaneStep = 'ideas' | 'review' | 'schedule';
+
+// Re-export domain types for internal component use
+export type {
+  FastlaneAssetItem,
+  FastlaneAssetStatus,
+  FastlaneFormat,
+  FastlaneIdea,
+  FastlaneScheduleTarget,
+};

--- a/packages/pages/studio/fastlane/utils/brand-readiness.test.ts
+++ b/packages/pages/studio/fastlane/utils/brand-readiness.test.ts
@@ -119,7 +119,7 @@ describe('isBrandReadyForFastlane', () => {
     expect(result.ready).toBe(true);
   });
 
-  it('treats defaultAvatarPhotoUrl as a valid avatar substitute', () => {
+  it('does NOT accept defaultAvatarPhotoUrl alone for avatar format (needs an ingredient id)', () => {
     const brand = makeBrand({
       agentConfig: {
         voice: { tone: 'casual' },
@@ -128,7 +128,10 @@ describe('isBrandReadyForFastlane', () => {
       },
     });
     const result = isBrandReadyForFastlane(brand, [shortFormCred], ['avatar']);
-    expect(result.ready).toBe(true);
+    expect(result.ready).toBe(false);
+    expect(result.reasons.some((r) => r.toLowerCase().includes('avatar'))).toBe(
+      true,
+    );
   });
 
   it('returns not-ready when voice tone is missing', () => {

--- a/packages/pages/studio/fastlane/utils/brand-readiness.test.ts
+++ b/packages/pages/studio/fastlane/utils/brand-readiness.test.ts
@@ -1,0 +1,155 @@
+import type { IBrand, ICredential } from '@genfeedai/interfaces';
+import { describe, expect, it } from 'vitest';
+import { isBrandReadyForFastlane } from './brand-readiness';
+
+// ────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────
+
+function makeCredential(platform: string): ICredential {
+  return {
+    id: `cred-${platform}`,
+    platform: platform as ICredential['platform'],
+    isConnected: true,
+    externalId: 'ext-1',
+    externalHandle: 'handle',
+    brand: 'brand-1',
+    user: {} as ICredential['user'],
+    organization: {} as ICredential['organization'],
+    isDeleted: false,
+    createdAt: '',
+    updatedAt: '',
+    token: '',
+  };
+}
+
+function makeBrand(overrides: Partial<IBrand> = {}): IBrand {
+  return {
+    id: 'brand-1',
+    label: 'Test Brand',
+    description: '',
+    slug: 'test-brand',
+    fontFamily: '',
+    primaryColor: '',
+    secondaryColor: '',
+    backgroundColor: '',
+    isVerified: false,
+    isDefault: false,
+    isDarkroomEnabled: false,
+    isActive: true,
+    isSelected: true,
+    scope: 'brand' as IBrand['scope'],
+    user: {} as IBrand['user'],
+    organization: {} as IBrand['organization'],
+    credentials: [],
+    links: [],
+    references: [{ id: 'ref-1' } as IBrand['references'][0]],
+    agentConfig: {
+      voice: { tone: 'professional' },
+    },
+    isDeleted: false,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+const shortFormCred = makeCredential('tiktok');
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe('isBrandReadyForFastlane', () => {
+  it('returns not-ready for null brand', () => {
+    const result = isBrandReadyForFastlane(null, [shortFormCred]);
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toContain('No brand selected');
+  });
+
+  it('returns not-ready when social credential is missing but voice + reference are set', () => {
+    const brand = makeBrand();
+    const result = isBrandReadyForFastlane(brand, []); // no credentials
+    expect(result.ready).toBe(false);
+    expect(result.reasons.some((r) => r.toLowerCase().includes('tiktok'))).toBe(
+      true,
+    );
+  });
+
+  it('returns ready for fully-configured brand', () => {
+    const brand = makeBrand();
+    const result = isBrandReadyForFastlane(brand, [shortFormCred]);
+    expect(result.ready).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it('accepts uppercase platform value (case-insensitive check)', () => {
+    const brand = makeBrand();
+    const upperCaseCred = makeCredential('INSTAGRAM');
+    const result = isBrandReadyForFastlane(brand, [upperCaseCred]);
+    expect(result.ready).toBe(true);
+  });
+
+  it('requires avatar + voice when avatar format is requested', () => {
+    const brand = makeBrand({
+      agentConfig: {
+        voice: { tone: 'casual' },
+        // no defaultAvatarIngredientId, no defaultVoiceId
+      },
+    });
+    const result = isBrandReadyForFastlane(brand, [shortFormCred], ['avatar']);
+    expect(result.ready).toBe(false);
+    expect(result.reasons.some((r) => r.toLowerCase().includes('avatar'))).toBe(
+      true,
+    );
+    expect(result.reasons.some((r) => r.toLowerCase().includes('voice'))).toBe(
+      true,
+    );
+  });
+
+  it('is ready for avatar format when avatar and voice are configured', () => {
+    const brand = makeBrand({
+      agentConfig: {
+        voice: { tone: 'casual' },
+        defaultAvatarIngredientId: 'avatar-1',
+        defaultVoiceId: 'voice-1',
+      },
+    });
+    const result = isBrandReadyForFastlane(brand, [shortFormCred], ['avatar']);
+    expect(result.ready).toBe(true);
+  });
+
+  it('treats defaultAvatarPhotoUrl as a valid avatar substitute', () => {
+    const brand = makeBrand({
+      agentConfig: {
+        voice: { tone: 'casual' },
+        defaultAvatarPhotoUrl: 'https://example.com/avatar.jpg',
+        defaultVoiceId: 'voice-1',
+      },
+    });
+    const result = isBrandReadyForFastlane(brand, [shortFormCred], ['avatar']);
+    expect(result.ready).toBe(true);
+  });
+
+  it('returns not-ready when voice tone is missing', () => {
+    const brand = makeBrand({
+      agentConfig: {
+        voice: { tone: '' },
+      },
+    });
+    const result = isBrandReadyForFastlane(brand, [shortFormCred]);
+    expect(result.ready).toBe(false);
+    expect(result.reasons.some((r) => r.toLowerCase().includes('tone'))).toBe(
+      true,
+    );
+  });
+
+  it('returns not-ready when no reference images', () => {
+    const brand = makeBrand({ references: [] });
+    const result = isBrandReadyForFastlane(brand, [shortFormCred]);
+    expect(result.ready).toBe(false);
+    expect(
+      result.reasons.some((r) => r.toLowerCase().includes('reference')),
+    ).toBe(true);
+  });
+});

--- a/packages/pages/studio/fastlane/utils/brand-readiness.ts
+++ b/packages/pages/studio/fastlane/utils/brand-readiness.ts
@@ -1,0 +1,75 @@
+import type { CredentialPlatform } from '@genfeedai/enums';
+import type { IBrand, ICredential } from '@genfeedai/interfaces';
+import type { FastlaneFormat } from '../types';
+
+const SHORT_FORM_PLATFORMS: string[] = ['tiktok', 'instagram', 'youtube'];
+
+export interface BrandReadinessResult {
+  ready: boolean;
+  reasons: string[];
+}
+
+/**
+ * Checks whether a brand has the minimum configuration required to run Fastlane.
+ *
+ * Required for all formats:
+ *  - Brand voice tone is set (agentConfig.voice.tone)
+ *  - At least one reference image
+ *  - At least one short-form social credential connected (TikTok / Instagram / YouTube)
+ *
+ * Additional requirements when `formats` includes 'avatar':
+ *  - defaultAvatarIngredientId (or defaultAvatarPhotoUrl) is set
+ *  - defaultVoiceId is set
+ */
+export function isBrandReadyForFastlane(
+  brand: IBrand | null | undefined,
+  credentials: ICredential[],
+  formats?: FastlaneFormat[],
+): BrandReadinessResult {
+  const reasons: string[] = [];
+
+  if (!brand) {
+    return { ready: false, reasons: ['No brand selected'] };
+  }
+
+  // Voice tone check
+  const hasVoiceTone = Boolean(brand.agentConfig?.voice?.tone?.trim());
+  if (!hasVoiceTone) {
+    reasons.push('Brand voice tone is not configured');
+  }
+
+  // Reference image check
+  const hasReferenceImage = (brand.references?.length ?? 0) >= 1;
+  if (!hasReferenceImage) {
+    reasons.push('At least one brand reference image is required');
+  }
+
+  // Short-form social credential check — case-insensitive
+  const hasShortFormSocial = credentials.some((cred) =>
+    SHORT_FORM_PLATFORMS.includes(
+      (cred.platform as string).toLowerCase() as CredentialPlatform,
+    ),
+  );
+  if (!hasShortFormSocial) {
+    reasons.push(
+      'A connected TikTok, Instagram, or YouTube account is required',
+    );
+  }
+
+  // Avatar-specific requirements
+  if (formats?.includes('avatar')) {
+    const hasAvatar =
+      Boolean(brand.agentConfig?.defaultAvatarIngredientId) ||
+      Boolean(brand.agentConfig?.defaultAvatarPhotoUrl);
+    if (!hasAvatar) {
+      reasons.push('A default avatar is required for avatar generation');
+    }
+
+    const hasVoice = Boolean(brand.agentConfig?.defaultVoiceId);
+    if (!hasVoice) {
+      reasons.push('A default voice is required for avatar generation');
+    }
+  }
+
+  return { ready: reasons.length === 0, reasons };
+}

--- a/packages/pages/studio/fastlane/utils/brand-readiness.ts
+++ b/packages/pages/studio/fastlane/utils/brand-readiness.ts
@@ -18,7 +18,9 @@ export interface BrandReadinessResult {
  *  - At least one short-form social credential connected (TikTok / Instagram / YouTube)
  *
  * Additional requirements when `formats` includes 'avatar':
- *  - defaultAvatarIngredientId (or defaultAvatarPhotoUrl) is set
+ *  - defaultAvatarIngredientId is set (the generation path only threads the
+ *    avatar ingredient id into the HeyGen payload; a photo-only avatar config
+ *    cannot drive avatar generation, so it is not accepted here)
  *  - defaultVoiceId is set
  */
 export function isBrandReadyForFastlane(
@@ -58,9 +60,7 @@ export function isBrandReadyForFastlane(
 
   // Avatar-specific requirements
   if (formats?.includes('avatar')) {
-    const hasAvatar =
-      Boolean(brand.agentConfig?.defaultAvatarIngredientId) ||
-      Boolean(brand.agentConfig?.defaultAvatarPhotoUrl);
+    const hasAvatar = Boolean(brand.agentConfig?.defaultAvatarIngredientId);
     if (!hasAvatar) {
       reasons.push('A default avatar is required for avatar generation');
     }

--- a/packages/pages/vitest.config.ts
+++ b/packages/pages/vitest.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
         replacement: path.resolve(appRoot, './tests/server-only.stub.ts'),
       },
       {
+        find: /^@testing-library\/react$/,
+        replacement: path.resolve(
+          appRoot,
+          './node_modules/@testing-library/react',
+        ),
+      },
+      {
         find: /^@pages$/,
         replacement: pagesRoot,
       },
@@ -264,6 +271,8 @@ export default defineConfig({
     include: [
       'packages/pages/analytics/overview/analytics-overview.test.tsx',
       'studio/generate/utils/**/*.test.ts',
+      'studio/fastlane/**/*.test.ts',
+      'studio/fastlane/**/*.test.tsx',
     ],
     name: '@genfeedai/pages',
     setupFiles: [path.resolve(appRoot, './vitest.setup.ts')],

--- a/packages/prisma/prisma/migrations/20260619120000_add_fastlane_support/migration.sql
+++ b/packages/prisma/prisma/migrations/20260619120000_add_fastlane_support/migration.sql
@@ -1,0 +1,8 @@
+-- Fastlane: org-level enablement flag + post origin label.
+-- Both additive and backward-compatible (boolean defaults false; source is nullable).
+
+-- AlterTable
+ALTER TABLE "organization_settings" ADD COLUMN     "isFastlaneEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "posts" ADD COLUMN     "source" TEXT;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -893,6 +893,7 @@ model OrganizationSetting {
   isGenerateImagesEnabled       Boolean           @default(true)
   isGenerateMusicEnabled        Boolean           @default(true)
   isAutoEvaluateEnabled         Boolean           @default(false)
+  isFastlaneEnabled             Boolean           @default(false)
   seatsLimit                    Int               @default(3)
   brandsLimit                   Int               @default(5)
   timezone                      String            @default("UTC")
@@ -1580,6 +1581,8 @@ model Post {
   sourceActionId        String?
   sourceWorkflowId      String?
   sourceWorkflowName    String?
+  // Origin label for the post (e.g. agent, fastlane, manual). Free-form string.
+  source                String?
   isDeleted             Boolean         @default(false)
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt

--- a/packages/serializers/src/attributes/organizations/organization-settings.attributes.ts
+++ b/packages/serializers/src/attributes/organizations/organization-settings.attributes.ts
@@ -12,6 +12,7 @@ export const organizationSettingsAttributes = createEntityAttributes([
   'isGenerateImagesEnabled',
   'isGenerateMusicEnabled',
   'isAutoEvaluateEnabled',
+  'isFastlaneEnabled',
   'isNotificationsDiscordEnabled',
   'isNotificationsEmailEnabled',
   'isDarkroomNsfwVisible',

--- a/packages/services/social/brands.service.test.ts
+++ b/packages/services/social/brands.service.test.ts
@@ -194,6 +194,41 @@ describe('BrandsService', () => {
     });
   });
 
+  describe('generateFastlaneIdeas', () => {
+    const dto = { count: 3, formats: ['image', 'video'] as const };
+
+    it('calls POST with the fastlane ideas endpoint and dto', async () => {
+      mockPost.mockResolvedValue({ data: { data: [] } });
+
+      await service.generateFastlaneIdeas(mockBrandId, dto);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        `/${mockBrandId}/fastlane/ideas`,
+        dto,
+      );
+    });
+
+    it('unwraps and returns the ideas array', async () => {
+      const ideas = [
+        { format: 'image', hook: 'a', id: 'i1' },
+        { format: 'video', hook: 'b', id: 'i2' },
+      ];
+      mockPost.mockResolvedValue({ data: { data: ideas } });
+
+      const result = await service.generateFastlaneIdeas(mockBrandId, dto);
+
+      expect(result).toEqual(ideas);
+    });
+
+    it('returns an empty array when the envelope has no data', async () => {
+      mockPost.mockResolvedValue({ data: {} });
+
+      const result = await service.generateFastlaneIdeas(mockBrandId, dto);
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('getInstance', () => {
     it('returns a BrandsService instance', () => {
       const instance = BrandsService.getInstance(mockToken);

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -1,6 +1,8 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type { DefaultVoiceRef } from '@genfeedai/helpers/voice/default-voice-ref.helper';
 import type {
+  FastlaneGenerateIdeasRequest,
+  FastlaneIdea,
   IActivity,
   IAnalytics,
   IArticle,
@@ -281,5 +283,19 @@ export class BrandsService extends BaseService<Brand> {
         params: query,
       })
       .then((res) => deserializeCollection<unknown>(res.data));
+  }
+
+  /**
+   * Generates a batch of brand-data-driven Fastlane content ideas. The ideas
+   * endpoint returns a plain `{ data: FastlaneIdea[] }` envelope (not JSON:API),
+   * mirroring the brand-voice generation endpoint.
+   */
+  public async generateFastlaneIdeas(
+    id: string,
+    dto: FastlaneGenerateIdeasRequest,
+  ): Promise<FastlaneIdea[]> {
+    return await this.instance
+      .post<{ data: FastlaneIdea[] }>(`/${id}/fastlane/ideas`, dto)
+      .then((res) => res.data?.data ?? []);
   }
 }


### PR DESCRIPTION
## Summary

- Adds `packages/pages/studio/fastlane/` — the complete frontend package for the Fastlane studio mode (brand data → ideas → generate → blitz review → schedule)
- Wires to the existing route wrapper at `apps/app/.../studio/fastlane/page.tsx` which imports `@pages/studio/fastlane` (default export)
- Adds `@testing-library/react` alias to `packages/pages/vitest.config.ts` so hook tests can use `renderHook`

## Architecture

3-step wizard in `FastlaneLayout`:
1. **Ideas** (`FastlaneIdeaSelector`) — format toggles (image/video/avatar), count stepper (3–9), optional angle, credit estimate, idea preview cards
2. **Review** (`FastlaneBlitz`) — Tinder-style CSS-transform swipe (translate+rotate+opacity, no GSAP). ←/→ arrow key support. Failed asset count badge.
3. **Schedule** (`FastlaneSchedulePanel`) — per-asset editable caption, per-credential datetime picker, "post now" or scheduled.

## Hooks

- `useFastlaneIdeas` — wraps `BrandsService.generateFastlaneIdeas`; AbortController; 400 errors surface back to step 1
- `useFastlaneGeneration` — fan-out to `ImagesService`/`VideosService`/`HeyGenService`; WS subscription per pending ID via `useSocketManager`; `Promise.allSettled` so per-asset failures don't abort the batch; full cleanup on unmount
- `useFastlaneSchedule` — one `PostsService.post` per approved asset × credential; shared `groupId`; `source: 'fastlane'`; partial failure surface

## Guards

- `useFastlaneEnabled` — org-level flag; renders "not available" empty state before any content loads
- `FastlaneBrandGate` — checks voice tone, ≥1 reference image, ≥1 short-form social; avatar format requires `defaultAvatarIngredientId` + `defaultVoiceId`

## Test plan

- [ ] `bun run test --filter=@genfeedai/pages` → 33 tests pass (6 suites)
- [ ] `bunx turbo run type-check --filter=@genfeedai/app` → 17 tasks successful
- [ ] `bunx biome check --write packages/pages/studio/fastlane` → 10 files fixed, 0 errors
- [ ] Pre-commit hooks (lint-staged, secretlint, lint-no-raw-html) all pass