### PR TITLE
fix(api): resolve Postgres TLS in code, strip sslmode from connection URL

### DIFF
--- a/apps/server/api/src/shared/modules/prisma/prisma.service.spec.ts
+++ b/apps/server/api/src/shared/modules/prisma/prisma.service.spec.ts
@@ -57,8 +57,47 @@ describe('createPrismaPgConfig', () => {
   it('maps sslmode=no-verify to encrypted TLS without chain verification', () => {
     const connectionString = pgUrl('db.example.com', '?sslmode=no-verify');
 
+    // sslmode is resolved into the explicit ssl object and stripped from the
+    // URL so pg never re-parses it (no deprecation warning, pg-upgrade safe).
     expect(createPrismaPgConfig(connectionString)).toEqual({
-      connectionString,
+      connectionString: pgUrl('db.example.com'),
+      ssl: { rejectUnauthorized: false },
+    });
+  });
+
+  it('maps sslmode=require to encrypted TLS without chain verification', () => {
+    const connectionString = pgUrl('db.example.com', '?sslmode=require');
+
+    expect(createPrismaPgConfig(connectionString)).toEqual({
+      connectionString: pgUrl('db.example.com'),
+      ssl: { rejectUnauthorized: false },
+    });
+  });
+
+  it('lets an available CA win over sslmode=require and strips the param', () => {
+    const connectionString = pgUrl('db.example.com', '?sslmode=require');
+
+    expect(
+      createPrismaPgConfig(connectionString, {
+        caFilePaths: [writeCaFile('require-ca')],
+      }),
+    ).toEqual({
+      connectionString: pgUrl('db.example.com'),
+      ssl: { ca: 'require-ca', rejectUnauthorized: true },
+    });
+  });
+
+  it('preserves other query params when stripping sslmode', () => {
+    const connectionString = pgUrl(
+      'db.example.com',
+      '?schema=public&sslmode=no-verify&connection_limit=5',
+    );
+
+    expect(createPrismaPgConfig(connectionString)).toEqual({
+      connectionString: pgUrl(
+        'db.example.com',
+        '?schema=public&connection_limit=5',
+      ),
       ssl: { rejectUnauthorized: false },
     });
   });

--- a/apps/server/api/src/shared/modules/prisma/prisma.service.ts
+++ b/apps/server/api/src/shared/modules/prisma/prisma.service.ts
@@ -37,6 +37,29 @@ function parseDatabaseUrl(connectionString: string): URL | undefined {
   }
 }
 
+/**
+ * Remove `sslmode`/`ssl` query params once we have resolved TLS into an explicit
+ * `ssl` object. node-postgres honours the explicit `ssl` config we pass to the
+ * adapter, so the URL params are redundant — and leaving `sslmode` in the
+ * connection string makes pg emit the `sslmode` deprecation warning and (worse)
+ * makes us hostage to pg's upcoming change to `sslmode=require` semantics.
+ * Resolving TLS in code keeps behaviour identical across pg upgrades.
+ */
+function stripSslParams(connectionString: string): string {
+  const databaseUrl = parseDatabaseUrl(connectionString);
+  if (!databaseUrl) {
+    return connectionString;
+  }
+  let mutated = false;
+  for (const key of ['sslmode', 'ssl'] as const) {
+    if (databaseUrl.searchParams.has(key)) {
+      databaseUrl.searchParams.delete(key);
+      mutated = true;
+    }
+  }
+  return mutated ? databaseUrl.toString() : connectionString;
+}
+
 function readConfiguredPostgresCa(
   caFilePaths: readonly (string | undefined)[] = [],
 ): string | undefined {
@@ -76,14 +99,20 @@ export function createPrismaPgConfig(
   }
 
   if (sslMode === 'no-verify') {
-    return { connectionString, ssl: { rejectUnauthorized: false } };
+    return {
+      connectionString: stripSslParams(connectionString),
+      ssl: { rejectUnauthorized: false },
+    };
   }
 
   const ca =
     readConfiguredPostgresCa(options.caFilePaths) ??
     readBundledRdsCa(databaseUrl);
   if (ca) {
-    return { connectionString, ssl: { ca, rejectUnauthorized: true } };
+    return {
+      connectionString: stripSslParams(connectionString),
+      ssl: { ca, rejectUnauthorized: true },
+    };
   }
 
   if (sslMode === 'verify-ca' || sslMode === 'verify-full') {
@@ -93,7 +122,10 @@ export function createPrismaPgConfig(
   }
 
   if (sslMode === 'require') {
-    return { connectionString, ssl: { rejectUnauthorized: false } };
+    return {
+      connectionString: stripSslParams(connectionString),
+      ssl: { rejectUnauthorized: false },
+    };
   }
 
   return { connectionString };


### PR DESCRIPTION
## What

`createPrismaPgConfig` already resolves `sslmode` into an explicit node-postgres `ssl` object (RDS CA bundle / `no-verify` / `require`). It just left `sslmode` *in* the connection string too, so pg re-parsed it and emitted the `sslmode` deprecation warning that shows up in **api and workers** prod logs (confirmed via CloudWatch — no actual TLS failures, just the warning).

This strips `sslmode`/`ssl` from the connection string in every path where we set an explicit `ssl` object.

## Why it matters beyond the warning

pg is changing what `sslmode=require` means (toward `verify-full`). Today our config works because we *also* pass an explicit `ssl` object — but relying on the URL's `sslmode` is a latent connection break on the next pg upgrade. Resolving TLS in code and dropping the URL param makes behaviour identical across pg versions.

## Safety

- TLS behaviour is **unchanged** — the `ssl` object is authoritative; we only remove now-redundant URL params.
- Other query params (`schema`, `connection_limit`, …) are preserved.
- Same connection path as #561 (RDS self-signed chain). That path already carries the CA-bundle fix and AWS logs show zero current TLS failures, so this hardens a verified-good path rather than changing runtime behaviour.

## Tests

`prisma.service.spec.ts` — 10/10 pass. Added: `sslmode=require` mapping, CA-wins-over-`require` precedence, other-param preservation, and updated the `no-verify` case to assert the stripped URL.