### PR TITLE
fix(api): validate darkroom training sourceIds at the HTTP boundary

### DIFF
--- a/apps/server/api/src/endpoints/admin/darkroom/dto/start-training.dto.spec.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/dto/start-training.dto.spec.ts
@@ -1,0 +1,30 @@
+import { StartTrainingDto } from '@api/endpoints/admin/darkroom/dto/start-training.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+describe('StartTrainingDto validation', () => {
+  const base = {
+    personaSlug: 'persona-a',
+    label: 'My LoRA',
+  };
+
+  it('accepts a valid set of entity-id sourceIds', async () => {
+    const dto = plainToInstance(StartTrainingDto, {
+      ...base,
+      sourceIds: ['507f1f77bcf86cd799439011', '507f1f77bcf86cd799439012'],
+    });
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'sourceIds')).toBe(false);
+  });
+
+  it('rejects a malformed sourceId so it cannot reach toObjectId and become null', async () => {
+    const dto = plainToInstance(StartTrainingDto, {
+      ...base,
+      sourceIds: ['507f1f77bcf86cd799439011', 'not-an-id'],
+    });
+    const errors = await validate(dto);
+
+    expect(errors.some((error) => error.property === 'sourceIds')).toBe(true);
+  });
+});

--- a/apps/server/api/src/endpoints/admin/darkroom/dto/start-training.dto.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/dto/start-training.dto.ts
@@ -1,3 +1,4 @@
+import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
 
@@ -10,8 +11,12 @@ export class StartTrainingDto {
   @ApiProperty({ description: 'Training label' })
   readonly label!: string;
 
+  // Validate each id at the HTTP boundary so a malformed id can never reach
+  // ObjectIdUtil.toObjectId (which returns null) and get non-null-asserted into
+  // a null entry in the persisted `sources` array. @IsEntityId mirrors exactly
+  // what toObjectId accepts (ObjectId / UUID / CUID / CUID2 / ULID).
   @IsArray()
-  @IsString({ each: true })
+  @IsEntityId({ each: true })
   @ApiProperty({ description: 'Source ingredient IDs', type: [String] })
   readonly sourceIds!: string[];
 


### PR DESCRIPTION
## Summary

Fixes a LOW-severity **data-corruption** bug in `StartTrainingDto` from [#690](https://github.com/genfeedai/genfeed.ai/commit/a03e671a0) (`a03e671a0`).

`sourceIds` was validated only as `@IsString({ each: true })`, so a malformed id passed validation, reached `ObjectIdUtil.toObjectId(id)!` in `DarkroomTrainingOrchestratorService`, and — since `toObjectId` returns `null` for an unrecognized id — the non-null assertion stored a **`null` entry in the persisted `sources` array**.

## Fix

Validate with `@IsEntityId({ each: true })`. This is the codebase's own validator and accepts **exactly** the id formats `toObjectId`/`isEntityId` recognize: ObjectId, UUID, CUID, CUID2, ULID.

> Note: the review finding suggested `@IsMongoId`, but I read `entity-id.validator.ts` first — `isEntityId` accepts UUID/CUID/ULID too, so `@IsMongoId` would have **wrongly rejected valid non-ObjectId ids** this codebase uses. `@IsEntityId` is the correct match.

Malformed ids now fail with a `400` at the validation pipe before reaching the service.

## Tests

New `start-training.dto.spec.ts`: valid entity-id `sourceIds` pass; a malformed id produces a `sourceIds` validation error.

## Verification

- `vitest`: DTO spec **2 passed**.
- `tsc --noEmit` (api): **0 errors**.
- Biome + secretlint: clean.

---

_From the automated daily commit review (2026-06-21). Related: #718, #720, #721, #723._