### PR TITLE
feat(ci): hermetic API boot-check gate on PRs (catch crash-on-boot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,3 +495,27 @@ jobs:
           else
             bun run build
           fi
+
+  # Boot gate — builds the COMPILED api bundle and loads its full provider graph
+  # with BOOT_CHECK=1, which exits 0 BEFORE NestFactory/config (no env, DB, or
+  # Redis needed). A circular-import TDZ — e.g. #711's "Cannot access 'X' before
+  # initialization", which crashed the API on boot and shipped because nothing in
+  # PR CI booted the build — crashes the process here and fails the PR. vitest
+  # cannot reproduce this class (its SWC/ESM resolution differs); only the
+  # compiled webpack bundle does, which is exactly what this runs.
+  api-boot-check:
+    name: API Boot Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: trust
+    if: needs.trust.outputs.is-trusted == 'true'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+      - name: Build api (compiled bundle)
+        run: bunx turbo run build --filter=@genfeedai/api
+      - name: Boot check — compiled graph must load
+        run: BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -292,5 +292,17 @@ async function main() {
   }
 }
 
+// Hermetic boot-check gate (CI, on PRs): by the time module evaluation reaches
+// here, every import above — including AppModule and its whole provider graph —
+// has loaded. A circular-import TDZ (e.g. #711's "Cannot access 'X' before
+// initialization") throws during that import and crashes the process before this
+// line, so exit 0 here means the compiled graph loads cleanly. We exit BEFORE
+// NestFactory/config so the check needs no env, DB, or Redis — unlike BOOT_SMOKE
+// (the full deploy-time init). Note: vitest can't reproduce this TDZ (its SWC/ESM
+// resolution differs); only the compiled build does, which is what CI runs here.
+if (process.env.BOOT_CHECK === '1') {
+  process.exit(0);
+}
+
 void main();
 setupGracefulShutdown();


### PR DESCRIPTION
The PR-level half of the boot-crash guard (pairs with the merged deploy-time pre-roll smoke #713).

**What:** new `api-boot-check` job in `ci.yml` (runs on PR + master push) — builds the **compiled** api bundle and runs it with `BOOT_CHECK=1`, which loads `AppModule`'s full provider graph then exits 0 **before** `NestFactory`/config. So it needs **no env, DB, or Redis** — fast and hermetic.

**Why this exact design:** the #711 crash was a circular-import TDZ (`Cannot access 'OrganizationSettingsService' before initialization`) that fired at **module load**. It shipped green because nothing in PR CI booted the build, and **vitest cannot reproduce it** (SWC/ESM resolution differs) — only the compiled webpack bundle does, which is what this runs.

**Validated locally, both directions:**
- clean build → `BOOT_CHECK=1 node dist/apps/api/main.js` exits **0** (no env).
- reintroduced the cycle → rebuild → exits **1** with the exact `ReferenceError`.

The `api-boot-check` job on **this PR** is the live proof it passes for healthy code. Recommend adding it to required status checks so it blocks merges. Layered coverage: this catches the import-cycle class pre-merge; #713 catches full-boot failures (DI, lifecycle) at deploy.