### PR TITLE
feat(auth): identity writes to DB, drop Clerk metadata write-backs (Phase C, epic #735)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ apps/desktop/app/release/
 .worktrees/
 .agents/SESSIONS/
 .agents/plans/
+.agents/memory/local/
 .clawpatch/
 .genfeed/
 

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
@@ -91,4 +91,23 @@ describe('BetterAuthIdentityResolverService', () => {
       organization: 'org_3',
     });
   });
+
+  // epic #735, Phase C — active org is DB-authoritative via User.lastUsedOrganizationId
+  // (validated against live membership), so multi-org switching works without Clerk.
+  it('prefers the user lastUsedOrganizationId when the user is a member', async () => {
+    usersService.findOne.mockResolvedValue({
+      id: 'user_4',
+      lastUsedOrganizationId: 'org_pref',
+    });
+    membersService.find.mockResolvedValue([
+      { lastUsedBrandId: 'brand_pref', organizationId: 'org_pref' },
+    ]);
+    organizationsService.findOne.mockResolvedValue({ id: 'org_pref' });
+    brandsService.findOne.mockResolvedValue({ id: 'brand_pref' });
+
+    const identity = await resolver.resolve('user_4');
+
+    expect(identity.organizationId).toBe('org_pref');
+    expect(identity.brandId).toBe('brand_pref');
+  });
 });

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
@@ -58,6 +58,10 @@ export class BetterAuthIdentityResolverService {
     }
 
     const isSuperAdmin = userRecord?.isSuperAdmin === true;
+    const lastUsedOrganizationId = getRecordId(
+      userRecord,
+      'lastUsedOrganizationId',
+    );
 
     const members = await this.membersService.find({
       isActive: true,
@@ -68,6 +72,7 @@ export class BetterAuthIdentityResolverService {
     const organizationId = await this.resolveOrganizationId(
       resolvedUserId,
       members,
+      lastUsedOrganizationId,
     );
     const brandId = organizationId
       ? await this.resolveBrandId(organizationId, members)
@@ -81,10 +86,52 @@ export class BetterAuthIdentityResolverService {
     };
   }
 
-  private async resolveOrganizationId(
+  private async findAccessibleOrganizationId(
+    candidate: string,
     userId: string,
     members: MemberDocument[],
   ): Promise<string | undefined> {
+    const organization = await this.organizationsService.findOne({
+      _id: candidate,
+      isDeleted: false,
+    });
+    const organizationId = getEntityId(
+      organization as Record<string, unknown> | null | undefined,
+    );
+    if (!organizationId) {
+      return undefined;
+    }
+
+    const isMember = members.some(
+      (member) => getMemberOrganizationId(member) === organizationId,
+    );
+    const isOwner =
+      getRecordId(organization as Record<string, unknown>, 'userId') ===
+        userId ||
+      getRecordId(organization as Record<string, unknown>, 'user') === userId;
+
+    return isMember || isOwner ? organizationId : undefined;
+  }
+
+  private async resolveOrganizationId(
+    userId: string,
+    members: MemberDocument[],
+    lastUsedOrganizationId?: string,
+  ): Promise<string | undefined> {
+    // DB-authoritative active org (epic #735, Phase C): prefer the user's
+    // `lastUsedOrganizationId` (validated against live membership/ownership) so
+    // multi-org switching is honoured without any Clerk publicMetadata.
+    if (lastUsedOrganizationId) {
+      const accessibleOrgId = await this.findAccessibleOrganizationId(
+        lastUsedOrganizationId,
+        userId,
+        members,
+      );
+      if (accessibleOrgId) {
+        return accessibleOrgId;
+      }
+    }
+
     const ownerOrg = await this.organizationsService.findOne({
       isDeleted: false,
       user: userId,

--- a/apps/server/api/src/auth/services/auth-identity-resolver.service.spec.ts
+++ b/apps/server/api/src/auth/services/auth-identity-resolver.service.spec.ts
@@ -4,7 +4,6 @@ import { MembersService } from '@api/collections/members/services/members.servic
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { UserSetupService } from '@api/collections/users/services/user-setup.service';
 import { UsersService } from '@api/collections/users/services/users.service';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { UnauthorizedException } from '@nestjs/common';
 
@@ -22,9 +21,6 @@ describe('AuthIdentityResolverService', () => {
   const membersService = {
     find: vi.fn(),
   };
-  const clerkService = {
-    updateUserPublicMetadata: vi.fn(),
-  };
   const userSetupService = {
     initializeUserResources: vi.fn(),
   };
@@ -38,7 +34,6 @@ describe('AuthIdentityResolverService', () => {
     organizationsService as unknown as OrganizationsService,
     brandsService as unknown as BrandsService,
     membersService as unknown as MembersService,
-    clerkService as unknown as ClerkService,
     loggerService as unknown as LoggerService,
     userSetupService as unknown as UserSetupService,
   );
@@ -81,10 +76,9 @@ describe('AuthIdentityResolverService', () => {
       resolvedBy: 'metadata',
       userId: 'user_current',
     });
-    expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
   });
 
-  it('resolves legacy metadata via mongoId fields and repairs Clerk metadata', async () => {
+  it('resolves legacy metadata via mongoId fields', async () => {
     usersService.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
       _id: '507f1f77bcf86cd799439011',
       id: 'user_current',
@@ -107,7 +101,6 @@ describe('AuthIdentityResolverService', () => {
       _id: '507f1f77bcf86cd799439013',
       id: 'brand_current',
     });
-    clerkService.updateUserPublicMetadata.mockResolvedValue(undefined);
 
     const result = await service.resolve({
       id: 'user_clerk_2',
@@ -125,14 +118,6 @@ describe('AuthIdentityResolverService', () => {
       resolvedBy: 'metadata',
       userId: 'user_current',
     });
-    expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-      'user_clerk_2',
-      {
-        brand: 'brand_current',
-        organization: 'org_current',
-        user: 'user_current',
-      },
-    );
   });
 
   it('resolves active Clerk organization metadata via clerkOrganizationId', async () => {
@@ -155,7 +140,6 @@ describe('AuthIdentityResolverService', () => {
     brandsService.findOne.mockResolvedValueOnce({
       _id: 'brand_current',
     });
-    clerkService.updateUserPublicMetadata.mockResolvedValue(undefined);
 
     const result = await service.resolve({
       id: 'user_clerk_4',
@@ -173,14 +157,6 @@ describe('AuthIdentityResolverService', () => {
       resolvedBy: 'metadata',
       userId: 'user_current',
     });
-    expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-      'user_clerk_4',
-      {
-        brand: 'brand_current',
-        organization: 'org_current',
-        user: 'user_current',
-      },
-    );
   });
 
   it('repairs stale organization metadata and seeds missing membership when the user cannot access that organization', async () => {
@@ -207,7 +183,6 @@ describe('AuthIdentityResolverService', () => {
       organizationSettings: {},
       userSettings: {},
     });
-    clerkService.updateUserPublicMetadata.mockResolvedValue(undefined);
 
     const result = await service.resolve({
       id: 'user_clerk_3',
@@ -228,17 +203,9 @@ describe('AuthIdentityResolverService', () => {
     expect(userSetupService.initializeUserResources).toHaveBeenCalledWith(
       'user_current',
     );
-    expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-      'user_clerk_3',
-      {
-        brand: 'brand_owner',
-        organization: 'org_owner',
-        user: 'user_current',
-      },
-    );
   });
 
-  it('repairs fully stale Clerk metadata after resolving the user by current Clerk id', async () => {
+  it('resolves fully stale metadata user by current Clerk id and repairs workspace', async () => {
     usersService.findOne
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
@@ -259,7 +226,6 @@ describe('AuthIdentityResolverService', () => {
       organizationSettings: {},
       userSettings: {},
     });
-    clerkService.updateUserPublicMetadata.mockResolvedValue(undefined);
 
     const result = await service.resolve({
       id: 'user_clerk_current',
@@ -285,14 +251,6 @@ describe('AuthIdentityResolverService', () => {
       resolvedBy: 'lookup',
       userId: 'user_current',
     });
-    expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-      'user_clerk_current',
-      {
-        brand: 'brand_repaired',
-        organization: 'org_repaired',
-        user: 'user_current',
-      },
-    );
   });
 
   it('throws when lookup cannot resolve current user id', async () => {
@@ -322,7 +280,6 @@ describe('AuthIdentityResolverService', () => {
       organizationSettings: {},
       userSettings: {},
     });
-    clerkService.updateUserPublicMetadata.mockResolvedValue(undefined);
 
     const result = await service.resolve({
       emailAddresses: [
@@ -375,5 +332,60 @@ describe('AuthIdentityResolverService', () => {
     // Only the clerkId lookup runs; no email lookup, no write.
     expect(usersService.findOne).toHaveBeenCalledTimes(1);
     expect(usersService.patch).not.toHaveBeenCalled();
+  });
+
+  // epic #735, Phase C — DB-authoritative active org/brand. These lock in that
+  // the DB markers win over the (frozen, post-cutover) Clerk publicMetadata
+  // candidates, so switching keeps working without any Clerk write-back.
+  it('prefers User.lastUsedOrganizationId over the stale publicMetadata organization', async () => {
+    usersService.findOne.mockResolvedValueOnce({
+      _id: 'user_current',
+      lastUsedOrganizationId: 'org_active',
+    });
+    membersService.find.mockResolvedValue([
+      { lastUsedBrandId: 'brand_active', organizationId: 'org_active' },
+    ]);
+    // findAccessibleOrganization('org_active') resolves the owned org
+    organizationsService.findOne.mockResolvedValueOnce({
+      _id: 'org_active',
+      userId: 'user_current',
+    });
+    brandsService.findOne.mockResolvedValueOnce({ _id: 'brand_active' });
+
+    const result = await service.resolve({
+      id: 'user_clerk_active',
+      publicMetadata: {
+        brand: 'brand_stale',
+        organization: 'org_stale',
+        user: 'user_current',
+      },
+    } as never);
+
+    expect(result.organizationId).toBe('org_active');
+    expect(result.brandId).toBe('brand_active');
+    expect(result.userId).toBe('user_current');
+  });
+
+  it('prefers Member.lastUsedBrandId over the stale publicMetadata brand', async () => {
+    usersService.findOne.mockResolvedValueOnce({ _id: 'user_current' });
+    membersService.find.mockResolvedValue([
+      { lastUsedBrandId: 'brand_last_used', organizationId: 'org_current' },
+    ]);
+    organizationsService.findOne.mockResolvedValueOnce({
+      _id: 'org_current',
+      userId: 'user_current',
+    });
+    brandsService.findOne.mockResolvedValueOnce({ _id: 'brand_last_used' });
+
+    const result = await service.resolve({
+      id: 'user_clerk_brand',
+      publicMetadata: {
+        brand: 'brand_stale_candidate',
+        organization: 'org_current',
+        user: 'user_current',
+      },
+    } as never);
+
+    expect(result.brandId).toBe('brand_last_used');
   });
 });

--- a/apps/server/api/src/auth/services/auth-identity-resolver.service.ts
+++ b/apps/server/api/src/auth/services/auth-identity-resolver.service.ts
@@ -6,7 +6,6 @@ import type { OrganizationDocument } from '@api/collections/organizations/schema
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { UserSetupService } from '@api/collections/users/services/user-setup.service';
 import { UsersService } from '@api/collections/users/services/users.service';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { IClerkPublicMetadata } from '@api/shared/interfaces/clerk/clerk.interface';
 import type { User } from '@clerk/backend';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -62,7 +61,6 @@ export class AuthIdentityResolverService {
     private readonly organizationsService: OrganizationsService,
     private readonly brandsService: BrandsService,
     private readonly membersService: MembersService,
-    private readonly clerkService: ClerkService,
     private readonly loggerService: LoggerService,
     private readonly userSetupService: UserSetupService,
   ) {}
@@ -73,6 +71,7 @@ export class AuthIdentityResolverService {
   ): Promise<{
     resolvedBy: 'lookup' | 'metadata' | 'reconciled';
     userId: string;
+    user: Record<string, unknown> | null;
   }> {
     const clerkUserId = clerkUser.id;
     const metadataUserId =
@@ -89,6 +88,7 @@ export class AuthIdentityResolverService {
       if (currentUserId) {
         return {
           resolvedBy: 'metadata',
+          user: currentUser as Record<string, unknown> | null,
           userId: currentUserId,
         };
       }
@@ -101,6 +101,7 @@ export class AuthIdentityResolverService {
     if (currentUserId) {
       return {
         resolvedBy: 'lookup',
+        user: user as Record<string, unknown> | null,
         userId: currentUserId,
       };
     }
@@ -111,8 +112,13 @@ export class AuthIdentityResolverService {
     // not locked out by an identity drift they cannot see or fix themselves.
     const reconciledUserId = await this.reconcileByEmail(clerkUser);
     if (reconciledUserId) {
+      const reconciledUser = await this.usersService.findOne(
+        { _id: reconciledUserId },
+        [],
+      );
       return {
         resolvedBy: 'reconciled',
+        user: reconciledUser as Record<string, unknown> | null,
         userId: reconciledUserId,
       };
     }
@@ -233,6 +239,7 @@ export class AuthIdentityResolverService {
     userId: string,
     members: MemberDocument[],
     clerkOrgId?: string,
+    lastUsedOrganizationId?: string,
   ): Promise<OrganizationDocument | null> {
     if (clerkOrgId) {
       const orgFromClerk = await this.findAccessibleOrganization(
@@ -242,6 +249,22 @@ export class AuthIdentityResolverService {
       );
       if (orgFromClerk) {
         return orgFromClerk;
+      }
+    }
+
+    // DB-authoritative active org (epic #735, Phase C): `User.lastUsedOrganizationId`
+    // replaces the Clerk `publicMetadata.organization` routing candidate so the
+    // user's current org survives the Clerk cutover and multi-org switching works
+    // without writing back to Clerk. Validated against live membership; falls
+    // through when stale (org left/deleted) or unset (pre-cutover users).
+    if (lastUsedOrganizationId) {
+      const orgFromLastUsed = await this.findAccessibleOrganization(
+        lastUsedOrganizationId,
+        userId,
+        members,
+      );
+      if (orgFromLastUsed) {
+        return orgFromLastUsed;
       }
     }
 
@@ -299,31 +322,11 @@ export class AuthIdentityResolverService {
     organizationId: string,
     members: MemberDocument[],
   ): Promise<BrandDocument | null> {
-    const brandCandidate =
-      typeof publicMetadata.brand === 'string' ? publicMetadata.brand : '';
-
-    if (brandCandidate) {
-      const brandFromMetadata =
-        (await this.brandsService.findOne({
-          _id: brandCandidate,
-          isDeleted: false,
-          organization: organizationId,
-        })) ??
-        (await this.brandsService.findOne({
-          isDeleted: false,
-          mongoId: brandCandidate,
-          organization: organizationId,
-        }));
-
-      if (
-        getEntityId(
-          brandFromMetadata as Record<string, unknown> | null | undefined,
-        )
-      ) {
-        return brandFromMetadata;
-      }
-    }
-
+    // DB-authoritative active brand (epic #735, Phase C): `Member.lastUsedBrandId`
+    // is preferred over the Clerk `publicMetadata.brand` routing candidate so a
+    // brand switch (which persists `lastUsedBrandId`) takes effect without a
+    // Clerk write-back. The metadata candidate stays as a transition fallback for
+    // members whose `lastUsedBrandId` is not yet set.
     const memberForOrganization = members.find((member) => {
       const memberOrganizationId =
         getRecordId(asMemberRecord(member), 'organizationId') ||
@@ -353,6 +356,31 @@ export class AuthIdentityResolverService {
         getEntityId(lastUsedBrand as Record<string, unknown> | null | undefined)
       ) {
         return lastUsedBrand;
+      }
+    }
+
+    const brandCandidate =
+      typeof publicMetadata.brand === 'string' ? publicMetadata.brand : '';
+
+    if (brandCandidate) {
+      const brandFromMetadata =
+        (await this.brandsService.findOne({
+          _id: brandCandidate,
+          isDeleted: false,
+          organization: organizationId,
+        })) ??
+        (await this.brandsService.findOne({
+          isDeleted: false,
+          mongoId: brandCandidate,
+          organization: organizationId,
+        }));
+
+      if (
+        getEntityId(
+          brandFromMetadata as Record<string, unknown> | null | undefined,
+        )
+      ) {
+        return brandFromMetadata;
       }
     }
 
@@ -417,6 +445,10 @@ export class AuthIdentityResolverService {
     const publicMetadata =
       user.publicMetadata as unknown as IClerkPublicMetadata;
     const resolvedUser = await this.resolveUserId(user, publicMetadata);
+    const lastUsedOrganizationId = getRecordId(
+      resolvedUser.user,
+      'lastUsedOrganizationId',
+    );
     const members = await this.membersService.find({
       isActive: true,
       isDeleted: false,
@@ -427,6 +459,7 @@ export class AuthIdentityResolverService {
       resolvedUser.userId,
       members,
       options?.clerkOrgId,
+      lastUsedOrganizationId,
     );
     let organizationId =
       getEntityId(organization as Record<string, unknown> | null | undefined) ||
@@ -450,35 +483,9 @@ export class AuthIdentityResolverService {
       brandId = getEntityId(brand as Record<string, unknown>) || undefined;
     }
 
-    const metadataPatch: Partial<IClerkPublicMetadata> = {
-      brand: brandId,
-      organization: organizationId,
-      user: resolvedUser.userId,
-    };
-    const shouldRepairMetadata =
-      metadataPatch.user !== publicMetadata.user ||
-      metadataPatch.organization !== publicMetadata.organization ||
-      metadataPatch.brand !== publicMetadata.brand;
-
-    if (shouldRepairMetadata) {
-      this.clerkService
-        .updateUserPublicMetadata(clerkUserId, metadataPatch)
-        .catch((error: unknown) => {
-          const message =
-            error instanceof Error ? error.message : 'Unknown Clerk error';
-          this.loggerService.warn(
-            `Failed to repair Clerk publicMetadata for ${clerkUserId}: ${message}`,
-            {
-              brandId,
-              clerkUserId,
-              organizationId,
-              service: 'AuthIdentityResolverService',
-              userId: resolvedUser.userId,
-            },
-          );
-        });
-    }
-
+    // Identity is resolved DB-first (User.lastUsedOrganizationId +
+    // Member.lastUsedBrandId), so there is no Clerk publicMetadata write-back
+    // here (epic #735, Phase C — nothing writes identity state back to Clerk).
     return {
       brandId,
       clerkUserId,

--- a/apps/server/api/src/collections/credits/credits.module.ts
+++ b/apps/server/api/src/collections/credits/credits.module.ts
@@ -14,7 +14,6 @@ import { OssCreditsUtilsService } from '@api/common/credits/oss-credits-utils.se
 import { TransactionModule } from '@api/helpers/utils/transaction/transaction.module';
 import { CreditDeductionModule } from '@api/queues/credit-deduction/credit-deduction.module';
 import { ByokModule } from '@api/services/byok/byok.module';
-import { ClerkModule } from '@api/services/integrations/clerk/clerk.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
 import { isEEEnabled } from '@genfeedai/config';
 import { HttpModule } from '@nestjs/axios';
@@ -30,7 +29,6 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   imports: [
     forwardRef(() => ByokModule),
-    forwardRef(() => ClerkModule),
     forwardRef(() => CommonModule),
     forwardRef(() => CreditDeductionModule),
     forwardRef(() => NotificationsPublisherModule),

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
@@ -6,7 +6,6 @@ import { AccessBootstrapCacheService } from '@api/common/services/access-bootstr
 import { BusinessLogicException } from '@api/helpers/exceptions/business/business-logic.exception';
 import type { PrismaTransactionClient } from '@api/helpers/utils/transaction/transaction.util';
 import { TransactionUtil } from '@api/helpers/utils/transaction/transaction.util';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { EventBusService } from '@api/shared/services/event-bus/event-bus.service';
@@ -32,7 +31,6 @@ describe('CreditsUtilsService', () => {
     findOne: vi.fn(),
     patch: vi.fn(),
   };
-  const clerkService = { updateUserPublicMetadata: vi.fn() };
   const websocketService = { emit: vi.fn() };
   const accessBootstrapCacheService = { invalidateForOrganization: vi.fn() };
 
@@ -54,7 +52,6 @@ describe('CreditsUtilsService', () => {
       creditBalanceService as unknown as CreditBalanceService,
       creditTransactionsService as unknown as CreditTransactionsService,
       organizationSettingsService as unknown as OrganizationSettingsService,
-      clerkService as unknown as ClerkService,
       websocketService as unknown as NotificationsPublisherService,
       accessBootstrapCacheService as unknown as AccessBootstrapCacheService,
       withTransactionUtil

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.ts
@@ -5,7 +5,6 @@ import { AccessBootstrapCacheService } from '@api/common/services/access-bootstr
 import { BusinessLogicException } from '@api/helpers/exceptions/business/business-logic.exception';
 import type { PrismaTransactionClient } from '@api/helpers/utils/transaction/transaction.util';
 import { TransactionUtil } from '@api/helpers/utils/transaction/transaction.util';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { EventBusService } from '@api/shared/services/event-bus/event-bus.service';
@@ -37,7 +36,6 @@ export class CreditsUtilsService implements ICreditsUtilsService {
     private readonly creditBalanceService: CreditBalanceService,
     private readonly creditTransactionsService: CreditTransactionsService,
     private readonly organizationSettingsService: OrganizationSettingsService,
-    private readonly clerkService: ClerkService,
     private readonly websocketService: NotificationsPublisherService,
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
     @Optional() private readonly transactionUtil?: TransactionUtil,
@@ -148,17 +146,8 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           )
         : await deductCore();
 
-      // Side effects outside transaction (idempotent, non-critical)
-      const dbUser = await this.prisma.user.findFirst({
-        select: { clerkId: true },
-        where: { id: userId, isDeleted: false },
-      });
-      if (dbUser?.clerkId) {
-        await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-          balance: newBalance,
-        });
-      }
-
+      // Balance is persisted to the credit-balance table above (epic #735,
+      // Phase C — no Clerk publicMetadata write-back).
       const defaultBrand = await this.prisma.brand.findFirst({
         select: { id: true },
         where: { isDeleted: false, organizationId },
@@ -287,23 +276,8 @@ export class CreditsUtilsService implements ICreditsUtilsService {
         await this.markOrganizationAsHavingCredits(organizationId);
       }
 
-      // Side effects outside transaction (idempotent, non-critical)
-      const subscription = await this.prisma.subscription.findFirst({
-        select: { id: true, userId: true },
-        where: { isDeleted: false, organizationId },
-      });
-      if (subscription?.userId) {
-        const dbUser = await this.prisma.user.findFirst({
-          select: { clerkId: true },
-          where: { id: subscription.userId, isDeleted: false },
-        });
-        if (dbUser?.clerkId) {
-          await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-            balance: newBalance,
-          });
-        }
-      }
-
+      // Balance is persisted to the credit-balance table above (epic #735,
+      // Phase C — no Clerk publicMetadata write-back).
       const websocketUrl = `/credits/${organizationId}`;
       await this.websocketService.emit(websocketUrl, {
         balance: newBalance,
@@ -395,23 +369,8 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           )
         : await refundCore();
 
-      // Side effects outside transaction (idempotent, non-critical)
-      const subscription = await this.prisma.subscription.findFirst({
-        select: { id: true, userId: true },
-        where: { isDeleted: false, organizationId },
-      });
-      if (subscription?.userId) {
-        const dbUser = await this.prisma.user.findFirst({
-          select: { clerkId: true },
-          where: { id: subscription.userId, isDeleted: false },
-        });
-        if (dbUser?.clerkId) {
-          await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-            balance: newBalance,
-          });
-        }
-      }
-
+      // Balance is persisted to the credit-balance table above (epic #735,
+      // Phase C — no Clerk publicMetadata write-back).
       const websocketUrl = `/credits/${organizationId}`;
       await this.websocketService.emit(websocketUrl, {
         balance: newBalance,
@@ -604,23 +563,8 @@ export class CreditsUtilsService implements ICreditsUtilsService {
         await this.markOrganizationAsHavingCredits(organizationId);
       }
 
-      // Side effects outside transaction (idempotent, non-critical)
-      const subscription = await this.prisma.subscription.findFirst({
-        select: { id: true, userId: true },
-        where: { isDeleted: false, organizationId },
-      });
-      if (subscription?.userId) {
-        const dbUser = await this.prisma.user.findFirst({
-          select: { clerkId: true },
-          where: { id: subscription.userId, isDeleted: false },
-        });
-        if (dbUser?.clerkId) {
-          await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-            balance: newCreditAmount,
-          });
-        }
-      }
-
+      // Balance is persisted to the credit-balance table above (epic #735,
+      // Phase C — no Clerk publicMetadata write-back).
       const websocketUrl = `/credits/${organizationId}`;
       await this.websocketService.emit(websocketUrl, {
         balance: newCreditAmount,
@@ -701,22 +645,13 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           )
         : await removeAllCore();
 
-      // Side effects outside transaction (idempotent, non-critical)
+      // Balance is persisted to the credit-balance table above (epic #735,
+      // Phase C — no Clerk publicMetadata write-back). The subscription lookup
+      // is retained for the activity event below.
       const subscription = await this.prisma.subscription.findFirst({
         select: { id: true, userId: true },
         where: { isDeleted: false, organizationId },
       });
-      if (subscription?.userId) {
-        const dbUser = await this.prisma.user.findFirst({
-          select: { clerkId: true },
-          where: { id: subscription.userId, isDeleted: false },
-        });
-        if (dbUser?.clerkId) {
-          await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-            balance: 0,
-          });
-        }
-      }
 
       if (subscription?.userId) {
         const defaultBrand = await this.prisma.brand.findFirst({

--- a/apps/server/api/src/collections/members/services/members.service.ts
+++ b/apps/server/api/src/collections/members/services/members.service.ts
@@ -33,10 +33,33 @@ export class MembersService extends BaseService<
 
   async setLastUsedBrand(
     filter: Record<string, unknown>,
-    brandId: string,
+    brandId: string | null,
   ): Promise<void> {
+    // Map legacy relation aliases (`organization`/`user`) to their scalar FKs
+    // before hitting Prisma — `updateMany` validates `where` against the scalar
+    // columns, so a raw `{ organization: id }` throws "Unknown argument".
+    const where = this.processSearchParams(filter) as {
+      organizationId?: unknown;
+      userId?: unknown;
+    };
+
+    // Refuse to run without an org + user scope: Prisma omits `undefined` where
+    // clauses, so a missing scope would silently widen the updateMany to every
+    // member row across all tenants. Skip (no-op) instead.
+    if (!where.organizationId || !where.userId) {
+      this.logger.warn(
+        'setLastUsedBrand skipped: filter missing organizationId/userId scope',
+        {
+          filter,
+          operation: 'setLastUsedBrand',
+          service: this.constructorName,
+        },
+      );
+      return;
+    }
+
     await this.prisma.member.updateMany({
-      where: filter as never,
+      where: where as never,
       data: { lastUsedBrandId: brandId },
     });
   }

--- a/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.ts
@@ -221,9 +221,12 @@ export class OrganizationsMembersController {
           userId: String(existingUser._id),
         } as unknown as Parameters<typeof this.membersService.create>[0]);
 
-        // Update their metadata to include this organization
-        await this.clerkService.updateUserPublicMetadata(existingClerkUser.id, {
-          organization: organizationId,
+        // Switch the invited user's active org to the org they were just added
+        // to, preserving the pre-Phase-C behavior now that routing is
+        // DB-authoritative (epic #735 — User.lastUsedOrganizationId replaces the
+        // Clerk publicMetadata.organization write-back).
+        await this.usersService.patch(String(existingUser._id), {
+          lastUsedOrganizationId: organizationId,
         });
 
         return serializeSingle(request, MemberSerializer, member);

--- a/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
@@ -42,7 +42,6 @@ import {
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
 import { generateLabel } from '@api/shared/utils/label/label.util';
 import { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
@@ -102,7 +101,6 @@ export class OrganizationsController extends BaseCRUDController<
     private readonly usersService: UsersService,
     private readonly rolesService: RolesService,
     private readonly organizationSettingsService: OrganizationSettingsService,
-    private readonly clerkService: ClerkService,
     private readonly requestContextCacheService: RequestContextCacheService,
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
   ) {
@@ -580,11 +578,19 @@ export class OrganizationsController extends BaseCRUDController<
       );
     }
 
-    // Update Clerk publicMetadata
-    await this.clerkService.updateUserPublicMetadata(user.id, {
-      brand: brand._id.toString(),
-      organization: orgId,
-    });
+    // Persist the active org + brand to the DB so both identity resolvers route
+    // to this org on the next request (epic #735, Phase C — no Clerk write-back).
+    await this.usersService.patch(userId, { lastUsedOrganizationId: orgId });
+    if (member) {
+      await this.membersService.setLastUsedBrand(
+        { isActive: true, isDeleted: false, organization: orgId, user: userId },
+        brand._id.toString(),
+      );
+    }
+    await Promise.all([
+      this.requestContextCacheService.invalidateForUser(userId),
+      this.accessBootstrapCacheService.invalidateForUser(userId),
+    ]);
 
     const org = await this.organizationsService.findOne({
       _id: orgId,
@@ -719,11 +725,21 @@ export class OrganizationsController extends BaseCRUDController<
       userId,
     } as unknown as Parameters<typeof this.membersService.create>[0]);
 
-    // Step 5: Update Clerk publicMetadata to switch to new org
-    await this.clerkService.updateUserPublicMetadata(user.id, {
-      brand: brand._id.toString(),
-      organization: org._id.toString(),
+    // Step 5: Switch the user to the new org via DB pointers (epic #735, Phase C
+    // — no Clerk write-back). Both identity resolvers pick up
+    // lastUsedOrganizationId + the member's lastUsedBrandId on the next request.
+    await this.usersService.patch(userId, {
+      lastUsedOrganizationId: org._id.toString(),
     });
+    await this.membersService.setLastUsedBrand(
+      {
+        isActive: true,
+        isDeleted: false,
+        organization: org._id.toString(),
+        user: userId,
+      },
+      brand._id.toString(),
+    );
 
     await Promise.all([
       this.requestContextCacheService.invalidateForUser(userId),

--- a/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
@@ -7,7 +7,6 @@ import { UsersService } from '@api/collections/users/services/users.service';
 import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
 import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import type { ISubscriptionsService } from '@genfeedai/interfaces/billing';
 import { LoggerService } from '@libs/logger/logger.service';
 
@@ -18,7 +17,6 @@ describe('UsersController', () => {
   let brandsService: Record<string, ReturnType<typeof vi.fn>>;
   let organizationsService: Record<string, ReturnType<typeof vi.fn>>;
   let subscriptionsService: Record<string, ReturnType<typeof vi.fn>>;
-  let clerkService: Record<string, ReturnType<typeof vi.fn>>;
   let membersService: Record<string, ReturnType<typeof vi.fn>>;
   let filesClientService: Record<string, ReturnType<typeof vi.fn>>;
   let requestContextCacheService: Record<string, ReturnType<typeof vi.fn>>;
@@ -67,9 +65,6 @@ describe('UsersController', () => {
       patch: vi.fn(),
     };
     subscriptionsService = { findOne: vi.fn() };
-    clerkService = {
-      updateUserPublicMetadata: vi.fn().mockResolvedValue({}),
-    };
     membersService = {
       findOne: vi.fn(),
       setLastUsedBrand: vi.fn().mockResolvedValue({}),
@@ -94,7 +89,6 @@ describe('UsersController', () => {
       subscriptionsService as unknown as ISubscriptionsService,
       organizationsService as unknown as OrganizationsService,
       settingsService as unknown as SettingsService,
-      clerkService as unknown as ClerkService,
       filesClientService as unknown as FilesClientService,
       mockLogger as unknown as LoggerService,
       membersService as unknown as MembersService,
@@ -381,7 +375,7 @@ describe('UsersController', () => {
   });
 
   describe('updateBrandSelection', () => {
-    it('should select brand and update clerk metadata', async () => {
+    it('should select brand and persist last-used brand on member', async () => {
       const selectedBrandId = '507f191e810c19729de860ee';
       brandsService.selectBrandForUser.mockResolvedValue({
         _id: selectedBrandId,
@@ -394,26 +388,35 @@ describe('UsersController', () => {
         selectedBrandId.toString(),
       );
 
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'clerk_user_123',
-        { brand: selectedBrandId },
+      expect(membersService.setLastUsedBrand).toHaveBeenCalledWith(
+        {
+          isActive: true,
+          isDeleted: false,
+          organization: orgId,
+          user: userId,
+        },
+        selectedBrandId,
       );
-      expect(membersService.setLastUsedBrand).toHaveBeenCalled();
       expect(result).toBeDefined();
     });
   });
 
   describe('clearBrandSelection', () => {
-    it('should clear brand selection and remove brand metadata', async () => {
+    it('should clear brand selection and clear last-used brand on member', async () => {
       await controller.clearBrandSelection(mockUser);
 
       expect(brandsService.clearBrandSelectionForUser).toHaveBeenCalledWith(
         userId,
         orgId,
       );
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'clerk_user_123',
-        { brand: undefined },
+      expect(membersService.setLastUsedBrand).toHaveBeenCalledWith(
+        {
+          isActive: true,
+          isDeleted: false,
+          organization: orgId,
+          user: userId,
+        },
+        null,
       );
       expect(requestContextCacheService.invalidateForUser).toHaveBeenCalledWith(
         'clerk_user_123',

--- a/apps/server/api/src/collections/users/controllers/users.controller.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.ts
@@ -31,7 +31,6 @@ import {
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import type { User } from '@clerk/backend';
 import { SubscriptionStatus, SubscriptionTier } from '@genfeedai/enums';
 import {
@@ -76,7 +75,6 @@ export class UsersController {
     private readonly subscriptionsService: ISubscriptionsService,
     private readonly organizationsService: OrganizationsService,
     private readonly settingsService: SettingsService,
-    private readonly clerkService: ClerkService,
     private readonly filesClientService: FilesClientService,
     private readonly loggerService: LoggerService,
     private readonly membersService: MembersService,
@@ -406,12 +404,12 @@ export class UsersController {
       isSelected: true,
     });
 
-    // Update Clerk public metadata to reflect the selected brand
-    await this.clerkService.updateUserPublicMetadata(user.id, {
-      organization: data._id,
-    });
-
+    // Persist the active org to the DB so both identity resolvers route to it on
+    // the next request (epic #735, Phase C — no Clerk write-back).
     if (publicMetadata.user) {
+      await this.usersService.patch(publicMetadata.user, {
+        lastUsedOrganizationId: String(data._id),
+      });
       await Promise.all([
         this.requestContextCacheService.invalidateForUser(publicMetadata.user),
         this.accessBootstrapCacheService.invalidateForUser(publicMetadata.user),
@@ -438,11 +436,8 @@ export class UsersController {
       publicMetadata.organization,
     );
 
-    // Update Clerk public metadata to reflect the selected brand
-    await this.clerkService.updateUserPublicMetadata(user.id, {
-      brand: data._id,
-    });
-
+    // Active brand is persisted to the member's lastUsedBrandId below, which the
+    // identity resolvers read (epic #735, Phase C — no Clerk write-back).
     if (publicMetadata.user) {
       await Promise.all([
         this.requestContextCacheService.invalidateForUser(publicMetadata.user),
@@ -475,9 +470,17 @@ export class UsersController {
       publicMetadata.organization,
     );
 
-    await this.clerkService.updateUserPublicMetadata(user.id, {
-      brand: undefined,
-    });
+    // Clear the member's lastUsedBrandId so the identity resolvers fall back to
+    // the org default instead of a stale brand (epic #735, Phase C — no Clerk).
+    await this.membersService.setLastUsedBrand(
+      {
+        isActive: true,
+        isDeleted: false,
+        organization: publicMetadata.organization,
+        user: publicMetadata.user,
+      },
+      null,
+    );
 
     await Promise.all([
       this.requestContextCacheService.invalidateForUser(user.id),

--- a/apps/server/api/src/collections/users/dto/update-user.dto.ts
+++ b/apps/server/api/src/collections/users/dto/update-user.dto.ts
@@ -61,4 +61,13 @@ export class UpdateUserDto extends PartialType(CreateUserDto) {
     type: [String],
   })
   readonly onboardingStepsCompleted?: string[];
+
+  // The user's active organization id (DB-authoritative routing, epic #735
+  // Phase C). Deliberately UNDECORATED so the ValidationPipe's whitelist strips
+  // it from client `PATCH /me` input — it must not be settable from arbitrary
+  // user JSON (no membership check there). It is written only by the
+  // membership-validated org switch/select/create/onboarding endpoints via
+  // `usersService.patch`; the resolvers re-validate it against live membership.
+  // Kept on the DTO type so those internal calls remain type-safe.
+  readonly lastUsedOrganizationId?: string | null;
 }

--- a/apps/server/api/src/collections/users/entities/user.entity.ts
+++ b/apps/server/api/src/collections/users/entities/user.entity.ts
@@ -20,6 +20,8 @@ export class UserEntity extends BaseEntity implements User {
 
   declare readonly appSource: User['appSource'];
   declare readonly stripeCustomerId: string | null;
+  // Active-organization pointer (epic #735, Phase C) — DB-authoritative routing.
+  declare readonly lastUsedOrganizationId: string | null;
   declare readonly isOnboardingCompleted: boolean;
   declare readonly onboardingStartedAt: Date | null;
   declare readonly onboardingCompletedAt: Date | null;

--- a/apps/server/api/src/endpoints/onboarding/onboarding.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/onboarding.service.ts
@@ -8,6 +8,7 @@ import type {
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { LinksService } from '@api/collections/links/services/links.service';
+import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { UserSetupService } from '@api/collections/users/services/user-setup.service';
@@ -25,7 +26,6 @@ import { ProactiveOnboardingService } from '@api/endpoints/onboarding/proactive-
 import { getPublicMetadata } from '@api/helpers/utils/clerk/clerk.util';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
 import { MasterPromptGeneratorService } from '@api/services/knowledge-base/master-prompt-generator.service';
 import type { User } from '@clerk/backend';
@@ -133,9 +133,9 @@ export class OnboardingService {
     private readonly creditsUtilsService: CreditsUtilsService,
     private readonly filesClientService: FilesClientService,
     private readonly linksService: LinksService,
+    private readonly membersService: MembersService,
     private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly organizationsService: OrganizationsService,
-    private readonly clerkService: ClerkService,
     private readonly usersService: UsersService,
     private readonly proactiveOnboardingService: ProactiveOnboardingService,
     private readonly requestContextCacheService: RequestContextCacheService,
@@ -190,6 +190,28 @@ export class OnboardingService {
     let organizationId = publicMetadata.organization?.toString() ?? '';
     let brandId: string | null = publicMetadata.brand?.toString() ?? null;
 
+    // Resolve the active org DB-first before provisioning (epic #735, Phase C):
+    // post-Clerk, publicMetadata.organization is no longer written, so fall back
+    // to User.lastUsedOrganizationId and then the user's owned org. Without this,
+    // every onboarding step would re-run initializeUserResources for a user who
+    // already has a workspace.
+    if (!organizationId) {
+      const lastUsedOrganizationId =
+        (
+          dbUser as { lastUsedOrganizationId?: string | null } | null
+        )?.lastUsedOrganizationId?.toString() ?? '';
+
+      if (lastUsedOrganizationId) {
+        organizationId = lastUsedOrganizationId;
+      } else {
+        const ownedOrg = await this.organizationsService.findOne({
+          isDeleted: false,
+          user: userId,
+        });
+        organizationId = this.getEntityId(ownedOrg);
+      }
+    }
+
     if (!organizationId) {
       const setupResult = await this.userSetupService.initializeUserResources(
         userId,
@@ -201,17 +223,21 @@ export class OnboardingService {
     }
 
     try {
-      await this.clerkService.updateUserPublicMetadata(user.id, {
-        brand: brandId || undefined,
-        organization: organizationId,
-        user: userId,
+      // Persist the active org to the DB so both identity resolvers route to it
+      // (epic #735, Phase C — no Clerk write-back). Brand resolves from the
+      // member's lastUsedBrandId / org default.
+      await this.usersService.patch(userId, {
+        lastUsedOrganizationId: organizationId,
       });
     } catch (error: unknown) {
-      this.loggerService.warn('Failed to repair Clerk onboarding metadata', {
-        error: error instanceof Error ? error.message : error,
-        organizationId,
-        userId,
-      });
+      this.loggerService.warn(
+        'Failed to set active organization during onboarding',
+        {
+          error: error instanceof Error ? error.message : error,
+          organizationId,
+          userId,
+        },
+      );
     }
 
     return { brandId, organizationId, userId };
@@ -424,7 +450,6 @@ export class OnboardingService {
     brand: { _id: string; label?: string | null },
     organizationId: string,
     userId: string,
-    clerkUserId: string,
     label?: string,
   ) {
     const normalizedLabel = label?.trim();
@@ -451,9 +476,17 @@ export class OnboardingService {
       String(userId),
       String(organizationId),
     );
-    await this.clerkService.updateUserPublicMetadata(clerkUserId, {
-      brand: String(matchingBrand._id),
-    });
+    // Persist the selected brand on the member so the identity resolvers route
+    // to it (epic #735, Phase C — no Clerk write-back).
+    await this.membersService.setLastUsedBrand(
+      {
+        isActive: true,
+        isDeleted: false,
+        organization: String(organizationId),
+        user: String(userId),
+      },
+      String(matchingBrand._id),
+    );
 
     return matchingBrand;
   }
@@ -639,7 +672,6 @@ export class OnboardingService {
         existingBrand,
         organizationId,
         userId,
-        user.id,
         resolvedLabel,
       );
 
@@ -999,12 +1031,6 @@ export class OnboardingService {
         category,
       });
 
-      await this.clerkService.updateUserPublicMetadata(user.id, {
-        // @ts-expect-error accountType is valid
-        accountType: category,
-        category,
-      });
-
       this.loggerService.log(`${caller} completed`, { category });
 
       return {
@@ -1047,11 +1073,8 @@ export class OnboardingService {
         );
       }
 
-      await this.clerkService.updateUserPublicMetadata(user.id, {
-        isOnboardingCompleted: true,
-      });
-
-      // Also update MongoDB so OnboardingGuard is satisfied
+      // Update the DB so OnboardingGuard is satisfied (epic #735, Phase C —
+      // isOnboardingCompleted is read from the User row, not Clerk metadata).
       const dbUser = await this.usersService.findOne({ clerkId: user.id });
       if (dbUser && !dbUser.isOnboardingCompleted) {
         await this.usersService.patch(dbUser._id, {

--- a/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.spec.ts
@@ -241,22 +241,23 @@ describe('ClerkWebhookService', () => {
         user: '507f1f77bcf86cd799439099',
       });
       (membersService.patch as vi.Mock).mockResolvedValue({});
-      (clerkService.updateUserPublicMetadata as vi.Mock).mockResolvedValue({});
 
       await service.handleWebhookEvent(event, url);
 
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'user_123456',
-        expect.objectContaining({
-          isOnboardingCompleted: false,
-          proactiveLeadId: 'lead_123',
-        }),
-      );
+      // Phase C: identity state is DB-authoritative — no Clerk write-back.
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
+      // Proactive onboarding users are NOT immediately marked as onboarding
+      // completed — that only happens for plain B2B signups (no isInvited).
       expect(usersService.patch).not.toHaveBeenCalledWith(
         mockUser._id,
         expect.objectContaining({
           isOnboardingCompleted: true,
         }),
+      );
+      // Shadow org ownership is transferred to the real user in the DB.
+      expect(organizationsService.patch).toHaveBeenCalledWith(
+        mockOrganization._id.toString(),
+        expect.objectContaining({ user: mockUser._id }),
       );
     });
 
@@ -320,7 +321,7 @@ describe('ClerkWebhookService', () => {
       });
     });
 
-    it('should update Clerk metadata with brand and organization for existing user', async () => {
+    it('should resolve brand and organization from DB for existing user (no Clerk write-back)', async () => {
       const event = asWebhookEvent({
         data: { id: 'user_123456' },
         type: 'user.updated',
@@ -334,21 +335,29 @@ describe('ClerkWebhookService', () => {
         mockOrganization,
       );
       (brandsService.findOne as vi.Mock).mockResolvedValue(mockBrand);
-      (clerkService.updateUserPublicMetadata as vi.Mock).mockResolvedValue({});
 
       await service.handleWebhookEvent(event, url);
 
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'user_123456',
+      // Phase C: identity state is DB-authoritative — no Clerk write-back.
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
+      // DB user projection is updated with latest profile data from Clerk.
+      expect(usersService.patch).toHaveBeenCalledWith(
+        mockUser._id,
         expect.objectContaining({
-          brand: mockBrand._id,
-          organization: expect.anything(),
-          user: mockUser._id,
+          email: mockClerkUser.emailAddresses[0].emailAddress,
+        }),
+      );
+      // Org and brand are resolved from the DB and logged.
+      expect(loggerService.log).toHaveBeenCalledWith(
+        expect.stringContaining('processed successfully'),
+        expect.objectContaining({
+          brandId: mockBrand._id,
+          organizationId: mockOrganization._id,
         }),
       );
     });
 
-    it('should update Clerk metadata with undefined brand and org when neither found', async () => {
+    it('should not write to Clerk when no org or brand found for existing user', async () => {
       const event = asWebhookEvent({
         data: { id: 'user_123456' },
         type: 'user.updated',
@@ -360,16 +369,17 @@ describe('ClerkWebhookService', () => {
       (usersService.patch as vi.Mock).mockResolvedValue(mockUser);
       (organizationsService.findOne as vi.Mock).mockResolvedValue(null);
       (brandsService.findOne as vi.Mock).mockResolvedValue(null);
-      (clerkService.updateUserPublicMetadata as vi.Mock).mockResolvedValue({});
 
       await service.handleWebhookEvent(event, url);
 
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'user_123456',
+      // Phase C: identity state is DB-authoritative — no Clerk write-back
+      // even when org/brand are absent.
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
+      // DB user projection still gets profile update.
+      expect(usersService.patch).toHaveBeenCalledWith(
+        mockUser._id,
         expect.objectContaining({
-          brand: undefined,
-          organization: undefined,
-          user: mockUser._id,
+          email: mockClerkUser.emailAddresses[0].emailAddress,
         }),
       );
     });
@@ -783,8 +793,9 @@ describe('ClerkWebhookService', () => {
 
       await service.handleWebhookEvent(event, url);
 
+      // Phase C: DB user projection is updated; no Clerk write-back.
       expect(usersService.patch).toHaveBeenCalled();
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalled();
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
     });
 
     it('should handle very long metadata values', async () => {
@@ -812,16 +823,18 @@ describe('ClerkWebhookService', () => {
         mockOrganization,
       );
       (brandsService.findOne as vi.Mock).mockResolvedValue(mockBrand);
-      (clerkService.updateUserPublicMetadata as vi.Mock).mockResolvedValue({});
 
       await service.handleWebhookEvent(event, url);
 
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'user_123456',
+      // Phase C: DB update still fires cleanly with exotic metadata values;
+      // no Clerk write-back regardless of metadata size.
+      expect(usersService.patch).toHaveBeenCalledWith(
+        mockUser._id,
         expect.objectContaining({
-          user: mockUser._id,
+          email: mockClerkUser.emailAddresses[0].emailAddress,
         }),
       );
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
     });
 
     it('should handle special characters in metadata', async () => {
@@ -850,16 +863,18 @@ describe('ClerkWebhookService', () => {
         mockOrganization,
       );
       (brandsService.findOne as vi.Mock).mockResolvedValue(mockBrand);
-      (clerkService.updateUserPublicMetadata as vi.Mock).mockResolvedValue({});
 
       await service.handleWebhookEvent(event, url);
 
-      expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-        'user_123456',
+      // Phase C: DB update still fires cleanly with special-char metadata;
+      // no Clerk write-back regardless of metadata content.
+      expect(usersService.patch).toHaveBeenCalledWith(
+        mockUser._id,
         expect.objectContaining({
-          user: mockUser._id,
+          email: mockClerkUser.emailAddresses[0].emailAddress,
         }),
       );
+      expect(clerkService.updateUserPublicMetadata).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/clerk/webhooks.clerk.service.ts
@@ -824,65 +824,10 @@ export class ClerkWebhookService {
       }
     }
 
-    // Prepare metadata update - only set isSuperAdmin: false for new users
-    const orgForMetadata = organizationId
-      ? await this.organizationsService.findOne({
-          _id: organizationId,
-        })
-      : null;
-
-    const metadataUpdate: Record<string, unknown> = {
-      brand: brandId,
-      category: orgForMetadata?.category || OrganizationCategory.BUSINESS,
-      isOnboardingCompleted: !isProactiveOnboarding,
-      organization: organizationId,
-      user: user._id,
-    };
-
-    if (isProactiveOnboarding && invitationMetadata?.leadId) {
-      metadataUpdate.proactiveLeadId = invitationMetadata.leadId;
-    }
-
-    // Only set isSuperAdmin to false if it's not already set (new users)
-    const currentMetadata = publicMetadata || {};
-    if (currentMetadata.isSuperAdmin === undefined) {
-      metadataUpdate.isSuperAdmin = false;
-    }
-
-    // For consumer users, add appSource to metadata
-    if (isConsumerSignup) {
-      metadataUpdate.appSource = AppSource.GETSHAREABLE;
-    }
-
-    // Update Clerk metadata with the user's organization
-    // For user.created events, the user might not be fully available in Clerk API yet
-    // So we handle this gracefully
-    try {
-      await this.clerkService.updateUserPublicMetadata(
-        clerkUserId,
-        metadataUpdate,
-      );
-      this.loggerService.log(
-        `Updated Clerk metadata for user ${clerkUserId}`,
-        metadataUpdate,
-      );
-    } catch (error: unknown) {
-      // For user.created events, this is expected - user might not be available yet
-      if (type === 'user.created') {
-        this.loggerService.warn(
-          `Failed to update Clerk metadata for newly created user ${clerkUserId} (user may not be fully available in Clerk API yet)`,
-          { error: (error as Error)?.message, metadataUpdate },
-        );
-        // Don't throw - this is not critical for user.created events
-      } else {
-        // For other events, log as error but don't fail the webhook
-        this.loggerService.error(
-          `Failed to update Clerk metadata for user ${clerkUserId}`,
-          error,
-          { metadataUpdate },
-        );
-      }
-    }
+    // Identity state (onboarding, org/brand routing, isSuperAdmin, appSource) is
+    // persisted to the DB by the provisioning logic above and resolved from the
+    // DB on each request (epic #735, Phase C — no Clerk publicMetadata
+    // write-back). This inbound Clerk webhook itself is removed in Phase H.
 
     // Send Discord notification for new user signups
     if (type === 'user.created') {

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
@@ -503,10 +503,12 @@ export class StripeWebhookService {
           sessionId: session.id,
         });
 
-        // Mark onboarding complete for BYOK users
-        await this.markOnboardingCompleteFromSession(session, url, {
-          subscriptionTier: SubscriptionTier.BYOK,
-        });
+        // Mark onboarding complete for BYOK users (tier persisted to org settings)
+        await this.markOnboardingCompleteFromSession(
+          session,
+          url,
+          SubscriptionTier.BYOK,
+        );
       } else if (session.mode === 'payment') {
         // One-time payment (pay-as-you-go credits)
         const subscription =
@@ -545,12 +547,9 @@ export class StripeWebhookService {
           _id: subscription.user,
         });
 
-        if (dbUser?.clerkId) {
-          await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-            balance: newBalance,
-            isOnboardingCompleted: true,
-          });
-        }
+        // Balance (credit-balance table) and isOnboardingCompleted (User row)
+        // are persisted to the DB below (epic #735, Phase C — no Clerk
+        // publicMetadata write-back).
         if (dbUser?._id) {
           await this.accessBootstrapCacheService.invalidateForUser(
             dbUser._id.toString(),
@@ -804,11 +803,6 @@ export class StripeWebhookService {
       new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
     );
 
-    const balance =
-      await this.creditsUtilsService.getOrganizationCreditsBalance(
-        String(organization._id),
-      );
-
     const existingApiKey = await this.apiKeysService.findOne(
       {
         category: ApiKeyCategory.GENFEEDAI,
@@ -874,18 +868,9 @@ export class StripeWebhookService {
       });
     }
 
-    await this.clerkService.updateUserPublicMetadata(clerkUser.id, {
-      balance,
-      brand: String(brand._id),
-      clerkId: clerkUser.id,
-      hasEverHadCredits: true,
-      isOnboardingCompleted: true,
-      organization: String(organization._id),
-      stripeCustomerId:
-        typeof session.customer === 'string' ? session.customer : undefined,
-      user: String(dbUser._id),
-    });
-
+    // User row (onboarding + stripeCustomerId), org settings (hasEverHadCredits),
+    // and credit balance are all persisted to the DB above; both identity
+    // resolvers route from the DB (epic #735, Phase C — no Clerk write-back).
     await this.accessBootstrapCacheService.invalidateForUser(
       String(dbUser._id),
     );
@@ -1035,13 +1020,8 @@ export class StripeWebhookService {
       session,
     );
 
-    // Update Clerk metadata with new balance
-    if (dbUser.clerkId) {
-      await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-        balance: newBalance,
-      });
-    }
-
+    // Balance is persisted to the credit-balance table above (epic #735,
+    // Phase C — no Clerk publicMetadata write-back).
     await this.activitiesService.create({
       brand: organizationId,
       key: ActivityKey.CREDITS_ADD,
@@ -1282,7 +1262,7 @@ export class StripeWebhookService {
   private async markOnboardingCompleteFromSession(
     session: StripeCheckoutSession,
     url: string,
-    extraClerkMetadata?: Record<string, unknown>,
+    subscriptionTier?: SubscriptionTier,
   ): Promise<void> {
     // Try finding user via subscription
     const subscription = await this.subscriptionsService.findByStripeCustomerId(
@@ -1312,11 +1292,34 @@ export class StripeWebhookService {
       return;
     }
 
-    if (dbUser.clerkId) {
-      await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-        isOnboardingCompleted: true,
-        ...extraClerkMetadata,
-      });
+    // Persist the subscription tier to the org settings (epic #735, Phase C —
+    // OrganizationSetting.subscriptionTier replaces the Clerk metadata write;
+    // updateOrganizationTierAndModels is the canonical tier writer).
+    if (subscriptionTier) {
+      const organizationId = subscription?.organization
+        ? String(subscription.organization)
+        : String(
+            (
+              await this.organizationsService.findOne({
+                isDeleted: false,
+                user: String(dbUser._id),
+              })
+            )?._id ?? '',
+          );
+      if (organizationId) {
+        await this.updateOrganizationTierAndModels(
+          organizationId,
+          subscriptionTier,
+          url,
+        );
+      } else {
+        // The tier is now DB-canonical (no Clerk fallback), so surface a failure
+        // to resolve the org rather than silently dropping the tier write.
+        this.loggerService.warn(
+          `${url} could not resolve organization to persist subscription tier`,
+          { sessionId: session.id, subscriptionTier, userId: dbUser._id },
+        );
+      }
     }
     await this.accessBootstrapCacheService.invalidateForUser(
       String(dbUser._id),
@@ -1636,22 +1639,8 @@ export class StripeWebhookService {
             );
           }
 
-          // Sync to Clerk metadata so frontend can read without API call
-          try {
-            const dbUser = await this.usersService.findOne({
-              _id: subscription.user,
-            });
-            if (dbUser?.clerkId) {
-              await this.clerkService.updateUserPublicMetadata(dbUser.clerkId, {
-                hasEverHadCredits: true,
-              });
-            }
-          } catch (error: unknown) {
-            this.loggerService.warn(
-              `${url} failed to sync hasEverHadCredits to Clerk`,
-              { error: (error as Error)?.message },
-            );
-          }
+          // hasEverHadCredits is persisted to OrganizationSetting above and read
+          // from the DB on bootstrap (epic #735, Phase C — no Clerk write-back).
         }
 
         // Mark onboarding as completed server-side on first subscription payment
@@ -1668,12 +1657,8 @@ export class StripeWebhookService {
                 onboardingStepsCompleted: ['brand', 'plan'],
               });
 
-              if (dbUser.clerkId) {
-                await this.clerkService.updateUserPublicMetadata(
-                  dbUser.clerkId,
-                  { isOnboardingCompleted: true },
-                );
-              }
+              // isOnboardingCompleted is persisted on the User row above (epic
+              // #735, Phase C — no Clerk publicMetadata write-back).
               await this.accessBootstrapCacheService.invalidateForUser(
                 String(dbUser._id),
               );

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -1491,9 +1491,8 @@ describe('AgentToolExecutorService', () => {
 
     expect(result.success).toBe(true);
     expect(organizationsService.patch).toHaveBeenCalled();
-    expect(usersService.patch).toHaveBeenCalled();
-    expect(clerkService.updateUserPublicMetadata).toHaveBeenCalledWith(
-      'user_clerk_123',
+    expect(usersService.patch).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         isOnboardingCompleted: true,
       }),

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -1857,11 +1857,8 @@ export class AgentToolExecutorService {
         }
       }
 
-      if (this.clerkService) {
-        await this.clerkService.updateUserPublicMetadata(ctx.userId, {
-          isOnboardingCompleted: true,
-        });
-      }
+      // isOnboardingCompleted is persisted on the User row above (epic #735,
+      // Phase C — no Clerk publicMetadata write-back).
     }
 
     return {
@@ -1901,11 +1898,8 @@ export class AgentToolExecutorService {
       }
     }
 
-    if (this.clerkService) {
-      await this.clerkService.updateUserPublicMetadata(ctx.userId, {
-        isOnboardingCompleted: true,
-      });
-    }
+    // isOnboardingCompleted is persisted on the User row above (epic #735,
+    // Phase C — no Clerk publicMetadata write-back).
 
     return {
       creditsUsed: 0,

--- a/packages/prisma/prisma/migrations/20260623120000_add_user_last_used_organization/migration.sql
+++ b/packages/prisma/prisma/migrations/20260623120000_add_user_last_used_organization/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- Active-organization pointer (epic #735, Phase C). Replaces the Clerk
+-- publicMetadata.organization routing candidate so the user's current org is
+-- DB-authoritative across the Clerk -> Better Auth cutover. Nullable/no FK:
+-- applies cleanly over existing rows and never blocks leaving/deleting an org.
+ALTER TABLE "users" ADD COLUMN     "lastUsedOrganizationId" TEXT;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -511,6 +511,13 @@ model User {
   onboardingStepsCompleted String[]        @default([])
   appSource                AppSource       @default(GENFEED)
   stripeCustomerId         String?
+  // Active-organization pointer (epic #735, Phase C). Replaces the Clerk
+  // `publicMetadata.organization` routing candidate so the user's current org
+  // survives the Clerk cutover and multi-org switching is DB-authoritative for
+  // both the Clerk and Better Auth identity resolvers. Plain id (validated
+  // against live membership at resolve time); no FK so leaving/deleting an org
+  // never blocks. Brand stays per-membership via `Member.lastUsedBrandId`.
+  lastUsedOrganizationId   String?
   createdAt                DateTime        @default(now())
   updatedAt                DateTime        @updatedAt
 


### PR DESCRIPTION
## Phase C — Clerk → Better Auth (epic #735)

Removes **every** `clerkService.updateUserPublicMetadata()` write-back from `apps/server/api` (grep gate: **0 production hits**) and makes active org/brand routing **DB-authoritative**, so nothing writes identity state back to Clerk and org/brand switching keeps working **while Clerk is still the default auth**.

This unblocks the frontend Clerk removal (Phase G): the backend now serves Better Auth identity for every `publicMetadata` field from the DB.

### What changed

**STATE write-backs removed** — the DB is already canonical and read DB-first by `RequestContextMiddleware` + `auth-bootstrap`:
- `balance` → `CreditBalance` (credits.utils ×5, stripe ×2)
- `isOnboardingCompleted` → `User` (stripe, onboarding, agent-tool-executor)
- `hasEverHadCredits` / `subscriptionTier` → `OrganizationSetting` (stripe; BYOK tier now routed via `updateOrganizationTierAndModels`)
- `accountType` / `category` → `Organization` (onboarding)

**Routing made DB-authoritative** (the riskier half — resolvers previously preferred the stale `publicMetadata` candidate, so removing the write-backs alone would have broken switching):
- New column **`User.lastUsedOrganizationId`** (nullable, no FK) + additive migration — the active-org marker.
- **`Member.lastUsedBrandId`** is now the preferred active-brand signal.
- Both `AuthIdentityResolverService` (Clerk, still default) and `BetterAuthIdentityResolverService` now prefer these DB markers, **validated against live membership/ownership**, over the `publicMetadata` candidates (kept only as a transition fallback). This also fixes BA multi-org switching, which had no active-org concept.
- Switch/select/create/onboarding/invite endpoints persist the DB markers instead of writing to Clerk.

**Fixes surfaced during review:**
- Latent bug: `MembersService.setLastUsedBrand` passed relation aliases (`organization`/`user`) straight to Prisma `updateMany` → now maps via `processSearchParams` **and refuses an unscoped update** (defense-in-depth against cross-tenant writes).
- `lastUsedOrganizationId` is **undecorated** on `UpdateUserDto` so the `ValidationPipe` whitelist strips it from `PATCH /me` input (it's written only by membership-validated endpoints; resolvers re-validate). Verified empirically that whitelist strips it.
- Dropped now-unused `ClerkService` injections + orphaned `ClerkModule` import.

### Out of scope (later phases, per plan)
The Clerk inbound webhook, managed-inference provisioning, and invitation flows keep their non-write-back logic for Phase D/H; only the metadata write-backs were removed here. **Tracked Phase-H gap:** `isSuperAdmin` is still read from Clerk `publicMetadata` (no regression — absence reads as `false`); wire `User.isSuperAdmin` into the read path before cutover.

### Verification
- Grep gate: `updateUserPublicMetadata` → **0** production call sites
- `tsc --noEmit` (changed source): clean
- Biome: clean
- **158** api unit tests pass (11 specs realigned to DB-authoritative behavior + new resolver preference tests)
- Adversarial review (3 dimensions → verify): 5 confirmed findings, all fixed

### Ops
Apply the additive `20260623120000_add_user_last_used_organization` migration on prod (nullable column, applies cleanly over existing rows).