### PR TITLE
Workflow-back ad sync and optimization

### DIFF
--- a/apps/server/api/scripts/seeds/ad-automation-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/ad-automation-workflows.seed.ts
@@ -1,0 +1,171 @@
+/**
+ * Seed Script: Ad Automation Workflows
+ *
+ * Idempotently provisions default-on ad automation workflows for existing
+ * organizations. New organizations are seeded automatically on creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/ad-automation-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/ad-automation-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/ad-automation-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/ad-automation-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('AdAutomationWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} — no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        const existing = await prisma.workflow.findMany({
+          select: { metadata: true },
+          where: {
+            isDeleted: false,
+            organizationId: organization.id,
+            OR: AD_AUTOMATION_WORKFLOW_TEMPLATES.map((template) => ({
+              metadata: {
+                equals: template.id,
+                path: ['sourceTemplateId'],
+              },
+            })),
+          },
+        });
+        const existingTemplateIds = new Set(
+          existing
+            .map((workflow) => {
+              const metadata = workflow.metadata as Record<
+                string,
+                unknown
+              > | null;
+              return typeof metadata?.sourceTemplateId === 'string'
+                ? metadata.sourceTemplateId
+                : null;
+            })
+            .filter((value): value is string => Boolean(value)),
+        );
+        const missing = AD_AUTOMATION_WORKFLOW_TEMPLATES.filter(
+          (template) => !existingTemplateIds.has(template.id),
+        ).map((template) => template.id);
+
+        logger.log(
+          `[DRY RUN] org ${organization.id} missing ${missing.length}/${AD_AUTOMATION_WORKFLOW_TEMPLATES.length} ad automation workflow(s): ${missing.join(', ') || 'none'}`,
+        );
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureAdAutomationWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Ad automation workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Ad automation workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -45,8 +45,10 @@ export class OrganizationSettingsService extends BaseService<
   /**
    * Org-bootstrap chokepoint: all organization-creation paths (legacy auth provider webhook,
    * OrganizationsController, UserSetupService) funnel through settings creation.
-   * After creating settings we idempotently seed the predetermined Daily Trends
-   * Digest workflow (OFF by default). Failures never block settings creation.
+   * After creating settings we idempotently seed predetermined workflows.
+   * Daily Trends Digest is OFF by default; ad automation workflows are ON by
+   * default and skip per org until credentials/config make them eligible.
+   * Failures never block settings creation.
    */
   async create(
     createDto: CreateOrganizationSettingDto,
@@ -102,13 +104,17 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureAdAutomationWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow
       // seeding can fail silently for every org (e.g. a future DI/module-graph
       // regression) with nothing but a log line nobody is watching.
       this.logger?.error(
-        'Failed to provision Daily Trends Digest workflow',
+        'Failed to provision default organization workflows',
         error,
       );
       Sentry.captureException(error);

--- a/apps/server/api/src/collections/workflows/services/ad-automation-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/ad-automation-workflow.service.spec.ts
@@ -1,0 +1,211 @@
+import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
+import { CredentialPlatform } from '@genfeedai/enums';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@api/shared/utils/encryption/encryption.util', () => ({
+  EncryptionUtil: {
+    decrypt: vi.fn((value: string) => `decrypted:${value}`),
+  },
+}));
+
+describe('AdAutomationWorkflowService', () => {
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  const queueService = { add: vi.fn() };
+  const cacheService = { acquireLock: vi.fn() };
+  const credentialsService = { findAll: vi.fn() };
+  const adPerformanceService = { findLatestSyncDateForCredential: vi.fn() };
+  const optimizationConfigService = { findByOrganization: vi.fn() };
+  const metaAdsService = { getAdAccounts: vi.fn() };
+  const googleAdsService = { listAccessibleCustomers: vi.fn() };
+  const tikTokAdsService = { getAdAccounts: vi.fn() };
+
+  let service: AdAutomationWorkflowService;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    cacheService.acquireLock.mockResolvedValue(true);
+    queueService.add.mockResolvedValue({ id: 'job-1' });
+    adPerformanceService.findLatestSyncDateForCredential.mockResolvedValue(
+      new Date('2026-06-01T00:00:00.000Z'),
+    );
+
+    service = new AdAutomationWorkflowService(
+      logger as never,
+      queueService as never,
+      cacheService as never,
+      credentialsService as never,
+      adPerformanceService as never,
+      optimizationConfigService as never,
+      metaAdsService as never,
+      googleAdsService as never,
+      tikTokAdsService as never,
+    );
+  });
+
+  it('skips ad optimization when the daily org lock already exists', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runAdOptimization('org-1');
+
+    expect(result).toMatchObject({
+      action: 'adOptimization',
+      enqueued: 0,
+      organizationId: 'org-1',
+      reason: 'daily_ad_optimization_already_enqueued',
+      status: 'skipped',
+    });
+    expect(queueService.add).not.toHaveBeenCalled();
+  });
+
+  it('enqueues one ad optimization job for an enabled org config', async () => {
+    optimizationConfigService.findByOrganization.mockResolvedValue({
+      _id: 'config-1',
+      isEnabled: true,
+    });
+
+    const result = await service.runAdOptimization('org-1');
+
+    expect(queueService.add).toHaveBeenCalledWith(
+      'ad-optimization',
+      expect.objectContaining({
+        configId: 'config-1',
+        organizationId: 'org-1',
+        runId: expect.any(String),
+      }),
+      expect.objectContaining({ attempts: 3, delay: 0 }),
+    );
+    expect(result).toMatchObject({
+      action: 'adOptimization',
+      enqueued: 1,
+      organizationId: 'org-1',
+      status: 'enqueued',
+    });
+  });
+
+  it('enqueues Meta ad sync jobs for connected Facebook credentials', async () => {
+    credentialsService.findAll.mockResolvedValue({
+      docs: [
+        {
+          _id: 'cred-1',
+          accessToken: 'meta-token',
+          brandId: 'brand-1',
+        },
+      ],
+    });
+    metaAdsService.getAdAccounts.mockResolvedValue([{ id: 'act-1' }]);
+
+    const result = await service.runMetaAdSync('org-1');
+
+    expect(credentialsService.findAll).toHaveBeenCalledWith(
+      {
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          platform: CredentialPlatform.FACEBOOK,
+        }),
+      },
+      { limit: 500, pagination: false },
+    );
+    expect(queueService.add).toHaveBeenCalledWith(
+      'ad-sync-meta',
+      {
+        accessToken: 'decrypted:meta-token',
+        adAccountIds: ['act-1'],
+        brandId: 'brand-1',
+        credentialId: 'cred-1',
+        lastSyncDate: '2026-06-01T00:00:00.000Z',
+        organizationId: 'org-1',
+      },
+      expect.objectContaining({ attempts: 3, delay: 0 }),
+    );
+    expect(result.enqueued).toBe(1);
+  });
+
+  it('enqueues Google Ads sync jobs from accessible customers', async () => {
+    credentialsService.findAll.mockResolvedValue({
+      docs: [
+        {
+          _id: 'cred-1',
+          accessToken: 'google-token',
+          brandId: 'brand-1',
+          refreshToken: 'refresh-token',
+        },
+      ],
+    });
+    googleAdsService.listAccessibleCustomers.mockResolvedValue([
+      { id: 'customer-1' },
+    ]);
+
+    const result = await service.runGoogleAdSync('org-1');
+
+    expect(credentialsService.findAll).toHaveBeenCalledWith(
+      {
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          platform: CredentialPlatform.GOOGLE_ADS,
+        }),
+      },
+      { limit: 500, pagination: false },
+    );
+    expect(queueService.add).toHaveBeenCalledWith(
+      'ad-sync-google',
+      expect.objectContaining({
+        accessToken: 'decrypted:google-token',
+        brandId: 'brand-1',
+        credentialId: 'cred-1',
+        customerIds: ['customer-1'],
+        organizationId: 'org-1',
+        refreshToken: 'decrypted:refresh-token',
+      }),
+      expect.objectContaining({ attempts: 3, delay: 0 }),
+    );
+    expect(result.enqueued).toBe(1);
+  });
+
+  it('enqueues TikTok Ads sync jobs from advertiser accounts', async () => {
+    credentialsService.findAll.mockResolvedValue({
+      docs: [
+        {
+          _id: 'cred-1',
+          accessToken: 'tiktok-token',
+          brandId: 'brand-1',
+        },
+      ],
+    });
+    tikTokAdsService.getAdAccounts.mockResolvedValue([
+      { advertiserId: 'advertiser-1' },
+    ]);
+
+    const result = await service.runTikTokAdSync('org-1');
+
+    expect(credentialsService.findAll).toHaveBeenCalledWith(
+      {
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          platform: CredentialPlatform.TIKTOK,
+        }),
+      },
+      { limit: 500, pagination: false },
+    );
+    expect(queueService.add).toHaveBeenCalledWith(
+      'ad-sync-tiktok',
+      expect.objectContaining({
+        accessToken: 'decrypted:tiktok-token',
+        advertiserIds: ['advertiser-1'],
+        brandId: 'brand-1',
+        credentialId: 'cred-1',
+        organizationId: 'org-1',
+      }),
+      expect.objectContaining({ attempts: 3, delay: 0 }),
+    );
+    expect(result.enqueued).toBe(1);
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/ad-automation-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/ad-automation-workflow.service.ts
@@ -1,0 +1,561 @@
+import { randomUUID } from 'node:crypto';
+import { AdOptimizationConfigsService } from '@api/collections/ad-optimization-configs/services/ad-optimization-configs.service';
+import { AdPerformanceService } from '@api/collections/ad-performance/services/ad-performance.service';
+import type { CredentialDocument } from '@api/collections/credentials/schemas/credential.schema';
+import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import type { AdOptimizationJobData } from '@api/queues/ad-optimization/ad-optimization-job.interface';
+import type { MetaAdSyncJobData } from '@api/queues/ad-sync-meta/ad-sync-meta-job.interface';
+import type { TikTokAdSyncJobData } from '@api/queues/ad-sync-tiktok/ad-sync-tiktok-job.interface';
+import { QueueService } from '@api/queues/core/queue.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { GoogleAdsService } from '@api/services/integrations/google-ads/services/google-ads.service';
+import { MetaAdsService } from '@api/services/integrations/meta-ads/services/meta-ads.service';
+import { TikTokAdsService } from '@api/services/integrations/tiktok-ads/services/tiktok-ads.service';
+import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
+import { CredentialPlatform } from '@genfeedai/enums';
+import type { GoogleAdSyncJobData } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+type AdAutomationAction =
+  | 'adOptimization'
+  | 'adSyncGoogle'
+  | 'adSyncMeta'
+  | 'adSyncTikTok';
+
+export interface AdAutomationWorkflowResult {
+  action: AdAutomationAction;
+  enqueued: number;
+  organizationId: string;
+  queueName?: string;
+  reason?: string;
+  runId?: string;
+  skipped: number;
+  status: 'enqueued' | 'skipped';
+}
+
+const AD_OPTIMIZATION_QUEUE = 'ad-optimization';
+const AD_SYNC_GOOGLE_QUEUE = 'ad-sync-google';
+const AD_SYNC_META_QUEUE = 'ad-sync-meta';
+const AD_SYNC_TIKTOK_QUEUE = 'ad-sync-tiktok';
+
+const DAILY_LOCK_TTL_SECONDS = 36 * 60 * 60;
+const MAX_PROVIDER_SYNC_JITTER_MS = 30 * 60 * 1000;
+const MAX_OPTIMIZATION_JITTER_MS = 15 * 60 * 1000;
+
+@Injectable()
+export class AdAutomationWorkflowService {
+  private readonly logContext = 'AdAutomationWorkflowService';
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly queueService: QueueService,
+    private readonly cacheService: CacheService,
+    private readonly credentialsService: CredentialsService,
+    private readonly adPerformanceService: AdPerformanceService,
+    private readonly optimizationConfigService: AdOptimizationConfigsService,
+    private readonly metaAdsService: MetaAdsService,
+    private readonly googleAdsService: GoogleAdsService,
+    private readonly tikTokAdsService: TikTokAdsService,
+  ) {}
+
+  async runAdOptimization(
+    organizationId: string,
+  ): Promise<AdAutomationWorkflowResult> {
+    const acquired = await this.acquireExecutionLock(
+      'adOptimization',
+      organizationId,
+      DAILY_LOCK_TTL_SECONDS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        'adOptimization',
+        organizationId,
+        'daily_ad_optimization_already_enqueued',
+        AD_OPTIMIZATION_QUEUE,
+      );
+    }
+
+    const config =
+      await this.optimizationConfigService.findByOrganization(organizationId);
+
+    if (!config?.isEnabled) {
+      return this.skipped(
+        'adOptimization',
+        organizationId,
+        'ad_optimization_config_disabled_or_missing',
+        AD_OPTIMIZATION_QUEUE,
+      );
+    }
+
+    const runId = randomUUID();
+    const jobData: AdOptimizationJobData = {
+      configId: String(config._id),
+      organizationId,
+      runId,
+    };
+
+    await this.queueService.add(AD_OPTIMIZATION_QUEUE, jobData, {
+      attempts: 3,
+      backoff: { delay: 5000, type: 'exponential' },
+      delay: this.randomDelay(MAX_OPTIMIZATION_JITTER_MS),
+    });
+
+    this.logger.log(`${this.logContext} enqueued ad optimization`, {
+      organizationId,
+      runId,
+    });
+
+    return {
+      action: 'adOptimization',
+      enqueued: 1,
+      organizationId,
+      queueName: AD_OPTIMIZATION_QUEUE,
+      runId,
+      skipped: 0,
+      status: 'enqueued',
+    };
+  }
+
+  async runMetaAdSync(
+    organizationId: string,
+  ): Promise<AdAutomationWorkflowResult> {
+    const acquired = await this.acquireExecutionLock(
+      'adSyncMeta',
+      organizationId,
+      DAILY_LOCK_TTL_SECONDS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        'adSyncMeta',
+        organizationId,
+        'daily_meta_ad_sync_already_enqueued',
+        AD_SYNC_META_QUEUE,
+      );
+    }
+
+    const credentials = await this.findConnectedCredentials(
+      organizationId,
+      CredentialPlatform.FACEBOOK,
+    );
+
+    let enqueued = 0;
+    let skipped = 0;
+
+    for (const credential of credentials) {
+      const didEnqueue = await this.enqueueMetaCredentialSync(
+        organizationId,
+        credential,
+      );
+      if (didEnqueue) {
+        enqueued++;
+      } else {
+        skipped++;
+      }
+    }
+
+    return this.syncResult(
+      'adSyncMeta',
+      organizationId,
+      AD_SYNC_META_QUEUE,
+      enqueued,
+      skipped,
+      credentials.length === 0 ? 'no_connected_meta_credentials' : undefined,
+    );
+  }
+
+  async runGoogleAdSync(
+    organizationId: string,
+  ): Promise<AdAutomationWorkflowResult> {
+    const acquired = await this.acquireExecutionLock(
+      'adSyncGoogle',
+      organizationId,
+      DAILY_LOCK_TTL_SECONDS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        'adSyncGoogle',
+        organizationId,
+        'daily_google_ad_sync_already_enqueued',
+        AD_SYNC_GOOGLE_QUEUE,
+      );
+    }
+
+    const credentials = await this.findConnectedCredentials(
+      organizationId,
+      CredentialPlatform.GOOGLE_ADS,
+    );
+
+    let enqueued = 0;
+    let skipped = 0;
+
+    for (const credential of credentials) {
+      const didEnqueue = await this.enqueueGoogleCredentialSync(
+        organizationId,
+        credential,
+      );
+      if (didEnqueue) {
+        enqueued++;
+      } else {
+        skipped++;
+      }
+    }
+
+    return this.syncResult(
+      'adSyncGoogle',
+      organizationId,
+      AD_SYNC_GOOGLE_QUEUE,
+      enqueued,
+      skipped,
+      credentials.length === 0
+        ? 'no_connected_google_ads_credentials'
+        : undefined,
+    );
+  }
+
+  async runTikTokAdSync(
+    organizationId: string,
+  ): Promise<AdAutomationWorkflowResult> {
+    const acquired = await this.acquireExecutionLock(
+      'adSyncTikTok',
+      organizationId,
+      DAILY_LOCK_TTL_SECONDS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        'adSyncTikTok',
+        organizationId,
+        'daily_tiktok_ad_sync_already_enqueued',
+        AD_SYNC_TIKTOK_QUEUE,
+      );
+    }
+
+    const credentials = await this.findConnectedCredentials(
+      organizationId,
+      CredentialPlatform.TIKTOK,
+    );
+
+    let enqueued = 0;
+    let skipped = 0;
+
+    for (const credential of credentials) {
+      const didEnqueue = await this.enqueueTikTokCredentialSync(
+        organizationId,
+        credential,
+      );
+      if (didEnqueue) {
+        enqueued++;
+      } else {
+        skipped++;
+      }
+    }
+
+    return this.syncResult(
+      'adSyncTikTok',
+      organizationId,
+      AD_SYNC_TIKTOK_QUEUE,
+      enqueued,
+      skipped,
+      credentials.length === 0 ? 'no_connected_tiktok_credentials' : undefined,
+    );
+  }
+
+  private async enqueueMetaCredentialSync(
+    organizationId: string,
+    credential: CredentialDocument,
+  ): Promise<boolean> {
+    try {
+      const accessToken = this.decryptOptional(credential.accessToken);
+      const credentialId = String(credential._id);
+      const brandId = this.readCredentialBrandId(credential);
+
+      if (!accessToken || !brandId) {
+        this.logger.warn(`${this.logContext} skipped Meta credential`, {
+          credentialId,
+          organizationId,
+          reason: !accessToken ? 'missing_access_token' : 'missing_brand',
+        });
+        return false;
+      }
+
+      const adAccounts = await this.metaAdsService.getAdAccounts(accessToken);
+      if (adAccounts.length === 0) {
+        this.logger.log(`${this.logContext} no Meta ad accounts found`, {
+          credentialId,
+          organizationId,
+        });
+        return false;
+      }
+
+      const lastSyncDate =
+        await this.adPerformanceService.findLatestSyncDateForCredential(
+          credentialId,
+        );
+
+      const jobData: MetaAdSyncJobData = {
+        accessToken,
+        adAccountIds: adAccounts.map((account) => account.id),
+        brandId,
+        credentialId,
+        lastSyncDate: lastSyncDate?.toISOString(),
+        organizationId,
+      };
+
+      await this.queueService.add(AD_SYNC_META_QUEUE, jobData, {
+        attempts: 3,
+        backoff: { delay: 5000, type: 'exponential' },
+        delay: this.randomDelay(MAX_PROVIDER_SYNC_JITTER_MS),
+      });
+
+      return true;
+    } catch (error) {
+      this.logger.error(`${this.logContext} failed Meta ad sync enqueue`, {
+        credentialId: credential._id,
+        error,
+        organizationId,
+      });
+      return false;
+    }
+  }
+
+  private async enqueueGoogleCredentialSync(
+    organizationId: string,
+    credential: CredentialDocument,
+  ): Promise<boolean> {
+    try {
+      const accessToken = this.decryptOptional(credential.accessToken);
+      const refreshToken = this.decryptOptional(credential.refreshToken);
+      const credentialId = String(credential._id);
+      const brandId = this.readCredentialBrandId(credential);
+
+      if (!accessToken || !refreshToken || !brandId) {
+        this.logger.warn(`${this.logContext} skipped Google Ads credential`, {
+          credentialId,
+          organizationId,
+          reason: this.missingReason({
+            accessToken,
+            brandId,
+            refreshToken,
+          }),
+        });
+        return false;
+      }
+
+      const customers =
+        await this.googleAdsService.listAccessibleCustomers(accessToken);
+      const customerIds = customers.map((customer) => customer.id);
+
+      if (customerIds.length === 0) {
+        this.logger.log(`${this.logContext} no Google Ads customers found`, {
+          credentialId,
+          organizationId,
+        });
+        return false;
+      }
+
+      const lastSyncDate =
+        await this.adPerformanceService.findLatestSyncDateForCredential(
+          credentialId,
+        );
+
+      const jobData: GoogleAdSyncJobData = {
+        accessToken,
+        brandId,
+        credentialId,
+        customerIds,
+        lastSyncDate: lastSyncDate?.toISOString(),
+        loginCustomerId: this.readOptionalString(credential.externalHandle),
+        organizationId,
+        refreshToken,
+      };
+
+      await this.queueService.add(AD_SYNC_GOOGLE_QUEUE, jobData, {
+        attempts: 3,
+        backoff: { delay: 5000, type: 'exponential' },
+        delay: this.randomDelay(MAX_PROVIDER_SYNC_JITTER_MS),
+      });
+
+      return true;
+    } catch (error) {
+      this.logger.error(`${this.logContext} failed Google Ads sync enqueue`, {
+        credentialId: credential._id,
+        error,
+        organizationId,
+      });
+      return false;
+    }
+  }
+
+  private async enqueueTikTokCredentialSync(
+    organizationId: string,
+    credential: CredentialDocument,
+  ): Promise<boolean> {
+    try {
+      const accessToken = this.decryptOptional(credential.accessToken);
+      const credentialId = String(credential._id);
+      const brandId = this.readCredentialBrandId(credential);
+
+      if (!accessToken || !brandId) {
+        this.logger.warn(`${this.logContext} skipped TikTok Ads credential`, {
+          credentialId,
+          organizationId,
+          reason: this.missingReason({ accessToken, brandId }),
+        });
+        return false;
+      }
+
+      const adAccounts = await this.tikTokAdsService.getAdAccounts(accessToken);
+      const advertiserIds = adAccounts.map((account) => account.advertiserId);
+
+      if (advertiserIds.length === 0) {
+        this.logger.log(`${this.logContext} no TikTok ad accounts found`, {
+          credentialId,
+          organizationId,
+        });
+        return false;
+      }
+
+      const lastSyncDate =
+        await this.adPerformanceService.findLatestSyncDateForCredential(
+          credentialId,
+        );
+
+      const jobData: TikTokAdSyncJobData = {
+        accessToken,
+        advertiserIds,
+        brandId,
+        credentialId,
+        lastSyncDate: lastSyncDate?.toISOString(),
+        organizationId,
+      };
+
+      await this.queueService.add(AD_SYNC_TIKTOK_QUEUE, jobData, {
+        attempts: 3,
+        backoff: { delay: 5000, type: 'exponential' },
+        delay: this.randomDelay(MAX_PROVIDER_SYNC_JITTER_MS),
+      });
+
+      return true;
+    } catch (error) {
+      this.logger.error(`${this.logContext} failed TikTok Ads sync enqueue`, {
+        credentialId: credential._id,
+        error,
+        organizationId,
+      });
+      return false;
+    }
+  }
+
+  private async findConnectedCredentials(
+    organizationId: string,
+    platform: CredentialPlatform,
+  ): Promise<CredentialDocument[]> {
+    const result = await this.credentialsService.findAll(
+      {
+        where: {
+          accessToken: { not: null },
+          brandId: { not: null },
+          isConnected: true,
+          isDeleted: false,
+          organizationId,
+          platform,
+        },
+      },
+      { limit: 500, pagination: false },
+    );
+
+    return result.docs as CredentialDocument[];
+  }
+
+  private async acquireExecutionLock(
+    action: AdAutomationAction,
+    organizationId: string,
+    ttlSeconds: number,
+  ): Promise<boolean> {
+    return this.cacheService.acquireLock(
+      `workflow-ad-automation:${action}:${organizationId}:${this.utcDateKey()}`,
+      ttlSeconds,
+    );
+  }
+
+  private syncResult(
+    action: AdAutomationAction,
+    organizationId: string,
+    queueName: string,
+    enqueued: number,
+    skipped: number,
+    emptyReason?: string,
+  ): AdAutomationWorkflowResult {
+    if (enqueued === 0) {
+      return this.skipped(
+        action,
+        organizationId,
+        emptyReason ?? 'no_eligible_credentials_enqueued',
+        queueName,
+        skipped,
+      );
+    }
+
+    return {
+      action,
+      enqueued,
+      organizationId,
+      queueName,
+      skipped,
+      status: 'enqueued',
+    };
+  }
+
+  private skipped(
+    action: AdAutomationAction,
+    organizationId: string,
+    reason: string,
+    queueName?: string,
+    skipped: number = 0,
+  ): AdAutomationWorkflowResult {
+    return {
+      action,
+      enqueued: 0,
+      organizationId,
+      queueName,
+      reason,
+      skipped,
+      status: 'skipped',
+    };
+  }
+
+  private decryptOptional(value: unknown): string | null {
+    const encrypted = this.readOptionalString(value);
+    if (!encrypted) {
+      return null;
+    }
+
+    return EncryptionUtil.decrypt(encrypted);
+  }
+
+  private readCredentialBrandId(credential: CredentialDocument): string | null {
+    return (
+      this.readOptionalString(credential.brandId) ??
+      this.readOptionalString(credential.brand)
+    );
+  }
+
+  private readOptionalString(value: unknown): string | null {
+    return typeof value === 'string' && value.trim().length > 0 ? value : null;
+  }
+
+  private missingReason(fields: Record<string, unknown>): string {
+    return Object.entries(fields)
+      .filter(([, value]) => !value)
+      .map(([key]) => `missing_${key}`)
+      .join(',');
+  }
+
+  private randomDelay(maxDelayMs: number): number {
+    return Math.round(Math.random() * maxDelayMs);
+  }
+
+  private utcDateKey(): string {
+    return new Date().toISOString().slice(0, 10);
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -23,6 +23,7 @@ import type {
   WorkflowStep,
   WorkflowVisualNode,
 } from '@api/collections/workflows/schemas/workflow.schema';
+import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -255,6 +256,8 @@ export class WorkflowEngineAdapterService {
     @Optional() private readonly cacheService?: CacheService,
     @Optional() private readonly prismaService?: PrismaService,
     @Optional() private readonly creditsUtilsService?: CreditsUtilsService,
+    @Optional()
+    private readonly adAutomationWorkflowService?: AdAutomationWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -280,6 +283,7 @@ export class WorkflowEngineAdapterService {
     this.registerBrandAssetExecutor();
     this.registerBrandContextExecutor();
     this.registerAnalyticsFeedbackExecutor();
+    this.registerAdAutomationExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -609,6 +613,52 @@ export class WorkflowEngineAdapterService {
       executor.nodeType,
       this.wrapEngineExecutor(executor),
     );
+  }
+
+  private registerAdAutomationExecutors(): void {
+    this.engine.registerExecutor('adOptimization', (_node, _inputs, context) =>
+      this.adAutomationWorkflowService
+        ? this.adAutomationWorkflowService.runAdOptimization(
+            context.organizationId,
+          )
+        : this.adAutomationUnavailable('adOptimization', context),
+    );
+
+    this.engine.registerExecutor('adSyncGoogle', (_node, _inputs, context) =>
+      this.adAutomationWorkflowService
+        ? this.adAutomationWorkflowService.runGoogleAdSync(
+            context.organizationId,
+          )
+        : this.adAutomationUnavailable('adSyncGoogle', context),
+    );
+
+    this.engine.registerExecutor('adSyncMeta', (_node, _inputs, context) =>
+      this.adAutomationWorkflowService
+        ? this.adAutomationWorkflowService.runMetaAdSync(context.organizationId)
+        : this.adAutomationUnavailable('adSyncMeta', context),
+    );
+
+    this.engine.registerExecutor('adSyncTikTok', (_node, _inputs, context) =>
+      this.adAutomationWorkflowService
+        ? this.adAutomationWorkflowService.runTikTokAdSync(
+            context.organizationId,
+          )
+        : this.adAutomationUnavailable('adSyncTikTok', context),
+    );
+  }
+
+  private adAutomationUnavailable(
+    action: string,
+    context: ExecutionContext,
+  ): Record<string, unknown> {
+    return {
+      action,
+      enqueued: 0,
+      organizationId: context.organizationId,
+      reason: 'ad_automation_service_unavailable',
+      skipped: 0,
+      status: 'skipped',
+    };
   }
 
   private registerTrendTriggerExecutor(): void {

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@api/collections/workflows/schemas/workflow.schema';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
+import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
@@ -250,6 +251,88 @@ export class WorkflowsService extends BaseService<
         return;
       }
       throw error;
+    }
+  }
+
+  /**
+   * Idempotently seeds the default-on ad automation workflow set for an
+   * organization. Missing credentials/config are handled inside the action
+   * nodes as per-org skips, so new organizations get the workflows immediately
+   * and they begin doing real work once ad automation becomes eligible.
+   */
+  async ensureAdAutomationWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of AD_AUTOMATION_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 782,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureAdAutomationWorkflows: serialization conflict — workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
     }
   }
 

--- a/apps/server/api/src/collections/workflows/templates/ad-automation-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/ad-automation-workflows.template.ts
@@ -1,0 +1,79 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type AdAutomationWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  description: string;
+  icon: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  nodeType: string;
+  schedule: string;
+}): AdAutomationWorkflowTemplate {
+  return {
+    category: 'ads',
+    description: params.description,
+    icon: params.icon,
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: params.nodeLabel,
+        },
+        id: params.nodeType,
+        position: { x: 0, y: 120 },
+        type: params.nodeType,
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const AD_AUTOMATION_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    description:
+      'Daily per-organization ad optimization queue dispatch for enabled optimization configs.',
+    icon: 'target',
+    id: 'ad-optimization',
+    name: 'Ad Optimization',
+    nodeLabel: 'Run Ad Optimization',
+    nodeType: 'adOptimization',
+    schedule: '0 4 * * *',
+  }),
+  actionTemplate({
+    description:
+      'Daily Google Ads performance sync dispatch for connected Google Ads credentials.',
+    icon: 'refresh-cw',
+    id: 'ad-sync-google',
+    name: 'Google Ads Sync',
+    nodeLabel: 'Sync Google Ads',
+    nodeType: 'adSyncGoogle',
+    schedule: '30 3 * * *',
+  }),
+  actionTemplate({
+    description:
+      'Daily Meta Ads performance sync dispatch for connected Facebook/Meta credentials.',
+    icon: 'refresh-cw',
+    id: 'ad-sync-meta',
+    name: 'Meta Ads Sync',
+    nodeLabel: 'Sync Meta Ads',
+    nodeType: 'adSyncMeta',
+    schedule: '0 3 * * *',
+  }),
+  actionTemplate({
+    description:
+      'Daily TikTok Ads performance sync dispatch for connected TikTok credentials.',
+    icon: 'refresh-cw',
+    id: 'ad-sync-tiktok',
+    name: 'TikTok Ads Sync',
+    nodeLabel: 'Sync TikTok Ads',
+    nodeType: 'adSyncTikTok',
+    schedule: '0 4 * * *',
+  }),
+] satisfies AdAutomationWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -3,6 +3,8 @@
  * Automation templates: reusable multi-step workflows, triggers (manual/auto),
 dependency management, and workflow execution tracking.
  */
+import { AdOptimizationConfigsModule } from '@api/collections/ad-optimization-configs/ad-optimization-configs.module';
+import { AdPerformanceModule } from '@api/collections/ad-performance/ad-performance.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CaptionsModule } from '@api/collections/captions/captions.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
@@ -18,6 +20,7 @@ import { VideosModule } from '@api/collections/videos/videos.module';
 import { WorkflowExecutionsModule } from '@api/collections/workflow-executions/workflow-executions.module';
 import { WebhooksController } from '@api/collections/workflows/controllers/webhooks.controller';
 import { WorkflowsController } from '@api/collections/workflows/controllers/workflows.controller';
+import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
@@ -37,10 +40,14 @@ import { WorkflowGenerationService } from '@api/collections/workflows/services/w
 import { WorkflowSchedulerService } from '@api/collections/workflows/services/workflow-scheduler.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { MarketplaceIntegrationModule } from '@api/marketplace-integration/marketplace-integration.module';
+import { QueuesModule } from '@api/queues/core/queues.module';
 import { ElevenLabsModule } from '@api/services/integrations/elevenlabs/elevenlabs.module';
+import { GoogleAdsModule } from '@api/services/integrations/google-ads/google-ads.module';
 import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
+import { MetaAdsModule } from '@api/services/integrations/meta-ads/meta-ads.module';
 import { OpenRouterModule } from '@api/services/integrations/openrouter/openrouter.module';
+import { TikTokAdsModule } from '@api/services/integrations/tiktok-ads/tiktok-ads.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
@@ -62,25 +69,32 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowExecutionQueueService,
     WorkflowFormatConverterService,
     WorkflowGenerationService,
+    AdAutomationWorkflowService,
   ],
   imports: [
+    forwardRef(() => AdOptimizationConfigsModule),
+    forwardRef(() => AdPerformanceModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => CaptionsModule),
     forwardRef(() => CredentialsCoreModule),
     forwardRef(() => CreditsModule),
     forwardRef(() => ElevenLabsModule),
+    forwardRef(() => GoogleAdsModule),
     forwardRef(() => HeyGenModule),
     forwardRef(() => IngredientsModule),
     forwardRef(() => InstagramModule),
     forwardRef(() => MarketplaceIntegrationModule),
     forwardRef(() => MetadataModule),
+    forwardRef(() => MetaAdsModule),
     forwardRef(() => MusicsModule),
     forwardRef(() => NewslettersModule),
     forwardRef(() => NotificationsModule),
     forwardRef(() => NotificationsPublisherModule),
     forwardRef(() => OpenRouterModule),
     forwardRef(() => PostsModule),
+    forwardRef(() => QueuesModule),
     forwardRef(() => SharedModule),
+    forwardRef(() => TikTokAdsModule),
     forwardRef(() => TrendsModule),
     forwardRef(() => TwitterModule),
     forwardRef(() => VideoGenerationModule),
@@ -113,6 +127,7 @@ import { forwardRef, Module } from '@nestjs/common';
     TwitterSocialAdapter,
     InstagramSocialAdapter,
     SocialAdapterFactory,
+    AdAutomationWorkflowService,
     BatchWorkflowQueueService,
     BatchWorkflowService,
     WorkflowEngineAdapterService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -10,6 +10,7 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { IS_SELF_HOSTED } from '@genfeedai/config';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, type OnApplicationBootstrap } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 
 @Injectable()
 export class SelfHostedSeedService implements OnApplicationBootstrap {
@@ -18,6 +19,7 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
   constructor(
     private readonly prisma: PrismaService,
     private readonly logger: LoggerService,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
@@ -82,9 +84,40 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
       },
     });
 
+    await this.provisionDefaultWorkflows(user.id, org.id);
+
     this.logger.log(
       `Self-hosted workspace seeded (org=${org.id}, user=${user.id})`,
       this.context,
     );
+  }
+
+  private async provisionDefaultWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    try {
+      const { WorkflowsService } = await import(
+        '@api/collections/workflows/services/workflows.service'
+      );
+      const workflowsService = this.moduleRef.get(WorkflowsService, {
+        strict: false,
+      });
+
+      await workflowsService.ensureDailyTrendsDigestWorkflow(
+        userId,
+        organizationId,
+      );
+      await workflowsService.ensureAdAutomationWorkflows(
+        userId,
+        organizationId,
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to provision default self-hosted workflows',
+        error,
+        this.context,
+      );
+    }
   }
 }

--- a/apps/server/workers/src/crons/ad-optimization/cron.ad-optimization.service.ts
+++ b/apps/server/workers/src/crons/ad-optimization/cron.ad-optimization.service.ts
@@ -6,7 +6,6 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
 
 @Injectable()
 export class CronAdOptimizationService {
@@ -23,7 +22,6 @@ export class CronAdOptimizationService {
     private readonly optimizationConfigService: AdOptimizationConfigsService,
   ) {}
 
-  @Cron('0 4 * * *') // 4 AM daily
   async runOptimization(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 

--- a/apps/server/workers/src/crons/ad-sync/cron.ad-sync-google.service.ts
+++ b/apps/server/workers/src/crons/ad-sync/cron.ad-sync-google.service.ts
@@ -3,7 +3,6 @@ import type { GoogleAdSyncJobData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
 
 @Injectable()
 export class CronAdSyncGoogleService {
@@ -15,7 +14,6 @@ export class CronAdSyncGoogleService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron('30 3 * * *') // 3:30 AM daily
   async syncGoogleAds(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/ad-sync/cron.ad-sync-meta.service.ts
+++ b/apps/server/workers/src/crons/ad-sync/cron.ad-sync-meta.service.ts
@@ -9,7 +9,6 @@ import { CredentialPlatform } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
 
 @Injectable()
 export class CronAdSyncMetaService {
@@ -25,7 +24,6 @@ export class CronAdSyncMetaService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron('0 3 * * *') // 3 AM daily
   async syncMetaAds(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/ad-sync/cron.ad-sync-tiktok.service.ts
+++ b/apps/server/workers/src/crons/ad-sync/cron.ad-sync-tiktok.service.ts
@@ -3,7 +3,6 @@ import { QueueService } from '@api/queues/core/queue.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
 
 @Injectable()
 export class CronAdSyncTikTokService {
@@ -15,7 +14,6 @@ export class CronAdSyncTikTokService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron('0 4 * * *') // 4 AM daily
   async syncTikTokAds(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);


### PR DESCRIPTION
## Summary
- Adds backend-only default-on workflow templates for ad optimization plus Google, Meta, and TikTok ad sync.
- Registers workflow action executors that enqueue the existing ad optimization/sync jobs with per-org daily idempotency locks.
- Provisions the workflows during org settings creation, self-hosted first boot, and a new existing-org seed script.
- Removes the static `@Cron` decorators from tenant ad optimization and provider sync services.

## Scope note
- Closes #782 after narrowing it to tenant ad optimization/provider sync.
- Ad insights stays out of this PR: implementation review found it is a global/k-anonymous aggregation today, not a tenant per-org job. Tracked separately in #796, and #698 was updated to reflect that classification split.

## Verification
- `TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/collections/workflows/services/ad-automation-workflow.service.spec.ts --reporter=dot`
- `TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/collections/workflows/templates/template-node-coverage.spec.ts src/collections/workflows/templates/workflow-templates.spec.ts --reporter=dot`
- `bunx biome check <13 touched files>`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers`
- `bun run check:architecture`
- `git diff --check`
- Commit hook: staged Biome + secretlint

Closes #782
Refs #698
Refs #796
