### PR TITLE
fix(auth): enable Better Auth dashboard plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ GENFEEDAI_API_KEY=
 # Shared Auth / Edition
 # --------------------------------------------
 BETTER_AUTH_ENABLED=true
+BETTER_AUTH_API_KEY=
 BETTER_AUTH_SECRET=replace_with_a_long_random_secret
 BETTER_AUTH_URL=http://local.genfeed.ai:3010
 BETTER_AUTH_TRUSTED_ORIGINS=http://local.genfeed.ai:3000,http://local.genfeed.ai:3002

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -3,6 +3,7 @@
     "@anthropic-ai/sdk": "0.100.1",
     "@aws-sdk/client-cloudfront": "3.1059.0",
     "@aws-sdk/client-ec2": "3.1059.0",
+    "@better-auth/infra": "0.3.2",
     "@genfeedai/config": "workspace:*",
     "@genfeedai/constants": "workspace:*",
     "@genfeedai/enums": "workspace:*",

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { dash } from '@better-auth/infra';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
@@ -110,6 +111,7 @@ export async function resolveBetterAuthJwtOrganizationId(
 export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
   const {
     prisma,
+    apiKey,
     secret,
     baseURL,
     trustedOrigins,
@@ -181,6 +183,7 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
       },
     },
     plugins: [
+      ...(apiKey ? [dash({ apiKey })] : []),
       magicLink({
         sendMagicLink: async ({ email, url, token }) => {
           await sendMagicLink({ email, url, token });

--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -85,6 +85,7 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
         }
 
         return createBetterAuthInstance({
+          apiKey: config.get('BETTER_AUTH_API_KEY'),
           baseURL: resolveBetterAuthBaseUrl(
             config.get('BETTER_AUTH_URL'),
             config.get('PORT'),

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -56,6 +56,7 @@ export interface IBetterAuthUserCreatedEvent {
 /** Options for {@link createBetterAuthInstance}. */
 export interface ICreateBetterAuthOptions {
   prisma: PrismaClient;
+  apiKey?: string;
   secret: string;
   baseURL: string;
   trustedOrigins: string[];

--- a/apps/server/api/src/config/config.service.ts
+++ b/apps/server/api/src/config/config.service.ts
@@ -37,6 +37,7 @@ import Joi from 'joi';
 
 interface ApiEnvConfig extends IEnvConfig {
   BETTER_AUTH_ENABLED?: 'true' | 'false';
+  BETTER_AUTH_API_KEY?: string;
   BETTER_AUTH_SECRET?: string;
   BETTER_AUTH_URL?: string;
   BETTER_AUTH_TRUSTED_ORIGINS?: string;

--- a/bun.lock
+++ b/bun.lock
@@ -430,6 +430,7 @@
         "@anthropic-ai/sdk": "0.100.1",
         "@aws-sdk/client-cloudfront": "3.1059.0",
         "@aws-sdk/client-ec2": "3.1059.0",
+        "@better-auth/infra": "0.3.2",
         "@genfeedai/config": "workspace:*",
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
@@ -1648,6 +1649,8 @@
     "@better-auth/core": ["@better-auth/core@1.6.20", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.6", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng=="],
 
     "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ=="],
+
+    "@better-auth/infra": ["@better-auth/infra@0.3.2", "", { "dependencies": { "@better-auth/utils": "^0.4.2", "@better-fetch/fetch": "1.3.1", "better-call": "^1.3.2", "jose": "^6.1.0", "libphonenumber-js": "^1.13.3" }, "peerDependencies": { "@better-auth/core": ">=1.4.0", "@react-native-async-storage/async-storage": ">=1.21.0", "better-auth": ">=1.4.0", "expo-constants": ">=16.0.0", "expo-crypto": ">=13.0.0", "expo-device": ">=6.0.0", "react-native": ">=0.74.0", "zod": ">=4.1.12" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo-constants", "expo-crypto", "expo-device", "react-native"] }, "sha512-4TLSzx3lntEB5s1gVmrjah7jbhVX+5PlD8OA6JtQ1elnapMtO2h7JEBk2UDTZa4iAScAIcYTbs5Kw+9fiLTvWQ=="],
 
     "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.20", "", { "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw=="],
 
@@ -7804,6 +7807,8 @@
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/traverse/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@better-auth/infra/libphonenumber-js": ["libphonenumber-js@1.13.7", "", {}, "sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A=="],
 
     "@develar/schema-utils/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -49,6 +49,7 @@ export interface IEnvConfig {
 
   // === Better Auth ===
   BETTER_AUTH_ENABLED?: 'true' | 'false';
+  BETTER_AUTH_API_KEY?: string;
   BETTER_AUTH_SECRET?: string;
   BETTER_AUTH_TRUSTED_ORIGINS?: string;
   BETTER_AUTH_URL?: string;

--- a/packages/config/src/schemas/better-auth.schema.ts
+++ b/packages/config/src/schemas/better-auth.schema.ts
@@ -18,6 +18,12 @@ export const betterAuthSchema = {
     .default('true'),
 
   /**
+   * Optional Better Auth Infrastructure dashboard key. When present, the API
+   * enables the dash plugin so dash.better-auth.com can verify ownership.
+   */
+  BETTER_AUTH_API_KEY: Joi.string().optional().allow(''),
+
+  /**
    * Signing secret for Better Auth sessions + JWTs. Required when enabled
    * (enforced in BetterAuthModule). Never falls back to a hardcoded value.
    */


### PR DESCRIPTION
## Summary
- install @better-auth/infra for the API service
- wire BETTER_AUTH_API_KEY into the Better Auth factory
- enable the dash() plugin only when the API key is configured
- document/validate BETTER_AUTH_API_KEY as an optional env var

## Verification
- bun run --cwd apps/server/api test:file src/auth/better-auth/better-auth.factory.spec.ts
- bunx turbo run type-check --filter=@genfeedai/api
- PATH=/Users/decod3rs/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/decod3rs/.codex/tmp/arg0/codex-arg0fNI981:/Users/decod3rs/bin:/Users/decod3rs/.bun/bin:/Users/decod3rs/.local/bin:/opt/homebrew/opt/jpeg/bin:/opt/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/decod3rs/.cargo/bin:/Applications/Codex.app/Contents/Resources bun run --cwd apps/server/api build
- pre-commit: secretlint + biome staged files
