### PR TITLE
test(app): fix workspace-page tests failing in isolation

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -50,11 +50,30 @@ vi.mock('@contexts/user/brand-context/brand-context', () => ({
       name: null,
     },
   }),
+  useBrandId: () => 'brand-1',
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
   getPlaywrightAuthState: vi.fn(() => null),
   resolveClerkToken: vi.fn(),
+}));
+
+vi.mock('@hooks/data/trends/use-trends/use-trends', () => ({
+  useTrends: () => ({
+    error: null,
+    isLoading: false,
+    isRefreshing: false,
+    refresh: vi.fn(),
+    refreshTrends: vi.fn(),
+    selectedPlatform: 'all',
+    setSelectedPlatform: vi.fn(),
+    summary: {
+      connectedPlatforms: [],
+      lockedPlatforms: [],
+      totalTrends: 0,
+    },
+    trends: [],
+  }),
 }));
 
 vi.mock('@hooks/utils/use-websocket-prompt/use-websocket-prompt', () => ({

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -36,10 +36,29 @@ vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => ({
     organizationId: 'org-1',
   }),
+  useBrandId: () => 'brand-1',
 }));
 
 vi.mock('@helpers/auth/clerk.helper', () => ({
   resolveClerkToken: mocks.resolveClerkToken,
+}));
+
+vi.mock('@hooks/data/trends/use-trends/use-trends', () => ({
+  useTrends: () => ({
+    error: null,
+    isLoading: false,
+    isRefreshing: false,
+    refresh: vi.fn(),
+    refreshTrends: vi.fn(),
+    selectedPlatform: 'all',
+    setSelectedPlatform: vi.fn(),
+    summary: {
+      connectedPlatforms: [],
+      lockedPlatforms: [],
+      totalTrends: 0,
+    },
+    trends: [],
+  }),
 }));
 
 vi.mock('@hooks/utils/use-socket-manager/use-socket-manager', () => ({


### PR DESCRIPTION
## What

Makes both `workspace-page.spec.tsx` and `workspace-page.test.tsx` self-sufficient so they pass when run in isolation, not just inside the full sharded CI run.

```
cd apps/app && bunx vitest run workspace-page --config ./vitest.config.mts
# → 2 files passed, 14 tests passed (11 spec + 3 test)
```

## Why

Both files failed in isolation, only passing in the full shard where a sibling file's mocks leaked through the reused forks worker and masked two pre-existing gaps. Verified failing on a clean `master` checkout, so this is pre-existing — not introduced here.

Root cause is a **single module**: `useTrends` is the *only* react-query consumer **and** the *only* `useBrandId` consumer in the workspace render graph (`packages/hooks/data/trends/use-trends/use-trends.ts` imports `useBrandId` on line 3 and `useQuery`/`useQueryClient` on line 10). The per-file mocks covered neither, so isolation surfaced two layered failures:

1. `No "useBrandId" export is defined on the "@contexts/user/brand-context/brand-context" mock` — at module load.
2. `No QueryClient set, use QueryClientProvider to set one` — once render reaches `useTrends` → `useQueryClient`.

## Change

In both test files:
- Add `useBrandId: () => 'brand-1'` to the `@contexts/.../brand-context` mock factory (matches the `brand-1` already used in each file's fixtures).
- Mock `@hooks/data/trends/use-trends/use-trends` to return a benign `UseTrendsReturn` (`trends: []`, `isLoading: false`), neutralizing the `QueryClient` dependency.

Mocking the hook directly (rather than `@tanstack/react-query`) matches the closest in-repo analog — `ContentTeamPage.test.tsx` in the same `orchestration/` sibling dir mocks feature hooks the same way — and avoids coupling to react-query's internal data shapes. `useTrends`' return is only passed to the overview sidebar (`trendItems`/`isTrendsLoading`); the tests assert nothing about trends, so behavior is unchanged.

## Reviewer notes

- No source changes — test-only, 2 files, +38 lines.
- Both failures trace to the same `useTrends` module, so the two mock additions are complementary (the `useBrandId` add also defends against any future non-`useTrends` consumer).
- Pre-commit hooks (secretlint, biome, no-raw-html) and `biome check` pass with no fixes.