### PR TITLE
fix(ci): include auth client in server image workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,9 @@ jobs:
         with:
           bun-version: '1.3.14'
       - name: Build api (compiled bundle)
-        run: bunx turbo run build --filter=@genfeedai/api
+        # The api package emits to apps/server/dist, outside apps/server/api.
+        # Force a real build so a Turbo cache-hit replay cannot skip restoring
+        # the compiled bundle this boot check loads.
+        run: bunx turbo run build --filter=@genfeedai/api --force
       - name: Boot check — compiled graph must load
         run: BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -41,7 +41,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/auth-client','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -61,6 +61,7 @@ COPY apps/server/videos/package.json ./apps/server/videos/
 # Match the reduced server-only workspace globs exactly.
 RUN --mount=type=bind,source=.,target=/ctx \
     for f in \
+      /ctx/packages/auth-client/package.json \
       /ctx/packages/client/package.json \
       /ctx/packages/config/package.json \
       /ctx/packages/constants/package.json \
@@ -227,6 +228,7 @@ RUN mkdir -p apps/server/api \
              apps/server/images \
              apps/server/voices \
              apps/server/videos \
+             packages/auth-client \
              packages/client \
              packages/config \
              packages/constants \
@@ -275,6 +277,7 @@ COPY --from=builder /usr/src/app/apps/server/clips/package.json ./apps/server/cl
 COPY --from=builder /usr/src/app/apps/server/images/package.json ./apps/server/images/package.json
 COPY --from=builder /usr/src/app/apps/server/voices/package.json ./apps/server/voices/package.json
 COPY --from=builder /usr/src/app/apps/server/videos/package.json ./apps/server/videos/package.json
+COPY --from=builder /usr/src/app/packages/auth-client/package.json ./packages/auth-client/package.json
 COPY --from=builder /usr/src/app/packages/client/package.json ./packages/client/package.json
 COPY --from=builder /usr/src/app/packages/config/package.json ./packages/config/package.json
 COPY --from=builder /usr/src/app/packages/constants/package.json ./packages/constants/package.json


### PR DESCRIPTION
## Summary
- Adds `packages/auth-client` to the reduced server Docker workspace graph.
- Copies its package manifest through the builder and production stages so Bun can resolve `@genfeedai/auth-client@workspace:*` during the unified server image install.

## Verification
- Reproduced the failing Docker install layer in a temp reduced workspace and ran `HUSKY=0 bun install --linker hoisted` successfully.
- `git diff --check`
- `bunx gitleaks git --staged --redact --no-banner`
