### PR TITLE
test(api): cover darkroom asset/publishing/training-orchestrator guards

### DIFF
--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-asset.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-asset.service.spec.ts
@@ -1,0 +1,112 @@
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { ConfigService } from '@api/config/config.service';
+import { DarkroomAssetService } from '@api/endpoints/admin/darkroom/services/darkroom-asset.service';
+import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import { DarkroomReviewStatus, IngredientCategory } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('DarkroomAssetService.reviewAsset', () => {
+  let service: DarkroomAssetService;
+  let ingredientsService: Record<string, ReturnType<typeof vi.fn>>;
+  let filesClientService: Record<string, ReturnType<typeof vi.fn>>;
+  let darkroomTrainingService: Record<string, ReturnType<typeof vi.fn>>;
+
+  const imageAsset = {
+    _id: { toString: () => 'asset-1' },
+    category: IngredientCategory.IMAGE,
+    cdnUrl: 'https://cdn/asset-1.jpg',
+    generationPrompt: 'a portrait',
+    personaSlug: 'alice',
+    reviewStatus: DarkroomReviewStatus.PENDING,
+  };
+
+  beforeEach(async () => {
+    ingredientsService = {
+      findAllByOrganization: vi.fn(),
+      findOne: vi.fn(),
+      patch: vi.fn().mockResolvedValue({ ...imageAsset }),
+    };
+    filesClientService = { uploadToS3: vi.fn().mockResolvedValue(undefined) };
+    darkroomTrainingService = {
+      syncDataset: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DarkroomAssetService,
+        { provide: IngredientsService, useValue: ingredientsService },
+        { provide: FilesClientService, useValue: filesClientService },
+        {
+          provide: DarkroomTrainingService,
+          useValue: darkroomTrainingService,
+        },
+        { provide: ConfigService, useValue: { get: () => 'darkroom-bucket' } },
+        { provide: LoggerService, useValue: { log: vi.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(DarkroomAssetService);
+  });
+
+  it('throws NotFound when the asset is not in the organization (multi-tenant guard)', async () => {
+    ingredientsService.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.reviewAsset('asset-1', 'org-1', DarkroomReviewStatus.APPROVED),
+    ).rejects.toThrow(NotFoundException);
+    expect(ingredientsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('syncs a freshly-approved IMAGE asset into the training dataset', async () => {
+    ingredientsService.findOne.mockResolvedValue(imageAsset);
+
+    await service.reviewAsset(
+      'asset-1',
+      'org-1',
+      DarkroomReviewStatus.APPROVED,
+    );
+
+    expect(ingredientsService.patch).toHaveBeenCalledWith('asset-1', {
+      reviewStatus: DarkroomReviewStatus.APPROVED,
+    });
+    // image + caption uploads, then the dataset sync.
+    expect(filesClientService.uploadToS3).toHaveBeenCalled();
+    expect(darkroomTrainingService.syncDataset).toHaveBeenCalledWith(
+      'alice',
+      expect.any(Array),
+      'darkroom-bucket',
+    );
+  });
+
+  it('does not sync a non-IMAGE asset on approval', async () => {
+    ingredientsService.findOne.mockResolvedValue({
+      ...imageAsset,
+      category: IngredientCategory.VIDEO,
+    });
+
+    await service.reviewAsset(
+      'asset-1',
+      'org-1',
+      DarkroomReviewStatus.APPROVED,
+    );
+
+    expect(filesClientService.uploadToS3).not.toHaveBeenCalled();
+    expect(darkroomTrainingService.syncDataset).not.toHaveBeenCalled();
+  });
+
+  it('does not sync on rejection', async () => {
+    ingredientsService.findOne.mockResolvedValue(imageAsset);
+
+    await service.reviewAsset(
+      'asset-1',
+      'org-1',
+      DarkroomReviewStatus.REJECTED,
+    );
+
+    expect(filesClientService.uploadToS3).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-publishing.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-publishing.service.spec.ts
@@ -1,0 +1,109 @@
+import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { DarkroomPublishingService } from '@api/endpoints/admin/darkroom/services/darkroom-publishing.service';
+import { FacebookService } from '@api/services/integrations/facebook/services/facebook.service';
+import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
+import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
+import { DarkroomReviewStatus } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('DarkroomPublishingService', () => {
+  let service: DarkroomPublishingService;
+  let ingredientsService: Record<string, ReturnType<typeof vi.fn>>;
+  let instagramService: Record<string, ReturnType<typeof vi.fn>>;
+  let twitterService: Record<string, ReturnType<typeof vi.fn>>;
+
+  const approvedAsset = {
+    _id: { toString: () => 'asset-1' },
+    cdnUrl: 'https://cdn/asset-1.jpg',
+    reviewStatus: DarkroomReviewStatus.APPROVED,
+  };
+
+  beforeEach(async () => {
+    ingredientsService = { findOne: vi.fn() };
+    instagramService = {
+      uploadImage: vi.fn().mockResolvedValue({ mediaId: 'ig-1' }),
+    };
+    twitterService = { uploadMedia: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DarkroomPublishingService,
+        { provide: IngredientsService, useValue: ingredientsService },
+        { provide: InstagramService, useValue: instagramService },
+        { provide: TwitterService, useValue: twitterService },
+        { provide: FacebookService, useValue: { uploadImage: vi.fn() } },
+        { provide: CredentialsService, useValue: { findOne: vi.fn() } },
+        { provide: LoggerService, useValue: { error: vi.fn(), log: vi.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(DarkroomPublishingService);
+  });
+
+  it('throws NotFound when the asset is not in the organization', async () => {
+    ingredientsService.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.publishAsset('asset-1', 'org-1', 'brand-1', ['instagram']),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('refuses to publish an asset that is not approved', async () => {
+    ingredientsService.findOne.mockResolvedValue({
+      ...approvedAsset,
+      reviewStatus: DarkroomReviewStatus.PENDING,
+    });
+
+    await expect(
+      service.publishAsset('asset-1', 'org-1', 'brand-1', ['instagram']),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('refuses to publish an approved asset with no CDN url', async () => {
+    ingredientsService.findOne.mockResolvedValue({
+      ...approvedAsset,
+      cdnUrl: undefined,
+    });
+
+    await expect(
+      service.publishAsset('asset-1', 'org-1', 'brand-1', ['instagram']),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('publishes to Instagram and reports success', async () => {
+    ingredientsService.findOne.mockResolvedValue(approvedAsset);
+
+    const result = await service.publishAsset(
+      'asset-1',
+      'org-1',
+      'brand-1',
+      ['instagram'],
+      'caption',
+    );
+
+    expect(instagramService.uploadImage).toHaveBeenCalledWith(
+      'org-1',
+      'brand-1',
+      approvedAsset.cdnUrl,
+      'caption',
+    );
+    expect(result.success).toBe(true);
+    expect(result.results.instagram).toEqual({ id: 'ig-1', success: true });
+  });
+
+  it('marks an unsupported platform as failed without failing the whole call', async () => {
+    ingredientsService.findOne.mockResolvedValue(approvedAsset);
+
+    const result = await service.publishAsset('asset-1', 'org-1', 'brand-1', [
+      'myspace',
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.results.myspace.success).toBe(false);
+    expect(result.results.myspace.error).toContain('Unsupported platform');
+  });
+});

--- a/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service.spec.ts
@@ -1,0 +1,72 @@
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { PersonasService } from '@api/collections/personas/services/personas.service';
+import { TrainingsService } from '@api/collections/trainings/services/trainings.service';
+import { DarkroomCharacterService } from '@api/endpoints/admin/darkroom/services/darkroom-character.service';
+import { DarkroomTrainingService } from '@api/endpoints/admin/darkroom/services/darkroom-training.service';
+import { DarkroomTrainingOrchestratorService } from '@api/endpoints/admin/darkroom/services/darkroom-training-orchestrator.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('DarkroomTrainingOrchestratorService', () => {
+  let service: DarkroomTrainingOrchestratorService;
+  let characterService: Record<string, ReturnType<typeof vi.fn>>;
+  let trainingsService: Record<string, ReturnType<typeof vi.fn>>;
+  let darkroomTrainingService: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    characterService = {
+      requirePersonaBySlug: vi
+        .fn()
+        .mockResolvedValue({ _id: { toString: () => 'persona-1' } }),
+    };
+    trainingsService = { create: vi.fn(), findOne: vi.fn() };
+    darkroomTrainingService = {
+      autoTuneHyperparameters: vi.fn(),
+      getDatasetInfo: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DarkroomTrainingOrchestratorService,
+        { provide: DarkroomCharacterService, useValue: characterService },
+        {
+          provide: IngredientsService,
+          useValue: { findAllByOrganization: vi.fn() },
+        },
+        { provide: TrainingsService, useValue: trainingsService },
+        { provide: PersonasService, useValue: { patch: vi.fn() } },
+        {
+          provide: DarkroomTrainingService,
+          useValue: darkroomTrainingService,
+        },
+        { provide: LoggerService, useValue: { error: vi.fn(), log: vi.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(DarkroomTrainingOrchestratorService);
+  });
+
+  it('throws NotFound when the training does not exist', async () => {
+    trainingsService.findOne.mockResolvedValue(null);
+
+    await expect(service.getTraining('t-1', 'org-1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('refuses to start training on an empty dataset and does not create a record', async () => {
+    darkroomTrainingService.getDatasetInfo.mockResolvedValue({ imageCount: 0 });
+
+    await expect(
+      service.startTraining('org-1', 'user-1', {
+        label: 'My LoRA',
+        personaSlug: 'alice',
+        sourceIds: ['507f1f77bcf86cd799439011'],
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(trainingsService.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the Darkroom peer services from the [#690](https://github.com/genfeedai/genfeed.ai/commit/a03e671a0) (`a03e671a0`) god-object decomposition. That refactor shipped 7 behaviour-bearing services with **no specs** — only `DarkroomCharacterService`, `DarkroomTrainingService`, and the value reader were covered, so a regression in any moved method would go uncaught locally.

This is the **first tranche**, covering the three highest-risk guard paths the review flagged:

- **`DarkroomAssetService.reviewAsset`** — multi-tenant `NotFound` guard; a freshly-approved IMAGE syncs into the training dataset; non-IMAGE and rejection do **not** sync.
- **`DarkroomPublishingService.publishAsset`** — `NotFound`; not-approved and missing-CDN `BadRequest` guards; Instagram dispatch success; an unsupported platform fails only that platform (not the whole call).
- **`DarkroomTrainingOrchestratorService`** — `getTraining` `NotFound`; **empty-dataset guard** refuses to start and creates no training record.

The remaining peer services (`generation`, `ingest`, `media`, `infra`, `stats`) are lower-risk and can follow in a second tranche.

## Verification

- `vitest`: **11 new tests** pass (publishing 5, asset 4, orchestrator 2).
- `tsc --noEmit` (api): **0 errors**.
- Biome + secretlint: clean.

This PR is tests-only — no production code changes.

---

_From the automated daily commit review (2026-06-21). Final PR in the set. Related: #718, #720, #721, #723, #724, #725, #726, #727, #728._