### PR TITLE
fix(shell): app-switcher dropdown opens left, no scrollbar shift

### DIFF
--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -189,7 +189,7 @@ export function AppSwitcher({
   const activeLabel = activeApp?.label ?? 'Workspace';
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         {variant === 'labeled' ? (
           <Button
@@ -217,7 +217,7 @@ export function AppSwitcher({
         )}
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        align="start"
+        align="end"
         sideOffset={8}
         className="w-48"
         onCloseAutoFocus={(event) => {


### PR DESCRIPTION
Small shell fix. The app-switcher (grid icon) **stays on the right**; only its dropdown behaviour changes:

- `align="end"` → the menu opens **leftward** into the page instead of overflowing toward the right viewport edge.
- `modal={false}` → Radix no longer locks body scroll + adds `padding-right` on open, which was **shifting the scrollbar**.

Verified earlier in preview: with the menu open, `body { padding-right: 0 }` (no jump) and the dropdown sits within the viewport.

Relates to the shell switcher work in #743.