### PR TITLE
feat(auth): Self-hosted invitations (Phase 4 — D1, epic #735)

### DIFF
--- a/apps/server/api/src/collections/members/controllers/invitations.controller.spec.ts
+++ b/apps/server/api/src/collections/members/controllers/invitations.controller.spec.ts
@@ -1,0 +1,78 @@
+import { InvitationsController } from '@api/collections/members/controllers/invitations.controller';
+import type { InvitationService } from '@api/collections/members/services/invitation.service';
+import { BadRequestException } from '@nestjs/common';
+import type { Response } from 'express';
+
+const acceptResult = {
+  invitation: {
+    acceptedAt: new Date('2026-06-23T12:00:00.000Z'),
+    createdAt: new Date('2026-06-22T12:00:00.000Z'),
+    email: 'new@example.com',
+    expiresAt: new Date('2026-06-30T12:00:00.000Z'),
+    id: 'inv_123',
+    invitedByUserId: 'user_123',
+    organizationId: 'org_123',
+    revokedAt: null,
+    roleId: 'role_user',
+    status: 'accepted' as const,
+    updatedAt: new Date('2026-06-23T12:00:00.000Z'),
+  },
+  memberId: 'member_123',
+  organizationId: 'org_123',
+  redirectUrl: 'https://app.test/login?invitation=accepted&org=org_123',
+  userId: 'user_123',
+};
+
+const invitationService = {
+  acceptInvitation: vi.fn(),
+} as unknown as InvitationService;
+
+function buildController() {
+  return new InvitationsController(invitationService);
+}
+
+describe('InvitationsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts an invitation and redirects to the resolved URL', async () => {
+    const controller = buildController();
+    vi.mocked(invitationService.acceptInvitation).mockResolvedValue(
+      acceptResult,
+    );
+    const response = {
+      redirect: vi.fn(),
+    } as unknown as Response;
+
+    await controller.acceptInvitationRedirect('token-123', response);
+
+    expect(invitationService.acceptInvitation).toHaveBeenCalledWith(
+      'token-123',
+    );
+    expect(response.redirect).toHaveBeenCalledWith(
+      303,
+      acceptResult.redirectUrl,
+    );
+  });
+
+  it('accepts an invitation and returns a JSON result', async () => {
+    const controller = buildController();
+    vi.mocked(invitationService.acceptInvitation).mockResolvedValue(
+      acceptResult,
+    );
+
+    const result = await controller.acceptInvitation('token-123');
+
+    expect(result).toEqual({ data: acceptResult });
+  });
+
+  it('rejects blank tokens before calling the service', async () => {
+    const controller = buildController();
+
+    await expect(controller.acceptInvitation('   ')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(invitationService.acceptInvitation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/members/controllers/invitations.controller.ts
+++ b/apps/server/api/src/collections/members/controllers/invitations.controller.ts
@@ -1,0 +1,48 @@
+import { InvitationService } from '@api/collections/members/services/invitation.service';
+import { Public } from '@libs/decorators/public.decorator';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Res,
+} from '@nestjs/common';
+import type { Response } from 'express';
+
+@Controller()
+export class InvitationsController {
+  constructor(private readonly invitationService: InvitationService) {}
+
+  @Public()
+  @Get('accept-invitation')
+  async acceptInvitationRedirect(
+    @Query('token') token: string | undefined,
+    @Res() response: Response,
+  ): Promise<void> {
+    const result = await this.invitationService.acceptInvitation(
+      this.requireToken(token),
+    );
+
+    response.redirect(303, result.redirectUrl);
+  }
+
+  @Public()
+  @Post('members/invitations/accept')
+  async acceptInvitation(@Body('token') token: string | undefined) {
+    const result = await this.invitationService.acceptInvitation(
+      this.requireToken(token),
+    );
+
+    return { data: result };
+  }
+
+  private requireToken(token: string | undefined): string {
+    if (!token?.trim()) {
+      throw new BadRequestException('Invitation token is required');
+    }
+
+    return token;
+  }
+}

--- a/apps/server/api/src/collections/members/controllers/members-invitation.controller.spec.ts
+++ b/apps/server/api/src/collections/members/controllers/members-invitation.controller.spec.ts
@@ -1,14 +1,13 @@
 import { MembersController } from '@api/collections/members/controllers/members.controller';
+import type { InvitationService } from '@api/collections/members/services/invitation.service';
 import type { MembersService } from '@api/collections/members/services/members.service';
-import type { RolesService } from '@api/collections/roles/services/roles.service';
-import type { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import type { User } from '@clerk/backend';
 import type { LoggerService } from '@libs/logger/logger.service';
 import { HttpException, HttpStatus } from '@nestjs/common';
 
-const userId = '507f191e810c19729de860ee'.toString();
-const orgId = '507f191e810c19729de860ee'.toString();
-const brandId = '507f191e810c19729de860ee'.toString();
+const userId = '507f191e810c19729de860ee';
+const orgId = '507f191e810c19729de860ee';
+const brandId = '507f191e810c19729de860ee';
 
 const makeUser = (overrides: Record<string, unknown> = {}): User =>
   ({
@@ -22,23 +21,33 @@ const makeUser = (overrides: Record<string, unknown> = {}): User =>
     },
   }) as unknown as User;
 
+const now = new Date('2026-06-23T12:00:00.000Z');
+
+const invitation = {
+  acceptedAt: null,
+  createdAt: now,
+  email: 'new@example.com',
+  expiresAt: new Date('2026-06-30T12:00:00.000Z'),
+  id: 'inv_123',
+  invitedByUserId: userId,
+  organizationId: orgId,
+  revokedAt: null,
+  roleId: 'role_member',
+  status: 'pending' as const,
+  updatedAt: now,
+};
+
 const mockMembersService = {
-  find: vi.fn(),
   findAll: vi.fn(),
   findOne: vi.fn(),
 } as unknown as MembersService;
 
-const mockClerkService = {
+const mockInvitationService = {
   createInvitation: vi.fn(),
-  getInvitation: vi.fn(),
-  getUserByEmail: vi.fn(),
-  listInvitations: vi.fn(),
+  listPendingInvitations: vi.fn(),
+  resendInvitation: vi.fn(),
   revokeInvitation: vi.fn(),
-} as unknown as ClerkService;
-
-const mockRolesService = {
-  findOne: vi.fn(),
-} as unknown as RolesService;
+} as unknown as InvitationService;
 
 const mockLoggerService = {
   debug: vi.fn(),
@@ -50,8 +59,7 @@ const mockLoggerService = {
 function buildController() {
   return new MembersController(
     mockMembersService,
-    mockClerkService,
-    mockRolesService,
+    mockInvitationService,
     mockLoggerService,
   );
 }
@@ -61,10 +69,10 @@ describe('MembersController — invitation endpoints', () => {
     vi.clearAllMocks();
   });
 
-  // ─── POST /members/invite ─────────────────────────────────────────────────
   describe('POST /members/invite', () => {
     it('throws 400 when organization missing from metadata', async () => {
       const controller = buildController();
+
       await expect(
         controller.invite(
           { email: 'test@example.com' },
@@ -81,140 +89,81 @@ describe('MembersController — invitation endpoints', () => {
       );
     });
 
-    it('throws 409 when user is already a member', async () => {
+    it('creates a self-hosted invitation with default member role semantics', async () => {
       const controller = buildController();
-      vi.mocked(mockClerkService.getUserByEmail).mockResolvedValue({
-        publicMetadata: { user: '507f191e810c19729de860ee'.toString() },
-      } as never);
-      vi.mocked(mockMembersService.findOne).mockResolvedValue({
-        _id: '507f191e810c19729de860ee',
-      } as never);
-
-      await expect(
-        controller.invite({ email: 'existing@example.com' }, makeUser()),
-      ).rejects.toThrow(
-        new HttpException(
-          {
-            detail: 'User is already a member of this organization',
-            title: 'Conflict',
-          },
-          HttpStatus.CONFLICT,
-        ),
+      vi.mocked(mockInvitationService.createInvitation).mockResolvedValue(
+        invitation,
       );
-    });
-
-    it('creates invitation with default member role when role not specified', async () => {
-      const controller = buildController();
-      const roleId = '507f191e810c19729de860ee';
-
-      vi.mocked(mockClerkService.getUserByEmail).mockResolvedValue(null);
-      vi.mocked(mockRolesService.findOne).mockResolvedValue({
-        _id: roleId,
-        key: 'member',
-      } as never);
-      vi.mocked(mockClerkService.createInvitation).mockResolvedValue({
-        id: 'inv_123',
-        status: 'pending',
-      } as never);
 
       const result = await controller.invite(
-        { email: 'new@example.com' },
+        { email: 'new@example.com', firstName: 'New', lastName: 'User' },
         makeUser(),
       );
 
-      expect(mockClerkService.createInvitation).toHaveBeenCalledWith(
-        'new@example.com',
-        expect.stringContaining(`org=${orgId}`),
-        expect.objectContaining({
-          invitedByUser: userId,
+      expect(mockInvitationService.createInvitation).toHaveBeenCalledWith({
+        defaultRoleKey: 'member',
+        email: 'new@example.com',
+        firstName: 'New',
+        invitedByUserId: userId,
+        lastName: 'User',
+        organizationId: orgId,
+        roleId: undefined,
+      });
+      expect(result).toEqual({
+        data: {
+          email: 'new@example.com',
+          id: 'inv_123',
           organization: orgId,
-          role: roleId.toString(),
-        }),
-      );
-      expect(result).toMatchObject({
-        data: { email: 'new@example.com', id: 'inv_123', status: 'pending' },
+          role: 'role_member',
+          status: 'pending',
+        },
       });
     });
 
-    it('uses provided role when specified', async () => {
+    it('passes a provided role through to the invitation service', async () => {
       const controller = buildController();
-      const customRole = '507f191e810c19729de860ee';
-
-      vi.mocked(mockClerkService.getUserByEmail).mockResolvedValue(null);
-      vi.mocked(mockClerkService.createInvitation).mockResolvedValue({
-        id: 'inv_456',
-        status: 'pending',
-      } as never);
+      vi.mocked(mockInvitationService.createInvitation).mockResolvedValue({
+        ...invitation,
+        roleId: 'role_custom',
+      });
 
       await controller.invite(
-        { email: 'new@example.com', role: customRole },
+        { email: 'new@example.com', role: 'role_custom' },
         makeUser(),
       );
 
-      expect(mockClerkService.createInvitation).toHaveBeenCalledWith(
-        'new@example.com',
-        expect.any(String),
-        expect.objectContaining({ role: customRole.toString() }),
-      );
-    });
-
-    it('includes firstName/lastName in metadata when provided', async () => {
-      const controller = buildController();
-      vi.mocked(mockClerkService.getUserByEmail).mockResolvedValue(null);
-      vi.mocked(mockRolesService.findOne).mockResolvedValue(null);
-      vi.mocked(mockClerkService.createInvitation).mockResolvedValue({
-        id: 'inv_789',
-        status: 'pending',
-      } as never);
-
-      await controller.invite(
-        { email: 'j@example.com', firstName: 'Jane', lastName: 'Doe' },
-        makeUser(),
-      );
-
-      expect(mockClerkService.createInvitation).toHaveBeenCalledWith(
-        'j@example.com',
-        expect.any(String),
-        expect.objectContaining({ firstName: 'Jane', lastName: 'Doe' }),
+      expect(mockInvitationService.createInvitation).toHaveBeenCalledWith(
+        expect.objectContaining({ roleId: 'role_custom' }),
       );
     });
   });
 
-  // ─── GET /members/invitations/pending ─────────────────────────────────────
   describe('GET /members/invitations/pending', () => {
     it('throws 400 when organization missing', async () => {
       const controller = buildController();
+
       await expect(
         controller.listInvitations(makeUser({ organization: undefined })),
       ).rejects.toThrow(HttpException);
     });
 
-    it('returns only invitations for current org', async () => {
+    it('returns pending invitations for current org', async () => {
       const controller = buildController();
-      vi.mocked(mockClerkService.listInvitations).mockResolvedValue([
-        {
-          createdAt: 1000,
-          emailAddress: 'a@test.com',
-          id: 'inv_1',
-          publicMetadata: { organization: orgId },
-          status: 'pending',
-        },
-        {
-          createdAt: 2000,
-          emailAddress: 'b@test.com',
-          id: 'inv_2',
-          publicMetadata: { organization: 'other-org' },
-          status: 'pending',
-        },
-      ] as never);
+      vi.mocked(mockInvitationService.listPendingInvitations).mockResolvedValue(
+        [invitation],
+      );
 
       const result = await controller.listInvitations(makeUser());
+
+      expect(mockInvitationService.listPendingInvitations).toHaveBeenCalledWith(
+        orgId,
+      );
       expect(result).toEqual({
         data: [
           {
-            createdAt: 1000,
-            email: 'a@test.com',
-            id: 'inv_1',
+            createdAt: now,
+            email: 'new@example.com',
+            id: 'inv_123',
             status: 'pending',
           },
         ],
@@ -222,10 +171,10 @@ describe('MembersController — invitation endpoints', () => {
     });
   });
 
-  // ─── DELETE /members/invitations/:id ──────────────────────────────────────
   describe('DELETE /members/invitations/:invitationId', () => {
     it('throws 400 when org missing', async () => {
       const controller = buildController();
+
       await expect(
         controller.revokeInvitation(
           'inv_1',
@@ -234,105 +183,46 @@ describe('MembersController — invitation endpoints', () => {
       ).rejects.toThrow(HttpException);
     });
 
-    it('throws 404 when invitation not found', async () => {
-      const controller = buildController();
-      vi.mocked(mockClerkService.getInvitation).mockResolvedValue(null);
-
-      await expect(
-        controller.revokeInvitation('inv_xxx', makeUser()),
-      ).rejects.toThrow(
-        new HttpException(
-          { detail: 'Invitation not found', title: 'Not Found' },
-          HttpStatus.NOT_FOUND,
-        ),
-      );
-    });
-
-    it('throws 403 when invitation belongs to different org', async () => {
-      const controller = buildController();
-      vi.mocked(mockClerkService.getInvitation).mockResolvedValue({
-        id: 'inv_1',
-        publicMetadata: { organization: 'other-org' },
-      } as never);
-
-      await expect(
-        controller.revokeInvitation('inv_1', makeUser()),
-      ).rejects.toThrow(
-        new HttpException(
-          {
-            detail: 'Invitation does not belong to this organization',
-            title: 'Forbidden',
-          },
-          HttpStatus.FORBIDDEN,
-        ),
-      );
-    });
-
     it('revokes invitation successfully', async () => {
       const controller = buildController();
-      vi.mocked(mockClerkService.getInvitation).mockResolvedValue({
+      vi.mocked(mockInvitationService.revokeInvitation).mockResolvedValue({
+        ...invitation,
         id: 'inv_1',
-        publicMetadata: { organization: orgId },
-      } as never);
-      vi.mocked(mockClerkService.revokeInvitation).mockResolvedValue(
-        undefined as never,
-      );
+        revokedAt: now,
+        status: 'revoked',
+      });
 
       const result = await controller.revokeInvitation('inv_1', makeUser());
-      expect(mockClerkService.revokeInvitation).toHaveBeenCalledWith('inv_1');
+
+      expect(mockInvitationService.revokeInvitation).toHaveBeenCalledWith(
+        'inv_1',
+        orgId,
+      );
       expect(result).toEqual({ data: { id: 'inv_1', status: 'revoked' } });
     });
   });
 
-  // ─── POST /members/invitations/:id/resend ─────────────────────────────────
   describe('POST /members/invitations/:id/resend', () => {
-    it('throws 404 when invitation not found', async () => {
+    it('resends a pending invitation', async () => {
       const controller = buildController();
-      vi.mocked(mockClerkService.getInvitation).mockResolvedValue(null);
-
-      await expect(
-        controller.resendInvitation('inv_xxx', makeUser()),
-      ).rejects.toThrow(HttpException);
-    });
-
-    it('throws 403 when invitation belongs to different org', async () => {
-      const controller = buildController();
-      vi.mocked(mockClerkService.getInvitation).mockResolvedValue({
-        id: 'inv_1',
-        publicMetadata: { organization: 'wrong-org' },
-      } as never);
-
-      await expect(
-        controller.resendInvitation('inv_1', makeUser()),
-      ).rejects.toThrow(HttpException);
-    });
-
-    it('revokes old invitation and creates new one', async () => {
-      const controller = buildController();
-      vi.mocked(mockClerkService.getInvitation).mockResolvedValue({
-        emailAddress: 'test@example.com',
-        id: 'inv_old',
-        publicMetadata: { organization: orgId, role: 'member' },
-      } as never);
-      vi.mocked(mockClerkService.revokeInvitation).mockResolvedValue(
-        undefined as never,
-      );
-      vi.mocked(mockClerkService.createInvitation).mockResolvedValue({
-        emailAddress: 'test@example.com',
+      vi.mocked(mockInvitationService.resendInvitation).mockResolvedValue({
+        ...invitation,
         id: 'inv_new',
-        status: 'pending',
-      } as never);
+      });
 
       const result = await controller.resendInvitation('inv_old', makeUser());
 
-      expect(mockClerkService.revokeInvitation).toHaveBeenCalledWith('inv_old');
-      expect(mockClerkService.createInvitation).toHaveBeenCalledWith(
-        'test@example.com',
-        expect.stringContaining(`org=${orgId}`),
-        { organization: orgId, role: 'member' },
-      );
-      expect(result).toMatchObject({
-        data: { email: 'test@example.com', id: 'inv_new', status: 'pending' },
+      expect(mockInvitationService.resendInvitation).toHaveBeenCalledWith({
+        invitationId: 'inv_old',
+        invitedByUserId: userId,
+        organizationId: orgId,
+      });
+      expect(result).toEqual({
+        data: {
+          email: 'new@example.com',
+          id: 'inv_new',
+          status: 'pending',
+        },
       });
     });
   });

--- a/apps/server/api/src/collections/members/controllers/members.controller.ts
+++ b/apps/server/api/src/collections/members/controllers/members.controller.ts
@@ -1,8 +1,6 @@
-import process from 'node:process';
 import { InviteMemberDto } from '@api/collections/members/dto/invite-member.dto';
-import { MemberEntity } from '@api/collections/members/entities/member.entity';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
 import { MembersService } from '@api/collections/members/services/members.service';
-import { RolesService } from '@api/collections/roles/services/roles.service';
 import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
@@ -18,7 +16,6 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { RateLimit } from '@api/shared/decorators/rate-limit/rate-limit.decorator';
 import type { User } from '@clerk/backend';
 import type { JsonApiCollectionResponse } from '@genfeedai/interfaces';
@@ -47,8 +44,7 @@ export class MembersController {
 
   constructor(
     private readonly membersService: MembersService,
-    private readonly clerkService: ClerkService,
-    private readonly rolesService: RolesService,
+    private readonly invitationService: InvitationService,
     readonly _loggerService: LoggerService,
   ) {}
 
@@ -103,7 +99,7 @@ export class MembersController {
   /**
    * POST /members/invite
    * Send an invitation to join the current organization.
-   * Creates a Clerk invitation and a pending member record.
+   * Creates a self-hosted invitation and sends an accept email.
    */
   @Post('invite')
   @RateLimit({ limit: 10, scope: 'organization', windowMs: 60000 })
@@ -121,59 +117,29 @@ export class MembersController {
         HttpStatus.BAD_REQUEST,
       );
     }
-
-    // Check for existing active member with this email
-    const existingClerkUser = await this.clerkService.getUserByEmail(dto.email);
-    if (existingClerkUser) {
-      const clerkMeta = existingClerkUser.publicMetadata as Record<
-        string,
-        unknown
-      >;
-      const existingMember = await this.membersService.findOne({
-        isActive: true,
-        isDeleted: false,
-        organization: orgId,
-        user: clerkMeta.user as string,
-      });
-      if (existingMember) {
-        throw new HttpException(
-          {
-            detail: 'User is already a member of this organization',
-            title: 'Conflict',
-          },
-          HttpStatus.CONFLICT,
-        );
-      }
+    if (!publicMetadata.user) {
+      throw new HttpException(
+        { detail: 'Inviting user not found in metadata', title: 'Bad Request' },
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
-    // Resolve role (default to 'member' if not specified)
-    let roleId = dto.role;
-    if (!roleId) {
-      const memberRole = await this.rolesService.findOne({ key: 'member' });
-      if (memberRole) {
-        roleId = memberRole._id;
-      }
-    }
-
-    // Create Clerk invitation
-    const invitation = await this.clerkService.createInvitation(
-      dto.email,
-      `${process.env.NEXT_PUBLIC_APP_URL || 'https://app.genfeed.ai'}/overview?org=${orgId}`,
-      {
-        invitedByUser: publicMetadata.user,
-        organization: orgId,
-        role: roleId?.toString(),
-        ...(dto.firstName && { firstName: dto.firstName }),
-        ...(dto.lastName && { lastName: dto.lastName }),
-      },
-    );
+    const invitation = await this.invitationService.createInvitation({
+      defaultRoleKey: 'member',
+      email: dto.email,
+      firstName: dto.firstName,
+      invitedByUserId: String(publicMetadata.user),
+      lastName: dto.lastName,
+      organizationId: orgId,
+      roleId: dto.role,
+    });
 
     return {
       data: {
         email: dto.email,
         id: invitation.id,
         organization: orgId,
-        role: roleId?.toString() ?? null,
+        role: invitation.roleId,
         status: invitation.status,
       },
     };
@@ -196,18 +162,13 @@ export class MembersController {
       );
     }
 
-    // Fetch all pending invitations from Clerk and filter by org
-    const invitations = await this.clerkService.listInvitations('pending');
-
-    const orgInvitations = invitations.filter((inv) => {
-      const meta = inv.publicMetadata as Record<string, unknown>;
-      return meta?.organization === orgId;
-    });
+    const invitations =
+      await this.invitationService.listPendingInvitations(orgId);
 
     return {
-      data: orgInvitations.map((inv) => ({
+      data: invitations.map((inv) => ({
         createdAt: inv.createdAt,
-        email: inv.emailAddress,
+        email: inv.email,
         id: inv.id,
         status: inv.status,
       })),
@@ -234,28 +195,7 @@ export class MembersController {
       );
     }
 
-    const invitation = await this.clerkService.getInvitation(invitationId);
-
-    if (!invitation) {
-      throw new HttpException(
-        { detail: 'Invitation not found', title: 'Not Found' },
-        HttpStatus.NOT_FOUND,
-      );
-    }
-
-    // Verify invitation belongs to this org
-    const meta = invitation.publicMetadata as Record<string, unknown>;
-    if (meta?.organization !== orgId) {
-      throw new HttpException(
-        {
-          detail: 'Invitation does not belong to this organization',
-          title: 'Forbidden',
-        },
-        HttpStatus.FORBIDDEN,
-      );
-    }
-
-    await this.clerkService.revokeInvitation(invitationId);
+    await this.invitationService.revokeInvitation(invitationId, orgId);
 
     return { data: { id: invitationId, status: 'revoked' } };
   }
@@ -279,39 +219,22 @@ export class MembersController {
         HttpStatus.BAD_REQUEST,
       );
     }
-
-    // Verify invitation exists and belongs to this org
-    const invitation = await this.clerkService.getInvitation(invitationId);
-
-    if (!invitation) {
+    if (!publicMetadata.user) {
       throw new HttpException(
-        { detail: 'Invitation not found', title: 'Not Found' },
-        HttpStatus.NOT_FOUND,
+        { detail: 'Inviting user not found in metadata', title: 'Bad Request' },
+        HttpStatus.BAD_REQUEST,
       );
     }
 
-    const meta = invitation.publicMetadata as Record<string, unknown>;
-    if (meta?.organization !== orgId) {
-      throw new HttpException(
-        {
-          detail: 'Invitation does not belong to this organization',
-          title: 'Forbidden',
-        },
-        HttpStatus.FORBIDDEN,
-      );
-    }
-
-    // Revoke old and create new invitation with same params
-    await this.clerkService.revokeInvitation(invitationId);
-    const newInvitation = await this.clerkService.createInvitation(
-      invitation.emailAddress,
-      `${process.env.NEXT_PUBLIC_APP_URL || 'https://app.genfeed.ai'}/overview?org=${orgId}`,
-      invitation.publicMetadata as Record<string, unknown>,
-    );
+    const newInvitation = await this.invitationService.resendInvitation({
+      invitationId,
+      invitedByUserId: String(publicMetadata.user),
+      organizationId: orgId,
+    });
 
     return {
       data: {
-        email: newInvitation.emailAddress,
+        email: newInvitation.email,
         id: newInvitation.id,
         status: newInvitation.status,
       },

--- a/apps/server/api/src/collections/members/members.module.ts
+++ b/apps/server/api/src/collections/members/members.module.ts
@@ -4,16 +4,21 @@
 and team collaboration features.
  */
 
+import { InvitationsController } from '@api/collections/members/controllers/invitations.controller';
 import { MembersController } from '@api/collections/members/controllers/members.controller';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
 import { MembersService } from '@api/collections/members/services/members.service';
 import { RolesModule } from '@api/collections/roles/roles.module';
-import { ClerkModule } from '@api/services/integrations/clerk/clerk.module';
+import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
-  controllers: [MembersController],
-  exports: [MembersService],
-  imports: [forwardRef(() => ClerkModule), forwardRef(() => RolesModule)],
-  providers: [MembersService],
+  controllers: [InvitationsController, MembersController],
+  exports: [InvitationService, MembersService],
+  imports: [
+    forwardRef(() => NotificationsModule),
+    forwardRef(() => RolesModule),
+  ],
+  providers: [InvitationService, MembersService],
 })
 export class MembersModule {}

--- a/apps/server/api/src/collections/members/services/invitation.service.spec.ts
+++ b/apps/server/api/src/collections/members/services/invitation.service.spec.ts
@@ -1,0 +1,473 @@
+import { createHash } from 'node:crypto';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
+import type { ConfigService } from '@api/config/config.service';
+import { NotificationsService } from '@api/services/notifications/notifications.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import {
+  ConflictException,
+  GoneException,
+  NotFoundException,
+} from '@nestjs/common';
+
+const now = new Date('2026-06-23T12:00:00.000Z');
+const orgId = 'org_123';
+const userId = 'user_123';
+const roleId = 'role_user';
+const memberId = 'member_123';
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+interface MockPrisma {
+  $transaction: MockFn;
+  invitation: {
+    create: MockFn;
+    findMany: MockFn;
+    findFirst: MockFn;
+    findUnique: MockFn;
+    update: MockFn;
+    updateMany: MockFn;
+  };
+  member: {
+    create: MockFn;
+    findFirst: MockFn;
+    update: MockFn;
+  };
+  organization: {
+    findFirst: MockFn;
+  };
+  role: {
+    findFirst: MockFn;
+  };
+  setting: {
+    create: MockFn;
+  };
+  user: {
+    create: MockFn;
+    findFirst: MockFn;
+    update: MockFn;
+  };
+}
+
+interface InvitationRow {
+  acceptedAt: Date | null;
+  acceptedByUserId: string | null;
+  createdAt: Date;
+  email: string;
+  expiresAt: Date;
+  firstName: string | null;
+  id: string;
+  invitedByUserId: string;
+  isDeleted: boolean;
+  lastName: string | null;
+  mongoId: string | null;
+  organization?: { label: string } | null;
+  organizationId: string;
+  redirectUrl: string | null;
+  revokedAt: Date | null;
+  roleId: string;
+  tokenHash: string;
+  updatedAt: Date;
+}
+
+interface UserRow {
+  email: string;
+  id: string;
+  isDeleted: boolean;
+  isInvited: boolean;
+}
+
+interface MemberRow {
+  id: string;
+  isActive: boolean;
+  isDeleted: boolean;
+  organizationId: string;
+  roleId: string;
+  userId: string;
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function makeInvitation(overrides: Partial<InvitationRow> = {}): InvitationRow {
+  return {
+    acceptedAt: null,
+    acceptedByUserId: null,
+    createdAt: now,
+    email: 'new@example.com',
+    expiresAt: new Date('2026-06-30T12:00:00.000Z'),
+    firstName: 'New',
+    id: 'inv_123',
+    invitedByUserId: userId,
+    isDeleted: false,
+    lastName: 'User',
+    mongoId: null,
+    organization: { label: 'Acme' },
+    organizationId: orgId,
+    redirectUrl: null,
+    revokedAt: null,
+    roleId,
+    tokenHash: hashToken('token-123'),
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeUser(overrides: Partial<UserRow> = {}): UserRow {
+  return {
+    email: 'new@example.com',
+    id: userId,
+    isDeleted: false,
+    isInvited: true,
+    ...overrides,
+  };
+}
+
+function makeMember(overrides: Partial<MemberRow> = {}): MemberRow {
+  return {
+    id: memberId,
+    isActive: false,
+    isDeleted: false,
+    organizationId: orgId,
+    roleId,
+    userId,
+    ...overrides,
+  };
+}
+
+function buildPrisma(): MockPrisma {
+  const prisma: MockPrisma = {
+    $transaction: vi.fn(),
+    invitation: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    member: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    organization: {
+      findFirst: vi.fn(),
+    },
+    role: {
+      findFirst: vi.fn(),
+    },
+    setting: {
+      create: vi.fn(),
+    },
+    user: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+
+  prisma.$transaction.mockImplementation(
+    async (callback: (tx: MockPrisma) => Promise<unknown>) => callback(prisma),
+  );
+
+  return prisma;
+}
+
+function buildService(prisma = buildPrisma()) {
+  const configService = {
+    get: vi.fn((key: string) => {
+      if (key === 'GENFEEDAI_API_URL') {
+        return 'https://api.test';
+      }
+      if (key === 'GENFEEDAI_APP_URL') {
+        return 'https://app.test';
+      }
+      return undefined;
+    }),
+  } as unknown as ConfigService;
+
+  const notificationsService = {
+    sendEmail: vi.fn().mockResolvedValue(undefined),
+  } as unknown as NotificationsService;
+
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggerService;
+
+  return {
+    configService,
+    logger,
+    notificationsService,
+    prisma,
+    service: new InvitationService(
+      prisma as unknown as PrismaService,
+      configService,
+      notificationsService,
+      logger,
+    ),
+  };
+}
+
+describe('InvitationService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('createInvitation', () => {
+    it('creates a hashed invitation token and sends an accept email', async () => {
+      const { notificationsService, prisma, service } = buildService();
+      prisma.role.findFirst.mockResolvedValue({ id: roleId });
+      prisma.organization.findFirst.mockResolvedValue({
+        id: orgId,
+        label: 'Acme',
+      });
+      prisma.user.findFirst.mockResolvedValue(null);
+      prisma.invitation.updateMany.mockResolvedValue({ count: 0 });
+      prisma.invitation.create.mockImplementation((args: unknown) => {
+        const data = (args as { data: Partial<InvitationRow> }).data;
+        return Promise.resolve(makeInvitation(data));
+      });
+
+      const result = await service.createInvitation({
+        email: 'NEW@Example.COM',
+        firstName: 'New',
+        invitedByUserId: userId,
+        lastName: 'User',
+        organizationId: orgId,
+      });
+
+      expect(prisma.invitation.updateMany).toHaveBeenCalledWith({
+        data: { isDeleted: true, revokedAt: now },
+        where: {
+          acceptedAt: null,
+          email: 'new@example.com',
+          isDeleted: false,
+          organizationId: orgId,
+          revokedAt: null,
+        },
+      });
+      expect(prisma.invitation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: 'new@example.com',
+          invitedByUserId: userId,
+          organizationId: orgId,
+          roleId,
+          tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        }),
+      });
+      expect(notificationsService.sendEmail).toHaveBeenCalledWith(
+        'new@example.com',
+        "You're invited to Acme",
+        expect.stringContaining('https://api.test/accept-invitation?token='),
+      );
+      expect(result).toMatchObject({
+        email: 'new@example.com',
+        organizationId: orgId,
+        roleId,
+        status: 'pending',
+      });
+    });
+
+    it('rejects invitations for users already active in the organization', async () => {
+      const { prisma, service } = buildService();
+      prisma.role.findFirst.mockResolvedValue({ id: roleId });
+      prisma.organization.findFirst.mockResolvedValue({
+        id: orgId,
+        label: 'Acme',
+      });
+      prisma.user.findFirst.mockResolvedValue(makeUser({ isInvited: false }));
+      prisma.member.findFirst.mockResolvedValue(makeMember({ isActive: true }));
+
+      await expect(
+        service.createInvitation({
+          email: 'new@example.com',
+          invitedByUserId: userId,
+          organizationId: orgId,
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(prisma.invitation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listPendingInvitations', () => {
+    it('returns only pending invitation views from Prisma results', async () => {
+      const { prisma, service } = buildService();
+      prisma.invitation.findMany.mockResolvedValue([makeInvitation()]);
+
+      const result = await service.listPendingInvitations(orgId);
+
+      expect(prisma.invitation.findMany).toHaveBeenCalledWith({
+        orderBy: { createdAt: 'desc' },
+        where: {
+          acceptedAt: null,
+          expiresAt: { gt: now },
+          isDeleted: false,
+          organizationId: orgId,
+          revokedAt: null,
+        },
+      });
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'inv_123',
+          status: 'pending',
+        }),
+      ]);
+    });
+  });
+
+  describe('revokeInvitation', () => {
+    it('revokes a pending invitation in the owning organization', async () => {
+      const { prisma, service } = buildService();
+      prisma.invitation.findFirst.mockResolvedValue(makeInvitation());
+      prisma.invitation.update.mockResolvedValue(
+        makeInvitation({ revokedAt: now }),
+      );
+
+      const result = await service.revokeInvitation('inv_123', orgId);
+
+      expect(prisma.invitation.update).toHaveBeenCalledWith({
+        data: { isDeleted: true, revokedAt: now },
+        where: { id: 'inv_123' },
+      });
+      expect(result.status).toBe('revoked');
+    });
+
+    it('returns not found for missing invitations', async () => {
+      const { prisma, service } = buildService();
+      prisma.invitation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.revokeInvitation('missing', orgId),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('acceptInvitation', () => {
+    it('accepts an invitation for an existing invited user and activates their member row', async () => {
+      const { prisma, service } = buildService();
+      const invitation = makeInvitation({ tokenHash: hashToken('token-123') });
+      const inactiveMember = makeMember({ isActive: false });
+      const acceptedAt = new Date('2026-06-23T12:00:00.000Z');
+
+      prisma.invitation.findUnique.mockResolvedValue(invitation);
+      prisma.invitation.updateMany.mockResolvedValue({ count: 1 });
+      prisma.user.findFirst.mockResolvedValue(makeUser());
+      prisma.user.update.mockResolvedValue(makeUser({ isInvited: false }));
+      prisma.member.findFirst.mockResolvedValue(inactiveMember);
+      prisma.member.update.mockResolvedValue(
+        makeMember({ isActive: true, roleId }),
+      );
+      prisma.invitation.update.mockResolvedValue(
+        makeInvitation({
+          acceptedAt,
+          acceptedByUserId: userId,
+          tokenHash: hashToken('token-123'),
+        }),
+      );
+
+      const result = await service.acceptInvitation('token-123');
+
+      expect(prisma.invitation.findUnique).toHaveBeenCalledWith({
+        include: { organization: { select: { label: true } } },
+        where: { tokenHash: hashToken('token-123') },
+      });
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        data: {
+          emailVerified: true,
+          isInvited: false,
+          lastUsedOrganizationId: orgId,
+        },
+        where: { id: userId },
+      });
+      expect(prisma.member.update).toHaveBeenCalledWith({
+        data: {
+          isActive: true,
+          roleId,
+        },
+        where: { id: memberId },
+      });
+      expect(prisma.setting.create).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        memberId,
+        organizationId: orgId,
+        redirectUrl: 'https://app.test/login?invitation=accepted&org=org_123',
+        userId,
+      });
+    });
+
+    it('creates a user, settings, and active member when no user exists', async () => {
+      const { prisma, service } = buildService();
+      prisma.invitation.findUnique.mockResolvedValue(makeInvitation());
+      prisma.invitation.updateMany.mockResolvedValue({ count: 1 });
+      prisma.user.findFirst.mockResolvedValue(null);
+      prisma.user.create.mockResolvedValue(makeUser({ isInvited: false }));
+      prisma.setting.create.mockResolvedValue({ id: 'setting_123' });
+      prisma.member.findFirst.mockResolvedValue(null);
+      prisma.member.create.mockResolvedValue(makeMember({ isActive: true }));
+      prisma.invitation.update.mockResolvedValue(
+        makeInvitation({ acceptedAt: now, acceptedByUserId: userId }),
+      );
+
+      const result = await service.acceptInvitation('token-123');
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: 'new@example.com',
+          emailVerified: true,
+          isInvited: false,
+          lastUsedOrganizationId: orgId,
+        }),
+      });
+      expect(prisma.setting.create).toHaveBeenCalledWith({
+        data: { userId },
+      });
+      expect(prisma.member.create).toHaveBeenCalledWith({
+        data: {
+          isActive: true,
+          organizationId: orgId,
+          roleId,
+          userId,
+        },
+      });
+      expect(result.memberId).toBe(memberId);
+    });
+
+    it('rejects expired invitations', async () => {
+      const { prisma, service } = buildService();
+      prisma.invitation.findUnique.mockResolvedValue(
+        makeInvitation({ expiresAt: new Date('2026-06-22T12:00:00.000Z') }),
+      );
+
+      await expect(
+        service.acceptInvitation('token-123'),
+      ).rejects.toBeInstanceOf(GoneException);
+
+      expect(prisma.invitation.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects revoked invitations', async () => {
+      const { prisma, service } = buildService();
+      prisma.invitation.findUnique.mockResolvedValue(
+        makeInvitation({ revokedAt: now }),
+      );
+
+      await expect(
+        service.acceptInvitation('token-123'),
+      ).rejects.toBeInstanceOf(GoneException);
+
+      expect(prisma.invitation.updateMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/api/src/collections/members/services/invitation.service.ts
+++ b/apps/server/api/src/collections/members/services/invitation.service.ts
@@ -1,0 +1,598 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { ConfigService } from '@api/config/config.service';
+import { NotificationsService } from '@api/services/notifications/notifications.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { Invitation, Member, Prisma, User } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  GoneException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+const INVITATION_TOKEN_BYTES = 32;
+const INVITATION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_APP_URL = 'https://app.genfeed.ai';
+const DEFAULT_API_PORT = '3010';
+
+type InvitationStatus = 'accepted' | 'expired' | 'pending' | 'revoked';
+
+export interface CreateInvitationInput {
+  email: string;
+  organizationId: string;
+  invitedByUserId: string;
+  roleId?: string;
+  defaultRoleKey?: 'member' | 'user';
+  firstName?: string;
+  lastName?: string;
+  redirectUrl?: string;
+  expiresAt?: Date;
+  sendEmail?: boolean;
+}
+
+export interface InvitationView {
+  id: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  organizationId: string;
+  invitedByUserId: string;
+  roleId: string;
+  status: InvitationStatus;
+  redirectUrl?: string;
+  expiresAt: Date;
+  acceptedAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AcceptInvitationResult {
+  invitation: InvitationView;
+  memberId: string;
+  organizationId: string;
+  redirectUrl: string;
+  userId: string;
+}
+
+type InvitationWithOrganization = Invitation & {
+  organization?: { label: string } | null;
+};
+
+type InvitationTransaction = Prisma.TransactionClient;
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function generateInvitationToken(): string {
+  return randomBytes(INVITATION_TOKEN_BYTES).toString('base64url');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function generateHandle(email: string): string {
+  const base =
+    email
+      .split('@')[0]
+      ?.toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 24) || 'user';
+
+  return `${base}-${randomUUID().slice(0, 8)}`;
+}
+
+function getInvitationStatus(
+  invitation: Pick<Invitation, 'acceptedAt' | 'expiresAt' | 'revokedAt'>,
+  now = new Date(),
+): InvitationStatus {
+  if (invitation.acceptedAt) {
+    return 'accepted';
+  }
+  if (invitation.revokedAt) {
+    return 'revoked';
+  }
+  if (invitation.expiresAt <= now) {
+    return 'expired';
+  }
+  return 'pending';
+}
+
+function toInvitationView(invitation: Invitation): InvitationView {
+  return {
+    acceptedAt: invitation.acceptedAt,
+    createdAt: invitation.createdAt,
+    email: invitation.email,
+    expiresAt: invitation.expiresAt,
+    firstName: invitation.firstName ?? undefined,
+    id: invitation.id,
+    invitedByUserId: invitation.invitedByUserId,
+    lastName: invitation.lastName ?? undefined,
+    organizationId: invitation.organizationId,
+    redirectUrl: invitation.redirectUrl ?? undefined,
+    revokedAt: invitation.revokedAt,
+    roleId: invitation.roleId,
+    status: getInvitationStatus(invitation),
+    updatedAt: invitation.updatedAt,
+  };
+}
+
+@Injectable()
+export class InvitationService {
+  private readonly context = { service: InvitationService.name };
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+    private readonly notificationsService: NotificationsService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async createInvitation(
+    input: CreateInvitationInput,
+  ): Promise<InvitationView> {
+    const email = normalizeEmail(input.email);
+    const roleId = await this.resolveRoleId(
+      input.roleId,
+      input.defaultRoleKey ?? 'member',
+    );
+
+    const organization = await this.prisma.organization.findFirst({
+      select: { id: true, label: true },
+      where: { id: input.organizationId, isDeleted: false },
+    });
+
+    if (!organization) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    await this.assertNoActiveMember(email, input.organizationId);
+
+    const token = generateInvitationToken();
+    const tokenHash = hashToken(token);
+    const expiresAt =
+      input.expiresAt ?? new Date(Date.now() + INVITATION_EXPIRY_MS);
+
+    const invitation = await this.prisma.$transaction(async (tx) => {
+      await tx.invitation.updateMany({
+        data: { isDeleted: true, revokedAt: new Date() },
+        where: {
+          acceptedAt: null,
+          email,
+          isDeleted: false,
+          organizationId: input.organizationId,
+          revokedAt: null,
+        },
+      });
+
+      return tx.invitation.create({
+        data: {
+          email,
+          expiresAt,
+          firstName: input.firstName,
+          invitedByUserId: input.invitedByUserId,
+          lastName: input.lastName,
+          organizationId: input.organizationId,
+          redirectUrl: input.redirectUrl,
+          roleId,
+          tokenHash,
+        },
+      });
+    });
+
+    if (input.sendEmail !== false) {
+      await this.sendInvitationEmail({
+        invitation: { ...invitation, organization },
+        token,
+      });
+    }
+
+    return toInvitationView(invitation);
+  }
+
+  async listPendingInvitations(
+    organizationId: string,
+  ): Promise<InvitationView[]> {
+    const invitations = await this.prisma.invitation.findMany({
+      orderBy: { createdAt: 'desc' },
+      where: {
+        acceptedAt: null,
+        expiresAt: { gt: new Date() },
+        isDeleted: false,
+        organizationId,
+        revokedAt: null,
+      },
+    });
+
+    return invitations.map(toInvitationView);
+  }
+
+  async revokeInvitation(
+    invitationId: string,
+    organizationId: string,
+  ): Promise<InvitationView> {
+    const invitation = await this.getInvitationForOrganization(
+      invitationId,
+      organizationId,
+    );
+
+    if (invitation.acceptedAt) {
+      throw new ConflictException('Invitation has already been accepted');
+    }
+    if (invitation.revokedAt || invitation.isDeleted) {
+      throw new GoneException('Invitation has already been revoked');
+    }
+
+    const revoked = await this.prisma.invitation.update({
+      data: { isDeleted: true, revokedAt: new Date() },
+      where: { id: invitation.id },
+    });
+
+    return toInvitationView(revoked);
+  }
+
+  async resendInvitation(input: {
+    invitationId: string;
+    organizationId: string;
+    invitedByUserId: string;
+  }): Promise<InvitationView> {
+    const invitation = await this.getInvitationForOrganization(
+      input.invitationId,
+      input.organizationId,
+    );
+
+    if (invitation.acceptedAt) {
+      throw new ConflictException('Invitation has already been accepted');
+    }
+
+    if (invitation.revokedAt || invitation.isDeleted) {
+      throw new GoneException('Invitation has already been revoked');
+    }
+
+    await this.revokeInvitation(input.invitationId, input.organizationId);
+
+    return this.createInvitation({
+      defaultRoleKey: 'member',
+      email: invitation.email,
+      firstName: invitation.firstName ?? undefined,
+      invitedByUserId: input.invitedByUserId,
+      lastName: invitation.lastName ?? undefined,
+      organizationId: input.organizationId,
+      redirectUrl: invitation.redirectUrl ?? undefined,
+      roleId: invitation.roleId,
+    });
+  }
+
+  async acceptInvitation(token: string): Promise<AcceptInvitationResult> {
+    const normalizedToken = token.trim();
+    if (!normalizedToken) {
+      throw new BadRequestException('Invitation token is required');
+    }
+    const tokenHash = hashToken(normalizedToken);
+
+    return this.prisma.$transaction(async (tx) => {
+      const invitation = await tx.invitation.findUnique({
+        include: { organization: { select: { label: true } } },
+        where: { tokenHash },
+      });
+
+      if (!invitation || invitation.isDeleted) {
+        throw new NotFoundException('Invitation not found');
+      }
+
+      this.assertInvitationAcceptable(invitation);
+
+      const consumeResult = await tx.invitation.updateMany({
+        data: { acceptedAt: new Date() },
+        where: {
+          acceptedAt: null,
+          id: invitation.id,
+          isDeleted: false,
+          revokedAt: null,
+        },
+      });
+
+      if (consumeResult.count !== 1) {
+        throw new GoneException('Invitation is no longer available');
+      }
+
+      const user = await this.findOrCreateAcceptedUser(tx, invitation);
+      const member = await this.findOrCreateAcceptedMember(
+        tx,
+        invitation,
+        user.id,
+      );
+
+      const acceptedInvitation = await tx.invitation.update({
+        data: { acceptedByUserId: user.id },
+        where: { id: invitation.id },
+      });
+
+      return {
+        invitation: toInvitationView(acceptedInvitation),
+        memberId: member.id,
+        organizationId: invitation.organizationId,
+        redirectUrl: this.resolveRedirectUrl(invitation),
+        userId: user.id,
+      };
+    });
+  }
+
+  buildAcceptUrl(token: string): string {
+    const url = new URL('/accept-invitation', this.getApiBaseUrl());
+    url.searchParams.set('token', token);
+    return url.toString();
+  }
+
+  resolveFallbackRedirectUrl(organizationId: string): string {
+    const url = new URL('/login', this.getAppBaseUrl());
+    url.searchParams.set('invitation', 'accepted');
+    url.searchParams.set('org', organizationId);
+    return url.toString();
+  }
+
+  private async resolveRoleId(
+    roleId: string | undefined,
+    defaultRoleKey: 'member' | 'user',
+  ): Promise<string> {
+    if (roleId) {
+      const role = await this.prisma.role.findFirst({
+        select: { id: true },
+        where: { id: roleId, isDeleted: false },
+      });
+      if (!role) {
+        throw new BadRequestException('Role not found');
+      }
+      return role.id;
+    }
+
+    const role =
+      (await this.prisma.role.findFirst({
+        select: { id: true },
+        where: { isDeleted: false, key: defaultRoleKey },
+      })) ??
+      (await this.prisma.role.findFirst({
+        select: { id: true },
+        where: { isDeleted: false, key: 'user' },
+      }));
+
+    if (!role) {
+      throw new BadRequestException('Default role not found');
+    }
+
+    return role.id;
+  }
+
+  private async assertNoActiveMember(
+    email: string,
+    organizationId: string,
+  ): Promise<void> {
+    const user = await this.prisma.user.findFirst({
+      select: { id: true },
+      where: { email, isDeleted: false },
+    });
+
+    if (!user) {
+      return;
+    }
+
+    const member = await this.prisma.member.findFirst({
+      select: { id: true },
+      where: {
+        isActive: true,
+        isDeleted: false,
+        organizationId,
+        userId: user.id,
+      },
+    });
+
+    if (member) {
+      throw new ConflictException(
+        'User is already a member of this organization',
+      );
+    }
+  }
+
+  private async getInvitationForOrganization(
+    invitationId: string,
+    organizationId: string,
+  ): Promise<Invitation> {
+    const invitation = await this.prisma.invitation.findFirst({
+      where: { id: invitationId, isDeleted: false },
+    });
+
+    if (!invitation) {
+      throw new NotFoundException('Invitation not found');
+    }
+
+    if (invitation.organizationId !== organizationId) {
+      throw new ForbiddenException(
+        'Invitation does not belong to this organization',
+      );
+    }
+
+    return invitation;
+  }
+
+  private assertInvitationAcceptable(invitation: Invitation): void {
+    if (invitation.acceptedAt) {
+      throw new GoneException('Invitation has already been accepted');
+    }
+    if (invitation.revokedAt) {
+      throw new GoneException('Invitation has been revoked');
+    }
+    if (invitation.expiresAt <= new Date()) {
+      throw new GoneException('Invitation has expired');
+    }
+  }
+
+  private async findOrCreateAcceptedUser(
+    tx: InvitationTransaction,
+    invitation: Invitation,
+  ): Promise<User> {
+    const existing = await tx.user.findFirst({
+      where: { email: invitation.email, isDeleted: false },
+    });
+
+    if (existing) {
+      return tx.user.update({
+        data: {
+          emailVerified: true,
+          isInvited: false,
+          lastUsedOrganizationId: invitation.organizationId,
+        },
+        where: { id: existing.id },
+      });
+    }
+
+    const name = [invitation.firstName, invitation.lastName]
+      .filter(Boolean)
+      .join(' ');
+
+    const user = await tx.user.create({
+      data: {
+        email: invitation.email,
+        emailVerified: true,
+        firstName: invitation.firstName,
+        handle: generateHandle(invitation.email),
+        isInvited: false,
+        lastName: invitation.lastName,
+        lastUsedOrganizationId: invitation.organizationId,
+        name: name || null,
+      },
+    });
+
+    await tx.setting.create({ data: { userId: user.id } });
+
+    return user;
+  }
+
+  private async findOrCreateAcceptedMember(
+    tx: InvitationTransaction,
+    invitation: Invitation,
+    userId: string,
+  ): Promise<Member> {
+    const existing = await tx.member.findFirst({
+      where: {
+        isDeleted: false,
+        organizationId: invitation.organizationId,
+        userId,
+      },
+    });
+
+    if (existing) {
+      if (existing.isActive) {
+        return existing;
+      }
+
+      return tx.member.update({
+        data: {
+          isActive: true,
+          roleId: invitation.roleId,
+        },
+        where: { id: existing.id },
+      });
+    }
+
+    return tx.member.create({
+      data: {
+        isActive: true,
+        organizationId: invitation.organizationId,
+        roleId: invitation.roleId,
+        userId,
+      },
+    });
+  }
+
+  private async sendInvitationEmail(input: {
+    invitation: InvitationWithOrganization;
+    token: string;
+  }): Promise<void> {
+    const acceptUrl = this.buildAcceptUrl(input.token);
+    const organizationLabel =
+      input.invitation.organization?.label ?? 'a Genfeed.ai organization';
+    const subject = `You're invited to ${organizationLabel}`;
+    const html = this.buildInvitationHtml({
+      acceptUrl,
+      email: input.invitation.email,
+      organizationLabel,
+    });
+
+    await this.notificationsService.sendEmail(
+      input.invitation.email,
+      subject,
+      html,
+    );
+
+    this.logger.log('Invitation email dispatched', {
+      ...this.context,
+      emailDomain: input.invitation.email.split('@')[1] ?? 'unknown',
+      invitationId: input.invitation.id,
+      organizationId: input.invitation.organizationId,
+    });
+  }
+
+  private buildInvitationHtml(input: {
+    acceptUrl: string;
+    email: string;
+    organizationLabel: string;
+  }): string {
+    const organizationLabel = escapeHtml(input.organizationLabel);
+    const email = escapeHtml(input.email);
+    const acceptUrl = escapeHtml(input.acceptUrl);
+
+    return [
+      '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:520px;margin:0 auto;padding:24px">',
+      `<h1 style="font-size:20px;margin:0 0 16px">Join ${organizationLabel} on Genfeed.ai</h1>`,
+      `<p style="font-size:14px;color:#444;margin:0 0 24px">An invitation was sent to ${email}. Click the button below to accept it. This link expires in 7 days and can only be used once.</p>`,
+      `<a href="${acceptUrl}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 20px;border-radius:8px;font-size:14px">Accept invitation</a>`,
+      '<p style="font-size:12px;color:#888;margin:24px 0 0">If you did not expect this invitation, you can safely ignore this email.</p>',
+      '</div>',
+    ].join('');
+  }
+
+  private resolveRedirectUrl(invitation: Invitation): string {
+    return (
+      invitation.redirectUrl ??
+      this.resolveFallbackRedirectUrl(invitation.organizationId)
+    );
+  }
+
+  private getApiBaseUrl(): string {
+    const configured =
+      this.configService.get('GENFEEDAI_API_URL') ??
+      this.configService.get('BETTER_AUTH_URL');
+
+    if (typeof configured === 'string' && configured.length > 0) {
+      return configured.replace(/\/$/, '');
+    }
+
+    const port = this.configService.get('PORT') ?? DEFAULT_API_PORT;
+    return `http://localhost:${port}`;
+  }
+
+  private getAppBaseUrl(): string {
+    const configured = this.configService.get('GENFEEDAI_APP_URL');
+
+    if (typeof configured === 'string' && configured.length > 0) {
+      return configured.replace(/\/$/, '');
+    }
+
+    return DEFAULT_APP_URL;
+  }
+}

--- a/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.spec.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.spec.ts
@@ -12,6 +12,7 @@ vi.mock('@api/helpers/utils/response/response.util', () => ({
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { InviteMemberDto } from '@api/collections/members/dto/invite-member.dto';
 import { UpdateMemberDto } from '@api/collections/members/dto/update-member.dto';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { OrganizationsMembersController } from '@api/collections/organizations/controllers/organizations-members.controller';
@@ -23,7 +24,6 @@ import { ConfigService } from '@api/config/config.service';
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import type { User } from '@clerk/backend';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -93,10 +93,8 @@ describe('OrganizationsMembersController', () => {
     get: vi.fn(),
   };
 
-  const mockClerkService = {
+  const mockInvitationService = {
     createInvitation: vi.fn(),
-    getUserByEmail: vi.fn(),
-    updateUserPublicMetadata: vi.fn(),
   };
 
   const mockBrandsService = {
@@ -140,8 +138,8 @@ describe('OrganizationsMembersController', () => {
           useValue: mockConfigService,
         },
         {
-          provide: ClerkService,
-          useValue: mockClerkService,
+          provide: InvitationService,
+          useValue: mockInvitationService,
         },
         {
           provide: BrandsService,
@@ -214,13 +212,16 @@ describe('OrganizationsMembersController', () => {
 
     it('should invite a member to organization', async () => {
       mockOrganizationsService.findOne.mockResolvedValue(mockOrganization);
-      mockClerkService.getUserByEmail.mockResolvedValue(null);
       mockUsersService.findOne.mockResolvedValue(null);
       mockRolesService.findOne.mockResolvedValue({
         _id: '507f1f77bcf86cd799439014',
         key: 'user',
       });
       mockMembersService.create.mockResolvedValue(mockMember);
+      mockInvitationService.createInvitation.mockResolvedValue({
+        id: 'inv_123',
+        status: 'pending',
+      });
 
       const request = {
         seatsLimit: {
@@ -245,6 +246,15 @@ describe('OrganizationsMembersController', () => {
       );
 
       expect(organizationsService.findOne).toHaveBeenCalled();
+      expect(mockInvitationService.createInvitation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultRoleKey: 'user',
+          email: inviteDto.email,
+          invitedByUserId: '507f1f77bcf86cd799439012',
+          organizationId: '507f1f77bcf86cd799439013',
+          roleId: '507f1f77bcf86cd799439014',
+        }),
+      );
       expect(result).toBeDefined();
     });
   });

--- a/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.ts
@@ -10,6 +10,7 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { InviteMemberDto } from '@api/collections/members/dto/invite-member.dto';
 import { UpdateMemberDto } from '@api/collections/members/dto/update-member.dto';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
@@ -25,6 +26,7 @@ import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
+import { getPublicMetadata } from '@api/helpers/utils/clerk/clerk.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
 import {
@@ -33,7 +35,6 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { generateLabel } from '@api/shared/utils/label/label.util';
 import type { User } from '@clerk/backend';
 import type { JsonApiCollectionResponse } from '@genfeedai/interfaces';
@@ -74,7 +75,7 @@ export class OrganizationsMembersController {
     private readonly settingsService: SettingsService,
     private readonly usersService: UsersService,
     private readonly configService: ConfigService,
-    private readonly clerkService: ClerkService,
+    private readonly invitationService: InvitationService,
     private readonly brandsService: BrandsService,
   ) {}
 
@@ -129,37 +130,14 @@ export class OrganizationsMembersController {
       return returnNotFound(this.constructorName, organizationId);
     }
 
-    // Check if a Clerk user already exists with this email
-    const existingClerkUser = await this.clerkService.getUserByEmail(
-      inviteDto.email,
-    );
+    const invitedByUserId = this.getInvitedByUserId(_user, organization);
+    const existingUser = await this.usersService.findOne({
+      email: inviteDto.email,
+      isInvited: false,
+      isDeleted: false,
+    });
 
-    let existingUser;
-
-    if (existingClerkUser) {
-      // User already has a Clerk brand
-      existingUser = await this.usersService.findOne({
-        clerkId: existingClerkUser.id,
-      });
-
-      if (!existingUser) {
-        // Create user record for existing Clerk user
-        const emailPrefix = inviteDto.email.split('@')[0];
-        const randomSuffix = Math.random().toString(36).substring(2, 8);
-        const handle = `${emailPrefix}-${randomSuffix}`;
-
-        existingUser = await this.usersService.create({
-          avatar: existingClerkUser.imageUrl || undefined,
-          clerkId: existingClerkUser.id,
-          email: inviteDto.email,
-          firstName:
-            inviteDto.firstName || existingClerkUser.firstName || undefined,
-          handle,
-          lastName:
-            inviteDto.lastName || existingClerkUser.lastName || undefined,
-        });
-      }
-
+    if (existingUser) {
       // Check if member already exists for this organization
       const member = await this.membersService.findOne({
         organization: organizationId,
@@ -171,13 +149,7 @@ export class OrganizationsMembersController {
         return serializeSingle(request, MemberSerializer, member);
       }
 
-      // Continue to create member for existing Clerk user below
-    } else {
-      // For new users (not yet in Clerk), check if email is already invited to another org
-      // We need to check if there's a pending invitation for this email in another org
-      // This would be stored in Clerk's invitation system, but we can also check our DB
-      // No Clerk user exists yet - we'll create the member after they sign up
-      // For now, just send the Clerk invitation
+      // Continue to create member for existing first-party user below
     }
 
     // Determine role to assign
@@ -196,8 +168,8 @@ export class OrganizationsMembersController {
       roleToAssign = defaultRole._id;
     }
 
-    if (existingClerkUser && existingUser) {
-      // Only create member for existing Clerk users
+    if (existingUser) {
+      // Existing first-party users can be added immediately.
       const limit = (
         request as unknown as { seatsLimit?: { id: string; current: number } }
       ).seatsLimit;
@@ -215,7 +187,7 @@ export class OrganizationsMembersController {
 
         // Create the member record for existing user
         const member = await this.membersService.create({
-          isActive: true, // Always active for existing Clerk users
+          isActive: true,
           organizationId,
           roleId: String(roleToAssign),
           userId: String(existingUser._id),
@@ -269,12 +241,8 @@ export class OrganizationsMembersController {
         // Create new user
         const handle = generateLabel('user');
 
-        // Generate a temporary Clerk ID (will be updated when user signs up)
-        const tempClerkId = `pending_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
-
         // Create the user with isInvited flag
         newUser = await this.usersService.create({
-          clerkId: tempClerkId, // Temporary ID until they sign up
           email: inviteDto.email,
           firstName: inviteDto.firstName || undefined,
           handle,
@@ -321,18 +289,16 @@ export class OrganizationsMembersController {
           userId: String(newUser._id),
         } as unknown as Parameters<typeof this.membersService.create>[0]);
 
-        // Send Clerk invitation with metadata including the user ID
-        await this.clerkService.createInvitation(
-          inviteDto.email,
-          `${this.configService.get('GENFEEDAI_APP_URL')}/login?org=${organizationId}`,
-          {
-            invitedFirstName: inviteDto.firstName,
-            invitedLastName: inviteDto.lastName,
-            organizationId: organizationId,
-            roleId: roleToAssign.toString(),
-            userId: newUser._id, // Include the pre-created user ID
-          },
-        );
+        await this.invitationService.createInvitation({
+          defaultRoleKey: 'user',
+          email: inviteDto.email,
+          firstName: inviteDto.firstName,
+          invitedByUserId,
+          lastName: inviteDto.lastName,
+          organizationId,
+          redirectUrl: this.getInvitationRedirectUrl(organizationId),
+          roleId: String(roleToAssign),
+        });
 
         return serializeSingle(request, MemberSerializer, member);
       } catch (error: unknown) {
@@ -415,5 +381,57 @@ export class OrganizationsMembersController {
     );
 
     return serializeSingle(request, MemberSerializer, updatedMember);
+  }
+
+  private getInvitedByUserId(
+    user: User,
+    organization: { user?: unknown; userId?: unknown },
+  ): string {
+    const publicMetadata = getPublicMetadata(user);
+    const userId =
+      this.toIdString(publicMetadata.user) ??
+      this.toIdString(organization.user) ??
+      this.toIdString(organization.userId);
+
+    if (!userId) {
+      throw new HttpException(
+        {
+          detail: 'Unable to resolve inviting user',
+          title: 'Bad Request',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return String(userId);
+  }
+
+  private toIdString(value: unknown): string | undefined {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (value && typeof value === 'object') {
+      const candidate = value as { _id?: unknown; id?: unknown };
+
+      if (typeof candidate._id === 'string') {
+        return candidate._id;
+      }
+      if (typeof candidate.id === 'string') {
+        return candidate.id;
+      }
+    }
+
+    return undefined;
+  }
+
+  private getInvitationRedirectUrl(organizationId: string): string | undefined {
+    const appUrl = this.configService.get('GENFEEDAI_APP_URL');
+
+    if (typeof appUrl !== 'string' || appUrl.length === 0) {
+      return undefined;
+    }
+
+    return `${appUrl.replace(/\/$/, '')}/login?org=${organizationId}`;
   }
 }

--- a/apps/server/api/src/collections/organizations/organizations.module.ts
+++ b/apps/server/api/src/collections/organizations/organizations.module.ts
@@ -29,7 +29,6 @@ import { IntegrationsModule } from '@api/endpoints/integrations/integrations.mod
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { ByokModule } from '@api/services/byok/byok.module';
-import { ClerkModule } from '@api/services/integrations/clerk/clerk.module';
 import { LoggerModule } from '@libs/logger/logger.module';
 import { forwardRef, Module } from '@nestjs/common';
 
@@ -47,7 +46,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => ActivitiesModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => ByokModule),
-    forwardRef(() => ClerkModule),
     forwardRef(() => CommonModule),
     forwardRef(() => CredentialsCoreModule),
     forwardRef(() => CreditsModule),

--- a/apps/server/api/src/endpoints/onboarding/onboarding.module.ts
+++ b/apps/server/api/src/endpoints/onboarding/onboarding.module.ts
@@ -16,7 +16,6 @@ import { ProactiveOnboardingService } from '@api/endpoints/onboarding/proactive-
 import { BatchGenerationModule } from '@api/services/batch-generation/batch-generation.module';
 import { BrandScraperModule } from '@api/services/brand-scraper/brand-scraper.module';
 import { FilesClientModule } from '@api/services/files-microservice/client/files-client.module';
-import { ClerkModule } from '@api/services/integrations/clerk/clerk.module';
 import { ComfyUIModule } from '@api/services/integrations/comfyui/comfyui.module';
 import { ReplicateModule } from '@api/services/integrations/replicate/replicate.module';
 import { MasterPromptGeneratorService } from '@api/services/knowledge-base/master-prompt-generator.service';
@@ -29,7 +28,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => BatchGenerationModule),
     forwardRef(() => BrandScraperModule),
     forwardRef(() => BrandsModule),
-    forwardRef(() => ClerkModule),
     forwardRef(() => ComfyUIModule),
     forwardRef(() => CommonModule),
     forwardRef(() => CreditsModule),

--- a/apps/server/api/src/endpoints/onboarding/proactive-onboarding.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/proactive-onboarding.service.ts
@@ -1,6 +1,7 @@
 import { BrandEntity } from '@api/collections/brands/entities/brand.entity';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
@@ -14,7 +15,6 @@ import type {
 } from '@api/endpoints/onboarding/dto/proactive-onboarding.dto';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
-import { ClerkService } from '@api/services/integrations/clerk/clerk.service';
 import { MasterPromptGeneratorService } from '@api/services/knowledge-base/master-prompt-generator.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { generateLabel } from '@api/shared/utils/label/label.util';
@@ -70,7 +70,7 @@ export class ProactiveOnboardingService {
     private readonly organizationsService: OrganizationsService,
     private readonly creditsUtilsService: CreditsUtilsService,
     private readonly batchGenerationService: BatchGenerationService,
-    private readonly clerkService: ClerkService,
+    private readonly invitationService: InvitationService,
     private readonly usersService: UsersService,
     private readonly membersService: MembersService,
     private readonly postsService: PostsService,
@@ -447,7 +447,7 @@ export class ProactiveOnboardingService {
   }
 
   /**
-   * Step 3: Send Clerk invitation to lead
+   * Step 3: Send self-hosted invitation to lead
    */
   async sendInvitation(
     leadId: string,
@@ -487,14 +487,22 @@ export class ProactiveOnboardingService {
 
       const shadowOrgUserId = this.resolveOrganizationOwnerId(shadowOrg);
 
-      // Send Clerk invitation with proactive onboarding metadata
       const redirectUrl = this.getProactiveRedirectUrl();
+      const roleId = await this.resolveDefaultRoleId();
+      const nameParts = (lead.data.name ?? '').trim().split(/\s+/);
+      const firstName = nameParts[0] || undefined;
+      const lastName =
+        nameParts.length > 1 ? nameParts.slice(1).join(' ') : undefined;
 
-      await this.clerkService.createInvitation(lead.data.email, redirectUrl, {
-        isProactiveOnboarding: true,
-        leadId,
+      await this.invitationService.createInvitation({
+        defaultRoleKey: 'user',
+        email: lead.data.email,
+        firstName,
+        invitedByUserId: shadowOrgUserId,
+        lastName,
         organizationId: lead.proactiveOrganizationId,
-        userId: shadowOrgUserId,
+        redirectUrl,
+        roleId,
       });
 
       const invitedAt = new Date();
@@ -906,10 +914,11 @@ export class ProactiveOnboardingService {
 
   private resolveOrganizationOwnerId(shadowOrg: {
     _id?: string;
-    user?: string | null;
-    userId?: string | null;
+    user?: unknown;
+    userId?: unknown;
   }): string {
-    const ownerId = shadowOrg.user ?? shadowOrg.userId;
+    const ownerId =
+      this.toIdString(shadowOrg.user) ?? this.toIdString(shadowOrg.userId);
 
     if (!ownerId) {
       throw new BadRequestException(
@@ -917,7 +926,26 @@ export class ProactiveOnboardingService {
       );
     }
 
-    return ownerId.toString();
+    return ownerId;
+  }
+
+  private toIdString(value: unknown): string | undefined {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (value && typeof value === 'object') {
+      const candidate = value as { _id?: unknown; id?: unknown };
+
+      if (typeof candidate._id === 'string') {
+        return candidate._id;
+      }
+      if (typeof candidate.id === 'string') {
+        return candidate.id;
+      }
+    }
+
+    return undefined;
   }
 
   private async resolveDefaultRoleId(): Promise<string> {

--- a/packages/prisma/prisma/migrations/20260623150000_add_invitations/migration.sql
+++ b/packages/prisma/prisma/migrations/20260623150000_add_invitations/migration.sql
@@ -1,0 +1,52 @@
+-- CreateTable
+CREATE TABLE "invitations" (
+    "id" TEXT NOT NULL,
+    "mongoId" TEXT,
+    "email" TEXT NOT NULL,
+    "firstName" TEXT,
+    "lastName" TEXT,
+    "organizationId" TEXT NOT NULL,
+    "invitedByUserId" TEXT NOT NULL,
+    "roleId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "redirectUrl" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "acceptedAt" TIMESTAMP(3),
+    "acceptedByUserId" TEXT,
+    "revokedAt" TIMESTAMP(3),
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "invitations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "invitations_mongoId_key" ON "invitations"("mongoId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "invitations_tokenHash_key" ON "invitations"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "invitations_org_email_deleted_idx" ON "invitations"("organizationId", "email", "isDeleted");
+
+-- CreateIndex
+CREATE INDEX "invitations_org_status_idx" ON "invitations"("organizationId", "acceptedAt", "revokedAt", "isDeleted");
+
+-- CreateIndex
+CREATE INDEX "invitations_email_deleted_idx" ON "invitations"("email", "isDeleted");
+
+-- CreateIndex
+CREATE INDEX "invitations_expiry_status_idx" ON "invitations"("expiresAt", "acceptedAt", "revokedAt", "isDeleted");
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_invitedByUserId_fkey" FOREIGN KEY ("invitedByUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "roles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "invitations" ADD CONSTRAINT "invitations_acceptedByUserId_fkey" FOREIGN KEY ("acceptedByUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -525,6 +525,8 @@ model User {
   organizations            Organization[]
   brands                   Brand[]
   members                  Member[]
+  invitationsSent          Invitation[]            @relation("invitation_invited_by")
+  invitationsAccepted      Invitation[]            @relation("invitation_accepted_by")
   sessions                 Session[]
   accounts                 Account[]
   settings                 Setting?
@@ -615,6 +617,7 @@ model Organization {
   // Ownership relations
   brands                        Brand[]
   members                       Member[]
+  invitations                   Invitation[]
   settings                      OrganizationSetting?
   credentials                   Credential[]
   orgIntegrations               OrgIntegration[]
@@ -890,6 +893,36 @@ model Member {
   @@map("members")
 }
 
+model Invitation {
+  id               String       @id @default(cuid())
+  mongoId          String?      @unique
+  email            String
+  firstName        String?
+  lastName         String?
+  organizationId   String
+  organization     Organization @relation(fields: [organizationId], references: [id])
+  invitedByUserId  String
+  invitedByUser    User         @relation("invitation_invited_by", fields: [invitedByUserId], references: [id])
+  roleId           String
+  role             Role         @relation(fields: [roleId], references: [id])
+  tokenHash        String       @unique
+  redirectUrl      String?
+  expiresAt        DateTime
+  acceptedAt       DateTime?
+  acceptedByUserId String?
+  acceptedByUser   User?        @relation("invitation_accepted_by", fields: [acceptedByUserId], references: [id])
+  revokedAt        DateTime?
+  isDeleted        Boolean      @default(false)
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
+
+  @@index([organizationId, email, isDeleted], map: "invitations_org_email_deleted_idx")
+  @@index([organizationId, acceptedAt, revokedAt, isDeleted], map: "invitations_org_status_idx")
+  @@index([email, isDeleted], map: "invitations_email_deleted_idx")
+  @@index([expiresAt, acceptedAt, revokedAt, isDeleted], map: "invitations_expiry_status_idx")
+  @@map("invitations")
+}
+
 model Role {
   id           String   @id @default(cuid())
   mongoId      String?  @unique
@@ -900,7 +933,8 @@ model Role {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  members Member[]
+  members     Member[]
+  invitations Invitation[]
 
   @@map("roles")
 }


### PR DESCRIPTION
## Summary
- Add a first-party Prisma `Invitation` model and migration with hashed one-time tokens, expiry, acceptance, revocation, and org/status lookup indexes.
- Add `InvitationService` and public accept endpoints for invitation creation, list/revoke/resend, and token acceptance that creates or activates the target user/member.
- Replace Clerk invitation usage in member, organization-member, and proactive onboarding flows with the self-hosted invitation path.

## Verification
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bunx prisma generate --schema packages/prisma/prisma/schema.prisma`
- `npx biome check --write` on touched files
- `bunx vitest run --config vitest.config.ts src/collections/members/services/invitation.service.spec.ts src/collections/members/controllers/invitations.controller.spec.ts src/collections/members/controllers/members-invitation.controller.spec.ts src/collections/organizations/controllers/organizations-members.controller.spec.ts`
- `bun run --cwd apps/server/api build`
- `git diff --check`
- `bunx secretlint` on staged files

## Notes
- Direct `bunx tsc -p apps/server/api/tsconfig.typecheck.json --noEmit` is currently blocked outside this patch by repo-wide package alias/build prerequisites (`@genfeedai/enums`, `@genfeedai/helpers`) after silencing the TypeScript 6 `baseUrl` deprecation. The package compile gate (`nest build api`) passes.
