### PR TITLE
refactor(api): decompose DarkroomService god object into facade + peer services (#690)

### DIFF
--- a/apps/server/api/src/collections/ingredients/services/ingredients.service.ts
+++ b/apps/server/api/src/collections/ingredients/services/ingredients.service.ts
@@ -565,4 +565,83 @@ export class IngredientsService extends BaseService<
 
     return where;
   }
+
+  /**
+   * Count persona-scoped darkroom assets for an organization. Encapsulates the
+   * raw Prisma aggregation so darkroom callers don't reach into `.prisma.*`.
+   */
+  async countPersonaAssets(organizationId: string): Promise<number> {
+    return this.prisma.ingredient.count({
+      where: { isDeleted: false, organizationId, personaId: { not: null } },
+    });
+  }
+
+  /**
+   * Group persona-scoped darkroom assets by ingredient status.
+   */
+  async groupPersonaAssetsByStatus(
+    organizationId: string,
+  ): Promise<Array<{ status: string | null; count: number }>> {
+    const groups = await this.prisma.ingredient.groupBy({
+      _count: { id: true },
+      by: ['status'],
+      where: { isDeleted: false, organizationId, personaId: { not: null } },
+    });
+
+    return groups.map((group) => ({
+      count: group._count.id,
+      status: group.status,
+    }));
+  }
+
+  /**
+   * Group persona-scoped darkroom assets by review status.
+   */
+  async groupPersonaAssetsByReviewStatus(
+    organizationId: string,
+  ): Promise<Array<{ reviewStatus: string | null; count: number }>> {
+    const groups = await this.prisma.ingredient.groupBy({
+      _count: { id: true },
+      by: ['reviewStatus'],
+      where: { isDeleted: false, organizationId, personaId: { not: null } },
+    });
+
+    return groups.map((group) => ({
+      count: group._count.id,
+      reviewStatus: group.reviewStatus,
+    }));
+  }
+
+  /**
+   * Group persona-scoped darkroom assets by campaign + review status, with the
+   * earliest creation timestamp per group.
+   */
+  async groupPersonaAssetCampaigns(organizationId: string): Promise<
+    Array<{
+      campaign: string | null;
+      reviewStatus: string | null;
+      count: number;
+      earliestCreatedAt: Date | null;
+    }>
+  > {
+    const groups = await this.prisma.ingredient.groupBy({
+      _count: { id: true },
+      _min: { createdAt: true },
+      by: ['campaign', 'reviewStatus'],
+      orderBy: { campaign: 'asc' },
+      where: {
+        campaign: { not: null },
+        isDeleted: false,
+        organizationId,
+        personaId: { not: null },
+      },
+    });
+
+    return groups.map((group) => ({
+      campaign: group.campaign,
+      count: group._count.id,
+      earliestCreatedAt: group._min.createdAt ?? null,
+      reviewStatus: group.reviewStatus,
+    }));
+  }
 }

--- a/apps/server/api/src/collections/trainings/services/trainings.service.ts
+++ b/apps/server/api/src/collections/trainings/services/trainings.service.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { CreateTrainingDto } from '@api/collections/trainings/dto/create-training.dto';
 import { UpdateTrainingDto } from '@api/collections/trainings/dto/update-training.dto';
 import type { TrainingDocument } from '@api/collections/trainings/schemas/training.schema';
@@ -282,5 +283,33 @@ export class TrainingsService extends BaseService<
     return typeof value === 'string' && value.trim().length > 0
       ? value
       : undefined;
+  }
+
+  /**
+   * Count an organization's trainings. Encapsulates the raw Prisma aggregation
+   * so darkroom callers don't reach into `.prisma.*`.
+   */
+  async countTrainingsByOrganization(organizationId: string): Promise<number> {
+    return this.prisma.training.count({
+      where: { isDeleted: false, organizationId },
+    });
+  }
+
+  /**
+   * Group an organization's trainings by stage.
+   */
+  async groupTrainingsByStage(
+    organizationId: string,
+  ): Promise<Array<{ stage: string | null; count: number }>> {
+    const groups = await this.prisma.training.groupBy({
+      _count: { id: true },
+      by: ['stage'],
+      where: { isDeleted: false, organizationId },
+    });
+
+    return groups.map((group) => ({
+      count: group._count.id,
+      stage: group.stage,
+    }));
   }
 }

--- a/apps/server/api/src/endpoints/admin/darkroom/darkroom.module.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/darkroom.module.ts
@@ -9,7 +9,16 @@ import { PersonasModule } from '@api/collections/personas/personas.module';
 import { TrainingsModule } from '@api/collections/trainings/trainings.module';
 import { DarkroomController } from '@api/endpoints/admin/darkroom/darkroom.controller';
 import { DarkroomService } from '@api/endpoints/admin/darkroom/darkroom.service';
+import { DarkroomAssetService } from '@api/endpoints/admin/darkroom/services/darkroom-asset.service';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { DarkroomGenerationService } from '@api/endpoints/admin/darkroom/services/darkroom-generation.service';
+import { DarkroomInfraService } from '@api/endpoints/admin/darkroom/services/darkroom-infra.service';
+import { DarkroomIngestService } from '@api/endpoints/admin/darkroom/services/darkroom-ingest.service';
+import { DarkroomMediaService } from '@api/endpoints/admin/darkroom/services/darkroom-media.service';
+import { DarkroomPublishingService } from '@api/endpoints/admin/darkroom/services/darkroom-publishing.service';
+import { DarkroomStatsService } from '@api/endpoints/admin/darkroom/services/darkroom-stats.service';
 import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
+import { DarkroomTrainingOrchestratorService } from '@api/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service';
 import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
 import { FilesClientModule } from '@api/services/files-microservice/client/files-client.module';
 import { ComfyUIModule } from '@api/services/integrations/comfyui/comfyui.module';
@@ -44,6 +53,15 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     DarkroomService,
+    DarkroomAssetService,
+    DarkroomCharacterService,
+    DarkroomGenerationService,
+    DarkroomInfraService,
+    DarkroomIngestService,
+    DarkroomMediaService,
+    DarkroomPublishingService,
+    DarkroomStatsService,
+    DarkroomTrainingOrchestratorService,
     DarkroomTrainingService,
     IpWhitelistGuard,
     ModelRegistrationService,

--- a/apps/server/api/src/endpoints/admin/darkroom/darkroom.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/darkroom.service.ts
@@ -1,2107 +1,264 @@
-import { BrandsService } from '@api/collections/brands/services/brands.service';
-import { CreatorScraperService } from '@api/collections/content-intelligence/services/creator-scraper.service';
-import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
-import { type IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
-import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
-import { type PersonaDocument } from '@api/collections/personas/schemas/persona.schema';
-import { PersonasService } from '@api/collections/personas/services/personas.service';
-import { type TrainingDocument } from '@api/collections/trainings/schemas/training.schema';
-import { TrainingsService } from '@api/collections/trainings/services/trainings.service';
-import { ConfigService } from '@api/config/config.service';
 import { GenerateImageDto } from '@api/endpoints/admin/darkroom/dto/generate-image.dto';
-import { DarkroomGenerationJob } from '@api/endpoints/admin/darkroom/interfaces/darkroom-generation-job.interface';
-import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
-import { ObjectIdUtil } from '@api/helpers/utils/objectid/objectid.util';
-import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
-import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
-import { ElevenLabsService } from '@api/services/integrations/elevenlabs/elevenlabs.service';
-import { FacebookService } from '@api/services/integrations/facebook/services/facebook.service';
-import { FleetService } from '@api/services/integrations/fleet/fleet.service';
-import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
-import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
-import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
-import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
-import {
-  CloudFrontClient,
-  CreateInvalidationCommand,
-} from '@aws-sdk/client-cloudfront';
-import {
-  DescribeInstancesCommand,
-  EC2Client,
-  StartInstancesCommand,
-  StopInstancesCommand,
-} from '@aws-sdk/client-ec2';
-import { MODEL_KEYS } from '@genfeedai/constants';
-import type { DarkroomReviewStatus } from '@genfeedai/enums';
-import {
-  ContentIntelligencePlatform,
-  type ContentRating,
-  CredentialPlatform,
-  type DarkroomAssetLabel,
-  DarkroomReviewStatus as DarkroomReviewStatusEnum,
-  FileInputType,
-  IngredientCategory,
-  IngredientStatus,
-  LoraStatus,
-  TrainingCategory,
-  TrainingProvider,
-  TrainingStage,
-} from '@genfeedai/enums';
-import { LoggerService } from '@libs/logger/logger.service';
-import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { SentryTraced } from '@sentry/nestjs';
-import axios from 'axios';
+import { DarkroomAssetService } from '@api/endpoints/admin/darkroom/services/darkroom-asset.service';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { DarkroomGenerationService } from '@api/endpoints/admin/darkroom/services/darkroom-generation.service';
+import { DarkroomInfraService } from '@api/endpoints/admin/darkroom/services/darkroom-infra.service';
+import { DarkroomIngestService } from '@api/endpoints/admin/darkroom/services/darkroom-ingest.service';
+import { DarkroomMediaService } from '@api/endpoints/admin/darkroom/services/darkroom-media.service';
+import { DarkroomPublishingService } from '@api/endpoints/admin/darkroom/services/darkroom-publishing.service';
+import { DarkroomStatsService } from '@api/endpoints/admin/darkroom/services/darkroom-stats.service';
+import { DarkroomTrainingOrchestratorService } from '@api/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service';
+import { Injectable } from '@nestjs/common';
 
-interface EC2InstanceStatus {
-  instanceId: string;
-  name: string;
-  role: string;
-  state: string;
-  instanceType: string;
-}
-
-interface DarkroomIngestFailure {
-  error: string;
-  filename: string;
-}
-
-interface DarkroomIngestResult {
-  failed: DarkroomIngestFailure[];
-  failedCount: number;
-  uploadedCount: number;
-}
-
-interface DarkroomSourceRecord extends Record<string, unknown> {
-  enabled: boolean;
-  handle: string;
-  lastIngestedAt?: Date;
-  platform: ContentIntelligencePlatform;
-}
-
+/**
+ * Thin facade over the darkroom collaborator services. Preserves the public
+ * surface the DarkroomController depends on while the implementation lives in
+ * focused, independently-ownable peer services under `./services`.
+ */
 @Injectable()
 export class DarkroomService {
-  private readonly constructorName: string = String(this.constructor.name);
-  private readonly ec2Client: EC2Client;
-  private readonly cloudFrontClient: CloudFrontClient;
-
   constructor(
-    private readonly brandsService: BrandsService,
-    private readonly personasService: PersonasService,
-    private readonly ingredientsService: IngredientsService,
-    private readonly trainingsService: TrainingsService,
-    private readonly darkroomTrainingService: DarkroomTrainingService,
-    private readonly configService: ConfigService,
-    private readonly loggerService: LoggerService,
-    private readonly comfyuiService: ComfyUIService,
-    private readonly instagramService: InstagramService,
-    private readonly twitterService: TwitterService,
-    private readonly facebookService: FacebookService,
-    private readonly credentialsService: CredentialsService,
-    private readonly filesClientService: FilesClientService,
-    private readonly creatorScraperService: CreatorScraperService,
-    private readonly fleetService: FleetService,
-    private readonly heyGenService: HeyGenService,
-    private readonly elevenLabsService: ElevenLabsService,
-  ) {
-    const region = this.configService.get('AWS_REGION') || 'us-east-1';
-    const credentials = {
-      accessKeyId: this.configService.get('AWS_ACCESS_KEY_ID') || '',
-      secretAccessKey: this.configService.get('AWS_SECRET_ACCESS_KEY') || '',
-    };
+    private readonly characterService: DarkroomCharacterService,
+    private readonly assetService: DarkroomAssetService,
+    private readonly generationService: DarkroomGenerationService,
+    private readonly ingestService: DarkroomIngestService,
+    private readonly trainingOrchestratorService: DarkroomTrainingOrchestratorService,
+    private readonly publishingService: DarkroomPublishingService,
+    private readonly mediaService: DarkroomMediaService,
+    private readonly statsService: DarkroomStatsService,
+    private readonly infraService: DarkroomInfraService,
+  ) {}
 
-    this.ec2Client = new EC2Client({ credentials, region });
-    this.cloudFrontClient = new CloudFrontClient({ credentials, region });
+  // === Characters ===
+
+  getCharacters(organizationId: string) {
+    return this.characterService.getCharacters(organizationId);
   }
 
-  private readObjectRecord(
-    value: unknown,
-  ): Record<string, unknown> | undefined {
-    return typeof value === 'object' && value !== null
-      ? (value as Record<string, unknown>)
-      : undefined;
+  getCharacterBySlug(slug: string, organizationId: string) {
+    return this.characterService.getCharacterBySlug(slug, organizationId);
   }
 
-  private readNumber(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value)
-      ? value
-      : undefined;
-  }
-
-  private readString(value: unknown): string | undefined {
-    return typeof value === 'string' && value.length > 0 ? value : undefined;
-  }
-
-  private readReferenceId(value: unknown): string | undefined {
-    if (typeof value === 'string' && value.length > 0) {
-      return value;
-    }
-
-    const record = this.readObjectRecord(value);
-    const nestedId =
-      this.readString(record?._id) ??
-      this.readString(record?.id) ??
-      this.readString(record?.mongoId);
-
-    if (nestedId) {
-      return nestedId;
-    }
-
-    if (
-      value &&
-      typeof value === 'object' &&
-      'toString' in (value as object) &&
-      typeof (value as { toString: () => string }).toString === 'function'
-    ) {
-      const stringified = (value as { toString: () => string }).toString();
-      return stringified !== '[object Object]' ? stringified : undefined;
-    }
-
-    return undefined;
-  }
-
-  private readPlatform(
-    value: unknown,
-  ): ContentIntelligencePlatform | undefined {
-    switch (this.readString(value)) {
-      case ContentIntelligencePlatform.INSTAGRAM:
-        return ContentIntelligencePlatform.INSTAGRAM;
-      case ContentIntelligencePlatform.LINKEDIN:
-        return ContentIntelligencePlatform.LINKEDIN;
-      case ContentIntelligencePlatform.TIKTOK:
-        return ContentIntelligencePlatform.TIKTOK;
-      case ContentIntelligencePlatform.TWITTER:
-        return ContentIntelligencePlatform.TWITTER;
-      default:
-        return undefined;
-    }
-  }
-
-  private getEnabledDarkroomSources(
-    persona: PersonaDocument,
-  ): DarkroomSourceRecord[] {
-    const sources = Array.isArray(persona.darkroomSources)
-      ? persona.darkroomSources
-      : [];
-
-    return sources.flatMap((source) => {
-      const record = this.readObjectRecord(source);
-      const handle = this.readString(record?.handle);
-      const platform = this.readPlatform(record?.platform);
-
-      if (!record || record.enabled !== true || !handle || !platform) {
-        return [];
-      }
-
-      return [record as DarkroomSourceRecord];
-    });
-  }
-
-  private hasIngredientCategory(
-    value: unknown,
-    expected: IngredientCategory,
-  ): boolean {
-    return this.readString(value) === expected;
-  }
-
-  private hasIngredientStatus(
-    value: unknown,
-    expected: IngredientStatus,
-  ): boolean {
-    return this.readString(value) === expected;
-  }
-
-  private hasReviewStatus(
-    value: unknown,
-    expected: DarkroomReviewStatusEnum,
-  ): boolean {
-    return this.readString(value) === expected;
-  }
-
-  /**
-   * Get all darkroom characters (personas with isDarkroomCharacter: true)
-   */
-  getCharacters(organizationId: string): Promise<PersonaDocument[]> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { organizationId });
-
-    return this.personasService.findAllByOrganization(organizationId, {
-      isDarkroomCharacter: true,
-    });
-  }
-
-  /**
-   * Get a single darkroom character by slug
-   */
-  async getCharacterBySlug(
-    slug: string,
-    organizationId: string,
-  ): Promise<PersonaDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { organizationId, slug });
-
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character with slug "${slug}" not found`);
-    }
-
-    return persona;
-  }
-
-  /**
-   * Create a new darkroom character
-   */
   createCharacter(
-    data: Partial<PersonaDocument> & {
-      user: string;
-      organization: string;
-      brand: string;
-    },
-  ): Promise<PersonaDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { slug: data.slug });
-
-    return this.personasService.create({
-      ...data,
-      isDarkroomCharacter: true,
-    } as Parameters<PersonasService['create']>[0]);
+    data: Parameters<DarkroomCharacterService['createCharacter']>[0],
+  ) {
+    return this.characterService.createCharacter(data);
   }
 
-  /**
-   * Update a darkroom character
-   */
   updateCharacter(
     id: string,
-    data: Partial<PersonaDocument>,
-  ): Promise<PersonaDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { id });
-
-    return this.personasService.patch(
-      id,
-      data as Parameters<PersonasService['patch']>[1],
-    );
+    data: Parameters<DarkroomCharacterService['updateCharacter']>[1],
+  ) {
+    return this.characterService.updateCharacter(id, data);
   }
 
-  /**
-   * Get assets (ingredients) for a persona
-   */
+  // === Assets ===
+
   getAssets(
     organizationId: string,
-    filters: {
-      personaSlug?: string;
-      reviewStatus?: DarkroomReviewStatus;
-      assetLabel?: DarkroomAssetLabel;
-      contentRating?: ContentRating;
-      campaign?: string;
-      page?: number;
-      limit?: number;
-    },
-  ): Promise<IngredientDocument[]> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { filters, organizationId });
-
-    const query: Record<string, unknown> = {
-      persona: { not: true },
-    };
-
-    if (filters.personaSlug) {
-      query.personaSlug = filters.personaSlug;
-    }
-    if (filters.reviewStatus) {
-      query.reviewStatus = filters.reviewStatus;
-    }
-    if (filters.assetLabel) {
-      query.assetLabel = filters.assetLabel;
-    }
-    if (filters.contentRating) {
-      query.contentRating = filters.contentRating;
-    }
-    if (filters.campaign) {
-      query.campaign = filters.campaign;
-    }
-
-    return this.ingredientsService.findAllByOrganization(organizationId, query);
+    filters: Parameters<DarkroomAssetService['getAssets']>[1],
+  ) {
+    return this.assetService.getAssets(organizationId, filters);
   }
 
-  private getDefaultDarkroomModerationState(): Pick<
-    Parameters<IngredientsService['create']>[0],
-    'contentRating' | 'reviewStatus'
-  > {
-    return {
-      contentRating: undefined,
-      reviewStatus: DarkroomReviewStatusEnum.PENDING,
-    };
-  }
-
-  /**
-   * Review an asset (approve/reject)
-   */
-  async reviewAsset(
+  reviewAsset(
     ingredientId: string,
     organizationId: string,
-    reviewStatus: DarkroomReviewStatus,
-  ): Promise<IngredientDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, {
+    reviewStatus: Parameters<DarkroomAssetService['reviewAsset']>[2],
+  ) {
+    return this.assetService.reviewAsset(
       ingredientId,
       organizationId,
       reviewStatus,
-    });
-
-    // Verify ingredient belongs to organization before updating (multi-tenant guard)
-    const ingredient = await this.ingredientsService.findOne({
-      _id: ingredientId,
-      isDeleted: false,
-      organization: organizationId,
-    });
-
-    if (!ingredient) {
-      throw new NotFoundException(
-        `Asset "${ingredientId}" not found in organization "${organizationId}"`,
-      );
-    }
-
-    const updated = await this.ingredientsService.patch(ingredientId, {
-      reviewStatus,
-    } as Parameters<IngredientsService['patch']>[1]);
-
-    if (
-      reviewStatus === DarkroomReviewStatusEnum.APPROVED &&
-      !this.hasReviewStatus(
-        ingredient.reviewStatus,
-        DarkroomReviewStatusEnum.APPROVED,
-      ) &&
-      ingredient.personaSlug &&
-      ingredient.cdnUrl &&
-      this.hasIngredientCategory(ingredient.category, IngredientCategory.IMAGE)
-    ) {
-      await this.syncApprovedAssetToDataset(
-        organizationId,
-        ingredient.personaSlug,
-        ingredient,
-      );
-    }
-
-    return updated;
-  }
-
-  /**
-   * Get trainings for a persona
-   */
-  getTrainings(
-    organizationId: string,
-    personaSlug?: string,
-  ): Promise<TrainingDocument[]> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { organizationId, personaSlug });
-
-    const filters: Record<string, unknown> = {};
-    if (personaSlug) {
-      filters.personaSlug = personaSlug;
-    }
-
-    return this.trainingsService.findAllByOrganization(organizationId, filters);
-  }
-
-  /**
-   * Get a single training by ID
-   */
-  async getTraining(
-    trainingId: string,
-    organizationId: string,
-  ): Promise<TrainingDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { organizationId, trainingId });
-
-    const training = await this.trainingsService.findOne({
-      _id: trainingId,
-      isDeleted: false,
-      organization: organizationId,
-    });
-
-    if (!training) {
-      throw new NotFoundException(`Training "${trainingId}" not found`);
-    }
-
-    return training;
-  }
-
-  /**
-   * Start a new darkroom training job.
-   * Creates a training record and fires off the pipeline asynchronously.
-   */
-  @SentryTraced()
-  async startTraining(
-    organizationId: string,
-    userId: string,
-    _brandId: string,
-    data: {
-      personaSlug: string;
-      label: string;
-      sourceIds: string[];
-      steps?: number;
-      learningRate?: number;
-      loraRank?: number;
-      loraName?: string;
-      baseModel?: string;
-    },
-  ): Promise<TrainingDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, {
-      organizationId,
-      personaSlug: data.personaSlug,
-    });
-
-    // Resolve persona
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug: data.personaSlug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character "${data.personaSlug}" not found`);
-    }
-
-    const dataset = await this.darkroomTrainingService.getDatasetInfo(
-      data.personaSlug,
     );
-    if (dataset.imageCount === 0) {
-      throw new BadRequestException(
-        `Dataset for "${data.personaSlug}" is empty. Upload training images before starting LoRA training.`,
-      );
-    }
-
-    // Auto-tune hyperparameters based on dataset size
-    const imageCount =
-      this.readNumber(
-        (persona as Record<string, unknown>).selectedImagesCount,
-      ) ?? 20;
-    const autoTuned =
-      this.darkroomTrainingService.autoTuneHyperparameters(imageCount);
-
-    const steps = data.steps ?? autoTuned.steps;
-    const loraRank = data.loraRank ?? autoTuned.rank;
-    const learningRate = data.learningRate ?? autoTuned.learningRate;
-    const baseModel = data.baseModel ?? MODEL_KEYS.GENFEED_AI_Z_IMAGE_TURBO;
-    const triggerWord = persona.triggerWord ?? data.personaSlug;
-    const loraName = data.loraName ?? `${triggerWord}_zimage`;
-
-    // Create training record
-    const sourceIds =
-      data.sourceIds.length > 0
-        ? data.sourceIds
-        : (
-            await this.ingredientsService.findAllByOrganization(
-              organizationId,
-              {
-                isDeleted: false,
-                persona: persona._id,
-                reviewStatus: DarkroomReviewStatusEnum.APPROVED,
-              },
-            )
-          ).map((ingredient) => ingredient._id.toString());
-
-    const training = await this.trainingsService.create({
-      baseModel,
-      category: TrainingCategory.SUBJECT,
-      label: data.label,
-      learningRate,
-      loraName,
-      loraRank,
-      model: baseModel,
-      organization: ObjectIdUtil.toObjectId(organizationId)!,
-      persona: persona._id,
-      personaSlug: data.personaSlug,
-      progress: 0,
-      provider: TrainingProvider.GENFEED_AI,
-      sources: sourceIds.map((id) => ObjectIdUtil.toObjectId(id)!),
-      stage: TrainingStage.QUEUED,
-      steps,
-      trigger: triggerWord,
-      user: ObjectIdUtil.toObjectId(userId)!,
-    } as Parameters<TrainingsService['create']>[0]);
-
-    await this.personasService.patch(persona._id.toString(), {
-      loraModelPath: undefined,
-      loraStatus: LoraStatus.TRAINING,
-    });
-
-    // Fire-and-forget: execute training pipeline asynchronously
-    this.darkroomTrainingService
-      .executeTrainingquery({
-        baseModel,
-        learningRate,
-        loraName,
-        loraRank,
-        organizationId,
-        personaSlug: data.personaSlug,
-        steps,
-        trainingId: training._id.toString(),
-        triggerWord,
-      })
-      .catch((error) => {
-        this.loggerService.error(caller, {
-          error: error instanceof Error ? error.message : String(error),
-          message: 'Training pipeline failed',
-          trainingId: training._id.toString(),
-        });
-      });
-
-    return training;
   }
 
-  // === Infrastructure ===
-
-  /**
-   * Get EC2 instance statuses filtered by the 'Project: darkroom' tag.
-   */
-  async getEC2Status(): Promise<EC2InstanceStatus[]> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller);
-
-    try {
-      const command = new DescribeInstancesCommand({
-        Filters: [
-          { Name: 'tag:Project', Values: ['darkroom', 'fleet'] },
-          {
-            Name: 'instance-state-name',
-            Values: ['pending', 'running', 'stopping', 'stopped'],
-          },
-        ],
-      });
-
-      const response = await this.ec2Client.send(command);
-      const instances: EC2InstanceStatus[] = [];
-
-      for (const reservation of response.Reservations ?? []) {
-        for (const instance of reservation.Instances ?? []) {
-          const nameTag = instance.Tags?.find((tag) => tag.Key === 'Name');
-          const roleTag = instance.Tags?.find((tag) => tag.Key === 'Role');
-          instances.push({
-            instanceId: instance.InstanceId ?? 'unknown',
-            instanceType: instance.InstanceType ?? 'unknown',
-            name: nameTag?.Value ?? 'unnamed',
-            role: roleTag?.Value ?? 'training',
-            state: instance.State?.Name ?? 'unknown',
-          });
-        }
-      }
-
-      return instances;
-    } catch (error: unknown) {
-      this.loggerService.error(caller, {
-        error: getErrorMessage(error),
-        message: 'Failed to describe EC2 instances',
-      });
-      throw error;
-    }
-  }
-
-  /**
-   * Start or stop an EC2 instance.
-   */
-  async ec2Action(
-    instanceId: string,
-    action: 'start' | 'stop',
-  ): Promise<{ message: string }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { action, instanceId });
-
-    try {
-      const stateChanges =
-        action === 'start'
-          ? (
-              await this.ec2Client.send(
-                new StartInstancesCommand({ InstanceIds: [instanceId] }),
-              )
-            ).StartingInstances
-          : (
-              await this.ec2Client.send(
-                new StopInstancesCommand({ InstanceIds: [instanceId] }),
-              )
-            ).StoppingInstances;
-
-      const currentState = stateChanges?.[0]?.CurrentState?.Name ?? 'unknown';
-      const previousState = stateChanges?.[0]?.PreviousState?.Name ?? 'unknown';
-
-      this.loggerService.log(caller, {
-        currentState,
-        instanceId,
-        message: `EC2 instance ${action} successful`,
-        previousState,
-      });
-
-      return {
-        message: `Instance ${instanceId} ${action} executed (${previousState} -> ${currentState})`,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(caller, {
-        action,
-        error: getErrorMessage(error),
-        instanceId,
-        message: `Failed to ${action} EC2 instance`,
-      });
-      throw error;
-    }
-  }
-
-  async ec2ActionAll(
-    action: 'start' | 'stop',
-    role?: string,
-  ): Promise<{
-    action: 'start' | 'stop';
-    results: Array<{
-      instanceId: string;
-      name: string;
-      state: string;
-      success: boolean;
-      error?: string;
-    }>;
-  }> {
-    const instances = await this.getEC2Status();
-    const matchingInstances = instances.filter((instance) => {
-      const matchesRole = role ? instance.role === role : true;
-      const matchesState =
-        action === 'start'
-          ? instance.state === 'stopped'
-          : instance.state === 'running';
-      return matchesRole && matchesState;
-    });
-
-    const results = await Promise.all(
-      matchingInstances.map(async (instance) => {
-        try {
-          await this.ec2Action(instance.instanceId, action);
-          return {
-            instanceId: instance.instanceId,
-            name: instance.name,
-            state: instance.state,
-            success: true,
-          };
-        } catch (error: unknown) {
-          return {
-            error: getErrorMessage(error),
-            instanceId: instance.instanceId,
-            name: instance.name,
-            state: instance.state,
-            success: false,
-          };
-        }
-      }),
-    );
-
-    return { action, results };
-  }
-
-  /**
-   * Invalidate CloudFront cache for the given distribution and paths.
-   */
-  async invalidateCloudFront(
-    distributionId: string,
-    paths?: string[],
-  ): Promise<{ message: string; invalidationId: string }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    const invalidationPaths = paths?.length ? paths : ['/*'];
-    if (!distributionId) {
-      throw new BadRequestException(
-        'CloudFront distribution ID is not configured for darkroom invalidation',
-      );
-    }
-    this.loggerService.log(caller, {
-      distributionId,
-      paths: invalidationPaths,
-    });
-
-    try {
-      const command = new CreateInvalidationCommand({
-        DistributionId: distributionId,
-        InvalidationBatch: {
-          CallerReference: `darkroom-${Date.now()}`,
-          Paths: {
-            Items: invalidationPaths,
-            Quantity: invalidationPaths.length,
-          },
-        },
-      });
-
-      const response = await this.cloudFrontClient.send(command);
-      const invalidationId = response.Invalidation?.Id ?? 'unknown';
-
-      this.loggerService.log(caller, {
-        distributionId,
-        invalidationId,
-        message: 'CloudFront invalidation created',
-        paths: invalidationPaths,
-      });
-
-      return {
-        invalidationId,
-        message: `CloudFront invalidation created for ${distributionId} (${invalidationPaths.join(', ')})`,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(caller, {
-        distributionId,
-        error: getErrorMessage(error),
-        message: 'Failed to create CloudFront invalidation',
-        paths: invalidationPaths,
-      });
-      throw error;
-    }
-  }
-
-  getDefaultCloudFrontDistributionId(): string {
-    return this.configService.get('DARKROOM_CLOUDFRONT_DISTRIBUTION_ID') || '';
-  }
-
-  /**
-   * Check health of ComfyUI and Ollama services.
-   */
-  async getServiceHealth(): Promise<
-    { name: string; status: 'online' | 'offline' | 'unknown'; url: string }[]
-  > {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller);
-
-    const services = [
-      {
-        name: 'images.genfeed.ai',
-        url: this.configService.get('GPU_IMAGES_URL') || '',
-      },
-      {
-        name: 'voices.genfeed.ai',
-        url: this.configService.get('GPU_VOICES_URL') || '',
-      },
-      {
-        name: 'videos.genfeed.ai',
-        url: this.configService.get('GPU_VIDEOS_URL') || '',
-      },
-      {
-        name: 'llm.genfeed.ai',
-        url: this.configService.get('GPU_LLM_URL') || '',
-      },
-    ].filter((s) => s.url);
-
-    const results = await Promise.all(
-      services.map(async (service) => {
-        try {
-          await axios.get(`${service.url}/v1/health`, { timeout: 5000 });
-          return {
-            name: service.name,
-            status: 'online' as const,
-            url: service.url,
-          };
-        } catch {
-          return {
-            name: service.name,
-            status: 'offline' as const,
-            url: service.url,
-          };
-        }
-      }),
-    );
-
-    return results;
-  }
-
-  // === Asset Publishing ===
-
-  /**
-   * Publish an approved asset to social platforms.
-   */
-  async publishAsset(
+  publishAsset(
     ingredientId: string,
     organizationId: string,
     brandId: string,
     platforms: string[],
     caption?: string,
-  ): Promise<{
-    success: boolean;
-    results: Record<string, { success: boolean; id?: string; error?: string }>;
-  }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, {
-      brandId,
+  ) {
+    return this.publishingService.publishAsset(
       ingredientId,
       organizationId,
+      brandId,
       platforms,
-    });
-
-    // Verify ingredient exists and is approved
-    const ingredient = await this.ingredientsService.findOne({
-      _id: ingredientId,
-      isDeleted: false,
-      organization: organizationId,
-    });
-
-    if (!ingredient) {
-      throw new NotFoundException(
-        `Asset "${ingredientId}" not found in organization "${organizationId}"`,
-      );
-    }
-
-    if (
-      !this.hasReviewStatus(
-        ingredient.reviewStatus,
-        DarkroomReviewStatusEnum.APPROVED,
-      )
-    ) {
-      throw new BadRequestException(
-        `Asset must be approved before publishing (current status: ${ingredient.reviewStatus})`,
-      );
-    }
-
-    if (!ingredient.cdnUrl) {
-      throw new BadRequestException(
-        'Asset must have a CDN URL to be published',
-      );
-    }
-
-    const results: Record<
-      string,
-      { success: boolean; id?: string; error?: string }
-    > = {};
-
-    // Publish to each platform
-    for (const platform of platforms) {
-      try {
-        let platformId: string;
-
-        switch (platform.toLowerCase()) {
-          case 'instagram': {
-            const igResult = await this.instagramService.uploadImage(
-              organizationId,
-              brandId,
-              ingredient.cdnUrl,
-              caption || '',
-            );
-            platformId = igResult.mediaId;
-            results.instagram = { id: platformId, success: true };
-            break;
-          }
-
-          case 'twitter':
-            platformId = await this.twitterService.uploadMedia(
-              organizationId,
-              brandId,
-              ingredient.cdnUrl,
-              caption || '',
-              'image/jpeg',
-            );
-            results.twitter = { id: platformId, success: true };
-            break;
-
-          case 'facebook': {
-            // Facebook requires pageId and pageAccessToken
-            const fbCredential = await this.credentialsService.findOne({
-              brand: ObjectIdUtil.toObjectId(brandId)!,
-              isDeleted: false,
-              organization: ObjectIdUtil.toObjectId(organizationId)!,
-              platform: CredentialPlatform.FACEBOOK,
-            });
-
-            if (!fbCredential?.accessToken || !fbCredential?.externalId) {
-              throw new Error('Facebook credential not found');
-            }
-
-            const decryptedToken = EncryptionUtil.decrypt(
-              fbCredential.accessToken,
-            );
-
-            platformId = await this.facebookService.uploadImage(
-              fbCredential.externalId,
-              decryptedToken,
-              ingredient.cdnUrl,
-              caption || '',
-            );
-            results.facebook = { id: platformId, success: true };
-            break;
-          }
-
-          default:
-            results[platform] = {
-              error: `Unsupported platform: ${platform}`,
-              success: false,
-            };
-        }
-      } catch (error: unknown) {
-        this.loggerService.error(caller, {
-          error: getErrorMessage(error),
-          ingredientId,
-          platform,
-        });
-        results[platform] = {
-          error: getErrorMessage(error),
-          success: false,
-        };
-      }
-    }
-
-    const allSuccessful = Object.values(results).every((r) => r.success);
-
-    return {
-      results,
-      success: allSuccessful,
-    };
+      caption,
+    );
   }
 
-  // === Image Generation ===
+  // === Generation ===
 
-  /**
-   * Generate an image for a character using ComfyUI.
-   */
-  @SentryTraced()
-  async generateImage(
+  generateImage(
     organizationId: string,
     brandId: string,
     userId: string,
     personaSlug: string,
     prompt: string,
-    options: {
-      model?: string;
-      negativePrompt?: string;
-      steps?: number;
-      seed?: number;
-      cfgScale?: number;
-      width?: number;
-      height?: number;
-      lora?: string;
-      loraStrength?: number;
-      ingredientId?: string;
-    },
-  ): Promise<IngredientDocument> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, {
-      organizationId,
-      personaSlug,
-      prompt,
-    });
-
-    // Verify persona exists
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug: personaSlug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character "${personaSlug}" not found`);
-    }
-
-    // Determine model and parameters
-    const model = options.model || MODEL_KEYS.GENFEED_AI_FLUX2_DEV;
-    const comfyParams: Record<string, unknown> = {
-      prompt,
-    };
-
-    if (options.negativePrompt) {
-      comfyParams.negativePrompt = options.negativePrompt;
-    }
-    if (options.steps) {
-      comfyParams.steps = options.steps;
-    }
-    if (options.seed !== undefined) {
-      comfyParams.seed = options.seed;
-    }
-    if (options.cfgScale) {
-      comfyParams.cfg = options.cfgScale;
-    }
-    if (options.width) {
-      comfyParams.width = options.width;
-    }
-    if (options.height) {
-      comfyParams.height = options.height;
-    }
-    if (options.lora) {
-      comfyParams.loraPath = options.lora;
-    }
-    if (options.loraStrength) {
-      comfyParams.loraStrength = options.loraStrength;
-    }
-
-    // Generate image via ComfyUI
-    const { imageBuffer, filename } = await this.comfyuiService.generateImage(
-      model,
-      comfyParams,
-    );
-
-    if (options.ingredientId) {
-      await this.ingredientsService.patch(options.ingredientId, {
-        generationProgress: 90,
-        generationStage: 'uploading',
-        status: IngredientStatus.PROCESSING,
-      });
-    }
-
-    // Upload image buffer to S3 via files microservice
-    const s3Meta = await this.filesClientService.uploadToS3(
-      `darkroom/${personaSlug}/${filename}`,
-      'images',
-      {
-        contentType: 'image/png',
-        data: imageBuffer,
-        type: FileInputType.BUFFER,
-      },
-    );
-    const cdnUrl =
-      s3Meta.publicUrl ??
-      `https://cdn.genfeed.ai/darkroom/${personaSlug}/${filename}`;
-
-    const ingredient =
-      options.ingredientId === undefined
-        ? await this.ingredientsService.create({
-            brand: ObjectIdUtil.toObjectId(brandId)!,
-            cdnUrl,
-            ...this.getDefaultDarkroomModerationState(),
-            generationSource: model,
-            modelUsed: model,
-            organization: ObjectIdUtil.toObjectId(organizationId)!,
-            persona: persona._id,
-            personaSlug,
-            s3Key: `darkroom/${personaSlug}/${filename}`,
-            status: IngredientStatus.GENERATED,
-            user: ObjectIdUtil.toObjectId(userId)!,
-          } as Parameters<IngredientsService['create']>[0])
-        : await this.ingredientsService.patch(options.ingredientId, {
-            cdnUrl,
-            generationCompletedAt: new Date(),
-            generationError: undefined,
-            generationProgress: 100,
-            generationSource: model,
-            generationStage: 'completed',
-            modelUsed: model,
-            reviewStatus: DarkroomReviewStatusEnum.PENDING,
-            s3Key: `darkroom/${personaSlug}/${filename}`,
-            status: IngredientStatus.GENERATED,
-          });
-
-    this.loggerService.log(caller, {
-      ingredientId: ingredient._id.toString(),
-      message: 'Image generated successfully',
-    });
-
-    return ingredient;
-  }
-
-  async uploadDataset(
-    organizationId: string,
-    slug: string,
-    files: Array<{ buffer: Buffer; mimetype: string; originalname: string }>,
-    captions?: Array<{ filenameStem: string; caption: string }>,
-  ): Promise<DarkroomIngestResult> {
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character "${slug}" not found`);
-    }
-
-    const captionMap = new Map(
-      (captions ?? []).map((entry) => [
-        entry.filenameStem.toLowerCase(),
-        entry,
-      ]),
-    );
-    const s3Keys: string[] = [];
-    let uploadedCount = 0;
-    let failedCount = 0;
-    const failed: Array<{ filename: string; error: string }> = [];
-
-    for (const file of files) {
-      const filename = file.originalname;
-      const stem = filename.replace(/\.[^.]+$/, '').toLowerCase();
-      const imageKey = `darkroom/datasets/${slug}/${filename}`;
-
-      try {
-        await this.filesClientService.uploadToS3(imageKey, 'images', {
-          contentType: file.mimetype,
-          data: file.buffer,
-          type: FileInputType.BUFFER,
-        });
-        s3Keys.push(imageKey);
-
-        const caption = captionMap.get(stem);
-        if (caption) {
-          const captionKey = `darkroom/datasets/${slug}/${caption.filenameStem}.txt`;
-          await this.filesClientService.uploadToS3(captionKey, 'images', {
-            contentType: 'text/plain',
-            data: Buffer.from(caption.caption, 'utf8'),
-            type: FileInputType.BUFFER,
-          });
-          s3Keys.push(captionKey);
-        }
-
-        uploadedCount++;
-      } catch (error: unknown) {
-        failedCount++;
-        failed.push({
-          error: getErrorMessage(error),
-          filename,
-        });
-      }
-    }
-
-    if (s3Keys.length > 0) {
-      await this.darkroomTrainingService.syncDataset(slug, s3Keys);
-    }
-
-    return { failed, failedCount, uploadedCount };
-  }
-
-  async ingestTrainingDataForCharacter(
-    organizationId: string,
-    userId: string,
-    slug: string,
-  ): Promise<DarkroomIngestResult> {
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character "${slug}" not found`);
-    }
-
-    return this.ingestTrainingDataForPersonaDocument(
-      organizationId,
-      userId,
-      persona,
-    );
-  }
-
-  async ingestTrainingDataForAllEnabledCharacters(
-    organizationId: string,
-    userId: string,
-  ): Promise<DarkroomIngestResult> {
-    const personas = await this.personasService.findAllByOrganization(
-      organizationId,
-      {
-        isDarkroomCharacter: true,
-      },
-    );
-
-    let uploadedCount = 0;
-    let failedCount = 0;
-    const failed: DarkroomIngestFailure[] = [];
-
-    for (const persona of personas) {
-      const brandId = this.readReferenceId(persona.brand);
-
-      if (!brandId) {
-        continue;
-      }
-
-      const brand = await this.brandsService.findOne(
-        {
-          _id: brandId,
-          isDeleted: false,
-          organization: organizationId,
-        },
-        'none',
-      );
-
-      if (!brand?.isDarkroomEnabled) {
-        continue;
-      }
-
-      const result = await this.ingestTrainingDataForPersonaDocument(
-        organizationId,
-        userId,
-        persona,
-      );
-
-      uploadedCount += result.uploadedCount;
-      failedCount += result.failedCount;
-      failed.push(...result.failed);
-    }
-
-    return {
-      failed,
-      failedCount,
-      uploadedCount,
-    };
-  }
-
-  async createGenerationJob(
-    organizationId: string,
-    brandId: string,
-    userId: string,
-    dto: GenerateImageDto,
-  ): Promise<DarkroomGenerationJob> {
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug: dto.personaSlug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character "${dto.personaSlug}" not found`);
-    }
-
-    const loraPath = dto.lora || undefined;
-
-    const ingredient = await this.ingredientsService.create({
-      brand: ObjectIdUtil.toObjectId(brandId)!,
-      category: 'image',
-      ...this.getDefaultDarkroomModerationState(),
-      generationError: undefined,
-      generationProgress: 5,
-      generationPrompt: dto.prompt,
-      generationSource: dto.model || MODEL_KEYS.GENFEED_AI_FLUX2_DEV,
-      generationStage: 'queued',
-      generationStartedAt: new Date(),
-      loraUsed: loraPath,
-      modelUsed: dto.model || MODEL_KEYS.GENFEED_AI_FLUX2_DEV,
-      negativePrompt: dto.negativePrompt,
-      organization: ObjectIdUtil.toObjectId(organizationId)!,
-      persona: persona._id,
-      personaSlug: dto.personaSlug,
-      status: IngredientStatus.PROCESSING,
-      user: ObjectIdUtil.toObjectId(userId)!,
-    } as Parameters<IngredientsService['create']>[0]);
-
-    void this.processGenerationJob(
-      ingredient._id.toString(),
+    options: Parameters<DarkroomGenerationService['generateImage']>[5],
+  ) {
+    return this.generationService.generateImage(
       organizationId,
       brandId,
       userId,
-      {
-        ...dto,
-        lora: loraPath,
-      },
+      personaSlug,
+      prompt,
+      options,
     );
-
-    return this.mapIngredientToGenerationJob(ingredient);
   }
 
-  async getGenerationJob(
-    jobId: string,
-    organizationId: string,
-  ): Promise<DarkroomGenerationJob> {
-    const ingredient = await this.ingredientsService.findOne({
-      _id: jobId,
-      isDeleted: false,
-      organization: organizationId,
-    });
-
-    if (!ingredient) {
-      throw new NotFoundException(`Generation job "${jobId}" not found`);
-    }
-
-    return this.mapIngredientToGenerationJob(ingredient);
-  }
-
-  private async updateGenerationJob(
-    jobId: string,
-    updates: Partial<DarkroomGenerationJob>,
-  ): Promise<void> {
-    await this.ingredientsService.patch(jobId, {
-      cdnUrl: updates.cdnUrl,
-      generationCompletedAt:
-        updates.status === 'completed' || updates.status === 'failed'
-          ? new Date()
-          : undefined,
-      generationError: updates.error,
-      generationProgress: updates.progress,
-      generationStage: updates.stage,
-      status:
-        updates.status === 'failed'
-          ? IngredientStatus.FAILED
-          : updates.status === 'completed'
-            ? IngredientStatus.GENERATED
-            : IngredientStatus.PROCESSING,
-    });
-  }
-
-  private async processGenerationJob(
-    jobId: string,
+  createGenerationJob(
     organizationId: string,
     brandId: string,
     userId: string,
     dto: GenerateImageDto,
-  ): Promise<void> {
-    await this.updateGenerationJob(jobId, {
-      progress: 15,
-      stage: 'validating inputs',
-      status: 'processing',
-    });
-
-    let pulseProgress = 20;
-    const pulse = setInterval(() => {
-      pulseProgress = Math.min(pulseProgress + 7, 82);
-      void this.updateGenerationJob(jobId, {
-        progress: pulseProgress,
-        stage: 'running on ComfyUI',
-        status: 'processing',
-      });
-    }, 2000);
-
-    try {
-      const ingredient = await this.generateImage(
-        organizationId,
-        brandId,
-        userId,
-        dto.personaSlug,
-        dto.prompt,
-        {
-          cfgScale: dto.cfgScale,
-          ingredientId: jobId,
-          lora: dto.lora,
-          model: dto.model,
-          negativePrompt: dto.negativePrompt,
-          seed: dto.seed,
-          steps: dto.steps,
-          ...this.getDimensionsFromAspectRatio(dto.aspectRatio),
-        },
-      );
-
-      clearInterval(pulse);
-      await this.updateGenerationJob(jobId, {
-        cdnUrl: ingredient.cdnUrl ?? undefined,
-        ingredientId: ingredient._id.toString(),
-        progress: 100,
-        stage: 'completed',
-        status: 'completed',
-      });
-    } catch (error: unknown) {
-      clearInterval(pulse);
-      await this.updateGenerationJob(jobId, {
-        error: getErrorMessage(error),
-        progress: 100,
-        stage: 'failed',
-        status: 'failed',
-      });
-    }
-  }
-
-  private getDimensionsFromAspectRatio(aspectRatio?: string): {
-    width?: number;
-    height?: number;
-  } {
-    if (!aspectRatio) {
-      return {};
-    }
-
-    const [w, h] = aspectRatio.split(':').map(Number);
-    if (!(w && h)) {
-      return {};
-    }
-
-    const scale = 1024 / Math.max(w, h);
-    return {
-      height: Math.round(h * scale),
-      width: Math.round(w * scale),
-    };
-  }
-
-  private mapIngredientToGenerationJob(
-    ingredient: IngredientDocument,
-  ): DarkroomGenerationJob {
-    const stage = ingredient.generationStage ?? 'queued';
-    const status = this.hasIngredientStatus(
-      ingredient.status,
-      IngredientStatus.FAILED,
-    )
-      ? 'failed'
-      : this.hasIngredientStatus(ingredient.status, IngredientStatus.GENERATED)
-        ? 'completed'
-        : stage === 'queued'
-          ? 'queued'
-          : stage === 'uploading'
-            ? 'uploading'
-            : 'processing';
-
-    return {
-      cdnUrl: ingredient.cdnUrl ?? undefined,
-      createdAt:
-        ingredient.createdAt?.toISOString() ?? new Date().toISOString(),
-      error: ingredient.generationError ?? undefined,
-      ingredientId: ingredient._id.toString(),
-      jobId: ingredient._id.toString(),
-      model: ingredient.modelUsed ?? ingredient.generationSource ?? '',
-      personaSlug: ingredient.personaSlug ?? '',
-      progress: ingredient.generationProgress ?? 0,
-      prompt: ingredient.generationPrompt ?? '',
-      stage,
-      status,
-      updatedAt:
-        ingredient.updatedAt?.toISOString() ?? new Date().toISOString(),
-    };
-  }
-
-  // === query Stats & Campaigns ===
-
-  /**
-   * List campaigns with asset counts.
-   */
-  async listCampaigns(organizationId: string): Promise<
-    {
-      campaign: string;
-      assetCount: number;
-      approvedCount: number;
-      createdAt: string;
-      status: 'active' | 'completed' | 'draft';
-    }[]
-  > {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { organizationId });
-
-    const campaignGroups =
-      await this.ingredientsService.prisma.ingredient.groupBy({
-        _count: { id: true },
-        _min: { createdAt: true },
-        by: ['campaign', 'reviewStatus'],
-        orderBy: { campaign: 'asc' },
-        where: {
-          campaign: { not: null },
-          isDeleted: false,
-          organizationId,
-          personaId: { not: null },
-        },
-      });
-
-    const campaigns = new Map<
-      string,
-      {
-        approvedCount: number;
-        assetCount: number;
-        campaign: string;
-        createdAt?: Date;
-      }
-    >();
-
-    for (const group of campaignGroups) {
-      if (!group.campaign) {
-        continue;
-      }
-
-      const existing = campaigns.get(group.campaign) ?? {
-        approvedCount: 0,
-        assetCount: 0,
-        campaign: group.campaign,
-        createdAt: group._min.createdAt ?? undefined,
-      };
-
-      existing.assetCount += group._count.id;
-
-      if (
-        this.hasReviewStatus(
-          group.reviewStatus,
-          DarkroomReviewStatusEnum.APPROVED,
-        )
-      ) {
-        existing.approvedCount += group._count.id;
-      }
-
-      if (
-        group._min.createdAt &&
-        (!existing.createdAt || group._min.createdAt < existing.createdAt)
-      ) {
-        existing.createdAt = group._min.createdAt;
-      }
-
-      campaigns.set(group.campaign, existing);
-    }
-
-    return Array.from(campaigns.values()).map((campaign) => ({
-      approvedCount: campaign.approvedCount,
-      assetCount: campaign.assetCount,
-      campaign: campaign.campaign,
-      createdAt: (campaign.createdAt ?? new Date(0)).toISOString(),
-      status:
-        campaign.approvedCount === 0
-          ? 'draft'
-          : campaign.approvedCount >= campaign.assetCount
-            ? 'completed'
-            : 'active',
-    }));
-  }
-
-  /**
-   * Get pipeline statistics aggregating assets and trainings.
-   */
-  async getPipelineStats(organizationId: string): Promise<{
-    assets: {
-      total: number;
-      byStatus: Record<string, number>;
-      byReviewStatus: Record<string, number>;
-    };
-    trainings: {
-      total: number;
-      byStage: Record<string, number>;
-    };
-  }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { organizationId });
-
-    const assetWhere = {
-      isDeleted: false,
+  ) {
+    return this.generationService.createGenerationJob(
       organizationId,
-      personaId: { not: null },
-    } as const;
-    const trainingWhere = {
-      isDeleted: false,
-      organizationId,
-    } as const;
-
-    const [
-      assetTotal,
-      assetStatusGroups,
-      assetReviewStatusGroups,
-      trainingTotal,
-      trainingStageGroups,
-    ] = await Promise.all([
-      this.ingredientsService.prisma.ingredient.count({ where: assetWhere }),
-      this.ingredientsService.prisma.ingredient.groupBy({
-        _count: { id: true },
-        by: ['status'],
-        where: assetWhere,
-      }),
-      this.ingredientsService.prisma.ingredient.groupBy({
-        _count: { id: true },
-        by: ['reviewStatus'],
-        where: assetWhere,
-      }),
-      this.trainingsService.prisma.training.count({ where: trainingWhere }),
-      this.trainingsService.prisma.training.groupBy({
-        _count: { id: true },
-        by: ['stage'],
-        where: trainingWhere,
-      }),
-    ]);
-
-    const byStatus: Record<string, number> = {};
-    for (const item of assetStatusGroups) {
-      byStatus[this.readString(item.status) ?? 'unknown'] = item._count.id;
-    }
-
-    const byReviewStatus: Record<string, number> = {};
-    for (const item of assetReviewStatusGroups) {
-      byReviewStatus[this.readString(item.reviewStatus) ?? 'unknown'] =
-        item._count.id;
-    }
-
-    const byStage: Record<string, number> = {};
-    for (const item of trainingStageGroups) {
-      byStage[this.readString(item.stage) ?? 'unknown'] = item._count.id;
-    }
-
-    return {
-      assets: {
-        byReviewStatus,
-        byStatus,
-        total: assetTotal,
-      },
-      trainings: {
-        byStage,
-        total: trainingTotal,
-      },
-    };
+      brandId,
+      userId,
+      dto,
+    );
   }
 
-  async getqueryStats(organizationId: string): Promise<{
-    assets: {
-      total: number;
-      byStatus: Record<string, number>;
-      byReviewStatus: Record<string, number>;
-    };
-    trainings: {
-      total: number;
-      byStage: Record<string, number>;
-    };
-  }> {
-    return this.getPipelineStats(organizationId);
+  getGenerationJob(jobId: string, organizationId: string) {
+    return this.generationService.getGenerationJob(jobId, organizationId);
+  }
+
+  // === Training Data Ingestion ===
+
+  uploadDataset(
+    organizationId: string,
+    slug: string,
+    files: Parameters<DarkroomIngestService['uploadDataset']>[2],
+    captions?: Parameters<DarkroomIngestService['uploadDataset']>[3],
+  ) {
+    return this.ingestService.uploadDataset(
+      organizationId,
+      slug,
+      files,
+      captions,
+    );
+  }
+
+  ingestTrainingDataForCharacter(
+    organizationId: string,
+    userId: string,
+    slug: string,
+  ) {
+    return this.ingestService.ingestTrainingDataForCharacter(
+      organizationId,
+      userId,
+      slug,
+    );
+  }
+
+  ingestTrainingDataForAllEnabledCharacters(
+    organizationId: string,
+    userId: string,
+  ) {
+    return this.ingestService.ingestTrainingDataForAllEnabledCharacters(
+      organizationId,
+      userId,
+    );
+  }
+
+  // === Training ===
+
+  getTrainings(organizationId: string, personaSlug?: string) {
+    return this.trainingOrchestratorService.getTrainings(
+      organizationId,
+      personaSlug,
+    );
+  }
+
+  getTraining(trainingId: string, organizationId: string) {
+    return this.trainingOrchestratorService.getTraining(
+      trainingId,
+      organizationId,
+    );
+  }
+
+  startTraining(
+    organizationId: string,
+    userId: string,
+    _brandId: string,
+    data: Parameters<DarkroomTrainingOrchestratorService['startTraining']>[2],
+  ) {
+    return this.trainingOrchestratorService.startTraining(
+      organizationId,
+      userId,
+      data,
+    );
+  }
+
+  // === Pipeline Stats & Campaigns ===
+
+  listCampaigns(organizationId: string) {
+    return this.statsService.listCampaigns(organizationId);
+  }
+
+  getPipelineStats(organizationId: string) {
+    return this.statsService.getPipelineStats(organizationId);
   }
 
   // === Lip Sync ===
 
-  /**
-   * Generate a lip-synced video using HeyGen photo avatar API.
-   * If text is provided instead of audioUrl, generates TTS first.
-   */
-  @SentryTraced()
-  async generateLipSync(
+  generateLipSync(
     organizationId: string,
-    data: {
-      personaSlug: string;
-      imageUrl: string;
-      audioUrl?: string;
-      text?: string;
-    },
-  ): Promise<{ jobId: string; status: string }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, {
-      organizationId,
-      personaSlug: data.personaSlug,
-    });
-
-    // Verify persona exists
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug: data.personaSlug,
-    });
-
-    if (!persona) {
-      throw new NotFoundException(`Character "${data.personaSlug}" not found`);
-    }
-
-    let audioUrl = data.audioUrl;
-
-    // If text is provided, generate TTS audio first
-    if (!audioUrl && data.text) {
-      const defaultVoiceId = (persona as Record<string, unknown>).voiceId as
-        | string
-        | undefined;
-
-      if (!defaultVoiceId) {
-        throw new BadRequestException(
-          'No audio URL provided and character has no default voice. Provide an audioUrl or set a voice for this character.',
-        );
-      }
-
-      const ttsResult = await this.elevenLabsService.generateAndUploadAudio(
-        defaultVoiceId,
-        data.text,
-        `lip-sync-${Date.now()}`,
-      );
-
-      audioUrl = ttsResult.audioUrl;
-    }
-
-    if (!audioUrl) {
-      throw new BadRequestException('Either audioUrl or text must be provided');
-    }
-
-    const metadataId = `lip-sync-${persona.slug}-${Date.now()}`;
-    const videoId = await this.heyGenService.generatePhotoAvatarVideo(
-      metadataId,
-      data.imageUrl,
-      audioUrl,
-    );
-
-    return {
-      jobId: videoId,
-      status: 'processing',
-    };
+    data: Parameters<DarkroomMediaService['generateLipSync']>[1],
+  ) {
+    return this.mediaService.generateLipSync(organizationId, data);
   }
 
-  /**
-   * Check lip sync job status via HeyGen.
-   */
-  async getLipSyncStatus(
-    jobId: string,
-  ): Promise<{ status: string; videoUrl?: string }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, { jobId });
-
-    const statusClient = this.heyGenService as unknown as {
-      getVideoStatus?: (
-        id: string,
-      ) => Promise<{ status: string; videoUrl?: string }>;
-    };
-
-    if (typeof statusClient.getVideoStatus === 'function') {
-      try {
-        const status = await statusClient.getVideoStatus(jobId);
-        if (status?.status) {
-          return status;
-        }
-      } catch (error: unknown) {
-        this.loggerService.warn(
-          `${caller} provider status polling unavailable, falling back to webhook-driven state`,
-          {
-            error: error instanceof Error ? error.message : 'Unknown error',
-            jobId,
-          },
-        );
-      }
-    }
-
-    this.loggerService.debug(
-      `${caller} returning processing state via fallback`,
-      { jobId },
-    );
-
-    return {
-      status: 'processing',
-    };
+  getLipSyncStatus(jobId: string) {
+    return this.mediaService.getLipSyncStatus(jobId);
   }
 
   // === Voices / TTS ===
 
-  /**
-   * Get available TTS voices from the self-hosted fleet first, then ElevenLabs.
-   */
-  async getVoices(): Promise<
-    { name: string; preview?: string; voiceId: string }[]
-  > {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller);
-
-    const voiceProfiles = await this.fleetService.getVoiceProfiles();
-    if (voiceProfiles && voiceProfiles.length > 0) {
-      return voiceProfiles.map((voice) => ({
-        name: voice.label,
-        preview: voice.sampleUrl,
-        voiceId: voice.handle,
-      }));
-    }
-
-    return this.elevenLabsService.getVoices();
+  getVoices() {
+    return this.mediaService.getVoices();
   }
 
-  /**
-   * Generate TTS audio using the self-hosted fleet first, then ElevenLabs.
-   */
-  async generateVoice(
+  generateVoice(
     organizationId: string,
-    data: {
-      personaSlug?: string;
-      text: string;
-      voiceId: string;
-      speed?: number;
-    },
-  ): Promise<{ audioUrl: string }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(caller, {
-      organizationId,
-      textLength: data.text.length,
-      voiceId: data.voiceId,
-    });
-
-    const referenceAudio = await this.resolveFleetReferenceAudio(
-      organizationId,
-      data.personaSlug,
-    );
-
-    const fleetResult = await this.fleetService.generateVoice({
-      organizationId,
-      referenceAudio,
-      text: data.text,
-      voicePreset: data.voiceId,
-    });
-
-    if (fleetResult?.jobId) {
-      const audioUrl = await this.pollFleetVoiceAudioUrl(
-        fleetResult.jobId,
-        organizationId,
-      );
-      if (audioUrl) {
-        return { audioUrl };
-      }
-
-      this.loggerService.warn(caller, {
-        jobId: fleetResult.jobId,
-        message:
-          'Fleet voice generation did not complete in time, falling back',
-      });
-    }
-
-    const ingredientId = `tts-${Date.now()}`;
-    const result = await this.elevenLabsService.generateAndUploadAudio(
-      data.voiceId,
-      data.text,
-      ingredientId,
-    );
-
-    return {
-      audioUrl: result.audioUrl,
-    };
-  }
-
-  private async ingestTrainingDataForPersonaDocument(
-    organizationId: string,
-    userId: string,
-    persona: PersonaDocument,
-  ): Promise<DarkroomIngestResult> {
-    const enabledSources = this.getEnabledDarkroomSources(persona);
-
-    if (enabledSources.length === 0) {
-      return {
-        failed: [],
-        failedCount: 0,
-        uploadedCount: 0,
-      };
-    }
-
-    const userObjectId = ObjectIdUtil.toObjectId(userId);
-    const organizationObjectId = ObjectIdUtil.toObjectId(organizationId);
-    const brandId = this.readReferenceId(persona.brand);
-    const brandObjectId = brandId ? ObjectIdUtil.toObjectId(brandId) : null;
-
-    if (!userObjectId || !organizationObjectId || !brandObjectId) {
-      throw new BadRequestException('Invalid darkroom ingest context');
-    }
-
-    let uploadedCount = 0;
-    let failedCount = 0;
-    const failed: DarkroomIngestFailure[] = [];
-
-    for (const source of enabledSources) {
-      try {
-        const result = await this.scrapeSourcePosts(
-          source.platform,
-          source.handle,
-        );
-        const mediaPosts = result.posts.filter((post) => post.mediaUrl);
-
-        for (const post of mediaPosts) {
-          if (!post.mediaUrl) {
-            continue;
-          }
-
-          const existing = await this.ingredientsService.findOne({
-            brand: brandObjectId,
-            category:
-              post.mediaType === 'video'
-                ? IngredientCategory.VIDEO
-                : IngredientCategory.IMAGE,
-            cdnUrl: post.mediaUrl,
-            generationSource: `darkroom-ingest:${source.platform}`,
-            isDeleted: false,
-            organization: organizationObjectId,
-            persona: persona._id,
-          });
-
-          if (existing) {
-            continue;
-          }
-
-          const created = await this.createDarkroomIngestAsset({
-            brandId: brandObjectId,
-            mediaType: post.mediaType,
-            organizationId: organizationObjectId,
-            persona,
-            postId: post.id,
-            sourcePlatform: source.platform,
-            sourceUrl: post.mediaUrl,
-            text: post.text,
-            userId: userObjectId,
-          });
-
-          if (created) {
-            uploadedCount++;
-          }
-        }
-
-        source.lastIngestedAt = new Date();
-      } catch (error: unknown) {
-        failedCount++;
-        failed.push({
-          error: getErrorMessage(error),
-          filename: `${persona.slug ?? persona._id.toString()}:${source.platform}:${source.handle}`,
-        });
-      }
-    }
-
-    await this.personasService.patch(persona._id.toString(), {
-      darkroomSources: persona.darkroomSources,
-    } as Parameters<PersonasService['patch']>[1]);
-
-    return {
-      failed,
-      failedCount,
-      uploadedCount,
-    };
-  }
-
-  private async createDarkroomIngestAsset(params: {
-    organizationId: string;
-    brandId: string;
-    userId: string;
-    persona: PersonaDocument;
-    sourcePlatform: ContentIntelligencePlatform;
-    postId: string;
-    sourceUrl: string;
-    text: string;
-    mediaType?: 'image' | 'video';
-  }): Promise<IngredientDocument | null> {
-    const category =
-      params.mediaType === 'video'
-        ? IngredientCategory.VIDEO
-        : IngredientCategory.IMAGE;
-
-    const ingredient = await this.ingredientsService.create({
-      brand: params.brandId,
-      category,
-      cdnUrl: params.sourceUrl,
-      ...this.getDefaultDarkroomModerationState(),
-      generationPrompt: params.text || undefined,
-      generationSource: `darkroom-ingest:${params.sourcePlatform}`,
-      organization: params.organizationId,
-      persona: params.persona._id,
-      personaSlug: params.persona.slug,
-      s3Key: `${params.sourcePlatform}:${params.postId}`,
-      status: IngredientStatus.GENERATED,
-      text: params.text || undefined,
-      user: params.userId,
-    } as Parameters<IngredientsService['create']>[0]);
-
-    const uploadMeta = await this.filesClientService.uploadToS3(
-      ingredient._id.toString(),
-      category === IngredientCategory.VIDEO ? 'videos' : 'images',
-      {
-        type: FileInputType.URL,
-        url: params.sourceUrl,
-      },
-    );
-
-    return this.ingredientsService.patch(ingredient._id.toString(), {
-      cdnUrl: params.sourceUrl,
-      s3Key: uploadMeta.s3Key ?? ingredient.s3Key,
-      status: IngredientStatus.GENERATED,
-    } as Parameters<IngredientsService['patch']>[1]);
-  }
-
-  private async scrapeSourcePosts(
-    platform: ContentIntelligencePlatform,
-    handle: string,
+    data: Parameters<DarkroomMediaService['generateVoice']>[1],
   ) {
-    if (
-      platform !== ContentIntelligencePlatform.INSTAGRAM &&
-      platform !== ContentIntelligencePlatform.TIKTOK
-    ) {
-      throw new BadRequestException(
-        `Darkroom auto-ingest does not support ${platform} yet`,
-      );
-    }
-
-    return this.creatorScraperService.scrapeByPlatform(platform, handle, 24);
+    return this.mediaService.generateVoice(organizationId, data);
   }
 
-  private async syncApprovedAssetToDataset(
-    organizationId: string,
-    slug: string,
-    ingredient: IngredientDocument,
-  ): Promise<void> {
-    const sourceUrl = ingredient.cdnUrl;
-    if (!sourceUrl) {
-      return;
-    }
+  // === Infrastructure ===
 
-    const extension = this.getDatasetExtension(sourceUrl, ingredient.category);
-    const datasetKey = `darkroom/datasets/${slug}/${ingredient._id.toString()}.${extension}`;
-    await this.filesClientService.uploadToS3(datasetKey, 'images', {
-      type: FileInputType.URL,
-      url: sourceUrl,
-    });
-
-    const s3Keys = [datasetKey];
-    const caption =
-      this.readString(ingredient.generationPrompt) ??
-      this.readString(ingredient.text);
-    if (caption) {
-      const captionKey = `darkroom/datasets/${slug}/${ingredient._id.toString()}.txt`;
-      await this.filesClientService.uploadToS3(captionKey, 'images', {
-        contentType: 'text/plain',
-        data: Buffer.from(caption, 'utf8'),
-        type: FileInputType.BUFFER,
-      });
-      s3Keys.push(captionKey);
-    }
-
-    await this.darkroomTrainingService.syncDataset(
-      slug,
-      s3Keys,
-      this.readString(this.configService.get('DARKROOM_S3_BUCKET')),
-    );
-
-    await this.ingredientsService.patch(ingredient._id.toString(), {
-      generationCompletedAt: ingredient.generationCompletedAt ?? new Date(),
-    } as Parameters<IngredientsService['patch']>[1]);
+  getServiceHealth() {
+    return this.infraService.getServiceHealth();
   }
 
-  private getDatasetExtension(
-    sourceUrl: string,
-    category: string,
-  ): 'jpg' | 'png' | 'webp' | 'mp4' {
-    const normalizedUrl = sourceUrl.toLowerCase();
-    if (normalizedUrl.includes('.png')) {
-      return 'png';
-    }
-    if (normalizedUrl.includes('.webp')) {
-      return 'webp';
-    }
-    if (
-      this.hasIngredientCategory(category, IngredientCategory.VIDEO) ||
-      normalizedUrl.includes('.mp4')
-    ) {
-      return 'mp4';
-    }
-    return 'jpg';
+  getEC2Status() {
+    return this.infraService.getEC2Status();
   }
 
-  private async resolveFleetReferenceAudio(
-    organizationId: string,
-    personaSlug?: string,
-  ): Promise<string | undefined> {
-    if (!personaSlug) {
-      return undefined;
-    }
-
-    const persona = await this.personasService.findOne({
-      isDarkroomCharacter: true,
-      isDeleted: false,
-      organization: organizationId,
-      slug: personaSlug,
-    });
-
-    if (!persona?.voice) {
-      return undefined;
-    }
-
-    const voiceIngredient = await this.ingredientsService.findOne({
-      _id: persona.voice.toString(),
-      isDeleted: false,
-      organization: organizationId,
-    });
-
-    return voiceIngredient?.cdnUrl ?? undefined;
+  ec2Action(
+    instanceId: string,
+    action: Parameters<DarkroomInfraService['ec2Action']>[1],
+  ) {
+    return this.infraService.ec2Action(instanceId, action);
   }
 
-  private async pollFleetVoiceAudioUrl(
-    jobId: string,
-    organizationId?: string,
-  ): Promise<string | undefined> {
-    for (let attempt = 0; attempt < 10; attempt++) {
-      const result = await this.fleetService.pollJob(
-        'voices',
-        jobId,
-        organizationId,
-      );
-      const audioUrl = result?.audioUrl;
-      if (typeof audioUrl === 'string' && audioUrl !== '') {
-        return audioUrl;
-      }
+  ec2ActionAll(
+    action: Parameters<DarkroomInfraService['ec2ActionAll']>[0],
+    role?: string,
+  ) {
+    return this.infraService.ec2ActionAll(action, role);
+  }
 
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1500);
-      });
-    }
+  invalidateCloudFront(distributionId: string, paths?: string[]) {
+    return this.infraService.invalidateCloudFront(distributionId, paths);
+  }
 
-    return undefined;
+  getDefaultCloudFrontDistributionId(): string {
+    return this.infraService.getDefaultCloudFrontDistributionId();
   }
 }

--- a/apps/server/api/src/endpoints/admin/darkroom/interfaces/darkroom-infra.interface.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/interfaces/darkroom-infra.interface.ts
@@ -1,0 +1,7 @@
+export interface EC2InstanceStatus {
+  instanceId: string;
+  name: string;
+  role: string;
+  state: string;
+  instanceType: string;
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/interfaces/darkroom-ingest.interface.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/interfaces/darkroom-ingest.interface.ts
@@ -1,0 +1,19 @@
+import type { ContentIntelligencePlatform } from '@genfeedai/enums';
+
+export interface DarkroomIngestFailure {
+  error: string;
+  filename: string;
+}
+
+export interface DarkroomIngestResult {
+  failed: DarkroomIngestFailure[];
+  failedCount: number;
+  uploadedCount: number;
+}
+
+export interface DarkroomSourceRecord extends Record<string, unknown> {
+  enabled: boolean;
+  handle: string;
+  lastIngestedAt?: Date;
+  platform: ContentIntelligencePlatform;
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-asset.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-asset.service.ts
@@ -1,0 +1,177 @@
+import { type IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { ConfigService } from '@api/config/config.service';
+import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import {
+  type ContentRating,
+  type DarkroomAssetLabel,
+  type DarkroomReviewStatus,
+  DarkroomReviewStatus as DarkroomReviewStatusEnum,
+  FileInputType,
+  IngredientCategory,
+} from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+/**
+ * Owns darkroom asset (ingredient) listing + review, and the approved-asset
+ * dataset sync that promotes approved images into the training dataset.
+ */
+@Injectable()
+export class DarkroomAssetService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly ingredientsService: IngredientsService,
+    private readonly filesClientService: FilesClientService,
+    private readonly darkroomTrainingService: DarkroomTrainingService,
+    private readonly configService: ConfigService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * Get assets (ingredients) for a persona
+   */
+  getAssets(
+    organizationId: string,
+    filters: {
+      personaSlug?: string;
+      reviewStatus?: DarkroomReviewStatus;
+      assetLabel?: DarkroomAssetLabel;
+      contentRating?: ContentRating;
+      campaign?: string;
+      page?: number;
+      limit?: number;
+    },
+  ): Promise<IngredientDocument[]> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { filters, organizationId });
+
+    const query: Record<string, unknown> = {
+      persona: { not: true },
+    };
+
+    if (filters.personaSlug) {
+      query.personaSlug = filters.personaSlug;
+    }
+    if (filters.reviewStatus) {
+      query.reviewStatus = filters.reviewStatus;
+    }
+    if (filters.assetLabel) {
+      query.assetLabel = filters.assetLabel;
+    }
+    if (filters.contentRating) {
+      query.contentRating = filters.contentRating;
+    }
+    if (filters.campaign) {
+      query.campaign = filters.campaign;
+    }
+
+    return this.ingredientsService.findAllByOrganization(organizationId, query);
+  }
+
+  /**
+   * Review an asset (approve/reject)
+   */
+  async reviewAsset(
+    ingredientId: string,
+    organizationId: string,
+    reviewStatus: DarkroomReviewStatus,
+  ): Promise<IngredientDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, {
+      ingredientId,
+      organizationId,
+      reviewStatus,
+    });
+
+    // Verify ingredient belongs to organization before updating (multi-tenant guard)
+    const ingredient = await this.ingredientsService.findOne({
+      _id: ingredientId,
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!ingredient) {
+      throw new NotFoundException(
+        `Asset "${ingredientId}" not found in organization "${organizationId}"`,
+      );
+    }
+
+    const updated = await this.ingredientsService.patch(ingredientId, {
+      reviewStatus,
+    } as Parameters<IngredientsService['patch']>[1]);
+
+    if (
+      reviewStatus === DarkroomReviewStatusEnum.APPROVED &&
+      !DarkroomValueReader.hasReviewStatus(
+        ingredient.reviewStatus,
+        DarkroomReviewStatusEnum.APPROVED,
+      ) &&
+      ingredient.personaSlug &&
+      ingredient.cdnUrl &&
+      DarkroomValueReader.hasIngredientCategory(
+        ingredient.category,
+        IngredientCategory.IMAGE,
+      )
+    ) {
+      await this.syncApprovedAssetToDataset(
+        organizationId,
+        ingredient.personaSlug,
+        ingredient,
+      );
+    }
+
+    return updated;
+  }
+
+  private async syncApprovedAssetToDataset(
+    _organizationId: string,
+    slug: string,
+    ingredient: IngredientDocument,
+  ): Promise<void> {
+    const sourceUrl = ingredient.cdnUrl;
+    if (!sourceUrl) {
+      return;
+    }
+
+    const extension = DarkroomValueReader.getDatasetExtension(
+      sourceUrl,
+      ingredient.category,
+    );
+    const datasetKey = `darkroom/datasets/${slug}/${ingredient._id.toString()}.${extension}`;
+    await this.filesClientService.uploadToS3(datasetKey, 'images', {
+      type: FileInputType.URL,
+      url: sourceUrl,
+    });
+
+    const s3Keys = [datasetKey];
+    const caption =
+      DarkroomValueReader.readString(ingredient.generationPrompt) ??
+      DarkroomValueReader.readString(ingredient.text);
+    if (caption) {
+      const captionKey = `darkroom/datasets/${slug}/${ingredient._id.toString()}.txt`;
+      await this.filesClientService.uploadToS3(captionKey, 'images', {
+        contentType: 'text/plain',
+        data: Buffer.from(caption, 'utf8'),
+        type: FileInputType.BUFFER,
+      });
+      s3Keys.push(captionKey);
+    }
+
+    await this.darkroomTrainingService.syncDataset(
+      slug,
+      s3Keys,
+      DarkroomValueReader.readString(
+        this.configService.get('DARKROOM_S3_BUCKET'),
+      ),
+    );
+
+    await this.ingredientsService.patch(ingredient._id.toString(), {
+      generationCompletedAt: ingredient.generationCompletedAt ?? new Date(),
+    } as Parameters<IngredientsService['patch']>[1]);
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-character.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-character.service.spec.ts
@@ -1,0 +1,120 @@
+import { PersonasService } from '@api/collections/personas/services/personas.service';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('DarkroomCharacterService', () => {
+  let service: DarkroomCharacterService;
+  let personasService: Record<string, ReturnType<typeof vi.fn>>;
+  let loggerService: Record<string, ReturnType<typeof vi.fn>>;
+
+  const persona = { _id: { toString: () => 'persona-1' }, slug: 'alice' };
+
+  beforeEach(async () => {
+    personasService = {
+      create: vi.fn().mockResolvedValue(persona),
+      findAllByOrganization: vi.fn().mockResolvedValue([persona]),
+      findOne: vi.fn().mockResolvedValue(persona),
+      patch: vi.fn().mockResolvedValue(persona),
+    };
+
+    loggerService = {
+      log: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DarkroomCharacterService,
+        { provide: PersonasService, useValue: personasService },
+        { provide: LoggerService, useValue: loggerService },
+      ],
+    }).compile();
+
+    service = module.get<DarkroomCharacterService>(DarkroomCharacterService);
+  });
+
+  describe('findPersonaBySlug', () => {
+    it('queries the canonical darkroom-character scope', async () => {
+      await service.findPersonaBySlug('alice', 'org-123');
+
+      expect(personasService.findOne).toHaveBeenCalledWith({
+        isDarkroomCharacter: true,
+        isDeleted: false,
+        organization: 'org-123',
+        slug: 'alice',
+      });
+    });
+
+    it('returns null when the persona is absent', async () => {
+      personasService.findOne.mockResolvedValue(null);
+
+      await expect(service.findPersonaBySlug('ghost', 'org-123')).resolves.toBe(
+        null,
+      );
+    });
+  });
+
+  describe('requirePersonaBySlug', () => {
+    it('returns the persona when present', async () => {
+      await expect(
+        service.requirePersonaBySlug('alice', 'org-123'),
+      ).resolves.toBe(persona);
+    });
+
+    it('throws NotFoundException with the default message when absent', async () => {
+      personasService.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.requirePersonaBySlug('ghost', 'org-123'),
+      ).rejects.toThrow(new NotFoundException('Character "ghost" not found'));
+    });
+
+    it('throws NotFoundException with a custom message when provided', async () => {
+      personasService.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.requirePersonaBySlug('ghost', 'org-123', 'custom message'),
+      ).rejects.toThrow(new NotFoundException('custom message'));
+    });
+  });
+
+  describe('getCharacterBySlug', () => {
+    it('preserves the slug-specific not-found message', async () => {
+      personasService.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getCharacterBySlug('ghost', 'org-123'),
+      ).rejects.toThrow(
+        new NotFoundException('Character with slug "ghost" not found'),
+      );
+    });
+  });
+
+  describe('getCharacters', () => {
+    it('lists darkroom characters for the organization', async () => {
+      await service.getCharacters('org-123');
+
+      expect(personasService.findAllByOrganization).toHaveBeenCalledWith(
+        'org-123',
+        { isDarkroomCharacter: true },
+      );
+    });
+  });
+
+  describe('createCharacter', () => {
+    it('forces the isDarkroomCharacter flag', async () => {
+      await service.createCharacter({
+        brand: 'brand-1',
+        organization: 'org-123',
+        slug: 'alice',
+        user: 'user-1',
+      });
+
+      expect(personasService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ isDarkroomCharacter: true, slug: 'alice' }),
+      );
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-character.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-character.service.ts
@@ -1,0 +1,118 @@
+import { type PersonaDocument } from '@api/collections/personas/schemas/persona.schema';
+import { PersonasService } from '@api/collections/personas/services/personas.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+/**
+ * Owns darkroom persona (character) reads/writes and the single shared
+ * persona-by-slug lookup that the other darkroom collaborators rely on.
+ */
+@Injectable()
+export class DarkroomCharacterService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly personasService: PersonasService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * Resolve a darkroom character persona by slug, or null when absent.
+   * Single canonical lookup replacing the previously duplicated query blocks.
+   */
+  findPersonaBySlug(
+    slug: string,
+    organizationId: string,
+  ): Promise<PersonaDocument | null> {
+    return this.personasService.findOne({
+      isDarkroomCharacter: true,
+      isDeleted: false,
+      organization: organizationId,
+      slug,
+    });
+  }
+
+  /**
+   * Resolve a darkroom character persona by slug or throw NotFoundException.
+   */
+  async requirePersonaBySlug(
+    slug: string,
+    organizationId: string,
+    notFoundMessage?: string,
+  ): Promise<PersonaDocument> {
+    const persona = await this.findPersonaBySlug(slug, organizationId);
+
+    if (!persona) {
+      throw new NotFoundException(
+        notFoundMessage ?? `Character "${slug}" not found`,
+      );
+    }
+
+    return persona;
+  }
+
+  /**
+   * Get all darkroom characters (personas with isDarkroomCharacter: true)
+   */
+  getCharacters(organizationId: string): Promise<PersonaDocument[]> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { organizationId });
+
+    return this.personasService.findAllByOrganization(organizationId, {
+      isDarkroomCharacter: true,
+    });
+  }
+
+  /**
+   * Get a single darkroom character by slug
+   */
+  getCharacterBySlug(
+    slug: string,
+    organizationId: string,
+  ): Promise<PersonaDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { organizationId, slug });
+
+    return this.requirePersonaBySlug(
+      slug,
+      organizationId,
+      `Character with slug "${slug}" not found`,
+    );
+  }
+
+  /**
+   * Create a new darkroom character
+   */
+  createCharacter(
+    data: Partial<PersonaDocument> & {
+      user: string;
+      organization: string;
+      brand: string;
+    },
+  ): Promise<PersonaDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { slug: data.slug });
+
+    return this.personasService.create({
+      ...data,
+      isDarkroomCharacter: true,
+    } as Parameters<PersonasService['create']>[0]);
+  }
+
+  /**
+   * Update a darkroom character
+   */
+  updateCharacter(
+    id: string,
+    data: Partial<PersonaDocument>,
+  ): Promise<PersonaDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { id });
+
+    return this.personasService.patch(
+      id,
+      data as Parameters<PersonasService['patch']>[1],
+    );
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-generation.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-generation.service.ts
@@ -1,0 +1,312 @@
+import { type IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { GenerateImageDto } from '@api/endpoints/admin/darkroom/dto/generate-image.dto';
+import { DarkroomGenerationJob } from '@api/endpoints/admin/darkroom/interfaces/darkroom-generation-job.interface';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import { ObjectIdUtil } from '@api/helpers/utils/objectid/objectid.util';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import {
+  DarkroomReviewStatus as DarkroomReviewStatusEnum,
+  FileInputType,
+  IngredientStatus,
+} from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { SentryTraced } from '@sentry/nestjs';
+
+/**
+ * Owns darkroom image generation: the synchronous ComfyUI generate path and
+ * the durable generation-job lifecycle.
+ */
+@Injectable()
+export class DarkroomGenerationService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly characterService: DarkroomCharacterService,
+    private readonly ingredientsService: IngredientsService,
+    private readonly comfyuiService: ComfyUIService,
+    private readonly filesClientService: FilesClientService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * Generate an image for a character using ComfyUI.
+   */
+  @SentryTraced()
+  async generateImage(
+    organizationId: string,
+    brandId: string,
+    userId: string,
+    personaSlug: string,
+    prompt: string,
+    options: {
+      model?: string;
+      negativePrompt?: string;
+      steps?: number;
+      seed?: number;
+      cfgScale?: number;
+      width?: number;
+      height?: number;
+      lora?: string;
+      loraStrength?: number;
+      ingredientId?: string;
+    },
+  ): Promise<IngredientDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, {
+      organizationId,
+      personaSlug,
+      prompt,
+    });
+
+    // Verify persona exists
+    const persona = await this.characterService.requirePersonaBySlug(
+      personaSlug,
+      organizationId,
+      `Character "${personaSlug}" not found`,
+    );
+
+    // Determine model and parameters
+    const model = options.model || MODEL_KEYS.GENFEED_AI_FLUX2_DEV;
+    const comfyParams: Record<string, unknown> = {
+      prompt,
+    };
+
+    if (options.negativePrompt) {
+      comfyParams.negativePrompt = options.negativePrompt;
+    }
+    if (options.steps) {
+      comfyParams.steps = options.steps;
+    }
+    if (options.seed !== undefined) {
+      comfyParams.seed = options.seed;
+    }
+    if (options.cfgScale) {
+      comfyParams.cfg = options.cfgScale;
+    }
+    if (options.width) {
+      comfyParams.width = options.width;
+    }
+    if (options.height) {
+      comfyParams.height = options.height;
+    }
+    if (options.lora) {
+      comfyParams.loraPath = options.lora;
+    }
+    if (options.loraStrength) {
+      comfyParams.loraStrength = options.loraStrength;
+    }
+
+    // Generate image via ComfyUI
+    const { imageBuffer, filename } = await this.comfyuiService.generateImage(
+      model,
+      comfyParams,
+    );
+
+    if (options.ingredientId) {
+      await this.ingredientsService.patch(options.ingredientId, {
+        generationProgress: 90,
+        generationStage: 'uploading',
+        status: IngredientStatus.PROCESSING,
+      });
+    }
+
+    // Upload image buffer to S3 via files microservice
+    const s3Meta = await this.filesClientService.uploadToS3(
+      `darkroom/${personaSlug}/${filename}`,
+      'images',
+      {
+        contentType: 'image/png',
+        data: imageBuffer,
+        type: FileInputType.BUFFER,
+      },
+    );
+    const cdnUrl =
+      s3Meta.publicUrl ??
+      `https://cdn.genfeed.ai/darkroom/${personaSlug}/${filename}`;
+
+    const ingredient =
+      options.ingredientId === undefined
+        ? await this.ingredientsService.create({
+            brand: ObjectIdUtil.toObjectId(brandId)!,
+            cdnUrl,
+            ...DarkroomValueReader.getDefaultDarkroomModerationState(),
+            generationSource: model,
+            modelUsed: model,
+            organization: ObjectIdUtil.toObjectId(organizationId)!,
+            persona: persona._id,
+            personaSlug,
+            s3Key: `darkroom/${personaSlug}/${filename}`,
+            status: IngredientStatus.GENERATED,
+            user: ObjectIdUtil.toObjectId(userId)!,
+          } as Parameters<IngredientsService['create']>[0])
+        : await this.ingredientsService.patch(options.ingredientId, {
+            cdnUrl,
+            generationCompletedAt: new Date(),
+            generationError: undefined,
+            generationProgress: 100,
+            generationSource: model,
+            generationStage: 'completed',
+            modelUsed: model,
+            reviewStatus: DarkroomReviewStatusEnum.PENDING,
+            s3Key: `darkroom/${personaSlug}/${filename}`,
+            status: IngredientStatus.GENERATED,
+          });
+
+    this.loggerService.log(caller, {
+      ingredientId: ingredient._id.toString(),
+      message: 'Image generated successfully',
+    });
+
+    return ingredient;
+  }
+
+  async createGenerationJob(
+    organizationId: string,
+    brandId: string,
+    userId: string,
+    dto: GenerateImageDto,
+  ): Promise<DarkroomGenerationJob> {
+    const persona = await this.characterService.requirePersonaBySlug(
+      dto.personaSlug,
+      organizationId,
+      `Character "${dto.personaSlug}" not found`,
+    );
+
+    const loraPath = dto.lora || undefined;
+
+    const ingredient = await this.ingredientsService.create({
+      brand: ObjectIdUtil.toObjectId(brandId)!,
+      category: 'image',
+      ...DarkroomValueReader.getDefaultDarkroomModerationState(),
+      generationError: undefined,
+      generationProgress: 5,
+      generationPrompt: dto.prompt,
+      generationSource: dto.model || MODEL_KEYS.GENFEED_AI_FLUX2_DEV,
+      generationStage: 'queued',
+      generationStartedAt: new Date(),
+      loraUsed: loraPath,
+      modelUsed: dto.model || MODEL_KEYS.GENFEED_AI_FLUX2_DEV,
+      negativePrompt: dto.negativePrompt,
+      organization: ObjectIdUtil.toObjectId(organizationId)!,
+      persona: persona._id,
+      personaSlug: dto.personaSlug,
+      status: IngredientStatus.PROCESSING,
+      user: ObjectIdUtil.toObjectId(userId)!,
+    } as Parameters<IngredientsService['create']>[0]);
+
+    void this.processGenerationJob(
+      ingredient._id.toString(),
+      organizationId,
+      brandId,
+      userId,
+      {
+        ...dto,
+        lora: loraPath,
+      },
+    );
+
+    return DarkroomValueReader.mapIngredientToGenerationJob(ingredient);
+  }
+
+  async getGenerationJob(
+    jobId: string,
+    organizationId: string,
+  ): Promise<DarkroomGenerationJob> {
+    const ingredient = await this.ingredientsService.findOne({
+      _id: jobId,
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!ingredient) {
+      throw new NotFoundException(`Generation job "${jobId}" not found`);
+    }
+
+    return DarkroomValueReader.mapIngredientToGenerationJob(ingredient);
+  }
+
+  private async updateGenerationJob(
+    jobId: string,
+    updates: Partial<DarkroomGenerationJob>,
+  ): Promise<void> {
+    await this.ingredientsService.patch(jobId, {
+      cdnUrl: updates.cdnUrl,
+      generationCompletedAt:
+        updates.status === 'completed' || updates.status === 'failed'
+          ? new Date()
+          : undefined,
+      generationError: updates.error,
+      generationProgress: updates.progress,
+      generationStage: updates.stage,
+      status: DarkroomValueReader.ingredientStatusForJobState(updates.status),
+    });
+  }
+
+  private async processGenerationJob(
+    jobId: string,
+    organizationId: string,
+    brandId: string,
+    userId: string,
+    dto: GenerateImageDto,
+  ): Promise<void> {
+    await this.updateGenerationJob(jobId, {
+      progress: 15,
+      stage: 'validating inputs',
+      status: 'processing',
+    });
+
+    let pulseProgress = 20;
+    const pulse = setInterval(() => {
+      pulseProgress = Math.min(pulseProgress + 7, 82);
+      void this.updateGenerationJob(jobId, {
+        progress: pulseProgress,
+        stage: 'running on ComfyUI',
+        status: 'processing',
+      });
+    }, 2000);
+
+    try {
+      const ingredient = await this.generateImage(
+        organizationId,
+        brandId,
+        userId,
+        dto.personaSlug,
+        dto.prompt,
+        {
+          cfgScale: dto.cfgScale,
+          ingredientId: jobId,
+          lora: dto.lora,
+          model: dto.model,
+          negativePrompt: dto.negativePrompt,
+          seed: dto.seed,
+          steps: dto.steps,
+          ...DarkroomValueReader.getDimensionsFromAspectRatio(dto.aspectRatio),
+        },
+      );
+
+      clearInterval(pulse);
+      await this.updateGenerationJob(jobId, {
+        cdnUrl: ingredient.cdnUrl ?? undefined,
+        ingredientId: ingredient._id.toString(),
+        progress: 100,
+        stage: 'completed',
+        status: 'completed',
+      });
+    } catch (error: unknown) {
+      clearInterval(pulse);
+      await this.updateGenerationJob(jobId, {
+        error: getErrorMessage(error),
+        progress: 100,
+        stage: 'failed',
+        status: 'failed',
+      });
+    }
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-infra.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-infra.service.ts
@@ -1,0 +1,310 @@
+import { ConfigService } from '@api/config/config.service';
+import type { EC2InstanceStatus } from '@api/endpoints/admin/darkroom/interfaces/darkroom-infra.interface';
+import {
+  CloudFrontClient,
+  CreateInvalidationCommand,
+} from '@aws-sdk/client-cloudfront';
+import {
+  DescribeInstancesCommand,
+  EC2Client,
+  StartInstancesCommand,
+  StopInstancesCommand,
+} from '@aws-sdk/client-ec2';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+/**
+ * Owns the darkroom AWS clients (EC2 + CloudFront) and GPU/service health
+ * checks. Centralises the previously duplicated AWS log-error-and-rethrow
+ * boilerplate behind a single runAws wrapper.
+ */
+@Injectable()
+export class DarkroomInfraService {
+  private readonly constructorName: string = String(this.constructor.name);
+  private readonly ec2Client: EC2Client;
+  private readonly cloudFrontClient: CloudFrontClient;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly loggerService: LoggerService,
+  ) {
+    const region = this.configService.get('AWS_REGION') || 'us-east-1';
+    const credentials = {
+      accessKeyId: this.configService.get('AWS_ACCESS_KEY_ID') || '',
+      secretAccessKey: this.configService.get('AWS_SECRET_ACCESS_KEY') || '',
+    };
+
+    this.ec2Client = new EC2Client({ credentials, region });
+    this.cloudFrontClient = new CloudFrontClient({ credentials, region });
+  }
+
+  /**
+   * Run an AWS SDK interaction, logging-and-rethrowing on failure with the
+   * caller's context. Replaces the duplicated try/catch in every AWS method.
+   */
+  private async runAws<T>(
+    caller: string,
+    failureMessage: string,
+    context: Record<string, unknown>,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      this.loggerService.error(caller, {
+        ...context,
+        error: getErrorMessage(error),
+        message: failureMessage,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get EC2 instance statuses filtered by the 'Project: darkroom' tag.
+   */
+  getEC2Status(): Promise<EC2InstanceStatus[]> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller);
+
+    return this.runAws(
+      caller,
+      'Failed to describe EC2 instances',
+      {},
+      async () => {
+        const command = new DescribeInstancesCommand({
+          Filters: [
+            { Name: 'tag:Project', Values: ['darkroom', 'fleet'] },
+            {
+              Name: 'instance-state-name',
+              Values: ['pending', 'running', 'stopping', 'stopped'],
+            },
+          ],
+        });
+
+        const response = await this.ec2Client.send(command);
+        const instances: EC2InstanceStatus[] = [];
+
+        for (const reservation of response.Reservations ?? []) {
+          for (const instance of reservation.Instances ?? []) {
+            const nameTag = instance.Tags?.find((tag) => tag.Key === 'Name');
+            const roleTag = instance.Tags?.find((tag) => tag.Key === 'Role');
+            instances.push({
+              instanceId: instance.InstanceId ?? 'unknown',
+              instanceType: instance.InstanceType ?? 'unknown',
+              name: nameTag?.Value ?? 'unnamed',
+              role: roleTag?.Value ?? 'training',
+              state: instance.State?.Name ?? 'unknown',
+            });
+          }
+        }
+
+        return instances;
+      },
+    );
+  }
+
+  /**
+   * Start or stop an EC2 instance.
+   */
+  ec2Action(
+    instanceId: string,
+    action: 'start' | 'stop',
+  ): Promise<{ message: string }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { action, instanceId });
+
+    return this.runAws(
+      caller,
+      `Failed to ${action} EC2 instance`,
+      { action, instanceId },
+      async () => {
+        const stateChanges =
+          action === 'start'
+            ? (
+                await this.ec2Client.send(
+                  new StartInstancesCommand({ InstanceIds: [instanceId] }),
+                )
+              ).StartingInstances
+            : (
+                await this.ec2Client.send(
+                  new StopInstancesCommand({ InstanceIds: [instanceId] }),
+                )
+              ).StoppingInstances;
+
+        const currentState = stateChanges?.[0]?.CurrentState?.Name ?? 'unknown';
+        const previousState =
+          stateChanges?.[0]?.PreviousState?.Name ?? 'unknown';
+
+        this.loggerService.log(caller, {
+          currentState,
+          instanceId,
+          message: `EC2 instance ${action} successful`,
+          previousState,
+        });
+
+        return {
+          message: `Instance ${instanceId} ${action} executed (${previousState} -> ${currentState})`,
+        };
+      },
+    );
+  }
+
+  async ec2ActionAll(
+    action: 'start' | 'stop',
+    role?: string,
+  ): Promise<{
+    action: 'start' | 'stop';
+    results: Array<{
+      instanceId: string;
+      name: string;
+      state: string;
+      success: boolean;
+      error?: string;
+    }>;
+  }> {
+    const instances = await this.getEC2Status();
+    const matchingInstances = instances.filter((instance) => {
+      const matchesRole = role ? instance.role === role : true;
+      const matchesState =
+        action === 'start'
+          ? instance.state === 'stopped'
+          : instance.state === 'running';
+      return matchesRole && matchesState;
+    });
+
+    const results = await Promise.all(
+      matchingInstances.map(async (instance) => {
+        try {
+          await this.ec2Action(instance.instanceId, action);
+          return {
+            instanceId: instance.instanceId,
+            name: instance.name,
+            state: instance.state,
+            success: true,
+          };
+        } catch (error: unknown) {
+          return {
+            error: getErrorMessage(error),
+            instanceId: instance.instanceId,
+            name: instance.name,
+            state: instance.state,
+            success: false,
+          };
+        }
+      }),
+    );
+
+    return { action, results };
+  }
+
+  /**
+   * Invalidate CloudFront cache for the given distribution and paths.
+   */
+  invalidateCloudFront(
+    distributionId: string,
+    paths?: string[],
+  ): Promise<{ message: string; invalidationId: string }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const invalidationPaths = paths?.length ? paths : ['/*'];
+    if (!distributionId) {
+      throw new BadRequestException(
+        'CloudFront distribution ID is not configured for darkroom invalidation',
+      );
+    }
+    this.loggerService.log(caller, {
+      distributionId,
+      paths: invalidationPaths,
+    });
+
+    return this.runAws(
+      caller,
+      'Failed to create CloudFront invalidation',
+      { distributionId, paths: invalidationPaths },
+      async () => {
+        const command = new CreateInvalidationCommand({
+          DistributionId: distributionId,
+          InvalidationBatch: {
+            CallerReference: `darkroom-${Date.now()}`,
+            Paths: {
+              Items: invalidationPaths,
+              Quantity: invalidationPaths.length,
+            },
+          },
+        });
+
+        const response = await this.cloudFrontClient.send(command);
+        const invalidationId = response.Invalidation?.Id ?? 'unknown';
+
+        this.loggerService.log(caller, {
+          distributionId,
+          invalidationId,
+          message: 'CloudFront invalidation created',
+          paths: invalidationPaths,
+        });
+
+        return {
+          invalidationId,
+          message: `CloudFront invalidation created for ${distributionId} (${invalidationPaths.join(', ')})`,
+        };
+      },
+    );
+  }
+
+  getDefaultCloudFrontDistributionId(): string {
+    return this.configService.get('DARKROOM_CLOUDFRONT_DISTRIBUTION_ID') || '';
+  }
+
+  /**
+   * Check health of ComfyUI and Ollama services.
+   */
+  async getServiceHealth(): Promise<
+    { name: string; status: 'online' | 'offline' | 'unknown'; url: string }[]
+  > {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller);
+
+    const services = [
+      {
+        name: 'images.genfeed.ai',
+        url: this.configService.get('GPU_IMAGES_URL') || '',
+      },
+      {
+        name: 'voices.genfeed.ai',
+        url: this.configService.get('GPU_VOICES_URL') || '',
+      },
+      {
+        name: 'videos.genfeed.ai',
+        url: this.configService.get('GPU_VIDEOS_URL') || '',
+      },
+      {
+        name: 'llm.genfeed.ai',
+        url: this.configService.get('GPU_LLM_URL') || '',
+      },
+    ].filter((s) => s.url);
+
+    const results = await Promise.all(
+      services.map(async (service) => {
+        try {
+          await axios.get(`${service.url}/v1/health`, { timeout: 5000 });
+          return {
+            name: service.name,
+            status: 'online' as const,
+            url: service.url,
+          };
+        } catch {
+          return {
+            name: service.name,
+            status: 'offline' as const,
+            url: service.url,
+          };
+        }
+      }),
+    );
+
+    return results;
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-ingest.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-ingest.service.ts
@@ -1,0 +1,331 @@
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { CreatorScraperService } from '@api/collections/content-intelligence/services/creator-scraper.service';
+import { type IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { type PersonaDocument } from '@api/collections/personas/schemas/persona.schema';
+import { PersonasService } from '@api/collections/personas/services/personas.service';
+import type {
+  DarkroomIngestFailure,
+  DarkroomIngestResult,
+} from '@api/endpoints/admin/darkroom/interfaces/darkroom-ingest.interface';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import { ObjectIdUtil } from '@api/helpers/utils/objectid/objectid.util';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import {
+  ContentIntelligencePlatform,
+  FileInputType,
+  IngredientCategory,
+  IngredientStatus,
+} from '@genfeedai/enums';
+import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+/**
+ * Owns darkroom training-data ingestion: manual dataset uploads and the
+ * automated scrape-and-ingest pipeline from a persona's enabled sources.
+ */
+@Injectable()
+export class DarkroomIngestService {
+  constructor(
+    private readonly characterService: DarkroomCharacterService,
+    private readonly personasService: PersonasService,
+    private readonly brandsService: BrandsService,
+    private readonly ingredientsService: IngredientsService,
+    private readonly creatorScraperService: CreatorScraperService,
+    private readonly filesClientService: FilesClientService,
+    private readonly darkroomTrainingService: DarkroomTrainingService,
+  ) {}
+
+  async uploadDataset(
+    organizationId: string,
+    slug: string,
+    files: Array<{ buffer: Buffer; mimetype: string; originalname: string }>,
+    captions?: Array<{ filenameStem: string; caption: string }>,
+  ): Promise<DarkroomIngestResult> {
+    await this.characterService.requirePersonaBySlug(slug, organizationId);
+
+    const captionMap = new Map(
+      (captions ?? []).map((entry) => [
+        entry.filenameStem.toLowerCase(),
+        entry,
+      ]),
+    );
+    const s3Keys: string[] = [];
+    let uploadedCount = 0;
+    let failedCount = 0;
+    const failed: Array<{ filename: string; error: string }> = [];
+
+    for (const file of files) {
+      const filename = file.originalname;
+      const stem = filename.replace(/\.[^.]+$/, '').toLowerCase();
+      const imageKey = `darkroom/datasets/${slug}/${filename}`;
+
+      try {
+        await this.filesClientService.uploadToS3(imageKey, 'images', {
+          contentType: file.mimetype,
+          data: file.buffer,
+          type: FileInputType.BUFFER,
+        });
+        s3Keys.push(imageKey);
+
+        const caption = captionMap.get(stem);
+        if (caption) {
+          const captionKey = `darkroom/datasets/${slug}/${caption.filenameStem}.txt`;
+          await this.filesClientService.uploadToS3(captionKey, 'images', {
+            contentType: 'text/plain',
+            data: Buffer.from(caption.caption, 'utf8'),
+            type: FileInputType.BUFFER,
+          });
+          s3Keys.push(captionKey);
+        }
+
+        uploadedCount++;
+      } catch (error: unknown) {
+        failedCount++;
+        failed.push({
+          error: getErrorMessage(error),
+          filename,
+        });
+      }
+    }
+
+    if (s3Keys.length > 0) {
+      await this.darkroomTrainingService.syncDataset(slug, s3Keys);
+    }
+
+    return { failed, failedCount, uploadedCount };
+  }
+
+  async ingestTrainingDataForCharacter(
+    organizationId: string,
+    userId: string,
+    slug: string,
+  ): Promise<DarkroomIngestResult> {
+    const persona = await this.characterService.requirePersonaBySlug(
+      slug,
+      organizationId,
+    );
+
+    return this.ingestTrainingDataForPersonaDocument(
+      organizationId,
+      userId,
+      persona,
+    );
+  }
+
+  async ingestTrainingDataForAllEnabledCharacters(
+    organizationId: string,
+    userId: string,
+  ): Promise<DarkroomIngestResult> {
+    const personas = await this.personasService.findAllByOrganization(
+      organizationId,
+      {
+        isDarkroomCharacter: true,
+      },
+    );
+
+    let uploadedCount = 0;
+    let failedCount = 0;
+    const failed: DarkroomIngestFailure[] = [];
+
+    for (const persona of personas) {
+      const brandId = DarkroomValueReader.readReferenceId(persona.brand);
+
+      if (!brandId) {
+        continue;
+      }
+
+      const brand = await this.brandsService.findOne(
+        {
+          _id: brandId,
+          isDeleted: false,
+          organization: organizationId,
+        },
+        'none',
+      );
+
+      if (!brand?.isDarkroomEnabled) {
+        continue;
+      }
+
+      const result = await this.ingestTrainingDataForPersonaDocument(
+        organizationId,
+        userId,
+        persona,
+      );
+
+      uploadedCount += result.uploadedCount;
+      failedCount += result.failedCount;
+      failed.push(...result.failed);
+    }
+
+    return {
+      failed,
+      failedCount,
+      uploadedCount,
+    };
+  }
+
+  private async ingestTrainingDataForPersonaDocument(
+    organizationId: string,
+    userId: string,
+    persona: PersonaDocument,
+  ): Promise<DarkroomIngestResult> {
+    const enabledSources =
+      DarkroomValueReader.getEnabledDarkroomSources(persona);
+
+    if (enabledSources.length === 0) {
+      return {
+        failed: [],
+        failedCount: 0,
+        uploadedCount: 0,
+      };
+    }
+
+    const userObjectId = ObjectIdUtil.toObjectId(userId);
+    const organizationObjectId = ObjectIdUtil.toObjectId(organizationId);
+    const brandId = DarkroomValueReader.readReferenceId(persona.brand);
+    const brandObjectId = brandId ? ObjectIdUtil.toObjectId(brandId) : null;
+
+    if (!userObjectId || !organizationObjectId || !brandObjectId) {
+      throw new BadRequestException('Invalid darkroom ingest context');
+    }
+
+    let uploadedCount = 0;
+    let failedCount = 0;
+    const failed: DarkroomIngestFailure[] = [];
+
+    for (const source of enabledSources) {
+      try {
+        const result = await this.scrapeSourcePosts(
+          source.platform,
+          source.handle,
+        );
+        const mediaPosts = result.posts.filter((post) => post.mediaUrl);
+
+        for (const post of mediaPosts) {
+          if (!post.mediaUrl) {
+            continue;
+          }
+
+          const existing = await this.ingredientsService.findOne({
+            brand: brandObjectId,
+            category:
+              post.mediaType === 'video'
+                ? IngredientCategory.VIDEO
+                : IngredientCategory.IMAGE,
+            cdnUrl: post.mediaUrl,
+            generationSource: `darkroom-ingest:${source.platform}`,
+            isDeleted: false,
+            organization: organizationObjectId,
+            persona: persona._id,
+          });
+
+          if (existing) {
+            continue;
+          }
+
+          const created = await this.createDarkroomIngestAsset({
+            brandId: brandObjectId,
+            mediaType: post.mediaType,
+            organizationId: organizationObjectId,
+            persona,
+            postId: post.id,
+            sourcePlatform: source.platform,
+            sourceUrl: post.mediaUrl,
+            text: post.text,
+            userId: userObjectId,
+          });
+
+          if (created) {
+            uploadedCount++;
+          }
+        }
+
+        source.lastIngestedAt = new Date();
+      } catch (error: unknown) {
+        failedCount++;
+        failed.push({
+          error: getErrorMessage(error),
+          filename: `${persona.slug ?? persona._id.toString()}:${source.platform}:${source.handle}`,
+        });
+      }
+    }
+
+    await this.personasService.patch(persona._id.toString(), {
+      darkroomSources: persona.darkroomSources,
+    } as Parameters<PersonasService['patch']>[1]);
+
+    return {
+      failed,
+      failedCount,
+      uploadedCount,
+    };
+  }
+
+  private async createDarkroomIngestAsset(params: {
+    organizationId: string;
+    brandId: string;
+    userId: string;
+    persona: PersonaDocument;
+    sourcePlatform: ContentIntelligencePlatform;
+    postId: string;
+    sourceUrl: string;
+    text: string;
+    mediaType?: 'image' | 'video';
+  }): Promise<IngredientDocument | null> {
+    const category =
+      params.mediaType === 'video'
+        ? IngredientCategory.VIDEO
+        : IngredientCategory.IMAGE;
+
+    const ingredient = await this.ingredientsService.create({
+      brand: params.brandId,
+      category,
+      cdnUrl: params.sourceUrl,
+      ...DarkroomValueReader.getDefaultDarkroomModerationState(),
+      generationPrompt: params.text || undefined,
+      generationSource: `darkroom-ingest:${params.sourcePlatform}`,
+      organization: params.organizationId,
+      persona: params.persona._id,
+      personaSlug: params.persona.slug,
+      s3Key: `${params.sourcePlatform}:${params.postId}`,
+      status: IngredientStatus.GENERATED,
+      text: params.text || undefined,
+      user: params.userId,
+    } as Parameters<IngredientsService['create']>[0]);
+
+    const uploadMeta = await this.filesClientService.uploadToS3(
+      ingredient._id.toString(),
+      category === IngredientCategory.VIDEO ? 'videos' : 'images',
+      {
+        type: FileInputType.URL,
+        url: params.sourceUrl,
+      },
+    );
+
+    return this.ingredientsService.patch(ingredient._id.toString(), {
+      cdnUrl: params.sourceUrl,
+      s3Key: uploadMeta.s3Key ?? ingredient.s3Key,
+      status: IngredientStatus.GENERATED,
+    } as Parameters<IngredientsService['patch']>[1]);
+  }
+
+  private async scrapeSourcePosts(
+    platform: ContentIntelligencePlatform,
+    handle: string,
+  ) {
+    if (
+      platform !== ContentIntelligencePlatform.INSTAGRAM &&
+      platform !== ContentIntelligencePlatform.TIKTOK
+    ) {
+      throw new BadRequestException(
+        `Darkroom auto-ingest does not support ${platform} yet`,
+      );
+    }
+
+    return this.creatorScraperService.scrapeByPlatform(platform, handle, 24);
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-media.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-media.service.ts
@@ -1,0 +1,265 @@
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { ElevenLabsService } from '@api/services/integrations/elevenlabs/elevenlabs.service';
+import { FleetService } from '@api/services/integrations/fleet/fleet.service';
+import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { SentryTraced } from '@sentry/nestjs';
+
+/**
+ * Owns darkroom lip-sync video generation and TTS voice generation, preferring
+ * the self-hosted fleet and falling back to ElevenLabs / HeyGen.
+ */
+@Injectable()
+export class DarkroomMediaService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly characterService: DarkroomCharacterService,
+    private readonly ingredientsService: IngredientsService,
+    private readonly heyGenService: HeyGenService,
+    private readonly elevenLabsService: ElevenLabsService,
+    private readonly fleetService: FleetService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * Generate a lip-synced video using HeyGen photo avatar API.
+   * If text is provided instead of audioUrl, generates TTS first.
+   */
+  @SentryTraced()
+  async generateLipSync(
+    organizationId: string,
+    data: {
+      personaSlug: string;
+      imageUrl: string;
+      audioUrl?: string;
+      text?: string;
+    },
+  ): Promise<{ jobId: string; status: string }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, {
+      organizationId,
+      personaSlug: data.personaSlug,
+    });
+
+    // Verify persona exists
+    const persona = await this.characterService.requirePersonaBySlug(
+      data.personaSlug,
+      organizationId,
+      `Character "${data.personaSlug}" not found`,
+    );
+
+    let audioUrl = data.audioUrl;
+
+    // If text is provided, generate TTS audio first
+    if (!audioUrl && data.text) {
+      const defaultVoiceId = (persona as Record<string, unknown>).voiceId as
+        | string
+        | undefined;
+
+      if (!defaultVoiceId) {
+        throw new BadRequestException(
+          'No audio URL provided and character has no default voice. Provide an audioUrl or set a voice for this character.',
+        );
+      }
+
+      const ttsResult = await this.elevenLabsService.generateAndUploadAudio(
+        defaultVoiceId,
+        data.text,
+        `lip-sync-${Date.now()}`,
+      );
+
+      audioUrl = ttsResult.audioUrl;
+    }
+
+    if (!audioUrl) {
+      throw new BadRequestException('Either audioUrl or text must be provided');
+    }
+
+    const metadataId = `lip-sync-${persona.slug}-${Date.now()}`;
+    const videoId = await this.heyGenService.generatePhotoAvatarVideo(
+      metadataId,
+      data.imageUrl,
+      audioUrl,
+    );
+
+    return {
+      jobId: videoId,
+      status: 'processing',
+    };
+  }
+
+  /**
+   * Check lip sync job status via HeyGen.
+   */
+  async getLipSyncStatus(
+    jobId: string,
+  ): Promise<{ status: string; videoUrl?: string }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { jobId });
+
+    const statusClient = this.heyGenService as unknown as {
+      getVideoStatus?: (
+        id: string,
+      ) => Promise<{ status: string; videoUrl?: string }>;
+    };
+
+    if (typeof statusClient.getVideoStatus === 'function') {
+      try {
+        const status = await statusClient.getVideoStatus(jobId);
+        if (status?.status) {
+          return status;
+        }
+      } catch (error: unknown) {
+        this.loggerService.warn(
+          `${caller} provider status polling unavailable, falling back to webhook-driven state`,
+          {
+            error: error instanceof Error ? error.message : 'Unknown error',
+            jobId,
+          },
+        );
+      }
+    }
+
+    this.loggerService.debug(
+      `${caller} returning processing state via fallback`,
+      { jobId },
+    );
+
+    return {
+      status: 'processing',
+    };
+  }
+
+  /**
+   * Get available TTS voices from the self-hosted fleet first, then ElevenLabs.
+   */
+  async getVoices(): Promise<
+    { name: string; preview?: string; voiceId: string }[]
+  > {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller);
+
+    const voiceProfiles = await this.fleetService.getVoiceProfiles();
+    if (voiceProfiles && voiceProfiles.length > 0) {
+      return voiceProfiles.map((voice) => ({
+        name: voice.label,
+        preview: voice.sampleUrl,
+        voiceId: voice.handle,
+      }));
+    }
+
+    return this.elevenLabsService.getVoices();
+  }
+
+  /**
+   * Generate TTS audio using the self-hosted fleet first, then ElevenLabs.
+   */
+  async generateVoice(
+    organizationId: string,
+    data: {
+      personaSlug?: string;
+      text: string;
+      voiceId: string;
+      speed?: number;
+    },
+  ): Promise<{ audioUrl: string }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, {
+      organizationId,
+      textLength: data.text.length,
+      voiceId: data.voiceId,
+    });
+
+    const referenceAudio = await this.resolveFleetReferenceAudio(
+      organizationId,
+      data.personaSlug,
+    );
+
+    const fleetResult = await this.fleetService.generateVoice({
+      organizationId,
+      referenceAudio,
+      text: data.text,
+      voicePreset: data.voiceId,
+    });
+
+    if (fleetResult?.jobId) {
+      const audioUrl = await this.pollFleetVoiceAudioUrl(
+        fleetResult.jobId,
+        organizationId,
+      );
+      if (audioUrl) {
+        return { audioUrl };
+      }
+
+      this.loggerService.warn(caller, {
+        jobId: fleetResult.jobId,
+        message:
+          'Fleet voice generation did not complete in time, falling back',
+      });
+    }
+
+    const ingredientId = `tts-${Date.now()}`;
+    const result = await this.elevenLabsService.generateAndUploadAudio(
+      data.voiceId,
+      data.text,
+      ingredientId,
+    );
+
+    return {
+      audioUrl: result.audioUrl,
+    };
+  }
+
+  private async resolveFleetReferenceAudio(
+    organizationId: string,
+    personaSlug?: string,
+  ): Promise<string | undefined> {
+    if (!personaSlug) {
+      return undefined;
+    }
+
+    const persona = await this.characterService.findPersonaBySlug(
+      personaSlug,
+      organizationId,
+    );
+
+    if (!persona?.voice) {
+      return undefined;
+    }
+
+    const voiceIngredient = await this.ingredientsService.findOne({
+      _id: persona.voice.toString(),
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    return voiceIngredient?.cdnUrl ?? undefined;
+  }
+
+  private async pollFleetVoiceAudioUrl(
+    jobId: string,
+    organizationId?: string,
+  ): Promise<string | undefined> {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const result = await this.fleetService.pollJob(
+        'voices',
+        jobId,
+        organizationId,
+      );
+      const audioUrl = result?.audioUrl;
+      if (typeof audioUrl === 'string' && audioUrl !== '') {
+        return audioUrl;
+      }
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1500);
+      });
+    }
+
+    return undefined;
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-publishing.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-publishing.service.ts
@@ -1,0 +1,176 @@
+import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import { ObjectIdUtil } from '@api/helpers/utils/objectid/objectid.util';
+import { FacebookService } from '@api/services/integrations/facebook/services/facebook.service';
+import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
+import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
+import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
+import {
+  CredentialPlatform,
+  DarkroomReviewStatus as DarkroomReviewStatusEnum,
+} from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+/**
+ * Owns publishing approved darkroom assets out to social platforms.
+ */
+@Injectable()
+export class DarkroomPublishingService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly ingredientsService: IngredientsService,
+    private readonly instagramService: InstagramService,
+    private readonly twitterService: TwitterService,
+    private readonly facebookService: FacebookService,
+    private readonly credentialsService: CredentialsService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * Publish an approved asset to social platforms.
+   */
+  async publishAsset(
+    ingredientId: string,
+    organizationId: string,
+    brandId: string,
+    platforms: string[],
+    caption?: string,
+  ): Promise<{
+    success: boolean;
+    results: Record<string, { success: boolean; id?: string; error?: string }>;
+  }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, {
+      brandId,
+      ingredientId,
+      organizationId,
+      platforms,
+    });
+
+    // Verify ingredient exists and is approved
+    const ingredient = await this.ingredientsService.findOne({
+      _id: ingredientId,
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!ingredient) {
+      throw new NotFoundException(
+        `Asset "${ingredientId}" not found in organization "${organizationId}"`,
+      );
+    }
+
+    if (
+      !DarkroomValueReader.hasReviewStatus(
+        ingredient.reviewStatus,
+        DarkroomReviewStatusEnum.APPROVED,
+      )
+    ) {
+      throw new BadRequestException(
+        `Asset must be approved before publishing (current status: ${ingredient.reviewStatus})`,
+      );
+    }
+
+    if (!ingredient.cdnUrl) {
+      throw new BadRequestException(
+        'Asset must have a CDN URL to be published',
+      );
+    }
+
+    const results: Record<
+      string,
+      { success: boolean; id?: string; error?: string }
+    > = {};
+
+    // Publish to each platform
+    for (const platform of platforms) {
+      try {
+        let platformId: string;
+
+        switch (platform.toLowerCase()) {
+          case 'instagram': {
+            const igResult = await this.instagramService.uploadImage(
+              organizationId,
+              brandId,
+              ingredient.cdnUrl,
+              caption || '',
+            );
+            platformId = igResult.mediaId;
+            results.instagram = { id: platformId, success: true };
+            break;
+          }
+
+          case 'twitter':
+            platformId = await this.twitterService.uploadMedia(
+              organizationId,
+              brandId,
+              ingredient.cdnUrl,
+              caption || '',
+              'image/jpeg',
+            );
+            results.twitter = { id: platformId, success: true };
+            break;
+
+          case 'facebook': {
+            // Facebook requires pageId and pageAccessToken
+            const fbCredential = await this.credentialsService.findOne({
+              brand: ObjectIdUtil.toObjectId(brandId)!,
+              isDeleted: false,
+              organization: ObjectIdUtil.toObjectId(organizationId)!,
+              platform: CredentialPlatform.FACEBOOK,
+            });
+
+            if (!fbCredential?.accessToken || !fbCredential?.externalId) {
+              throw new Error('Facebook credential not found');
+            }
+
+            const decryptedToken = EncryptionUtil.decrypt(
+              fbCredential.accessToken,
+            );
+
+            platformId = await this.facebookService.uploadImage(
+              fbCredential.externalId,
+              decryptedToken,
+              ingredient.cdnUrl,
+              caption || '',
+            );
+            results.facebook = { id: platformId, success: true };
+            break;
+          }
+
+          default:
+            results[platform] = {
+              error: `Unsupported platform: ${platform}`,
+              success: false,
+            };
+        }
+      } catch (error: unknown) {
+        this.loggerService.error(caller, {
+          error: getErrorMessage(error),
+          ingredientId,
+          platform,
+        });
+        results[platform] = {
+          error: getErrorMessage(error),
+          success: false,
+        };
+      }
+    }
+
+    const allSuccessful = Object.values(results).every((r) => r.success);
+
+    return {
+      results,
+      success: allSuccessful,
+    };
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-stats.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-stats.service.ts
@@ -1,0 +1,161 @@
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { TrainingsService } from '@api/collections/trainings/services/trainings.service';
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import { DarkroomReviewStatus as DarkroomReviewStatusEnum } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Owns darkroom pipeline aggregation (campaigns + pipeline stats). Reads
+ * aggregates through the owning collection services rather than touching their
+ * Prisma client directly.
+ */
+@Injectable()
+export class DarkroomStatsService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly ingredientsService: IngredientsService,
+    private readonly trainingsService: TrainingsService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * List campaigns with asset counts.
+   */
+  async listCampaigns(organizationId: string): Promise<
+    {
+      campaign: string;
+      assetCount: number;
+      approvedCount: number;
+      createdAt: string;
+      status: 'active' | 'completed' | 'draft';
+    }[]
+  > {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { organizationId });
+
+    const campaignGroups =
+      await this.ingredientsService.groupPersonaAssetCampaigns(organizationId);
+
+    const campaigns = new Map<
+      string,
+      {
+        approvedCount: number;
+        assetCount: number;
+        campaign: string;
+        createdAt?: Date;
+      }
+    >();
+
+    for (const group of campaignGroups) {
+      if (!group.campaign) {
+        continue;
+      }
+
+      const existing = campaigns.get(group.campaign) ?? {
+        approvedCount: 0,
+        assetCount: 0,
+        campaign: group.campaign,
+        createdAt: group.earliestCreatedAt ?? undefined,
+      };
+
+      existing.assetCount += group.count;
+
+      if (
+        DarkroomValueReader.hasReviewStatus(
+          group.reviewStatus,
+          DarkroomReviewStatusEnum.APPROVED,
+        )
+      ) {
+        existing.approvedCount += group.count;
+      }
+
+      if (
+        group.earliestCreatedAt &&
+        (!existing.createdAt || group.earliestCreatedAt < existing.createdAt)
+      ) {
+        existing.createdAt = group.earliestCreatedAt;
+      }
+
+      campaigns.set(group.campaign, existing);
+    }
+
+    return Array.from(campaigns.values()).map((campaign) => ({
+      approvedCount: campaign.approvedCount,
+      assetCount: campaign.assetCount,
+      campaign: campaign.campaign,
+      createdAt: (campaign.createdAt ?? new Date(0)).toISOString(),
+      status:
+        campaign.approvedCount === 0
+          ? 'draft'
+          : campaign.approvedCount >= campaign.assetCount
+            ? 'completed'
+            : 'active',
+    }));
+  }
+
+  /**
+   * Get pipeline statistics aggregating assets and trainings.
+   */
+  async getPipelineStats(organizationId: string): Promise<{
+    assets: {
+      total: number;
+      byStatus: Record<string, number>;
+      byReviewStatus: Record<string, number>;
+    };
+    trainings: {
+      total: number;
+      byStage: Record<string, number>;
+    };
+  }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { organizationId });
+
+    const [
+      assetTotal,
+      assetStatusGroups,
+      assetReviewStatusGroups,
+      trainingTotal,
+      trainingStageGroups,
+    ] = await Promise.all([
+      this.ingredientsService.countPersonaAssets(organizationId),
+      this.ingredientsService.groupPersonaAssetsByStatus(organizationId),
+      this.ingredientsService.groupPersonaAssetsByReviewStatus(organizationId),
+      this.trainingsService.countTrainingsByOrganization(organizationId),
+      this.trainingsService.groupTrainingsByStage(organizationId),
+    ]);
+
+    const byStatus: Record<string, number> = {};
+    for (const item of assetStatusGroups) {
+      byStatus[DarkroomValueReader.readString(item.status) ?? 'unknown'] =
+        item.count;
+    }
+
+    const byReviewStatus: Record<string, number> = {};
+    for (const item of assetReviewStatusGroups) {
+      byReviewStatus[
+        DarkroomValueReader.readString(item.reviewStatus) ?? 'unknown'
+      ] = item.count;
+    }
+
+    const byStage: Record<string, number> = {};
+    for (const item of trainingStageGroups) {
+      byStage[DarkroomValueReader.readString(item.stage) ?? 'unknown'] =
+        item.count;
+    }
+
+    return {
+      assets: {
+        byReviewStatus,
+        byStatus,
+        total: assetTotal,
+      },
+      trainings: {
+        byStage,
+        total: trainingTotal,
+      },
+    };
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service.ts
@@ -1,0 +1,204 @@
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { PersonasService } from '@api/collections/personas/services/personas.service';
+import { type TrainingDocument } from '@api/collections/trainings/schemas/training.schema';
+import { TrainingsService } from '@api/collections/trainings/services/trainings.service';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import { ObjectIdUtil } from '@api/helpers/utils/objectid/objectid.util';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import {
+  DarkroomReviewStatus as DarkroomReviewStatusEnum,
+  LoraStatus,
+  TrainingCategory,
+  TrainingProvider,
+  TrainingStage,
+} from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { SentryTraced } from '@sentry/nestjs';
+
+/**
+ * Orchestrates darkroom training lifecycle: training reads plus kicking off a
+ * new LoRA training run. Delegates the GPU/HTTP pipeline mechanics to
+ * DarkroomTrainingService.
+ */
+@Injectable()
+export class DarkroomTrainingOrchestratorService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly characterService: DarkroomCharacterService,
+    private readonly ingredientsService: IngredientsService,
+    private readonly trainingsService: TrainingsService,
+    private readonly personasService: PersonasService,
+    private readonly darkroomTrainingService: DarkroomTrainingService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  /**
+   * Get trainings for a persona
+   */
+  getTrainings(
+    organizationId: string,
+    personaSlug?: string,
+  ): Promise<TrainingDocument[]> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { organizationId, personaSlug });
+
+    const filters: Record<string, unknown> = {};
+    if (personaSlug) {
+      filters.personaSlug = personaSlug;
+    }
+
+    return this.trainingsService.findAllByOrganization(organizationId, filters);
+  }
+
+  /**
+   * Get a single training by ID
+   */
+  async getTraining(
+    trainingId: string,
+    organizationId: string,
+  ): Promise<TrainingDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, { organizationId, trainingId });
+
+    const training = await this.trainingsService.findOne({
+      _id: trainingId,
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!training) {
+      throw new NotFoundException(`Training "${trainingId}" not found`);
+    }
+
+    return training;
+  }
+
+  /**
+   * Start a new darkroom training job.
+   * Creates a training record and fires off the pipeline asynchronously.
+   */
+  @SentryTraced()
+  async startTraining(
+    organizationId: string,
+    userId: string,
+    data: {
+      personaSlug: string;
+      label: string;
+      sourceIds: string[];
+      steps?: number;
+      learningRate?: number;
+      loraRank?: number;
+      loraName?: string;
+      baseModel?: string;
+    },
+  ): Promise<TrainingDocument> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(caller, {
+      organizationId,
+      personaSlug: data.personaSlug,
+    });
+
+    // Resolve persona
+    const persona = await this.characterService.requirePersonaBySlug(
+      data.personaSlug,
+      organizationId,
+      `Character "${data.personaSlug}" not found`,
+    );
+
+    const dataset = await this.darkroomTrainingService.getDatasetInfo(
+      data.personaSlug,
+    );
+    if (dataset.imageCount === 0) {
+      throw new BadRequestException(
+        `Dataset for "${data.personaSlug}" is empty. Upload training images before starting LoRA training.`,
+      );
+    }
+
+    // Auto-tune hyperparameters based on dataset size
+    const imageCount =
+      DarkroomValueReader.readNumber(
+        (persona as Record<string, unknown>).selectedImagesCount,
+      ) ?? 20;
+    const autoTuned =
+      this.darkroomTrainingService.autoTuneHyperparameters(imageCount);
+
+    const steps = data.steps ?? autoTuned.steps;
+    const loraRank = data.loraRank ?? autoTuned.rank;
+    const learningRate = data.learningRate ?? autoTuned.learningRate;
+    const baseModel = data.baseModel ?? MODEL_KEYS.GENFEED_AI_Z_IMAGE_TURBO;
+    const triggerWord = persona.triggerWord ?? data.personaSlug;
+    const loraName = data.loraName ?? `${triggerWord}_zimage`;
+
+    // Create training record
+    const sourceIds =
+      data.sourceIds.length > 0
+        ? data.sourceIds
+        : (
+            await this.ingredientsService.findAllByOrganization(
+              organizationId,
+              {
+                isDeleted: false,
+                persona: persona._id,
+                reviewStatus: DarkroomReviewStatusEnum.APPROVED,
+              },
+            )
+          ).map((ingredient) => ingredient._id.toString());
+
+    const training = await this.trainingsService.create({
+      baseModel,
+      category: TrainingCategory.SUBJECT,
+      label: data.label,
+      learningRate,
+      loraName,
+      loraRank,
+      model: baseModel,
+      organization: ObjectIdUtil.toObjectId(organizationId)!,
+      persona: persona._id,
+      personaSlug: data.personaSlug,
+      progress: 0,
+      provider: TrainingProvider.GENFEED_AI,
+      sources: sourceIds.map((id) => ObjectIdUtil.toObjectId(id)!),
+      stage: TrainingStage.QUEUED,
+      steps,
+      trigger: triggerWord,
+      user: ObjectIdUtil.toObjectId(userId)!,
+    } as Parameters<TrainingsService['create']>[0]);
+
+    await this.personasService.patch(persona._id.toString(), {
+      loraModelPath: undefined,
+      loraStatus: LoraStatus.TRAINING,
+    });
+
+    // Fire-and-forget: execute training pipeline asynchronously
+    this.darkroomTrainingService
+      .executeTrainingquery({
+        baseModel,
+        learningRate,
+        loraName,
+        loraRank,
+        organizationId,
+        personaSlug: data.personaSlug,
+        steps,
+        trainingId: training._id.toString(),
+        triggerWord,
+      })
+      .catch((error) => {
+        this.loggerService.error(caller, {
+          error: error instanceof Error ? error.message : String(error),
+          message: 'Training pipeline failed',
+          trainingId: training._id.toString(),
+        });
+      });
+
+    return training;
+  }
+}

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-value-reader.util.spec.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-value-reader.util.spec.ts
@@ -1,0 +1,162 @@
+import { DarkroomValueReader } from '@api/endpoints/admin/darkroom/services/darkroom-value-reader.util';
+import {
+  ContentIntelligencePlatform,
+  IngredientStatus,
+} from '@genfeedai/enums';
+import { describe, expect, it } from 'vitest';
+
+describe('DarkroomValueReader', () => {
+  describe('deriveGenerationJobState', () => {
+    // Every (status, stage) input pair the derivation can receive.
+    const statuses = [
+      IngredientStatus.FAILED,
+      IngredientStatus.GENERATED,
+      IngredientStatus.PROCESSING,
+      IngredientStatus.DRAFT,
+      undefined,
+      'unexpected-status',
+    ];
+    const stages = ['queued', 'uploading', 'running on ComfyUI', ''];
+
+    it('returns failed for any FAILED status regardless of stage', () => {
+      for (const stage of stages) {
+        expect(
+          DarkroomValueReader.deriveGenerationJobState(
+            IngredientStatus.FAILED,
+            stage,
+          ),
+        ).toBe('failed');
+      }
+    });
+
+    it('returns completed for any GENERATED status regardless of stage', () => {
+      for (const stage of stages) {
+        expect(
+          DarkroomValueReader.deriveGenerationJobState(
+            IngredientStatus.GENERATED,
+            stage,
+          ),
+        ).toBe('completed');
+      }
+    });
+
+    it('falls back to the stage when status is non-terminal', () => {
+      const nonTerminal = statuses.filter(
+        (status) =>
+          status !== IngredientStatus.FAILED &&
+          status !== IngredientStatus.GENERATED,
+      );
+
+      for (const status of nonTerminal) {
+        expect(
+          DarkroomValueReader.deriveGenerationJobState(status, 'queued'),
+        ).toBe('queued');
+        expect(
+          DarkroomValueReader.deriveGenerationJobState(status, 'uploading'),
+        ).toBe('uploading');
+        expect(
+          DarkroomValueReader.deriveGenerationJobState(
+            status,
+            'running on ComfyUI',
+          ),
+        ).toBe('processing');
+        expect(DarkroomValueReader.deriveGenerationJobState(status, '')).toBe(
+          'processing',
+        );
+      }
+    });
+  });
+
+  describe('ingredientStatusForJobState', () => {
+    it('maps terminal and non-terminal job states to ingredient statuses', () => {
+      expect(DarkroomValueReader.ingredientStatusForJobState('failed')).toBe(
+        IngredientStatus.FAILED,
+      );
+      expect(DarkroomValueReader.ingredientStatusForJobState('completed')).toBe(
+        IngredientStatus.GENERATED,
+      );
+      expect(
+        DarkroomValueReader.ingredientStatusForJobState('processing'),
+      ).toBe(IngredientStatus.PROCESSING);
+      expect(DarkroomValueReader.ingredientStatusForJobState('queued')).toBe(
+        IngredientStatus.PROCESSING,
+      );
+      expect(DarkroomValueReader.ingredientStatusForJobState('uploading')).toBe(
+        IngredientStatus.PROCESSING,
+      );
+      expect(DarkroomValueReader.ingredientStatusForJobState(undefined)).toBe(
+        IngredientStatus.PROCESSING,
+      );
+    });
+  });
+
+  describe('value coercion helpers', () => {
+    it('readString returns the string only when non-empty', () => {
+      expect(DarkroomValueReader.readString('hello')).toBe('hello');
+      expect(DarkroomValueReader.readString('')).toBeUndefined();
+      expect(DarkroomValueReader.readString(42)).toBeUndefined();
+      expect(DarkroomValueReader.readString(null)).toBeUndefined();
+    });
+
+    it('readNumber returns finite numbers only', () => {
+      expect(DarkroomValueReader.readNumber(7)).toBe(7);
+      expect(DarkroomValueReader.readNumber(Number.NaN)).toBeUndefined();
+      expect(DarkroomValueReader.readNumber('7')).toBeUndefined();
+    });
+
+    it('readReferenceId resolves nested id shapes', () => {
+      expect(DarkroomValueReader.readReferenceId('abc')).toBe('abc');
+      expect(DarkroomValueReader.readReferenceId({ _id: 'nested' })).toBe(
+        'nested',
+      );
+      expect(DarkroomValueReader.readReferenceId({})).toBeUndefined();
+    });
+
+    it('readPlatform only accepts known platforms', () => {
+      expect(DarkroomValueReader.readPlatform('instagram')).toBe(
+        ContentIntelligencePlatform.INSTAGRAM,
+      );
+      expect(DarkroomValueReader.readPlatform('myspace')).toBeUndefined();
+    });
+  });
+
+  describe('getDimensionsFromAspectRatio', () => {
+    it('returns empty for missing or invalid ratios', () => {
+      expect(DarkroomValueReader.getDimensionsFromAspectRatio()).toEqual({});
+      expect(DarkroomValueReader.getDimensionsFromAspectRatio('0:0')).toEqual(
+        {},
+      );
+    });
+
+    it('scales the longest edge to 1024', () => {
+      expect(DarkroomValueReader.getDimensionsFromAspectRatio('1:1')).toEqual({
+        height: 1024,
+        width: 1024,
+      });
+      expect(DarkroomValueReader.getDimensionsFromAspectRatio('16:9')).toEqual({
+        height: 576,
+        width: 1024,
+      });
+    });
+  });
+
+  describe('getDatasetExtension', () => {
+    it('infers the extension from the url and category', () => {
+      expect(DarkroomValueReader.getDatasetExtension('a/b.png', 'image')).toBe(
+        'png',
+      );
+      expect(DarkroomValueReader.getDatasetExtension('a/b.webp', 'image')).toBe(
+        'webp',
+      );
+      expect(DarkroomValueReader.getDatasetExtension('a/b.mp4', 'image')).toBe(
+        'mp4',
+      );
+      expect(DarkroomValueReader.getDatasetExtension('a/b', 'video')).toBe(
+        'mp4',
+      );
+      expect(DarkroomValueReader.getDatasetExtension('a/b.jpg', 'image')).toBe(
+        'jpg',
+      );
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-value-reader.util.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-value-reader.util.ts
@@ -1,0 +1,240 @@
+import type { IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
+import type { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import type { PersonaDocument } from '@api/collections/personas/schemas/persona.schema';
+import type {
+  DarkroomGenerationJob,
+  DarkroomGenerationJobStatus,
+} from '@api/endpoints/admin/darkroom/interfaces/darkroom-generation-job.interface';
+import type { DarkroomSourceRecord } from '@api/endpoints/admin/darkroom/interfaces/darkroom-ingest.interface';
+import {
+  ContentIntelligencePlatform,
+  DarkroomReviewStatus as DarkroomReviewStatusEnum,
+  IngredientCategory,
+  IngredientStatus,
+} from '@genfeedai/enums';
+
+/**
+ * Pure value-coercion and mapping helpers for the darkroom domain.
+ * Extracted verbatim from the former DarkroomService god object so the
+ * collaborator services can share a single typed reader without re-deriving
+ * the loose-input parsing rules.
+ */
+export const DarkroomValueReader = {
+  readObjectRecord(value: unknown): Record<string, unknown> | undefined {
+    return typeof value === 'object' && value !== null
+      ? (value as Record<string, unknown>)
+      : undefined;
+  },
+
+  readNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : undefined;
+  },
+
+  readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  },
+
+  readReferenceId(value: unknown): string | undefined {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+
+    const record = DarkroomValueReader.readObjectRecord(value);
+    const nestedId =
+      DarkroomValueReader.readString(record?._id) ??
+      DarkroomValueReader.readString(record?.id) ??
+      DarkroomValueReader.readString(record?.mongoId);
+
+    if (nestedId) {
+      return nestedId;
+    }
+
+    if (
+      value &&
+      typeof value === 'object' &&
+      'toString' in (value as object) &&
+      typeof (value as { toString: () => string }).toString === 'function'
+    ) {
+      const stringified = (value as { toString: () => string }).toString();
+      return stringified !== '[object Object]' ? stringified : undefined;
+    }
+
+    return undefined;
+  },
+
+  readPlatform(value: unknown): ContentIntelligencePlatform | undefined {
+    switch (DarkroomValueReader.readString(value)) {
+      case ContentIntelligencePlatform.INSTAGRAM:
+        return ContentIntelligencePlatform.INSTAGRAM;
+      case ContentIntelligencePlatform.LINKEDIN:
+        return ContentIntelligencePlatform.LINKEDIN;
+      case ContentIntelligencePlatform.TIKTOK:
+        return ContentIntelligencePlatform.TIKTOK;
+      case ContentIntelligencePlatform.TWITTER:
+        return ContentIntelligencePlatform.TWITTER;
+      default:
+        return undefined;
+    }
+  },
+
+  getEnabledDarkroomSources(persona: PersonaDocument): DarkroomSourceRecord[] {
+    const sources = Array.isArray(persona.darkroomSources)
+      ? persona.darkroomSources
+      : [];
+
+    return sources.flatMap((source) => {
+      const record = DarkroomValueReader.readObjectRecord(source);
+      const handle = DarkroomValueReader.readString(record?.handle);
+      const platform = DarkroomValueReader.readPlatform(record?.platform);
+
+      if (!record || record.enabled !== true || !handle || !platform) {
+        return [];
+      }
+
+      return [record as DarkroomSourceRecord];
+    });
+  },
+
+  hasIngredientCategory(value: unknown, expected: IngredientCategory): boolean {
+    return DarkroomValueReader.readString(value) === expected;
+  },
+
+  hasIngredientStatus(value: unknown, expected: IngredientStatus): boolean {
+    return DarkroomValueReader.readString(value) === expected;
+  },
+
+  hasReviewStatus(value: unknown, expected: DarkroomReviewStatusEnum): boolean {
+    return DarkroomValueReader.readString(value) === expected;
+  },
+
+  getDefaultDarkroomModerationState(): Pick<
+    Parameters<IngredientsService['create']>[0],
+    'contentRating' | 'reviewStatus'
+  > {
+    return {
+      contentRating: undefined,
+      reviewStatus: DarkroomReviewStatusEnum.PENDING,
+    };
+  },
+
+  getDimensionsFromAspectRatio(aspectRatio?: string): {
+    width?: number;
+    height?: number;
+  } {
+    if (!aspectRatio) {
+      return {};
+    }
+
+    const [w, h] = aspectRatio.split(':').map(Number);
+    if (!(w && h)) {
+      return {};
+    }
+
+    const scale = 1024 / Math.max(w, h);
+    return {
+      height: Math.round(h * scale),
+      width: Math.round(w * scale),
+    };
+  },
+
+  getDatasetExtension(
+    sourceUrl: string,
+    category: string,
+  ): 'jpg' | 'png' | 'webp' | 'mp4' {
+    const normalizedUrl = sourceUrl.toLowerCase();
+    if (normalizedUrl.includes('.png')) {
+      return 'png';
+    }
+    if (normalizedUrl.includes('.webp')) {
+      return 'webp';
+    }
+    if (
+      DarkroomValueReader.hasIngredientCategory(
+        category,
+        IngredientCategory.VIDEO,
+      ) ||
+      normalizedUrl.includes('.mp4')
+    ) {
+      return 'mp4';
+    }
+    return 'jpg';
+  },
+
+  /**
+   * Derive the generation-job lifecycle state from an ingredient's persisted
+   * status + stage. Replaces the former 5-level nested ternary with an
+   * explicit precedence ladder: terminal statuses win, then the stage decides.
+   */
+  deriveGenerationJobState(
+    status: unknown,
+    stage: string,
+  ): DarkroomGenerationJobStatus {
+    if (
+      DarkroomValueReader.hasIngredientStatus(status, IngredientStatus.FAILED)
+    ) {
+      return 'failed';
+    }
+    if (
+      DarkroomValueReader.hasIngredientStatus(
+        status,
+        IngredientStatus.GENERATED,
+      )
+    ) {
+      return 'completed';
+    }
+    switch (stage) {
+      case 'queued':
+        return 'queued';
+      case 'uploading':
+        return 'uploading';
+      default:
+        return 'processing';
+    }
+  },
+
+  /**
+   * Map a generation-job lifecycle state to the persisted ingredient status.
+   * Replaces the former nested ternary in updateGenerationJob.
+   */
+  ingredientStatusForJobState(
+    status: DarkroomGenerationJobStatus | undefined,
+  ): IngredientStatus {
+    switch (status) {
+      case 'failed':
+        return IngredientStatus.FAILED;
+      case 'completed':
+        return IngredientStatus.GENERATED;
+      default:
+        return IngredientStatus.PROCESSING;
+    }
+  },
+
+  mapIngredientToGenerationJob(
+    ingredient: IngredientDocument,
+  ): DarkroomGenerationJob {
+    const stage = ingredient.generationStage ?? 'queued';
+    const status = DarkroomValueReader.deriveGenerationJobState(
+      ingredient.status,
+      stage,
+    );
+
+    return {
+      cdnUrl: ingredient.cdnUrl ?? undefined,
+      createdAt:
+        ingredient.createdAt?.toISOString() ?? new Date().toISOString(),
+      error: ingredient.generationError ?? undefined,
+      ingredientId: ingredient._id.toString(),
+      jobId: ingredient._id.toString(),
+      model: ingredient.modelUsed ?? ingredient.generationSource ?? '',
+      personaSlug: ingredient.personaSlug ?? '',
+      progress: ingredient.generationProgress ?? 0,
+      prompt: ingredient.generationPrompt ?? '',
+      stage,
+      status,
+      updatedAt:
+        ingredient.updatedAt?.toISOString() ?? new Date().toISOString(),
+    };
+  },
+} as const;


### PR DESCRIPTION
## Why

`apps/server/api/src/endpoints/admin/darkroom/darkroom.service.ts` was a **2,107-line `@Injectable()` god object** with **17 constructor deps** spanning 7+ domains (character CRUD, asset review, AWS infra, social publishing, image generation/jobs, dataset ingest, stats, lip-sync, voice/TTS). This splits it into a **thin delegating facade** plus focused peer services under `services/`, following the existing `darkroom-training.service.ts` precedent. Closes #690.

## Behaviour-preserving

The `DarkroomController` and **`darkroom.controller.spec.ts` are unchanged** — the facade keeps the exact public method surface the controller calls, so the controller spec passes verbatim. Every method body was moved, not rewritten.

## New collaborators (`endpoints/admin/darkroom/services/`)

| Service | Owns |
|---|---|
| `DarkroomCharacterService` | persona CRUD + the single shared `findPersonaBySlug` / `requirePersonaBySlug` |
| `DarkroomAssetService` | asset listing/review + approved-asset dataset sync |
| `DarkroomInfraService` | **owns the EC2 + CloudFront clients** (removed from the main constructor); single `runAws` wrapper |
| `DarkroomPublishingService` | publish approved assets to platforms |
| `DarkroomGenerationService` | ComfyUI generate + durable generation jobs |
| `DarkroomIngestService` | dataset upload + scrape-and-ingest pipeline |
| `DarkroomStatsService` | campaigns + pipeline stats |
| `DarkroomMediaService` | lip-sync + voice/TTS |
| `DarkroomTrainingOrchestratorService` | training reads + `startTraining` |
| `DarkroomValueReader` (util) | shared pure value-coercion + mapping helpers |

Facade is now **264 lines** (from 2,107); no peer service exceeds ~331 lines.

## Acceptance criteria (#690)

- [x] `darkroom.service.ts` reduced to a thin facade; implementation in peer services
- [x] **8 duplicated persona-lookup blocks → one `requirePersonaBySlug`** (per-call-site `NotFoundException` messages preserved exactly, incl. the slug-specific `getCharacterBySlug` message and the no-throw `findPersonaBySlug` used by `resolveFleetReferenceAudio`)
- [x] **`EC2Client`/`CloudFrontClient` moved out of the main constructor** into `DarkroomInfraService`; duplicated AWS try/catch collapsed into `runAws`
- [x] **Dead `getqueryStats` deleted** (`grep` → 0 references)
- [x] Unused `brandId` dropped from the training implementation (see note)
- [x] **Nested-ternary status derivations → explicit switch functions** (`deriveGenerationJobState`, `ingredientStatusForJobState`), covered by a unit test over the full status/stage matrix
- [x] `listCampaigns`/`getPipelineStats` **no longer touch `.prisma.*`** — new aggregation methods (`countPersonaAssets`, `groupPersonaAssetsByStatus`, `groupPersonaAssetsByReviewStatus`, `groupPersonaAssetCampaigns`, `countTrainingsByOrganization`, `groupTrainingsByStage`) added to `IngredientsService`/`TrainingsService`, returning domain-neutral typed shapes (Prisma generics stay internal)

## Notes / deliberate deviations

- **`startTraining` lives in a new `DarkroomTrainingOrchestratorService`, not the existing `DarkroomTrainingService`.** The issue suggested the latter, but it is already 405 lines and moving `startTraining` into it would push it past the ~350-line cap **and** force breaking changes to its passing spec. The new orchestrator keeps the GPU-client service (and its spec) untouched.
- **`_brandId` placeholder on the facade.** The issue asks to remove the unused `brandId`; the controller spec asserts the 4-arg `startTraining('org','user','brand',dto)` call. To satisfy *both* "remove unused brandId" and "controller spec unchanged", the brandId is dropped from the orchestrator implementation while the facade keeps a lint-clean `_brandId` placeholder to preserve the HTTP/controller call shape.
- A biome pre-commit auto-fix added a `node:process` import to `trainings.service.ts` for its pre-existing `process.cwd()` usage (repo-mandated lint rule), riding along with the aggregation-method addition.

## Verification

- ✅ Scoped type-check: `tsc -p apps/server/api/tsconfig.typecheck.json --noEmit` → clean (only the pre-existing `baseUrl` deprecation notice)
- ✅ `biome check` → clean
- ✅ Tests: `darkroom.controller.spec.ts` + `darkroom-training.service.spec.ts` (unchanged) + new `darkroom-value-reader.util.spec.ts` + `darkroom-character.service.spec.ts` → **70 passed**
- Diff scoped to `apps/server/api/src/endpoints/admin/darkroom/**` + the two collection-service aggregation methods. Heavy/integration tests deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)