### PR TITLE
Workflow-back reply polling crons

### DIFF
--- a/apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts
@@ -1,0 +1,176 @@
+/**
+ * Seed Script: Reply Polling Workflows
+ *
+ * Idempotently provisions default-on reply/social polling workflows for
+ * existing organizations. New organizations are seeded automatically on
+ * creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { REPLY_POLLING_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/reply-polling-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('ReplyPollingWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} - no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        await logDryRun(prisma, organization.id);
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureReplyPollingWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Reply polling workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+async function logDryRun(
+  prisma: PrismaService,
+  organizationId: string,
+): Promise<void> {
+  const existing = await prisma.workflow.findMany({
+    select: { metadata: true },
+    where: {
+      isDeleted: false,
+      organizationId,
+      OR: REPLY_POLLING_WORKFLOW_TEMPLATES.map((template) => ({
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+      })),
+    },
+  });
+  const existingTemplateIds = new Set(
+    existing
+      .map((workflow) => {
+        const metadata = workflow.metadata as Record<string, unknown> | null;
+        return typeof metadata?.sourceTemplateId === 'string'
+          ? metadata.sourceTemplateId
+          : null;
+      })
+      .filter((value): value is string => Boolean(value)),
+  );
+  const missing = REPLY_POLLING_WORKFLOW_TEMPLATES.filter(
+    (template) => !existingTemplateIds.has(template.id),
+  ).map((template) => template.id);
+
+  logger.log(
+    `[DRY RUN] org ${organizationId} missing ${missing.length}/${REPLY_POLLING_WORKFLOW_TEMPLATES.length} reply polling workflow(s): ${missing.join(', ') || 'none'}`,
+  );
+}
+
+main().catch((error) => {
+  logger.error('Reply polling workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -124,6 +124,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureReplyPollingWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.spec.ts
@@ -1,0 +1,216 @@
+import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
+import { ReplyBotPlatform } from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ReplyPollingWorkflowService', () => {
+  const replyBotConfigsService = { find: vi.fn() };
+  const credentialsService = { findOne: vi.fn() };
+  const replyBotOrchestratorService = { processOrganizationBots: vi.fn() };
+  const prisma = {
+    workflow: { findMany: vi.fn(), update: vi.fn() },
+  };
+  const executionQueue = { queueTriggerEvent: vi.fn() };
+  const twitterAdapter = {
+    createEngagementChecker: vi.fn(),
+    createFollowerChecker: vi.fn(),
+    createKeywordChecker: vi.fn(),
+    createLikeChecker: vi.fn(),
+    createMentionChecker: vi.fn(),
+    createRepostChecker: vi.fn(),
+  };
+  const instagramAdapter = {
+    createFollowerChecker: vi.fn(),
+    createLikeChecker: vi.fn(),
+    createMentionChecker: vi.fn(),
+    createRepostChecker: vi.fn(),
+  };
+  const configService = { isDevSchedulersEnabled: true };
+  const cacheService = { acquireLock: vi.fn(), releaseLock: vi.fn() };
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  let service: ReplyPollingWorkflowService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configService.isDevSchedulersEnabled = true;
+    replyBotConfigsService.find.mockResolvedValue([]);
+    credentialsService.findOne.mockResolvedValue(null);
+    replyBotOrchestratorService.processOrganizationBots.mockResolvedValue([]);
+    prisma.workflow.findMany.mockResolvedValue([]);
+    prisma.workflow.update.mockResolvedValue({});
+    executionQueue.queueTriggerEvent.mockResolvedValue('job-1');
+    cacheService.acquireLock.mockResolvedValue(true);
+    cacheService.releaseLock.mockResolvedValue(undefined);
+    twitterAdapter.createMentionChecker.mockReturnValue(
+      vi.fn().mockResolvedValue(null),
+    );
+
+    service = new ReplyPollingWorkflowService(
+      replyBotConfigsService as never,
+      credentialsService as never,
+      replyBotOrchestratorService as never,
+      prisma as never,
+      executionQueue as never,
+      twitterAdapter as never,
+      instagramAdapter as never,
+      configService as never,
+      cacheService as never,
+      logger as never,
+    );
+  });
+
+  it('skips reply bot polling when the per-org lock is held', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runReplyBotPolling('org-1');
+
+    expect(replyBotConfigsService.find).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'replyBotPolling',
+      organizationId: 'org-1',
+      reason: 'reply_bot_polling_locked',
+      status: 'skipped',
+    });
+  });
+
+  it('discovers active reply bot credentials inside the workflow organization', async () => {
+    replyBotConfigsService.find.mockResolvedValue([
+      {
+        _id: 'config-1',
+        config: { credential: 'credential-1' },
+        isActive: true,
+        organization: 'org-1',
+      },
+    ]);
+    credentialsService.findOne.mockResolvedValue({
+      accessToken: 'token',
+      accessTokenSecret: 'secret',
+      externalId: 'external-1',
+      platform: ReplyBotPlatform.TWITTER,
+      refreshToken: 'refresh',
+      username: 'brand',
+    });
+    replyBotOrchestratorService.processOrganizationBots.mockResolvedValue([
+      {
+        botConfigId: 'config-1',
+        contentProcessed: 2,
+        dmsSent: 0,
+        errors: 0,
+        platform: ReplyBotPlatform.TWITTER,
+        repliesSent: 1,
+        skipped: 1,
+      },
+    ]);
+
+    const result = await service.runReplyBotPolling('org-1');
+
+    expect(replyBotConfigsService.find).toHaveBeenCalledWith({
+      isActive: true,
+      isDeleted: false,
+      organizationId: 'org-1',
+    });
+    expect(credentialsService.findOne).toHaveBeenCalledWith({
+      _id: 'credential-1',
+      isDeleted: false,
+      organization: 'org-1',
+    });
+    expect(
+      replyBotOrchestratorService.processOrganizationBots,
+    ).toHaveBeenCalledWith(
+      'org-1',
+      expect.objectContaining({
+        platform: ReplyBotPlatform.TWITTER,
+        username: 'brand',
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'replyBotPolling',
+      checked: 1,
+      errors: 0,
+      organizationId: 'org-1',
+      status: 'completed',
+      triggered: 1,
+    });
+  });
+
+  it('skips social trigger polling when local schedulers are disabled', async () => {
+    configService.isDevSchedulersEnabled = false;
+
+    const result = await service.runSocialTriggerPolling('org-1');
+
+    expect(prisma.workflow.findMany).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'socialTriggerPolling',
+      reason: 'local_schedulers_disabled',
+      status: 'skipped',
+    });
+  });
+
+  it('polls social trigger workflows by organization and queues trigger events', async () => {
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        config: {},
+        id: 'workflow-1',
+        nodes: [
+          {
+            data: { config: { platform: 'twitter' } },
+            id: 'mention-1',
+            type: 'mentionTrigger',
+          },
+        ],
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+    twitterAdapter.createMentionChecker.mockReturnValue(
+      vi.fn().mockResolvedValue({
+        authorUsername: 'customer',
+        postId: 'tweet-1',
+        text: 'hello',
+      }),
+    );
+
+    const result = await service.runSocialTriggerPolling('org-1');
+
+    expect(prisma.workflow.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          isDeleted: false,
+          organizationId: 'org-1',
+        }),
+      }),
+    );
+    expect(executionQueue.queueTriggerEvent).toHaveBeenCalledWith({
+      data: expect.objectContaining({ postId: 'tweet-1' }),
+      organizationId: 'org-1',
+      platform: 'twitter',
+      type: 'mentionTrigger',
+      userId: 'user-1',
+    });
+    expect(prisma.workflow.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          config: expect.objectContaining({
+            metadata: expect.objectContaining({
+              pollState: expect.objectContaining({
+                'mention-1': 'tweet-1',
+              }),
+            }),
+          }),
+        }),
+        where: { id: 'workflow-1' },
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'socialTriggerPolling',
+      checked: 1,
+      organizationId: 'org-1',
+      status: 'completed',
+      triggered: 1,
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.ts
@@ -1,17 +1,24 @@
+import type { CredentialDocument } from '@api/collections/credentials/schemas/credential.schema';
+import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import type { ReplyBotConfigDocument } from '@api/collections/reply-bot-configs/schemas/reply-bot-config.schema';
+import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/services/reply-bot-configs.service';
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
 import type { TriggerEvent } from '@api/collections/workflows/services/workflow-executor.service';
 import { ConfigService } from '@api/config/config.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import {
+  type ProcessingResult,
+  ReplyBotOrchestratorService,
+} from '@api/services/reply-bot/reply-bot-orchestrator.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { WorkflowStatus } from '@genfeedai/enums';
+import { ReplyBotPlatform, WorkflowStatus } from '@genfeedai/enums';
+import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import type { Workflow } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
-/**
- * Social trigger node types that require polling.
- */
 const SOCIAL_TRIGGER_TYPES = [
   'mentionTrigger',
   'newLikeTrigger',
@@ -22,11 +29,12 @@ const SOCIAL_TRIGGER_TYPES = [
 ] as const;
 
 type SocialTriggerType = (typeof SOCIAL_TRIGGER_TYPES)[number];
+type ReplyPollingAction = 'replyBotPolling' | 'socialTriggerPolling';
 
 type WorkflowNode = {
+  data?: { config?: Record<string, unknown>; label?: string };
   id: string;
   type: string;
-  data: { config: Record<string, unknown> };
 };
 
 type WorkflowConfig = {
@@ -36,147 +44,271 @@ type WorkflowConfig = {
   [key: string]: unknown;
 };
 
-/**
- * Poll state stored per-workflow for tracking last seen event IDs.
- * Stored in workflow.config.metadata.pollState.
- */
 interface PollState {
-  /** Last seen event ID per trigger node */
   [nodeId: string]: PollState | string | null | undefined;
-  /** Timestamp of last successful poll */
   lastPolledAt?: string;
 }
 
-/**
- * Social Polling Service
- *
- * Periodically checks social platform APIs for new events (mentions, likes,
- * reposts, followers, keywords, engagement) and triggers workflow executions.
- */
+interface ReplyBotTarget {
+  credentialId: string;
+  organizationId: string;
+}
+
+export interface ReplyPollingWorkflowResult {
+  action: ReplyPollingAction;
+  checked: number;
+  errors: number;
+  organizationId: string;
+  reason?: string;
+  skipped: number;
+  status: 'completed' | 'skipped';
+  triggered: number;
+}
+
 @Injectable()
-export class SocialPollingService {
-  private readonly logContext = 'SocialPollingService';
-  private isRunning = false;
+export class ReplyPollingWorkflowService {
+  private readonly logContext = 'ReplyPollingWorkflowService';
 
   constructor(
+    private readonly replyBotConfigsService: ReplyBotConfigsService,
+    private readonly credentialsService: CredentialsService,
+    private readonly replyBotOrchestratorService: ReplyBotOrchestratorService,
     private readonly prisma: PrismaService,
     private readonly executionQueue: WorkflowExecutionQueueService,
     private readonly twitterAdapter: TwitterSocialAdapter,
     private readonly instagramAdapter: InstagramSocialAdapter,
     private readonly configService: ConfigService,
+    private readonly cacheService: CacheService,
     private readonly logger: LoggerService,
   ) {}
 
-  /**
-   * Main polling loop — runs every 5 minutes in production.
-   * Disabled in development to avoid hitting API rate limits.
-   */
-  async pollSocialTriggers(): Promise<void> {
-    if (!this.configService.isDevSchedulersEnabled) {
-      this.logger.debug(
-        `${this.logContext} skipping — local schedulers disabled`,
-      );
-      return;
+  async runReplyBotPolling(
+    organizationId: string,
+  ): Promise<ReplyPollingWorkflowResult> {
+    const action: ReplyPollingAction = 'replyBotPolling';
+    const lockKey = this.lockKey(action, organizationId);
+    const acquired = await this.cacheService.acquireLock(lockKey, 600);
+
+    if (!acquired) {
+      return this.skipped(action, organizationId, 'reply_bot_polling_locked');
     }
 
-    if (this.isRunning) {
-      this.logger.warn(
-        `${this.logContext} skipping — previous poll in progress`,
-      );
-      return;
-    }
-
-    this.isRunning = true;
-    const startTime = Date.now();
+    let checked = 0;
+    let triggered = 0;
+    let errors = 0;
+    let skipped = 0;
 
     try {
-      this.logger.log(`${this.logContext} starting poll cycle`);
+      const targets = await this.findReplyBotTargets(organizationId);
+      skipped = targets.length === 0 ? 1 : 0;
 
-      // Find active workflows that have social trigger nodes
-      const workflows = await this.findWorkflowsWithSocialTriggers();
-      this.logger.log(
-        `${this.logContext} found ${workflows.length} workflows with social triggers`,
-      );
-
-      let triggeredCount = 0;
-
-      for (const workflow of workflows) {
+      for (const target of targets) {
+        checked += 1;
         try {
-          const triggered = await this.pollWorkflow(workflow);
-          if (triggered) {
-            triggeredCount++;
+          const credential = await this.loadCredential(target);
+          if (!credential) {
+            skipped += 1;
+            continue;
           }
-        } catch (error) {
-          this.logger.error(
-            `${this.logContext} failed to poll workflow ${workflow.id}`,
-            { error },
-          );
+
+          const results =
+            await this.replyBotOrchestratorService.processOrganizationBots(
+              organizationId,
+              credential,
+            );
+
+          triggered += results.length;
+          errors += this.countReplyBotErrors(results);
+        } catch (error: unknown) {
+          errors += 1;
+          this.logger.error(`${this.logContext} reply bot polling failed`, {
+            credentialId: target.credentialId,
+            error: this.errorMessage(error),
+            organizationId,
+          });
         }
       }
 
-      const duration = Date.now() - startTime;
-      this.logger.log(
-        `${this.logContext} poll cycle complete: ${workflows.length} checked, ${triggeredCount} triggered (${duration}ms)`,
-      );
-    } catch (error) {
-      this.logger.error(`${this.logContext} poll cycle failed`, { error });
+      return {
+        action,
+        checked,
+        errors,
+        organizationId,
+        skipped,
+        status: 'completed',
+        triggered,
+      };
     } finally {
-      this.isRunning = false;
+      await this.cacheService.releaseLock(lockKey);
     }
   }
 
-  /**
-   * Find all active workflows that contain social trigger nodes.
-   */
-  private async findWorkflowsWithSocialTriggers(): Promise<Workflow[]> {
-    const all = await this.prisma.workflow.findMany({
+  async runSocialTriggerPolling(
+    organizationId: string,
+  ): Promise<ReplyPollingWorkflowResult> {
+    const action: ReplyPollingAction = 'socialTriggerPolling';
+
+    if (!this.configService.isDevSchedulersEnabled) {
+      return this.skipped(action, organizationId, 'local_schedulers_disabled');
+    }
+
+    const lockKey = this.lockKey(action, organizationId);
+    const acquired = await this.cacheService.acquireLock(lockKey, 300);
+
+    if (!acquired) {
+      return this.skipped(action, organizationId, 'social_polling_locked');
+    }
+
+    let checked = 0;
+    let triggered = 0;
+    let errors = 0;
+
+    try {
+      const workflows =
+        await this.findWorkflowsWithSocialTriggers(organizationId);
+
+      for (const workflow of workflows) {
+        checked += 1;
+        try {
+          const didTrigger = await this.pollWorkflow(workflow);
+          if (didTrigger) {
+            triggered += 1;
+          }
+        } catch (error: unknown) {
+          errors += 1;
+          this.logger.error(`${this.logContext} social polling failed`, {
+            error: this.errorMessage(error),
+            organizationId,
+            workflowId: workflow.id,
+          });
+        }
+      }
+
+      return {
+        action,
+        checked,
+        errors,
+        organizationId,
+        skipped: workflows.length === 0 ? 1 : 0,
+        status: 'completed',
+        triggered,
+      };
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+
+  private async findReplyBotTargets(
+    organizationId: string,
+  ): Promise<ReplyBotTarget[]> {
+    const configs = await this.replyBotConfigsService.find({
+      isActive: true,
+      isDeleted: false,
+      organizationId,
+    });
+
+    const targets = new Map<string, ReplyBotTarget>();
+
+    for (const config of configs) {
+      const credentialId = this.readCredentialId(config);
+      if (!credentialId) {
+        continue;
+      }
+      const key = `${organizationId}:${credentialId}`;
+      if (!targets.has(key)) {
+        targets.set(key, { credentialId, organizationId });
+      }
+    }
+
+    return [...targets.values()];
+  }
+
+  private readCredentialId(config: ReplyBotConfigDocument): string | undefined {
+    const configRecord = this.readRecord(config.config);
+    return (
+      this.optionalString(config.credential) ??
+      this.optionalString(config.credentialId) ??
+      this.optionalString(configRecord.credential) ??
+      this.optionalString(configRecord.credentialId)
+    );
+  }
+
+  private async loadCredential(
+    target: ReplyBotTarget,
+  ): Promise<IReplyBotCredentialData | null> {
+    const credential = (await this.credentialsService.findOne({
+      _id: target.credentialId,
+      isDeleted: false,
+      organization: target.organizationId,
+    })) as CredentialDocument | null;
+
+    if (!credential) {
+      this.logger.warn(`${this.logContext} credential not found`, {
+        credentialId: target.credentialId,
+        organizationId: target.organizationId,
+      });
+      return null;
+    }
+
+    return {
+      accessToken: credential.accessToken ?? '',
+      accessTokenSecret: credential.accessTokenSecret ?? undefined,
+      externalId: credential.externalId ?? undefined,
+      platform: credential.platform as ReplyBotPlatform,
+      refreshToken: credential.refreshToken ?? undefined,
+      username: credential.username ?? undefined,
+    };
+  }
+
+  private countReplyBotErrors(results: ProcessingResult[]): number {
+    return results.reduce((sum, result) => sum + result.errors, 0);
+  }
+
+  private async findWorkflowsWithSocialTriggers(
+    organizationId: string,
+  ): Promise<Workflow[]> {
+    const workflows = await this.prisma.workflow.findMany({
       take: 200,
       where: {
         isDeleted: false,
+        organizationId,
         status: WorkflowStatus.ACTIVE as never,
       },
     });
 
-    // Filter in-memory for social trigger nodes
-    return all.filter((w) => {
-      const nodes = (w.nodes as WorkflowNode[]) ?? [];
-      return nodes.some((n) =>
-        SOCIAL_TRIGGER_TYPES.includes(n.type as SocialTriggerType),
+    return workflows.filter((workflow) => {
+      const nodes = (workflow.nodes as WorkflowNode[]) ?? [];
+      return nodes.some((node) =>
+        SOCIAL_TRIGGER_TYPES.includes(node.type as SocialTriggerType),
       );
     });
   }
 
-  /**
-   * Poll a single workflow's social triggers for new events.
-   * Returns true if any trigger fired.
-   */
   private async pollWorkflow(workflow: Workflow): Promise<boolean> {
     const wfConfig = (workflow.config as WorkflowConfig) ?? {};
     const pollState: PollState = wfConfig.metadata?.pollState ?? {};
     let triggered = false;
 
     const nodes = (workflow.nodes as WorkflowNode[]) ?? [];
-    const triggerNodes = nodes.filter((n) =>
-      SOCIAL_TRIGGER_TYPES.includes(n.type as SocialTriggerType),
+    const triggerNodes = nodes.filter((node) =>
+      SOCIAL_TRIGGER_TYPES.includes(node.type as SocialTriggerType),
     );
 
     for (const node of triggerNodes) {
       try {
         if (!workflow.organizationId || !workflow.userId) {
-          this.logger.warn(
-            `${this.logContext} skipping workflow with missing organization/user`,
-            { workflowId: workflow.id },
-          );
+          this.logger.warn(`${this.logContext} workflow missing ownership`, {
+            workflowId: workflow.id,
+          });
           continue;
         }
 
         const previousEventId = pollState[node.id];
-        const lastEventId: string | null =
+        const lastEventId =
           typeof previousEventId === 'string' ? previousEventId : null;
         const result = await this.checkTrigger(workflow, node, lastEventId);
 
         if (result) {
-          // Queue workflow execution
           const triggerEvent: TriggerEvent = {
             data: result.data,
             organizationId: workflow.organizationId,
@@ -187,24 +319,18 @@ export class SocialPollingService {
 
           await this.executionQueue.queueTriggerEvent(triggerEvent);
           triggered = true;
-
-          // Update poll state with latest event ID
           pollState[node.id] = result.lastEventId;
-
-          this.logger.log(
-            `${this.logContext} triggered ${node.type} for workflow ${workflow.id}`,
-            { eventId: result.lastEventId, platform: result.platform },
-          );
         }
-      } catch (error) {
-        this.logger.error(
-          `${this.logContext} trigger check failed for node ${node.id} in workflow ${workflow.id}`,
-          { error, nodeType: node.type },
-        );
+      } catch (error: unknown) {
+        this.logger.error(`${this.logContext} trigger check failed`, {
+          error: this.errorMessage(error),
+          nodeId: node.id,
+          nodeType: node.type,
+          workflowId: workflow.id,
+        });
       }
     }
 
-    // Persist updated poll state
     pollState.lastPolledAt = new Date().toISOString();
     const updatedConfig: WorkflowConfig = {
       ...wfConfig,
@@ -222,21 +348,16 @@ export class SocialPollingService {
     return triggered;
   }
 
-  /**
-   * Check a single trigger node for new events.
-   * Returns event data if a new event was found, null otherwise.
-   */
   private checkTrigger(
     workflow: Workflow,
     node: WorkflowNode,
     lastEventId: string | null,
   ): Promise<{
     data: Record<string, unknown>;
-    platform: string;
     lastEventId: string;
+    platform: string;
   } | null> {
     const config = node.data?.config || {};
-
     const orgId = workflow.organizationId;
     const platform = (config.platform as string) || 'twitter';
 
@@ -268,7 +389,11 @@ export class SocialPollingService {
     platform: string,
     config: Record<string, unknown>,
     lastEventId: string | null,
-  ) {
+  ): Promise<{
+    data: Record<string, unknown>;
+    lastEventId: string;
+    platform: string;
+  } | null> {
     const checker =
       platform === 'twitter'
         ? this.twitterAdapter.createMentionChecker()
@@ -425,7 +550,7 @@ export class SocialPollingService {
       keywords: (config.keywords as string[]) || [],
       lastPostId: lastEventId,
       matchMode:
-        (config.matchMode as 'exact' | 'contains' | 'regex') || 'contains',
+        (config.matchMode as 'contains' | 'exact' | 'regex') || 'contains',
       organizationId: orgId,
       platform: platform as 'twitter' | 'instagram',
     });
@@ -464,7 +589,7 @@ export class SocialPollingService {
           : rawMetricType === 'engagement_rate'
             ? 'likes'
             : rawMetricType;
-    const metricType: 'likes' | 'comments' | 'shares' | 'views' =
+    const metricType: 'comments' | 'likes' | 'shares' | 'views' =
       mappedMetricType === 'likes' ||
       mappedMetricType === 'comments' ||
       mappedMetricType === 'shares' ||
@@ -489,5 +614,40 @@ export class SocialPollingService {
       lastEventId: result.postId,
       platform,
     };
+  }
+
+  private lockKey(action: ReplyPollingAction, organizationId: string): string {
+    return ['workflow-reply-polling', action, organizationId].join(':');
+  }
+
+  private skipped(
+    action: ReplyPollingAction,
+    organizationId: string,
+    reason: string,
+  ): ReplyPollingWorkflowResult {
+    return {
+      action,
+      checked: 0,
+      errors: 0,
+      organizationId,
+      reason,
+      skipped: 1,
+      status: 'skipped',
+      triggered: 0,
+    };
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private optionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Unknown error';
   }
 }

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -29,6 +29,7 @@ import { AgentAutopilotWorkflowService } from '@api/collections/workflows/servic
 import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
+import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
@@ -270,6 +271,8 @@ export class WorkflowEngineAdapterService {
     private readonly analyticsSyncWorkflowService?: AnalyticsSyncWorkflowService,
     @Optional()
     private readonly contentProductionWorkflowService?: ContentProductionWorkflowService,
+    @Optional()
+    private readonly replyPollingWorkflowService?: ReplyPollingWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -300,6 +303,7 @@ export class WorkflowEngineAdapterService {
     this.registerAgentAutopilotExecutors();
     this.registerAnalyticsSyncExecutors();
     this.registerContentProductionExecutors();
+    this.registerReplyPollingExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -905,6 +909,44 @@ export class WorkflowEngineAdapterService {
       reason,
       skipped: 1,
       status: 'skipped',
+    };
+  }
+
+  private registerReplyPollingExecutors(): void {
+    this.engine.registerExecutor(
+      'replyBotPolling',
+      (_node, _inputs, context) =>
+        this.replyPollingWorkflowService
+          ? this.replyPollingWorkflowService.runReplyBotPolling(
+              context.organizationId,
+            )
+          : this.replyPollingUnavailable('replyBotPolling', context),
+    );
+
+    this.engine.registerExecutor(
+      'socialTriggerPolling',
+      (_node, _inputs, context) =>
+        this.replyPollingWorkflowService
+          ? this.replyPollingWorkflowService.runSocialTriggerPolling(
+              context.organizationId,
+            )
+          : this.replyPollingUnavailable('socialTriggerPolling', context),
+    );
+  }
+
+  private async replyPollingUnavailable(
+    action: string,
+    context: ExecutionContext,
+  ): Promise<Record<string, unknown>> {
+    return {
+      action,
+      checked: 0,
+      errors: 0,
+      organizationId: context.organizationId,
+      reason: 'reply_polling_service_unavailable',
+      skipped: 1,
+      status: 'skipped',
+      triggered: 0,
     };
   }
 

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -25,6 +25,7 @@ import {
   CONTENT_SCHEDULE_WORKFLOW_TEMPLATE_ID,
 } from '@api/collections/workflows/templates/content-production-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
+import { REPLY_POLLING_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/reply-polling-workflows.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -848,6 +849,88 @@ export class WorkflowsService extends BaseService<
         type: 'contentScheduleRun',
       },
     ];
+  }
+
+  /**
+   * Idempotently seeds default-on reply/social polling workflow schedules for
+   * an organization. Nodes preserve the previous cron scanner behavior by
+   * discovering active reply configs and workflow social trigger nodes during
+   * execution, scoped to the workflow organization.
+   */
+  async ensureReplyPollingWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of REPLY_POLLING_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 787,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureReplyPollingWorkflows: serialization conflict - workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
   }
 
   async executeWorkflow(workflowId: string): Promise<void> {

--- a/apps/server/api/src/collections/workflows/templates/reply-polling-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/reply-polling-workflows.template.ts
@@ -1,0 +1,59 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type ReplyPollingWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  description: string;
+  icon: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  nodeType: string;
+  schedule: string;
+}): ReplyPollingWorkflowTemplate {
+  return {
+    category: 'automation',
+    description: params.description,
+    icon: params.icon,
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: params.nodeLabel,
+        },
+        id: params.nodeType,
+        position: { x: 0, y: 120 },
+        type: params.nodeType,
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const REPLY_POLLING_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    description:
+      'Ten-minute per-organization reply bot polling for active reply configurations and credentials.',
+    icon: 'message-circle-reply',
+    id: 'reply-bot-polling',
+    name: 'Reply Bot Polling',
+    nodeLabel: 'Poll Reply Bots',
+    nodeType: 'replyBotPolling',
+    schedule: '*/10 * * * *',
+  }),
+  actionTemplate({
+    description:
+      'Five-minute per-organization social trigger polling for workflow trigger nodes.',
+    icon: 'radio',
+    id: 'social-trigger-polling',
+    name: 'Social Trigger Polling',
+    nodeLabel: 'Poll Social Triggers',
+    nodeType: 'socialTriggerPolling',
+    schedule: '*/5 * * * *',
+  }),
+] satisfies ReplyPollingWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -18,6 +18,7 @@ import { MusicsModule } from '@api/collections/musics/musics.module';
 import { NewslettersModule } from '@api/collections/newsletters/newsletters.module';
 import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
+import { ReplyBotConfigsModule } from '@api/collections/reply-bot-configs/reply-bot-configs.module';
 import { TrendsModule } from '@api/collections/trends/trends.module';
 import { VideoGenerationModule } from '@api/collections/videos/video-generation.module';
 import { VideosModule } from '@api/collections/videos/videos.module';
@@ -37,6 +38,7 @@ import {
 } from '@api/collections/workflows/services/batch-workflow-queue.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
+import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import {
   WORKFLOW_EXECUTION_QUEUE,
@@ -64,6 +66,7 @@ import { TikTokAdsModule } from '@api/services/integrations/tiktok-ads/tiktok-ad
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
+import { ReplyBotModule } from '@api/services/reply-bot/reply-bot.module';
 import { WhisperModule } from '@api/services/whisper/whisper.module';
 import { WorkflowExecutorModule } from '@api/services/workflow-executor/workflow-executor.module';
 import { SharedModule } from '@api/shared/shared.module';
@@ -87,6 +90,7 @@ import { forwardRef, Module } from '@nestjs/common';
     AnalyticsSyncWorkflowService,
     CampaignOrchestrationWorkflowService,
     ContentProductionWorkflowService,
+    ReplyPollingWorkflowService,
   ],
   imports: [
     forwardRef(() => AdOptimizationConfigsModule),
@@ -119,6 +123,8 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => OpenRouterModule),
     forwardRef(() => PostsModule),
     forwardRef(() => QueuesModule),
+    forwardRef(() => ReplyBotConfigsModule),
+    forwardRef(() => ReplyBotModule),
     forwardRef(() => SharedModule),
     forwardRef(() => TikTokAdsModule),
     forwardRef(() => TrendsModule),
@@ -160,6 +166,7 @@ import { forwardRef, Module } from '@nestjs/common';
     BatchWorkflowService,
     CampaignOrchestrationWorkflowService,
     ContentProductionWorkflowService,
+    ReplyPollingWorkflowService,
     WorkflowEngineAdapterService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -128,6 +128,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureReplyPollingWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',

--- a/apps/server/workers/src/crons/reply-bot/cron.reply-bot.service.ts
+++ b/apps/server/workers/src/crons/reply-bot/cron.reply-bot.service.ts
@@ -6,7 +6,6 @@ import { ReplyBotPlatform } from '@genfeedai/enums';
 import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 
 interface ReplyBotCronTarget {
   organizationId: string;
@@ -26,7 +25,6 @@ export class CronReplyBotService {
     private readonly logger: LoggerService,
   ) {}
 
-  @Cron(CronExpression.EVERY_10_MINUTES)
   async processReplyBots(): Promise<void> {
     const acquired = await this.cacheService.acquireLock(
       CronReplyBotService.LOCK_KEY,


### PR DESCRIPTION
# PRD Implementation

Closes #787.
Part of #698.

## What changed

- Adds default-on workflow templates for reply bot polling and social trigger polling.
- Seeds those workflows for every new organization and the self-hosted default organization.
- Adds a live/backfill seed script for existing organizations.
- Registers workflow engine executors for `replyBotPolling` and `socialTriggerPolling`.
- Removes the static Nest cron decorators/imports from the legacy reply bot and social polling workers.

## Verification

- `bunx biome check --write apps/server/api/src/collections/workflows/templates/reply-polling-workflows.template.ts apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.ts apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/workflows.module.ts apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts apps/server/api/src/seeds/self-hosted-seed.service.ts apps/server/api/scripts/seeds/reply-polling-workflows.seed.ts apps/server/workers/src/crons/reply-bot/cron.reply-bot.service.ts apps/server/workers/src/crons/social-polling/social-polling.service.ts`
- `bunx vitest run --config vitest.config.ts src/collections/workflows/services/reply-polling-workflow.service.spec.ts`
- `bunx vitest run --config vitest.config.ts src/collections/organization-settings/services/organization-settings.service.spec.ts`
- `rg "@Cron|@nestjs/schedule" apps/server/workers/src/crons/reply-bot apps/server/workers/src/crons/social-polling -n` returned no matches
- `bun run check:architecture`
- `bun run db:generate`
- `bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/workers --force`
- `BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers --force`
- `git diff --check && git diff --cached --check`
- `gitleaks detect --source . --log-opts="HEAD~1..HEAD" --redact --no-banner`
- `git diff --name-only HEAD~1..HEAD | xargs bunx secretlint`