### PR TITLE
fix(workflows): honor trends-digest platform filter + log skipped charge

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -1267,6 +1267,30 @@ describe('WorkflowEngineAdapterService', () => {
       expect(deduct).not.toHaveBeenCalled();
     });
 
+    it('warns and skips (no charge, no lock) when the owner userId is missing after delivery', async () => {
+      const acquireLock = vi.fn().mockResolvedValue(true);
+      const deduct = vi.fn();
+      const adapter = makeChargeAdapter(
+        { acquireLock },
+        { deductCreditsFromOrganization: deduct },
+      );
+
+      await adapter.applyScheduledDigestCharge('wf-1', [
+        {
+          nodeType: 'trendDigest',
+          output: { creditCost: 5, orgId: 'org-1', skipped: false },
+        },
+        { nodeType: 'sendEmail', output: { sent: true } },
+      ]);
+
+      expect(deduct).not.toHaveBeenCalled();
+      expect(acquireLock).not.toHaveBeenCalled();
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.stringContaining('charge skipped'),
+        expect.objectContaining({ orgId: 'org-1', ownerUserId: null }),
+      );
+    });
+
     it('releases the marker so a transient deduction failure can retry', async () => {
       const acquireLock = vi.fn().mockResolvedValue(true);
       const releaseLock = vi.fn().mockResolvedValue(true);
@@ -1285,6 +1309,44 @@ describe('WorkflowEngineAdapterService', () => {
       expect(releaseLock.mock.calls[0][0]).toMatch(
         /^workflow-digest-charged:wf-1:\d{4}-\d{2}-\d{2}$/,
       );
+    });
+  });
+
+  describe('buildDigestTrends platform filter', () => {
+    const makeTrends = () => ({
+      getViralVideos: vi.fn().mockResolvedValue([
+        {
+          platform: 'youtube',
+          title: 'YT vid',
+          url: 'u1',
+          views: 100,
+          viralScore: 90,
+        },
+        {
+          platform: 'tiktok',
+          title: 'TT vid',
+          url: 'u2',
+          views: 100,
+          viralScore: 80,
+        },
+      ]),
+      getTrendingHashtags: vi.fn().mockResolvedValue([]),
+      getTrendingSounds: vi.fn().mockResolvedValue([]),
+    });
+
+    it('keeps only entries on the configured platforms', async () => {
+      const result = await service.buildDigestTrends(makeTrends(), 10, 0, [
+        'youtube',
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].platform).toBe('youtube');
+    });
+
+    it('treats an empty platform list as no constraint', async () => {
+      const result = await service.buildDigestTrends(makeTrends(), 10, 0, []);
+
+      expect(result).toHaveLength(2);
     });
   });
 

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -712,8 +712,8 @@ export class WorkflowEngineAdapterService {
       };
     });
 
-    executor.setTrendsProvider(({ topN, minViralScore }) =>
-      this.buildDigestTrends(trends, topN, minViralScore),
+    executor.setTrendsProvider(({ topN, minViralScore, platforms }) =>
+      this.buildDigestTrends(trends, topN, minViralScore, platforms),
     );
 
     executor.setIdempotencyGuard((key, ttlSeconds) =>
@@ -750,6 +750,7 @@ export class WorkflowEngineAdapterService {
     trends: TrendsService,
     topN: number,
     minViralScore: number,
+    platforms: string[],
   ): Promise<TrendDigestEntry[]> {
     type RawTrend = {
       platform?: string;
@@ -818,7 +819,18 @@ export class WorkflowEngineAdapterService {
         })),
     ];
 
-    return mapped.sort((a, b) => b.viralScore - a.viralScore).slice(0, topN);
+    // Honour the configured platform filter. The fetchers return a mixed-platform
+    // corpus, so a workflow that narrows `platforms` (e.g. just ['youtube']) must
+    // actually constrain the digest. An empty list is treated as "no constraint".
+    const allowed = new Set(
+      platforms.map((platform) => platform.toLowerCase()),
+    );
+    const filtered =
+      allowed.size > 0
+        ? mapped.filter((entry) => allowed.has(entry.platform.toLowerCase()))
+        : mapped;
+
+    return filtered.sort((a, b) => b.viralScore - a.viralScore).slice(0, topN);
   }
 
   /**
@@ -859,6 +871,13 @@ export class WorkflowEngineAdapterService {
         : TREND_DIGEST_CREDIT_COST;
 
     if (!orgId || !ownerUserId) {
+      // The digest was rendered and the email was sent, but we cannot resolve who
+      // to bill (org has a null owner userId). Charging is skipped — log it so the
+      // billing gap is observable instead of silently giving away the delivery.
+      this.loggerService.warn(
+        `${this.logContext} trend digest charge skipped — missing orgId or ownerUserId after delivery`,
+        { orgId, ownerUserId, workflowId },
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary

Two defects in the workflow-backed daily trends digest from [#697](https://github.com/genfeedai/genfeed.ai/commit/f38c4ab3a) (`f38c4ab3a`), both LOW severity:

### 1. `platforms` filter silently discarded
The executor passes `{ topN, minViralScore, platforms }` to the trends provider, but the adapter's `setTrendsProvider` closure only destructured `{ topN, minViralScore }`, and `buildDigestTrends` had no `platforms` parameter. A workflow that **narrowed** `platforms` (e.g. `['youtube']`) saw no change — every platform was always included.

**Fix:** thread `platforms` through and filter the mapped trend corpus by the allowlist (case-insensitive). An empty list means "no constraint", so the default 4-platform behavior (`tiktok, instagram, youtube, twitter`) is preserved.

### 2. Credit charge silently skipped after delivery
`applyScheduledDigestCharge` returned with no log when `ownerUserId` was null *after* the digest email had already been sent — a free delivery with no trace. (The early return is *before* the idempotency lock, so nothing is left half-acquired.)

**Fix:** log a `warn` at that branch so the billing gap is observable.

## Tests

- `buildDigestTrends`: keeps only configured platforms; empty list → no constraint.
- `applyScheduledDigestCharge`: missing `ownerUserId` → warns, **no charge, no lock acquired**.

## Verification

- `vitest`: adapter spec **41 passed** (+3); workflow-engine executor spec **7 passed**.
- `tsc --noEmit` (api): **0 errors**.
- Biome + secretlint: clean.

---

_From the automated daily commit review (2026-06-21). Related: #718, #720, #721._