### PR TITLE
Workflow-back analytics sync crons

### DIFF
--- a/apps/server/api/scripts/seeds/analytics-sync-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/analytics-sync-workflows.seed.ts
@@ -1,0 +1,171 @@
+/**
+ * Seed Script: Analytics Sync Workflows
+ *
+ * Idempotently provisions default-on analytics sync workflows for existing
+ * organizations. New organizations are seeded automatically on creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/analytics-sync-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/analytics-sync-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/analytics-sync-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/analytics-sync-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { ANALYTICS_SYNC_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/analytics-sync-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('AnalyticsSyncWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} - no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        const existing = await prisma.workflow.findMany({
+          select: { metadata: true },
+          where: {
+            isDeleted: false,
+            organizationId: organization.id,
+            OR: ANALYTICS_SYNC_WORKFLOW_TEMPLATES.map((template) => ({
+              metadata: {
+                equals: template.id,
+                path: ['sourceTemplateId'],
+              },
+            })),
+          },
+        });
+        const existingTemplateIds = new Set(
+          existing
+            .map((workflow) => {
+              const metadata = workflow.metadata as Record<
+                string,
+                unknown
+              > | null;
+              return typeof metadata?.sourceTemplateId === 'string'
+                ? metadata.sourceTemplateId
+                : null;
+            })
+            .filter((value): value is string => Boolean(value)),
+        );
+        const missing = ANALYTICS_SYNC_WORKFLOW_TEMPLATES.filter(
+          (template) => !existingTemplateIds.has(template.id),
+        ).map((template) => template.id);
+
+        logger.log(
+          `[DRY RUN] org ${organization.id} missing ${missing.length}/${ANALYTICS_SYNC_WORKFLOW_TEMPLATES.length} analytics sync workflow(s): ${missing.join(', ') || 'none'}`,
+        );
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureAnalyticsSyncWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Analytics sync workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Analytics sync workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -116,6 +116,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureAnalyticsSyncWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/services/analytics-sync-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/analytics-sync-workflow.service.spec.ts
@@ -1,0 +1,254 @@
+import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
+import { CredentialPlatform } from '@genfeedai/enums';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('AnalyticsSyncWorkflowService', () => {
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  const postsService = { findAll: vi.fn() };
+  const queueService = { add: vi.fn() };
+  const cacheService = { acquireLock: vi.fn() };
+
+  let service: AnalyticsSyncWorkflowService;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T09:00:00.000Z'));
+    cacheService.acquireLock.mockResolvedValue(true);
+    postsService.findAll.mockResolvedValue({ docs: [] });
+    queueService.add.mockResolvedValue({ id: 'job-1' });
+
+    service = new AnalyticsSyncWorkflowService(
+      logger as never,
+      postsService as never,
+      queueService as never,
+      cacheService as never,
+    );
+  });
+
+  it('skips provider dispatch when the org window lock already exists', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runFacebookAnalytics('org-1');
+
+    expect(result).toMatchObject({
+      action: 'analyticsFacebookSync',
+      enqueued: 0,
+      organizationId: 'org-1',
+      queueName: 'analytics-facebook',
+      reason: 'facebook_analytics_already_enqueued',
+      status: 'skipped',
+    });
+    expect(postsService.findAll).not.toHaveBeenCalled();
+    expect(queueService.add).not.toHaveBeenCalled();
+  });
+
+  it('queries Facebook posts by organization and enqueues analytics chunks', async () => {
+    postsService.findAll.mockResolvedValue({
+      docs: Array.from({ length: 51 }, (_, index) => ({
+        _id: `post-${index}`,
+        brand: 'brand-1',
+        credential: { _id: 'credential-1' },
+        externalId: `facebook-${index}`,
+        organization: 'org-1',
+        platform: CredentialPlatform.FACEBOOK,
+      })),
+    });
+
+    const result = await service.runFacebookAnalytics('org-1');
+
+    expect(postsService.findAll).toHaveBeenCalledWith(
+      {
+        include: { credential: true },
+        where: expect.objectContaining({
+          isAnalyticsEnabled: { not: false },
+          organizationId: 'org-1',
+          platform: CredentialPlatform.FACEBOOK,
+        }),
+      },
+      expect.objectContaining({ pagination: false }),
+    );
+    expect(queueService.add).toHaveBeenCalledTimes(2);
+    expect(queueService.add).toHaveBeenNthCalledWith(
+      1,
+      'analytics-facebook',
+      expect.objectContaining({
+        posts: expect.arrayContaining([
+          expect.objectContaining({
+            _id: 'post-0',
+            credential: 'credential-1',
+            organization: 'org-1',
+            platform: CredentialPlatform.FACEBOOK,
+          }),
+        ]),
+      }),
+      expect.objectContaining({ attempts: 3 }),
+    );
+    expect(result).toMatchObject({
+      action: 'analyticsFacebookSync',
+      enqueued: 2,
+      organizationId: 'org-1',
+      posts: 51,
+      status: 'enqueued',
+    });
+  });
+
+  it('groups Twitter analytics batches by credential and skips malformed posts', async () => {
+    postsService.findAll.mockResolvedValue({
+      docs: [
+        {
+          _id: 'post-1',
+          brand: 'brand-1',
+          credential: { _id: 'credential-1' },
+          externalId: 'tweet-1',
+          platform: CredentialPlatform.TWITTER,
+        },
+        {
+          _id: 'post-2',
+          brand: 'brand-1',
+          credential: { _id: 'credential-1' },
+          externalId: 'tweet-2',
+          platform: CredentialPlatform.TWITTER,
+        },
+        {
+          _id: 'post-without-credential',
+          brand: 'brand-1',
+          externalId: 'tweet-3',
+          platform: CredentialPlatform.TWITTER,
+        },
+      ],
+    });
+
+    const result = await service.runTwitterAnalytics('org-1');
+
+    expect(postsService.findAll).toHaveBeenCalledWith(
+      {
+        include: { credential: true },
+        orderBy: { publishedAt: 'desc' },
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          platform: CredentialPlatform.TWITTER,
+        }),
+      },
+      expect.objectContaining({ pagination: false }),
+    );
+    expect(queueService.add).toHaveBeenCalledWith(
+      'analytics-twitter',
+      {
+        credentialId: 'credential-1',
+        posts: [
+          {
+            _id: 'post-1',
+            brand: 'brand-1',
+            externalId: 'tweet-1',
+            organization: 'org-1',
+          },
+          {
+            _id: 'post-2',
+            brand: 'brand-1',
+            externalId: 'tweet-2',
+            organization: 'org-1',
+          },
+        ],
+      },
+      expect.objectContaining({
+        backoff: { delay: 5000, type: 'exponential' },
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'analyticsTwitterSync',
+      enqueued: 1,
+      posts: 3,
+      skipped: 1,
+      status: 'enqueued',
+    });
+  });
+
+  it('enqueues the generic incremental analytics sync for the workflow organization', async () => {
+    const result = await service.runGenericAnalyticsSync('org-1');
+
+    expect(queueService.add).toHaveBeenCalledWith(
+      'analytics-sync',
+      {
+        incremental: true,
+        organizationId: 'org-1',
+      },
+      expect.objectContaining({
+        attempts: 3,
+        jobId: expect.stringMatching(/^analytics-sync-org-1-\d+$/),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'analyticsGenericSync',
+      enqueued: 1,
+      organizationId: 'org-1',
+      queueName: 'analytics-sync',
+      status: 'enqueued',
+    });
+  });
+
+  it('groups YouTube analytics batches by brand within the workflow organization', async () => {
+    postsService.findAll.mockResolvedValue({
+      docs: [
+        {
+          _id: 'post-1',
+          brand: 'brand-1',
+          externalId: 'video-1',
+          platform: CredentialPlatform.YOUTUBE,
+        },
+        {
+          _id: 'post-2',
+          brand: 'brand-1',
+          externalId: 'video-2',
+          platform: CredentialPlatform.YOUTUBE,
+        },
+        {
+          _id: 'post-without-brand',
+          externalId: 'video-3',
+          platform: CredentialPlatform.YOUTUBE,
+        },
+      ],
+    });
+
+    const result = await service.runYouTubeAnalytics('org-1');
+
+    expect(queueService.add).toHaveBeenCalledWith(
+      'analytics-youtube',
+      {
+        brandId: 'brand-1',
+        organizationId: 'org-1',
+        posts: [
+          {
+            _id: 'post-1',
+            brand: 'brand-1',
+            externalId: 'video-1',
+            organization: 'org-1',
+          },
+          {
+            _id: 'post-2',
+            brand: 'brand-1',
+            externalId: 'video-2',
+            organization: 'org-1',
+          },
+        ],
+      },
+      expect.objectContaining({ attempts: 3 }),
+    );
+    expect(result).toMatchObject({
+      action: 'youtubeAnalyticsSync',
+      enqueued: 1,
+      posts: 3,
+      skipped: 1,
+      status: 'enqueued',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/analytics-sync-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/analytics-sync-workflow.service.ts
@@ -1,0 +1,561 @@
+import { PostEntity } from '@api/collections/posts/entities/post.entity';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
+import type { FacebookAnalyticsJobData } from '@api/queues/analytics-facebook/analytics-facebook-job.interface';
+import type { AnalyticsSyncJobData } from '@api/queues/analytics-sync/analytics-sync-job.interface';
+import type { ThreadsAnalyticsJobData } from '@api/queues/analytics-threads/analytics-threads-job.interface';
+import type { TwitterAnalyticsJobData } from '@api/queues/analytics-twitter/analytics-twitter-job.interface';
+import type { YouTubeAnalyticsJobData } from '@api/queues/analytics-youtube/analytics-youtube-job.interface';
+import { QueueService } from '@api/queues/core/queue.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
+import type { SocialAnalyticsJobData } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+type AnalyticsSyncWorkflowAction =
+  | 'analyticsFacebookSync'
+  | 'analyticsGenericSync'
+  | 'analyticsSocialSync'
+  | 'analyticsThreadsSync'
+  | 'analyticsTwitterSync'
+  | 'youtubeAnalyticsSync';
+
+type AnalyticsPost = PostEntity & {
+  _id?: unknown;
+  brand?: unknown;
+  credential?: unknown;
+  externalId?: string | null;
+  organization?: unknown;
+  organizationId?: string;
+  platform: CredentialPlatform;
+};
+
+interface QueuePostsOptions {
+  analyticsEnabledOnly: boolean;
+  orderBy?: Record<string, 'asc' | 'desc'>;
+  platforms: CredentialPlatform[];
+}
+
+export interface AnalyticsSyncWorkflowResult {
+  action: AnalyticsSyncWorkflowAction;
+  enqueued: number;
+  organizationId: string;
+  posts: number;
+  queueName: string;
+  reason?: string;
+  skipped: number;
+  status: 'enqueued' | 'skipped';
+}
+
+const ANALYTICS_FACEBOOK_QUEUE = 'analytics-facebook';
+const ANALYTICS_GENERIC_QUEUE = 'analytics-sync';
+const ANALYTICS_SOCIAL_QUEUE = 'analytics-social';
+const ANALYTICS_THREADS_QUEUE = 'analytics-threads';
+const ANALYTICS_TWITTER_QUEUE = 'analytics-twitter';
+const ANALYTICS_YOUTUBE_QUEUE = 'analytics-youtube';
+
+const HOUR_MS = 60 * 60 * 1000;
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+const SIX_HOURS_MS = 6 * HOUR_MS;
+const CHUNK_SIZE = 50;
+const TWITTER_BATCH_SIZE = 100;
+const YOUTUBE_BATCH_SIZE = 50;
+
+@Injectable()
+export class AnalyticsSyncWorkflowService {
+  private readonly logContext = 'AnalyticsSyncWorkflowService';
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly postsService: PostsService,
+    private readonly queueService: QueueService,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async runFacebookAnalytics(
+    organizationId: string,
+  ): Promise<AnalyticsSyncWorkflowResult> {
+    const action: AnalyticsSyncWorkflowAction = 'analyticsFacebookSync';
+    const acquired = await this.acquireWindowLock(
+      action,
+      organizationId,
+      HOUR_MS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        ANALYTICS_FACEBOOK_QUEUE,
+        'facebook_analytics_already_enqueued',
+      );
+    }
+
+    const posts = await this.findAnalyticsPosts(organizationId, {
+      analyticsEnabledOnly: true,
+      platforms: [CredentialPlatform.FACEBOOK],
+    });
+
+    let enqueued = 0;
+    for (const chunk of this.chunk(posts, CHUNK_SIZE)) {
+      const jobData: FacebookAnalyticsJobData = {
+        posts: chunk.map((post) => ({
+          _id: this.requiredId(post),
+          brand: this.requiredBrandId(post),
+          credential: this.optionalId(post.credential),
+          externalId: this.requiredExternalId(post),
+          organization: organizationId,
+          platform: post.platform,
+        })),
+      };
+      await this.enqueue(ANALYTICS_FACEBOOK_QUEUE, jobData, 2000);
+      enqueued++;
+    }
+
+    return this.result(
+      action,
+      organizationId,
+      ANALYTICS_FACEBOOK_QUEUE,
+      enqueued,
+      posts.length,
+      0,
+      posts.length === 0 ? 'no_facebook_posts_to_track' : undefined,
+    );
+  }
+
+  async runSocialAnalytics(
+    organizationId: string,
+  ): Promise<AnalyticsSyncWorkflowResult> {
+    const action: AnalyticsSyncWorkflowAction = 'analyticsSocialSync';
+    const acquired = await this.acquireWindowLock(
+      action,
+      organizationId,
+      HOUR_MS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        ANALYTICS_SOCIAL_QUEUE,
+        'social_analytics_already_enqueued',
+      );
+    }
+
+    const posts = await this.findAnalyticsPosts(organizationId, {
+      analyticsEnabledOnly: true,
+      platforms: [
+        CredentialPlatform.INSTAGRAM,
+        CredentialPlatform.LINKEDIN,
+        CredentialPlatform.MASTODON,
+        CredentialPlatform.PINTEREST,
+        CredentialPlatform.TIKTOK,
+      ],
+    });
+
+    let enqueued = 0;
+    for (const chunk of this.chunk(posts, CHUNK_SIZE)) {
+      const jobData: SocialAnalyticsJobData = {
+        posts: chunk.map((post) => ({
+          _id: this.requiredId(post),
+          brand: this.requiredBrandId(post),
+          externalId: this.requiredExternalId(post),
+          organization: organizationId,
+          platform: post.platform,
+        })),
+      };
+      await this.enqueue(ANALYTICS_SOCIAL_QUEUE, jobData, 2000);
+      enqueued++;
+    }
+
+    return this.result(
+      action,
+      organizationId,
+      ANALYTICS_SOCIAL_QUEUE,
+      enqueued,
+      posts.length,
+      0,
+      posts.length === 0 ? 'no_social_posts_to_track' : undefined,
+    );
+  }
+
+  async runThreadsAnalytics(
+    organizationId: string,
+  ): Promise<AnalyticsSyncWorkflowResult> {
+    const action: AnalyticsSyncWorkflowAction = 'analyticsThreadsSync';
+    const acquired = await this.acquireWindowLock(
+      action,
+      organizationId,
+      HOUR_MS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        ANALYTICS_THREADS_QUEUE,
+        'threads_analytics_already_enqueued',
+      );
+    }
+
+    const posts = await this.findAnalyticsPosts(organizationId, {
+      analyticsEnabledOnly: true,
+      platforms: [CredentialPlatform.THREADS],
+    });
+
+    let enqueued = 0;
+    for (const chunk of this.chunk(posts, CHUNK_SIZE)) {
+      const jobData: ThreadsAnalyticsJobData = {
+        posts: chunk.map((post) => ({
+          _id: this.requiredId(post),
+          brand: this.requiredBrandId(post),
+          credential: this.optionalId(post.credential),
+          externalId: this.requiredExternalId(post),
+          organization: organizationId,
+          platform: post.platform,
+        })),
+      };
+      await this.enqueue(ANALYTICS_THREADS_QUEUE, jobData, 2000);
+      enqueued++;
+    }
+
+    return this.result(
+      action,
+      organizationId,
+      ANALYTICS_THREADS_QUEUE,
+      enqueued,
+      posts.length,
+      0,
+      posts.length === 0 ? 'no_threads_posts_to_track' : undefined,
+    );
+  }
+
+  async runTwitterAnalytics(
+    organizationId: string,
+  ): Promise<AnalyticsSyncWorkflowResult> {
+    const action: AnalyticsSyncWorkflowAction = 'analyticsTwitterSync';
+    const acquired = await this.acquireWindowLock(
+      action,
+      organizationId,
+      THIRTY_MINUTES_MS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        ANALYTICS_TWITTER_QUEUE,
+        'twitter_analytics_already_enqueued',
+      );
+    }
+
+    const posts = await this.findAnalyticsPosts(organizationId, {
+      analyticsEnabledOnly: false,
+      orderBy: { publishedAt: 'desc' },
+      platforms: [CredentialPlatform.TWITTER],
+    });
+
+    const postsByCredential = new Map<string, AnalyticsPost[]>();
+    let skipped = 0;
+
+    for (const post of posts) {
+      const credentialId = this.optionalId(post.credential);
+      if (!credentialId) {
+        skipped++;
+        this.logger.warn(`${this.logContext} skipped Twitter post`, {
+          organizationId,
+          postId: this.optionalId(post._id),
+          reason: 'missing_credential',
+        });
+        continue;
+      }
+      const group = postsByCredential.get(credentialId) ?? [];
+      group.push(post);
+      postsByCredential.set(credentialId, group);
+    }
+
+    let enqueued = 0;
+    for (const [credentialId, credentialPosts] of postsByCredential.entries()) {
+      for (const batch of this.chunk(credentialPosts, TWITTER_BATCH_SIZE)) {
+        const jobData: TwitterAnalyticsJobData = {
+          credentialId,
+          posts: batch.map((post) => ({
+            _id: this.requiredId(post),
+            brand: this.requiredBrandId(post),
+            externalId: this.requiredExternalId(post),
+            organization: organizationId,
+          })),
+        };
+        await this.enqueue(ANALYTICS_TWITTER_QUEUE, jobData, 5000);
+        enqueued++;
+      }
+    }
+
+    return this.result(
+      action,
+      organizationId,
+      ANALYTICS_TWITTER_QUEUE,
+      enqueued,
+      posts.length,
+      skipped,
+      posts.length === 0 ? 'no_twitter_posts_to_track' : undefined,
+    );
+  }
+
+  async runGenericAnalyticsSync(
+    organizationId: string,
+  ): Promise<AnalyticsSyncWorkflowResult> {
+    const action: AnalyticsSyncWorkflowAction = 'analyticsGenericSync';
+    const window = this.windowKey(SIX_HOURS_MS);
+    const acquired = await this.acquireWindowLock(
+      action,
+      organizationId,
+      SIX_HOURS_MS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        ANALYTICS_GENERIC_QUEUE,
+        'analytics_sync_already_enqueued',
+      );
+    }
+
+    const jobData: AnalyticsSyncJobData = {
+      incremental: true,
+      organizationId,
+    };
+
+    await this.queueService.add(ANALYTICS_GENERIC_QUEUE, jobData, {
+      attempts: 3,
+      backoff: { delay: 5000, type: 'exponential' },
+      jobId: `analytics-sync-${organizationId}-${window}`,
+    });
+
+    return this.result(
+      action,
+      organizationId,
+      ANALYTICS_GENERIC_QUEUE,
+      1,
+      0,
+      0,
+    );
+  }
+
+  async runYouTubeAnalytics(
+    organizationId: string,
+  ): Promise<AnalyticsSyncWorkflowResult> {
+    const action: AnalyticsSyncWorkflowAction = 'youtubeAnalyticsSync';
+    const acquired = await this.acquireWindowLock(
+      action,
+      organizationId,
+      HOUR_MS,
+    );
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        ANALYTICS_YOUTUBE_QUEUE,
+        'youtube_analytics_already_enqueued',
+      );
+    }
+
+    const posts = await this.findAnalyticsPosts(organizationId, {
+      analyticsEnabledOnly: false,
+      platforms: [CredentialPlatform.YOUTUBE],
+    });
+
+    const postsByBrand = new Map<string, AnalyticsPost[]>();
+    let skipped = 0;
+
+    for (const post of posts) {
+      const brandId = this.optionalId(post.brand);
+      if (!brandId) {
+        skipped++;
+        this.logger.warn(`${this.logContext} skipped YouTube post`, {
+          organizationId,
+          postId: this.optionalId(post._id),
+          reason: 'missing_brand',
+        });
+        continue;
+      }
+      const group = postsByBrand.get(brandId) ?? [];
+      group.push(post);
+      postsByBrand.set(brandId, group);
+    }
+
+    let enqueued = 0;
+    for (const [brandId, brandPosts] of postsByBrand.entries()) {
+      for (const batch of this.chunk(brandPosts, YOUTUBE_BATCH_SIZE)) {
+        const jobData: YouTubeAnalyticsJobData = {
+          brandId,
+          organizationId,
+          posts: batch.map((post) => ({
+            _id: this.requiredId(post),
+            brand: brandId,
+            externalId: this.requiredExternalId(post),
+            organization: organizationId,
+          })),
+        };
+        await this.enqueue(ANALYTICS_YOUTUBE_QUEUE, jobData, 2000);
+        enqueued++;
+      }
+    }
+
+    return this.result(
+      action,
+      organizationId,
+      ANALYTICS_YOUTUBE_QUEUE,
+      enqueued,
+      posts.length,
+      skipped,
+      posts.length === 0 ? 'no_youtube_posts_to_track' : undefined,
+    );
+  }
+
+  private async findAnalyticsPosts(
+    organizationId: string,
+    options: QueuePostsOptions,
+  ): Promise<AnalyticsPost[]> {
+    const where: Record<string, unknown> = {
+      externalId: { not: null },
+      isDeleted: false,
+      organizationId,
+      platform:
+        options.platforms.length === 1
+          ? options.platforms[0]
+          : { in: options.platforms },
+      status: PostStatus.PUBLIC,
+    };
+
+    if (options.analyticsEnabledOnly) {
+      where.isAnalyticsEnabled = { not: false };
+    }
+
+    const result = await this.postsService.findAll(
+      {
+        include: { credential: true },
+        ...(options.orderBy ? { orderBy: options.orderBy } : {}),
+        where,
+      },
+      { customLabels, pagination: false },
+    );
+
+    return result.docs as unknown as AnalyticsPost[];
+  }
+
+  private async enqueue<T>(
+    queueName: string,
+    jobData: T,
+    backoffDelay: number,
+  ): Promise<void> {
+    await this.queueService.add(queueName, jobData, {
+      attempts: 3,
+      backoff: {
+        delay: backoffDelay,
+        type: 'exponential',
+      },
+    });
+  }
+
+  private async acquireWindowLock(
+    action: AnalyticsSyncWorkflowAction,
+    organizationId: string,
+    windowMs: number,
+  ): Promise<boolean> {
+    const ttlSeconds = Math.ceil(windowMs / 1000);
+    return this.cacheService.acquireLock(
+      `workflow-analytics-sync:${action}:${organizationId}:${this.windowKey(windowMs)}`,
+      ttlSeconds,
+    );
+  }
+
+  private windowKey(windowMs: number): number {
+    return Math.floor(Date.now() / windowMs);
+  }
+
+  private result(
+    action: AnalyticsSyncWorkflowAction,
+    organizationId: string,
+    queueName: string,
+    enqueued: number,
+    posts: number,
+    skipped: number,
+    reason?: string,
+  ): AnalyticsSyncWorkflowResult {
+    return {
+      action,
+      enqueued,
+      organizationId,
+      posts,
+      queueName,
+      reason,
+      skipped,
+      status: enqueued > 0 ? 'enqueued' : 'skipped',
+    };
+  }
+
+  private skipped(
+    action: AnalyticsSyncWorkflowAction,
+    organizationId: string,
+    queueName: string,
+    reason: string,
+  ): AnalyticsSyncWorkflowResult {
+    return {
+      action,
+      enqueued: 0,
+      organizationId,
+      posts: 0,
+      queueName,
+      reason,
+      skipped: 0,
+      status: 'skipped',
+    };
+  }
+
+  private chunk<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += size) {
+      chunks.push(items.slice(i, i + size));
+    }
+    return chunks;
+  }
+
+  private optionalId(value: unknown): string | undefined {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      if (typeof record._id === 'string' && record._id.length > 0) {
+        return record._id;
+      }
+      if (typeof record.id === 'string' && record.id.length > 0) {
+        return record.id;
+      }
+    }
+    return undefined;
+  }
+
+  private requiredId(post: AnalyticsPost): string {
+    const id = this.optionalId(post._id) ?? this.optionalId(post);
+    if (!id) {
+      throw new Error('Analytics post missing id');
+    }
+    return id;
+  }
+
+  private requiredBrandId(post: AnalyticsPost): string {
+    const brandId = this.optionalId(post.brand);
+    if (!brandId) {
+      throw new Error(`Analytics post ${this.requiredId(post)} missing brand`);
+    }
+    return brandId;
+  }
+
+  private requiredExternalId(post: AnalyticsPost): string {
+    if (typeof post.externalId === 'string' && post.externalId.length > 0) {
+      return post.externalId;
+    }
+    throw new Error(
+      `Analytics post ${this.requiredId(post)} missing externalId`,
+    );
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -26,6 +26,7 @@ import type {
 import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
+import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -264,6 +265,8 @@ export class WorkflowEngineAdapterService {
     private readonly campaignOrchestrationWorkflowService?: CampaignOrchestrationWorkflowService,
     @Optional()
     private readonly agentAutopilotWorkflowService?: AgentAutopilotWorkflowService,
+    @Optional()
+    private readonly analyticsSyncWorkflowService?: AnalyticsSyncWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -292,6 +295,7 @@ export class WorkflowEngineAdapterService {
     this.registerAdAutomationExecutors();
     this.registerCampaignOrchestrationExecutors();
     this.registerAgentAutopilotExecutors();
+    this.registerAnalyticsSyncExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -743,6 +747,84 @@ export class WorkflowEngineAdapterService {
       generated: 0,
       organizationId: context.organizationId,
       reason: 'agent_autopilot_service_unavailable',
+      skipped: 0,
+      status: 'skipped',
+    };
+  }
+
+  private registerAnalyticsSyncExecutors(): void {
+    this.engine.registerExecutor(
+      'analyticsFacebookSync',
+      (_node, _inputs, context) =>
+        this.analyticsSyncWorkflowService
+          ? this.analyticsSyncWorkflowService.runFacebookAnalytics(
+              context.organizationId,
+            )
+          : this.analyticsSyncUnavailable('analyticsFacebookSync', context),
+    );
+
+    this.engine.registerExecutor(
+      'analyticsSocialSync',
+      (_node, _inputs, context) =>
+        this.analyticsSyncWorkflowService
+          ? this.analyticsSyncWorkflowService.runSocialAnalytics(
+              context.organizationId,
+            )
+          : this.analyticsSyncUnavailable('analyticsSocialSync', context),
+    );
+
+    this.engine.registerExecutor(
+      'analyticsThreadsSync',
+      (_node, _inputs, context) =>
+        this.analyticsSyncWorkflowService
+          ? this.analyticsSyncWorkflowService.runThreadsAnalytics(
+              context.organizationId,
+            )
+          : this.analyticsSyncUnavailable('analyticsThreadsSync', context),
+    );
+
+    this.engine.registerExecutor(
+      'analyticsTwitterSync',
+      (_node, _inputs, context) =>
+        this.analyticsSyncWorkflowService
+          ? this.analyticsSyncWorkflowService.runTwitterAnalytics(
+              context.organizationId,
+            )
+          : this.analyticsSyncUnavailable('analyticsTwitterSync', context),
+    );
+
+    this.engine.registerExecutor(
+      'analyticsGenericSync',
+      (_node, _inputs, context) =>
+        this.analyticsSyncWorkflowService
+          ? this.analyticsSyncWorkflowService.runGenericAnalyticsSync(
+              context.organizationId,
+            )
+          : this.analyticsSyncUnavailable('analyticsGenericSync', context),
+    );
+
+    this.engine.registerExecutor(
+      'youtubeAnalyticsSync',
+      (_node, _inputs, context) =>
+        this.analyticsSyncWorkflowService
+          ? this.analyticsSyncWorkflowService.runYouTubeAnalytics(
+              context.organizationId,
+            )
+          : this.analyticsSyncUnavailable('youtubeAnalyticsSync', context),
+    );
+  }
+
+  private async analyticsSyncUnavailable(
+    action: string,
+    context: ExecutionContext,
+  ): Promise<Record<string, unknown>> {
+    return {
+      action,
+      enqueued: 0,
+      organizationId: context.organizationId,
+      posts: 0,
+      queueName: '',
+      reason: 'analytics_sync_service_unavailable',
       skipped: 0,
       status: 'skipped',
     };

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -18,6 +18,7 @@ import { WorkflowEngineAdapterService } from '@api/collections/workflows/service
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
 import { AGENT_AUTOPILOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/agent-autopilot-workflows.template';
+import { ANALYTICS_SYNC_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/analytics-sync-workflows.template';
 import { CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/campaign-orchestration-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
@@ -491,6 +492,87 @@ export class WorkflowsService extends BaseService<
         if (errorCode === 'P2034') {
           this.logger?.debug(
             'ensureAgentAutopilotWorkflows: serialization conflict - workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Idempotently seeds the default-on analytics sync workflow set for an
+   * organization. Nodes preserve previous cron behavior by dispatching existing
+   * provider queue jobs scoped to the workflow organization.
+   */
+  async ensureAnalyticsSyncWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of ANALYTICS_SYNC_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 785,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureAnalyticsSyncWorkflows: serialization conflict - workflow already seeded by concurrent request',
             { organizationId, templateId: template.id },
           );
           continue;

--- a/apps/server/api/src/collections/workflows/templates/analytics-sync-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/analytics-sync-workflows.template.ts
@@ -1,0 +1,99 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type AnalyticsSyncWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  description: string;
+  icon: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  nodeType: string;
+  schedule: string;
+}): AnalyticsSyncWorkflowTemplate {
+  return {
+    category: 'analytics',
+    description: params.description,
+    icon: params.icon,
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: params.nodeLabel,
+        },
+        id: params.nodeType,
+        position: { x: 0, y: 120 },
+        type: params.nodeType,
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const ANALYTICS_SYNC_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    description:
+      'Hourly per-organization Facebook post analytics queue dispatch for published posts.',
+    icon: 'bar-chart-3',
+    id: 'analytics-facebook-sync',
+    name: 'Facebook Analytics Sync',
+    nodeLabel: 'Sync Facebook Analytics',
+    nodeType: 'analyticsFacebookSync',
+    schedule: '0 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Hourly per-organization social analytics queue dispatch for published Instagram, LinkedIn, Mastodon, TikTok, and Pinterest posts.',
+    icon: 'bar-chart-3',
+    id: 'analytics-social-sync',
+    name: 'Social Analytics Sync',
+    nodeLabel: 'Sync Social Analytics',
+    nodeType: 'analyticsSocialSync',
+    schedule: '0 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Hourly per-organization Threads analytics queue dispatch for published Threads posts.',
+    icon: 'bar-chart-3',
+    id: 'analytics-threads-sync',
+    name: 'Threads Analytics Sync',
+    nodeLabel: 'Sync Threads Analytics',
+    nodeType: 'analyticsThreadsSync',
+    schedule: '0 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Per-organization Twitter/X analytics queue dispatch for published posts with Twitter credentials.',
+    icon: 'bar-chart-3',
+    id: 'analytics-twitter-sync',
+    name: 'Twitter Analytics Sync',
+    nodeLabel: 'Sync Twitter Analytics',
+    nodeType: 'analyticsTwitterSync',
+    schedule: '*/30 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Six-hour per-organization incremental analytics sync queue dispatch.',
+    icon: 'refresh-cw',
+    id: 'analytics-sync',
+    name: 'Analytics Sync',
+    nodeLabel: 'Run Analytics Sync',
+    nodeType: 'analyticsGenericSync',
+    schedule: '0 */6 * * *',
+  }),
+  actionTemplate({
+    description:
+      'Hourly per-organization YouTube analytics queue dispatch for published videos grouped by brand.',
+    icon: 'youtube',
+    id: 'youtube-analytics-sync',
+    name: 'YouTube Analytics Sync',
+    nodeLabel: 'Sync YouTube Analytics',
+    nodeType: 'youtubeAnalyticsSync',
+    schedule: '0 * * * *',
+  }),
+] satisfies AnalyticsSyncWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -28,6 +28,7 @@ import { InstagramSocialAdapter } from '@api/collections/workflows/services/adap
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
 import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
+import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { BatchWorkflowService } from '@api/collections/workflows/services/batch-workflow.service';
 import {
   BATCH_WORKFLOW_QUEUE,
@@ -78,6 +79,7 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowGenerationService,
     AdAutomationWorkflowService,
     AgentAutopilotWorkflowService,
+    AnalyticsSyncWorkflowService,
     CampaignOrchestrationWorkflowService,
   ],
   imports: [
@@ -143,6 +145,7 @@ import { forwardRef, Module } from '@nestjs/common';
     SocialAdapterFactory,
     AdAutomationWorkflowService,
     AgentAutopilotWorkflowService,
+    AnalyticsSyncWorkflowService,
     BatchWorkflowQueueService,
     BatchWorkflowService,
     CampaignOrchestrationWorkflowService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -120,6 +120,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureAnalyticsSyncWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',

--- a/apps/server/workers/src/crons/analytics/cron.analytics-facebook.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-facebook.service.ts
@@ -7,7 +7,6 @@ import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 /**
  * Facebook Analytics Cron Service
@@ -26,7 +25,6 @@ export class CronAnalyticsFacebookService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
   async trackFacebookAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/analytics/cron.analytics-social.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-social.service.ts
@@ -7,7 +7,6 @@ import type { SocialAnalyticsJobData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 /**
  * Social Media Analytics Cron Service
@@ -26,7 +25,6 @@ export class CronAnalyticsSocialService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
   async trackSocialAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/analytics/cron.analytics-sync.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-sync.service.ts
@@ -4,7 +4,6 @@ import { QueueService } from '@api/queues/core/queue.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 @Injectable()
 export class CronAnalyticsSyncService {
@@ -17,7 +16,6 @@ export class CronAnalyticsSyncService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron(CronExpression.EVERY_6_HOURS)
   async triggerAnalyticsSync(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/analytics/cron.analytics-threads.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-threads.service.ts
@@ -7,7 +7,6 @@ import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 /**
  * Threads Analytics Cron Service
@@ -25,7 +24,6 @@ export class CronAnalyticsThreadsService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
   async trackThreadsAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/analytics/cron.analytics-twitter.service.ts
+++ b/apps/server/workers/src/crons/analytics/cron.analytics-twitter.service.ts
@@ -6,7 +6,6 @@ import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 type AnalyticsTwitterPost = {
   _id: unknown;
@@ -33,7 +32,6 @@ export class CronAnalyticsTwitterService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron(CronExpression.EVERY_30_MINUTES)
   async trackTwitterAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);

--- a/apps/server/workers/src/crons/youtube/cron.youtube-analytics.service.ts
+++ b/apps/server/workers/src/crons/youtube/cron.youtube-analytics.service.ts
@@ -7,7 +7,6 @@ import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 type AnalyticsYoutubePost = PostEntity & {
   brand: unknown;
@@ -31,7 +30,6 @@ export class CronYoutubeAnalyticsService {
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
   async trackYouTubeAnalytics(): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);


### PR DESCRIPTION
## Summary
- add default-on per-org analytics sync workflow templates for Facebook, social, Threads, Twitter/X, generic analytics sync, and YouTube
- add backend workflow executors that enqueue the existing analytics queues scoped to the workflow organization
- provision analytics sync workflows on org creation/self-hosted seed and add an existing-org dry-run/live seed
- remove static @Cron scheduling from the six tenant analytics cron services while leaving platform YouTube status cron untouched

## Verification
- bunx biome check --write <touched files>
- bunx vitest run --config vitest.config.ts src/collections/workflows/services/analytics-sync-workflow.service.spec.ts
- rg "@Cron|@nestjs/schedule" apps/server/workers/src/crons/analytics apps/server/workers/src/crons/youtube/cron.youtube-analytics.service.ts -n (no matches)
- bun run check:architecture
- bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers --force
- bun run db:generate (packages/prisma)
- bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/workers --force
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js

Closes #785