### PR TITLE
chore(skills): use bunx (not npx) for biome in prepush-guard

### DIFF
--- a/.agents/skills/prepush-guard/SKILL.md
+++ b/.agents/skills/prepush-guard/SKILL.md
@@ -22,7 +22,7 @@ Use when preparing to push changes.
 ## Execution checklist
 
 1. Format changed files (or full repo when needed):
-   - `npx biome check --write .`
+   - `bunx biome check --write .`
 2. Lint:
    - `bunx turbo lint`
 3. Type-check:


### PR DESCRIPTION
## What

`.agents/skills/prepush-guard/SKILL.md` step 1 still said `npx biome check --write .`, contradicting the corrected commands in `CLAUDE.md` (this repo standardizes on `bunx`; npm/npx are not used). One-line alignment with the Pre-Push Checklist.

Surfaced by the merged-PR follow-up audit (trailing reference from #591's git-workflow migration).