### PR TITLE
Migrate legacy cron jobs to workflows

### DIFF
--- a/apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts
+++ b/apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts
@@ -1,0 +1,122 @@
+/**
+ * Migration Script: Legacy Cron Jobs To Workflows
+ *
+ * Idempotently migrates legacy cron-jobs rows of type workflow_execution,
+ * agent_strategy_execution, and newsletter_substack into schedule-enabled
+ * workflow rows. Migrated cron jobs are marked so the legacy dynamic runner
+ * ignores them.
+ *
+ * Dry-run is the default. Pass `--live` to apply changes.
+ *
+ * Usage:
+ *   bun run apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts
+ *   bun run apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts --live
+ *   bun run apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts --organizationId=<id>
+ *   bun run apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts --limit=100 --live
+ *   bun run apps/server/api/scripts/seeds/legacy-cron-jobs-workflows.seed.ts --env=production --live
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { AppModule } from '@api/app.module';
+import { CronJobsService } from '@api/collections/cron-jobs/services/cron-jobs.service';
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+const logger = new Logger('LegacyCronJobsWorkflowMigration');
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+type MigrationArgs = {
+  dryRun: boolean;
+  env?: string;
+  limit?: number;
+  organizationId?: string;
+};
+
+function loadEnvFile(): void {
+  const args = process.argv.slice(2);
+  const envArg = args.find((arg) => arg.startsWith('--env='))?.split('=')[1];
+  const envSuffix = envArg || 'local';
+  const envPath = resolve(scriptDir, '..', '..', `.env.${envSuffix}`);
+
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (envArg || !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+    logger.log(`Loaded env from .env.${envSuffix}`);
+  } catch {
+    logger.log(`No .env.${envSuffix} found, using process env / defaults`);
+  }
+}
+
+function parseArgs(): MigrationArgs {
+  const args = process.argv.slice(2);
+  const limitArg = args
+    .find((arg) => arg.startsWith('--limit='))
+    ?.split('=')[1];
+  const parsedLimit = limitArg ? Number(limitArg) : undefined;
+
+  return {
+    dryRun: !args.includes('--live'),
+    env: args.find((arg) => arg.startsWith('--env='))?.split('=')[1],
+    limit:
+      parsedLimit !== undefined && Number.isFinite(parsedLimit)
+        ? parsedLimit
+        : undefined,
+    organizationId: args
+      .find((arg) => arg.startsWith('--organizationId='))
+      ?.split('=')[1],
+  };
+}
+
+async function main(): Promise<void> {
+  loadEnvFile();
+  const args = parseArgs();
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'log', 'warn'],
+  });
+
+  try {
+    const cronJobsService = app.get(CronJobsService);
+    const report = await cronJobsService.migrateLegacyJobsToWorkflows({
+      dryRun: args.dryRun,
+      limit: args.limit,
+      organizationId: args.organizationId,
+    });
+
+    logger.log(
+      `${report.dryRun ? 'DRY RUN' : 'LIVE'} legacy cron migration summary: scanned=${report.scanned}, migrated=${report.migrated}, invalid=${report.invalid}, skipped=${report.skipped}, failed=${report.failed}${args.env ? `, env=${args.env}` : ''}`,
+    );
+
+    for (const detail of report.details) {
+      if (detail.status === 'invalid' || detail.status === 'failed') {
+        logger.warn(
+          `${detail.status} cronJob=${detail.cronJobId} type=${detail.jobType ?? 'unknown'} errors=${(detail.errors ?? []).join('; ')}`,
+        );
+      }
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Legacy cron jobs workflow migration failed', error);
+  process.exit(1);
+});

--- a/apps/server/api/src/collections/cron-jobs/cron-jobs.module.ts
+++ b/apps/server/api/src/collections/cron-jobs/cron-jobs.module.ts
@@ -1,6 +1,7 @@
 import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
 import { CreditsModule } from '@api/collections/credits/credits.module';
 import { CronJobsController } from '@api/collections/cron-jobs/controllers/cron-jobs.controller';
+import { LEGACY_CRON_JOB_EXECUTOR } from '@api/collections/cron-jobs/legacy-cron-job-executor.token';
 import { CronJobsService } from '@api/collections/cron-jobs/services/cron-jobs.service';
 import { WorkflowsModule } from '@api/collections/workflows/workflows.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
@@ -11,7 +12,7 @@ import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [CronJobsController],
-  exports: [CronJobsService],
+  exports: [CronJobsService, LEGACY_CRON_JOB_EXECUTOR],
   imports: [
     forwardRef(() => CreditsModule),
     forwardRef(() => WorkflowsModule),
@@ -22,6 +23,12 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => OpenRouterModule),
     forwardRef(() => SubstackModule),
   ],
-  providers: [CronJobsService],
+  providers: [
+    CronJobsService,
+    {
+      provide: LEGACY_CRON_JOB_EXECUTOR,
+      useExisting: CronJobsService,
+    },
+  ],
 })
 export class CronJobsModule {}

--- a/apps/server/api/src/collections/cron-jobs/legacy-cron-job-executor.token.ts
+++ b/apps/server/api/src/collections/cron-jobs/legacy-cron-job-executor.token.ts
@@ -1,0 +1,9 @@
+export const LEGACY_CRON_JOB_EXECUTOR = Symbol('LEGACY_CRON_JOB_EXECUTOR');
+
+export interface LegacyCronJobExecutor {
+  executeMigratedLegacyCronJob(params: {
+    legacyCronJobId: string;
+    organizationId: string;
+    userId: string;
+  }): Promise<Record<string, unknown>>;
+}

--- a/apps/server/api/src/collections/cron-jobs/services/cron-jobs.service.spec.ts
+++ b/apps/server/api/src/collections/cron-jobs/services/cron-jobs.service.spec.ts
@@ -1,5 +1,9 @@
-import { computeNextRunAtOrThrow } from '@api/collections/cron-jobs/services/cron-jobs.service';
-import { describe, expect, it } from 'vitest';
+import {
+  CronJobsService,
+  computeNextRunAtOrThrow,
+} from '@api/collections/cron-jobs/services/cron-jobs.service';
+import type { CronJob as PrismaCronJob } from '@genfeedai/prisma';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('CronJobsService schedule validation', () => {
   it('should compute next run for valid cron expression', () => {
@@ -9,5 +13,307 @@ describe('CronJobsService schedule validation', () => {
 
   it('should throw for invalid cron expression', () => {
     expect(() => computeNextRunAtOrThrow('invalid-cron', 'UTC')).toThrow();
+  });
+});
+
+describe('CronJobsService legacy cron workflow migration', () => {
+  const now = new Date('2026-06-24T08:00:00.000Z');
+
+  function buildCronJob(overrides: Partial<PrismaCronJob> = {}): PrismaCronJob {
+    return {
+      config: {
+        consecutiveFailures: 0,
+        enabled: true,
+        jobType: 'newsletter_substack',
+        lastStatus: 'never',
+        name: 'Weekly newsletter',
+        payload: { topic: 'Growth' },
+        schedule: '0 9 * * 1',
+        timezone: 'UTC',
+      },
+      createdAt: now,
+      expression: '0 9 * * 1',
+      id: 'cron-1',
+      isDeleted: false,
+      label: 'Weekly newsletter',
+      lastRunAt: now,
+      mongoId: null,
+      nextRunAt: now,
+      organizationId: 'org-1',
+      status: 'ACTIVE',
+      updatedAt: now,
+      userId: 'user-1',
+      ...overrides,
+    } as PrismaCronJob;
+  }
+
+  function createService() {
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: unknown) => unknown) =>
+        callback(prisma),
+      ),
+      agentStrategy: {
+        findFirst: vi.fn(),
+      },
+      cronJob: {
+        create: vi.fn(),
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        update: vi.fn(),
+      },
+      cronRun: {
+        count: vi.fn().mockResolvedValue(0),
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      workflow: {
+        create: vi.fn(),
+        findFirst: vi.fn(),
+      },
+    };
+    const workflowsService = {
+      executeWorkflow: vi.fn(),
+      findOne: vi.fn(),
+    };
+    const cacheService = {
+      acquireLock: vi.fn(),
+      releaseLock: vi.fn(),
+    };
+    const creditsUtilsService = {
+      checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
+    };
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    const service = new CronJobsService(
+      prisma as never,
+      workflowsService as never,
+      { create: vi.fn() } as never,
+      { queueRun: vi.fn() } as never,
+      { chatCompletion: vi.fn() } as never,
+      { createDraft: vi.fn(), deliverDraftWebhook: vi.fn() } as never,
+      cacheService as never,
+      creditsUtilsService as never,
+      logger as never,
+    );
+
+    return {
+      cacheService,
+      creditsUtilsService,
+      logger,
+      prisma,
+      service,
+      workflowsService,
+    };
+  }
+
+  it('reports invalid supported rows without creating workflows', async () => {
+    const { prisma, service } = createService();
+    prisma.cronJob.findMany.mockResolvedValue([
+      buildCronJob({
+        config: {
+          enabled: true,
+          jobType: 'workflow_execution',
+          payload: {},
+          schedule: '0 9 * * *',
+          timezone: 'UTC',
+        },
+      }),
+    ]);
+    prisma.workflow.findFirst.mockResolvedValue(null);
+
+    const report = await service.migrateLegacyJobsToWorkflows();
+
+    expect(report.invalid).toBe(1);
+    expect(report.details[0]).toMatchObject({
+      cronJobId: 'cron-1',
+      jobType: 'workflow_execution',
+      status: 'invalid',
+    });
+    expect(report.details[0]?.errors).toContain(
+      'payload.workflowId is required for workflow_execution',
+    );
+    expect(prisma.workflow.create).not.toHaveBeenCalled();
+    expect(prisma.cronJob.update).not.toHaveBeenCalled();
+  });
+
+  it('creates a scheduled workflow and marks the legacy row migrated', async () => {
+    const { prisma, service } = createService();
+    prisma.cronJob.findMany.mockResolvedValue([
+      buildCronJob({
+        config: {
+          enabled: true,
+          jobType: 'newsletter_substack',
+          lastStatus: 'success',
+          name: 'Weekly newsletter',
+          payload: {
+            topic: 'Growth',
+            webhookSecret: 'super-secret',
+          },
+          schedule: '0 9 * * 1',
+          timezone: 'Europe/Malta',
+        },
+        expression: '0 9 * * 1',
+      }),
+    ]);
+    prisma.workflow.findFirst.mockResolvedValue(null);
+    prisma.cronRun.count.mockResolvedValue(7);
+    prisma.workflow.create.mockResolvedValue({ id: 'workflow-migrated' });
+
+    const report = await service.migrateLegacyJobsToWorkflows({
+      dryRun: false,
+    });
+
+    expect(report.migrated).toBe(1);
+    expect(prisma.workflow.create).toHaveBeenCalledTimes(1);
+    const createArg = prisma.workflow.create.mock.calls[0]?.[0] as {
+      data: Record<string, unknown>;
+    };
+    expect(createArg.data).toMatchObject({
+      executionCount: 7,
+      isScheduleEnabled: true,
+      label: 'Migrated: Weekly newsletter',
+      organizationId: 'org-1',
+      schedule: '0 9 * * 1',
+      status: 'active',
+      timezone: 'Europe/Malta',
+      userId: 'user-1',
+    });
+    expect(JSON.stringify(createArg.data.nodes)).not.toContain('super-secret');
+    expect(createArg.data.nodes).toMatchObject([
+      {
+        data: {
+          config: {
+            jobType: 'newsletter_substack',
+            legacyCronJobId: 'cron-1',
+          },
+        },
+        type: 'legacyCronJob',
+      },
+    ]);
+    expect(prisma.cronJob.update).toHaveBeenCalledWith({
+      data: {
+        config: expect.objectContaining({
+          enabled: false,
+          migration: expect.objectContaining({
+            originalEnabled: true,
+            status: 'workflow_migrated',
+            workflowId: 'workflow-migrated',
+          }),
+        }),
+        status: 'PAUSED',
+      },
+      where: { id: 'cron-1' },
+    });
+  });
+
+  it('reuses an existing migrated workflow on rerun', async () => {
+    const { prisma, service } = createService();
+    prisma.cronJob.findMany.mockResolvedValue([buildCronJob()]);
+    prisma.workflow.findFirst.mockResolvedValue({ id: 'workflow-existing' });
+
+    const report = await service.migrateLegacyJobsToWorkflows({
+      dryRun: false,
+    });
+
+    expect(report.migrated).toBe(1);
+    expect(report.details[0]).toMatchObject({
+      status: 'migrated',
+      workflowId: 'workflow-existing',
+    });
+    expect(prisma.workflow.create).not.toHaveBeenCalled();
+    expect(prisma.cronJob.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'PAUSED',
+        }),
+      }),
+    );
+  });
+
+  it('skips migrated rows in the legacy runner even if they are returned', async () => {
+    const { cacheService, prisma, service } = createService();
+    prisma.cronJob.findMany.mockResolvedValue([
+      buildCronJob({
+        config: {
+          enabled: true,
+          jobType: 'newsletter_substack',
+          migration: {
+            status: 'workflow_migrated',
+            workflowId: 'workflow-migrated',
+          },
+          payload: { topic: 'Growth' },
+          schedule: '0 9 * * 1',
+          timezone: 'UTC',
+        },
+      }),
+    ]);
+
+    const processed = await service.processDueJobs();
+
+    expect(processed).toBe(0);
+    expect(cacheService.acquireLock).not.toHaveBeenCalled();
+  });
+
+  it('does not run migrated rows through runNow', async () => {
+    const { prisma, service, workflowsService } = createService();
+    prisma.cronJob.findFirst.mockResolvedValue(
+      buildCronJob({
+        config: {
+          enabled: false,
+          jobType: 'workflow_execution',
+          migration: {
+            status: 'workflow_migrated',
+            workflowId: 'workflow-migrated',
+          },
+          payload: { workflowId: 'workflow-target' },
+          schedule: '0 9 * * *',
+          timezone: 'UTC',
+        },
+        status: 'PAUSED',
+      }),
+    );
+
+    const result = await service.runNow('cron-1', 'org-1');
+
+    expect(result).toBeNull();
+    expect(workflowsService.executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('executes migrated workflow_execution rows through the workflow service', async () => {
+    const { prisma, service, workflowsService } = createService();
+    prisma.cronJob.findFirst.mockResolvedValue(
+      buildCronJob({
+        config: {
+          enabled: false,
+          jobType: 'workflow_execution',
+          migration: {
+            status: 'workflow_migrated',
+            workflowId: 'workflow-migrated',
+          },
+          payload: { workflowId: 'workflow-target' },
+          schedule: '0 9 * * *',
+          timezone: 'UTC',
+        },
+        status: 'PAUSED',
+      }),
+    );
+    workflowsService.findOne.mockResolvedValue({ id: 'workflow-target' });
+
+    const result = await service.executeMigratedLegacyCronJob({
+      legacyCronJobId: 'cron-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({ workflowId: 'workflow-target' });
+    expect(workflowsService.executeWorkflow).toHaveBeenCalledWith(
+      'workflow-target',
+    );
   });
 });

--- a/apps/server/api/src/collections/cron-jobs/services/cron-jobs.service.ts
+++ b/apps/server/api/src/collections/cron-jobs/services/cron-jobs.service.ts
@@ -3,15 +3,17 @@ import type { AgentStrategyDocument } from '@api/collections/agent-strategies/sc
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { CreateCronJobDto } from '@api/collections/cron-jobs/dto/create-cron-job.dto';
 import { UpdateCronJobDto } from '@api/collections/cron-jobs/dto/update-cron-job.dto';
-import type {
-  CronJobDocument,
-  CronJobLastStatus,
-  CronJobType,
+import {
+  CRON_JOB_TYPES,
+  type CronJobDocument,
+  type CronJobLastStatus,
+  type CronJobType,
 } from '@api/collections/cron-jobs/schemas/cron-job.schema';
 import type {
   CronRunDocument,
   CronRunTrigger,
 } from '@api/collections/cron-jobs/schemas/cron-run.schema';
+import { validateCronPayload } from '@api/collections/cron-jobs/utils/cron-payload-validation.util';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -26,6 +28,8 @@ import {
   AgentAutonomyMode,
   AgentExecutionTrigger,
   AgentType,
+  WorkflowLifecycle,
+  WorkflowStatus,
 } from '@genfeedai/enums';
 import type {
   CronJob as PrismaCronJob,
@@ -37,6 +41,11 @@ import { CronJob as CronParser } from 'cron';
 
 /** Minimum credits required before executing a paid AI cron job type. */
 const MIN_CREDITS_FOR_AI_JOB = 10;
+const LEGACY_CRON_JOB_MIGRATION_STATUS = 'workflow_migrated';
+const LEGACY_CRON_JOB_MIGRATION_SOURCE = 'legacy-cron-job';
+const LEGACY_CRON_JOB_NODE_TYPE = 'legacyCronJob';
+const LEGACY_CRON_JOB_MIGRATION_VERSION = 1;
+const LEGACY_CRON_JOB_TYPES = new Set<string>(CRON_JOB_TYPES);
 
 interface NewsletterPayload {
   topic?: string;
@@ -57,6 +66,44 @@ interface AgentStrategyPayload {
   agentType?: string;
   autonomyMode?: string;
 }
+
+export type LegacyCronJobMigrationDetailStatus =
+  | 'already_migrated'
+  | 'failed'
+  | 'invalid'
+  | 'migrated'
+  | 'skipped'
+  | 'would_migrate';
+
+export interface LegacyCronJobMigrationDetail {
+  cronJobId: string;
+  errors?: string[];
+  jobType?: CronJobType;
+  reason?: string;
+  status: LegacyCronJobMigrationDetailStatus;
+  workflowId?: string;
+}
+
+export interface LegacyCronJobMigrationReport {
+  details: LegacyCronJobMigrationDetail[];
+  dryRun: boolean;
+  failed: number;
+  invalid: number;
+  migrated: number;
+  scanned: number;
+  skipped: number;
+}
+
+export interface LegacyCronJobMigrationOptions {
+  dryRun?: boolean;
+  limit?: number;
+  organizationId?: string;
+}
+
+type CronJobMigrationClient = Pick<
+  PrismaService,
+  'cronJob' | 'cronRun' | 'workflow'
+>;
 
 export function computeNextRunAtOrThrow(
   schedule: string,
@@ -295,6 +342,21 @@ export class CronJobsService {
       value === 'workflow_execution'
       ? value
       : 'workflow_execution';
+  }
+
+  private readCronJobType(value: unknown): CronJobType | undefined {
+    return typeof value === 'string' && LEGACY_CRON_JOB_TYPES.has(value)
+      ? (value as CronJobType)
+      : undefined;
+  }
+
+  private isWorkflowMigratedConfig(config: unknown): boolean {
+    const migration = this.asRecord(this.asRecord(config).migration);
+    return migration.status === LEGACY_CRON_JOB_MIGRATION_STATUS;
+  }
+
+  private isWorkflowMigratedJob(job: CronJobDocument): boolean {
+    return this.isWorkflowMigratedConfig(job.config);
   }
 
   private asCronJobLastStatus(value: unknown): CronJobLastStatus {
@@ -540,6 +602,15 @@ export class CronJobsService {
 
     // Use unredacted document for execution so webhook secrets are available.
     const job = this.toCronJobDocument(dbJob, { redactSecrets: false });
+    if (this.isWorkflowMigratedJob(job)) {
+      this.logger.warn('Migrated cron job runNow ignored', {
+        jobId: job.id,
+        migrationStatus: LEGACY_CRON_JOB_MIGRATION_STATUS,
+        organizationId,
+      });
+      return null;
+    }
+
     return await this.executeJob(job, 'manual');
   }
 
@@ -551,6 +622,12 @@ export class CronJobsService {
         where: {
           isDeleted: false,
           nextRunAt: { lte: new Date() },
+          NOT: {
+            config: {
+              equals: LEGACY_CRON_JOB_MIGRATION_STATUS,
+              path: ['migration', 'status'],
+            },
+          },
           status: 'ACTIVE',
         },
       })
@@ -561,6 +638,10 @@ export class CronJobsService {
     let processed = 0;
 
     for (const job of dueJobs) {
+      if (this.isWorkflowMigratedJob(job)) {
+        continue;
+      }
+
       const lockKey = `cron-job:lock:${(job as Record<string, unknown>).id as string}`;
       const acquired = await this.cacheService.acquireLock(lockKey, 300);
 
@@ -577,6 +658,318 @@ export class CronJobsService {
     }
 
     return processed;
+  }
+
+  async migrateLegacyJobsToWorkflows(
+    options: LegacyCronJobMigrationOptions = {},
+  ): Promise<LegacyCronJobMigrationReport> {
+    const dryRun = options.dryRun !== false;
+    const report: LegacyCronJobMigrationReport = {
+      details: [],
+      dryRun,
+      failed: 0,
+      invalid: 0,
+      migrated: 0,
+      scanned: 0,
+      skipped: 0,
+    };
+
+    const rows = await this.prisma.cronJob.findMany({
+      orderBy: { createdAt: 'asc' },
+      ...(options.limit ? { take: options.limit } : {}),
+      where: {
+        isDeleted: false,
+        ...(options.organizationId
+          ? { organizationId: options.organizationId }
+          : {}),
+      },
+    });
+
+    for (const row of rows) {
+      const rawConfig = this.asRecord(row.config);
+      const jobType = this.readCronJobType(rawConfig.jobType);
+      const cronJobId = row.id;
+      report.scanned += 1;
+
+      if (!jobType) {
+        report.skipped += 1;
+        report.details.push({
+          cronJobId,
+          reason: 'unsupported_job_type',
+          status: 'skipped',
+        });
+        continue;
+      }
+
+      const job = this.toCronJobDocument(row, { redactSecrets: false });
+      const existingWorkflow = await this.findMigratedWorkflow(
+        this.prisma,
+        cronJobId,
+      );
+
+      if (this.isWorkflowMigratedJob(job)) {
+        report.skipped += 1;
+        report.details.push({
+          cronJobId,
+          jobType,
+          reason: 'already_migrated',
+          status: 'already_migrated',
+          workflowId:
+            this.asString(this.asRecord(job.config?.migration).workflowId) ??
+            existingWorkflow?.id,
+        });
+        continue;
+      }
+
+      const errors = await this.validateMigrationCandidate(job);
+      if (errors.length > 0) {
+        report.invalid += 1;
+        report.details.push({
+          cronJobId,
+          errors,
+          jobType,
+          status: 'invalid',
+        });
+        continue;
+      }
+
+      if (dryRun) {
+        report.migrated += 1;
+        report.details.push({
+          cronJobId,
+          jobType,
+          reason: existingWorkflow
+            ? 'existing_migrated_workflow_found'
+            : 'dry_run',
+          status: 'would_migrate',
+          workflowId: existingWorkflow?.id,
+        });
+        continue;
+      }
+
+      try {
+        const workflowId = await this.migrateCronJobToWorkflow(job);
+        report.migrated += 1;
+        report.details.push({
+          cronJobId,
+          jobType,
+          status: 'migrated',
+          workflowId,
+        });
+      } catch (error: unknown) {
+        report.failed += 1;
+        report.details.push({
+          cronJobId,
+          errors: [error instanceof Error ? error.message : String(error)],
+          jobType,
+          status: 'failed',
+        });
+      }
+    }
+
+    return report;
+  }
+
+  async executeMigratedLegacyCronJob(params: {
+    legacyCronJobId: string;
+    organizationId: string;
+    userId: string;
+  }): Promise<Record<string, unknown>> {
+    const row = await this.prisma.cronJob.findFirst({
+      where: {
+        id: params.legacyCronJobId,
+        isDeleted: false,
+        organizationId: params.organizationId,
+        userId: params.userId,
+      },
+    });
+
+    if (!row) {
+      throw new Error('Migrated legacy cron job not found');
+    }
+
+    const job = this.toCronJobDocument(row, { redactSecrets: false });
+    if (!this.isWorkflowMigratedJob(job)) {
+      throw new Error('Legacy cron job has not been migrated to workflow');
+    }
+
+    return await this.executeByType(job.jobType, job.payload, job);
+  }
+
+  private async validateMigrationCandidate(
+    job: CronJobDocument,
+  ): Promise<string[]> {
+    const errors = validateCronPayload(job.jobType, job.payload);
+
+    try {
+      computeNextRunAtOrThrow(job.schedule, job.timezone);
+    } catch {
+      errors.push('schedule or timezone is invalid');
+    }
+
+    if (!job.organizationId) {
+      errors.push('organizationId is required');
+    }
+    if (!job.userId) {
+      errors.push('userId is required');
+    }
+
+    if (job.jobType === 'workflow_execution') {
+      const workflowId = this.asString(job.payload.workflowId);
+      if (workflowId) {
+        const workflow = await this.prisma.workflow.findFirst({
+          select: { id: true },
+          where: {
+            id: workflowId,
+            isDeleted: false,
+            organizationId: job.organizationId,
+            userId: job.userId,
+          },
+        });
+        if (!workflow) {
+          errors.push('payload.workflowId does not reference a live workflow');
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  private async migrateCronJobToWorkflow(
+    job: CronJobDocument,
+  ): Promise<string> {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        return await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await this.findMigratedWorkflow(tx, job.id);
+            const workflowId =
+              existing?.id ?? (await this.createMigratedWorkflow(tx, job)).id;
+
+            await this.markCronJobMigrated(tx, job, workflowId);
+            return workflowId;
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error: unknown) {
+        if ((error as { code?: string }).code === 'P2034' && attempt === 0) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error('Failed to migrate legacy cron job after retry');
+  }
+
+  private async findMigratedWorkflow(
+    client: CronJobMigrationClient,
+    legacyCronJobId: string,
+  ): Promise<{ id: string } | null> {
+    return await client.workflow.findFirst({
+      select: { id: true },
+      where: {
+        isDeleted: false,
+        metadata: {
+          equals: legacyCronJobId,
+          path: ['legacyCronJobId'],
+        },
+      },
+    });
+  }
+
+  private async createMigratedWorkflow(
+    client: CronJobMigrationClient,
+    job: CronJobDocument,
+  ): Promise<{ id: string }> {
+    const executionCount = await client.cronRun.count({
+      where: {
+        cronJobId: job.id,
+        isDeleted: false,
+        status: 'COMPLETED',
+      },
+    });
+
+    return await client.workflow.create({
+      data: {
+        edges: [] as never,
+        executionCount,
+        inputVariables: [] as never,
+        isDeleted: false,
+        isScheduleEnabled: job.status === 'ACTIVE' && job.enabled,
+        label: `Migrated: ${job.name}`,
+        lastExecutedAt: job.lastRunAt,
+        lifecycle: WorkflowLifecycle.PUBLISHED,
+        metadata: {
+          legacyCronJobId: job.id,
+          legacyCronJobMongoId: job.mongoId,
+          legacyCronJobType: job.jobType,
+          migrationVersion: LEGACY_CRON_JOB_MIGRATION_VERSION,
+          originalEnabled: job.enabled,
+          originalNextRunAt: job.nextRunAt?.toISOString(),
+          originalStatus: job.status,
+          sourceIssue: 789,
+          sourceType: LEGACY_CRON_JOB_MIGRATION_SOURCE,
+        } as never,
+        nodes: [
+          {
+            data: {
+              config: {
+                jobType: job.jobType,
+                legacyCronJobId: job.id,
+              },
+              label: this.legacyCronNodeLabel(job.jobType),
+            },
+            id: LEGACY_CRON_JOB_NODE_TYPE,
+            position: { x: 0, y: 120 },
+            type: LEGACY_CRON_JOB_NODE_TYPE,
+          },
+        ] as never,
+        organizationId: job.organizationId,
+        progress: 0,
+        schedule: job.schedule,
+        status: WorkflowStatus.ACTIVE,
+        steps: [] as never,
+        timezone: job.timezone,
+        userId: job.userId,
+      },
+      select: { id: true },
+    });
+  }
+
+  private legacyCronNodeLabel(jobType: CronJobType): string {
+    switch (jobType) {
+      case 'workflow_execution':
+        return 'Execute Legacy Workflow Schedule';
+      case 'agent_strategy_execution':
+        return 'Execute Legacy Agent Strategy';
+      case 'newsletter_substack':
+        return 'Generate Legacy Substack Newsletter';
+    }
+  }
+
+  private async markCronJobMigrated(
+    client: CronJobMigrationClient,
+    job: CronJobDocument,
+    workflowId: string,
+  ): Promise<void> {
+    const nextConfig = this.buildCronJobConfig({ enabled: false }, job.config);
+    nextConfig.migration = {
+      migratedAt: new Date().toISOString(),
+      originalEnabled: job.enabled,
+      originalNextRunAt: job.nextRunAt?.toISOString(),
+      originalStatus: job.status,
+      status: LEGACY_CRON_JOB_MIGRATION_STATUS,
+      workflowId,
+    };
+
+    await client.cronJob.update({
+      data: {
+        config: nextConfig as never,
+        status: 'PAUSED',
+      },
+      where: { id: job.id },
+    });
   }
 
   private async assertCreditBalance(

--- a/apps/server/api/src/collections/workflows/registry/node-registry.ts
+++ b/apps/server/api/src/collections/workflows/registry/node-registry.ts
@@ -1660,6 +1660,39 @@ export const NODE_REGISTRY: Record<string, NodeDefinition> = {
     outputs: {},
   },
 
+  legacyCronJob: {
+    category: 'control',
+    configSchema: {
+      jobType: {
+        description: 'Legacy cron job type migrated into workflow execution',
+        label: 'Job Type',
+        options: [
+          'workflow_execution',
+          'agent_strategy_execution',
+          'newsletter_substack',
+        ],
+        required: true,
+        type: 'select',
+      },
+      legacyCronJobId: {
+        description: 'Legacy cron job row that backs this migrated workflow',
+        label: 'Legacy Cron Job ID',
+        required: true,
+        type: 'string',
+      },
+    },
+    description:
+      'Executes a migrated legacy automation row through the workflow scheduler',
+    icon: 'HiArrowPath',
+    inputs: {},
+    isEnabled: false,
+    isPremium: false,
+    label: 'Legacy Automation Adapter',
+    outputs: {
+      result: { label: 'Execution Result', type: 'any' },
+    },
+  },
+
   'workflow-ref': {
     category: 'control',
     configSchema: {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -4,6 +4,11 @@ import { CaptionsService } from '@api/collections/captions/services/captions.ser
 import { PerformanceSummaryService } from '@api/collections/content-performance/services/performance-summary.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import {
+  LEGACY_CRON_JOB_EXECUTOR,
+  type LegacyCronJobExecutor,
+} from '@api/collections/cron-jobs/legacy-cron-job-executor.token';
+import type { CronJobType } from '@api/collections/cron-jobs/schemas/cron-job.schema';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
@@ -101,7 +106,7 @@ import {
 } from '@genfeedai/workflow-engine';
 import { LoggerService } from '@libs/logger/logger.service';
 import { getUserRoomName } from '@libs/websockets/room-name.util';
-import { Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 
 /**
  * Shape of workflow document passed to convertToExecutableWorkflow.
@@ -277,6 +282,9 @@ export class WorkflowEngineAdapterService {
     private readonly replyPollingWorkflowService?: ReplyPollingWorkflowService,
     @Optional()
     private readonly trendNotificationWorkflowService?: TrendNotificationWorkflowService,
+    @Optional()
+    @Inject(LEGACY_CRON_JOB_EXECUTOR)
+    private readonly legacyCronJobExecutor?: LegacyCronJobExecutor,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -309,6 +317,7 @@ export class WorkflowEngineAdapterService {
     this.registerContentProductionExecutors();
     this.registerReplyPollingExecutors();
     this.registerTrendNotificationExecutors();
+    this.registerLegacyCronJobExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
     this.registerSendEmailExecutor();
@@ -998,6 +1007,55 @@ export class WorkflowEngineAdapterService {
       status: 'skipped',
       trends: 0,
     };
+  }
+
+  private registerLegacyCronJobExecutors(): void {
+    this.engine.registerExecutor('legacyCronJob', (node, _inputs, context) => {
+      if (!this.legacyCronJobExecutor) {
+        return this.legacyCronJobUnavailable(context, 'cron_jobs_unavailable');
+      }
+
+      const legacyCronJobId = this.readConfigString(
+        node.config,
+        'legacyCronJobId',
+      );
+      const jobType = this.readConfigString(node.config, 'jobType');
+      if (!legacyCronJobId || !this.isLegacyCronJobType(jobType)) {
+        return this.legacyCronJobUnavailable(
+          context,
+          'legacy_cron_job_config_invalid',
+        );
+      }
+
+      return this.legacyCronJobExecutor.executeMigratedLegacyCronJob({
+        legacyCronJobId,
+        organizationId: context.organizationId,
+        userId: context.userId,
+      });
+    });
+  }
+
+  private async legacyCronJobUnavailable(
+    context: ExecutionContext,
+    reason: string,
+  ): Promise<Record<string, unknown>> {
+    return {
+      action: 'legacyCronJob',
+      organizationId: context.organizationId,
+      reason,
+      skipped: 1,
+      status: 'skipped',
+    };
+  }
+
+  private isLegacyCronJobType(
+    jobType: string | undefined,
+  ): jobType is CronJobType {
+    return (
+      jobType === 'workflow_execution' ||
+      jobType === 'agent_strategy_execution' ||
+      jobType === 'newsletter_substack'
+    );
   }
 
   private isTrendNotificationCadence(

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -12,6 +12,7 @@ import { CaptionsModule } from '@api/collections/captions/captions.module';
 import { ContentSchedulesModule } from '@api/collections/content-schedules/content-schedules.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
 import { CreditsModule } from '@api/collections/credits/credits.module';
+import { CronJobsModule } from '@api/collections/cron-jobs/cron-jobs.module';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
 import { MusicsModule } from '@api/collections/musics/musics.module';
@@ -108,6 +109,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => ContentOrchestrationModule),
     forwardRef(() => ContentSchedulesModule),
     forwardRef(() => CredentialsCoreModule),
+    forwardRef(() => CronJobsModule),
     forwardRef(() => CreditsModule),
     forwardRef(() => ElevenLabsModule),
     forwardRef(() => GoogleAdsModule),


### PR DESCRIPTION
## Summary
- add an idempotent legacy cron-jobs to workflows migration with dry-run/live reporting
- create scheduled workflow rows backed by a disabled legacy adapter node, preserving schedule/timezone/enabled state while keeping webhook secrets server-side on the legacy row until the retirement follow-up
- mark migrated legacy rows so scheduled and manual legacy execution paths ignore them
- register the workflow engine legacyCronJob executor through a narrow DI token to avoid module import cycles

## Verification
- bunx vitest run --config vitest.config.ts src/collections/cron-jobs/services/cron-jobs.service.spec.ts
- bunx vitest run --config vitest.config.ts src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
- bunx turbo run type-check --filter=@genfeedai/api --force
- bun run check:architecture
- bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/workers --force
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js
- gitleaks protect --staged --redact --no-banner
- gitleaks detect --source . --log-opts="HEAD~1..HEAD" --redact --no-banner
- secretlint on staged and committed files

Closes #789.
Part of #698.