### PR TITLE
Convert content production crons to workflows

### DIFF
--- a/apps/server/api/scripts/seeds/content-production-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/content-production-workflows.seed.ts
@@ -1,0 +1,200 @@
+/**
+ * Seed Script: Content Production Workflows
+ *
+ * Idempotently provisions default-on content production workflows for existing
+ * organizations and mirrors existing content schedules into workflow rows.
+ * New organizations are seeded automatically on creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/content-production-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/content-production-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/content-production-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/content-production-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { CONTENT_PRODUCTION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/content-production-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('ContentProductionWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} - no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        await logDryRun(prisma, organization.id);
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureContentProductionWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Content production workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+async function logDryRun(
+  prisma: PrismaService,
+  organizationId: string,
+): Promise<void> {
+  const existingTemplates = await prisma.workflow.findMany({
+    select: { metadata: true },
+    where: {
+      isDeleted: false,
+      organizationId,
+      OR: CONTENT_PRODUCTION_WORKFLOW_TEMPLATES.map((template) => ({
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+      })),
+    },
+  });
+  const existingTemplateIds = new Set(
+    existingTemplates
+      .map((workflow) => {
+        const metadata = workflow.metadata as Record<string, unknown> | null;
+        return typeof metadata?.sourceTemplateId === 'string'
+          ? metadata.sourceTemplateId
+          : null;
+      })
+      .filter((value): value is string => Boolean(value)),
+  );
+  const missingTemplates = CONTENT_PRODUCTION_WORKFLOW_TEMPLATES.filter(
+    (template) => !existingTemplateIds.has(template.id),
+  ).map((template) => template.id);
+
+  const schedules = await prisma.contentSchedule.findMany({
+    orderBy: { createdAt: 'asc' },
+    select: { id: true },
+    where: { isDeleted: false, organizationId },
+  });
+
+  let missingScheduleWorkflows = 0;
+  for (const schedule of schedules) {
+    const existingWorkflow = await prisma.workflow.findFirst({
+      select: { id: true },
+      where: {
+        isDeleted: false,
+        metadata: {
+          equals: schedule.id,
+          path: ['contentScheduleId'],
+        },
+        organizationId,
+      },
+    });
+    if (!existingWorkflow) {
+      missingScheduleWorkflows += 1;
+    }
+  }
+
+  logger.log(
+    `[DRY RUN] org ${organizationId} missing ${missingTemplates.length}/${CONTENT_PRODUCTION_WORKFLOW_TEMPLATES.length} content production workflow(s): ${missingTemplates.join(', ') || 'none'}; content schedules missing workflows=${missingScheduleWorkflows}/${schedules.length}`,
+  );
+}
+
+main().catch((error) => {
+  logger.error('Content production workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/content-schedules/services/content-schedules.service.ts
+++ b/apps/server/api/src/collections/content-schedules/services/content-schedules.service.ts
@@ -6,7 +6,8 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { CronJob } from 'cron';
 
 @Injectable()
@@ -19,6 +20,7 @@ export class ContentSchedulesService extends BaseService<
   constructor(
     public readonly prisma: PrismaService,
     public readonly logger: LoggerService,
+    @Optional() private readonly moduleRef?: ModuleRef,
   ) {
     super(prisma, 'contentSchedule', logger);
   }
@@ -31,7 +33,7 @@ export class ContentSchedulesService extends BaseService<
     const now = new Date();
     const timezone = dto.timezone ?? 'UTC';
 
-    return this.delegate.create({
+    const created = (await this.delegate.create({
       data: {
         brandId,
         cronExpression: dto.cronExpression,
@@ -44,7 +46,11 @@ export class ContentSchedulesService extends BaseService<
         skillSlugs: dto.skillSlugs ?? [],
         timezone,
       } as Record<string, unknown>,
-    }) as Promise<ContentScheduleDocument>;
+    })) as ContentScheduleDocument;
+
+    await this.syncWorkflowForSchedule(organizationId, created.id);
+
+    return created;
   }
 
   listByBrand(
@@ -87,11 +93,15 @@ export class ContentSchedulesService extends BaseService<
     scheduleId: string,
     dto: UpdateContentScheduleDto,
   ): Promise<ContentScheduleDocument> {
-    await this.getById(organizationId, brandId, scheduleId);
+    const existingSchedule = await this.getById(
+      organizationId,
+      brandId,
+      scheduleId,
+    );
 
     const updatePayload: Record<string, unknown> = { ...dto };
     const expression = dto.cronExpression;
-    const timezone = dto.timezone ?? 'UTC';
+    const timezone = dto.timezone ?? existingSchedule.timezone ?? 'UTC';
 
     if (expression) {
       updatePayload.nextRunAt = this.calculateNextRunAt(
@@ -109,10 +119,14 @@ export class ContentSchedulesService extends BaseService<
       throw new NotFoundException('ContentSchedule', scheduleId);
     }
 
-    return this.delegate.update({
+    const updatedSchedule = (await this.delegate.update({
       where: { id: scheduleId },
       data: updatePayload,
-    }) as Promise<ContentScheduleDocument>;
+    })) as ContentScheduleDocument;
+
+    await this.syncWorkflowForSchedule(organizationId, updatedSchedule.id);
+
+    return updatedSchedule;
   }
 
   async removeForBrand(
@@ -128,10 +142,14 @@ export class ContentSchedulesService extends BaseService<
       throw new NotFoundException('ContentSchedule', scheduleId);
     }
 
-    return this.delegate.update({
+    const removed = (await this.delegate.update({
       where: { id: scheduleId },
       data: { isDeleted: true },
-    }) as Promise<ContentScheduleDocument>;
+    })) as ContentScheduleDocument;
+
+    await this.disableWorkflowForSchedule(organizationId, removed.id);
+
+    return removed;
   }
 
   getActiveSchedules(
@@ -183,5 +201,80 @@ export class ContentSchedulesService extends BaseService<
     }
 
     return next.toJSDate();
+  }
+
+  private async syncWorkflowForSchedule(
+    organizationId: string,
+    scheduleId: string,
+  ): Promise<void> {
+    const workflowsService = await this.getWorkflowsService();
+    if (!workflowsService) {
+      return;
+    }
+
+    const userId = await this.getOrganizationOwnerUserId(organizationId);
+    if (!userId) {
+      this.logger.warn('Skipping content schedule workflow sync - no owner', {
+        organizationId,
+        scheduleId,
+      });
+      return;
+    }
+
+    await workflowsService.ensureContentScheduleWorkflow(
+      userId,
+      organizationId,
+      scheduleId,
+    );
+  }
+
+  private async disableWorkflowForSchedule(
+    organizationId: string,
+    scheduleId: string,
+  ): Promise<void> {
+    const workflowsService = await this.getWorkflowsService();
+    if (!workflowsService) {
+      return;
+    }
+
+    await workflowsService.disableContentScheduleWorkflow(
+      organizationId,
+      scheduleId,
+    );
+  }
+
+  private async getOrganizationOwnerUserId(
+    organizationId: string,
+  ): Promise<string | undefined> {
+    const organization = await this.prisma.organization.findFirst({
+      select: { userId: true },
+      where: { id: organizationId, isDeleted: false },
+    });
+
+    return organization?.userId ?? undefined;
+  }
+
+  private async getWorkflowsService(): Promise<
+    | {
+        disableContentScheduleWorkflow: (
+          organizationId: string,
+          contentScheduleId: string,
+        ) => Promise<void>;
+        ensureContentScheduleWorkflow: (
+          userId: string,
+          organizationId: string,
+          contentScheduleId: string,
+        ) => Promise<void>;
+      }
+    | undefined
+  > {
+    if (!this.moduleRef) {
+      return undefined;
+    }
+
+    const { WorkflowsService } = await import(
+      '../../workflows/services/workflows.service'
+    );
+    return this.moduleRef.get(WorkflowsService, { strict: false });
   }
 }

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -120,6 +120,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureContentProductionWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/services/content-production-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/content-production-workflow.service.spec.ts
@@ -1,0 +1,273 @@
+import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
+import { PersonaContentFormat } from '@genfeedai/enums';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ContentProductionWorkflowService', () => {
+  const brandsService = { findForOrganization: vi.fn() };
+  const contentPlannerService = { generatePlan: vi.fn() };
+  const contentExecutionService = { executePlan: vi.fn() };
+  const contentReviewService = { autoApproveIfEligible: vi.fn() };
+  const prisma = {
+    contentSchedule: { findFirst: vi.fn() },
+    persona: { findMany: vi.fn(), update: vi.fn() },
+  };
+  const contentPipelineQueueService = { queueGenerateAndPublish: vi.fn() };
+  const contentSchedulesService = {
+    calculateNextRunAt: vi.fn(),
+    markScheduleRan: vi.fn(),
+  };
+  const contentGatewayService = { routeSignal: vi.fn() };
+  const cacheService = { acquireLock: vi.fn(), releaseLock: vi.fn() };
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  let service: ContentProductionWorkflowService;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T09:00:00.000Z'));
+    cacheService.acquireLock.mockResolvedValue(true);
+    cacheService.releaseLock.mockResolvedValue(undefined);
+    brandsService.findForOrganization.mockResolvedValue([]);
+    contentPlannerService.generatePlan.mockResolvedValue({
+      items: [{}],
+      plan: { _id: 'plan-1' },
+    });
+    contentExecutionService.executePlan.mockResolvedValue({
+      results: [{ contentDraftId: 'draft-1' }],
+      summary: { completed: 1, total: 1 },
+    });
+    contentReviewService.autoApproveIfEligible.mockResolvedValue(undefined);
+    prisma.persona.findMany.mockResolvedValue([]);
+    prisma.persona.update.mockResolvedValue({});
+    prisma.contentSchedule.findFirst.mockResolvedValue(null);
+    contentPipelineQueueService.queueGenerateAndPublish.mockResolvedValue(
+      'job-1',
+    );
+    contentGatewayService.routeSignal.mockResolvedValue({
+      drafts: [],
+      runs: ['run-1'],
+    });
+    contentSchedulesService.calculateNextRunAt.mockReturnValue(
+      new Date('2026-06-24T09:05:00.000Z'),
+    );
+    contentSchedulesService.markScheduleRan.mockResolvedValue(undefined);
+
+    service = new ContentProductionWorkflowService(
+      brandsService as never,
+      contentPlannerService as never,
+      contentExecutionService as never,
+      contentReviewService as never,
+      prisma as never,
+      contentPipelineQueueService as never,
+      contentSchedulesService as never,
+      contentGatewayService as never,
+      cacheService as never,
+      logger as never,
+    );
+  });
+
+  it('runs content engine only for eligible brands in the workflow organization', async () => {
+    brandsService.findForOrganization.mockResolvedValue([
+      {
+        _id: 'brand-1',
+        agentConfig: {
+          autoPublish: { enabled: true },
+          strategy: {
+            contentTypes: ['post'],
+            goals: ['launch'],
+            platforms: ['instagram'],
+          },
+        },
+        id: 'brand-1',
+        isActive: true,
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+      {
+        _id: 'brand-2',
+        agentConfig: {
+          autoPublish: { enabled: false },
+          strategy: { contentTypes: ['post'] },
+        },
+        id: 'brand-2',
+        isActive: true,
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+
+    const result = await service.runContentEngineProduction('org-1');
+
+    expect(brandsService.findForOrganization).toHaveBeenCalledWith('org-1');
+    expect(contentPlannerService.generatePlan).toHaveBeenCalledWith(
+      'org-1',
+      'brand-1',
+      'user-1',
+      expect.objectContaining({
+        itemCount: 5,
+        platforms: ['instagram'],
+        topics: ['launch'],
+      }),
+    );
+    expect(contentExecutionService.executePlan).toHaveBeenCalledWith(
+      'org-1',
+      'brand-1',
+      'plan-1',
+      'user-1',
+    );
+    expect(contentReviewService.autoApproveIfEligible).toHaveBeenCalledWith(
+      'org-1',
+      'brand-1',
+      'draft-1',
+    );
+    expect(result).toMatchObject({
+      action: 'contentEngineProduction',
+      failed: 0,
+      organizationId: 'org-1',
+      processed: 1,
+      skipped: 1,
+      status: 'completed',
+    });
+  });
+
+  it('queues due autopilot personas with per-org query guards and idempotency', async () => {
+    prisma.persona.findMany.mockResolvedValue([
+      {
+        brandId: 'brand-1',
+        config: {
+          contentStrategy: {
+            formats: [PersonaContentFormat.VIDEO],
+            frequency: 'daily',
+            platforms: ['instagram'],
+            topics: ['launch'],
+          },
+          profileImageUrl: 'https://example.test/avatar.png',
+        },
+        credentials: [{ id: 'credential-1' }],
+        id: 'persona-1',
+        label: 'Ada',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+
+    const result = await service.runContentPipelineAutopilot('org-1');
+
+    expect(prisma.persona.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: { credentials: true },
+        where: expect.objectContaining({ organizationId: 'org-1' }),
+      }),
+    );
+    expect(
+      contentPipelineQueueService.queueGenerateAndPublish,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: 'brand-1',
+        idempotencyKey: 'autopilot:persona-1:2026-06-24T09',
+        organizationId: 'org-1',
+        personaId: 'persona-1',
+        platforms: ['instagram'],
+        userId: 'user-1',
+      }),
+    );
+    expect(prisma.persona.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'persona-1' },
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'contentPipelineAutopilot',
+      organizationId: 'org-1',
+      processed: 1,
+      skipped: 0,
+      status: 'completed',
+    });
+  });
+
+  it('skips disabled content schedules without routing a signal', async () => {
+    prisma.contentSchedule.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      cronExpression: '* * * * *',
+      id: 'schedule-1',
+      isEnabled: false,
+      nextRunAt: new Date('2026-06-24T08:59:00.000Z'),
+      organizationId: 'org-1',
+      skillParams: {},
+      skillSlugs: [],
+      timezone: 'UTC',
+    });
+
+    const result = await service.runContentSchedule('org-1', 'schedule-1');
+
+    expect(contentGatewayService.routeSignal).not.toHaveBeenCalled();
+    expect(contentSchedulesService.markScheduleRan).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'contentScheduleRun',
+      reason: 'content_schedule_disabled',
+      status: 'skipped',
+    });
+  });
+
+  it('routes due content schedules and advances nextRunAt', async () => {
+    const nextRunAt = new Date('2026-06-24T09:05:00.000Z');
+    prisma.contentSchedule.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      cronExpression: '*/5 * * * *',
+      id: 'schedule-1',
+      isEnabled: true,
+      nextRunAt: new Date('2026-06-24T08:55:00.000Z'),
+      organizationId: 'org-1',
+      skillParams: { topic: 'launch' },
+      skillSlugs: ['daily-post'],
+      timezone: 'Europe/Malta',
+    });
+    contentSchedulesService.calculateNextRunAt.mockReturnValue(nextRunAt);
+
+    const result = await service.runContentSchedule(
+      'org-1',
+      'schedule-1',
+      'workflow-1',
+    );
+
+    expect(contentGatewayService.routeSignal).toHaveBeenCalledWith({
+      brandId: 'brand-1',
+      organizationId: 'org-1',
+      payload: {
+        scheduleId: 'schedule-1',
+        skillParams: { topic: 'launch' },
+        skillSlugs: ['daily-post'],
+        workflowId: 'workflow-1',
+      },
+      type: 'cron',
+    });
+    expect(contentSchedulesService.calculateNextRunAt).toHaveBeenCalledWith(
+      '*/5 * * * *',
+      'Europe/Malta',
+      new Date('2026-06-24T09:00:00.000Z'),
+    );
+    expect(contentSchedulesService.markScheduleRan).toHaveBeenCalledWith(
+      'schedule-1',
+      'org-1',
+      nextRunAt,
+      new Date('2026-06-24T09:00:00.000Z'),
+    );
+    expect(result).toMatchObject({
+      action: 'contentScheduleRun',
+      organizationId: 'org-1',
+      processed: 1,
+      skipped: 0,
+      status: 'completed',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/content-production-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/content-production-workflow.service.ts
@@ -1,0 +1,518 @@
+import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { ContentSchedulesService } from '@api/collections/content-schedules/services/content-schedules.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { ContentExecutionService } from '@api/services/content-engine/content-execution.service';
+import { ContentPlannerService } from '@api/services/content-engine/content-planner.service';
+import { ContentReviewService } from '@api/services/content-engine/content-review.service';
+import { ContentGatewayService } from '@api/services/content-gateway/content-gateway.service';
+import { ContentOrchestrationService } from '@api/services/content-orchestration/content-orchestration.service';
+import { ContentPipelineQueueService } from '@api/services/content-orchestration/content-pipeline-queue.service';
+import type { PipelineStep } from '@api/services/content-orchestration/pipeline.interfaces';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  ImageTaskModel,
+  MusicTaskModel,
+  PersonaContentFormat,
+  PersonaStatus,
+  VideoTaskModel,
+} from '@genfeedai/enums';
+import type { ContentSchedule, Credential, Persona } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+const MAX_BRANDS_PER_CYCLE = 10;
+const MAX_PERSONAS_PER_CYCLE = 20;
+const FIFTEEN_MINUTES_SECONDS = 900;
+const CONTENT_SCHEDULE_LOCK_SECONDS = 55;
+
+type ContentProductionAction =
+  | 'contentEngineProduction'
+  | 'contentPipelineAutopilot'
+  | 'contentScheduleRun';
+
+type PersonaContentStrategy = {
+  formats?: PersonaContentFormat[];
+  frequency?: string;
+  platforms?: string[];
+  tone?: string;
+  topics?: string[];
+};
+
+type PersonaConfig = {
+  contentStrategy?: PersonaContentStrategy;
+  lastAutopilotRunAt?: string;
+  profileImageUrl?: string;
+};
+
+type PersonaWithCredentials = Persona & {
+  config: PersonaConfig;
+  credentials: Credential[];
+};
+
+export interface ContentProductionWorkflowResult {
+  action: ContentProductionAction;
+  failed: number;
+  organizationId: string;
+  processed: number;
+  reason?: string;
+  skipped: number;
+  status: 'completed' | 'skipped';
+}
+
+@Injectable()
+export class ContentProductionWorkflowService {
+  private readonly logContext = 'ContentProductionWorkflowService';
+
+  constructor(
+    private readonly brandsService: BrandsService,
+    private readonly contentPlannerService: ContentPlannerService,
+    private readonly contentExecutionService: ContentExecutionService,
+    private readonly contentReviewService: ContentReviewService,
+    private readonly prisma: PrismaService,
+    private readonly contentPipelineQueueService: ContentPipelineQueueService,
+    private readonly contentSchedulesService: ContentSchedulesService,
+    private readonly contentGatewayService: ContentGatewayService,
+    private readonly cacheService: CacheService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async runContentEngineProduction(
+    organizationId: string,
+  ): Promise<ContentProductionWorkflowResult> {
+    const action: ContentProductionAction = 'contentEngineProduction';
+    const lockKey = this.lockKey(action, organizationId);
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      FIFTEEN_MINUTES_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        'content_engine_already_running',
+      );
+    }
+
+    let processed = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    try {
+      const brands =
+        await this.brandsService.findForOrganization(organizationId);
+      const eligibleBrands = brands
+        .filter((brand) => {
+          if (brand.isActive !== true) {
+            return false;
+          }
+          const agentConfig = this.readRecord(brand.agentConfig);
+          const autoPublish = this.readRecord(agentConfig.autoPublish);
+          const strategy = this.readRecord(agentConfig.strategy);
+          return (
+            autoPublish.enabled === true &&
+            Array.isArray(strategy.contentTypes) &&
+            strategy.contentTypes.length > 0
+          );
+        })
+        .slice(0, MAX_BRANDS_PER_CYCLE);
+
+      skipped = Math.max(brands.length - eligibleBrands.length, 0);
+
+      for (const brand of eligibleBrands) {
+        try {
+          await this.processBrand(brand, organizationId);
+          processed += 1;
+        } catch (error: unknown) {
+          failed += 1;
+          this.logger.error(`${this.logContext} brand content engine failed`, {
+            brandId: this.optionalString(brand._id ?? brand.id),
+            error: this.errorMessage(error),
+            organizationId,
+          });
+        }
+      }
+
+      return {
+        action,
+        failed,
+        organizationId,
+        processed,
+        skipped,
+        status: 'completed',
+      };
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  async runContentPipelineAutopilot(
+    organizationId: string,
+  ): Promise<ContentProductionWorkflowResult> {
+    const action: ContentProductionAction = 'contentPipelineAutopilot';
+    const lockKey = this.lockKey(action, organizationId);
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      FIFTEEN_MINUTES_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        'content_pipeline_already_running',
+      );
+    }
+
+    let processed = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    try {
+      const now = new Date();
+      const duePersonas = (await this.prisma.persona.findMany({
+        include: { credentials: true },
+        take: MAX_PERSONAS_PER_CYCLE,
+        where: {
+          isAutopilotEnabled: true,
+          isDeleted: false,
+          nextAutopilotRunAt: { lte: now },
+          organizationId,
+          status: PersonaStatus.ACTIVE as never,
+        },
+      })) as PersonaWithCredentials[];
+
+      for (const persona of duePersonas) {
+        try {
+          const queued = await this.processPersona(persona, now);
+          if (queued) {
+            processed += 1;
+          } else {
+            skipped += 1;
+          }
+        } catch (error: unknown) {
+          failed += 1;
+          this.logger.error(`${this.logContext} persona autopilot failed`, {
+            error: this.errorMessage(error),
+            organizationId,
+            personaId: persona.id,
+          });
+        }
+      }
+
+      return {
+        action,
+        failed,
+        organizationId,
+        processed,
+        skipped,
+        status: 'completed',
+      };
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  async runContentSchedule(
+    organizationId: string,
+    contentScheduleId: string,
+    workflowId?: string,
+  ): Promise<ContentProductionWorkflowResult> {
+    const action: ContentProductionAction = 'contentScheduleRun';
+    const schedule = await this.prisma.contentSchedule.findFirst({
+      where: {
+        id: contentScheduleId,
+        isDeleted: false,
+        organizationId,
+      },
+    });
+
+    if (!schedule) {
+      return this.skipped(action, organizationId, 'content_schedule_not_found');
+    }
+
+    if (!schedule.isEnabled) {
+      return this.skipped(action, organizationId, 'content_schedule_disabled');
+    }
+
+    const now = new Date();
+    if (schedule.nextRunAt && schedule.nextRunAt.getTime() > now.getTime()) {
+      return this.skipped(action, organizationId, 'content_schedule_not_due');
+    }
+
+    const lockKey = this.lockKey(action, organizationId, schedule.id);
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      CONTENT_SCHEDULE_LOCK_SECONDS,
+    );
+
+    if (!acquired) {
+      return this.skipped(
+        action,
+        organizationId,
+        'content_schedule_already_running',
+      );
+    }
+
+    try {
+      await this.routeSchedule(schedule, workflowId);
+
+      const nextRunAt = this.contentSchedulesService.calculateNextRunAt(
+        schedule.cronExpression ?? '* * * * *',
+        schedule.timezone ?? 'UTC',
+        now,
+      );
+
+      await this.contentSchedulesService.markScheduleRan(
+        schedule.id,
+        organizationId,
+        nextRunAt,
+        now,
+      );
+
+      return {
+        action,
+        failed: 0,
+        organizationId,
+        processed: 1,
+        skipped: 0,
+        status: 'completed',
+      };
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  private async processBrand(
+    brand: BrandDocument,
+    organizationId: string,
+  ): Promise<void> {
+    const brandId = String(brand._id ?? brand.id);
+    const userId =
+      this.optionalString(brand.user ?? brand.userId) ?? organizationId;
+    const strategy = this.readRecord(
+      this.readRecord(brand.agentConfig).strategy,
+    );
+    const contentTypes = strategy.contentTypes;
+
+    if (!Array.isArray(contentTypes) || contentTypes.length === 0) {
+      return;
+    }
+
+    const now = new Date();
+    const weekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+    const { plan } = await this.contentPlannerService.generatePlan(
+      organizationId,
+      brandId,
+      userId,
+      {
+        itemCount: 5,
+        periodEnd: weekFromNow.toISOString(),
+        periodStart: now.toISOString(),
+        platforms: this.stringArray(strategy.platforms),
+        topics: this.stringArray(strategy.goals),
+      },
+    );
+
+    const result = await this.contentExecutionService.executePlan(
+      organizationId,
+      brandId,
+      String(plan._id),
+      userId,
+    );
+
+    for (const executionResult of result.results) {
+      if (executionResult.contentDraftId) {
+        await this.contentReviewService.autoApproveIfEligible(
+          organizationId,
+          brandId,
+          executionResult.contentDraftId,
+        );
+      }
+    }
+  }
+
+  private async processPersona(
+    persona: PersonaWithCredentials,
+    now: Date,
+  ): Promise<boolean> {
+    const personaId = persona.id;
+    const config = (persona.config ?? {}) as PersonaConfig;
+
+    if (!persona.credentials || persona.credentials.length === 0) {
+      await this.scheduleNextRun(persona, now, false);
+      return false;
+    }
+
+    if (!config.profileImageUrl) {
+      await this.scheduleNextRun(persona, now, false);
+      return false;
+    }
+
+    const prompt = this.buildPromptFromStrategy(persona);
+    const steps = this.buildStepsFromStrategy(persona, prompt);
+
+    await this.contentPipelineQueueService.queueGenerateAndPublish({
+      brandId: persona.brandId ?? '',
+      idempotencyKey: `autopilot:${personaId}:${now.toISOString().slice(0, 13)}`,
+      organizationId: persona.organizationId,
+      personaId,
+      platforms: config.contentStrategy?.platforms,
+      prompt,
+      steps,
+      userId: persona.userId,
+    });
+
+    await this.scheduleNextRun(persona, now);
+    return true;
+  }
+
+  private buildPromptFromStrategy(persona: PersonaWithCredentials): string {
+    const config = (persona.config ?? {}) as PersonaConfig;
+    const strategy = config.contentStrategy;
+    if (!strategy?.topics?.length) {
+      return `Create engaging content for ${persona.label}`;
+    }
+
+    const topic =
+      strategy.topics[Math.floor(Math.random() * strategy.topics.length)];
+    const tone = strategy.tone ?? 'engaging';
+
+    return `Create a ${tone} video about: ${topic}`;
+  }
+
+  private buildStepsFromStrategy(
+    persona: PersonaWithCredentials,
+    prompt: string,
+  ): PipelineStep[] {
+    const config = (persona.config ?? {}) as PersonaConfig;
+    const formats = config.contentStrategy?.formats ?? [];
+
+    if (
+      formats.includes(PersonaContentFormat.VIDEO) ||
+      formats.includes(PersonaContentFormat.REEL)
+    ) {
+      return [
+        {
+          imageUrl: config.profileImageUrl,
+          model: VideoTaskModel.KLINGAI,
+          prompt,
+          type: 'image-to-video',
+        },
+      ];
+    }
+
+    if (formats.includes(PersonaContentFormat.AUDIO)) {
+      return [
+        {
+          duration: 8,
+          model: MusicTaskModel.REPLICATE,
+          prompt,
+          type: 'text-to-music',
+        },
+      ];
+    }
+
+    return [
+      {
+        model: ImageTaskModel.FAL,
+        prompt,
+        type: 'text-to-image',
+      },
+    ];
+  }
+
+  private async scheduleNextRun(
+    persona: PersonaWithCredentials,
+    now: Date,
+    updateLastRun = true,
+  ): Promise<void> {
+    const config = (persona.config ?? {}) as PersonaConfig;
+    const frequencyMs = ContentOrchestrationService.parseFrequencyToMs(
+      config.contentStrategy?.frequency,
+    );
+    const nextRun = new Date(now.getTime() + frequencyMs);
+
+    const updatedConfig: PersonaConfig = {
+      ...config,
+      ...(updateLastRun ? { lastAutopilotRunAt: now.toISOString() } : {}),
+    };
+
+    await this.prisma.persona.update({
+      data: {
+        config: updatedConfig as never,
+        nextAutopilotRunAt: nextRun,
+      },
+      where: { id: persona.id },
+    });
+  }
+
+  private async routeSchedule(
+    schedule: ContentSchedule,
+    workflowId?: string,
+  ): Promise<void> {
+    await this.contentGatewayService.routeSignal({
+      brandId: String(schedule.brandId),
+      organizationId: schedule.organizationId,
+      payload: {
+        scheduleId: schedule.id,
+        skillParams: this.readRecord(schedule.skillParams),
+        skillSlugs: schedule.skillSlugs ?? [],
+        workflowId,
+      },
+      type: 'cron',
+    });
+  }
+
+  private lockKey(
+    action: ContentProductionAction,
+    organizationId: string,
+    suffix?: string,
+  ): string {
+    return ['workflow-content-production', action, organizationId, suffix]
+      .filter((part): part is string => Boolean(part))
+      .join(':');
+  }
+
+  private skipped(
+    action: ContentProductionAction,
+    organizationId: string,
+    reason: string,
+  ): ContentProductionWorkflowResult {
+    return {
+      action,
+      failed: 0,
+      organizationId,
+      processed: 0,
+      reason,
+      skipped: 1,
+      status: 'skipped',
+    };
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private stringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) {
+      return undefined;
+    }
+    const strings = value.filter(
+      (entry): entry is string => typeof entry === 'string',
+    );
+    return strings.length > 0 ? strings : undefined;
+  }
+
+  private optionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Unknown error';
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -28,6 +28,7 @@ import { SocialAdapterFactory } from '@api/collections/workflows/services/adapte
 import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
 import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
+import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
@@ -267,6 +268,8 @@ export class WorkflowEngineAdapterService {
     private readonly agentAutopilotWorkflowService?: AgentAutopilotWorkflowService,
     @Optional()
     private readonly analyticsSyncWorkflowService?: AnalyticsSyncWorkflowService,
+    @Optional()
+    private readonly contentProductionWorkflowService?: ContentProductionWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -296,6 +299,7 @@ export class WorkflowEngineAdapterService {
     this.registerCampaignOrchestrationExecutors();
     this.registerAgentAutopilotExecutors();
     this.registerAnalyticsSyncExecutors();
+    this.registerContentProductionExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -826,6 +830,80 @@ export class WorkflowEngineAdapterService {
       queueName: '',
       reason: 'analytics_sync_service_unavailable',
       skipped: 0,
+      status: 'skipped',
+    };
+  }
+
+  private registerContentProductionExecutors(): void {
+    this.engine.registerExecutor(
+      'contentEngineProduction',
+      (_node, _inputs, context) =>
+        this.contentProductionWorkflowService
+          ? this.contentProductionWorkflowService.runContentEngineProduction(
+              context.organizationId,
+            )
+          : this.contentProductionUnavailable(
+              'contentEngineProduction',
+              context,
+            ),
+    );
+
+    this.engine.registerExecutor(
+      'contentPipelineAutopilot',
+      (_node, _inputs, context) =>
+        this.contentProductionWorkflowService
+          ? this.contentProductionWorkflowService.runContentPipelineAutopilot(
+              context.organizationId,
+            )
+          : this.contentProductionUnavailable(
+              'contentPipelineAutopilot',
+              context,
+            ),
+    );
+
+    this.engine.registerExecutor(
+      'contentScheduleRun',
+      (node, _inputs, context) => {
+        if (!this.contentProductionWorkflowService) {
+          return this.contentProductionUnavailable(
+            'contentScheduleRun',
+            context,
+          );
+        }
+
+        const contentScheduleId = this.readConfigString(
+          node.config,
+          'contentScheduleId',
+        );
+        if (!contentScheduleId) {
+          return this.contentProductionUnavailable(
+            'contentScheduleRun',
+            context,
+            'content_schedule_id_missing',
+          );
+        }
+
+        return this.contentProductionWorkflowService.runContentSchedule(
+          context.organizationId,
+          contentScheduleId,
+          context.workflowId,
+        );
+      },
+    );
+  }
+
+  private async contentProductionUnavailable(
+    action: string,
+    context: ExecutionContext,
+    reason = 'content_production_service_unavailable',
+  ): Promise<Record<string, unknown>> {
+    return {
+      action,
+      failed: 0,
+      organizationId: context.organizationId,
+      processed: 0,
+      reason,
+      skipped: 1,
       status: 'skipped',
     };
   }

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -20,6 +20,10 @@ import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/tem
 import { AGENT_AUTOPILOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/agent-autopilot-workflows.template';
 import { ANALYTICS_SYNC_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/analytics-sync-workflows.template';
 import { CAMPAIGN_ORCHESTRATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/campaign-orchestration-workflows.template';
+import {
+  CONTENT_PRODUCTION_WORKFLOW_TEMPLATES,
+  CONTENT_SCHEDULE_WORKFLOW_TEMPLATE_ID,
+} from '@api/collections/workflows/templates/content-production-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
@@ -580,6 +584,270 @@ export class WorkflowsService extends BaseService<
         throw error;
       }
     }
+  }
+
+  /**
+   * Idempotently seeds the default-on content production workflow set for an
+   * organization. Existing content schedules are mirrored into workflow rows
+   * with their own cron expression/timezone and enabled state.
+   */
+  async ensureContentProductionWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of CONTENT_PRODUCTION_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 786,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureContentProductionWorkflows: serialization conflict - workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    const schedules = await this.prisma.contentSchedule.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+      where: { isDeleted: false, organizationId },
+    });
+
+    for (const schedule of schedules) {
+      await this.ensureContentScheduleWorkflow(
+        userId,
+        organizationId,
+        schedule.id,
+      );
+    }
+  }
+
+  async ensureContentScheduleWorkflow(
+    userId: string,
+    organizationId: string,
+    contentScheduleId: string,
+  ): Promise<void> {
+    const schedule = await this.prisma.contentSchedule.findFirst({
+      select: {
+        brandId: true,
+        cronExpression: true,
+        id: true,
+        isEnabled: true,
+        name: true,
+        timezone: true,
+      },
+      where: {
+        id: contentScheduleId,
+        isDeleted: false,
+        organizationId,
+      },
+    });
+
+    if (!schedule) {
+      await this.disableContentScheduleWorkflow(
+        organizationId,
+        contentScheduleId,
+      );
+      return;
+    }
+
+    const where = {
+      isDeleted: false,
+      metadata: {
+        equals: contentScheduleId,
+        path: ['contentScheduleId'],
+      },
+      organizationId,
+    };
+
+    const existing = await this.prisma.workflow.findFirst({
+      select: { id: true },
+      where,
+    });
+    const data = this.buildContentScheduleWorkflowData(schedule);
+
+    if (existing) {
+      await this.prisma.workflow.update({
+        data,
+        where: { id: existing.id },
+      });
+      return;
+    }
+
+    try {
+      await this.prisma.$transaction(
+        async (tx) => {
+          const concurrent = await tx.workflow.findFirst({
+            select: { id: true },
+            where,
+          });
+
+          if (concurrent) {
+            await tx.workflow.update({
+              data,
+              where: { id: concurrent.id },
+            });
+            return;
+          }
+
+          await tx.workflow.create({
+            data: {
+              ...data,
+              executionCount: 0,
+              inputVariables: [] as never,
+              isDeleted: false,
+              organizationId,
+              progress: 0,
+              steps: [] as never,
+              userId,
+            },
+          });
+        },
+        { isolationLevel: 'Serializable' },
+      );
+    } catch (error) {
+      const errorCode = (error as { code?: string }).code;
+      if (errorCode === 'P2034') {
+        this.logger?.debug(
+          'ensureContentScheduleWorkflow: serialization conflict - workflow already synced by concurrent request',
+          { contentScheduleId, organizationId },
+        );
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async disableContentScheduleWorkflow(
+    organizationId: string,
+    contentScheduleId: string,
+  ): Promise<void> {
+    await this.prisma.workflow.updateMany({
+      data: {
+        isDeleted: true,
+        isScheduleEnabled: false,
+        status: WorkflowStatus.ARCHIVED,
+      },
+      where: {
+        isDeleted: false,
+        metadata: {
+          equals: contentScheduleId,
+          path: ['contentScheduleId'],
+        },
+        organizationId,
+      },
+    });
+  }
+
+  private buildContentScheduleWorkflowData(schedule: {
+    brandId: string | null;
+    cronExpression: string | null;
+    id: string;
+    isEnabled: boolean;
+    name: string | null;
+    timezone: string | null;
+  }): Record<string, unknown> {
+    return {
+      description: `Workflow-backed content schedule ${schedule.id}`,
+      edges: [] as never,
+      isScheduleEnabled: schedule.isEnabled === true,
+      label: `Content Schedule: ${schedule.name || schedule.id}`,
+      metadata: {
+        brandId: schedule.brandId,
+        contentScheduleId: schedule.id,
+        sourceIssue: 786,
+        sourceTemplateId: CONTENT_SCHEDULE_WORKFLOW_TEMPLATE_ID,
+        sourceType: 'content-schedule',
+      },
+      nodes: this.buildContentScheduleNodes(schedule) as never,
+      schedule: schedule.cronExpression ?? '* * * * *',
+      status: WorkflowStatus.ACTIVE,
+      timezone: schedule.timezone ?? 'UTC',
+    };
+  }
+
+  private buildContentScheduleNodes(schedule: {
+    brandId: string | null;
+    id: string;
+  }): WorkflowVisualNode[] {
+    const config: Record<string, unknown> = {
+      contentScheduleId: schedule.id,
+    };
+
+    if (schedule.brandId) {
+      config.brandId = schedule.brandId;
+    }
+
+    return [
+      {
+        data: {
+          config,
+          label: 'Run Content Schedule',
+        },
+        id: 'contentScheduleRun',
+        position: { x: 0, y: 120 },
+        type: 'contentScheduleRun',
+      },
+    ];
   }
 
   async executeWorkflow(workflowId: string): Promise<void> {

--- a/apps/server/api/src/collections/workflows/templates/content-production-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/content-production-workflows.template.ts
@@ -1,0 +1,61 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type ContentProductionWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  description: string;
+  icon: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  nodeType: string;
+  schedule: string;
+}): ContentProductionWorkflowTemplate {
+  return {
+    category: 'content',
+    description: params.description,
+    icon: params.icon,
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: params.nodeLabel,
+        },
+        id: params.nodeType,
+        position: { x: 0, y: 120 },
+        type: params.nodeType,
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const CONTENT_PRODUCTION_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    description:
+      'Per-organization content engine cycle for brands with active auto-publish strategy.',
+    icon: 'sparkles',
+    id: 'content-engine-production',
+    name: 'Content Engine Production',
+    nodeLabel: 'Run Content Engine',
+    nodeType: 'contentEngineProduction',
+    schedule: '*/30 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Per-organization persona autopilot content pipeline dispatch for due personas.',
+    icon: 'bot',
+    id: 'content-pipeline-autopilot',
+    name: 'Content Pipeline Autopilot',
+    nodeLabel: 'Run Content Pipeline Autopilot',
+    nodeType: 'contentPipelineAutopilot',
+    schedule: '*/30 * * * *',
+  }),
+] satisfies ContentProductionWorkflowTemplate[];
+
+export const CONTENT_SCHEDULE_WORKFLOW_TEMPLATE_ID = 'content-schedule';

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -9,6 +9,7 @@ import { AgentGoalsModule } from '@api/collections/agent-goals/agent-goals.modul
 import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CaptionsModule } from '@api/collections/captions/captions.module';
+import { ContentSchedulesModule } from '@api/collections/content-schedules/content-schedules.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
 import { CreditsModule } from '@api/collections/credits/credits.module';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
@@ -35,6 +36,7 @@ import {
   BatchWorkflowQueueService,
 } from '@api/collections/workflows/services/batch-workflow-queue.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
+import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import {
   WORKFLOW_EXECUTION_QUEUE,
@@ -49,6 +51,9 @@ import { MarketplaceIntegrationModule } from '@api/marketplace-integration/marke
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { AgentCampaignOrchestratorModule } from '@api/services/agent-campaign/agent-campaign-orchestrator.module';
 import { AiInfluencerModule } from '@api/services/ai-influencer/ai-influencer.module';
+import { ContentEngineModule } from '@api/services/content-engine/content-engine.module';
+import { ContentGatewayModule } from '@api/services/content-gateway/content-gateway.module';
+import { ContentOrchestrationModule } from '@api/services/content-orchestration/content-orchestration.module';
 import { ElevenLabsModule } from '@api/services/integrations/elevenlabs/elevenlabs.module';
 import { GoogleAdsModule } from '@api/services/integrations/google-ads/google-ads.module';
 import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
@@ -81,6 +86,7 @@ import { forwardRef, Module } from '@nestjs/common';
     AgentAutopilotWorkflowService,
     AnalyticsSyncWorkflowService,
     CampaignOrchestrationWorkflowService,
+    ContentProductionWorkflowService,
   ],
   imports: [
     forwardRef(() => AdOptimizationConfigsModule),
@@ -91,6 +97,10 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => AiInfluencerModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => CaptionsModule),
+    forwardRef(() => ContentEngineModule),
+    forwardRef(() => ContentGatewayModule),
+    forwardRef(() => ContentOrchestrationModule),
+    forwardRef(() => ContentSchedulesModule),
     forwardRef(() => CredentialsCoreModule),
     forwardRef(() => CreditsModule),
     forwardRef(() => ElevenLabsModule),
@@ -149,6 +159,7 @@ import { forwardRef, Module } from '@nestjs/common';
     BatchWorkflowQueueService,
     BatchWorkflowService,
     CampaignOrchestrationWorkflowService,
+    ContentProductionWorkflowService,
     WorkflowEngineAdapterService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -124,6 +124,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureContentProductionWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',

--- a/apps/server/workers/src/crons/content-engine/cron.content-engine.service.ts
+++ b/apps/server/workers/src/crons/content-engine/cron.content-engine.service.ts
@@ -5,7 +5,6 @@ import { ContentPlannerService } from '@api/services/content-engine/content-plan
 import { ContentReviewService } from '@api/services/content-engine/content-review.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 const MAX_BRANDS_PER_CYCLE = 10;
 
@@ -28,7 +27,6 @@ export class CronContentEngineService {
    * Finds brands with active content strategy and auto-publish enabled,
    * generates plans if needed, and executes pending items.
    */
-  @Cron(CronExpression.EVERY_30_MINUTES)
   async processContentEngine(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       CronContentEngineService.LOCK_KEY,

--- a/apps/server/workers/src/crons/content-pipeline/cron.content-pipeline.service.ts
+++ b/apps/server/workers/src/crons/content-pipeline/cron.content-pipeline.service.ts
@@ -13,7 +13,6 @@ import {
 import type { Credential, Persona } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 const MAX_PERSONAS_PER_CYCLE = 20;
 
@@ -48,7 +47,6 @@ export class CronContentPipelineService {
     private readonly logger: LoggerService,
   ) {}
 
-  @Cron(CronExpression.EVERY_30_MINUTES)
   async processAutopilotPersonas(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       CronContentPipelineService.LOCK_KEY,

--- a/apps/server/workers/src/crons/content-schedules/cron.content-schedules.service.ts
+++ b/apps/server/workers/src/crons/content-schedules/cron.content-schedules.service.ts
@@ -3,7 +3,6 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { ContentGatewayService } from '@api/services/content-gateway/content-gateway.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 const LOCK_KEY = 'cron:content-schedules';
 const LOCK_TTL_SECONDS = 55;
@@ -30,7 +29,6 @@ export class CronContentSchedulesService {
     private readonly logger: LoggerService,
   ) {}
 
-  @Cron(CronExpression.EVERY_MINUTE)
   async processContentSchedules(): Promise<void> {
     const lockAcquired = await this.cacheService.acquireLock(
       LOCK_KEY,


### PR DESCRIPTION
Closes #786

## Summary
- Adds default-on per-organization workflow templates for content engine production and content pipeline autopilot.
- Mirrors each content schedule into its own scheduled workflow row, preserving cron expression, timezone, and enabled/disabled state.
- Syncs content schedule workflow rows on schedule create/update/remove and provisions the new defaults during org creation and self-hosted seed.
- Registers backend workflow executors for content engine production, content pipeline autopilot, and content schedule runs.
- Removes the static `@Cron` triggers from the legacy content-engine, content-pipeline, and content-schedules worker services.

## Verification
- `bunx biome check --write <touched files>`
- `bunx vitest run --config vitest.config.ts src/collections/workflows/services/content-production-workflow.service.spec.ts`
- `bunx vitest run --config vitest.config.ts src/collections/organization-settings/services/organization-settings.service.spec.ts`
- `bun run check:architecture`
- `bun run db:generate`
- `bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/workers --force`
- `BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers --force`
- `git diff --check`
- `rg "@Cron|@nestjs/schedule" apps/server/workers/src/crons/content-engine apps/server/workers/src/crons/content-pipeline apps/server/workers/src/crons/content-schedules -n` returned no matches
