### PR TITLE
feat(desktop): auto-update via electron-updater (#485)

### DIFF
--- a/apps/desktop/app/package.json
+++ b/apps/desktop/app/package.json
@@ -42,6 +42,14 @@
           "genfeedai-desktop"
         ]
       }
+    ],
+    "publish": [
+      {
+        "owner": "genfeedai",
+        "provider": "github",
+        "releaseType": "release",
+        "repo": "genfeed.ai"
+      }
     ]
   },
   "dependencies": {
@@ -54,6 +62,7 @@
     "@sentry/browser": "10.56.0",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "6.0.0",
+    "electron-updater": "6.8.3",
     "next": "16.2.7",
     "node-pty": "1.1.0",
     "react": "19.2.7",
@@ -85,7 +94,7 @@
   "scripts": {
     "build": "bun run build:native && bun run build:app-shell && bun run copy:app-shell",
     "build:app-shell": "node ./scripts/build-app-shell.cjs",
-    "build:main": "bunx esbuild src/main.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/main.js --external:electron --external:@electric-sql/pglite --external:@electric-sql/pglite/* --external:@electric-sql/pglite-socket --external:@prisma/client --external:@prisma/client/* --external:node-pty --tsconfig=tsconfig.json",
+    "build:main": "bunx esbuild src/main.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/main.js --external:electron --external:@electric-sql/pglite --external:@electric-sql/pglite/* --external:@electric-sql/pglite-socket --external:@prisma/client --external:@prisma/client/* --external:node-pty --external:electron-updater --tsconfig=tsconfig.json",
     "build:native": "bun run clean && bun run build:main && bun run build:preload && bun run copy:assets",
     "build:preload": "bunx esbuild src/preload.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/preload.js --external:electron --tsconfig=tsconfig.json",
     "build:release": "bun run build && bun run prepare:release",

--- a/apps/desktop/app/src/main.ts
+++ b/apps/desktop/app/src/main.ts
@@ -25,6 +25,7 @@ import {
   Notification,
   shell,
 } from 'electron';
+import { autoUpdater } from 'electron-updater';
 import { DesktopAppShellService } from './main/app-shell.service';
 import {
   buildDesktopFailureScreenUrl,
@@ -48,6 +49,7 @@ import { DesktopSyncService } from './main/sync.service';
 import { DesktopTelemetryService } from './main/telemetry.service';
 import { DesktopTerminalService } from './main/terminal.service';
 import { DesktopTrayService } from './main/tray.service';
+import { DesktopUpdaterService } from './main/updater.service';
 import { DesktopWorkspaceService } from './main/workspace.service';
 
 const configService = new DesktopConfigService();
@@ -909,6 +911,20 @@ app.whenReady().then(async () => {
     trayService.initialize(mainWindow, emitQuickGenerate);
     shortcutsService.register(mainWindow, emitQuickGenerate);
   }
+
+  const updaterService = new DesktopUpdaterService({
+    autoUpdater,
+    isPackaged: app.isPackaged,
+    notify: ({ body, title }) => {
+      if (Notification.isSupported()) {
+        void new Notification({ body, title }).show();
+      }
+    },
+    onError: (error, context) => {
+      telemetryService.captureException(error, context);
+    },
+  });
+  updaterService.initialize();
 
   const deepLinkArgument = process.argv.find((value: string) =>
     value.startsWith('genfeedai-desktop://'),

--- a/apps/desktop/app/src/main/updater.service.test.ts
+++ b/apps/desktop/app/src/main/updater.service.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { IDesktopUpdaterDeps } from './updater.service';
+import { DesktopUpdaterService } from './updater.service';
+
+// Typed fake autoUpdater — cast to AppUpdater via 'as unknown as' only in test context.
+type Listener = (arg: unknown) => void;
+
+interface FakeAutoUpdater {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  checkForUpdatesCallCount: number;
+  checkForUpdatesShouldReject: boolean;
+  emit: (event: string, arg?: unknown) => void;
+  listeners: Map<string, Listener>;
+  logger: null | unknown;
+  checkForUpdates(): Promise<null>;
+  on(event: string, listener: Listener): FakeAutoUpdater;
+}
+
+function buildFakeAutoUpdater(shouldReject = false): FakeAutoUpdater {
+  const listeners = new Map<string, Listener>();
+  let checkForUpdatesCallCount = 0;
+
+  const fake: FakeAutoUpdater = {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    checkForUpdatesCallCount: 0,
+    checkForUpdatesShouldReject: shouldReject,
+    listeners,
+    logger: undefined,
+    emit(event: string, arg?: unknown) {
+      const listener = listeners.get(event);
+      if (listener) {
+        listener(arg);
+      }
+    },
+    on(event: string, listener: Listener) {
+      listeners.set(event, listener);
+      return this;
+    },
+    async checkForUpdates() {
+      checkForUpdatesCallCount++;
+      fake.checkForUpdatesCallCount = checkForUpdatesCallCount;
+      if (fake.checkForUpdatesShouldReject) {
+        throw new Error('update check failed');
+      }
+      return null;
+    },
+  };
+
+  return fake;
+}
+
+interface FakeDeps {
+  autoUpdater: FakeAutoUpdater;
+  isPackaged: boolean;
+  notifyCalls: Array<{ body: string; title: string }>;
+  onErrorCalls: Array<{ context?: Record<string, unknown>; error: unknown }>;
+  deps: IDesktopUpdaterDeps;
+}
+
+function buildDeps(opts: {
+  isPackaged: boolean;
+  shouldReject?: boolean;
+}): FakeDeps {
+  const autoUpdater = buildFakeAutoUpdater(opts.shouldReject ?? false);
+  const notifyCalls: Array<{ body: string; title: string }> = [];
+  const onErrorCalls: Array<{
+    context?: Record<string, unknown>;
+    error: unknown;
+  }> = [];
+
+  const deps: IDesktopUpdaterDeps = {
+    // Cast acceptable only in test files — provides a controllable fake without native bindings.
+    autoUpdater: autoUpdater as unknown as IDesktopUpdaterDeps['autoUpdater'],
+    isPackaged: opts.isPackaged,
+    notify: (n) => notifyCalls.push(n),
+    onError: (error, context) => onErrorCalls.push({ context, error }),
+  };
+
+  return {
+    autoUpdater,
+    deps,
+    isPackaged: opts.isPackaged,
+    notifyCalls,
+    onErrorCalls,
+  };
+}
+
+describe('DesktopUpdaterService', () => {
+  describe('when isPackaged is false', () => {
+    let fake: FakeDeps;
+
+    beforeEach(() => {
+      fake = buildDeps({ isPackaged: false });
+    });
+
+    it('does not touch autoUpdater on initialize', () => {
+      const svc = new DesktopUpdaterService(fake.deps);
+      svc.initialize();
+
+      expect(fake.autoUpdater.autoDownload).toBe(false);
+      expect(fake.autoUpdater.autoInstallOnAppQuit).toBe(false);
+      expect(fake.autoUpdater.logger).toBeUndefined();
+      expect(fake.autoUpdater.listeners.size).toBe(0);
+    });
+
+    it('does not call checkForUpdates', () => {
+      const svc = new DesktopUpdaterService(fake.deps);
+      svc.initialize();
+
+      expect(fake.autoUpdater.checkForUpdatesCallCount).toBe(0);
+    });
+  });
+
+  describe('when isPackaged is true', () => {
+    let fake: FakeDeps;
+    let svc: DesktopUpdaterService;
+
+    beforeEach(async () => {
+      fake = buildDeps({ isPackaged: true });
+      svc = new DesktopUpdaterService(fake.deps);
+      svc.initialize();
+      // Let the async checkForUpdates settle
+      await Promise.resolve();
+    });
+
+    it('sets autoDownload to true', () => {
+      expect(fake.autoUpdater.autoDownload).toBe(true);
+    });
+
+    it('sets autoInstallOnAppQuit to true', () => {
+      expect(fake.autoUpdater.autoInstallOnAppQuit).toBe(true);
+    });
+
+    it('sets logger to null', () => {
+      expect(fake.autoUpdater.logger).toBeNull();
+    });
+
+    it('registers update-available, update-downloaded, and error listeners', () => {
+      expect(fake.autoUpdater.listeners.has('update-available')).toBe(true);
+      expect(fake.autoUpdater.listeners.has('update-downloaded')).toBe(true);
+      expect(fake.autoUpdater.listeners.has('error')).toBe(true);
+    });
+
+    it('calls checkForUpdates exactly once', () => {
+      expect(fake.autoUpdater.checkForUpdatesCallCount).toBe(1);
+    });
+
+    it('emitting update-available calls notify with correct title and version in body', () => {
+      fake.autoUpdater.emit('update-available', { version: '1.2.3' });
+
+      expect(fake.notifyCalls).toHaveLength(1);
+      expect(fake.notifyCalls[0].title).toBe('Update available');
+      expect(fake.notifyCalls[0].body).toContain('1.2.3');
+    });
+
+    it('emitting update-downloaded calls notify with correct title and version in body', () => {
+      fake.autoUpdater.emit('update-downloaded', { version: '1.2.3' });
+
+      expect(fake.notifyCalls).toHaveLength(1);
+      expect(fake.notifyCalls[0].title).toBe('Update ready');
+      expect(fake.notifyCalls[0].body).toContain('1.2.3');
+    });
+
+    it('emitting error forwards to onError with source auto-updater', () => {
+      const err = new Error('boom');
+      fake.autoUpdater.emit('error', err);
+
+      expect(fake.onErrorCalls).toHaveLength(1);
+      expect(fake.onErrorCalls[0].error).toBe(err);
+      expect(fake.onErrorCalls[0].context).toEqual({ source: 'auto-updater' });
+    });
+
+    it('calling initialize twice only initializes once', async () => {
+      svc.initialize();
+      await Promise.resolve();
+
+      expect(fake.autoUpdater.checkForUpdatesCallCount).toBe(1);
+    });
+  });
+
+  describe('checkForUpdates rejection handling', () => {
+    it('catches rejection and forwards to onError with source auto-updater.check', async () => {
+      const fake = buildDeps({ isPackaged: true, shouldReject: true });
+      const svc = new DesktopUpdaterService(fake.deps);
+
+      await expect(svc.checkForUpdates()).resolves.toBeUndefined();
+
+      expect(fake.onErrorCalls).toHaveLength(1);
+      expect(fake.onErrorCalls[0].context).toEqual({
+        source: 'auto-updater.check',
+      });
+      expect(fake.onErrorCalls[0].error).toBeInstanceOf(Error);
+    });
+
+    it('does not throw when checkForUpdates rejects during initialize', async () => {
+      const fake = buildDeps({ isPackaged: true, shouldReject: true });
+      const svc = new DesktopUpdaterService(fake.deps);
+
+      expect(() => svc.initialize()).not.toThrow();
+      // Let async settle
+      await Promise.resolve();
+
+      expect(fake.onErrorCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/apps/desktop/app/src/main/updater.service.ts
+++ b/apps/desktop/app/src/main/updater.service.ts
@@ -1,0 +1,64 @@
+import type { AppUpdater } from 'electron-updater';
+
+export interface IDesktopUpdaterDeps {
+  autoUpdater: Pick<
+    AppUpdater,
+    | 'autoDownload'
+    | 'autoInstallOnAppQuit'
+    | 'checkForUpdates'
+    | 'logger'
+    | 'on'
+  >;
+  isPackaged: boolean;
+  notify: (notification: { body: string; title: string }) => void;
+  onError: (error: unknown, context?: Record<string, unknown>) => void;
+}
+
+export class DesktopUpdaterService {
+  private isInitialized = false;
+
+  constructor(private readonly deps: IDesktopUpdaterDeps) {}
+
+  initialize(): void {
+    if (this.isInitialized) {
+      return;
+    }
+    // Auto-update only runs in a packaged build; dev and smoke runs have no update feed.
+    if (!this.deps.isPackaged) {
+      return;
+    }
+    this.isInitialized = true;
+
+    const { autoUpdater } = this.deps;
+    autoUpdater.autoDownload = true;
+    autoUpdater.autoInstallOnAppQuit = true;
+    // electron-updater logs to console by default; route the signal we care about through telemetry instead.
+    autoUpdater.logger = null;
+
+    autoUpdater.on('update-available', (info) => {
+      this.deps.notify({
+        body: `GenFeed ${info.version} is downloading in the background.`,
+        title: 'Update available',
+      });
+    });
+    autoUpdater.on('update-downloaded', (info) => {
+      this.deps.notify({
+        body: `GenFeed ${info.version} will install the next time you quit.`,
+        title: 'Update ready',
+      });
+    });
+    autoUpdater.on('error', (error: Error) => {
+      this.deps.onError(error, { source: 'auto-updater' });
+    });
+
+    void this.checkForUpdates();
+  }
+
+  async checkForUpdates(): Promise<void> {
+    try {
+      await this.deps.autoUpdater.checkForUpdates();
+    } catch (error) {
+      this.deps.onError(error, { source: 'auto-updater.check' });
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -273,6 +273,7 @@
         "@sentry/browser": "10.56.0",
         "@xterm/addon-fit": "0.11.0",
         "@xterm/xterm": "6.0.0",
+        "electron-updater": "6.8.3",
         "next": "16.2.7",
         "node-pty": "1.1.0",
         "react": "19.2.7",
@@ -4856,6 +4857,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.353", "", {}, "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w=="],
 
+    "electron-updater": ["electron-updater@6.8.3", "", { "dependencies": { "builder-util-runtime": "9.5.1", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ=="],
+
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "element-vir": ["element-vir@26.16.0", "", { "dependencies": { "@augment-vir/assert": "^31.70.0", "@augment-vir/common": "^31.70.0", "date-vir": "^8.3.2", "lit": "^3.3.2", "lit-css-vars": "^3.6.2", "lit-html": "^3.3.2", "object-shape-tester": "^6.12.1", "observavir": "^2.3.2", "typed-event-target": "^4.3.0" } }, "sha512-qoAmbHVPUIy85obp4NhS6EmG4MuVleKljV9kiHbfTddbPoNEZXAP5u/rwbKF1ClXo+R9Z05klUMyxaR1uvNm5A=="],
@@ -7426,6 +7429,8 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
@@ -8811,6 +8816,8 @@
     "electron-publish/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "electron-publish/mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
+
+    "electron-updater/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 


### PR DESCRIPTION
## Summary

Wires background auto-update into the desktop app's main process via `electron-updater`. Packaged builds now check the configured GitHub feed on launch, surface a non-blocking notification when an update is available/downloaded, and install on quit — all without blocking startup.

Implements the **app-side** of #485 (criteria 1, 2, 5) end-to-end with full unit coverage. The release-pipeline feed-publish (criteria 3, 4) is deferred behind a tag-scheme decision + a real tagged-release validation — see **Deferred** below.

## Changes

- **`src/main/updater.service.ts`** — `DesktopUpdaterService`, a dependency-injected wrapper around `electron-updater`'s `autoUpdater`:
  - `autoDownload` + `autoInstallOnAppQuit`; `update-available`/`update-downloaded` → native `Notification`; `error` → telemetry.
  - Guarded by `app.isPackaged`, so dev/smoke runs no-op (no update feed exists there).
  - `checkForUpdates()` catches its own rejection → startup stays non-blocking, never throws.
  - Decoupled via a `deps` object (`autoUpdater`/`isPackaged`/`notify`/`onError`) so it unit-tests without Electron native bindings.
- **`src/main.ts`** — constructs + `initialize()`s the service inside `app.whenReady()` after window/tray init. Non-blocking; install-on-quit is handled by `autoInstallOnAppQuit` (no change to the existing `before-quit` handler).
- **`package.json`**:
  - `electron-updater@6.8.3` dependency (pairs with the existing `electron-builder@26.x`).
  - `--external:electron-updater` in the esbuild `build:main` bundle (mirrors `@prisma/client`/`node-pty`, so it resolves from the packaged asar at runtime).
  - `build.publish` = `{ provider: github, owner: genfeedai, repo: genfeed.ai, releaseType: release }` — the feed `electron-updater` reads at runtime to locate updates.
- **`src/main/updater.service.test.ts`** — 13 `bun:test` cases: packaged/unpackaged gating, idempotent `initialize`, event→notification content (version in body), error routing (`auto-updater` / `auto-updater.check` sources), and rejection handling.

## Verification (local)

- `bun run type-check` (scoped to `@genfeedai/desktop`) → **0 errors**
- `bunx biome check` on touched files → **0**
- `bun test ./src/main/updater.service.test.ts` → **13 pass / 0 fail**
- Pre-commit `secretlint` + `biome` hooks → pass

Heavy desktop packaging/smoke was **not** run (laptop-restricted routine); it's exercised by `desktop-qa.yml` in CI.

## Deferred (needs a release decision + real-release validation) — criteria 3 & 4 of #485

Enabling CI to actually publish the update feed is intentionally **not** in this PR. Investigation found a hard blocker that can't be validated on the build-restricted routine host:

- `electron-builder` only generates `latest-mac.yml` (the update manifest `electron-updater` requires) **during the publish phase** — `--publish never` skips it entirely (`app-builder-lib` `PublishManager`: update-info tasks are gated on `isPublish`).
- When publishing, `electron-builder`'s GitHub publisher targets a release tagged **`v${version}`** (`electron-publish/gitHubPublisher.js:35` → `githubTagPrefix(info) + version`), with no option to emit the repo's existing **`desktop-v*`** tag prefix. So naïvely enabling publish would push the manifest to a divergent `v0.1.0` release instead of the `desktop-v*` release the pipeline cuts.

Reconciling this is a release-engineering decision (align the desktop tag scheme to `v*`, or pin the publisher tag) that must be validated against a real signed `desktop-v*` release — out of scope for an autonomous, packaging-restricted run. Tracked as the remaining work on #485.

Interim runtime behavior: until the feed carries `latest-mac.yml`, `checkForUpdates()` in packaged builds fails gracefully (caught → telemetry, non-fatal, non-blocking). No effect on dev/self-hosted/unpackaged runs.

Refs #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)