### PR TITLE
feat: mirror Brand OS skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -9,11 +9,13 @@ Genfeed.ai content and product skills — used by the application itself to powe
 | `ad-copy-creator` | Generate ad copy for campaigns |
 | `ad-performance-analyzer` | Analyze ad performance metrics |
 | `blog-content-creator` | Create blog posts and articles |
+| `brand-os-architect` | Create source-backed Brand OS systems |
 | `competitor-analyzer` | Analyze competitor content strategies |
 | `content-atomizer` | Break long-form content into social posts |
 | `content-reviewer` | Review and score content quality |
 | `content-seo-optimizer` | Optimize content for search engines |
 | `content-strategist` | Plan content calendars and strategy |
+| `genfeed-brand-os` | Apply the Genfeed.ai Brand OS |
 | `image-prompt-engineer` | Generate image prompts for AI models |
 | `instagram-content-creator` | Create Instagram-optimized content |
 | `linkedin-content-creator` | Create LinkedIn posts and articles |

--- a/skills/brand-os-architect/README.md
+++ b/skills/brand-os-architect/README.md
@@ -1,0 +1,5 @@
+# Brand OS Architect
+
+Create source-backed Brand OS systems for AI-era brands: positioning, voice, visual rules, content pillars, launch storytelling, CTA strategy, evidence, and AI generation checklists.
+
+Use this skill for Brand OS creation, brand kit generators, AI-readable brand books, and source-backed brand strategy.

--- a/skills/brand-os-architect/SKILL.md
+++ b/skills/brand-os-architect/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: brand-os-architect
+description: 'Create source-backed Brand OS systems for AI-era brands, including positioning, voice, visual rules, content pillars, launch storytelling, CTA strategy, evidence, and generation checklists. Triggers on Brand OS, brand system, brand operating system, AI-readable brand book, brand kit generator, launch storytelling, Japanese color references, cute studies, and source-backed brand strategy.'
+license: MIT
+metadata:
+  author: genfeedai
+  version: 1.0.0
+  tags: brand, brand-os, positioning, visual-identity, content-strategy, launch-storytelling
+---
+
+# Brand OS Architect
+
+Build a Brand OS, not a decorative brand kit. A Brand OS is an AI-readable operating layer that tells humans and agents how a brand should think, speak, look, launch, generate, review, and improve.
+
+Use this skill when the user wants to create, audit, or turn a brand into a reusable system for content creation, product UI, campaigns, agents, and generation workflows.
+
+## Source Discipline
+
+When the user asks for a source-backed Brand OS, read `references/source-pack.md` before producing the final strategy. Use the references for principles and rationale, not for copying another brand's private system, exact visual identity, mascot, palette, typography, or proprietary assets.
+
+If the user provides a website, product docs, screenshots, codebase, or existing assets:
+
+1. Extract observable brand evidence first.
+2. Separate evidence from recommendations.
+3. Label unsupported assumptions.
+4. Preserve existing brand truth unless the user asks for a rebrand.
+5. Cite public references by URL when using them as rationale.
+
+## Brand OS Contract
+
+Produce this structure unless the user asks for a narrower artifact:
+
+```markdown
+# Brand OS: {brand}
+
+## Evidence
+- Source URLs, files, screenshots, product docs, or assets used
+- Existing claims, words, visual tokens, product behaviors, and audience signals
+- Confidence and gaps
+
+## Positioning
+- Category
+- Primary audience
+- Enemy or rejected alternative
+- Core promise
+- Differentiator
+- Positioning statement
+
+## Brand Principles
+- 3-5 rules that guide product, content, and visual decisions
+- Each principle includes: rule, rationale, do, don't
+
+## Voice System
+- Personality
+- Tone spectrum
+- Vocabulary
+- Phrases to use
+- Phrases to avoid
+- Sample copy
+
+## Content System
+- Content pillars
+- Recurring formats
+- Proof assets
+- Launch storytelling patterns
+- CTA hierarchy
+- Review checklist
+
+## Visual System
+- Color roles and rationale
+- Typography direction, not just font names
+- Layout and density rules
+- Scale tokens
+- Motion rules
+- Image/video prompt rules
+
+## AI Context
+- Compact prompt block for agents
+- Generation checklist
+- Quality gates
+- Negative instructions
+
+## Activation
+- Website CTA
+- Freebie or lead magnet
+- SaaS conversion path
+- First 3 campaigns or assets to build
+```
+
+## Reference-Informed Rules
+
+- Treat brand as a compounding trust system, not a logo exercise.
+- Make launch assets story-first: show stakes, transformation, and artifact value.
+- Use visual systems as durable memory for agents: color roles, type roles, scale, motion, and negative rules.
+- Prefer distinctive constraints over generic "premium/minimal" language.
+- Use Japanese color references for harmony and naming depth when they fit the brand, not as a default aesthetic.
+- Use mascot, cuteness, or maximalism only when it serves audience psychology and business context.
+- Build review checklists so generated output can be scored, corrected, and learned from.
+
+## Output Quality Gate
+
+Before finalizing:
+
+- Every recommendation is tied to evidence, source-backed principle, or explicit assumption.
+- The Brand OS includes both human-readable guidance and compact AI context.
+- Visual rules define usage and hierarchy, not only a list of colors.
+- The CTA/funnel recommendation maps to a concrete conversion behavior.
+- Competitor references are marked as references only and are not copied.

--- a/skills/brand-os-architect/SKILL.md
+++ b/skills/brand-os-architect/SKILL.md
@@ -71,6 +71,7 @@ Produce this structure unless the user asks for a narrower artifact:
 - Typography direction, not just font names
 - Layout and density rules
 - Scale tokens
+- Semantic size roles, such as block, hero, and one-per-page campaign scale
 - Motion rules
 - Image/video prompt rules
 
@@ -92,6 +93,7 @@ Produce this structure unless the user asks for a narrower artifact:
 - Treat brand as a compounding trust system, not a logo exercise.
 - Make launch assets story-first: show stakes, transformation, and artifact value.
 - Use visual systems as durable memory for agents: color roles, type roles, scale, motion, and negative rules.
+- Define relative object sizes with semantic roles and ratios, not only pixel values.
 - Prefer distinctive constraints over generic "premium/minimal" language.
 - Use Japanese color references for harmony and naming depth when they fit the brand, not as a default aesthetic.
 - Use mascot, cuteness, or maximalism only when it serves audience psychology and business context.
@@ -104,5 +106,6 @@ Before finalizing:
 - Every recommendation is tied to evidence, source-backed principle, or explicit assumption.
 - The Brand OS includes both human-readable guidance and compact AI context.
 - Visual rules define usage and hierarchy, not only a list of colors.
+- Scale rules define role, ratio, and usage context, not only a list of sizes.
 - The CTA/funnel recommendation maps to a concrete conversion behavior.
 - Competitor references are marked as references only and are not copied.

--- a/skills/brand-os-architect/metadata.json
+++ b/skills/brand-os-architect/metadata.json
@@ -1,0 +1,32 @@
+{
+  "name": "brand-os-architect",
+  "version": "1.0.0",
+  "description": "Create source-backed Brand OS systems for AI-era brands",
+  "author": "genfeedai",
+  "license": "MIT",
+  "triggers": [
+    "brand os",
+    "brand operating system",
+    "brand system",
+    "ai-readable brand book",
+    "brand kit generator",
+    "source-backed brand strategy",
+    "launch storytelling",
+    "japanese color references",
+    "cute studies",
+    "build a brand os"
+  ],
+  "references": {
+    "source_pack": "references/source-pack.md"
+  },
+  "outputs": ["text"],
+  "tags": [
+    "branding",
+    "brand-os",
+    "positioning",
+    "visual-identity",
+    "content-strategy",
+    "launch-storytelling",
+    "source-backed"
+  ]
+}

--- a/skills/brand-os-architect/references/source-pack.md
+++ b/skills/brand-os-architect/references/source-pack.md
@@ -55,6 +55,19 @@ Validation rule:
 - Use nearest-color matching as diagnostics only. Never claim an exact match when the codebase token and source swatch differ.
 - Keep accessibility and product semantics ahead of historic color matching: contrast, state meaning, and readable hierarchy still win.
 
+## Relative Object Scale
+
+Useful principle: a Brand OS should define how large objects feel in relation to each other. Agents should receive semantic scale roles instead of vague instructions like "bigger" or "smaller."
+
+Apply it this way:
+
+- Keep dense product UI on an ergonomic grid, such as 4px or 8px.
+- Use a rounded golden-ratio progression for campaign, launch, and brand objects when the brand needs harmony and drama.
+- Name scale roles by usage, such as micro, chip, control, block, hero, monument, and god.
+- Treat "god" scale as a rare campaign-only focal object, not an everyday UI size.
+- Define each role with dimensions, type behavior, motion budget, and usage constraints.
+- Round exact ratios to implementation-friendly values so the system can be used in CSS, design tools, and image prompts.
+
 ## Cute Studies And Kawaii
 
 Sources:

--- a/skills/brand-os-architect/references/source-pack.md
+++ b/skills/brand-os-architect/references/source-pack.md
@@ -1,0 +1,97 @@
+# Brand OS Source Pack
+
+Use this reference when creating source-backed Brand OS systems. These sources are public references and principles. Do not copy any brand's private kit, exact identity, mascot, UI, palette, or typography.
+
+## Paul Graham: The Brand Age
+
+Source: https://www.paulgraham.com/brandage.html
+
+Useful principle: when product capability commoditizes or becomes hard to evaluate directly, brand becomes a larger part of perceived value, trust, and market memory.
+
+Apply it this way:
+
+- Treat brand as a trust and status system, not as decoration.
+- Build a brand that helps buyers choose when feature comparison is noisy.
+- Preserve product proof: brand cannot compensate for weak product experience.
+- Turn positioning into repeated signals across site, UI, content, launch assets, and support.
+
+## a16z: New Media And Launch Storytelling
+
+Sources:
+
+- https://a16z.com/what-is-new-media/
+- https://a16z.com/what-is-new-media-in-2026/
+
+Useful principle: startups can now own distribution by creating their own media moments. Launch videos and founder-led media work because they combine story, emotion, proof, and brand feel in a shareable artifact.
+
+Apply it this way:
+
+- Build launch assets as narrative systems, not announcement posts.
+- Include stakes, antagonist, transformation, product proof, and emotional texture.
+- Give the Brand OS rules for video, founder posts, screenshots, demos, and launch pages.
+- Measure attention-to-action, not only impressions.
+
+## Wada Sanzo And Japanese Color Harmony
+
+Sources:
+
+- https://en.seigensha.com/books/978-4-86152-247-5/
+- https://www.wada-sanzo-colors.com/
+
+Useful principle: color systems can gain depth from named, historically grounded harmonies. Wada Sanzo's color-combination work is useful because it treats palettes as relationships, not isolated hex values.
+
+Apply it this way:
+
+- Start from a reference color and define supporting roles.
+- Name colors semantically and culturally only when accurate.
+- Store color roles: canvas, surface, text, accent, warning, proof, campaign, image grade.
+- Avoid defaulting every brand to Japanese color names; use them when they improve clarity and taste.
+
+## Cute Studies And Kawaii
+
+Sources:
+
+- https://www.cutestudies.org/
+- https://www.cutestudies.com/
+- https://japanpastandpresent.org/en/teaching-aids/reading-lists/core-readings-in-kawaii-studies-an-annotated-guide
+
+Useful principle: cuteness can create approachability, attachment, shareability, and status. It is not automatically frivolous, but it can become unserious if used without audience fit.
+
+Apply it this way:
+
+- Use cute, mascot, or character systems when they reduce anxiety or create attachment.
+- Define character states, boundaries, and usage contexts.
+- Keep enterprise and high-trust product surfaces clear, useful, and non-distracting.
+- Use mascot/status mechanics as optional identity layers, not mandatory decoration.
+
+## Implementation Reference Boundary
+
+Use source material for principles, not competitor implementations for templates.
+
+Apply it this way:
+
+- Prefer primary essays, books, academic references, and direct product evidence from the user's own brand.
+- Do not use another startup's exact implementation as a Brand OS source.
+- Do not copy a competitor's font choices, palette, mascot, UI metaphors, launch mechanics, or private brand kit.
+- If competitor examples are supplied by the user, treat them as market context or anti-copy constraints, not as source-of-truth references.
+- For Genfeed, prioritize content operations, brand memory, autonomous generation, source evidence, and trust.
+
+## Brand OS Generator Implications
+
+A Brand OS generator should output:
+
+- Evidence and confidence, not only recommendations.
+- Visual identity and verbal identity.
+- Content pillars and launch storytelling.
+- AI-readable context and negative rules.
+- Review checklists and readiness states.
+- CTA and conversion path.
+- Source references for non-obvious recommendations.
+
+It should not output:
+
+- Unsupported factual claims.
+- Competitor-cloned style.
+- Unlicensed assets.
+- A full rebrand when the user asked for extraction.
+- A static PDF with no machine-readable generation context.

--- a/skills/brand-os-architect/references/source-pack.md
+++ b/skills/brand-os-architect/references/source-pack.md
@@ -47,6 +47,14 @@ Apply it this way:
 - Store color roles: canvas, surface, text, accent, warning, proof, campaign, image grade.
 - Avoid defaulting every brand to Japanese color names; use them when they improve clarity and taste.
 
+Validation rule:
+
+- A palette is Wada/Sanzo-matched only when each matched role records the Wada color name, collection, combination id when relevant, source URL, HEX, RGB, LAB when available, and whether the match is exact or nearest.
+- A palette is Wada/Sanzo-informed when it uses Wada's color-relationship method without claiming exact source swatches.
+- Do not rename product tokens with Japanese or Wada color names unless the exact or nearest mapping is documented.
+- Use nearest-color matching as diagnostics only. Never claim an exact match when the codebase token and source swatch differ.
+- Keep accessibility and product semantics ahead of historic color matching: contrast, state meaning, and readable hierarchy still win.
+
 ## Cute Studies And Kawaii
 
 Sources:

--- a/skills/genfeed-brand-os/README.md
+++ b/skills/genfeed-brand-os/README.md
@@ -1,0 +1,5 @@
+# Genfeed Brand OS
+
+Apply the Genfeed.ai Brand OS to product copy, website CTAs, launch content, examples, prompts, and generation context.
+
+This is Brand OS v0 derived from the current Genfeed.ai repo and product docs.

--- a/skills/genfeed-brand-os/SKILL.md
+++ b/skills/genfeed-brand-os/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: genfeed-brand-os
+description: 'Apply the Genfeed.ai Brand OS to product copy, website CTAs, launch content, skills, examples, prompts, and generation context. Triggers when creating Genfeed-branded content, Genfeed website copy, Genfeed launch narratives, Brand OS generator examples, product messaging, or AI-readable Genfeed brand guidance.'
+license: MIT
+metadata:
+  author: genfeedai
+  version: 0.1.0
+  tags: genfeed, brand-os, product-copy, website, launch, prompts
+---
+
+# Genfeed.ai Brand OS
+
+Use this skill to create or review Genfeed-branded content and product messaging. Treat this as Brand OS v0: derived from the current Genfeed.ai repo, product memory, README, DESIGN.md, and public skills positioning.
+
+For the full artifact, read `references/brand-os.md`.
+
+## Compact AI Context
+
+Genfeed.ai is the open-source AI OS for content creation. It helps creators, founders, agencies, and self-hosted operators generate, optimize, automate, and publish content across platforms through agents, workflows, brand memory, and BYOK/self-hosted infrastructure.
+
+Voice: direct, technical, operational, founder-aware, high-agency. Avoid generic SaaS hype, vague AI magic, mascot-first branding, and decorative minimalism. Explain the system, show the workflow, make the value concrete.
+
+Primary promise: configure the brand and content system once; Genfeed turns it into repeatable, reviewable, multi-platform content operations.
+
+Visual baseline: dark-first, information-dense, precise, premium, trustworthy. Product UI uses near-black layered surfaces, white CTAs, semantic status colors, compact controls, and explicit states. Marketing may be more cinematic and source-backed, but must still feel operational rather than fluffy.
+
+## Default CTA Hierarchy
+
+1. Build your Brand OS
+2. Generate your first content system
+3. Self-host Genfeed
+4. Join the open-source repo
+5. Book a managed setup
+
+## Do
+
+- Say "AI OS for content creation" when introducing the category.
+- Make workflows, agents, brand memory, review gates, and publishing loops tangible.
+- Use founder/operator language: control, pipeline, feedback loop, distribution, evidence.
+- Show source-backed examples and before/after outputs.
+- Keep copy concise and specific.
+
+## Do Not
+
+- Do not copy any competitor's identity, font choices, palette, mascot, or UI metaphors.
+- Do not claim full autonomy without review, permissions, or quality gates.
+- Do not sound like a generic social media scheduler.
+- Do not over-index on "cute", "fun", or "magical".
+- Do not bury the self-hosted/BYOK/open-source advantage.

--- a/skills/genfeed-brand-os/metadata.json
+++ b/skills/genfeed-brand-os/metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "genfeed-brand-os",
+  "version": "0.1.0",
+  "description": "Apply the Genfeed.ai Brand OS to product copy, prompts, launch content, and website CTAs",
+  "author": "genfeedai",
+  "license": "MIT",
+  "triggers": [
+    "genfeed brand os",
+    "genfeed brand voice",
+    "genfeed website copy",
+    "genfeed launch content",
+    "genfeed product messaging",
+    "build your brand os",
+    "genfeed cta",
+    "genfeed prompt context",
+    "genfeed brand guidance"
+  ],
+  "references": {
+    "brand_os": "references/brand-os.md"
+  },
+  "outputs": ["text"],
+  "tags": [
+    "genfeed",
+    "brand-os",
+    "product-copy",
+    "website",
+    "launch",
+    "prompts"
+  ]
+}

--- a/skills/genfeed-brand-os/references/brand-os.md
+++ b/skills/genfeed-brand-os/references/brand-os.md
@@ -1,0 +1,298 @@
+# Brand OS: Genfeed.ai
+
+## Evidence
+
+Sources used:
+
+- `README.md`: "The open source AI OS for content creation", self-hostable content platform, images/video/text/voice/music, visual workflow editor, multi-platform publishing, desktop/mobile/API/SDK, self-hosted GPU.
+- `DESIGN.md`: dark-first, information-dense UI, ShipCode/Linear visual language, operational confidence over flashy aesthetics, calm neutral surfaces, explicit states.
+- `.agents/memory/context/product-context.md`: autonomous content generation, multi-platform distribution, brand consistency, self-hosted control, extensibility.
+- `.agents/memory/context/project-brief.md`: self-hosted sovereignty, open-source extensibility, brand consistency, quality scoring, multi-platform reach.
+- `.agents/memory/context/project-vision.md`: autonomous content operations, strategic oversight, community marketplace, enterprise team operations.
+- `genfeedai/skills` README: public skills for content creation, optimization, analysis, communications, visual systems, advertising, GTM, platform development, and onboarding.
+
+Confidence:
+
+- High for category, audience, product promise, and UI tone.
+- Medium for marketing tone and visual campaign language.
+- Low for final public color/type direction beyond existing product UI tokens.
+
+## Positioning
+
+Category: open-source AI operating system for content creation and content operations.
+
+Primary audience:
+
+- Self-hosted operators who want control of AI content infrastructure.
+- Founders and creators who need repeatable content output.
+- Agencies and marketing teams managing multi-brand content systems.
+- Developers extending workflows, nodes, models, and integrations.
+
+Rejected alternative:
+
+- Disposable AI content tools that generate isolated assets with no memory, review loop, or distribution system.
+- Closed SaaS schedulers that own the data and stop at posting.
+- Manual content calendars that depend on constant human coordination.
+
+Core promise:
+
+Configure the brand, agents, workflows, and channels once; Genfeed turns them into repeatable, reviewable, multi-platform content operations.
+
+Differentiator:
+
+Open-source, self-hostable, workflow-native, multi-modal, and built around brand memory plus quality gates instead of one-off generation.
+
+Positioning statement:
+
+For creators, founders, agencies, and operators who need consistent content at scale, Genfeed.ai is the open-source AI OS for content creation that turns brand memory, agents, workflows, and publishing into one controlled operating loop. Unlike one-off AI generators or closed schedulers, Genfeed lets teams own the stack, bring their own models, and run repeatable content systems across platforms.
+
+## Brand Principles
+
+### 1. Operations Over Magic
+
+Rule: show the system behind the output.
+
+Rationale: Genfeed wins when users trust pipelines, review gates, state, and control.
+
+Do: "Create, review, schedule, publish, and learn from one workflow."
+
+Do not: "Make viral content instantly with AI magic."
+
+### 2. Sovereignty Is A Feature
+
+Rule: make self-hosted, BYOK, open-source, and data control visible.
+
+Rationale: Genfeed's trust advantage is ownership and extensibility.
+
+Do: "Run it on your stack. Bring your keys. Keep your content pipeline yours."
+
+Do not: hide open source under generic productivity copy.
+
+### 3. Brand Memory Before Volume
+
+Rule: content volume only matters when brand, sources, and quality gates survive scale.
+
+Rationale: the Brand OS generator should teach users that consistency compounds.
+
+Do: "Every generation carries the same voice, visual rules, and review checklist."
+
+Do not: promise unlimited content with no review or evidence.
+
+### 4. Explicit State Builds Trust
+
+Rule: always expose status, ownership, confidence, and next action.
+
+Rationale: autonomous systems feel safe when their state is visible.
+
+Do: use states like draft, partial, blocked, accepted, scheduled, published, learning.
+
+Do not: silently mutate brand data or hide failure.
+
+### 5. Source-Backed Creativity
+
+Rule: creative recommendations should cite evidence or state assumptions.
+
+Rationale: Genfeed's Brand OS generator should feel like a strategist with receipts.
+
+Do: show extracted colors, source URLs, content examples, and confidence.
+
+Do not: invent a full brand system from a thin website scan without caveats.
+
+## Voice System
+
+Personality:
+
+- Pragmatic
+- Technical
+- Founder-aware
+- Direct
+- Trustworthy
+- Ambitious without hype
+
+Tone spectrum:
+
+- More operational than whimsical.
+- More concrete than inspirational.
+- More system-builder than social media guru.
+- More premium than playful.
+
+Vocabulary to use:
+
+- operating system
+- content operations
+- workflow
+- agent
+- brand memory
+- review gate
+- content loop
+- self-hosted
+- BYOK
+- generation context
+- source-backed
+- multi-platform
+- publish-ready
+- feedback loop
+
+Vocabulary to avoid:
+
+- magic
+- effortless virality
+- growth hack
+- AI slop
+- cute-first
+- set it and forget it
+- one-click empire
+- generic "10x your content" without proof
+
+Sample headline options:
+
+- Build your Brand OS.
+- Turn your brand into a content system.
+- The open-source AI OS for content creation.
+- From brand memory to multi-platform publishing.
+- Generate content your brand can actually stand behind.
+
+Sample CTA copy:
+
+- Build your Brand OS
+- Generate my Brand OS
+- Save this Brand OS in Genfeed
+- Run this content loop
+- Self-host Genfeed
+
+## Content System
+
+Core pillars:
+
+1. Brand OS and brand memory
+2. Autonomous content workflows
+3. Open-source/self-hosted control
+4. Multi-platform publishing
+5. AI generation quality and review
+6. Founder/operator content strategy
+
+Recurring formats:
+
+- "From source to system" teardown
+- Brand OS teardown
+- Workflow blueprint
+- Before/after content loop
+- Model/provider comparison
+- Self-hosted setup guide
+- Launch content breakdown
+- Agent workflow demo
+
+Launch storytelling pattern:
+
+1. The content problem is operational, not creative alone.
+2. One-off AI tools increase output but fragment brand memory.
+3. Genfeed turns brand, agents, workflows, review, and publishing into one loop.
+4. The user keeps control through open source and self-hosting.
+5. The first action is to build a Brand OS.
+
+Review checklist:
+
+- Is the claim concrete?
+- Is the audience clear?
+- Is the next action obvious?
+- Does it mention a Genfeed differentiator?
+- Does it avoid generic AI hype?
+- Does it preserve source/quality/review boundaries?
+
+## Visual System
+
+Product UI baseline:
+
+- Dark-first canvas.
+- Layered near-black backgrounds.
+- Compact, information-dense controls.
+- White or near-white primary CTAs.
+- Semantic status colors for success, warning, danger, info, agent, and done.
+- Radius stays restrained: 2px, 6px, 8px, 10px.
+- Base spacing uses a 4px grid.
+
+Current product tokens:
+
+- Primary background: `#050607`
+- Secondary background: `#0c0d10`
+- Tertiary background: `#131518`
+- Elevated background: `#1a1c21`
+- Hover background: `#20232a`
+- Primary text: `#f4f4f5`
+- Secondary text: `#b4b4bc`
+- Muted text: `#6b6b78`
+- Accent: `#fafafa`
+- Agent: `#38bdf8`
+- Done: `#a855f7`
+- Success: `#10b981`
+- Warning: `#f59e0b`
+- Danger: `#ef4444`
+- Info: `#3b82f6`
+
+Typography direction:
+
+- Product UI: system sans and mono for speed, density, and native feel.
+- Marketing: can introduce a distinctive display direction later, but must remain technical, precise, and readable.
+- Do not adopt a competitor's font pairing as the default.
+
+Image/video direction:
+
+- Show real workflows, boards, nodes, queues, cards, content states, and output artifacts.
+- Favor inspectable interfaces and launch-story scenes over abstract AI blobs.
+- Use motion to clarify state transitions: scan, draft, review, accepted, scheduled, published, learning.
+- Avoid decorative mascot-first visuals unless a specific campaign calls for it.
+
+Scale tokens:
+
+- Compact UI: 4, 8, 12, 16, 24, 32.
+- Marketing/story assets: 24, 40, 64, 104, 168.
+- Use larger jumps for launch content, not inside dense product UI.
+
+## AI Context
+
+Use this compact prompt block when generating Genfeed-branded output:
+
+```text
+Genfeed.ai is the open-source AI OS for content creation. It helps creators, founders, agencies, and self-hosted operators turn brand memory, agents, workflows, review gates, and multi-platform publishing into one controlled content operating loop. Use direct, technical, founder-aware language. Make the system concrete. Emphasize self-hosted/BYOK control, brand consistency, source-backed generation, workflow automation, review states, and publishing feedback loops. Avoid generic AI hype, mascot-first branding, unsupported autonomy claims, and vague "viral content" promises.
+```
+
+Quality gates:
+
+- The output names the job Genfeed does.
+- The output explains a workflow or operating loop.
+- The output includes a concrete CTA.
+- The output preserves trust boundaries.
+- The output feels useful to a founder/operator.
+
+Negative instructions:
+
+- Do not copy any competitor identity.
+- Do not use cute/kawaii as Genfeed's default identity.
+- Do not promise unreviewed autonomous publishing.
+- Do not bury open source and self-hosted control.
+- Do not produce generic social scheduler copy.
+
+## Activation
+
+Primary public freebie:
+
+- CTA: "Build your Brand OS"
+- Input: website URL, pasted guidance, uploaded references, manual brand notes
+- Output: public preview with visual identity, voice, content pillars, source evidence, diagnostics, and save prompt
+- Conversion: sign in or sign up to save into a brand workspace
+- Product loop: review, edit, accept, then use in generation context
+
+First launch campaign:
+
+- Page: `/brand-os` or homepage hero module
+- Hook: "Turn your website into an AI-readable Brand OS."
+- Demo: URL scan -> evidence -> preview -> save -> generation context
+- Proof: source-backed recommendations, readiness states, before/after generated content
+- CTA: "Build your Brand OS"
+
+## Open Questions
+
+- Final public marketing typeface direction.
+- Whether Genfeed uses an illustrated agent/mascot in campaigns or stays tool/system-first.
+- Exact public color expansion beyond current dark product tokens.
+- Which source-backed references become visible in the public generator UI.

--- a/skills/genfeed-brand-os/references/brand-os.md
+++ b/skills/genfeed-brand-os/references/brand-os.md
@@ -264,8 +264,35 @@ Image/video direction:
 Scale tokens:
 
 - Compact UI: 4, 8, 12, 16, 24, 32.
-- Marketing/story assets: 24, 40, 64, 104, 168.
+- Marketing/story assets: 24, 40, 64, 104, 168, 272, 440.
 - Use larger jumps for launch content, not inside dense product UI.
+
+Scale model:
+
+- Product UI uses a practical 4px grid. It is not required to follow the golden ratio because dense interfaces need alignment, scannability, and predictable control heights.
+- Brand and campaign objects use a rounded golden-ratio progression. The ratio is approximate because values are rounded to CSS-friendly grid numbers.
+- The working phi-rounded sequence is `24 -> 40 -> 64 -> 104 -> 168 -> 272 -> 440`.
+- Use semantic scale roles in prompts and specs instead of "make it bigger" or "make it smaller."
+- Never use the largest campaign roles inside dense product UI.
+
+Semantic size roles:
+
+| Role | Size band | Use |
+| --- | --- | --- |
+| `micro` | 4-8px | Dividers, tiny offsets, state dots, hairline spacing |
+| `chip` | 12-16px | Badges, inline icons, metadata marks |
+| `control` | 32px | Buttons, inputs, select triggers, toolbar actions |
+| `block` | 40-64px | Small brand marks, content-card anchors, compact campaign objects |
+| `hero` | 104px | Section-leading visual objects, hero marks, screenshot highlights |
+| `monument` | 168-272px | First-viewport visual anchors, launch page objects, large proof artifacts |
+| `god` | 440px+ | One-per-page or one-per-campaign focal object; full-bleed or dominant launch visual only |
+
+Font-by-size rule:
+
+- Product UI typography stays on the app scale.
+- Campaign typography should be assigned by semantic role, not by arbitrary px values.
+- Until the final marketing typeface is selected, use the role scale with system sans and mono.
+- Do not copy a competitor's font-size/typeface pairing.
 
 Element size contract:
 

--- a/skills/genfeed-brand-os/references/brand-os.md
+++ b/skills/genfeed-brand-os/references/brand-os.md
@@ -10,12 +10,14 @@ Sources used:
 - `.agents/memory/context/project-brief.md`: self-hosted sovereignty, open-source extensibility, brand consistency, quality scoring, multi-platform reach.
 - `.agents/memory/context/project-vision.md`: autonomous content operations, strategic oversight, community marketplace, enterprise team operations.
 - `genfeedai/skills` README: public skills for content creation, optimization, analysis, communications, visual systems, advertising, GTM, platform development, and onboarding.
+- `brand-os-architect/references/source-pack.md`, Seigensha's Sanzo Wada book page, and Wada Sanzo Colors: Wada/Sanzo is used as a color-harmony and palette-validation reference, not as an existing Genfeed product palette source.
 
 Confidence:
 
 - High for category, audience, product promise, and UI tone.
+- High for current product UI tokens, app typography, compact controls, radius, and base spacing because they come from `DESIGN.md`.
 - Medium for marketing tone and visual campaign language.
-- Low for final public color/type direction beyond existing product UI tokens.
+- Low for final public marketing color/type direction until exact source-backed palette choices are pinned.
 
 ## Positioning
 
@@ -201,6 +203,14 @@ Review checklist:
 
 ## Visual System
 
+Color system status:
+
+- Genfeed's current palette is codebase-derived, not Wada/Sanzo-matched.
+- Wada/Sanzo is a reference for harmony, named color relationships, and generator validation. It is not a mandate to recolor the current product UI.
+- A Genfeed palette can only claim "Wada/Sanzo-matched" when each mapped color role includes Wada color name, collection, combination id when relevant, source URL, HEX, RGB, LAB when available, and exact-vs-nearest status.
+- Nearest-color matching is useful for diagnostics and exploration only. It is not the same as an exact match.
+- Do not use Japanese or Wada color names for Genfeed tokens unless the mapping has been documented.
+
 Product UI baseline:
 
 - Dark-first canvas.
@@ -229,6 +239,15 @@ Current product tokens:
 - Danger: `#ef4444`
 - Info: `#3b82f6`
 
+Wada/Sanzo audit note:
+
+- A 2026-06-24 diagnostic pass against the public Wada Sanzo Colors swatches found no exact match for the current Genfeed product tokens above.
+- Useful nearest anchors for future marketing exploration include Black `#111314` near the dark surfaces, Deep Indigo `#051230` as a campaign-canvas candidate, Neutral Gray `#b6bfc1` near secondary text, and Yellow Orange `#f99d1b` near warning.
+- Candidate Wada-informed campaign modes to test visually:
+  - System calm: Classic #139, Deep Indigo `#051230`, Salvia Blue `#97acc8`, Neutral Gray `#b6bfc1`.
+  - Launch pulse: Classic #155, Jasper Red `#eb5324`, Benzol Green `#00978d`, Deep Indigo `#051230`.
+- These are marketing exploration palettes only. They do not replace the locked product UI tokens without accessibility, contrast, and product-state review.
+
 Typography direction:
 
 - Product UI: system sans and mono for speed, density, and native feel.
@@ -247,6 +266,16 @@ Scale tokens:
 - Compact UI: 4, 8, 12, 16, 24, 32.
 - Marketing/story assets: 24, 40, 64, 104, 168.
 - Use larger jumps for launch content, not inside dense product UI.
+
+Element size contract:
+
+- Base grid: 4px.
+- Dense controls: 32px height for primary buttons, secondary buttons, ghost buttons, destructive buttons, inputs, and selects.
+- App typography: badges/chips 10px, table heads 11px, table cells 12px, body/buttons 13px, card titles 14px, section headings 1.875rem.
+- Radius: 2px for badges/tags/chips, 6px for cards/buttons/inputs/tooltips/popovers/dropdowns, 8px for toasts/overlay panels, 10px for dialogs and command palettes.
+- Containment: cards, dialogs, and dropdowns use inset box-shadow containment; structural dividers can use borders.
+- Shared layout guardrails from the Tailwind base: charts 280-300px, dropdown max-height 300px, card min-height 160px, code blocks 180-280px, textarea min-height 60-80px, workflow nodes min-width 180px, skill columns min-width 200px.
+- Wada/Sanzo does not define Genfeed element sizes. Element size comes from the product design system; Wada/Sanzo only informs color relationships.
 
 ## AI Context
 
@@ -294,5 +323,5 @@ First launch campaign:
 
 - Final public marketing typeface direction.
 - Whether Genfeed uses an illustrated agent/mascot in campaigns or stays tool/system-first.
-- Exact public color expansion beyond current dark product tokens.
+- Final public marketing palette after Wada/Sanzo source matching and accessibility review.
 - Which source-backed references become visible in the public generator UI.


### PR DESCRIPTION
## Summary
- Mirror `brand-os-architect` from `genfeedai/skills` into app-local `skills/`.
- Mirror `genfeed-brand-os` into app-local `skills/`.
- Update the local skills README inventory.

## Validation
- `quick_validate.py skills/brand-os-architect`
- `quick_validate.py skills/genfeed-brand-os`
- `gitleaks protect --staged --redact --exit-code 1`

## Notes
- Canonical public skills source PR: https://github.com/genfeedai/skills/pull/10
- Existing generated Prisma changes in this worktree were left unstaged and untouched.
