### PR TITLE
feat(ci): snapshot RDS before prod migrations (fail-closed) — AWS port of Vitae's pre-migration backup

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -207,7 +207,12 @@ jobs:
           # Mirrors the Vitae GCP db-migrate "Create pre-migration Cloud SQL backup".
           # If create/wait fails, the job stops HERE — before the migrate task can
           # touch the database — so a bad migration is always recoverable.
-          SNAP_ID="pre-migrate-${IMAGE_SHA}-$(date -u +%Y%m%d%H%M%S)"
+          # RDS snapshot identifiers allow only letters, digits and single
+          # hyphens — but the image tag charset permits '.' and '_' (e.g.
+          # release_2026.06.20), which would fail-closed the snapshot and block
+          # the deploy. Sanitize for the id; keep the raw tag in git_sha below.
+          SAFE_SHA="$(printf '%s' "${IMAGE_SHA}" | tr '._' '-' | tr -s '-' | sed 's/-$//')"
+          SNAP_ID="pre-migrate-${SAFE_SHA}-$(date -u +%Y%m%d%H%M%S)"
           echo "Creating pre-migration snapshot ${SNAP_ID} of ${RDS_INSTANCE_ID}..."
           aws rds create-db-snapshot \
             --db-instance-identifier "$RDS_INSTANCE_ID" \

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -195,6 +195,30 @@ jobs:
             -var="image_tag=${{ steps.image.outputs.sha }}" \
             -var="enable_dns_cutover=true"
 
+      - name: Snapshot RDS before migrations (fail-closed)
+        env:
+          # Source of truth: infra/terraform/genfeed-prod/data.tf (data.aws_db_instance.genfeed).
+          RDS_INSTANCE_ID: genfeed-data
+          # Read via env, never interpolate ${{ }} into the script body directly.
+          IMAGE_SHA: ${{ steps.image.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Fail closed: never run migrations without a fresh pre-migration snapshot.
+          # Mirrors the Vitae GCP db-migrate "Create pre-migration Cloud SQL backup".
+          # If create/wait fails, the job stops HERE — before the migrate task can
+          # touch the database — so a bad migration is always recoverable.
+          SNAP_ID="pre-migrate-${IMAGE_SHA}-$(date -u +%Y%m%d%H%M%S)"
+          echo "Creating pre-migration snapshot ${SNAP_ID} of ${RDS_INSTANCE_ID}..."
+          aws rds create-db-snapshot \
+            --db-instance-identifier "$RDS_INSTANCE_ID" \
+            --db-snapshot-identifier "$SNAP_ID" \
+            --tags "Key=purpose,Value=pre-migration" \
+                   "Key=git_sha,Value=${IMAGE_SHA}" \
+                   "Key=run_id,Value=${GITHUB_RUN_ID}" >/dev/null
+          echo "Waiting for snapshot ${SNAP_ID} to become available..."
+          aws rds wait db-snapshot-available --db-snapshot-identifier "$SNAP_ID"
+          echo "Pre-migration snapshot ready: ${SNAP_ID}"
+
       - name: Run DB migrations (one-off task, gated before services roll)
         working-directory: ${{ env.TF_DIR }}
         run: |

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -192,13 +192,26 @@ data "aws_iam_policy_document" "gha_deploy" {
       "ec2:*LaunchTemplate*", "autoscaling:*", "iam:GetRole", "iam:ListRolePolicies",
       "iam:ListAttachedRolePolicies", "iam:GetRolePolicy", "acm:*", "ssm:GetParameters",
       "ssm:GetParametersByPath", "ssm:GetParameter", "ssm:DescribeParameters",
-      "rds:DescribeDBInstances", "route53:*",
-      # Pre-migration safety snapshot taken by deploy-ecs.yml before the migrate
-      # task runs (fail-closed). Mirrors the Vitae GCP "gcloud sql backups create"
-      # pre-migration step. Keep these if the broader wildcard is ever tightened.
-      "rds:CreateDBSnapshot", "rds:DescribeDBSnapshots", "rds:AddTagsToResource",
+      # rds:Describe* are read-only and don't support resource-level scoping;
+      # the pre-migration snapshot WRITE actions are scoped separately below.
+      "rds:DescribeDBInstances", "rds:DescribeDBSnapshots", "route53:*",
     ]
     resources = ["*"]
+  }
+  statement {
+    # Least-privilege for the deploy-ecs.yml pre-migration snapshot (mirrors the
+    # Vitae GCP "gcloud sql backups create" step): create/tag only the genfeed-data
+    # snapshots, never account-wide.
+    sid    = "RdsPreMigrationSnapshot"
+    effect = "Allow"
+    actions = [
+      "rds:CreateDBSnapshot",
+      "rds:AddTagsToResource",
+    ]
+    resources = [
+      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:db:genfeed-data",
+      "arn:aws:rds:*:${data.aws_caller_identity.current.account_id}:snapshot:pre-migrate-*",
+    ]
   }
   statement {
     sid    = "ManageGenfeedIam"

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -193,6 +193,10 @@ data "aws_iam_policy_document" "gha_deploy" {
       "iam:ListAttachedRolePolicies", "iam:GetRolePolicy", "acm:*", "ssm:GetParameters",
       "ssm:GetParametersByPath", "ssm:GetParameter", "ssm:DescribeParameters",
       "rds:DescribeDBInstances", "route53:*",
+      # Pre-migration safety snapshot taken by deploy-ecs.yml before the migrate
+      # task runs (fail-closed). Mirrors the Vitae GCP "gcloud sql backups create"
+      # pre-migration step. Keep these if the broader wildcard is ever tightened.
+      "rds:CreateDBSnapshot", "rds:DescribeDBSnapshots", "rds:AddTagsToResource",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## What

Ports the **pre-migration backup** safety rail from Vitae's GCP `db-migrate.yml` to genfeed's AWS deploy. [`deploy-ecs.yml`](.github/workflows/deploy-ecs.yml) now takes an on-demand RDS snapshot of `genfeed-data` and waits for it before the one-off migrate task runs. Fail-closed: if the snapshot create/wait fails, the deploy halts **before** the migration can touch the DB.

## Why

The prod deploy ran `prisma migrate deploy` (via the migrate ECS task) with **no pre-migration backup**. RDS automated backup retention on `genfeed-data` is only **1 day** and deletion protection is **off** — so a bad migration had a thin recovery window. This makes every migration recoverable to an explicit, tagged point-in-time.

Reference (the "we already did this for GCP" pattern): Vitae `db-migrate.yml` → *Create pre-migration Cloud SQL backup* (`gcloud sql backups create`, "never run migrations without a fresh on-demand backup").

## Changes

- **`deploy-ecs.yml`** — new `Snapshot RDS before migrations (fail-closed)` step before *Run DB migrations*. Snapshot id `pre-migrate-<sha>-<utc-ts>`, tagged `purpose/git_sha/run_id`. `aws rds wait db-snapshot-available` gates the migrate task.
- **`infra/terraform/bootstrap/main.tf`** — the deploy role (`gha-genfeed-deploy`) had scoped rds perms (`rds:DescribeDBInstances` only). Adds `rds:CreateDBSnapshot`, `rds:DescribeDBSnapshots` (waiter), `rds:AddTagsToResource`.

## ⚠️ Apply order

Apply the **bootstrap** stack first (grants the new rds perms), *then* the next production deploy will have the snapshot step working. Until bootstrap is applied, the snapshot step fails-closed and blocks the deploy (safe, but blocking).

## Deliberately not in this PR

The **read-only pre-flight integrity gate** (Vitae's `prod-db-readonly-check.yml` + the `RUN_PRODUCTION_MIGRATIONS` preflight gate) has **no drop-in AWS analogue**: genfeed RDS is private, so a GitHub runner can't reach it the way Vitae does via Cloud SQL Auth Proxy. The AWS version must run the read-only checks as an ECS task (or SSM tunnel) in the private subnet, plus genfeed-specific integrity SQL and a `*_readonly` DB user. That's a separate, larger piece — happy to do it next.

Surfaced by your question: *"do we have a backup taken before the migration? check CI."* The answer was no — this fixes that.