### PR TITLE
Classify ad insights scheduling

### DIFF
--- a/.agents/memory/architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md
+++ b/.agents/memory/architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md
@@ -52,6 +52,17 @@ The legacy product surface is retired:
 - SDK mutation methods fail before making HTTP calls
 - new product code must not create legacy cron rows or call legacy mutation APIs
 
+Ad insights aggregation is explicitly classified as platform scheduling:
+
+- `cron.ad-insights` runs once per weekly platform window, not once per
+  organization
+- the aggregation queue payload carries `scope: "platform"` plus a deterministic
+  weekly idempotency key
+- the worker processor rejects non-platform scope
+- the data contract is public-scope ad performance with k-anonymity across at
+  least five organizations, so a per-org workflow would duplicate global work
+  and weaken the anonymity boundary
+
 ## Consequences
 
 ### Required for new work

--- a/apps/server/workers/src/crons/ad-insights/ad-insights-scheduling.config.ts
+++ b/apps/server/workers/src/crons/ad-insights/ad-insights-scheduling.config.ts
@@ -1,0 +1,43 @@
+export const AD_INSIGHTS_AGGREGATION_QUEUE = 'ad-insights-aggregation';
+export const AD_INSIGHTS_PLATFORM_SCOPE = 'platform';
+export const AD_INSIGHTS_SCHEDULE_CRON = '0 6 * * 0';
+export const AD_INSIGHTS_SOURCE_ISSUE = 796;
+export const AD_INSIGHTS_MIN_ORGS_FOR_AGGREGATION = 5;
+
+export const AD_INSIGHTS_INSIGHT_TYPES = [
+  'top_headlines',
+  'best_ctas',
+  'optimal_spend',
+  'platform_comparison',
+  'industry_benchmark',
+] as const;
+
+export const AD_INSIGHTS_SCHEDULING_CLASSIFICATION = {
+  dataScope: 'public_ad_performance',
+  minOrganizations: AD_INSIGHTS_MIN_ORGS_FOR_AGGREGATION,
+  queueName: AD_INSIGHTS_AGGREGATION_QUEUE,
+  rationale:
+    'Ad insights aggregate public-scope ad performance with k-anonymity across organizations; per-org workflows would duplicate global work and weaken the data contract.',
+  schedule: AD_INSIGHTS_SCHEDULE_CRON,
+  scope: AD_INSIGHTS_PLATFORM_SCOPE,
+  sourceIssue: AD_INSIGHTS_SOURCE_ISSUE,
+} as const;
+
+export function buildAdInsightsAggregationWindow(
+  now: Date = new Date(),
+): string {
+  const utcMidnight = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  );
+  const dayOffset = now.getUTCDay();
+  const weekStart = new Date(utcMidnight - dayOffset * 24 * 60 * 60 * 1000);
+  return weekStart.toISOString().slice(0, 10);
+}
+
+export function buildAdInsightsAggregationJobId(
+  aggregationWindow: string,
+): string {
+  return `${AD_INSIGHTS_AGGREGATION_QUEUE}:${AD_INSIGHTS_PLATFORM_SCOPE}:weekly:${aggregationWindow}`;
+}

--- a/apps/server/workers/src/crons/ad-insights/cron.ad-insights.service.spec.ts
+++ b/apps/server/workers/src/crons/ad-insights/cron.ad-insights.service.spec.ts
@@ -1,6 +1,13 @@
 import { QueueService } from '@api/queues/core/queue.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  AD_INSIGHTS_AGGREGATION_QUEUE,
+  AD_INSIGHTS_PLATFORM_SCOPE,
+  AD_INSIGHTS_SOURCE_ISSUE,
+  buildAdInsightsAggregationJobId,
+  buildAdInsightsAggregationWindow,
+} from '@workers/crons/ad-insights/ad-insights-scheduling.config';
 import { CronAdInsightsService } from '@workers/crons/ad-insights/cron.ad-insights.service';
 import type { Mocked } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,7 +49,7 @@ describe('CronAdInsightsService', () => {
       await service.computeWeeklyInsights();
 
       expect(queueService.add).toHaveBeenCalledWith(
-        'ad-insights-aggregation',
+        AD_INSIGHTS_AGGREGATION_QUEUE,
         expect.any(Object),
         expect.any(Object),
       );
@@ -79,7 +86,29 @@ describe('CronAdInsightsService', () => {
       await service.computeWeeklyInsights();
 
       expect(logger.log).toHaveBeenCalledWith(
-        expect.stringContaining('weekly ad insights aggregation job enqueued'),
+        expect.stringContaining(
+          'weekly platform ad insights aggregation job enqueued',
+        ),
+      );
+    });
+
+    it('classifies the aggregation as one platform-scoped weekly window', async () => {
+      const now = new Date('2026-06-24T12:00:00.000Z');
+      const aggregationWindow = buildAdInsightsAggregationWindow(now);
+
+      await service.computeWeeklyInsights(now);
+
+      expect(queueService.add).toHaveBeenCalledWith(
+        AD_INSIGHTS_AGGREGATION_QUEUE,
+        expect.objectContaining({
+          aggregationWindow,
+          idempotencyKey: buildAdInsightsAggregationJobId(aggregationWindow),
+          scope: AD_INSIGHTS_PLATFORM_SCOPE,
+          sourceIssue: AD_INSIGHTS_SOURCE_ISSUE,
+        }),
+        expect.objectContaining({
+          jobId: buildAdInsightsAggregationJobId(aggregationWindow),
+        }),
       );
     });
 

--- a/apps/server/workers/src/crons/ad-insights/cron.ad-insights.service.ts
+++ b/apps/server/workers/src/crons/ad-insights/cron.ad-insights.service.ts
@@ -4,39 +4,50 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import {
+  AD_INSIGHTS_AGGREGATION_QUEUE,
+  AD_INSIGHTS_INSIGHT_TYPES,
+  AD_INSIGHTS_PLATFORM_SCOPE,
+  AD_INSIGHTS_SCHEDULE_CRON,
+  AD_INSIGHTS_SOURCE_ISSUE,
+  buildAdInsightsAggregationJobId,
+  buildAdInsightsAggregationWindow,
+} from '@workers/crons/ad-insights/ad-insights-scheduling.config';
 
 @Injectable()
 export class CronAdInsightsService {
   private readonly constructorName: string = String(this.constructor.name);
-  private readonly QUEUE_NAME = 'ad-insights-aggregation';
 
   constructor(
     private readonly logger: LoggerService,
     private readonly queueService: QueueService,
   ) {}
 
-  @Cron('0 6 * * 0') // 6 AM every Sunday
-  async computeWeeklyInsights(): Promise<void> {
+  @Cron(AD_INSIGHTS_SCHEDULE_CRON) // 6 AM UTC every Sunday
+  async computeWeeklyInsights(now: Date = new Date()): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.logger.log(`${url} started`);
 
     try {
+      const aggregationWindow = buildAdInsightsAggregationWindow(now);
+      const idempotencyKey = buildAdInsightsAggregationJobId(aggregationWindow);
       const jobData: AdInsightsAggregationJobData = {
-        insightTypes: [
-          'top_headlines',
-          'best_ctas',
-          'optimal_spend',
-          'platform_comparison',
-          'industry_benchmark',
-        ],
+        aggregationWindow,
+        idempotencyKey,
+        insightTypes: [...AD_INSIGHTS_INSIGHT_TYPES],
+        scope: AD_INSIGHTS_PLATFORM_SCOPE,
+        sourceIssue: AD_INSIGHTS_SOURCE_ISSUE,
       };
 
-      await this.queueService.add(this.QUEUE_NAME, jobData, {
+      await this.queueService.add(AD_INSIGHTS_AGGREGATION_QUEUE, jobData, {
         attempts: 2,
         backoff: { delay: 10000, type: 'exponential' },
+        jobId: idempotencyKey,
       });
 
-      this.logger.log(`${url} weekly ad insights aggregation job enqueued`);
+      this.logger.log(
+        `${url} weekly platform ad insights aggregation job enqueued for ${aggregationWindow}`,
+      );
     } catch (error: unknown) {
       this.logger.error(`${url} failed`, error);
     }

--- a/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
@@ -1,6 +1,7 @@
 import type { AdInsightsAggregationJobData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, type TestingModule } from '@nestjs/testing';
+import { AD_INSIGHTS_PLATFORM_SCOPE } from '@workers/crons/ad-insights/ad-insights-scheduling.config';
 import type { Job } from 'bullmq';
 
 import { AdInsightsAggregationProcessor } from './ad-insights-aggregation.processor';
@@ -46,8 +47,17 @@ describe('AdInsightsAggregationProcessor', () => {
   });
 
   it('should log start message when processing insight types', async () => {
-    const job = makeJob({ insightTypes: ['ctr', 'cpm'] });
+    const job = makeJob({
+      aggregationWindow: '2026-06-21',
+      insightTypes: ['ctr', 'cpm'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
+    });
     await processor.process(job);
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'platform ad insights aggregation for window 2026-06-21',
+      ),
+    );
     expect(loggerService.log).toHaveBeenCalledWith(
       expect.stringContaining('ctr, cpm'),
     );
@@ -86,6 +96,21 @@ describe('AdInsightsAggregationProcessor', () => {
       insightTypes: ['ctr'],
     });
     await expect(processor.process(job)).resolves.toBeUndefined();
+  });
+
+  it('rejects non-platform aggregation scope', async () => {
+    const job = makeJob({
+      insightTypes: ['ctr'],
+      scope: 'tenant' as never,
+    });
+
+    await expect(processor.process(job)).rejects.toThrow(
+      'Unsupported ad insights aggregation scope: tenant',
+    );
+    expect(loggerService.error).toHaveBeenCalledWith(
+      'Ad insights aggregation failed',
+      'Unsupported ad insights aggregation scope: tenant',
+    );
   });
 
   it('should log error and re-throw if a top-level exception occurs', async () => {

--- a/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
@@ -64,13 +64,19 @@ describe('AdInsightsAggregationProcessor', () => {
   });
 
   it('should call updateProgress(100) on completion', async () => {
-    const job = makeJob({ insightTypes: ['spend'] });
+    const job = makeJob({
+      insightTypes: ['spend'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
+    });
     await processor.process(job);
     expect(job.updateProgress).toHaveBeenCalledWith(100);
   });
 
   it('should log completion after processing', async () => {
-    const job = makeJob({ insightTypes: ['spend'] });
+    const job = makeJob({
+      insightTypes: ['spend'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
+    });
     await processor.process(job);
     expect(loggerService.log).toHaveBeenCalledWith(
       expect.stringContaining('completed'),
@@ -78,13 +84,17 @@ describe('AdInsightsAggregationProcessor', () => {
   });
 
   it('should process an empty insightTypes array without throwing', async () => {
-    const job = makeJob({ insightTypes: [] });
+    const job = makeJob({
+      insightTypes: [],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
+    });
     await expect(processor.process(job)).resolves.toBeUndefined();
   });
 
   it('should process multiple insight types without throwing', async () => {
     const job = makeJob({
       insightTypes: ['ctr', 'cpm', 'roas', 'cpa'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
     });
     await expect(processor.process(job)).resolves.toBeUndefined();
     expect(job.updateProgress).toHaveBeenCalledWith(100);
@@ -94,6 +104,7 @@ describe('AdInsightsAggregationProcessor', () => {
     const job = makeJob({
       industries: ['e-commerce', 'saas'],
       insightTypes: ['ctr'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
     });
     await expect(processor.process(job)).resolves.toBeUndefined();
   });
@@ -113,8 +124,25 @@ describe('AdInsightsAggregationProcessor', () => {
     );
   });
 
+  it('rejects missing aggregation scope', async () => {
+    const job = makeJob({
+      insightTypes: ['ctr'],
+    } as AdInsightsAggregationJobData);
+
+    await expect(processor.process(job)).rejects.toThrow(
+      'Unsupported ad insights aggregation scope: undefined',
+    );
+    expect(loggerService.error).toHaveBeenCalledWith(
+      'Ad insights aggregation failed',
+      'Unsupported ad insights aggregation scope: undefined',
+    );
+  });
+
   it('should log error and re-throw if a top-level exception occurs', async () => {
-    const job = makeJob({ insightTypes: ['throw-me'] });
+    const job = makeJob({
+      insightTypes: ['throw-me'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
+    });
     // Spy on updateProgress to throw a critical error
     vi.spyOn(job, 'updateProgress').mockRejectedValueOnce(
       new Error('redis failure'),
@@ -131,7 +159,10 @@ describe('AdInsightsAggregationProcessor', () => {
     // computeInsight is private; we can verify that the processor doesn't abort
     // the whole run when individual insight computation fails.
     // Since the internal loop swallows per-insight errors, all types should complete.
-    const job = makeJob({ insightTypes: ['type-a', 'type-b', 'type-c'] });
+    const job = makeJob({
+      insightTypes: ['type-a', 'type-b', 'type-c'],
+      scope: AD_INSIGHTS_PLATFORM_SCOPE,
+    });
     await expect(processor.process(job)).resolves.toBeUndefined();
     // updateProgress(100) means it reached the end
     expect(job.updateProgress).toHaveBeenCalledWith(100);

--- a/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts
@@ -1,7 +1,7 @@
 import type { AdInsightsAggregationJobData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import {
   AD_INSIGHTS_AGGREGATION_QUEUE,
   AD_INSIGHTS_MIN_ORGS_FOR_AGGREGATION,
@@ -17,15 +17,11 @@ export class AdInsightsAggregationProcessor extends WorkerHost {
   }
 
   async process(job: Job<AdInsightsAggregationJobData>): Promise<void> {
-    const {
-      aggregationWindow = 'legacy',
-      insightTypes,
-      scope = AD_INSIGHTS_PLATFORM_SCOPE,
-    } = job.data;
+    const { aggregationWindow = 'legacy', insightTypes, scope } = job.data;
 
     try {
       if (scope !== AD_INSIGHTS_PLATFORM_SCOPE) {
-        throw new Error(
+        throw new BadRequestException(
           `Unsupported ad insights aggregation scope: ${String(scope)}`,
         );
       }

--- a/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts
@@ -2,25 +2,38 @@ import type { AdInsightsAggregationJobData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
+import {
+  AD_INSIGHTS_AGGREGATION_QUEUE,
+  AD_INSIGHTS_MIN_ORGS_FOR_AGGREGATION,
+  AD_INSIGHTS_PLATFORM_SCOPE,
+} from '@workers/crons/ad-insights/ad-insights-scheduling.config';
 import { Job } from 'bullmq';
 
 @Injectable()
-@Processor('ad-insights-aggregation')
+@Processor(AD_INSIGHTS_AGGREGATION_QUEUE)
 export class AdInsightsAggregationProcessor extends WorkerHost {
-  private readonly MIN_ORGS_FOR_AGGREGATION = 5;
-
   constructor(private readonly logger: LoggerService) {
     super();
   }
 
   async process(job: Job<AdInsightsAggregationJobData>): Promise<void> {
-    const { insightTypes } = job.data;
-
-    this.logger.log(
-      `Processing ad insights aggregation for types: ${insightTypes.join(', ')}`,
-    );
+    const {
+      aggregationWindow = 'legacy',
+      insightTypes,
+      scope = AD_INSIGHTS_PLATFORM_SCOPE,
+    } = job.data;
 
     try {
+      if (scope !== AD_INSIGHTS_PLATFORM_SCOPE) {
+        throw new Error(
+          `Unsupported ad insights aggregation scope: ${String(scope)}`,
+        );
+      }
+
+      this.logger.log(
+        `Processing platform ad insights aggregation for window ${aggregationWindow}, min orgs ${AD_INSIGHTS_MIN_ORGS_FOR_AGGREGATION}, and types: ${insightTypes.join(', ')}`,
+      );
+
       for (const insightType of insightTypes) {
         try {
           await this.computeInsight(insightType);
@@ -46,7 +59,7 @@ export class AdInsightsAggregationProcessor extends WorkerHost {
   private async computeInsight(_insightType: string): Promise<void> {
     // Implementation will:
     // 1. Query ad_performance with scope: 'public'
-    // 2. Check k-anonymity (>= 5 distinct orgs per slice)
+    // 2. Check k-anonymity (>= AD_INSIGHTS_MIN_ORGS_FOR_AGGREGATION distinct orgs per slice)
     // 3. Compute aggregated metrics weighted by dataConfidence
     // 4. Store in ad_insights collection
     // 5. Set validUntil to 7 days from now

--- a/packages/interfaces/src/queues/job-data.interface.ts
+++ b/packages/interfaces/src/queues/job-data.interface.ts
@@ -1,8 +1,12 @@
 import type { CredentialPlatform } from '@genfeedai/enums';
 
 export interface AdInsightsAggregationJobData {
+  aggregationWindow?: string;
+  idempotencyKey?: string;
   insightTypes: string[];
   industries?: string[];
+  scope?: 'platform';
+  sourceIssue?: number;
 }
 
 export interface GoogleAdSyncJobData {

--- a/packages/interfaces/src/queues/job-data.interface.ts
+++ b/packages/interfaces/src/queues/job-data.interface.ts
@@ -5,7 +5,7 @@ export interface AdInsightsAggregationJobData {
   idempotencyKey?: string;
   insightTypes: string[];
   industries?: string[];
-  scope?: 'platform';
+  scope: 'platform';
   sourceIssue?: number;
 }
 


### PR DESCRIPTION
## Summary
- Classify weekly ad insights aggregation as platform-scoped scheduling, not a per-org workflow.
- Add platform-scope metadata and deterministic weekly BullMQ job IDs to avoid duplicate platform windows.
- Reject non-platform aggregation scope in the worker processor and document the decision in the dynamic scheduling ADR.

## Verification
- bun run test:cron src/crons/ad-insights/cron.ad-insights.service.spec.ts
- bun run test src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
- bun run check:architecture
- bunx turbo run type-check --force
- bunx turbo run build --filter=@genfeedai/workers --force
- bunx biome check --write .agents/memory/architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md apps/server/workers/src/crons/ad-insights/ad-insights-scheduling.config.ts apps/server/workers/src/crons/ad-insights/cron.ad-insights.service.ts apps/server/workers/src/crons/ad-insights/cron.ad-insights.service.spec.ts apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts packages/interfaces/src/queues/job-data.interface.ts
- git diff --cached --check
- gitleaks protect --staged --no-banner --redact
- bunx secretlint --secretlintignore .gitignore <touched files>
- gitleaks detect --no-banner --redact --log-opts=HEAD~1..HEAD

Closes #796
Part of #698