### PR TITLE
[codex] Improve Genfeed system email templates

### DIFF
--- a/apps/app/app/(public)/auth-callback-url.test.ts
+++ b/apps/app/app/(public)/auth-callback-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getAuthCallbackURL,
+  toAbsoluteAuthCallbackURL,
+} from './auth-callback-url';
+
+describe('auth callback URL helpers', () => {
+  it('prefers callbackUrl and falls back to root', () => {
+    expect(
+      getAuthCallbackURL(new URLSearchParams('callbackUrl=%2Fonboarding')),
+    ).toBe('/onboarding');
+    expect(getAuthCallbackURL(new URLSearchParams())).toBe('/');
+  });
+
+  it('expands relative callbacks to the active app origin', () => {
+    expect(toAbsoluteAuthCallbackURL('/oauth/cli?port=4321')).toBe(
+      `${window.location.origin}/oauth/cli?port=4321`,
+    );
+  });
+
+  it('leaves absolute callbacks and desktop deep links unchanged', () => {
+    expect(toAbsoluteAuthCallbackURL('https://app.genfeed.ai/')).toBe(
+      'https://app.genfeed.ai/',
+    );
+    expect(toAbsoluteAuthCallbackURL('genfeedai-desktop://auth')).toBe(
+      'genfeedai-desktop://auth',
+    );
+  });
+});

--- a/apps/app/app/(public)/auth-callback-url.ts
+++ b/apps/app/app/(public)/auth-callback-url.ts
@@ -1,0 +1,27 @@
+export function getAuthCallbackURL(
+  searchParams: Pick<URLSearchParams, 'get'>,
+): string {
+  return (
+    searchParams.get('callbackUrl') ||
+    searchParams.get('return_to') ||
+    searchParams.get('redirect_url') ||
+    '/'
+  );
+}
+
+export function toAbsoluteAuthCallbackURL(callbackURL: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(callbackURL)) {
+    return callbackURL;
+  }
+
+  const origin =
+    typeof window === 'undefined'
+      ? 'https://app.genfeed.ai'
+      : window.location.origin;
+
+  if (callbackURL.startsWith('/')) {
+    return `${origin}${callbackURL}`;
+  }
+
+  return `${origin}/${callbackURL}`;
+}

--- a/apps/app/app/(public)/login/content.test.tsx
+++ b/apps/app/app/(public)/login/content.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@ui/layouts/auth/AuthFormLayout', () => ({
 }));
 
 const getEmailInput = () => screen.getByRole('textbox', { name: /^Email/ });
+const absoluteCallback = (path: string) => `${window.location.origin}${path}`;
 
 describe('LoginPage', () => {
   beforeEach(() => {
@@ -108,7 +109,7 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
-        callbackURL: '/',
+        callbackURL: absoluteCallback('/'),
         provider: 'google',
       });
     });
@@ -125,7 +126,7 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
-        callbackURL: '/onboarding',
+        callbackURL: absoluteCallback('/onboarding'),
         provider: 'google',
       });
     });
@@ -155,7 +156,7 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(authClientMocks.magicLink).toHaveBeenCalledWith({
-        callbackURL: '/',
+        callbackURL: absoluteCallback('/'),
         email: 'user@example.com',
       });
     });
@@ -180,7 +181,7 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(authClientMocks.magicLink).toHaveBeenCalledWith({
-        callbackURL: '/oauth/cli?port=4321',
+        callbackURL: absoluteCallback('/oauth/cli?port=4321'),
         email: 'cli@example.com',
       });
     });
@@ -199,7 +200,7 @@ describe('LoginPage', () => {
 
     await waitFor(() => {
       expect(authClientMocks.email).toHaveBeenCalledWith({
-        callbackURL: '/',
+        callbackURL: absoluteCallback('/'),
         email: 'saved@example.com',
         password: 'correct horse battery staple',
       });

--- a/apps/app/app/(public)/login/login-better-auth.tsx
+++ b/apps/app/app/(public)/login/login-better-auth.tsx
@@ -16,6 +16,10 @@ import {
   useSyncExternalStore,
 } from 'react';
 import { FcGoogle } from 'react-icons/fc';
+import {
+  getAuthCallbackURL,
+  toAbsoluteAuthCallbackURL,
+} from '../auth-callback-url';
 
 const subscribe = () => () => {};
 const getSnapshot = () => true;
@@ -32,15 +36,6 @@ const AUTH_BUTTON_CLASS_NAME =
 
 const AUTH_LINK_CLASS_NAME =
   'text-sm font-medium text-foreground underline underline-offset-4';
-
-function getCallbackURL(searchParams: Pick<URLSearchParams, 'get'>) {
-  return (
-    searchParams.get('callbackUrl') ||
-    searchParams.get('return_to') ||
-    searchParams.get('redirect_url') ||
-    '/'
-  );
-}
 
 function getLoginModeHref(path: string, callbackURL: string) {
   if (callbackURL === '/') {
@@ -74,7 +69,8 @@ export default function LoginBetterAuth({
   const [socialErrorMessage, setSocialErrorMessage] = useState<string | null>(
     null,
   );
-  const callbackURL = getCallbackURL(searchParams);
+  const callbackURL = getAuthCallbackURL(searchParams);
+  const authCallbackURL = toAbsoluteAuthCallbackURL(callbackURL);
   const chooserHref = getLoginModeHref('/login', callbackURL);
   const magicLinkHref = getLoginModeHref('/login/magic-link', callbackURL);
   const passwordHref = getLoginModeHref('/login/password', callbackURL);
@@ -87,7 +83,10 @@ export default function LoginBetterAuth({
     setIsSubmitting(true);
 
     try {
-      const result = await signIn.magicLink({ email, callbackURL });
+      const result = await signIn.magicLink({
+        callbackURL: authCallbackURL,
+        email,
+      });
       if (result?.error) {
         setErrorMessage(
           result.error.message ??
@@ -111,7 +110,7 @@ export default function LoginBetterAuth({
 
     try {
       const result = await signIn.email({
-        callbackURL,
+        callbackURL: authCallbackURL,
         email,
         password,
       });
@@ -137,7 +136,10 @@ export default function LoginBetterAuth({
     setIsSocialSubmitting(true);
 
     try {
-      const result = await signIn.social({ provider: 'google', callbackURL });
+      const result = await signIn.social({
+        callbackURL: authCallbackURL,
+        provider: 'google',
+      });
       if (result?.error) {
         setSocialErrorMessage(
           result.error.message ??

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -16,6 +16,10 @@ import {
   useSyncExternalStore,
 } from 'react';
 import { persistOnboardingHandoffParams } from '@/lib/onboarding/onboarding-access.util';
+import {
+  getAuthCallbackURL,
+  toAbsoluteAuthCallbackURL,
+} from '../auth-callback-url';
 
 const subscribe = () => () => {};
 const getSnapshot = () => true;
@@ -33,11 +37,8 @@ export default function SignUpBetterAuth() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const callbackURL =
-    searchParams.get('callbackUrl') ||
-    searchParams.get('return_to') ||
-    searchParams.get('redirect_url') ||
-    '/';
+  const callbackURL = getAuthCallbackURL(searchParams);
+  const authCallbackURL = toAbsoluteAuthCallbackURL(callbackURL);
 
   useEffect(() => {
     persistOnboardingHandoffParams(window.location.search);
@@ -49,7 +50,10 @@ export default function SignUpBetterAuth() {
     setIsSubmitting(true);
 
     try {
-      const result = await signIn.magicLink({ email, callbackURL });
+      const result = await signIn.magicLink({
+        callbackURL: authCallbackURL,
+        email,
+      });
       if (result?.error) {
         setErrorMessage(
           result.error.message ??
@@ -67,7 +71,7 @@ export default function SignUpBetterAuth() {
 
   async function handleGoogleSignUp() {
     setErrorMessage(null);
-    await signIn.social({ provider: 'google', callbackURL });
+    await signIn.social({ callbackURL: authCallbackURL, provider: 'google' });
   }
 
   if (!isMounted) {

--- a/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@ui/layouts/auth/AuthFormLayout', () => ({
 }));
 
 const getEmailInput = () => screen.getByRole('textbox', { name: /^Email/ });
+const absoluteCallback = (path: string) => `${window.location.origin}${path}`;
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -90,7 +91,7 @@ describe('SignUpForm', () => {
 
     await waitFor(() => {
       expect(authClientMocks.magicLink).toHaveBeenCalledWith({
-        callbackURL: '/onboarding',
+        callbackURL: absoluteCallback('/onboarding'),
         email: 'new@example.com',
       });
     });

--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BetterAuthMailerService } from './better-auth-mailer.service';
+
+describe('BetterAuthMailerService', () => {
+  it('sends magic links with the shared Genfeed system email shell', async () => {
+    const notificationsService = {
+      sendEmail: vi.fn().mockResolvedValue(undefined),
+    };
+    const logger = { log: vi.fn() };
+    const service = new BetterAuthMailerService(
+      notificationsService as never,
+      logger as never,
+    );
+    const url =
+      'https://api.genfeed.ai/v1/auth/magic-link/verify?token=tok&callbackURL=https%3A%2F%2Fapp.genfeed.ai%2F';
+
+    await service.sendMagicLink({
+      email: 'user@example.com',
+      token: 'tok',
+      url,
+    });
+
+    expect(notificationsService.sendEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      'Your Genfeed.ai sign-in link',
+      expect.stringContaining('<!doctype html>'),
+    );
+    const html = notificationsService.sendEmail.mock.calls[0]?.[2] as string;
+    expect(html).toContain('Genfeed.ai');
+    expect(html).toContain('Sign in to Genfeed.ai');
+    expect(html).toContain(
+      'https://api.genfeed.ai/v1/auth/magic-link/verify?token=tok&amp;callbackURL=https%3A%2F%2Fapp.genfeed.ai%2F',
+    );
+    expect(html).toContain('If you did not request this sign-in link');
+  });
+});

--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
@@ -1,4 +1,9 @@
 import { NotificationsService } from '@api/services/notifications/notifications.service';
+import {
+  buildSystemEmailHtml,
+  buildSystemEmailParagraph,
+  escapeSystemEmailHtml,
+} from '@genfeedai/helpers';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
@@ -35,13 +40,21 @@ export class BetterAuthMailerService {
   }
 
   private buildMagicLinkHtml(url: string): string {
-    return [
-      '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:480px;margin:0 auto;padding:24px">',
-      '<h1 style="font-size:20px;margin:0 0 16px">Sign in to Genfeed.ai</h1>',
-      '<p style="font-size:14px;color:#444;margin:0 0 24px">Click the button below to sign in. This link expires shortly and can only be used once.</p>',
-      `<a href="${url}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 20px;border-radius:8px;font-size:14px">Sign in</a>`,
-      '<p style="font-size:12px;color:#888;margin:24px 0 0">If you did not request this, you can safely ignore this email.</p>',
-      '</div>',
-    ].join('');
+    const escapedUrl = escapeSystemEmailHtml(url);
+
+    return buildSystemEmailHtml({
+      action: { label: 'Sign in', url },
+      bodyHtml: [
+        buildSystemEmailParagraph(
+          'Click the button below to sign in. This link expires shortly and can only be used once.',
+        ),
+        '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
+        `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
+      ].join(''),
+      footerNote:
+        'If you did not request this sign-in link, you can safely ignore this email.',
+      preheader: 'Use this one-time link to sign in to Genfeed.ai.',
+      title: 'Sign in to Genfeed.ai',
+    });
   }
 }

--- a/apps/server/api/src/collections/content-performance/services/email-digest.service.ts
+++ b/apps/server/api/src/collections/content-performance/services/email-digest.service.ts
@@ -4,6 +4,10 @@ import {
 } from '@api/collections/content-performance/services/performance-summary.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  buildSystemEmailHtml,
+  escapeSystemEmailHtml,
+} from '@genfeedai/helpers';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
@@ -70,7 +74,7 @@ export class EmailDigestService {
 
       // Build email HTML
       const html = this.buildDigestHtml(summary, orgName);
-      const subject = `📊 Weekly Performance Digest — ${orgName}`;
+      const subject = `Weekly Performance Digest - ${orgName}`;
 
       // Send to each recipient
       for (const email of recipients) {
@@ -124,8 +128,18 @@ export class EmailDigestService {
    */
   buildDigestHtml(summary: WeeklySummary, orgName: string): string {
     const trend = summary.weekOverWeekTrend;
-    const trendEmoji =
-      trend.direction === 'up' ? '📈' : trend.direction === 'down' ? '📉' : '➡️';
+    const trendLabel =
+      trend.direction === 'up'
+        ? 'Up'
+        : trend.direction === 'down'
+          ? 'Down'
+          : 'Flat';
+    const trendColor =
+      trend.direction === 'up'
+        ? '#10b981'
+        : trend.direction === 'down'
+          ? '#ef4444'
+          : '#8c8c96';
     const trendPct = Math.abs(trend.percentageChange).toFixed(1);
 
     const topPerformersHtml = summary.topPerformers
@@ -133,11 +147,11 @@ export class EmailDigestService {
       .map(
         (p, i) => `
         <tr>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${i + 1}</td>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${this.escapeHtml(p.title || p.description || 'Untitled').substring(0, 60)}</td>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${p.platform}</td>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${p.engagementRate.toFixed(2)}%</td>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${this.formatNumber(p.views)}</td>
+          <td style="border-bottom:1px solid #1e2022;color:#8c8c96;padding:8px;">${i + 1}</td>
+          <td style="border-bottom:1px solid #1e2022;color:#f4f4f5;padding:8px;">${this.escapeHtml(p.title || p.description || 'Untitled').substring(0, 60)}</td>
+          <td style="border-bottom:1px solid #1e2022;color:#b4b4bc;padding:8px;">${this.escapeHtml(p.platform)}</td>
+          <td style="border-bottom:1px solid #1e2022;color:#b4b4bc;padding:8px;">${p.engagementRate.toFixed(2)}%</td>
+          <td style="border-bottom:1px solid #1e2022;color:#b4b4bc;padding:8px;">${this.formatNumber(p.views)}</td>
         </tr>`,
       )
       .join('');
@@ -146,9 +160,9 @@ export class EmailDigestService {
       .map(
         (p) => `
         <tr>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${p.platform}</td>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${p.avgEngagementRate.toFixed(2)}%</td>
-          <td style="padding:8px;border-bottom:1px solid #eee;">${p.totalPosts}</td>
+          <td style="border-bottom:1px solid #1e2022;color:#f4f4f5;padding:8px;">${this.escapeHtml(p.platform)}</td>
+          <td style="border-bottom:1px solid #1e2022;color:#b4b4bc;padding:8px;">${p.avgEngagementRate.toFixed(2)}%</td>
+          <td style="border-bottom:1px solid #1e2022;color:#b4b4bc;padding:8px;">${p.totalPosts}</td>
         </tr>`,
       )
       .join('');
@@ -158,96 +172,79 @@ export class EmailDigestService {
       .map((t) => {
         const period = t.hour >= 12 ? 'PM' : 'AM';
         const displayHour = t.hour > 12 ? t.hour - 12 : t.hour || 12;
-        return `<li>${displayHour}:00 ${period} (${t.avgEngagementRate.toFixed(2)}% avg engagement, ${t.postCount} posts)</li>`;
+        return `<li style="margin:0 0 8px;">${displayHour}:00 ${period} (${t.avgEngagementRate.toFixed(2)}% avg engagement, ${t.postCount} posts)</li>`;
       })
       .join('');
 
-    return `
-<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#333;">
-  <h1 style="color:#1a1a2e;border-bottom:2px solid #e94560;padding-bottom:10px;">
-    📊 Weekly Performance Digest
-  </h1>
-  <p style="color:#666;">Report for <strong>${this.escapeHtml(orgName)}</strong></p>
+    const bodyHtml = `
+  <p style="color:#b4b4bc;font-size:15px;line-height:24px;margin:0 0 18px;">Report for <strong style="color:#f4f4f5;">${this.escapeHtml(orgName)}</strong></p>
 
-  <!-- Trend Summary -->
-  <div style="background:#f8f9fa;border-radius:8px;padding:16px;margin:20px 0;">
-    <h2 style="margin:0 0 8px 0;font-size:18px;">${trendEmoji} Week-over-Week Trend</h2>
-    <p style="margin:0;font-size:24px;font-weight:bold;color:${trend.direction === 'up' ? '#28a745' : trend.direction === 'down' ? '#dc3545' : '#6c757d'};">
+  <div style="background:#131518;border:1px solid #333538;border-radius:8px;padding:16px;margin:0 0 24px;">
+    <h2 style="color:#f4f4f5;font-size:16px;line-height:22px;margin:0 0 8px;">Week-over-Week Trend</h2>
+    <p style="margin:0;font-size:28px;font-weight:700;line-height:34px;color:${trendColor};">
       ${trend.direction === 'up' ? '+' : trend.direction === 'down' ? '-' : ''}${trendPct}%
     </p>
-    <p style="margin:4px 0 0;color:#666;font-size:14px;">
-      Engagement: ${this.formatNumber(trend.currentEngagement)} (prev: ${this.formatNumber(trend.previousEngagement)})
+    <p style="margin:4px 0 0;color:#8c8c96;font-size:13px;line-height:20px;">
+      ${trendLabel} from ${this.formatNumber(trend.previousEngagement)} to ${this.formatNumber(trend.currentEngagement)} engagements.
     </p>
   </div>
 
-  <!-- Top Performers -->
-  <h2 style="color:#1a1a2e;font-size:18px;">🏆 Top Performers</h2>
+  <h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Top Performers</h2>
   ${
     summary.topPerformers.length > 0
-      ? `<table style="width:100%;border-collapse:collapse;font-size:14px;">
+      ? `<table style="border-collapse:collapse;font-size:13px;width:100%;">
     <thead>
-      <tr style="background:#f8f9fa;">
-        <th style="padding:8px;text-align:left;">#</th>
-        <th style="padding:8px;text-align:left;">Content</th>
-        <th style="padding:8px;text-align:left;">Platform</th>
-        <th style="padding:8px;text-align:left;">Engagement</th>
-        <th style="padding:8px;text-align:left;">Views</th>
+      <tr>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">#</th>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Content</th>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Platform</th>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Engagement</th>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Views</th>
       </tr>
     </thead>
     <tbody>${topPerformersHtml}</tbody>
   </table>`
-      : '<p style="color:#999;">No performance data this week.</p>'
+      : '<p style="color:#8c8c96;margin:0 0 16px;">No performance data this week.</p>'
   }
 
-  <!-- Platform Breakdown -->
-  <h2 style="color:#1a1a2e;font-size:18px;margin-top:24px;">📱 Platform Breakdown</h2>
+  <h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Platform Breakdown</h2>
   ${
     summary.avgEngagementByPlatform.length > 0
-      ? `<table style="width:100%;border-collapse:collapse;font-size:14px;">
+      ? `<table style="border-collapse:collapse;font-size:13px;width:100%;">
     <thead>
-      <tr style="background:#f8f9fa;">
-        <th style="padding:8px;text-align:left;">Platform</th>
-        <th style="padding:8px;text-align:left;">Avg Engagement</th>
-        <th style="padding:8px;text-align:left;">Posts</th>
+      <tr>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Platform</th>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Avg Engagement</th>
+        <th style="color:#8c8c96;font-weight:700;padding:8px;text-align:left;">Posts</th>
       </tr>
     </thead>
     <tbody>${platformHtml}</tbody>
   </table>`
-      : '<p style="color:#999;">No platform data available.</p>'
+      : '<p style="color:#8c8c96;margin:0 0 16px;">No platform data available.</p>'
   }
 
-  <!-- Best Posting Times -->
-  <h2 style="color:#1a1a2e;font-size:18px;margin-top:24px;">⏰ Best Posting Times</h2>
-  ${bestTimesHtml ? `<ul style="font-size:14px;">${bestTimesHtml}</ul>` : '<p style="color:#999;">Not enough data yet.</p>'}
+  <h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Best Posting Times</h2>
+  ${bestTimesHtml ? `<ul style="color:#b4b4bc;font-size:14px;line-height:22px;margin:0 0 16px;padding-left:18px;">${bestTimesHtml}</ul>` : '<p style="color:#8c8c96;margin:0 0 16px;">Not enough data yet.</p>'}
 
-  <!-- Top Hooks -->
   ${
     summary.topHooks.length > 0
-      ? `<h2 style="color:#1a1a2e;font-size:18px;margin-top:24px;">🎣 Top Hooks</h2>
-  <ol style="font-size:14px;">
+      ? `<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Top Hooks</h2>
+  <ol style="color:#b4b4bc;font-size:14px;line-height:22px;margin:0 0 16px;padding-left:18px;">
     ${summary.topHooks.map((h) => `<li>"${this.escapeHtml(h.substring(0, 80))}"</li>`).join('')}
   </ol>`
       : ''
-  }
+  }`;
 
-  <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
-  <p style="color:#999;font-size:12px;">
-    This is an automated performance digest from GenFeed AI.
-    To unsubscribe, update your notification preferences in the dashboard.
-  </p>
-</body>
-</html>`;
+    return buildSystemEmailHtml({
+      bodyHtml,
+      footerNote:
+        'This is an automated performance digest. To unsubscribe, update your notification preferences in Genfeed.',
+      title: 'Weekly Performance Digest',
+    });
   }
 
   private escapeHtml(text: string): string {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+    return escapeSystemEmailHtml(text);
   }
 
   private formatNumber(num: number): string {

--- a/apps/server/api/src/collections/members/services/invitation.service.ts
+++ b/apps/server/api/src/collections/members/services/invitation.service.ts
@@ -2,6 +2,10 @@ import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { ConfigService } from '@api/config/config.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  buildSystemEmailHtml,
+  buildSystemEmailParagraph,
+} from '@genfeedai/helpers';
 import type { Invitation, Member, Prisma, User } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import {
@@ -74,15 +78,6 @@ function hashToken(token: string): string {
 
 function generateInvitationToken(): string {
   return randomBytes(INVITATION_TOKEN_BYTES).toString('base64url');
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
 }
 
 function generateHandle(email: string): string {
@@ -552,18 +547,16 @@ export class InvitationService {
     email: string;
     organizationLabel: string;
   }): string {
-    const organizationLabel = escapeHtml(input.organizationLabel);
-    const email = escapeHtml(input.email);
-    const acceptUrl = escapeHtml(input.acceptUrl);
-
-    return [
-      '<div style="font-family:system-ui,-apple-system,sans-serif;max-width:520px;margin:0 auto;padding:24px">',
-      `<h1 style="font-size:20px;margin:0 0 16px">Join ${organizationLabel} on Genfeed.ai</h1>`,
-      `<p style="font-size:14px;color:#444;margin:0 0 24px">An invitation was sent to ${email}. Click the button below to accept it. This link expires in 7 days and can only be used once.</p>`,
-      `<a href="${acceptUrl}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 20px;border-radius:8px;font-size:14px">Accept invitation</a>`,
-      '<p style="font-size:12px;color:#888;margin:24px 0 0">If you did not expect this invitation, you can safely ignore this email.</p>',
-      '</div>',
-    ].join('');
+    return buildSystemEmailHtml({
+      action: { label: 'Accept invitation', url: input.acceptUrl },
+      bodyHtml: buildSystemEmailParagraph(
+        `An invitation was sent to ${input.email}. Accept it to join ${input.organizationLabel}. This link expires in 7 days and can only be used once.`,
+      ),
+      footerNote:
+        'If you did not expect this invitation, you can safely ignore this email.',
+      preheader: `Join ${input.organizationLabel} on Genfeed.ai.`,
+      title: `Join ${input.organizationLabel} on Genfeed.ai`,
+    });
   }
 
   private resolveRedirectUrl(invitation: Invitation): string {

--- a/apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/trend-notification-workflow.service.spec.ts
@@ -132,7 +132,7 @@ describe('TrendNotificationWorkflowService', () => {
     expect(notificationsService.sendEmail).toHaveBeenCalledWith(
       'notify@example.com',
       expect.stringContaining('Trend Summary'),
-      expect.stringContaining('<!DOCTYPE html>'),
+      expect.stringContaining('<!doctype html>'),
     );
     expect(notificationsService.sendNotification).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/server/api/src/services/workflow-executor/processors/trend-inspiration.processor.ts
+++ b/apps/server/api/src/services/workflow-executor/processors/trend-inspiration.processor.ts
@@ -16,6 +16,11 @@ import {
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { ActivitySource } from '@genfeedai/enums';
+import {
+  buildSystemEmailHtml,
+  buildSystemEmailParagraph,
+  escapeSystemEmailHtml,
+} from '@helpers/email/system-email.helper';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
@@ -447,47 +452,54 @@ export class TrendInspirationProcessor {
    * Format trend summary for Email
    */
   private formatTrendSummaryForEmail(summary: TrendSummary): string {
-    return `
-      <h2>Your Trend Summary</h2>
-      <p>Here's what's trending right now:</p>
+    const sections: string[] = [
+      buildSystemEmailParagraph("Here's what's trending right now."),
+    ];
 
-      ${
-        summary.topVideos.length > 0
-          ? `
-        <h3>Top Viral Videos</h3>
-        <ul>
-          ${summary.topVideos.map((v) => `<li><strong>${v.title}</strong> - Viral Score: ${v.viralScore}</li>`).join('')}
-        </ul>
-      `
-          : ''
-      }
+    if (summary.topVideos.length > 0) {
+      sections.push(
+        '<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Top Viral Videos</h2>',
+        `<ul style="color:#b4b4bc;font-size:14px;line-height:22px;margin:0 0 16px;padding-left:18px;">${summary.topVideos
+          .map(
+            (video) =>
+              `<li><strong style="color:#f4f4f5;">${escapeSystemEmailHtml(video.title)}</strong> - Viral Score: ${video.viralScore}</li>`,
+          )
+          .join('')}</ul>`,
+      );
+    }
 
-      ${
-        summary.topHashtags.length > 0
-          ? `
-        <h3>Trending Hashtags</h3>
-        <ul>
-          ${summary.topHashtags.map((h) => `<li>#${h.hashtag.replace('#', '')} - ${this.formatNumber(h.postCount)} posts</li>`).join('')}
-        </ul>
-      `
-          : ''
-      }
+    if (summary.topHashtags.length > 0) {
+      sections.push(
+        '<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Trending Hashtags</h2>',
+        `<ul style="color:#b4b4bc;font-size:14px;line-height:22px;margin:0 0 16px;padding-left:18px;">${summary.topHashtags
+          .map(
+            (hashtag) =>
+              `<li>#${escapeSystemEmailHtml(hashtag.hashtag.replace('#', ''))} - ${this.formatNumber(hashtag.postCount)} posts</li>`,
+          )
+          .join('')}</ul>`,
+      );
+    }
 
-      ${
-        summary.topSounds.length > 0
-          ? `
-        <h3>Trending Sounds</h3>
-        <ul>
-          ${summary.topSounds.map((s) => `<li>${s.soundName} - ${this.formatNumber(s.usageCount)} uses</li>`).join('')}
-        </ul>
-      `
-          : ''
-      }
+    if (summary.topSounds.length > 0) {
+      sections.push(
+        '<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Trending Sounds</h2>',
+        `<ul style="color:#b4b4bc;font-size:14px;line-height:22px;margin:0 0 16px;padding-left:18px;">${summary.topSounds
+          .map(
+            (sound) =>
+              `<li>${escapeSystemEmailHtml(sound.soundName)} - ${this.formatNumber(sound.usageCount)} uses</li>`,
+          )
+          .join('')}</ul>`,
+      );
+    }
 
-      <p style="color: #666; font-size: 12px;">
-        Generated at ${summary.generatedAt.toLocaleString()}
-      </p>
-    `;
+    sections.push(
+      `<p style="color:#8c8c96;font-size:12px;line-height:18px;margin:24px 0 0;">Generated at ${escapeSystemEmailHtml(summary.generatedAt.toLocaleString())}</p>`,
+    );
+
+    return buildSystemEmailHtml({
+      bodyHtml: sections.join(''),
+      title: 'Your Trend Summary',
+    });
   }
 
   /**

--- a/apps/server/notifications/src/services/notification-handler.service.ts
+++ b/apps/server/notifications/src/services/notification-handler.service.ts
@@ -1,5 +1,9 @@
 import process from 'node:process';
 import { IngredientCategory } from '@genfeedai/enums';
+import {
+  buildSystemEmailHtml,
+  escapeSystemEmailHtml,
+} from '@helpers/email/system-email.helper';
 import type { NotificationEvent } from '@libs/interfaces/events.interface';
 import { LoggerService } from '@libs/logger/logger.service';
 import { RedisService } from '@libs/redis/redis.service';
@@ -419,20 +423,17 @@ export class NotificationHandlerService implements OnModuleInit {
     ctaLabel?: string;
     ctaUrl?: string;
   }): string {
-    const cta =
-      input.ctaLabel && input.ctaUrl
-        ? `<p style="margin-top:24px;"><a href="${this.escapeHtml(input.ctaUrl)}" style="background:#111827;border-radius:8px;color:#ffffff;display:inline-block;padding:12px 16px;text-decoration:none;">${this.escapeHtml(input.ctaLabel)}</a></p>`
-        : '';
-
-    return `<!DOCTYPE html><html><body style="background:#f8fafc;color:#0f172a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;margin:0;padding:24px;"><div style="background:#ffffff;border:1px solid #e2e8f0;border-radius:16px;max-width:640px;margin:0 auto;padding:32px;"><h1 style="font-size:24px;line-height:1.2;margin:0 0 16px;">${this.escapeHtml(input.title)}</h1>${input.body}${cta}</div></body></html>`;
+    return buildSystemEmailHtml({
+      action:
+        input.ctaLabel && input.ctaUrl
+          ? { label: input.ctaLabel, url: input.ctaUrl }
+          : undefined,
+      bodyHtml: input.body,
+      title: input.title,
+    });
   }
 
   private escapeHtml(value: string): string {
-    return value
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#39;');
+    return escapeSystemEmailHtml(value);
   }
 }

--- a/apps/server/notifications/src/services/resend/resend.service.spec.ts
+++ b/apps/server/notifications/src/services/resend/resend.service.spec.ts
@@ -94,7 +94,7 @@ describe('ResendService', () => {
   it('sends successfully', async () => {
     configMock.get.mockImplementation((key: string) => {
       if (key === 'RESEND_API_KEY') return 're_test';
-      if (key === 'RESEND_FROM_EMAIL') return 'Genfeed <updates@genfeed.ai>';
+      if (key === 'RESEND_FROM_EMAIL') return 'Genfeed <no-reply@genfeed.ai>';
       return '';
     });
     mockSend.mockResolvedValue({
@@ -113,7 +113,7 @@ describe('ResendService', () => {
 
     expect(mockSend).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: 'Genfeed <updates@genfeed.ai>',
+        from: 'Genfeed <no-reply@genfeed.ai>',
         subject: 'Subject',
         to: 'test@example.com',
       }),

--- a/apps/server/notifications/src/services/resend/resend.service.ts
+++ b/apps/server/notifications/src/services/resend/resend.service.ts
@@ -44,7 +44,7 @@ export class ResendService {
           from:
             payload.from ||
             this.configService.get('RESEND_FROM_EMAIL') ||
-            'Genfeed <updates@genfeed.ai>',
+            'Genfeed <no-reply@genfeed.ai>',
           html: payload.html,
           replyTo:
             payload.replyTo || this.configService.get('RESEND_REPLY_TO_EMAIL'),

--- a/apps/server/notifications/vitest.config.ts
+++ b/apps/server/notifications/vitest.config.ts
@@ -46,6 +46,10 @@ export default defineConfig({
         replacement: path.resolve(serviceDir, '../../../packages/config/src'),
       },
       {
+        find: '@genfeedai/pricing',
+        replacement: path.resolve(serviceDir, '../../../packages/pricing/src'),
+      },
+      {
         find: /^@genfeedai\/config\/(.*)$/,
         replacement: path.resolve(
           serviceDir,

--- a/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts
+++ b/apps/server/workers/src/crons/trends/cron.trend-summary-notifications.service.spec.ts
@@ -5,8 +5,8 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { ParseMode } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
-import { CronTrendSummaryNotificationsService } from '@workers/crons/trends/cron.trend-summary-notifications.service';
 import { ConfigService } from '@workers/config/config.service';
+import { CronTrendSummaryNotificationsService } from '@workers/crons/trends/cron.trend-summary-notifications.service';
 
 vi.mock('@nestjs/schedule', () => ({
   Cron: () => () => undefined,
@@ -221,7 +221,7 @@ describe('CronTrendSummaryNotificationsService', () => {
       expect(notificationsService.sendEmail).toHaveBeenCalledWith(
         'user@example.com',
         expect.stringContaining('Trend Summary'),
-        expect.stringContaining('<!DOCTYPE html>'),
+        expect.stringContaining('<!doctype html>'),
       );
     });
 

--- a/packages/config/__tests__/schemas.test.ts
+++ b/packages/config/__tests__/schemas.test.ts
@@ -121,6 +121,16 @@ describe('Config Schemas', () => {
         expect(error.message).toContain('required');
       }
     });
+
+    it('accepts a Resend sender with a display name', () => {
+      const schema = Joi.object(resendSchema);
+      const { error } = schema.validate(
+        { RESEND_FROM_EMAIL: 'Genfeed <no-reply@genfeed.ai>' },
+        { allowUnknown: true },
+      );
+
+      expect(error).toBeUndefined();
+    });
   });
 
   describe('twitchSchema', () => {

--- a/packages/config/src/schemas/notifications.schema.ts
+++ b/packages/config/src/schemas/notifications.schema.ts
@@ -1,5 +1,8 @@
 import Joi from 'joi';
 
+const EMAIL_WITH_OPTIONAL_DISPLAY_NAME =
+  /^(?:[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+|[^<>\r\n]+<[^<>\s@]+@[^<>\s@]+\.[^<>\s@]+>)$/;
+
 /**
  * Discord bot configuration (for notifications service)
  */
@@ -31,7 +34,10 @@ export const telegramBotSchema = {
  */
 export const resendSchema = {
   RESEND_API_KEY: Joi.string().optional().allow(''),
-  RESEND_FROM_EMAIL: Joi.string().email().optional().allow(''),
+  RESEND_FROM_EMAIL: Joi.string()
+    .pattern(EMAIL_WITH_OPTIONAL_DISPLAY_NAME)
+    .optional()
+    .allow(''),
   RESEND_REPLY_TO_EMAIL: Joi.string().email().optional().allow(''),
 };
 

--- a/packages/helpers/src/email/system-email.helper.test.ts
+++ b/packages/helpers/src/email/system-email.helper.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSystemEmailHtml,
+  buildSystemEmailParagraph,
+  escapeSystemEmailHtml,
+} from './system-email.helper';
+
+describe('system email helpers', () => {
+  it('escapes html-sensitive characters', () => {
+    expect(escapeSystemEmailHtml(`<a href="x">'&'</a>`)).toBe(
+      '&lt;a href=&quot;x&quot;&gt;&#39;&amp;&#39;&lt;/a&gt;',
+    );
+  });
+
+  it('renders a branded system email shell', () => {
+    const html = buildSystemEmailHtml({
+      action: {
+        label: 'Open',
+        url: 'https://app.genfeed.ai/settings',
+      },
+      bodyHtml: buildSystemEmailParagraph('Use this secure link once.'),
+      footerNote: 'Ignore this email if you did not request it.',
+      title: 'Secure Genfeed link',
+    });
+
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Genfeed.ai');
+    expect(html).toContain('Secure Genfeed link');
+    expect(html).toContain('https://app.genfeed.ai/settings');
+    expect(html).toContain('Ignore this email if you did not request it.');
+  });
+});

--- a/packages/helpers/src/email/system-email.helper.ts
+++ b/packages/helpers/src/email/system-email.helper.ts
@@ -1,0 +1,105 @@
+export interface SystemEmailAction {
+  label: string;
+  url: string;
+}
+
+export interface SystemEmailOptions {
+  title: string;
+  preheader?: string;
+  eyebrow?: string;
+  bodyHtml: string;
+  action?: SystemEmailAction;
+  footerNote?: string;
+  appUrl?: string;
+}
+
+const DEFAULT_APP_URL = 'https://app.genfeed.ai';
+const BRAND_NAME = 'Genfeed.ai';
+
+export function escapeSystemEmailHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function buildSystemEmailParagraph(text: string): string {
+  return `<p style="margin:0 0 16px;color:#b4b4bc;font-size:15px;line-height:24px;">${escapeSystemEmailHtml(text)}</p>`;
+}
+
+export function buildSystemEmailHtml(input: SystemEmailOptions): string {
+  const appUrl = input.appUrl ?? DEFAULT_APP_URL;
+  const brandMark = appUrl
+    ? `<a href="${escapeSystemEmailHtml(appUrl)}" style="color:#f4f4f5;font-size:14px;font-weight:700;letter-spacing:0;text-decoration:none;">${BRAND_NAME}</a>`
+    : `<span style="color:#f4f4f5;font-size:14px;font-weight:700;letter-spacing:0;">${BRAND_NAME}</span>`;
+  const footerLink = appUrl
+    ? ` <a href="${escapeSystemEmailHtml(appUrl)}" style="color:#b4b4bc;text-decoration:underline;">Open Genfeed</a>`
+    : '';
+  const preheader =
+    input.preheader ??
+    `${input.title} - a secure notification from ${BRAND_NAME}.`;
+  const eyebrow = input.eyebrow ?? BRAND_NAME;
+  const action = input.action
+    ? `<tr><td style="padding:8px 32px 24px;"><a href="${escapeSystemEmailHtml(input.action.url)}" style="background:#fafafa;border-radius:8px;color:#050607;display:inline-block;font-size:14px;font-weight:700;line-height:20px;padding:12px 18px;text-decoration:none;">${escapeSystemEmailHtml(input.action.label)}</a></td></tr>`
+    : '';
+  const footerNote = input.footerNote
+    ? `<p style="margin:0 0 12px;color:#8c8c96;font-size:12px;line-height:18px;">${escapeSystemEmailHtml(input.footerNote)}</p>`
+    : '';
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="color-scheme" content="dark light">
+    <meta name="supported-color-schemes" content="dark light">
+    <title>${escapeSystemEmailHtml(input.title)}</title>
+  </head>
+  <body style="background:#050607;margin:0;padding:0;">
+    <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">${escapeSystemEmailHtml(preheader)}</div>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#050607;border-collapse:collapse;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;margin:0;padding:0;width:100%;">
+      <tr>
+        <td align="center" style="padding:32px 16px;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;max-width:600px;width:100%;">
+            <tr>
+              <td style="padding:0 0 14px;">
+                ${brandMark}
+              </td>
+            </tr>
+            <tr>
+              <td style="background:#0c0d10;border:1px solid #333538;border-radius:10px;padding:0;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;width:100%;">
+                  <tr>
+                    <td style="padding:32px 32px 8px;">
+                      <div style="color:#6b6b78;font-size:12px;font-weight:700;letter-spacing:.08em;line-height:16px;text-transform:uppercase;">${escapeSystemEmailHtml(eyebrow)}</div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding:0 32px 14px;">
+                      <h1 style="color:#f4f4f5;font-size:24px;font-weight:700;letter-spacing:0;line-height:30px;margin:0;">${escapeSystemEmailHtml(input.title)}</h1>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="color:#b4b4bc;font-size:15px;line-height:24px;padding:0 32px;">
+                      ${input.bodyHtml}
+                    </td>
+                  </tr>
+                  ${action}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 4px 0;">
+                ${footerNote}
+                <p style="margin:0;color:#6b6b78;font-size:12px;line-height:18px;">This message was sent by ${BRAND_NAME}.${footerLink}</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -5,6 +5,7 @@ export * from './brand-completeness.helper';
 export * from './business/pricing/pricing.helper';
 export * from './business/tier-models/tier-models.helper';
 export * from './deserializer.helper';
+export * from './email/system-email.helper';
 export * from './formatting/cn/cn.util';
 export * from './generation-controls.helper';
 export * from './generation-eta.helper';

--- a/packages/helpers/src/trends/trend-digest.helper.test.ts
+++ b/packages/helpers/src/trends/trend-digest.helper.test.ts
@@ -89,7 +89,8 @@ describe('buildTrendDigestHtml', () => {
     expect(html).toContain('Trending Sounds');
     expect(html).toContain('Score: 92');
     expect(html).toContain('1.5M views');
-    expect(html).toContain('<a href="https://app.genfeed.ai">Open Genfeed</a>');
+    expect(html).toContain('href="https://app.genfeed.ai"');
+    expect(html).toContain('Open Genfeed');
   });
 
   it('omits the footer link when appUrl is empty', () => {

--- a/packages/helpers/src/trends/trend-digest.helper.ts
+++ b/packages/helpers/src/trends/trend-digest.helper.ts
@@ -7,6 +7,11 @@
  * (trends + branding/threshold options) are passed in by the caller so this file
  * can live in a public package that the engine and workers both consume.
  */
+import {
+  buildSystemEmailHtml,
+  buildSystemEmailParagraph,
+  escapeSystemEmailHtml,
+} from '../email/system-email.helper';
 
 export type TrendDigestItemType = 'video' | 'hashtag' | 'sound' | 'topic';
 
@@ -43,12 +48,7 @@ export function formatTrendCount(num: number): string {
 
 /** Escapes a string for safe interpolation into the digest HTML. */
 export function escapeTrendHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return escapeSystemEmailHtml(text);
 }
 
 /** Markdown summary (used for chat/Telegram channels). */
@@ -117,89 +117,57 @@ export function buildTrendDigestHtml(
   const hashtags = trends.filter((trend) => trend.type === 'hashtag');
   const sounds = trends.filter((trend) => trend.type === 'sound');
 
-  let html = `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <style>
-          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 20px; background: #f5f5f5; }
-          .container { max-width: 600px; margin: 0 auto; background: white; border-radius: 8px; padding: 24px; }
-          h1 { color: #1a1a1a; margin-bottom: 8px; }
-          .subtitle { color: #666; font-size: 14px; margin-bottom: 24px; }
-          .section { margin-bottom: 24px; }
-          .section-title { font-size: 16px; font-weight: 600; color: #333; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 2px solid #eee; }
-          .trend-item { padding: 8px 0; border-bottom: 1px solid #f0f0f0; }
-          .trend-item:last-child { border-bottom: none; }
-          .trend-name { font-weight: 500; color: #1a1a1a; }
-          .trend-meta { font-size: 12px; color: #888; margin-top: 4px; }
-          .viral-score { display: inline-block; background: #10b981; color: white; padding: 2px 6px; border-radius: 4px; font-size: 11px; }
-          .platform { display: inline-block; background: #e5e7eb; color: #374151; padding: 2px 6px; border-radius: 4px; font-size: 11px; margin-left: 4px; }
-          .footer { margin-top: 24px; padding-top: 16px; border-top: 1px solid #eee; text-align: center; color: #888; font-size: 12px; }
-        </style>
-      </head>
-      <body>
-        <div class="container">
-          <h1>${escapeTrendHtml(headerTitle)}</h1>
-          <p class="subtitle">Filtered for viral score >= ${minViralScore}</p>
-    `;
+  const sections: string[] = [
+    buildSystemEmailParagraph(`Filtered for viral score >= ${minViralScore}.`),
+  ];
 
   if (videos.length > 0) {
-    html += `<div class="section"><div class="section-title">Viral Videos</div>`;
+    sections.push(
+      '<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Viral Videos</h2>',
+    );
     videos.slice(0, 5).forEach((video) => {
-      html += `
-          <div class="trend-item">
-            <div class="trend-name">${escapeTrendHtml(video.topic)}</div>
-            <div class="trend-meta">
-              <span class="viral-score">Score: ${video.viralScore}</span>
-              <span class="platform">${escapeTrendHtml(video.platform)}</span>
-              ${video.usageCount ? `<span> • ${formatTrendCount(video.usageCount)} views</span>` : ''}
-            </div>
-          </div>
-        `;
+      sections.push(buildTrendRow(video, 'views'));
     });
-    html += `</div>`;
   }
 
   if (hashtags.length > 0) {
-    html += `<div class="section"><div class="section-title">Trending Hashtags</div>`;
+    sections.push(
+      '<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Trending Hashtags</h2>',
+    );
     hashtags.slice(0, 5).forEach((hashtag) => {
-      html += `
-          <div class="trend-item">
-            <div class="trend-name">${escapeTrendHtml(hashtag.topic)}</div>
-            <div class="trend-meta">
-              <span class="platform">${escapeTrendHtml(hashtag.platform)}</span>
-              ${hashtag.usageCount ? `<span> • ${formatTrendCount(hashtag.usageCount)} posts</span>` : ''}
-            </div>
-          </div>
-        `;
+      sections.push(buildTrendRow(hashtag, 'posts'));
     });
-    html += `</div>`;
   }
 
   if (sounds.length > 0) {
-    html += `<div class="section"><div class="section-title">Trending Sounds</div>`;
+    sections.push(
+      '<h2 style="border-bottom:1px solid #333538;color:#f4f4f5;font-size:16px;line-height:22px;margin:24px 0 10px;padding:0 0 8px;">Trending Sounds</h2>',
+    );
     sounds.slice(0, 5).forEach((sound) => {
-      html += `
-          <div class="trend-item">
-            <div class="trend-name">${escapeTrendHtml(sound.topic)}</div>
-            <div class="trend-meta">
-              ${sound.usageCount ? `<span>${formatTrendCount(sound.usageCount)} uses</span>` : ''}
-            </div>
-          </div>
-        `;
+      sections.push(buildTrendRow(sound, 'uses'));
     });
-    html += `</div>`;
   }
 
-  html += `
-          <div class="footer">
-            Use these trends to create viral content!<br>
-            ${appUrl ? `<a href="${escapeTrendHtml(appUrl)}">Open Genfeed</a>` : ''}
-          </div>
-        </div>
-      </body>
-      </html>
-    `;
+  return buildSystemEmailHtml({
+    action: appUrl ? { label: 'Open Genfeed', url: appUrl } : undefined,
+    appUrl,
+    bodyHtml: sections.join(''),
+    preheader: `Trends filtered for viral score >= ${minViralScore}.`,
+    title: headerTitle,
+  });
+}
 
-  return html;
+function buildTrendRow(trend: TrendDigestItem, usageLabel: string): string {
+  const usage = trend.usageCount
+    ? `<span style="color:#8c8c96;"> - ${formatTrendCount(trend.usageCount)} ${usageLabel}</span>`
+    : '';
+
+  return `
+    <div style="border-bottom:1px solid #1e2022;padding:10px 0;">
+      <div style="color:#f4f4f5;font-size:14px;font-weight:700;line-height:20px;">${escapeTrendHtml(trend.topic)}</div>
+      <div style="font-size:12px;line-height:18px;margin-top:4px;">
+        <span style="background:#10b981;border-radius:4px;color:#050607;display:inline-block;font-weight:700;padding:2px 6px;">Score: ${trend.viralScore}</span>
+        <span style="background:#20232a;border-radius:4px;color:#b4b4bc;display:inline-block;margin-left:4px;padding:2px 6px;">${escapeTrendHtml(trend.platform)}</span>${usage}
+      </div>
+    </div>`;
 }


### PR DESCRIPTION
## Summary
- add a shared Genfeed system email shell and route first-party auth, invitation, notification, trend digest, performance digest, and trend-inspiration emails through it
- normalize Better Auth callback URLs to the active app origin before requesting magic links/social/email auth
- update Resend fallback sender to `Genfeed <no-reply@genfeed.ai>` and allow display-name sender env values

## Root Cause
- Better Auth emails used a hard-coded minimal HTML fragment and the frontend passed a relative `callbackURL=/`, so production magic links redirected relative to the API host.
- System emails were rendered by several one-off HTML builders, so styling drifted across auth, invitations, notifications, and digests.
- The Resend fallback still used the old updates sender; production remains controlled by SSM `RESEND_FROM_EMAIL`.

## Validation
- `bun --filter @genfeedai/app test -- 'app/(public)/auth-callback-url.test.ts' 'app/(public)/login/content.test.tsx' 'app/(public)/sign-up/sign-up-form.test.tsx'`
- `bun --filter @genfeedai/config test`
- `bun --filter @genfeedai/config type-check`
- `bun --filter @genfeedai/helpers type-check`
- `cd packages/helpers && bunx vitest run --config vitest.config.ts src/email/system-email.helper.test.ts src/trends/trend-digest.helper.test.ts`
- `cd apps/server/api && bun run test:file src/auth/better-auth/services/better-auth-mailer.service.spec.ts src/collections/members/services/invitation.service.spec.ts src/collections/workflows/services/trend-notification-workflow.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `cd apps/server/notifications && bun run test -- src/services/resend/resend.service.spec.ts src/services/notification-handler.service.spec.ts`
- `cd apps/server/notifications && bun run build`
- `bun run design:lint`
- `git diff --check`

## Production Notes
- `BETTER_AUTH_URL=https://api.genfeed.ai` is expected for token verification.
- Production SSM still has `GENFEEDAI_APP_URL=https://dashboard.genfeed.ai` and `RESEND_FROM_EMAIL=no-reply@send.genfeed.ai`; update SSM/Resend if `app.genfeed.ai` and `no-reply@genfeed.ai` are the desired live values.
