### PR TITLE
fix(app): mood-board auto-placement overlap + cancellable asset paging

### DIFF
--- a/apps/app/src/features/moodboard/MediaAssetNode.tsx
+++ b/apps/app/src/features/moodboard/MediaAssetNode.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { isVideoIngredient } from '@genfeedai/utils/media/ingredient-type.util';
-import { MOOD_BOARD_TILE_WIDTH } from '@genfeedai/utils/moodboard/mood-board-layout.util';
+import {
+  MOOD_BOARD_DEFAULT_ASPECT_RATIO,
+  MOOD_BOARD_TILE_WIDTH,
+} from '@genfeedai/utils/moodboard/mood-board-layout.util';
 import Image from 'next/image';
 import { memo } from 'react';
 import type { MediaAssetNodeProps } from '@/features/moodboard/moodboard.types';
 
-const DEFAULT_ASPECT_RATIO = 4 / 5;
+const DEFAULT_ASPECT_RATIO = MOOD_BOARD_DEFAULT_ASPECT_RATIO;
 
 function resolveAspectRatio(width?: number, height?: number): number {
   if (typeof width === 'number' && typeof height === 'number' && height > 0) {

--- a/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.ts
+++ b/packages/hooks/data/moodboard/use-brand-media-assets/use-brand-media-assets.ts
@@ -24,7 +24,10 @@ const DISPLAYABLE_STATUSES = [
 ];
 
 interface PageableService {
-  findAll(query: Record<string, unknown>): Promise<IIngredient[]>;
+  findAll(
+    query: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<IIngredient[]>;
 }
 
 function isVisualMediaIngredient(ingredient: IIngredient): boolean {
@@ -53,13 +56,18 @@ async function fetchAllPages(
       break;
     }
 
-    const batch = await service.findAll({
-      brand: brandId,
-      lightweight: true,
-      status: DISPLAYABLE_STATUSES,
-      limit: PAGE_SIZE,
-      page,
-    });
+    const batch = await service.findAll(
+      {
+        brand: brandId,
+        lightweight: true,
+        status: DISPLAYABLE_STATUSES,
+        limit: PAGE_SIZE,
+        page,
+      },
+      // Forward the abort signal so an in-flight page request is cancelled on
+      // unmount, not just checked between pages.
+      signal,
+    );
 
     collected.push(...batch);
 

--- a/packages/services/core/base.service.test.ts
+++ b/packages/services/core/base.service.test.ts
@@ -377,6 +377,19 @@ describe('BaseService', () => {
       });
     });
 
+    it('forwards an AbortSignal to the request config so the fetch is cancellable', async () => {
+      const mockResponse = { data: { data: [] } };
+      service.getInstanceForTest().get.mockResolvedValue(mockResponse);
+      const controller = new AbortController();
+
+      await service.findAll({ page: 1 }, controller.signal);
+
+      expect(service.getInstanceForTest().get).toHaveBeenCalledWith('', {
+        params: { page: 1 },
+        signal: controller.signal,
+      });
+    });
+
     it('should set pagination when page is provided', async () => {
       const mockResponse = {
         data: {

--- a/packages/services/core/base.service.ts
+++ b/packages/services/core/base.service.ts
@@ -234,11 +234,14 @@ export abstract class BaseService<
     }
   }
 
-  public findAll(query: Record<string, unknown> = {}): Promise<T[]> {
+  public findAll(
+    query: Record<string, unknown> = {},
+    signal?: AbortSignal,
+  ): Promise<T[]> {
     return this.executeWithErrorHandling(
       `GET ${this.baseURL}`,
       this.instance
-        .get<JsonApiResponseDocument>('', { params: query })
+        .get<JsonApiResponseDocument>('', { params: query, signal })
         .then((res) => res.data)
         .then(async (res) => {
           const page = (query as { page?: number }).page;

--- a/packages/utils/moodboard/mood-board-layout.util.test.ts
+++ b/packages/utils/moodboard/mood-board-layout.util.test.ts
@@ -42,6 +42,26 @@ describe('mergeMoodBoardLayout', () => {
     expect(fresh?.position.y).toBeGreaterThanOrEqual(MOOD_BOARD_TILE_HEIGHT);
   });
 
+  it('places new assets below the true bottom edge of a tall saved tile', () => {
+    // A portrait tile (400x800 → aspectRatio 0.5) renders 560 tall
+    // (MOOD_BOARD_TILE_WIDTH 280 / 0.5), well past the default tile height.
+    const tall = {
+      ...asset('tall'),
+      metadataWidth: 400,
+      metadataHeight: 800,
+    } as IIngredient;
+
+    const { seeds } = mergeMoodBoardLayout(
+      [tall, asset('fresh')],
+      [saved('tall', 0, 0)],
+    );
+
+    const fresh = seeds.find((seed) => seed.assetId === 'fresh');
+    // Must clear the saved tile's rendered bottom (560), not just the default
+    // tile height (320) — the previous implementation overlapped here.
+    expect(fresh?.position.y).toBeGreaterThan(560);
+  });
+
   it('places all assets from origin when there is no saved layout', () => {
     const { seeds } = mergeMoodBoardLayout([asset('a'), asset('b')], []);
 

--- a/packages/utils/moodboard/mood-board-layout.util.ts
+++ b/packages/utils/moodboard/mood-board-layout.util.ts
@@ -8,6 +8,32 @@ export const MOOD_BOARD_TILE_WIDTH = 280;
 export const MOOD_BOARD_TILE_HEIGHT = 320;
 export const MOOD_BOARD_GRID_GAP = 32;
 export const MOOD_BOARD_DEFAULT_COLUMNS = 5;
+/**
+ * Fallback aspect ratio (width / height) when an ingredient has no usable
+ * dimensions. Must match `MediaAssetNode`, which renders each tile at
+ * `width: MOOD_BOARD_TILE_WIDTH; aspectRatio`.
+ */
+export const MOOD_BOARD_DEFAULT_ASPECT_RATIO = 4 / 5;
+
+/**
+ * The rendered height (in canvas units) of a tile for the given ingredient.
+ * Tiles are fixed-width and keep the asset's aspect ratio, so height varies — a
+ * portrait asset is taller than {@link MOOD_BOARD_TILE_HEIGHT}. Mirrors the
+ * `MediaAssetNode` sizing so auto-placement can sit below saved tiles without
+ * overlapping their lower edge.
+ */
+export function moodBoardTileHeight(ingredient?: {
+  metadataWidth?: number;
+  metadataHeight?: number;
+}): number {
+  const width = ingredient?.metadataWidth;
+  const height = ingredient?.metadataHeight;
+  const aspectRatio =
+    typeof width === 'number' && typeof height === 'number' && height > 0
+      ? width / height
+      : MOOD_BOARD_DEFAULT_ASPECT_RATIO;
+  return MOOD_BOARD_TILE_WIDTH / aspectRatio;
+}
 
 /**
  * A canvas-ready asset: a live ingredient paired with the position it should
@@ -71,25 +97,29 @@ export function mergeMoodBoardLayout(
   );
 
   const liveIds = new Set(assets.map((asset) => asset.id));
+  const ingredientById = new Map(assets.map((asset) => [asset.id, asset]));
 
   // Band where freshly added (un-positioned) assets start, kept clear of saved
-  // tiles. Tracked as an explicit two-state (presence + value) rather than an
-  // infinity sentinel.
+  // tiles. Use each saved tile's BOTTOM edge (y + its rendered height), not just
+  // its top-left y — tiles are variable height, so keying off y alone let a new
+  // row overlap the lower portion of a taller saved tile. Tracked as an explicit
+  // two-state (presence + value) rather than an infinity sentinel.
   let hasSavedLiveItem = false;
-  let maxSavedY = 0;
+  let maxSavedBottom = 0;
   for (const item of savedLayout) {
     if (!liveIds.has(item.assetId)) {
       continue;
     }
     const y = item.position?.y ?? 0;
-    if (!hasSavedLiveItem || y > maxSavedY) {
-      maxSavedY = y;
+    const bottom = y + moodBoardTileHeight(ingredientById.get(item.assetId));
+    if (!hasSavedLiveItem || bottom > maxSavedBottom) {
+      maxSavedBottom = bottom;
       hasSavedLiveItem = true;
     }
   }
 
   const newAssetBaseY = hasSavedLiveItem
-    ? maxSavedY + MOOD_BOARD_TILE_HEIGHT + MOOD_BOARD_GRID_GAP
+    ? maxSavedBottom + MOOD_BOARD_GRID_GAP
     : 0;
 
   let newAssetIndex = 0;


### PR DESCRIPTION
## Summary

Two LOW-severity issues in the library mood board from [#693](https://github.com/genfeedai/genfeed.ai/commit/e90926db8) (`e90926db8`).

### 1. New-asset auto-placement overlapped tall saved tiles
New (un-positioned) assets were placed at `maxSavedY + MOOD_BOARD_TILE_HEIGHT + GAP`, where `maxSavedY` is the **top-left y** of the bottommost saved tile. But tiles are fixed-width and keep the asset's aspect ratio, so a portrait tile renders **taller** than `MOOD_BOARD_TILE_HEIGHT` (e.g. a 4:5 asset is 350 tall, not 320) — the new row overlapped its lower edge.

**Fix:** compute each saved tile's **true bottom** (`y + rendered height`, derived from the ingredient aspect ratio, mirroring `MediaAssetNode`) and start the new band below the lowest bottom. Extracted `moodBoardTileHeight()` + `MOOD_BOARD_DEFAULT_ASPECT_RATIO` and pointed `MediaAssetNode` at the shared default so the two sizings can't drift.

### 2. Asset paging wasn't cancellable
`useBrandMediaAssets.fetchAllPages` checked `signal.aborted` *between* pages but never forwarded the signal to the HTTP request, so the in-flight page kept running after unmount (wasted bandwidth; no stale-state bug — the result guards already prevent that).

**Fix:** `BaseService.findAll` now accepts an optional `AbortSignal` and forwards it to axios (backward-compatible — existing callers unaffected); the hook threads its controller signal through.

## Tests

- Layout: new-asset placement clears a tall (portrait) saved tile's real bottom (regression: previously overlapped).
- `BaseService.findAll` forwards the `AbortSignal` to the axios request config.

## Verification

- `vitest`: utils **7**, services **52** (+1), hooks **3**, MediaAssetNode **2** — all pass.
- `tsc --noEmit` (utils/services/hooks): **0** non-noise errors (remaining `TS2307`s are pre-existing unbuilt-workspace-dep noise in this checkout).
- Biome + secretlint + no-raw-html: clean.

---

_From the automated daily commit review (2026-06-21). Related: #718, #720, #721, #723, #724, #725, #726._