### PR TITLE
fix(config): cover all consumed env vars in service ConfigServices (#484)

### DIFF
--- a/apps/server/mcp/src/config/config.service.spec.ts
+++ b/apps/server/mcp/src/config/config.service.spec.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { ConfigService } from '@mcp/config/config.service';
 
 describe('ConfigService (MCP)', () => {
@@ -54,5 +55,30 @@ describe('ConfigService (MCP)', () => {
     expect(service.isStaging).toBe(true);
     expect(service.isDevelopment).toBe(false);
     expect(service.isProduction).toBe(false);
+  });
+
+  describe('consumed env-var schema coverage (#484)', () => {
+    // main.ts reads CHROME_EXTENSION_ID for CORS; it must be validated.
+    it('validates CHROME_EXTENSION_ID', () => {
+      expect(ConfigService.schema.describe().keys).toHaveProperty(
+        'CHROME_EXTENSION_ID',
+      );
+    });
+
+    it('accepts a well-formed 32-char CHROME_EXTENSION_ID', () => {
+      process.env.CHROME_EXTENSION_ID = 'a'.repeat(32);
+
+      expect(() => new ConfigService()).not.toThrow();
+
+      delete process.env.CHROME_EXTENSION_ID;
+    });
+
+    it('rejects a malformed CHROME_EXTENSION_ID at startup', () => {
+      process.env.CHROME_EXTENSION_ID = 'too-short';
+
+      expect(() => new ConfigService()).toThrow(/CHROME_EXTENSION_ID/);
+
+      delete process.env.CHROME_EXTENSION_ID;
+    });
   });
 });

--- a/apps/server/mcp/src/config/config.service.ts
+++ b/apps/server/mcp/src/config/config.service.ts
@@ -4,6 +4,7 @@ import {
   type IEnvConfig,
   redisSchema,
   sentryOptionalSchema,
+  webhooksSchema,
 } from '@genfeedai/config';
 import { Injectable } from '@nestjs/common';
 import Joi from 'joi';
@@ -11,7 +12,14 @@ import Joi from 'joi';
 @Injectable()
 export class ConfigService extends createServiceConfig<IEnvConfig>({
   appName: 'mcp',
-  schemas: [redisSchema, sentryOptionalSchema, genfeedaiMinimalSchema],
+  // #484: main.ts reads CHROME_EXTENSION_ID for CORS but the schema never
+  // validated it; webhooksSchema is its canonical home (length-32 constraint).
+  schemas: [
+    redisSchema,
+    sentryOptionalSchema,
+    genfeedaiMinimalSchema,
+    webhooksSchema,
+  ],
   extend: {
     // MCP-specific
     GENFEEDAI_API_KEY: Joi.string().optional().allow(''),

--- a/apps/server/notifications/src/config/config.service.spec.ts
+++ b/apps/server/notifications/src/config/config.service.spec.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { ConfigService } from '@notifications/config/config.service';
 
 // Mock fs and dotenv modules
@@ -62,5 +63,39 @@ describe('ConfigService (Notifications)', () => {
     expect(service.isStaging).toBe(true);
     expect(service.isDevelopment).toBe(false);
     expect(service.isProduction).toBe(false);
+  });
+
+  describe('consumed env-var schema coverage (#484)', () => {
+    // Every env var the notifications service reads must be in its schema.
+    const consumedKeys = [
+      'CHROME_EXTENSION_ID', // main.ts CORS
+      'SLACK_NOTIFICATION_BOT_TOKEN', // slack.service
+      'GENFEED_CLOUD', // terminal.service cloud gate
+      'NEXT_PUBLIC_GENFEED_CLOUD', // terminal.service cloud gate
+      'VALIDATION_MAX_FILE_SIZE', // validation.config
+      'VALIDATION_VIDEO_FORMATS', // validation.config
+      'VALIDATION_IMAGE_FORMATS', // validation.config
+      'VALIDATION_AUDIO_FORMATS', // validation.config
+    ] as const;
+
+    it.each(consumedKeys)('validates %s', (key) => {
+      expect(ConfigService.schema.describe().keys).toHaveProperty(key);
+    });
+
+    it('rejects a malformed CHROME_EXTENSION_ID at startup', () => {
+      process.env.CHROME_EXTENSION_ID = 'too-short';
+
+      expect(() => new ConfigService()).toThrow(/CHROME_EXTENSION_ID/);
+
+      delete process.env.CHROME_EXTENSION_ID;
+    });
+
+    it('keeps the new consumed vars optional (absent does not throw)', () => {
+      for (const key of consumedKeys) {
+        delete process.env[key];
+      }
+
+      expect(() => new ConfigService()).not.toThrow();
+    });
   });
 });

--- a/apps/server/notifications/src/config/config.service.ts
+++ b/apps/server/notifications/src/config/config.service.ts
@@ -9,6 +9,7 @@ import {
   sentryOptionalSchema,
   telegramBotSchema,
   twitchSchema,
+  webhooksSchema,
 } from '@genfeedai/config';
 import { Injectable, Logger } from '@nestjs/common';
 import Joi from 'joi';
@@ -25,6 +26,9 @@ export class ConfigService extends createServiceConfig<IEnvConfig>({
     telegramBotSchema,
     resendSchema,
     twitchSchema,
+    // #484: main.ts reads CHROME_EXTENSION_ID for CORS; webhooksSchema is the
+    // canonical home (length-32 constraint fails fast on a malformed value).
+    webhooksSchema,
   ],
   extend: {
     API_BASE_URL: Joi.string().uri().default('http://localhost:3010'),
@@ -37,6 +41,20 @@ export class ConfigService extends createServiceConfig<IEnvConfig>({
     // Notifications-specific
     GENFEEDAI_APP_URL: Joi.string().uri().optional().allow(''),
     GENFEED_TERMINAL_CWD: Joi.string().optional().allow(''),
+    // #484: more vars notifications consumes but never validated. Optional so a
+    // deployment without them still boots; GENFEED_CLOUD/NEXT_PUBLIC_GENFEED_CLOUD
+    // are kept format-free (not .valid('true','false')) so an existing cloud env
+    // with an unconventional value is not rejected at boot.
+    // - SLACK_NOTIFICATION_BOT_TOKEN: slack.service
+    // - GENFEED_CLOUD / NEXT_PUBLIC_GENFEED_CLOUD: terminal.service cloud gate
+    // - VALIDATION_*: validation.config file-upload limits
+    GENFEED_CLOUD: Joi.string().optional().allow(''),
+    NEXT_PUBLIC_GENFEED_CLOUD: Joi.string().optional().allow(''),
+    SLACK_NOTIFICATION_BOT_TOKEN: Joi.string().optional().allow(''),
+    VALIDATION_AUDIO_FORMATS: Joi.string().optional().allow(''),
+    VALIDATION_IMAGE_FORMATS: Joi.string().optional().allow(''),
+    VALIDATION_MAX_FILE_SIZE: Joi.string().optional().allow(''),
+    VALIDATION_VIDEO_FORMATS: Joi.string().optional().allow(''),
   },
 }) {
   private readonly logger = new Logger(ConfigService.name);

--- a/apps/server/workers/src/config/config.service.spec.ts
+++ b/apps/server/workers/src/config/config.service.spec.ts
@@ -166,11 +166,23 @@ describe('ConfigService (Workers)', () => {
     });
 
     it('keeps the new consumed vars optional (absent does not throw)', () => {
+      const previous: Record<string, string | undefined> = {};
       for (const key of consumedKeys) {
+        previous[key] = process.env[key];
         delete process.env[key];
       }
 
-      expect(() => new ConfigService()).not.toThrow();
+      try {
+        expect(() => new ConfigService()).not.toThrow();
+      } finally {
+        for (const key of consumedKeys) {
+          if (previous[key] === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = previous[key];
+          }
+        }
+      }
     });
 
     it('does not inject an AWS_REGION default (cron fallback preserved)', () => {

--- a/apps/server/workers/src/config/config.service.spec.ts
+++ b/apps/server/workers/src/config/config.service.spec.ts
@@ -144,4 +144,49 @@ describe('ConfigService (Workers)', () => {
       );
     });
   });
+
+  describe('consumed env-var schema coverage (#484)', () => {
+    // Every env var the workers service reads via configService.get() must be
+    // part of its validation schema so misconfiguration is visible and the
+    // schema is the single source of truth (no silent passthrough).
+    const consumedKeys = [
+      'OPENROUTER_API_KEY', // clip-factory / clip-analyze processors
+      'REPLICATE_KEY', // model-watcher cron + model-discovery service
+      'AWS_REGION', // llm-idle cron EC2Client
+      'AWS_ACCESS_KEY_ID', // llm-idle cron EC2Client
+      'AWS_SECRET_ACCESS_KEY', // llm-idle cron EC2Client
+      'FAL_API_KEY', // fal-discovery service
+      'HUGGINGFACE_API_KEY', // hugging-face-discovery service
+      'GPU_LLM_INSTANCE_ID', // llm-idle cron
+      'SERVICE_NAME', // health-response label
+    ] as const;
+
+    it.each(consumedKeys)('validates %s', (key) => {
+      expect(ConfigService.schema.describe().keys).toHaveProperty(key);
+    });
+
+    it('keeps the new consumed vars optional (absent does not throw)', () => {
+      for (const key of consumedKeys) {
+        delete process.env[key];
+      }
+
+      expect(() => new ConfigService()).not.toThrow();
+    });
+
+    it('does not inject an AWS_REGION default (cron fallback preserved)', () => {
+      delete process.env.AWS_REGION;
+      configService = new ConfigService();
+
+      expect(configService.get('AWS_REGION')).toBeUndefined();
+    });
+
+    it('flows a provided REPLICATE_KEY through the validated config', () => {
+      process.env.REPLICATE_KEY = 'r8_test_key';
+      configService = new ConfigService();
+
+      expect(configService.get('REPLICATE_KEY')).toBe('r8_test_key');
+
+      delete process.env.REPLICATE_KEY;
+    });
+  });
 });

--- a/apps/server/workers/src/config/config.service.ts
+++ b/apps/server/workers/src/config/config.service.ts
@@ -1,5 +1,7 @@
 import {
   createServiceConfig,
+  falSchema,
+  huggingFaceSchema,
   type IEnvConfig,
   microservicesSchema,
   postgresSchema,
@@ -24,6 +26,11 @@ export class ConfigService extends createServiceConfig<WorkersEnvConfig>({
     // microservices URLs default to localhost in self-hosted instead of
     // silently resolving to undefined.
     microservicesSchema,
+    // #484: workers' model-discovery reads these AI-provider keys
+    // (fal-discovery.service, hugging-face-discovery.service). Both are optional
+    // fragments — absence is tolerated at runtime, presence is schema-documented.
+    falSchema,
+    huggingFaceSchema,
   ],
   extend: {
     GF_DEV_ENABLE_SCHEDULERS: Joi.string()
@@ -39,6 +46,23 @@ export class ConfigService extends createServiceConfig<WorkersEnvConfig>({
     GENFEEDAI_APP_URL: Joi.string().uri().optional().allow(''),
     GENFEEDAI_CDN_URL: Joi.string().uri().optional().allow(''),
     GENFEEDAI_WEBHOOKS_URL: Joi.string().uri().optional().allow(''),
+    // #484: more vars workers consumes via configService.get() but never
+    // validated. Kept optional (no required/conditionalRequired) so a service
+    // that runs without them does not crash at boot, and AWS_REGION carries no
+    // default so the llm-idle cron's own `|| 'us-east-1'` fallback is preserved.
+    // - OPENROUTER_API_KEY: clip-factory/clip-analyze processors
+    // - REPLICATE_KEY: model-watcher cron + model-discovery service (soft-fails)
+    // - AWS_*: llm-idle cron's EC2Client credentials/region
+    // - GPU_LLM_INSTANCE_ID: llm-idle cron (gpuFleetSchema is not exported from
+    //   @genfeedai/config, so the single consumed key is inlined here)
+    // - SERVICE_NAME: health-response label (main.ts)
+    AWS_ACCESS_KEY_ID: Joi.string().optional().allow(''),
+    AWS_REGION: Joi.string().optional(),
+    AWS_SECRET_ACCESS_KEY: Joi.string().optional().allow(''),
+    GPU_LLM_INSTANCE_ID: Joi.string().optional().allow(''),
+    OPENROUTER_API_KEY: Joi.string().optional().allow(''),
+    REPLICATE_KEY: Joi.string().optional().allow(''),
+    SERVICE_NAME: Joi.string().optional().allow(''),
   },
 }) {
   public get isDevSchedulersEnabled(): boolean {

--- a/packages/config/src/services/create-service-config.spec.ts
+++ b/packages/config/src/services/create-service-config.spec.ts
@@ -134,6 +134,21 @@ describe('createServiceConfig', () => {
     );
   });
 
+  it('exposes the composed schema for introspection (#484)', () => {
+    const ServiceConfig = createServiceConfig<SampleEnvConfig>({
+      appName: 'sample',
+      schemas: [sharedFragment],
+      extend: { SAMPLE_INLINE: Joi.string().optional().allow('') },
+    });
+
+    const keys = ServiceConfig.schema.describe().keys;
+
+    // baseSchema + fragment + extend keys are all present on the static schema.
+    expect(keys).toHaveProperty('PORT');
+    expect(keys).toHaveProperty('SAMPLE_SHARED');
+    expect(keys).toHaveProperty('SAMPLE_INLINE');
+  });
+
   it('exposes subclass getters backed by validated config', () => {
     class ConfigService extends createServiceConfig<SampleEnvConfig>({
       appName: 'sample',

--- a/packages/config/src/services/create-service-config.ts
+++ b/packages/config/src/services/create-service-config.ts
@@ -51,7 +51,7 @@ export interface CreateServiceConfigOptions {
  */
 export function createServiceConfig<T extends Partial<IEnvConfig> = IEnvConfig>(
   options: CreateServiceConfigOptions,
-): new () => BaseConfigService<T> {
+): (new () => BaseConfigService<T>) & { readonly schema: Joi.ObjectSchema } {
   const {
     appName,
     workingDir = 'apps/server',
@@ -62,6 +62,14 @@ export function createServiceConfig<T extends Partial<IEnvConfig> = IEnvConfig>(
   const schema = Joi.object(Object.assign({}, baseSchema, ...schemas, extend));
 
   class ServiceConfigService extends BaseConfigService<T> {
+    /**
+     * The composed Joi schema (baseSchema + fragments + extend) this service
+     * validates against. Exposed for introspection/tests so a service's
+     * env-var contract can be asserted without instantiating it (e.g.
+     * verifying every consumed var is covered — issue #484).
+     */
+    static readonly schema: Joi.ObjectSchema = schema;
+
     constructor() {
       super(schema, { appName, workingDir });
     }


### PR DESCRIPTION
## Summary

Completes the final open acceptance criterion of #484 — *"No env var documented in any service schema is missing from any other service that logically needs it."*

The #484 consolidation itself (the `createServiceConfig` factory, all 5 services migrated to it, and the `clips` `microservicesSchema` fix) **already landed** in [#505](https://github.com/genfeedai/genfeed.ai/pull/505) and its workers follow-up `bc655b22f`. What remained was the drift audit: every env var a service reads at runtime must be in its validation schema, so the schema is the single source of truth and misconfiguration is visible.

I audited all five services (`workers`, `notifications`, `files`, `mcp`, `clips`) for runtime env reads (`configService.get(...)` / raw `process.env`) not covered by their `createServiceConfig` schema, with an adversarial verify pass to drop false positives. `files` and `clips` were already clean.

## Confirmed drift fixed

**workers** — `OPENROUTER_API_KEY` (clip processors), `REPLICATE_KEY` (model-watcher cron + model-discovery), `AWS_REGION`/`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (llm-idle cron EC2Client), `GPU_LLM_INSTANCE_ID` (llm-idle cron), `FAL_API_KEY`, `HUGGINGFACE_API_KEY`, `SERVICE_NAME`

**notifications** — `CHROME_EXTENSION_ID` (CORS), `SLACK_NOTIFICATION_BOT_TOKEN`, `GENFEED_CLOUD` + `NEXT_PUBLIC_GENFEED_CLOUD` (terminal cloud gate), `VALIDATION_{MAX_FILE_SIZE,VIDEO,IMAGE,AUDIO}_FORMATS`

**mcp** — `CHROME_EXTENSION_ID` (CORS)

## Safety guarantees

`BaseConfigService` validates with `allowUnknown: true, stripUnknown: false`, so present values already pass through — these additions add **schema coverage + fail-fast on malformed values**, not new runtime resolution. To avoid any boot regression (incl. the hermetic boot-check gate):

- **All additions are `optional`** — no new `required`/`conditionalRequired`, so no service that currently boots without a var can crash. (This is why `replicateSchema`, whose `REPLICATE_KEY` is cloud-required, was *not* composed — `REPLICATE_KEY` is inlined `optional` instead, matching the cron's soft-fail behavior.)
- **No `.default()` that overrides an existing fallback** — `AWS_REGION` carries no default so the llm-idle cron's own `|| 'us-east-1'` is preserved (this is why `awsOptionalSchema`, which defaults `AWS_REGION` to `us-west-1`, was not composed).
- **Existing safe, all-optional fragments are reused where exported** (`falSchema`, `huggingFaceSchema`, `webhooksSchema`); the rest are inlined in `extend`. `packages/config/src/schemas/*` is otherwise untouched.

`createServiceConfig` now exposes the composed Joi schema as a static (`ConfigService.schema`) so a service's env contract can be asserted in tests without instantiating it.

## Verification

- `bun run test --filter=@genfeedai/config` → 143 pass (incl. new factory `schema`-exposure test)
- `bun run test --filter=@genfeedai/mcp` → 136 pass
- `bun run test --filter=@genfeedai/notifications` → 47 pass
- `bun run test --filter=@genfeedai/workers` → 249 pass (config spec 28, incl. per-key schema-coverage assertions + `CHROME_EXTENSION_ID` length-32 enforcement + AWS_REGION-no-default + optional-tolerance)
- `bunx biome check` clean; pre-commit secretlint clean
- Real `nest build` of `workers` + `notifications` + `mcp` and `@genfeedai/config` tsc build — all green (run on a peer machine to keep the dev laptop light)

## Noted, deliberately out of scope (follow-ups)

- `gpuFleetSchema` is defined in `ai.schema.ts` but never re-exported from `packages/config/src/schemas/index.ts`; `images`/`voices`/`videos` may have their own GPU-var drift as a result. Inlined the one key `workers` needs rather than widen scope here.
- `terminal.service.ts` reads `GENFEED_CLOUD` via raw `process.env` (not the validated config); the cloud gate would benefit from routing through `configService`, but that is a behavior/security change beyond schema coverage.
- workers' llm-idle cron defaults `AWS_REGION` to `us-east-1` while the org-standard schema default is `us-west-1` — left as-is to avoid an unvalidated region change.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)