### PR TITLE
fix(api-audit): correct SQL-aggregation classification + enforce bulk-write regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,23 @@ jobs:
           cache-turbo: 'false'
       - run: bun run check:architecture
 
+  sql-risk-audit:
+    name: SQL Risk Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: trust
+    if: needs.trust.outputs.is-trusted == 'true'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+          cache-turbo: 'false'
+      - run: bun run audit:api:sql:ci
+
   ui-guards:
     name: UI Guards
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "audit:api:endpoints": "bun run scripts/api-audit/endpoint-inventory.ts",
     "audit:api:smoke": "bun run scripts/api-audit/openapi-smoke.ts",
     "audit:api:sql": "bun run scripts/api-audit/sql-risk-audit.ts",
+    "audit:api:sql:ci": "bun run scripts/api-audit/sql-risk-audit.ts --fail-on-high",
     "postinstall": "scripts/setup-skills.sh",
     "setup:skills": "scripts/setup-skills.sh",
     "setup:skills:sync": "scripts/setup-skills.sh --sync",

--- a/scripts/api-audit/sql-risk-audit.regression.test.ts
+++ b/scripts/api-audit/sql-risk-audit.regression.test.ts
@@ -1,0 +1,53 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { runSqlRiskAudit } from './sql-risk-audit';
+
+// Repo root is two levels up from scripts/api-audit/.
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+
+// Regression gate over the real API source. The bulk-write tenant-scoping work
+// (PR #647, refs #632) cleared every high-severity finding; this test fails the
+// build if a new unguarded bulk write or unsafe raw-SQL call reintroduces one,
+// so the audit's manual pass is enforced rather than left to rot.
+describe('sql risk audit — real codebase regression gate', () => {
+  const result = runSqlRiskAudit({ rootDir: REPO_ROOT });
+
+  it('scans the API source tree', () => {
+    expect(result.filesScanned).toBeGreaterThan(0);
+  });
+
+  it('has zero high-severity findings', () => {
+    const highFindings = result.findings.filter(
+      (finding) => finding.severity === 'high',
+    );
+    expect(
+      highFindings,
+      `Unexpected high-severity SQL risk findings:\n${highFindings
+        .map(
+          (finding) =>
+            `  - ${finding.category} ${finding.file}:${finding.line}`,
+        )
+        .join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  it('has zero unguarded bulk-write findings', () => {
+    const bulkWriteFindings = result.findings.filter(
+      (finding) => finding.category === 'bulk-write-tenant-review',
+    );
+    expect(
+      bulkWriteFindings,
+      `Bulk writes missing a tenant/user/isDeleted guard or documented suppression:\n${bulkWriteFindings
+        .map(
+          (finding) =>
+            `  - ${finding.file}:${finding.line} (${finding.method})`,
+        )
+        .join('\n')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/scripts/api-audit/sql-risk-audit.test.ts
+++ b/scripts/api-audit/sql-risk-audit.test.ts
@@ -95,6 +95,48 @@ describe('sql risk audit', () => {
       ]),
     );
   });
+
+  it('classifies aggregate/groupBy as bounded aggregate-scan-review, not unbounded-read', () => {
+    writeFixture(
+      'apps/server/api/src/analytics/analytics.service.ts',
+      `
+      export class AnalyticsService {
+        constructor(private readonly prisma: PrismaService) {}
+
+        async totals(organizationId: string) {
+          return this.prisma.postAnalytics.aggregate({
+            _sum: { totalViews: true },
+            where: { organizationId },
+          });
+        }
+
+        async byDate(organizationId: string) {
+          return this.prisma.postAnalytics.groupBy({
+            _avg: { engagementRate: true },
+            by: ['date'],
+            where: { organizationId },
+          });
+        }
+      }
+      `,
+    );
+
+    const result = runSqlRiskAudit({ rootDir: testDir });
+    const categories = result.findings.map((finding) => finding.category);
+
+    // The migrated SQL-aggregation pattern must not be flagged as an unbounded
+    // row read (the pre-fix false positive) and must not raise severity.
+    expect(categories).not.toContain('unbounded-read');
+    expect(
+      result.findings.filter(
+        (finding) => finding.category === 'aggregate-scan-review',
+      ),
+    ).toHaveLength(2);
+    expect(
+      result.findings.every((finding) => finding.severity !== 'high'),
+    ).toBe(true);
+    expect(result.summary.high).toBe(0);
+  });
 });
 
 function writeFixture(relativePath: string, content: string): void {

--- a/scripts/api-audit/sql-risk-audit.ts
+++ b/scripts/api-audit/sql-risk-audit.ts
@@ -68,6 +68,7 @@ export interface SqlRiskAuditOptions {
 }
 
 interface CliOptions extends SqlRiskAuditOptions {
+  failOnHigh: boolean;
   isJsonOutput: boolean;
   out?: string;
 }
@@ -290,7 +291,7 @@ function createFindingsForCall(call: PrismaCall): SqlRiskFinding[] {
     );
   }
 
-  if (isCollectionRead(call.method) && !hasPagination(callText)) {
+  if (isRowCollectionRead(call.method) && !hasPagination(callText)) {
     findings.push(
       createFinding(
         call,
@@ -301,13 +302,30 @@ function createFindingsForCall(call: PrismaCall): SqlRiskFinding[] {
     );
   }
 
-  if (isCollectionRead(call.method) && hasBroadInclude(callText)) {
+  if (isRowCollectionRead(call.method) && hasBroadInclude(callText)) {
     findings.push(
       createFinding(
         call,
         'broad-include',
         'medium',
         'Prefer select or a narrower include so reload paths do not hydrate unused relation graphs.',
+      ),
+    );
+  }
+
+  // `aggregate`/`groupBy` are SQL-side aggregations: an `aggregate` returns a
+  // single row and a `groupBy` is bounded by group cardinality, so "add
+  // pagination" never applies. Flagging them as `unbounded-read` (the behaviour
+  // before this rule existed) produced false positives against the exact
+  // SQL-aggregation pattern the analytics services were migrated to. The real
+  // residual risk is an unindexed scan, so surface that at low severity instead.
+  if (isAggregateRead(call.method)) {
+    findings.push(
+      createFinding(
+        call,
+        'aggregate-scan-review',
+        'low',
+        'Aggregate/groupBy results are bounded; pagination does not apply. Confirm the where clause (and any high-cardinality group key) is index-backed.',
       ),
     );
   }
@@ -381,10 +399,16 @@ function looksLikePrismaReceiver(receiver: string, method: string): boolean {
   );
 }
 
-function isCollectionRead(method: string): boolean {
-  return (
-    method === 'findMany' || method === 'aggregate' || method === 'groupBy'
-  );
+// Reads that return an unbounded set of entity rows and therefore need
+// pagination. `aggregate`/`groupBy` are deliberately excluded — they aggregate
+// server-side and are handled by `isAggregateRead`.
+function isRowCollectionRead(method: string): boolean {
+  return method === 'findMany';
+}
+
+// SQL-side aggregations whose result set is bounded by construction.
+function isAggregateRead(method: string): boolean {
+  return method === 'aggregate' || method === 'groupBy';
 }
 
 function isBulkWrite(method: string): boolean {
@@ -457,12 +481,14 @@ function escapeMarkdownCell(value: string): string {
 }
 
 function parseArgs(argv: string[]): CliOptions {
-  const options: CliOptions = { isJsonOutput: false };
+  const options: CliOptions = { failOnHigh: false, isJsonOutput: false };
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--json') {
       options.isJsonOutput = true;
+    } else if (arg === '--fail-on-high') {
+      options.failOnHigh = true;
     } else if (arg === '--out') {
       options.out = readRequiredArg(argv, index, arg);
       index += 1;
@@ -508,4 +534,24 @@ if (isMainModule()) {
     : formatSqlRiskAudit(result);
 
   writeOutput(body, options.out);
+
+  // `--fail-on-high` turns the audit into a CI gate: any high-severity finding
+  // (unsafe raw SQL or an unguarded bulk write) fails the build so prior
+  // tenant-scoping work cannot silently regress.
+  if (options.failOnHigh && result.summary.high > 0) {
+    const highFindings = result.findings.filter(
+      (finding) => finding.severity === 'high',
+    );
+    process.stderr.write(
+      `\nSQL risk audit failed: ${result.summary.high} high-severity finding(s).\n` +
+        highFindings
+          .map(
+            (finding) =>
+              `  - ${finding.category} ${finding.file}:${finding.line} (${finding.method})`,
+          )
+          .join('\n') +
+        '\n',
+    );
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Why

While picking up the SQL-risk-audit cluster (#627, #628, #631, #632) I found the cluster's substantive work was **already shipped** — analytics moved to SQL `aggregate`/`groupBy`, business-analytics indexed, lists paginated, and bulk writes tenant-scoped in PR #647 ("scope reviewed bulk writes", refs #632). The audit reports **0 high-severity findings**. What was left were two real gaps:

1. **A false-positive in the audit tool.** `scripts/api-audit/sql-risk-audit.ts` flagged `aggregate` and `groupBy` as `unbounded-read` and recommended *"add take/limit/cursor pagination"* — meaningless for a `SUM` or `GROUP BY`, and it penalised the exact SQL-aggregation pattern #627/#628 migrated to. This inflated the `unbounded-read` count by 18 and made the cluster's audit AC ("audit shows cluster reduced/documented as bounded") impossible to satisfy honestly.
2. **No regression gate.** `sql-risk-audit.test.ts` only exercised the audit logic against fixtures. Nothing asserted the *real* codebase stays at 0 high-severity findings, so #647's tenant-scoping work could silently regress.

## What

- **Fix the false-positive:** `unbounded-read`/`broad-include` now apply to `findMany` only. `aggregate`/`groupBy` get a new low-severity **`aggregate-scan-review`** category whose recommendation points at the real risk (unindexed scan) instead of pagination.
- **Enforce the baseline:** new `--fail-on-high` CLI flag + `audit:api:sql:ci` script + a standalone **`SQL Risk Audit`** CI job (mirrors `architecture-guards`/`ui-guards`). Any new unsafe raw SQL or unguarded bulk write now fails the PR.
- **Tests:** unit test for the new classification + a real-codebase regression test asserting `summary.high === 0` and zero `bulk-write-tenant-review` findings.

## Effect on the audit

| Category | Before | After |
|---|---|---|
| high (raw-sql-unsafe + bulk-write-tenant-review) | 0 | 0 |
| unbounded-read (medium) | 179 | 161 |
| aggregate-scan-review (low) | — | 27 |

The analytics aggregations in `analytics-aggregation.service.ts` / `performance-summary.service.ts` now correctly read as bounded low-severity, which is what #627/#628 asked for.

## Verification

- `bunx vitest run --config scripts/api-audit/vitest.config.ts` — 9 passing (incl. new classification + regression tests)
- `bun run audit:api:sql:ci` — exits 0 (high = 0)
- `bunx biome check` clean; isolated strict `tsc` clean; `ci.yml` validated

Refs #627, #628, #632. Enables closing #627/#628/#631/#632 as implemented + now guarded.