### PR TITLE
fix(ci): enable API E2E gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,19 +39,14 @@ jobs:
       - name: Check route coverage
         run: node scripts/e2e-route-coverage.mjs
 
-  # API E2E Tests — DISABLED by default. The test infrastructure is incomplete:
-  # the suite fails every run on E2ETestModule DI wiring (PrismaService/
-  # FilesClientService not provided) and a missing @api/collections/subscriptions
-  # path alias. It was already continue-on-error (never gated), so it only burned
-  # ~2 min/run and added noise. Gated behind the E2E_API_ENABLED repo variable
-  # (mirrors e2e-frontend-authed): set it to 'true' to re-enable once the DI /
-  # path-alias fixes land.
+  # API E2E Tests — boot/smoke gate for the real API test graph.
+  # The #702 blockers are resolved in-source: E2ETestModule provides the
+  # files client mock, API E2E resolves the OSS billing provider alias, and the
+  # payment integration spec uses the canonical subscription DI token.
   e2e-api:
     name: API E2E Tests
-    if: ${{ vars.E2E_API_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     services:
       postgres:
         image: postgres:17-alpine
@@ -203,19 +198,24 @@ jobs:
     name: E2E Gate (all shards)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [e2e-route-coverage, e2e-frontend]
+    needs: [e2e-route-coverage, e2e-frontend, e2e-api]
     if: always()
     steps:
       - name: Check shard results
         run: |
           echo "Route coverage: ${{ needs.e2e-route-coverage.result }}"
           echo "Frontend matrix: ${{ needs.e2e-frontend.result }}"
+          echo "API E2E: ${{ needs.e2e-api.result }}"
           if [[ "${{ needs.e2e-route-coverage.result }}" == "failure" ]]; then
             echo "Route coverage gate failed" && exit 1
           fi
           if [[ "${{ needs.e2e-frontend.result }}" == "failure" || \
                 "${{ needs.e2e-frontend.result }}" == "cancelled" ]]; then
             echo "One or more E2E shards failed or were cancelled" && exit 1
+          fi
+          if [[ "${{ needs.e2e-api.result }}" == "failure" || \
+                "${{ needs.e2e-api.result }}" == "cancelled" ]]; then
+            echo "API E2E boot gate failed or was cancelled" && exit 1
           fi
           echo "All required E2E checks passed."
 

--- a/apps/server/api/test/e2e-test.module.ts
+++ b/apps/server/api/test/e2e-test.module.ts
@@ -26,10 +26,10 @@ import { InternalIntegrationsController } from '@api/endpoints/integrations/inte
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { AdminApiKeyGuard } from '@api/helpers/guards/admin-api-key/admin-api-key.guard';
 import { CacheService } from '@api/services/cache/services/cache.service';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { StripeService } from '@api/services/integrations/stripe/services/stripe.service';
-import { PrismaModule } from '@api/shared/modules/prisma/prisma.module';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 // External service mock imports
 import {
@@ -38,6 +38,7 @@ import {
   createMockCryptoService,
   createMockEventEmitter,
   createMockFileQueueService,
+  createMockFilesClientService,
   createMockHttpService,
   createMockLoggerService,
   createMockRedisService,
@@ -110,6 +111,10 @@ export const EXTERNAL_SERVICE_MOCK_PROVIDERS = [
   {
     provide: StripeService,
     useFactory: () => createMockStripeService(),
+  },
+  {
+    provide: FilesClientService,
+    useFactory: () => createMockFilesClientService(),
   },
   {
     provide: FileQueueService,
@@ -412,8 +417,8 @@ export class E2ETestModule {
 
     return {
       controllers,
-      exports: [PrismaModule],
-      imports: [PrismaModule],
+      exports: [PrismaService],
+      imports: [],
       module: E2ETestModule,
       providers: [
         ...EXTERNAL_SERVICE_MOCK_PROVIDERS.map((provider) => {
@@ -425,6 +430,7 @@ export class E2ETestModule {
           }
           return provider;
         }),
+        PrismaService,
         ...guardProviders,
         ...providers,
       ],

--- a/apps/server/api/test/integration/payment-processing.integration.spec.ts
+++ b/apps/server/api/test/integration/payment-processing.integration.spec.ts
@@ -1,10 +1,9 @@
 import process from 'node:process';
-import { SubscriptionsService } from '@api/collections/subscriptions/services/subscriptions.service';
 import { ConfigService } from '@api/config/config.service';
 import { StripeService } from '@api/services/integrations/stripe/services/stripe.service';
-import { PrismaModule } from '@api/shared/modules/prisma/prisma.module';
 import { CreditTransactionsService } from '@credits/services/credit-transactions.service';
 import { CustomersService } from '@customers/services/customers.service';
+import { SUBSCRIPTIONS_SERVICE } from '@genfeedai/interfaces/billing';
 import { LoggerService } from '@libs/logger/logger.service';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -27,6 +26,15 @@ if (process.env.SKIP_DB_INTEGRATION === 'true') {
   g.test = g.it;
 }
 
+type PaymentSubscriptionsServiceMock = {
+  cancel: vi.Mock;
+  create: vi.Mock;
+  findByCustomer: vi.Mock;
+  findOne: vi.Mock;
+  update: vi.Mock;
+  updateStatus: vi.Mock;
+};
+
 describe('Payment Processing Integration Tests (Stripe)', () => {
   // Increase timeout for MongoDB memory server operations
   // vi timeout configured in vitest.config(30000);
@@ -35,7 +43,7 @@ describe('Payment Processing Integration Tests (Stripe)', () => {
   let moduleRef: TestingModule;
 
   let stripeService: StripeService;
-  let subscriptionsService: SubscriptionsService;
+  let subscriptionsService: PaymentSubscriptionsServiceMock;
   let customersService: CustomersService;
   let creditTransactionsService: CreditTransactionsService;
   let mockStripe: any;
@@ -107,7 +115,6 @@ describe('Payment Processing Integration Tests (Stripe)', () => {
     };
 
     moduleRef = await Test.createTestingModule({
-      imports: [PrismaModule],
       providers: [
         {
           provide: StripeService,
@@ -130,7 +137,7 @@ describe('Payment Processing Integration Tests (Stripe)', () => {
           },
         },
         {
-          provide: SubscriptionsService,
+          provide: SUBSCRIPTIONS_SERVICE,
           useValue: {
             cancel: vi.fn(),
             create: vi.fn(),
@@ -178,8 +185,9 @@ describe('Payment Processing Integration Tests (Stripe)', () => {
     await app.init();
 
     stripeService = moduleRef.get<StripeService>(StripeService);
-    subscriptionsService =
-      moduleRef.get<SubscriptionsService>(SubscriptionsService);
+    subscriptionsService = moduleRef.get<PaymentSubscriptionsServiceMock>(
+      SUBSCRIPTIONS_SERVICE,
+    );
     customersService = moduleRef.get<CustomersService>(CustomersService);
     creditTransactionsService = moduleRef.get<CreditTransactionsService>(
       CreditTransactionsService,

--- a/apps/server/api/test/mocks/external-services.mocks.ts
+++ b/apps/server/api/test/mocks/external-services.mocks.ts
@@ -656,6 +656,46 @@ export const createMockRedisService = () => ({
 // File Queue Service Mocks
 // ============================================================================
 
+export const createMockFilesClientService = () => ({
+  audioOverlay: vi.fn().mockResolvedValue({
+    publicUrl: 'https://example.com/audio-overlay.mp4',
+    s3Key: 'mock-audio-overlay-key',
+  }),
+  copyInS3: vi.fn().mockResolvedValue({
+    publicUrl: 'https://example.com/copied-file.jpg',
+    s3Key: 'mock-copied-file-key',
+  }),
+  extractMetadataFromUrl: vi.fn().mockResolvedValue({
+    duration: 5,
+    height: 1080,
+    publicUrl: 'https://example.com/metadata-source.mp4',
+    size: 1024,
+    width: 1920,
+  }),
+  generateThumbnail: vi.fn().mockResolvedValue({
+    publicUrl: 'https://example.com/thumbnail.jpg',
+    s3Key: 'mock-thumbnail-key',
+  }),
+  getFileFromS3: vi.fn().mockResolvedValue(Buffer.from('mock-file')),
+  getPresignedDownloadUrl: vi
+    .fn()
+    .mockResolvedValue('https://example.com/download/mock-file'),
+  getPresignedUploadUrl: vi.fn().mockResolvedValue({
+    publicUrl: 'https://example.com/uploaded-file.jpg',
+    s3Key: 'mock-upload-key',
+    uploadUrl: 'https://example.com/upload/mock-file',
+  }),
+  uploadToS3: vi.fn().mockResolvedValue({
+    duration: 5,
+    hasAudio: true,
+    height: 1080,
+    publicUrl: 'https://example.com/uploaded-file.jpg',
+    s3Key: 'mock-upload-key',
+    size: 1024,
+    width: 1920,
+  }),
+});
+
 export const createMockFileQueueService = () => ({
   getJobStatus: vi.fn().mockResolvedValue({
     progress: 100,

--- a/apps/server/api/vitest.config.e2e.ts
+++ b/apps/server/api/vitest.config.e2e.ts
@@ -53,12 +53,60 @@ export default defineConfig({
         replacement: path.resolve(serviceDir, '../files/src'),
       },
       {
+        find: '@genfeedai/constants',
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/constants/src',
+        ),
+      },
+      {
+        find: '@genfeedai/enums',
+        replacement: path.resolve(serviceDir, '../../../packages/enums/src'),
+      },
+      {
+        find: '@genfeedai/helpers',
+        replacement: path.resolve(serviceDir, '../../../packages/helpers/src'),
+      },
+      {
+        find: '@genfeedai/harness',
+        replacement: path.resolve(serviceDir, '../../../packages/harness/src'),
+      },
+      {
+        find: /^@genfeedai\/harness\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/harness/src/$1',
+        ),
+      },
+      {
+        find: '@genfeedai/prisma',
+        replacement: path.resolve(serviceDir, '../../../packages/prisma/src'),
+      },
+      {
         find: '@genfeedai/types',
         replacement: path.resolve(serviceDir, '../../../packages/types/src'),
       },
       {
+        find: /^@genfeedai\/interfaces\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/interfaces/src/$1',
+        ),
+      },
+      {
+        find: '@genfeedai/interfaces',
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/interfaces/src',
+        ),
+      },
+      {
         find: '@genfeedai/config',
         replacement: path.resolve(serviceDir, '../../../packages/config/src'),
+      },
+      {
+        find: '@genfeedai/pricing',
+        replacement: path.resolve(serviceDir, '../../../packages/pricing/src'),
       },
       {
         find: /^@genfeedai\/config\/(.*)$/,
@@ -180,6 +228,16 @@ export default defineConfig({
       {
         find: /^@test\/(.*)$/,
         replacement: path.resolve(serviceDir, './test/$1'),
+      },
+      {
+        // Mirrors the webpack/tsconfig `@billing-providers` alias for API E2E:
+        // OSS CI resolves billing collection modules to the in-tree stub
+        // fragment while EE billing remains covered by its own package tests.
+        find: '@billing-providers',
+        replacement: path.resolve(
+          serviceDir,
+          './src/common/subscriptions/billing.providers.oss.ts',
+        ),
       },
     ],
   },


### PR DESCRIPTION
## Summary
- enable the API E2E job as a required gate in `.github/workflows/e2e.yml`
- provide `PrismaService` and `FilesClientService` through the API E2E module without test-only service shims
- move the payment integration spec to the canonical `SUBSCRIPTIONS_SERVICE` token and mirror required workspace aliases in the E2E Vitest config

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `npx biome check --write .github/workflows/e2e.yml apps/server/api/test/e2e-test.module.ts apps/server/api/test/integration/payment-processing.integration.spec.ts apps/server/api/test/mocks/external-services.mocks.ts apps/server/api/vitest.config.e2e.ts`
- `bunx prisma generate` for local ignored Prisma client generation
- local Postgres `test` DB created and migrated with `bunx prisma migrate deploy`
- `bunx vitest run --config vitest.config.e2e.ts test/integration/payment-processing.integration.spec.ts` (17 tests)
- `bun run --cwd apps/server/api test:e2e:ci` (3 files, 34 tests)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `actionlint .github/workflows/e2e.yml`
- `git diff --cached --check` and stale import / E2E_API guard scan
- staged filename/diff secret scans and pre-commit secretlint/Biome hooks

Closes #702