### PR TITLE
fix(api): address Sentry production feed errors

### DIFF
--- a/apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.spec.ts
@@ -5,7 +5,7 @@ import { PublicPostsController } from '@api/endpoints/public/controllers/posts/p
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import type { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
-import { AssetScope, PostStatus } from '@genfeedai/enums';
+import { PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
@@ -181,9 +181,9 @@ describe('PublicPostsController', () => {
       };
       expect(callArgs.where).toEqual({
         isDeleted: false,
-        scope: AssetScope.PUBLIC,
         status: PostStatus.PUBLIC,
       });
+      expect(callArgs.where.scope).toBeUndefined();
     });
 
     it('should handle invalid account id gracefully', async () => {

--- a/apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.ts
+++ b/apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.ts
@@ -64,7 +64,6 @@ export class PublicPostsController {
 
     const matchQuery: PrismaWhereQuery = {
       isDeleted: false,
-      scope: AssetScope.PUBLIC,
       status: PostStatus.PUBLIC,
     };
 

--- a/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.spec.ts
@@ -55,6 +55,16 @@ describe('CollectionFilterUtil', () => {
       const result = CollectionFilterUtil.buildScopeFilter(undefined);
       expect(result).toBeUndefined();
     });
+
+    it('omits malformed scope filter objects', () => {
+      const result = CollectionFilterUtil.buildScopeFilter({ not: null });
+      expect(result).toBeUndefined();
+    });
+
+    it('omits unknown scope strings', () => {
+      const result = CollectionFilterUtil.buildScopeFilter('unknown');
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('buildSearchFilter', () => {

--- a/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.ts
@@ -147,8 +147,14 @@ export class CollectionFilterUtil {
    * CollectionFilterUtil.buildScopeFilter(undefined)
    * // Returns: undefined
    */
-  static buildScopeFilter(scope?: AssetScope): AssetScope | undefined {
-    return scope;
+  static buildScopeFilter(scope?: unknown): AssetScope | undefined {
+    if (typeof scope !== 'string') {
+      return undefined;
+    }
+
+    return Object.values(AssetScope).includes(scope as AssetScope)
+      ? (scope as AssetScope)
+      : undefined;
   }
 
   /**

--- a/apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
+++ b/apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
@@ -5,7 +5,10 @@ import { SkillCheckoutService } from '@api/skills-pro/services/skill-checkout.se
 import { SkillRegistryService } from '@api/skills-pro/services/skill-registry.service';
 import type { IEnvConfig } from '@genfeedai/config';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type Stripe from 'stripe';
 
@@ -20,7 +23,16 @@ describe('SkillCheckoutService', () => {
 
   const buildConfigGetMock = (
     values: Partial<Record<keyof IEnvConfig, string>>,
-  ) => vi.fn((key: keyof IEnvConfig) => values[key]);
+  ) => {
+    const defaults: Partial<Record<keyof IEnvConfig, string>> = {
+      GENFEEDAI_APP_URL: 'https://app.genfeed.ai',
+      STRIPE_PRICE_SKILLS_PRO: '',
+      STRIPE_PROMOTION_CODE_SKILLS_PRO: '',
+      STRIPE_SECRET_KEY: ['sk', 'test', 'valid'].join('_'),
+    };
+
+    return vi.fn((key: keyof IEnvConfig) => ({ ...defaults, ...values })[key]);
+  };
 
   beforeEach(async () => {
     const mockStripeSessionCreate = vi.fn();
@@ -227,6 +239,23 @@ describe('SkillCheckoutService', () => {
       await expect(service.createCheckoutSession({})).rejects.toThrow(
         BadRequestException,
       );
+    });
+
+    it('should reject placeholder Stripe secret keys before creating a checkout session', async () => {
+      configService.get.mockImplementation(
+        buildConfigGetMock({
+          GENFEEDAI_APP_URL: 'https://app.genfeed.ai',
+          STRIPE_PRICE_SKILLS_PRO: 'price_env_123',
+          STRIPE_SECRET_KEY: 'PLACEHOLDER_NOT_CONFIGURED',
+        }),
+      );
+
+      await expect(service.createCheckoutSession({})).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+      expect(
+        stripeService.stripe.checkout.sessions.create,
+      ).not.toHaveBeenCalled();
     });
 
     it('should use default success and cancel URLs when not provided in DTO', async () => {

--- a/apps/server/api/src/skills-pro/services/skill-checkout.service.ts
+++ b/apps/server/api/src/skills-pro/services/skill-checkout.service.ts
@@ -4,7 +4,11 @@ import { StripeService } from '@api/services/integrations/stripe/services/stripe
 import { CreateSkillCheckoutDto } from '@api/skills-pro/dto/create-skill-checkout.dto';
 import { SkillRegistryService } from '@api/skills-pro/services/skill-registry.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import StripeConstructor from 'stripe';
 
 type StripeClient = InstanceType<typeof StripeConstructor>;
@@ -17,6 +21,8 @@ type CheckoutSessionCreateParams = Parameters<
 type CheckoutLineItem = NonNullable<
   CheckoutSessionCreateParams['line_items']
 >[number];
+
+const STRIPE_SECRET_KEY_PATTERN = /^[sr]k_(live|test)_/;
 
 @Injectable()
 export class SkillCheckoutService {
@@ -34,6 +40,7 @@ export class SkillCheckoutService {
     dto: CreateSkillCheckoutDto,
   ): Promise<{ url: string }> {
     this.loggerService.log(`${this.constructorName} createCheckoutSession`);
+    this.assertStripeCheckoutConfigured();
 
     const lineItem = await this.resolveBundleLineItem();
 
@@ -74,6 +81,20 @@ export class SkillCheckoutService {
     });
 
     return { url: session.url || '' };
+  }
+
+  private assertStripeCheckoutConfigured(): void {
+    const secretKey = this.configService.get('STRIPE_SECRET_KEY')?.trim();
+
+    if (
+      !this.stripeService.stripe ||
+      !secretKey ||
+      !STRIPE_SECRET_KEY_PATTERN.test(secretKey)
+    ) {
+      throw new ServiceUnavailableException(
+        'Skills Pro checkout is not configured. Stripe secret key is missing or invalid.',
+      );
+    }
   }
 
   private async resolveBundleLineItem(): Promise<CheckoutLineItem> {

--- a/packages/prisma/prisma/migrations/20260625085045_restore_auth_provider_column_names/migration.sql
+++ b/packages/prisma/prisma/migrations/20260625085045_restore_auth_provider_column_names/migration.sql
@@ -1,0 +1,137 @@
+-- Bridge production databases that ran pre-rename auth-provider migrations.
+-- Current Prisma schema expects authProvider* column names, while some live
+-- databases still have earlier Clerk-specific column names.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'clerkId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'authProviderId'
+  ) THEN
+    ALTER TABLE "users" RENAME COLUMN "clerkId" TO "authProviderId";
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'authProviderId'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "authProviderId" TEXT;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'users_clerkId_key'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'authProviderId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'clerkId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'users_authProviderId_key'
+  ) THEN
+    ALTER INDEX "users_clerkId_key" RENAME TO "users_authProviderId_key";
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'users_authProviderId_key'
+  ) THEN
+    CREATE UNIQUE INDEX "users_authProviderId_key" ON "users"("authProviderId");
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'organizations'
+      AND column_name = 'clerkOrganizationId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'organizations'
+      AND column_name = 'authProviderOrganizationId'
+  ) THEN
+    ALTER TABLE "organizations" RENAME COLUMN "clerkOrganizationId" TO "authProviderOrganizationId";
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'organizations_clerkOrganizationId_key'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'organizations'
+      AND column_name = 'authProviderOrganizationId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'organizations'
+      AND column_name = 'clerkOrganizationId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'organizations_authProviderOrganizationId_key'
+  ) THEN
+    ALTER INDEX "organizations_clerkOrganizationId_key" RENAME TO "organizations_authProviderOrganizationId_key";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'members'
+      AND column_name = 'clerkMembershipId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'members'
+      AND column_name = 'authProviderMembershipId'
+  ) THEN
+    ALTER TABLE "members" RENAME COLUMN "clerkMembershipId" TO "authProviderMembershipId";
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'members_clerkMembershipId_key'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'members'
+      AND column_name = 'authProviderMembershipId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'members'
+      AND column_name = 'clerkMembershipId'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'members_authProviderMembershipId_key'
+  ) THEN
+    ALTER INDEX "members_clerkMembershipId_key" RENAME TO "members_authProviderMembershipId_key";
+  END IF;
+END $$;


### PR DESCRIPTION
## Sentry coverage

Covers these unresolved production issues:

- API-GENFEED-AI-65, GET /v1/public/articles/slug/*: Prisma selected users.authProviderId, but the live DB can still have the pre-rename clerkId column. Added a conditional Prisma migration to restore authProvider* column/index names.
- API-GENFEED-AI-62, GET /v1/public/posts: public posts copied an asset scope filter onto Post queries; Post has no scope field. Removed the invalid filter.
- API-GENFEED-AI-61 and API-GENFEED-AI-5X, GET /v1/images and GET /v1/musics: malformed scope query objects could reach Prisma as scope: { not: null }. Scope filters now only accept real AssetScope string values.
- API-GENFEED-AI-63, POST /v1/skills-pro/checkout: placeholder Stripe secrets reached the Stripe API. Checkout now returns a service-unavailable response before creating a Stripe session when the secret is missing or placeholder-shaped.

Also found existing master fixes for API-GENFEED-AI-64 and GENFEED-AI-43; those are not changed in this PR.

## Validation

- bunx biome check --write apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.ts apps/server/api/src/endpoints/public/controllers/posts/public.posts.controller.spec.ts apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.ts apps/server/api/src/helpers/utils/collection-filter/collection-filter.util.spec.ts apps/server/api/src/skills-pro/services/skill-checkout.service.ts apps/server/api/src/skills-pro/services/skill-checkout.service.spec.ts
- bun run --cwd apps/server/api test:file src/endpoints/public/controllers/posts/public.posts.controller.spec.ts src/helpers/utils/collection-filter/collection-filter.util.spec.ts src/skills-pro/services/skill-checkout.service.spec.ts
- bunx turbo run type-check --filter=@genfeedai/api
- git diff --cached --check plus staged credential-pattern scan

No production deploys or production migrations were run.
