### PR TITLE
feat(auth): rebuild login method chooser

### DIFF
--- a/apps/app/app/(public)/login/content.test.tsx
+++ b/apps/app/app/(public)/login/content.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import LoginPage from './content';
+import LoginBetterAuth from './login-better-auth';
 
 const authClientMocks = vi.hoisted(() => ({
   email: vi.fn(),
@@ -22,8 +23,16 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@ui/layouts/auth/AuthFormLayout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="auth-form-layout">{children}</div>
+  default: ({
+    children,
+    logoSize,
+  }: {
+    children: React.ReactNode;
+    logoSize?: string;
+  }) => (
+    <div data-logo-size={logoSize} data-testid="auth-form-layout">
+      {children}
+    </div>
   ),
 }));
 
@@ -36,27 +45,106 @@ describe('LoginPage', () => {
     authClientMocks.magicLink.mockReset();
     authClientMocks.magicLink.mockResolvedValue({});
     authClientMocks.social.mockReset();
+    authClientMocks.social.mockResolvedValue({});
     window.history.replaceState({}, '', '/login');
   });
 
-  it('renders the Better Auth magic-link form', () => {
+  it('renders the Better Auth sign-in chooser', () => {
     render(<LoginPage />);
 
     expect(screen.getByTestId('auth-form-layout')).toBeInTheDocument();
+    expect(screen.getByTestId('auth-form-layout')).toHaveAttribute(
+      'data-logo-size',
+      'compact',
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Welcome Back' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: /^Email/ })).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Sign in with Google' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Sign in with a magic link' }),
+    ).toHaveAttribute('href', '/login/magic-link');
+    expect(
+      screen.getByRole('link', {
+        name: 'Sign in with email and password',
+      }),
+    ).toHaveAttribute('href', '/login/password');
+  });
+
+  it('preserves callbackUrl across chooser links', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/login?callbackUrl=%2Foauth%2Fcli%3Fport%3D4321',
+    );
+
+    render(<LoginPage />);
+
+    expect(
+      screen.getByRole('link', { name: 'Sign in with a magic link' }),
+    ).toHaveAttribute(
+      'href',
+      '/login/magic-link?callbackUrl=%2Foauth%2Fcli%3Fport%3D4321',
+    );
+    expect(
+      screen.getByRole('link', {
+        name: 'Sign in with email and password',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/login/password?callbackUrl=%2Foauth%2Fcli%3Fport%3D4321',
+    );
+  });
+
+  it('starts Google sign-in with the default callback URL', async () => {
+    render(<LoginPage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Sign in with Google' }),
+    );
+
+    await waitFor(() => {
+      expect(authClientMocks.social).toHaveBeenCalledWith({
+        callbackURL: '/',
+        provider: 'google',
+      });
+    });
+  });
+
+  it('preserves callbackUrl when starting Google sign-in', async () => {
+    window.history.replaceState({}, '', '/login?return_to=%2Fonboarding');
+
+    render(<LoginPage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Sign in with Google' }),
+    );
+
+    await waitFor(() => {
+      expect(authClientMocks.social).toHaveBeenCalledWith({
+        callbackURL: '/onboarding',
+        provider: 'google',
+      });
+    });
+  });
+
+  it('renders the magic-link page form', () => {
+    render(<LoginBetterAuth mode="magic-link" />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Sign in with a magic link' }),
+    ).toBeInTheDocument();
     expect(getEmailInput()).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Email me a sign-in link' }),
     ).toBeDisabled();
-    expect(
-      screen.getByRole('button', { name: 'Continue with Google' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Use email and password' }),
-    ).toBeInTheDocument();
   });
 
   it('sends a magic-link sign-in with the default callback URL', async () => {
-    render(<LoginPage />);
+    render(<LoginBetterAuth mode="magic-link" />);
 
     fireEvent.change(getEmailInput(), {
       target: { value: 'user@example.com' },
@@ -78,10 +166,10 @@ describe('LoginPage', () => {
     window.history.replaceState(
       {},
       '',
-      '/login?callbackUrl=%2Foauth%2Fcli%3Fport%3D4321',
+      '/login/magic-link?callbackUrl=%2Foauth%2Fcli%3Fport%3D4321',
     );
 
-    render(<LoginPage />);
+    render(<LoginBetterAuth mode="magic-link" />);
 
     fireEvent.change(getEmailInput(), {
       target: { value: 'cli@example.com' },
@@ -98,23 +186,16 @@ describe('LoginPage', () => {
     });
   });
 
-  it('shows and submits the email password fallback', async () => {
-    render(<LoginPage />);
+  it('submits the email password page form', async () => {
+    render(<LoginBetterAuth mode="password" />);
 
     fireEvent.change(getEmailInput(), {
       target: { value: 'saved@example.com' },
     });
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Use email and password' }),
-    );
     fireEvent.change(screen.getByLabelText(/^Password/), {
       target: { value: 'correct horse battery staple' },
     });
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'Sign in with email and password',
-      }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
       expect(authClientMocks.email).toHaveBeenCalledWith({

--- a/apps/app/app/(public)/login/content.tsx
+++ b/apps/app/app/(public)/login/content.tsx
@@ -3,5 +3,5 @@
 import LoginBetterAuth from './login-better-auth';
 
 export default function LoginPage() {
-  return <LoginBetterAuth />;
+  return <LoginBetterAuth mode="chooser" />;
 }

--- a/apps/app/app/(public)/login/login-better-auth.tsx
+++ b/apps/app/app/(public)/login/login-better-auth.tsx
@@ -6,6 +6,7 @@ import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
 import { Button } from '@ui/primitives/button';
 import Field from '@ui/primitives/field';
 import { Input } from '@ui/primitives/input';
+import { ArrowLeft, KeyRound, MailCheck, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -14,12 +15,45 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
+import { FcGoogle } from 'react-icons/fc';
 
 const subscribe = () => () => {};
 const getSnapshot = () => true;
 const getServerSnapshot = () => false;
 
-export default function LoginBetterAuth() {
+type LoginMode = 'chooser' | 'magic-link' | 'password';
+
+interface LoginBetterAuthProps {
+  mode?: LoginMode;
+}
+
+const AUTH_BUTTON_CLASS_NAME =
+  'h-10 w-full justify-center gap-3 rounded-md border-border bg-background text-[15px] font-medium tracking-normal shadow-sm hover:bg-accent/50';
+
+const AUTH_LINK_CLASS_NAME =
+  'text-sm font-medium text-foreground underline underline-offset-4';
+
+function getCallbackURL(searchParams: Pick<URLSearchParams, 'get'>) {
+  return (
+    searchParams.get('callbackUrl') ||
+    searchParams.get('return_to') ||
+    searchParams.get('redirect_url') ||
+    '/'
+  );
+}
+
+function getLoginModeHref(path: string, callbackURL: string) {
+  if (callbackURL === '/') {
+    return path;
+  }
+
+  const params = new URLSearchParams({ callbackUrl: callbackURL });
+  return `${path}?${params.toString()}`;
+}
+
+export default function LoginBetterAuth({
+  mode = 'chooser',
+}: LoginBetterAuthProps) {
   const searchParams = useSearchParams();
   const isMounted = useSyncExternalStore(
     subscribe,
@@ -29,23 +63,27 @@ export default function LoginBetterAuth() {
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [isPasswordModeVisible, setIsPasswordModeVisible] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isPasswordSubmitting, setIsPasswordSubmitting] = useState(false);
+  const [isSocialSubmitting, setIsSocialSubmitting] = useState(false);
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [passwordErrorMessage, setPasswordErrorMessage] = useState<
     string | null
   >(null);
-  const callbackURL =
-    searchParams.get('callbackUrl') ||
-    searchParams.get('return_to') ||
-    searchParams.get('redirect_url') ||
-    '/';
+  const [socialErrorMessage, setSocialErrorMessage] = useState<string | null>(
+    null,
+  );
+  const callbackURL = getCallbackURL(searchParams);
+  const chooserHref = getLoginModeHref('/login', callbackURL);
+  const magicLinkHref = getLoginModeHref('/login/magic-link', callbackURL);
+  const passwordHref = getLoginModeHref('/login/password', callbackURL);
+  const signUpHref = getLoginModeHref('/sign-up', callbackURL);
 
   async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorMessage(null);
+    setSocialErrorMessage(null);
     setIsSubmitting(true);
 
     try {
@@ -68,6 +106,7 @@ export default function LoginBetterAuth() {
   async function handleEmailPassword(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setPasswordErrorMessage(null);
+    setSocialErrorMessage(null);
     setIsPasswordSubmitting(true);
 
     try {
@@ -92,93 +131,132 @@ export default function LoginBetterAuth() {
   }
 
   async function handleGoogleSignIn() {
+    setSocialErrorMessage(null);
     setErrorMessage(null);
     setPasswordErrorMessage(null);
-    await signIn.social({ provider: 'google', callbackURL });
+    setIsSocialSubmitting(true);
+
+    try {
+      const result = await signIn.social({ provider: 'google', callbackURL });
+      if (result?.error) {
+        setSocialErrorMessage(
+          result.error.message ??
+            'Failed to continue with Google. Please try again.',
+        );
+      }
+    } catch {
+      setSocialErrorMessage(
+        'Failed to continue with Google. Please try again.',
+      );
+    } finally {
+      setIsSocialSubmitting(false);
+    }
   }
 
   if (!isMounted) {
-    return <AuthFormLayout>{null}</AuthFormLayout>;
+    return <AuthFormLayout logoSize="compact">{null}</AuthFormLayout>;
   }
 
-  if (isEmailSent) {
+  if (mode === 'magic-link' && isEmailSent) {
     return (
-      <AuthFormLayout>
+      <AuthFormLayout logoSize="compact">
         <div className="w-full max-w-sm space-y-4 text-center">
-          <p className="gen-heading-sm">Check your email</p>
+          <MailCheck
+            className="mx-auto size-8 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <p className="text-3xl font-semibold tracking-normal">
+            Check your email
+          </p>
           <p className="text-sm text-muted-foreground">
             We sent a sign-in link to <strong>{email}</strong>. Click the link
             in the email to sign in.
           </p>
+          <Button
+            asChild
+            variant={ButtonVariant.OUTLINE}
+            className={AUTH_BUTTON_CLASS_NAME}
+            withWrapper={false}
+          >
+            <Link href={chooserHref}>Back to sign in</Link>
+          </Button>
         </div>
       </AuthFormLayout>
     );
   }
 
-  return (
-    <AuthFormLayout>
-      <div className="w-full max-w-sm space-y-6">
-        <div className="space-y-1.5 text-center">
-          <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground">
-            Account access
-          </p>
-          <h1 className="text-xl font-semibold tracking-tight">Welcome back</h1>
-          <p className="text-sm text-muted-foreground">
-            Sign in with a magic link, Google, or your password.
-          </p>
+  if (mode === 'magic-link') {
+    return (
+      <AuthFormLayout logoSize="compact">
+        <div className="w-full max-w-[320px] space-y-8">
+          <AuthHeader
+            title="Sign in with a magic link"
+            description="Enter your email and we'll send you a secure sign-in link."
+          />
+
+          <form onSubmit={handleMagicLink} className="space-y-4">
+            <Field label="Email" isRequired>
+              <Input
+                type="email"
+                name="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setEmail(e.target.value)
+                }
+                isRequired
+                isDisabled={isSubmitting}
+                hasError={!!errorMessage}
+              />
+            </Field>
+
+            {errorMessage ? (
+              <p className="text-sm text-destructive">{errorMessage}</p>
+            ) : null}
+
+            <Button
+              type="submit"
+              variant={ButtonVariant.DEFAULT}
+              isLoading={isSubmitting}
+              isDisabled={!email || isSubmitting}
+              className="h-10 w-full justify-center text-[15px] font-medium tracking-normal"
+              withWrapper={false}
+            >
+              Email me a sign-in link
+            </Button>
+          </form>
+
+          <BackToChooser href={chooserHref} />
         </div>
+      </AuthFormLayout>
+    );
+  }
 
-        <form onSubmit={handleMagicLink} className="space-y-3">
-          <Field label="Email" isRequired>
-            <Input
-              type="email"
-              name="email"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setEmail(e.target.value)
-              }
-              isRequired
-              isDisabled={isSubmitting}
-              hasError={!!errorMessage}
-            />
-          </Field>
+  if (mode === 'password') {
+    return (
+      <AuthFormLayout logoSize="compact">
+        <div className="w-full max-w-[320px] space-y-8">
+          <AuthHeader
+            title="Sign in with email and password"
+            description="Use the email and password attached to your Genfeed account."
+          />
 
-          {errorMessage ? (
-            <p className="text-sm text-destructive">{errorMessage}</p>
-          ) : null}
+          <form onSubmit={handleEmailPassword} className="space-y-4">
+            <Field label="Email" isRequired>
+              <Input
+                type="email"
+                name="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setEmail(e.target.value)
+                }
+                isRequired
+                isDisabled={isPasswordSubmitting}
+                hasError={!!passwordErrorMessage}
+              />
+            </Field>
 
-          <Button
-            type="submit"
-            variant={ButtonVariant.DEFAULT}
-            isLoading={isSubmitting}
-            isDisabled={!email || isSubmitting}
-            className="w-full"
-            withWrapper={false}
-          >
-            Email me a sign-in link
-          </Button>
-        </form>
-
-        <Button
-          type="button"
-          variant={ButtonVariant.OUTLINE}
-          onClick={handleGoogleSignIn}
-          className="w-full"
-          withWrapper={false}
-        >
-          Continue with Google
-        </Button>
-
-        <div className="relative">
-          <div className="gen-divider" />
-          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs uppercase tracking-[0.14em] text-muted-foreground">
-            or
-          </span>
-        </div>
-
-        {isPasswordModeVisible ? (
-          <form onSubmit={handleEmailPassword} className="space-y-3">
             <Field label="Password" isRequired>
               <Input
                 type="password"
@@ -200,40 +278,109 @@ export default function LoginBetterAuth() {
 
             <Button
               type="submit"
-              variant={ButtonVariant.OUTLINE}
+              variant={ButtonVariant.DEFAULT}
               isLoading={isPasswordSubmitting}
               isDisabled={!email || !password || isPasswordSubmitting}
-              className="w-full"
+              className="h-10 w-full justify-center text-[15px] font-medium tracking-normal"
               withWrapper={false}
             >
-              Sign in with email and password
+              Sign in
             </Button>
           </form>
-        ) : (
+
+          <BackToChooser href={chooserHref} />
+        </div>
+      </AuthFormLayout>
+    );
+  }
+
+  return (
+    <AuthFormLayout logoSize="compact">
+      <div className="w-full max-w-[320px] space-y-8">
+        <AuthHeader title="Welcome Back" description="Sign in to Genfeed" />
+
+        <div className="space-y-4">
           <Button
             type="button"
             variant={ButtonVariant.OUTLINE}
-            onClick={() => {
-              setIsPasswordModeVisible(true);
-              setErrorMessage(null);
-            }}
-            className="w-full"
+            onClick={handleGoogleSignIn}
+            icon={<FcGoogle className="size-4" aria-hidden="true" />}
+            isLoading={isSocialSubmitting}
+            className={AUTH_BUTTON_CLASS_NAME}
             withWrapper={false}
           >
-            Use email and password
+            Sign in with Google
           </Button>
-        )}
 
-        <p className="text-center text-sm text-muted-foreground">
-          Don&apos;t have an account?{' '}
-          <Link
-            href={`/sign-up?callbackUrl=${encodeURIComponent(callbackURL)}`}
-            className="text-foreground underline underline-offset-4"
+          <Button
+            asChild
+            variant={ButtonVariant.OUTLINE}
+            className={AUTH_BUTTON_CLASS_NAME}
+            withWrapper={false}
           >
+            <Link href={magicLinkHref}>
+              <Sparkles className="size-4" aria-hidden="true" />
+              <span>Sign in with a magic link</span>
+            </Link>
+          </Button>
+
+          <Button
+            asChild
+            variant={ButtonVariant.OUTLINE}
+            className={AUTH_BUTTON_CLASS_NAME}
+            withWrapper={false}
+          >
+            <Link href={passwordHref}>
+              <KeyRound className="size-4" aria-hidden="true" />
+              <span>Sign in with email and password</span>
+            </Link>
+          </Button>
+        </div>
+
+        {socialErrorMessage ? (
+          <p className="text-center text-sm text-destructive">
+            {socialErrorMessage}
+          </p>
+        ) : null}
+
+        <p className="text-center text-xs leading-5 text-muted-foreground">
+          Don&apos;t have an account?{' '}
+          <Link href={signUpHref} className={AUTH_LINK_CLASS_NAME}>
             Sign up
           </Link>
         </p>
       </div>
     </AuthFormLayout>
+  );
+}
+
+function AuthHeader({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="space-y-2 text-center">
+      <h1 className="text-3xl font-semibold tracking-normal text-foreground">
+        {title}
+      </h1>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function BackToChooser({ href }: { href: string }) {
+  return (
+    <div className="text-center">
+      <Link
+        href={href}
+        className="inline-flex items-center justify-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" aria-hidden="true" />
+        Back to sign in options
+      </Link>
+    </div>
   );
 }

--- a/apps/app/app/(public)/login/magic-link/page.spec.tsx
+++ b/apps/app/app/(public)/login/magic-link/page.spec.tsx
@@ -1,0 +1,4 @@
+import * as PageModule from '@app/(public)/login/magic-link/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests('app/(public)/login/magic-link/page', PageModule);

--- a/apps/app/app/(public)/login/magic-link/page.tsx
+++ b/apps/app/app/(public)/login/magic-link/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import LoginBetterAuth from '../login-better-auth';
+
+export const metadata: Metadata = {
+  title: 'Magic Link Sign In | Genfeed',
+};
+
+export default function MagicLinkLoginPage() {
+  return <LoginBetterAuth mode="magic-link" />;
+}

--- a/apps/app/app/(public)/login/password/page.spec.tsx
+++ b/apps/app/app/(public)/login/password/page.spec.tsx
@@ -1,0 +1,4 @@
+import * as PageModule from '@app/(public)/login/password/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests('app/(public)/login/password/page', PageModule);

--- a/apps/app/app/(public)/login/password/page.tsx
+++ b/apps/app/app/(public)/login/password/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import LoginBetterAuth from '../login-better-auth';
+
+export const metadata: Metadata = {
+  title: 'Password Sign In | Genfeed',
+};
+
+export default function PasswordLoginPage() {
+  return <LoginBetterAuth mode="password" />;
+}

--- a/packages/props/layout/auth-form-layout.props.ts
+++ b/packages/props/layout/auth-form-layout.props.ts
@@ -1,5 +1,8 @@
 import type { ReactNode } from 'react';
 
+export type AuthFormLayoutLogoSize = 'default' | 'compact';
+
 export interface AuthFormLayoutProps {
   children: ReactNode;
+  logoSize?: AuthFormLayoutLogoSize;
 }

--- a/packages/ui/src/components/layouts/auth/AuthFormLayout.test.tsx
+++ b/packages/ui/src/components/layouts/auth/AuthFormLayout.test.tsx
@@ -74,4 +74,17 @@ describe('AuthFormLayout', () => {
     const logo = screen.getByRole('img');
     expect(logo).toHaveAttribute('src', '/mock-logo.png');
   });
+
+  it('should support compact logo sizing', () => {
+    render(
+      <AuthFormLayout logoSize="compact">
+        <div>Content</div>
+      </AuthFormLayout>,
+    );
+
+    const logo = screen.getByRole('img');
+    expect(logo).toHaveAttribute('width', '48');
+    expect(logo).toHaveAttribute('height', '48');
+    expect(logo).toHaveClass('mb-8');
+  });
 });

--- a/packages/ui/src/components/layouts/auth/AuthFormLayout.tsx
+++ b/packages/ui/src/components/layouts/auth/AuthFormLayout.tsx
@@ -5,19 +5,34 @@ import type { AuthFormLayoutProps } from '@genfeedai/props/layout/auth-form-layo
 import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import Image from 'next/image';
 
-export default function AuthFormLayout({ children }: AuthFormLayoutProps) {
+const LOGO_DIMENSIONS = {
+  compact: 48,
+  default: 80,
+} as const;
+
+export default function AuthFormLayout({
+  children,
+  logoSize = 'default',
+}: AuthFormLayoutProps) {
   const logoUrl = useThemeLogo();
+  const logoDimension = LOGO_DIMENSIONS[logoSize];
 
   return (
-    <div className="min-h-screen flex flex-col justify-center items-center">
+    <div
+      className={`min-h-screen flex flex-col justify-center items-center ${
+        logoSize === 'compact' ? 'bg-background px-4 text-foreground' : ''
+      }`}
+    >
       <div className="mb-4">
         {logoUrl && (
           <Image
             src={logoUrl}
-            className="mx-auto mb-20 object-contain dark:invert"
+            className={`mx-auto object-contain dark:invert ${
+              logoSize === 'compact' ? 'mb-8' : 'mb-20'
+            }`}
             alt={EnvironmentService.LOGO_ALT}
-            width={80}
-            height={80}
+            width={logoDimension}
+            height={logoDimension}
             priority
           />
         )}


### PR DESCRIPTION
## Summary
- Rebuild `/login` as an Ashby-style method chooser with Google first, magic link second, and email/password third.
- Add nested `/login/magic-link` and `/login/password` pages backed by the same Better Auth client logic.
- Add compact auth-layout logo sizing for this flow while preserving default layout behavior elsewhere.

## Verification
- `bunx biome check --write ...`
- `bun run --cwd apps/app test app/(public)/login/content.test.tsx app/(public)/login/page.spec.tsx app/(public)/login/magic-link/page.spec.tsx app/(public)/login/password/page.spec.tsx`
- `bun run --cwd packages/ui test src/components/layouts/auth/AuthFormLayout.test.tsx`
- `bun run --cwd packages/props type-check`
- `bun run --cwd packages/ui build`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/app build`
- `bun run check:ui-guards`
- `bun run check:design-system`
- Browser smoke via local Chrome against `http://127.0.0.1:3000/login`, `/login/magic-link`, and `/login/password`; mobile viewport had no horizontal overflow.
