### PR TITLE
docs(arch): deployment-modes + auth ADR (3 modes, Clerk->Better Auth)

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -10,6 +10,7 @@
 - [Settings Routing](project_settings_routing.md) — canonical personal/org/brand settings URL shapes
 - [Desktop BYOK Generation](project_desktop_byok_generation.md) — desktop local/BYOK generation works without Clerk; Clerk is sync-only
 - [TS6.0/Prisma-7 build regression](project_ts6_prisma7_build_regression.md) — **BUILD REGRESSION RESOLVED 2026-06-03** (develop CI green @ 2e66b0aa8). Root cause was stale turbo cache + mv-dist-src hack, not ~2020 real errors; removed the hack + fixed ~7 Prisma-7 Document interfaces. Stage 4 + migration-apply still pending.
+- **Deployment Modes & Auth Refactor (2026-06-22)** — canonical 3-mode model (SaaS / Community / Desktop as `deployment × client` axes) locked in [ADR-DEPLOYMENT-MODES](architecture/ADR-DEPLOYMENT-MODES.md). Two P0 epics: **#735** Clerk → Better Auth (own self-hostable auth across ALL modes incl. SaaS; phased dual-run; headless API-keys UI+CLI #747) and **#740** deployment modes (canonical mode #742, switcher #743, CI rework #744, community-just-works #745, release QA #746). Multi-tenancy stays EE/SaaS; managed credits cloud-only; Community = funnel charter. Supersedes the auth half of #95.
 
 ## Feedback (user corrections — permanent)
 
@@ -79,6 +80,7 @@
 - [PLG Boundary](architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md) — OSS vs cloud feature split
 - [Workflow-Backed Agents](architecture/ADR-WORKFLOW-BACKED-RECURRING-AGENT-AUTOMATION.md) — recurring agent automation
 - [Skills, Routines, and Memory Boundary](architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md) — OSS single-player loop vs cloud collaborative governance
+- [Deployment Modes & Auth](architecture/ADR-DEPLOYMENT-MODES.md) — 3 product modes (SaaS/Community/Desktop) as `deployment × client` axes; Clerk → Better Auth everywhere; brand-always/org-SaaS-only switcher; multi-tenancy = EE/SaaS; managed credits cloud-only; Community funnel charter. Epics #735, #740. (contributor doc: `docs/deployment-modes.md`)
 
 ## Rules (symlinked to .claude/rules/)
 

--- a/.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md
+++ b/.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md
@@ -1,0 +1,128 @@
+# ADR: Deployment Modes & Auth — SaaS / Community / Desktop
+
+## Status
+
+Accepted
+
+## Spec Version
+
+v1.1.0
+
+## Last Updated
+
+2026-06-22
+
+## Canonical Source
+
+This file. Contributor summary: [`docs/deployment-modes.md`](../../../docs/deployment-modes.md) (public: https://docs.genfeed.ai/deployment-modes). Implementation tracking: **epic #740** (deployment modes) + **epic #735** (Clerk → Better Auth).
+
+## Context
+
+Genfeed ships from one monorepo to **three deployment targets**, but the codebase had no canonical definition of them. Mode was detected by 3–4 overlapping mechanisms that could disagree (`GenfeedMode` enum, `IS_SELF_HOSTED`/`IS_CLOUD`, a duplicate frontend `edition.ts`, `NEXT_PUBLIC_DESKTOP_SHELL`), and auth/switcher/billing behaviour was wired inconsistently as a result — e.g. the brand switcher silently disappeared in self-hosted while a useless org switcher was always shown.
+
+**Validated against peers** (Cal.com, PostHog, Supabase, Nango, Dub, Twenty, Documenso, Medusa): gating org-level multi-tenancy behind EE is market-standard (Cal.com, PostHog); BYOK-free with zero call-home is the Supabase model; community-self-host-as-funnel (not a revenue tier) is PostHog's hard-won lesson; and **no peer requires a proprietary SaaS auth vendor to self-host** — which is why depending on Clerk in self-hosted was the one genuinely out-of-step decision.
+
+This ADR locks the product model, the boundaries, and the auth direction so every mode-conditional decision has one place to refer to.
+
+## Decision
+
+### 1. Three product modes = two axes
+
+"Mode" is **two independent axes**, not one enum:
+
+- **deployment**: `cloud` (SaaS) | `self-hosted` (Community)
+- **client**: `web` | `desktop`
+
+The three product modes are named combinations:
+
+| Mode | deployment × client | Detection |
+|---|---|---|
+| **SaaS** | cloud × web | `GENFEED_CLOUD=1` |
+| **Community** | self-hosted × web | no `GENFEED_CLOUD` |
+| **Desktop** | (cloud **or** self-hosted) × desktop | `NEXT_PUBLIC_DESKTOP_SHELL=1` |
+
+Desktop is a **client surface** that connects to either backend — never its own backend. The current `CLOUD`/`HYBRID`/`LOCAL` + `DESKTOP_SHELL` tangle collapses onto these two axes (#742).
+
+### 2. Org / Brand structure (and the switcher rule)
+
+The **brand** is the unit of content context (a brand owns one or more social accounts; you select a brand to create content). The **org** is the multi-tenancy boundary and only matters in SaaS.
+
+| | SaaS | Community | Desktop |
+|---|---|---|---|
+| Orgs | **multiple** (isolated tenants) | **one** | one (local) |
+| Brands | multiple per org | **multiple** | multiple (local) |
+| **Org switcher** | **shown** | **hidden** | hidden |
+| **Brand switcher** | **shown** | **shown** | **shown** |
+
+**Switcher rule (canonical):** the **brand switcher is always shown and populated** in every mode; the **org switcher only renders in SaaS**. This corrects the prior bug where self-hosted hid the brand switcher and showed an org switcher that couldn't switch anything (#743).
+
+### 3. Auth — own it; Clerk removed entirely
+
+**One self-hostable auth system across all three modes: [Better Auth](https://better-auth.com)** (MIT, free). It runs **in-process** against our existing Postgres — no separate instance, no SaaS vendor, no call-home. **Clerk is removed everywhere, SaaS included** (one auth system; no Clerk-shaped fields lingering in modes that don't use them).
+
+Better Auth ships **magic link, Google/GitHub OAuth, organizations/teams, and admin impersonation** as first-party plugins, with a Prisma/Postgres adapter and NestJS + Electron integrations.
+
+| Mode | Auth |
+|---|---|
+| **SaaS** | Better Auth (email/password, magic link, Google) + multi-tenant orgs |
+| **Community** | Better Auth, fully self-hostable + offline; **single org**. None required for solo/local; a login wall is just enabling it. |
+| **Desktop** | local-first; the optional "connect" signs in via Better Auth → desktop↔cloud sync + cloud features + credits |
+
+**Headless / API-first:** first-party `gf_*` API keys with a self-service management UI **and** CLI (#747) make the whole product drivable via the API + MCP with zero web-UI dependency.
+
+Client features gate on **mode**, never on raw auth signals.
+
+**Migration** is a phased, dual-run epic (#735): Better Auth lands beside Clerk feature-flagged (zero user impact), with a **staged production cutover** — a magic-link "set your password" campaign, since Clerk can't export password hashes. Drop `User.clerkId` / `Organization.clerkOrganizationId` / `Member.clerkMembershipId`; move `isSuperAdmin` + subscription state out of Clerk `publicMetadata` into DB columns.
+
+### 4. Tenancy
+
+**Multi-tenant org isolation is a SaaS / EE feature** (`ee/packages/multi-tenancy`, commercial). Community and Desktop are **single-tenant** (one org per instance). Multi-tenancy is the SaaS differentiator and is not given away in OSS.
+
+> `ee/packages/multi-tenancy` is currently a scaffold (no enforcement code yet — #87). Until built, "multi-tenant" is the SaaS-only intent and Community's single-org model is the only path wired end-to-end.
+
+### 5. Billing & generation
+
+| Path | Availability | Bills |
+|---|---|---|
+| **BYOK** (your OpenAI/Replicate/fal/Ollama keys) | all modes | **free** — OSS infinite-credit stub, zero call-home |
+| **Genfeed-managed inference** (`provider=genfeedai`, Fleet/LoRA) | cloud-connected only | credits, **purchased cloud-side** |
+
+**Managed credits are cloud-only.** Community/Desktop buy credits on `api.genfeed.ai` (→ a `gf_` key scoped `managed-inference:execute`) and call the **cloud** `/v1/managed-inference`. A self-hosted backend cannot sell credits locally (`ManagedStripeCheckoutService` returns `503` when `IS_SELF_HOSTED`). This is the "API-only credits" funnel.
+
+### 6. Build / ship / distribution
+
+| Mode | Build | Ship |
+|---|---|---|
+| SaaS | `docker/Dockerfile.server` (includes `ee/`) | ECS/Fargate + Vercel |
+| Community | `docker/Dockerfile.selfhosted` (excludes `ee/`) | GHCR `:latest`; `docker compose -f docker-compose.selfhosted.yml up` |
+| Desktop | Electron (`desktop-v*` tags) | DMG/ZIP installers |
+
+### 7. Canonical mode source of truth
+
+**One** mode authority in `packages/config`, modeled as the two axes (§1), consumed by backend **and** frontend. Delete the duplicate frontend `edition.ts`, collapse the redundant `IS_SELF_HOSTED`/`IS_CLOUD` helpers, and standardize the `NEXT_PUBLIC_GENFEED_CLOUD` comparison to one truthiness helper (today `=== 'true'` vs truthy split-brains 6 sites). Tracked in #742.
+
+### 8. Community charter
+
+Community is a **funnel and credibility driver, not a revenue tier** (PostHog killed their paid self-hosted tier as a support black hole). Scope it explicitly: **Docker-Compose-only, single-tenant, community support, no SLA**, near-zero-maintenance for the Genfeed team, BYOK-free and fully offline-capable. The moment Community demands SaaS feature-parity it stops being a funnel and becomes a competing product to maintain.
+
+### 9. Desktop
+
+**Local-first**: offline BYOK generation + PGlite local cache, no account needed. The optional **"connect"** (Better Auth sign-in) unlocks desktop↔cloud sync + managed features + credits. **No bundled backend** — a thin local-first client, not a fourth product. (Community-in-a-box — bundling the single-container self-hosted stack for a fully-offline full-featured app — is feasible later since Community is one image, but is **deferred**.)
+
+## Consequences (implementation — tracked on epics #735 and #740)
+
+1. **Mode consolidation** → one canonical source, two axes (#742).
+2. **Auth** → replace Clerk with Better Auth across all modes; phased dual-run migration (#735), incl. headless API-keys UI + CLI (#747).
+3. **Switcher rule** → brand always shown+populated; org SaaS-only (#743).
+4. **CI** → fast PRs; heavy gates at release-cut; self-hosted E2E nightly-only; community build split from SaaS deploy (#744).
+5. **Community "just works"** → fix docs/ports/compose + healthcheck (#745).
+6. **Release-stage QA** → consolidated gate + post-deploy smoke (#746).
+7. **EE extraction (#87)** → credits/subscriptions/Stripe/multi-tenancy → `ee/packages/*`; multi-tenancy stays the SaaS line.
+
+## Related
+
+- [ADR: PLG Boundary Between OSS and Genfeed Cloud](ADR-PLG-BOUNDARY-OSS-CLOUD.md)
+- **Epic #735** — Clerk → Better Auth (self-hostable auth, all modes)
+- **Epic #740** — Deployment modes (canonical split, switcher, CI, community, QA)
+- Supersedes the **auth half** of the closed One-API epic #95
+- Issue #87 — EE billing / multi-tenancy extraction

--- a/apps/docs/content/core-loop/generation-service.mdx
+++ b/apps/docs/content/core-loop/generation-service.mdx
@@ -18,7 +18,7 @@ The generation story in the current repo spans a small set of stable entrypoints
 - [`apps/server/api/src/services/batch-generation/batch-generation.service.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/services/batch-generation/batch-generation.service.ts)
   - builds batch plans
   - delegates actual generation to `ContentGeneratorService`
-- [`packages/tools/src/registry/source.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/tools/src/registry/source.ts)
+- [`packages/tools/src/registry/source/index.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/tools/src/registry/source/index.ts)
   - defines the canonical agent-visible generation tools
 - [`packages/tools/src/registry/tool-registry.ts`](https://github.com/genfeedai/genfeed.ai/blob/master/packages/tools/src/registry/tool-registry.ts)
   - assigns generation tool categories and UI action cards
@@ -41,7 +41,7 @@ For v1, the important point is not every experimental flow. It is the stable pat
 
 ## Stable `generate_*` Tool Surface
 
-The v1 stable generation tools are the agent-facing tools that create generation work or route users into a generation review flow. Their metadata is defined in `packages/tools/src/registry/source.ts` and rendered through the canonical registry in `packages/tools/src/registry/tool-registry.ts`.
+The v1 stable generation tools are the agent-facing tools that create generation work or route users into a generation review flow. Their metadata is defined in `packages/tools/src/registry/source/index.ts` and rendered through the canonical registry in `packages/tools/src/registry/tool-registry.ts`.
 
 | Tool                     | Stable input contract                                                                                   | Execution path                                                                                            | Output contract                                               |
 | ------------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
@@ -58,7 +58,7 @@ These are the stable tool names callers should depend on for v1. Lower-level wor
 
 | Layer              | Files                                                                                         | Responsibility                                                                           |
 | ------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Tool metadata      | `packages/tools/src/registry/source.ts`, `packages/tools/src/registry/tool-registry.ts` | Defines tool names, parameters, categories, and UI action card types                     |
+| Tool metadata      | `packages/tools/src/registry/source/index.ts`, `packages/tools/src/registry/tool-registry.ts` | Defines tool names, parameters, categories, and UI action card types                     |
 | Agent dispatch     | `apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts`        | Converts tool calls into internal API requests and normalizes preview-card responses     |
 | Media APIs         | `/v1/images`, `/v1/videos`, `/v1/musics`, `/v1/voices/generate`                               | Own request validation, model selection, credits, persistence, and completion polling    |
 | Skill execution    | `apps/server/api/src/services/skill-executor/*`                                               | Runs content skills such as `image-generation` and records Content Runs                  |

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -19,7 +19,7 @@ summary; the canonical, decision-of-record version is the ADR at
 
 ## Choosing a mode (env)
 
-- **SaaS** — `GENFEED_CLOUD=1` (+ Clerk, AWS, Stripe).
+- **SaaS** — `GENFEED_CLOUD=1` (+ Better Auth, AWS, Stripe).
 - **Community** — leave `GENFEED_CLOUD` unset. Zero-config runs single-user with
   no auth and seeds a default workspace. Turn on a login wall (Better Auth) for a
   team — still one org. Auth is self-hostable; no SaaS auth vendor, works offline.

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -1,0 +1,46 @@
+# Deployment Modes
+
+Genfeed runs in **three modes** from one codebase. This is the contributor-facing
+summary; the canonical, decision-of-record version is the ADR at
+[`.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md`](../.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md).
+
+## The three modes
+
+| | **SaaS** | **Community** | **Desktop** |
+|---|---|---|---|
+| **For** | Customers using the hosted product | Self-hosters running the whole stack | Solo creators on their own machine |
+| **Get it** | app.genfeed.ai | `docker compose -f docker-compose.selfhosted.yml up` | Download the installer |
+| **Orgs** | many (isolated tenants) | **one** | one |
+| **Brands** | many per org | **many** | many |
+| **Auth** | Better Auth (email/password, magic link, Google) | Better Auth, self-hostable — none for solo, optional login wall | local-first sign-in |
+| **Storage** | S3 | local filesystem | local (PGlite) + optional cloud sync |
+| **Generation** | managed | your own provider keys (BYOK), free | BYOK local, free |
+| **Managed inference** | included | buy cloud credits, use via API | buy cloud credits, use via API |
+
+## Choosing a mode (env)
+
+- **SaaS** — `GENFEED_CLOUD=1` (+ Clerk, AWS, Stripe).
+- **Community** — leave `GENFEED_CLOUD` unset. Zero-config runs single-user with
+  no auth and seeds a default workspace. Turn on a login wall (Better Auth) for a
+  team — still one org. Auth is self-hostable; no SaaS auth vendor, works offline.
+- **Desktop** — the Electron shell sets `NEXT_PUBLIC_DESKTOP_SHELL=1`.
+
+## Key rules
+
+- **Brand is the content context.** You always pick a brand to create content, so
+  the **brand switcher is shown in every mode**. The **org switcher only appears
+  in SaaS**, where there are multiple tenants to switch between.
+- **Single-tenant by default.** Community and Desktop are one org. Multi-tenant
+  isolation (many orgs in one deployment) is a SaaS/Enterprise feature.
+- **BYOK is always free.** Bring your own provider keys and generate at no cost to
+  Genfeed.
+- **Managed inference is cloud-only.** To have Genfeed run the models for you, buy
+  credits on the cloud and use the issued API key against the cloud
+  `/v1/managed-inference` endpoint. A self-hosted instance does not sell credits
+  locally.
+
+## See also
+
+- [Self-hosting guide](self-hosting.md)
+- [Architecture overview](architecture.md)
+- [OSS ↔ Cloud execution boundaries](execution-boundaries.md)


### PR DESCRIPTION
Locks the canonical deployment-modes + auth model as **ADR-DEPLOYMENT-MODES** (+ a contributor `docs/deployment-modes.md` page) and indexes it in `MEMORY.md` — so every decision from the modes/auth review is recorded in-repo.

## Decisions locked
- **3 product modes** (SaaS / Community / Desktop) modeled as `deployment × client` axes; one canonical mode source of truth.
- **Auth**: replace Clerk with **Better Auth** (MIT, self-hostable, runs in-process — no separate instance) across **all** modes, SaaS included. Phased dual-run migration tracked in epic #735 (incl. headless API-keys UI+CLI #747).
- **Switcher**: brand always shown + populated; org switcher SaaS-only.
- **Tenancy**: multi-tenant = EE/SaaS; Community/Desktop single-tenant.
- **Billing**: BYOK free everywhere (zero call-home); managed inference cloud-only.
- **Community** = funnel charter (Docker-Compose-only, single-tenant, no SLA).
- **Desktop** = local-first client; connect (Better Auth) → sync + cloud features + credits.

Implementation tracked on epics #735 (auth) and #740 (deployment modes).

Closes #741.