### PR TITLE
feat(auth): WebSocket + terminal JWKS verification (Phase 4 — D3, epic #735)

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveBetterAuthJwtOrganizationId } from './better-auth.factory';
+import type { ICreateBetterAuthOptions } from './better-auth.types';
+
+type PrismaForBetterAuth = ICreateBetterAuthOptions['prisma'];
+
+function createPrismaMock() {
+  return {
+    member: {
+      findFirst: vi.fn(),
+    },
+    organization: {
+      findFirst: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+  };
+}
+
+describe('resolveBetterAuthJwtOrganizationId', () => {
+  it('prefers lastUsedOrganizationId when the user can access it', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue({
+      lastUsedOrganizationId: 'org_active',
+    });
+    prisma.organization.findFirst.mockResolvedValue({ id: 'org_active' });
+
+    await expect(
+      resolveBetterAuthJwtOrganizationId(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_1',
+      ),
+    ).resolves.toBe('org_active');
+
+    expect(prisma.organization.findFirst).toHaveBeenCalledWith({
+      select: { id: true },
+      where: {
+        id: 'org_active',
+        isDeleted: false,
+        OR: [
+          { userId: 'user_1' },
+          {
+            members: {
+              some: {
+                isActive: true,
+                isDeleted: false,
+                userId: 'user_1',
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(prisma.member.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an owned organization when lastUsedOrganizationId is inaccessible', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue({
+      lastUsedOrganizationId: 'org_stale',
+    });
+    prisma.organization.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'org_owner' });
+
+    await expect(
+      resolveBetterAuthJwtOrganizationId(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_2',
+      ),
+    ).resolves.toBe('org_owner');
+
+    expect(prisma.organization.findFirst).toHaveBeenLastCalledWith({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+      where: {
+        isDeleted: false,
+        userId: 'user_2',
+      },
+    });
+  });
+
+  it('falls back to an active membership organization when the user owns none', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue({
+      lastUsedOrganizationId: null,
+    });
+    prisma.organization.findFirst.mockResolvedValue(null);
+    prisma.member.findFirst.mockResolvedValue({
+      organizationId: 'org_member',
+    });
+
+    await expect(
+      resolveBetterAuthJwtOrganizationId(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_3',
+      ),
+    ).resolves.toBe('org_member');
+
+    expect(prisma.member.findFirst).toHaveBeenCalledWith({
+      orderBy: { createdAt: 'asc' },
+      select: { organizationId: true },
+      where: {
+        isActive: true,
+        isDeleted: false,
+        organization: { isDeleted: false },
+        userId: 'user_3',
+      },
+    });
+  });
+
+  it('returns undefined when no accessible organization exists', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.organization.findFirst.mockResolvedValue(null);
+    prisma.member.findFirst.mockResolvedValue(null);
+
+    await expect(
+      resolveBetterAuthJwtOrganizationId(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_4',
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { jwt, magicLink } from 'better-auth/plugins';
@@ -193,12 +194,7 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
           // because DB-less websocket consumers cannot verify membership at
           // connection time.
           definePayload: async ({ user }) => {
-            const typed = user as unknown as {
-              id?: string;
-              email?: string | null;
-              name?: string | null;
-              isSuperAdmin?: boolean;
-            };
+            const typed = user as unknown as IBetterAuthJwtUserPayloadSource;
             const userId = getString(typed.id);
             const organizationId = userId
               ? await resolveBetterAuthJwtOrganizationId(prisma, userId)

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -6,6 +6,10 @@ import { jwt, magicLink } from 'better-auth/plugins';
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
 import type { ICreateBetterAuthOptions } from './better-auth.types';
 
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
 /**
  * Derive a unique, URL-safe `User.handle` for first-party sign-ups. The existing
  * `handle` column is required + unique and Better Auth does not populate it, so a
@@ -23,6 +27,73 @@ function generateHandle(input: {
       .replace(/^-+|-+$/g, '')
       .slice(0, 24) || 'user';
   return `${base}-${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Resolve the active organization embedded in BA JWTs for DB-less consumers
+ * such as the notifications websocket process. Mirrors
+ * BetterAuthIdentityResolverService's org precedence without importing Nest
+ * services into the auth factory.
+ */
+export async function resolveBetterAuthJwtOrganizationId(
+  prisma: ICreateBetterAuthOptions['prisma'],
+  userId: string,
+): Promise<string | undefined> {
+  const user = await prisma.user.findUnique({
+    select: { lastUsedOrganizationId: true },
+    where: { id: userId },
+  });
+
+  const lastUsedOrganizationId = getString(user?.lastUsedOrganizationId);
+  if (lastUsedOrganizationId) {
+    const activeOrganization = await prisma.organization.findFirst({
+      select: { id: true },
+      where: {
+        id: lastUsedOrganizationId,
+        isDeleted: false,
+        OR: [
+          { userId },
+          {
+            members: {
+              some: {
+                isActive: true,
+                isDeleted: false,
+                userId,
+              },
+            },
+          },
+        ],
+      },
+    });
+    if (activeOrganization) {
+      return activeOrganization.id;
+    }
+  }
+
+  const ownerOrganization = await prisma.organization.findFirst({
+    orderBy: { createdAt: 'asc' },
+    select: { id: true },
+    where: {
+      isDeleted: false,
+      userId,
+    },
+  });
+  if (ownerOrganization) {
+    return ownerOrganization.id;
+  }
+
+  const membership = await prisma.member.findFirst({
+    orderBy: { createdAt: 'asc' },
+    select: { organizationId: true },
+    where: {
+      isActive: true,
+      isDeleted: false,
+      organization: { isDeleted: false },
+      userId,
+    },
+  });
+
+  return getString(membership?.organizationId);
 }
 
 /**
@@ -118,17 +189,24 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
         jwt: {
           issuer: baseURL,
           audience: baseURL,
-          // sub defaults to user.id (= genfeed User.id). Embed the cheap,
-          // stable claims; org/brand are resolved per-request in the strategy.
-          definePayload: ({ user }) => {
+          // sub defaults to user.id (= genfeed User.id). Embed the active org
+          // because DB-less websocket consumers cannot verify membership at
+          // connection time.
+          definePayload: async ({ user }) => {
             const typed = user as unknown as {
+              id?: string;
               email?: string | null;
               name?: string | null;
               isSuperAdmin?: boolean;
             };
+            const userId = getString(typed.id);
+            const organizationId = userId
+              ? await resolveBetterAuthJwtOrganizationId(prisma, userId)
+              : undefined;
             return {
               email: typed.email ?? undefined,
               name: typed.name ?? undefined,
+              organizationId,
               isSuperAdmin: typed.isSuperAdmin === true,
             };
           },

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -19,6 +19,7 @@ export interface IBetterAuthJwtClaims {
   sub: string;
   email?: string;
   name?: string;
+  organizationId?: string;
   isSuperAdmin?: boolean;
   iss?: string;
   aud?: string | string[];

--- a/apps/server/notifications/package.json
+++ b/apps/server/notifications/package.json
@@ -4,6 +4,7 @@
     "@genfeedai/config": "workspace:*",
     "@genfeedai/enums": "workspace:*",
     "@slack/web-api": "7.16.0",
+    "jose": "^6.2.3",
     "node-pty": "1.1.0"
   },
   "description": "Genfeed Notifications Service",

--- a/apps/server/notifications/package.json
+++ b/apps/server/notifications/package.json
@@ -3,6 +3,7 @@
     "@clerk/backend": "3.4.14",
     "@genfeedai/config": "workspace:*",
     "@genfeedai/enums": "workspace:*",
+    "@genfeedai/interfaces": "workspace:*",
     "@slack/web-api": "7.16.0",
     "jose": "^6.2.3",
     "node-pty": "1.1.0"

--- a/apps/server/notifications/src/config/config.service.ts
+++ b/apps/server/notifications/src/config/config.service.ts
@@ -33,6 +33,10 @@ export class ConfigService extends createServiceConfig<IEnvConfig>({
   extend: {
     API_BASE_URL: Joi.string().uri().default('http://localhost:3010'),
     API_SECRET_KEY: Joi.string().optional().allow(''),
+    // The terminal gateway verifies socket JWTs against the API's JWKS at
+    // `${BETTER_AUTH_URL}/v1/auth/jwks` (epic #735, Phase 4 — D3). Only this BA
+    // key is consumed here; the secret/origins/google keys stay in the API.
+    BETTER_AUTH_URL: Joi.string().uri().optional().allow(''),
     GENFEED_LOCAL_TERMINAL: Joi.string()
       .valid('true', 'false')
       .optional()

--- a/apps/server/notifications/src/services/terminal/terminal.gateway.spec.ts
+++ b/apps/server/notifications/src/services/terminal/terminal.gateway.spec.ts
@@ -2,10 +2,15 @@ import type { Socket } from 'socket.io';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TerminalGateway } from './terminal.gateway';
 
-const verifyTokenMock = vi.hoisted(() => vi.fn());
+const verifyMock = vi.hoisted(() => vi.fn());
 
-vi.mock('@clerk/backend', () => ({
-  verifyToken: verifyTokenMock,
+/** A Better Auth `sub` is the genfeed User.id (a UUID), not a Clerk user id. */
+const TEST_USER_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+vi.mock('@libs/auth/better-auth-jwks.verifier', () => ({
+  BetterAuthJwksVerifier: class {
+    verify = verifyMock;
+  },
 }));
 
 vi.mock('./terminal.service', () => ({
@@ -29,7 +34,7 @@ function createTerminalService(isAvailable = true) {
   return {
     attach: vi.fn(),
     createSession: vi.fn(),
-    getClerkSecretKey: vi.fn(() => 'test-clerk-secret'),
+    getBetterAuthJwksUrl: vi.fn(() => 'http://localhost:3010/v1/auth/jwks'),
     isAvailable: vi.fn(() => isAvailable),
     killAllForSocket: vi.fn(),
     killSession: vi.fn(),
@@ -42,7 +47,7 @@ function createTerminalService(isAvailable = true) {
 describe('TerminalGateway', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    verifyTokenMock.mockResolvedValue({ sub: 'user_123' });
+    verifyMock.mockResolvedValue({ sub: TEST_USER_ID });
   });
 
   it('rejects originless terminal socket connections', async () => {
@@ -80,13 +85,29 @@ describe('TerminalGateway', () => {
 
     await gateway.handleConnection(socket);
 
-    expect(verifyTokenMock).toHaveBeenCalledWith('session-token', {
-      secretKey: 'test-clerk-secret',
-    });
+    expect(verifyMock).toHaveBeenCalledWith('session-token');
     expect(socket.emit).toHaveBeenCalledWith('terminal:ready', {
       socketId: 'socket-1',
     });
     expect(socket.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('rejects the connection when Better Auth verification throws', async () => {
+    verifyMock.mockRejectedValue(new Error('invalid signature'));
+    const terminalService = createTerminalService();
+    const gateway = new TerminalGateway(terminalService as never);
+    const socket = createSocket('http://localhost:3000', 'bad-token');
+
+    await gateway.handleConnection(socket);
+
+    expect(verifyMock).toHaveBeenCalledWith('bad-token');
+    expect(socket.emit).toHaveBeenCalledWith('terminal:error', {
+      message: 'Local terminal requires an authenticated session.',
+    });
+    expect(socket.disconnect).toHaveBeenCalledWith(true);
+    expect(socket.emit).not.toHaveBeenCalledWith('terminal:ready', {
+      socketId: 'socket-1',
+    });
   });
 
   it('rejects terminal events from sockets that have not completed authentication', () => {
@@ -127,7 +148,7 @@ describe('TerminalGateway', () => {
     await gateway.handleConnection(socket);
     gateway.handleList(socket);
 
-    expect(terminalService.listForOwner).toHaveBeenCalledWith('user_123');
+    expect(terminalService.listForOwner).toHaveBeenCalledWith(TEST_USER_ID);
     expect(socket.emit).toHaveBeenCalledWith('terminal:sessions', []);
   });
 
@@ -164,7 +185,7 @@ describe('TerminalGateway', () => {
 
     expect(terminalService.attach).toHaveBeenCalledWith(
       'socket-1',
-      'user_123',
+      TEST_USER_ID,
       'session-abc',
       expect.objectContaining({
         onData: expect.any(Function),

--- a/apps/server/notifications/src/services/terminal/terminal.gateway.spec.ts
+++ b/apps/server/notifications/src/services/terminal/terminal.gateway.spec.ts
@@ -35,6 +35,11 @@ function createTerminalService(isAvailable = true) {
     attach: vi.fn(),
     createSession: vi.fn(),
     getBetterAuthJwksUrl: vi.fn(() => 'http://localhost:3010/v1/auth/jwks'),
+    getBetterAuthJwksVerifierOptions: vi.fn(() => ({
+      audience: 'http://localhost:3010',
+      issuer: 'http://localhost:3010',
+      jwksUrl: 'http://localhost:3010/v1/auth/jwks',
+    })),
     isAvailable: vi.fn(() => isAvailable),
     killAllForSocket: vi.fn(),
     killSession: vi.fn(),

--- a/apps/server/notifications/src/services/terminal/terminal.gateway.ts
+++ b/apps/server/notifications/src/services/terminal/terminal.gateway.ts
@@ -1,4 +1,4 @@
-import { verifyToken } from '@clerk/backend';
+import { BetterAuthJwksVerifier } from '@libs/auth/better-auth-jwks.verifier';
 import { Logger } from '@nestjs/common';
 import {
   ConnectedSocket,
@@ -40,6 +40,8 @@ export class TerminalGateway
   private readonly logger = new Logger(TerminalGateway.name);
   /** Maps socketId → auth record for all authenticated connections. */
   private readonly authenticatedSockets = new Map<string, SocketAuthRecord>();
+  /** Lazily built once; `jose` caches the remote JWKS internally. */
+  private betterAuthVerifier?: BetterAuthJwksVerifier;
 
   constructor(private readonly terminalService: TerminalService) {}
 
@@ -235,8 +237,8 @@ export class TerminalGateway
   }
 
   /**
-   * Verifies the socket's Clerk token and returns the Clerk user id (`sub`).
-   * Returns null when verification fails.
+   * Verifies the socket's Better Auth JWT and returns the genfeed `User.id`
+   * (`sub`). Returns null when verification fails.
    */
   private async resolveAuthenticatedUserId(
     client: Socket,
@@ -246,19 +248,9 @@ export class TerminalGateway
       return null;
     }
 
-    const clerkSecret = this.terminalService.getClerkSecretKey();
-    if (!clerkSecret) {
-      this.logger.warn(
-        'CLERK_SECRET_KEY is required before local terminal sockets can authenticate.',
-      );
-      return null;
-    }
-
     try {
-      const payload = await verifyToken(token, { secretKey: clerkSecret });
-      return typeof payload.sub === 'string' && payload.sub.length > 0
-        ? payload.sub
-        : null;
+      const { sub } = await this.getBetterAuthVerifier().verify(token);
+      return sub;
     } catch (error: unknown) {
       this.logger.warn('Failed to verify local terminal socket token', {
         error: error instanceof Error ? error.message : String(error),
@@ -266,6 +258,15 @@ export class TerminalGateway
       });
       return null;
     }
+  }
+
+  private getBetterAuthVerifier(): BetterAuthJwksVerifier {
+    if (!this.betterAuthVerifier) {
+      this.betterAuthVerifier = new BetterAuthJwksVerifier(
+        this.terminalService.getBetterAuthJwksUrl(),
+      );
+    }
+    return this.betterAuthVerifier;
   }
 
   private extractToken(client: Socket): string | undefined {

--- a/apps/server/notifications/src/services/terminal/terminal.gateway.ts
+++ b/apps/server/notifications/src/services/terminal/terminal.gateway.ts
@@ -263,7 +263,7 @@ export class TerminalGateway
   private getBetterAuthVerifier(): BetterAuthJwksVerifier {
     if (!this.betterAuthVerifier) {
       this.betterAuthVerifier = new BetterAuthJwksVerifier(
-        this.terminalService.getBetterAuthJwksUrl(),
+        this.terminalService.getBetterAuthJwksVerifierOptions(),
       );
     }
     return this.betterAuthVerifier;

--- a/apps/server/notifications/src/services/terminal/terminal.service.ts
+++ b/apps/server/notifications/src/services/terminal/terminal.service.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
-import { resolveBetterAuthJwksUrl } from '@libs/auth/better-auth-jwks.verifier';
+import type { IBetterAuthJwksVerifierOptions } from '@genfeedai/interfaces';
+import {
+  createBetterAuthJwksVerifierOptions,
+  resolveBetterAuthJwksUrl,
+} from '@libs/auth/better-auth-jwks.verifier';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@notifications/config/config.service';
 import type {
@@ -191,11 +195,19 @@ export class TerminalService {
    * localhost so a default local boot works (epic #735, Phase 4 — D3).
    */
   getBetterAuthJwksUrl(): string {
+    return resolveBetterAuthJwksUrl(this.getBetterAuthBaseUrl());
+  }
+
+  getBetterAuthJwksVerifierOptions(): IBetterAuthJwksVerifierOptions {
+    return createBetterAuthJwksVerifierOptions(this.getBetterAuthBaseUrl());
+  }
+
+  private getBetterAuthBaseUrl(): string {
     const baseUrl =
       this.configService.get('BETTER_AUTH_URL') ||
       this.configService.get('API_BASE_URL') ||
       'http://localhost:3010';
-    return resolveBetterAuthJwksUrl(baseUrl);
+    return baseUrl;
   }
 
   /**

--- a/apps/server/notifications/src/services/terminal/terminal.service.ts
+++ b/apps/server/notifications/src/services/terminal/terminal.service.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
+import { resolveBetterAuthJwksUrl } from '@libs/auth/better-auth-jwks.verifier';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@notifications/config/config.service';
 import type {
@@ -64,7 +65,7 @@ interface TerminalProcess {
   kind: TerminalSessionKind;
   /** Socket currently receiving live pty output. */
   ownerSocketId: string;
-  /** Clerk user id (sub) that owns this session. */
+  /** genfeed User.id (Better Auth `sub`) that owns this session. */
   ownerUserId: string;
   pty: IPtyHandle;
   /** Ring buffer holding last MAX_BUFFER_BYTES of output. */
@@ -183,12 +184,22 @@ export class TerminalService {
     return !isCloud && (isDevelopment || explicitlyEnabled === 'true');
   }
 
-  getClerkSecretKey(): string | undefined {
-    return this.configService.get('CLERK_SECRET_KEY') || undefined;
+  /**
+   * Better Auth JWKS endpoint the terminal gateway verifies socket JWTs against.
+   * The jwt plugin (in the API process) publishes JWKS at
+   * `${BETTER_AUTH_URL}/v1/auth/jwks`; falls back to `API_BASE_URL` then
+   * localhost so a default local boot works (epic #735, Phase 4 — D3).
+   */
+  getBetterAuthJwksUrl(): string {
+    const baseUrl =
+      this.configService.get('BETTER_AUTH_URL') ||
+      this.configService.get('API_BASE_URL') ||
+      'http://localhost:3010';
+    return resolveBetterAuthJwksUrl(baseUrl);
   }
 
   /**
-   * Returns all sessions owned by the given Clerk user id.
+   * Returns all sessions owned by the given user id.
    */
   listForOwner(ownerUserId: string): TerminalSessionDto[] {
     const result: TerminalSessionDto[] = [];

--- a/bun.lock
+++ b/bun.lock
@@ -537,6 +537,7 @@
         "@genfeedai/config": "workspace:*",
         "@genfeedai/enums": "workspace:*",
         "@slack/web-api": "7.16.0",
+        "jose": "^6.2.3",
         "node-pty": "1.1.0",
       },
     },
@@ -949,6 +950,7 @@
       "name": "@genfeedai/hooks",
       "version": "1.0.0",
       "dependencies": {
+        "@genfeedai/auth-client": "workspace:*",
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/contexts": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
@@ -1002,6 +1004,9 @@
     "packages/libs": {
       "name": "@genfeedai/libs",
       "version": "0.1.0",
+      "dependencies": {
+        "jose": "^6.2.3",
+      },
     },
     "packages/models": {
       "name": "@genfeedai/models",

--- a/bun.lock
+++ b/bun.lock
@@ -536,6 +536,7 @@
         "@clerk/backend": "3.4.14",
         "@genfeedai/config": "workspace:*",
         "@genfeedai/enums": "workspace:*",
+        "@genfeedai/interfaces": "workspace:*",
         "@slack/web-api": "7.16.0",
         "jose": "^6.2.3",
         "node-pty": "1.1.0",
@@ -1006,6 +1007,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@genfeedai/enums": "workspace:*",
+        "@genfeedai/interfaces": "workspace:*",
         "jose": "^6.2.3",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -1005,6 +1005,7 @@
       "name": "@genfeedai/libs",
       "version": "0.1.0",
       "dependencies": {
+        "@genfeedai/enums": "workspace:*",
         "jose": "^6.2.3",
       },
     },

--- a/packages/interfaces/src/auth/better-auth.interface.ts
+++ b/packages/interfaces/src/auth/better-auth.interface.ts
@@ -1,0 +1,19 @@
+export interface IBetterAuthJwksVerifierOptions {
+  audience: string;
+  issuer: string;
+  jwksUrl: string;
+}
+
+export interface IBetterAuthJwtUserPayloadSource {
+  id?: string;
+  email?: string | null;
+  name?: string | null;
+  isSuperAdmin?: boolean;
+}
+
+export interface IBetterAuthVerifiedClaims {
+  /** Subject - the Prisma `User.id` (the jwt plugin sets `sub = user.id`). */
+  sub: string;
+  /** Active organization id signed by the API for DB-less websocket authz. */
+  organizationId?: string;
+}

--- a/packages/interfaces/src/auth/index.ts
+++ b/packages/interfaces/src/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './authentication.interface';
+export * from './better-auth.interface';
 export * from './role.interface';

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -31,6 +31,7 @@ export * from './analytics/viral-hooks.interface';
 export * from './analytics/vote.interface';
 export * from './analytics/watchlist.interface';
 export * from './auth/authentication.interface';
+export * from './auth/better-auth.interface';
 export * from './auth/role.interface';
 export * from './automation/calendar-event.interface';
 export * from './automation/metadata.interface';

--- a/packages/libs/auth/better-auth-jwks.verifier.spec.ts
+++ b/packages/libs/auth/better-auth-jwks.verifier.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createRemoteJWKSetMock = vi.hoisted(() => vi.fn(() => 'jwks'));
+const jwtVerifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: createRemoteJWKSetMock,
+  jwtVerify: jwtVerifyMock,
+}));
+
+import {
+  BetterAuthJwksVerifier,
+  createBetterAuthJwksVerifierOptions,
+  normalizeBetterAuthBaseUrl,
+  resolveBetterAuthJwksUrl,
+} from './better-auth-jwks.verifier';
+
+describe('BetterAuthJwksVerifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes the base URL used for issuer, audience, and JWKS URL', () => {
+    expect(normalizeBetterAuthBaseUrl('https://api.genfeed.ai///')).toBe(
+      'https://api.genfeed.ai',
+    );
+    expect(resolveBetterAuthJwksUrl('https://api.genfeed.ai///')).toBe(
+      'https://api.genfeed.ai/v1/auth/jwks',
+    );
+    expect(
+      createBetterAuthJwksVerifierOptions('https://api.genfeed.ai///'),
+    ).toEqual({
+      audience: 'https://api.genfeed.ai',
+      issuer: 'https://api.genfeed.ai',
+      jwksUrl: 'https://api.genfeed.ai/v1/auth/jwks',
+    });
+  });
+
+  it('verifies signature and issuer/audience claims against the configured base URL', async () => {
+    jwtVerifyMock.mockResolvedValue({
+      payload: {
+        organizationId: 'org-123',
+        sub: 'user-123',
+      },
+    });
+    const verifier = new BetterAuthJwksVerifier(
+      createBetterAuthJwksVerifierOptions('https://api.genfeed.ai/'),
+    );
+
+    await expect(verifier.verify('jwt-token')).resolves.toEqual({
+      organizationId: 'org-123',
+      sub: 'user-123',
+    });
+
+    expect(createRemoteJWKSetMock).toHaveBeenCalledOnce();
+    expect(createRemoteJWKSetMock.mock.calls[0][0].toString()).toBe(
+      'https://api.genfeed.ai/v1/auth/jwks',
+    );
+    expect(jwtVerifyMock).toHaveBeenCalledWith('jwt-token', 'jwks', {
+      audience: 'https://api.genfeed.ai',
+      issuer: 'https://api.genfeed.ai',
+    });
+  });
+
+  it('rejects tokens without a subject claim after jose verification', async () => {
+    jwtVerifyMock.mockResolvedValue({ payload: {} });
+    const verifier = new BetterAuthJwksVerifier(
+      createBetterAuthJwksVerifierOptions('https://api.genfeed.ai'),
+    );
+
+    await expect(verifier.verify('jwt-token')).rejects.toThrow(
+      'Better Auth JWT is missing a subject (sub) claim',
+    );
+  });
+});

--- a/packages/libs/auth/better-auth-jwks.verifier.ts
+++ b/packages/libs/auth/better-auth-jwks.verifier.ts
@@ -1,0 +1,52 @@
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+/**
+ * Path the Better Auth jwt plugin publishes its JWKS at, relative to
+ * `BETTER_AUTH_URL`. Mirrors `BETTER_AUTH_BASE_PATH` ('/v1/auth') in the API's
+ * `better-auth.constants` — duplicated here so this shared lib carries no
+ * app-layer import (epic #735, Phase 4 — D3).
+ */
+export const BETTER_AUTH_JWKS_PATH = '/v1/auth/jwks';
+
+/** Verified Better Auth JWT claims the websocket gateways rely on. */
+export interface IBetterAuthVerifiedClaims {
+  /** Subject — the Prisma `User.id` (the jwt plugin sets `sub = user.id`). */
+  sub: string;
+}
+
+/** Builds the JWKS URL from a Better Auth base URL, tolerating trailing slashes. */
+export function resolveBetterAuthJwksUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}${BETTER_AUTH_JWKS_PATH}`;
+}
+
+/**
+ * Verifies Better Auth-issued JWTs against the remote JWKS published by the jwt
+ * plugin. First-party replacement for the Clerk `verifyToken` call the
+ * websocket and terminal gateways used (epic #735, Phase 4 — D3).
+ *
+ * Construct one instance per JWKS URL: `jose`'s `createRemoteJWKSet` fetches and
+ * caches the key set internally (with cooldown + rotation handling), so a single
+ * long-lived verifier is reused across socket connections.
+ */
+export class BetterAuthJwksVerifier {
+  private readonly jwks: ReturnType<typeof createRemoteJWKSet>;
+
+  constructor(jwksUrl: string) {
+    this.jwks = createRemoteJWKSet(new URL(jwksUrl));
+  }
+
+  /**
+   * Resolves the verified `sub` (the genfeed `User.id`). Throws when the token
+   * fails signature/claims verification or carries no usable subject — callers
+   * treat a throw as "unauthenticated".
+   */
+  async verify(token: string): Promise<IBetterAuthVerifiedClaims> {
+    const { payload } = await jwtVerify(token, this.jwks);
+
+    if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+      throw new Error('Better Auth JWT is missing a subject (sub) claim');
+    }
+
+    return { sub: payload.sub };
+  }
+}

--- a/packages/libs/auth/better-auth-jwks.verifier.ts
+++ b/packages/libs/auth/better-auth-jwks.verifier.ts
@@ -12,6 +12,8 @@ export const BETTER_AUTH_JWKS_PATH = '/v1/auth/jwks';
 export interface IBetterAuthVerifiedClaims {
   /** Subject — the Prisma `User.id` (the jwt plugin sets `sub = user.id`). */
   sub: string;
+  /** Active organization id signed by the API for DB-less websocket authz. */
+  organizationId?: string;
 }
 
 /** Builds the JWKS URL from a Better Auth base URL, tolerating trailing slashes. */
@@ -47,6 +49,13 @@ export class BetterAuthJwksVerifier {
       throw new Error('Better Auth JWT is missing a subject (sub) claim');
     }
 
-    return { sub: payload.sub };
+    return {
+      organizationId:
+        typeof payload.organizationId === 'string' &&
+        payload.organizationId.length > 0
+          ? payload.organizationId
+          : undefined,
+      sub: payload.sub,
+    };
   }
 }

--- a/packages/libs/auth/better-auth-jwks.verifier.ts
+++ b/packages/libs/auth/better-auth-jwks.verifier.ts
@@ -1,3 +1,7 @@
+import type {
+  IBetterAuthJwksVerifierOptions,
+  IBetterAuthVerifiedClaims,
+} from '@genfeedai/interfaces';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
 /**
@@ -8,17 +12,25 @@ import { createRemoteJWKSet, jwtVerify } from 'jose';
  */
 export const BETTER_AUTH_JWKS_PATH = '/v1/auth/jwks';
 
-/** Verified Better Auth JWT claims the websocket gateways rely on. */
-export interface IBetterAuthVerifiedClaims {
-  /** Subject — the Prisma `User.id` (the jwt plugin sets `sub = user.id`). */
-  sub: string;
-  /** Active organization id signed by the API for DB-less websocket authz. */
-  organizationId?: string;
+/** Normalizes the issuer/audience base URL to match the API JWT config. */
+export function normalizeBetterAuthBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
 }
 
 /** Builds the JWKS URL from a Better Auth base URL, tolerating trailing slashes. */
 export function resolveBetterAuthJwksUrl(baseUrl: string): string {
-  return `${baseUrl.replace(/\/+$/, '')}${BETTER_AUTH_JWKS_PATH}`;
+  return `${normalizeBetterAuthBaseUrl(baseUrl)}${BETTER_AUTH_JWKS_PATH}`;
+}
+
+export function createBetterAuthJwksVerifierOptions(
+  baseUrl: string,
+): IBetterAuthJwksVerifierOptions {
+  const normalizedBaseUrl = normalizeBetterAuthBaseUrl(baseUrl);
+  return {
+    audience: normalizedBaseUrl,
+    issuer: normalizedBaseUrl,
+    jwksUrl: resolveBetterAuthJwksUrl(normalizedBaseUrl),
+  };
 }
 
 /**
@@ -33,8 +45,8 @@ export function resolveBetterAuthJwksUrl(baseUrl: string): string {
 export class BetterAuthJwksVerifier {
   private readonly jwks: ReturnType<typeof createRemoteJWKSet>;
 
-  constructor(jwksUrl: string) {
-    this.jwks = createRemoteJWKSet(new URL(jwksUrl));
+  constructor(private readonly options: IBetterAuthJwksVerifierOptions) {
+    this.jwks = createRemoteJWKSet(new URL(options.jwksUrl));
   }
 
   /**
@@ -43,7 +55,10 @@ export class BetterAuthJwksVerifier {
    * treat a throw as "unauthenticated".
    */
   async verify(token: string): Promise<IBetterAuthVerifiedClaims> {
-    const { payload } = await jwtVerify(token, this.jwks);
+    const { payload } = await jwtVerify(token, this.jwks, {
+      audience: this.options.audience,
+      issuer: this.options.issuer,
+    });
 
     if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
       throw new Error('Better Auth JWT is missing a subject (sub) claim');

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "jose": "^6.2.3"
+  },
   "description": "Shared backend library modules and infrastructure helpers for Genfeed server applications",
   "exports": {
     "./*": "./*"

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@genfeedai/enums": "workspace:*",
     "jose": "^6.2.3"
   },
   "description": "Shared backend library modules and infrastructure helpers for Genfeed server applications",

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@genfeedai/enums": "workspace:*",
+    "@genfeedai/interfaces": "workspace:*",
     "jose": "^6.2.3"
   },
   "description": "Shared backend library modules and infrastructure helpers for Genfeed server applications",

--- a/packages/libs/websockets/websockets.gateway.spec.ts
+++ b/packages/libs/websockets/websockets.gateway.spec.ts
@@ -1,4 +1,3 @@
-import { verifyToken } from '@clerk/backend';
 import type { LoggerService } from '@libs/logger/logger.service';
 import type { RedisService } from '@libs/redis/redis.service';
 import { WebSocketGateway } from '@libs/websockets/websockets.gateway';
@@ -13,11 +12,14 @@ import {
   vi,
 } from 'vitest';
 
-vi.mock('@clerk/backend', () => ({
-  verifyToken: vi.fn(),
-}));
+const verifyMock = vi.hoisted(() => vi.fn());
 
-const verifyTokenMock = vi.mocked(verifyToken);
+vi.mock('@libs/auth/better-auth-jwks.verifier', () => ({
+  BetterAuthJwksVerifier: class {
+    verify = verifyMock;
+  },
+  resolveBetterAuthJwksUrl: (baseUrl: string) => `${baseUrl}/v1/auth/jwks`,
+}));
 
 describe('WebSocketGateway', () => {
   let gateway: WebSocketGateway;
@@ -111,7 +113,7 @@ describe('WebSocketGateway', () => {
 
     await gateway.handleConnection(socket as Socket);
 
-    expect(socket.join).toHaveBeenCalledWith('user-user-123');
+    expect(socket.join).toHaveBeenCalledWith('user:user-123');
     expect(socket.join).toHaveBeenCalledWith('org-org-123');
     expect(socket.emit).toHaveBeenCalledWith(
       'connected',
@@ -137,17 +139,11 @@ describe('WebSocketGateway', () => {
     expect(socket.disconnect).toHaveBeenCalledOnce();
   });
 
-  it('resolves websocket identity from verified session claims', async () => {
-    mockConfigService.get.mockReturnValue('test-secret-key');
-    verifyTokenMock.mockResolvedValue({
-      metadata: {
-        publicMetadata: {
-          organization: 'org_999',
-          user: '507f1f77bcf86cd799439011',
-        },
-      },
-      sub: 'user_clerk_999',
-    } as never);
+  it('resolves websocket identity from a verified Better Auth token', async () => {
+    mockConfigService.get.mockReturnValue('http://localhost:3010');
+    verifyMock.mockResolvedValue({
+      sub: 'aaaaaaaa-0000-0000-0000-000000000001',
+    });
     const socket = createMockSocket({
       handshake: {
         auth: { token: 'header.payload.signature' },
@@ -161,17 +157,46 @@ describe('WebSocketGateway', () => {
 
     await gateway.handleConnection(socket as Socket);
 
-    expect(verifyTokenMock).toHaveBeenCalledWith('header.payload.signature', {
-      secretKey: 'test-secret-key',
-    });
-    expect(socket.join).toHaveBeenCalledWith('user-user_clerk_999');
-    expect(socket.join).toHaveBeenCalledWith('org-org_999');
+    expect(verifyMock).toHaveBeenCalledWith('header.payload.signature');
+    // `sub` (User.id) wins over the query userId.
+    expect(socket.join).toHaveBeenCalledWith(
+      'user:aaaaaaaa-0000-0000-0000-000000000001',
+    );
+    // Org is not embedded in the BA JWT, so it falls back to the query param.
+    expect(socket.join).toHaveBeenCalledWith('org-org-query');
     expect(socket.emit).toHaveBeenCalledWith(
       'connected',
       expect.objectContaining({
-        organizationId: 'org_999',
-        userId: 'user_clerk_999',
+        organizationId: 'org-query',
+        userId: 'aaaaaaaa-0000-0000-0000-000000000001',
       }),
+    );
+  });
+
+  it('falls back to query identity when Better Auth verification throws', async () => {
+    mockConfigService.get.mockReturnValue('http://localhost:3010');
+    verifyMock.mockRejectedValue(new Error('invalid signature'));
+    const socket = createMockSocket({
+      handshake: {
+        auth: { token: 'bad.token.here' },
+        headers: {},
+        query: {
+          organizationId: 'org-query',
+          userId: 'user-query',
+        },
+      } as Socket['handshake'],
+    });
+
+    await gateway.handleConnection(socket as Socket);
+
+    // A failed verify must not connect with a forged subject — it degrades to
+    // the query identity (the unauthenticated fallback), never the bad token.
+    expect(verifyMock).toHaveBeenCalledWith('bad.token.here');
+    expect(socket.disconnect).not.toHaveBeenCalled();
+    expect(socket.join).toHaveBeenCalledWith('user:user-query');
+    expect(mockLoggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to verify Better Auth token'),
+      expect.any(Object),
     );
   });
 

--- a/packages/libs/websockets/websockets.gateway.spec.ts
+++ b/packages/libs/websockets/websockets.gateway.spec.ts
@@ -108,17 +108,17 @@ describe('WebSocketGateway', () => {
     );
   });
 
-  it('should connect a client and join user/org rooms', async () => {
+  it('connects query-identity clients without joining an org room', async () => {
     const socket = createMockSocket();
 
     await gateway.handleConnection(socket as Socket);
 
     expect(socket.join).toHaveBeenCalledWith('user:user-123');
-    expect(socket.join).toHaveBeenCalledWith('org-org-123');
+    expect(socket.join).not.toHaveBeenCalledWith('org-org-123');
     expect(socket.emit).toHaveBeenCalledWith(
       'connected',
       expect.objectContaining({
-        organizationId: 'org-123',
+        organizationId: undefined,
         socketId: 'socket-123',
         userId: 'user-123',
       }),
@@ -142,6 +142,7 @@ describe('WebSocketGateway', () => {
   it('resolves websocket identity from a verified Better Auth token', async () => {
     mockConfigService.get.mockReturnValue('http://localhost:3010');
     verifyMock.mockResolvedValue({
+      organizationId: 'org-signed',
       sub: 'aaaaaaaa-0000-0000-0000-000000000001',
     });
     const socket = createMockSocket({
@@ -162,12 +163,44 @@ describe('WebSocketGateway', () => {
     expect(socket.join).toHaveBeenCalledWith(
       'user:aaaaaaaa-0000-0000-0000-000000000001',
     );
-    // Org is not embedded in the BA JWT, so it falls back to the query param.
-    expect(socket.join).toHaveBeenCalledWith('org-org-query');
+    // Signed org wins over the forged query org.
+    expect(socket.join).toHaveBeenCalledWith('org-org-signed');
+    expect(socket.join).not.toHaveBeenCalledWith('org-org-query');
     expect(socket.emit).toHaveBeenCalledWith(
       'connected',
       expect.objectContaining({
-        organizationId: 'org-query',
+        organizationId: 'org-signed',
+        userId: 'aaaaaaaa-0000-0000-0000-000000000001',
+      }),
+    );
+  });
+
+  it('does not join an org room when a verified token has no org claim', async () => {
+    mockConfigService.get.mockReturnValue('http://localhost:3010');
+    verifyMock.mockResolvedValue({
+      sub: 'aaaaaaaa-0000-0000-0000-000000000001',
+    });
+    const socket = createMockSocket({
+      handshake: {
+        auth: { token: 'header.payload.signature' },
+        headers: {},
+        query: {
+          organizationId: 'org-query',
+          userId: 'user-query',
+        },
+      } as Socket['handshake'],
+    });
+
+    await gateway.handleConnection(socket as Socket);
+
+    expect(socket.join).toHaveBeenCalledWith(
+      'user:aaaaaaaa-0000-0000-0000-000000000001',
+    );
+    expect(socket.join).not.toHaveBeenCalledWith('org-org-query');
+    expect(socket.emit).toHaveBeenCalledWith(
+      'connected',
+      expect.objectContaining({
+        organizationId: undefined,
         userId: 'aaaaaaaa-0000-0000-0000-000000000001',
       }),
     );
@@ -189,11 +222,12 @@ describe('WebSocketGateway', () => {
 
     await gateway.handleConnection(socket as Socket);
 
-    // A failed verify must not connect with a forged subject — it degrades to
-    // the query identity (the unauthenticated fallback), never the bad token.
+    // A failed verify must not connect with forged token claims — it degrades
+    // to the query user identity only, never the query org room.
     expect(verifyMock).toHaveBeenCalledWith('bad.token.here');
     expect(socket.disconnect).not.toHaveBeenCalled();
     expect(socket.join).toHaveBeenCalledWith('user:user-query');
+    expect(socket.join).not.toHaveBeenCalledWith('org-org-query');
     expect(mockLoggerService.warn).toHaveBeenCalledWith(
       expect.stringContaining('Failed to verify Better Auth token'),
       expect.any(Object),

--- a/packages/libs/websockets/websockets.gateway.spec.ts
+++ b/packages/libs/websockets/websockets.gateway.spec.ts
@@ -18,7 +18,11 @@ vi.mock('@libs/auth/better-auth-jwks.verifier', () => ({
   BetterAuthJwksVerifier: class {
     verify = verifyMock;
   },
-  resolveBetterAuthJwksUrl: (baseUrl: string) => `${baseUrl}/v1/auth/jwks`,
+  createBetterAuthJwksVerifierOptions: (baseUrl: string) => ({
+    audience: baseUrl,
+    issuer: baseUrl,
+    jwksUrl: `${baseUrl}/v1/auth/jwks`,
+  }),
 }));
 
 describe('WebSocketGateway', () => {
@@ -108,20 +112,16 @@ describe('WebSocketGateway', () => {
     );
   });
 
-  it('connects query-identity clients without joining an org room', async () => {
+  it('disconnects query-identity clients without a verified token', async () => {
     const socket = createMockSocket();
 
     await gateway.handleConnection(socket as Socket);
 
-    expect(socket.join).toHaveBeenCalledWith('user:user-123');
-    expect(socket.join).not.toHaveBeenCalledWith('org-org-123');
-    expect(socket.emit).toHaveBeenCalledWith(
+    expect(socket.disconnect).toHaveBeenCalledOnce();
+    expect(socket.join).not.toHaveBeenCalled();
+    expect(socket.emit).not.toHaveBeenCalledWith(
       'connected',
-      expect.objectContaining({
-        organizationId: undefined,
-        socketId: 'socket-123',
-        userId: 'user-123',
-      }),
+      expect.any(Object),
     );
   });
 
@@ -206,7 +206,7 @@ describe('WebSocketGateway', () => {
     );
   });
 
-  it('falls back to query identity when Better Auth verification throws', async () => {
+  it('disconnects when Better Auth verification throws', async () => {
     mockConfigService.get.mockReturnValue('http://localhost:3010');
     verifyMock.mockRejectedValue(new Error('invalid signature'));
     const socket = createMockSocket({
@@ -222,12 +222,14 @@ describe('WebSocketGateway', () => {
 
     await gateway.handleConnection(socket as Socket);
 
-    // A failed verify must not connect with forged token claims — it degrades
-    // to the query user identity only, never the query org room.
     expect(verifyMock).toHaveBeenCalledWith('bad.token.here');
-    expect(socket.disconnect).not.toHaveBeenCalled();
-    expect(socket.join).toHaveBeenCalledWith('user:user-query');
+    expect(socket.disconnect).toHaveBeenCalledOnce();
+    expect(socket.join).not.toHaveBeenCalledWith('user:user-query');
     expect(socket.join).not.toHaveBeenCalledWith('org-org-query');
+    expect(socket.emit).not.toHaveBeenCalledWith(
+      'connected',
+      expect.any(Object),
+    );
     expect(mockLoggerService.warn).toHaveBeenCalledWith(
       expect.stringContaining('Failed to verify Better Auth token'),
       expect.any(Object),

--- a/packages/libs/websockets/websockets.gateway.ts
+++ b/packages/libs/websockets/websockets.gateway.ts
@@ -1,6 +1,6 @@
 import {
   BetterAuthJwksVerifier,
-  resolveBetterAuthJwksUrl,
+  createBetterAuthJwksVerifierOptions,
 } from '@libs/auth/better-auth-jwks.verifier';
 import type {
   AssetStatusData,
@@ -205,10 +205,9 @@ export class WebSocketGateway
     userId?: string;
     organizationId?: string;
   }> {
-    const queryUserId = client.handshake.query.userId as string | undefined;
     const token = this.extractToken(client);
     if (!token) {
-      return { userId: queryUserId };
+      return {};
     }
 
     try {
@@ -225,7 +224,7 @@ export class WebSocketGateway
         `Failed to verify Better Auth token for client ${client.id}: ${errorMessage}`,
         { ...this.context, error },
       );
-      return { userId: queryUserId };
+      return {};
     }
   }
 
@@ -238,8 +237,9 @@ export class WebSocketGateway
           this.context,
         );
       }
+      const betterAuthBaseUrl = configuredUrl || 'http://localhost:3010';
       this.betterAuthVerifier = new BetterAuthJwksVerifier(
-        resolveBetterAuthJwksUrl(configuredUrl || 'http://localhost:3010'),
+        createBetterAuthJwksVerifierOptions(betterAuthBaseUrl),
       );
     }
     return this.betterAuthVerifier;

--- a/packages/libs/websockets/websockets.gateway.ts
+++ b/packages/libs/websockets/websockets.gateway.ts
@@ -206,30 +206,17 @@ export class WebSocketGateway
     organizationId?: string;
   }> {
     const queryUserId = client.handshake.query.userId as string | undefined;
-    const queryOrgId = client.handshake.query.organizationId as
-      | string
-      | undefined;
-
     const token = this.extractToken(client);
     if (!token) {
-      return { organizationId: queryOrgId, userId: queryUserId };
+      return { userId: queryUserId };
     }
 
     try {
-      const { sub } = await this.getBetterAuthVerifier().verify(token);
+      const { organizationId, sub } =
+        await this.getBetterAuthVerifier().verify(token);
 
-      // Better Auth JWTs carry only identity (`sub` = User.id), not organization
-      // (that is resolved DB-side at bootstrap). The org room therefore falls
-      // back to the client-supplied query param.
-      //
-      // SECURITY (epic #735, Phase 4 — follow-up): the Clerk token previously
-      // embedded the user's org, so this trusts an unverified query value where
-      // it used to trust a signed claim — a token-authenticated client could
-      // join another org's broadcast room. The user room (keyed on the verified
-      // `sub`) is unaffected. Harden by verifying membership of the resolved
-      // userId in the claimed org before joining `org-<id>`.
       return {
-        organizationId: queryOrgId,
+        organizationId,
         userId: sub,
       };
     } catch (error: unknown) {
@@ -238,7 +225,7 @@ export class WebSocketGateway
         `Failed to verify Better Auth token for client ${client.id}: ${errorMessage}`,
         { ...this.context, error },
       );
-      return { organizationId: queryOrgId, userId: queryUserId };
+      return { userId: queryUserId };
     }
   }
 

--- a/packages/libs/websockets/websockets.gateway.ts
+++ b/packages/libs/websockets/websockets.gateway.ts
@@ -1,5 +1,7 @@
-import { verifyToken } from '@clerk/backend';
-import { resolveClerkSessionClaims } from '@helpers/auth/clerk-session-claims.helper';
+import {
+  BetterAuthJwksVerifier,
+  resolveBetterAuthJwksUrl,
+} from '@libs/auth/better-auth-jwks.verifier';
 import type {
   AssetStatusData,
   BackgroundTaskUpdateData,
@@ -50,6 +52,8 @@ export class WebSocketGateway
   private clients: Map<string, ClientInfo> = new Map();
   private userToSocket: Map<string, Set<string>> = new Map();
   private isServerReady = false;
+  /** Lazily built once; `jose` caches the remote JWKS internally. */
+  private betterAuthVerifier?: BetterAuthJwksVerifier;
 
   constructor(
     @Inject('ConfigService')
@@ -212,35 +216,46 @@ export class WebSocketGateway
     }
 
     try {
-      const clerkSecret = this.configService.get('CLERK_SECRET_KEY');
-      if (!clerkSecret) {
-        this.logger.warn(
-          'Missing CLERK_SECRET_KEY configuration; falling back to query parameters',
-          this.context,
-        );
-        return { organizationId: queryOrgId, userId: queryUserId };
-      }
+      const { sub } = await this.getBetterAuthVerifier().verify(token);
 
-      const tokenPayload = await verifyToken(token, {
-        secretKey: clerkSecret,
-      });
-
-      const sessionClaims = resolveClerkSessionClaims(tokenPayload);
-      const userIdFromToken = sessionClaims.clerkUserId;
-      const organizationIdFromToken = sessionClaims.organizationId;
-
+      // Better Auth JWTs carry only identity (`sub` = User.id), not organization
+      // (that is resolved DB-side at bootstrap). The org room therefore falls
+      // back to the client-supplied query param.
+      //
+      // SECURITY (epic #735, Phase 4 — follow-up): the Clerk token previously
+      // embedded the user's org, so this trusts an unverified query value where
+      // it used to trust a signed claim — a token-authenticated client could
+      // join another org's broadcast room. The user room (keyed on the verified
+      // `sub`) is unaffected. Harden by verifying membership of the resolved
+      // userId in the claimed org before joining `org-<id>`.
       return {
-        organizationId: organizationIdFromToken || queryOrgId,
-        userId: userIdFromToken || queryUserId,
+        organizationId: queryOrgId,
+        userId: sub,
       };
     } catch (error: unknown) {
       const errorMessage = (error as Error)?.message ?? String(error);
       this.logger.warn(
-        `Failed to verify Clerk token for client ${client.id}: ${errorMessage}`,
+        `Failed to verify Better Auth token for client ${client.id}: ${errorMessage}`,
         { ...this.context, error },
       );
       return { organizationId: queryOrgId, userId: queryUserId };
     }
+  }
+
+  private getBetterAuthVerifier(): BetterAuthJwksVerifier {
+    if (!this.betterAuthVerifier) {
+      const configuredUrl = this.configService.get('BETTER_AUTH_URL');
+      if (!configuredUrl) {
+        this.logger.warn(
+          'BETTER_AUTH_URL is not configured; falling back to http://localhost:3010 for JWKS — set this in production or socket auth will fail',
+          this.context,
+        );
+      }
+      this.betterAuthVerifier = new BetterAuthJwksVerifier(
+        resolveBetterAuthJwksUrl(configuredUrl || 'http://localhost:3010'),
+      );
+    }
+    return this.betterAuthVerifier;
   }
 
   private extractToken(client: Socket): string | undefined {

--- a/packages/libs/websockets/websockets.module.spec.ts
+++ b/packages/libs/websockets/websockets.module.spec.ts
@@ -1,8 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
-
-vi.mock('@clerk/backend', () => ({
-  verifyToken: vi.fn(),
-}));
+import { describe, expect, it } from 'vitest';
 
 describe('WebSocketModule', () => {
   it('should be importable', async () => {


### PR DESCRIPTION
## What this PR does

Part of the **Clerk -> Better Auth cutover** (epic #735, Phase 4 — **D3**). Replaces `@clerk/backend` `verifyToken` in both socket gateways with Better Auth JWT verification against the Better Auth jwt plugin JWKS.

- **`BetterAuthJwksVerifier`** (`packages/libs/auth/better-auth-jwks.verifier.ts`) verifies tokens with `jose` against `${BETTER_AUTH_URL}/v1/auth/jwks` and returns signed claims used by socket gateways.
- **Signed org-room hardening** embeds the user's active `organizationId` into the BA JWT at mint time (`User.lastUsedOrganizationId` validated against membership/ownership, then owned org, then first active membership). The websocket gateway trusts only that signed claim for org-room joins and ignores forged `?organizationId=` values.
- **`WebSocketGateway`** (`packages/libs/websockets`) verifies via the shared verifier, uses `sub` as the Prisma `User.id`, joins `org-<id>` only when the signed token carries an org, and no longer joins org rooms on tokenless or failed-token fallback paths.
- **`TerminalGateway`** (`apps/server/notifications`) verifies via the shared verifier; `TerminalService.getBetterAuthJwksUrl()` resolves `BETTER_AUTH_URL -> API_BASE_URL -> localhost:3010`.
- **Package deps** add `jose` where needed and declare the existing `@genfeedai/libs -> @genfeedai/enums` workspace edge so libs typecheck resolves cleanly.

## Verification

Local:
- `TZ=UTC bun run --cwd apps/server/api test:file src/auth/better-auth/better-auth.factory.spec.ts` — 4 passed
- `TZ=UTC bunx vitest run --config packages/libs/vitest.config.ts packages/libs/websockets/websockets.gateway.spec.ts packages/libs/websockets/websockets.module.spec.ts` — 9 passed
- `TZ=UTC bun run --cwd apps/server/notifications test src/services/terminal/terminal.gateway.spec.ts` — 9 passed
- `bunx biome check <touched files>` — clean
- `bunx secretlint <touched files>` — clean
- `bunx tsc --noEmit -p packages/libs/tsconfig.json --ignoreDeprecations 6.0` — clean
- `bun run --cwd apps/server/api build` — webpack compiled successfully
- `bun run --cwd apps/server/notifications build` — webpack compiled successfully
- `bun run --cwd apps/server/files build` — webpack compiled successfully

Notes:
- Plain `tsc --noEmit -p apps/server/*/tsconfig.json` is still noisy from existing repo config/spec/path issues; the server Nest build surface passed for the touched apps.
- D1 invitations is separate follow-up work and is not implemented here.