### PR TITLE
feat(auth): Stripe managed-checkout provisioning on Better Auth (Phase 4 — D2, epic #735)

### DIFF
--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
@@ -256,6 +256,44 @@ describe('StripeWebhookService', () => {
       expect(apiKeysService.createWithKey).toHaveBeenCalledTimes(1);
     });
 
+    it('reactivates a soft-deleted user when email creation hits a unique constraint race', async () => {
+      usersService.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        _id: 'user_deleted_1',
+        isDeleted: true,
+        isOnboardingCompleted: false,
+        onboardingStepsCompleted: [],
+      });
+      usersService.create.mockRejectedValueOnce({ code: 'P2002' });
+      usersService.patch
+        .mockResolvedValueOnce({
+          _id: 'user_deleted_1',
+          isDeleted: false,
+          isOnboardingCompleted: false,
+          onboardingStepsCompleted: [],
+        })
+        .mockResolvedValueOnce({});
+      const service = buildService();
+
+      await service.provisionManagedCheckoutAccount(
+        session as never,
+        email,
+        'test',
+      );
+
+      expect(usersService.findOne).toHaveBeenNthCalledWith(1, {
+        email,
+        isDeleted: false,
+      });
+      expect(usersService.findOne).toHaveBeenNthCalledWith(2, { email }, []);
+      expect(usersService.patch).toHaveBeenNthCalledWith(1, 'user_deleted_1', {
+        isDeleted: false,
+      });
+      expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+      expect(
+        creditsUtilsService.addOrganizationCreditsWithExpiration,
+      ).toHaveBeenCalled();
+    });
+
     it('reuses an existing user by email, skips provisioning, but still tops up credits for a returning buyer', async () => {
       usersService.findOne.mockResolvedValue({
         _id: 'user_existing_1',

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts
@@ -1,4 +1,6 @@
+import { BETTER_AUTH_USER_CREATED_EVENT } from '@api/auth/better-auth/better-auth.constants';
 import { StripeWebhookService } from '@api/endpoints/webhooks/stripe/webhooks.stripe.service';
+import type { ManagedCheckoutResult } from '@api/services/integrations/stripe/services/managed-stripe-checkout.service';
 import type Stripe from 'stripe';
 
 type InvoiceHandlerAccessor = {
@@ -9,7 +11,15 @@ type InvoiceHandlerAccessor = {
   ): Promise<void>;
 };
 
-describe('StripeWebhookService invoice handlers', () => {
+type ProvisionAccessor = {
+  provisionManagedCheckoutAccount(
+    session: unknown,
+    email: string,
+    url: string,
+  ): Promise<ManagedCheckoutResult>;
+};
+
+describe('StripeWebhookService', () => {
   const configService = { get: vi.fn().mockReturnValue(undefined) };
   const loggerService = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
   const subscriptionsService = {
@@ -23,29 +33,41 @@ describe('StripeWebhookService invoice handlers', () => {
     resetOrganizationCredits: vi.fn(),
   };
   const activitiesService = { create: vi.fn() };
+  const apiKeysService = {
+    createWithKey: vi.fn(),
+    findOne: vi.fn(),
+    patch: vi.fn(),
+  };
+  const brandsService = { findOne: vi.fn() };
+  const usersService = { create: vi.fn(), findOne: vi.fn(), patch: vi.fn() };
+  const organizationsService = { findOne: vi.fn() };
+  const organizationSettingsService = { findOne: vi.fn(), patch: vi.fn() };
+  const accessBootstrapCacheService = { invalidateForUser: vi.fn() };
+  const userSetupService = { initializeUserResources: vi.fn() };
+  const eventEmitter = { emitAsync: vi.fn() };
 
-  function buildService(): InvoiceHandlerAccessor {
+  function buildService(): InvoiceHandlerAccessor & ProvisionAccessor {
     return new StripeWebhookService(
       configService as never,
       loggerService as never,
-      {} as never, // apiKeysService
-      {} as never, // brandsService
+      apiKeysService as never,
+      brandsService as never,
       subscriptionsService as never,
       creditsUtilsService as never,
       activitiesService as never,
-      {} as never, // usersService
-      {} as never, // clerkService
+      usersService as never,
       {} as never, // stripeService
       {} as never, // managedStripeCheckoutService
-      {} as never, // organizationsService
+      organizationsService as never,
       {} as never, // subscriptionAttributionsService
       {} as never, // userSubscriptionsService
-      {} as never, // organizationSettingsService
+      organizationSettingsService as never,
       {} as never, // prisma
       {} as never, // requestContextCacheService
-      {} as never, // accessBootstrapCacheService
-      {} as never, // userSetupService
-    ) as unknown as InvoiceHandlerAccessor;
+      accessBootstrapCacheService as never,
+      userSetupService as never,
+      eventEmitter as never,
+    ) as unknown as InvoiceHandlerAccessor & ProvisionAccessor;
   }
 
   function invoiceWith(overrides: Record<string, unknown>): Stripe.Invoice {
@@ -167,6 +189,99 @@ describe('StripeWebhookService invoice handlers', () => {
       await service.handleInvoicePaymentFailed(invoiceWith({}), 'test');
 
       expect(subscriptionsService.findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('provisionManagedCheckoutAccount', () => {
+    const email = 'ada@example.com';
+    const session = {
+      customer: 'cus_123',
+      id: 'cs_test_1',
+      metadata: { credits: '100', firstName: 'Ada', lastName: 'Lovelace' },
+    };
+
+    beforeEach(() => {
+      organizationsService.findOne.mockResolvedValue({ _id: 'org_1' });
+      brandsService.findOne.mockResolvedValue({ _id: 'brand_1' });
+      organizationSettingsService.findOne.mockResolvedValue({ _id: 'os_1' });
+      organizationSettingsService.patch.mockResolvedValue({});
+      creditsUtilsService.addOrganizationCreditsWithExpiration.mockResolvedValue(
+        undefined,
+      );
+      apiKeysService.findOne.mockResolvedValue({ id: 'key_1', scopes: [] });
+      apiKeysService.patch.mockResolvedValue({});
+      usersService.patch.mockResolvedValue({});
+      activitiesService.create.mockResolvedValue({});
+      accessBootstrapCacheService.invalidateForUser.mockResolvedValue(
+        undefined,
+      );
+      eventEmitter.emitAsync.mockResolvedValue([]);
+    });
+
+    it('creates a clerkId-free user, mints a managed key, and emits better-auth.user.created for a net-new buyer', async () => {
+      usersService.findOne.mockResolvedValue(null);
+      usersService.create.mockResolvedValue({
+        _id: 'user_new_1',
+        isOnboardingCompleted: false,
+        onboardingStepsCompleted: [],
+      });
+      // A net-new buyer has no managed key yet → the createWithKey path runs.
+      apiKeysService.findOne.mockResolvedValue(null);
+      apiKeysService.createWithKey.mockResolvedValue({
+        plainKey: 'gf_managed',
+      });
+      const service = buildService();
+
+      await service.provisionManagedCheckoutAccount(
+        session as never,
+        email,
+        'test',
+      );
+
+      expect(usersService.findOne).toHaveBeenCalledWith({
+        email,
+        isDeleted: false,
+      });
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+      const createArg = usersService.create.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      expect(createArg.email).toBe(email);
+      expect(createArg.clerkId).toBeUndefined();
+      expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+        BETTER_AUTH_USER_CREATED_EVENT,
+        { email, userId: 'user_new_1' },
+      );
+      expect(apiKeysService.createWithKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses an existing user by email, skips provisioning, but still tops up credits for a returning buyer', async () => {
+      usersService.findOne.mockResolvedValue({
+        _id: 'user_existing_1',
+        isOnboardingCompleted: true,
+        onboardingStepsCompleted: ['brand', 'plan'],
+      });
+      const service = buildService();
+
+      await service.provisionManagedCheckoutAccount(
+        session as never,
+        email,
+        'test',
+      );
+
+      expect(usersService.findOne).toHaveBeenCalledWith({
+        email,
+        isDeleted: false,
+      });
+      expect(usersService.create).not.toHaveBeenCalled();
+      expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+      // Resources already exist, so the defensive setup fallback never fires …
+      expect(userSetupService.initializeUserResources).not.toHaveBeenCalled();
+      // … but the purchased credits are still granted.
+      expect(
+        creditsUtilsService.addOrganizationCreditsWithExpiration,
+      ).toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
@@ -1,3 +1,5 @@
+import { BETTER_AUTH_USER_CREATED_EVENT } from '@api/auth/better-auth/better-auth.constants';
+import type { IBetterAuthUserCreatedEvent } from '@api/auth/better-auth/better-auth.types';
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { ApiKeysService } from '@api/collections/api-keys/services/api-keys.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
@@ -11,7 +13,6 @@ import { AccessBootstrapCacheService } from '@api/common/services/access-bootstr
 import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
 import { ConfigService } from '@api/config/config.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import {
   type ManagedCheckoutResult,
   ManagedStripeCheckoutService,
@@ -51,6 +52,7 @@ import {
 } from '@genfeedai/interfaces/billing';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { nanoid } from 'nanoid';
 
 type StripeEvent = {
@@ -75,7 +77,6 @@ export class StripeWebhookService {
     private readonly creditsUtilsService: CreditsUtilsService,
     private readonly activitiesService: ActivitiesService,
     private readonly usersService: UsersService,
-    private readonly clerkService: ClerkService,
     private readonly stripeService: StripeService,
     private readonly managedStripeCheckoutService: ManagedStripeCheckoutService,
     private readonly organizationsService: OrganizationsService,
@@ -88,6 +89,7 @@ export class StripeWebhookService {
     private readonly requestContextCacheService: RequestContextCacheService,
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
     private readonly userSetupService: UserSetupService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async handleWebhookEvent(event: StripeEvent, url: string) {
@@ -680,51 +682,54 @@ export class StripeWebhookService {
     const firstName = session.metadata?.firstName?.trim() || undefined;
     const lastName = session.metadata?.lastName?.trim() || undefined;
 
-    let clerkUser = await this.clerkService.getUserByEmail(email);
-
-    if (!clerkUser) {
-      clerkUser = await this.clerkService.createUser({
-        emailAddress: [email],
-        firstName,
-        lastName,
-        skipLegalChecks: true,
-        skipPasswordRequirement: true,
-      });
-    }
-
+    // Find or create the DB user by email. Better Auth keys identity off the
+    // email, so there is no Clerk round-trip and managed-checkout users carry no
+    // clerkId (epic #735, Phase 4 — D2).
     let dbUser = await this.usersService.findOne({
-      clerkId: clerkUser.id,
+      email,
       isDeleted: false,
     });
 
-    if (!dbUser) {
-      const existingUserByEmail = await this.usersService.findOne({
-        email,
-        isDeleted: false,
-      });
+    let isNewUser = false;
 
-      if (existingUserByEmail) {
-        dbUser = await this.usersService.patch(
-          String(existingUserByEmail._id),
-          {
-            clerkId: clerkUser.id,
+    if (!dbUser) {
+      try {
+        dbUser = await this.usersService.create(
+          new UserEntity({
             email,
-            firstName: firstName || existingUserByEmail.firstName || undefined,
-            lastName: lastName || existingUserByEmail.lastName || undefined,
-          },
+            firstName,
+            handle: generateLabel('user'),
+            lastName,
+          }) as Parameters<UsersService['create']>[0],
         );
+        isNewUser = true;
+      } catch (error: unknown) {
+        // A concurrent provisioning (a second checkout session for the same
+        // email) can win the users.email unique-index race (#764). Reuse the row
+        // it created instead of failing the webhook; re-throw anything that is
+        // not a uniqueness conflict.
+        if ((error as { code?: string })?.code !== 'P2002') {
+          throw error;
+        }
+        dbUser = await this.usersService.findOne({ email, isDeleted: false });
+        if (!dbUser) {
+          throw error;
+        }
       }
     }
 
-    if (!dbUser) {
-      dbUser = await this.usersService.create(
-        new UserEntity({
-          clerkId: clerkUser.id,
-          email,
-          firstName,
-          handle: generateLabel('user'),
-          lastName,
-        }) as Parameters<UsersService['create']>[0],
+    // Provision org / settings / brand / member / credits via the same
+    // idempotent listener a Better Auth signup drives (reuses Phase B). Awaited,
+    // so a brand-new user's resources exist before the credit grant below;
+    // returning managed-checkout customers already have them and skip the emit.
+    if (isNewUser) {
+      const userCreatedEvent: IBetterAuthUserCreatedEvent = {
+        email,
+        userId: String(dbUser._id),
+      };
+      await this.eventEmitter.emitAsync(
+        BETTER_AUTH_USER_CREATED_EVENT,
+        userCreatedEvent,
       );
     }
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts
@@ -711,9 +711,14 @@ export class StripeWebhookService {
         if ((error as { code?: string })?.code !== 'P2002') {
           throw error;
         }
-        dbUser = await this.usersService.findOne({ email, isDeleted: false });
+        dbUser = await this.usersService.findOne({ email }, []);
         if (!dbUser) {
           throw error;
+        }
+        if (dbUser.isDeleted === true) {
+          dbUser = await this.usersService.patch(String(dbUser._id), {
+            isDeleted: false,
+          });
         }
       }
     }


### PR DESCRIPTION
## What & why

Part of the **Clerk → Better Auth hard cutover** (epic #735, Phase 4 — **D2**). The Stripe managed-checkout webhook was the last billing path that minted a Clerk user. This replaces it with a DB-keyed find-or-create plus the shared Better Auth provisioning event, so managed checkout no longer touches Clerk.

## Changes

`apps/server/api/src/endpoints/webhooks/stripe/webhooks.stripe.service.ts` — `provisionManagedCheckoutAccount`:

- **Find-or-create by email** — `usersService.findOne({ email, isDeleted: false })` then `create(...)` with **no `clerkId`** and no Clerk round-trip. Removes the old `clerkService.getUserByEmail` / `createUser` calls and the clerkId-keyed lookup + clerkId back-patch branch.
- **Provision via the event bus** — for net-new users, emit `better-auth.user.created` (awaited). The existing idempotent `UserProvisioningListener` → `UserSetupService.initializeUserResources` sets up org / settings / brand / member / credits — the *same* path a Better Auth signup drives (reuses Phase B). Returning buyers already have resources and skip the emit; the pre-existing org/brand fallback still covers partial state.
- **Race-safe** — on a `users.email` unique-index conflict (`P2002`, index added in #764) from a concurrent checkout session for the same email, re-fetch and reuse the row instead of 5xx-ing the webhook.
- `ClerkService` is **dropped from `StripeWebhookService` entirely** — its only two calls lived in this method. (`ClerkModule` stays registered for `ClerkWebhookService`; full Clerk backend deletion is Phase H.)

There was no `updateUserPublicMetadata` left to remove here — Phase C already routed those writes to the DB.

## Tests

`webhooks.stripe.service.spec.ts` adds a `provisionManagedCheckoutAccount` suite:
- **net-new buyer** → creates a clerkId-free user, mints a managed API key (`createWithKey`), and emits `better-auth.user.created` with `{ email, userId }`.
- **returning buyer** → reuses the existing user by email, skips provisioning (no create, no emit, no setup fallback), still grants the purchased credits.

## Verification

- `vitest` — 7/7 pass (5 existing invoice-handler + 2 new).
- `tsc --noEmit -p tsconfig.typecheck.json` — no source errors (only the repo's pre-existing TS6 `baseUrl` deprecation).
- `biome check` clean; pre-commit secretlint clean.

## Notes / scope

- Adversarially reviewed (3 lenses: correctness/races, plan-conformance, rules/tests) — verdict ship; the race-safety fix above came out of that review.
- Independent of D1 (invitations) and D3 (WS/terminal JWKS) — no file overlap, mergeable in any order.
- Out of scope (Phase H): a pre-existing `clerkId?: string | null` param type on the unrelated `addCreditsToOrgFromUserCheckout` helper.