### PR TITLE
fix(ui): expose asset fallback state

### DIFF
--- a/packages/ui/src/components/masonry/image/MasonryImage.test.tsx
+++ b/packages/ui/src/components/masonry/image/MasonryImage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
   useBrand: vi.fn(() => ({
@@ -92,6 +92,11 @@ import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
 import type { IImage } from '@genfeedai/interfaces';
 import MasonryImage from '@ui/masonry/image/MasonryImage';
 
+const defaultBrandContext = {
+  selectedBrand: { isDarkroomEnabled: false },
+  settings: { isDarkroomNsfwVisible: false },
+} as ReturnType<typeof useBrand>;
+
 const mockImage: IImage = {
   id: 'img-123',
   ingredientUrl: 'https://example.com/image.png',
@@ -101,6 +106,10 @@ const mockImage: IImage = {
 } as IImage;
 
 describe('MasonryImage', () => {
+  beforeEach(() => {
+    vi.mocked(useBrand).mockReturnValue(defaultBrandContext);
+  });
+
   it('should render without crashing', () => {
     const { container } = render(<MasonryImage image={mockImage} />);
     expect(container.firstChild).toBeInTheDocument();
@@ -175,5 +184,46 @@ describe('MasonryImage', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(handleClickIngredient).not.toHaveBeenCalled();
+  });
+
+  it('keeps broken remote assets in an explicit fallback state', () => {
+    render(<MasonryImage image={mockImage} />);
+
+    fireEvent.error(screen.getByRole('img'));
+
+    expect(screen.getByTestId('masonry-ingredient-img-123')).toHaveAttribute(
+      'data-asset-media-state',
+      'fallback',
+    );
+    expect(
+      screen.getByTestId('asset-media-fallback-img-123'),
+    ).toHaveTextContent('Preview unavailable');
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://assets.test.com/placeholders/portrait.jpg',
+    );
+
+    fireEvent.load(screen.getByRole('img'));
+
+    expect(screen.getByTestId('masonry-ingredient-img-123')).toHaveAttribute(
+      'data-asset-media-state',
+      'fallback',
+    );
+  });
+
+  it('marks missing asset urls as fallback previews', () => {
+    render(<MasonryImage image={{ ...mockImage, ingredientUrl: undefined }} />);
+
+    expect(screen.getByTestId('masonry-ingredient-img-123')).toHaveAttribute(
+      'data-asset-media-state',
+      'fallback',
+    );
+    expect(
+      screen.getByTestId('asset-media-fallback-img-123'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://assets.test.com/placeholders/portrait.jpg',
+    );
   });
 });

--- a/packages/ui/src/components/masonry/image/MasonryImage.test.tsx
+++ b/packages/ui/src/components/masonry/image/MasonryImage.test.tsx
@@ -89,6 +89,7 @@ vi.mock('@genfeedai/services/core/environment.service', () => ({
 }));
 
 import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
+import { IngredientStatus } from '@genfeedai/enums';
 import type { IImage } from '@genfeedai/interfaces';
 import MasonryImage from '@ui/masonry/image/MasonryImage';
 
@@ -225,5 +226,41 @@ describe('MasonryImage', () => {
       'src',
       'https://assets.test.com/placeholders/portrait.jpg',
     );
+  });
+
+  it('keeps processing assets in a processing state, not a fallback', () => {
+    render(
+      <MasonryImage
+        image={{
+          ...mockImage,
+          ingredientUrl: undefined,
+          status: IngredientStatus.PROCESSING,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('masonry-ingredient-img-123')).toHaveAttribute(
+      'data-asset-media-state',
+      'processing',
+    );
+    expect(
+      screen.queryByTestId('asset-media-fallback-img-123'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reports a genuine asset load but not the post-error placeholder load', () => {
+    const handleImageLoad = vi.fn();
+
+    render(<MasonryImage image={mockImage} onImageLoad={handleImageLoad} />);
+
+    // A genuine load of the real asset is reported once.
+    fireEvent.load(screen.getByRole('img'));
+    expect(handleImageLoad).toHaveBeenCalledTimes(1);
+
+    // The real image then errors, swapping src to the placeholder.
+    fireEvent.error(screen.getByRole('img'));
+    // The placeholder finishing its load must NOT be reported as a success.
+    fireEvent.load(screen.getByRole('img'));
+    expect(handleImageLoad).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/components/masonry/image/MasonryImage.tsx
+++ b/packages/ui/src/components/masonry/image/MasonryImage.tsx
@@ -58,8 +58,8 @@ export default function MasonryImage({
   onHoverChange,
 }: MasonryImageProps): React.ReactElement {
   const { selectedBrand, settings } = useBrand();
-  const [isLoading, setIsLoading] = useState(true);
-  const [imageError, setImageError] = useState(false);
+  const [loadedImageUrl, setLoadedImageUrl] = useState<string | null>(null);
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
 
   const {
     isHovered,
@@ -91,16 +91,21 @@ export default function MasonryImage({
 
   const handleDownload = useMemo(() => createDownloadHandler(), []);
 
+  const currentImageUrl = image.ingredientUrl ?? '';
+  const imageError =
+    currentImageUrl === '' || failedImageUrl === currentImageUrl;
+  const isLoading =
+    currentImageUrl !== '' && loadedImageUrl !== currentImageUrl && !imageError;
+
   const handleImageLoad = useCallback(() => {
-    setIsLoading(false);
-    setImageError(false);
+    setLoadedImageUrl(currentImageUrl);
     onImageLoad?.();
-  }, [onImageLoad]);
+  }, [currentImageUrl, onImageLoad]);
 
   const handleImageError = useCallback(() => {
-    setIsLoading(false);
-    setImageError(true);
-  }, []);
+    setLoadedImageUrl(currentImageUrl);
+    setFailedImageUrl(currentImageUrl);
+  }, [currentImageUrl]);
 
   const handleIngredientDrop = useCallback(
     (

--- a/packages/ui/src/components/masonry/image/MasonryImage.tsx
+++ b/packages/ui/src/components/masonry/image/MasonryImage.tsx
@@ -91,16 +91,29 @@ export default function MasonryImage({
 
   const handleDownload = useMemo(() => createDownloadHandler(), []);
 
+  const isProcessing = image.status === IngredientStatus.PROCESSING;
+  const isFailed = image.status === IngredientStatus.FAILED;
+
   const currentImageUrl = image.ingredientUrl ?? '';
+  // A still-processing asset has no generated URL yet — that is not an error,
+  // the processing overlay covers it. Only treat a missing or failed URL as a
+  // fallback when the asset is not actively processing.
   const imageError =
-    currentImageUrl === '' || failedImageUrl === currentImageUrl;
+    !isProcessing &&
+    (currentImageUrl === '' || failedImageUrl === currentImageUrl);
   const isLoading =
     currentImageUrl !== '' && loadedImageUrl !== currentImageUrl && !imageError;
 
   const handleImageLoad = useCallback(() => {
+    // After a real-image error, imageSrc swaps to the placeholder; when that
+    // placeholder finishes loading, onLoad fires again. Do not report the
+    // placeholder (or a missing URL) to the parent as a successful asset load.
+    if (currentImageUrl === '' || failedImageUrl === currentImageUrl) {
+      return;
+    }
     setLoadedImageUrl(currentImageUrl);
     onImageLoad?.();
-  }, [currentImageUrl, onImageLoad]);
+  }, [currentImageUrl, failedImageUrl, onImageLoad]);
 
   const handleImageError = useCallback(() => {
     setLoadedImageUrl(currentImageUrl);
@@ -120,8 +133,6 @@ export default function MasonryImage({
   );
 
   const metadata = image?.metadata as IMetadata;
-  const isProcessing = image.status === IngredientStatus.PROCESSING;
-  const isFailed = image.status === IngredientStatus.FAILED;
   const aspectRatioStyle = getAspectRatioStyle(isSquare, metadata);
   const imageSrc = getImageSrc(image?.ingredientUrl, imageError);
   const shouldShowBadges = isActionsEnabled && !isProcessing && !isFailed;

--- a/packages/ui/src/components/masonry/image/MasonryImageMediaArea.tsx
+++ b/packages/ui/src/components/masonry/image/MasonryImageMediaArea.tsx
@@ -43,11 +43,21 @@ export default function MasonryImageMediaArea({
   handleContentClick,
   onRefresh,
 }: MasonryImageMediaAreaProps): React.ReactElement {
+  const mediaState = imageError
+    ? 'fallback'
+    : isProcessing
+      ? 'processing'
+      : isLoading
+        ? 'loading'
+        : 'ready';
+
   return (
     <>
       <div
         role="button"
         tabIndex={0}
+        aria-label={imageError ? 'Asset preview unavailable' : undefined}
+        data-asset-media-state={mediaState}
         data-testid={`masonry-ingredient-${image.id}`}
         className={cn(
           'relative size-full cursor-pointer overflow-hidden border border-white/[0.08] bg-card transition-[border-color,background-color] duration-200 hover:border-white/[0.14]',
@@ -94,6 +104,17 @@ export default function MasonryImageMediaArea({
           )}
           src={imageSrc}
         />
+
+        {imageError && (
+          <div
+            aria-live="polite"
+            className="absolute inset-x-3 bottom-3 rounded-md border border-white/15 bg-black/70 px-3 py-2 text-center text-xs font-medium text-white shadow-lg backdrop-blur-sm"
+            data-testid={`asset-media-fallback-${image.id}`}
+            role="status"
+          >
+            Preview unavailable
+          </div>
+        )}
 
         {isDarkroomLocked && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/35 backdrop-blur-sm px-4 text-center">


### PR DESCRIPTION
## Summary
- Keep masonry image tiles in an explicit fallback state for missing or failed generated asset URLs instead of silently treating the placeholder as a healthy render.
- Add `data-asset-media-state` and a visible fallback marker for asset cards.
- Cover failed remote images and missing asset URLs in focused `MasonryImage` regression tests.

Closes #623

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/ui test -- src/components/masonry/image/MasonryImage.test.tsx`
- `npx biome check --write packages/ui/src/components/masonry/image/MasonryImage.tsx packages/ui/src/components/masonry/image/MasonryImageMediaArea.tsx packages/ui/src/components/masonry/image/MasonryImage.test.tsx`
- `bunx turbo run type-check --filter=@genfeedai/ui`
- `git diff --check`
- Staged sensitive filename scan, staged secret-pattern scan, and `bunx secretlint` on staged files

## Notes
- A focused Playwright browser check was attempted after installing Chromium, but the library route stayed on an existing bootstrap spinner with a `mapProtectedBootstrapPayload` client error before asset cards mounted. I did not keep that unstable E2E spec in this PR.