### PR TITLE
feat(auth): Better Auth frontend dual-run beside Clerk (Phase 2, #737)

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.behavior.test.tsx
@@ -34,7 +34,7 @@ vi.mock('@clerk/nextjs', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@hooks/ui/use-gsap-entrance', () => ({

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { LinkCategory, type OrganizationCategory } from '@genfeedai/enums';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useGsapTimeline } from '@hooks/ui/use-gsap-entrance';
 import { logger } from '@services/core/logger.service';
 import { OnboardingService } from '@services/onboarding/onboarding.service';
@@ -90,7 +90,7 @@ function BrandContentContent() {
 
     const prefill = async () => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token || controller.signal.aborted) {
           return;
         }
@@ -143,7 +143,7 @@ function BrandContentContent() {
     async (category: OrganizationCategory) => {
       setAccountType(category);
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (token) {
           const service = OnboardingFunnelService.getInstance(token);
           await service.setAccountType(category);
@@ -173,7 +173,7 @@ function BrandContentContent() {
       setSubmitting(true);
 
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token) {
           return;
         }
@@ -220,7 +220,7 @@ function BrandContentContent() {
     setSubmitting(true);
 
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         return;
       }

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-content.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAuth } from '@clerk/nextjs';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import {
   OnboardingService,
   type ProactiveWorkspaceResponse,
@@ -91,7 +91,7 @@ export default function ProactiveContent() {
     let isCancelled = false;
 
     const loadWorkspace = async (mode: 'claim' | 'refresh') => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         return;
       }

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@contexts/user/user-context/user-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from '@clerk/nextjs';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
 import type { OnboardingAccessMode } from '@genfeedai/interfaces';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useGsapTimeline } from '@hooks/ui/use-gsap-entrance';
 import { logger } from '@services/core/logger.service';
@@ -137,7 +137,7 @@ export default function ProvidersContent() {
 
     const loadReadiness = async () => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token || cancelled) {
           setLoading(false);
           return;

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.behavior.test.tsx
@@ -48,7 +48,7 @@ vi.mock('@contexts/user/user-context/user-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@hooks/ui/use-gsap-entrance', () => ({

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
@@ -5,7 +5,7 @@ import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
 import { ButtonVariant } from '@genfeedai/enums';
 import { ONBOARDING_SIGNUP_GIFT_CREDITS } from '@genfeedai/types';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useGsapTimeline } from '@hooks/ui/use-gsap-entrance';
 import { logger } from '@services/core/logger.service';
 import { OnboardingFunnelService } from '@services/onboarding/onboarding-funnel.service';
@@ -97,7 +97,7 @@ export default function SuccessContent() {
     // Save content preferences if any selected
     if (selected.size > 0 && currentUser) {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (token) {
           const service = UsersService.getInstance(token);
           await service.patchSettings(currentUser.id, {
@@ -111,7 +111,7 @@ export default function SuccessContent() {
 
     // Mark onboarding complete and refresh Clerk session token
     try {
-      const token = await resolveClerkToken(getToken, { forceRefresh: true });
+      const token = await resolveAuthToken(getToken, { forceRefresh: true });
       if (token) {
         const funnelService = OnboardingFunnelService.getInstance(token);
         await funnelService.completeFunnel();

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.behavior.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@contexts/user/user-context/user-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@clerk/nextjs';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { OnboardingAccessMode } from '@genfeedai/interfaces';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useGsapTimeline } from '@hooks/ui/use-gsap-entrance';
 import { logger } from '@services/core/logger.service';
@@ -137,7 +137,7 @@ export default function SummaryContent() {
 
     const loadReadiness = async () => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token || cancelled) {
           setLoading(false);
           return;

--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
@@ -56,7 +56,7 @@ vi.mock('@contexts/user/user-context/user-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('next/navigation', () => ({

--- a/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
@@ -7,7 +7,7 @@ import {
 import { useAuth, useUser } from '@clerk/nextjs';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
 import { getResumeStep, ONBOARDING_STEPS } from '@genfeedai/constants';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { ManagedCreditsService } from '@services/billing/managed-credits.service';
 import { StripeService } from '@services/billing/stripe.service';
 import { EnvironmentService } from '@services/core/environment.service';
@@ -67,7 +67,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
       return onboardingHref;
     }
 
-    const token = await resolveClerkToken(getToken);
+    const token = await resolveAuthToken(getToken);
     if (!token) {
       return onboardingHref;
     }
@@ -139,7 +139,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
 
         try {
           const onboardingHref = await resolveOnboardingHref();
-          const token = await resolveClerkToken(getToken);
+          const token = await resolveAuthToken(getToken);
           if (!token) {
             redirectTo('/onboarding/providers');
             return;
@@ -234,7 +234,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
 
         try {
           const onboardingHref = await resolveOnboardingHref();
-          const token = await resolveClerkToken(getToken);
+          const token = await resolveAuthToken(getToken);
           if (!token) {
             redirectTo('/onboarding/providers');
             return;

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunContentGrid.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunContentGrid.tsx
@@ -5,7 +5,7 @@ import type {
   IAgentRunContent,
   IAgentRunContentItem,
 } from '@genfeedai/interfaces';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import type { AgentRunContentGridProps } from '@props/automation/agent-strategy.props';
 import { AgentRunsService } from '@services/ai/agent-runs.service';
 import { logger } from '@services/core/logger.service';
@@ -40,7 +40,7 @@ export default function AgentRunContentGrid({
     async (signal: AbortSignal) => {
       try {
         setIsLoading(true);
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token) return;
 
         const service = AgentRunsService.getInstance(token);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/agent-configuration-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/agent-configuration-page.tsx
@@ -3,7 +3,7 @@
 import { useAuth } from '@clerk/nextjs';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { type AgentApiConfig, AgentSettings } from '@genfeedai/agent';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import Container from '@ui/layout/container/Container';
 import { useMemo } from 'react';
 import { HiOutlineCog6Tooth } from 'react-icons/hi2';
@@ -15,7 +15,7 @@ export default function AgentConfigurationPage() {
   const apiConfig = useMemo<AgentApiConfig>(
     () => ({
       baseUrl: process.env.NEXT_PUBLIC_API_ENDPOINT ?? '',
-      getToken: async () => resolveClerkToken(getToken),
+      getToken: async () => resolveAuthToken(getToken),
     }),
     [getToken],
   );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.spec.tsx
@@ -46,7 +46,7 @@ vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@services/content/skills.service', async () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useBrandEnabledSkills } from '@hooks/data/skills/use-brand-enabled-skills';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { type Skill, SkillsService } from '@services/content/skills.service';
@@ -156,7 +156,7 @@ export default function OrchestrationSkillsPage() {
   } = state;
 
   const getSkillsService = useCallback(async () => {
-    const token = await resolveClerkToken(getToken);
+    const token = await resolveAuthToken(getToken);
     if (!token) {
       throw new Error('Authentication token unavailable');
     }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
@@ -1,5 +1,5 @@
 import { useAuth } from '@clerk/nextjs';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useDocumentVisibility } from '@hooks/ui/use-document-visibility/use-document-visibility';
 import type {
   AvatarProvider,
@@ -17,7 +17,7 @@ export function useStudioClipsPage() {
   const { getToken } = useAuth();
 
   const resolveToken = useCallback(async (): Promise<string> => {
-    return (await resolveClerkToken(getToken)) ?? '';
+    return (await resolveAuthToken(getToken)) ?? '';
   }, [getToken]);
 
   const clipsService = useMemo(

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
@@ -4,7 +4,7 @@ import { useAuth } from '@clerk/nextjs';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import type { IAgentRun, IAnalytics } from '@genfeedai/interfaces';
 import type { AgentRunStats } from '@genfeedai/types';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useSocketManager } from '@hooks/utils/use-socket-manager/use-socket-manager';
 import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props';
 import { AgentRunsService } from '@services/ai/agent-runs.service';
@@ -239,7 +239,7 @@ export function useWorkspacePageContent({
     const controller = new AbortController();
 
     const loadWorkspaceTasks = async () => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token || controller.signal.aborted) {
         return;
       }
@@ -266,7 +266,7 @@ export function useWorkspacePageContent({
     let isMounted = true;
 
     const loadWorkspaceRuns = async () => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token || !isMounted) {
         return;
       }
@@ -347,7 +347,7 @@ export function useWorkspacePageContent({
     setWorkspaceRefreshing(true);
 
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         return;
       }
@@ -370,7 +370,7 @@ export function useWorkspacePageContent({
     setWorkspaceActionError(null);
 
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         return;
       }
@@ -400,7 +400,7 @@ export function useWorkspacePageContent({
     setWorkspaceActionError(null);
 
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         setWorkspaceActionError('Authentication token unavailable.');
         return;

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-task-composer.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-task-composer.ts
@@ -1,7 +1,7 @@
 import { useAuth } from '@clerk/nextjs';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { PromptCategory, SystemPromptKey } from '@genfeedai/enums';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useWebsocketPrompt } from '@hooks/utils/use-websocket-prompt/use-websocket-prompt';
 import { Prompt } from '@models/content/prompt.model';
 import { PromptsService } from '@services/content/prompts.service';
@@ -104,7 +104,7 @@ export function useWorkspaceTaskComposer({
 
     const run = async () => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token) {
           setFacecamError('Authentication token unavailable.');
           return;
@@ -373,7 +373,7 @@ export function useWorkspaceTaskComposer({
     setTaskError(null);
 
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         setTaskError('Authentication token unavailable.');
         setTaskEnhancementBusy(false);
@@ -488,7 +488,7 @@ export function useWorkspaceTaskComposer({
     setTaskError(null);
 
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         setTaskError('Authentication token unavailable.');
         return;

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 'use client';
 
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { AgentRunsService } from '@services/ai/agent-runs.service';
 import { IngredientsService } from '@services/content/ingredients.service';
 import { TasksService } from '@services/management/tasks.service';
@@ -54,7 +54,7 @@ vi.mock('@contexts/user/brand-context/brand-context', () => ({
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
   getPlaywrightAuthState: vi.fn(() => null),
-  resolveClerkToken: vi.fn(),
+  resolveAuthToken: vi.fn(),
 }));
 
 vi.mock('@hooks/utils/use-websocket-prompt/use-websocket-prompt', () => ({
@@ -195,7 +195,7 @@ describe('WorkspacePageContent', () => {
     vi.clearAllMocks();
     window.history.replaceState({}, '', '/workspace/overview');
     getTokenMock.mockResolvedValue('clerk-token');
-    vi.mocked(resolveClerkToken).mockResolvedValue('api-token');
+    vi.mocked(resolveAuthToken).mockResolvedValue('api-token');
     listMock.mockResolvedValue([]);
     createTaskMock.mockResolvedValue(buildTask());
     ensurePlanningThreadMock.mockResolvedValue({

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   replace: vi.fn(),
   requestChanges: vi.fn(),
-  resolveClerkToken: vi.fn(),
+  resolveAuthToken: vi.fn(),
   subscribe: vi.fn(),
   trashOutput: vi.fn(),
   unkeepOutput: vi.fn(),
@@ -39,7 +39,7 @@ vi.mock('@contexts/user/brand-context/brand-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: mocks.resolveClerkToken,
+  resolveAuthToken: mocks.resolveAuthToken,
 }));
 
 vi.mock('@hooks/utils/use-socket-manager/use-socket-manager', () => ({
@@ -164,7 +164,7 @@ function makeInspectorTask(overrides: Record<string, unknown> = {}) {
 describe('WorkspacePageContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveClerkToken.mockResolvedValue('token-1');
+    mocks.resolveAuthToken.mockResolvedValue('token-1');
     mocks.subscribe.mockReturnValue(vi.fn());
     mocks.agentRunsList.mockResolvedValue([]);
     mocks.getActiveRuns.mockResolvedValue([]);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-composer.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-composer.test.tsx
@@ -48,7 +48,7 @@ const mocks = vi.hoisted(() => ({
   onOpenChange: vi.fn(),
   onTaskCreated: vi.fn(),
   promptPost: vi.fn(),
-  resolveClerkToken: vi.fn(),
+  resolveAuthToken: vi.fn(),
   websocketOptions: undefined as
     | {
         onError: () => void;
@@ -70,7 +70,7 @@ vi.mock('@contexts/user/brand-context/brand-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: mocks.resolveClerkToken,
+  resolveAuthToken: mocks.resolveAuthToken,
 }));
 
 vi.mock('@hooks/utils/use-websocket-prompt/use-websocket-prompt', () => ({
@@ -346,7 +346,7 @@ describe('WorkspaceTaskComposer', () => {
     mocks.editorOptions = undefined;
     mocks.websocketOptions = undefined;
     mocks.getToken.mockResolvedValue('clerk-token');
-    mocks.resolveClerkToken.mockResolvedValue('api-token');
+    mocks.resolveAuthToken.mockResolvedValue('api-token');
     mocks.createTask.mockResolvedValue({
       id: 'task-1',
       request: 'Create a product launch brief',
@@ -627,7 +627,7 @@ describe('WorkspaceTaskComposer', () => {
   });
 
   it('surfaces auth, facecam load, enhancement, and create failures', async () => {
-    mocks.resolveClerkToken.mockResolvedValueOnce(null);
+    mocks.resolveAuthToken.mockResolvedValueOnce(null);
     renderComposer();
     fillRequest('Create a product image');
 
@@ -636,7 +636,7 @@ describe('WorkspaceTaskComposer', () => {
       await screen.findByText('Authentication token unavailable.'),
     ).toBeVisible();
 
-    mocks.resolveClerkToken.mockResolvedValue('api-token');
+    mocks.resolveAuthToken.mockResolvedValue('api-token');
     mocks.fetch.mockResolvedValueOnce(new Response('{}', { status: 500 }));
     fireEvent.click(screen.getByRole('button', { name: 'Facecam' }));
     expect(
@@ -689,13 +689,13 @@ describe('WorkspaceTaskComposer', () => {
       ...mocks.brandContext,
       organizationId: 'org-1',
     };
-    mocks.resolveClerkToken.mockResolvedValueOnce(null);
+    mocks.resolveAuthToken.mockResolvedValueOnce(null);
     fireEvent.click(screen.getByRole('button', { name: /create task/i }));
     expect(
       await screen.findByText('Authentication token unavailable.'),
     ).toBeVisible();
 
-    mocks.resolveClerkToken.mockResolvedValue('api-token');
+    mocks.resolveAuthToken.mockResolvedValue('api-token');
     mocks.fetch
       .mockResolvedValueOnce(new Response('{}', { status: 404 }))
       .mockResolvedValueOnce(new Response('{}', { status: 403 }));

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-inspector-hooks.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-inspector-hooks.ts
@@ -1,5 +1,5 @@
 import { useAuth } from '@clerk/nextjs';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import type { Ingredient } from '@models/content/ingredient.model';
 import { AgentRunsService } from '@services/ai/agent-runs.service';
 import { IngredientsService } from '@services/content/ingredients.service';
@@ -46,7 +46,7 @@ export function useWorkspaceTaskLinkedRunSummary(
     async function loadLinkedRunSummary() {
       try {
         setIsLoading(true);
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (isCancelled) {
           return;
         }
@@ -141,7 +141,7 @@ export function useWorkspaceTaskLinkedOutputs(
           isLoading: true,
         }));
 
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (isCancelled) {
           return;
         }
@@ -225,7 +225,7 @@ export function useWorkspaceTaskLinkedIssue(
           return;
         }
 
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token || isCancelled) {
           setSummary(getEmptyLinkedIssueSummary());
           return;

--- a/apps/app/app/(protected)/[orgSlug]/~/chat/ChatWorkspaceLayoutClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/chat/ChatWorkspaceLayoutClient.tsx
@@ -9,7 +9,7 @@ import {
 } from '@genfeedai/agent';
 import {
   getPlaywrightAuthState,
-  resolveClerkToken,
+  resolveAuthToken,
 } from '@helpers/auth/clerk.helper';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { logger } from '@services/core/logger.service';
@@ -73,7 +73,7 @@ function ChatWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
     () =>
       new AgentApiService({
         baseUrl: process.env.NEXT_PUBLIC_API_ENDPOINT ?? '',
-        getToken: async () => resolveClerkToken(getToken),
+        getToken: async () => resolveAuthToken(getToken),
       }),
     [getToken],
   );
@@ -85,7 +85,7 @@ function ChatWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
 
     completedRef.current = true;
 
-    const effectiveToken = await resolveClerkToken(getToken);
+    const effectiveToken = await resolveAuthToken(getToken);
     if (effectiveToken) {
       const funnelService = OnboardingFunnelService.getInstance(effectiveToken);
       await funnelService.completeFunnel();
@@ -101,7 +101,7 @@ function ChatWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
   const handleOAuthConnect = useCallback(
     async (platform: string) => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token) {
           return;
         }

--- a/apps/app/app/(protected)/[orgSlug]/~/chat/ChatWorkspacePageShell.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/chat/ChatWorkspacePageShell.spec.tsx
@@ -1,4 +1,4 @@
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { TasksService } from '@services/management/tasks.service';
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -36,7 +36,7 @@ vi.mock('@clerk/nextjs', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: vi.fn(),
+  resolveAuthToken: vi.fn(),
 }));
 
 vi.mock('@/lib/config/edition', () => ({
@@ -74,7 +74,7 @@ describe('ChatWorkspacePageShell', () => {
     agentFullPageSpy.mockClear();
     pushMock.mockClear();
     getTokenMock.mockResolvedValue('clerk-token');
-    vi.mocked(resolveClerkToken).mockResolvedValue('api-token');
+    vi.mocked(resolveAuthToken).mockResolvedValue('api-token');
     createFollowUpTasksMock.mockResolvedValue([
       { id: 'task-1' },
       { id: 'task-2' },

--- a/apps/app/app/(protected)/[orgSlug]/~/chat/ChatWorkspacePageShell.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/chat/ChatWorkspacePageShell.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { AgentFullPage } from '@genfeedai/agent';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { TasksService } from '@services/management/tasks.service';
 import { useRouter } from 'next/navigation';
@@ -30,7 +30,7 @@ export function ChatWorkspacePageShell({
 
   const handleCreateFollowUpTasks = useCallback(
     async (taskId: string) => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) {
         throw new Error('Authentication token unavailable.');
       }

--- a/apps/app/app/(public)/login/content.tsx
+++ b/apps/app/app/(public)/login/content.tsx
@@ -4,12 +4,14 @@ import { SignIn, useAuth } from '@clerk/nextjs';
 import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
 import { useRouter } from 'next/navigation';
 import { useEffect, useSyncExternalStore } from 'react';
+import { isBetterAuthEnabled } from '@/lib/config/edition';
+import LoginBetterAuth from './login-better-auth';
 
 const subscribe = () => () => {};
 const getSnapshot = () => true;
 const getServerSnapshot = () => false;
 
-export default function LoginPage() {
+function ClerkLoginPage() {
   const isMounted = useSyncExternalStore(
     subscribe,
     getSnapshot,
@@ -41,4 +43,12 @@ export default function LoginPage() {
       )}
     </AuthFormLayout>
   );
+}
+
+export default function LoginPage() {
+  if (isBetterAuthEnabled()) {
+    return <LoginBetterAuth />;
+  }
+
+  return <ClerkLoginPage />;
 }

--- a/apps/app/app/(public)/login/login-better-auth.tsx
+++ b/apps/app/app/(public)/login/login-better-auth.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { signIn } from '@genfeedai/auth-client';
+import { ButtonVariant } from '@genfeedai/enums';
+import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
+import { Button } from '@ui/primitives/button';
+import Field from '@ui/primitives/field';
+import { Input } from '@ui/primitives/input';
+import Link from 'next/link';
+import {
+  type ChangeEvent,
+  type FormEvent,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export default function LoginBetterAuth() {
+  const isMounted = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isEmailSent, setIsEmailSent] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await signIn.magicLink({ email, callbackURL: '/' });
+      if (result?.error) {
+        setErrorMessage(
+          result.error.message ??
+            'Failed to send sign-in link. Please try again.',
+        );
+      } else {
+        setIsEmailSent(true);
+      }
+    } catch {
+      setErrorMessage('Failed to send sign-in link. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleGoogleSignIn() {
+    setErrorMessage(null);
+    await signIn.social({ provider: 'google', callbackURL: '/' });
+  }
+
+  if (!isMounted) {
+    return <AuthFormLayout>{null}</AuthFormLayout>;
+  }
+
+  if (isEmailSent) {
+    return (
+      <AuthFormLayout>
+        <div className="w-full max-w-sm space-y-4 text-center">
+          <p className="gen-heading-sm">Check your email</p>
+          <p className="text-sm text-muted-foreground">
+            We sent a sign-in link to <strong>{email}</strong>. Click the link
+            in the email to sign in.
+          </p>
+        </div>
+      </AuthFormLayout>
+    );
+  }
+
+  return (
+    <AuthFormLayout>
+      <div className="w-full max-w-sm space-y-6">
+        <form onSubmit={handleMagicLink} className="space-y-4">
+          <Field label="Email" isRequired>
+            <Input
+              type="email"
+              name="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setEmail(e.target.value)
+              }
+              isRequired
+              isDisabled={isSubmitting}
+              hasError={!!errorMessage}
+            />
+          </Field>
+
+          {errorMessage ? (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          ) : null}
+
+          <Button
+            type="submit"
+            variant={ButtonVariant.DEFAULT}
+            isLoading={isSubmitting}
+            isDisabled={!email || isSubmitting}
+            className="w-full"
+            withWrapper={false}
+          >
+            Continue with email
+          </Button>
+        </form>
+
+        <div className="relative">
+          <div className="gen-divider" />
+          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
+            or
+          </span>
+        </div>
+
+        <Button
+          type="button"
+          variant={ButtonVariant.OUTLINE}
+          onClick={handleGoogleSignIn}
+          className="w-full"
+          withWrapper={false}
+        >
+          Continue with Google
+        </Button>
+
+        <p className="text-center text-sm text-muted-foreground">
+          Don&apos;t have an account?{' '}
+          <Link
+            href="/sign-up"
+            className="text-foreground underline underline-offset-4"
+          >
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </AuthFormLayout>
+  );
+}

--- a/apps/app/app/(public)/logout/content.tsx
+++ b/apps/app/app/(public)/logout/content.tsx
@@ -1,9 +1,39 @@
 'use client';
 
 import { useClerk } from '@clerk/nextjs';
+import { signOut } from '@genfeedai/auth-client';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { isBetterAuthEnabled } from '@/lib/config/edition';
 
-export default function LogoutPage() {
+function BetterAuthLogoutPage() {
+  const { push } = useRouter();
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function performSignOut() {
+      await signOut();
+      if (!isCancelled) {
+        push('/login');
+      }
+    }
+
+    performSignOut();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [push]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <p className="text-muted-foreground">Signing out…</p>
+    </div>
+  );
+}
+
+function ClerkLogoutPage() {
   const { signOut } = useClerk();
 
   useEffect(() => {
@@ -15,4 +45,12 @@ export default function LogoutPage() {
       <p className="text-muted-foreground">Signing out…</p>
     </div>
   );
+}
+
+export default function LogoutPage() {
+  if (isBetterAuthEnabled()) {
+    return <BetterAuthLogoutPage />;
+  }
+
+  return <ClerkLogoutPage />;
 }

--- a/apps/app/app/(public)/oauth/cli/content.test.tsx
+++ b/apps/app/app/(public)/oauth/cli/content.test.tsx
@@ -26,7 +26,7 @@ vi.mock('@clerk/nextjs', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@services/core/environment.service', () => ({

--- a/apps/app/app/(public)/oauth/cli/content.tsx
+++ b/apps/app/app/(public)/oauth/cli/content.tsx
@@ -3,7 +3,7 @@
 import { SignIn, useAuth, useUser } from '@clerk/nextjs';
 import { ButtonSize, ButtonVariant, ComponentSize } from '@genfeedai/enums';
 import { Code } from '@genfeedai/ui';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { EnvironmentService } from '@services/core/environment.service';
 import Spinner from '@ui/feedback/spinner/Spinner';
 import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
@@ -216,7 +216,7 @@ function CliAuthPageContent() {
       try {
         // Use standard session JWT (not custom template) — the API's ClerkStrategy
         // calls verifyToken() which requires standard Clerk session claims (sub, iss, etc.)
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
 
         if (signal.aborted) {
           return;

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { signIn } from '@genfeedai/auth-client';
+import { ButtonVariant } from '@genfeedai/enums';
+import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
+import { Button } from '@ui/primitives/button';
+import Field from '@ui/primitives/field';
+import { Input } from '@ui/primitives/input';
+import Link from 'next/link';
+import {
+  type ChangeEvent,
+  type FormEvent,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { persistOnboardingHandoffParams } from '@/lib/onboarding/onboarding-access.util';
+
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export default function SignUpBetterAuth() {
+  const isMounted = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isEmailSent, setIsEmailSent] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    persistOnboardingHandoffParams(window.location.search);
+  }, []);
+
+  async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      // Better Auth sign-up is also via magic link — same flow as sign-in
+      const result = await signIn.magicLink({ email, callbackURL: '/' });
+      if (result?.error) {
+        setErrorMessage(
+          result.error.message ??
+            'Failed to send sign-up link. Please try again.',
+        );
+      } else {
+        setIsEmailSent(true);
+      }
+    } catch {
+      setErrorMessage('Failed to send sign-up link. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleGoogleSignUp() {
+    setErrorMessage(null);
+    await signIn.social({ provider: 'google', callbackURL: '/' });
+  }
+
+  if (!isMounted) {
+    return <AuthFormLayout>{null}</AuthFormLayout>;
+  }
+
+  if (isEmailSent) {
+    return (
+      <AuthFormLayout>
+        <div className="w-full max-w-sm space-y-4 text-center">
+          <p className="gen-heading-sm">Check your email</p>
+          <p className="text-sm text-muted-foreground">
+            We sent a sign-up link to <strong>{email}</strong>. Click the link
+            in the email to continue.
+          </p>
+        </div>
+      </AuthFormLayout>
+    );
+  }
+
+  return (
+    <AuthFormLayout>
+      <div className="w-full max-w-sm space-y-6">
+        <form onSubmit={handleMagicLink} className="space-y-4">
+          <Field label="Email" isRequired>
+            <Input
+              type="email"
+              name="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setEmail(e.target.value)
+              }
+              isRequired
+              isDisabled={isSubmitting}
+              hasError={!!errorMessage}
+            />
+          </Field>
+
+          {errorMessage ? (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          ) : null}
+
+          <Button
+            type="submit"
+            variant={ButtonVariant.DEFAULT}
+            isLoading={isSubmitting}
+            isDisabled={!email || isSubmitting}
+            className="w-full"
+            withWrapper={false}
+          >
+            Continue with email
+          </Button>
+        </form>
+
+        <div className="relative">
+          <div className="gen-divider" />
+          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
+            or
+          </span>
+        </div>
+
+        <Button
+          type="button"
+          variant={ButtonVariant.OUTLINE}
+          onClick={handleGoogleSignUp}
+          className="w-full"
+          withWrapper={false}
+        >
+          Continue with Google
+        </Button>
+
+        <p className="text-center text-sm text-muted-foreground">
+          Already have an account?{' '}
+          <Link
+            href="/login"
+            className="text-foreground underline underline-offset-4"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </AuthFormLayout>
+  );
+}

--- a/apps/app/app/(public)/sign-up/sign-up-form.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.tsx
@@ -3,13 +3,15 @@
 import { SignUp } from '@clerk/nextjs';
 import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
 import { useEffect, useSyncExternalStore } from 'react';
+import { isBetterAuthEnabled } from '@/lib/config/edition';
 import { persistOnboardingHandoffParams } from '@/lib/onboarding/onboarding-access.util';
+import SignUpBetterAuth from './sign-up-better-auth';
 
 function subscribe() {
   return () => {};
 }
 
-export default function SignUpForm() {
+function ClerkSignUpForm() {
   const isMounted = useSyncExternalStore(
     subscribe,
     () => true,
@@ -25,4 +27,12 @@ export default function SignUpForm() {
       {isMounted && <SignUp routing="hash" signInUrl="/login" />}
     </AuthFormLayout>
   );
+}
+
+export default function SignUpForm() {
+  if (isBetterAuthEnabled()) {
+    return <SignUpBetterAuth />;
+  }
+
+  return <ClerkSignUpForm />;
 }

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -5,6 +5,7 @@
     "@fullcalendar/react": "6.1.20",
     "@fullcalendar/timegrid": "6.1.20",
     "@genfeedai/agent": "*",
+    "@genfeedai/auth-client": "*",
     "@genfeedai/client": "*",
     "@genfeedai/config": "*",
     "@genfeedai/constants": "*",

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -24,7 +24,7 @@ import {
 } from '@genfeedai/constants';
 import type { AppContext } from '@genfeedai/interfaces';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useUserRole } from '@hooks/auth/use-user-role';
 import {
   STUDIO_CATEGORY_CONFIG,
@@ -212,7 +212,7 @@ export function useAppProtectedLayout(
 
     return new AgentApiService({
       baseUrl: process.env.NEXT_PUBLIC_API_ENDPOINT ?? '',
-      getToken: async () => resolveClerkToken(getTokenRef.current),
+      getToken: async () => resolveAuthToken(getTokenRef.current),
     });
   }, [shouldInitAgentApiService]);
 

--- a/apps/app/packages/server/protected-bootstrap.server.ts
+++ b/apps/app/packages/server/protected-bootstrap.server.ts
@@ -1,6 +1,10 @@
 import 'server-only';
 
 import { auth } from '@clerk/nextjs/server';
+import {
+  getBetterAuthServerToken,
+  isBetterAuthEnabled,
+} from '@genfeedai/auth-client/server';
 import type { ProtectedBootstrapData } from '@props/layout/protected-bootstrap.props';
 import { AuthService } from '@services/auth/auth.service';
 import { logger } from '@services/core/logger.service';
@@ -24,6 +28,27 @@ export const getServerAuthToken = cache(async (): Promise<string> => {
 
   if (await isServerBootstrapBypassed()) {
     return '';
+  }
+
+  // Better Auth dual run (#735): when enabled, the server-side bearer JWT is
+  // minted by forwarding the BA session cookies to the jwt plugin's /token
+  // endpoint. Takes precedence over Clerk so flipping the flag swaps RSC auth.
+  if (isBetterAuthEnabled()) {
+    try {
+      const cookieStore = await cookies();
+      const cookieHeader = cookieStore
+        .getAll()
+        .map((cookie) => `${cookie.name}=${cookie.value}`)
+        .join('; ');
+
+      return (await getBetterAuthServerToken(cookieHeader)) ?? '';
+    } catch (error) {
+      logger.warn('Better Auth token unavailable during protected bootstrap', {
+        error,
+        reportToSentry: false,
+      });
+      return '';
+    }
   }
 
   if (isDesktopShell) {

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -37,6 +37,13 @@ const hasClerkKeys =
   Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim()) &&
   Boolean(process.env.CLERK_SECRET_KEY?.trim());
 const isDesktopShell = process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1';
+// Better Auth dual-run flag (#735). NEXT_PUBLIC_ so it is inlined into the
+// middleware bundle — a plain server env is unreadable in edge middleware.
+// Precedence: the BA guard below only fires when !isCloudConnected (no Clerk
+// keys). If both Clerk keys AND this flag are set (a misconfiguration), Clerk
+// wins and the BA guard is skipped — keep BA and Clerk keys mutually exclusive.
+const isBetterAuthEnabled =
+  process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED === 'true';
 const ONBOARDING_PATH = '/onboarding';
 const SEEDED_WORKSPACE_PATH = '/default/default/workspace/overview';
 
@@ -710,6 +717,23 @@ const clerkProxy = isCloudConnected
     )
   : null;
 
+/**
+ * Public (no-session) routes under the Better Auth guard. Unlike the keyless
+ * self-hosted branch, /login, /sign-up and /logout are real auth pages here.
+ * /oauth/* are integration callbacks and must never be gated.
+ */
+function isBetterAuthPublicRoute(pathname: string): boolean {
+  return (
+    pathname.startsWith('/login') ||
+    pathname.startsWith('/sign-in') ||
+    pathname.startsWith('/sign-up') ||
+    pathname.startsWith('/logout') ||
+    pathname.startsWith('/onboarding') ||
+    pathname.startsWith('/oauth') ||
+    pathname.startsWith('/request-access')
+  );
+}
+
 export default async function proxy(req: NextRequest, event: NextFetchEvent) {
   if (req.nextUrl.pathname === '/playwright-ready') {
     return NextResponse.next();
@@ -798,6 +822,29 @@ export default async function proxy(req: NextRequest, event: NextFetchEvent) {
         return response;
       }
 
+      return redirectPreservingSearch(req, '/login');
+    }
+
+    return NextResponse.next();
+  }
+
+  // Better Auth dual run (#735): self-hosted / Community with first-party auth.
+  // Unlike the keyless branch below, /login, /sign-up and /logout are REAL auth
+  // pages, so they stay public; every other route requires a BA session cookie
+  // (the API still validates the JWT — this is a cheap presence gate).
+  if (isBetterAuthEnabled && !isCloudConnected) {
+    const { pathname } = req.nextUrl;
+
+    if (isBetterAuthPublicRoute(pathname)) {
+      return NextResponse.next();
+    }
+
+    const hasBetterAuthSession = Boolean(
+      req.cookies.get('better-auth.session_token')?.value ||
+        req.cookies.get('__Secure-better-auth.session_token')?.value,
+    );
+
+    if (!hasBetterAuthSession) {
       return redirectPreservingSearch(req, '/login');
     }
 

--- a/apps/app/src/hooks/useOptionalAuth.ts
+++ b/apps/app/src/hooks/useOptionalAuth.ts
@@ -1,8 +1,12 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
+import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 
-/** Returns auth helpers from the app-level Clerk provider. */
+/**
+ * Returns auth helpers from the active provider — Clerk by default, Better Auth
+ * when the dual-run flag is on (epic #735). The shared dispatcher narrows both
+ * to a single `AuthIdentity` shape so callers stay provider-agnostic.
+ */
 export function useOptionalAuth() {
-  return useAuth();
+  return useAuthIdentity();
 }

--- a/apps/app/src/lib/config/edition.ts
+++ b/apps/app/src/lib/config/edition.ts
@@ -25,6 +25,15 @@ export function isCloudConnected(): boolean {
   return !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim();
 }
 
+/**
+ * True when Better Auth is the active frontend session provider (dual-run flag,
+ * epic #735). Off by default — Clerk stays the default until cutover. Mirrors
+ * the backend `BETTER_AUTH_ENABLED` flag.
+ */
+export function isBetterAuthEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED === 'true';
+}
+
 /** True when local app with optional Clerk cloud connection configured */
 export function isHybridMode(): boolean {
   return (

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -43,6 +43,8 @@
       "@cloud-types/*": ["../../packages/types/src/*"],
       "@genfeedai/agent": ["../../packages/agent/src/index.ts"],
       "@genfeedai/agent/*": ["../../packages/agent/src/*"],
+      "@genfeedai/auth-client": ["../../packages/auth-client/src/index.ts"],
+      "@genfeedai/auth-client/*": ["../../packages/auth-client/src/*"],
       "@genfeedai/contexts": ["../../packages/contexts/index.ts"],
       "@genfeedai/contexts/*": ["../../packages/contexts/*"],
       "@genfeedai/config": ["../../packages/config/src/index.ts"],

--- a/apps/desktop/app/tsconfig.json
+++ b/apps/desktop/app/tsconfig.json
@@ -6,6 +6,8 @@
       "@components/*": ["../../../packages/ui/src/components/*"],
       "@genfeedai/agent": ["../../../packages/agent/src/index.ts"],
       "@genfeedai/agent/*": ["../../../packages/agent/src/*"],
+      "@genfeedai/auth-client": ["../../../packages/auth-client/src/index.ts"],
+      "@genfeedai/auth-client/*": ["../../../packages/auth-client/src/*"],
       "@genfeedai/contexts/*": ["../../../packages/contexts/*"],
       "@genfeedai/desktop-contracts": [
         "../../../packages/desktop-contracts/src/index.ts"

--- a/apps/vitest.config.mts
+++ b/apps/vitest.config.mts
@@ -78,6 +78,17 @@ export default defineConfig({
         replacement: path.resolve(repoRoot, './packages/agent/src/$1'),
       },
       {
+        find: /^@genfeedai\/auth-client$/,
+        replacement: path.resolve(
+          repoRoot,
+          './packages/auth-client/src/index.ts',
+        ),
+      },
+      {
+        find: /^@genfeedai\/auth-client\/(.*)$/,
+        replacement: path.resolve(repoRoot, './packages/auth-client/src/$1'),
+      },
+      {
         find: /^@genfeedai\/config$/,
         replacement: path.resolve(repoRoot, './packages/config/src/index.ts'),
       },

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -33,6 +33,8 @@
       "@genfeedai/client/schemas/*": ["../../packages/client/src/schemas/*"],
       "@genfeedai/enums": ["../../packages/enums/src/index.ts"],
       "@genfeedai/enums/*": ["../../packages/enums/src/*"],
+      "@genfeedai/auth-client": ["../../packages/auth-client/src/index.ts"],
+      "@genfeedai/auth-client/*": ["../../packages/auth-client/src/*"],
       "@genfeedai/constants": ["../../packages/constants/src/index.ts"],
       "@genfeedai/constants/*": ["../../packages/constants/src/*"],
       "@genfeedai/helpers": ["../../packages/helpers/src/index.ts"],

--- a/bun.lock
+++ b/bun.lock
@@ -195,6 +195,7 @@
         "@fullcalendar/react": "6.1.20",
         "@fullcalendar/timegrid": "6.1.20",
         "@genfeedai/agent": "*",
+        "@genfeedai/auth-client": "*",
         "@genfeedai/client": "*",
         "@genfeedai/config": "*",
         "@genfeedai/constants": "*",
@@ -719,6 +720,23 @@
         "typescript": "6.0.2",
       },
     },
+    "packages/auth-client": {
+      "name": "@genfeedai/auth-client",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-auth": "^1.6.20",
+        "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@types/node": "25.9.1",
+        "@types/react": "19.2.16",
+        "react": "19.2.7",
+        "typescript": "6.0.2",
+      },
+      "peerDependencies": {
+        "react": ">=19",
+      },
+    },
     "packages/cli": {
       "name": "@genfeedai/cli",
       "version": "0.4.0",
@@ -788,6 +806,7 @@
       "name": "@genfeedai/contexts",
       "version": "0.1.0",
       "dependencies": {
+        "@genfeedai/auth-client": "workspace:*",
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
         "@genfeedai/helpers": "workspace:*",
@@ -901,6 +920,7 @@
       "name": "@genfeedai/helpers",
       "version": "2.2.12",
       "dependencies": {
+        "@genfeedai/auth-client": "workspace:*",
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
@@ -1625,6 +1645,24 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
+    "@better-auth/core": ["@better-auth/core@1.6.20", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.6", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng=="],
+
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ=="],
+
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw=="],
+
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2" } }, "sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ=="],
+
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw=="],
+
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ=="],
+
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ=="],
+
+    "@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
+
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.3.1", "", {}, "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
@@ -1966,6 +2004,8 @@
     "@genfeedai/api-types": ["@genfeedai/api-types@workspace:packages/api-types"],
 
     "@genfeedai/app": ["@genfeedai/app@workspace:apps/app"],
+
+    "@genfeedai/auth-client": ["@genfeedai/auth-client@workspace:packages/auth-client"],
 
     "@genfeedai/cli": ["@genfeedai/cli@workspace:packages/cli"],
 
@@ -2453,7 +2493,7 @@
 
     "@next/third-parties": ["@next/third-parties@16.2.7", "", { "dependencies": { "third-party-capital": "1.0.20" }, "peerDependencies": { "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0" } }, "sha512-mSvF8eg2egIqP0GaPYn0sDvsP45CodwVsavl7RkLsOVQL/CDy7wUg0WUV5uEtlWoWOq0pEYRRsbld7NQIh+Eqg=="],
 
-    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+    "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
@@ -4271,6 +4311,10 @@
 
     "bcrypt": ["bcrypt@6.0.0", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" } }, "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg=="],
 
+    "better-auth": ["better-auth@1.6.20", "", { "dependencies": { "@better-auth/core": "1.6.20", "@better-auth/drizzle-adapter": "1.6.20", "@better-auth/kysely-adapter": "1.6.20", "@better-auth/memory-adapter": "1.6.20", "@better-auth/mongo-adapter": "1.6.20", "@better-auth/prisma-adapter": "1.6.20", "@better-auth/telemetry": "1.6.20", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.6", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA=="],
+
+    "better-call": ["better-call@1.3.6", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA=="],
+
     "better-react-mathjax": ["better-react-mathjax@2.3.0", "", { "dependencies": { "mathjax-full": "^3.2.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w=="],
 
     "better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
@@ -5785,6 +5829,8 @@
 
     "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
 
+    "kysely": ["kysely@0.29.2", "", {}, "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg=="],
+
     "lan-network": ["lan-network@0.2.1", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
@@ -6236,6 +6282,8 @@
     "nanocolors": ["nanocolors@0.2.13", "", {}, "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA=="],
 
     "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+
+    "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -7019,6 +7067,8 @@
 
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
+    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
@@ -7088,6 +7138,8 @@
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -11024,6 +11076,8 @@
     "unzipper/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "unzipper/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "viem/ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "viem/ox/abitype": ["abitype@1.2.4", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg=="],
 

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -1,0 +1,51 @@
+{
+  "dependencies": {
+    "better-auth": "^1.6.20",
+    "zod": "4.4.3"
+  },
+  "description": "Genfeed.ai first-party auth client (Better Auth) — Clerk replacement, epic #735",
+  "devDependencies": {
+    "@types/node": "25.9.1",
+    "@types/react": "19.2.16",
+    "react": "19.2.7",
+    "typescript": "6.0.2"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "name": "@genfeedai/auth-client",
+  "peerDependencies": {
+    "react": ">=19"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "directory": "auth-client",
+    "type": "git",
+    "url": "git+https://github.com/genfeedai/packages.git"
+  },
+  "scripts": {
+    "build": "tsc --build && test -f dist/index.js",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "deps:update": "bunx npm-check-updates -u && bun install",
+    "test": "vitest run --config vitest.config.ts",
+    "test:cov": "vitest run --config vitest.config.ts --coverage"
+  },
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "version": "0.1.0"
+}

--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { jwtClient, magicLinkClient } from 'better-auth/client/plugins';
+import { createAuthClient } from 'better-auth/react';
+
+import { BETTER_AUTH_BASE_PATH, getApiOrigin } from './config';
+
+/**
+ * Singleton Better Auth browser client (epic #735). Mounted against the Phase 1
+ * handler at `${origin}/v1/auth/*`.
+ *
+ * - `baseURL` is the bare origin and `basePath` carries the full `/v1/auth`
+ *   prefix — see {@link BETTER_AUTH_BASE_PATH} for why the prefix cannot live in
+ *   `baseURL`.
+ * - `magicLinkClient` powers passwordless `signIn.magicLink()` — it routes via
+ *   the dynamic client proxy, so it requires the server `magicLink` plugin
+ *   (Phase 1) to be enabled or the call 404s with no compile-time error.
+ * - `jwtClient` adds the `jwks` action; the Bearer JWT itself is read from the
+ *   server's `GET /token` endpoint (see {@link getBetterAuthToken}).
+ *
+ * Better Auth's React client is provider-less (nanostores-backed), so no
+ * `<Provider>` is required for `useSession()` to work anywhere in the tree.
+ */
+export const authClient = createAuthClient({
+  basePath: BETTER_AUTH_BASE_PATH,
+  baseURL: getApiOrigin(),
+  plugins: [magicLinkClient(), jwtClient()],
+});
+
+export const { getSession, signIn, signOut, signUp, useSession } = authClient;
+
+/**
+ * Retrieves a Bearer JWT minted by the Better Auth `jwt` plugin via its server
+ * `GET /token` endpoint (the jwt *client* plugin only exposes `jwks`, not a
+ * `token()` action in 1.6.x — so we call `$fetch` directly). Non-hook, so it is
+ * safe to call from the token choke point in `@genfeedai/helpers` and other
+ * non-React contexts. Returns `null` when there is no active session.
+ */
+export async function getBetterAuthToken(): Promise<string | null> {
+  const { data } = await authClient.$fetch<{ token: string }>('/token', {
+    method: 'GET',
+  });
+  return data?.token ?? null;
+}

--- a/packages/auth-client/src/config.test.ts
+++ b/packages/auth-client/src/config.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  BETTER_AUTH_BASE_PATH,
+  getApiEndpoint,
+  getApiOrigin,
+  isBetterAuthEnabled,
+} from './config';
+
+describe('auth-client config', () => {
+  const originalEnabled = process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+  const originalEndpoint = process.env.NEXT_PUBLIC_API_ENDPOINT;
+
+  beforeEach(() => {
+    // Note: `process.env.X = undefined` coerces to the string "undefined" (a
+    // truthy value) — delete the keys so the defaults are actually exercised.
+    delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    delete process.env.NEXT_PUBLIC_API_ENDPOINT;
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) {
+      delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = originalEnabled;
+    }
+    if (originalEndpoint === undefined) {
+      delete process.env.NEXT_PUBLIC_API_ENDPOINT;
+    } else {
+      process.env.NEXT_PUBLIC_API_ENDPOINT = originalEndpoint;
+    }
+  });
+
+  it('carries the full /v1/auth prefix (basePath, not baseURL)', () => {
+    // Critical: Better Auth drops basePath when baseURL already has a path, so
+    // the whole prefix must live here and baseURL must be the bare origin.
+    expect(BETTER_AUTH_BASE_PATH).toBe('/v1/auth');
+  });
+
+  describe('getApiOrigin', () => {
+    it('strips the /v1 path to a bare origin (default)', () => {
+      expect(getApiOrigin()).toBe('https://api.genfeed.ai');
+    });
+
+    it('strips the path from a custom endpoint', () => {
+      process.env.NEXT_PUBLIC_API_ENDPOINT = 'http://local.genfeed.ai:3010/v1';
+      expect(getApiOrigin()).toBe('http://local.genfeed.ai:3010');
+    });
+
+    it('produces the correct effective auth base URL', () => {
+      // This is exactly what the client/server concatenate before hitting the
+      // Phase 1 handler — guards against the basePath-drop bug.
+      expect(`${getApiOrigin()}${BETTER_AUTH_BASE_PATH}`).toBe(
+        'https://api.genfeed.ai/v1/auth',
+      );
+    });
+  });
+
+  describe('isBetterAuthEnabled', () => {
+    it('is false by default (dual-run off — Clerk stays default)', () => {
+      expect(isBetterAuthEnabled()).toBe(false);
+    });
+
+    it('is true only for the exact string "true"', () => {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'true';
+      expect(isBetterAuthEnabled()).toBe(true);
+    });
+
+    it('is false for any non-"true" value', () => {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = '1';
+      expect(isBetterAuthEnabled()).toBe(false);
+    });
+  });
+
+  describe('getApiEndpoint', () => {
+    it('falls back to the production API origin when unset', () => {
+      expect(getApiEndpoint()).toBe('https://api.genfeed.ai/v1');
+    });
+
+    it('honours NEXT_PUBLIC_API_ENDPOINT when present', () => {
+      process.env.NEXT_PUBLIC_API_ENDPOINT = 'http://local.genfeed.ai:3010/v1';
+      expect(getApiEndpoint()).toBe('http://local.genfeed.ai:3010/v1');
+    });
+  });
+});

--- a/packages/auth-client/src/config.ts
+++ b/packages/auth-client/src/config.ts
@@ -1,0 +1,65 @@
+/**
+ * Better Auth client configuration — epic #735, Phase 2 (#737).
+ *
+ * Resolves the auth server base URL and the dual-run feature flag from
+ * `NEXT_PUBLIC_*` env vars (inlined at build time in Next.js bundles). Kept
+ * dependency-free so both the browser client and the server token helper can
+ * import it without pulling React.
+ */
+
+const DEFAULT_API_ENDPOINT = 'https://api.genfeed.ai/v1';
+
+/**
+ * Better Auth is mounted by the API at `${origin}/v1/auth/*` (Phase 1).
+ *
+ * IMPORTANT: this is the FULL path, not just `/auth`. Better Auth's `withPath()`
+ * returns the base URL unchanged whenever it already carries a non-root path, so
+ * passing `baseURL=${origin}/v1` + `basePath=/auth` silently drops `/auth` and
+ * every request 404s. We therefore pass the bare origin as `baseURL` (see
+ * {@link getApiOrigin}) and carry the whole prefix here.
+ */
+export const BETTER_AUTH_BASE_PATH = '/v1/auth';
+
+/**
+ * Canonical API endpoint incl. the `/v1` prefix. Mirrors
+ * `EnvironmentService.apiEndpoint` (kept dep-free here to avoid pulling
+ * `@genfeedai/services` into the auth foundation) including the desktop runtime
+ * override.
+ */
+export function getApiEndpoint(): string {
+  const desktopOverride = (
+    globalThis as typeof globalThis & {
+      __GENFEED_DESKTOP_ENV__?: { apiEndpoint?: string };
+    }
+  ).__GENFEED_DESKTOP_ENV__?.apiEndpoint;
+
+  return (
+    desktopOverride ||
+    process.env.NEXT_PUBLIC_API_ENDPOINT ||
+    DEFAULT_API_ENDPOINT
+  );
+}
+
+/**
+ * Bare API origin (scheme + host + port, no path) — the value Better Auth needs
+ * as `baseURL` so it appends {@link BETTER_AUTH_BASE_PATH} instead of discarding
+ * it. Falls back to the raw endpoint if it is somehow not a valid absolute URL.
+ */
+export function getApiOrigin(): string {
+  const endpoint = getApiEndpoint();
+  try {
+    return new URL(endpoint).origin;
+  } catch {
+    return endpoint;
+  }
+}
+
+/**
+ * Dual-run switch. When `true`, Better Auth becomes the active session source on
+ * the frontend; when `false` (default) every auth path flows through Clerk
+ * exactly as before. `NEXT_PUBLIC_` so it is inlined into client + middleware
+ * bundles. Mirrors the backend `BETTER_AUTH_ENABLED` flag (Phase 1).
+ */
+export function isBetterAuthEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED === 'true';
+}

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -1,0 +1,3 @@
+export * from './client';
+export * from './config';
+export * from './session';

--- a/packages/auth-client/src/server.ts
+++ b/packages/auth-client/src/server.ts
@@ -1,0 +1,42 @@
+import { BETTER_AUTH_BASE_PATH, getApiOrigin } from './config';
+
+export { isBetterAuthEnabled } from './config';
+
+interface BetterAuthTokenResponse {
+  token?: string;
+}
+
+/**
+ * Server-side Bearer JWT retrieval for RSC bootstrap. Forwards the incoming
+ * Better Auth session cookies to the `jwt` plugin's `/token` endpoint and
+ * returns the minted JWT (the same token the API guard verifies via JWKS).
+ *
+ * Returns `null` when there is no session cookie or on any failure, so callers
+ * degrade gracefully to client-side fetching instead of throwing during render.
+ */
+export async function getBetterAuthServerToken(
+  cookieHeader: string,
+): Promise<string | null> {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `${getApiOrigin()}${BETTER_AUTH_BASE_PATH}/token`,
+      {
+        cache: 'no-store',
+        headers: { cookie: cookieHeader },
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as BetterAuthTokenResponse;
+    return data.token ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/auth-client/src/session.ts
+++ b/packages/auth-client/src/session.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { authClient, getBetterAuthToken } from './client';
+
+/**
+ * The subset of Clerk's `useAuth()` shape that the app's token choke points
+ * consume. Keeping the contract narrow is what lets a single module-load swap
+ * replace Clerk without touching the ~30 downstream call sites.
+ */
+export interface AuthIdentity {
+  getToken: (opts?: {
+    forceRefresh?: boolean;
+    template?: string;
+  }) => Promise<string | null>;
+  isLoaded: boolean;
+  isSignedIn: boolean;
+  orgId: string | null;
+  userId: string | null;
+}
+
+interface BetterAuthSessionShape {
+  activeOrganizationId?: string | null;
+}
+
+/**
+ * Adapts the Better Auth session to {@link AuthIdentity}. Selected at module
+ * load (never per-render) in place of Clerk's `useAuth()` when the dual-run flag
+ * is on, so there are no conditional hook calls and Clerk is never contacted
+ * while Better Auth is the active provider.
+ *
+ * `orgId` stays `null` until the organization plugin lands (Phase 3+); the
+ * choke-point cache keys on `userId`, which is the value that matters here.
+ */
+export function useBetterAuthIdentity(): AuthIdentity {
+  const { data, isPending } = authClient.useSession();
+
+  const getToken = useCallback(() => getBetterAuthToken(), []);
+
+  const session = data?.session as BetterAuthSessionShape | undefined;
+
+  return {
+    getToken,
+    isLoaded: !isPending,
+    isSignedIn: Boolean(data?.session),
+    orgId: session?.activeOrganizationId ?? null,
+    userId: data?.user?.id ?? null,
+  };
+}

--- a/packages/auth-client/tsconfig.json
+++ b/packages/auth-client/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "paths": {
+      "@genfeedai/auth-client": ["./src"],
+      "@genfeedai/auth-client/*": ["./src/*"]
+    },
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022",
+    "types": ["node"]
+  },
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts", "src/**/*.spec.ts"],
+  "include": ["src/**/*"]
+}

--- a/packages/auth-client/vitest.config.ts
+++ b/packages/auth-client/vitest.config.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@genfeedai/auth-client',
+        replacement: path.resolve(__dirname, './src'),
+      },
+      {
+        find: /^@genfeedai\/auth-client\/(.*)$/,
+        replacement: path.resolve(__dirname, './src/$1'),
+      },
+    ],
+  },
+  test: {
+    globals: true,
+    include: ['src/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+});

--- a/packages/contexts/onboarding/onboarding-context.tsx
+++ b/packages/contexts/onboarding/onboarding-context.tsx
@@ -9,7 +9,7 @@ import type { OnboardingProviderProps } from '@genfeedai/props/onboarding/onboar
 import { logger } from '@genfeedai/services/core/logger.service';
 import type { UpdateUserOnboardingPayload } from '@genfeedai/services/onboarding/user-onboarding.service';
 import { UserOnboardingService } from '@genfeedai/services/onboarding/user-onboarding.service';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { usePathname, useRouter } from 'next/navigation';
 import {
   createContext,
@@ -61,7 +61,7 @@ export default function OnboardingProvider({
   }, [isLoading, currentUser]);
 
   const getService = useCallback(async () => {
-    const token = await resolveClerkToken(getToken);
+    const token = await resolveAuthToken(getToken);
     if (!token) {
       throw new Error('Not authenticated');
     }

--- a/packages/contexts/package.json
+++ b/packages/contexts/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@genfeedai/auth-client": "workspace:*",
     "@genfeedai/constants": "workspace:*",
     "@genfeedai/enums": "workspace:*",
     "@genfeedai/helpers": "workspace:*",

--- a/packages/contexts/providers/protected-providers/protected-providers.test.tsx
+++ b/packages/contexts/providers/protected-providers/protected-providers.test.tsx
@@ -17,7 +17,13 @@ vi.mock('@clerk/nextjs', () => ({
 vi.mock('@genfeedai/helpers/auth/clerk.helper', () => ({
   getPlaywrightAuthState: () => getPlaywrightAuthStateMock(),
   hasPlaywrightJwtToken: () => hasPlaywrightJwtTokenMock(),
-  resolveClerkToken: vi.fn().mockResolvedValue('jwt-token'),
+  resolveAuthToken: (getToken: () => Promise<string | null>) => getToken(),
+}));
+
+// Better Auth off (default): the shared identity dispatcher resolves to Clerk.
+vi.mock('@genfeedai/auth-client', () => ({
+  isBetterAuthEnabled: () => false,
+  useBetterAuthIdentity: vi.fn(),
 }));
 
 vi.mock('@genfeedai/contexts/ui/asset-selection-context', () => ({

--- a/packages/contexts/providers/protected-providers/protected-providers.tsx
+++ b/packages/contexts/providers/protected-providers/protected-providers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
+import { isBetterAuthEnabled } from '@genfeedai/auth-client';
 import { AssetSelectionProvider } from '@genfeedai/contexts/ui/asset-selection-context';
 import { BackgroundTaskProvider } from '@genfeedai/contexts/ui/background-task-context';
 import { BrandProvider } from '@genfeedai/contexts/user/brand-context/brand-context';
@@ -8,8 +8,9 @@ import { UserProvider } from '@genfeedai/contexts/user/user-context/user-context
 import {
   getPlaywrightAuthState,
   hasPlaywrightJwtToken,
-  resolveClerkToken,
+  resolveAuthToken,
 } from '@genfeedai/helpers/auth/clerk.helper';
+import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { clearTokenCache } from '@genfeedai/hooks/auth/use-authed-service/use-authed-service';
 import type { LayoutProps } from '@genfeedai/props/layout/layout.props';
 import type { ProtectedBootstrapData } from '@genfeedai/props/layout/protected-bootstrap.props';
@@ -32,7 +33,12 @@ export interface ProtectedProvidersProps extends LayoutProps {
 }
 
 export function ProtectedAuthGate({ children }: LayoutProps): ReactNode {
-  const { getToken, isLoaded: isAuthLoaded, isSignedIn, userId } = useAuth();
+  const {
+    getToken,
+    isLoaded: isAuthLoaded,
+    isSignedIn,
+    userId,
+  } = useAuthIdentity();
   const playwrightAuth = getPlaywrightAuthState();
   const effectiveIsAuthLoaded =
     isAuthLoaded || playwrightAuth?.isLoaded === true;
@@ -64,7 +70,7 @@ export function ProtectedAuthGate({ children }: LayoutProps): ReactNode {
 
     const ensureToken = async (): Promise<void> => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
 
         if (isCancelled) {
           return;
@@ -176,8 +182,13 @@ export default function ProtectedProviders({
     content = <ApiStatusProvider>{content}</ApiStatusProvider>;
   }
 
-  // LOCAL mode: bypass Clerk auth gate — backend handles identity via LocalIdentityInterceptor.
-  if (!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+  // LOCAL mode: bypass the auth gate only when NEITHER Clerk nor Better Auth is
+  // active — backend handles identity via LocalIdentityInterceptor. With Better
+  // Auth enabled (Community), the gate still applies and reads the BA session.
+  if (
+    !process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY &&
+    !isBetterAuthEnabled()
+  ) {
     return content;
   }
 

--- a/packages/contexts/user/internal/context-authed-service.ts
+++ b/packages/contexts/user/internal/context-authed-service.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useCallback, useEffect, useRef } from 'react';
 
 const tokenCache = new Map<
@@ -73,7 +73,7 @@ function getCachedToken(
     return cached.promise;
   }
 
-  const promise = resolveClerkToken(getTokenFn, tokenOptions).then((token) => {
+  const promise = resolveAuthToken(getTokenFn, tokenOptions).then((token) => {
     if (!token) {
       tokenCache.delete(cacheKey);
       throw new ContextAuthenticationTokenUnavailableError();
@@ -107,7 +107,7 @@ export function useContextAuthedService<T>(
   factory: (token: string) => T,
   template?: string,
 ) {
-  const { getToken, orgId, userId } = useAuth();
+  const { getToken, orgId, userId } = useAuthIdentity();
   const factoryRef = useRef(factory);
   const getTokenRef = useRef(
     getToken as (opts?: TokenOptions) => Promise<string | null>,

--- a/packages/contexts/vitest.config.ts
+++ b/packages/contexts/vitest.config.ts
@@ -45,6 +45,14 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../utils'),
       },
       {
+        find: '@genfeedai/auth-client',
+        replacement: path.resolve(__dirname, '../auth-client/src/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/auth-client\/(.*)$/,
+        replacement: path.resolve(__dirname, '../auth-client/src/$1'),
+      },
+      {
         find: '@genfeedai/helpers',
         replacement: path.resolve(__dirname, '../helpers/src'),
       },

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@genfeedai/auth-client": "workspace:*",
     "@genfeedai/constants": "workspace:*",
     "@genfeedai/enums": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",

--- a/packages/helpers/src/auth/clerk.helper.test.ts
+++ b/packages/helpers/src/auth/clerk.helper.test.ts
@@ -1,5 +1,19 @@
-import { getClerkPublicData } from '@helpers/auth/clerk.helper';
-import { describe, expect, it } from 'vitest';
+import {
+  getClerkPublicData,
+  resolveAuthToken,
+} from '@helpers/auth/clerk.helper';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authClientMocks = vi.hoisted(() => ({
+  getBetterAuthToken: vi.fn<() => Promise<string | null>>(async () => null),
+}));
+
+// resolveAuthToken reads NEXT_PUBLIC_BETTER_AUTH_ENABLED inline and dynamically
+// imports getBetterAuthToken only when on — vi.mock intercepts the dynamic
+// import too.
+vi.mock('@genfeedai/auth-client', () => ({
+  getBetterAuthToken: authClientMocks.getBetterAuthToken,
+}));
 
 describe('clerk.helper', () => {
   describe('getClerkPublicData', () => {
@@ -31,6 +45,56 @@ describe('clerk.helper', () => {
       const mockUser = { publicMetadata: metadata } as never;
       const result = getClerkPublicData(mockUser);
       expect(result).toEqual(metadata);
+    });
+  });
+
+  describe('resolveAuthToken (dual-run, #735)', () => {
+    beforeEach(() => {
+      // This jsdom env does not provide localStorage; define a fresh in-memory
+      // stub each test so getPlaywrightJwtToken's fallback is exercisable.
+      const store = new Map<string, string>();
+      Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: {
+          clear: () => store.clear(),
+          getItem: (key: string) => store.get(key) ?? null,
+          removeItem: (key: string) => store.delete(key),
+          setItem: (key: string, value: string) => store.set(key, value),
+        },
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+      delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    });
+
+    it('delegates to the Clerk getToken callback when Better Auth is off', async () => {
+      delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+      const getToken = vi.fn(async () => 'clerk-token');
+
+      await expect(resolveAuthToken(getToken)).resolves.toBe('clerk-token');
+      expect(getToken).toHaveBeenCalledTimes(1);
+      expect(authClientMocks.getBetterAuthToken).not.toHaveBeenCalled();
+    });
+
+    it('uses the Better Auth JWT and ignores Clerk getToken when on', async () => {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'true';
+      authClientMocks.getBetterAuthToken.mockResolvedValue('ba-jwt');
+      const getToken = vi.fn(async () => 'clerk-token');
+
+      await expect(resolveAuthToken(getToken)).resolves.toBe('ba-jwt');
+      expect(getToken).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the Playwright JWT when Better Auth has no token', async () => {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'true';
+      authClientMocks.getBetterAuthToken.mockResolvedValue(null);
+      window.localStorage.setItem('clerk-db-jwt', 'pw-jwt');
+      const getToken = vi.fn(async () => 'clerk-token');
+
+      await expect(resolveAuthToken(getToken)).resolves.toBe('pw-jwt');
     });
   });
 });

--- a/packages/helpers/src/auth/clerk.helper.ts
+++ b/packages/helpers/src/auth/clerk.helper.ts
@@ -90,6 +90,39 @@ export async function resolveClerkToken(
   return (await getToken(opts)) ?? getPlaywrightJwtToken();
 }
 
+/**
+ * Unified token resolver for the Clerk → Better Auth dual run (epic #735).
+ *
+ * - **Better Auth on:** returns the JWT minted by the `jwt` plugin's
+ *   `authClient.token()` (the Clerk `getToken` callback is ignored), falling
+ *   back to the Playwright E2E JWT.
+ * - **Better Auth off (default):** delegates to {@link resolveClerkToken}
+ *   unchanged — so the Clerk path is byte-for-byte identical and existing tests
+ *   that mock `resolveClerkToken` keep intercepting.
+ *
+ * This is the single token choke point every authenticated frontend surface
+ * flows through; migrating a call site is a mechanical `resolveClerkToken` ->
+ * `resolveAuthToken` rename (the signature is backward-compatible).
+ */
+export async function resolveAuthToken(
+  getToken: ClerkTokenGetter,
+  opts?: {
+    forceRefresh?: boolean;
+    template?: string;
+  },
+): Promise<string | null> {
+  // Read the flag inline (no static import) and load the Better Auth client via
+  // a dynamic import only when it is on. This keeps `better-auth/react` (and its
+  // React hooks) out of `@genfeedai/helpers`' static graph, so this module stays
+  // server/RSC-safe and adds zero cost to the default Clerk path.
+  if (process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED === 'true') {
+    const { getBetterAuthToken } = await import('@genfeedai/auth-client');
+    return (await getBetterAuthToken()) ?? getPlaywrightJwtToken();
+  }
+
+  return resolveClerkToken(getToken, opts);
+}
+
 export function hasPlaywrightJwtToken(): boolean {
   return getPlaywrightJwtToken() !== null;
 }

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -11,6 +11,8 @@
     "moduleResolution": "bundler",
     "outDir": "./dist",
     "paths": {
+      "@genfeedai/auth-client": ["../auth-client/src/index.ts"],
+      "@genfeedai/auth-client/*": ["../auth-client/src/*"],
       "@genfeedai/constants": ["../constants/src/index.ts"],
       "@genfeedai/constants/*": ["../constants/src/*"],
       "@genfeedai/pricing": ["../pricing/src/index.ts"],
@@ -43,6 +45,9 @@
   ],
   "include": ["src/**/*.ts"],
   "references": [
+    {
+      "path": "../auth-client"
+    },
     {
       "path": "../constants"
     },

--- a/packages/helpers/vitest.config.ts
+++ b/packages/helpers/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@constants': path.resolve(__dirname, '../ui/constants'),
+      '@genfeedai/auth-client': path.resolve(
+        __dirname,
+        '../auth-client/src/index.ts',
+      ),
       '@genfeedai/constants': path.resolve(
         __dirname,
         '../constants/dist/index.js',

--- a/packages/hooks/auth/use-auth-identity/use-auth-identity.ts
+++ b/packages/hooks/auth/use-auth-identity/use-auth-identity.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useAuth } from '@clerk/nextjs';
+import {
+  type AuthIdentity,
+  isBetterAuthEnabled,
+  useBetterAuthIdentity,
+} from '@genfeedai/auth-client';
+
+export type { AuthIdentity };
+
+/**
+ * Clerk's `useAuth()` narrowed to the {@link AuthIdentity} contract. Only
+ * invoked when Clerk is the active provider.
+ */
+function useClerkIdentity(): AuthIdentity {
+  const { getToken, isLoaded, isSignedIn, orgId, userId } = useAuth();
+
+  return {
+    getToken: getToken as AuthIdentity['getToken'],
+    isLoaded,
+    isSignedIn: Boolean(isSignedIn),
+    orgId: orgId ?? null,
+    userId: userId ?? null,
+  };
+}
+
+/**
+ * The single frontend auth-identity choke point for the Clerk -> Better Auth
+ * dual run (epic #735). Bound once at module load (never per-render) so the
+ * React hook order is stable, Clerk's `useAuth()` is never called under Better
+ * Auth, and Better Auth's session is never fetched while Clerk is the default.
+ *
+ * Every authenticated frontend surface — the two token caches
+ * (`useAuthedService` / `useContextAuthedService`), the route gate
+ * (`ProtectedAuthGate`) and `useOptionalAuth` — resolves identity through here,
+ * so the cutover is a single flag flip. When Clerk is removed (Phase 4) this
+ * collapses to `useBetterAuthIdentity`.
+ */
+export const useAuthIdentity: () => AuthIdentity = isBetterAuthEnabled()
+  ? useBetterAuthIdentity
+  : useClerkIdentity;

--- a/packages/hooks/auth/use-authed-service/use-authed-service.test.ts
+++ b/packages/hooks/auth/use-authed-service/use-authed-service.test.ts
@@ -1,5 +1,5 @@
 import { useAuth } from '@clerk/nextjs';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import {
   clearTokenCache,
   useAuthedService,
@@ -11,13 +11,20 @@ vi.mock('@clerk/nextjs', () => ({
   useAuth: vi.fn(() => ({ getToken: vi.fn() })),
 }));
 
+// Better Auth off (default): the module-selected identity hook resolves to the
+// Clerk path, and the token choke point delegates to the Clerk getToken.
+vi.mock('@genfeedai/auth-client', () => ({
+  isBetterAuthEnabled: () => false,
+  useBetterAuthIdentity: vi.fn(),
+}));
+
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: vi.fn(),
+  resolveAuthToken: vi.fn(),
 }));
 
 describe('useAuthedService', () => {
   const getTokenMock = vi.fn();
-  const mockResolveClerkToken = resolveClerkToken as unknown as ReturnType<
+  const mockResolveAuthToken = resolveAuthToken as unknown as ReturnType<
     typeof vi.fn
   >;
   const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
@@ -39,7 +46,7 @@ describe('useAuthedService', () => {
     clearTokenCache();
     orgIdMock = 'org-123';
     userIdMock = 'user-123';
-    mockResolveClerkToken.mockImplementation(async (getToken, opts) =>
+    mockResolveAuthToken.mockImplementation(async (getToken, opts) =>
       getToken(opts),
     );
     mockUseAuth.mockReturnValue({
@@ -99,13 +106,13 @@ describe('useAuthedService', () => {
 
   it('falls back to the playwright jwt token when Clerk returns null', async () => {
     const mockService = vi.fn();
-    mockResolveClerkToken.mockResolvedValue('playwright-jwt');
+    mockResolveAuthToken.mockResolvedValue('playwright-jwt');
 
     const { result } = renderHook(() => useAuthedService(mockService));
 
     await result.current();
 
-    expect(resolveClerkToken).toHaveBeenCalledWith(getTokenMock, undefined);
+    expect(resolveAuthToken).toHaveBeenCalledWith(getTokenMock, undefined);
     expect(mockService).toHaveBeenCalledWith('playwright-jwt');
   });
 

--- a/packages/hooks/auth/use-authed-service/use-authed-service.ts
+++ b/packages/hooks/auth/use-authed-service/use-authed-service.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
+import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useCallback, useEffect, useRef } from 'react';
 
 /**
@@ -47,7 +47,7 @@ function getCachedToken(
     return cached.promise;
   }
 
-  const promise = resolveClerkToken(getTokenFn, tokenOptions).then((token) => {
+  const promise = resolveAuthToken(getTokenFn, tokenOptions).then((token) => {
     if (!token) {
       tokenCache.delete(cacheKey);
       throw new AuthenticationTokenUnavailableError();
@@ -112,7 +112,7 @@ export function useAuthedService<T>(
   factory: (token: string) => T,
   template?: string,
 ) {
-  const { getToken, orgId, userId } = useAuth();
+  const { getToken, orgId, userId } = useAuthIdentity();
 
   // Store factory in ref to avoid callback recreation
   const factoryRef = useRef(factory);

--- a/packages/hooks/automation/use-workflow-builder/use-workflow-builder.ts
+++ b/packages/hooks/automation/use-workflow-builder/use-workflow-builder.ts
@@ -10,7 +10,7 @@ import type {
 import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import { logger } from '@genfeedai/services/core/logger.service';
 import { NotificationsService } from '@genfeedai/services/core/notifications.service';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import type {
   Connection,
   Edge,
@@ -150,7 +150,7 @@ export function useWorkflowBuilder({
         setIsLoading(true);
         setError(null);
 
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         // Fetch node registry from API
         const response = await fetch(`${apiBaseUrl}/workflows/nodes/registry`, {
           headers: {
@@ -310,7 +310,7 @@ export function useWorkflowBuilder({
         targetHandle: edge.targetHandle || undefined,
       }));
 
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       const response = await fetch(`${apiBaseUrl}/workflows/${workflowId}`, {
         body: JSON.stringify({
           edges: workflowEdges,
@@ -341,7 +341,7 @@ export function useWorkflowBuilder({
   // Validate workflow
   const validateWorkflow = useCallback(async (): Promise<boolean> => {
     try {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       const response = await fetch(
         `${apiBaseUrl}/workflows/${workflowId}/validate`,
         {
@@ -384,7 +384,7 @@ export function useWorkflowBuilder({
         await saveWorkflow();
       }
 
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       const response = await fetch(`${apiBaseUrl}/workflow-executions`, {
         body: JSON.stringify({
           workflow: workflowId,

--- a/packages/hooks/data/agent-campaigns/use-agent-campaigns.test.ts
+++ b/packages/hooks/data/agent-campaigns/use-agent-campaigns.test.ts
@@ -21,7 +21,7 @@ vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
-  resolveClerkToken: vi.fn().mockResolvedValue('test-token'),
+  resolveAuthToken: vi.fn().mockResolvedValue('test-token'),
 }));
 
 vi.mock('@genfeedai/services/automation/agent-campaigns.service', () => ({
@@ -96,8 +96,8 @@ describe('useAgentCampaigns', () => {
   });
 
   it('returns empty array when token is unavailable', async () => {
-    const { resolveClerkToken } = await import('@helpers/auth/clerk.helper');
-    vi.mocked(resolveClerkToken).mockResolvedValueOnce(null);
+    const { resolveAuthToken } = await import('@helpers/auth/clerk.helper');
+    vi.mocked(resolveAuthToken).mockResolvedValueOnce(null);
 
     const { useAgentCampaigns } = await import('./use-agent-campaigns');
     const { createQueryWrapper } = await import('@hooks/tests/query-wrapper');

--- a/packages/hooks/data/agent-campaigns/use-agent-campaigns.ts
+++ b/packages/hooks/data/agent-campaigns/use-agent-campaigns.ts
@@ -6,7 +6,7 @@ import {
   type AgentCampaign,
   AgentCampaignsService,
 } from '@genfeedai/services/automation/agent-campaigns.service';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useQuery } from '@tanstack/react-query';
 
 export interface UseAgentCampaignsOptions {
@@ -32,7 +32,7 @@ export function useAgentCampaigns(
   } = useQuery({
     queryKey: ['agent-campaigns', brandId, options.status],
     queryFn: async () => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) return [];
 
       const service = AgentCampaignsService.getInstance(token);

--- a/packages/hooks/data/agent-runs/use-active-agent-runs.ts
+++ b/packages/hooks/data/agent-runs/use-active-agent-runs.ts
@@ -1,9 +1,9 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
 import type { IAgentRun } from '@genfeedai/interfaces';
 import { AgentRunsService } from '@genfeedai/services/ai/agent-runs.service';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
+import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
@@ -25,7 +25,7 @@ export interface UseActiveAgentRunsOptions {
 export function useActiveAgentRuns(
   options: UseActiveAgentRunsOptions = {},
 ): UseActiveAgentRunsReturn {
-  const { getToken, orgId, userId } = useAuth();
+  const { getToken, orgId, userId } = useAuthIdentity();
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const shouldRevalidateOnMount =
@@ -38,7 +38,7 @@ export function useActiveAgentRuns(
   } = useQuery({
     queryKey: ['active-agent-runs', userId ?? 'anonymous', orgId ?? 'no-org'],
     queryFn: async () => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) return [];
 
       const service = AgentRunsService.getInstance(token);

--- a/packages/hooks/data/agent-runs/use-agent-runs.ts
+++ b/packages/hooks/data/agent-runs/use-agent-runs.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
 import type { IAgentRun } from '@genfeedai/interfaces';
 import { AgentRunsService } from '@genfeedai/services/ai/agent-runs.service';
 import type {
@@ -8,7 +7,8 @@ import type {
   AgentRunStats,
   AgentRunTimeRange,
 } from '@genfeedai/types';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
+import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 
@@ -30,7 +30,7 @@ export interface UseAgentRunsReturn {
 export function useAgentRuns(
   options: UseAgentRunsOptions = {},
 ): UseAgentRunsReturn {
-  const { getToken, orgId, userId } = useAuth();
+  const { getToken, orgId, userId } = useAuthIdentity();
   const [stats, setStats] = useState<AgentRunStats | null>(
     options.initialStats ?? null,
   );
@@ -60,7 +60,7 @@ export function useAgentRuns(
       options.webSearchEnabled,
     ],
     queryFn: async () => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) return [];
 
       const service = AgentRunsService.getInstance(token);
@@ -90,7 +90,7 @@ export function useAgentRuns(
 
   const cancelRun = useCallback(
     async (id: string) => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) return;
 
       const service = AgentRunsService.getInstance(token);

--- a/packages/hooks/data/agent-strategies/use-agent-strategies.ts
+++ b/packages/hooks/data/agent-strategies/use-agent-strategies.ts
@@ -5,7 +5,7 @@ import {
   AgentStrategiesService,
   type AgentStrategy,
 } from '@genfeedai/services/automation/agent-strategies.service';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useQuery } from '@tanstack/react-query';
 
 export interface UseAgentStrategiesOptions {
@@ -31,7 +31,7 @@ export function useAgentStrategies(
   } = useQuery({
     queryKey: ['agent-strategies', options.agentType, options.isActive],
     queryFn: async () => {
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) return [];
 
       const service = AgentStrategiesService.getInstance(token);

--- a/packages/hooks/data/agent-strategies/use-agent-strategy.ts
+++ b/packages/hooks/data/agent-strategies/use-agent-strategy.ts
@@ -5,7 +5,7 @@ import {
   AgentStrategiesService,
   type AgentStrategy,
 } from '@genfeedai/services/automation/agent-strategies.service';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useQuery } from '@tanstack/react-query';
 
 export interface UseAgentStrategyReturn {
@@ -25,7 +25,7 @@ export function useAgentStrategy(id: string): UseAgentStrategyReturn {
     queryKey: ['agent-strategy', id],
     queryFn: async () => {
       if (!id) return null;
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       if (!token) return null;
 
       const service = AgentStrategiesService.getInstance(token);

--- a/packages/hooks/data/skills/use-brand-enabled-skills.ts
+++ b/packages/hooks/data/skills/use-brand-enabled-skills.ts
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useCallback, useEffect, useState } from 'react';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
@@ -66,7 +66,7 @@ export function useBrandEnabledSkills(): UseBrandEnabledSkillsReturn {
       setEnabledSlugs(nextSlugs);
 
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
         if (!token) throw new Error('No auth token');
 
         const response = await fetch(

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@genfeedai/auth-client": "workspace:*",
     "@genfeedai/constants": "workspace:*",
     "@genfeedai/contexts": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -8,6 +8,8 @@
       "@genfeedai-types/*": ["../types/src/*"],
       "@genfeedai/agent": ["../agent/src/index.ts"],
       "@genfeedai/agent/*": ["../agent/src/*"],
+      "@genfeedai/auth-client": ["../auth-client/src/index.ts"],
+      "@genfeedai/auth-client/*": ["../auth-client/src/*"],
       "@genfeedai/client": ["../client/src/index.ts"],
       "@genfeedai/client/*": ["../client/src/*"],
       "@genfeedai/constants": ["../constants/src/index.ts"],

--- a/packages/hooks/utils/use-socket-manager/use-socket-manager.test.ts
+++ b/packages/hooks/utils/use-socket-manager/use-socket-manager.test.ts
@@ -26,7 +26,7 @@ vi.mock('@clerk/nextjs', () => ({
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
   getPlaywrightAuthState: vi.fn(() => null),
-  resolveClerkToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
+  resolveAuthToken: (...args: unknown[]) => resolveClerkTokenMock(...args),
 }));
 
 vi.mock('@genfeedai/services/core/socket-manager.service', () => ({

--- a/packages/hooks/utils/use-socket-manager/use-socket-manager.ts
+++ b/packages/hooks/utils/use-socket-manager/use-socket-manager.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { useAuth } from '@clerk/nextjs';
 import type {
   ISocketEventHandler,
   ISocketManagerConfig,
@@ -10,8 +9,9 @@ import { logger } from '@genfeedai/services/core/logger.service';
 import { SocketManager } from '@genfeedai/services/core/socket-manager.service';
 import {
   getPlaywrightAuthState,
-  resolveClerkToken,
+  resolveAuthToken,
 } from '@helpers/auth/clerk.helper';
+import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export interface SocketSubscription<T = unknown> {
@@ -23,7 +23,7 @@ export interface SocketSubscription<T = unknown> {
  * React hook for managing socket connections with automatic cleanup
  */
 export function useSocketManager(options: ISocketManagerConfig = {}) {
-  const { getToken, isLoaded: isAuthLoaded, isSignedIn } = useAuth();
+  const { getToken, isLoaded: isAuthLoaded, isSignedIn } = useAuthIdentity();
   const playwrightAuth = getPlaywrightAuthState();
   const effectiveIsAuthLoaded =
     isAuthLoaded || playwrightAuth?.isLoaded === true;
@@ -65,7 +65,7 @@ export function useSocketManager(options: ISocketManagerConfig = {}) {
 
     const initializeSocket = async () => {
       try {
-        const token = await resolveClerkToken(getToken);
+        const token = await resolveAuthToken(getToken);
 
         if (!token) {
           if (isMounted) {

--- a/packages/hooks/vitest.config.mts
+++ b/packages/hooks/vitest.config.mts
@@ -77,6 +77,18 @@ export default defineConfig({
         replacement: path.join(ENUMS_SRC, '$1'),
       },
       {
+        find: /^@genfeedai\/auth-client$/,
+        replacement: path.resolve(__dirname, '../auth-client/src/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/auth-client\/(.*)$/,
+        replacement: path.resolve(__dirname, '../auth-client/src/$1'),
+      },
+      {
+        find: /^@genfeedai\/hooks\/(.*)$/,
+        replacement: path.resolve(__dirname, './$1'),
+      },
+      {
         find: /^@genfeedai\/helpers$/,
         replacement: path.join(HELPERS_SRC, 'index.ts'),
       },

--- a/packages/pages/agent/agent-page-content.tsx
+++ b/packages/pages/agent/agent-page-content.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { AgentApiService, AgentFullPage } from '@genfeedai/agent';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import { useUserRole } from '@hooks/auth/use-user-role';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { useCallback, useMemo } from 'react';
@@ -30,7 +30,7 @@ export default function AgentPageContent({
     () =>
       new AgentApiService({
         baseUrl: process.env.NEXT_PUBLIC_API_ENDPOINT ?? '',
-        getToken: async () => resolveClerkToken(getToken),
+        getToken: async () => resolveAuthToken(getToken),
       }),
     [getToken],
   );

--- a/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.tsx
@@ -6,7 +6,7 @@ import {
   ButtonVariant,
   CredentialPlatform,
 } from '@genfeedai/enums';
-import { resolveClerkToken } from '@helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@helpers/auth/clerk.helper';
 import type { BrandDetailSocialMediaCardProps } from '@props/pages/brand-detail.props';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
@@ -164,7 +164,7 @@ export default function BrandDetailSocialMediaCard({
   const handleConnectPlatform = async (platform: string) => {
     try {
       setConnectingPlatform(platform);
-      const token = (await resolveClerkToken(getToken)) ?? '';
+      const token = (await resolveAuthToken(getToken)) ?? '';
       const service = new ServicesService(platform, token);
       const credentialOAuth = await service.postConnect({ brand: brandId });
       window.open(credentialOAuth.url, '_self');

--- a/packages/ui/src/components/providers/AppProviders.tsx
+++ b/packages/ui/src/components/providers/AppProviders.tsx
@@ -16,7 +16,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import dynamic from 'next/dynamic';
 import { ThemeProvider, useTheme } from 'next-themes';
-import { type ComponentProps, useState } from 'react';
+import { type ComponentProps, type ReactNode, useState } from 'react';
 import { Toaster } from 'sonner';
 
 type ClerkProviderProps = Omit<
@@ -90,6 +90,17 @@ function ClerkProviderWithTheme({
   );
 }
 
+/**
+ * Dual-run cutover seam for Better Auth (epic #735). Better Auth's React client
+ * is provider-less (nanostores-backed), so no runtime provider is required for
+ * `useSession()` — this sibling to `MaybeClerkProvider` passes children through
+ * unchanged and exists so the eventual Clerk removal (Phase 4) has one obvious
+ * place to mount any Better-Auth-only context.
+ */
+function MaybeBetterAuthProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
 function MaybeClerkProvider({
   children,
   clerkProps,
@@ -132,19 +143,21 @@ export default function AppProviders({
         storageKey={storageKey}
         disableTransitionOnChange={disableTransitionOnChange}
       >
-        <MaybeClerkProvider clerkProps={clerkProps}>
-          <ThemeCookieSync />
-          {children}
-          {includeToaster ? (
-            <Toaster richColors closeButton position="top-right" />
-          ) : null}
-          {includeLazyModalErrorDebug ? <LazyModalErrorDebug /> : null}
-          {googleAnalyticsId ? (
-            <GoogleAnalytics gaId={googleAnalyticsId} />
-          ) : null}
-          {includeVercelAnalytics ? <Analytics /> : null}
-          {includeSpeedInsights ? <SpeedInsights /> : null}
-        </MaybeClerkProvider>
+        <MaybeBetterAuthProvider>
+          <MaybeClerkProvider clerkProps={clerkProps}>
+            <ThemeCookieSync />
+            {children}
+            {includeToaster ? (
+              <Toaster richColors closeButton position="top-right" />
+            ) : null}
+            {includeLazyModalErrorDebug ? <LazyModalErrorDebug /> : null}
+            {googleAnalyticsId ? (
+              <GoogleAnalytics gaId={googleAnalyticsId} />
+            ) : null}
+            {includeVercelAnalytics ? <Analytics /> : null}
+            {includeSpeedInsights ? <SpeedInsights /> : null}
+          </MaybeClerkProvider>
+        </MaybeBetterAuthProvider>
       </ThemeProvider>
       <LazyReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/packages/ui/src/components/workflow-builder/panels/SchedulePanel.tsx
+++ b/packages/ui/src/components/workflow-builder/panels/SchedulePanel.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { ButtonSize, ButtonVariant, ComponentSize } from '@genfeedai/enums';
-import { resolveClerkToken } from '@genfeedai/helpers/auth/clerk.helper';
+import { resolveAuthToken } from '@genfeedai/helpers/auth/clerk.helper';
 import { formatRecurringSchedule } from '@genfeedai/helpers/formatting/recurring-schedule/recurring-schedule.helper';
 import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import { NotificationsService } from '@genfeedai/services/core/notifications.service';
@@ -86,7 +86,7 @@ export default function SchedulePanel({
 
     try {
       setIsSaving(true);
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       const response = await fetch(
         `${EnvironmentService.apiEndpoint}/workflows/${workflowId}/schedule`,
         {
@@ -119,7 +119,7 @@ export default function SchedulePanel({
   const handleRemoveSchedule = useCallback(async () => {
     try {
       setIsSaving(true);
-      const token = await resolveClerkToken(getToken);
+      const token = await resolveAuthToken(getToken);
       const response = await fetch(
         `${EnvironmentService.apiEndpoint}/workflows/${workflowId}/schedule`,
         {


### PR DESCRIPTION
## Summary

Phase 2 of the Clerk → Better Auth epic (#735): the **frontend session layer** lands beside Clerk as a **dual run**, gated by `NEXT_PUBLIC_BETTER_AUTH_ENABLED` (**off by default — Clerk stays the default until cutover**). No cutover here; flipping the flag is what activates Better Auth.

Depends on Phase 1 backend ([#750](https://github.com/genfeedai/genfeed.ai/pull/750)) which mounts the BA handler at `/v1/auth/*`, publishes JWKS, and already accepts BA bearer JWTs.

## What's in it

- **`packages/auth-client`** (new `@genfeedai/auth-client`): `createAuthClient()` (`better-auth/react`) with `magicLink` + `jwt` client plugins. `baseURL` = bare **origin** + `basePath` = `/v1/auth` (Better Auth's `withPath` *drops* `basePath` when `baseURL` already carries a path — verified against installed source). Bearer JWT read from the jwt plugin's `GET /token`. A `/server` entry forwards session cookies to `/v1/auth/token` for an RSC bearer JWT.
- **Edition flag**: `isBetterAuthEnabled()` in `apps/app/src/lib/config/edition.ts`.
- **Token choke point**: `resolveAuthToken()` in `clerk.helper.ts` switches on the flag and **dynamic-imports** the BA client (keeps `better-auth/react` out of the helpers + RSC static graph); delegates to `resolveClerkToken` when off so the Clerk path is byte-identical and existing mocks keep intercepting.
- **Shared `use-auth-identity` dispatcher** (selected once at module load): routes both token caches (`useAuthedService` / `useContextAuthedService`), `ProtectedAuthGate`, `useOptionalAuth`, and the agent-runs / socket-manager hooks through one Clerk→BA identity seam — **no conditional hooks, no BA network when off, no Clerk hooks when on**.
- **`MaybeBetterAuthProvider`** passthrough seam in `AppProviders` (BA's React client is provider-less).
- **Flag-conditional `/login`, `/sign-up`, `/logout`** — magic-link + Google via `@ui/primitives`; Clerk pages render unchanged when off.
- **`proxy.ts`**: sibling BA route-guard gated on the flag, ahead of the keyless self-hosted branch; Clerk wins if both are misconfigured.

## Verification

- ✅ `bun type-check` (46/46 packages)
- ✅ `bunx turbo lint` + `biome check` (incl. `useHookAtTopLevel`)
- ✅ Targeted tests: `auth-client` (9), `helpers` (782), `hooks` (907), `contexts` (86), server-bootstrap + oauth/cli, and the renamed onboarding/orchestration/chat tests
- ✅ **4-dimension adversarial review** (Clerk-path integrity, BA correctness, hook-rules/SSR, test/build residue). It caught a **blocker** — the `baseURL`+`basePath` URL construction dropped `/auth`, 404ing every BA call — now fixed and locked with a unit test asserting the effective base URL.

## Known limitations / follow-ups (BA-mode only; flag is off)

- **Activation**: BA mode needs the Phase 1 server live + `BETTER_AUTH_*` / `GOOGLE_CLIENT_*` env, and `NEXT_PUBLIC_BETTER_AUTH_ENABLED=true`. The `magicLink`/`google` calls route via the dynamic client proxy, so they require the matching server plugins.
- **E2E**: the Playwright bypass still reads Clerk window/localStorage state; a BA-mode E2E injection path is a later phase.
- **Pre-existing (not from this PR)**: `workspace-page.spec/.test.tsx` fail in *isolation* on `master` (a `brand-context` mock is missing `useBrandId`) — verified via stash A/B; tracked separately.

Part of #735 · implements #737. Dual-run, no cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)