### PR TITLE
fix(e2e): repair app-core Better Auth mocks and authed-job wiring

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,12 +127,14 @@ jobs:
           # Build the app in Playwright test mode. This NEXT_PUBLIC_* flag is
           # inlined at build time and is the master switch for the proxy.ts auth
           # bypass (middleware can't read a plain server env at request time on
-          # edge), disables live sockets (use-socket-manager), and bypasses the
-          # Better Auth publishable-key requirement client-side (AppProviders).
+          # edge) and disables live sockets (use-socket-manager).
           NEXT_PUBLIC_PLAYWRIGHT_TEST: "true"
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'test-better-auth-secret' }}
           NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
-          NEXT_PUBLIC_API_URL: http://localhost:3010
+          # Correct var name (app reads NEXT_PUBLIC_API_ENDPOINT, not _API_URL).
+          # NEXT_PUBLIC_* is inlined at build time. Point at the prod host the
+          # api-interceptor mocks; localhost:3010 is NOT intercepted.
+          NEXT_PUBLIC_API_ENDPOINT: https://api.genfeed.ai/v1
 
       - name: Run core E2E shard ${{ matrix.shard }}/12
         # --reporter=blob (passed inline, overriding the config reporter) so the
@@ -251,7 +253,8 @@ jobs:
           NEXT_PUBLIC_PLAYWRIGHT_TEST: "false"
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
           NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
-          NEXT_PUBLIC_API_URL: http://localhost:3010
+          # Correct var name (app reads NEXT_PUBLIC_API_ENDPOINT, not _API_URL).
+          NEXT_PUBLIC_API_ENDPOINT: https://api.genfeed.ai/v1
 
       - name: Run authed E2E (Better Auth setup + app-authed)
         run: bun run test:e2e:authed
@@ -259,6 +262,11 @@ jobs:
           CI: true
           APP_BASE_URL: http://localhost:3000
           NEXT_PUBLIC_PLAYWRIGHT_TEST: "false"
+          # Unlocks the better-auth-setup + app-authed projects in
+          # playwright.config.ts, which gate on process.env.E2E_AUTHED_ENABLED.
+          # The job-level `if` checks the GitHub repo var; this plumbs the value
+          # into the runner process so --project=app-authed actually resolves.
+          E2E_AUTHED_ENABLED: "1"
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
           NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
           E2E_BETTER_AUTH_SESSION_TOKEN: ${{ secrets.E2E_BETTER_AUTH_SESSION_TOKEN }}

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -31,8 +31,8 @@ vi.mock('@genfeedai/auth-client/server', () => ({
 describe('proxy', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubEnv('NEXT_PUBLIC_BETTER_AUTH_ENABLED', 'pk_test');
-    vi.stubEnv('BETTER_AUTH_SECRET', 'sk_test');
+    vi.stubEnv('NEXT_PUBLIC_BETTER_AUTH_ENABLED', 'true');
+    vi.stubEnv('BETTER_AUTH_SECRET', 'test-better-auth-secret');
     vi.stubEnv('NEXT_PUBLIC_API_ENDPOINT', 'http://localhost:3010/v1');
     vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', undefined);
     vi.resetModules();
@@ -573,7 +573,8 @@ describe('proxy', () => {
 
   it('redirects desktop shell bare settings to seeded workspace without a desktop token', async () => {
     const previousDesktopShell = process.env.NEXT_PUBLIC_DESKTOP_SHELL;
-    const previousPublishableKey = process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    const previousBetterAuthEnabled =
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
     const previousSecretKey = process.env.BETTER_AUTH_SECRET;
 
     try {
@@ -605,10 +606,10 @@ describe('proxy', () => {
         process.env.NEXT_PUBLIC_DESKTOP_SHELL = previousDesktopShell;
       }
 
-      if (previousPublishableKey === undefined) {
+      if (previousBetterAuthEnabled === undefined) {
         delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
       } else {
-        process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = previousPublishableKey;
+        process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = previousBetterAuthEnabled;
       }
 
       if (previousSecretKey === undefined) {

--- a/apps/website/packages/ui/providers/AppProviders.tsx
+++ b/apps/website/packages/ui/providers/AppProviders.tsx
@@ -57,18 +57,11 @@ function ThemedBetterAuthProvider({
   authProps?: BetterAuthProviderProps;
 }) {
   const { resolvedTheme } = useTheme();
-  const isPlaywrightTest = process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST === 'true';
   const appearance = authProps?.appearance;
 
   return (
     <BetterAuthProvider
       {...authProps}
-      {...(isPlaywrightTest
-        ? {
-            __internal_bypassMissingPublishableKey: true,
-            publishableKey: '',
-          }
-        : {})}
       appearance={{
         ...(appearance ?? {}),
         theme: resolvedTheme === 'dark' ? dark : appearance?.theme,

--- a/playwright/e2e/fixtures/auth.fixture.ts
+++ b/playwright/e2e/fixtures/auth.fixture.ts
@@ -277,17 +277,25 @@ async function setupBetterAuthMocks(
     },
   };
 
-  await page.route('**/v1/auth/session**', async (route) => {
-    await route.fulfill({
-      body: JSON.stringify(sessionPayload),
-      contentType: 'application/json',
-      status: 200,
-    });
-  });
+  // Playwright matches routes in REVERSE registration order (last-registered =
+  // highest priority). Register the broad catch-all FIRST so it has the LOWEST
+  // priority, then the specific endpoints, so each specific mock wins over the
+  // catch-all. Getting this order wrong makes the catch-all shadow the session
+  // mock, useSession() resolves signed-out, and protected shells spin forever.
 
-  await page.route('**/v1/auth/token**', async (route) => {
+  // Lowest priority: anything under /v1/auth/* the client touches but we do not
+  // explicitly mock (e.g. sign-out) returns an inert empty payload.
+  await page.route('**/v1/auth/**', async (route) => {
+    // /v1/auth/bootstrap is a Genfeed API endpoint (NOT a Better Auth client
+    // call) mocked by setupApiMocks. setupBetterAuthMocks runs AFTER it, so this
+    // catch-all would otherwise shadow it — fall through so the real bootstrap
+    // payload (and thus accessState) loads instead of {data:null}.
+    if (route.request().url().includes('/auth/bootstrap')) {
+      await route.fallback();
+      return;
+    }
     await route.fulfill({
-      body: JSON.stringify({ token: `mock-jwt-${session.sessionId}` }),
+      body: JSON.stringify({ data: null }),
       contentType: 'application/json',
       status: 200,
     });
@@ -301,9 +309,19 @@ async function setupBetterAuthMocks(
     });
   });
 
-  await page.route('**/v1/auth/**', async (route) => {
+  await page.route('**/v1/auth/token**', async (route) => {
     await route.fulfill({
-      body: JSON.stringify({ data: null }),
+      body: JSON.stringify({ token: `mock-jwt-${session.sessionId}` }),
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+
+  // Highest priority: Better Auth's client fetches GET /v1/auth/get-session
+  // (NOT /v1/auth/session). This must win over the catch-all above.
+  await page.route('**/v1/auth/get-session**', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify(sessionPayload),
       contentType: 'application/json',
       status: 200,
     });
@@ -394,7 +412,7 @@ export const test = base.extend<AuthFixtures>({
     await setupApiMocks(page);
 
     // Return unauthenticated state from Better Auth
-    await page.route('**/v1/auth/session**', async (route) => {
+    await page.route('**/v1/auth/get-session**', async (route) => {
       await route.fulfill({
         body: JSON.stringify({ session: null, user: null }),
         contentType: 'application/json',
@@ -446,7 +464,7 @@ export async function simulateLogout(page: Page): Promise<void> {
 }
 
 export async function simulateSessionExpiry(page: Page): Promise<void> {
-  await page.route('**/v1/auth/session**', async (route) => {
+  await page.route('**/v1/auth/get-session**', async (route) => {
     await route.fulfill({
       body: JSON.stringify({ session: null, user: null }),
       contentType: 'application/json',

--- a/playwright/e2e/fixtures/auth.fixture.ts
+++ b/playwright/e2e/fixtures/auth.fixture.ts
@@ -290,7 +290,11 @@ async function setupBetterAuthMocks(
     // call) mocked by setupApiMocks. setupBetterAuthMocks runs AFTER it, so this
     // catch-all would otherwise shadow it — fall through so the real bootstrap
     // payload (and thus accessState) loads instead of {data:null}.
-    if (route.request().url().includes('/auth/bootstrap')) {
+    // Match on pathname, not the raw URL, so an unrelated auth call whose query
+    // string happens to contain "/auth/bootstrap" (e.g. a callbackURL) does not
+    // wrongly fall through to the real bootstrap handler.
+    const { pathname } = new URL(route.request().url());
+    if (pathname.endsWith('/auth/bootstrap')) {
       await route.fallback();
       return;
     }


### PR DESCRIPTION
## Why

The nightly **E2E Tests** suite has been red every night since the Better Auth cutover (#769) — last green `de9ece424` (Jun 23), red from `c9839d96c` (Jun 24) onward (e.g. [run 28215148291](https://github.com/genfeedai/genfeed.ai/actions/runs/28215148291)). Diagnosis traced it to the E2E auth scaffolding, not app code.

## What broke

**1. Blocking — app-core shards spun forever (the red).**
`setupBetterAuthMocks` registered the broad `**/v1/auth/**` catch-all **last**. Playwright matches routes in reverse registration order, so the catch-all became highest-priority and shadowed the specific session mock. Better Auth's client fetches `GET /v1/auth/get-session` (not `/v1/auth/session`, which the old glob targeted), hit the catch-all, received `{data:null}`, and resolved signed-out. `UserProvider`/`AccessStateProvider` never populated, so `OnboardingGuard` rendered a permanent spinner over an empty `<main>` — failing every deep workspace assertion (Workspace Dashboard, Operator tools, Templates, Execution History, Publishing Inbox, Drafts). Ground truth: the failure-run ARIA snapshots showed a fully-rendered sidebar with a bare `<main>` spinner.

**2. Non-blocking — authed job "project not found".**
`e2e-frontend-authed` runs `--project=app-authed`, but the config only includes that project when `process.env.E2E_AUTHED_ENABLED === '1'`. The job gates on the GitHub repo var `vars.E2E_AUTHED_ENABLED == 'true'` and never plumbed the value into the runner → `Project(s) "app-authed" not found`. (`continue-on-error: true`, so cosmetic — but a permanently broken authed path.)

**3. Wrong API env var.**
Both build blocks baked `NEXT_PUBLIC_API_URL` (the app reads `NEXT_PUBLIC_API_ENDPOINT`), silently falling back to the prod host. Corrected to a host the api-interceptor mocks; `localhost:3010` is **not** intercepted.

## Fixes

- `auth.fixture.ts`: register the catch-all first (lowest priority); add an explicit `**/v1/auth/get-session**` route; fall through for the genfeed `/v1/auth/bootstrap` API call so `accessState` loads. Updated the two other stale `session` globs.
- `e2e.yml`: `NEXT_PUBLIC_API_URL` → `NEXT_PUBLIC_API_ENDPOINT: https://api.genfeed.ai/v1` (both builds); add `E2E_AUTHED_ENABLED: "1"` to the authed step.
- Clerk purge: removed dead `__internal_bypassMissingPublishableKey` / `publishableKey` props on the website `BetterAuthProvider`; fixed a mislabeled `proxy.test.ts` var/value. Repo is now Clerk-free except the immutable migration ledger.

## Verification

Production build + CI webserver (faithful CI repro): **all 14 previously-failing app-core specs pass** (automation-loop, content-loop, modal-cleanup, page-context-contract). No production component changed — the guard resolves through the corrected mocks alone. Typecheck green on `@genfeedai/app` + `@genfeedai/website`.

> Note: `apps/app/proxy.test.ts` is pre-existing red **locally** (`COOKIE_SECRET`/fetchMock env) on `master` too — unrelated to this change; not touched beyond the cosmetic rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)