### PR TITLE
test(desktop): cover offline generation with no provider configured

### DIFF
--- a/apps/desktop/app/src/main/generation.service.test.ts
+++ b/apps/desktop/app/src/main/generation.service.test.ts
@@ -187,6 +187,21 @@ describe('DesktopGenerationService', () => {
     expect(jobs[0]?.type).toBe('generation');
   });
 
+  it('throws and records no job when generating offline without a provider configured', async () => {
+    const database = createDatabaseMock();
+    const service = new DesktopGenerationService(
+      database as unknown as DesktopGenerationStore,
+    );
+
+    await expect(service.generateContent(generationParams)).rejects.toThrow(
+      'Configure a local generation provider before generating content.',
+    );
+
+    // The provider guard short-circuits before any job is created or any
+    // network call is attempted, so no orphaned sync job is left behind.
+    expect(Array.from(database.syncJobs.values())).toHaveLength(0);
+  });
+
   it('injects saved trend brief context into the local provider prompt', () => {
     const prompt = __desktopGenerationServiceTestUtils.buildUserPrompt({
       ...generationParams,


### PR DESCRIPTION
## What

Adds a single error-path test for desktop offline/local generation, covering the previously-untested "no provider configured" case.

The new test in `apps/desktop/app/src/main/generation.service.test.ts` asserts that `DesktopGenerationService.generateContent` rejects with the exact guidance message — *"Configure a local generation provider before generating content."* — when no local provider is configured, and that the provider guard (`requireProviderConfig`) short-circuits **before** any sync job row is created. This proves the offline guarantee: no orphaned job rows and no network attempt when generation is invoked without a provider.

## Why

`#262` (Verify Offline Desktop Packaging) calls for smoke coverage of desktop local generation. The happy paths (OpenAI-compatible, Replicate, fal) and the provider-failure path were already tested, but the no-provider error path had no coverage. A regression that removed the guard (or created a job before checking) would have shipped silently.

## Verification

- `bun test ./src/main/generation.service.test.ts` → **15 pass / 0 fail** (14 existing + 1 new)
- `bunx tsc --noEmit` (desktop app) → clean
- `bunx biome check` on the changed file → clean

No network mock needed — the guard throws before any `fetch`. No production code changed; test-only.

Closes #262