### PR TITLE
test(workers): cover trend-summary threshold filter + empty-trend skip (#699)

### DIFF
--- a/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts
+++ b/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts
@@ -251,6 +251,59 @@ describe('CronTrendSummaryNotificationsService', () => {
     });
   });
 
+  describe('threshold filtering', () => {
+    it('drops hashtags below the user minViralScore threshold', async () => {
+      prismaService.setting.findMany.mockResolvedValue([
+        {
+          ...mockSettings[0],
+          isTrendNotificationsEmail: false,
+          isTrendNotificationsInApp: false,
+          trendNotificationsMinViralScore: 70,
+        },
+      ]);
+      // Only the hashtag path contributes trends; the service filters in-process.
+      trendsService.getViralVideos.mockResolvedValue([]);
+      trendsService.getTrendingSounds.mockResolvedValue([]);
+      trendsService.getTrendingHashtags.mockResolvedValue([
+        {
+          hashtag: 'belowthreshold',
+          platform: 'tiktok',
+          postCount: 1000,
+          viralityScore: 50,
+        },
+        {
+          hashtag: 'abovethreshold',
+          platform: 'tiktok',
+          postCount: 500000,
+          viralityScore: 85,
+        },
+      ]);
+
+      await service.sendHourlyTrendSummaries();
+
+      expect(notificationsService.sendTelegramMessage).toHaveBeenCalledTimes(1);
+      const telegramMessage =
+        notificationsService.sendTelegramMessage.mock.calls[0][1];
+      expect(telegramMessage).toContain('#abovethreshold');
+      expect(telegramMessage).not.toContain('#belowthreshold');
+    });
+
+    it('skips sending entirely when no trends are above threshold', async () => {
+      trendsService.getViralVideos.mockResolvedValue([]);
+      trendsService.getTrendingHashtags.mockResolvedValue([]);
+      trendsService.getTrendingSounds.mockResolvedValue([]);
+
+      await service.sendHourlyTrendSummaries();
+
+      expect(notificationsService.sendEmail).not.toHaveBeenCalled();
+      expect(notificationsService.sendTelegramMessage).not.toHaveBeenCalled();
+      expect(notificationsService.sendNotification).not.toHaveBeenCalled();
+      expect(loggerService.debug).toHaveBeenCalledWith(
+        expect.stringContaining('No trends above threshold'),
+      );
+    });
+  });
+
   describe('lock contention', () => {
     it('should log skip message when lock is already held', async () => {
       cacheService.withLock.mockResolvedValue(null);


### PR DESCRIPTION
## What

Closes #699.

`CronTrendSummaryNotificationsService` was filed as having *no* spec. Ground truth: a 12-case spec already exists ([`cron.trend-summary-notifications.service.spec.ts`](apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts)) covering frequency selection, channel dispatch (email/telegram/in-app), lock contention, and error handling. It runs nightly via `bun run test:cron` (`vitest.cron.config.ts`) — cron specs are deliberately excluded from the default fast workers suite.

The two scenarios #699 actually enumerated were the real gaps; this PR adds them:

- **Threshold filter** — a hashtag below the user's `trendNotificationsMinViralScore` (default 70) is dropped from the summary; one above it is kept. Asserted on the rendered telegram message.
- **Empty-trend skip** — when nothing clears the threshold, no channel is notified and the service returns after a `debug` log.

Both assert on the notification-call boundary, not rendered HTML (the digest builder is covered separately).

## Verification

```
bunx vitest run --config vitest.cron.config.ts cron.trend-summary-notifications
→ Test Files 1 passed (1) · Tests 14 passed (14)
```

This is the behavior baseline #698 should preserve when it converts this cron to a per-org workflow.