### PR TITLE
fix(scripts): reseed voice catalog fails closed on missing API key

### DIFF
--- a/scripts/migrations/reseed-voice-catalog.incontainer.mjs
+++ b/scripts/migrations/reseed-voice-catalog.incontainer.mjs
@@ -36,8 +36,11 @@ function genId() {
 async function fetchElevenLabs() {
   const key = process.env.ELEVENLABS_API_KEY;
   if (!key) {
-    console.error('ELEVENLABS_API_KEY missing — skipping ElevenLabs');
-    return [];
+    // Throw rather than return [] so a missing credential fails the run loudly
+    // (caught by main() -> exit 1), instead of silently reporting "0 voices" as
+    // success and — in live mode — writing nothing while exiting 0. Matches the
+    // .ts variant's fail-closed behavior.
+    throw new Error('ELEVENLABS_API_KEY is not set');
   }
   const res = await fetch('https://api.elevenlabs.io/v1/voices', {
     headers: { 'xi-api-key': key, accept: 'application/json' },
@@ -56,8 +59,8 @@ async function fetchElevenLabs() {
 async function fetchHeyGen() {
   const key = process.env.HEYGEN_KEY;
   if (!key) {
-    console.error('HEYGEN_KEY missing — skipping HeyGen');
-    return [];
+    // Fail closed on a missing credential (see fetchElevenLabs).
+    throw new Error('HEYGEN_KEY is not set');
   }
   const res = await fetch('https://api.heygen.com/v2/voices', {
     headers: { 'X-Api-Key': key, accept: 'application/json' },


### PR DESCRIPTION
## Summary

Fixes a LOW-severity operator footgun in the in-container voice-catalog reseed script from [#682](https://github.com/genfeedai/genfeed.ai/commit/e3a7bb5d5) (`e3a7bb5d5`).

`fetchElevenLabs` / `fetchHeyGen` logged a warning and `return []` when their API key was missing. `main()` has no zero-result guard, so a missing-credential run printed "0 voices" and **exited 0** — a false success that, in live mode, writes nothing while reporting success.

## Fix

Throw on a missing key (caught by `main()` → `exit 1`), matching the `.ts` variant's fail-closed behavior.

## Verification

- `node --check`: syntax OK.
- Biome: clean.
- No test framework covers this standalone migration script; the change is a guard inversion (`return []` → `throw`) verified by reading the `main()` try/catch → `process.exit(1)` path.

---

_From the automated daily commit review (2026-06-21). Related: #718, #720, #721, #723, #724._