### PR TITLE
ci: move heavy gates to release cut

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -20,10 +20,35 @@ env:
   IMAGE_NAME: genfeed-server-verify
 
 jobs:
+  # Release-cut boot gate — builds the COMPILED api bundle and loads its full
+  # provider graph with BOOT_CHECK=1, which exits 0 BEFORE NestFactory/config
+  # (no env, DB, or Redis needed). Kept out of normal PR CI so pull requests stay
+  # fast, but still runs before Docker release verification.
+  api-boot-check:
+    name: API Boot Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+      - name: Build api (compiled bundle)
+        # The api package emits to apps/server/dist, outside apps/server/api.
+        # Force a real build so a Turbo cache-hit replay cannot skip restoring
+        # the compiled bundle this boot check loads.
+        run: bunx turbo run build --filter=@genfeedai/api --force
+      - name: Boot check — compiled graph must load
+        run: BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js
+
   build-and-boot:
     name: Build & Boot Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: api-boot-check
     permissions:
       contents: read
       packages: write
@@ -120,6 +145,8 @@ jobs:
       - name: Build summary
         if: success()
         run: |
-          echo "## ✅ Build Verification Passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Docker image built + all 12 bundles verified; EE api bundle booted past module init (#574 guard)." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## ✅ Build Verification Passed"
+            echo ""
+            echo "Docker image built + all 12 bundles verified; EE api bundle booted past module init (#574 guard)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,30 +534,3 @@ jobs:
           else
             bun run build
           fi
-
-  # Boot gate — builds the COMPILED api bundle and loads its full provider graph
-  # with BOOT_CHECK=1, which exits 0 BEFORE NestFactory/config (no env, DB, or
-  # Redis needed). A circular-import TDZ — e.g. #711's "Cannot access 'X' before
-  # initialization", which crashed the API on boot and shipped because nothing in
-  # PR CI booted the build — crashes the process here and fails the PR. vitest
-  # cannot reproduce this class (its SWC/ESM resolution differs); only the
-  # compiled webpack bundle does, which is exactly what this runs.
-  api-boot-check:
-    name: API Boot Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
-    steps:
-      - uses: actions/checkout@v5
-      - name: Setup Bun environment
-        uses: ./.github/actions/setup-bun-env
-        with:
-          bun-version: '1.3.14'
-      - name: Build api (compiled bundle)
-        # The api package emits to apps/server/dist, outside apps/server/api.
-        # Force a real build so a Turbo cache-hit replay cannot skip restoring
-        # the compiled bundle this boot check loads.
-        run: bunx turbo run build --filter=@genfeedai/api --force
-      - name: Boot check — compiled graph must load
-        run: BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js

--- a/.github/workflows/e2e-selfhosted-release.yml
+++ b/.github/workflows/e2e-selfhosted-release.yml
@@ -1,23 +1,18 @@
 name: Self-Hosted Release E2E
 
-# Tests the RELEASED self-hosted image — the exact artifact users `docker run`,
-# produced by "Docker Publish (Self-Hosted)" on release (ghcr :latest). Boots it
-# against a throwaway Postgres in LOCAL mode (no Better Auth, no secrets), then drives
-# Playwright critical-path specs through the live API + frontend + DB stack.
+# Tests the latest RELEASED self-hosted image on a nightly schedule. This is
+# intentionally decoupled from Docker Publish so community image flakiness never
+# blocks a SaaS release or deploy.
 #
 # This is the only suite that proves real API ↔ frontend ↔ Postgres integration.
 # The weekly e2e.yml runs the frontend against a MOCKED backend; this runs the
 # shipped container end to end.
 
 on:
-  # Run right after a publish so :latest is the freshly-released artifact.
-  workflow_run:
-    workflows: ["Docker Publish (Self-Hosted)"]
-    types: [completed]
-  # Every 3 days, 05:23 UTC (off-:00 hygiene; */3 resets at month boundaries).
+  # Nightly, 05:23 UTC (off-:00 hygiene).
   schedule:
-    - cron: "23 5 */3 * *"
-  # Manual / CI dry-run against an explicit tag.
+    - cron: "23 5 * * *"
+  # Manual non-blocking dry-run against an explicit tag.
   workflow_dispatch:
     inputs:
       image_tag:
@@ -36,7 +31,7 @@ permissions:
 
 env:
   COMPOSE_FILE: docker/docker-compose.selfhosted.yml
-  # workflow_dispatch supplies image_tag; schedule/workflow_run fall back to latest.
+  # workflow_dispatch supplies image_tag; schedule falls back to latest.
   IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
   APP_BASE_URL: http://localhost:3000
   API_BASE_URL: http://localhost:3010
@@ -46,9 +41,6 @@ jobs:
     name: Release E2E (LOCAL mode)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # On a workflow_run trigger, only proceed if the publish actually succeeded.
-    # schedule / workflow_dispatch always proceed.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -1,12 +1,13 @@
-# Full Suite — on-demand caller for CI, heavy build verification, then E2E.
+# Full Suite — on-demand caller for CI, SaaS release verification, then E2E.
 #
 # Dispatch from any branch: Actions → "Full Suite (CI + Release Gates + E2E)"
 # → Run workflow → pick the branch. E2E runs only if the CI gate (format, lint,
-# typecheck, design, unit tests, build) and release-time build verification pass
-# first.
+# typecheck, design, unit tests, build) and SaaS release-time build verification
+# pass first.
 #
 # Reuses existing workflows via workflow_call — no job logic is duplicated here;
-# this file only orders the release-prep gates.
+# this file only orders the SaaS release-prep gates. Community self-hosted image
+# verification lives in build-verify-selfhosted.yml and runs independently.
 
 name: Full Suite (CI + Release Gates + E2E)
 
@@ -30,14 +31,8 @@ jobs:
     # login), which every called workflow gets automatically. Inheriting the full
     # secret set here would over-scope it (least-privilege).
 
-  selfhosted-build-verify:
-    name: Self-Hosted Build & Boot Check
-    uses: ./.github/workflows/build-verify-selfhosted.yml
-    # Release-time self-hosted image validation. Kept out of normal PR CI so
-    # routine pull requests stay fast; run through Full Suite before release.
-
   e2e:
     name: E2E Suite
-    needs: [ci, build-verify, selfhosted-build-verify]
+    needs: [ci, build-verify]
     uses: ./.github/workflows/e2e.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- remove the compiled API boot check from PR CI and run it first in release `build-verify.yml`
- make self-hosted release E2E nightly/manual only by dropping the Docker Publish `workflow_run` trigger
- decouple self-hosted build verification from the SaaS full-suite E2E gate

## Validation
- `actionlint .github/workflows/ci.yml .github/workflows/build-verify.yml .github/workflows/e2e-selfhosted-release.yml .github/workflows/full-suite.yml`
- static workflow contract assertions for #744
- `git diff --check`
- staged filename/diff secret scans
- `./node_modules/.bin/secretlint .github/workflows/ci.yml .github/workflows/build-verify.yml .github/workflows/e2e-selfhosted-release.yml .github/workflows/full-suite.yml`
- pre-commit `bun scripts/run-secretlint.ts --no-glob`

Closes #744
Related #732