### PR TITLE
Convert livestream bot cron to workflow

### DIFF
--- a/apps/server/api/src/collections/bots/services/bots-livestream.service.spec.ts
+++ b/apps/server/api/src/collections/bots/services/bots-livestream.service.spec.ts
@@ -1,0 +1,209 @@
+import { BotsLivestreamService } from '@api/collections/bots/services/bots-livestream.service';
+import { BotPlatform } from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('BotsLivestreamService', () => {
+  const prisma = {
+    bot: { findFirst: vi.fn() },
+    livestreamBotSession: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+  const deliveryService = { deliverMessage: vi.fn() };
+  const loggerService = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  const replicateService = {};
+  const runtimeService = {
+    getDeliveryEligibility: vi.fn(),
+  };
+
+  let service: BotsLivestreamService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.livestreamBotSession.findMany.mockResolvedValue([]);
+    prisma.bot.findFirst.mockResolvedValue(null);
+    runtimeService.getDeliveryEligibility.mockReturnValue({ allowed: false });
+
+    service = new BotsLivestreamService(
+      prisma as never,
+      deliveryService as never,
+      loggerService as never,
+      replicateService as never,
+      runtimeService as never,
+    );
+  });
+
+  it('processes only active livestream sessions for the workflow organization', async () => {
+    prisma.livestreamBotSession.findMany.mockResolvedValue([
+      sessionRow('session-1', {
+        botId: 'bot-1',
+        organizationId: 'org-1',
+        status: 'active',
+      }),
+      sessionRow('session-2', {
+        botId: 'bot-2',
+        organizationId: 'org-1',
+        status: 'paused',
+      }),
+      sessionRow('session-3', {
+        botId: 'bot-3',
+        organizationId: 'org-2',
+        status: 'active',
+      }),
+    ]);
+    prisma.bot.findFirst.mockResolvedValue(botRow('bot-1'));
+
+    const result = await service.processActiveSessionsForOrganization('org-1');
+
+    expect(prisma.livestreamBotSession.findMany).toHaveBeenCalledWith({
+      where: { isDeleted: false },
+    });
+    expect(prisma.bot.findFirst).toHaveBeenCalledTimes(1);
+    expect(prisma.bot.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'bot-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(result).toMatchObject({
+      action: 'livestreamBotSessionProcessing',
+      failed: 0,
+      organizationId: 'org-1',
+      processed: 1,
+      sessions: 1,
+      skipped: 0,
+      status: 'completed',
+    });
+  });
+
+  it('skips active sessions whose bot is missing or deleted', async () => {
+    prisma.livestreamBotSession.findMany.mockResolvedValue([
+      sessionRow('session-1', {
+        botId: 'missing-bot',
+        organizationId: 'org-1',
+        status: 'active',
+      }),
+    ]);
+    prisma.bot.findFirst.mockResolvedValue(null);
+
+    const result = await service.processActiveSessionsForOrganization('org-1');
+
+    expect(result).toMatchObject({
+      failed: 0,
+      processed: 0,
+      sessions: 1,
+      skipped: 1,
+      status: 'completed',
+    });
+  });
+
+  it('isolates one session failure and continues processing the next session', async () => {
+    prisma.livestreamBotSession.findMany.mockResolvedValue([
+      sessionRow('session-1', {
+        botId: 'bot-1',
+        organizationId: 'org-1',
+        status: 'active',
+      }),
+      sessionRow('session-2', {
+        botId: 'bot-2',
+        organizationId: 'org-1',
+        status: 'active',
+      }),
+    ]);
+    prisma.bot.findFirst
+      .mockResolvedValueOnce(
+        botRow('bot-1', {
+          targets: [
+            {
+              channelId: 'channel-1',
+              isEnabled: true,
+              platform: BotPlatform.TWITCH,
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(botRow('bot-2'));
+    runtimeService.getDeliveryEligibility.mockImplementationOnce(() => {
+      throw new Error('provider failed');
+    });
+
+    const result = await service.processActiveSessionsForOrganization('org-1');
+
+    expect(loggerService.error).toHaveBeenCalledWith(
+      'Failed to process livestream session',
+      expect.any(Error),
+      {
+        botId: 'bot-1',
+        organizationId: 'org-1',
+        sessionId: 'session-1',
+      },
+    );
+    expect(result).toMatchObject({
+      failed: 1,
+      processed: 1,
+      sessions: 2,
+      skipped: 0,
+      status: 'completed',
+    });
+  });
+
+  it('returns a skipped result when the organization has no active sessions', async () => {
+    prisma.livestreamBotSession.findMany.mockResolvedValue([
+      sessionRow('session-1', {
+        botId: 'bot-1',
+        organizationId: 'org-1',
+        status: 'paused',
+      }),
+    ]);
+
+    const result = await service.processActiveSessionsForOrganization('org-1');
+
+    expect(prisma.bot.findFirst).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      reason: 'no_active_livestream_sessions',
+      sessions: 0,
+      skipped: 1,
+      status: 'skipped',
+    });
+  });
+});
+
+function sessionRow(
+  id: string,
+  data: {
+    botId: string;
+    organizationId: string;
+    status: string;
+  },
+): Record<string, unknown> {
+  return {
+    createdAt: new Date('2026-06-24T09:00:00.000Z'),
+    data,
+    id,
+    isDeleted: false,
+    mongoId: null,
+    updatedAt: new Date('2026-06-24T09:00:00.000Z'),
+  };
+}
+
+function botRow(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    brandId: 'brand-1',
+    id,
+    isDeleted: false,
+    livestreamSettings: {},
+    organizationId: 'org-1',
+    targets: [],
+    userId: 'user-1',
+    ...overrides,
+  };
+}

--- a/apps/server/api/src/collections/bots/services/bots-livestream.service.ts
+++ b/apps/server/api/src/collections/bots/services/bots-livestream.service.ts
@@ -13,14 +13,12 @@ import type {
   LivestreamSessionContext,
   LivestreamTranscriptChunk,
 } from '@api/collections/bots/schemas/livestream-bot-session.schema';
-import { ConfigService } from '@api/config/config.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BotPlatform } from '@genfeedai/enums';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { Cron } from '@nestjs/schedule';
 
 import { BotsLivestreamDeliveryService } from './bots-livestream-delivery.service';
 import {
@@ -50,6 +48,17 @@ interface SendNowPayload {
   message?: string;
   platform: LivestreamPlatform;
   type?: LivestreamMessageType;
+}
+
+export interface LivestreamBotProcessingResult {
+  action: 'livestreamBotSessionProcessing';
+  failed: number;
+  organizationId: string;
+  processed: number;
+  reason?: string;
+  sessions: number;
+  skipped: number;
+  status: 'completed' | 'skipped';
 }
 
 function isLivestreamPlatform(
@@ -136,7 +145,6 @@ export class BotsLivestreamService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly deliveryService: BotsLivestreamDeliveryService,
-    private readonly configService: ConfigService,
     private readonly loggerService: LoggerService,
     private readonly replicateService: ReplicateService,
     private readonly runtimeService: BotsLivestreamRuntimeService,
@@ -723,12 +731,9 @@ export class BotsLivestreamService {
     return session;
   }
 
-  @Cron('0 * * * * *')
-  async processActiveSessions(): Promise<void> {
-    if (!this.configService.isDevSchedulersEnabled) {
-      return;
-    }
-
+  async processActiveSessionsForOrganization(
+    organizationId: string,
+  ): Promise<LivestreamBotProcessingResult> {
     const sessions = (
       await this.prisma.livestreamBotSession.findMany({
         where: { isDeleted: false },
@@ -737,19 +742,33 @@ export class BotsLivestreamService {
       .map((session) =>
         this.normalizeSessionDocument(session as Record<string, unknown>),
       )
-      .filter((session) => session.status === 'active');
+      .filter(
+        (session) =>
+          session.status === 'active' &&
+          (session.organizationId ?? session.organization) === organizationId,
+      );
+
+    let failed = 0;
+    let processed = 0;
+    let skipped = sessions.length === 0 ? 1 : 0;
 
     for (const session of sessions) {
       try {
+        if (!session.botId) {
+          skipped++;
+          continue;
+        }
+
         const bot = await this.prisma.bot.findFirst({
           where: {
             id: session.botId,
             isDeleted: false,
-            organizationId: session.organizationId,
+            organizationId,
           },
         });
 
         if (!bot) {
+          skipped++;
           continue;
         }
 
@@ -757,10 +776,32 @@ export class BotsLivestreamService {
           this.normalizeBotDocument(bot as unknown as BotDocument),
           session,
         );
+        processed++;
       } catch (error) {
-        this.loggerService.error('Failed to process livestream session', error);
+        failed++;
+        this.loggerService.error(
+          'Failed to process livestream session',
+          error,
+          {
+            botId: session.botId,
+            organizationId,
+            sessionId: session.id,
+          },
+        );
       }
     }
+
+    return {
+      action: 'livestreamBotSessionProcessing',
+      failed,
+      organizationId,
+      processed,
+      reason:
+        sessions.length === 0 ? 'no_active_livestream_sessions' : undefined,
+      sessions: sessions.length,
+      skipped,
+      status: sessions.length === 0 ? 'skipped' : 'completed',
+    };
   }
 
   private async processSession(

--- a/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
+++ b/apps/server/api/src/collections/organization-settings/services/organization-settings.service.ts
@@ -132,6 +132,10 @@ export class OrganizationSettingsService extends BaseService<
         organization.userId,
         organizationId,
       );
+      await workflowsService.ensureLivestreamBotWorkflows(
+        organization.userId,
+        organizationId,
+      );
     } catch (error) {
       // Swallowed so a non-critical provisioning step never fails org creation,
       // but reported to Sentry as well as the log: otherwise new-org workflow

--- a/apps/server/api/src/collections/workflows/services/livestream-bot-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/livestream-bot-workflow.service.spec.ts
@@ -1,0 +1,72 @@
+import { LivestreamBotWorkflowService } from '@api/collections/workflows/services/livestream-bot-workflow.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('LivestreamBotWorkflowService', () => {
+  const botsLivestreamService = {
+    processActiveSessionsForOrganization: vi.fn(),
+  };
+  const cacheService = {
+    acquireLock: vi.fn(),
+    releaseLock: vi.fn(),
+  };
+
+  let service: LivestreamBotWorkflowService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheService.acquireLock.mockResolvedValue(true);
+    cacheService.releaseLock.mockResolvedValue(undefined);
+    botsLivestreamService.processActiveSessionsForOrganization.mockResolvedValue(
+      {
+        action: 'livestreamBotSessionProcessing',
+        failed: 0,
+        organizationId: 'org-1',
+        processed: 1,
+        sessions: 1,
+        skipped: 0,
+        status: 'completed',
+      },
+    );
+
+    service = new LivestreamBotWorkflowService(
+      botsLivestreamService as never,
+      cacheService as never,
+    );
+  });
+
+  it('runs active-session processing behind a per-org lock', async () => {
+    const result = await service.runActiveSessionProcessing('org-1');
+
+    expect(cacheService.acquireLock).toHaveBeenCalledWith(
+      'livestreamBotSessionProcessing:org-1',
+      60,
+    );
+    expect(
+      botsLivestreamService.processActiveSessionsForOrganization,
+    ).toHaveBeenCalledWith('org-1');
+    expect(cacheService.releaseLock).toHaveBeenCalledWith(
+      'livestreamBotSessionProcessing:org-1',
+    );
+    expect(result).toMatchObject({
+      action: 'livestreamBotSessionProcessing',
+      processed: 1,
+      status: 'completed',
+    });
+  });
+
+  it('skips duplicate workflow executions when the lock is held', async () => {
+    cacheService.acquireLock.mockResolvedValue(false);
+
+    const result = await service.runActiveSessionProcessing('org-1');
+
+    expect(
+      botsLivestreamService.processActiveSessionsForOrganization,
+    ).not.toHaveBeenCalled();
+    expect(cacheService.releaseLock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      reason: 'livestream_bot_processing_locked',
+      skipped: 1,
+      status: 'skipped',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/livestream-bot-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/livestream-bot-workflow.service.ts
@@ -1,0 +1,48 @@
+import {
+  BotsLivestreamService,
+  type LivestreamBotProcessingResult,
+} from '@api/collections/bots/services/bots-livestream.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { Injectable } from '@nestjs/common';
+
+const LIVESTREAM_BOT_LOCK_TTL_SECONDS = 60;
+
+@Injectable()
+export class LivestreamBotWorkflowService {
+  constructor(
+    private readonly botsLivestreamService: BotsLivestreamService,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async runActiveSessionProcessing(
+    organizationId: string,
+  ): Promise<LivestreamBotProcessingResult> {
+    const action = 'livestreamBotSessionProcessing';
+    const lockKey = `${action}:${organizationId}`;
+    const acquired = await this.cacheService.acquireLock(
+      lockKey,
+      LIVESTREAM_BOT_LOCK_TTL_SECONDS,
+    );
+
+    if (!acquired) {
+      return {
+        action,
+        failed: 0,
+        organizationId,
+        processed: 0,
+        reason: 'livestream_bot_processing_locked',
+        sessions: 0,
+        skipped: 1,
+        status: 'skipped',
+      };
+    }
+
+    try {
+      return await this.botsLivestreamService.processActiveSessionsForOrganization(
+        organizationId,
+      );
+    } finally {
+      await this.cacheService.releaseLock(lockKey);
+    }
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -258,6 +258,45 @@ describe('WorkflowEngineAdapterService', () => {
       expect(result.status).toBe('completed');
     });
 
+    it('executes livestream bot session processing with workflow organization scope', async () => {
+      const livestreamBotWorkflowService = {
+        runActiveSessionProcessing: vi.fn().mockResolvedValue({
+          action: 'livestreamBotSessionProcessing',
+          failed: 0,
+          organizationId: 'org-1',
+          processed: 1,
+          sessions: 1,
+          skipped: 0,
+          status: 'completed',
+        }),
+      };
+      const args = new Array(37).fill(undefined);
+      args[0] = { ingredientsEndpoint: 'https://ingredients.example.com' };
+      args[1] = loggerService;
+      args[36] = livestreamBotWorkflowService;
+      const livestreamAdapter = new WorkflowEngineAdapterService(...args);
+
+      const workflow = livestreamAdapter.convertToExecutableWorkflow({
+        _id: { toString: () => 'wf-livestream' },
+        nodes: [
+          {
+            data: { config: {}, label: 'Process Livestream Sessions' },
+            id: 'livestream-sessions',
+            type: 'livestreamBotSessionProcessing',
+          },
+        ],
+        organization: { toString: () => 'org-1' },
+        user: { toString: () => 'user-1' },
+      });
+
+      const result = await livestreamAdapter.executeWorkflow(workflow);
+
+      expect(
+        livestreamBotWorkflowService.runActiveSessionProcessing,
+      ).toHaveBeenCalledWith('org-1');
+      expect(result.status).toBe('completed');
+    });
+
     it('executes image inputs from picker-backed config', async () => {
       const workflow = service.convertToExecutableWorkflow({
         _id: { toString: () => 'wf-image-input' },

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -34,6 +34,7 @@ import { AgentAutopilotWorkflowService } from '@api/collections/workflows/servic
 import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
+import { LivestreamBotWorkflowService } from '@api/collections/workflows/services/livestream-bot-workflow.service';
 import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
 import type { TrendNotificationCadence } from '@api/collections/workflows/templates/trend-notification-workflows.template';
@@ -285,6 +286,8 @@ export class WorkflowEngineAdapterService {
     @Optional()
     @Inject(LEGACY_CRON_JOB_EXECUTOR)
     private readonly legacyCronJobExecutor?: LegacyCronJobExecutor,
+    @Optional()
+    private readonly livestreamBotWorkflowService?: LivestreamBotWorkflowService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -317,6 +320,7 @@ export class WorkflowEngineAdapterService {
     this.registerContentProductionExecutors();
     this.registerReplyPollingExecutors();
     this.registerTrendNotificationExecutors();
+    this.registerLivestreamBotExecutors();
     this.registerLegacyCronJobExecutors();
     this.registerTrendTriggerExecutor();
     this.registerTrendDigestExecutor();
@@ -1016,6 +1020,37 @@ export class WorkflowEngineAdapterService {
       skipped: 1,
       status: 'skipped',
       trends: 0,
+    };
+  }
+
+  private registerLivestreamBotExecutors(): void {
+    this.engine.registerExecutor(
+      'livestreamBotSessionProcessing',
+      async (_node, _inputs, context) =>
+        this.livestreamBotWorkflowService
+          ? this.livestreamBotWorkflowService.runActiveSessionProcessing(
+              context.organizationId,
+            )
+          : this.livestreamBotUnavailable(
+              'livestreamBotSessionProcessing',
+              context,
+            ),
+    );
+  }
+
+  private async livestreamBotUnavailable(
+    action: string,
+    context: ExecutionContext,
+  ): Promise<Record<string, unknown>> {
+    return {
+      action,
+      failed: 0,
+      organizationId: context.organizationId,
+      processed: 0,
+      reason: 'livestream_bot_service_unavailable',
+      sessions: 0,
+      skipped: 1,
+      status: 'skipped',
     };
   }
 

--- a/apps/server/api/src/collections/workflows/services/workflows.service.seed.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.seed.spec.ts
@@ -1,0 +1,76 @@
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { WorkflowStatus } from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('WorkflowsService seeded livestream bot workflows', () => {
+  const tx = {
+    workflow: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  };
+  const prisma = {
+    $transaction: vi.fn(),
+    workflow: {
+      findFirst: vi.fn(),
+    },
+  };
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  let service: WorkflowsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.workflow.findFirst.mockResolvedValue(null);
+    tx.workflow.findFirst.mockResolvedValue(null);
+    tx.workflow.create.mockResolvedValue({});
+    prisma.$transaction.mockImplementation(
+      async (
+        callback: (transactionClient: typeof tx) => Promise<void>,
+      ): Promise<void> => callback(tx),
+    );
+
+    service = new WorkflowsService(prisma as never, logger as never);
+  });
+
+  it('seeds the livestream bot workflow default-on for an organization', async () => {
+    await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
+
+    expect(tx.workflow.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        isScheduleEnabled: true,
+        label: 'Livestream Bot Session Processing',
+        metadata: {
+          sourceIssue: 793,
+          sourceTemplateId: 'livestream-bot-session-processing',
+          sourceType: 'seeded-template',
+        },
+        organizationId: 'org-1',
+        schedule: '*/1 * * * *',
+        status: WorkflowStatus.ACTIVE,
+        timezone: 'UTC',
+        userId: 'user-1',
+      }),
+    });
+    expect(tx.workflow.create.mock.calls[0][0].data.nodes).toEqual([
+      expect.objectContaining({
+        id: 'livestreamBotSessionProcessing',
+        type: 'livestreamBotSessionProcessing',
+      }),
+    ]);
+  });
+
+  it('does not seed a duplicate livestream bot workflow', async () => {
+    prisma.workflow.findFirst.mockResolvedValue({ id: 'workflow-1' });
+
+    await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(tx.workflow.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -25,6 +25,7 @@ import {
   CONTENT_SCHEDULE_WORKFLOW_TEMPLATE_ID,
 } from '@api/collections/workflows/templates/content-production-workflows.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
+import { LIVESTREAM_BOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/livestream-bot-workflows.template';
 import { REPLY_POLLING_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/reply-polling-workflows.template';
 import { TREND_NOTIFICATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/trend-notification-workflows.template';
 import { WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/workflow-templates';
@@ -1008,6 +1009,87 @@ export class WorkflowsService extends BaseService<
         if (errorCode === 'P2034') {
           this.logger?.debug(
             'ensureTrendNotificationWorkflows: serialization conflict - workflow already seeded by concurrent request',
+            { organizationId, templateId: template.id },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Idempotently seeds default-on livestream bot active-session processing for
+   * an organization. The executor preserves the previous per-minute cron scan
+   * while keeping execution scoped to the workflow organization.
+   */
+  async ensureLivestreamBotWorkflows(
+    userId: string,
+    organizationId: string,
+  ): Promise<void> {
+    for (const template of LIVESTREAM_BOT_WORKFLOW_TEMPLATES) {
+      const where = {
+        isDeleted: false,
+        metadata: {
+          equals: template.id,
+          path: ['sourceTemplateId'],
+        },
+        organizationId,
+      };
+
+      const preCheck = await this.prisma.workflow.findFirst({
+        select: { id: true },
+        where,
+      });
+
+      if (preCheck) {
+        continue;
+      }
+
+      try {
+        await this.prisma.$transaction(
+          async (tx) => {
+            const existing = await tx.workflow.findFirst({
+              select: { id: true },
+              where,
+            });
+
+            if (existing) {
+              return;
+            }
+
+            await tx.workflow.create({
+              data: {
+                description: template.description,
+                edges: (template.edges ?? []) as never,
+                executionCount: 0,
+                inputVariables: (template.inputVariables ?? []) as never,
+                isDeleted: false,
+                isScheduleEnabled: true,
+                label: template.name,
+                metadata: {
+                  sourceIssue: 793,
+                  sourceTemplateId: template.id,
+                  sourceType: 'seeded-template',
+                },
+                nodes: (template.nodes ?? []) as never,
+                organizationId,
+                progress: 0,
+                schedule: template.schedule,
+                status: WorkflowStatus.ACTIVE,
+                steps: template.steps as never,
+                timezone: 'UTC',
+                userId,
+              },
+            });
+          },
+          { isolationLevel: 'Serializable' },
+        );
+      } catch (error) {
+        const errorCode = (error as { code?: string }).code;
+        if (errorCode === 'P2034') {
+          this.logger?.debug(
+            'ensureLivestreamBotWorkflows: serialization conflict - workflow already seeded by concurrent request',
             { organizationId, templateId: template.id },
           );
           continue;

--- a/apps/server/api/src/collections/workflows/templates/livestream-bot-workflows.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/livestream-bot-workflows.template.ts
@@ -1,0 +1,31 @@
+import type { WorkflowTemplate } from '@api/collections/workflows/templates/workflow-templates';
+
+export type LivestreamBotWorkflowTemplate = WorkflowTemplate & {
+  schedule: string;
+};
+
+export const LIVESTREAM_BOT_WORKFLOW_TEMPLATES = [
+  {
+    category: 'automation',
+    description:
+      'Per-organization livestream bot active-session scanner for enabled live chat bots.',
+    edges: [],
+    icon: 'radio',
+    id: 'livestream-bot-session-processing',
+    inputVariables: [],
+    name: 'Livestream Bot Session Processing',
+    nodes: [
+      {
+        data: {
+          config: {},
+          label: 'Process Livestream Sessions',
+        },
+        id: 'livestreamBotSessionProcessing',
+        position: { x: 0, y: 120 },
+        type: 'livestreamBotSessionProcessing',
+      },
+    ],
+    schedule: '*/1 * * * *',
+    steps: [],
+  },
+] satisfies LivestreamBotWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -7,6 +7,7 @@ import { AdOptimizationConfigsModule } from '@api/collections/ad-optimization-co
 import { AdPerformanceModule } from '@api/collections/ad-performance/ad-performance.module';
 import { AgentGoalsModule } from '@api/collections/agent-goals/agent-goals.module';
 import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
+import { BotsModule } from '@api/collections/bots/bots.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CaptionsModule } from '@api/collections/captions/captions.module';
 import { ContentSchedulesModule } from '@api/collections/content-schedules/content-schedules.module';
@@ -39,6 +40,7 @@ import {
 } from '@api/collections/workflows/services/batch-workflow-queue.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
 import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
+import { LivestreamBotWorkflowService } from '@api/collections/workflows/services/livestream-bot-workflow.service';
 import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
@@ -92,6 +94,7 @@ import { forwardRef, Module } from '@nestjs/common';
     AnalyticsSyncWorkflowService,
     CampaignOrchestrationWorkflowService,
     ContentProductionWorkflowService,
+    LivestreamBotWorkflowService,
     ReplyPollingWorkflowService,
     TrendNotificationWorkflowService,
   ],
@@ -102,6 +105,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => AgentGoalsModule),
     forwardRef(() => AgentRunsModule),
     forwardRef(() => AiInfluencerModule),
+    forwardRef(() => BotsModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => CaptionsModule),
     forwardRef(() => ContentEngineModule),
@@ -170,6 +174,7 @@ import { forwardRef, Module } from '@nestjs/common';
     BatchWorkflowService,
     CampaignOrchestrationWorkflowService,
     ContentProductionWorkflowService,
+    LivestreamBotWorkflowService,
     ReplyPollingWorkflowService,
     TrendNotificationWorkflowService,
     WorkflowEngineAdapterService,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -136,6 +136,10 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
         userId,
         organizationId,
       );
+      await workflowsService.ensureLivestreamBotWorkflows(
+        userId,
+        organizationId,
+      );
     } catch (error) {
       this.logger.error(
         'Failed to provision default self-hosted workflows',


### PR DESCRIPTION
## Summary
- Replace the hard-coded livestream bot @Cron with a per-organization workflow-backed executor.
- Seed the default-on livestream bot session processing workflow during org provisioning and self-hosted seed.
- Add scoped session-processing, per-org locking, seed, and workflow-engine adapter tests.

## Verification
- bun run test:file src/collections/bots/services/bots-livestream.service.spec.ts src/collections/workflows/services/livestream-bot-workflow.service.spec.ts src/collections/workflows/services/workflows.service.seed.spec.ts src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
- bun run check:architecture
- bunx turbo run type-check --filter=@genfeedai/api --force
- bunx turbo run type-check --filter=@genfeedai/ee-billing --force
- bunx turbo run type-check --force
- bunx turbo run build --filter=@genfeedai/api --force
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js
- gitleaks protect --staged --no-banner --redact
- gitleaks detect --no-banner --redact --log-opts=HEAD~1..HEAD

Closes #793
Part of #698