### PR TITLE
fix(api): break org-settings↔workflows boot cycle (TDZ crash from #697)

### DIFF
--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -3,8 +3,7 @@ import { ModelsService } from '@api/collections/models/services/models.service';
 import { CreateOrganizationSettingDto } from '@api/collections/organization-settings/dto/create-organization-setting.dto';
 import { UpdateOrganizationSettingDto } from '@api/collections/organization-settings/dto/update-organization-setting.dto';
 import type { OrganizationSettingDocument } from '@api/collections/organization-settings/schemas/organization-setting.schema';
-// biome-ignore lint/style/useImportType: resolved at runtime via ModuleRef as a DI token
-import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import type { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import {
@@ -86,9 +85,18 @@ export class OrganizationSettingsService extends BaseService<
         return;
       }
 
-      const workflowsService = this.moduleRef.get(WorkflowsService, {
-        strict: false,
-      });
+      // Load the class for the ModuleRef token via a relative dynamic import.
+      // A top-level value import of workflows.service here completes a module
+      // cycle (workflows → … → organization-settings) that TDZ-crashes the API
+      // on boot: "Cannot access 'OrganizationSettingsService' before
+      // initialization". Deferring the load to call time breaks the cycle.
+      const { WorkflowsService } = await import(
+        '../../workflows/services/workflows.service'
+      );
+      const workflowsService = this.moduleRef.get<WorkflowsService>(
+        WorkflowsService,
+        { strict: false },
+      );
       await workflowsService.ensureDailyTrendsDigestWorkflow(
         organization.userId,
         organizationId,


### PR DESCRIPTION
## Incident
v0.2.6 (cut from `6ed7cf43f`) **crash-loops the API on boot**:
\`\`\`
ReferenceError: Cannot access 'OrganizationSettingsService' before initialization
\`\`\`
- prod ECS deploy → new task fails health → **auto-rolled-back** (prod safe on old image)
- self-hosted release E2E → liveness gate timed out (same image won't boot)

## Root cause
#697 added a **top-level value import** of `WorkflowsService` into `OrganizationSettingsService` (used only as a `ModuleRef.get()` token). That eager import completes a module cycle (`workflows → … → organization-settings`) → TDZ on boot. CI never caught it (no boot test).

## Fix
- `import type { WorkflowsService }` (erased at compile — no runtime import edge)
- load the class for the ModuleRef token via a **relative dynamic `import()`** at call time, deferring `workflows.service` load past boot.

Behavior unchanged (auto-seed still runs on org bootstrap); cycle broken. `@genfeedai/api` type-check green. **Real validation is the redeploy** (CI has no boot test — that gap is why this slipped; worth a follow-up smoke).