### PR TITLE
feat(videos): media provenance export — asset ID + transcript sidecar + manifest (#31)

### DIFF
--- a/apps/server/api/src/collections/videos/controllers/provenance/videos-provenance.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/provenance/videos-provenance.controller.spec.ts
@@ -1,0 +1,61 @@
+import { VideosProvenanceController } from '@api/collections/videos/controllers/provenance/videos-provenance.controller';
+import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import type { User } from '@clerk/backend';
+import type { IMediaProvenancePackage } from '@genfeedai/interfaces';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+const mockUser = {
+  id: 'user_clerk',
+  publicMetadata: { organization: 'org-1', user: 'user-1' },
+} as unknown as User;
+
+const mockPackage = {
+  assetId: 'video-1',
+  manifest: { assetId: 'video-1' },
+  manifestFilename: 'video-1.manifest.json',
+  transcriptSidecar: { filename: 'video-1.transcript.vtt' },
+} as unknown as IMediaProvenancePackage;
+
+describe('VideosProvenanceController', () => {
+  let controller: VideosProvenanceController;
+  let videoProvenanceService: { buildProvenance: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    videoProvenanceService = {
+      buildProvenance: vi.fn().mockResolvedValue(mockPackage),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VideosProvenanceController],
+      providers: [
+        {
+          provide: VideoProvenanceService,
+          useValue: videoProvenanceService,
+        },
+      ],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: vi.fn().mockReturnValue(true) })
+      .compile();
+
+    controller = module.get<VideosProvenanceController>(
+      VideosProvenanceController,
+    );
+  });
+
+  it('returns the provenance package wrapped in a data envelope', async () => {
+    const result = await controller.getProvenance(mockUser, 'video-1');
+
+    expect(result).toEqual({ data: mockPackage });
+  });
+
+  it('passes the caller scope to the service', async () => {
+    await controller.getProvenance(mockUser, 'video-1');
+
+    expect(videoProvenanceService.buildProvenance).toHaveBeenCalledWith(
+      'video-1',
+      { organizationId: 'org-1', userId: 'user-1' },
+    );
+  });
+});

--- a/apps/server/api/src/collections/videos/controllers/provenance/videos-provenance.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/provenance/videos-provenance.controller.ts
@@ -1,0 +1,41 @@
+import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
+import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { getPublicMetadata } from '@api/helpers/utils/clerk/clerk.util';
+import type { User } from '@clerk/backend';
+import type { IMediaProvenancePackage } from '@genfeedai/interfaces';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+
+/**
+ * VideosProvenance Controller
+ * Emits the canonical media provenance package for a video (issue #31):
+ * - Stable asset ID
+ * - Transcript sidecar with timestamps
+ * - JSON manifest with canonical URLs + generation metadata
+ */
+@AutoSwagger()
+@Controller('videos')
+@UseGuards(RolesGuard)
+export class VideosProvenanceController {
+  constructor(
+    private readonly videoProvenanceService: VideoProvenanceService,
+  ) {}
+
+  @Get(':videoId/provenance')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async getProvenance(
+    @CurrentUser() user: User,
+    @Param('videoId') videoId: string,
+  ): Promise<{ data: IMediaProvenancePackage }> {
+    const publicMetadata = getPublicMetadata(user);
+
+    const data = await this.videoProvenanceService.buildProvenance(videoId, {
+      organizationId: publicMetadata.organization,
+      userId: publicMetadata.user,
+    });
+
+    return { data };
+  }
+}

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
@@ -119,6 +119,11 @@ describe('VideoProvenanceService', () => {
       _id: 'video-1',
       isDeleted: false,
     });
+    // Soft-deleted metadata must never leak into the provenance package.
+    expect(metadataService.findOne).toHaveBeenCalledWith({
+      _id: 'meta-1',
+      isDeleted: false,
+    });
   });
 
   it('throws NotFound when the video does not exist', async () => {

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
@@ -1,0 +1,163 @@
+import { CaptionsService } from '@api/collections/captions/services/captions.service';
+import { MetadataService } from '@api/collections/metadata/services/metadata.service';
+import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
+import { VideosService } from '@api/collections/videos/services/videos.service';
+import { IngredientCategory } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+const makeVideo = (overrides: Record<string, unknown> = {}) => ({
+  _id: 'video-1',
+  category: IngredientCategory.VIDEO,
+  cdnUrl: 'https://cdn.example.com/video-1.mp4',
+  fileSize: 2048,
+  generationCompletedAt: new Date('2026-06-20T10:00:00.000Z'),
+  generationPrompt: 'a sunset',
+  generationSeed: 7,
+  generationSource: 'studio',
+  id: 'video-1',
+  language: 'en',
+  loraUsed: 'lora-a',
+  metadataId: 'meta-1',
+  mimeType: 'video/mp4',
+  modelUsed: 'wan-2.2',
+  negativePrompt: 'blur',
+  s3Key: 'videos/video-1.mp4',
+  workflowUsed: 'wf-1',
+  ...overrides,
+});
+
+describe('VideoProvenanceService', () => {
+  let service: VideoProvenanceService;
+  let videosService: { findOne: ReturnType<typeof vi.fn> };
+  let metadataService: { findOne: ReturnType<typeof vi.fn> };
+  let captionsService: { find: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    videosService = { findOne: vi.fn() };
+    metadataService = { findOne: vi.fn() };
+    captionsService = { find: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VideoProvenanceService,
+        { provide: VideosService, useValue: videosService },
+        { provide: MetadataService, useValue: metadataService },
+        { provide: CaptionsService, useValue: captionsService },
+        {
+          provide: LoggerService,
+          useValue: {
+            debug: vi.fn(),
+            error: vi.fn(),
+            log: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<VideoProvenanceService>(VideoProvenanceService);
+  });
+
+  it('builds the canonical media package from ingredient, metadata, and captions', async () => {
+    videosService.findOne.mockResolvedValue(makeVideo());
+    metadataService.findOne.mockResolvedValue({
+      duration: 12,
+      fps: 24,
+      hasAudio: true,
+      height: 1920,
+      resolution: '1080x1920',
+      width: 1080,
+    });
+    captionsService.find.mockResolvedValue([{ content: 'Hello there' }]);
+
+    const pkg = await service.buildProvenance('video-1', {
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+
+    expect(pkg.assetId).toBe('video-1');
+    expect(pkg.manifest.canonicalUrl).toBe(
+      'https://cdn.example.com/video-1.mp4',
+    );
+    expect(pkg.manifest.storageKey).toBe('videos/video-1.mp4');
+    expect(pkg.manifest.media).toEqual({
+      durationSeconds: 12,
+      fps: 24,
+      hasAudio: true,
+      height: 1920,
+      resolution: '1080x1920',
+      width: 1080,
+    });
+    expect(pkg.manifest.generation).toMatchObject({
+      completedAt: '2026-06-20T10:00:00.000Z',
+      lora: 'lora-a',
+      model: 'wan-2.2',
+      seed: 7,
+    });
+    // Caption text becomes a single timestamped cue using the media duration.
+    expect(pkg.transcriptSidecar.segments).toEqual([
+      { end: 12, start: 0, text: 'Hello there' },
+    ]);
+    expect(pkg.transcriptSidecar.hasTimestamps).toBe(true);
+    expect(typeof pkg.manifest.generatedAt).toBe('string');
+  });
+
+  it('scopes the lookup to the requesting user and organization', async () => {
+    videosService.findOne.mockResolvedValue(makeVideo());
+    metadataService.findOne.mockResolvedValue(null);
+    captionsService.find.mockResolvedValue([]);
+
+    await service.buildProvenance('video-1', {
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+
+    expect(videosService.findOne).toHaveBeenCalledWith({
+      OR: [{ user: 'user-1' }, { organization: 'org-1' }],
+      _id: 'video-1',
+      isDeleted: false,
+    });
+  });
+
+  it('throws NotFound when the video does not exist', async () => {
+    videosService.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.buildProvenance('missing', { userId: 'user-1' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws NotFound when the ingredient is not a video', async () => {
+    videosService.findOne.mockResolvedValue(
+      makeVideo({ category: IngredientCategory.IMAGE }),
+    );
+
+    await expect(
+      service.buildProvenance('video-1', { userId: 'user-1' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('refuses an unscoped lookup without issuing a query', async () => {
+    await expect(
+      service.buildProvenance('video-1', { organizationId: '', userId: '' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    await expect(service.buildProvenance('video-1')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(videosService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('emits an empty transcript and null media when none are available', async () => {
+    videosService.findOne.mockResolvedValue(makeVideo({ metadataId: null }));
+    captionsService.find.mockResolvedValue([]);
+
+    const pkg = await service.buildProvenance('video-1', { userId: 'user-1' });
+
+    expect(metadataService.findOne).not.toHaveBeenCalled();
+    expect(pkg.manifest.media.durationSeconds).toBeNull();
+    expect(pkg.transcriptSidecar.segmentCount).toBe(0);
+    expect(pkg.transcriptSidecar.vtt).toBe('WEBVTT\n');
+  });
+});

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.ts
@@ -1,0 +1,175 @@
+import { CaptionsService } from '@api/collections/captions/services/captions.service';
+import { MetadataService } from '@api/collections/metadata/services/metadata.service';
+import { VideosService } from '@api/collections/videos/services/videos.service';
+import { IngredientCategory } from '@genfeedai/enums';
+import { buildMediaProvenancePackage } from '@genfeedai/helpers';
+import type {
+  IMediaProvenanceInput,
+  IMediaProvenancePackage,
+} from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+/** Caller scope used to constrain the lookup to the requester's user/org. */
+interface ProvenanceScope {
+  organizationId?: string;
+  userId?: string;
+}
+
+/** Read shape of the fields this service consumes from a video Ingredient row. */
+interface VideoProvenanceRecord {
+  _id?: string;
+  id?: string;
+  category?: string;
+  cdnUrl?: string | null;
+  s3Key?: string | null;
+  mimeType?: string | null;
+  fileSize?: number | null;
+  language?: string | null;
+  metadataId?: string | null;
+  modelUsed?: string | null;
+  loraUsed?: string | null;
+  generationPrompt?: string | null;
+  negativePrompt?: string | null;
+  generationSeed?: number | null;
+  generationSource?: string | null;
+  workflowUsed?: string | null;
+  generationCompletedAt?: Date | string | null;
+}
+
+/** Read shape of the fields this service consumes from a Metadata row. */
+interface MetadataRecord {
+  duration?: number | null;
+  width?: number | null;
+  height?: number | null;
+  fps?: number | null;
+  resolution?: string | null;
+  hasAudio?: boolean | null;
+}
+
+function toIsoString(value: Date | string | null | undefined): string | null {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * Video provenance export step (issue #31).
+ *
+ * Emits the canonical media package for a Genfeed video — a stable asset ID, a
+ * transcript sidecar with timestamps, and a JSON manifest with canonical URLs
+ * and generation metadata — assembled from the video's existing Ingredient,
+ * Metadata, and Caption records. Pure assembly: no external generation or upload
+ * side effects.
+ */
+@Injectable()
+export class VideoProvenanceService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly videosService: VideosService,
+    private readonly metadataService: MetadataService,
+    private readonly captionsService: CaptionsService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  async buildProvenance(
+    videoId: string,
+    scope: ProvenanceScope = {},
+  ): Promise<IMediaProvenancePackage> {
+    this.loggerService.debug(`${this.constructorName} buildProvenance`, {
+      videoId,
+    });
+
+    const orScopes: Record<string, unknown>[] = [];
+    if (scope.userId) {
+      orScopes.push({ user: scope.userId });
+    }
+    if (scope.organizationId) {
+      orScopes.push({ organization: scope.organizationId });
+    }
+
+    // Refuse to run an unscoped lookup. Empty/missing user and org would
+    // otherwise resolve any video by id regardless of ownership — a
+    // cross-tenant leak. Treat the absence of any owner constraint as not found.
+    if (orScopes.length === 0) {
+      throw new NotFoundException(
+        `${this.constructorName}: video ${videoId} not found`,
+      );
+    }
+
+    const where: Record<string, unknown> = {
+      OR: orScopes,
+      _id: videoId,
+      isDeleted: false,
+    };
+
+    const video = (await this.videosService.findOne(
+      where,
+    )) as unknown as VideoProvenanceRecord | null;
+
+    if (!video || video.category !== IngredientCategory.VIDEO) {
+      throw new NotFoundException(
+        `${this.constructorName}: video ${videoId} not found`,
+      );
+    }
+
+    const assetId = video.id ?? video._id ?? videoId;
+
+    const metadata = video.metadataId
+      ? ((await this.metadataService.findOne({
+          _id: video.metadataId,
+        })) as unknown as MetadataRecord | null)
+      : null;
+
+    const captions = (await this.captionsService.find({
+      ingredient: videoId,
+      isDeleted: false,
+    })) as unknown as Array<{ content?: string | null }>;
+
+    const transcriptText =
+      captions.find(
+        (caption) =>
+          typeof caption.content === 'string' &&
+          caption.content.trim().length > 0,
+      )?.content ?? null;
+
+    const input: IMediaProvenanceInput = {
+      assetId,
+      canonicalUrl: video.cdnUrl ?? null,
+      contentHash: null,
+      generatedAt: new Date().toISOString(),
+      generation: {
+        completedAt: toIsoString(video.generationCompletedAt),
+        lora: video.loraUsed ?? null,
+        model: video.modelUsed ?? null,
+        negativePrompt: video.negativePrompt ?? null,
+        prompt: video.generationPrompt ?? null,
+        seed: video.generationSeed ?? null,
+        source: video.generationSource ?? null,
+        workflow: video.workflowUsed ?? null,
+      },
+      kind: 'video',
+      language: video.language ?? null,
+      media: metadata
+        ? {
+            durationSeconds: metadata.duration ?? null,
+            fps: metadata.fps ?? null,
+            hasAudio: metadata.hasAudio ?? null,
+            height: metadata.height ?? null,
+            resolution: metadata.resolution ?? null,
+            width: metadata.width ?? null,
+          }
+        : null,
+      mimeType: video.mimeType ?? null,
+      sizeBytes: video.fileSize ?? null,
+      storageKey: video.s3Key ?? null,
+      transcript: transcriptText
+        ? { language: video.language ?? null, text: transcriptText }
+        : null,
+    };
+
+    return buildMediaProvenancePackage(input);
+  }
+}

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.ts
@@ -6,46 +6,12 @@ import { buildMediaProvenancePackage } from '@genfeedai/helpers';
 import type {
   IMediaProvenanceInput,
   IMediaProvenancePackage,
+  IMetadataProvenanceRecord,
+  IProvenanceScope,
+  IVideoProvenanceRecord,
 } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, NotFoundException } from '@nestjs/common';
-
-/** Caller scope used to constrain the lookup to the requester's user/org. */
-interface ProvenanceScope {
-  organizationId?: string;
-  userId?: string;
-}
-
-/** Read shape of the fields this service consumes from a video Ingredient row. */
-interface VideoProvenanceRecord {
-  _id?: string;
-  id?: string;
-  category?: string;
-  cdnUrl?: string | null;
-  s3Key?: string | null;
-  mimeType?: string | null;
-  fileSize?: number | null;
-  language?: string | null;
-  metadataId?: string | null;
-  modelUsed?: string | null;
-  loraUsed?: string | null;
-  generationPrompt?: string | null;
-  negativePrompt?: string | null;
-  generationSeed?: number | null;
-  generationSource?: string | null;
-  workflowUsed?: string | null;
-  generationCompletedAt?: Date | string | null;
-}
-
-/** Read shape of the fields this service consumes from a Metadata row. */
-interface MetadataRecord {
-  duration?: number | null;
-  width?: number | null;
-  height?: number | null;
-  fps?: number | null;
-  resolution?: string | null;
-  hasAudio?: boolean | null;
-}
 
 function toIsoString(value: Date | string | null | undefined): string | null {
   if (value instanceof Date) {
@@ -76,7 +42,7 @@ export class VideoProvenanceService {
 
   async buildProvenance(
     videoId: string,
-    scope: ProvenanceScope = {},
+    scope: IProvenanceScope = {},
   ): Promise<IMediaProvenancePackage> {
     this.loggerService.debug(`${this.constructorName} buildProvenance`, {
       videoId,
@@ -107,7 +73,7 @@ export class VideoProvenanceService {
 
     const video = (await this.videosService.findOne(
       where,
-    )) as unknown as VideoProvenanceRecord | null;
+    )) as unknown as IVideoProvenanceRecord | null;
 
     if (!video || video.category !== IngredientCategory.VIDEO) {
       throw new NotFoundException(
@@ -120,7 +86,8 @@ export class VideoProvenanceService {
     const metadata = video.metadataId
       ? ((await this.metadataService.findOne({
           _id: video.metadataId,
-        })) as unknown as MetadataRecord | null)
+          isDeleted: false,
+        })) as unknown as IMetadataProvenanceRecord | null)
       : null;
 
     const captions = (await this.captionsService.find({

--- a/apps/server/api/src/collections/videos/videos.module.ts
+++ b/apps/server/api/src/collections/videos/videos.module.ts
@@ -18,10 +18,12 @@ import { OrganizationSettingsModule } from '@api/collections/organization-settin
 import { PostsModule } from '@api/collections/posts/posts.module';
 import { PromptsModule } from '@api/collections/prompts/prompts.module';
 import { VideosCaptionsController } from '@api/collections/videos/controllers/captions/videos-captions.controller';
+import { VideosProvenanceController } from '@api/collections/videos/controllers/provenance/videos-provenance.controller';
 import { VideosRelationshipsController } from '@api/collections/videos/controllers/relationships/videos-relationships.controller';
 import { VideosUploadController } from '@api/collections/videos/controllers/upload/videos-upload.controller';
 import { VideosController } from '@api/collections/videos/controllers/videos.controller';
 import { VideoMusicOrchestrationService } from '@api/collections/videos/services/video-music-orchestration.service';
+import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
 import { VotesModule } from '@api/collections/votes/votes.module';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
@@ -47,12 +49,17 @@ import { forwardRef, Module } from '@nestjs/common';
 @Module({
   controllers: [
     VideosCaptionsController,
+    VideosProvenanceController,
     // Core controllers only - transformations and generation in sub-modules
     VideosController,
     VideosRelationshipsController,
     VideosUploadController,
   ],
-  exports: [VideoMusicOrchestrationService, VideosService],
+  exports: [
+    VideoMusicOrchestrationService,
+    VideoProvenanceService,
+    VideosService,
+  ],
   imports: [
     forwardRef(() => ActivitiesModule),
     forwardRef(() => AssetsModule),
@@ -90,6 +97,7 @@ import { forwardRef, Module } from '@nestjs/common';
     ModelRegistrationService,
     ModelsGuard,
     VideoMusicOrchestrationService,
+    VideoProvenanceService,
     VideosService,
   ],
 })

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -8,6 +8,7 @@ export * from './deserializer.helper';
 export * from './formatting/cn/cn.util';
 export * from './generation-controls.helper';
 export * from './generation-eta.helper';
+export * from './media/provenance/provenance.helper';
 export * from './model-capability.helper';
 export * from './quality-routing.helper';
 export * from './serializer.helper';

--- a/packages/helpers/src/media/provenance/provenance.helper.test.ts
+++ b/packages/helpers/src/media/provenance/provenance.helper.test.ts
@@ -1,0 +1,350 @@
+import type { IMediaProvenanceInput } from '@genfeedai/interfaces';
+import { describe, expect, it } from 'vitest';
+import {
+  buildMediaProvenancePackage,
+  buildProvenanceManifest,
+  buildTranscriptSidecar,
+  formatVttTimestamp,
+  parseSrt,
+} from './provenance.helper';
+
+const baseInput = (
+  overrides: Partial<IMediaProvenanceInput> = {},
+): IMediaProvenanceInput => ({
+  assetId: 'clvideo123',
+  generatedAt: '2026-06-21T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('formatVttTimestamp', () => {
+  it('formats zero', () => {
+    expect(formatVttTimestamp(0)).toBe('00:00:00.000');
+  });
+
+  it('formats sub-second milliseconds', () => {
+    expect(formatVttTimestamp(1.234)).toBe('00:00:01.234');
+    expect(formatVttTimestamp(0.5)).toBe('00:00:00.500');
+  });
+
+  it('formats hours, minutes, and seconds', () => {
+    expect(formatVttTimestamp(3661.5)).toBe('01:01:01.500');
+    expect(formatVttTimestamp(60)).toBe('00:01:00.000');
+  });
+
+  it('clamps negative and non-finite values to zero', () => {
+    expect(formatVttTimestamp(-5)).toBe('00:00:00.000');
+    expect(formatVttTimestamp(Number.NaN)).toBe('00:00:00.000');
+    expect(formatVttTimestamp(Number.POSITIVE_INFINITY)).toBe('00:00:00.000');
+  });
+});
+
+describe('parseSrt', () => {
+  it('parses well-formed SRT with comma milliseconds', () => {
+    const srt = [
+      '1',
+      '00:00:01,000 --> 00:00:04,000',
+      'Hello world',
+      '',
+      '2',
+      '00:00:04,500 --> 00:00:06,250',
+      'Second line',
+    ].join('\n');
+
+    expect(parseSrt(srt)).toEqual([
+      { end: 4, start: 1, text: 'Hello world' },
+      { end: 6.25, start: 4.5, text: 'Second line' },
+    ]);
+  });
+
+  it('accepts dot milliseconds and multi-line cue text', () => {
+    const srt = ['1', '00:00:00.000 --> 00:00:02.000', 'Line A', 'Line B'].join(
+      '\n',
+    );
+
+    expect(parseSrt(srt)).toEqual([
+      { end: 2, start: 0, text: 'Line A\nLine B' },
+    ]);
+  });
+
+  it('skips malformed blocks and empty input', () => {
+    expect(parseSrt('')).toEqual([]);
+    expect(parseSrt('not an srt block')).toEqual([]);
+    const partial = [
+      'garbage without arrow',
+      '',
+      '1',
+      '00:00:01,000 --> 00:00:02,000',
+      'Valid',
+    ].join('\n');
+    expect(parseSrt(partial)).toEqual([{ end: 2, start: 1, text: 'Valid' }]);
+  });
+});
+
+describe('buildTranscriptSidecar', () => {
+  it('builds a VTT sidecar from structured segments', () => {
+    const sidecar = buildTranscriptSidecar(
+      'asset1',
+      {
+        language: 'en',
+        segments: [
+          { end: 2, start: 0, text: 'Hello' },
+          { end: 5, start: 2, text: 'World' },
+        ],
+      },
+      {},
+    );
+
+    expect(sidecar.filename).toBe('asset1.transcript.vtt');
+    expect(sidecar.format).toBe('vtt');
+    expect(sidecar.language).toBe('en');
+    expect(sidecar.hasTimestamps).toBe(true);
+    expect(sidecar.segmentCount).toBe(2);
+    expect(sidecar.vtt).toBe(
+      'WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nHello\n\n2\n00:00:02.000 --> 00:00:05.000\nWorld\n',
+    );
+  });
+
+  it('falls back to SRT parsing when no segments are provided', () => {
+    const sidecar = buildTranscriptSidecar('asset1', {
+      srt: '1\n00:00:00,000 --> 00:00:01,000\nHi',
+    });
+
+    expect(sidecar.segmentCount).toBe(1);
+    expect(sidecar.segments).toEqual([{ end: 1, start: 0, text: 'Hi' }]);
+    expect(sidecar.hasTimestamps).toBe(true);
+  });
+
+  it('builds a single cue from plain text using the fallback duration', () => {
+    const sidecar = buildTranscriptSidecar(
+      'asset1',
+      { text: 'A spoken line' },
+      { fallbackDurationSeconds: 10 },
+    );
+
+    expect(sidecar.segments).toEqual([
+      { end: 10, start: 0, text: 'A spoken line' },
+    ]);
+    expect(sidecar.hasTimestamps).toBe(true);
+  });
+
+  it('emits a single zero-length cue (no timestamps) when text has no duration', () => {
+    const sidecar = buildTranscriptSidecar('asset1', { text: 'No timing' });
+
+    expect(sidecar.segments).toEqual([{ end: 0, start: 0, text: 'No timing' }]);
+    expect(sidecar.hasTimestamps).toBe(false);
+    expect(sidecar.vtt).toBe(
+      'WEBVTT\n\n1\n00:00:00.000 --> 00:00:00.000\nNo timing\n',
+    );
+  });
+
+  it('returns a valid empty sidecar when no transcript data exists', () => {
+    const sidecar = buildTranscriptSidecar('asset1', null);
+
+    expect(sidecar.segments).toEqual([]);
+    expect(sidecar.segmentCount).toBe(0);
+    expect(sidecar.hasTimestamps).toBe(false);
+    expect(sidecar.language).toBeNull();
+    expect(sidecar.vtt).toBe('WEBVTT\n');
+  });
+
+  it('prefers transcript language, then options language', () => {
+    expect(
+      buildTranscriptSidecar(
+        'a',
+        { language: 'fr', text: 'x' },
+        { language: 'en' },
+      ).language,
+    ).toBe('fr');
+    expect(
+      buildTranscriptSidecar('a', { text: 'x' }, { language: 'en' }).language,
+    ).toBe('en');
+  });
+
+  it('sorts segments by start and drops invalid ones', () => {
+    const sidecar = buildTranscriptSidecar('a', {
+      segments: [
+        { end: 5, start: 3, text: 'second' },
+        { end: 2, start: 0, text: 'first' },
+        { end: 1, start: 9, text: 'invalid end < start' },
+        { end: 8, start: 7, text: '   ' },
+        { end: Number.NaN, start: 0, text: 'invalid number' },
+      ],
+    });
+
+    expect(sidecar.segments).toEqual([
+      { end: 2, start: 0, text: 'first' },
+      { end: 5, start: 3, text: 'second' },
+    ]);
+  });
+
+  it('treats a zero-duration cue at a non-zero start as timestamped', () => {
+    const sidecar = buildTranscriptSidecar('a', {
+      segments: [{ end: 5, start: 5, text: 'chapter marker' }],
+    });
+
+    expect(sidecar.segmentCount).toBe(1);
+    expect(sidecar.hasTimestamps).toBe(true);
+  });
+});
+
+describe('buildMediaProvenancePackage', () => {
+  it('builds the full package and maps every manifest field', () => {
+    const input = baseInput({
+      canonicalUrl: 'https://cdn.example.com/v/clvideo123.mp4',
+      contentHash: 'sha256:abc',
+      generation: {
+        completedAt: '2026-06-20T12:00:00.000Z',
+        lora: 'lora-x',
+        model: 'wan-2.2',
+        negativePrompt: 'blurry',
+        prompt: 'a cat surfing',
+        seed: 42,
+        source: 'studio',
+        workflow: 'wf-1',
+      },
+      language: 'en',
+      media: {
+        durationSeconds: 12.5,
+        fps: 24,
+        hasAudio: true,
+        height: 1920,
+        resolution: '1080x1920',
+        width: 1080,
+      },
+      mimeType: 'video/mp4',
+      sizeBytes: 1024,
+      storageKey: 'videos/clvideo123.mp4',
+      transcript: { segments: [{ end: 3, start: 0, text: 'hi' }] },
+    });
+
+    const pkg = buildMediaProvenancePackage(input);
+
+    expect(pkg.assetId).toBe('clvideo123');
+    expect(pkg.manifestFilename).toBe('clvideo123.manifest.json');
+    expect(pkg.transcriptSidecar.filename).toBe('clvideo123.transcript.vtt');
+
+    expect(pkg.manifest).toEqual({
+      assetId: 'clvideo123',
+      canonicalUrl: 'https://cdn.example.com/v/clvideo123.mp4',
+      contentHash: 'sha256:abc',
+      generatedAt: '2026-06-21T00:00:00.000Z',
+      generation: {
+        completedAt: '2026-06-20T12:00:00.000Z',
+        lora: 'lora-x',
+        model: 'wan-2.2',
+        negativePrompt: 'blurry',
+        prompt: 'a cat surfing',
+        seed: 42,
+        source: 'studio',
+        workflow: 'wf-1',
+      },
+      kind: 'video',
+      language: 'en',
+      media: {
+        durationSeconds: 12.5,
+        fps: 24,
+        hasAudio: true,
+        height: 1920,
+        resolution: '1080x1920',
+        width: 1080,
+      },
+      mimeType: 'video/mp4',
+      schemaVersion: 1,
+      sizeBytes: 1024,
+      storageKey: 'videos/clvideo123.mp4',
+      transcript: {
+        filename: 'clvideo123.transcript.vtt',
+        format: 'vtt',
+        hasTimestamps: true,
+        language: 'en',
+        segmentCount: 1,
+      },
+    });
+  });
+
+  it('normalizes missing media and generation to nulls', () => {
+    const pkg = buildMediaProvenancePackage(baseInput());
+
+    expect(pkg.manifest.media).toEqual({
+      durationSeconds: null,
+      fps: null,
+      hasAudio: null,
+      height: null,
+      resolution: null,
+      width: null,
+    });
+    expect(pkg.manifest.generation).toEqual({
+      completedAt: null,
+      lora: null,
+      model: null,
+      negativePrompt: null,
+      prompt: null,
+      seed: null,
+      source: null,
+      workflow: null,
+    });
+    expect(pkg.manifest.canonicalUrl).toBeNull();
+    expect(pkg.manifest.kind).toBe('video');
+    expect(pkg.transcriptSidecar.vtt).toBe('WEBVTT\n');
+  });
+
+  it('uses media duration as the transcript fallback for text-only transcripts', () => {
+    const pkg = buildMediaProvenancePackage(
+      baseInput({
+        media: { durationSeconds: 8 },
+        transcript: { text: 'spoken' },
+      }),
+    );
+
+    expect(pkg.transcriptSidecar.segments).toEqual([
+      { end: 8, start: 0, text: 'spoken' },
+    ]);
+    expect(pkg.manifest.transcript.hasTimestamps).toBe(true);
+  });
+
+  it('honors a custom kind', () => {
+    expect(
+      buildMediaProvenancePackage(baseInput({ kind: 'avatar' })).manifest.kind,
+    ).toBe('avatar');
+  });
+
+  it('throws when assetId is empty or whitespace', () => {
+    expect(() =>
+      buildMediaProvenancePackage(baseInput({ assetId: '' })),
+    ).toThrow(/assetId/);
+    expect(() =>
+      buildMediaProvenancePackage(baseInput({ assetId: '   ' })),
+    ).toThrow(/assetId/);
+  });
+
+  it('is deterministic for identical input', () => {
+    const input = baseInput({
+      media: { durationSeconds: 4 },
+      transcript: { segments: [{ end: 1, start: 0, text: 'a' }] },
+    });
+
+    expect(buildMediaProvenancePackage(input)).toEqual(
+      buildMediaProvenancePackage(input),
+    );
+  });
+});
+
+describe('buildProvenanceManifest', () => {
+  it('reuses an already-built sidecar reference', () => {
+    const sidecar = buildTranscriptSidecar('asset1', {
+      segments: [{ end: 2, start: 0, text: 'hi' }],
+    });
+    const manifest = buildProvenanceManifest(
+      baseInput({ assetId: 'asset1' }),
+      sidecar,
+    );
+
+    expect(manifest.transcript).toEqual({
+      filename: 'asset1.transcript.vtt',
+      format: 'vtt',
+      hasTimestamps: true,
+      language: null,
+      segmentCount: 1,
+    });
+  });
+});

--- a/packages/helpers/src/media/provenance/provenance.helper.ts
+++ b/packages/helpers/src/media/provenance/provenance.helper.ts
@@ -1,0 +1,300 @@
+import type {
+  IMediaGenerationProvenance,
+  IMediaProvenanceInput,
+  IMediaProvenanceManifest,
+  IMediaProvenancePackage,
+  IMediaTechnicalMetadata,
+  IMediaTranscriptInput,
+  IMediaTranscriptReference,
+  IMediaTranscriptSidecar,
+  IProvenanceTranscriptSegment,
+} from '@genfeedai/interfaces';
+
+/** Current manifest schema version. Bump when the manifest shape changes. */
+export const MEDIA_PROVENANCE_SCHEMA_VERSION = 1;
+
+const DEFAULT_KIND = 'video';
+const VTT_HEADER = 'WEBVTT';
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+/**
+ * Format a number of seconds as a WebVTT timestamp (`HH:MM:SS.mmm`).
+ * Negative or non-finite inputs are clamped to zero.
+ */
+export function formatVttTimestamp(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const totalMs = Math.round(safe * 1000);
+  const ms = totalMs % 1000;
+  const totalSeconds = Math.floor(totalMs / 1000);
+  const secs = totalSeconds % 60;
+  const minutes = Math.floor(totalSeconds / 60) % 60;
+  const hours = Math.floor(totalSeconds / 3600);
+
+  const pad = (value: number, size = 2): string =>
+    value.toString().padStart(size, '0');
+
+  return `${pad(hours)}:${pad(minutes)}:${pad(secs)}.${pad(ms, 3)}`;
+}
+
+function parseSrtTimestamp(value: string): number | null {
+  // Accepts `HH:MM:SS,mmm` or `HH:MM:SS.mmm`.
+  const match = value.trim().match(/^(\d{1,2}):(\d{2}):(\d{2})[,.](\d{1,3})$/);
+  if (!match) {
+    return null;
+  }
+  const [, hours, minutes, secs, millis] = match;
+  return (
+    Number(hours) * 3600 +
+    Number(minutes) * 60 +
+    Number(secs) +
+    Number(millis.padEnd(3, '0')) / 1000
+  );
+}
+
+/** Parse an SRT document into timestamped segments. Malformed blocks are skipped. */
+export function parseSrt(srt: string): IProvenanceTranscriptSegment[] {
+  if (typeof srt !== 'string' || srt.trim().length === 0) {
+    return [];
+  }
+
+  const segments: IProvenanceTranscriptSegment[] = [];
+  const blocks = srt.replace(/\r\n/g, '\n').split(/\n\s*\n/);
+
+  for (const block of blocks) {
+    const lines = block.split('\n').filter((line) => line.trim().length > 0);
+    if (lines.length === 0) {
+      continue;
+    }
+
+    const timeLineIndex = lines.findIndex((line) => line.includes('-->'));
+    if (timeLineIndex === -1) {
+      continue;
+    }
+
+    const [rawStart, rawEnd] = lines[timeLineIndex].split('-->');
+    const start = parseSrtTimestamp(rawStart ?? '');
+    const end = parseSrtTimestamp(rawEnd ?? '');
+    if (start === null || end === null) {
+      continue;
+    }
+
+    const text = lines
+      .slice(timeLineIndex + 1)
+      .join('\n')
+      .trim();
+    if (text.length === 0) {
+      continue;
+    }
+
+    segments.push({ end, start, text });
+  }
+
+  return segments;
+}
+
+function sanitizeSegments(
+  segments: IProvenanceTranscriptSegment[],
+): IProvenanceTranscriptSegment[] {
+  return segments
+    .filter(
+      (segment) =>
+        segment &&
+        typeof segment.text === 'string' &&
+        segment.text.trim().length > 0 &&
+        Number.isFinite(segment.start) &&
+        Number.isFinite(segment.end) &&
+        segment.end >= segment.start,
+    )
+    .map((segment) => ({
+      end: Math.max(0, segment.end),
+      start: Math.max(0, segment.start),
+      text: segment.text.trim(),
+    }))
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+}
+
+/**
+ * Resolve raw transcript input into normalized timestamped segments.
+ * Priority: explicit `segments` → `srt` → single cue from `text`.
+ */
+function resolveSegments(
+  transcript: IMediaTranscriptInput | null | undefined,
+  fallbackDurationSeconds: number | null,
+): IProvenanceTranscriptSegment[] {
+  if (!transcript) {
+    return [];
+  }
+
+  if (Array.isArray(transcript.segments) && transcript.segments.length > 0) {
+    return sanitizeSegments(transcript.segments);
+  }
+
+  if (stringOrNull(transcript.srt)) {
+    return sanitizeSegments(parseSrt(transcript.srt as string));
+  }
+
+  const text = stringOrNull(transcript.text);
+  if (text) {
+    const end =
+      fallbackDurationSeconds && fallbackDurationSeconds > 0
+        ? fallbackDurationSeconds
+        : 0;
+    return [{ end, start: 0, text: text.trim() }];
+  }
+
+  return [];
+}
+
+function buildVtt(segments: IProvenanceTranscriptSegment[]): string {
+  if (segments.length === 0) {
+    return `${VTT_HEADER}\n`;
+  }
+
+  const cues = segments.map((segment, index) => {
+    const range = `${formatVttTimestamp(segment.start)} --> ${formatVttTimestamp(segment.end)}`;
+    return `${index + 1}\n${range}\n${segment.text}`;
+  });
+
+  return `${VTT_HEADER}\n\n${cues.join('\n\n')}\n`;
+}
+
+/**
+ * Build the transcript sidecar (WebVTT + structured segments) for an asset.
+ * Always returns a valid sidecar, even when no transcript data is available.
+ */
+export function buildTranscriptSidecar(
+  assetId: string,
+  transcript: IMediaTranscriptInput | null | undefined,
+  options: {
+    fallbackDurationSeconds?: number | null;
+    language?: string | null;
+  } = {},
+): IMediaTranscriptSidecar {
+  const segments = resolveSegments(
+    transcript,
+    numberOrNull(options.fallbackDurationSeconds ?? null),
+  );
+
+  return {
+    filename: `${assetId}.transcript.vtt`,
+    format: 'vtt',
+    // A cue carries real timing if it has a positive duration OR a non-zero
+    // start (e.g. a zero-duration chapter marker at t=5s). Only the text-only
+    // fallback cue at 0→0 counts as "no timestamps".
+    hasTimestamps: segments.some(
+      (segment) => segment.start > 0 || segment.end > segment.start,
+    ),
+    language:
+      stringOrNull(transcript?.language) ?? stringOrNull(options.language),
+    segmentCount: segments.length,
+    segments,
+    vtt: buildVtt(segments),
+  };
+}
+
+function normalizeMedia(
+  media: Partial<IMediaTechnicalMetadata> | null | undefined,
+): IMediaTechnicalMetadata {
+  return {
+    durationSeconds: numberOrNull(media?.durationSeconds),
+    fps: numberOrNull(media?.fps),
+    hasAudio: booleanOrNull(media?.hasAudio),
+    height: numberOrNull(media?.height),
+    resolution: stringOrNull(media?.resolution),
+    width: numberOrNull(media?.width),
+  };
+}
+
+function normalizeGeneration(
+  generation: Partial<IMediaGenerationProvenance> | null | undefined,
+): IMediaGenerationProvenance {
+  return {
+    completedAt: stringOrNull(generation?.completedAt),
+    lora: stringOrNull(generation?.lora),
+    model: stringOrNull(generation?.model),
+    negativePrompt: stringOrNull(generation?.negativePrompt),
+    prompt: stringOrNull(generation?.prompt),
+    seed: numberOrNull(generation?.seed),
+    source: stringOrNull(generation?.source),
+    workflow: stringOrNull(generation?.workflow),
+  };
+}
+
+function toTranscriptReference(
+  sidecar: IMediaTranscriptSidecar,
+): IMediaTranscriptReference {
+  return {
+    filename: sidecar.filename,
+    format: sidecar.format,
+    hasTimestamps: sidecar.hasTimestamps,
+    language: sidecar.language,
+    segmentCount: sidecar.segmentCount,
+  };
+}
+
+/**
+ * Build the canonical provenance manifest for an asset from resolved input and
+ * the already-built transcript sidecar.
+ */
+export function buildProvenanceManifest(
+  input: IMediaProvenanceInput,
+  sidecar: IMediaTranscriptSidecar,
+): IMediaProvenanceManifest {
+  return {
+    assetId: input.assetId,
+    canonicalUrl: stringOrNull(input.canonicalUrl),
+    contentHash: stringOrNull(input.contentHash),
+    generatedAt: input.generatedAt,
+    generation: normalizeGeneration(input.generation),
+    kind: stringOrNull(input.kind) ?? DEFAULT_KIND,
+    language: stringOrNull(input.language),
+    media: normalizeMedia(input.media),
+    mimeType: stringOrNull(input.mimeType),
+    schemaVersion: MEDIA_PROVENANCE_SCHEMA_VERSION,
+    sizeBytes: numberOrNull(input.sizeBytes),
+    storageKey: stringOrNull(input.storageKey),
+    transcript: toTranscriptReference(sidecar),
+  };
+}
+
+/**
+ * Build the full canonical media package for a single video: a stable asset ID,
+ * a transcript sidecar with timestamps, and a JSON manifest with canonical URLs
+ * and generation metadata. Pure and deterministic — the caller supplies
+ * `generatedAt`.
+ */
+export function buildMediaProvenancePackage(
+  input: IMediaProvenanceInput,
+): IMediaProvenancePackage {
+  const assetId = stringOrNull(input.assetId);
+  if (!assetId) {
+    throw new Error(
+      'buildMediaProvenancePackage: a non-empty assetId is required',
+    );
+  }
+
+  const sidecar = buildTranscriptSidecar(assetId, input.transcript, {
+    fallbackDurationSeconds: input.media?.durationSeconds ?? null,
+    language: input.language,
+  });
+
+  const manifest = buildProvenanceManifest({ ...input, assetId }, sidecar);
+
+  return {
+    assetId,
+    manifest,
+    manifestFilename: `${assetId}.manifest.json`,
+    transcriptSidecar: sidecar,
+  };
+}

--- a/packages/interfaces/src/content/media-provenance.interface.ts
+++ b/packages/interfaces/src/content/media-provenance.interface.ts
@@ -1,0 +1,130 @@
+/**
+ * Media provenance types.
+ *
+ * Shapes for the canonical "media package" emitted by the provenance export step
+ * (issue #31): a stable asset ID, a transcript sidecar with timestamps, and a
+ * JSON manifest carrying canonical URLs + generation metadata.
+ *
+ * These are pure data shapes with no framework or DB coupling so the builder in
+ * `@genfeedai/helpers` (and any consumer) can produce a deterministic package.
+ */
+
+/** Sidecar transcript output format. Currently WebVTT only. */
+export type MediaTranscriptFormat = 'vtt';
+
+/**
+ * A timestamped transcript segment. `start`/`end` are in SECONDS to match the
+ * `ITranscriptSegment` shape produced across the Whisper/clip pipeline.
+ */
+export interface IProvenanceTranscriptSegment {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/** Technical media metadata for a video asset (sourced from the Metadata row). */
+export interface IMediaTechnicalMetadata {
+  durationSeconds: number | null;
+  width: number | null;
+  height: number | null;
+  fps: number | null;
+  resolution: string | null;
+  hasAudio: boolean | null;
+}
+
+/** Generation provenance for a media asset (model, prompt, seed, etc.). */
+export interface IMediaGenerationProvenance {
+  model: string | null;
+  lora: string | null;
+  prompt: string | null;
+  negativePrompt: string | null;
+  seed: number | null;
+  source: string | null;
+  workflow: string | null;
+  completedAt: string | null;
+}
+
+/**
+ * Raw transcript input. Resolution priority: `segments` → `srt` → `text`.
+ * Whichever is present (in that order) is used to build the sidecar.
+ */
+export interface IMediaTranscriptInput {
+  segments?: IProvenanceTranscriptSegment[] | null;
+  srt?: string | null;
+  text?: string | null;
+  language?: string | null;
+}
+
+/**
+ * Input describing a single video for which to build a provenance package.
+ * Pure data only — callers map their DB records onto this shape.
+ */
+export interface IMediaProvenanceInput {
+  /** Stable asset identifier (e.g. the Ingredient id). Required, non-empty. */
+  assetId: string;
+  /** Media kind. Defaults to `'video'`. */
+  kind?: string;
+  /** Public/canonical URL of the asset (e.g. the CDN URL). */
+  canonicalUrl?: string | null;
+  /** Storage key/path of the asset (e.g. the S3 key). */
+  storageKey?: string | null;
+  mimeType?: string | null;
+  sizeBytes?: number | null;
+  language?: string | null;
+  /** Content hash (e.g. sha256), when known. Reserved for content-addressing. */
+  contentHash?: string | null;
+  media?: Partial<IMediaTechnicalMetadata> | null;
+  generation?: Partial<IMediaGenerationProvenance> | null;
+  transcript?: IMediaTranscriptInput | null;
+  /**
+   * ISO timestamp marking when the package was generated. Supplied by the caller
+   * so the builder stays pure and deterministic.
+   */
+  generatedAt: string;
+}
+
+/** The transcript sidecar artifact emitted alongside the manifest. */
+export interface IMediaTranscriptSidecar {
+  filename: string;
+  format: MediaTranscriptFormat;
+  language: string | null;
+  hasTimestamps: boolean;
+  segmentCount: number;
+  segments: IProvenanceTranscriptSegment[];
+  /** The serialized WebVTT document. */
+  vtt: string;
+}
+
+/** Reference to the transcript sidecar embedded in the manifest. */
+export interface IMediaTranscriptReference {
+  filename: string;
+  format: MediaTranscriptFormat;
+  language: string | null;
+  hasTimestamps: boolean;
+  segmentCount: number;
+}
+
+/** The canonical provenance manifest (serialized to `<assetId>.manifest.json`). */
+export interface IMediaProvenanceManifest {
+  schemaVersion: number;
+  assetId: string;
+  kind: string;
+  canonicalUrl: string | null;
+  storageKey: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  language: string | null;
+  contentHash: string | null;
+  media: IMediaTechnicalMetadata;
+  generation: IMediaGenerationProvenance;
+  transcript: IMediaTranscriptReference;
+  generatedAt: string;
+}
+
+/** The full canonical media package emitted by the export step. */
+export interface IMediaProvenancePackage {
+  assetId: string;
+  manifestFilename: string;
+  manifest: IMediaProvenanceManifest;
+  transcriptSidecar: IMediaTranscriptSidecar;
+}

--- a/packages/interfaces/src/content/media-provenance.interface.ts
+++ b/packages/interfaces/src/content/media-provenance.interface.ts
@@ -128,3 +128,46 @@ export interface IMediaProvenancePackage {
   manifest: IMediaProvenanceManifest;
   transcriptSidecar: IMediaTranscriptSidecar;
 }
+
+/*
+ * Read shapes consumed by the API provenance export service. They describe the
+ * narrow projection of DB rows the service reads when assembling a package, kept
+ * here (not inline in the service) so the type contracts stay centralized.
+ */
+
+/** Caller scope used to constrain a provenance lookup to the requester's user/org. */
+export interface IProvenanceScope {
+  organizationId?: string;
+  userId?: string;
+}
+
+/** Read shape of the fields the provenance export consumes from a video Ingredient row. */
+export interface IVideoProvenanceRecord {
+  _id?: string;
+  id?: string;
+  category?: string;
+  cdnUrl?: string | null;
+  s3Key?: string | null;
+  mimeType?: string | null;
+  fileSize?: number | null;
+  language?: string | null;
+  metadataId?: string | null;
+  modelUsed?: string | null;
+  loraUsed?: string | null;
+  generationPrompt?: string | null;
+  negativePrompt?: string | null;
+  generationSeed?: number | null;
+  generationSource?: string | null;
+  workflowUsed?: string | null;
+  generationCompletedAt?: Date | string | null;
+}
+
+/** Read shape of the fields the provenance export consumes from a Metadata row. */
+export interface IMetadataProvenanceRecord {
+  duration?: number | null;
+  width?: number | null;
+  height?: number | null;
+  fps?: number | null;
+  resolution?: string | null;
+  hasAudio?: boolean | null;
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -79,6 +79,7 @@ export * from './content/content-run.interface';
 export * from './content/content-run-service.contract';
 export * from './content/enhancement-response.interface';
 export * from './content/generation-payload.interface';
+export * from './content/media-provenance.interface';
 export * from './content/model.interface';
 export * from './content/mood-board.interface';
 export * from './content/persona.interface';


### PR DESCRIPTION
## Summary

Implements the media provenance export step (#31): the canonical "media package" for a Genfeed video — a **stable asset ID**, a **transcript sidecar with timestamps**, and a **JSON manifest with canonical URLs + generation metadata**.

A "Genfeed video" is an `Ingredient` with `category = VIDEO` (cdnUrl/s3Key/mimeType/generation provenance live on the Ingredient; technical specs on the related `Metadata`; timestamped transcript segments follow the `{ start, end, text }` shape used across the Whisper/clip pipeline).

### What's added
- **`@genfeedai/interfaces`** — `media-provenance.interface.ts`: pure, type-only shapes for the input, manifest, transcript sidecar, and package.
- **`@genfeedai/helpers`** — `media/provenance/provenance.helper.ts`: `buildMediaProvenancePackage`, a **pure, deterministic** builder.
  - Stable asset ID = the Ingredient id (no new hashing — that's #318).
  - Transcript sidecar = WebVTT, resolved from structured segments → SRT → plain text + duration, degrading to a valid empty sidecar; `hasTimestamps` reflects real timing.
  - Manifest = schema-versioned JSON with canonical URL, storage key, media specs, generation provenance, a content-hash slot, and a transcript reference.
  - `generatedAt` is supplied by the caller so the builder stays pure (fully unit-testable).
- **`apps/server/api`** — `VideoProvenanceService` assembles the package from the video's existing `Ingredient` + `Metadata` + `Caption` records (no external generation or S3 side effects). Exposed via `GET /videos/:videoId/provenance`, **org/user-scoped** (mirrors the sibling captions controller; unscoped lookups are refused to prevent cross-tenant access). Wired into `VideosModule`.

### Design decisions (autonomous run)
- No Prisma schema change: every field needed already exists on `Ingredient`/`Metadata`/`Caption`.
- No Whisper/transcription or S3 writes on this path — the export step assembles from data already associated with the video. Transcription and persisting sidecars to storage are separate concerns.
- Issue selection: no `claude:routine`-flagged issues and the earliest dated milestone (W1) had no eligible issue, so the milestone command's result (`Backlog / Deferred`) was used; this was the highest-value cleanly-implementable code task there.

## Verification
- `bunx vitest run` on the new files: **30 passing** (22 builder + 5 service + 3 controller) plus the existing `videos.module` DI spec.
- Adversarial multi-agent review (find → verify); 2 confirmed findings fixed: `hasTimestamps` for zero-duration cues at a non-zero start, and refusing the empty-scope unscoped query (cross-tenant guard) + coverage.
- `bunx turbo run type-check` (interfaces, helpers) clean; `tsc --noEmit` on `@genfeedai/api` clean (only the pre-existing repo-wide `baseUrl` TS5101 deprecation).
- `bunx turbo run lint` (helpers, interfaces, api) + `biome check` clean.
- Full suite left to CI per laptop resource limits.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)