### PR TITLE
Workflow-back agent autopilot

### DIFF
--- a/apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts
@@ -1,0 +1,171 @@
+/**
+ * Seed Script: Agent Autopilot Workflows
+ *
+ * Idempotently provisions default-on agent autopilot workflows for existing
+ * organizations. New organizations are seeded automatically on creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { AGENT_AUTOPILOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/agent-autopilot-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('AgentAutopilotWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} - no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        const existing = await prisma.workflow.findMany({
+          select: { metadata: true },
+          where: {
+            isDeleted: false,
+            organizationId: organization.id,
+            OR: AGENT_AUTOPILOT_WORKFLOW_TEMPLATES.map((template) => ({
+              metadata: {
+                equals: template.id,
+                path: ['sourceTemplateId'],
+              },
+            })),
+          },
+        });
+        const existingTemplateIds = new Set(
+          existing
+            .map((workflow) => {
+              const metadata = workflow.metadata as Record<
+                string,
+                unknown
+              > | null;
+              return typeof metadata?.sourceTemplateId === 'string'
+                ? metadata.sourceTemplateId
+                : null;
+            })
+            .filter((value): value is string => Boolean(value)),
+        );
+        const missing = AGENT_AUTOPILOT_WORKFLOW_TEMPLATES.filter(
+          (template) => !existingTemplateIds.has(template.id),
+        ).map((template) => template.id);
+
+        logger.log(
+          `[DRY RUN] org ${organization.id} missing ${missing.length}/${AGENT_AUTOPILOT_WORKFLOW_TEMPLATES.length} agent autopilot workflow(s): ${missing.join(', ') || 'none'}`,
+        );
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureAgentAutopilotWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Agent autopilot workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Agent autopilot workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -112,6 +112,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureAgentAutopilotWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts
@@ -1,0 +1,192 @@
+import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
+import { AgentRunFrequency } from '@genfeedai/enums';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('AgentAutopilotWorkflowService', () => {
+  const prisma = {
+    agentStrategy: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+  const agentRunsService = { create: vi.fn() };
+  const agentRunQueueService = { queueRun: vi.fn() };
+  const creditsUtilsService = { getOrganizationCreditsBalance: vi.fn() };
+  const organizationSettingsService = { findOne: vi.fn() };
+  const agentGoalsService = { getGoalSummary: vi.fn() };
+  const aiInfluencerService = { scheduleDailyPosts: vi.fn() };
+  const cacheService = {
+    acquireLock: vi.fn(),
+    releaseLock: vi.fn(),
+  };
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  let service: AgentAutopilotWorkflowService;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T09:00:00.000Z'));
+    cacheService.acquireLock.mockResolvedValue(true);
+    cacheService.releaseLock.mockResolvedValue(undefined);
+    agentRunsService.create.mockResolvedValue({ id: 'run-1' });
+    agentRunQueueService.queueRun.mockResolvedValue(undefined);
+    creditsUtilsService.getOrganizationCreditsBalance.mockResolvedValue(500);
+    organizationSettingsService.findOne.mockResolvedValue(null);
+    agentGoalsService.getGoalSummary.mockResolvedValue('Goal summary');
+    aiInfluencerService.scheduleDailyPosts.mockResolvedValue([]);
+    prisma.agentStrategy.findFirst.mockResolvedValue({
+      config: {
+        dailyResetAt: '2026-06-25T00:00:00.000Z',
+        nextRunAt: '2026-06-24T08:59:00.000Z',
+        weeklyResetAt: '2026-06-29T00:00:00.000Z',
+      },
+      id: 'strategy-1',
+    });
+    prisma.agentStrategy.update.mockResolvedValue({});
+
+    service = new AgentAutopilotWorkflowService(
+      prisma as never,
+      agentRunsService as never,
+      agentRunQueueService as never,
+      creditsUtilsService as never,
+      organizationSettingsService as never,
+      agentGoalsService as never,
+      aiInfluencerService as never,
+      cacheService as never,
+      logger as never,
+    );
+  });
+
+  it('skips proactive strategy processing when the org lock already exists', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runProactiveStrategies('org-1');
+
+    expect(result).toMatchObject({
+      action: 'proactiveAgentStrategies',
+      enqueued: 0,
+      organizationId: 'org-1',
+      reason: 'proactive_agent_already_running',
+      status: 'skipped',
+    });
+    expect(prisma.agentStrategy.findMany).not.toHaveBeenCalled();
+    expect(cacheService.releaseLock).not.toHaveBeenCalled();
+  });
+
+  it('queues due active proactive strategies for the organization', async () => {
+    prisma.agentStrategy.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          brandId: null,
+          config: {
+            creditsUsedThisWeek: 0,
+            creditsUsedToday: 0,
+            dailyCreditBudget: 100,
+            dailyCreditsUsed: 0,
+            dailyResetAt: '2026-06-25T00:00:00.000Z',
+            minCreditThreshold: 10,
+            nextRunAt: '2026-06-24T08:59:00.000Z',
+            postsPerWeek: 3,
+            runFrequency: AgentRunFrequency.DAILY,
+            weeklyCreditBudget: 300,
+            weeklyResetAt: '2026-06-29T00:00:00.000Z',
+          },
+          goalId: null,
+          id: 'strategy-1',
+          label: 'Growth strategy',
+          organizationId: 'org-1',
+          userId: 'user-1',
+        },
+      ]);
+
+    const result = await service.runProactiveStrategies('org-1');
+
+    expect(prisma.agentStrategy.findMany).toHaveBeenNthCalledWith(2, {
+      take: 100,
+      where: {
+        isActive: true,
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(agentRunsService.create).toHaveBeenCalledWith({
+      creditBudget: 100,
+      label: 'Proactive: Growth strategy',
+      objective: expect.stringContaining('Run proactive session'),
+      organization: 'org-1',
+      strategy: 'strategy-1',
+      trigger: 'cron',
+      user: 'user-1',
+    });
+    expect(agentRunQueueService.queueRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creditBudget: 100,
+        organizationId: 'org-1',
+        runId: 'run-1',
+        strategyId: 'strategy-1',
+        userId: 'user-1',
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'proactiveAgentStrategies',
+      enqueued: 1,
+      organizationId: 'org-1',
+      status: 'enqueued',
+    });
+  });
+
+  it('returns skipped when no proactive strategies are due', async () => {
+    prisma.agentStrategy.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const result = await service.runProactiveStrategies('org-1');
+
+    expect(result).toMatchObject({
+      action: 'proactiveAgentStrategies',
+      enqueued: 0,
+      organizationId: 'org-1',
+      reason: 'no_due_strategies',
+      status: 'skipped',
+    });
+    expect(agentRunsService.create).not.toHaveBeenCalled();
+  });
+
+  it('runs AI influencer daily posts with organization scope', async () => {
+    aiInfluencerService.scheduleDailyPosts.mockResolvedValue([
+      { ingredientId: 'ingredient-1', personaSlug: 'luna' },
+      { ingredientId: 'ingredient-2', personaSlug: 'nova' },
+    ]);
+
+    const result = await service.runAiInfluencerDailyPosts('org-1');
+
+    expect(cacheService.acquireLock).toHaveBeenCalledWith(
+      'workflow-agent-autopilot:aiInfluencerDailyPosts:org-1',
+      1800,
+    );
+    expect(aiInfluencerService.scheduleDailyPosts).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+    });
+    expect(result).toMatchObject({
+      action: 'aiInfluencerDailyPosts',
+      generated: 2,
+      organizationId: 'org-1',
+      status: 'completed',
+    });
+    expect(cacheService.releaseLock).toHaveBeenCalledWith(
+      'workflow-agent-autopilot:aiInfluencerDailyPosts:org-1',
+    );
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts
@@ -1,0 +1,576 @@
+import { AgentGoalsService } from '@api/collections/agent-goals/services/agent-goals.service';
+import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
+import { AiInfluencerService } from '@api/services/ai-influencer/ai-influencer.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  AgentAutonomyMode,
+  AgentExecutionTrigger,
+  AgentRunFrequency,
+} from '@genfeedai/enums';
+import type { AgentStrategy } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+type AgentAutopilotWorkflowAction =
+  | 'proactiveAgentStrategies'
+  | 'aiInfluencerDailyPosts';
+
+type ContentMixConfig = {
+  carouselPercent: number;
+  imagePercent: number;
+  videoPercent: number;
+};
+
+type AgentStrategyConfig = {
+  agentType?: string;
+  autonomyMode?: AgentAutonomyMode;
+  contentMix?: ContentMixConfig;
+  consecutiveFailures?: number;
+  creditsUsedThisWeek?: number;
+  creditsUsedToday?: number;
+  dailyCreditBudget?: number;
+  dailyCreditResetAt?: string;
+  dailyCreditsUsed?: number;
+  dailyResetAt?: string;
+  engagementEnabled?: boolean;
+  engagementKeywords?: string[];
+  engagementTone?: string;
+  maxEngagementsPerDay?: number;
+  minCreditThreshold?: number;
+  model?: string;
+  nextRunAt?: string;
+  platforms?: string[];
+  postsPerWeek?: number;
+  requiresManualReactivation?: boolean;
+  runFrequency?: AgentRunFrequency;
+  topics?: string[];
+  voice?: string;
+  weeklyCreditBudget?: number;
+  weeklyResetAt?: string;
+};
+
+type AgentStrategyWithConfig = AgentStrategy & {
+  config: AgentStrategyConfig;
+};
+
+export interface AgentAutopilotWorkflowResult {
+  action: AgentAutopilotWorkflowAction;
+  enqueued: number;
+  generated: number;
+  organizationId: string;
+  reason?: string;
+  skipped: number;
+  status: 'completed' | 'enqueued' | 'skipped';
+}
+
+const MAX_CONSECUTIVE_FAILURES = 5;
+const MAX_STRATEGIES_PER_CYCLE = 20;
+const FAILURES_BEFORE_PAUSE = 3;
+const FAILURE_RETRY_MINUTES = 30;
+const PROACTIVE_LOCK_TTL_SECONDS = 900;
+const AI_INFLUENCER_LOCK_TTL_SECONDS = 1800;
+
+@Injectable()
+export class AgentAutopilotWorkflowService {
+  private readonly logContext = 'AgentAutopilotWorkflowService';
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly agentRunsService: AgentRunsService,
+    private readonly agentRunQueueService: AgentRunQueueService,
+    private readonly creditsUtilsService: CreditsUtilsService,
+    private readonly organizationSettingsService: OrganizationSettingsService,
+    private readonly agentGoalsService: AgentGoalsService,
+    private readonly aiInfluencerService: AiInfluencerService,
+    private readonly cacheService: CacheService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async runProactiveStrategies(
+    organizationId: string,
+  ): Promise<AgentAutopilotWorkflowResult> {
+    const action: AgentAutopilotWorkflowAction = 'proactiveAgentStrategies';
+    const lockKey = this.lockKey(action, organizationId);
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      PROACTIVE_LOCK_TTL_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        'proactive_agent_already_running',
+      );
+    }
+
+    try {
+      await this.resetCreditCounters(organizationId);
+
+      const now = new Date();
+      const strategies = (await this.prisma.agentStrategy.findMany({
+        take: MAX_STRATEGIES_PER_CYCLE * 5,
+        where: {
+          isActive: true,
+          isDeleted: false,
+          organizationId,
+        },
+      })) as AgentStrategyWithConfig[];
+
+      const dueStrategies = strategies
+        .filter((strategy) => this.isDueStrategy(strategy, now))
+        .slice(0, MAX_STRATEGIES_PER_CYCLE);
+
+      let enqueued = 0;
+      let skipped = 0;
+
+      for (const strategy of dueStrategies) {
+        const queued = await this.executeStrategy(strategy);
+        if (queued) {
+          enqueued++;
+        } else {
+          skipped++;
+        }
+      }
+
+      return this.result(
+        action,
+        organizationId,
+        enqueued,
+        0,
+        skipped,
+        dueStrategies.length === 0 ? 'no_due_strategies' : undefined,
+      );
+    } catch (error) {
+      this.logger.error(`${this.logContext} proactive agent cycle failed`, {
+        error,
+        organizationId,
+      });
+      return this.skipped(
+        action,
+        organizationId,
+        'proactive_agent_cycle_failed',
+      );
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  async runAiInfluencerDailyPosts(
+    organizationId: string,
+  ): Promise<AgentAutopilotWorkflowResult> {
+    const action: AgentAutopilotWorkflowAction = 'aiInfluencerDailyPosts';
+    const lockKey = this.lockKey(action, organizationId);
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      AI_INFLUENCER_LOCK_TTL_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        'ai_influencer_already_running',
+      );
+    }
+
+    try {
+      const results = await this.aiInfluencerService.scheduleDailyPosts({
+        organizationId,
+      });
+
+      return this.result(
+        action,
+        organizationId,
+        0,
+        results.length,
+        0,
+        results.length === 0 ? 'no_ai_influencer_posts_generated' : undefined,
+      );
+    } catch (error) {
+      this.logger.error(`${this.logContext} AI influencer cycle failed`, {
+        error,
+        organizationId,
+      });
+      return this.skipped(action, organizationId, 'ai_influencer_cycle_failed');
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  private isDueStrategy(strategy: AgentStrategyWithConfig, now: Date): boolean {
+    const config = this.readConfig(strategy);
+    const consecutiveFailures = config.consecutiveFailures ?? 0;
+    const requiresManualReactivation =
+      config.requiresManualReactivation ?? false;
+    const nextRunAt = this.parseDate(config.nextRunAt);
+
+    return (
+      consecutiveFailures < MAX_CONSECUTIVE_FAILURES &&
+      !requiresManualReactivation &&
+      (!nextRunAt || nextRunAt <= now)
+    );
+  }
+
+  private async executeStrategy(
+    strategy: AgentStrategyWithConfig,
+  ): Promise<boolean> {
+    const organizationId = strategy.organizationId;
+    const userId = strategy.userId;
+    const strategyId = strategy.id;
+    const config = this.readConfig(strategy);
+
+    const organizationSettings = await this.organizationSettingsService.findOne(
+      {
+        isDeleted: false,
+        organization: organizationId,
+      },
+    );
+    const orgAgentDailyCap =
+      organizationSettings?.agentPolicy?.creditGovernance
+        ?.agentDailyCreditCap ?? null;
+    const brandDailyCap =
+      organizationSettings?.agentPolicy?.creditGovernance
+        ?.brandDailyCreditCap ?? null;
+
+    const dailyCreditBudget = config.dailyCreditBudget ?? 0;
+    const weeklyCreditBudget = config.weeklyCreditBudget ?? 0;
+    const effectiveDailyBudget = orgAgentDailyCap
+      ? Math.min(dailyCreditBudget, orgAgentDailyCap)
+      : dailyCreditBudget;
+
+    const dailyCreditsUsed = Math.max(
+      config.creditsUsedToday ?? 0,
+      config.dailyCreditsUsed ?? 0,
+    );
+
+    if (dailyCreditsUsed >= effectiveDailyBudget) {
+      await this.scheduleNextRun(strategyId, config.runFrequency);
+      return false;
+    }
+
+    const creditsUsedThisWeek = config.creditsUsedThisWeek ?? 0;
+    if (creditsUsedThisWeek >= weeklyCreditBudget) {
+      await this.scheduleNextRun(strategyId, config.runFrequency);
+      return false;
+    }
+
+    if (brandDailyCap && strategy.brandId) {
+      const brandCreditsUsedToday = await this.getBrandCreditsUsedToday(
+        organizationId,
+        strategy.brandId,
+      );
+
+      if (brandCreditsUsedToday >= brandDailyCap) {
+        await this.scheduleNextRun(strategyId, config.runFrequency);
+        return false;
+      }
+    }
+
+    const orgBalance =
+      await this.creditsUtilsService.getOrganizationCreditsBalance(
+        organizationId,
+      );
+
+    const minCreditThreshold = config.minCreditThreshold ?? 50;
+    if (orgBalance < minCreditThreshold) {
+      await this.prisma.agentStrategy.update({
+        data: { isActive: false },
+        where: { id: strategyId },
+      });
+      return false;
+    }
+
+    const remainingBudget = Math.min(
+      effectiveDailyBudget - dailyCreditsUsed,
+      weeklyCreditBudget - creditsUsedThisWeek,
+    );
+    const objective = await this.buildSyntheticUserMessage(strategy);
+
+    try {
+      const run = await this.agentRunsService.create({
+        creditBudget: remainingBudget,
+        label: `Proactive: ${strategy.label}`,
+        objective,
+        organization: organizationId,
+        strategy: strategyId,
+        trigger: AgentExecutionTrigger.CRON,
+        user: userId,
+      });
+
+      await this.agentRunQueueService.queueRun({
+        agentType: config.agentType,
+        autonomyMode: config.autonomyMode,
+        creditBudget: remainingBudget,
+        model: config.model,
+        objective,
+        organizationId,
+        runId: run.id,
+        strategyId,
+        userId,
+      });
+
+      await this.scheduleNextRun(strategyId, config.runFrequency);
+      return true;
+    } catch (error) {
+      const consecutiveFailures = config.consecutiveFailures ?? 0;
+      const newFailureCount = consecutiveFailures + 1;
+      const shouldPause = newFailureCount >= FAILURES_BEFORE_PAUSE;
+      const updatedConfig: AgentStrategyConfig = {
+        ...config,
+        consecutiveFailures: newFailureCount,
+      };
+
+      await this.prisma.agentStrategy.update({
+        data: {
+          config: updatedConfig as never,
+          ...(shouldPause ? { isActive: false } : {}),
+        },
+        where: { id: strategyId },
+      });
+
+      if (newFailureCount >= MAX_CONSECUTIVE_FAILURES) {
+        await this.prisma.agentStrategy.update({
+          data: {
+            config: {
+              ...updatedConfig,
+              requiresManualReactivation: true,
+            } as never,
+          },
+          where: { id: strategyId },
+        });
+      }
+
+      await this.scheduleNextRun(
+        strategyId,
+        config.runFrequency,
+        FAILURE_RETRY_MINUTES,
+      );
+
+      this.logger.error(`${this.logContext} strategy execution failed`, {
+        error,
+        organizationId,
+        strategyId,
+      });
+      return false;
+    }
+  }
+
+  private async buildSyntheticUserMessage(
+    strategy: AgentStrategyWithConfig,
+  ): Promise<string> {
+    const config = this.readConfig(strategy);
+    const tasks: string[] = [
+      'Check the content calendar for gaps this week',
+      `Generate content to maintain ${config.postsPerWeek ?? 0} posts/week cadence`,
+    ];
+
+    if (strategy.goalId) {
+      const goalSummary = await this.agentGoalsService.getGoalSummary(
+        strategy.goalId,
+        strategy.organizationId,
+      );
+      tasks.push(`Advance the linked goal: ${goalSummary}`);
+    }
+
+    if (config.engagementEnabled) {
+      tasks.push(
+        `Find engagement opportunities for keywords: ${(config.engagementKeywords ?? []).join(', ')}`,
+        'Draft replies for the most relevant opportunities',
+      );
+    }
+
+    tasks.push('Summarize what you accomplished');
+
+    return `Run proactive session for strategy "${strategy.label ?? ''}". Tasks:\n${tasks.map((task, index) => `${index + 1}. ${task}`).join('\n')}`;
+  }
+
+  private async resetCreditCounters(organizationId: string): Promise<void> {
+    const now = new Date();
+    const strategies = (await this.prisma.agentStrategy.findMany({
+      where: {
+        isActive: true,
+        isDeleted: false,
+        organizationId,
+      },
+    })) as AgentStrategyWithConfig[];
+
+    for (const strategy of strategies) {
+      const config = this.readConfig(strategy);
+      let updated = false;
+      const updatedConfig: AgentStrategyConfig = { ...config };
+
+      const dailyResetAt = this.parseDate(config.dailyResetAt);
+      if (!dailyResetAt || dailyResetAt <= now) {
+        const nextDailyReset = this.getNextDailyReset();
+        updatedConfig.creditsUsedToday = 0;
+        updatedConfig.dailyCreditsUsed = 0;
+        updatedConfig.dailyResetAt = nextDailyReset.toISOString();
+        updatedConfig.dailyCreditResetAt = nextDailyReset.toISOString();
+        updated = true;
+      }
+
+      const weeklyResetAt = this.parseDate(config.weeklyResetAt);
+      if (!weeklyResetAt || weeklyResetAt <= now) {
+        updatedConfig.creditsUsedThisWeek = 0;
+        updatedConfig.weeklyResetAt = this.getNextWeeklyReset().toISOString();
+        updated = true;
+      }
+
+      if (updated) {
+        await this.prisma.agentStrategy.update({
+          data: { config: updatedConfig as never },
+          where: { id: strategy.id },
+        });
+      }
+    }
+  }
+
+  private async scheduleNextRun(
+    strategyId: string,
+    frequency: AgentRunFrequency | undefined,
+    retryInMinutes?: number,
+  ): Promise<void> {
+    const now = new Date();
+    let nextRun: Date;
+
+    if (retryInMinutes && retryInMinutes > 0) {
+      nextRun = new Date(now.getTime() + retryInMinutes * 60 * 1000);
+    } else {
+      switch (frequency) {
+        case AgentRunFrequency.EVERY_6_HOURS:
+          nextRun = new Date(now.getTime() + 6 * 60 * 60 * 1000);
+          break;
+        case AgentRunFrequency.TWICE_DAILY:
+          nextRun = new Date(now.getTime() + 12 * 60 * 60 * 1000);
+          break;
+        default:
+          nextRun = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+          break;
+      }
+    }
+
+    const record = await this.prisma.agentStrategy.findFirst({
+      where: { id: strategyId },
+    });
+    if (!record) {
+      return;
+    }
+
+    const existingConfig = (record.config ?? {}) as AgentStrategyConfig;
+    await this.prisma.agentStrategy.update({
+      data: {
+        config: {
+          ...existingConfig,
+          nextRunAt: nextRun.toISOString(),
+        } as never,
+      },
+      where: { id: strategyId },
+    });
+  }
+
+  private async getBrandCreditsUsedToday(
+    organizationId: string,
+    brandId: string,
+  ): Promise<number> {
+    const strategies = (await this.prisma.agentStrategy.findMany({
+      where: {
+        brandId,
+        isDeleted: false,
+        organizationId,
+      },
+    })) as AgentStrategyWithConfig[];
+
+    return strategies.reduce((sum, strategy) => {
+      const config = this.readConfig(strategy);
+      return (
+        sum +
+        Math.max(config.creditsUsedToday ?? 0, config.dailyCreditsUsed ?? 0)
+      );
+    }, 0);
+  }
+
+  private result(
+    action: AgentAutopilotWorkflowAction,
+    organizationId: string,
+    enqueued: number,
+    generated: number,
+    skipped: number,
+    emptyReason?: string,
+  ): AgentAutopilotWorkflowResult {
+    if (enqueued === 0 && generated === 0) {
+      return this.skipped(
+        action,
+        organizationId,
+        emptyReason ?? 'no_agent_autopilot_work_enqueued',
+        skipped,
+      );
+    }
+
+    return {
+      action,
+      enqueued,
+      generated,
+      organizationId,
+      skipped,
+      status: enqueued > 0 ? 'enqueued' : 'completed',
+    };
+  }
+
+  private skipped(
+    action: AgentAutopilotWorkflowAction,
+    organizationId: string,
+    reason: string,
+    skipped: number = 0,
+  ): AgentAutopilotWorkflowResult {
+    return {
+      action,
+      enqueued: 0,
+      generated: 0,
+      organizationId,
+      reason,
+      skipped,
+      status: 'skipped',
+    };
+  }
+
+  private readConfig(strategy: AgentStrategyWithConfig): AgentStrategyConfig {
+    return strategy.config ?? {};
+  }
+
+  private parseDate(value: unknown): Date | null {
+    if (typeof value !== 'string' && !(value instanceof Date)) {
+      return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  private getNextDailyReset(): Date {
+    const next = new Date();
+    next.setDate(next.getDate() + 1);
+    next.setHours(0, 0, 0, 0);
+    return next;
+  }
+
+  private getNextWeeklyReset(): Date {
+    const next = new Date();
+    const dayOfWeek = next.getDay();
+    const daysUntilMonday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
+    next.setDate(next.getDate() + daysUntilMonday);
+    next.setHours(0, 0, 0, 0);
+    return next;
+  }
+
+  private lockKey(
+    action: AgentAutopilotWorkflowAction,
+    organizationId: string,
+  ): string {
+    return `workflow-agent-autopilot:${action}:${organizationId}`;
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -25,6 +25,7 @@ import type {
 } from '@api/collections/workflows/schemas/workflow.schema';
 import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
+import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -261,6 +262,8 @@ export class WorkflowEngineAdapterService {
     private readonly adAutomationWorkflowService?: AdAutomationWorkflowService,
     @Optional()
     private readonly campaignOrchestrationWorkflowService?: CampaignOrchestrationWorkflowService,
+    @Optional()
+    private readonly agentAutopilotWorkflowService?: AgentAutopilotWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -288,6 +291,7 @@ export class WorkflowEngineAdapterService {
     this.registerAnalyticsFeedbackExecutor();
     this.registerAdAutomationExecutors();
     this.registerCampaignOrchestrationExecutors();
+    this.registerAgentAutopilotExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -702,6 +706,43 @@ export class WorkflowEngineAdapterService {
       enqueued: 0,
       organizationId: context.organizationId,
       reason: 'campaign_orchestration_service_unavailable',
+      skipped: 0,
+      status: 'skipped',
+    };
+  }
+
+  private registerAgentAutopilotExecutors(): void {
+    this.engine.registerExecutor(
+      'proactiveAgentStrategies',
+      (_node, _inputs, context) =>
+        this.agentAutopilotWorkflowService
+          ? this.agentAutopilotWorkflowService.runProactiveStrategies(
+              context.organizationId,
+            )
+          : this.agentAutopilotUnavailable('proactiveAgentStrategies', context),
+    );
+
+    this.engine.registerExecutor(
+      'aiInfluencerDailyPosts',
+      (_node, _inputs, context) =>
+        this.agentAutopilotWorkflowService
+          ? this.agentAutopilotWorkflowService.runAiInfluencerDailyPosts(
+              context.organizationId,
+            )
+          : this.agentAutopilotUnavailable('aiInfluencerDailyPosts', context),
+    );
+  }
+
+  private agentAutopilotUnavailable(
+    action: string,
+    context: ExecutionContext,
+  ): Record<string, unknown> {
+    return {
+      action,
+      enqueued: 0,
+      generated: 0,
+      organizationId: context.organizationId,
+      reason: 'agent_autopilot_service_unavailable',
       skipped: 0,
       status: 'skipped',
     };

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -17,6 +17,7 @@ import {
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
+import { AGENT_AUTOPILOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/agent-autopilot-workflows.template';
 import { CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/campaign-orchestration-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
@@ -409,6 +410,87 @@ export class WorkflowsService extends BaseService<
         if (errorCode === 'P2034') {
           this.logger?.debug(
             'ensureCampaignOrchestrationWorkflows: serialization conflict — workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Idempotently seeds the default-on recurring agent automation workflow set
+   * for an organization. The workflow nodes preserve the previous cron scanner
+   * behavior by filtering active strategies/personas inside execution.
+   */
+  async ensureAgentAutopilotWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of AGENT_AUTOPILOT_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 784,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureAgentAutopilotWorkflows: serialization conflict - workflow already seeded by concurrent request',
             { organizationId, templateId: template.id },
           );
           continue;

--- a/apps/server/api/src/collections/workflows/templates/agent-autopilot-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/agent-autopilot-workflows.template.ts
@@ -1,0 +1,59 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type AgentAutopilotWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  description: string;
+  icon: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  nodeType: string;
+  schedule: string;
+}): AgentAutopilotWorkflowTemplate {
+  return {
+    category: 'agents',
+    description: params.description,
+    icon: params.icon,
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: params.nodeLabel,
+        },
+        id: params.nodeType,
+        position: { x: 0, y: 120 },
+        type: params.nodeType,
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const AGENT_AUTOPILOT_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    description:
+      'Per-organization proactive agent scanner that queues due active strategies.',
+    icon: 'bot',
+    id: 'proactive-agent-strategies',
+    name: 'Proactive Agent Strategies',
+    nodeLabel: 'Process Due Strategies',
+    nodeType: 'proactiveAgentStrategies',
+    schedule: '*/1 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Per-organization AI influencer autopilot scanner for enabled darkroom personas.',
+    icon: 'sparkles',
+    id: 'ai-influencer-daily-posts',
+    name: 'AI Influencer Daily Posts',
+    nodeLabel: 'Generate Daily Influencer Posts',
+    nodeType: 'aiInfluencerDailyPosts',
+    schedule: '0 */6 * * *',
+  }),
+] satisfies AgentAutopilotWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -5,6 +5,8 @@ dependency management, and workflow execution tracking.
  */
 import { AdOptimizationConfigsModule } from '@api/collections/ad-optimization-configs/ad-optimization-configs.module';
 import { AdPerformanceModule } from '@api/collections/ad-performance/ad-performance.module';
+import { AgentGoalsModule } from '@api/collections/agent-goals/agent-goals.module';
+import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CaptionsModule } from '@api/collections/captions/captions.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
@@ -13,6 +15,7 @@ import { IngredientsModule } from '@api/collections/ingredients/ingredients.modu
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
 import { MusicsModule } from '@api/collections/musics/musics.module';
 import { NewslettersModule } from '@api/collections/newsletters/newsletters.module';
+import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
 import { TrendsModule } from '@api/collections/trends/trends.module';
 import { VideoGenerationModule } from '@api/collections/videos/video-generation.module';
@@ -24,6 +27,7 @@ import { AdAutomationWorkflowService } from '@api/collections/workflows/services
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
+import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
 import { BatchWorkflowService } from '@api/collections/workflows/services/batch-workflow.service';
 import {
   BATCH_WORKFLOW_QUEUE,
@@ -43,6 +47,7 @@ import { WorkflowsService } from '@api/collections/workflows/services/workflows.
 import { MarketplaceIntegrationModule } from '@api/marketplace-integration/marketplace-integration.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { AgentCampaignOrchestratorModule } from '@api/services/agent-campaign/agent-campaign-orchestrator.module';
+import { AiInfluencerModule } from '@api/services/ai-influencer/ai-influencer.module';
 import { ElevenLabsModule } from '@api/services/integrations/elevenlabs/elevenlabs.module';
 import { GoogleAdsModule } from '@api/services/integrations/google-ads/google-ads.module';
 import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
@@ -72,12 +77,16 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowFormatConverterService,
     WorkflowGenerationService,
     AdAutomationWorkflowService,
+    AgentAutopilotWorkflowService,
     CampaignOrchestrationWorkflowService,
   ],
   imports: [
     forwardRef(() => AdOptimizationConfigsModule),
     forwardRef(() => AdPerformanceModule),
     forwardRef(() => AgentCampaignOrchestratorModule),
+    forwardRef(() => AgentGoalsModule),
+    forwardRef(() => AgentRunsModule),
+    forwardRef(() => AiInfluencerModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => CaptionsModule),
     forwardRef(() => CredentialsCoreModule),
@@ -94,6 +103,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => NewslettersModule),
     forwardRef(() => NotificationsModule),
     forwardRef(() => NotificationsPublisherModule),
+    forwardRef(() => OrganizationSettingsModule),
     forwardRef(() => OpenRouterModule),
     forwardRef(() => PostsModule),
     forwardRef(() => QueuesModule),
@@ -132,6 +142,7 @@ import { forwardRef, Module } from '@nestjs/common';
     InstagramSocialAdapter,
     SocialAdapterFactory,
     AdAutomationWorkflowService,
+    AgentAutopilotWorkflowService,
     BatchWorkflowQueueService,
     BatchWorkflowService,
     CampaignOrchestrationWorkflowService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -116,6 +116,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureAgentAutopilotWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',

--- a/apps/server/api/src/services/ai-influencer/ai-influencer.service.spec.ts
+++ b/apps/server/api/src/services/ai-influencer/ai-influencer.service.spec.ts
@@ -791,6 +791,29 @@ describe('AiInfluencerService', () => {
       expect(loggerService.warn).toHaveBeenCalled();
     });
 
+    it('should scope scheduled posts to an organization when provided', async () => {
+      personasService.findAll.mockResolvedValue({
+        docs: [],
+        limit: 100,
+        page: 1,
+        totalDocs: 0,
+      });
+
+      await service.scheduleDailyPosts({ organizationId: 'org-1' });
+
+      expect(personasService.findAll).toHaveBeenCalledWith(
+        {
+          where: {
+            isAutopilotEnabled: true,
+            isDarkroomCharacter: true,
+            isDeleted: false,
+            organizationId: 'org-1',
+          },
+        },
+        { limit: 100, page: 1 },
+      );
+    });
+
     it('should continue with other personas when one fails', async () => {
       const persona1 = createMockPersona({ slug: 'persona-fail' });
       const persona2 = createMockPersona({

--- a/apps/server/api/src/services/ai-influencer/ai-influencer.service.ts
+++ b/apps/server/api/src/services/ai-influencer/ai-influencer.service.ts
@@ -235,10 +235,13 @@ export class AiInfluencerService {
   /**
    * Find all personas with autopilot enabled and generate daily posts for each.
    */
-  async scheduleDailyPosts(): Promise<GeneratePostResult[]> {
+  async scheduleDailyPosts(options?: {
+    organizationId?: string;
+  }): Promise<GeneratePostResult[]> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(caller, {
       message: 'Starting scheduled daily posts',
+      organizationId: options?.organizationId,
     });
 
     const personas = await this.personasService.findAll(
@@ -247,6 +250,9 @@ export class AiInfluencerService {
           isAutopilotEnabled: true,
           isDarkroomCharacter: true,
           isDeleted: false,
+          ...(options?.organizationId
+            ? { organizationId: options.organizationId }
+            : {}),
         },
       },
       { limit: 100, page: 1 },

--- a/apps/server/workers/src/crons/agent/cron.proactive-agent.service.ts
+++ b/apps/server/workers/src/crons/agent/cron.proactive-agent.service.ts
@@ -13,7 +13,6 @@ import {
 import type { AgentStrategy } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 const MAX_CONSECUTIVE_FAILURES = 5;
 const MAX_STRATEGIES_PER_CYCLE = 20;
@@ -76,7 +75,6 @@ export class CronProactiveAgentService {
    * Main cron entry point — runs every minute
    * Finds due strategies and executes proactive agent runs
    */
-  @Cron(CronExpression.EVERY_MINUTE)
   async processProactiveStrategies(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       CronProactiveAgentService.LOCK_KEY,

--- a/apps/server/workers/src/crons/ai-influencer/cron.ai-influencer.service.ts
+++ b/apps/server/workers/src/crons/ai-influencer/cron.ai-influencer.service.ts
@@ -2,7 +2,6 @@ import { AiInfluencerService } from '@api/services/ai-influencer/ai-influencer.s
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 @Injectable()
 export class CronAiInfluencerService {
@@ -19,7 +18,6 @@ export class CronAiInfluencerService {
    * Run daily autopilot posts for all AI influencer personas.
    * Runs every 6 hours in production (disabled in development).
    */
-  @Cron(CronExpression.EVERY_6_HOURS)
   async runDailyInfluencerPosts(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       CronAiInfluencerService.LOCK_KEY,


### PR DESCRIPTION
## Summary
- adds backend-only default-on agent autopilot workflow templates for proactive strategies and AI influencer daily posts
- registers workflow executors that run per-organization scanners with org-scoped locking
- provisions the workflows during org creation and self-hosted seeding, plus adds an idempotent seed for existing orgs
- scopes AI influencer scheduled posts by organization when called from workflow execution
- removes the static Nest cron decorators from the proactive-agent and AI-influencer worker cron services

## Scope note
This uses per-organization scanner workflows, not one workflow row per strategy/persona. That matches #698's default-on-per-org requirement and preserves the old scanner semantics while disabled entities are filtered inside the workflow action.

## Verification
- bunx biome check --write apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/templates/agent-autopilot-workflows.template.ts apps/server/api/src/collections/workflows/workflows.module.ts apps/server/api/src/seeds/self-hosted-seed.service.ts apps/server/api/src/services/ai-influencer/ai-influencer.service.spec.ts apps/server/api/src/services/ai-influencer/ai-influencer.service.ts apps/server/workers/src/crons/agent/cron.proactive-agent.service.ts apps/server/workers/src/crons/ai-influencer/cron.ai-influencer.service.ts
- TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts --reporter=dot
- TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/services/ai-influencer/ai-influencer.service.spec.ts --reporter=dot
- TZ=UTC ../../../scripts/sh/sanitize-node-color-env.sh ../../../node_modules/.bin/vitest run --config vitest.config.ts src/collections/workflows/templates/template-node-coverage.spec.ts src/collections/workflows/templates/workflow-templates.spec.ts --reporter=dot
- rg "@Cron|@nestjs/schedule" apps/server/workers/src/crons/agent apps/server/workers/src/crons/ai-influencer -n
- bunx biome check apps/server/api/scripts/seeds/agent-autopilot-workflows.seed.ts apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/templates/agent-autopilot-workflows.template.ts apps/server/api/src/collections/workflows/workflows.module.ts apps/server/api/src/seeds/self-hosted-seed.service.ts apps/server/api/src/services/ai-influencer/ai-influencer.service.spec.ts apps/server/api/src/services/ai-influencer/ai-influencer.service.ts apps/server/workers/src/crons/agent/cron.proactive-agent.service.ts apps/server/workers/src/crons/ai-influencer/cron.ai-influencer.service.ts
- bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers
- bun run check:architecture
- bun run db:generate (from packages/prisma, local generated client for compiled boot check)
- bunx turbo run build --filter=@genfeedai/api --force
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js
- git diff --check
- git diff --cached --check

Closes #784
Refs #698