### PR TITLE
feat(ci): pre-roll boot smoke in prod deploy (catch crash-on-boot)

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -186,12 +186,14 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: tofu init -input=false
 
-      - name: Register migration task definition
+      - name: Register migration + boot-smoke task definitions
         working-directory: ${{ env.TF_DIR }}
         run: |
           tofu apply -input=false -auto-approve \
             -target=aws_cloudwatch_log_group.migrate \
             -target=aws_ecs_task_definition.migrate \
+            -target=aws_cloudwatch_log_group.boot_smoke \
+            -target=aws_ecs_task_definition.boot_smoke \
             -var="image_tag=${{ steps.image.outputs.sha }}" \
             -var="enable_dns_cutover=true"
 
@@ -244,6 +246,29 @@ jobs:
             --query 'tasks[0].containers[0].exitCode' --output text)
           echo "migrate exit code: $CODE"
           [ "$CODE" = "0" ] || { echo "::error::migration failed"; exit 1; }
+
+      - name: Boot smoke — verify new image boots (gated before services roll)
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          set -euo pipefail
+          # Run the api with BOOT_SMOKE=1 as a one-off task: it fully initializes
+          # (catching crash-on-boot like the #711 circular-dep TDZ) then exits 0.
+          # If it can't boot, fail HERE — before any service rolls — so a bad
+          # image never reaches traffic (vs. rolling then circuit-breaker rollback).
+          CLUSTER=$(tofu output -raw cluster_name)
+          TASK_DEFINITION=$(tofu output -raw boot_smoke_task_definition_arn)
+          SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
+          SG=$(tofu output -raw task_security_group)
+          echo "Running boot smoke on $CLUSTER ($TASK_DEFINITION)..."
+          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEFINITION" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
+            --query 'tasks[0].taskArn' --output text)
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
+          CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          echo "boot smoke exit code: $CODE"
+          [ "$CODE" = "0" ] || { echo "::error::API failed to boot (crash-on-boot) — aborting before rolling services"; exit 1; }
 
       - name: Tofu apply (roll services to new image)
         working-directory: ${{ env.TF_DIR }}

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -269,10 +269,26 @@ async function main() {
 
     expressApp.use('/admin/queues', bullBoardAuth, serverAdapter.getRouter());
 
+    if (process.env.BOOT_SMOKE === '1') {
+      // Boot smoke (used as a pre-roll gate in deploy-ecs before services roll):
+      // fully initialize the app — which surfaces crash-on-boot bugs like the
+      // circular-dependency TDZ that shipped because CI has no boot test — then
+      // exit cleanly without listening. Any boot failure throws into the catch
+      // below, which exits non-zero so the gate fails.
+      await app.init();
+      await app.close();
+      logger.debug('Boot smoke OK — API initialized cleanly.');
+      process.exit(0);
+    }
+
     await app.listen(port);
     logger.debug(`API service is running on port ${port}`);
   } catch (error: unknown) {
     logger.error('Failed to start API service:', error);
+    if (process.env.BOOT_SMOKE === '1') {
+      // Fail the boot-smoke gate loudly — never let a startup error pass as green.
+      process.exit(1);
+    }
   }
 }
 

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -39,6 +39,10 @@ output "migrate_task_definition_arn" {
   value = aws_ecs_task_definition.migrate.arn
 }
 
+output "boot_smoke_task_definition_arn" {
+  value = aws_ecs_task_definition.boot_smoke.arn
+}
+
 # Network config for `aws ecs run-task` (migrate) in CI — private subnets (NAT egress).
 output "task_subnets" {
   value = local.private_subnet_ids

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -89,3 +89,45 @@ resource "aws_ecs_task_definition" "migrate" {
     }
   }])
 }
+
+# ── One-off boot smoke (run via `aws ecs run-task` BEFORE services roll) ─
+# Boots the api with BOOT_SMOKE=1 so it fully initializes (catching crash-on-boot
+# bugs like the circular-dependency TDZ in #711 that CI's lack of a boot test let
+# ship) then exits 0 — without listening. Uses the api service's full env so the
+# boot path is realistic. If the new image can't boot, the deploy fails HERE,
+# before any service rolls.
+resource "aws_cloudwatch_log_group" "boot_smoke" {
+  name              = "/ecs/${local.name_prefix}/boot-smoke"
+  retention_in_days = 30
+}
+
+resource "aws_ecs_task_definition" "boot_smoke" {
+  family                   = "${local.name_prefix}-boot-smoke"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = local.services.api.cpu
+  memory                   = local.services.api.mem
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([{
+    name      = "boot-smoke"
+    image     = local.image
+    essential = true
+    command   = ["bun", "--filter", local.services.api.filter, "start:prod"]
+    secrets   = local.task_secrets
+    environment = concat(local.internal_env, [
+      { name = "PORT", value = tostring(local.services.api.port) },
+      { name = "SERVICE_NAME", value = "api" },
+      { name = "BOOT_SMOKE", value = "1" },
+    ])
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.boot_smoke.name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "boot-smoke"
+      }
+    }
+  }])
+}


### PR DESCRIPTION
Adds a **boot smoke gate** to `deploy-ecs.yml`: run the new image as a one-off task with `BOOT_SMOKE=1` **before** rolling services. A crash-on-boot (like the #711 circular-dep TDZ) now **fails the deploy before any service rolls**, instead of rolling → failing health → circuit-breaker rollback.

- `api/src/main.ts`: `BOOT_SMOKE=1` path — fully `app.init()` then exit 0 (reproduces the boot path incl. `onApplicationBootstrap` where #711 crashed); startup error in smoke mode exits non-zero so the gate fails loud.
- terraform: `boot_smoke` task def mirroring `migrate` but with the api command + the **full service env** (`internal_env` + `task_secrets` + PORT + `BOOT_SMOKE=1`), so the boot is realistic.
- `deploy-ecs.yml`: registers it in the targeted apply; runs it gated between migrate and the service roll.

Validated locally: api type-check ✓, `tofu fmt` ✓, `tofu validate` ✓, actionlint ✓. The run-task step is exercised by the **next prod deploy** (CI can't run it).

Pairs with #712 (e2e-api boot gate in CI) — this catches at deploy time, #712 catches pre-merge.