### PR TITLE
feat(workflows): workflow-backed daily trends digest + overview trends widget

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.test.tsx
@@ -1,5 +1,6 @@
 import { AgentExecutionStatus, AgentExecutionTrigger } from '@genfeedai/enums';
 import type { IAgentRun } from '@genfeedai/interfaces';
+import type { TrendItem } from '@genfeedai/props/trends/trends-page.props';
 import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props';
 import { render, screen } from '@testing-library/react';
 import type { Key, ReactNode } from 'react';
@@ -10,6 +11,7 @@ import {
   OverviewPublishingInboxSection,
   OverviewStatusBadge,
   OverviewTopStatStrip,
+  OverviewTrendsPanel,
 } from './overview-dashboard-sections';
 
 vi.mock('next/link', () => ({
@@ -289,5 +291,63 @@ describe('Overview dashboard sections', () => {
       'href',
       '/posts/review',
     );
+  });
+
+  it('renders the overview trends panel with top trends and view-all link', () => {
+    const trends: TrendItem[] = [
+      {
+        createdAt: '2026-06-01T00:00:00.000Z',
+        expiresAt: '2026-06-08T00:00:00.000Z',
+        growthRate: 1.5,
+        id: 'trend-a',
+        isCurrent: true,
+        mentions: 1200,
+        platform: 'instagram',
+        requiresAuth: false,
+        topic: 'Reels growth',
+        viralityScore: 950,
+      },
+      {
+        createdAt: '2026-06-01T00:00:00.000Z',
+        expiresAt: '2026-06-08T00:00:00.000Z',
+        growthRate: 1.1,
+        id: 'trend-b',
+        isCurrent: true,
+        mentions: 800,
+        platform: 'tiktok',
+        requiresAuth: false,
+        topic: 'AI comedy skits',
+        viralityScore: 720,
+      },
+    ];
+
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={trends}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByText('Social Trends')).toBeInTheDocument();
+    expect(screen.getByText('Research Trends')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view all/i })).toHaveAttribute(
+      'href',
+      '/research/discovery',
+    );
+    expect(screen.getByText('Reels growth')).toBeInTheDocument();
+    expect(screen.getByText('AI comedy skits')).toBeInTheDocument();
+  });
+
+  it('renders the overview trends panel empty state', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={[]}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByText('No trends yet.')).toBeInTheDocument();
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.tsx
@@ -11,12 +11,15 @@ import type { TableColumn } from '@props/ui/display/table.props';
 import type { OverviewBootstrapPayload } from '@services/auth/auth.service';
 import Card from '@ui/card/Card';
 import AppTable from '@ui/display/table/Table';
+import { OverviewTrendsPanel } from '@ui/overview/OverviewTrendsPanel';
 import { WorkspaceSurface } from '@ui/overview/WorkspaceSurface';
 import { Button } from '@ui/primitives/button';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { HiOutlineArrowRight } from 'react-icons/hi2';
+
+export { OverviewTrendsPanel };
 
 const PlatformTimeSeriesChart = dynamic(
   () =>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-page.tsx
@@ -9,6 +9,7 @@ import { getPublisherPostsHref } from '@helpers/content/posts.helper';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import { formatCompactNumber } from '@helpers/formatting/format/format.helper';
 import { useOverviewBootstrap } from '@hooks/data/overview/use-overview-bootstrap';
+import { useTrends } from '@hooks/data/trends/use-trends/use-trends';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type {
   PlatformTimeSeriesDataPoint,
@@ -39,6 +40,7 @@ import {
   OverviewPerformanceChartSection,
   OverviewPublishingInboxSection,
   OverviewTopStatStrip,
+  OverviewTrendsPanel,
 } from './overview-dashboard-sections';
 
 interface SectionStat {
@@ -270,6 +272,7 @@ export default function OverviewPageContent({
   initialTimeSeriesData = EMPTY_TIME_SERIES,
 }: OverviewPageContentProps) {
   const { href } = useOrgUrl();
+  const { trends, isLoading: isTrendsLoading } = useTrends();
   const {
     activeRuns,
     analytics,
@@ -445,6 +448,14 @@ export default function OverviewPageContent({
           <OverviewPublishingInboxSection
             readyCount={reviewInbox.readyCount}
             recentItems={reviewInbox.recentItems}
+          />
+        </div>
+
+        <div className="min-w-0" data-testid="overview-trends-section">
+          <OverviewTrendsPanel
+            trends={trends}
+            isLoading={isTrendsLoading}
+            viewAllHref={href('/research/discovery')}
           />
         </div>
       </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.test.tsx
@@ -48,6 +48,27 @@ vi.mock('@ui/dashboard/DashboardGrid', () => ({
   ),
 }));
 
+vi.mock('@ui/overview/OverviewTrendsPanel', () => ({
+  OverviewTrendsPanel: ({
+    isLoading,
+    trends,
+    viewAllHref,
+  }: {
+    isLoading: boolean;
+    trends: unknown[];
+    viewAllHref: string;
+  }) => (
+    <div data-testid="overview-trends-panel">
+      <a href={viewAllHref}>View All</a>
+      {isLoading ? (
+        <div data-testid="trends-loading">Loading</div>
+      ) : trends.length === 0 ? (
+        <div data-testid="trends-empty">No trends yet.</div>
+      ) : null}
+    </div>
+  ),
+}));
+
 vi.mock('@ui/primitives/button', () => ({
   Button: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }));
@@ -288,5 +309,33 @@ describe('workspace dashboard sections', () => {
     expect(screen.getByTestId('dashboard-stats-strip')).toBeVisible();
     expect(screen.getByText('Recent Activity')).toBeVisible();
     expect(screen.getByText('Recent Tasks')).toBeVisible();
+    expect(screen.getByTestId('overview-trends-panel')).toBeVisible();
+  });
+
+  it('renders the trends panel with the configured viewAllHref', () => {
+    render(
+      <WorkspaceDashboard
+        activeRuns={[]}
+        reviewInbox={{
+          approvedCount: 0,
+          changesRequestedCount: 0,
+          pendingCount: 0,
+          readyCount: 0,
+          recentItems: [],
+          rejectedCount: 0,
+        }}
+        runs={[]}
+        stats={null}
+        trendsHref="/org/brand/research/discovery"
+        trendItems={[]}
+        workspaceTasks={[]}
+      />,
+    );
+
+    const trendsPanel = screen.getByTestId('overview-trends-panel');
+    expect(trendsPanel.querySelector('a')).toHaveAttribute(
+      'href',
+      '/org/brand/research/discovery',
+    );
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
@@ -6,11 +6,13 @@ import {
   ButtonVariant,
 } from '@genfeedai/enums';
 import type { IAgentRun } from '@genfeedai/interfaces';
+import type { TrendItem } from '@genfeedai/props/trends/trends-page.props';
 import type { AgentRunStats, AgentRunTrendPoint } from '@genfeedai/types';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import type { Task } from '@services/management/tasks.service';
 import Card from '@ui/card/Card';
 import { DashboardGrid } from '@ui/dashboard/DashboardGrid';
+import { OverviewTrendsPanel } from '@ui/overview/OverviewTrendsPanel';
 import { Button } from '@ui/primitives/button';
 import {
   Table,
@@ -62,9 +64,12 @@ interface ReviewInboxSummary {
 
 interface DashboardProps {
   activeRuns: IAgentRun[];
+  isTrendsLoading?: boolean;
   reviewInbox: ReviewInboxSummary;
   runs: IAgentRun[];
   stats: AgentRunStats | null;
+  trendsHref?: string;
+  trendItems?: TrendItem[];
   workspaceTasks: Task[];
 }
 
@@ -799,9 +804,12 @@ export function DashboardRecentTasks({
 
 export function WorkspaceDashboard({
   activeRuns,
+  isTrendsLoading = false,
   reviewInbox,
   runs,
   stats,
+  trendsHref = '/research/discovery',
+  trendItems = [],
   workspaceTasks,
 }: DashboardProps) {
   return (
@@ -821,6 +829,12 @@ export function WorkspaceDashboard({
         <DashboardRecentActivity workspaceTasks={workspaceTasks} />
         <DashboardRecentTasks workspaceTasks={workspaceTasks} />
       </DashboardGrid>
+
+      <OverviewTrendsPanel
+        trends={trendItems}
+        isLoading={isTrendsLoading}
+        viewAllHref={trendsHref}
+      />
     </div>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -3,6 +3,8 @@
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { IAgentRun, IAnalytics } from '@genfeedai/interfaces';
 import type { AgentRunStats } from '@genfeedai/types';
+import { useTrends } from '@hooks/data/trends/use-trends/use-trends';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props';
 import type { Task } from '@services/management/tasks.service';
 import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
@@ -58,6 +60,8 @@ function WorkspacePageContentContent({
   initialTimeSeriesData,
   section = 'overview',
 }: WorkspacePageContentProps) {
+  const { href } = useOrgUrl();
+  const { trends: trendItems, isLoading: isTrendsLoading } = useTrends();
   const {
     activityItems,
     busyTaskId,
@@ -183,9 +187,12 @@ function WorkspacePageContentContent({
       {isOverviewSection ? (
         <WorkspaceDashboard
           activeRuns={initialActiveRuns}
+          isTrendsLoading={isTrendsLoading}
           reviewInbox={initialReviewInbox}
           runs={initialRuns}
           stats={initialStats}
+          trendsHref={href('/research/discovery')}
+          trendItems={trendItems}
           workspaceTasks={workspaceTasks}
         />
       ) : null}

--- a/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
@@ -5,6 +5,7 @@ import Card from '@ui/card/Card';
 import Container from '@ui/layout/container/Container';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
+import { Switch } from '@ui/primitives/switch';
 import { Cloud, CloudUpload } from 'lucide-react';
 import Link from 'next/link';
 import {
@@ -36,6 +37,7 @@ export default function WorkflowLibraryPage() {
     loadWorkflows,
     handleDuplicate,
     handleDelete,
+    handleToggleSchedule,
     filteredWorkflows,
   } = useWorkflowLibraryPage();
 
@@ -200,6 +202,17 @@ export default function WorkflowLibraryPage() {
                     >
                       {workflow.lifecycle}
                     </span>
+                    {workflow.schedule ? (
+                      <span role="none" onClick={(e) => e.preventDefault()}>
+                        <Switch
+                          checked={workflow.isScheduleEnabled ?? false}
+                          aria-label={`${workflow.isScheduleEnabled ? 'Disable' : 'Enable'} schedule for ${workflow.name}`}
+                          onCheckedChange={(checked) =>
+                            handleToggleSchedule(workflow._id, checked)
+                          }
+                        />
+                      </span>
+                    ) : null}
                     <WorkflowCardDropdown
                       onDuplicate={() => handleDuplicate(workflow._id)}
                       onDelete={() => handleDelete(workflow._id)}

--- a/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
+++ b/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
@@ -1,0 +1,156 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowSummary } from '@/features/workflows/services/workflow-api';
+import { useWorkflowLibraryPage } from './useWorkflowLibraryPage';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  href: vi.fn((path: string) => `/org/brand${path}`),
+  push: vi.fn(),
+  isConnected: false,
+  isCapable: false,
+  serviceList: vi.fn(),
+  serviceDuplicate: vi.fn(),
+  serviceRemove: vi.fn(),
+  serviceSetSchedule: vi.fn(),
+  getService: vi.fn(),
+}));
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({ href: mocks.href }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock('@/hooks/useCloudSession', () => ({
+  useCloudSession: () => ({
+    isConnected: mocks.isConnected,
+    isCapable: mocks.isCapable,
+  }),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getService,
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: { error: vi.fn(), info: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const makeWorkflow = (
+  overrides: Partial<WorkflowSummary> = {},
+): WorkflowSummary => ({
+  _id: 'wf-1',
+  name: 'Test Workflow',
+  lifecycle: 'published',
+  nodeCount: 3,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useWorkflowLibraryPage — handleToggleSchedule', () => {
+  beforeEach(() => {
+    mocks.serviceList.mockResolvedValue([
+      makeWorkflow({
+        _id: 'wf-1',
+        name: 'Scheduled Workflow',
+        schedule: '0 9 * * 1',
+        timezone: 'UTC',
+        isScheduleEnabled: false,
+      }),
+      makeWorkflow({
+        _id: 'wf-2',
+        name: 'Unscheduled Workflow',
+      }),
+    ]);
+    mocks.serviceSetSchedule.mockResolvedValue(undefined);
+    mocks.getService.mockResolvedValue({
+      list: mocks.serviceList,
+      duplicate: mocks.serviceDuplicate,
+      remove: mocks.serviceRemove,
+      setSchedule: mocks.serviceSetSchedule,
+    });
+  });
+
+  it('calls setSchedule with enabled=true when toggling on a workflow that has a schedule', async () => {
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+
+    await waitFor(() => expect(result.current.workflows).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.handleToggleSchedule('wf-1', true);
+    });
+
+    expect(mocks.serviceSetSchedule).toHaveBeenCalledWith('wf-1', {
+      enabled: true,
+      schedule: '0 9 * * 1',
+      timezone: 'UTC',
+    });
+  });
+
+  it('applies an optimistic update before the API resolves', async () => {
+    let resolveSchedule!: () => void;
+    mocks.serviceSetSchedule.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSchedule = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(2));
+
+    act(() => {
+      void result.current.handleToggleSchedule('wf-1', true);
+    });
+
+    // Optimistic state should be applied immediately
+    await waitFor(() => {
+      const wf = result.current.workflows.find((w) => w._id === 'wf-1');
+      expect(wf?.isScheduleEnabled).toBe(true);
+    });
+
+    // Resolve the API call
+    act(() => resolveSchedule());
+  });
+
+  it('reverts the optimistic update when the API call fails', async () => {
+    mocks.serviceSetSchedule.mockRejectedValueOnce(new Error('network error'));
+
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.handleToggleSchedule('wf-1', true);
+    });
+
+    // Should revert to the original isScheduleEnabled value (false)
+    const wf = result.current.workflows.find((w) => w._id === 'wf-1');
+    expect(wf?.isScheduleEnabled).toBe(false);
+  });
+
+  it('does nothing when toggling a workflow with no schedule', async () => {
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.handleToggleSchedule('wf-2', true);
+    });
+
+    expect(mocks.serviceSetSchedule).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.ts
+++ b/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.ts
@@ -108,6 +108,43 @@ export function useWorkflowLibraryPage() {
     [getService],
   );
 
+  const handleToggleSchedule = useCallback(
+    async (id: string, enabled: boolean) => {
+      const previous = workflows.find((w) => w._id === id);
+      if (!previous?.schedule) return;
+
+      // Optimistic update
+      setWorkflows((prev) =>
+        prev.map((w) =>
+          w._id === id ? { ...w, isScheduleEnabled: enabled } : w,
+        ),
+      );
+
+      try {
+        const service = await getService();
+        await service.setSchedule(id, {
+          enabled,
+          schedule: previous.schedule,
+          timezone: previous.timezone,
+        });
+      } catch (err) {
+        // Revert on error
+        setWorkflows((prev) =>
+          prev.map((w) =>
+            w._id === id
+              ? { ...w, isScheduleEnabled: previous.isScheduleEnabled }
+              : w,
+          ),
+        );
+        logger.error('Failed to toggle workflow schedule', {
+          error: err,
+          workflowId: id,
+        });
+      }
+    },
+    [getService, workflows],
+  );
+
   // Filter client-side for instant feedback during debounce
   const filteredWorkflows = useMemo(() => {
     if (!searchInput || searchInput === debouncedSearch) return workflows;
@@ -131,6 +168,7 @@ export function useWorkflowLibraryPage() {
     loadWorkflows,
     handleDuplicate,
     handleDelete,
+    handleToggleSchedule,
     filteredWorkflows,
   };
 }

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -49,6 +49,16 @@ export interface WorkflowSummary {
     remoteId: string;
     syncDirection: 'push' | 'pull';
   } | null;
+  schedule?: string;
+  timezone?: string;
+  isScheduleEnabled?: boolean;
+}
+
+/** Payload for POST /workflows/:id/schedule */
+export interface SetScheduleInput {
+  enabled: boolean;
+  schedule: string;
+  timezone?: string;
 }
 
 /** Payload for creating a new workflow */
@@ -411,6 +421,19 @@ export class WorkflowApiService extends HTTPBaseService {
       await this.instance.delete(`/${id}`);
     } catch (error) {
       logger.error('Failed to delete workflow', { error, workflowId: id });
+      throw error;
+    }
+  }
+
+  /** Enable or disable the schedule for a workflow (POST /workflows/:id/schedule) */
+  async setSchedule(id: string, body: SetScheduleInput): Promise<void> {
+    try {
+      await this.instance.post(`/${id}/schedule`, body);
+    } catch (error) {
+      logger.error('Failed to set workflow schedule', {
+        error,
+        workflowId: id,
+      });
       throw error;
     }
   }

--- a/apps/server/api/scripts/seeds/trends-digest-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/trends-digest-workflows.seed.ts
@@ -1,0 +1,142 @@
+/**
+ * Seed Script: Daily Trends Digest Workflows
+ *
+ * Idempotently provisions the predetermined "Daily Trends Digest" workflow for
+ * existing organizations (seeded OFF — owners enable it from the workflow list).
+ * New organizations are seeded automatically on creation; this backfills the
+ * organizations that existed before the feature shipped.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/trends-digest-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/trends-digest-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/trends-digest-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/trends-digest-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('TrendsDigestSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let seeded = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} — no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        logger.log(
+          `[DRY RUN] would ensure Daily Trends Digest workflow for org ${organization.id}`,
+        );
+        seeded += 1;
+        continue;
+      }
+
+      await workflowsService.ensureDailyTrendsDigestWorkflow(
+        organization.userId,
+        organization.id,
+      );
+      seeded += 1;
+    }
+
+    logger.log(
+      `Trends digest seed summary: processed=${seeded}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Trends digest seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -3,6 +3,8 @@ import { ModelsService } from '@api/collections/models/services/models.service';
 import { CreateOrganizationSettingDto } from '@api/collections/organization-settings/dto/create-organization-setting.dto';
 import { UpdateOrganizationSettingDto } from '@api/collections/organization-settings/dto/update-organization-setting.dto';
 import type { OrganizationSettingDocument } from '@api/collections/organization-settings/schemas/organization-setting.schema';
+// biome-ignore lint/style/useImportType: resolved at runtime via ModuleRef as a DI token
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import {
@@ -38,6 +40,65 @@ export class OrganizationSettingsService extends BaseService<
       this.modelsService = this.moduleRef.get(ModelsService, { strict: false });
     }
     return this.modelsService;
+  }
+
+  /**
+   * Org-bootstrap chokepoint: all organization-creation paths (Clerk webhook,
+   * OrganizationsController, UserSetupService) funnel through settings creation.
+   * After creating settings we idempotently seed the predetermined Daily Trends
+   * Digest workflow (OFF by default). Failures never block settings creation.
+   */
+  async create(
+    createDto: CreateOrganizationSettingDto,
+    populate?: Parameters<
+      BaseService<
+        OrganizationSettingDocument,
+        CreateOrganizationSettingDto,
+        UpdateOrganizationSettingDto
+      >['create']
+    >[1],
+  ): Promise<OrganizationSettingDocument> {
+    const settings = await super.create(createDto, populate ?? []);
+    await this.provisionDefaultWorkflows(settings);
+    return settings;
+  }
+
+  private async provisionDefaultWorkflows(
+    settings: OrganizationSettingDocument,
+  ): Promise<void> {
+    try {
+      const settingsRecord = settings as unknown as {
+        organization?: unknown;
+        organizationId?: unknown;
+      };
+      const organizationId = String(
+        settingsRecord.organizationId ?? settingsRecord.organization ?? '',
+      );
+      if (!organizationId) {
+        return;
+      }
+
+      const organization = await this.prisma.organization.findFirst({
+        select: { userId: true },
+        where: { id: organizationId, isDeleted: false },
+      });
+      if (!organization?.userId) {
+        return;
+      }
+
+      const workflowsService = this.moduleRef.get(WorkflowsService, {
+        strict: false,
+      });
+      await workflowsService.ensureDailyTrendsDigestWorkflow(
+        organization.userId,
+        organizationId,
+      );
+    } catch (error) {
+      this.logger?.error(
+        'Failed to provision Daily Trends Digest workflow',
+        error,
+      );
+    }
   }
 
   private readJourneyState(

--- a/apps/server/api/src/collections/workflows/registry/node-registry.ts
+++ b/apps/server/api/src/collections/workflows/registry/node-registry.ts
@@ -1195,6 +1195,51 @@ export const NODE_REGISTRY: Record<string, NodeDefinition> = {
     },
   },
 
+  sendEmail: {
+    category: 'output',
+    configSchema: {},
+    description: 'Send a single email (subject + HTML body) to a recipient',
+    icon: 'HiMail',
+    inputs: {
+      html: { label: 'HTML Body', type: 'text' },
+      subject: { label: 'Subject', type: 'text' },
+      to: { label: 'To', type: 'text' },
+    },
+    label: 'Send Email',
+    outputs: {
+      sent: { label: 'Sent', type: 'boolean' },
+    },
+  },
+
+  trendDigest: {
+    category: 'processing',
+    configSchema: {
+      minViralScore: {
+        default: 70,
+        label: 'Min Viral Score',
+        max: 100,
+        min: 0,
+        type: 'number',
+      },
+      topN: {
+        default: 5,
+        label: 'Number of Trends',
+        type: 'number',
+      },
+    },
+    description:
+      'Assemble a curated daily trends digest email from the global trend corpus',
+    icon: 'HiTrendingUp',
+    inputs: {},
+    isPremium: true,
+    label: 'Trend Digest',
+    outputs: {
+      html: { label: 'HTML Body', type: 'text' },
+      subject: { label: 'Subject', type: 'text' },
+      to: { label: 'Recipient', type: 'text' },
+    },
+  },
+
   'output-export': {
     category: 'output',
     configSchema: {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -1266,6 +1266,26 @@ describe('WorkflowEngineAdapterService', () => {
 
       expect(deduct).not.toHaveBeenCalled();
     });
+
+    it('releases the marker so a transient deduction failure can retry', async () => {
+      const acquireLock = vi.fn().mockResolvedValue(true);
+      const releaseLock = vi.fn().mockResolvedValue(true);
+      const deduct = vi
+        .fn()
+        .mockRejectedValue(new Error('transient credits failure'));
+      const adapter = makeChargeAdapter(
+        { acquireLock, releaseLock },
+        { deductCreditsFromOrganization: deduct },
+      );
+
+      await adapter.applyScheduledDigestCharge('wf-1', readySummaries());
+
+      expect(deduct).toHaveBeenCalledTimes(1);
+      expect(releaseLock).toHaveBeenCalledTimes(1);
+      expect(releaseLock.mock.calls[0][0]).toMatch(
+        /^workflow-digest-charged:wf-1:\d{4}-\d{2}-\d{2}$/,
+      );
+    });
   });
 
   describe('convertStepsToExecutableWorkflow - multiple dependencies', () => {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -1173,6 +1173,101 @@ describe('WorkflowEngineAdapterService', () => {
     });
   });
 
+  describe('applyScheduledDigestCharge', () => {
+    const CACHE_INDEX = 25; // 0-based position of cacheService
+    const CREDITS_INDEX = 27; // 0-based position of creditsUtilsService
+
+    const makeChargeAdapter = (
+      cacheService: unknown,
+      creditsUtilsService: unknown,
+    ) => {
+      const args = new Array(28).fill(undefined);
+      args[0] = { ingredientsEndpoint: 'https://ingredients.example.com' };
+      args[1] = loggerService;
+      args[CACHE_INDEX] = cacheService;
+      args[CREDITS_INDEX] = creditsUtilsService;
+      return new WorkflowEngineAdapterService(...args);
+    };
+
+    const readySummaries = (sent = true) => [
+      {
+        nodeType: 'trendDigest',
+        output: {
+          creditCost: 5,
+          orgId: 'org-1',
+          ownerUserId: 'user-1',
+          skipped: false,
+        },
+      },
+      { nodeType: 'sendEmail', output: { sent } },
+    ];
+
+    it('deducts exactly once on a confirmed send', async () => {
+      const acquireLock = vi.fn().mockResolvedValue(true);
+      const deduct = vi.fn().mockResolvedValue(undefined);
+      const adapter = makeChargeAdapter(
+        { acquireLock },
+        { deductCreditsFromOrganization: deduct },
+      );
+
+      await adapter.applyScheduledDigestCharge('wf-1', readySummaries());
+
+      expect(acquireLock).toHaveBeenCalledTimes(1);
+      expect(acquireLock.mock.calls[0][0]).toMatch(
+        /^workflow-digest-charged:wf-1:\d{4}-\d{2}-\d{2}$/,
+      );
+      expect(deduct).toHaveBeenCalledWith(
+        'org-1',
+        'user-1',
+        5,
+        'Daily trends digest',
+        'trend-scan',
+      );
+    });
+
+    it('does not charge when the digest was skipped', async () => {
+      const deduct = vi.fn();
+      const adapter = makeChargeAdapter(
+        { acquireLock: vi.fn().mockResolvedValue(true) },
+        { deductCreditsFromOrganization: deduct },
+      );
+
+      await adapter.applyScheduledDigestCharge('wf-1', [
+        {
+          nodeType: 'trendDigest',
+          output: { reason: 'no-trends', skipped: true },
+        },
+        { nodeType: 'sendEmail', output: { sent: false } },
+      ]);
+
+      expect(deduct).not.toHaveBeenCalled();
+    });
+
+    it('does not charge when the email was not sent', async () => {
+      const deduct = vi.fn();
+      const adapter = makeChargeAdapter(
+        { acquireLock: vi.fn().mockResolvedValue(true) },
+        { deductCreditsFromOrganization: deduct },
+      );
+
+      await adapter.applyScheduledDigestCharge('wf-1', readySummaries(false));
+
+      expect(deduct).not.toHaveBeenCalled();
+    });
+
+    it('does not double-charge when the daily marker is already held', async () => {
+      const deduct = vi.fn();
+      const adapter = makeChargeAdapter(
+        { acquireLock: vi.fn().mockResolvedValue(false) },
+        { deductCreditsFromOrganization: deduct },
+      );
+
+      await adapter.applyScheduledDigestCharge('wf-1', readySummaries());
+
+      expect(deduct).not.toHaveBeenCalled();
+    });
+  });
+
   describe('convertStepsToExecutableWorkflow - multiple dependencies', () => {
     it('should create edges for all dependencies', () => {
       const steps = [

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -862,14 +862,10 @@ export class WorkflowEngineAdapterService {
       return;
     }
 
-    const charged = await this.cacheService.acquireLock(
-      `workflow-digest-charged:${workflowId}:${this.digestUtcDateKey()}`,
-      93_600,
-    );
-    if (!charged) {
-      return;
-    }
-
+    // Deduct credits FIRST — only set the durable daily marker after a
+    // confirmed successful deduction. Setting the marker before the deduction
+    // is incorrect: a transient failure would leave the marker set for ~26 h
+    // and permanently skip that day's charge.
     try {
       await this.creditsUtilsService.deductCreditsFromOrganization(
         orgId,
@@ -882,6 +878,24 @@ export class WorkflowEngineAdapterService {
       this.loggerService.error(
         `${this.logContext} trend digest charge failed`,
         { error, organizationId: orgId, workflowId },
+      );
+      // Do not set the lock — allow a retry on the next scheduled run.
+      return;
+    }
+
+    // Deduction succeeded — now acquire the idempotency lock to prevent
+    // double-charging on concurrent replicas or retries within the same day.
+    const charged = await this.cacheService.acquireLock(
+      `workflow-digest-charged:${workflowId}:${this.digestUtcDateKey()}`,
+      93_600,
+    );
+    if (!charged) {
+      // Another replica already set the marker after a successful deduction —
+      // this path should be unreachable in practice (the caller guards with
+      // a per-execution check), but log it so we can detect unexpected retries.
+      this.loggerService.warn(
+        `${this.logContext} digest already marked as charged for today — skipping duplicate`,
+        { organizationId: orgId, workflowId },
       );
     }
   }

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -3,12 +3,14 @@ import { CaptionEntity } from '@api/collections/captions/entities/caption.entity
 import { CaptionsService } from '@api/collections/captions/services/captions.service';
 import { PerformanceSummaryService } from '@api/collections/content-performance/services/performance-summary.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { MusicsService } from '@api/collections/musics/services/musics.service';
 import { NewslettersService } from '@api/collections/newsletters/services/newsletters.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { TrendsService } from '@api/collections/trends/services/trends.service';
 import { AvatarVideoGenerationService } from '@api/collections/videos/services/avatar-video-generation.service';
 import { VideoMusicOrchestrationService } from '@api/collections/videos/services/video-music-orchestration.service';
 import {
@@ -23,17 +25,21 @@ import type {
 } from '@api/collections/workflows/schemas/workflow.schema';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { ConfigService } from '@api/config/config.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { ElevenLabsService } from '@api/services/integrations/elevenlabs/elevenlabs.service';
 import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
 import { OpenRouterService } from '@api/services/integrations/openrouter/services/openrouter.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
+import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
 import { WhisperService } from '@api/services/whisper/whisper.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { SharedService } from '@api/shared/services/shared/shared.service';
-import { MODEL_KEYS } from '@genfeedai/constants';
+import { MODEL_KEYS, TREND_DIGEST_CREDIT_COST } from '@genfeedai/constants';
 import {
+  ActivitySource,
   CaptionFormat,
   CaptionLanguage,
   type CredentialPlatform,
@@ -47,6 +53,7 @@ import {
   PostStatus,
   TransformationCategory,
 } from '@genfeedai/enums';
+import { buildTrendDigestHtml } from '@genfeedai/helpers';
 import type {
   ExecutableEdge,
   ExecutableNode,
@@ -71,12 +78,15 @@ import {
   createPublishExecutor,
   createReframeExecutor,
   createSendDmExecutor,
+  createSendEmailExecutor,
   createTextToSpeechExecutor,
+  createTrendDigestExecutor,
   createTrendTriggerExecutor,
   createUpscaleExecutor,
   type KeywordTriggerPlatform,
   type NodeExecutor,
   type SocialPlatform,
+  type TrendDigestEntry,
   type TrendPlatform,
   type TrendTriggerOutput,
   WorkflowEngine,
@@ -240,6 +250,11 @@ export class WorkflowEngineAdapterService {
     @Optional() private readonly brandsService?: BrandsService,
     @Optional()
     private readonly performanceSummaryService?: PerformanceSummaryService,
+    @Optional() private readonly trendsService?: TrendsService,
+    @Optional() private readonly notificationsService?: NotificationsService,
+    @Optional() private readonly cacheService?: CacheService,
+    @Optional() private readonly prismaService?: PrismaService,
+    @Optional() private readonly creditsUtilsService?: CreditsUtilsService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -266,6 +281,8 @@ export class WorkflowEngineAdapterService {
     this.registerBrandContextExecutor();
     this.registerAnalyticsFeedbackExecutor();
     this.registerTrendTriggerExecutor();
+    this.registerTrendDigestExecutor();
+    this.registerSendEmailExecutor();
     this.registerPublishExecutor();
   }
 
@@ -625,6 +642,252 @@ export class WorkflowEngineAdapterService {
       executor.nodeType,
       this.wrapEngineExecutor(executor),
     );
+  }
+
+  /**
+   * Registers the generic sendEmail action node, wiring it to the
+   * NotificationsService email transport. No-op registration if the transport
+   * is unavailable (e.g. lightweight unit context) — the node then throws a
+   * clear "sender not configured" error if it is ever invoked.
+   */
+  private registerSendEmailExecutor(): void {
+    if (!this.notificationsService) {
+      this.loggerService.warn(
+        `${this.logContext} NotificationsService unavailable — sendEmail node disabled`,
+      );
+      return;
+    }
+
+    const notifications = this.notificationsService;
+    const executor = createSendEmailExecutor(async ({ to, subject, html }) => {
+      await notifications.sendEmail(to, subject, html);
+    });
+
+    this.engine.registerExecutor(
+      executor.nodeType,
+      this.wrapEngineExecutor(executor),
+    );
+  }
+
+  /**
+   * Registers the trendDigest action node. It assembles a curated daily digest
+   * from the existing global trend corpus (deterministic — no scrape, no LLM),
+   * resolving the org owner recipient, enforcing a durable per-day idempotency
+   * marker (multi-replica safe via Redis SET NX), pre-checking credits, and
+   * rendering the branded email. The actual charge happens post-send in
+   * {@link applyScheduledDigestCharge}.
+   */
+  private registerTrendDigestExecutor(): void {
+    if (
+      !this.trendsService ||
+      !this.prismaService ||
+      !this.cacheService ||
+      !this.creditsUtilsService
+    ) {
+      this.loggerService.warn(
+        `${this.logContext} dependencies unavailable — trendDigest node disabled`,
+      );
+      return;
+    }
+
+    const trends = this.trendsService;
+    const prisma = this.prismaService;
+    const cache = this.cacheService;
+    const credits = this.creditsUtilsService;
+    const appUrl = String(this.configService.get('GENFEEDAI_APP_URL') ?? '');
+
+    const executor = createTrendDigestExecutor();
+
+    executor.setOwnerResolver(async (organizationId) => {
+      const organization = await prisma.organization.findFirst({
+        select: { user: { select: { email: true } }, userId: true },
+        where: { id: organizationId, isDeleted: false },
+      });
+      if (!organization) {
+        return null;
+      }
+      return {
+        email: organization.user?.email ?? null,
+        userId: organization.userId ?? null,
+      };
+    });
+
+    executor.setTrendsProvider(({ topN, minViralScore }) =>
+      this.buildDigestTrends(trends, topN, minViralScore),
+    );
+
+    executor.setIdempotencyGuard((key, ttlSeconds) =>
+      cache.acquireLock(key, ttlSeconds),
+    );
+
+    executor.setCreditsChecker((organizationId, cost) =>
+      credits.checkOrganizationCreditsAvailable(organizationId, cost),
+    );
+
+    executor.setRenderer((items, options) => ({
+      html: buildTrendDigestHtml(items, {
+        appUrl,
+        headerTitle: options.headerTitle,
+        minViralScore: options.minViralScore,
+      }),
+      subject: `Your daily trends — ${items.length} trending ${
+        items.length === 1 ? 'topic' : 'topics'
+      }`,
+    }));
+
+    this.engine.registerExecutor(
+      executor.nodeType,
+      this.wrapEngineExecutor(executor),
+    );
+  }
+
+  /**
+   * Fetches the curated top-N trends from the existing corpus and maps them to
+   * the engine's structural trend shape. Mirrors the per-user digest fetch
+   * (viral videos + trending hashtags + trending sounds), ranked by score.
+   */
+  private async buildDigestTrends(
+    trends: TrendsService,
+    topN: number,
+    minViralScore: number,
+  ): Promise<TrendDigestEntry[]> {
+    type RawTrend = {
+      platform?: string;
+      title?: string;
+      description?: string;
+      hashtag?: string;
+      soundName?: string;
+      url?: string;
+      playUrl?: string;
+      views?: number;
+      playCount?: number;
+      postCount?: number;
+      viewCount?: number;
+      usageCount?: number;
+      viralScore?: number;
+      viralityScore?: number;
+    };
+
+    const safeFetch = async (
+      fetcher: () => Promise<unknown>,
+    ): Promise<RawTrend[]> => {
+      try {
+        return ((await fetcher()) as RawTrend[]) ?? [];
+      } catch (error) {
+        this.loggerService.error(
+          `${this.logContext} trend digest fetch failed`,
+          { error },
+        );
+        return [];
+      }
+    };
+
+    const [videos, hashtags, sounds] = await Promise.all([
+      safeFetch(() => trends.getViralVideos({ limit: 10, minViralScore })),
+      safeFetch(() => trends.getTrendingHashtags({ limit: 10 })),
+      safeFetch(() => trends.getTrendingSounds({ limit: 10 })),
+    ]);
+
+    const mapped: TrendDigestEntry[] = [
+      ...videos.map((video) => ({
+        platform: video.platform || 'tiktok',
+        topic: video.title || video.description || 'Trending Video',
+        type: 'video' as const,
+        url: video.url,
+        usageCount: video.views || video.playCount,
+        viralScore: video.viralScore || 0,
+      })),
+      ...hashtags
+        .filter((hashtag) => (hashtag.viralityScore || 0) >= minViralScore)
+        .map((hashtag) => ({
+          platform: hashtag.platform || 'tiktok',
+          topic: `#${hashtag.hashtag}`,
+          type: 'hashtag' as const,
+          usageCount: hashtag.postCount || hashtag.viewCount,
+          viralScore: hashtag.viralityScore || 0,
+        })),
+      ...sounds
+        .filter((sound) => (sound.usageCount || 0) >= 10000)
+        .map((sound) => ({
+          platform: 'tiktok',
+          topic: sound.soundName || 'Trending Sound',
+          type: 'sound' as const,
+          url: sound.playUrl,
+          usageCount: sound.usageCount,
+          viralScore: sound.viralityScore || 80,
+        })),
+    ];
+
+    return mapped.sort((a, b) => b.viralScore - a.viralScore).slice(0, topN);
+  }
+
+  /**
+   * Deducts credits for a completed scheduled digest exactly once. Reads the
+   * serializable node outputs (trendDigest payload + sendEmail result) and
+   * charges only when the digest was rendered (skipped === false) AND the email
+   * was sent. Guarded by a durable, non-released per-day Redis marker so a retry
+   * or multi-replica run can never double-charge.
+   */
+  async applyScheduledDigestCharge(
+    workflowId: string,
+    summaries: Array<{ nodeType: string; output?: Record<string, unknown> }>,
+  ): Promise<void> {
+    if (!this.creditsUtilsService || !this.cacheService) {
+      return;
+    }
+
+    const digest = summaries.find(
+      (summary) => summary.nodeType === 'trendDigest',
+    )?.output;
+    const email = summaries.find(
+      (summary) => summary.nodeType === 'sendEmail',
+    )?.output;
+
+    if (!digest || digest.skipped !== false) {
+      return;
+    }
+    if (!email || email.sent !== true) {
+      return;
+    }
+
+    const orgId = typeof digest.orgId === 'string' ? digest.orgId : null;
+    const ownerUserId =
+      typeof digest.ownerUserId === 'string' ? digest.ownerUserId : null;
+    const creditCost =
+      typeof digest.creditCost === 'number'
+        ? digest.creditCost
+        : TREND_DIGEST_CREDIT_COST;
+
+    if (!orgId || !ownerUserId) {
+      return;
+    }
+
+    const charged = await this.cacheService.acquireLock(
+      `workflow-digest-charged:${workflowId}:${this.digestUtcDateKey()}`,
+      93_600,
+    );
+    if (!charged) {
+      return;
+    }
+
+    try {
+      await this.creditsUtilsService.deductCreditsFromOrganization(
+        orgId,
+        ownerUserId,
+        creditCost,
+        'Daily trends digest',
+        ActivitySource.TREND_SCAN,
+      );
+    } catch (error) {
+      this.loggerService.error(
+        `${this.logContext} trend digest charge failed`,
+        { error, organizationId: orgId, workflowId },
+      );
+    }
+  }
+
+  private digestUtcDateKey(): string {
+    return new Date().toISOString().slice(0, 10);
   }
 
   private registerPublishExecutor(): void {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -862,10 +862,16 @@ export class WorkflowEngineAdapterService {
       return;
     }
 
-    // Deduct credits FIRST — only set the durable daily marker after a
-    // confirmed successful deduction. Setting the marker before the deduction
-    // is incorrect: a transient failure would leave the marker set for ~26 h
-    // and permanently skip that day's charge.
+    // Acquire the durable daily marker FIRST (atomic SET NX). Only the winning
+    // replica/retry proceeds to deduct — this is what prevents a double charge
+    // across concurrent scheduler replicas. If the marker already exists, the
+    // charge for today is already (being) handled, so skip.
+    const chargeKey = `workflow-digest-charged:${workflowId}:${this.digestUtcDateKey()}`;
+    const charged = await this.cacheService.acquireLock(chargeKey, 93_600);
+    if (!charged) {
+      return;
+    }
+
     try {
       await this.creditsUtilsService.deductCreditsFromOrganization(
         orgId,
@@ -879,24 +885,9 @@ export class WorkflowEngineAdapterService {
         `${this.logContext} trend digest charge failed`,
         { error, organizationId: orgId, workflowId },
       );
-      // Do not set the lock — allow a retry on the next scheduled run.
-      return;
-    }
-
-    // Deduction succeeded — now acquire the idempotency lock to prevent
-    // double-charging on concurrent replicas or retries within the same day.
-    const charged = await this.cacheService.acquireLock(
-      `workflow-digest-charged:${workflowId}:${this.digestUtcDateKey()}`,
-      93_600,
-    );
-    if (!charged) {
-      // Another replica already set the marker after a successful deduction —
-      // this path should be unreachable in practice (the caller guards with
-      // a per-execution check), but log it so we can detect unexpected retries.
-      this.loggerService.warn(
-        `${this.logContext} digest already marked as charged for today — skipping duplicate`,
-        { organizationId: orgId, workflowId },
-      );
+      // Release the marker so the next scheduled run can retry the charge —
+      // a transient deduction failure must not permanently skip today's charge.
+      await this.cacheService.releaseLock(chargeKey);
     }
   }
 

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
@@ -683,12 +683,17 @@ export class WorkflowExecutorService {
         workflowLabel,
       });
 
-      // Update workflow status
+      // Update workflow status. Scheduled (recurring) workflows must stay
+      // ACTIVE so the scheduler keeps firing them — the per-run state lives on
+      // the WorkflowExecution record, not on Workflow.status.
       await this.prisma.workflow.update({
         data: {
           executionCount: { increment: 1 },
           lastExecutedAt: new Date(),
-          status: WorkflowStatus.RUNNING,
+          status:
+            trigger === WorkflowExecutionTrigger.SCHEDULED
+              ? WorkflowStatus.ACTIVE
+              : WorkflowStatus.RUNNING,
         },
         where: { id: workflowId },
       });
@@ -747,17 +752,37 @@ export class WorkflowExecutorService {
           }
         }
 
-        // Update workflow status
+        // Update workflow status. Scheduled (recurring) workflows are re-armed
+        // to ACTIVE on every run regardless of outcome — a terminal COMPLETED/
+        // FAILED would drop them out of the scheduler's ACTIVE filter.
         await this.prisma.workflow.update({
           data: {
             completedAt: new Date(),
             status:
-              finalStatus === WorkflowExecutionStatus.COMPLETED
-                ? WorkflowStatus.COMPLETED
-                : WorkflowStatus.FAILED,
+              trigger === WorkflowExecutionTrigger.SCHEDULED
+                ? WorkflowStatus.ACTIVE
+                : finalStatus === WorkflowExecutionStatus.COMPLETED
+                  ? WorkflowStatus.COMPLETED
+                  : WorkflowStatus.FAILED,
           } as never,
           where: { id: workflowId },
         });
+
+        // Charge for paid scheduled actions (e.g. trends digest) exactly once,
+        // after a confirmed send, guarded by a durable per-day marker.
+        if (
+          trigger === WorkflowExecutionTrigger.SCHEDULED &&
+          finalStatus === WorkflowExecutionStatus.COMPLETED
+        ) {
+          const nodeSummaries = this.buildNodeSummaries(
+            result,
+            executableWorkflow.nodes,
+          );
+          await this.engineAdapter.applyScheduledDigestCharge(
+            workflowId,
+            nodeSummaries,
+          );
+        }
 
         await this.emitEvent(
           workflowId,
@@ -825,7 +850,15 @@ export class WorkflowExecutorService {
       );
 
       await this.prisma.workflow.update({
-        data: { status: WorkflowStatus.FAILED } as never,
+        // Scheduled workflows stay ACTIVE even after a failed run so the
+        // scheduler retries on the next tick; the failure is recorded on the
+        // WorkflowExecution record.
+        data: {
+          status:
+            trigger === WorkflowExecutionTrigger.SCHEDULED
+              ? WorkflowStatus.ACTIVE
+              : WorkflowStatus.FAILED,
+        } as never,
         where: { id: workflowId },
       });
 

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
@@ -686,9 +686,15 @@ export class WorkflowExecutorService {
       // Update workflow status. Scheduled (recurring) workflows must stay
       // ACTIVE so the scheduler keeps firing them — the per-run state lives on
       // the WorkflowExecution record, not on Workflow.status.
+      //
+      // executionCount is NOT incremented here for SCHEDULED runs because the
+      // scheduler already increments it in executeScheduledWorkflow() before
+      // dispatching. Incrementing again would double-count every scheduled run.
       await this.prisma.workflow.update({
         data: {
-          executionCount: { increment: 1 },
+          ...(trigger !== WorkflowExecutionTrigger.SCHEDULED && {
+            executionCount: { increment: 1 },
+          }),
           lastExecutedAt: new Date(),
           status:
             trigger === WorkflowExecutionTrigger.SCHEDULED

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
@@ -4,8 +4,7 @@ import { WorkflowExecutorService } from '@api/collections/workflows/services/wor
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { ConfigService } from '@api/config/config.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { WorkflowExecutionTrigger } from '@genfeedai/enums';
-import { WorkflowStatus as PrismaWorkflowStatus } from '@genfeedai/prisma';
+import { WorkflowExecutionTrigger, WorkflowStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Inject, Injectable, type OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule';
@@ -62,7 +61,10 @@ export class WorkflowSchedulerService implements OnModuleInit {
           isDeleted: false,
           isScheduleEnabled: true,
           schedule: { not: null },
-          status: 'ACTIVE',
+          // Canonical workflow status is the lowercase enum value ('active');
+          // the column is a drifted String (see schema). Must match what
+          // createWorkflow / the executor persist, or scheduled rows never load.
+          status: WorkflowStatus.ACTIVE,
         },
       });
 
@@ -165,7 +167,10 @@ export class WorkflowSchedulerService implements OnModuleInit {
         where: {
           id: workflowId,
           isDeleted: false,
-          status: 'ACTIVE',
+          // Canonical workflow status is the lowercase enum value ('active');
+          // the column is a drifted String (see schema). Must match what
+          // createWorkflow / the executor persist, or scheduled rows never load.
+          status: WorkflowStatus.ACTIVE,
         },
       });
 

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@api/collections/workflows/schemas/workflow.schema';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
+import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -168,34 +169,88 @@ export class WorkflowsService extends BaseService<
    * organization. Seeded OFF (`isScheduleEnabled: false`) so it stays invisible
    * to the scheduler until the owner enables it from the workflow list UI.
    * Safe to call repeatedly (e.g. on every org bootstrap + a one-time backfill).
+   *
+   * Race protection: the check-and-insert runs inside a SERIALIZABLE transaction
+   * using the same `tx` client for both the read and the write. Two concurrent
+   * callers cannot both observe "not found" and both insert — Postgres guarantees
+   * that at most one of the two transactions commits; the other receives a
+   * serialization error and this method silently returns (no row was seeded twice).
    */
   async ensureDailyTrendsDigestWorkflow(
     userId: string,
     organizationId: string,
   ): Promise<void> {
-    const existing = await this.prisma.workflow.findFirst({
-      select: { id: true },
-      where: {
-        isDeleted: false,
-        metadata: {
-          equals: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
-          path: ['sourceTemplateId'],
-        },
-        organizationId,
+    const where = {
+      isDeleted: false,
+      metadata: {
+        equals: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
+        path: ['sourceTemplateId'],
       },
+      organizationId,
+    };
+
+    // Fast path: most calls hit an already-seeded org.
+    const preCheck = await this.prisma.workflow.findFirst({
+      select: { id: true },
+      where,
     });
 
-    if (existing) {
+    if (preCheck) {
       return;
     }
 
-    await this.createWorkflow(userId, organizationId, {
-      isScheduleEnabled: false,
-      label: 'Daily Trends Digest',
-      schedule: '0 7 * * *',
-      templateId: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
-      timezone: 'UTC',
-    } as CreateWorkflowDto);
+    // Serializable transaction: both the re-check AND the insert use the same
+    // `tx` client so Postgres can detect a concurrent conflicting write and
+    // serialise the two callers correctly.
+    try {
+      await this.prisma.$transaction(
+        async (tx) => {
+          const existing = await tx.workflow.findFirst({
+            select: { id: true },
+            where,
+          });
+
+          if (existing) {
+            return;
+          }
+
+          await tx.workflow.create({
+            data: {
+              edges: DAILY_TRENDS_DIGEST_TEMPLATE.edges as never,
+              executionCount: 0,
+              isDeleted: false,
+              isScheduleEnabled: false,
+              label: 'Daily Trends Digest',
+              metadata: {
+                sourceTemplateId: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
+                sourceType: 'seeded-template',
+              },
+              nodes: DAILY_TRENDS_DIGEST_TEMPLATE.nodes as never,
+              organizationId,
+              progress: 0,
+              schedule: '0 7 * * *',
+              status: WorkflowStatus.ACTIVE,
+              steps: [],
+              timezone: 'UTC',
+              userId,
+            },
+          });
+        },
+        { isolationLevel: 'Serializable' },
+      );
+    } catch (error) {
+      // A serialization failure means a concurrent caller already seeded this
+      // workflow — treat it as success.
+      const errorCode = (error as { code?: string }).code;
+      if (errorCode === 'P2034') {
+        this.logger?.debug(
+          'ensureDailyTrendsDigestWorkflow: serialization conflict — workflow already seeded by concurrent request',
+          { organizationId },
+        );
+        return;
+      }
+      throw error;
+    }
   }
 
   async executeWorkflow(workflowId: string): Promise<void> {

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { type WorkflowExecutionDocument } from '@api/collections/workflow-executions/schemas/workflow-execution.schema';
@@ -49,6 +50,9 @@ import {
   NotFoundException,
   Optional,
 } from '@nestjs/common';
+
+/** Template id for the predetermined per-org Daily Trends Digest workflow. */
+const DAILY_TRENDS_DIGEST_TEMPLATE_ID = 'daily-trends-digest';
 
 @Injectable()
 export class WorkflowsService extends BaseService<
@@ -157,6 +161,41 @@ export class WorkflowsService extends BaseService<
     }
 
     return EntityFactory.fromDocument(WorkflowEntity, workflow);
+  }
+
+  /**
+   * Idempotently seeds the predetermined "Daily Trends Digest" workflow for an
+   * organization. Seeded OFF (`isScheduleEnabled: false`) so it stays invisible
+   * to the scheduler until the owner enables it from the workflow list UI.
+   * Safe to call repeatedly (e.g. on every org bootstrap + a one-time backfill).
+   */
+  async ensureDailyTrendsDigestWorkflow(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    const existing = await this.prisma.workflow.findFirst({
+      select: { id: true },
+      where: {
+        isDeleted: false,
+        metadata: {
+          equals: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      },
+    });
+
+    if (existing) {
+      return;
+    }
+
+    await this.createWorkflow(userId, organizationId, {
+      isScheduleEnabled: false,
+      label: 'Daily Trends Digest',
+      schedule: '0 7 * * *',
+      templateId: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
+      timezone: 'UTC',
+    } as CreateWorkflowDto);
   }
 
   async executeWorkflow(workflowId: string): Promise<void> {

--- a/apps/server/api/src/collections/workflows/templates/daily-trends-digest.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/daily-trends-digest.template.ts
@@ -1,0 +1,86 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+import { TREND_DIGEST_CREDIT_COST } from '@genfeedai/constants';
+
+/**
+ * Daily Trends Digest — a predetermined, per-org workflow.
+ *
+ * Seeded OFF (`isScheduleEnabled: false`) for every organization and toggled on
+ * from the automation/workflow list UI. When enabled, the canonical
+ * WorkflowSchedulerService fires it daily; the node graph assembles a curated
+ * digest from the existing global trend corpus (no scrape, no LLM) and emails it
+ * to the org owner. Credits are charged once per confirmed send by the adapter.
+ *
+ * Node graph: trendDigest → sendEmail (explicit edge handles carry the rendered
+ * `to`/`subject`/`html` plus the `skipped`/`reason` short-circuit signal).
+ */
+export const DAILY_TRENDS_DIGEST_TEMPLATE: WorkflowTemplate = {
+  category: 'trends',
+  description:
+    'Scan the latest social trends daily and email a curated digest to the organization owner. Uses credits per delivered email.',
+  icon: 'trending-up',
+  id: 'daily-trends-digest',
+  name: 'Daily Trends Digest',
+  nodes: [
+    {
+      data: {
+        config: {
+          creditCost: TREND_DIGEST_CREDIT_COST,
+          minViralScore: 70,
+          platforms: ['tiktok', 'instagram', 'youtube', 'twitter'],
+          topN: 5,
+        },
+        label: 'Assemble Trend Digest',
+      },
+      id: 'trend-digest',
+      position: { x: 0, y: 120 },
+      type: 'trendDigest',
+    },
+    {
+      data: {
+        config: {},
+        label: 'Email Digest to Owner',
+      },
+      id: 'send-email',
+      position: { x: 360, y: 120 },
+      type: 'sendEmail',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-digest-to',
+      source: 'trend-digest',
+      sourceHandle: 'to',
+      target: 'send-email',
+      targetHandle: 'to',
+    },
+    {
+      id: 'edge-digest-subject',
+      source: 'trend-digest',
+      sourceHandle: 'subject',
+      target: 'send-email',
+      targetHandle: 'subject',
+    },
+    {
+      id: 'edge-digest-html',
+      source: 'trend-digest',
+      sourceHandle: 'html',
+      target: 'send-email',
+      targetHandle: 'html',
+    },
+    {
+      id: 'edge-digest-skipped',
+      source: 'trend-digest',
+      sourceHandle: 'skipped',
+      target: 'send-email',
+      targetHandle: 'skipped',
+    },
+    {
+      id: 'edge-digest-reason',
+      source: 'trend-digest',
+      sourceHandle: 'reason',
+      target: 'send-email',
+      targetHandle: 'reason',
+    },
+  ],
+  steps: [],
+};

--- a/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
+++ b/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
@@ -1,4 +1,5 @@
 import { CONTENT_LOOP_TEMPLATE } from '@api/collections/workflows/templates/content-loop.template';
+import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { GENERATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/generation-templates';
 import { WorkflowStepCategory } from '@genfeedai/enums';
 
@@ -46,6 +47,7 @@ export interface WorkflowTemplate {
 export const WORKFLOW_TEMPLATES: Record<string, WorkflowTemplate> = {
   ...GENERATION_WORKFLOW_TEMPLATES,
   'content-loop': CONTENT_LOOP_TEMPLATE,
+  'daily-trends-digest': DAILY_TRENDS_DIGEST_TEMPLATE,
   'ad-remix-review': {
     category: 'ads',
     description:

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -12,6 +12,7 @@ import { MetadataModule } from '@api/collections/metadata/metadata.module';
 import { MusicsModule } from '@api/collections/musics/musics.module';
 import { NewslettersModule } from '@api/collections/newsletters/newsletters.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
+import { TrendsModule } from '@api/collections/trends/trends.module';
 import { VideoGenerationModule } from '@api/collections/videos/video-generation.module';
 import { VideosModule } from '@api/collections/videos/videos.module';
 import { WorkflowExecutionsModule } from '@api/collections/workflow-executions/workflow-executions.module';
@@ -41,6 +42,7 @@ import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
 import { OpenRouterModule } from '@api/services/integrations/openrouter/openrouter.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
+import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
 import { WhisperModule } from '@api/services/whisper/whisper.module';
 import { WorkflowExecutorModule } from '@api/services/workflow-executor/workflow-executor.module';
@@ -74,10 +76,12 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => MetadataModule),
     forwardRef(() => MusicsModule),
     forwardRef(() => NewslettersModule),
+    forwardRef(() => NotificationsModule),
     forwardRef(() => NotificationsPublisherModule),
     forwardRef(() => OpenRouterModule),
     forwardRef(() => PostsModule),
     forwardRef(() => SharedModule),
+    forwardRef(() => TrendsModule),
     forwardRef(() => TwitterModule),
     forwardRef(() => VideoGenerationModule),
     forwardRef(() => VideosModule),

--- a/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts
+++ b/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts
@@ -6,6 +6,7 @@ import { ParseMode } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CronTrendSummaryNotificationsService } from '@workers/crons/trends/cron.trend-summary-notifications.service';
+import { ConfigService } from '@workers/config/config.service';
 
 vi.mock('@nestjs/schedule', () => ({
   Cron: () => () => undefined,
@@ -131,6 +132,10 @@ describe('CronTrendSummaryNotificationsService', () => {
         { provide: CacheService, useValue: cacheService },
         { provide: NotificationsService, useValue: notificationsService },
         { provide: LoggerService, useValue: loggerService },
+        {
+          provide: ConfigService,
+          useValue: { get: vi.fn().mockReturnValue('https://app.genfeed.ai') },
+        },
       ],
     }).compile();
 

--- a/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts
+++ b/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import { TrendsService } from '@api/collections/trends/services/trends.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
@@ -14,6 +13,7 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@workers/config/config.service';
 
 type TrendRecord = {
   description?: string;
@@ -46,6 +46,7 @@ export class CronTrendSummaryNotificationsService {
     private readonly cacheService: CacheService,
     private readonly notificationsService: NotificationsService,
     private readonly loggerService: LoggerService,
+    private readonly configService: ConfigService,
   ) {}
 
   /**
@@ -180,7 +181,7 @@ export class CronTrendSummaryNotificationsService {
     // Build summary message via the shared digest builder
     const summaryMessage = buildTrendDigestMessage(trends, { minViralScore });
     const summaryHtml = buildTrendDigestHtml(trends, {
-      appUrl: process.env.GENFEEDAI_APP_URL ?? '',
+      appUrl: this.configService.get('GENFEEDAI_APP_URL') ?? '',
       minViralScore,
     });
 

--- a/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts
+++ b/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts
@@ -4,20 +4,16 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { ParseMode } from '@genfeedai/enums';
+import {
+  buildTrendDigestHtml,
+  buildTrendDigestMessage,
+  type TrendDigestItem,
+} from '@genfeedai/helpers';
 import type { Setting } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-
-interface TrendSummary {
-  platform: string;
-  topic: string;
-  viralScore: number;
-  type: 'video' | 'hashtag' | 'sound' | 'topic';
-  url?: string;
-  usageCount?: number;
-}
 
 type TrendRecord = {
   description?: string;
@@ -168,7 +164,7 @@ export class CronTrendSummaryNotificationsService {
       this.getTrendingSounds(),
     ]);
 
-    const trends: TrendSummary[] = [
+    const trends: TrendDigestItem[] = [
       ...viralVideos,
       ...trendingHashtags,
       ...trendingSounds,
@@ -181,9 +177,12 @@ export class CronTrendSummaryNotificationsService {
       return;
     }
 
-    // Build summary message
-    const summaryMessage = this.buildSummaryMessage(trends, minViralScore);
-    const summaryHtml = this.buildSummaryHtml(trends, minViralScore);
+    // Build summary message via the shared digest builder
+    const summaryMessage = buildTrendDigestMessage(trends, { minViralScore });
+    const summaryHtml = buildTrendDigestHtml(trends, {
+      appUrl: process.env.GENFEEDAI_APP_URL ?? '',
+      minViralScore,
+    });
 
     // Send via configured channels
     if (
@@ -222,7 +221,9 @@ export class CronTrendSummaryNotificationsService {
     }
   }
 
-  private async getViralVideos(minViralScore: number): Promise<TrendSummary[]> {
+  private async getViralVideos(
+    minViralScore: number,
+  ): Promise<TrendDigestItem[]> {
     try {
       const videos = await this.trendsService.getViralVideos({
         limit: 10,
@@ -245,7 +246,7 @@ export class CronTrendSummaryNotificationsService {
 
   private async getTrendingHashtags(
     minViralScore: number,
-  ): Promise<TrendSummary[]> {
+  ): Promise<TrendDigestItem[]> {
     try {
       const hashtags = await this.trendsService.getTrendingHashtags({
         limit: 10,
@@ -269,7 +270,7 @@ export class CronTrendSummaryNotificationsService {
     }
   }
 
-  private async getTrendingSounds(): Promise<TrendSummary[]> {
+  private async getTrendingSounds(): Promise<TrendDigestItem[]> {
     try {
       const sounds = await this.trendsService.getTrendingSounds({
         limit: 10,
@@ -292,171 +293,5 @@ export class CronTrendSummaryNotificationsService {
       this.loggerService.error('Failed to get trending sounds', error);
       return [];
     }
-  }
-
-  private buildSummaryMessage(
-    trends: TrendSummary[],
-    minViralScore: number,
-  ): string {
-    const lines: string[] = [
-      `*Your Trend Summary*`,
-      `_Filtered for viral score >= ${minViralScore}_`,
-      ``,
-    ];
-
-    // Group by type
-    const videos = trends.filter((t) => t.type === 'video');
-    const hashtags = trends.filter((t) => t.type === 'hashtag');
-    const sounds = trends.filter((t) => t.type === 'sound');
-
-    if (videos.length > 0) {
-      lines.push(`*Viral Videos:*`);
-      videos.slice(0, 5).forEach((v, i) => {
-        lines.push(
-          `${i + 1}. ${v.topic} (${v.platform}, score: ${v.viralScore})`,
-        );
-      });
-      lines.push(``);
-    }
-
-    if (hashtags.length > 0) {
-      lines.push(`*Trending Hashtags:*`);
-      hashtags.slice(0, 5).forEach((h, i) => {
-        const count = h.usageCount
-          ? ` - ${this.formatNumber(h.usageCount)} posts`
-          : '';
-        lines.push(`${i + 1}. ${h.topic}${count}`);
-      });
-      lines.push(``);
-    }
-
-    if (sounds.length > 0) {
-      lines.push(`*Trending Sounds:*`);
-      sounds.slice(0, 5).forEach((s, i) => {
-        const count = s.usageCount
-          ? ` - ${this.formatNumber(s.usageCount)} uses`
-          : '';
-        lines.push(`${i + 1}. ${s.topic}${count}`);
-      });
-    }
-
-    lines.push(``);
-    lines.push(`_Use these trends to create viral content!_`);
-
-    return lines.join('\n');
-  }
-
-  private buildSummaryHtml(
-    trends: TrendSummary[],
-    minViralScore: number,
-  ): string {
-    const videos = trends.filter((t) => t.type === 'video');
-    const hashtags = trends.filter((t) => t.type === 'hashtag');
-    const sounds = trends.filter((t) => t.type === 'sound');
-
-    let html = `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <style>
-          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 20px; background: #f5f5f5; }
-          .container { max-width: 600px; margin: 0 auto; background: white; border-radius: 8px; padding: 24px; }
-          h1 { color: #1a1a1a; margin-bottom: 8px; }
-          .subtitle { color: #666; font-size: 14px; margin-bottom: 24px; }
-          .section { margin-bottom: 24px; }
-          .section-title { font-size: 16px; font-weight: 600; color: #333; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 2px solid #eee; }
-          .trend-item { padding: 8px 0; border-bottom: 1px solid #f0f0f0; }
-          .trend-item:last-child { border-bottom: none; }
-          .trend-name { font-weight: 500; color: #1a1a1a; }
-          .trend-meta { font-size: 12px; color: #888; margin-top: 4px; }
-          .viral-score { display: inline-block; background: #10b981; color: white; padding: 2px 6px; border-radius: 4px; font-size: 11px; }
-          .platform { display: inline-block; background: #e5e7eb; color: #374151; padding: 2px 6px; border-radius: 4px; font-size: 11px; margin-left: 4px; }
-          .footer { margin-top: 24px; padding-top: 16px; border-top: 1px solid #eee; text-align: center; color: #888; font-size: 12px; }
-        </style>
-      </head>
-      <body>
-        <div class="container">
-          <h1>Your Trend Summary</h1>
-          <p class="subtitle">Filtered for viral score >= ${minViralScore}</p>
-    `;
-
-    if (videos.length > 0) {
-      html += `<div class="section"><div class="section-title">Viral Videos</div>`;
-      videos.slice(0, 5).forEach((v) => {
-        html += `
-          <div class="trend-item">
-            <div class="trend-name">${this.escapeHtml(v.topic)}</div>
-            <div class="trend-meta">
-              <span class="viral-score">Score: ${v.viralScore}</span>
-              <span class="platform">${v.platform}</span>
-              ${v.usageCount ? `<span> • ${this.formatNumber(v.usageCount)} views</span>` : ''}
-            </div>
-          </div>
-        `;
-      });
-      html += `</div>`;
-    }
-
-    if (hashtags.length > 0) {
-      html += `<div class="section"><div class="section-title">Trending Hashtags</div>`;
-      hashtags.slice(0, 5).forEach((h) => {
-        html += `
-          <div class="trend-item">
-            <div class="trend-name">${this.escapeHtml(h.topic)}</div>
-            <div class="trend-meta">
-              <span class="platform">${h.platform}</span>
-              ${h.usageCount ? `<span> • ${this.formatNumber(h.usageCount)} posts</span>` : ''}
-            </div>
-          </div>
-        `;
-      });
-      html += `</div>`;
-    }
-
-    if (sounds.length > 0) {
-      html += `<div class="section"><div class="section-title">Trending Sounds</div>`;
-      sounds.slice(0, 5).forEach((s) => {
-        html += `
-          <div class="trend-item">
-            <div class="trend-name">${this.escapeHtml(s.topic)}</div>
-            <div class="trend-meta">
-              ${s.usageCount ? `<span>${this.formatNumber(s.usageCount)} uses</span>` : ''}
-            </div>
-          </div>
-        `;
-      });
-      html += `</div>`;
-    }
-
-    html += `
-          <div class="footer">
-            Use these trends to create viral content!<br>
-            <a href="${process.env.GENFEEDAI_APP_URL ?? ''}">Open Genfeed</a>
-          </div>
-        </div>
-      </body>
-      </html>
-    `;
-
-    return html;
-  }
-
-  private formatNumber(num: number): string {
-    if (num >= 1000000) {
-      return `${(num / 1000000).toFixed(1)}M`;
-    }
-    if (num >= 1000) {
-      return `${(num / 1000).toFixed(1)}K`;
-    }
-    return num.toString();
-  }
-
-  private escapeHtml(text: string): string {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
   }
 }

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -19,5 +19,6 @@ export * from './post-quick-actions.constant';
 export * from './routes.constant';
 export * from './settings-scope.constant';
 export * from './theme.constant';
+export * from './trends.constant';
 export * from './upload.constant';
 export * from './variation-presets.constant';

--- a/packages/constants/src/trends.constant.ts
+++ b/packages/constants/src/trends.constant.ts
@@ -1,0 +1,7 @@
+/**
+ * Flat credit cost charged once per successfully delivered daily trends-digest
+ * email. The digest is a deterministic ranking of the already-collected global
+ * trend corpus (no LLM call), so the cost is low and fixed. Deducted only after
+ * a confirmed, non-empty send by the workflow adapter's post-run hook.
+ */
+export const TREND_DIGEST_CREDIT_COST = 5;

--- a/packages/enums/src/activity.enum.ts
+++ b/packages/enums/src/activity.enum.ts
@@ -33,6 +33,7 @@ export enum ActivitySource {
   WEB = 'web',
   BOT_GENERATION = 'bot-generate',
   VOICE_GENERATION = 'voice-generate',
+  TREND_SCAN = 'trend-scan',
 }
 
 export enum ActivityKey {

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -12,4 +12,5 @@ export * from './model-capability.helper';
 export * from './quality-routing.helper';
 export * from './serializer.helper';
 export * from './social-url.helper';
+export * from './trends/trend-digest.helper';
 export * from './video-duration.helper';

--- a/packages/helpers/src/trends/trend-digest.helper.test.ts
+++ b/packages/helpers/src/trends/trend-digest.helper.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildTrendDigestHtml,
+  buildTrendDigestMessage,
+  escapeTrendHtml,
+  formatTrendCount,
+  type TrendDigestItem,
+} from './trend-digest.helper';
+
+const sampleTrends: TrendDigestItem[] = [
+  {
+    platform: 'tiktok',
+    topic: 'Dancing cats',
+    type: 'video',
+    url: 'https://example.com/v',
+    usageCount: 1_500_000,
+    viralScore: 92,
+  },
+  {
+    platform: 'instagram',
+    topic: '#trendingnow',
+    type: 'hashtag',
+    usageCount: 23_400,
+    viralScore: 81,
+  },
+  {
+    platform: 'tiktok',
+    topic: 'Catchy hook',
+    type: 'sound',
+    usageCount: 12_000,
+    viralScore: 80,
+  },
+];
+
+describe('formatTrendCount', () => {
+  it('formats millions', () => {
+    expect(formatTrendCount(1_500_000)).toBe('1.5M');
+  });
+
+  it('formats thousands', () => {
+    expect(formatTrendCount(23_400)).toBe('23.4K');
+  });
+
+  it('leaves small numbers untouched', () => {
+    expect(formatTrendCount(942)).toBe('942');
+  });
+});
+
+describe('escapeTrendHtml', () => {
+  it('escapes html-sensitive characters', () => {
+    expect(escapeTrendHtml(`<a href="x">'&'</a>`)).toBe(
+      '&lt;a href=&quot;x&quot;&gt;&#39;&amp;&#39;&lt;/a&gt;',
+    );
+  });
+});
+
+describe('buildTrendDigestMessage', () => {
+  it('groups trends by type and includes the threshold', () => {
+    const message = buildTrendDigestMessage(sampleTrends, {
+      minViralScore: 70,
+    });
+    expect(message).toContain('viral score >= 70');
+    expect(message).toContain('Viral Videos:');
+    expect(message).toContain('Trending Hashtags:');
+    expect(message).toContain('Trending Sounds:');
+    // hashtags/sounds render usageCount in the message; videos render score
+    expect(message).toContain('23.4K posts');
+    expect(message).toContain('score: 92');
+  });
+
+  it('honors a custom header title', () => {
+    const message = buildTrendDigestMessage(sampleTrends, {
+      headerTitle: 'Daily Trends',
+      minViralScore: 50,
+    });
+    expect(message).toContain('*Daily Trends*');
+  });
+});
+
+describe('buildTrendDigestHtml', () => {
+  it('renders sections, escapes content, and links the footer when appUrl is set', () => {
+    const html = buildTrendDigestHtml(sampleTrends, {
+      appUrl: 'https://app.genfeed.ai',
+      minViralScore: 70,
+    });
+    expect(html).toContain('Viral Videos');
+    expect(html).toContain('Trending Hashtags');
+    expect(html).toContain('Trending Sounds');
+    expect(html).toContain('Score: 92');
+    expect(html).toContain('1.5M views');
+    expect(html).toContain('<a href="https://app.genfeed.ai">Open Genfeed</a>');
+  });
+
+  it('omits the footer link when appUrl is empty', () => {
+    const html = buildTrendDigestHtml(sampleTrends, { minViralScore: 70 });
+    expect(html).not.toContain('<a href=');
+  });
+
+  it('renders an empty digest without crashing', () => {
+    const html = buildTrendDigestHtml([], { minViralScore: 70 });
+    expect(html).toContain('Your Trend Summary');
+    expect(html).not.toContain('Viral Videos');
+  });
+});

--- a/packages/helpers/src/trends/trend-digest.helper.ts
+++ b/packages/helpers/src/trends/trend-digest.helper.ts
@@ -1,0 +1,205 @@
+/**
+ * Trend digest builder — pure render/format helpers shared by:
+ *  - the per-user trend-summary cron (apps/server/workers)
+ *  - the workflow-backed `trendDigest` node (injected into the engine via the API adapter)
+ *
+ * Pure functions only: no I/O, no `process.env`, no service access. All inputs
+ * (trends + branding/threshold options) are passed in by the caller so this file
+ * can live in a public package that the engine and workers both consume.
+ */
+
+export type TrendDigestItemType = 'video' | 'hashtag' | 'sound' | 'topic';
+
+export interface TrendDigestItem {
+  platform: string;
+  topic: string;
+  viralScore: number;
+  type: TrendDigestItemType;
+  url?: string;
+  usageCount?: number;
+}
+
+export interface TrendDigestOptions {
+  /** Minimum virality score the trends were filtered for (shown in the subtitle). */
+  minViralScore: number;
+  /** Absolute URL the email footer links back to. Empty string omits the link. */
+  appUrl?: string;
+  /** Heading text. Defaults to "Your Trend Summary". */
+  headerTitle?: string;
+}
+
+const DEFAULT_HEADER_TITLE = 'Your Trend Summary';
+
+/** Human-readable compact number (1.2K / 3.4M). */
+export function formatTrendCount(num: number): string {
+  if (num >= 1_000_000) {
+    return `${(num / 1_000_000).toFixed(1)}M`;
+  }
+  if (num >= 1_000) {
+    return `${(num / 1_000).toFixed(1)}K`;
+  }
+  return num.toString();
+}
+
+/** Escapes a string for safe interpolation into the digest HTML. */
+export function escapeTrendHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Markdown summary (used for chat/Telegram channels). */
+export function buildTrendDigestMessage(
+  trends: TrendDigestItem[],
+  options: TrendDigestOptions,
+): string {
+  const { minViralScore } = options;
+  const lines: string[] = [
+    `*${options.headerTitle ?? DEFAULT_HEADER_TITLE}*`,
+    `_Filtered for viral score >= ${minViralScore}_`,
+    ``,
+  ];
+
+  const videos = trends.filter((trend) => trend.type === 'video');
+  const hashtags = trends.filter((trend) => trend.type === 'hashtag');
+  const sounds = trends.filter((trend) => trend.type === 'sound');
+
+  if (videos.length > 0) {
+    lines.push(`*Viral Videos:*`);
+    videos.slice(0, 5).forEach((video, index) => {
+      lines.push(
+        `${index + 1}. ${video.topic} (${video.platform}, score: ${video.viralScore})`,
+      );
+    });
+    lines.push(``);
+  }
+
+  if (hashtags.length > 0) {
+    lines.push(`*Trending Hashtags:*`);
+    hashtags.slice(0, 5).forEach((hashtag, index) => {
+      const count = hashtag.usageCount
+        ? ` - ${formatTrendCount(hashtag.usageCount)} posts`
+        : '';
+      lines.push(`${index + 1}. ${hashtag.topic}${count}`);
+    });
+    lines.push(``);
+  }
+
+  if (sounds.length > 0) {
+    lines.push(`*Trending Sounds:*`);
+    sounds.slice(0, 5).forEach((sound, index) => {
+      const count = sound.usageCount
+        ? ` - ${formatTrendCount(sound.usageCount)} uses`
+        : '';
+      lines.push(`${index + 1}. ${sound.topic}${count}`);
+    });
+  }
+
+  lines.push(``);
+  lines.push(`_Use these trends to create viral content!_`);
+
+  return lines.join('\n');
+}
+
+/** Branded HTML email body. */
+export function buildTrendDigestHtml(
+  trends: TrendDigestItem[],
+  options: TrendDigestOptions,
+): string {
+  const { minViralScore } = options;
+  const headerTitle = options.headerTitle ?? DEFAULT_HEADER_TITLE;
+  const appUrl = options.appUrl ?? '';
+
+  const videos = trends.filter((trend) => trend.type === 'video');
+  const hashtags = trends.filter((trend) => trend.type === 'hashtag');
+  const sounds = trends.filter((trend) => trend.type === 'sound');
+
+  let html = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 20px; background: #f5f5f5; }
+          .container { max-width: 600px; margin: 0 auto; background: white; border-radius: 8px; padding: 24px; }
+          h1 { color: #1a1a1a; margin-bottom: 8px; }
+          .subtitle { color: #666; font-size: 14px; margin-bottom: 24px; }
+          .section { margin-bottom: 24px; }
+          .section-title { font-size: 16px; font-weight: 600; color: #333; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 2px solid #eee; }
+          .trend-item { padding: 8px 0; border-bottom: 1px solid #f0f0f0; }
+          .trend-item:last-child { border-bottom: none; }
+          .trend-name { font-weight: 500; color: #1a1a1a; }
+          .trend-meta { font-size: 12px; color: #888; margin-top: 4px; }
+          .viral-score { display: inline-block; background: #10b981; color: white; padding: 2px 6px; border-radius: 4px; font-size: 11px; }
+          .platform { display: inline-block; background: #e5e7eb; color: #374151; padding: 2px 6px; border-radius: 4px; font-size: 11px; margin-left: 4px; }
+          .footer { margin-top: 24px; padding-top: 16px; border-top: 1px solid #eee; text-align: center; color: #888; font-size: 12px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <h1>${escapeTrendHtml(headerTitle)}</h1>
+          <p class="subtitle">Filtered for viral score >= ${minViralScore}</p>
+    `;
+
+  if (videos.length > 0) {
+    html += `<div class="section"><div class="section-title">Viral Videos</div>`;
+    videos.slice(0, 5).forEach((video) => {
+      html += `
+          <div class="trend-item">
+            <div class="trend-name">${escapeTrendHtml(video.topic)}</div>
+            <div class="trend-meta">
+              <span class="viral-score">Score: ${video.viralScore}</span>
+              <span class="platform">${escapeTrendHtml(video.platform)}</span>
+              ${video.usageCount ? `<span> • ${formatTrendCount(video.usageCount)} views</span>` : ''}
+            </div>
+          </div>
+        `;
+    });
+    html += `</div>`;
+  }
+
+  if (hashtags.length > 0) {
+    html += `<div class="section"><div class="section-title">Trending Hashtags</div>`;
+    hashtags.slice(0, 5).forEach((hashtag) => {
+      html += `
+          <div class="trend-item">
+            <div class="trend-name">${escapeTrendHtml(hashtag.topic)}</div>
+            <div class="trend-meta">
+              <span class="platform">${escapeTrendHtml(hashtag.platform)}</span>
+              ${hashtag.usageCount ? `<span> • ${formatTrendCount(hashtag.usageCount)} posts</span>` : ''}
+            </div>
+          </div>
+        `;
+    });
+    html += `</div>`;
+  }
+
+  if (sounds.length > 0) {
+    html += `<div class="section"><div class="section-title">Trending Sounds</div>`;
+    sounds.slice(0, 5).forEach((sound) => {
+      html += `
+          <div class="trend-item">
+            <div class="trend-name">${escapeTrendHtml(sound.topic)}</div>
+            <div class="trend-meta">
+              ${sound.usageCount ? `<span>${formatTrendCount(sound.usageCount)} uses</span>` : ''}
+            </div>
+          </div>
+        `;
+    });
+    html += `</div>`;
+  }
+
+  html += `
+          <div class="footer">
+            Use these trends to create viral content!<br>
+            ${appUrl ? `<a href="${escapeTrendHtml(appUrl)}">Open Genfeed</a>` : ''}
+          </div>
+        </div>
+      </body>
+      </html>
+    `;
+
+  return html;
+}

--- a/packages/ui/src/components/overview/OverviewTrendsPanel.test.tsx
+++ b/packages/ui/src/components/overview/OverviewTrendsPanel.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import type { ButtonVariant } from '@genfeedai/enums';
+import type { TrendItem } from '@genfeedai/props/trends/trends-page.props';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { OverviewTrendsPanel } from './OverviewTrendsPanel';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    asChild,
+    children,
+  }: {
+    asChild?: boolean;
+    children?: ReactNode;
+    variant?: ButtonVariant;
+  }) => {
+    void asChild;
+    return <>{children}</>;
+  },
+}));
+
+vi.mock('@ui/overview/WorkspaceSurface', () => ({
+  WorkspaceSurface: ({
+    actions,
+    children,
+    eyebrow,
+    title,
+  }: {
+    actions?: ReactNode;
+    children: ReactNode;
+    eyebrow?: ReactNode;
+    title?: ReactNode;
+  }) => (
+    <section>
+      {eyebrow ? <p>{eyebrow}</p> : null}
+      {title ? <h2>{title}</h2> : null}
+      {actions ? <div>{actions}</div> : null}
+      {children}
+    </section>
+  ),
+}));
+
+function makeTrend(overrides: Partial<TrendItem> = {}): TrendItem {
+  return {
+    createdAt: '2026-06-01T00:00:00.000Z',
+    expiresAt: '2026-06-08T00:00:00.000Z',
+    growthRate: 1.2,
+    id: 'trend-1',
+    isCurrent: true,
+    mentions: 500,
+    platform: 'instagram',
+    requiresAuth: false,
+    topic: 'AI video trends',
+    viralityScore: 850,
+    ...overrides,
+  };
+}
+
+const TRENDS: TrendItem[] = [
+  makeTrend({
+    id: 'trend-1',
+    platform: 'instagram',
+    topic: 'Reels growth',
+    viralityScore: 950,
+  }),
+  makeTrend({
+    id: 'trend-2',
+    platform: 'tiktok',
+    topic: 'Short form comedy',
+    viralityScore: 800,
+  }),
+  makeTrend({
+    id: 'trend-3',
+    platform: 'youtube',
+    topic: 'AI tutorials',
+    viralityScore: 700,
+  }),
+  makeTrend({
+    id: 'trend-4',
+    platform: 'twitter',
+    topic: 'Tech layoffs',
+    viralityScore: 600,
+  }),
+  makeTrend({
+    id: 'trend-5',
+    platform: 'linkedin',
+    topic: 'B2B content tips',
+    viralityScore: 500,
+  }),
+  makeTrend({
+    id: 'trend-6',
+    platform: 'reddit',
+    topic: 'Low-score outlier',
+    viralityScore: 100,
+  }),
+];
+
+describe('OverviewTrendsPanel', () => {
+  it('renders the eyebrow and title via WorkspaceSurface', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={TRENDS}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByText('Social Trends')).toBeInTheDocument();
+    expect(screen.getByText('Research Trends')).toBeInTheDocument();
+  });
+
+  it('renders the "View All" link with the correct href', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={TRENDS}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: /view all/i })).toHaveAttribute(
+      'href',
+      '/research/discovery',
+    );
+  });
+
+  it('renders at most 5 trends sorted by virality score descending', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={TRENDS}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    const list = screen.getByTestId('overview-trends-list');
+    const rows = list.querySelectorAll('[class*="gen-shell-surface"]');
+    expect(rows).toHaveLength(5);
+
+    // First item should be highest virality
+    expect(rows[0]).toHaveTextContent('Reels growth');
+    expect(rows[4]).toHaveTextContent('B2B content tips');
+
+    // The low-score trend-6 should NOT appear
+    expect(screen.queryByText('Low-score outlier')).not.toBeInTheDocument();
+  });
+
+  it('renders platform badges and virality scores', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={TRENDS}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getAllByText('instagram')[0]).toBeInTheDocument();
+    expect(screen.getByText('950')).toBeInTheDocument();
+  });
+
+  it('renders the loading skeleton when isLoading is true', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={true}
+        trends={[]}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByTestId('overview-trends-loading')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('overview-trends-list'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state when trends is empty and not loading', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={[]}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByTestId('overview-trends-empty')).toHaveTextContent(
+      'No trends yet.',
+    );
+  });
+});

--- a/packages/ui/src/components/overview/OverviewTrendsPanel.tsx
+++ b/packages/ui/src/components/overview/OverviewTrendsPanel.tsx
@@ -1,0 +1,119 @@
+import { ButtonVariant } from '@genfeedai/enums';
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
+import type { TrendItem } from '@genfeedai/props/trends/trends-page.props';
+import { Button } from '@ui/primitives/button';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { HiOutlineArrowRight } from 'react-icons/hi2';
+import { WorkspaceSurface } from './WorkspaceSurface';
+
+const PLATFORM_BADGE_CLASSES: Record<string, string> = {
+  instagram: 'bg-fuchsia-500/12 text-fuchsia-300 border-fuchsia-500/20',
+  tiktok: 'bg-zinc-500/12 text-zinc-200 border-zinc-500/20',
+  twitter: 'bg-sky-500/12 text-sky-300 border-sky-500/20',
+  youtube: 'bg-rose-500/12 text-rose-300 border-rose-500/20',
+  linkedin: 'bg-blue-500/12 text-blue-300 border-blue-500/20',
+  reddit: 'bg-orange-500/12 text-orange-300 border-orange-500/20',
+  pinterest: 'bg-red-500/12 text-red-300 border-red-500/20',
+  facebook: 'bg-indigo-500/12 text-indigo-300 border-indigo-500/20',
+};
+
+const DEFAULT_BADGE_CLASS = 'bg-zinc-500/12 text-zinc-300 border-zinc-500/20';
+
+function getPlatformBadgeClass(platform: string): string {
+  return PLATFORM_BADGE_CLASSES[platform.toLowerCase()] ?? DEFAULT_BADGE_CLASS;
+}
+
+function formatViralityScore(score: number): string {
+  if (score >= 1000) {
+    return `${(score / 1000).toFixed(1)}k`;
+  }
+  return String(Math.round(score));
+}
+
+export interface OverviewTrendsPanelProps {
+  isLoading: boolean;
+  trends: TrendItem[];
+  viewAllHref: string;
+}
+
+export function OverviewTrendsPanel({
+  isLoading,
+  trends,
+  viewAllHref,
+}: OverviewTrendsPanelProps) {
+  const topTrends = useMemo(
+    () =>
+      trends.toSorted((a, b) => b.viralityScore - a.viralityScore).slice(0, 5),
+    [trends],
+  );
+
+  return (
+    <WorkspaceSurface
+      eyebrow="Social Trends"
+      title="Research Trends"
+      tone="default"
+      className="flex h-full flex-col gap-4"
+      data-testid="overview-trends-panel"
+      actions={
+        <Button asChild variant={ButtonVariant.SECONDARY}>
+          <Link href={viewAllHref}>
+            <HiOutlineArrowRight className="size-4" />
+            View All
+          </Link>
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <div
+          data-testid="overview-trends-loading"
+          className="space-y-3"
+          aria-busy="true"
+        >
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-10 animate-pulse rounded-[0.75rem] bg-muted/40"
+            />
+          ))}
+        </div>
+      ) : topTrends.length === 0 ? (
+        <div
+          data-testid="overview-trends-empty"
+          className="ship-ui gen-shell-empty-state flex items-center justify-center rounded-[1rem] p-8 text-sm text-foreground/55"
+        >
+          No trends yet.
+        </div>
+      ) : (
+        <div className="space-y-2" data-testid="overview-trends-list">
+          {topTrends.map((trend) => (
+            <div
+              key={trend.id}
+              className="ship-ui gen-shell-surface flex items-center gap-3 rounded-[1rem] border-white/[0.06] bg-background/52 px-4 py-3"
+            >
+              <span
+                className={cn(
+                  'shrink-0 inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em]',
+                  getPlatformBadgeClass(trend.platform),
+                )}
+              >
+                {trend.platform}
+              </span>
+
+              <span
+                className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
+                title={trend.topic}
+              >
+                {trend.topic}
+              </span>
+
+              <span className="shrink-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/45">
+                {formatViralityScore(trend.viralityScore)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </WorkspaceSurface>
+  );
+}

--- a/packages/workflow-engine/src/executors/executor-registry.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.ts
@@ -112,6 +112,10 @@ import {
   SendDmExecutor,
 } from '@workflow-engine/executors/saas/send-dm-executor';
 import {
+  createSendEmailExecutor,
+  SendEmailExecutor,
+} from '@workflow-engine/executors/saas/send-email-executor';
+import {
   createSocialPublishExecutor,
   SocialPublishExecutor,
 } from '@workflow-engine/executors/saas/social-publish-executor';
@@ -123,6 +127,10 @@ import {
   createTextToSpeechExecutor,
   TextToSpeechExecutor,
 } from '@workflow-engine/executors/saas/text-to-speech-executor';
+import {
+  createTrendDigestExecutor,
+  TrendDigestExecutor,
+} from '@workflow-engine/executors/saas/trend-digest-executor';
 import {
   createTrendTriggerExecutor,
   TrendTriggerExecutor,
@@ -411,6 +419,13 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     nodeType: 'sendDm',
     requiresResolver: true,
   },
+  sendEmail: {
+    description: 'Sends a single email via the notifications publisher',
+    executorClass: SendEmailExecutor,
+    factory: () => createSendEmailExecutor(),
+    nodeType: 'sendEmail',
+    requiresResolver: true,
+  },
   socialPublish: {
     description: 'Publishes video to a single social media platform',
     executorClass: SocialPublishExecutor,
@@ -431,6 +446,14 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     executorClass: TextToSpeechExecutor,
     factory: () => createTextToSpeechExecutor(),
     nodeType: 'textToSpeech',
+    requiresResolver: true,
+  },
+  trendDigest: {
+    description:
+      'Assembles a curated daily trends digest email from the global trend corpus',
+    executorClass: TrendDigestExecutor,
+    factory: () => createTrendDigestExecutor(),
+    nodeType: 'trendDigest',
     requiresResolver: true,
   },
   trendTrigger: {
@@ -649,6 +672,14 @@ export class ExecutorRegistryInstance {
   }
 
   /**
+   * Get the trend digest executor for resolver/provider injection
+   */
+  getTrendDigestExecutor(): TrendDigestExecutor | undefined {
+    const executor = this.executors.get('trendDigest');
+    return executor instanceof TrendDigestExecutor ? executor : undefined;
+  }
+
+  /**
    * Get the sound overlay executor for processor injection
    */
   getSoundOverlayExecutor(): SoundOverlayExecutor | undefined {
@@ -744,6 +775,14 @@ export class ExecutorRegistryInstance {
   getSendDmExecutor(): SendDmExecutor | undefined {
     const executor = this.executors.get('sendDm');
     return executor instanceof SendDmExecutor ? executor : undefined;
+  }
+
+  /**
+   * Get the send email executor for sender injection
+   */
+  getSendEmailExecutor(): SendEmailExecutor | undefined {
+    const executor = this.executors.get('sendEmail');
+    return executor instanceof SendEmailExecutor ? executor : undefined;
   }
 
   /**

--- a/packages/workflow-engine/src/executors/saas/index.ts
+++ b/packages/workflow-engine/src/executors/saas/index.ts
@@ -32,6 +32,7 @@ export * from '@workflow-engine/executors/saas/publish-executor';
 export * from '@workflow-engine/executors/saas/reframe-executor';
 export * from '@workflow-engine/executors/saas/rss-input-executor';
 export * from '@workflow-engine/executors/saas/send-dm-executor';
+export * from '@workflow-engine/executors/saas/send-email-executor';
 export {
   createSocialPublishExecutor,
   SocialPublishExecutor,
@@ -43,6 +44,7 @@ export {
 export * from '@workflow-engine/executors/saas/sound-overlay-executor';
 // Text to speech executor
 export * from '@workflow-engine/executors/saas/text-to-speech-executor';
+export * from '@workflow-engine/executors/saas/trend-digest-executor';
 export * from '@workflow-engine/executors/saas/trend-trigger-executor';
 export * from '@workflow-engine/executors/saas/tweet-input-executor';
 export * from '@workflow-engine/executors/saas/tweet-remix-executor';

--- a/packages/workflow-engine/src/executors/saas/send-email-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/send-email-executor.spec.ts
@@ -1,0 +1,115 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createSendEmailExecutor,
+  type EmailSender,
+  type SendEmailExecutor,
+} from '@workflow-engine/executors/saas/send-email-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeInput(
+  config: Record<string, unknown>,
+  inputData?: Record<string, unknown>,
+): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'email-1',
+    inputs: [],
+    label: 'Send Email',
+    type: 'sendEmail',
+  };
+  const inputs = new Map<string, unknown>();
+  if (inputData) {
+    for (const [key, value] of Object.entries(inputData)) {
+      inputs.set(key, value);
+    }
+  }
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs, node };
+}
+
+describe('SendEmailExecutor', () => {
+  let executor: SendEmailExecutor;
+  let mockSender: EmailSender;
+
+  beforeEach(() => {
+    executor = createSendEmailExecutor();
+    mockSender = vi.fn().mockResolvedValue(undefined);
+    executor.setSender(mockSender);
+  });
+
+  it('creates via factory with the correct node type', () => {
+    expect(executor.nodeType).toBe('sendEmail');
+  });
+
+  it('throws if sender not configured', async () => {
+    const fresh = createSendEmailExecutor();
+    await expect(
+      fresh.execute(
+        makeInput({}, { html: '<p>x</p>', subject: 's', to: 'a@b.c' }),
+      ),
+    ).rejects.toThrow('Email sender not configured');
+  });
+
+  it('no-ops when the upstream node marks the run as skipped', async () => {
+    const result = await executor.execute(
+      makeInput({}, { reason: 'no-trends', skipped: true }),
+    );
+    expect(mockSender).not.toHaveBeenCalled();
+    expect(result.data).toMatchObject({
+      sent: false,
+      skippedReason: 'no-trends',
+    });
+  });
+
+  it('sends using wired inputs', async () => {
+    const result = await executor.execute(
+      makeInput(
+        {},
+        { html: '<p>Hello</p>', subject: 'Daily trends', to: 'owner@org.com' },
+      ),
+    );
+    expect(mockSender).toHaveBeenCalledWith({
+      html: '<p>Hello</p>',
+      subject: 'Daily trends',
+      to: 'owner@org.com',
+    });
+    expect(result.data).toMatchObject({ sent: true, to: 'owner@org.com' });
+  });
+
+  it('falls back to node config when inputs are absent', async () => {
+    const result = await executor.execute(
+      makeInput({ html: '<p>cfg</p>', subject: 'cfg', to: 'cfg@org.com' }),
+    );
+    expect(mockSender).toHaveBeenCalledWith({
+      html: '<p>cfg</p>',
+      subject: 'cfg',
+      to: 'cfg@org.com',
+    });
+    expect(result.data).toMatchObject({ sent: true });
+  });
+
+  it('throws if recipient is missing', async () => {
+    await expect(
+      executor.execute(makeInput({}, { html: '<p>x</p>', subject: 's' })),
+    ).rejects.toThrow('Email recipient (to) is required');
+  });
+
+  it('throws if subject is missing', async () => {
+    await expect(
+      executor.execute(makeInput({}, { html: '<p>x</p>', to: 'a@b.c' })),
+    ).rejects.toThrow('Email subject is required');
+  });
+
+  it('throws if html body is missing', async () => {
+    await expect(
+      executor.execute(makeInput({}, { subject: 's', to: 'a@b.c' })),
+    ).rejects.toThrow('Email body (html) is required');
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/send-email-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/send-email-executor.ts
@@ -1,0 +1,124 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SendEmailResult {
+  /** Whether an email was dispatched. False when the upstream node skipped. */
+  sent: boolean;
+  /** Recipient the email was sent to (omitted when skipped). */
+  to?: string;
+  /** Reason the send was skipped, propagated from upstream. */
+  skippedReason?: string;
+}
+
+/**
+ * Function signature for the injected email sender. The NestJS service layer
+ * wires this to the notifications publisher at runtime so the engine package
+ * stays free of app/server dependencies.
+ */
+export type EmailSender = (params: {
+  to: string;
+  subject: string;
+  html: string;
+}) => Promise<void>;
+
+// =============================================================================
+// EXECUTOR
+// =============================================================================
+
+/**
+ * Send Email Executor
+ *
+ * Generic, reusable action node that dispatches a single email. Reads
+ * `to` / `subject` / `html` from wired edge inputs (falling back to node
+ * config). If an upstream node marks the run as `skipped` (e.g. the trend
+ * digest found nothing / lacked credits), this node no-ops without sending.
+ *
+ * Node Type: sendEmail
+ */
+export class SendEmailExecutor extends BaseExecutor {
+  readonly nodeType = 'sendEmail';
+  private sender: EmailSender | null = null;
+
+  setSender(sender: EmailSender): void {
+    this.sender = sender;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, inputs } = input;
+
+    if (!this.sender) {
+      throw new Error('Email sender not configured');
+    }
+
+    const skipped =
+      (inputs.get('skipped') as boolean | undefined) ??
+      this.getOptionalConfig<boolean>(node.config, 'skipped', false);
+
+    if (skipped) {
+      const skippedReason =
+        (inputs.get('reason') as string | undefined) ?? 'upstream-skipped';
+      const result: SendEmailResult = { sent: false, skippedReason };
+      return {
+        data: result,
+        metadata: { sent: false, skippedReason },
+      };
+    }
+
+    const to =
+      (inputs.get('to') as string | undefined) ??
+      this.getOptionalConfig<string | undefined>(node.config, 'to', undefined);
+    const subject =
+      (inputs.get('subject') as string | undefined) ??
+      this.getOptionalConfig<string | undefined>(
+        node.config,
+        'subject',
+        undefined,
+      );
+    const html =
+      (inputs.get('html') as string | undefined) ??
+      this.getOptionalConfig<string | undefined>(
+        node.config,
+        'html',
+        undefined,
+      );
+
+    if (!to) {
+      throw new Error('Email recipient (to) is required (via input or config)');
+    }
+    if (!subject) {
+      throw new Error('Email subject is required (via input or config)');
+    }
+    if (!html) {
+      throw new Error('Email body (html) is required (via input or config)');
+    }
+
+    await this.sender({ html, subject, to });
+
+    const result: SendEmailResult = { sent: true, to };
+    return {
+      data: result,
+      metadata: { sent: true, to },
+    };
+  }
+
+  estimateCost(): number {
+    return 0;
+  }
+}
+
+export function createSendEmailExecutor(
+  sender?: EmailSender,
+): SendEmailExecutor {
+  const executor = new SendEmailExecutor();
+  if (sender) {
+    executor.setSender(sender);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/executors/saas/trend-digest-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-digest-executor.spec.ts
@@ -1,0 +1,149 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createTrendDigestExecutor,
+  type DigestCreditsChecker,
+  type DigestIdempotencyGuard,
+  type DigestOwnerResolver,
+  type DigestRenderer,
+  type DigestTrendsProvider,
+  type TrendDigestEntry,
+  type TrendDigestExecutor,
+  type TrendDigestReadyOutput,
+  type TrendDigestSkippedOutput,
+} from '@workflow-engine/executors/saas/trend-digest-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const SAMPLE_TRENDS: TrendDigestEntry[] = [
+  { platform: 'tiktok', topic: 'Dancing cats', type: 'video', viralScore: 92 },
+];
+
+function makeInput(config: Record<string, unknown> = {}): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'digest-1',
+    inputs: [],
+    label: 'Trend Digest',
+    type: 'trendDigest',
+  };
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs: new Map(), node };
+}
+
+interface Mocks {
+  ownerResolver: ReturnType<typeof vi.fn>;
+  trendsProvider: ReturnType<typeof vi.fn>;
+  idempotencyGuard: ReturnType<typeof vi.fn>;
+  creditsChecker: ReturnType<typeof vi.fn>;
+  renderer: ReturnType<typeof vi.fn>;
+}
+
+function wire(executor: TrendDigestExecutor): Mocks {
+  const ownerResolver = vi
+    .fn()
+    .mockResolvedValue({ email: 'owner@org.com', userId: 'user-1' });
+  const trendsProvider = vi.fn().mockResolvedValue(SAMPLE_TRENDS);
+  const idempotencyGuard = vi.fn().mockResolvedValue(true);
+  const creditsChecker = vi.fn().mockResolvedValue(true);
+  const renderer = vi
+    .fn()
+    .mockReturnValue({ html: '<p>digest</p>', subject: 'Daily trends' });
+
+  executor.setOwnerResolver(ownerResolver as unknown as DigestOwnerResolver);
+  executor.setTrendsProvider(trendsProvider as unknown as DigestTrendsProvider);
+  executor.setIdempotencyGuard(
+    idempotencyGuard as unknown as DigestIdempotencyGuard,
+  );
+  executor.setCreditsChecker(creditsChecker as unknown as DigestCreditsChecker);
+  executor.setRenderer(renderer as unknown as DigestRenderer);
+
+  return {
+    creditsChecker,
+    idempotencyGuard,
+    ownerResolver,
+    renderer,
+    trendsProvider,
+  };
+}
+
+describe('TrendDigestExecutor', () => {
+  let executor: TrendDigestExecutor;
+  let mocks: Mocks;
+
+  beforeEach(() => {
+    executor = createTrendDigestExecutor();
+    mocks = wire(executor);
+  });
+
+  it('throws when dependencies are not configured', async () => {
+    const fresh = createTrendDigestExecutor();
+    await expect(fresh.execute(makeInput())).rejects.toThrow(
+      'Trend digest dependencies not configured',
+    );
+  });
+
+  it('produces a ready payload on the happy path (no charge in node)', async () => {
+    const result = await executor.execute(makeInput({ creditCost: 5 }));
+    const data = result.data as TrendDigestReadyOutput;
+    expect(data.skipped).toBe(false);
+    expect(data).toMatchObject({
+      creditCost: 5,
+      html: '<p>digest</p>',
+      orgId: 'org-1',
+      ownerUserId: 'user-1',
+      subject: 'Daily trends',
+      to: 'owner@org.com',
+    });
+    expect(mocks.renderer).toHaveBeenCalledWith(
+      SAMPLE_TRENDS,
+      expect.objectContaining({ minViralScore: 70 }),
+    );
+  });
+
+  it('keys the idempotency marker by workflow id and UTC date', async () => {
+    await executor.execute(makeInput());
+    const key = mocks.idempotencyGuard.mock.calls[0]?.[0] as string;
+    expect(key).toMatch(/^workflow-digest:wf-1:\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('skips with no-owner-email and never acquires the marker', async () => {
+    mocks.ownerResolver.mockResolvedValueOnce({ email: null, userId: null });
+    const result = await executor.execute(makeInput());
+    expect((result.data as TrendDigestSkippedOutput).reason).toBe(
+      'no-owner-email',
+    );
+    expect(mocks.idempotencyGuard).not.toHaveBeenCalled();
+  });
+
+  it('skips with already-ran-today when the marker is already held', async () => {
+    mocks.idempotencyGuard.mockResolvedValueOnce(false);
+    const result = await executor.execute(makeInput());
+    expect((result.data as TrendDigestSkippedOutput).reason).toBe(
+      'already-ran-today',
+    );
+    expect(mocks.creditsChecker).not.toHaveBeenCalled();
+    expect(mocks.trendsProvider).not.toHaveBeenCalled();
+  });
+
+  it('skips with insufficient-credits without fetching trends', async () => {
+    mocks.creditsChecker.mockResolvedValueOnce(false);
+    const result = await executor.execute(makeInput());
+    expect((result.data as TrendDigestSkippedOutput).reason).toBe(
+      'insufficient-credits',
+    );
+    expect(mocks.trendsProvider).not.toHaveBeenCalled();
+  });
+
+  it('skips with no-trends and does not render', async () => {
+    mocks.trendsProvider.mockResolvedValueOnce([]);
+    const result = await executor.execute(makeInput());
+    expect((result.data as TrendDigestSkippedOutput).reason).toBe('no-trends');
+    expect(mocks.renderer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/trend-digest-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-digest-executor.ts
@@ -1,0 +1,254 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Structural shape of a ranked trend item. Kept local (not imported from
+ * `@genfeedai/helpers`) so the engine package retains its minimal dependency
+ * surface; it is structurally compatible with `TrendDigestItem` from helpers.
+ */
+export interface TrendDigestEntry {
+  platform: string;
+  topic: string;
+  viralScore: number;
+  type: 'video' | 'hashtag' | 'sound' | 'topic';
+  url?: string;
+  usageCount?: number;
+}
+
+export interface RenderedDigest {
+  subject: string;
+  html: string;
+}
+
+/** Resolves the org owner the digest is addressed to. */
+export type DigestOwnerResolver = (
+  organizationId: string,
+) => Promise<{ userId: string | null; email: string | null } | null>;
+
+/** Fetches the deterministically-ranked top-N trends for an org. */
+export type DigestTrendsProvider = (params: {
+  organizationId: string;
+  platforms: string[];
+  topN: number;
+  minViralScore: number;
+}) => Promise<TrendDigestEntry[]>;
+
+/**
+ * Durable "ran today" marker. Returns true if THIS caller acquired the marker
+ * (i.e. is the first across all replicas today). Implemented with Redis
+ * `SET key val NX EX ttl` — the marker is NOT released, so it survives the run.
+ */
+export type DigestIdempotencyGuard = (
+  key: string,
+  ttlSeconds: number,
+) => Promise<boolean>;
+
+/** Credit availability pre-check (no deduction here — that happens post-send). */
+export type DigestCreditsChecker = (
+  organizationId: string,
+  cost: number,
+) => Promise<boolean>;
+
+/** Renders the branded subject + HTML for the digest. */
+export type DigestRenderer = (
+  trends: TrendDigestEntry[],
+  options: { minViralScore: number; appUrl?: string; headerTitle?: string },
+) => RenderedDigest;
+
+export interface TrendDigestSkippedOutput {
+  skipped: true;
+  reason:
+    | 'no-owner-email'
+    | 'already-ran-today'
+    | 'insufficient-credits'
+    | 'no-trends';
+}
+
+export interface TrendDigestReadyOutput {
+  skipped: false;
+  to: string;
+  subject: string;
+  html: string;
+  orgId: string;
+  ownerUserId: string | null;
+  creditCost: number;
+}
+
+export type TrendDigestOutput =
+  | TrendDigestSkippedOutput
+  | TrendDigestReadyOutput;
+
+const DEFAULT_PLATFORMS = ['tiktok', 'instagram', 'youtube', 'twitter'];
+const DEFAULT_TOP_N = 5;
+const DEFAULT_MIN_VIRAL_SCORE = 70;
+const DEFAULT_CREDIT_COST = 5;
+const IDEMPOTENCY_TTL_SECONDS = 93_600; // ~26h — spans a daily run + clock skew
+
+function utcDateKey(): string {
+  // Executors run in normal Node runtime (unlike the sandboxed workflow script
+  // layer), so Date is available here. UTC day boundary, documented.
+  return new Date().toISOString().slice(0, 10);
+}
+
+// =============================================================================
+// EXECUTOR
+// =============================================================================
+
+/**
+ * Trend Digest Executor
+ *
+ * Action node that assembles a curated daily trends digest from the already
+ * collected global corpus (deterministic ranking — no LLM, no scrape). It
+ * resolves the org-owner recipient, enforces a durable per-day idempotency
+ * marker (multi-replica safe), pre-checks credits, and renders the branded
+ * email. It does NOT send or deduct — it emits a serializable payload that the
+ * downstream `sendEmail` node sends and the adapter's post-run hook charges.
+ *
+ * Node Type: trendDigest
+ */
+export class TrendDigestExecutor extends BaseExecutor {
+  readonly nodeType = 'trendDigest';
+  private ownerResolver: DigestOwnerResolver | null = null;
+  private trendsProvider: DigestTrendsProvider | null = null;
+  private idempotencyGuard: DigestIdempotencyGuard | null = null;
+  private creditsChecker: DigestCreditsChecker | null = null;
+  private renderer: DigestRenderer | null = null;
+
+  setOwnerResolver(resolver: DigestOwnerResolver): void {
+    this.ownerResolver = resolver;
+  }
+
+  setTrendsProvider(provider: DigestTrendsProvider): void {
+    this.trendsProvider = provider;
+  }
+
+  setIdempotencyGuard(guard: DigestIdempotencyGuard): void {
+    this.idempotencyGuard = guard;
+  }
+
+  setCreditsChecker(checker: DigestCreditsChecker): void {
+    this.creditsChecker = checker;
+  }
+
+  setRenderer(renderer: DigestRenderer): void {
+    this.renderer = renderer;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, context } = input;
+
+    if (
+      !this.ownerResolver ||
+      !this.trendsProvider ||
+      !this.idempotencyGuard ||
+      !this.creditsChecker ||
+      !this.renderer
+    ) {
+      throw new Error('Trend digest dependencies not configured');
+    }
+
+    const orgId = context.organizationId;
+    const platforms = this.getOptionalConfig<string[]>(
+      node.config,
+      'platforms',
+      DEFAULT_PLATFORMS,
+    );
+    const topN = this.getOptionalConfig<number>(
+      node.config,
+      'topN',
+      DEFAULT_TOP_N,
+    );
+    const minViralScore = this.getOptionalConfig<number>(
+      node.config,
+      'minViralScore',
+      DEFAULT_MIN_VIRAL_SCORE,
+    );
+    const creditCost = this.getOptionalConfig<number>(
+      node.config,
+      'creditCost',
+      DEFAULT_CREDIT_COST,
+    );
+    const appUrl = this.getOptionalConfig<string | undefined>(
+      node.config,
+      'appUrl',
+      undefined,
+    );
+    const headerTitle = this.getOptionalConfig<string | undefined>(
+      node.config,
+      'headerTitle',
+      undefined,
+    );
+
+    const owner = await this.ownerResolver(orgId);
+    if (!owner?.email) {
+      return this.skip('no-owner-email');
+    }
+
+    const acquired = await this.idempotencyGuard(
+      `workflow-digest:${context.workflowId}:${utcDateKey()}`,
+      IDEMPOTENCY_TTL_SECONDS,
+    );
+    if (!acquired) {
+      return this.skip('already-ran-today');
+    }
+
+    const hasCredits = await this.creditsChecker(orgId, creditCost);
+    if (!hasCredits) {
+      return this.skip('insufficient-credits');
+    }
+
+    const trends = await this.trendsProvider({
+      minViralScore,
+      organizationId: orgId,
+      platforms,
+      topN,
+    });
+
+    if (trends.length === 0) {
+      return this.skip('no-trends');
+    }
+
+    const { subject, html } = this.renderer(trends, {
+      appUrl,
+      headerTitle,
+      minViralScore,
+    });
+
+    const output: TrendDigestReadyOutput = {
+      creditCost,
+      html,
+      orgId,
+      ownerUserId: owner.userId,
+      skipped: false,
+      subject,
+      to: owner.email,
+    };
+
+    return {
+      data: output,
+      metadata: { skipped: false, trendCount: trends.length },
+    };
+  }
+
+  estimateCost(): number {
+    // Charge is applied explicitly by the adapter post-run hook after a
+    // confirmed send, not via the engine credit accumulator.
+    return 0;
+  }
+
+  private skip(reason: TrendDigestSkippedOutput['reason']): ExecutorOutput {
+    const output: TrendDigestSkippedOutput = { reason, skipped: true };
+    return { data: output, metadata: { reason, skipped: true } };
+  }
+}
+
+export function createTrendDigestExecutor(): TrendDigestExecutor {
+  return new TrendDigestExecutor();
+}

--- a/packages/workflow-engine/src/utils/credit-calculator.ts
+++ b/packages/workflow-engine/src/utils/credit-calculator.ts
@@ -41,7 +41,13 @@ export const DEFAULT_CREDIT_COSTS: CreditCostConfig = {
   // ----- publish / output (free — billed by platform API limits, not credits) -----
   publish: 0,
   sendDm: 0,
+  // sendEmail is free at the node level; the trends digest is charged explicitly
+  // by the workflow adapter post-run hook after a confirmed send (see trendDigest).
+  sendEmail: 0,
   socialPublish: 0,
+  // trendDigest assembles the email payload only; the credit is deducted by the
+  // adapter post-run hook on a confirmed send, not via the engine accumulator.
+  trendDigest: 0,
   webhook: 0, // legacy alias
 
   // ----- text / content generation -----


### PR DESCRIPTION
## What

Ships the proactive **research trends agent** as the first workflow-backed conversion, plus the reusable primitives it needs.

### 1. Overview trends widget (no backend, no credits)
- New `OverviewTrendsPanel` (`@ui/overview`) rendered on **both** the Overview page and the Workspace dashboard, reading the already-collected global trend corpus via `useTrends()`. Always visible; "View all" → `/research/discovery`.

### 2. Daily Trends Digest = a predetermined, per-org **workflow** (toggled from the automation UI)
- **No new hard-coded cron** — driven by the canonical `WorkflowSchedulerService` per the dynamic-scheduling ADR.
- New reusable engine nodes:
  - `sendEmail` — generic email action (wired to `NotificationsService` via the adapter).
  - `trendDigest` — fetch + deterministic rank of the corpus (no scrape, no LLM), owner-email resolution, **durable per-day idempotency marker** (Redis `SET NX`, multi-replica safe), credit pre-check, branded render via the shared builder.
- `daily-trends-digest` template (`trendDigest → sendEmail` via explicit edge handles), registered in the executor registry, **node registry**, credit map, and template catalog.
- **Credit charged exactly once per confirmed send** via an adapter post-run hook, guarded by a separate durable Redis marker (no double-charge on retry/replica).
- Seeded **OFF** per org at the org-bootstrap chokepoint (`OrganizationSettingsService.create`, covering all 3 creation paths) + idempotent backfill seed script for existing orgs.
- Workflow-list **ON/OFF toggle** wired to the existing `setSchedule` endpoint.

### 3. Shared builder
- Pure trend-digest HTML/summary builder extracted to `@genfeedai/helpers`; the existing per-user trend-summary cron now consumes it.

## Root-cause scheduler/executor fixes (required for **any** workflow-backed schedule)
- Scheduler filtered `status: 'ACTIVE'` (uppercase) but the column is canonically **lowercase** → fixed to `WorkflowStatus.ACTIVE`. Durable scheduling was previously broken.
- Scheduled runs no longer flip `Workflow.status` to `COMPLETED`/`FAILED` (which dropped them from the scheduler after a single run) — they stay `ACTIVE`.

## Cron audit (answer to "are there crons that should be workflows?")
~24 tenant-product crons are workflow candidates (all default-ON); ~22 stay platform crons. This PR converts only the trends digest; the rest is a separate migration program (tracking issue to follow).

## Tests / verification
- `@genfeedai/workflow-engine`: 688 pass (incl. new `sendEmail`/`trendDigest` specs + registry/credit coverage).
- `@genfeedai/api`: adapter charge-hook (deduct-once + double-charge guard), template node-coverage, workflows/org-settings services, module — all green; `tsc --noEmit` clean.
- `@genfeedai/helpers`/`ui`/`app`: builder + overview panel + toggle specs green.
- type-check + lint green across all touched packages.

## Not in scope (follow-ups)
- Global workflow credit-deduction stays OFF (would bill every existing workflow).
- The broader ~24-cron → workflow migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)