### PR TITLE
fix(app): stop Fastlane swipe review skipping every other asset

### DIFF
--- a/apps/server/api/src/collections/brands/dto/generate-fastlane-ideas.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/generate-fastlane-ideas.dto.ts
@@ -19,6 +19,14 @@ export const FASTLANE_FORMATS: readonly FastlaneFormat[] = [
   'avatar',
 ] as const;
 
+/**
+ * Idea-count bounds for a Fastlane batch. These mirror the UI stepper limits in
+ * `FastlaneIdeaSelector` (the only consumer of this endpoint) so the server
+ * rejects counts the UI can never produce, instead of silently accepting 1–12.
+ */
+export const FASTLANE_MIN_IDEAS = 3;
+export const FASTLANE_MAX_IDEAS = 9;
+
 export class GenerateFastlaneIdeasDto {
   @IsArray()
   @ArrayMinSize(1)
@@ -31,11 +39,11 @@ export class GenerateFastlaneIdeasDto {
   readonly formats!: FastlaneFormat[];
 
   @IsInt()
-  @Min(1)
-  @Max(12)
+  @Min(FASTLANE_MIN_IDEAS)
+  @Max(FASTLANE_MAX_IDEAS)
   @ApiProperty({
     default: 6,
-    description: 'Number of ideas to generate (1-12)',
+    description: `Number of ideas to generate (${FASTLANE_MIN_IDEAS}-${FASTLANE_MAX_IDEAS})`,
   })
   readonly count!: number;
 

--- a/packages/pages/studio/fastlane/components/FastlaneBlitz.test.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneBlitz.test.tsx
@@ -1,0 +1,153 @@
+import type { FastlaneAssetItem } from '@genfeedai/interfaces';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import FastlaneBlitz from './FastlaneBlitz';
+
+function makeAsset(id: string, hook: string): FastlaneAssetItem {
+  return {
+    idea: {
+      id,
+      format: 'image',
+      hook,
+      caption: `${hook} caption`,
+      visualPrompt: `${hook} prompt`,
+      platformHints: ['tiktok'],
+    },
+    ingredientId: id,
+    status: 'ready',
+  };
+}
+
+/**
+ * Mirrors FastlaneLayout: it owns the approval overlay and re-derives the asset
+ * list so an approved/rejected asset drops out of the `ready` set. Reviewing
+ * through this harness is what surfaces the skip bug — the real parent shrinks
+ * the list on every swipe.
+ */
+function Harness({ initial }: { initial: FastlaneAssetItem[] }) {
+  const [approvals, setApprovals] = useState<
+    Record<string, 'approved' | 'rejected'>
+  >({});
+  const enriched = initial.map((a) =>
+    approvals[a.idea.id] ? { ...a, status: approvals[a.idea.id] } : a,
+  );
+  return (
+    <FastlaneBlitz
+      assets={enriched}
+      failedCount={0}
+      isGenerating={false}
+      onApprove={(id) =>
+        setApprovals((prev) => ({ ...prev, [id]: 'approved' }))
+      }
+      onReject={(id) => setApprovals((prev) => ({ ...prev, [id]: 'rejected' }))}
+      onDone={vi.fn()}
+    />
+  );
+}
+
+function settleSwipe() {
+  // The swipe animation defers the approve/reject + advance by 250ms.
+  act(() => {
+    vi.advanceTimersByTime(260);
+  });
+}
+
+describe('FastlaneBlitz', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('shows the generating state when nothing is ready yet', () => {
+    render(
+      <FastlaneBlitz
+        assets={[]}
+        failedCount={0}
+        isGenerating={true}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/generating your assets/i)).toBeTruthy();
+  });
+
+  it('reviews every asset in order without skipping (regression: skip-every-other)', () => {
+    render(
+      <Harness
+        initial={[
+          makeAsset('a', 'Hook A'),
+          makeAsset('b', 'Hook B'),
+          makeAsset('c', 'Hook C'),
+        ]}
+      />,
+    );
+
+    // First card is A.
+    expect(screen.getByText('Hook A')).toBeTruthy();
+    expect(screen.getByText('1 / 3 — ← reject · approve →')).toBeTruthy();
+
+    // Approve A → the very next card must be B, not C.
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    settleSwipe();
+    expect(screen.getByText('Hook B')).toBeTruthy();
+    expect(screen.queryByText('Hook C')).toBeNull();
+    expect(screen.getByText('2 / 3 — ← reject · approve →')).toBeTruthy();
+
+    // Approve B → C.
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    settleSwipe();
+    expect(screen.getByText('Hook C')).toBeTruthy();
+  });
+
+  it('advances on keyboard arrows and reaches the complete state', () => {
+    render(
+      <Harness
+        initial={[makeAsset('a', 'Hook A'), makeAsset('b', 'Hook B')]}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    settleSwipe();
+    expect(screen.getByText('Hook B')).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    settleSwipe();
+
+    // One approved (A) means the schedule CTA is offered on completion.
+    expect(screen.getByText(/review complete/i)).toBeTruthy();
+    expect(screen.getByText('1 approved')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /schedule approved/i }),
+    ).toBeTruthy();
+  });
+
+  it('ignores a second swipe while one is mid-animation', () => {
+    const onApprove = vi.fn();
+    render(
+      <FastlaneBlitz
+        assets={[makeAsset('a', 'Hook A'), makeAsset('b', 'Hook B')]}
+        failedCount={0}
+        isGenerating={false}
+        onApprove={onApprove}
+        onReject={vi.fn()}
+        onDone={vi.fn()}
+      />,
+    );
+
+    const approve = screen.getByRole('button', { name: /approve/i });
+    fireEvent.click(approve);
+    // Second click before the 250ms settle must be a no-op (swipe in progress).
+    fireEvent.click(approve);
+    settleSwipe();
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+    expect(onApprove).toHaveBeenCalledWith('a');
+  });
+});

--- a/packages/pages/studio/fastlane/components/FastlaneBlitz.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneBlitz.tsx
@@ -27,22 +27,27 @@ export default function FastlaneBlitz({
   const approvedCount = assets.filter((a) => a.status === 'approved').length;
   const rejectedCount = assets.filter((a) => a.status === 'rejected').length;
 
-  const [currentIndex, setCurrentIndex] = useState(0);
   const [swipeDir, setSwipeDir] = useState<'left' | 'right' | null>(null);
 
-  const currentAsset = readyAssets[currentIndex] ?? null;
-  const isExhausted = currentIndex >= readyAssets.length;
+  // The card under review is always the first still-`ready` asset. Approving or
+  // rejecting flips that asset's status in the parent, so it drops out of
+  // `readyAssets` and the queue advances on its own — there is no index to keep
+  // in sync. A previous integer-index approach skipped every other asset,
+  // because the list shrank by one on each swipe while the index moved forward.
+  const reviewedCount = approvedCount + rejectedCount;
+  const currentAsset = readyAssets[0] ?? null;
+  const isExhausted = readyAssets.length === 0;
 
   function triggerSwipe(dir: 'left' | 'right') {
     if (!currentAsset || swipeDir) return;
+    const { id } = currentAsset.idea;
     setSwipeDir(dir);
     setTimeout(() => {
       if (dir === 'right') {
-        onApprove(currentAsset.idea.id);
+        onApprove(id);
       } else {
-        onReject(currentAsset.idea.id);
+        onReject(id);
       }
-      setCurrentIndex((i) => i + 1);
       setSwipeDir(null);
     }, 250);
   }
@@ -140,7 +145,8 @@ export default function FastlaneBlitz({
       )}
 
       <p className="gen-label-sm text-muted-foreground">
-        {currentIndex + 1} / {readyAssets.length} — ← reject · approve →
+        {reviewedCount + 1} / {reviewedCount + readyAssets.length} — ← reject ·
+        approve →
       </p>
 
       {/* Card */}

--- a/packages/pages/studio/fastlane/components/FastlaneIdeaSelector.tsx
+++ b/packages/pages/studio/fastlane/components/FastlaneIdeaSelector.tsx
@@ -18,6 +18,8 @@ const FORMAT_LABELS: Record<FastlaneFormat, string> = {
   avatar: 'Avatar',
 };
 
+// Keep in sync with FASTLANE_MIN_IDEAS / FASTLANE_MAX_IDEAS on the API DTO
+// (generate-fastlane-ideas.dto.ts) — the server enforces these same bounds.
 const MIN_COUNT = 3;
 const MAX_COUNT = 9;
 


### PR DESCRIPTION
## Summary

Fixes a **MEDIUM-severity UX bug** in the Fastlane swipe review introduced by [#694](https://github.com/genfeedai/genfeed.ai/commit/cca6695d6) (`cca6695d6`): **every other asset was skipped** during review.

`FastlaneBlitz` tracked the current card with an integer `currentIndex`. But approving/rejecting an asset flips its status in the parent (`FastlaneLayout`'s `approvalMap` → `enrichedAssets`), so the asset **drops out of `readyAssets`**. The list shrank by one on each swipe *while the index advanced* — so:

```
readyAssets=[A,B,C], index=0  → swipe A → A leaves → readyAssets=[B,C], index=1 → shows C  (B skipped)
```

## Fix

- The card under review is always `readyAssets[0]`. Reviewed assets leave the list, so the queue advances itself — there is no index to desync. `isExhausted = readyAssets.length === 0`; the progress counter is derived from `reviewed + remaining`.
- **Contract alignment** (companion LOW finding): the API DTO accepted `1–12` ideas while the UI stepper only produces `3–9`, so direct API callers could request counts the product never intends. Added `FASTLANE_MIN_IDEAS`/`FASTLANE_MAX_IDEAS` and enforced them on `GenerateFastlaneIdeasDto` (the endpoint's only consumer is the UI). Documented the shared bound on the UI stepper.

## Tests (new `FastlaneBlitz.test.tsx`)

A controlled harness mirrors `FastlaneLayout`'s approval overlay so the list shrinks on each swipe — exactly the condition that produced the skip:
- **Regression**: `[A,B,C]` → approve A → next card is **B, not C**; then C. No skip.
- Keyboard arrows advance + reach the "Review complete" state with the schedule CTA.
- Mid-animation double-swipe is a no-op (`onApprove` fires once).
- Generating-empty state renders.

## Verification

- `vitest` fastlane suite: **26 passed** (was 22; +4 FastlaneBlitz).
- `tsc --noEmit`: **0 errors** in the fastlane files (pages) and **0** in the API (DTO change); remaining pages `TS2307`s are pre-existing unbuilt-workspace-dep noise in this checkout, unrelated to this change.
- Biome + secretlint + no-raw-html: clean (pre-commit hooks).

---

_From the automated daily commit review (2026-06-21). Related: #718, #720._