### PR TITLE
Workflow-back campaign orchestration

### DIFF
--- a/apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts
@@ -1,0 +1,172 @@
+/**
+ * Seed Script: Campaign Orchestration Workflows
+ *
+ * Idempotently provisions default-on campaign orchestration workflows for
+ * existing organizations. New organizations are seeded automatically on
+ * creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/campaign-orchestration-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('CampaignOrchestrationWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} — no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        const existing = await prisma.workflow.findMany({
+          select: { metadata: true },
+          where: {
+            isDeleted: false,
+            organizationId: organization.id,
+            OR: CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES.map((template) => ({
+              metadata: {
+                equals: template.id,
+                path: ['sourceTemplateId'],
+              },
+            })),
+          },
+        });
+        const existingTemplateIds = new Set(
+          existing
+            .map((workflow) => {
+              const metadata = workflow.metadata as Record<
+                string,
+                unknown
+              > | null;
+              return typeof metadata?.sourceTemplateId === 'string'
+                ? metadata.sourceTemplateId
+                : null;
+            })
+            .filter((value): value is string => Boolean(value)),
+        );
+        const missing = CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES.filter(
+          (template) => !existingTemplateIds.has(template.id),
+        ).map((template) => template.id);
+
+        logger.log(
+          `[DRY RUN] org ${organization.id} missing ${missing.length}/${CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES.length} campaign workflow(s): ${missing.join(', ') || 'none'}`,
+        );
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureCampaignOrchestrationWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Campaign orchestration workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Campaign orchestration workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -108,6 +108,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureCampaignOrchestrationWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.spec.ts
@@ -1,0 +1,201 @@
+import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('CampaignOrchestrationWorkflowService', () => {
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  const prisma = {
+    agentCampaign: {
+      findMany: vi.fn(),
+    },
+  };
+  const cacheService = {
+    acquireLock: vi.fn(),
+    releaseLock: vi.fn(),
+  };
+  const campaignMemoryQueueService = { queueExtraction: vi.fn() };
+  const orchestratorQueueService = { queueCampaignRun: vi.fn() };
+  const triggerEvaluatorQueueService = { queueCampaignEvaluation: vi.fn() };
+
+  let service: CampaignOrchestrationWorkflowService;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T09:00:00.000Z'));
+    cacheService.acquireLock.mockResolvedValue(true);
+    cacheService.releaseLock.mockResolvedValue(undefined);
+    campaignMemoryQueueService.queueExtraction.mockResolvedValue('memory-job');
+    orchestratorQueueService.queueCampaignRun.mockResolvedValue(
+      'orchestrator-job',
+    );
+    triggerEvaluatorQueueService.queueCampaignEvaluation.mockResolvedValue(
+      'trigger-job',
+    );
+
+    service = new CampaignOrchestrationWorkflowService(
+      logger as never,
+      prisma as never,
+      cacheService as never,
+      campaignMemoryQueueService as never,
+      orchestratorQueueService as never,
+      triggerEvaluatorQueueService as never,
+    );
+  });
+
+  it('skips due campaign orchestration when the org lock already exists', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runDueCampaignOrchestration('org-1');
+
+    expect(result).toMatchObject({
+      action: 'agentCampaignOrchestration',
+      enqueued: 0,
+      organizationId: 'org-1',
+      reason: 'campaign_orchestration_already_running',
+      status: 'skipped',
+    });
+    expect(prisma.agentCampaign.findMany).not.toHaveBeenCalled();
+    expect(cacheService.releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('queues due active campaigns for orchestration and memory extraction', async () => {
+    prisma.agentCampaign.findMany.mockResolvedValue([
+      {
+        config: {
+          nextOrchestratedAt: '2026-06-24T08:59:00.000Z',
+          orchestrationEnabled: true,
+          status: 'active',
+        },
+        id: 'campaign-1',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+      {
+        config: {
+          nextOrchestratedAt: '2026-06-24T08:59:00.000Z',
+          orchestrationEnabled: false,
+          status: 'active',
+        },
+        id: 'campaign-disabled',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+      {
+        config: {
+          nextOrchestratedAt: '2026-06-24T09:05:00.000Z',
+          orchestrationEnabled: true,
+          status: 'active',
+        },
+        id: 'campaign-future',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+
+    const result = await service.runDueCampaignOrchestration('org-1');
+
+    expect(prisma.agentCampaign.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'asc' },
+      take: 100,
+      where: { isDeleted: false, organizationId: 'org-1' },
+    });
+    expect(orchestratorQueueService.queueCampaignRun).toHaveBeenCalledWith({
+      campaignId: 'campaign-1',
+      organizationId: 'org-1',
+      scheduledAt: new Date('2026-06-24T08:59:00.000Z'),
+      userId: 'user-1',
+    });
+    expect(campaignMemoryQueueService.queueExtraction).toHaveBeenCalledWith({
+      campaignId: 'campaign-1',
+      organizationId: 'org-1',
+      scheduledAt: new Date('2026-06-24T08:59:00.000Z'),
+      userId: 'user-1',
+    });
+    expect(result).toMatchObject({
+      action: 'agentCampaignOrchestration',
+      enqueued: 1,
+      organizationId: 'org-1',
+      skipped: 0,
+      status: 'enqueued',
+    });
+    expect(cacheService.releaseLock).toHaveBeenCalledWith(
+      'workflow-agent-campaign:agentCampaignOrchestration:org-1',
+    );
+  });
+
+  it('returns a skipped trigger evaluation result when no campaigns are eligible', async () => {
+    prisma.agentCampaign.findMany.mockResolvedValue([
+      {
+        agents: [],
+        config: { orchestrationEnabled: true, status: 'active' },
+        id: 'campaign-without-agents',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+      {
+        agents: [{}],
+        config: { orchestrationEnabled: true, status: 'paused' },
+        id: 'campaign-paused',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+
+    const result = await service.runTriggerEvaluations('org-1');
+
+    expect(result).toMatchObject({
+      action: 'agentCampaignTriggerEvaluation',
+      enqueued: 0,
+      organizationId: 'org-1',
+      reason: 'no_trigger_evaluation_campaigns',
+      status: 'skipped',
+    });
+    expect(
+      triggerEvaluatorQueueService.queueCampaignEvaluation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('queues trigger evaluation for active campaigns with agents', async () => {
+    prisma.agentCampaign.findMany.mockResolvedValue([
+      {
+        agents: [{}],
+        config: { orchestrationEnabled: true, status: 'active' },
+        id: 'campaign-1',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+
+    const result = await service.runTriggerEvaluations('org-1');
+
+    expect(prisma.agentCampaign.findMany).toHaveBeenCalledWith({
+      include: { agents: true },
+      orderBy: { updatedAt: 'desc' },
+      take: 100,
+      where: { isDeleted: false, organizationId: 'org-1' },
+    });
+    expect(
+      triggerEvaluatorQueueService.queueCampaignEvaluation,
+    ).toHaveBeenCalledWith({
+      campaignId: 'campaign-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+    expect(result).toMatchObject({
+      action: 'agentCampaignTriggerEvaluation',
+      enqueued: 1,
+      organizationId: 'org-1',
+      skipped: 0,
+      status: 'enqueued',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.ts
@@ -1,0 +1,304 @@
+import { CampaignMemoryQueueService } from '@api/services/agent-campaign/campaign-memory-queue.service';
+import { OrchestratorQueueService } from '@api/services/agent-campaign/orchestrator-queue.service';
+import { TriggerEvaluatorQueueService } from '@api/services/agent-campaign/trigger-evaluator-queue.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { AgentCampaign } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+type CampaignWorkflowAction =
+  | 'agentCampaignOrchestration'
+  | 'agentCampaignTriggerEvaluation';
+
+type AgentCampaignConfig = {
+  nextOrchestratedAt?: string;
+  orchestrationEnabled?: boolean;
+  status?: 'active' | 'completed' | 'draft' | 'paused';
+};
+
+type AgentCampaignWithConfig = AgentCampaign & {
+  config: AgentCampaignConfig;
+};
+
+type AgentCampaignWithAgents = AgentCampaignWithConfig & {
+  agents: unknown[];
+};
+
+export interface CampaignOrchestrationWorkflowResult {
+  action: CampaignWorkflowAction;
+  enqueued: number;
+  organizationId: string;
+  reason?: string;
+  skipped: number;
+  status: 'enqueued' | 'skipped';
+}
+
+const MAX_CAMPAIGNS_PER_CYCLE = 20;
+const LOCK_TTL_SECONDS = 900;
+
+@Injectable()
+export class CampaignOrchestrationWorkflowService {
+  private readonly logContext = 'CampaignOrchestrationWorkflowService';
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly prisma: PrismaService,
+    private readonly cacheService: CacheService,
+    private readonly campaignMemoryQueueService: CampaignMemoryQueueService,
+    private readonly orchestratorQueueService: OrchestratorQueueService,
+    private readonly triggerEvaluatorQueueService: TriggerEvaluatorQueueService,
+  ) {}
+
+  async runDueCampaignOrchestration(
+    organizationId: string,
+  ): Promise<CampaignOrchestrationWorkflowResult> {
+    const lockKey = this.lockKey('agentCampaignOrchestration', organizationId);
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      LOCK_TTL_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        'agentCampaignOrchestration',
+        organizationId,
+        'campaign_orchestration_already_running',
+      );
+    }
+
+    try {
+      const now = new Date();
+      const campaigns = (await this.prisma.agentCampaign.findMany({
+        orderBy: { updatedAt: 'asc' },
+        take: MAX_CAMPAIGNS_PER_CYCLE * 5,
+        where: { isDeleted: false, organizationId },
+      })) as AgentCampaignWithConfig[];
+
+      const dueCampaigns = campaigns
+        .filter((campaign) => this.isDueForOrchestration(campaign, now))
+        .slice(0, MAX_CAMPAIGNS_PER_CYCLE);
+
+      let enqueued = 0;
+      let skipped = 0;
+
+      for (const campaign of dueCampaigns) {
+        const queued = await this.queueCampaignOrchestration(campaign, now);
+        if (queued) {
+          enqueued++;
+        } else {
+          skipped++;
+        }
+      }
+
+      return this.result(
+        'agentCampaignOrchestration',
+        organizationId,
+        enqueued,
+        skipped,
+        dueCampaigns.length === 0 ? 'no_due_campaigns' : undefined,
+      );
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  async runTriggerEvaluations(
+    organizationId: string,
+  ): Promise<CampaignOrchestrationWorkflowResult> {
+    const lockKey = this.lockKey(
+      'agentCampaignTriggerEvaluation',
+      organizationId,
+    );
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      LOCK_TTL_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        'agentCampaignTriggerEvaluation',
+        organizationId,
+        'campaign_trigger_evaluation_already_running',
+      );
+    }
+
+    try {
+      const campaigns = (await this.prisma.agentCampaign.findMany({
+        include: { agents: true },
+        orderBy: { updatedAt: 'desc' },
+        take: MAX_CAMPAIGNS_PER_CYCLE * 5,
+        where: { isDeleted: false, organizationId },
+      })) as AgentCampaignWithAgents[];
+
+      const eligibleCampaigns = campaigns
+        .filter((campaign) => this.isEligibleForTriggerEvaluation(campaign))
+        .slice(0, MAX_CAMPAIGNS_PER_CYCLE);
+
+      let enqueued = 0;
+      let skipped = 0;
+
+      for (const campaign of eligibleCampaigns) {
+        const queued = await this.queueCampaignTriggerEvaluation(campaign);
+        if (queued) {
+          enqueued++;
+        } else {
+          skipped++;
+        }
+      }
+
+      return this.result(
+        'agentCampaignTriggerEvaluation',
+        organizationId,
+        enqueued,
+        skipped,
+        eligibleCampaigns.length === 0
+          ? 'no_trigger_evaluation_campaigns'
+          : undefined,
+      );
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  private isDueForOrchestration(
+    campaign: AgentCampaignWithConfig,
+    now: Date,
+  ): boolean {
+    const config = this.readConfig(campaign);
+    const nextOrchestratedAt = this.parseDate(config.nextOrchestratedAt);
+
+    return (
+      config.orchestrationEnabled === true &&
+      config.status === 'active' &&
+      nextOrchestratedAt !== null &&
+      nextOrchestratedAt <= now
+    );
+  }
+
+  private isEligibleForTriggerEvaluation(
+    campaign: AgentCampaignWithAgents,
+  ): boolean {
+    const config = this.readConfig(campaign);
+
+    return (
+      config.orchestrationEnabled === true &&
+      config.status === 'active' &&
+      campaign.agents.length > 0
+    );
+  }
+
+  private async queueCampaignOrchestration(
+    campaign: AgentCampaignWithConfig,
+    now: Date,
+  ): Promise<boolean> {
+    try {
+      const config = this.readConfig(campaign);
+      const scheduledAt = this.parseDate(config.nextOrchestratedAt) ?? now;
+
+      await this.orchestratorQueueService.queueCampaignRun({
+        campaignId: campaign.id,
+        organizationId: campaign.organizationId,
+        scheduledAt,
+        userId: campaign.userId,
+      });
+      await this.campaignMemoryQueueService.queueExtraction({
+        campaignId: campaign.id,
+        organizationId: campaign.organizationId,
+        scheduledAt,
+        userId: campaign.userId,
+      });
+
+      return true;
+    } catch (error) {
+      this.logger.error(`${this.logContext} failed campaign orchestration`, {
+        campaignId: campaign.id,
+        error,
+        organizationId: campaign.organizationId,
+      });
+      return false;
+    }
+  }
+
+  private async queueCampaignTriggerEvaluation(
+    campaign: AgentCampaignWithAgents,
+  ): Promise<boolean> {
+    try {
+      await this.triggerEvaluatorQueueService.queueCampaignEvaluation({
+        campaignId: campaign.id,
+        organizationId: campaign.organizationId,
+        userId: campaign.userId,
+      });
+
+      return true;
+    } catch (error) {
+      this.logger.error(`${this.logContext} failed trigger evaluation`, {
+        campaignId: campaign.id,
+        error,
+        organizationId: campaign.organizationId,
+      });
+      return false;
+    }
+  }
+
+  private result(
+    action: CampaignWorkflowAction,
+    organizationId: string,
+    enqueued: number,
+    skipped: number,
+    emptyReason?: string,
+  ): CampaignOrchestrationWorkflowResult {
+    if (enqueued === 0) {
+      return this.skipped(
+        action,
+        organizationId,
+        emptyReason ?? 'no_campaign_jobs_enqueued',
+        skipped,
+      );
+    }
+
+    return {
+      action,
+      enqueued,
+      organizationId,
+      skipped,
+      status: 'enqueued',
+    };
+  }
+
+  private skipped(
+    action: CampaignWorkflowAction,
+    organizationId: string,
+    reason: string,
+    skipped: number = 0,
+  ): CampaignOrchestrationWorkflowResult {
+    return {
+      action,
+      enqueued: 0,
+      organizationId,
+      reason,
+      skipped,
+      status: 'skipped',
+    };
+  }
+
+  private readConfig(campaign: AgentCampaignWithConfig): AgentCampaignConfig {
+    return campaign.config ?? {};
+  }
+
+  private parseDate(value: unknown): Date | null {
+    if (typeof value !== 'string' && !(value instanceof Date)) {
+      return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  private lockKey(
+    action: CampaignWorkflowAction,
+    organizationId: string,
+  ): string {
+    return `workflow-agent-campaign:${action}:${organizationId}`;
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -25,6 +25,7 @@ import type {
 } from '@api/collections/workflows/schemas/workflow.schema';
 import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
+import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
@@ -258,6 +259,8 @@ export class WorkflowEngineAdapterService {
     @Optional() private readonly creditsUtilsService?: CreditsUtilsService,
     @Optional()
     private readonly adAutomationWorkflowService?: AdAutomationWorkflowService,
+    @Optional()
+    private readonly campaignOrchestrationWorkflowService?: CampaignOrchestrationWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -284,6 +287,7 @@ export class WorkflowEngineAdapterService {
     this.registerBrandContextExecutor();
     this.registerAnalyticsFeedbackExecutor();
     this.registerAdAutomationExecutors();
+    this.registerCampaignOrchestrationExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -656,6 +660,48 @@ export class WorkflowEngineAdapterService {
       enqueued: 0,
       organizationId: context.organizationId,
       reason: 'ad_automation_service_unavailable',
+      skipped: 0,
+      status: 'skipped',
+    };
+  }
+
+  private registerCampaignOrchestrationExecutors(): void {
+    this.engine.registerExecutor(
+      'agentCampaignOrchestration',
+      (_node, _inputs, context) =>
+        this.campaignOrchestrationWorkflowService
+          ? this.campaignOrchestrationWorkflowService.runDueCampaignOrchestration(
+              context.organizationId,
+            )
+          : this.campaignOrchestrationUnavailable(
+              'agentCampaignOrchestration',
+              context,
+            ),
+    );
+
+    this.engine.registerExecutor(
+      'agentCampaignTriggerEvaluation',
+      (_node, _inputs, context) =>
+        this.campaignOrchestrationWorkflowService
+          ? this.campaignOrchestrationWorkflowService.runTriggerEvaluations(
+              context.organizationId,
+            )
+          : this.campaignOrchestrationUnavailable(
+              'agentCampaignTriggerEvaluation',
+              context,
+            ),
+    );
+  }
+
+  private campaignOrchestrationUnavailable(
+    action: string,
+    context: ExecutionContext,
+  ): Record<string, unknown> {
+    return {
+      action,
+      enqueued: 0,
+      organizationId: context.organizationId,
+      reason: 'campaign_orchestration_service_unavailable',
       skipped: 0,
       status: 'skipped',
     };

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -17,6 +17,7 @@ import {
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
+import { CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/campaign-orchestration-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
@@ -327,6 +328,87 @@ export class WorkflowsService extends BaseService<
         if (errorCode === 'P2034') {
           this.logger?.debug(
             'ensureAdAutomationWorkflows: serialization conflict — workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Idempotently seeds the default-on campaign orchestration workflow set for an
+   * organization. The workflow actions preserve the previous cron scanner
+   * behavior by filtering eligible campaigns inside the node execution.
+   */
+  async ensureCampaignOrchestrationWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 783,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureCampaignOrchestrationWorkflows: serialization conflict — workflow already seeded by concurrent request',
             { organizationId, templateId: template.id },
           );
           continue;

--- a/apps/server/api/src/collections/workflows/templates/campaign-orchestration-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/campaign-orchestration-workflows.template.ts
@@ -1,0 +1,59 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type CampaignOrchestrationWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  description: string;
+  icon: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  nodeType: string;
+  schedule: string;
+}): CampaignOrchestrationWorkflowTemplate {
+  return {
+    category: 'campaigns',
+    description: params.description,
+    icon: params.icon,
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: params.nodeLabel,
+        },
+        id: params.nodeType,
+        position: { x: 0, y: 120 },
+        type: params.nodeType,
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    description:
+      'Per-organization campaign orchestration scanner that queues due active campaigns.',
+    icon: 'send',
+    id: 'agent-campaign-orchestration',
+    name: 'Agent Campaign Orchestration',
+    nodeLabel: 'Process Due Campaigns',
+    nodeType: 'agentCampaignOrchestration',
+    schedule: '*/1 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Per-organization campaign trigger evaluation scanner for active campaigns with agents.',
+    icon: 'radar',
+    id: 'agent-campaign-trigger-evaluation',
+    name: 'Agent Campaign Trigger Evaluation',
+    nodeLabel: 'Evaluate Campaign Triggers',
+    nodeType: 'agentCampaignTriggerEvaluation',
+    schedule: '*/15 * * * *',
+  }),
+] satisfies CampaignOrchestrationWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -29,6 +29,7 @@ import {
   BATCH_WORKFLOW_QUEUE,
   BatchWorkflowQueueService,
 } from '@api/collections/workflows/services/batch-workflow-queue.service';
+import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import {
   WORKFLOW_EXECUTION_QUEUE,
@@ -41,6 +42,7 @@ import { WorkflowSchedulerService } from '@api/collections/workflows/services/wo
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { MarketplaceIntegrationModule } from '@api/marketplace-integration/marketplace-integration.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
+import { AgentCampaignOrchestratorModule } from '@api/services/agent-campaign/agent-campaign-orchestrator.module';
 import { ElevenLabsModule } from '@api/services/integrations/elevenlabs/elevenlabs.module';
 import { GoogleAdsModule } from '@api/services/integrations/google-ads/google-ads.module';
 import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
@@ -70,10 +72,12 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowFormatConverterService,
     WorkflowGenerationService,
     AdAutomationWorkflowService,
+    CampaignOrchestrationWorkflowService,
   ],
   imports: [
     forwardRef(() => AdOptimizationConfigsModule),
     forwardRef(() => AdPerformanceModule),
+    forwardRef(() => AgentCampaignOrchestratorModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => CaptionsModule),
     forwardRef(() => CredentialsCoreModule),
@@ -130,6 +134,7 @@ import { forwardRef, Module } from '@nestjs/common';
     AdAutomationWorkflowService,
     BatchWorkflowQueueService,
     BatchWorkflowService,
+    CampaignOrchestrationWorkflowService,
     WorkflowEngineAdapterService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -112,6 +112,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureCampaignOrchestrationWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',

--- a/apps/server/workers/src/crons/agent-campaign/cron.agent-campaign-orchestrator.service.ts
+++ b/apps/server/workers/src/crons/agent-campaign/cron.agent-campaign-orchestrator.service.ts
@@ -7,7 +7,6 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import type { AgentCampaign } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 const MAX_CAMPAIGNS_PER_CYCLE = 20;
 
@@ -36,7 +35,6 @@ export class CronAgentCampaignOrchestratorService {
     private readonly logger: LoggerService,
   ) {}
 
-  @Cron(CronExpression.EVERY_MINUTE)
   async processDueCampaigns(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       CronAgentCampaignOrchestratorService.LOCK_KEY,
@@ -136,7 +134,6 @@ export class CronAgentCampaignOrchestratorService {
     }
   }
 
-  @Cron('0 */15 * * * *')
   async processTriggerEvaluations(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       `${CronAgentCampaignOrchestratorService.LOCK_KEY}:triggers`,


### PR DESCRIPTION
## Summary
- adds backend-only default-on campaign orchestration workflow templates for per-org due-campaign and trigger-evaluation scanners
- registers workflow executors that enqueue the existing campaign orchestration, memory extraction, and trigger evaluation queues with org-scoped locking
- provisions the workflows during org creation and self-hosted seeding, and adds an idempotent seed for existing orgs
- removes the static Nest cron decorators from the legacy worker campaign orchestrator service

## Scope note
This intentionally uses per-organization scanner workflows, not one workflow row per campaign. That matches #698's default-on-per-org requirement and preserves the old cron scanner semantics while moving execution under workflow schedules.

## Verification
- bunx biome check --write apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/templates/campaign-orchestration-workflows.template.ts apps/server/api/src/collections/workflows/workflows.module.ts apps/server/api/src/seeds/self-hosted-seed.service.ts apps/server/workers/src/crons/agent-campaign/cron.agent-campaign-orchestrator.service.ts
- TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/collections/workflows/services/campaign-orchestration-workflow.service.spec.ts --reporter=dot
- TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/collections/workflows/templates/template-node-coverage.spec.ts src/collections/workflows/templates/workflow-templates.spec.ts --reporter=dot
- bunx biome check apps/server/api/scripts/seeds/campaign-orchestration-workflows.seed.ts apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/campaign-orchestration-workflow.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/templates/campaign-orchestration-workflows.template.ts apps/server/api/src/collections/workflows/workflows.module.ts apps/server/api/src/seeds/self-hosted-seed.service.ts apps/server/workers/src/crons/agent-campaign/cron.agent-campaign-orchestrator.service.ts
- rg "@Cron|@nestjs/schedule" apps/server/workers/src/crons/agent-campaign -n
- bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers
- bun run check:architecture
- git diff --check
- git diff --cached --check

Closes #783
Refs #698