### PR TITLE
Workflow-back trend notification crons

### DIFF
--- a/apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts
@@ -1,0 +1,176 @@
+/**
+ * Seed Script: Trend Notification Workflows
+ *
+ * Idempotently provisions default-on hourly/daily/weekly trend notification
+ * workflows for existing organizations. New organizations are seeded
+ * automatically on creation.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { TREND_NOTIFICATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/trend-notification-workflows.template';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('TrendNotificationWorkflowSeed');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type SeedArgs = {
+  dryRun: boolean;
+  env?: string;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): SeedArgs {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const workflowsService = app.get(WorkflowsService);
+    const prisma = app.get(PrismaService);
+
+    const where: Record<string, unknown> = { isDeleted: false };
+    if (args.organizationId) {
+      where.id = args.organizationId;
+    }
+
+    const organizations = await prisma.organization.findMany({
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, userId: true },
+      where: where as never,
+    });
+
+    logger.log(
+      `${args.dryRun ? 'DRY RUN' : 'LIVE'} evaluating ${organizations.length} organization(s)${args.env ? ` for ${args.env}` : ''}`,
+    );
+
+    let processed = 0;
+    let skipped = 0;
+
+    for (const organization of organizations) {
+      if (!organization.userId) {
+        logger.warn(
+          `Skipping organization ${organization.id} - no owner userId`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      if (args.dryRun) {
+        await logDryRun(prisma, organization.id);
+        processed += 1;
+        continue;
+      }
+
+      await workflowsService.ensureTrendNotificationWorkflows(
+        organization.userId,
+        organization.id,
+      );
+      processed += 1;
+    }
+
+    logger.log(
+      `Trend notification workflow seed summary: processed=${processed}, skipped=${skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+async function logDryRun(
+  prisma: PrismaService,
+  organizationId: string,
+): Promise<void> {
+  const existing = await prisma.workflow.findMany({
+    select: { metadata: true },
+    where: {
+      isDeleted: false,
+      organizationId,
+      OR: TREND_NOTIFICATION_WORKFLOW_TEMPLATES.map((template) => ({
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+      })),
+    },
+  });
+  const existingTemplateIds = new Set(
+    existing
+      .map((workflow) => {
+        const metadata = workflow.metadata as Record<string, unknown> | null;
+        return typeof metadata?.sourceTemplateId === 'string'
+          ? metadata.sourceTemplateId
+          : null;
+      })
+      .filter((value): value is string => Boolean(value)),
+  );
+  const missing = TREND_NOTIFICATION_WORKFLOW_TEMPLATES.filter(
+    (template) => !existingTemplateIds.has(template.id),
+  ).map((template) => template.id);
+
+  logger.log(
+    `[DRY RUN] org ${organizationId} missing ${missing.length}/${TREND_NOTIFICATION_WORKFLOW_TEMPLATES.length} trend notification workflow(s): ${missing.join(', ') || 'none'}`,
+  );
+}
+
+main().catch((error) => {
+  logger.error('Trend notification workflow seed failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -128,6 +128,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureTrendNotificationWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/registry/node-registry.ts
+++ b/apps/server/api/src/collections/workflows/registry/node-registry.ts
@@ -1240,6 +1240,29 @@ export const NODE_REGISTRY: Record<string, NodeDefinition> = {
     },
   },
 
+  trendSummaryNotifications: {
+    category: 'processing',
+    configSchema: {
+      cadence: {
+        default: 'daily',
+        label: 'Cadence',
+        options: ['hourly', 'daily', 'weekly'],
+        type: 'select',
+      },
+    },
+    description:
+      'Send trend summary notifications using the organization owner notification settings',
+    icon: 'HiTrendingUp',
+    inputs: {},
+    isPremium: true,
+    label: 'Trend Summary Notifications',
+    outputs: {
+      errors: { label: 'Errors', type: 'number' },
+      sent: { label: 'Sent', type: 'number' },
+      trends: { label: 'Trends', type: 'number' },
+    },
+  },
+
   'output-export': {
     category: 'output',
     configSchema: {

--- a/apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.spec.ts
@@ -1,0 +1,220 @@
+import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
+import { ParseMode } from '@genfeedai/enums';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('TrendNotificationWorkflowService', () => {
+  const prisma = {
+    organization: { findFirst: vi.fn() },
+    setting: { findFirst: vi.fn() },
+  };
+  const trendsService = {
+    getTrendingHashtags: vi.fn(),
+    getTrendingSounds: vi.fn(),
+    getViralVideos: vi.fn(),
+  };
+  const cacheService = { acquireLock: vi.fn() };
+  const notificationsService = {
+    sendEmail: vi.fn(),
+    sendNotification: vi.fn(),
+    sendTelegramMessage: vi.fn(),
+  };
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  const configService = { get: vi.fn() };
+
+  let service: TrendNotificationWorkflowService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T09:15:00.000Z'));
+    vi.clearAllMocks();
+
+    prisma.organization.findFirst.mockResolvedValue({
+      user: { email: 'owner@example.com' },
+      userId: 'user-1',
+    });
+    prisma.setting.findFirst.mockResolvedValue({
+      isTrendNotificationsEmail: true,
+      isTrendNotificationsInApp: true,
+      isTrendNotificationsTelegram: true,
+      trendNotificationsEmailAddress: 'notify@example.com',
+      trendNotificationsFrequency: 'HOURLY',
+      trendNotificationsMinViralScore: 70,
+      trendNotificationsTelegramChatId: 'chat-1',
+      userId: 'user-1',
+    });
+    trendsService.getViralVideos.mockResolvedValue([
+      {
+        platform: 'tiktok',
+        title: 'Fast video',
+        url: 'https://example.com/video',
+        viralScore: 91,
+        views: 1000000,
+      },
+    ]);
+    trendsService.getTrendingHashtags.mockResolvedValue([
+      {
+        hashtag: 'above',
+        platform: 'tiktok',
+        postCount: 500000,
+        viralityScore: 88,
+      },
+      {
+        hashtag: 'below',
+        platform: 'tiktok',
+        postCount: 500,
+        viralityScore: 20,
+      },
+    ]);
+    trendsService.getTrendingSounds.mockResolvedValue([
+      {
+        playUrl: 'https://example.com/sound',
+        soundName: 'Viral sound',
+        usageCount: 50000,
+        viralityScore: 80,
+      },
+    ]);
+    cacheService.acquireLock.mockResolvedValue(true);
+    notificationsService.sendEmail.mockResolvedValue(undefined);
+    notificationsService.sendNotification.mockResolvedValue(undefined);
+    notificationsService.sendTelegramMessage.mockResolvedValue(undefined);
+    configService.get.mockReturnValue('https://app.genfeed.ai');
+
+    service = new TrendNotificationWorkflowService(
+      prisma as never,
+      trendsService as never,
+      cacheService as never,
+      notificationsService as never,
+      logger as never,
+      configService as never,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends configured channels for the owner setting matching the cadence', async () => {
+    const result = await service.runTrendSummaryNotifications(
+      'org-1',
+      'hourly',
+    );
+
+    expect(prisma.organization.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'org-1', isDeleted: false },
+      }),
+    );
+    expect(prisma.setting.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          trendNotificationsFrequency: 'HOURLY',
+          userId: 'user-1',
+        }),
+      }),
+    );
+    expect(cacheService.acquireLock).toHaveBeenCalledWith(
+      expect.stringContaining('workflow-trend-summary:org-1:hourly:user-1'),
+      7200,
+    );
+    expect(notificationsService.sendTelegramMessage).toHaveBeenCalledWith(
+      'chat-1',
+      expect.stringContaining('#above'),
+      { parse_mode: ParseMode.MARKDOWN },
+    );
+    expect(
+      notificationsService.sendTelegramMessage.mock.calls[0][1],
+    ).not.toContain('#below');
+    expect(notificationsService.sendEmail).toHaveBeenCalledWith(
+      'notify@example.com',
+      expect.stringContaining('Trend Summary'),
+      expect.stringContaining('<!DOCTYPE html>'),
+    );
+    expect(notificationsService.sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'trend_summary',
+        userId: 'user-1',
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'trendSummaryNotifications',
+      cadence: 'hourly',
+      errors: 0,
+      organizationId: 'org-1',
+      sent: 3,
+      status: 'completed',
+      trends: 3,
+    });
+  });
+
+  it('skips when the owner has no settings for the cadence', async () => {
+    prisma.setting.findFirst.mockResolvedValue(null);
+
+    const result = await service.runTrendSummaryNotifications(
+      'org-1',
+      'weekly',
+    );
+
+    expect(cacheService.acquireLock).not.toHaveBeenCalled();
+    expect(notificationsService.sendEmail).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      cadence: 'weekly',
+      reason: 'settings_missing',
+      status: 'skipped',
+    });
+  });
+
+  it('skips duplicate cadence windows by org, cadence, recipient set, and window', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runTrendSummaryNotifications('org-1', 'daily');
+
+    expect(notificationsService.sendEmail).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      cadence: 'daily',
+      reason: 'notification_window_already_sent',
+      status: 'skipped',
+    });
+  });
+
+  it('skips without sending when no trends match threshold', async () => {
+    trendsService.getViralVideos.mockResolvedValue([]);
+    trendsService.getTrendingHashtags.mockResolvedValue([]);
+    trendsService.getTrendingSounds.mockResolvedValue([]);
+
+    const result = await service.runTrendSummaryNotifications(
+      'org-1',
+      'hourly',
+    );
+
+    expect(cacheService.acquireLock).not.toHaveBeenCalled();
+    expect(notificationsService.sendEmail).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      reason: 'no_trends',
+      status: 'skipped',
+    });
+  });
+
+  it('reports delivery errors and continues other channels', async () => {
+    notificationsService.sendEmail.mockRejectedValueOnce(
+      new Error('email failed'),
+    );
+
+    const result = await service.runTrendSummaryNotifications(
+      'org-1',
+      'hourly',
+    );
+
+    expect(notificationsService.sendTelegramMessage).toHaveBeenCalled();
+    expect(notificationsService.sendNotification).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      errors: 1,
+      sent: 2,
+      status: 'completed',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.ts
@@ -1,0 +1,420 @@
+import { createHash } from 'node:crypto';
+import { TrendsService } from '@api/collections/trends/services/trends.service';
+import type { TrendNotificationCadence } from '@api/collections/workflows/templates/trend-notification-workflows.template';
+import { ConfigService } from '@api/config/config.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { NotificationsService } from '@api/services/notifications/notifications.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { ParseMode } from '@genfeedai/enums';
+import {
+  buildTrendDigestHtml,
+  buildTrendDigestMessage,
+  type TrendDigestItem,
+} from '@genfeedai/helpers';
+import type { Setting } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+type TrendNotificationAction = 'trendSummaryNotifications';
+
+type TrendRecord = {
+  description?: string;
+  hashtag?: string;
+  platform?: string;
+  playCount?: number;
+  playUrl?: string;
+  postCount?: number;
+  soundName?: string;
+  usageCount?: number;
+  url?: string;
+  viralScore?: number;
+  viralityScore?: number;
+  viewCount?: number;
+  views?: number;
+  title?: string;
+};
+
+type DeliveryChannels = {
+  email: boolean;
+  inApp: boolean;
+  telegram: boolean;
+};
+
+export interface TrendNotificationWorkflowResult {
+  action: TrendNotificationAction;
+  cadence: TrendNotificationCadence;
+  channels: DeliveryChannels;
+  errors: number;
+  organizationId: string;
+  reason?: string;
+  sent: number;
+  skipped: number;
+  status: 'completed' | 'skipped';
+  trends: number;
+}
+
+@Injectable()
+export class TrendNotificationWorkflowService {
+  private readonly logContext = 'TrendNotificationWorkflowService';
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly trendsService: TrendsService,
+    private readonly cacheService: CacheService,
+    private readonly notificationsService: NotificationsService,
+    private readonly logger: LoggerService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async runTrendSummaryNotifications(
+    organizationId: string,
+    cadence: TrendNotificationCadence,
+  ): Promise<TrendNotificationWorkflowResult> {
+    const action: TrendNotificationAction = 'trendSummaryNotifications';
+    const owner = await this.findOrganizationOwner(organizationId);
+    if (!owner) {
+      return this.skipped(
+        cadence,
+        organizationId,
+        'organization_owner_missing',
+      );
+    }
+
+    const setting = await this.findOwnerSetting(owner.userId, cadence);
+    if (!setting) {
+      return this.skipped(cadence, organizationId, 'settings_missing');
+    }
+
+    const recipients = this.resolveRecipients(setting);
+    if (!recipients.email && !recipients.inApp && !recipients.telegram) {
+      return this.skipped(cadence, organizationId, 'recipients_missing');
+    }
+
+    const minViralScore = setting.trendNotificationsMinViralScore || 70;
+    const trends = await this.buildTrends(minViralScore);
+    if (trends.length === 0) {
+      this.logger.debug(
+        `${this.logContext} no trends above threshold for workflow notification`,
+        { cadence, minViralScore, organizationId, userId: owner.userId },
+      );
+      return this.skipped(cadence, organizationId, 'no_trends');
+    }
+
+    const markerKey = this.idempotencyKey(
+      organizationId,
+      cadence,
+      owner.userId,
+      setting,
+    );
+    const acquired = await this.cacheService.acquireLock(
+      markerKey,
+      this.markerTtlSeconds(cadence),
+    );
+    if (!acquired) {
+      return this.skipped(
+        cadence,
+        organizationId,
+        'notification_window_already_sent',
+      );
+    }
+
+    const summaryMessage = buildTrendDigestMessage(trends, { minViralScore });
+    const summaryHtml = buildTrendDigestHtml(trends, {
+      appUrl: String(this.configService.get('GENFEEDAI_APP_URL') ?? ''),
+      minViralScore,
+    });
+
+    let sent = 0;
+    let errors = 0;
+
+    if (recipients.telegram && setting.trendNotificationsTelegramChatId) {
+      try {
+        await this.notificationsService.sendTelegramMessage(
+          setting.trendNotificationsTelegramChatId,
+          summaryMessage,
+          { parse_mode: ParseMode.MARKDOWN },
+        );
+        sent += 1;
+      } catch (error) {
+        errors += 1;
+        this.logDeliveryError('telegram', error, cadence, organizationId);
+      }
+    }
+
+    if (recipients.email && setting.trendNotificationsEmailAddress) {
+      try {
+        await this.notificationsService.sendEmail(
+          setting.trendNotificationsEmailAddress,
+          `Your Trend Summary - ${trends.length} Trending Topics`,
+          summaryHtml,
+        );
+        sent += 1;
+      } catch (error) {
+        errors += 1;
+        this.logDeliveryError('email', error, cadence, organizationId);
+      }
+    }
+
+    if (recipients.inApp) {
+      try {
+        await this.notificationsService.sendNotification({
+          action: 'trend_summary',
+          payload: {
+            cadence,
+            minViralScore,
+            organizationId,
+            trends: trends.slice(0, 10),
+          } as never,
+          type: 'discord',
+          userId: owner.userId,
+        });
+        sent += 1;
+      } catch (error) {
+        errors += 1;
+        this.logDeliveryError('in_app', error, cadence, organizationId);
+      }
+    }
+
+    return {
+      action,
+      cadence,
+      channels: recipients,
+      errors,
+      organizationId,
+      sent,
+      skipped: sent === 0 ? 1 : 0,
+      status: 'completed',
+      trends: trends.length,
+    };
+  }
+
+  private async findOrganizationOwner(
+    organizationId: string,
+  ): Promise<{ email: string | null; userId: string } | null> {
+    const organization = await this.prisma.organization.findFirst({
+      select: {
+        user: { select: { email: true } },
+        userId: true,
+      },
+      where: { id: organizationId, isDeleted: false },
+    });
+
+    if (!organization?.userId) {
+      return null;
+    }
+
+    return {
+      email: organization.user?.email ?? null,
+      userId: organization.userId,
+    };
+  }
+
+  private async findOwnerSetting(
+    userId: string,
+    cadence: TrendNotificationCadence,
+  ): Promise<Setting | null> {
+    return this.prisma.setting.findFirst({
+      where: {
+        isDeleted: false,
+        OR: [
+          { isTrendNotificationsEmail: true },
+          { isTrendNotificationsInApp: true },
+          { isTrendNotificationsTelegram: true },
+        ],
+        trendNotificationsFrequency: cadence.toUpperCase() as never,
+        userId,
+      },
+    });
+  }
+
+  private resolveRecipients(setting: Setting): DeliveryChannels {
+    return {
+      email:
+        setting.isTrendNotificationsEmail &&
+        Boolean(setting.trendNotificationsEmailAddress),
+      inApp: setting.isTrendNotificationsInApp,
+      telegram:
+        setting.isTrendNotificationsTelegram &&
+        Boolean(setting.trendNotificationsTelegramChatId),
+    };
+  }
+
+  private async buildTrends(minViralScore: number): Promise<TrendDigestItem[]> {
+    const [viralVideos, trendingHashtags, trendingSounds] = await Promise.all([
+      this.getViralVideos(minViralScore),
+      this.getTrendingHashtags(minViralScore),
+      this.getTrendingSounds(),
+    ]);
+
+    return [...viralVideos, ...trendingHashtags, ...trendingSounds];
+  }
+
+  private async getViralVideos(
+    minViralScore: number,
+  ): Promise<TrendDigestItem[]> {
+    try {
+      const videos = await this.trendsService.getViralVideos({
+        limit: 10,
+        minViralScore,
+      });
+
+      return (videos as TrendRecord[]).map((video) => ({
+        platform: video.platform || 'tiktok',
+        topic: video.title || video.description || 'Trending Video',
+        type: 'video' as const,
+        url: video.url,
+        usageCount: video.views || video.playCount,
+        viralScore: video.viralScore || 0,
+      }));
+    } catch (error) {
+      this.logger.error(`${this.logContext} failed to get viral videos`, error);
+      return [];
+    }
+  }
+
+  private async getTrendingHashtags(
+    minViralScore: number,
+  ): Promise<TrendDigestItem[]> {
+    try {
+      const hashtags = await this.trendsService.getTrendingHashtags({
+        limit: 10,
+      });
+
+      return (hashtags as TrendRecord[])
+        .filter((hashtag) => (hashtag.viralityScore || 0) >= minViralScore)
+        .map((hashtag) => ({
+          platform: hashtag.platform || 'tiktok',
+          topic: `#${hashtag.hashtag}`,
+          type: 'hashtag' as const,
+          usageCount: hashtag.postCount || hashtag.viewCount,
+          viralScore: hashtag.viralityScore || 0,
+        }));
+    } catch (error) {
+      this.logger.error(
+        `${this.logContext} failed to get trending hashtags`,
+        error,
+      );
+      return [];
+    }
+  }
+
+  private async getTrendingSounds(): Promise<TrendDigestItem[]> {
+    try {
+      const sounds = await this.trendsService.getTrendingSounds({ limit: 10 });
+
+      return (sounds as TrendRecord[])
+        .filter((sound) => (sound.usageCount || 0) >= 10000)
+        .slice(0, 5)
+        .map((sound) => ({
+          platform: 'tiktok',
+          topic: sound.soundName || 'Trending Sound',
+          type: 'sound' as const,
+          url: sound.playUrl,
+          usageCount: sound.usageCount,
+          viralScore: sound.viralityScore || 80,
+        }));
+    } catch (error) {
+      this.logger.error(
+        `${this.logContext} failed to get trending sounds`,
+        error,
+      );
+      return [];
+    }
+  }
+
+  private idempotencyKey(
+    organizationId: string,
+    cadence: TrendNotificationCadence,
+    userId: string,
+    setting: Setting,
+  ): string {
+    const recipientFingerprint = createHash('sha256')
+      .update(
+        JSON.stringify({
+          email: setting.trendNotificationsEmailAddress ?? null,
+          emailEnabled: setting.isTrendNotificationsEmail,
+          inAppEnabled: setting.isTrendNotificationsInApp,
+          telegram: setting.trendNotificationsTelegramChatId ?? null,
+          telegramEnabled: setting.isTrendNotificationsTelegram,
+        }),
+      )
+      .digest('hex')
+      .slice(0, 16);
+
+    return [
+      'workflow-trend-summary',
+      organizationId,
+      cadence,
+      userId,
+      recipientFingerprint,
+      this.windowKey(cadence),
+    ].join(':');
+  }
+
+  private windowKey(cadence: TrendNotificationCadence): string {
+    const now = new Date();
+    if (cadence === 'hourly') {
+      return now.toISOString().slice(0, 13);
+    }
+    if (cadence === 'weekly') {
+      return this.isoWeekKey(now);
+    }
+    return now.toISOString().slice(0, 10);
+  }
+
+  private isoWeekKey(date: Date): string {
+    const utc = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+    const day = utc.getUTCDay() || 7;
+    utc.setUTCDate(utc.getUTCDate() + 4 - day);
+    const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
+    const week = Math.ceil(
+      ((utc.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7,
+    );
+    return `${utc.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+  }
+
+  private markerTtlSeconds(cadence: TrendNotificationCadence): number {
+    if (cadence === 'hourly') {
+      return 7200;
+    }
+    if (cadence === 'weekly') {
+      return 691_200;
+    }
+    return 93_600;
+  }
+
+  private skipped(
+    cadence: TrendNotificationCadence,
+    organizationId: string,
+    reason: string,
+  ): TrendNotificationWorkflowResult {
+    return {
+      action: 'trendSummaryNotifications',
+      cadence,
+      channels: { email: false, inApp: false, telegram: false },
+      errors: 0,
+      organizationId,
+      reason,
+      sent: 0,
+      skipped: 1,
+      status: 'skipped',
+      trends: 0,
+    };
+  }
+
+  private logDeliveryError(
+    channel: string,
+    error: unknown,
+    cadence: TrendNotificationCadence,
+    organizationId: string,
+  ): void {
+    this.logger.error(`${this.logContext} delivery failed`, {
+      cadence,
+      channel,
+      error: error instanceof Error ? error.message : String(error),
+      organizationId,
+    });
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -30,6 +30,8 @@ import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/service
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
 import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
+import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
+import type { TrendNotificationCadence } from '@api/collections/workflows/templates/trend-notification-workflows.template';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
@@ -273,6 +275,8 @@ export class WorkflowEngineAdapterService {
     private readonly contentProductionWorkflowService?: ContentProductionWorkflowService,
     @Optional()
     private readonly replyPollingWorkflowService?: ReplyPollingWorkflowService,
+    @Optional()
+    private readonly trendNotificationWorkflowService?: TrendNotificationWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -304,6 +308,7 @@ export class WorkflowEngineAdapterService {
     this.registerAnalyticsSyncExecutors();
     this.registerContentProductionExecutors();
     this.registerReplyPollingExecutors();
+    this.registerTrendNotificationExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -948,6 +953,57 @@ export class WorkflowEngineAdapterService {
       status: 'skipped',
       triggered: 0,
     };
+  }
+
+  private registerTrendNotificationExecutors(): void {
+    this.engine.registerExecutor(
+      'trendSummaryNotifications',
+      (node, _inputs, context) => {
+        if (!this.trendNotificationWorkflowService) {
+          return this.trendNotificationUnavailable(
+            'trendSummaryNotifications',
+            context,
+          );
+        }
+
+        const cadence = this.readConfigString(node.config, 'cadence');
+        if (!this.isTrendNotificationCadence(cadence)) {
+          return this.trendNotificationUnavailable(
+            'trendSummaryNotifications',
+            context,
+            'trend_notification_cadence_invalid',
+          );
+        }
+
+        return this.trendNotificationWorkflowService.runTrendSummaryNotifications(
+          context.organizationId,
+          cadence,
+        );
+      },
+    );
+  }
+
+  private async trendNotificationUnavailable(
+    action: string,
+    context: ExecutionContext,
+    reason = 'trend_notification_service_unavailable',
+  ): Promise<Record<string, unknown>> {
+    return {
+      action,
+      errors: 0,
+      organizationId: context.organizationId,
+      reason,
+      sent: 0,
+      skipped: 1,
+      status: 'skipped',
+      trends: 0,
+    };
+  }
+
+  private isTrendNotificationCadence(
+    cadence: string | undefined,
+  ): cadence is TrendNotificationCadence {
+    return cadence === 'hourly' || cadence === 'daily' || cadence === 'weekly';
   }
 
   private registerTrendTriggerExecutor(): void {

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -26,6 +26,7 @@ import {
 } from '@api/collections/workflows/templates/content-production-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { REPLY_POLLING_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/reply-polling-workflows.template';
+import { TREND_NOTIFICATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/trend-notification-workflows.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -924,6 +925,89 @@ export class WorkflowsService extends BaseService<
         if (errorCode === 'P2034') {
           this.logger?.debug(
             'ensureReplyPollingWorkflows: serialization conflict - workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Idempotently seeds default-on trend notification workflow schedules for an
+   * organization. Each cadence executor checks the org owner's current settings
+   * at run time, preserving legacy frequency/recipient semantics while letting
+   * workflow schedule toggles pause the tenant-facing notification path.
+   */
+  async ensureTrendNotificationWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of TREND_NOTIFICATION_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  cadence: template.cadence,
+                  sourceIssue: 788,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureTrendNotificationWorkflows: serialization conflict - workflow already seeded by concurrent request',
             { organizationId, templateId: template.id },
           );
           continue;

--- a/apps/server/api/src/collections/workflows/templates/trend-notification-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/trend-notification-workflows.template.ts
@@ -1,0 +1,69 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type TrendNotificationCadence = 'daily' | 'hourly' | 'weekly';
+
+export type TrendNotificationWorkflowTemplate = WorkflowTemplate & {
+  cadence: TrendNotificationCadence;
+  schedule: string;
+};
+
+function actionTemplate(params: {
+  cadence: TrendNotificationCadence;
+  description: string;
+  id: string;
+  name: string;
+  nodeLabel: string;
+  schedule: string;
+}): TrendNotificationWorkflowTemplate {
+  return {
+    cadence: params.cadence,
+    category: 'trends',
+    description: params.description,
+    icon: 'trending-up',
+    id: params.id,
+    name: params.name,
+    nodes: [
+      {
+        data: {
+          config: { cadence: params.cadence },
+          label: params.nodeLabel,
+        },
+        id: 'trendSummaryNotifications',
+        position: { x: 0, y: 120 },
+        type: 'trendSummaryNotifications',
+      },
+    ],
+    schedule: params.schedule,
+    steps: [],
+  };
+}
+
+export const TREND_NOTIFICATION_WORKFLOW_TEMPLATES = [
+  actionTemplate({
+    cadence: 'hourly',
+    description:
+      'Hourly per-organization trend summary notifications using the owner trend notification settings.',
+    id: 'trend-summary-notifications-hourly',
+    name: 'Hourly Trend Summary Notifications',
+    nodeLabel: 'Send Hourly Trend Summary',
+    schedule: '0 * * * *',
+  }),
+  actionTemplate({
+    cadence: 'daily',
+    description:
+      'Daily per-organization trend summary notifications using the owner trend notification settings.',
+    id: 'trend-summary-notifications-daily',
+    name: 'Daily Trend Summary Notifications',
+    nodeLabel: 'Send Daily Trend Summary',
+    schedule: '0 9 * * *',
+  }),
+  actionTemplate({
+    cadence: 'weekly',
+    description:
+      'Weekly per-organization trend summary notifications using the owner trend notification settings.',
+    id: 'trend-summary-notifications-weekly',
+    name: 'Weekly Trend Summary Notifications',
+    nodeLabel: 'Send Weekly Trend Summary',
+    schedule: '0 9 * * 1',
+  }),
+] satisfies TrendNotificationWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -39,6 +39,7 @@ import {
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
 import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
+import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import {
   WORKFLOW_EXECUTION_QUEUE,
@@ -91,6 +92,7 @@ import { forwardRef, Module } from '@nestjs/common';
     CampaignOrchestrationWorkflowService,
     ContentProductionWorkflowService,
     ReplyPollingWorkflowService,
+    TrendNotificationWorkflowService,
   ],
   imports: [
     forwardRef(() => AdOptimizationConfigsModule),
@@ -167,6 +169,7 @@ import { forwardRef, Module } from '@nestjs/common';
     CampaignOrchestrationWorkflowService,
     ContentProductionWorkflowService,
     ReplyPollingWorkflowService,
+    TrendNotificationWorkflowService,
     WorkflowEngineAdapterService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -132,6 +132,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureTrendNotificationWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',

--- a/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts
+++ b/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts
@@ -12,7 +12,6 @@ import type { Setting } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@workers/config/config.service';
 
 type TrendRecord = {
@@ -53,7 +52,6 @@ export class CronTrendSummaryNotificationsService {
    * Hourly trend summary notifications
    * Runs every hour for users with 'hourly' frequency
    */
-  @Cron(CronExpression.EVERY_HOUR)
   async sendHourlyTrendSummaries() {
     await this.sendTrendSummariesByFrequency('hourly', this.LOCK_KEY_HOURLY);
   }
@@ -62,7 +60,6 @@ export class CronTrendSummaryNotificationsService {
    * Daily trend summary notifications
    * Runs every day at 9 AM for users with 'daily' frequency
    */
-  @Cron('0 9 * * *')
   async sendDailyTrendSummaries() {
     await this.sendTrendSummariesByFrequency('daily', this.LOCK_KEY_DAILY);
   }
@@ -71,7 +68,6 @@ export class CronTrendSummaryNotificationsService {
    * Weekly trend summary notifications
    * Runs every Monday at 9 AM for users with 'weekly' frequency
    */
-  @Cron('0 9 * * 1')
   async sendWeeklyTrendSummaries() {
     await this.sendTrendSummariesByFrequency('weekly', this.LOCK_KEY_WEEKLY);
   }


### PR DESCRIPTION
# PRD Implementation

Closes #788.
Part of #698.

## What changed

- Adds hourly/daily/weekly trend notification workflow templates, default-enabled per organization.
- Adds `TrendNotificationWorkflowService` to execute those workflows using the org owner's existing trend notification settings.
- Preserves legacy channels: Telegram, email, and in-app notifications.
- Adds per-org/cadence/recipient/window idempotency markers to avoid duplicate sends.
- Adds an existing-org seed script for trend notification workflows.
- Registers a `trendSummaryNotifications` workflow node and engine executor.
- Removes static `@Cron` scheduling from the legacy trend summary notification worker while leaving global trend collection crons untouched.

## Verification

- `bunx biome check --write apps/server/api/src/collections/workflows/templates/trend-notification-workflows.template.ts apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.ts apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/workflows.module.ts apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts apps/server/api/src/seeds/self-hosted-seed.service.ts apps/server/api/src/collections/workflows/registry/node-registry.ts apps/server/api/scripts/seeds/trend-notification-workflows.seed.ts apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts`
- `bunx vitest run --config vitest.config.ts src/collections/workflows/services/trend-notification-workflow.service.spec.ts`
- `bunx vitest run --config vitest.config.ts src/collections/organization-settings/services/organization-settings.service.spec.ts`
- `bunx vitest run --config vitest.cron.config.ts src/crons/trends/cron.trend-summary-notifications.service.spec.ts`
- `rg "@Cron|@nestjs/schedule" apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.ts -n` returned no matches
- `bun run check:architecture`
- `bun run db:generate`
- `bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/workers --force`
- `BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers --force`
- `git diff --check && git diff --cached --check`
- `gitleaks protect --staged --redact --no-banner`
- `gitleaks detect --source . --log-opts="HEAD~1..HEAD" --redact --no-banner`
- `git diff --name-only HEAD~1..HEAD | xargs bunx secretlint`