### PR TITLE
fix(api): surface provisionDefaultWorkflows failures to Sentry

### DIFF
--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.spec.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.spec.ts
@@ -1,0 +1,68 @@
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { ModuleRef } from '@nestjs/core';
+import * as Sentry from '@sentry/nestjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sentry/nestjs', () => ({
+  captureException: vi.fn(),
+}));
+
+describe('OrganizationSettingsService.provisionDefaultWorkflows', () => {
+  const organization = { findFirst: vi.fn() };
+  const prisma = { organization, organizationSetting: {} };
+  const logger: Partial<LoggerService> = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  const moduleRef = { get: vi.fn() };
+
+  let service: OrganizationSettingsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new OrganizationSettingsService(
+      prisma as never,
+      logger as LoggerService,
+      moduleRef as unknown as ModuleRef,
+    );
+  });
+
+  // Private side-effect method; exercised directly to cover the bootstrap path.
+  const provision = (settings: unknown) =>
+    (
+      service as unknown as {
+        provisionDefaultWorkflows: (s: unknown) => Promise<void>;
+      }
+    ).provisionDefaultWorkflows(settings);
+
+  it('reports to Sentry (and logs) instead of failing silently when provisioning throws', async () => {
+    organization.findFirst.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      provision({ organizationId: 'org-1' }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips quietly when the organization has no owner userId', async () => {
+    organization.findFirst.mockResolvedValueOnce({ userId: null });
+
+    await provision({ organizationId: 'org-1' });
+
+    expect(moduleRef.get).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('skips without a DB lookup when there is no organization id', async () => {
+    await provision({});
+
+    expect(organization.findFirst).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -17,6 +17,7 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { ModuleRef } from '@nestjs/core';
+import * as Sentry from '@sentry/nestjs';
 
 @Injectable()
 export class OrganizationSettingsService extends BaseService<
@@ -102,10 +103,15 @@ export class OrganizationSettingsService extends BaseService<
         organizationId,
       );
     } catch (error) {
+      // Swallowed so a non-critical provisioning step never fails org creation,
+      // but reported to Sentry as well as the log: otherwise new-org workflow
+      // seeding can fail silently for every org (e.g. a future DI/module-graph
+      // regression) with nothing but a log line nobody is watching.
       this.logger?.error(
         'Failed to provision Daily Trends Digest workflow',
         error,
       );
+      Sentry.captureException(error);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes the observability gap in the org-bootstrap chokepoint from [#711](https://github.com/genfeedai/genfeed.ai/commit/f45b3869b) (`f45b3869b`).

All org-creation paths (Clerk webhook, `OrganizationsController`, `UserSetupService`) funnel through `OrganizationSettingsService.create`, which seeds the Daily Trends Digest workflow in a `try/catch`. The catch swallowed any failure with only a `logger.error` — so a DI / module-graph regression (the very class of bug this code works around: the org-settings↔workflows TDZ cycle) could break workflow seeding for **every new org silently**, with nothing but a log line.

## Fix

Report the swallowed error to **Sentry** (`@sentry/nestjs`, the pattern already used in the API's exception filters) in addition to logging. Org creation still never fails on this non-critical step.

## Tests

The service's first spec:
- provisioning failure → `logger.error` **and** `Sentry.captureException` called; the method still resolves (never throws).
- both early-return guards (no org id; no owner `userId`) skip without alerting.

## Verification

- `vitest`: org-settings service spec **3 passed**.
- `tsc --noEmit` (api): **0 errors**.
- Biome + secretlint: clean.

---

_From the automated daily commit review (2026-06-21). Final PR in the set. Related: #718, #720, #721, #723, #724, #725, #726, #727._