### PR TITLE
fix(mcp): close TOCTOU double-execution in the approval queue

### DIFF
--- a/apps/server/api/src/collections/mcp-approvals/controllers/mcp-approvals.controller.spec.ts
+++ b/apps/server/api/src/collections/mcp-approvals/controllers/mcp-approvals.controller.spec.ts
@@ -1,6 +1,7 @@
 import { McpApprovalsController } from '@api/collections/mcp-approvals/controllers/mcp-approvals.controller';
 import { McpApprovalsService } from '@api/collections/mcp-approvals/services/mcp-approvals.service';
 import { ClerkGuard } from '@api/helpers/guards/clerk/clerk.guard';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -33,6 +34,7 @@ describe('McpApprovalsController', () => {
   let controller: McpApprovalsController;
 
   const mockServiceMethods = {
+    attachResult: vi.fn(),
     createPending: vi.fn(),
     findByOrganization: vi.fn(),
     findOne: vi.fn(),
@@ -58,6 +60,8 @@ describe('McpApprovalsController', () => {
       ],
     })
       .overrideGuard(ClerkGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
       .useValue({ canActivate: () => true })
       .compile();
 
@@ -207,6 +211,50 @@ describe('McpApprovalsController', () => {
           decision: 'approve',
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('POST /:id/result', () => {
+    it('attaches result then returns the refreshed approval, org-scoped', async () => {
+      const withResult = {
+        ...fakeApproval,
+        status: 'APPROVED',
+        result: { output: 42 },
+      };
+      mockServiceMethods.attachResult.mockResolvedValue(undefined);
+      mockServiceMethods.findOne.mockResolvedValue(withResult);
+
+      const result = await controller.attachResult(
+        mockUser as never,
+        'approval-1',
+        { result: { output: 42 } },
+      );
+
+      expect(mockServiceMethods.attachResult).toHaveBeenCalledWith(
+        'approval-1',
+        'org-abc',
+        { output: 42 },
+      );
+      expect(mockServiceMethods.findOne).toHaveBeenCalledWith({
+        id: 'approval-1',
+        organizationId: 'org-abc',
+        isDeleted: false,
+      });
+      expect(result.data).toMatchObject({
+        id: 'approval-1',
+        result: { output: 42 },
+      });
+    });
+
+    it('throws NotFoundException when the approval is gone after the write', async () => {
+      mockServiceMethods.attachResult.mockResolvedValue(undefined);
+      mockServiceMethods.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.attachResult(mockUser as never, 'missing', {
+          result: {},
+        }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/server/api/src/collections/mcp-approvals/controllers/mcp-approvals.controller.ts
+++ b/apps/server/api/src/collections/mcp-approvals/controllers/mcp-approvals.controller.ts
@@ -1,3 +1,4 @@
+import { AttachMcpApprovalResultDto } from '@api/collections/mcp-approvals/dto/attach-mcp-approval-result.dto';
 import { CreateMcpApprovalDto } from '@api/collections/mcp-approvals/dto/create-mcp-approval.dto';
 import { ResolveMcpApprovalDto } from '@api/collections/mcp-approvals/dto/resolve-mcp-approval.dto';
 import type { McpApprovalDocument } from '@api/collections/mcp-approvals/schemas/mcp-approval.schema';
@@ -130,5 +131,34 @@ export class McpApprovalsController {
       dto.result,
     );
     return { data: this.toResponse(result) };
+  }
+
+  @Post(':id/result')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RolesGuard)
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
+  @ApiOperation({
+    summary: 'Attach the execution result to an approved MCP approval',
+  })
+  @ApiResponse({ description: 'Result attached', status: HttpStatus.OK })
+  async attachResult(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: AttachMcpApprovalResultDto,
+  ): Promise<{ data: McpApprovalResponse }> {
+    const { organization } = getPublicMetadata(user);
+    await this.service.attachResult(id, organization, dto.result);
+
+    const approval = await this.service.findOne({
+      id,
+      organizationId: organization,
+      isDeleted: false,
+    });
+
+    if (!approval) {
+      throw new NotFoundException('MCP approval not found');
+    }
+
+    return { data: this.toResponse(approval) };
   }
 }

--- a/apps/server/api/src/collections/mcp-approvals/dto/attach-mcp-approval-result.dto.ts
+++ b/apps/server/api/src/collections/mcp-approvals/dto/attach-mcp-approval-result.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsObject } from 'class-validator';
+
+export class AttachMcpApprovalResultDto {
+  @ApiProperty({
+    description: 'Execution result payload to persist on the approved approval',
+    type: 'object',
+  })
+  @IsObject()
+  result!: Record<string, unknown>;
+}

--- a/apps/server/api/src/collections/mcp-approvals/services/mcp-approvals.service.spec.ts
+++ b/apps/server/api/src/collections/mcp-approvals/services/mcp-approvals.service.spec.ts
@@ -12,6 +12,7 @@ describe('McpApprovalsService', () => {
     findFirst: vi.fn(),
     findMany: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   };
 
   const mockLogger: Partial<LoggerService> = {
@@ -132,29 +133,29 @@ describe('McpApprovalsService', () => {
   });
 
   describe('resolve', () => {
-    it('updates status to APPROVED and sets resolvedAt + result', async () => {
-      const existing = {
+    it('atomically flips PENDING -> APPROVED via updateMany and sets resolvedAt + result', async () => {
+      const updated = {
         id: 'approval-3',
         organizationId: 'org-1',
-        status: 'PENDING',
-      };
-      const updated = {
-        ...existing,
         status: 'APPROVED',
-        resolvedAt: expect.any(Date),
+        resolvedAt: new Date(),
+        result: { ok: true },
       };
-      mcpApproval.findFirst.mockResolvedValue(existing);
-      mcpApproval.update.mockResolvedValue(updated);
+      mcpApproval.updateMany.mockResolvedValue({ count: 1 });
+      mcpApproval.findFirst.mockResolvedValue(updated);
 
       const result = await service.resolve('approval-3', 'org-1', 'approve', {
         ok: true,
       });
 
-      expect(mcpApproval.findFirst).toHaveBeenCalledWith({
-        where: { id: 'approval-3', organizationId: 'org-1', isDeleted: false },
-      });
-      expect(mcpApproval.update).toHaveBeenCalledWith({
-        where: { id: 'approval-3' },
+      // The PENDING status is in the WHERE clause — this is the concurrency fence.
+      expect(mcpApproval.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'approval-3',
+          organizationId: 'org-1',
+          isDeleted: false,
+          status: 'PENDING',
+        },
         data: expect.objectContaining({
           status: 'APPROVED',
           resolvedAt: expect.any(Date),
@@ -165,40 +166,39 @@ describe('McpApprovalsService', () => {
     });
 
     it('updates status to DECLINED when decision is decline', async () => {
-      const existing = {
+      mcpApproval.updateMany.mockResolvedValue({ count: 1 });
+      mcpApproval.findFirst.mockResolvedValue({
         id: 'approval-4',
         organizationId: 'org-1',
-        status: 'PENDING',
-      };
-      mcpApproval.findFirst.mockResolvedValue(existing);
-      mcpApproval.update.mockResolvedValue({ ...existing, status: 'DECLINED' });
+        status: 'DECLINED',
+      });
 
       await service.resolve('approval-4', 'org-1', 'decline');
 
-      expect(mcpApproval.update).toHaveBeenCalledWith({
-        where: { id: 'approval-4' },
+      expect(mcpApproval.updateMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({ id: 'approval-4', status: 'PENDING' }),
         data: expect.objectContaining({ status: 'DECLINED' }),
       });
     });
 
     it('does not include result key when result is undefined', async () => {
-      const existing = {
+      mcpApproval.updateMany.mockResolvedValue({ count: 1 });
+      mcpApproval.findFirst.mockResolvedValue({
         id: 'approval-5',
         organizationId: 'org-1',
-        status: 'PENDING',
-      };
-      mcpApproval.findFirst.mockResolvedValue(existing);
-      mcpApproval.update.mockResolvedValue({ ...existing, status: 'APPROVED' });
+        status: 'APPROVED',
+      });
 
       await service.resolve('approval-5', 'org-1', 'approve');
 
-      const updateCall = mcpApproval.update.mock.calls[0][0] as {
+      const updateCall = mcpApproval.updateMany.mock.calls[0][0] as {
         data: Record<string, unknown>;
       };
       expect(updateCall.data).not.toHaveProperty('result');
     });
 
     it('throws NotFoundException when approval not found or cross-org', async () => {
+      mcpApproval.updateMany.mockResolvedValue({ count: 0 });
       mcpApproval.findFirst.mockResolvedValue(null);
 
       await expect(
@@ -206,17 +206,40 @@ describe('McpApprovalsService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('throws BadRequestException when status is not PENDING', async () => {
-      const existing = {
+    it('throws BadRequestException when the approval was already resolved (lost race)', async () => {
+      // updateMany matched 0 rows because status was no longer PENDING, but the
+      // row still exists for this org — i.e. a concurrent caller won the race.
+      mcpApproval.updateMany.mockResolvedValue({ count: 0 });
+      mcpApproval.findFirst.mockResolvedValue({
         id: 'approval-6',
         organizationId: 'org-1',
         status: 'APPROVED',
-      };
-      mcpApproval.findFirst.mockResolvedValue(existing);
+      });
 
       await expect(
         service.resolve('approval-6', 'org-1', 'approve'),
       ).rejects.toThrow(BadRequestException);
+
+      // Critically, no second writer flipped the row a second time.
+      expect(mcpApproval.updateMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('attachResult', () => {
+    it('writes result only to an APPROVED row scoped to the org', async () => {
+      mcpApproval.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.attachResult('approval-7', 'org-1', { output: 42 });
+
+      expect(mcpApproval.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'approval-7',
+          organizationId: 'org-1',
+          isDeleted: false,
+          status: 'APPROVED',
+        },
+        data: { result: { output: 42 } },
+      });
     });
   });
 

--- a/apps/server/api/src/collections/mcp-approvals/services/mcp-approvals.service.ts
+++ b/apps/server/api/src/collections/mcp-approvals/services/mcp-approvals.service.ts
@@ -110,30 +110,69 @@ export class McpApprovalsService extends BaseService<
     decision: 'approve' | 'decline',
     result?: Record<string, unknown>,
   ): Promise<McpApprovalDocument> {
-    const existing = (await this.delegate.findFirst({
-      where: { id, organizationId, isDeleted: false },
-    })) as McpApprovalDocument | null;
-
-    if (!existing) {
-      throw new NotFoundException('MCP approval not found');
-    }
-
-    if (existing.status !== McpApprovalStatus.PENDING) {
-      throw new BadRequestException('Approval already resolved');
-    }
-
     const status =
       decision === 'approve'
         ? McpApprovalStatus.APPROVED
         : McpApprovalStatus.DECLINED;
 
-    return (await this.delegate.update({
-      where: { id },
+    // Atomic claim: the PENDING status is part of the WHERE clause, so the
+    // transition itself is the concurrency fence. Two callers racing to resolve
+    // the same approval cannot both succeed — whoever flips PENDING first wins,
+    // and the loser's updateMany matches 0 rows. This is what lets the MCP layer
+    // safely gate tool execution on a successful resolve (no double-execution).
+    const { count } = await this.delegate.updateMany({
+      where: {
+        id,
+        organizationId,
+        isDeleted: false,
+        status: McpApprovalStatus.PENDING,
+      },
       data: {
         status,
         resolvedAt: new Date(),
         ...(result !== undefined && { result }),
       },
+    });
+
+    if (count === 0) {
+      // Either the approval does not exist / is cross-org, or it was already
+      // resolved by a concurrent caller. Distinguish the two for a clear error.
+      const existing = (await this.delegate.findFirst({
+        where: { id, organizationId, isDeleted: false },
+      })) as McpApprovalDocument | null;
+
+      if (!existing) {
+        throw new NotFoundException('MCP approval not found');
+      }
+
+      throw new BadRequestException('Approval already resolved');
+    }
+
+    return (await this.delegate.findFirst({
+      where: { id, organizationId, isDeleted: false },
     })) as McpApprovalDocument;
+  }
+
+  /**
+   * Attach the execution result to an already-APPROVED approval. Used by the MCP
+   * layer after it has atomically claimed the approval (via {@link resolve}) and
+   * executed the underlying tool, so the audit record carries the tool output
+   * (or the execution error). Scoped to APPROVED rows so it cannot resurrect or
+   * mutate a PENDING/DECLINED approval.
+   */
+  async attachResult(
+    id: string,
+    organizationId: string,
+    result: Record<string, unknown>,
+  ): Promise<void> {
+    await this.delegate.updateMany({
+      where: {
+        id,
+        organizationId,
+        isDeleted: false,
+        status: McpApprovalStatus.APPROVED,
+      },
+      data: { result },
+    });
   }
 }

--- a/apps/server/mcp/src/services/client.service.ts
+++ b/apps/server/mcp/src/services/client.service.ts
@@ -207,8 +207,11 @@ export class ClientService {
   }
 
   /**
-   * Resolve an approval. On `approve`, the caller passes the execution `result`
-   * so it is persisted alongside the APPROVED status.
+   * Resolve an approval (atomic CLAIM on the API: PENDING -> APPROVED/DECLINED).
+   * Throws if the approval was already resolved, which is what lets the caller
+   * gate tool execution on a successful claim. The optional `result` is accepted
+   * for completeness, but the MCP flow persists the execution outcome separately
+   * via {@link attachApprovalResult} after the tool has run.
    */
   async resolveApproval(
     approvalId: string,
@@ -225,6 +228,35 @@ export class ClientService {
       this.logError(`resolving approval ${approvalId}`, error as ApiError);
       throw new Error(
         this.getErrorMessage(error as ApiError, 'Failed to resolve approval'),
+      );
+    }
+  }
+
+  /**
+   * Attach the tool execution result (or error) to an already-APPROVED approval.
+   * Called after the approval has been atomically claimed via {@link resolveApproval}
+   * and the tool has run, so the audit record reflects the outcome.
+   */
+  async attachApprovalResult(
+    approvalId: string,
+    result: Record<string, unknown>,
+  ): Promise<McpApprovalResource> {
+    try {
+      const response = await this.client.post(
+        `/mcp-approvals/${encodeURIComponent(approvalId)}/result`,
+        { result },
+      );
+      return response.data?.data as McpApprovalResource;
+    } catch (error: unknown) {
+      this.logError(
+        `attaching result to approval ${approvalId}`,
+        error as ApiError,
+      );
+      throw new Error(
+        this.getErrorMessage(
+          error as ApiError,
+          'Failed to attach approval result',
+        ),
       );
     }
   }

--- a/apps/server/mcp/src/services/tool-registry.approval.spec.ts
+++ b/apps/server/mcp/src/services/tool-registry.approval.spec.ts
@@ -37,6 +37,9 @@ vi.mock('@mcp/guards/mcp-auth.guard', () => ({
 
 function build() {
   const client = {
+    attachApprovalResult: vi
+      .fn()
+      .mockResolvedValue({ id: 'apr-1', status: 'APPROVED' }),
     createApproval: vi.fn().mockResolvedValue({
       id: 'apr-1',
       status: 'PENDING',
@@ -46,9 +49,14 @@ function build() {
       .fn()
       .mockResolvedValue({ data: { id: 'post-1' }, success: true }),
     getApproval: vi.fn(),
-    resolveApproval: vi
-      .fn()
-      .mockResolvedValue({ id: 'apr-1', status: 'APPROVED' }),
+    // resolveApproval now performs the atomic CLAIM (PENDING -> APPROVED) and
+    // returns the claimed approval, so its default resolves with toolName + args.
+    resolveApproval: vi.fn().mockResolvedValue({
+      arguments: { content: 'hello' },
+      id: 'apr-1',
+      status: 'APPROVED',
+      toolName: 'create_post',
+    }),
     getVideoStatus: vi
       .fn()
       .mockResolvedValue({ progress: 100, status: 'completed' }),
@@ -97,13 +105,13 @@ describe('ToolRegistryService — approval queue', () => {
     expect(result.content[0].text).toContain('declined');
   });
 
-  it('approves an approval: executes the deferred tool and persists the result', async () => {
+  it('approves an approval: CLAIMS first, executes the deferred tool, then persists the result', async () => {
     const { client, registry } = build();
-    client.getApproval.mockResolvedValue({
-      arguments: { videoId: 'v1' },
+    client.resolveApproval.mockResolvedValue({
+      arguments: { content: 'hello' },
       id: 'apr-1',
-      status: 'PENDING',
-      toolName: 'get_video_status',
+      status: 'APPROVED',
+      toolName: 'create_post',
     });
 
     const result = (await registry.handleToolCall({
@@ -111,13 +119,17 @@ describe('ToolRegistryService — approval queue', () => {
       name: 'resolve_approval',
     })) as { content: { text: string }[] };
 
+    // The claim happens BEFORE execution and carries no result yet (the atomic
+    // PENDING -> APPROVED fence). getApproval is no longer part of the flow.
+    expect(client.resolveApproval).toHaveBeenCalledWith('apr-1', 'approve');
+    expect(client.getApproval).not.toHaveBeenCalled();
     // The deferred tool actually ran...
-    expect(client.getVideoStatus).toHaveBeenCalledWith('v1');
-    expect(result.content[0].text).toContain('completed');
-    // ...and the execution result was persisted back on the approval.
-    expect(client.resolveApproval).toHaveBeenCalledWith(
+    expect(client.executeAgentTool).toHaveBeenCalledWith('create_post', {
+      content: 'hello',
+    });
+    // ...and the execution result was persisted via the dedicated result path.
+    expect(client.attachApprovalResult).toHaveBeenCalledWith(
       'apr-1',
-      'approve',
       expect.objectContaining({ content: expect.any(Array) }),
     );
   });
@@ -128,10 +140,10 @@ describe('ToolRegistryService — approval queue', () => {
     // executeTool (which bypasses the approval gate) — NOT re-enter the gate
     // and queue a second approval, which would be an infinite loop.
     const { client, registry } = build();
-    client.getApproval.mockResolvedValue({
+    client.resolveApproval.mockResolvedValue({
       arguments: { content: 'hello' },
       id: 'apr-1',
-      status: 'PENDING',
+      status: 'APPROVED',
       toolName: 'create_post',
     });
 
@@ -146,16 +158,33 @@ describe('ToolRegistryService — approval queue', () => {
     // The approval gate was NOT re-applied on execution.
     expect(client.createApproval).not.toHaveBeenCalled();
     expect(result.isError).toBeFalsy();
-    expect(client.resolveApproval).toHaveBeenCalledWith(
-      'apr-1',
-      'approve',
-      expect.anything(),
-    );
   });
 
-  it('refuses to approve an already-resolved approval', async () => {
+  it('refuses to approve when the claim loses the race (already resolved)', async () => {
+    // The API rejects the concurrent claim (updateMany matched 0 rows), so the
+    // client throws and the tool must NOT execute — closing the TOCTOU window.
     const { client, registry } = build();
-    client.getApproval.mockResolvedValue({
+    client.resolveApproval.mockRejectedValue(
+      new Error('Approval already resolved'),
+    );
+
+    const result = (await registry.handleToolCall({
+      arguments: { approvalId: 'apr-1', decision: 'approve' },
+      name: 'resolve_approval',
+    })) as { isError?: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('already resolved');
+    expect(client.executeAgentTool).not.toHaveBeenCalled();
+    expect(client.getVideoStatus).not.toHaveBeenCalled();
+  });
+
+  it('refuses to execute a non-approval-gated tool referenced by an approval', async () => {
+    // Defense-in-depth: a claimed approval whose toolName is not in the
+    // approval-required set must not run via the admin resolve path.
+    const { client, registry } = build();
+    client.resolveApproval.mockResolvedValue({
+      arguments: { videoId: 'v1' },
       id: 'apr-1',
       status: 'APPROVED',
       toolName: 'get_video_status',
@@ -167,8 +196,35 @@ describe('ToolRegistryService — approval queue', () => {
     })) as { isError?: boolean; content: { text: string }[] };
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('already approved');
+    expect(result.content[0].text).toContain('non-approval-gated');
     expect(client.getVideoStatus).not.toHaveBeenCalled();
+    expect(client.executeAgentTool).not.toHaveBeenCalled();
+    expect(client.attachApprovalResult).toHaveBeenCalledWith(
+      'apr-1',
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  it('records the error on the approval when execution fails after claiming', async () => {
+    const { client, registry } = build();
+    client.resolveApproval.mockResolvedValue({
+      arguments: { content: 'hello' },
+      id: 'apr-1',
+      status: 'APPROVED',
+      toolName: 'create_post',
+    });
+    client.executeAgentTool.mockRejectedValue(new Error('boom'));
+
+    const result = (await registry.handleToolCall({
+      arguments: { approvalId: 'apr-1', decision: 'approve' },
+      name: 'resolve_approval',
+    })) as { isError?: boolean; content: { text: string }[] };
+
+    expect(result.isError).toBe(true);
+    expect(client.attachApprovalResult).toHaveBeenCalledWith(
+      'apr-1',
+      expect.objectContaining({ error: expect.stringContaining('boom') }),
+    );
   });
 
   it('errors when resolve_approval is missing arguments', async () => {

--- a/apps/server/mcp/src/services/tool-registry.service.ts
+++ b/apps/server/mcp/src/services/tool-registry.service.ts
@@ -180,28 +180,66 @@ export class ToolRegistryService {
       );
     }
 
-    const approval = await this.clientService.getApproval(approvalId);
-    if (!approval) {
-      throw new Error(`Approval ${approvalId} not found`);
-    }
-    if (approval.status !== 'PENDING') {
-      throw new Error(
-        `Approval ${approvalId} is already ${approval.status.toLowerCase()}`,
-      );
-    }
-
-    const result = await this.executeTool(
-      approval.toolName,
-      approval.arguments ?? {},
-    );
-
-    await this.clientService.resolveApproval(
+    // Atomically CLAIM the approval (PENDING -> APPROVED) BEFORE executing the
+    // tool. The API resolves via a conditional updateMany on status=PENDING, so
+    // a concurrent resolve_approval for the same id loses the race and throws
+    // "already resolved" here — which means the underlying tool runs at most
+    // once even though the MCP server is stateless and handles each request in
+    // isolation. (Previously the claim happened AFTER execution, leaving a
+    // TOCTOU window where two callers could both execute an irreversible tool.)
+    const approval = await this.clientService.resolveApproval(
       approvalId,
       'approve',
+    );
+
+    // Defense-in-depth: only execute tools that are actually approval-gated, so
+    // a stray approval row created for a non-write tool cannot be run via the
+    // admin resolve path.
+    if (!APPROVAL_REQUIRED_TOOLS.has(approval.toolName)) {
+      const message = `Approval ${approvalId} references non-approval-gated tool "${approval.toolName}"; not executed.`;
+      await this.attachApprovalResultSafe(approvalId, { error: message });
+      throw new Error(message);
+    }
+
+    let result: Awaited<ReturnType<typeof this.executeTool>>;
+    try {
+      result = await this.executeTool(
+        approval.toolName,
+        approval.arguments ?? {},
+      );
+    } catch (error: unknown) {
+      // The approval is already claimed; record the failure on the audit row so
+      // the outcome is observable rather than a silently-APPROVED-but-failed row.
+      await this.attachApprovalResultSafe(approvalId, {
+        error: (error as Error)?.message ?? String(error),
+      });
+      throw error;
+    }
+
+    await this.attachApprovalResultSafe(
+      approvalId,
       result as Record<string, unknown>,
     );
 
     return result;
+  }
+
+  /**
+   * Persist a result/error on an approved approval without letting an audit-write
+   * failure mask the actual tool outcome.
+   */
+  private async attachApprovalResultSafe(
+    approvalId: string,
+    result: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await this.clientService.attachApprovalResult(approvalId, result);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to attach result to approval ${approvalId}:`,
+        error,
+      );
+    }
   }
 
   private pendingApprovalResult(approval: McpApprovalResource) {


### PR DESCRIPTION
## Summary

Closes a **MEDIUM-severity TOCTOU** in the MCP human-in-the-loop approval queue introduced by [#683](https://github.com/genfeedai/genfeed.ai/commit/6ed7cf43f) (`6ed7cf43f`).

`handleResolveApproval` did a non-atomic **check-then-act**:
1. `getApproval` reads status `PENDING`
2. `executeTool` fires the (often irreversible/expensive) tool
3. `resolveApproval` flips status to `APPROVED`

Two concurrent `resolve_approval` calls for the same `approvalId` both pass the PENDING check at step 1 and both reach `executeTool` at step 2 before either resolves at step 3 → **double execution** (double GPU spend, double content generation, double `delete_dataset`). The MCP server is **stateless per request**, so concurrent requests are the normal operating mode, not an edge case. The API-side `resolve()` rejected the second *resolution*, but only after the tool had already run twice.

## Fix

- **`McpApprovalsService.resolve()` → atomic.** Flip `PENDING → APPROVED/DECLINED` via a conditional `updateMany` with `status: PENDING` in the WHERE clause. The transition itself is the concurrency fence: the loser matches 0 rows. `count === 0` then distinguishes not-found (`404`) from already-resolved (`400`).
- **New `attachResult()` + `POST :id/result`** (admin-gated, `OWNER`/`ADMIN`). Persists the execution outcome on an already-`APPROVED` row — necessary because the result is only known *after* execution, and the claim now happens *before*.
- **MCP `handleResolveApproval` → claim-first.** `resolveApproval(id, 'approve')` atomically claims and returns `toolName`+`arguments`; only then does the tool execute; then the result is attached. A concurrent caller loses the claim, the API throws, and the tool runs **at most once**.
- **Defense-in-depth** (addresses the companion LOW finding): refuse to execute a claimed approval whose `toolName` is not in `APPROVAL_REQUIRED_TOOLS`; on execution failure, record the error on the audit row rather than leaving it silently `APPROVED`.

## Tests

- Service: atomic-resolve happy path asserts `PENDING` is in the `updateMany` WHERE; **lost-race → `400` with a single write**; not-found → `404`; `attachResult` scoped to `APPROVED` + org.
- MCP flow: **claim-before-execute ordering** (`resolveApproval` called before `executeAgentTool`, `getApproval` no longer used); lost-race → tool not executed; **non-approval-gated tool refused**; execution failure records the error on the approval.

## Verification

- `vitest`: API mcp-approvals **25 passed**, MCP tool-registry/client/role suites **57 passed**.
- `tsc --noEmit` (api `tsconfig.typecheck.json` + mcp `tsconfig.app.json`): **0 source type errors**.
- Biome + secretlint: clean (pre-commit hooks).

### Behavior-change note for reviewers
On the claim-first model, if execution fails *after* claiming, the row is `APPROVED` with an `error` result rather than reverting to `PENDING` (there is no `FAILED` status in `McpApprovalStatus`). This trades silent retry-ability for an observable, non-double-executable outcome — the safer default for irreversible tools. Re-running requires a fresh approval.

---

_From the automated daily commit review (2026-06-21). Related: #718 (mood-boards IDOR)._