### PR TITLE
[codex] Replace superadmin flag with platform role

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth-access.util.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth-access.util.ts
@@ -1,0 +1,8 @@
+import { PlatformRole } from '@genfeedai/enums';
+
+export function isPlatformSuperAdmin(platformRole: unknown): boolean {
+  return (
+    typeof platformRole === 'string' &&
+    platformRole.toUpperCase() === PlatformRole.SUPERADMIN
+  );
+}

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveBetterAuthJwtOrganizationId } from './better-auth.factory';
+import {
+  resolveBetterAuthJwtAccess,
+  resolveBetterAuthJwtIsSuperAdmin,
+  resolveBetterAuthJwtOrganizationId,
+} from './better-auth.factory';
 import type { ICreateBetterAuthOptions } from './better-auth.types';
 
 type PrismaForBetterAuth = ICreateBetterAuthOptions['prisma'];
@@ -122,5 +126,58 @@ describe('resolveBetterAuthJwtOrganizationId', () => {
         'user_4',
       ),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('resolveBetterAuthJwtIsSuperAdmin', () => {
+  it('derives signed superadmin compatibility claims from platformRole', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue({
+      platformRole: 'SUPERADMIN',
+    });
+
+    await expect(
+      resolveBetterAuthJwtIsSuperAdmin(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_superadmin',
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('does not grant superadmin for default platform users', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue({
+      platformRole: 'USER',
+    });
+
+    await expect(
+      resolveBetterAuthJwtIsSuperAdmin(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_org_admin',
+      ),
+    ).resolves.toBe(false);
+  });
+});
+
+describe('resolveBetterAuthJwtAccess', () => {
+  it('resolves active organization and superadmin compatibility from one user lookup', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findUnique.mockResolvedValue({
+      lastUsedOrganizationId: 'org_active',
+      platformRole: 'SUPERADMIN',
+    });
+    prisma.organization.findFirst.mockResolvedValue({ id: 'org_active' });
+
+    await expect(
+      resolveBetterAuthJwtAccess(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_superadmin',
+      ),
+    ).resolves.toEqual({
+      isSuperAdmin: true,
+      organizationId: 'org_active',
+    });
+
+    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -17,7 +17,7 @@ function createPrismaMock() {
       findFirst: vi.fn(),
     },
     user: {
-      findUnique: vi.fn(),
+      findFirst: vi.fn(),
     },
   };
 }
@@ -25,7 +25,7 @@ function createPrismaMock() {
 describe('resolveBetterAuthJwtOrganizationId', () => {
   it('prefers lastUsedOrganizationId when the user can access it', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue({
+    prisma.user.findFirst.mockResolvedValue({
       lastUsedOrganizationId: 'org_active',
     });
     prisma.organization.findFirst.mockResolvedValue({ id: 'org_active' });
@@ -37,6 +37,10 @@ describe('resolveBetterAuthJwtOrganizationId', () => {
       ),
     ).resolves.toBe('org_active');
 
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      select: { lastUsedOrganizationId: true },
+      where: { id: 'user_1', isDeleted: false },
+    });
     expect(prisma.organization.findFirst).toHaveBeenCalledWith({
       select: { id: true },
       where: {
@@ -61,7 +65,7 @@ describe('resolveBetterAuthJwtOrganizationId', () => {
 
   it('falls back to an owned organization when lastUsedOrganizationId is inaccessible', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue({
+    prisma.user.findFirst.mockResolvedValue({
       lastUsedOrganizationId: 'org_stale',
     });
     prisma.organization.findFirst
@@ -87,7 +91,7 @@ describe('resolveBetterAuthJwtOrganizationId', () => {
 
   it('falls back to an active membership organization when the user owns none', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue({
+    prisma.user.findFirst.mockResolvedValue({
       lastUsedOrganizationId: null,
     });
     prisma.organization.findFirst.mockResolvedValue(null);
@@ -116,7 +120,7 @@ describe('resolveBetterAuthJwtOrganizationId', () => {
 
   it('returns undefined when no accessible organization exists', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.user.findFirst.mockResolvedValue(null);
     prisma.organization.findFirst.mockResolvedValue(null);
     prisma.member.findFirst.mockResolvedValue(null);
 
@@ -126,13 +130,16 @@ describe('resolveBetterAuthJwtOrganizationId', () => {
         'user_4',
       ),
     ).resolves.toBeUndefined();
+
+    expect(prisma.organization.findFirst).not.toHaveBeenCalled();
+    expect(prisma.member.findFirst).not.toHaveBeenCalled();
   });
 });
 
 describe('resolveBetterAuthJwtIsSuperAdmin', () => {
   it('derives signed superadmin compatibility claims from platformRole', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue({
+    prisma.user.findFirst.mockResolvedValue({
       platformRole: 'SUPERADMIN',
     });
 
@@ -142,11 +149,16 @@ describe('resolveBetterAuthJwtIsSuperAdmin', () => {
         'user_superadmin',
       ),
     ).resolves.toBe(true);
+
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      select: { platformRole: true },
+      where: { id: 'user_superadmin', isDeleted: false },
+    });
   });
 
   it('does not grant superadmin for default platform users', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue({
+    prisma.user.findFirst.mockResolvedValue({
       platformRole: 'USER',
     });
 
@@ -162,7 +174,7 @@ describe('resolveBetterAuthJwtIsSuperAdmin', () => {
 describe('resolveBetterAuthJwtAccess', () => {
   it('resolves active organization and superadmin compatibility from one user lookup', async () => {
     const prisma = createPrismaMock();
-    prisma.user.findUnique.mockResolvedValue({
+    prisma.user.findFirst.mockResolvedValue({
       lastUsedOrganizationId: 'org_active',
       platformRole: 'SUPERADMIN',
     });
@@ -178,6 +190,24 @@ describe('resolveBetterAuthJwtAccess', () => {
       organizationId: 'org_active',
     });
 
-    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      select: { lastUsedOrganizationId: true, platformRole: true },
+      where: { id: 'user_superadmin', isDeleted: false },
+    });
+  });
+
+  it('fails closed when the user is missing or soft-deleted', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findFirst.mockResolvedValue(null);
+
+    await expect(
+      resolveBetterAuthJwtAccess(
+        prisma as unknown as PrismaForBetterAuth,
+        'user_deleted',
+      ),
+    ).resolves.toEqual({ isSuperAdmin: false });
+
+    expect(prisma.organization.findFirst).not.toHaveBeenCalled();
+    expect(prisma.member.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { dash } from '@better-auth/infra';
+import { PlatformRole } from '@genfeedai/enums';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
@@ -10,6 +11,13 @@ import type { ICreateBetterAuthOptions } from './better-auth.types';
 
 function getString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isPlatformSuperAdmin(platformRole: unknown): boolean {
+  return (
+    typeof platformRole === 'string' &&
+    platformRole.toUpperCase() === PlatformRole.SUPERADMIN
+  );
 }
 
 /**
@@ -46,7 +54,19 @@ export async function resolveBetterAuthJwtOrganizationId(
     where: { id: userId },
   });
 
-  const lastUsedOrganizationId = getString(user?.lastUsedOrganizationId);
+  return resolveBetterAuthJwtOrganizationIdFromLastUsed(
+    prisma,
+    userId,
+    user?.lastUsedOrganizationId,
+  );
+}
+
+async function resolveBetterAuthJwtOrganizationIdFromLastUsed(
+  prisma: ICreateBetterAuthOptions['prisma'],
+  userId: string,
+  lastUsedOrganizationIdValue: unknown,
+): Promise<string | undefined> {
+  const lastUsedOrganizationId = getString(lastUsedOrganizationIdValue);
   if (lastUsedOrganizationId) {
     const activeOrganization = await prisma.organization.findFirst({
       select: { id: true },
@@ -96,6 +116,36 @@ export async function resolveBetterAuthJwtOrganizationId(
   });
 
   return getString(membership?.organizationId);
+}
+
+export async function resolveBetterAuthJwtAccess(
+  prisma: ICreateBetterAuthOptions['prisma'],
+  userId: string,
+): Promise<{ isSuperAdmin: boolean; organizationId?: string }> {
+  const user = await prisma.user.findUnique({
+    select: { lastUsedOrganizationId: true, platformRole: true },
+    where: { id: userId },
+  });
+  const isSuperAdmin = isPlatformSuperAdmin(user?.platformRole);
+  const organizationId = await resolveBetterAuthJwtOrganizationIdFromLastUsed(
+    prisma,
+    userId,
+    user?.lastUsedOrganizationId,
+  );
+
+  return organizationId ? { isSuperAdmin, organizationId } : { isSuperAdmin };
+}
+
+export async function resolveBetterAuthJwtIsSuperAdmin(
+  prisma: ICreateBetterAuthOptions['prisma'],
+  userId: string,
+): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    select: { platformRole: true },
+    where: { id: userId },
+  });
+
+  return isPlatformSuperAdmin(user?.platformRole);
 }
 
 /**
@@ -199,14 +249,15 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
           definePayload: async ({ user }) => {
             const typed = user as unknown as IBetterAuthJwtUserPayloadSource;
             const userId = getString(typed.id);
-            const organizationId = userId
-              ? await resolveBetterAuthJwtOrganizationId(prisma, userId)
-              : undefined;
+            const access: { isSuperAdmin: boolean; organizationId?: string } =
+              userId
+                ? await resolveBetterAuthJwtAccess(prisma, userId)
+                : { isSuperAdmin: false };
             return {
               email: typed.email ?? undefined,
               name: typed.name ?? undefined,
-              organizationId,
-              isSuperAdmin: typed.isSuperAdmin === true,
+              organizationId: access.organizationId,
+              isSuperAdmin: access.isSuperAdmin,
             };
           },
         },

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,23 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import { dash } from '@better-auth/infra';
-import { PlatformRole } from '@genfeedai/enums';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { jwt, magicLink } from 'better-auth/plugins';
-
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
 import type { ICreateBetterAuthOptions } from './better-auth.types';
+import { isPlatformSuperAdmin } from './better-auth-access.util';
 
 function getString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function isPlatformSuperAdmin(platformRole: unknown): boolean {
-  return (
-    typeof platformRole === 'string' &&
-    platformRole.toUpperCase() === PlatformRole.SUPERADMIN
-  );
 }
 
 /**
@@ -49,10 +41,13 @@ export async function resolveBetterAuthJwtOrganizationId(
   prisma: ICreateBetterAuthOptions['prisma'],
   userId: string,
 ): Promise<string | undefined> {
-  const user = await prisma.user.findUnique({
+  const user = await prisma.user.findFirst({
     select: { lastUsedOrganizationId: true },
-    where: { id: userId },
+    where: { id: userId, isDeleted: false },
   });
+  if (!user) {
+    return undefined;
+  }
 
   return resolveBetterAuthJwtOrganizationIdFromLastUsed(
     prisma,
@@ -122,10 +117,14 @@ export async function resolveBetterAuthJwtAccess(
   prisma: ICreateBetterAuthOptions['prisma'],
   userId: string,
 ): Promise<{ isSuperAdmin: boolean; organizationId?: string }> {
-  const user = await prisma.user.findUnique({
+  const user = await prisma.user.findFirst({
     select: { lastUsedOrganizationId: true, platformRole: true },
-    where: { id: userId },
+    where: { id: userId, isDeleted: false },
   });
+  if (!user) {
+    return { isSuperAdmin: false };
+  }
+
   const isSuperAdmin = isPlatformSuperAdmin(user?.platformRole);
   const organizationId = await resolveBetterAuthJwtOrganizationIdFromLastUsed(
     prisma,
@@ -140,9 +139,9 @@ export async function resolveBetterAuthJwtIsSuperAdmin(
   prisma: ICreateBetterAuthOptions['prisma'],
   userId: string,
 ): Promise<boolean> {
-  const user = await prisma.user.findUnique({
+  const user = await prisma.user.findFirst({
     select: { platformRole: true },
-    where: { id: userId },
+    where: { id: userId, isDeleted: false },
   });
 
   return isPlatformSuperAdmin(user?.platformRole);

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -29,9 +29,9 @@ export interface IBetterAuthJwtClaims {
 
 /**
  * Genfeed identity resolved from a verified Better Auth JWT. Mirrors the subset
- * of `IAuthPublicMetadata` that `RequestContextMiddleware` reads; subscription
- * tier / status are filled by the middleware from the DB, so they are not
- * resolved here.
+ * of `IAuthPublicMetadata` that `RequestContextMiddleware` reads. The
+ * compatibility `isSuperAdmin` boolean is derived from the persisted platform
+ * role; subscription tier / status are filled by the middleware from the DB.
  */
 export interface IBetterAuthResolvedIdentity {
   userId: string;

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
@@ -36,10 +36,10 @@ describe('BetterAuthIdentityResolverService', () => {
     );
   });
 
-  it('resolves the owner organization and its first brand, carrying isSuperAdmin', async () => {
+  it('resolves the owner organization and its first brand, deriving isSuperAdmin from the platform role', async () => {
     usersService.findOne.mockResolvedValue({
       id: 'user_1',
-      isSuperAdmin: true,
+      platformRole: 'SUPERADMIN',
     });
     organizationsService.findOne.mockResolvedValue({ id: 'org_1' });
     brandsService.findOne.mockResolvedValue({ id: 'brand_1' });
@@ -55,6 +55,32 @@ describe('BetterAuthIdentityResolverService', () => {
     expect(organizationsService.findOne).toHaveBeenCalledWith({
       isDeleted: false,
       user: 'user_1',
+    });
+  });
+
+  it('does not treat organization admins as platform superadmins', async () => {
+    usersService.findOne.mockResolvedValue({
+      id: 'user_org_admin',
+      platformRole: 'USER',
+    });
+    membersService.find.mockResolvedValue([
+      {
+        organizationId: 'org_admin',
+        role: { key: 'admin' },
+      },
+    ]);
+    organizationsService.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'org_admin' });
+    brandsService.findOne.mockResolvedValue({ id: 'brand_admin' });
+
+    const identity = await resolver.resolve('user_org_admin');
+
+    expect(identity).toEqual({
+      brandId: 'brand_admin',
+      isSuperAdmin: false,
+      organizationId: 'org_admin',
+      userId: 'user_org_admin',
     });
   });
 

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
@@ -34,6 +34,10 @@ describe('BetterAuthIdentityResolverService', () => {
     await expect(resolver.resolve('missing')).rejects.toBeInstanceOf(
       UnauthorizedException,
     );
+    expect(usersService.findOne).toHaveBeenCalledWith(
+      { _id: 'missing', isDeleted: false },
+      [],
+    );
   });
 
   it('resolves the owner organization and its first brand, deriving isSuperAdmin from the platform role', async () => {
@@ -56,6 +60,10 @@ describe('BetterAuthIdentityResolverService', () => {
       isDeleted: false,
       user: 'user_1',
     });
+    expect(usersService.findOne).toHaveBeenCalledWith(
+      { _id: 'user_1', isDeleted: false },
+      [],
+    );
   });
 
   it('does not treat organization admins as platform superadmins', async () => {

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
@@ -3,10 +3,9 @@ import type { MemberDocument } from '@api/collections/members/schemas/member.sch
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { UsersService } from '@api/collections/users/services/users.service';
-import { PlatformRole } from '@genfeedai/enums';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-
 import type { IBetterAuthResolvedIdentity } from '../better-auth.types';
+import { isPlatformSuperAdmin } from '../better-auth-access.util';
 
 function getRecordId(
   record: Record<string, unknown> | null | undefined,
@@ -26,13 +25,6 @@ function getMemberOrganizationId(member: MemberDocument): string {
   const record = member as unknown as Record<string, unknown>;
   return (
     getRecordId(record, 'organizationId') || getRecordId(record, 'organization')
-  );
-}
-
-function isPlatformSuperAdmin(platformRole: unknown): boolean {
-  return (
-    typeof platformRole === 'string' &&
-    platformRole.toUpperCase() === PlatformRole.SUPERADMIN
   );
 }
 
@@ -57,7 +49,10 @@ export class BetterAuthIdentityResolverService {
   ) {}
 
   async resolve(userId: string): Promise<IBetterAuthResolvedIdentity> {
-    const user = await this.usersService.findOne({ _id: userId }, []);
+    const user = await this.usersService.findOne(
+      { _id: userId, isDeleted: false },
+      [],
+    );
     const userRecord = user as Record<string, unknown> | null | undefined;
     const resolvedUserId = getEntityId(userRecord);
 

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
@@ -3,6 +3,7 @@ import type { MemberDocument } from '@api/collections/members/schemas/member.sch
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { UsersService } from '@api/collections/users/services/users.service';
+import { PlatformRole } from '@genfeedai/enums';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 
 import type { IBetterAuthResolvedIdentity } from '../better-auth.types';
@@ -25,6 +26,13 @@ function getMemberOrganizationId(member: MemberDocument): string {
   const record = member as unknown as Record<string, unknown>;
   return (
     getRecordId(record, 'organizationId') || getRecordId(record, 'organization')
+  );
+}
+
+function isPlatformSuperAdmin(platformRole: unknown): boolean {
+  return (
+    typeof platformRole === 'string' &&
+    platformRole.toUpperCase() === PlatformRole.SUPERADMIN
   );
 }
 
@@ -57,7 +65,7 @@ export class BetterAuthIdentityResolverService {
       throw new UnauthorizedException('User account not found');
     }
 
-    const isSuperAdmin = userRecord?.isSuperAdmin === true;
+    const isSuperAdmin = isPlatformSuperAdmin(userRecord?.platformRole);
     const lastUsedOrganizationId = getRecordId(
       userRecord,
       'lastUsedOrganizationId',

--- a/apps/server/api/src/collections/users/entities/user.entity.ts
+++ b/apps/server/api/src/collections/users/entities/user.entity.ts
@@ -14,7 +14,7 @@ export class UserEntity extends BaseEntity implements User {
   // Better Auth (epic #735) — first-party identity columns on the User model.
   declare readonly name: string | null;
   declare readonly emailVerified: boolean;
-  declare readonly isSuperAdmin: boolean;
+  declare readonly platformRole: User['platformRole'];
 
   declare readonly isInvited: boolean;
 

--- a/apps/server/api/src/common/guards/super-admin.guard.spec.ts
+++ b/apps/server/api/src/common/guards/super-admin.guard.spec.ts
@@ -28,14 +28,14 @@ describe('SuperAdminGuard', () => {
     expect(() => guard.canActivate(ctx as never)).toThrow(ForbiddenException);
   });
 
-  it('authenticated user publicMetadata.isSuperAdmin = true → passes without request context', () => {
+  it('authenticated user publicMetadata.isSuperAdmin = true without request context → ForbiddenException', () => {
     const ctx = buildContext({
       user: {
         publicMetadata: { isSuperAdmin: true },
       },
     });
 
-    expect(guard.canActivate(ctx as never)).toBe(true);
+    expect(() => guard.canActivate(ctx as never)).toThrow(ForbiddenException);
   });
 
   it('missing superadmin context and user metadata → ForbiddenException', () => {

--- a/apps/server/api/src/common/guards/super-admin.guard.spec.ts
+++ b/apps/server/api/src/common/guards/super-admin.guard.spec.ts
@@ -28,7 +28,17 @@ describe('SuperAdminGuard', () => {
     expect(() => guard.canActivate(ctx as never)).toThrow(ForbiddenException);
   });
 
-  it('req.context missing → ForbiddenException', () => {
+  it('authenticated user publicMetadata.isSuperAdmin = true → passes without request context', () => {
+    const ctx = buildContext({
+      user: {
+        publicMetadata: { isSuperAdmin: true },
+      },
+    });
+
+    expect(guard.canActivate(ctx as never)).toBe(true);
+  });
+
+  it('missing superadmin context and user metadata → ForbiddenException', () => {
     const ctx = buildContext({});
     expect(() => guard.canActivate(ctx as never)).toThrow(ForbiddenException);
   });

--- a/apps/server/api/src/common/guards/super-admin.guard.ts
+++ b/apps/server/api/src/common/guards/super-admin.guard.ts
@@ -1,4 +1,5 @@
 import type { RequestWithContext } from '@api/common/middleware/request-context.middleware';
+import { getIsSuperAdmin } from '@api/helpers/utils/auth/auth.util';
 import {
   type CanActivate,
   type ExecutionContext,
@@ -11,11 +12,7 @@ export class SuperAdminGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest<RequestWithContext>();
 
-    if (!req.context) {
-      throw new ForbiddenException('Request context not available');
-    }
-
-    if (!req.context.isSuperAdmin) {
+    if (!getIsSuperAdmin(req.user, req)) {
       throw new ForbiddenException('Super admin access required');
     }
 

--- a/apps/server/api/src/common/guards/super-admin.guard.ts
+++ b/apps/server/api/src/common/guards/super-admin.guard.ts
@@ -1,5 +1,4 @@
 import type { RequestWithContext } from '@api/common/middleware/request-context.middleware';
-import { getIsSuperAdmin } from '@api/helpers/utils/auth/auth.util';
 import {
   type CanActivate,
   type ExecutionContext,
@@ -12,7 +11,7 @@ export class SuperAdminGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest<RequestWithContext>();
 
-    if (!getIsSuperAdmin(req.user, req)) {
+    if (req.context?.isSuperAdmin !== true) {
       throw new ForbiddenException('Super admin access required');
     }
 

--- a/apps/server/api/src/endpoints/admin/announcements/announcements.controller.spec.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.controller.spec.ts
@@ -1,5 +1,7 @@
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import type { BroadcastAnnouncementDto } from '@api/endpoints/admin/announcements/dto/broadcast-announcement.dto';
 import { LoggerService } from '@libs/logger/logger.service';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnnouncementsController } from './announcements.controller';
@@ -88,6 +90,8 @@ describe('AnnouncementsController', () => {
     })
       .overrideGuard('IpWhitelistGuard')
       .useValue({ canActivate: () => true })
+      .overrideGuard(SuperAdminGuard)
+      .useValue({ canActivate: () => true })
       .compile();
 
     controller = module.get<AnnouncementsController>(AnnouncementsController);
@@ -95,6 +99,16 @@ describe('AnnouncementsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('requires IP whitelist and platform superadmin guards', () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      AnnouncementsController,
+    );
+
+    expect(guards).toHaveLength(2);
+    expect(guards).toContain(SuperAdminGuard);
   });
 
   describe('broadcast()', () => {

--- a/apps/server/api/src/endpoints/admin/announcements/announcements.controller.spec.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.controller.spec.ts
@@ -1,5 +1,6 @@
 import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import type { BroadcastAnnouncementDto } from '@api/endpoints/admin/announcements/dto/broadcast-announcement.dto';
+import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
 import { LoggerService } from '@libs/logger/logger.service';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -107,8 +108,7 @@ describe('AnnouncementsController', () => {
       AnnouncementsController,
     );
 
-    expect(guards).toHaveLength(2);
-    expect(guards).toContain(SuperAdminGuard);
+    expect(guards).toEqual([IpWhitelistGuard, SuperAdminGuard]);
   });
 
   describe('broadcast()', () => {

--- a/apps/server/api/src/endpoints/admin/announcements/announcements.controller.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.controller.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import { AdminAnnouncementsService } from '@api/endpoints/admin/announcements/announcements.service';
 import { BroadcastAnnouncementDto } from '@api/endpoints/admin/announcements/dto/broadcast-announcement.dto';
 import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
@@ -26,7 +27,7 @@ import type { Request } from 'express';
 
 @ApiTags('Admin / Announcements')
 @Controller('admin/announcements')
-@UseGuards(IpWhitelistGuard)
+@UseGuards(IpWhitelistGuard, SuperAdminGuard)
 export class AnnouncementsController {
   constructor(
     private readonly adminAnnouncementsService: AdminAnnouncementsService,

--- a/apps/server/api/src/endpoints/admin/announcements/announcements.module.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.module.ts
@@ -1,5 +1,6 @@
 import { AnnouncementsCollectionModule } from '@api/collections/announcements/announcements.collection.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import { AnnouncementsController } from '@api/endpoints/admin/announcements/announcements.controller';
 import { AdminAnnouncementsService } from '@api/endpoints/admin/announcements/announcements.service';
 import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
@@ -11,6 +12,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => AnnouncementsCollectionModule),
     forwardRef(() => CredentialsCoreModule),
   ],
-  providers: [AdminAnnouncementsService, IpWhitelistGuard],
+  providers: [AdminAnnouncementsService, IpWhitelistGuard, SuperAdminGuard],
 })
 export class AdminAnnouncementsModule {}

--- a/apps/server/api/src/endpoints/admin/fleet/fleet.controller.spec.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/fleet.controller.spec.ts
@@ -21,6 +21,7 @@ vi.mock('@api/helpers/utils/objectid/objectid.util', () => ({
 }));
 
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import {
   BulkEc2ActionDto,
   CloudFrontInvalidateDto,
@@ -35,9 +36,11 @@ import {
 } from '@api/endpoints/admin/fleet/dto';
 import { AdminFleetController } from '@api/endpoints/admin/fleet/fleet.controller';
 import { AdminFleetService } from '@api/endpoints/admin/fleet/fleet.service';
+import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
 import { FleetService } from '@api/services/integrations/fleet/fleet.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { NotFoundException } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import type { Request } from 'express';
 
 describe('AdminFleetController', () => {
@@ -110,6 +113,12 @@ describe('AdminFleetController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('requires IP whitelist and platform superadmin guards', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, AdminFleetController);
+
+    expect(guards).toEqual([IpWhitelistGuard, SuperAdminGuard]);
   });
 
   describe('Characters', () => {

--- a/apps/server/api/src/endpoints/admin/fleet/fleet.controller.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/fleet.controller.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import {
   AdminFleetGenerateVoiceDto,
   BulkEc2ActionDto,
@@ -67,7 +68,7 @@ import type { Request } from 'express';
 
 @ApiTags('Admin / Fleet')
 @Controller(['admin/fleet', 'admin/darkroom'])
-@UseGuards(IpWhitelistGuard)
+@UseGuards(IpWhitelistGuard, SuperAdminGuard)
 export class AdminFleetController {
   constructor(
     private readonly adminFleetService: AdminFleetService,

--- a/apps/server/api/src/endpoints/admin/fleet/fleet.module.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/fleet.module.ts
@@ -7,6 +7,7 @@ import { ModelRegistrationService } from '@api/collections/models/services/model
 import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
 import { PersonasModule } from '@api/collections/personas/personas.module';
 import { TrainingsModule } from '@api/collections/trainings/trainings.module';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import { AdminFleetController } from '@api/endpoints/admin/fleet/fleet.controller';
 import { AdminFleetService } from '@api/endpoints/admin/fleet/fleet.service';
 import { AdminFleetAssetService } from '@api/endpoints/admin/fleet/services/fleet-asset.service';
@@ -65,6 +66,7 @@ import { forwardRef, Module } from '@nestjs/common';
     AdminFleetTrainingService,
     IpWhitelistGuard,
     ModelRegistrationService,
+    SuperAdminGuard,
   ],
 })
 export class AdminFleetModule {}

--- a/apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts
@@ -64,6 +64,24 @@ describe('RolesGuard', () => {
     );
   });
 
+  it('denies organization admins when a route requires platform superadmin', async () => {
+    vi.spyOn(reflector, 'get').mockReturnValue(['superadmin']);
+
+    const organizationId = 'b13yktd0f1e38me3f55swu0n';
+    const userId = 'hkh2jbovtpcsrzw3oyxr11oj';
+    const context = createContext({
+      publicMetadata: {
+        isSuperAdmin: false,
+        organization: organizationId,
+        role: 'admin',
+        user: userId,
+      },
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(HttpException);
+    expect(mockMembersService.findOne).not.toHaveBeenCalled();
+  });
+
   it('throws forbidden when organization context exists but user metadata is invalid', async () => {
     vi.spyOn(reflector, 'get').mockReturnValue(undefined);
 

--- a/apps/server/api/src/services/ai-influencer/ai-influencer.controller.spec.ts
+++ b/apps/server/api/src/services/ai-influencer/ai-influencer.controller.spec.ts
@@ -1,7 +1,9 @@
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
 import { AiInfluencerController } from '@api/services/ai-influencer/ai-influencer.controller';
 import { AiInfluencerService } from '@api/services/ai-influencer/ai-influencer.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 describe('AiInfluencerController', () => {
@@ -34,6 +36,8 @@ describe('AiInfluencerController', () => {
     })
       .overrideGuard(IpWhitelistGuard)
       .useValue({ canActivate: () => true })
+      .overrideGuard(SuperAdminGuard)
+      .useValue({ canActivate: () => true })
       .compile();
 
     controller = module.get(AiInfluencerController);
@@ -41,6 +45,12 @@ describe('AiInfluencerController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('requires IP whitelist and platform superadmin guards', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, AiInfluencerController);
+
+    expect(guards).toEqual([IpWhitelistGuard, SuperAdminGuard]);
   });
 
   describe('generatePost', () => {

--- a/apps/server/api/src/services/ai-influencer/ai-influencer.controller.ts
+++ b/apps/server/api/src/services/ai-influencer/ai-influencer.controller.ts
@@ -1,3 +1,4 @@
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
 import { ErrorResponse } from '@api/helpers/utils/error-response/error-response.util';
 import { AiInfluencerService } from '@api/services/ai-influencer/ai-influencer.service';
@@ -20,7 +21,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Admin / AI Influencer')
 @Controller('admin/ai-influencer')
-@UseGuards(IpWhitelistGuard)
+@UseGuards(IpWhitelistGuard, SuperAdminGuard)
 export class AiInfluencerController {
   constructor(
     private readonly aiInfluencerService: AiInfluencerService,

--- a/apps/server/api/src/services/ai-influencer/ai-influencer.module.ts
+++ b/apps/server/api/src/services/ai-influencer/ai-influencer.module.ts
@@ -1,5 +1,6 @@
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { PersonasModule } from '@api/collections/personas/personas.module';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
 import { ConfigModule } from '@api/config/config.module';
 import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
 import { AiInfluencerController } from '@api/services/ai-influencer/ai-influencer.controller';
@@ -26,6 +27,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => TwitterModule),
     forwardRef(() => PersonaContentModule),
   ],
-  providers: [AiInfluencerService, IpWhitelistGuard],
+  providers: [AiInfluencerService, IpWhitelistGuard, SuperAdminGuard],
 })
 export class AiInfluencerModule {}

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -41,6 +41,9 @@ summary; the canonical, decision-of-record version is the ADR at
   credits on the cloud and use the issued API key against the cloud
   `/v1/managed-inference` endpoint. A self-hosted instance does not sell credits
   locally.
+- **SaaS admin access is a platform role.** `/admin` is gated by
+  `users.platformRole = 'SUPERADMIN'`, separate from organization owner/admin
+  roles. See [Platform Admin Role](platform-admin-role.md).
 
 ## See also
 

--- a/docs/platform-admin-role.md
+++ b/docs/platform-admin-role.md
@@ -1,0 +1,35 @@
+# Platform Admin Role
+
+SaaS control-plane access is stored on `users.platformRole`, not on organization
+membership. Organization owners/admins do not receive `/admin` access unless
+their user row has `platformRole = 'SUPERADMIN'`.
+
+## Initial Assignment Runbook
+
+The migration `20260624120000_replace_superadmin_flag_with_platform_role`
+backfills legacy `isSuperAdmin = true` rows and assigns
+`vincent@genfeed.ai` as the intended initial platform administrator.
+
+Dry-run verification:
+
+```sql
+BEGIN;
+
+UPDATE "users"
+SET "platformRole" = 'SUPERADMIN'
+WHERE lower("email") = lower('vincent@genfeed.ai')
+RETURNING "id", "email", "platformRole";
+
+SELECT "id", "email", "platformRole"
+FROM "users"
+WHERE "platformRole" = 'SUPERADMIN'
+ORDER BY "email";
+
+ROLLBACK;
+```
+
+Expected result: exactly one row, `vincent@genfeed.ai`.
+
+If production verification after deploy shows no platform administrator, rerun
+the `UPDATE ... RETURNING` statement above inside a transaction and `COMMIT`
+only after the returned row is the intended account.

--- a/docs/platform-admin-role.md
+++ b/docs/platform-admin-role.md
@@ -28,8 +28,9 @@ ORDER BY "email";
 ROLLBACK;
 ```
 
-Expected result: exactly one row, `vincent@genfeed.ai`.
+Expected result: `vincent@genfeed.ai` is present as a `SUPERADMIN`; other rows
+may also appear if they were backfilled from legacy `isSuperAdmin = true`.
 
 If production verification after deploy shows no platform administrator, rerun
 the `UPDATE ... RETURNING` statement above inside a transaction and `COMMIT`
-only after the returned row is the intended account.
+only after the returned row is exactly the intended `vincent@genfeed.ai` account.

--- a/packages/enums/__tests__/platform-role.enum.test.ts
+++ b/packages/enums/__tests__/platform-role.enum.test.ts
@@ -1,5 +1,5 @@
+import { PlatformRole } from '@genfeedai/enums';
 import { describe, expect, it } from 'vitest';
-import { PlatformRole } from '../src/platform-role.enum';
 
 describe('platform-role.enum', () => {
   describe('PlatformRole', () => {

--- a/packages/enums/__tests__/platform-role.enum.test.ts
+++ b/packages/enums/__tests__/platform-role.enum.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { PlatformRole } from '../src/platform-role.enum';
+
+describe('platform-role.enum', () => {
+  describe('PlatformRole', () => {
+    it('has default user and superadmin members', () => {
+      expect(Object.values(PlatformRole)).toEqual(['USER', 'SUPERADMIN']);
+    });
+  });
+});

--- a/packages/enums/src/index.ts
+++ b/packages/enums/src/index.ts
@@ -71,6 +71,7 @@ export * from './page-scope.enum';
 export * from './parse-mode.enum';
 export * from './persona.enum';
 export * from './platform.enum';
+export * from './platform-role.enum';
 export * from './post.enum';
 export * from './priority.enum';
 export * from './prompt.enum';

--- a/packages/enums/src/platform-role.enum.ts
+++ b/packages/enums/src/platform-role.enum.ts
@@ -1,0 +1,4 @@
+export enum PlatformRole {
+  USER = 'USER',
+  SUPERADMIN = 'SUPERADMIN',
+}

--- a/packages/enums/vitest.config.ts
+++ b/packages/enums/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: '@genfeedai/enums',
+        replacement: path.resolve(__dirname, 'src/index.ts'),
+      },
+      {
         find: '@genfeedai/constants',
         replacement: path.resolve(__dirname, '../constants/src/index.ts'),
       },

--- a/packages/interfaces/src/auth/better-auth.interface.ts
+++ b/packages/interfaces/src/auth/better-auth.interface.ts
@@ -8,7 +8,7 @@ export interface IBetterAuthJwtUserPayloadSource {
   id?: string;
   email?: string | null;
   name?: string | null;
-  isSuperAdmin?: boolean;
+  platformRole?: string | null;
 }
 
 export interface IBetterAuthVerifiedClaims {

--- a/packages/interfaces/src/auth/better-auth.interface.ts
+++ b/packages/interfaces/src/auth/better-auth.interface.ts
@@ -1,3 +1,5 @@
+import type { PlatformRole } from '@genfeedai/enums';
+
 export interface IBetterAuthJwksVerifierOptions {
   audience: string;
   issuer: string;
@@ -8,7 +10,7 @@ export interface IBetterAuthJwtUserPayloadSource {
   id?: string;
   email?: string | null;
   name?: string | null;
-  platformRole?: string | null;
+  platformRole?: PlatformRole | null;
 }
 
 export interface IBetterAuthVerifiedClaims {

--- a/packages/prisma/prisma/migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql
+++ b/packages/prisma/prisma/migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql
@@ -10,25 +10,14 @@ SET "platformRole" = 'SUPERADMIN'
 WHERE "isSuperAdmin" = true;
 
 -- InitialPlatformAdmin
-DO $$
-DECLARE
-  bootstrap_match_count integer;
-BEGIN
-  SELECT COUNT(*)
-  INTO bootstrap_match_count
-  FROM "users"
-  WHERE lower("email") = lower('vincent@genfeed.ai');
-
-  IF bootstrap_match_count <> 1 THEN
-    RAISE EXCEPTION
-      'Expected exactly one bootstrap superadmin account for vincent@genfeed.ai, found %',
-      bootstrap_match_count;
-  END IF;
-
-  UPDATE "users"
-  SET "platformRole" = 'SUPERADMIN'
-  WHERE lower("email") = lower('vincent@genfeed.ai');
-END $$;
+-- Bootstrap the initial platform superadmin when that account exists. This is a
+-- no-op on databases that do not have it (fresh installs, community/self-hosted
+-- deployments, ephemeral CI test DBs), so `prisma migrate deploy` stays portable
+-- across every deployment mode instead of aborting when the account is absent.
+-- The users.email unique index guarantees this matches at most one row.
+UPDATE "users"
+SET "platformRole" = 'SUPERADMIN'
+WHERE lower("email") = lower('vincent@genfeed.ai');
 
 -- DropFlag
 ALTER TABLE "users" DROP COLUMN "isSuperAdmin";

--- a/packages/prisma/prisma/migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql
+++ b/packages/prisma/prisma/migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql
@@ -1,0 +1,18 @@
+-- CreateEnum
+CREATE TYPE "PlatformRole" AS ENUM ('USER', 'SUPERADMIN');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "platformRole" "PlatformRole" NOT NULL DEFAULT 'USER';
+
+-- BackfillRole
+UPDATE "users"
+SET "platformRole" = 'SUPERADMIN'
+WHERE "isSuperAdmin" = true;
+
+-- InitialPlatformAdmin
+UPDATE "users"
+SET "platformRole" = 'SUPERADMIN'
+WHERE lower("email") = lower('vincent@genfeed.ai');
+
+-- DropFlag
+ALTER TABLE "users" DROP COLUMN "isSuperAdmin";

--- a/packages/prisma/prisma/migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql
+++ b/packages/prisma/prisma/migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql
@@ -10,9 +10,25 @@ SET "platformRole" = 'SUPERADMIN'
 WHERE "isSuperAdmin" = true;
 
 -- InitialPlatformAdmin
-UPDATE "users"
-SET "platformRole" = 'SUPERADMIN'
-WHERE lower("email") = lower('vincent@genfeed.ai');
+DO $$
+DECLARE
+  bootstrap_match_count integer;
+BEGIN
+  SELECT COUNT(*)
+  INTO bootstrap_match_count
+  FROM "users"
+  WHERE lower("email") = lower('vincent@genfeed.ai');
+
+  IF bootstrap_match_count <> 1 THEN
+    RAISE EXCEPTION
+      'Expected exactly one bootstrap superadmin account for vincent@genfeed.ai, found %',
+      bootstrap_match_count;
+  END IF;
+
+  UPDATE "users"
+  SET "platformRole" = 'SUPERADMIN'
+  WHERE lower("email") = lower('vincent@genfeed.ai');
+END $$;
 
 -- DropFlag
 ALTER TABLE "users" DROP COLUMN "isSuperAdmin";

--- a/packages/prisma/prisma/platform-role-migration.test.ts
+++ b/packages/prisma/prisma/platform-role-migration.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const prismaDir = join(process.cwd(), 'prisma');
+const prismaDir = fileURLToPath(new URL('./', import.meta.url));
 const schemaSource = readFileSync(join(prismaDir, 'schema.prisma'), 'utf8');
 const migrationSource = readFileSync(
   join(
@@ -25,6 +26,8 @@ describe('platform role migration', () => {
     );
     expect(migrationSource).toContain('WHERE "isSuperAdmin" = true');
     expect(migrationSource).toContain("lower('vincent@genfeed.ai')");
+    expect(migrationSource).toContain('bootstrap_match_count <> 1');
+    expect(migrationSource).toContain('Expected exactly one bootstrap');
     expect(migrationSource).toContain('DROP COLUMN "isSuperAdmin"');
   });
 });

--- a/packages/prisma/prisma/platform-role-migration.test.ts
+++ b/packages/prisma/prisma/platform-role-migration.test.ts
@@ -26,8 +26,15 @@ describe('platform role migration', () => {
     );
     expect(migrationSource).toContain('WHERE "isSuperAdmin" = true');
     expect(migrationSource).toContain("lower('vincent@genfeed.ai')");
-    expect(migrationSource).toContain('bootstrap_match_count <> 1');
-    expect(migrationSource).toContain('Expected exactly one bootstrap');
     expect(migrationSource).toContain('DROP COLUMN "isSuperAdmin"');
+  });
+
+  it('bootstraps the initial admin without aborting on databases that lack it', () => {
+    // The bootstrap must be a plain conditional UPDATE so `prisma migrate deploy`
+    // stays portable across fresh/community/CI databases instead of raising.
+    expect(migrationSource).not.toContain('RAISE EXCEPTION');
+    expect(migrationSource).toMatch(
+      /SET "platformRole" = 'SUPERADMIN'\s*\nWHERE lower\("email"\) = lower\('vincent@genfeed\.ai'\)/,
+    );
   });
 });

--- a/packages/prisma/prisma/platform-role-migration.test.ts
+++ b/packages/prisma/prisma/platform-role-migration.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const prismaDir = join(process.cwd(), 'prisma');
+const schemaSource = readFileSync(join(prismaDir, 'schema.prisma'), 'utf8');
+const migrationSource = readFileSync(
+  join(
+    prismaDir,
+    'migrations/20260624120000_replace_superadmin_flag_with_platform_role/migration.sql',
+  ),
+  'utf8',
+);
+
+describe('platform role migration', () => {
+  it('stores platform authorization as a role instead of a boolean flag', () => {
+    expect(schemaSource).toContain('enum PlatformRole');
+    expect(schemaSource).toContain('platformRole             PlatformRole');
+    expect(schemaSource).not.toContain('isSuperAdmin             Boolean');
+  });
+
+  it('backfills legacy superadmins and assigns the initial production admin', () => {
+    expect(migrationSource).toContain(
+      "CREATE TYPE \"PlatformRole\" AS ENUM ('USER', 'SUPERADMIN')",
+    );
+    expect(migrationSource).toContain('WHERE "isSuperAdmin" = true');
+    expect(migrationSource).toContain("lower('vincent@genfeed.ai')");
+    expect(migrationSource).toContain('DROP COLUMN "isSuperAdmin"');
+  });
+});

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -479,6 +479,11 @@ enum BatchStatus {
   FAILED
 }
 
+enum PlatformRole {
+  USER
+  SUPERADMIN
+}
+
 // ═══════════════════════════════════════════════════════════════
 // CORE IDENTITY — The ownership chain
 // User → Organization → Brand → Member
@@ -494,13 +499,11 @@ model User {
   email                    String?         @unique
   avatar                   String?
   // Better Auth (epic #735, dual-run beside legacy auth provider). `name`/`emailVerified` are
-  // the BA core user fields (BA `image` maps onto `avatar` above via config);
-  // `isSuperAdmin` moves the super-admin flag off legacy auth provider publicMetadata into the
-  // DB so it survives the legacy auth provider cutover. All nullable/defaulted so the migration
-  // applies cleanly over existing rows.
+  // the BA core user fields (BA `image` maps onto `avatar` above via config).
+  // Platform access is explicit and separate from organization/member roles.
   name                     String?
   emailVerified            Boolean         @default(false)
-  isSuperAdmin             Boolean         @default(false)
+  platformRole             PlatformRole    @default(USER)
   isDefault                Boolean         @default(false)
   isDeleted                Boolean         @default(false)
   isInvited                Boolean         @default(false)

--- a/packages/tools/src/registry/source/mcp-only/admin.tools.ts
+++ b/packages/tools/src/registry/source/mcp-only/admin.tools.ts
@@ -170,7 +170,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
   {
     creditCost: 0,
     description:
-      'Approve or decline a pending MCP write action that was queued for human review, executing it on approval. Pass the approvalId returned by the original (pending) tool call. Admin-only.',
+      'Approve or decline a pending MCP write action that was queued for human review, executing it on approval. Pass the approvalId returned by the original (pending) tool call. Superadmin-only.',
     name: 'resolve_approval',
     parameters: {
       properties: {

--- a/packages/tools/src/registry/source/mcp-only/admin.tools.ts
+++ b/packages/tools/src/registry/source/mcp-only/admin.tools.ts
@@ -10,7 +10,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       properties: {},
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -35,7 +35,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['action'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -46,7 +46,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       properties: {},
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -57,7 +57,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       properties: {},
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -74,7 +74,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['jobId'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -107,7 +107,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['handle'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -124,7 +124,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['jobId'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -142,7 +142,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['handle'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -164,7 +164,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['handle'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
   {
@@ -188,7 +188,7 @@ export const MCP_ADMIN_TOOLS: SourceTool[] = [
       required: ['approvalId', 'decision'],
       type: 'object',
     },
-    requiredRole: 'admin',
+    requiredRole: 'superadmin',
     surfaces: { agent: false, cliAgentVisible: false, mcp: true },
   },
 ];

--- a/packages/tools/src/registry/source/source-tools.test.ts
+++ b/packages/tools/src/registry/source/source-tools.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { AGENT_ONLY_TOOLS } from './agent-only/index.js';
 import { SOURCE_TOOLS } from './index.js';
+import { MCP_ADMIN_TOOLS } from './mcp-only/admin.tools.js';
 import { MCP_ONLY_TOOLS } from './mcp-only/index.js';
 import { OVERLAP_TOOLS } from './overlap.tools.js';
 
@@ -209,6 +210,13 @@ describe('SOURCE_TOOLS registry split (#692)', () => {
       expect(typeof tool.surfaces.agent).toBe('boolean');
       expect(typeof tool.surfaces.mcp).toBe('boolean');
     }
+  });
+
+  it('keeps MCP admin tools behind platform superadmin authorization', () => {
+    expect(MCP_ADMIN_TOOLS.length).toBeGreaterThan(0);
+    expect(
+      MCP_ADMIN_TOOLS.every((tool) => tool.requiredRole === 'superadmin'),
+    ).toBe(true);
   });
 
   it('keeps every data module within the line budget', () => {


### PR DESCRIPTION
## Summary
- replace persisted `User.isSuperAdmin` with `PlatformRole.USER` / `PlatformRole.SUPERADMIN`
- backfill legacy superadmins and assign `vincent@genfeed.ai` in the migration/runbook
- derive Better Auth compatibility `isSuperAdmin` from `platformRole`
- protect backend `/admin` control-plane routes and MCP admin tools with platform superadmin authorization

## Verification
- `bunx --bun prisma validate --config prisma.config.mjs`
- `bun run test:file src/auth/better-auth/better-auth.factory.spec.ts src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts src/auth/better-auth/passport/better-auth.strategy.spec.ts src/helpers/guards/roles/roles.guard.spec.ts src/common/guards/super-admin.guard.spec.ts src/endpoints/admin/announcements/announcements.controller.spec.ts src/endpoints/admin/darkroom/darkroom.controller.spec.ts src/services/ai-influencer/ai-influencer.controller.spec.ts`
- `bun run test` in `packages/prisma`
- `bunx vitest run --config vitest.config.ts __tests__/platform-role.enum.test.ts __tests__/member.enum.test.ts`
- `bunx vitest run --config vitest.config.ts src/registry/source/source-tools.test.ts`
- `bun run type-check` in `packages/enums`, `packages/interfaces`, and `packages/tools`
- `bunx turbo run type-check --filter=@genfeedai/api`
- changed-file Biome pass and `git diff --check`

Closes #806