### PR TITLE
feat(auth): Better Auth user-provisioning lifecycle (Phase B, epic #735)

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.constants.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.constants.ts
@@ -13,3 +13,10 @@ export const BETTER_AUTH_BASE_PATH = '/v1/auth';
 
 /** DI token for the constructed Better Auth instance. */
 export const BETTER_AUTH_INSTANCE = Symbol('BETTER_AUTH_INSTANCE');
+
+/**
+ * Emitted (awaited via `emitAsync`) from the `user.create.after` hook so a new
+ * user is provisioned before the create completes. Replaces the Clerk
+ * `user.created` webhook (epic #735, Phase 4).
+ */
+export const BETTER_AUTH_USER_CREATED_EVENT = 'better-auth.user.created';

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -36,8 +36,15 @@ function generateHandle(input: {
  * a JWKS at `${baseURL}${BETTER_AUTH_BASE_PATH}/jwks`.
  */
 export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
-  const { prisma, secret, baseURL, trustedOrigins, google, sendMagicLink } =
-    options;
+  const {
+    prisma,
+    secret,
+    baseURL,
+    trustedOrigins,
+    google,
+    sendMagicLink,
+    onUserCreated,
+  } = options;
 
   return betterAuth({
     appName: 'Genfeed.ai',
@@ -86,6 +93,17 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
                 }),
               },
             };
+          },
+          // Provision org/settings/brand/member/credits for the new user. Awaited
+          // so a brand-new user is fully set up before their first request, and
+          // (idempotently) a no-op for returning preserved users. Replaces the
+          // Clerk `user.created` webhook (epic #735, Phase 4).
+          after: async (user) => {
+            const typed = user as { id: string; email?: string | null };
+            await onUserCreated?.({
+              email: typed.email ?? null,
+              userId: typed.id,
+            });
           },
         },
       },

--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -1,12 +1,14 @@
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { MembersModule } from '@api/collections/members/members.module';
 import { OrganizationsModule } from '@api/collections/organizations/organizations.module';
+import { UserSetupModule } from '@api/collections/users/user-setup.module';
 import { UsersModule } from '@api/collections/users/users.module';
 import { ConfigService } from '@api/config/config.service';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { IS_BETTER_AUTH_ENABLED } from '@genfeedai/config';
 import { forwardRef, Module } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PassportModule } from '@nestjs/passport';
 
 import {
@@ -14,12 +16,16 @@ import {
   resolveBetterAuthBaseUrl,
   resolveGoogleConfig,
 } from './better-auth.config';
-import { BETTER_AUTH_INSTANCE } from './better-auth.constants';
+import {
+  BETTER_AUTH_INSTANCE,
+  BETTER_AUTH_USER_CREATED_EVENT,
+} from './better-auth.constants';
 import {
   type BetterAuthInstance,
   createBetterAuthInstance,
 } from './better-auth.factory';
 import { BetterAuthService } from './better-auth.service';
+import { UserProvisioningListener } from './listeners/user-provisioning.listener';
 import { BetterAuthStrategy } from './passport/better-auth.strategy';
 import { BetterAuthIdentityResolverService } from './services/better-auth-identity-resolver.service';
 import { BetterAuthMailerService } from './services/better-auth-mailer.service';
@@ -41,6 +47,7 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
     forwardRef(() => OrganizationsModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => MembersModule),
+    forwardRef(() => UserSetupModule),
     NotificationsModule,
   ],
   providers: [
@@ -48,13 +55,20 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
     BetterAuthIdentityResolverService,
     BetterAuthStrategy,
     BetterAuthService,
+    UserProvisioningListener,
     {
-      inject: [PrismaService, ConfigService, BetterAuthMailerService],
+      inject: [
+        PrismaService,
+        ConfigService,
+        BetterAuthMailerService,
+        EventEmitter2,
+      ],
       provide: BETTER_AUTH_INSTANCE,
       useFactory: (
         prisma: PrismaService,
         config: ConfigService,
         mailer: BetterAuthMailerService,
+        eventEmitter: EventEmitter2,
       ): BetterAuthInstance | null => {
         // Off by default — the instance stays null and the Clerk path is the
         // only one wired. Flip BETTER_AUTH_ENABLED per-environment to light up.
@@ -80,6 +94,11 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
             config.get('GOOGLE_CLIENT_ID'),
             config.get('GOOGLE_CLIENT_SECRET'),
           ),
+          // Awaited so provisioning completes before the create resolves; the
+          // UserProvisioningListener (@OnEvent) runs under Nest DI.
+          onUserCreated: async (event) => {
+            await eventEmitter.emitAsync(BETTER_AUTH_USER_CREATED_EVENT, event);
+          },
           prisma,
           secret,
           sendMagicLink: (params) => mailer.sendMagicLink(params),

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -46,6 +46,12 @@ export interface IBetterAuthMagicLinkParams {
   token: string;
 }
 
+/** Payload emitted after Better Auth creates a new user row. */
+export interface IBetterAuthUserCreatedEvent {
+  userId: string;
+  email: string | null;
+}
+
 /** Options for {@link createBetterAuthInstance}. */
 export interface ICreateBetterAuthOptions {
   prisma: PrismaClient;
@@ -54,4 +60,11 @@ export interface ICreateBetterAuthOptions {
   trustedOrigins: string[];
   google?: IBetterAuthGoogleConfig;
   sendMagicLink: (params: IBetterAuthMagicLinkParams) => Promise<void>;
+  /**
+   * Invoked (and awaited) from the `user.create.after` hook so a newly created
+   * user is provisioned — org / settings / brand / member / credits — before the
+   * create completes. Replaces the Clerk `user.created` webhook (epic #735,
+   * Phase 4).
+   */
+  onUserCreated?: (event: IBetterAuthUserCreatedEvent) => Promise<void>;
 }

--- a/apps/server/api/src/auth/better-auth/listeners/user-provisioning.listener.spec.ts
+++ b/apps/server/api/src/auth/better-auth/listeners/user-provisioning.listener.spec.ts
@@ -1,0 +1,52 @@
+import type { UserSetupService } from '@api/collections/users/services/user-setup.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserProvisioningListener } from './user-provisioning.listener';
+
+describe('UserProvisioningListener', () => {
+  let userSetupService: { initializeUserResources: ReturnType<typeof vi.fn> };
+  let logger: {
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+  };
+  let listener: UserProvisioningListener;
+
+  beforeEach(() => {
+    userSetupService = {
+      initializeUserResources: vi.fn().mockResolvedValue(undefined),
+    };
+    logger = { error: vi.fn(), log: vi.fn() };
+
+    listener = new UserProvisioningListener(
+      userSetupService as unknown as UserSetupService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  it('provisions resources for the newly created user', async () => {
+    await listener.handleUserCreated({
+      email: 'new@genfeed.ai',
+      userId: 'u_1',
+    });
+
+    expect(userSetupService.initializeUserResources).toHaveBeenCalledWith(
+      'u_1',
+    );
+    expect(logger.log).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when provisioning fails — logs for ops instead', async () => {
+    userSetupService.initializeUserResources.mockRejectedValue(
+      new Error('db down'),
+    );
+
+    await expect(
+      listener.handleUserCreated({ email: null, userId: 'u_2' }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/auth/better-auth/listeners/user-provisioning.listener.ts
+++ b/apps/server/api/src/auth/better-auth/listeners/user-provisioning.listener.ts
@@ -1,0 +1,51 @@
+import { UserSetupService } from '@api/collections/users/services/user-setup.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { BETTER_AUTH_USER_CREATED_EVENT } from '../better-auth.constants';
+import type { IBetterAuthUserCreatedEvent } from '../better-auth.types';
+
+/**
+ * Provisions a newly created Better Auth user — organization, settings, brand,
+ * member and credit balance — by reusing the idempotent
+ * {@link UserSetupService.initializeUserResources} chain (the same one the Clerk
+ * `user.created` webhook drove). First-party replacement for that webhook
+ * (epic #735, Phase 4).
+ *
+ * Driven by `BetterAuthModule`'s `onUserCreated` callback via
+ * `eventEmitter.emitAsync`, so the `user.create.after` hook awaits this handler:
+ * a brand-new user is fully set up before their first request, while a returning
+ * (magic-link-preserved) user keeps their existing resources because every step
+ * is get-or-create.
+ */
+@Injectable()
+export class UserProvisioningListener {
+  private readonly context = 'UserProvisioningListener';
+
+  constructor(
+    private readonly userSetupService: UserSetupService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  @OnEvent(BETTER_AUTH_USER_CREATED_EVENT)
+  async handleUserCreated(event: IBetterAuthUserCreatedEvent): Promise<void> {
+    try {
+      await this.userSetupService.initializeUserResources(event.userId);
+      this.logger.log(
+        `Provisioned resources for Better Auth user ${event.userId}`,
+        this.context,
+      );
+    } catch (error: unknown) {
+      // Never fail sign-in on a provisioning hiccup — initializeUserResources is
+      // idempotent, so a later request can complete it. Log loudly for ops.
+      this.logger.error(
+        `Failed to provision Better Auth user ${event.userId}`,
+        {
+          error: (error as Error)?.message,
+          stack: (error as Error)?.stack,
+        },
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**Phase B of the Clerk → Better Auth hard cutover (epic #735).** Replaces the Clerk `user.created` webhook with a first-party provisioning path so a Better-Auth-created user gets the org/brand/member/settings/credits they need — the single biggest gap before Clerk can leave the backend.

> ⚠️ **Stacked on Phase 1 ([#750](https://github.com/genfeedai/genfeed.ai/pull/750))** — base is `feat/735-better-auth-phase1`. Merge #750 first; I'll retarget this to `master` on rebase.

## How

- `better-auth.factory.ts`: the `user.create.after` hook **awaits** an `onUserCreated` callback.
- `better-auth.module.ts`: the callback emits `better-auth.user.created` via `EventEmitter2.emitAsync` (awaited → provisioning completes before the create resolves, so there's no race with the user's first request).
- `UserProvisioningListener` (`@OnEvent`, under Nest DI) reuses the **existing, idempotent** `UserSetupService.initializeUserResources(userId)` — the same chain the Clerk webhook drove (org → settings → user settings → brand → credit balance + signup gift → member).

## Why it's safe for the magic-link-preserve cutover

Every `UserSetupService` step is get-or-create, so:
- **Brand-new user** → fully provisioned before first request.
- **Returning (preserved) user** signing in via magic link → keeps existing org/brand/member (no duplicate resources, no gift-credit re-award).
- **Provisioning failure** → logged for ops, **never blocks sign-in** (idempotent, so a later request can complete it).

## Verification

- ✅ Better Auth unit specs green (4 files, 16 tests — incl. the new `UserProvisioningListener` spec: provisions on create; swallows + logs failures).
- ✅ `tsc --noEmit` on the API: zero errors in the changed code (the lone `baseUrl` TS5101 deprecation is pre-existing tsconfig noise on this branch, resolves on rebase to master).
- Integration check (Vincent / staging): magic-link sign-in as a new email → DB has `Organization` + `Brand` + `Member` + `OrganizationSetting` rows.

Part of epic #735, Phase 4 (the hard cutover). Next: Phase C — redirect the ~12 `updateUserPublicMetadata` write-backs to DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)