### PR TITLE
chore: gitignore stray .clone/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ test-results/
 # Agent scratch dirs at any depth (apps/<name>/.agents/, apps/<surface>/<name>/.agents/)
 # Covers apps/app/.agents, apps/mobile/app/.agents, apps/extensions/browser/app/.agents, etc.
 **/apps/**/.agents/
+# Stray nested clone/worktree scratch dir — never a real git worktree, never committed.
+# Without this, `git add -A` grabs its placeholder files into unrelated commits.
+.clone/


### PR DESCRIPTION
`.clone/` is **not a registered git worktree** (real worktrees live under `.claude/worktrees/`) — it was an orphaned directory holding a single `placeholder;` stub file.

While left untracked, `git add -A` grabs its contents into unrelated commits — it nearly leaked a `placeholder;` junk file into the #570 PR before I caught and unstaged it. This ignores `.clone/` so that can't recur, and removes the orphaned stub.

One-line `.gitignore` change; no code paths touched.