### PR TITLE
chore(db): email-dedup precheck for Better Auth users.email unique index

### DIFF
--- a/scripts/migrations/better-auth-email-dedup-precheck.sql
+++ b/scripts/migrations/better-auth-email-dedup-precheck.sql
@@ -1,0 +1,39 @@
+-- Better Auth email-dedup precheck — PRE-RELEASE GATE (epic #735).
+--
+-- Phase 1 (#750) adds a UNIQUE index on `users.email`
+-- (migration `20260622143420_better_auth_phase1_dual_run`). Building that index
+-- FAILS if any two rows share an exact email. Run this against the TARGET
+-- database BEFORE the migration deploys (i.e. before cutting the release that
+-- ships #750's schema). Query (a) MUST return zero rows.
+--
+--   psql "$DATABASE_URL" -f scripts/migrations/better-auth-email-dedup-precheck.sql
+--
+-- Releases are tag-driven, so merging #750 did NOT apply this migration — this
+-- gate is owed before the first prod deploy carrying it.
+
+-- (a) BLOCKER — exact-duplicate emails fail `CREATE UNIQUE INDEX users_email_key`.
+--     Must be empty before deploy. Merge/clean any rows returned here first
+--     (keep the newer/more-complete row, repoint its FKs, soft-delete the rest).
+SELECT email, count(*) AS n
+FROM users
+WHERE email IS NOT NULL
+GROUP BY email
+HAVING count(*) > 1
+ORDER BY n DESC;
+
+-- (b) LOGIN-SAFETY (not a migration blocker) — Better Auth lowercases emails on
+--     magic-link / sign-in, so case-variant duplicates (Foo@x.com vs foo@x.com)
+--     pass the unique index but collide at login. Worth merging too.
+SELECT lower(email) AS email_lc, count(*) AS n
+FROM users
+WHERE email IS NOT NULL
+GROUP BY lower(email)
+HAVING count(*) > 1
+ORDER BY n DESC;
+
+-- (c) LOCKOUT TRIAGE (not a blocker) — NULL-email rows cannot be magic-linked,
+--     so those users have no Better Auth sign-in path post-cutover (they keep
+--     API keys). Triage / set an email before Clerk is removed.
+SELECT count(*) AS null_email_users
+FROM users
+WHERE email IS NULL;


### PR DESCRIPTION
## Why

#750's migration (`20260622143420_better_auth_phase1_dual_run`) adds a **UNIQUE index on `users.email`**. Building that index **fails if any two rows share an exact email** — and merging #750 did *not* apply it (releases are tag-driven), so this gate is owed before the first prod deploy that carries the schema.

This pre-release check kept living only in PR descriptions / session handoffs and slipped through. Committing it next to the migrations so anyone cutting the release trips over it.

## What

`scripts/migrations/better-auth-email-dedup-precheck.sql` — run against the target DB before deploying:

```
psql "$DATABASE_URL" -f scripts/migrations/better-auth-email-dedup-precheck.sql
```

- **(a)** exact-duplicate emails — the migration **blocker**; must return zero rows.
- **(b)** case-insensitive dups — not a blocker, but BA lowercases emails at login so they'd collide; merge too.
- **(c)** NULL-email rows — not a blocker; those users have no magic-link path post-cutover (they keep API keys). Triage.

Read-only; nothing here runs automatically. Part of the Clerk → Better Auth cutover (epic #735).

🤖 Generated with [Claude Code](https://claude.com/claude-code)