### PR TITLE
refactor(tasks): decompose TasksService into routing/planning/actions services + serializer (#837)

### DIFF
--- a/apps/server/api/src/collections/tasks/services/task-actions.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-actions.service.ts
@@ -1,0 +1,408 @@
+import { randomUUID } from 'node:crypto';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { type TaskDocument } from '@api/collections/tasks/schemas/task.schema';
+import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  buildWorkspaceTaskRealtimeSnapshot,
+  serializeWorkspaceTaskProgress,
+  type WorkspaceTaskProgressSnapshot,
+} from '@genfeedai/serializers';
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+
+export type TaskEventInput = {
+  payload?: Record<string, unknown>;
+  timestamp?: Date;
+  type: string;
+};
+
+type TaskRealtimePayload = {
+  event: {
+    id: string;
+    payload?: Record<string, unknown>;
+    timestamp: string;
+    type: string;
+  };
+  organizationId: string;
+  progress: WorkspaceTaskProgressSnapshot;
+  room: string;
+  task: Record<string, unknown>;
+  taskId: string;
+  userId: string;
+};
+
+type OutputIdArrayField = 'approvedOutputIds' | 'linkedOutputIds';
+
+type TaskDelegate = {
+  findFirst: (args: { where: Record<string, unknown> }) => Promise<unknown>;
+  update: (args: {
+    data: Record<string, unknown>;
+    where: Record<string, unknown>;
+  }) => Promise<unknown>;
+};
+
+/**
+ * Review-gate transitions, output-array mutations, and the realtime
+ * event-broadcast machinery for tasks. Extracted out of `TasksService` so the
+ * latter stays a thin persistence/CRUD/lifecycle surface. `TasksService` keeps
+ * thin delegators to these methods, so the HTTP contract is unchanged.
+ */
+@Injectable()
+export class TaskActionsService {
+  constructor(
+    @Inject(forwardRef(() => TasksService))
+    private readonly tasksService: TasksService,
+    private readonly prisma: PrismaService,
+    private readonly ingredientsService: IngredientsService,
+    private readonly notificationsPublisher: NotificationsPublisherService,
+  ) {}
+
+  private get delegate(): TaskDelegate {
+    return (this.prisma as unknown as Record<string, TaskDelegate>).task;
+  }
+
+  async approve(id: string, organizationId: string): Promise<TaskDocument> {
+    const task = await this.tasksService.requireTask(id, organizationId);
+    const updated = await this.applyReviewTransition(id, {
+      completedAt: new Date(),
+      reviewState: 'approved',
+      status: 'done',
+      dismissedReason: null,
+      failureReason: null,
+      requestedChangesReason: null,
+    });
+    const userId = task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      type: 'task_approved',
+    });
+    return updated;
+  }
+
+  async requestChanges(
+    id: string,
+    organizationId: string,
+    userId: string,
+    reason: string,
+  ): Promise<TaskDocument> {
+    await this.tasksService.requireTask(id, organizationId);
+    const updated = await this.applyReviewTransition(id, {
+      requestedChangesReason: reason,
+      reviewState: 'changes_requested',
+      status: 'in_review',
+      dismissedReason: null,
+    });
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: { reason },
+      type: 'task_changes_requested',
+    });
+    return updated;
+  }
+
+  async dismiss(
+    id: string,
+    organizationId: string,
+    userId: string,
+    reason?: string,
+  ): Promise<TaskDocument> {
+    await this.tasksService.requireTask(id, organizationId);
+    const updated = await this.applyReviewTransition(id, {
+      dismissedAt: new Date(),
+      dismissedReason: reason ?? null,
+      reviewState: 'dismissed',
+      status: 'cancelled',
+      failureReason: null,
+      requestedChangesReason: null,
+    });
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: reason ? { reason } : undefined,
+      type: 'task_dismissed',
+    });
+    return updated;
+  }
+
+  async keepOutput(
+    id: string,
+    outputId: string,
+    organizationId: string,
+  ): Promise<TaskDocument> {
+    const task = await this.requireLinkedOutputTask(
+      id,
+      organizationId,
+      outputId,
+    );
+    const updated = await this.mutateOutputIdArray(
+      id,
+      organizationId,
+      'approvedOutputIds',
+      'add',
+      outputId,
+    );
+    const userId = task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: { outputId },
+      type: 'output_kept',
+    });
+    return updated;
+  }
+
+  async unkeepOutput(
+    id: string,
+    outputId: string,
+    organizationId: string,
+  ): Promise<TaskDocument> {
+    const task = await this.requireLinkedOutputTask(
+      id,
+      organizationId,
+      outputId,
+    );
+    const updated = await this.mutateOutputIdArray(
+      id,
+      organizationId,
+      'approvedOutputIds',
+      'remove',
+      outputId,
+    );
+    const userId = task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: { outputId },
+      type: 'output_unkept',
+    });
+    return updated;
+  }
+
+  async trashOutput(
+    id: string,
+    outputId: string,
+    organizationId: string,
+  ): Promise<TaskDocument> {
+    const task = await this.requireLinkedOutputTask(
+      id,
+      organizationId,
+      outputId,
+    );
+    const ingredient = await this.ingredientsService.findOne({
+      id: outputId,
+      isDeleted: false,
+      organizationId,
+    });
+    if (!ingredient) throw new NotFoundException('Ingredient', outputId);
+    await this.ingredientsService.patch(outputId, { isDeleted: true });
+    const updated = await this.mutateOutputIdArray(
+      id,
+      organizationId,
+      'approvedOutputIds',
+      'remove',
+      outputId,
+    );
+    const userId = task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: { outputId },
+      type: 'output_trashed',
+    });
+    return updated;
+  }
+
+  async attachOutput(
+    id: string,
+    outputId: string,
+    organizationId: string,
+    userId: string,
+  ): Promise<TaskDocument> {
+    await this.tasksService.requireTask(id, organizationId);
+    const updated = await this.mutateOutputIdArray(
+      id,
+      organizationId,
+      'linkedOutputIds',
+      'add',
+      outputId,
+    );
+    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+      payload: { outputId },
+      type: 'output_attached',
+    });
+    return updated;
+  }
+
+  async recordTaskEvent(
+    id: string,
+    organizationId: string,
+    userId: string,
+    event: TaskEventInput,
+    patch: Record<string, unknown> = {},
+  ): Promise<TaskDocument> {
+    const task = await this.tasksService.requireTask(id, organizationId);
+    const updated = await this.patchTaskAndReturn(id, organizationId, patch);
+    await this.appendEventAndBroadcast(
+      updated ?? task,
+      organizationId,
+      userId,
+      event,
+    );
+    return updated ?? task;
+  }
+
+  /**
+   * Update a task and return it, or throw the canonical not-found. Shared by
+   * the review-action methods (approve / requestChanges / dismiss).
+   */
+  private async applyReviewTransition(
+    id: string,
+    data: Record<string, unknown>,
+  ): Promise<TaskDocument> {
+    const updated = (await this.delegate.update({
+      data,
+      where: { id },
+    })) as unknown as TaskDocument | null;
+    if (!updated) throw new NotFoundException('Task', id);
+    return updated;
+  }
+
+  /**
+   * Add/remove an outputId on a task's id-array field (dedup on add, filter on
+   * remove). Shared by keepOutput / unkeepOutput / trashOutput / attachOutput.
+   */
+  private async mutateOutputIdArray(
+    id: string,
+    organizationId: string,
+    field: OutputIdArrayField,
+    op: 'add' | 'remove',
+    outputId: string,
+  ): Promise<TaskDocument> {
+    const current = (await this.delegate.findFirst({
+      where: { id, isDeleted: false, organizationId },
+    })) as Record<string, unknown> | null;
+    const existingIds = (current?.[field] as string[] | undefined) ?? [];
+    const nextIds =
+      op === 'add'
+        ? Array.from(new Set([...existingIds, outputId]))
+        : existingIds.filter((oid) => oid !== outputId);
+    const updated = (await this.delegate.update({
+      data: { [field]: nextIds },
+      where: { id },
+    })) as unknown as TaskDocument | null;
+    if (!updated) throw new NotFoundException('Task', id);
+    return updated;
+  }
+
+  private async patchTaskAndReturn(
+    id: string,
+    organizationId: string,
+    patch: Record<string, unknown>,
+  ): Promise<TaskDocument | null> {
+    if (Object.keys(patch).length === 0) {
+      return this.tasksService.findOne({
+        id,
+        isDeleted: false,
+        organizationId,
+      });
+    }
+    return (await this.delegate.update({
+      data: patch,
+      where: { id },
+    })) as unknown as TaskDocument | null;
+  }
+
+  private async requireLinkedOutputTask(
+    id: string,
+    organizationId: string,
+    outputId: string,
+  ): Promise<TaskDocument> {
+    const task = await this.tasksService.requireTask(id, organizationId);
+    const linkedOutputIds = task.linkedOutputIds ?? [];
+    const isLinked = linkedOutputIds.some(
+      (linkedOutputId) => linkedOutputId.toString() === outputId,
+    );
+    if (!isLinked)
+      throw new BadRequestException(
+        'This output is not linked to the requested task.',
+      );
+    return task;
+  }
+
+  private createTaskEventEntry(input: TaskEventInput): {
+    createdAt: Date;
+    id: string;
+    payload?: Record<string, unknown>;
+    timestamp: Date;
+    type: string;
+  } {
+    const now = input.timestamp ?? new Date();
+    return {
+      createdAt: now,
+      id: randomUUID(),
+      payload: input.payload,
+      timestamp: now,
+      type: input.type,
+    };
+  }
+
+  private async appendEventAndBroadcast(
+    task: TaskDocument,
+    organizationId: string,
+    userId: string,
+    eventInput: TaskEventInput,
+  ): Promise<void> {
+    const entry = this.createTaskEventEntry(eventInput);
+    const taskId = (task as Record<string, unknown>).id as string;
+
+    const eventDoc = {
+      createdAt: entry.createdAt,
+      id: entry.id,
+      payload: entry.payload,
+      timestamp: entry.timestamp,
+      type: entry.type,
+      userId: userId || undefined,
+    };
+
+    const current = (await this.delegate.findFirst({
+      where: { id: taskId, isDeleted: false },
+    })) as { eventStream?: unknown[] } | null;
+    const currentStream = current?.eventStream ?? [];
+    const newStream = [...currentStream, eventDoc];
+
+    const updated = (await this.delegate.update({
+      data: { eventStream: newStream },
+      where: { id: taskId },
+    })) as unknown as TaskDocument | null;
+
+    if (!updated) return;
+
+    const payload: TaskRealtimePayload = {
+      event: {
+        id: entry.id,
+        payload: entry.payload,
+        timestamp: entry.timestamp.toISOString(),
+        type: entry.type,
+      },
+      organizationId,
+      progress: serializeWorkspaceTaskProgress(updated.progress),
+      room: `org-${organizationId}`,
+      task: buildWorkspaceTaskRealtimeSnapshot(
+        updated as unknown as Parameters<
+          typeof buildWorkspaceTaskRealtimeSnapshot
+        >[0],
+      ),
+      taskId,
+      userId,
+    };
+
+    await Promise.all([
+      this.notificationsPublisher.emit(
+        WebSocketPaths.workspaceTask(taskId),
+        payload,
+      ),
+      this.notificationsPublisher.emit(
+        WebSocketPaths.workspaceTaskOverview(organizationId),
+        payload,
+      ),
+    ]);
+  }
+}

--- a/apps/server/api/src/collections/tasks/services/task-planning.service.spec.ts
+++ b/apps/server/api/src/collections/tasks/services/task-planning.service.spec.ts
@@ -1,0 +1,148 @@
+import { AgentMessagesService } from '@api/collections/agent-messages/services/agent-messages.service';
+import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { AgentThreadsService } from '@api/collections/agent-threads/services/agent-threads.service';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
+import { TaskPlanningService } from '@api/collections/tasks/services/task-planning.service';
+import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { BadRequestException } from '@nestjs/common';
+
+describe('TaskPlanningService', () => {
+  let service: TaskPlanningService;
+  let tasksService: {
+    requireTask: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+  let agentThreadsService: { findOne: ReturnType<typeof vi.fn> };
+  let agentMessagesService: { getMessagesByRoom: ReturnType<typeof vi.fn> };
+  let agentRunsService: { getById: ReturnType<typeof vi.fn> };
+  let taskCountersService: { getNextNumber: ReturnType<typeof vi.fn> };
+  let organizationsService: { findOne: ReturnType<typeof vi.fn> };
+
+  const baseTask = {
+    brandId: 'brand-1',
+    id: 'task-1',
+    linkedRunIds: [],
+    organizationId: 'org-1',
+    outputType: 'ingredient',
+    planningThreadId: 'thread-1',
+    platforms: ['x'],
+    priority: 'medium',
+    request: 'Original request',
+    title: 'Parent task',
+  };
+
+  beforeEach(() => {
+    tasksService = {
+      create: vi.fn().mockImplementation((d) => Promise.resolve(d)),
+      patch: vi.fn(),
+      requireTask: vi.fn().mockResolvedValue(baseTask),
+    };
+    agentThreadsService = {
+      findOne: vi.fn().mockResolvedValue({ id: 'thread-1' }),
+    };
+    agentMessagesService = { getMessagesByRoom: vi.fn() };
+    agentRunsService = { getById: vi.fn() };
+    taskCountersService = { getNextNumber: vi.fn().mockResolvedValue(7) };
+    organizationsService = {
+      findOne: vi.fn().mockResolvedValue({ prefix: 'ACME' }),
+    };
+
+    service = new TaskPlanningService(
+      tasksService as unknown as TasksService,
+      agentThreadsService as unknown as AgentThreadsService,
+      agentMessagesService as unknown as AgentMessagesService,
+      agentRunsService as unknown as AgentRunsService,
+      taskCountersService as unknown as TaskCountersService,
+      organizationsService as unknown as OrganizationsService,
+    );
+  });
+
+  describe('createFollowUpTasks', () => {
+    it('creates child tasks from the latest approved plan steps', async () => {
+      agentMessagesService.getMessagesByRoom.mockResolvedValue([
+        {
+          metadata: {
+            proposedPlan: {
+              status: 'approved',
+              steps: [
+                {
+                  details: 'Shoot the hero shot',
+                  outputType: 'image',
+                  title: 'Create hero image',
+                },
+                { title: 'Write the caption', type: 'caption' },
+              ],
+            },
+          },
+          role: 'assistant',
+        },
+      ]);
+
+      const created = await service.createFollowUpTasks(
+        'task-1',
+        'org-1',
+        'user-1',
+      );
+
+      expect(created).toHaveLength(2);
+      expect(tasksService.create).toHaveBeenCalledTimes(2);
+      expect(tasksService.create).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          identifier: 'ACME-7',
+          outputType: 'image',
+          title: 'Create hero image',
+          userId: 'user-1',
+        }),
+      );
+      // request bundles the source-task context
+      const firstArg = tasksService.create.mock.calls[0][0];
+      expect(firstArg.request).toContain('Source task: Parent task (task-1)');
+      expect(firstArg.request).toContain('Shoot the hero shot');
+    });
+
+    it('throws when no planning thread is accessible', async () => {
+      agentThreadsService.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.createFollowUpTasks('task-1', 'org-1', 'user-1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws when the latest plan is not approved', async () => {
+      agentMessagesService.getMessagesByRoom.mockResolvedValue([
+        {
+          metadata: { proposedPlan: { status: 'draft', steps: [] } },
+          role: 'assistant',
+        },
+      ]);
+
+      await expect(
+        service.createFollowUpTasks('task-1', 'org-1', 'user-1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws when an approved plan has no usable steps', async () => {
+      agentMessagesService.getMessagesByRoom.mockResolvedValue([
+        {
+          metadata: { proposedPlan: { status: 'approved', steps: [] } },
+          role: 'assistant',
+        },
+      ]);
+
+      await expect(
+        service.createFollowUpTasks('task-1', 'org-1', 'user-1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getPlanningPrompt', () => {
+    it('builds a kickoff prompt from the task title', async () => {
+      const prompt = await service.getPlanningPrompt('task-1', 'org-1');
+      expect(prompt).toContain('Parent task');
+      expect(prompt).toContain('what SHOULD happen next');
+    });
+  });
+});

--- a/apps/server/api/src/collections/tasks/services/task-planning.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-planning.service.ts
@@ -1,0 +1,442 @@
+import { AgentMessagesService } from '@api/collections/agent-messages/services/agent-messages.service';
+import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { AgentThreadsService } from '@api/collections/agent-threads/services/agent-threads.service';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
+import { CreateTaskDto } from '@api/collections/tasks/dto/create-task.dto';
+import { type TaskDocument } from '@api/collections/tasks/schemas/task.schema';
+import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { serializeWorkspaceTaskDate } from '@genfeedai/serializers';
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+
+const PLANNING_THREAD_SOURCE_PREFIX = 'workspace-planning:';
+const PLANNING_THREAD_TITLE_PREFIX = 'Plan next steps: ';
+
+export type PlanningThreadResult = {
+  created: boolean;
+  seeded: boolean;
+  threadId: string;
+};
+
+type FollowUpPlanStep = {
+  outputType?: TaskDocument['outputType'];
+  request: string;
+  title: string;
+};
+
+/**
+ * Planning-thread + follow-up-task orchestration for tasks. Extracted out of
+ * `TasksService` (which keeps thin delegating methods so the HTTP contract is
+ * unchanged). Persistence/CRUD is delegated back to `TasksService`.
+ */
+@Injectable()
+export class TaskPlanningService {
+  constructor(
+    @Inject(forwardRef(() => TasksService))
+    private readonly tasksService: TasksService,
+    private readonly agentThreadsService: AgentThreadsService,
+    private readonly agentMessagesService: AgentMessagesService,
+    private readonly agentRunsService: AgentRunsService,
+    private readonly taskCountersService: TaskCountersService,
+    private readonly organizationsService: OrganizationsService,
+  ) {}
+
+  async openPlanningThread(
+    id: string,
+    organizationId: string,
+    userId: string,
+  ): Promise<PlanningThreadResult> {
+    const task = await this.tasksService.requireTask(id, organizationId);
+    const systemPrompt = await this.buildPlanningSystemPrompt(
+      task,
+      organizationId,
+    );
+    const planningThreadIdStr = task.planningThreadId?.toString();
+    const existingThreadId = await this.resolveAccessiblePlanningThreadId(
+      planningThreadIdStr,
+      organizationId,
+    );
+
+    if (existingThreadId) {
+      await this.agentThreadsService.updateThreadMetadata(
+        existingThreadId,
+        organizationId,
+        {
+          planModeEnabled: true,
+          systemPrompt,
+          title: this.buildPlanningThreadTitle(task.title),
+        },
+      );
+      return {
+        created: false,
+        seeded: await this.shouldSeedPlanningThread(
+          existingThreadId,
+          organizationId,
+        ),
+        threadId: existingThreadId,
+      };
+    }
+
+    const thread = await this.agentThreadsService.create({
+      organizationId,
+      planModeEnabled: true,
+      source: this.buildPlanningThreadSource(id),
+      systemPrompt,
+      title: this.buildPlanningThreadTitle(task.title),
+      userId,
+    } as Record<string, unknown>);
+
+    const threadId = (thread as Record<string, unknown>).id as string;
+    await this.tasksService.patch(id, { planningThreadId: threadId } as Record<
+      string,
+      unknown
+    >);
+
+    return { created: true, seeded: true, threadId };
+  }
+
+  async getPlanningPrompt(id: string, organizationId: string): Promise<string> {
+    const task = await this.tasksService.requireTask(id, organizationId);
+    return this.buildPlanningKickoffPrompt(task.title);
+  }
+
+  async createFollowUpTasks(
+    id: string,
+    organizationId: string,
+    userId: string,
+  ): Promise<TaskDocument[]> {
+    const task = await this.tasksService.requireTask(id, organizationId);
+    const planningThreadIdStr = task.planningThreadId?.toString();
+    const threadId = await this.resolveAccessiblePlanningThreadId(
+      planningThreadIdStr,
+      organizationId,
+    );
+
+    if (!threadId) {
+      throw new BadRequestException(
+        'No planning conversation exists for this task yet.',
+      );
+    }
+
+    const latestPlan = await this.getLatestApprovedPlanningMessage(
+      threadId,
+      organizationId,
+    );
+    const followUpSteps = this.extractFollowUpSteps(latestPlan, task);
+
+    if (followUpSteps.length === 0) {
+      throw new BadRequestException(
+        'The latest approved plan does not contain any follow-up steps to create.',
+      );
+    }
+
+    const taskOrgId =
+      ((task as Record<string, unknown>).organizationId as string) ??
+      organizationId;
+    const org = await this.organizationsService.findOne({
+      id: taskOrgId,
+      isDeleted: false,
+    });
+
+    return Promise.all(
+      followUpSteps.map(async (step) => {
+        const taskNumber =
+          await this.taskCountersService.getNextNumber(taskOrgId);
+        const identifier = `${org?.prefix ?? 'TASK'}-${taskNumber}`;
+        return this.tasksService.create({
+          brandId: (task as Record<string, unknown>).brandId as string,
+          identifier,
+          organizationId: taskOrgId,
+          outputType: step.outputType ?? task.outputType,
+          platforms: task.platforms,
+          priority: task.priority,
+          request: step.request,
+          taskNumber,
+          title: step.title,
+          userId,
+        } as CreateTaskDto & {
+          identifier: string;
+          organizationId: string;
+          taskNumber: number;
+          userId: string;
+        });
+      }),
+    );
+  }
+
+  private readObjectRecord(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
+    }
+
+    return value as Record<string, unknown>;
+  }
+
+  private async resolveAccessiblePlanningThreadId(
+    planningThreadId: string | undefined,
+    organizationId: string,
+  ): Promise<string | null> {
+    if (!planningThreadId) return null;
+    const thread = await this.agentThreadsService.findOne({
+      id: planningThreadId,
+      isDeleted: false,
+      organizationId,
+    });
+    return thread ? ((thread as Record<string, unknown>).id as string) : null;
+  }
+
+  private async shouldSeedPlanningThread(
+    threadId: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    const existingMessages = await this.agentMessagesService.getMessagesByRoom(
+      threadId,
+      organizationId,
+      { limit: 1, page: 1 },
+    );
+    return existingMessages.length === 0;
+  }
+
+  private buildPlanningThreadSource(taskId: string): string {
+    return `${PLANNING_THREAD_SOURCE_PREFIX}${taskId}`;
+  }
+
+  private buildPlanningThreadTitle(taskTitle: string): string {
+    const normalized = taskTitle.trim();
+    const title = normalized.length > 0 ? normalized : 'Task';
+    return `${PLANNING_THREAD_TITLE_PREFIX}${title}`.slice(0, 140);
+  }
+
+  private buildPlanningKickoffPrompt(taskTitle: string): string {
+    const subject = taskTitle.trim() || 'this task';
+    return `Review ${subject} and tell me what has already been done, what remains unresolved, what SHOULD happen next, and what COULD happen next.`;
+  }
+
+  private async buildPlanningSystemPrompt(
+    task: TaskDocument,
+    organizationId: string,
+  ): Promise<string> {
+    const linkedRuns = await this.buildLinkedRunSummaries(task, organizationId);
+    const taskId = (task as Record<string, unknown>).id as string;
+    const bundle = {
+      decomposition: task.decomposition ?? null,
+      dismissedReason: task.dismissedReason ?? null,
+      failureReason: task.failureReason ?? null,
+      linkedApprovalIds: (task.linkedApprovalIds ?? []).map((id) =>
+        id.toString(),
+      ),
+      linkedOutputIds: (task.linkedOutputIds ?? []).map((id) => id.toString()),
+      linkedRunIds: (task.linkedRunIds ?? []).map((id) => id.toString()),
+      linkedRuns,
+      outputType: task.outputType,
+      platforms: task.platforms,
+      priority: task.priority,
+      requestedChangesReason: task.requestedChangesReason ?? null,
+      resultPreview: task.resultPreview ?? null,
+      reviewState: task.reviewState,
+      reviewTriggered: task.reviewTriggered,
+      routingSummary: task.routingSummary ?? null,
+      status: task.status,
+      taskId,
+      title: task.title,
+      userRequest: task.request,
+    };
+
+    return [
+      "You are Genfeed's task-aware planning assistant for a single task.",
+      'Use the live task bundle below as the source of truth for what has already happened.',
+      'Stay conversational and concise, but be explicit about state.',
+      'When you answer planning questions, you must:',
+      '1. Summarize what has already been done.',
+      '2. Separate what is complete from what remains unresolved.',
+      '3. Recommend what SHOULD happen next.',
+      '4. List what COULD happen next as optional follow-ups.',
+      '5. When appropriate, propose a sequenced multi-task plan where each step is concrete enough to become a follow-up task.',
+      '',
+      'Live task bundle:',
+      JSON.stringify(bundle, null, 2),
+    ].join('\n');
+  }
+
+  private async buildLinkedRunSummaries(
+    task: TaskDocument,
+    organizationId: string,
+  ): Promise<
+    Array<{
+      completedAt?: string;
+      error?: string;
+      id: string;
+      label: string;
+      startedAt?: string;
+      status: string;
+      summary?: string;
+      threadId?: string;
+    }>
+  > {
+    const runSummaries: Array<{
+      completedAt?: string;
+      error?: string;
+      id: string;
+      label: string;
+      startedAt?: string;
+      status: string;
+      summary?: string;
+      threadId?: string;
+    }> = [];
+
+    for (const linkedRunId of task.linkedRunIds ?? []) {
+      const run = await this.agentRunsService.getById(
+        linkedRunId.toString(),
+        organizationId,
+      );
+
+      if (!run) {
+        continue;
+      }
+
+      runSummaries.push({
+        completedAt: serializeWorkspaceTaskDate(run.completedAt),
+        error: typeof run.error === 'string' ? run.error : undefined,
+        id: (run as Record<string, unknown>).id as string,
+        label: typeof run.label === 'string' ? run.label : '',
+        startedAt: serializeWorkspaceTaskDate(run.startedAt),
+        status: typeof run.status === 'string' ? run.status : 'unknown',
+        summary: typeof run.summary === 'string' ? run.summary : undefined,
+        threadId: run.thread?.toString(),
+      });
+    }
+
+    return runSummaries;
+  }
+
+  private async getLatestApprovedPlanningMessage(
+    threadId: string,
+    organizationId: string,
+  ): Promise<Record<string, unknown>> {
+    const recentMessages = await this.agentMessagesService.getMessagesByRoom(
+      threadId,
+      organizationId,
+      { limit: 100, page: 1 },
+    );
+
+    const latestPlanningMessage = recentMessages.find((message) => {
+      if (message.role !== 'assistant') return false;
+      const metadata = this.readObjectRecord(message.metadata);
+      const proposedPlan = metadata?.['proposedPlan'];
+      return (
+        proposedPlan !== null &&
+        typeof proposedPlan === 'object' &&
+        !Array.isArray(proposedPlan)
+      );
+    });
+
+    const latestMetadata = this.readObjectRecord(
+      latestPlanningMessage?.metadata,
+    );
+    const plan = latestMetadata?.['proposedPlan'];
+
+    if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
+      throw new BadRequestException(
+        'No proposed plan is available in the planning conversation yet.',
+      );
+    }
+
+    const status =
+      typeof (plan as { status?: unknown }).status === 'string'
+        ? (plan as { status: string }).status
+        : null;
+
+    if (status !== 'approved') {
+      throw new BadRequestException(
+        'Approve the proposed plan before creating follow-up tasks.',
+      );
+    }
+
+    return plan as Record<string, unknown>;
+  }
+
+  private extractFollowUpSteps(
+    plan: Record<string, unknown>,
+    task: TaskDocument,
+  ): FollowUpPlanStep[] {
+    const steps = Array.isArray(plan['steps']) ? plan['steps'] : [];
+    const taskId = (task as Record<string, unknown>).id as string;
+
+    return steps.flatMap((step) => {
+      if (!step || typeof step !== 'object' || Array.isArray(step)) return [];
+
+      const title =
+        this.readStringField(step as Record<string, unknown>, [
+          'step',
+          'title',
+          'task',
+          'label',
+          'name',
+        ]) ?? null;
+      if (!title) return [];
+
+      const detail =
+        this.readStringField(step as Record<string, unknown>, [
+          'details',
+          'description',
+          'request',
+          'summary',
+          'brief',
+        ]) ?? '';
+      const request = [
+        detail.length > 0 ? `${title}\n\n${detail}` : title,
+        `Source task: ${task.title} (${taskId})`,
+        `Original task request: ${task.request}`,
+      ].join('\n\n');
+
+      const outputType = this.normalizeOutputType(
+        this.readStringField(step as Record<string, unknown>, [
+          'outputType',
+          'type',
+        ]),
+      );
+
+      return [
+        {
+          outputType: outputType ?? task.outputType,
+          request,
+          title: title.slice(0, 140),
+        },
+      ];
+    });
+  }
+
+  private normalizeOutputType(
+    value: string | null,
+  ): TaskDocument['outputType'] | null {
+    if (!value) return null;
+    return [
+      'caption',
+      'facecam',
+      'image',
+      'ingredient',
+      'newsletter',
+      'post',
+      'video',
+    ].includes(value)
+      ? (value as TaskDocument['outputType'])
+      : null;
+  }
+
+  private readStringField(
+    value: Record<string, unknown>,
+    keys: string[],
+  ): string | null {
+    for (const key of keys) {
+      const candidate = value[key];
+      if (typeof candidate === 'string' && candidate.trim().length > 0)
+        return candidate.trim();
+    }
+    return null;
+  }
+}

--- a/apps/server/api/src/collections/tasks/services/task-routing.service.spec.ts
+++ b/apps/server/api/src/collections/tasks/services/task-routing.service.spec.ts
@@ -1,0 +1,147 @@
+import { SkillsService } from '@api/collections/skills/services/skills.service';
+import type { CreateTaskDto } from '@api/collections/tasks/dto/create-task.dto';
+import { TaskRoutingService } from '@api/collections/tasks/services/task-routing.service';
+
+describe('TaskRoutingService', () => {
+  let service: TaskRoutingService;
+  let skillsService: { resolveBrandSkills: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    skillsService = { resolveBrandSkills: vi.fn().mockResolvedValue([]) };
+    service = new TaskRoutingService(skillsService as unknown as SkillsService);
+  });
+
+  const dto = (overrides: Record<string, unknown>): CreateTaskDto =>
+    ({ ...overrides }) as unknown as CreateTaskDto;
+
+  describe('keyword fallback routing', () => {
+    it.each([
+      [
+        'Make a 30s video reel for launch',
+        'video',
+        'video_generation',
+        'in_progress',
+        false,
+      ],
+      [
+        'Write a newsletter issue for subscribers',
+        'newsletter',
+        'caption_generation',
+        'backlog',
+        true,
+      ],
+      [
+        'Draft a tweet thread with a hook',
+        'post',
+        'caption_generation',
+        'backlog',
+        true,
+      ],
+      [
+        'Write a caption / copy for the photo',
+        'caption',
+        'caption_generation',
+        'backlog',
+        true,
+      ],
+      [
+        'Create a thumbnail image visual',
+        'image',
+        'image_generation',
+        'in_progress',
+        false,
+      ],
+      [
+        'Some broad open-ended request',
+        'ingredient',
+        'agent_orchestrator',
+        'backlog',
+        false,
+      ],
+    ])('routes "%s" → %s via %s', async (request, outputType, executionPathUsed, status, reviewTriggered) => {
+      const decision = await service.buildRoutingDecision(
+        dto({ request }),
+        'Title',
+      );
+
+      expect(decision.outputType).toBe(outputType);
+      expect(decision.executionPathUsed).toBe(executionPathUsed);
+      expect(decision.status).toBe(status);
+      expect(decision.reviewTriggered).toBe(reviewTriggered);
+      expect(decision.chosenProvider).toBe('genfeed-router');
+      expect(decision.skillsUsed).toEqual([]);
+    });
+
+    it('honours an explicit outputType over keyword inference', async () => {
+      const decision = await service.buildRoutingDecision(
+        dto({ outputType: 'image', request: 'write a video script' }),
+        'Title',
+      );
+
+      expect(decision.outputType).toBe('image');
+      expect(decision.executionPathUsed).toBe('image_generation');
+      expect(decision.status).toBe('in_progress');
+    });
+
+    it('does not look up skills when brand/organization are missing', async () => {
+      await service.buildRoutingDecision(dto({ request: 'make a video' }), 'T');
+      expect(skillsService.resolveBrandSkills).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('skill-driven routing', () => {
+    it('uses a matched brand skill that requires approval', async () => {
+      skillsService.resolveBrandSkills.mockResolvedValue([
+        {
+          targetSkill: {
+            name: 'Newsletter Pro',
+            requiredProviders: ['beehiiv'],
+            reviewDefaults: { requiresApproval: true },
+            slug: 'newsletter-pro',
+            workflowStage: 'creation',
+          },
+          variant: { _id: 'variant-123' },
+        },
+      ]);
+
+      const decision = await service.buildRoutingDecision(
+        dto({
+          brand: 'brand-1',
+          organization: 'org-1',
+          request: 'write a newsletter',
+        }),
+        'Weekly digest',
+      );
+
+      expect(skillsService.resolveBrandSkills).toHaveBeenCalledWith(
+        'org-1',
+        'brand-1',
+        expect.objectContaining({ workflowStage: 'creation' }),
+      );
+      expect(decision.chosenProvider).toBe('beehiiv');
+      expect(decision.reviewState).toBe('pending_approval');
+      expect(decision.reviewTriggered).toBe(true);
+      expect(decision.status).toBe('in_review');
+      expect(decision.skillsUsed).toEqual(['newsletter-pro']);
+      expect(decision.skillVariantIds).toEqual(['variant-123']);
+      expect(decision.resultPreview).toContain('Newsletter Pro');
+      expect(decision.resultPreview).toContain('Weekly digest');
+    });
+
+    it('falls back to keyword routing when no skill matches', async () => {
+      skillsService.resolveBrandSkills.mockResolvedValue([]);
+
+      const decision = await service.buildRoutingDecision(
+        dto({
+          brand: 'brand-1',
+          organization: 'org-1',
+          request: 'make a video',
+        }),
+        'Title',
+      );
+
+      expect(decision.outputType).toBe('video');
+      expect(decision.skillsUsed).toEqual([]);
+    });
+  });
+});

--- a/apps/server/api/src/collections/tasks/services/task-routing.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-routing.service.ts
@@ -1,0 +1,295 @@
+import { type SkillDocument } from '@api/collections/skills/schemas/skill.schema';
+import { SkillsService } from '@api/collections/skills/services/skills.service';
+import { CreateTaskDto } from '@api/collections/tasks/dto/create-task.dto';
+import { type TaskDocument } from '@api/collections/tasks/schemas/task.schema';
+import { Injectable } from '@nestjs/common';
+
+export type TaskRoutingDecision = Pick<
+  TaskDocument,
+  | 'chosenModel'
+  | 'chosenProvider'
+  | 'executionPathUsed'
+  | 'outputType'
+  | 'resultPreview'
+  | 'reviewState'
+  | 'reviewTriggered'
+  | 'routingSummary'
+  | 'skillVariantIds'
+  | 'skillsUsed'
+  | 'status'
+>;
+
+export type AiTaskIntent = {
+  channel?: string;
+  modality: 'image' | 'text' | 'video';
+  outputType: TaskDocument['outputType'];
+  workflowStage: 'creation';
+};
+
+type CreateTaskDtoExtended = CreateTaskDto & {
+  brand?: string;
+  organization?: string;
+  outputType?: TaskDocument['outputType'];
+  platforms?: string[];
+  request?: string;
+  user?: string;
+};
+
+type ExecutionPath = TaskRoutingDecision['executionPathUsed'];
+
+/**
+ * Ordered request-keyword → outputType inference table. The first pattern that
+ * matches the (lower-cased) request wins; nothing matching falls through to
+ * `ingredient`.
+ */
+const OUTPUT_TYPE_PATTERNS: ReadonlyArray<
+  [RegExp, TaskDocument['outputType']]
+> = [
+  [/\b(video|reel|short|clip)\b/, 'video'],
+  [/\b(newsletter|issue|beehiiv|email)\b/, 'newsletter'],
+  [/\b(thread|tweet|post|reply|hook)\b/, 'post'],
+  [/\b(caption|copy|text)\b/, 'caption'],
+  [/\b(image|photo|thumbnail|visual)\b/, 'image'],
+];
+
+const EXECUTION_PATH_BY_OUTPUT_TYPE: Partial<
+  Record<NonNullable<TaskDocument['outputType']>, ExecutionPath>
+> = {
+  caption: 'caption_generation',
+  facecam: 'video_generation',
+  image: 'image_generation',
+  newsletter: 'caption_generation',
+  post: 'caption_generation',
+  video: 'video_generation',
+};
+
+function executionPathForOutputType(
+  outputType: TaskDocument['outputType'],
+): ExecutionPath {
+  return (
+    (outputType && EXECUTION_PATH_BY_OUTPUT_TYPE[outputType]) ??
+    'agent_orchestrator'
+  );
+}
+
+type FallbackConfig = {
+  outputType: TaskDocument['outputType'];
+  reviewTriggered: boolean;
+  routingSummary: string;
+  status: TaskRoutingDecision['status'];
+};
+
+/**
+ * Per-outputType fallback routing config (used when no brand skill matches).
+ * `executionPathUsed` is derived from {@link executionPathForOutputType} so it
+ * never drifts from the skill-driven path.
+ */
+const FALLBACK_BY_OUTPUT_TYPE: Partial<
+  Record<NonNullable<TaskDocument['outputType']>, FallbackConfig>
+> = {
+  caption: {
+    outputType: 'caption',
+    reviewTriggered: true,
+    routingSummary:
+      'Detected a writing request and routed it to the caption generation path for review.',
+    status: 'backlog',
+  },
+  facecam: {
+    outputType: 'facecam',
+    reviewTriggered: false,
+    routingSummary:
+      'Detected a facecam video request and routed it to the video generation path.',
+    status: 'in_progress',
+  },
+  image: {
+    outputType: 'image',
+    reviewTriggered: false,
+    routingSummary:
+      'Detected an image ingredient request and routed it to the image generation path.',
+    status: 'in_progress',
+  },
+  newsletter: {
+    outputType: 'newsletter',
+    reviewTriggered: true,
+    routingSummary:
+      'Detected a newsletter request and routed it to the writing generation path for review.',
+    status: 'backlog',
+  },
+  post: {
+    outputType: 'post',
+    reviewTriggered: true,
+    routingSummary:
+      'Detected a social post request and routed it to the writing generation path for review.',
+    status: 'backlog',
+  },
+  video: {
+    outputType: 'video',
+    reviewTriggered: false,
+    routingSummary:
+      'Detected a short-form video request and routed it to the video generation path.',
+    status: 'in_progress',
+  },
+};
+
+const FALLBACK_DEFAULT: FallbackConfig = {
+  outputType: 'ingredient',
+  reviewTriggered: false,
+  routingSummary:
+    'Detected a broader ingredient request and routed it to the orchestration path.',
+  status: 'backlog',
+};
+
+/**
+ * Pure routing-decision engine for tasks. Resolves a request to an
+ * outputType + execution path, preferring a matched brand skill and falling
+ * back to keyword inference. Extracted out of `TasksService` so the
+ * classification logic is testable in isolation and free of persistence.
+ */
+@Injectable()
+export class TaskRoutingService {
+  constructor(private readonly skillsService: SkillsService) {}
+
+  async buildRoutingDecision(
+    createDto: CreateTaskDto,
+    taskTitle: string,
+  ): Promise<TaskRoutingDecision> {
+    const extended = createDto as CreateTaskDtoExtended;
+    const inferredOutputType = this.inferOutputType(createDto);
+    const taskIntent = this.buildTaskIntent(createDto, inferredOutputType);
+    const brandId = extended.brand ?? undefined;
+    const organizationId = extended.organization ?? undefined;
+
+    if (brandId && organizationId) {
+      const resolvedSkills = await this.skillsService.resolveBrandSkills(
+        organizationId,
+        brandId,
+        {
+          channel: taskIntent.channel,
+          modality: taskIntent.modality,
+          workflowStage: taskIntent.workflowStage,
+        },
+      );
+      const matchedSkill = resolvedSkills[0];
+      if (matchedSkill) {
+        return this.buildSkillDrivenDecision(
+          taskIntent,
+          matchedSkill,
+          taskTitle,
+        );
+      }
+    }
+
+    return this.buildFallbackRoutingDecision(inferredOutputType);
+  }
+
+  private buildTaskIntent(
+    createDto: CreateTaskDto,
+    outputType: TaskDocument['outputType'],
+  ): AiTaskIntent {
+    const extended = createDto as CreateTaskDtoExtended;
+    const platforms = extended.platforms ?? [];
+    const normalizedPlatforms = platforms.map((p) => p.toLowerCase());
+    const primaryChannel = normalizedPlatforms[0];
+
+    switch (outputType) {
+      case 'image':
+        return {
+          channel: primaryChannel,
+          modality: 'image',
+          outputType: 'image',
+          workflowStage: 'creation',
+        };
+      case 'video':
+        return {
+          channel: primaryChannel,
+          modality: 'video',
+          outputType: 'video',
+          workflowStage: 'creation',
+        };
+      default:
+        return {
+          channel: primaryChannel,
+          modality: 'text',
+          outputType,
+          workflowStage: 'creation',
+        };
+    }
+  }
+
+  private inferOutputType(
+    createDto: CreateTaskDto,
+  ): TaskDocument['outputType'] {
+    const extended = createDto as CreateTaskDtoExtended;
+    if (extended.outputType) {
+      return extended.outputType;
+    }
+
+    const normalizedRequest = (extended.request ?? '').toLowerCase();
+    const matched = OUTPUT_TYPE_PATTERNS.find(([pattern]) =>
+      pattern.test(normalizedRequest),
+    );
+    return matched ? matched[1] : 'ingredient';
+  }
+
+  private buildSkillDrivenDecision(
+    taskIntent: AiTaskIntent,
+    matchedSkill: Awaited<
+      ReturnType<SkillsService['resolveBrandSkills']>
+    >[number],
+    taskTitle: string,
+  ): TaskRoutingDecision {
+    const targetSkill = matchedSkill.targetSkill;
+    const requiresApproval = this.skillRequiresApproval(targetSkill);
+    const executionPathUsed = executionPathForOutputType(taskIntent.outputType);
+
+    return {
+      chosenModel: 'auto',
+      chosenProvider: targetSkill.requiredProviders?.[0] ?? 'genfeed-router',
+      executionPathUsed,
+      outputType: taskIntent.outputType,
+      resultPreview: requiresApproval
+        ? `Prepared with ${targetSkill.name}: ${taskTitle}`
+        : undefined,
+      reviewState: requiresApproval ? 'pending_approval' : 'none',
+      reviewTriggered: requiresApproval,
+      routingSummary: `Resolved the request using the brand skill "${targetSkill.name}" (${targetSkill.slug}) for the ${taskIntent.workflowStage} stage.`,
+      skillsUsed: targetSkill.slug ? [targetSkill.slug] : [],
+      skillVariantIds: matchedSkill.variant?._id
+        ? [String(matchedSkill.variant._id)]
+        : [],
+      status: requiresApproval
+        ? 'in_review'
+        : executionPathUsed === 'agent_orchestrator'
+          ? 'backlog'
+          : 'in_progress',
+    };
+  }
+
+  private buildFallbackRoutingDecision(
+    inferredOutputType: TaskDocument['outputType'],
+  ): TaskRoutingDecision {
+    const config =
+      (inferredOutputType && FALLBACK_BY_OUTPUT_TYPE[inferredOutputType]) ??
+      FALLBACK_DEFAULT;
+
+    return {
+      chosenModel: 'auto',
+      chosenProvider: 'genfeed-router',
+      executionPathUsed: executionPathForOutputType(config.outputType),
+      outputType: config.outputType,
+      reviewState: 'none',
+      reviewTriggered: config.reviewTriggered,
+      routingSummary: config.routingSummary,
+      skillsUsed: [],
+      skillVariantIds: [],
+      status: config.status,
+    };
+  }
+
+  private skillRequiresApproval(skill: SkillDocument): boolean {
+    const reviewDefaults = skill.reviewDefaults;
+    if (!reviewDefaults) return skill.workflowStage === 'review';
+    const requiresApproval = reviewDefaults['requiresApproval'];
+    return typeof requiresApproval === 'boolean' ? requiresApproval : false;
+  }
+}

--- a/apps/server/api/src/collections/tasks/services/tasks.service.ts
+++ b/apps/server/api/src/collections/tasks/services/tasks.service.ts
@@ -1,28 +1,29 @@
-import { randomUUID } from 'node:crypto';
-import { AgentMessagesService } from '@api/collections/agent-messages/services/agent-messages.service';
-import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
-import { AgentThreadsService } from '@api/collections/agent-threads/services/agent-threads.service';
-import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
-import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
-import { type SkillDocument } from '@api/collections/skills/schemas/skill.schema';
-import { SkillsService } from '@api/collections/skills/services/skills.service';
-import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
 import { CreateTaskDto } from '@api/collections/tasks/dto/create-task.dto';
 import { UpdateTaskDto } from '@api/collections/tasks/dto/update-task.dto';
 import {
   type TaskDocument,
-  type TaskEvent,
-  type TaskProgress,
   type TaskStatus,
 } from '@api/collections/tasks/schemas/task.schema';
+import {
+  TaskActionsService,
+  type TaskEventInput,
+} from '@api/collections/tasks/services/task-actions.service';
+import {
+  type PlanningThreadResult,
+  TaskPlanningService,
+} from '@api/collections/tasks/services/task-planning.service';
+import { TaskRoutingService } from '@api/collections/tasks/services/task-routing.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
-import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
-import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 
 const STATUS_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
   backlog: ['todo', 'in_progress', 'cancelled'],
@@ -35,72 +36,19 @@ const STATUS_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
   todo: ['in_progress', 'blocked', 'backlog', 'cancelled'],
 };
 
-const PLANNING_THREAD_SOURCE_PREFIX = 'workspace-planning:';
-const PLANNING_THREAD_TITLE_PREFIX = 'Plan next steps: ';
-
-type TaskRoutingDecision = Pick<
-  TaskDocument,
-  | 'chosenModel'
-  | 'chosenProvider'
-  | 'executionPathUsed'
-  | 'outputType'
-  | 'resultPreview'
-  | 'reviewState'
-  | 'reviewTriggered'
-  | 'routingSummary'
-  | 'skillVariantIds'
-  | 'skillsUsed'
-  | 'status'
->;
-
-type AiTaskIntent = {
-  channel?: string;
-  modality: 'image' | 'text' | 'video';
-  outputType: TaskDocument['outputType'];
-  workflowStage: 'creation';
-};
-
-type PlanningThreadResult = {
-  created: boolean;
-  seeded: boolean;
-  threadId: string;
-};
-
-type TaskEventInput = {
-  payload?: Record<string, unknown>;
-  timestamp?: Date;
-  type: string;
-};
-
-type TaskRealtimePayload = {
-  event: {
-    id: string;
-    payload?: Record<string, unknown>;
-    timestamp: string;
-    type: string;
-  };
-  organizationId: string;
-  progress: TaskProgress;
-  room: string;
-  task: Record<string, unknown>;
-  taskId: string;
-  userId: string;
-};
-
-type FollowUpPlanStep = {
-  outputType?: TaskDocument['outputType'];
-  request: string;
-  title: string;
-};
-
 type CreateTaskDtoExtended = CreateTaskDto & {
-  brand?: string;
-  organization?: string;
   platforms?: string[];
   request?: string;
-  user?: string;
 };
 
+/**
+ * Thin persistence / CRUD / lifecycle surface for tasks. Routing classification
+ * lives in {@link TaskRoutingService}, review-gate + output actions + realtime
+ * broadcast in {@link TaskActionsService}, and planning/follow-up orchestration
+ * in {@link TaskPlanningService}. The review/output/planning methods below are
+ * thin delegators so the HTTP contract (the controller still calls them here) is
+ * preserved.
+ */
 @Injectable()
 export class TasksService extends BaseService<
   TaskDocument,
@@ -111,25 +59,25 @@ export class TasksService extends BaseService<
   constructor(
     public readonly prisma: PrismaService,
     readonly logger: LoggerService,
-    private readonly skillsService: SkillsService,
-    private readonly ingredientsService: IngredientsService,
-    private readonly agentThreadsService: AgentThreadsService,
-    private readonly agentMessagesService: AgentMessagesService,
-    private readonly agentRunsService: AgentRunsService,
-    private readonly notificationsPublisher: NotificationsPublisherService,
-    private readonly taskCountersService: TaskCountersService,
-    private readonly organizationsService: OrganizationsService,
+    private readonly taskRoutingService: TaskRoutingService,
+    @Inject(forwardRef(() => TaskActionsService))
+    private readonly taskActionsService: TaskActionsService,
+    @Inject(forwardRef(() => TaskPlanningService))
+    private readonly taskPlanningService: TaskPlanningService,
   ) {
     super(prisma, 'task', logger);
   }
 
   override async create(createDto: CreateTaskDto): Promise<TaskDocument> {
     const extended = createDto as CreateTaskDtoExtended;
+    const normalizedTitle = this.buildTaskTitle(createDto);
     const routing = extended.request
-      ? await this.buildRoutingDecision(createDto)
+      ? await this.taskRoutingService.buildRoutingDecision(
+          createDto,
+          normalizedTitle,
+        )
       : null;
 
-    const normalizedTitle = this.buildTaskTitle(createDto);
     const createPayload = {
       ...createDto,
       ...(routing ?? {}),
@@ -303,25 +251,12 @@ export class TasksService extends BaseService<
     })) as unknown as TaskDocument[];
   }
 
+  // ===========================================================================
+  // Review / output actions — thin delegators to TaskActionsService.
+  // ===========================================================================
+
   async approve(id: string, organizationId: string): Promise<TaskDocument> {
-    const task = await this.requireAiTask(id, organizationId);
-    const updated = (await this.delegate.update({
-      data: {
-        completedAt: new Date(),
-        reviewState: 'approved',
-        status: 'done',
-        dismissedReason: null,
-        failureReason: null,
-        requestedChangesReason: null,
-      },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      type: 'task_approved',
-    });
-    return updated;
+    return this.taskActionsService.approve(id, organizationId);
   }
 
   async requestChanges(
@@ -330,22 +265,12 @@ export class TasksService extends BaseService<
     userId: string,
     reason: string,
   ): Promise<TaskDocument> {
-    await this.requireAiTask(id, organizationId);
-    const updated = (await this.delegate.update({
-      data: {
-        requestedChangesReason: reason,
-        reviewState: 'changes_requested',
-        status: 'in_review',
-        dismissedReason: null,
-      },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      payload: { reason },
-      type: 'task_changes_requested',
-    });
-    return updated;
+    return this.taskActionsService.requestChanges(
+      id,
+      organizationId,
+      userId,
+      reason,
+    );
   }
 
   async dismiss(
@@ -354,24 +279,7 @@ export class TasksService extends BaseService<
     userId: string,
     reason?: string,
   ): Promise<TaskDocument> {
-    await this.requireAiTask(id, organizationId);
-    const updated = (await this.delegate.update({
-      data: {
-        dismissedAt: new Date(),
-        dismissedReason: reason ?? null,
-        reviewState: 'dismissed',
-        status: 'cancelled',
-        failureReason: null,
-        requestedChangesReason: null,
-      },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      payload: reason ? { reason } : undefined,
-      type: 'task_dismissed',
-    });
-    return updated;
+    return this.taskActionsService.dismiss(id, organizationId, userId, reason);
   }
 
   async keepOutput(
@@ -379,27 +287,7 @@ export class TasksService extends BaseService<
     outputId: string,
     organizationId: string,
   ): Promise<TaskDocument> {
-    const task = await this.requireLinkedOutputTask(
-      id,
-      organizationId,
-      outputId,
-    );
-    const current = (await this.delegate.findFirst({
-      where: { id, isDeleted: false, organizationId },
-    })) as { approvedOutputIds?: string[] } | null;
-    const existingIds = current?.approvedOutputIds ?? [];
-    const deduped = Array.from(new Set([...existingIds, outputId]));
-    const updated = (await this.delegate.update({
-      data: { approvedOutputIds: deduped },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      payload: { outputId },
-      type: 'output_kept',
-    });
-    return updated;
+    return this.taskActionsService.keepOutput(id, outputId, organizationId);
   }
 
   async unkeepOutput(
@@ -407,27 +295,7 @@ export class TasksService extends BaseService<
     outputId: string,
     organizationId: string,
   ): Promise<TaskDocument> {
-    const task = await this.requireLinkedOutputTask(
-      id,
-      organizationId,
-      outputId,
-    );
-    const current = (await this.delegate.findFirst({
-      where: { id, isDeleted: false, organizationId },
-    })) as { approvedOutputIds?: string[] } | null;
-    const existingIds = current?.approvedOutputIds ?? [];
-    const filtered = existingIds.filter((oid) => oid !== outputId);
-    const updated = (await this.delegate.update({
-      data: { approvedOutputIds: filtered },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      payload: { outputId },
-      type: 'output_unkept',
-    });
-    return updated;
+    return this.taskActionsService.unkeepOutput(id, outputId, organizationId);
   }
 
   async trashOutput(
@@ -435,34 +303,7 @@ export class TasksService extends BaseService<
     outputId: string,
     organizationId: string,
   ): Promise<TaskDocument> {
-    const task = await this.requireLinkedOutputTask(
-      id,
-      organizationId,
-      outputId,
-    );
-    const ingredient = await this.ingredientsService.findOne({
-      id: outputId,
-      isDeleted: false,
-      organizationId,
-    });
-    if (!ingredient) throw new NotFoundException('Ingredient', outputId);
-    await this.ingredientsService.patch(outputId, { isDeleted: true });
-    const current = (await this.delegate.findFirst({
-      where: { id, isDeleted: false, organizationId },
-    })) as { approvedOutputIds?: string[] } | null;
-    const existingIds = current?.approvedOutputIds ?? [];
-    const filtered = existingIds.filter((oid) => oid !== outputId);
-    const updated = (await this.delegate.update({
-      data: { approvedOutputIds: filtered },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      payload: { outputId },
-      type: 'output_trashed',
-    });
-    return updated;
+    return this.taskActionsService.trashOutput(id, outputId, organizationId);
   }
 
   async attachOutput(
@@ -471,22 +312,12 @@ export class TasksService extends BaseService<
     organizationId: string,
     userId: string,
   ): Promise<TaskDocument> {
-    await this.requireAiTask(id, organizationId);
-    const current = (await this.delegate.findFirst({
-      where: { id, isDeleted: false, organizationId },
-    })) as { linkedOutputIds?: string[] } | null;
-    const existingIds = current?.linkedOutputIds ?? [];
-    const deduped = Array.from(new Set([...existingIds, outputId]));
-    const updated = (await this.delegate.update({
-      data: { linkedOutputIds: deduped },
-      where: { id },
-    })) as unknown as TaskDocument | null;
-    if (!updated) throw new NotFoundException('Task', id);
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
-      payload: { outputId },
-      type: 'output_attached',
-    });
-    return updated;
+    return this.taskActionsService.attachOutput(
+      id,
+      outputId,
+      organizationId,
+      userId,
+    );
   }
 
   async recordTaskEvent(
@@ -496,74 +327,33 @@ export class TasksService extends BaseService<
     event: TaskEventInput,
     patch: Record<string, unknown> = {},
   ): Promise<TaskDocument> {
-    const task = await this.requireAiTask(id, organizationId);
-    const updated = await this.patchAiTaskAndReturn(id, organizationId, patch);
-    await this.appendEventAndBroadcast(
-      updated ?? task,
+    return this.taskActionsService.recordTaskEvent(
+      id,
       organizationId,
       userId,
       event,
+      patch,
     );
-    return updated ?? task;
   }
+
+  // ===========================================================================
+  // Planning / follow-up orchestration — thin delegators to TaskPlanningService.
+  // ===========================================================================
 
   async openPlanningThread(
     id: string,
     organizationId: string,
     userId: string,
   ): Promise<PlanningThreadResult> {
-    const task = await this.requireAiTask(id, organizationId);
-    const systemPrompt = await this.buildPlanningSystemPrompt(
-      task,
+    return this.taskPlanningService.openPlanningThread(
+      id,
       organizationId,
-    );
-    const planningThreadIdStr = task.planningThreadId?.toString();
-    const existingThreadId = await this.resolveAccessiblePlanningThreadId(
-      planningThreadIdStr,
-      organizationId,
-    );
-
-    if (existingThreadId) {
-      await this.agentThreadsService.updateThreadMetadata(
-        existingThreadId,
-        organizationId,
-        {
-          planModeEnabled: true,
-          systemPrompt,
-          title: this.buildPlanningThreadTitle(task.title),
-        },
-      );
-      return {
-        created: false,
-        seeded: await this.shouldSeedPlanningThread(
-          existingThreadId,
-          organizationId,
-        ),
-        threadId: existingThreadId,
-      };
-    }
-
-    const thread = await this.agentThreadsService.create({
-      organizationId,
-      planModeEnabled: true,
-      source: this.buildPlanningThreadSource(id),
-      systemPrompt,
-      title: this.buildPlanningThreadTitle(task.title),
       userId,
-    } as Record<string, unknown>);
-
-    const threadId = (thread as Record<string, unknown>).id as string;
-    await this.patch(id, { planningThreadId: threadId } as Record<
-      string,
-      unknown
-    >);
-
-    return { created: true, seeded: true, threadId };
+    );
   }
 
   async getPlanningPrompt(id: string, organizationId: string): Promise<string> {
-    const task = await this.requireAiTask(id, organizationId);
-    return this.buildPlanningKickoffPrompt(task.title);
+    return this.taskPlanningService.getPlanningPrompt(id, organizationId);
   }
 
   async createFollowUpTasks(
@@ -571,63 +361,22 @@ export class TasksService extends BaseService<
     organizationId: string,
     userId: string,
   ): Promise<TaskDocument[]> {
-    const task = await this.requireAiTask(id, organizationId);
-    const planningThreadIdStr = task.planningThreadId?.toString();
-    const threadId = await this.resolveAccessiblePlanningThreadId(
-      planningThreadIdStr,
+    return this.taskPlanningService.createFollowUpTasks(
+      id,
       organizationId,
+      userId,
     );
+  }
 
-    if (!threadId) {
-      throw new BadRequestException(
-        'No planning conversation exists for this task yet.',
-      );
-    }
-
-    const latestPlan = await this.getLatestApprovedPlanningMessage(
-      threadId,
-      organizationId,
-    );
-    const followUpSteps = this.extractFollowUpSteps(latestPlan, task);
-
-    if (followUpSteps.length === 0) {
-      throw new BadRequestException(
-        'The latest approved plan does not contain any follow-up steps to create.',
-      );
-    }
-
-    const taskOrgId =
-      ((task as Record<string, unknown>).organizationId as string) ??
-      organizationId;
-    const org = await this.organizationsService.findOne({
-      id: taskOrgId,
-      isDeleted: false,
-    });
-
-    return Promise.all(
-      followUpSteps.map(async (step) => {
-        const taskNumber =
-          await this.taskCountersService.getNextNumber(taskOrgId);
-        const identifier = `${org?.prefix ?? 'TASK'}-${taskNumber}`;
-        return this.create({
-          brandId: (task as Record<string, unknown>).brandId as string,
-          identifier,
-          organizationId: taskOrgId,
-          outputType: step.outputType ?? task.outputType,
-          platforms: task.platforms,
-          priority: task.priority,
-          request: step.request,
-          taskNumber,
-          title: step.title,
-          userId,
-        } as CreateTaskDto & {
-          identifier: string;
-          organizationId: string;
-          taskNumber: number;
-          userId: string;
-        });
-      }),
-    );
+  /**
+   * Fetch an org-scoped, non-deleted task or throw. Public so the extracted
+   * task services ({@link TaskActionsService}, {@link TaskPlanningService}) can
+   * reuse the canonical lookup.
+   */
+  async requireTask(id: string, organizationId: string): Promise<TaskDocument> {
+    const task = await this.findOne({ id, isDeleted: false, organizationId });
+    if (!task) throw new NotFoundException('Task', id);
+    return task;
   }
 
   private buildTaskTitle(createDto: CreateTaskDto): string {
@@ -640,699 +389,6 @@ export class TasksService extends BaseService<
     if (!compactRequest) return 'Untitled task';
     if (compactRequest.length <= 72) return compactRequest;
     return `${compactRequest.slice(0, 69).trimEnd()}...`;
-  }
-
-  private async buildRoutingDecision(
-    createDto: CreateTaskDto,
-  ): Promise<TaskRoutingDecision> {
-    const extended = createDto as CreateTaskDtoExtended;
-    const inferredOutputType = this.inferOutputType(createDto);
-    const taskIntent = this.buildTaskIntent(createDto, inferredOutputType);
-    const brandId = extended.brand ?? undefined;
-    const organizationId = extended.organization ?? undefined;
-
-    if (brandId && organizationId) {
-      const resolvedSkills = await this.skillsService.resolveBrandSkills(
-        organizationId,
-        brandId,
-        {
-          channel: taskIntent.channel,
-          modality: taskIntent.modality,
-          workflowStage: taskIntent.workflowStage,
-        },
-      );
-      const matchedSkill = resolvedSkills[0];
-      if (matchedSkill) {
-        return this.buildSkillDrivenDecision(
-          createDto,
-          taskIntent,
-          matchedSkill,
-        );
-      }
-    }
-
-    return this.buildFallbackRoutingDecision(inferredOutputType);
-  }
-
-  private buildTaskIntent(
-    createDto: CreateTaskDto,
-    outputType: TaskDocument['outputType'],
-  ): AiTaskIntent {
-    const extended = createDto as CreateTaskDtoExtended;
-    const platforms = extended.platforms ?? [];
-    const normalizedPlatforms = platforms.map((p) => p.toLowerCase());
-    const primaryChannel = normalizedPlatforms[0];
-
-    switch (outputType) {
-      case 'image':
-        return {
-          channel: primaryChannel,
-          modality: 'image',
-          outputType: 'image',
-          workflowStage: 'creation',
-        };
-      case 'video':
-        return {
-          channel: primaryChannel,
-          modality: 'video',
-          outputType: 'video',
-          workflowStage: 'creation',
-        };
-      default:
-        return {
-          channel: primaryChannel,
-          modality: 'text',
-          outputType,
-          workflowStage: 'creation',
-        };
-    }
-  }
-
-  private inferOutputType(
-    createDto: CreateTaskDto,
-  ): TaskDocument['outputType'] {
-    const extended = createDto as CreateTaskDtoExtended;
-    const outputType = extended.outputType;
-    const request = extended.request ?? '';
-    const normalizedRequest = request.toLowerCase();
-
-    return (outputType ??
-      (normalizedRequest.match(/\b(video|reel|short|clip)\b/)
-        ? 'video'
-        : normalizedRequest.match(/\b(newsletter|issue|beehiiv|email)\b/)
-          ? 'newsletter'
-          : normalizedRequest.match(/\b(thread|tweet|post|reply|hook)\b/)
-            ? 'post'
-            : normalizedRequest.match(/\b(caption|copy|text)\b/)
-              ? 'caption'
-              : normalizedRequest.match(/\b(image|photo|thumbnail|visual)\b/)
-                ? 'image'
-                : 'ingredient')) as TaskDocument['outputType'];
-  }
-
-  private buildSkillDrivenDecision(
-    createDto: CreateTaskDto,
-    taskIntent: AiTaskIntent,
-    matchedSkill: Awaited<
-      ReturnType<SkillsService['resolveBrandSkills']>
-    >[number],
-  ): TaskRoutingDecision {
-    const targetSkill = matchedSkill.targetSkill;
-    const requiresApproval = this.skillRequiresApproval(targetSkill);
-    const taskTitle = this.buildTaskTitle(createDto);
-    const executionPathUsed =
-      taskIntent.outputType === 'image'
-        ? 'image_generation'
-        : taskIntent.outputType === 'video' ||
-            taskIntent.outputType === 'facecam'
-          ? 'video_generation'
-          : taskIntent.outputType === 'caption' ||
-              taskIntent.outputType === 'post' ||
-              taskIntent.outputType === 'newsletter'
-            ? 'caption_generation'
-            : 'agent_orchestrator';
-
-    return {
-      chosenModel: 'auto',
-      chosenProvider: targetSkill.requiredProviders?.[0] ?? 'genfeed-router',
-      executionPathUsed,
-      outputType: taskIntent.outputType,
-      resultPreview: requiresApproval
-        ? `Prepared with ${targetSkill.name}: ${taskTitle}`
-        : undefined,
-      reviewState: requiresApproval ? 'pending_approval' : 'none',
-      reviewTriggered: requiresApproval,
-      routingSummary: `Resolved the request using the brand skill "${targetSkill.name}" (${targetSkill.slug}) for the ${taskIntent.workflowStage} stage.`,
-      skillsUsed: targetSkill.slug ? [targetSkill.slug] : [],
-      skillVariantIds: matchedSkill.variant?._id
-        ? [String(matchedSkill.variant._id)]
-        : [],
-      status: requiresApproval
-        ? 'in_review'
-        : executionPathUsed === 'agent_orchestrator'
-          ? 'backlog'
-          : 'in_progress',
-    };
-  }
-
-  private buildFallbackRoutingDecision(
-    inferredOutputType: TaskDocument['outputType'],
-  ): TaskRoutingDecision {
-    switch (inferredOutputType) {
-      case 'image':
-        return {
-          chosenModel: 'auto',
-          chosenProvider: 'genfeed-router',
-          executionPathUsed: 'image_generation',
-          outputType: 'image',
-          reviewState: 'none',
-          reviewTriggered: false,
-          routingSummary:
-            'Detected an image ingredient request and routed it to the image generation path.',
-          skillsUsed: [],
-          skillVariantIds: [],
-          status: 'in_progress',
-        };
-      case 'video':
-        return {
-          chosenModel: 'auto',
-          chosenProvider: 'genfeed-router',
-          executionPathUsed: 'video_generation',
-          outputType: 'video',
-          reviewState: 'none',
-          reviewTriggered: false,
-          routingSummary:
-            'Detected a short-form video request and routed it to the video generation path.',
-          skillsUsed: [],
-          skillVariantIds: [],
-          status: 'in_progress',
-        };
-      case 'facecam':
-        return {
-          chosenModel: 'auto',
-          chosenProvider: 'genfeed-router',
-          executionPathUsed: 'video_generation',
-          outputType: 'facecam',
-          reviewState: 'none',
-          reviewTriggered: false,
-          routingSummary:
-            'Detected a facecam video request and routed it to the video generation path.',
-          skillsUsed: [],
-          skillVariantIds: [],
-          status: 'in_progress',
-        };
-      case 'caption':
-      case 'newsletter':
-      case 'post':
-        return {
-          chosenModel: 'auto',
-          chosenProvider: 'genfeed-router',
-          executionPathUsed: 'caption_generation',
-          outputType: inferredOutputType,
-          reviewState: 'none',
-          reviewTriggered: true,
-          routingSummary:
-            inferredOutputType === 'newsletter'
-              ? 'Detected a newsletter request and routed it to the writing generation path for review.'
-              : inferredOutputType === 'post'
-                ? 'Detected a social post request and routed it to the writing generation path for review.'
-                : 'Detected a writing request and routed it to the caption generation path for review.',
-          skillsUsed: [],
-          skillVariantIds: [],
-          status: 'backlog',
-        };
-      default:
-        return {
-          chosenModel: 'auto',
-          chosenProvider: 'genfeed-router',
-          executionPathUsed: 'agent_orchestrator',
-          outputType: 'ingredient',
-          reviewState: 'none',
-          reviewTriggered: false,
-          routingSummary:
-            'Detected a broader ingredient request and routed it to the orchestration path.',
-          skillsUsed: [],
-          skillVariantIds: [],
-          status: 'backlog',
-        };
-    }
-  }
-
-  private skillRequiresApproval(skill: SkillDocument): boolean {
-    const reviewDefaults = skill.reviewDefaults;
-    if (!reviewDefaults) return skill.workflowStage === 'review';
-    const requiresApproval = reviewDefaults['requiresApproval'];
-    return typeof requiresApproval === 'boolean' ? requiresApproval : false;
-  }
-
-  private async patchAiTaskAndReturn(
-    id: string,
-    organizationId: string,
-    patch: Record<string, unknown>,
-  ): Promise<TaskDocument | null> {
-    if (Object.keys(patch).length === 0) {
-      return this.findOne({ id, isDeleted: false, organizationId });
-    }
-    return (await this.delegate.update({
-      data: patch,
-      where: { id },
-    })) as unknown as TaskDocument | null;
-  }
-
-  private async requireAiTask(
-    id: string,
-    organizationId: string,
-  ): Promise<TaskDocument> {
-    const task = await this.findOne({ id, isDeleted: false, organizationId });
-    if (!task) throw new NotFoundException('Task', id);
-    return task;
-  }
-
-  private async requireLinkedOutputTask(
-    id: string,
-    organizationId: string,
-    outputId: string,
-  ): Promise<TaskDocument> {
-    const task = await this.requireAiTask(id, organizationId);
-    const linkedOutputIds = task.linkedOutputIds ?? [];
-    const isLinked = linkedOutputIds.some(
-      (linkedOutputId) => linkedOutputId.toString() === outputId,
-    );
-    if (!isLinked)
-      throw new BadRequestException(
-        'This output is not linked to the requested task.',
-      );
-    return task;
-  }
-
-  private createTaskEventEntry(input: TaskEventInput): {
-    createdAt: Date;
-    id: string;
-    payload?: Record<string, unknown>;
-    timestamp: Date;
-    type: string;
-  } {
-    const now = input.timestamp ?? new Date();
-    return {
-      createdAt: now,
-      id: randomUUID(),
-      payload: input.payload,
-      timestamp: now,
-      type: input.type,
-    };
-  }
-
-  private serializeTaskProgress(
-    progress: TaskDocument['progress'],
-  ): TaskProgress {
-    return {
-      activeRunCount: progress?.activeRunCount ?? 0,
-      message: progress?.message,
-      percent: progress?.percent ?? 0,
-      stage: progress?.stage,
-    };
-  }
-
-  private serializeDate(value: unknown): string | undefined {
-    if (value instanceof Date) {
-      return value.toISOString();
-    }
-
-    return typeof value === 'string' && value.length > 0 ? value : undefined;
-  }
-
-  private serializeTaskEvent(event: TaskEvent): Record<string, unknown> {
-    const createdAt = event.createdAt ?? event.timestamp;
-    const timestamp =
-      this.serializeDate(event.timestamp) ??
-      this.serializeDate(event.createdAt);
-
-    return {
-      createdAt: this.serializeDate(createdAt),
-      id: event.id,
-      payload: event.payload,
-      timestamp,
-      type: event.type,
-      userId: event.userId,
-    };
-  }
-
-  private serializeTaskRealtimeSnapshot(
-    task: TaskDocument,
-  ): Record<string, unknown> {
-    const approvedOutputIds = task.approvedOutputIds ?? [];
-    const linkedApprovalIds = task.linkedApprovalIds ?? [];
-    const linkedOutputIds = task.linkedOutputIds ?? [];
-    const linkedRunIds = task.linkedRunIds ?? [];
-    const skillVariantIds = task.skillVariantIds ?? [];
-    const eventStream = task.eventStream ?? [];
-    const taskRecord = task as Record<string, unknown>;
-
-    return {
-      approvedOutputIds: approvedOutputIds.map((id) => id.toString()),
-      brandId: taskRecord.brandId,
-      chosenModel: task.chosenModel,
-      chosenProvider: task.chosenProvider,
-      completedAt: this.serializeDate(task.completedAt),
-      createdAt: this.serializeDate(task.createdAt),
-      decomposition: task.decomposition,
-      dismissedAt: this.serializeDate(task.dismissedAt),
-      dismissedReason: task.dismissedReason,
-      eventStream: eventStream.map((event) => this.serializeTaskEvent(event)),
-      executionPathUsed: task.executionPathUsed,
-      failureReason: task.failureReason,
-      id: taskRecord.id,
-      linkedApprovalIds: linkedApprovalIds.map((id) => id.toString()),
-      linkedOutputIds: linkedOutputIds.map((id) => id.toString()),
-      linkedRunIds: linkedRunIds.map((id) => id.toString()),
-      organizationId: taskRecord.organizationId,
-      outputType: task.outputType,
-      planningThreadId: task.planningThreadId?.toString(),
-      platforms: task.platforms,
-      priority: task.priority,
-      progress: this.serializeTaskProgress(task.progress),
-      qualityAssessment: task.qualityAssessment,
-      request: task.request,
-      requestedChangesReason: task.requestedChangesReason,
-      resultPreview: task.resultPreview,
-      reviewState: task.reviewState,
-      reviewTriggered: task.reviewTriggered,
-      routingSummary: task.routingSummary,
-      skillsUsed: task.skillsUsed,
-      skillVariantIds: skillVariantIds.map((id) => id.toString()),
-      status: task.status,
-      title: task.title,
-      updatedAt: this.serializeDate(task.updatedAt),
-    };
-  }
-
-  private async appendEventAndBroadcast(
-    task: TaskDocument,
-    organizationId: string,
-    userId: string,
-    eventInput: TaskEventInput,
-  ): Promise<void> {
-    const entry = this.createTaskEventEntry(eventInput);
-    const taskId = (task as Record<string, unknown>).id as string;
-
-    const eventDoc = {
-      createdAt: entry.createdAt,
-      id: entry.id,
-      payload: entry.payload,
-      timestamp: entry.timestamp,
-      type: entry.type,
-      userId: userId || undefined,
-    };
-
-    const current = (await this.delegate.findFirst({
-      where: { id: taskId, isDeleted: false },
-    })) as { eventStream?: unknown[] } | null;
-    const currentStream = current?.eventStream ?? [];
-    const newStream = [...currentStream, eventDoc];
-
-    const updated = (await this.delegate.update({
-      data: { eventStream: newStream },
-      where: { id: taskId },
-    })) as unknown as TaskDocument | null;
-
-    if (!updated) return;
-
-    const payload: TaskRealtimePayload = {
-      event: {
-        id: entry.id,
-        payload: entry.payload,
-        timestamp: entry.timestamp.toISOString(),
-        type: entry.type,
-      },
-      organizationId,
-      progress: this.serializeTaskProgress(updated.progress),
-      room: `org-${organizationId}`,
-      task: this.serializeTaskRealtimeSnapshot(updated),
-      taskId,
-      userId,
-    };
-
-    await Promise.all([
-      this.notificationsPublisher.emit(
-        WebSocketPaths.workspaceTask(taskId),
-        payload,
-      ),
-      this.notificationsPublisher.emit(
-        WebSocketPaths.workspaceTaskOverview(organizationId),
-        payload,
-      ),
-    ]);
-  }
-
-  private readObjectRecord(value: unknown): Record<string, unknown> | null {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return null;
-    }
-
-    return value as Record<string, unknown>;
-  }
-
-  private async resolveAccessiblePlanningThreadId(
-    planningThreadId: string | undefined,
-    organizationId: string,
-  ): Promise<string | null> {
-    if (!planningThreadId) return null;
-    const thread = await this.agentThreadsService.findOne({
-      id: planningThreadId,
-      isDeleted: false,
-      organizationId,
-    });
-    return thread ? ((thread as Record<string, unknown>).id as string) : null;
-  }
-
-  private async shouldSeedPlanningThread(
-    threadId: string,
-    organizationId: string,
-  ): Promise<boolean> {
-    const existingMessages = await this.agentMessagesService.getMessagesByRoom(
-      threadId,
-      organizationId,
-      { limit: 1, page: 1 },
-    );
-    return existingMessages.length === 0;
-  }
-
-  private buildPlanningThreadSource(taskId: string): string {
-    return `${PLANNING_THREAD_SOURCE_PREFIX}${taskId}`;
-  }
-
-  private buildPlanningThreadTitle(taskTitle: string): string {
-    const normalized = taskTitle.trim();
-    const title = normalized.length > 0 ? normalized : 'Task';
-    return `${PLANNING_THREAD_TITLE_PREFIX}${title}`.slice(0, 140);
-  }
-
-  private buildPlanningKickoffPrompt(taskTitle: string): string {
-    const subject = taskTitle.trim() || 'this task';
-    return `Review ${subject} and tell me what has already been done, what remains unresolved, what SHOULD happen next, and what COULD happen next.`;
-  }
-
-  private async buildPlanningSystemPrompt(
-    task: TaskDocument,
-    organizationId: string,
-  ): Promise<string> {
-    const linkedRuns = await this.buildLinkedRunSummaries(task, organizationId);
-    const taskId = (task as Record<string, unknown>).id as string;
-    const bundle = {
-      decomposition: task.decomposition ?? null,
-      dismissedReason: task.dismissedReason ?? null,
-      failureReason: task.failureReason ?? null,
-      linkedApprovalIds: (task.linkedApprovalIds ?? []).map((id) =>
-        id.toString(),
-      ),
-      linkedOutputIds: (task.linkedOutputIds ?? []).map((id) => id.toString()),
-      linkedRunIds: (task.linkedRunIds ?? []).map((id) => id.toString()),
-      linkedRuns,
-      outputType: task.outputType,
-      platforms: task.platforms,
-      priority: task.priority,
-      requestedChangesReason: task.requestedChangesReason ?? null,
-      resultPreview: task.resultPreview ?? null,
-      reviewState: task.reviewState,
-      reviewTriggered: task.reviewTriggered,
-      routingSummary: task.routingSummary ?? null,
-      status: task.status,
-      taskId,
-      title: task.title,
-      userRequest: task.request,
-    };
-
-    return [
-      "You are Genfeed's task-aware planning assistant for a single task.",
-      'Use the live task bundle below as the source of truth for what has already happened.',
-      'Stay conversational and concise, but be explicit about state.',
-      'When you answer planning questions, you must:',
-      '1. Summarize what has already been done.',
-      '2. Separate what is complete from what remains unresolved.',
-      '3. Recommend what SHOULD happen next.',
-      '4. List what COULD happen next as optional follow-ups.',
-      '5. When appropriate, propose a sequenced multi-task plan where each step is concrete enough to become a follow-up task.',
-      '',
-      'Live task bundle:',
-      JSON.stringify(bundle, null, 2),
-    ].join('\n');
-  }
-
-  private async buildLinkedRunSummaries(
-    task: TaskDocument,
-    organizationId: string,
-  ): Promise<
-    Array<{
-      completedAt?: string;
-      error?: string;
-      id: string;
-      label: string;
-      startedAt?: string;
-      status: string;
-      summary?: string;
-      threadId?: string;
-    }>
-  > {
-    const runSummaries: Array<{
-      completedAt?: string;
-      error?: string;
-      id: string;
-      label: string;
-      startedAt?: string;
-      status: string;
-      summary?: string;
-      threadId?: string;
-    }> = [];
-
-    for (const linkedRunId of task.linkedRunIds ?? []) {
-      const run = await this.agentRunsService.getById(
-        linkedRunId.toString(),
-        organizationId,
-      );
-
-      if (!run) {
-        continue;
-      }
-
-      runSummaries.push({
-        completedAt: this.serializeDate(run.completedAt),
-        error: typeof run.error === 'string' ? run.error : undefined,
-        id: (run as Record<string, unknown>).id as string,
-        label: typeof run.label === 'string' ? run.label : '',
-        startedAt: this.serializeDate(run.startedAt),
-        status: typeof run.status === 'string' ? run.status : 'unknown',
-        summary: typeof run.summary === 'string' ? run.summary : undefined,
-        threadId: run.thread?.toString(),
-      });
-    }
-
-    return runSummaries;
-  }
-
-  private async getLatestApprovedPlanningMessage(
-    threadId: string,
-    organizationId: string,
-  ): Promise<Record<string, unknown>> {
-    const recentMessages = await this.agentMessagesService.getMessagesByRoom(
-      threadId,
-      organizationId,
-      { limit: 100, page: 1 },
-    );
-
-    const latestPlanningMessage = recentMessages.find((message) => {
-      if (message.role !== 'assistant') return false;
-      const metadata = this.readObjectRecord(message.metadata);
-      const proposedPlan = metadata?.['proposedPlan'];
-      return (
-        proposedPlan !== null &&
-        typeof proposedPlan === 'object' &&
-        !Array.isArray(proposedPlan)
-      );
-    });
-
-    const latestMetadata = this.readObjectRecord(
-      latestPlanningMessage?.metadata,
-    );
-    const plan = latestMetadata?.['proposedPlan'];
-
-    if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
-      throw new BadRequestException(
-        'No proposed plan is available in the planning conversation yet.',
-      );
-    }
-
-    const status =
-      typeof (plan as { status?: unknown }).status === 'string'
-        ? (plan as { status: string }).status
-        : null;
-
-    if (status !== 'approved') {
-      throw new BadRequestException(
-        'Approve the proposed plan before creating follow-up tasks.',
-      );
-    }
-
-    return plan as Record<string, unknown>;
-  }
-
-  private extractFollowUpSteps(
-    plan: Record<string, unknown>,
-    task: TaskDocument,
-  ): FollowUpPlanStep[] {
-    const steps = Array.isArray(plan['steps']) ? plan['steps'] : [];
-    const taskId = (task as Record<string, unknown>).id as string;
-
-    return steps.flatMap((step) => {
-      if (!step || typeof step !== 'object' || Array.isArray(step)) return [];
-
-      const title =
-        this.readStringField(step as Record<string, unknown>, [
-          'step',
-          'title',
-          'task',
-          'label',
-          'name',
-        ]) ?? null;
-      if (!title) return [];
-
-      const detail =
-        this.readStringField(step as Record<string, unknown>, [
-          'details',
-          'description',
-          'request',
-          'summary',
-          'brief',
-        ]) ?? '';
-      const request = [
-        detail.length > 0 ? `${title}\n\n${detail}` : title,
-        `Source task: ${task.title} (${taskId})`,
-        `Original task request: ${task.request}`,
-      ].join('\n\n');
-
-      const outputType = this.normalizeOutputType(
-        this.readStringField(step as Record<string, unknown>, [
-          'outputType',
-          'type',
-        ]),
-      );
-
-      return [
-        {
-          outputType: outputType ?? task.outputType,
-          request,
-          title: title.slice(0, 140),
-        },
-      ];
-    });
-  }
-
-  private normalizeOutputType(
-    value: string | null,
-  ): TaskDocument['outputType'] | null {
-    if (!value) return null;
-    return [
-      'caption',
-      'facecam',
-      'image',
-      'ingredient',
-      'newsletter',
-      'post',
-      'video',
-    ].includes(value)
-      ? (value as TaskDocument['outputType'])
-      : null;
-  }
-
-  private readStringField(
-    value: Record<string, unknown>,
-    keys: string[],
-  ): string | null {
-    for (const key of keys) {
-      const candidate = value[key];
-      if (typeof candidate === 'string' && candidate.trim().length > 0)
-        return candidate.trim();
-    }
-    return null;
   }
 
   private validateStatusTransition(

--- a/apps/server/api/src/collections/tasks/tasks.module.ts
+++ b/apps/server/api/src/collections/tasks/tasks.module.ts
@@ -7,6 +7,9 @@ import { SkillsModule } from '@api/collections/skills/skills.module';
 import { TaskCommentsModule } from '@api/collections/task-comments/task-comments.module';
 import { TaskCountersModule } from '@api/collections/task-counters/task-counters.module';
 import { TasksController } from '@api/collections/tasks/controllers/tasks.controller';
+import { TaskActionsService } from '@api/collections/tasks/services/task-actions.service';
+import { TaskPlanningService } from '@api/collections/tasks/services/task-planning.service';
+import { TaskRoutingService } from '@api/collections/tasks/services/task-routing.service';
 import { TasksService } from '@api/collections/tasks/services/tasks.service';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { AgentOrchestratorModule } from '@api/services/agent-orchestrator/agent-orchestrator.module';
@@ -31,6 +34,11 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => OrganizationsModule),
     forwardRef(() => LoggerModule),
   ],
-  providers: [TasksService],
+  providers: [
+    TaskActionsService,
+    TaskPlanningService,
+    TaskRoutingService,
+    TasksService,
+  ],
 })
 export class TasksModule {}

--- a/packages/serializers/src/server/content/index.ts
+++ b/packages/serializers/src/server/content/index.ts
@@ -36,3 +36,4 @@ export * from '@serializers/server/content/speech-transcription.serializer';
 export * from '@serializers/server/content/template.serializer';
 export * from '@serializers/server/content/transcript.serializer';
 export * from '@serializers/server/content/workspace-task.serializer';
+export * from '@serializers/server/content/workspace-task-realtime.builder';

--- a/packages/serializers/src/server/content/workspace-task-realtime.builder.ts
+++ b/packages/serializers/src/server/content/workspace-task-realtime.builder.ts
@@ -1,0 +1,158 @@
+/**
+ * Workspace-task realtime snapshot builder.
+ *
+ * Produces the flat `payload.task` / `payload.progress` shapes broadcast over
+ * the workspace-task websocket channels. This is the single source of truth for
+ * that wire shape — it used to live as private `serialize*` methods inside the
+ * API `TasksService`, violating the repo rule that serialization belongs in
+ * `packages/serializers`. The output is intentionally byte-compatible with the
+ * previous in-service serialization (the frontend consumes `payload.task` as a
+ * flat object via `new Task(payload.task)`, not a JSON:API envelope).
+ */
+
+type IdLike = string | { toString(): string };
+
+export interface WorkspaceTaskProgressInput {
+  activeRunCount?: number | null;
+  message?: string | null;
+  percent?: number | null;
+  stage?: string | null;
+}
+
+export interface WorkspaceTaskProgressSnapshot {
+  activeRunCount: number;
+  message?: string | null;
+  percent: number;
+  stage?: string | null;
+}
+
+export interface WorkspaceTaskEventInput {
+  createdAt?: Date | string | null;
+  id?: string;
+  payload?: Record<string, unknown>;
+  timestamp?: Date | string | null;
+  type?: string;
+  userId?: string;
+}
+
+export interface WorkspaceTaskRealtimeSnapshotInput {
+  approvedOutputIds?: IdLike[] | null;
+  chosenModel?: unknown;
+  chosenProvider?: unknown;
+  completedAt?: Date | string | null;
+  createdAt?: Date | string | null;
+  decomposition?: unknown;
+  dismissedAt?: Date | string | null;
+  dismissedReason?: unknown;
+  eventStream?: WorkspaceTaskEventInput[] | null;
+  executionPathUsed?: unknown;
+  failureReason?: unknown;
+  linkedApprovalIds?: IdLike[] | null;
+  linkedOutputIds?: IdLike[] | null;
+  linkedRunIds?: IdLike[] | null;
+  outputType?: unknown;
+  planningThreadId?: IdLike | null;
+  platforms?: unknown;
+  priority?: unknown;
+  progress?: WorkspaceTaskProgressInput | null;
+  qualityAssessment?: unknown;
+  request?: unknown;
+  requestedChangesReason?: unknown;
+  resultPreview?: unknown;
+  reviewState?: unknown;
+  reviewTriggered?: unknown;
+  routingSummary?: unknown;
+  skillVariantIds?: IdLike[] | null;
+  skillsUsed?: unknown;
+  status?: unknown;
+  title?: unknown;
+  updatedAt?: Date | string | null;
+  // Record-accessed fields (brandId / id / organizationId) are not first-class
+  // columns on the wire shape but are emitted inline.
+  [key: string]: unknown;
+}
+
+export function serializeWorkspaceTaskDate(value: unknown): string | undefined {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function serializeWorkspaceTaskProgress(
+  progress: WorkspaceTaskProgressInput | null | undefined,
+): WorkspaceTaskProgressSnapshot {
+  return {
+    activeRunCount: progress?.activeRunCount ?? 0,
+    message: progress?.message,
+    percent: progress?.percent ?? 0,
+    stage: progress?.stage,
+  };
+}
+
+export function serializeWorkspaceTaskEvent(
+  event: WorkspaceTaskEventInput,
+): Record<string, unknown> {
+  const createdAt = event.createdAt ?? event.timestamp;
+  const timestamp =
+    serializeWorkspaceTaskDate(event.timestamp) ??
+    serializeWorkspaceTaskDate(event.createdAt);
+
+  return {
+    createdAt: serializeWorkspaceTaskDate(createdAt),
+    id: event.id,
+    payload: event.payload,
+    timestamp,
+    type: event.type,
+    userId: event.userId,
+  };
+}
+
+export function buildWorkspaceTaskRealtimeSnapshot(
+  task: WorkspaceTaskRealtimeSnapshotInput,
+): Record<string, unknown> {
+  const approvedOutputIds = task.approvedOutputIds ?? [];
+  const linkedApprovalIds = task.linkedApprovalIds ?? [];
+  const linkedOutputIds = task.linkedOutputIds ?? [];
+  const linkedRunIds = task.linkedRunIds ?? [];
+  const skillVariantIds = task.skillVariantIds ?? [];
+  const eventStream = task.eventStream ?? [];
+
+  return {
+    approvedOutputIds: approvedOutputIds.map((id) => id.toString()),
+    brandId: task.brandId,
+    chosenModel: task.chosenModel,
+    chosenProvider: task.chosenProvider,
+    completedAt: serializeWorkspaceTaskDate(task.completedAt),
+    createdAt: serializeWorkspaceTaskDate(task.createdAt),
+    decomposition: task.decomposition,
+    dismissedAt: serializeWorkspaceTaskDate(task.dismissedAt),
+    dismissedReason: task.dismissedReason,
+    eventStream: eventStream.map((event) => serializeWorkspaceTaskEvent(event)),
+    executionPathUsed: task.executionPathUsed,
+    failureReason: task.failureReason,
+    id: task.id,
+    linkedApprovalIds: linkedApprovalIds.map((id) => id.toString()),
+    linkedOutputIds: linkedOutputIds.map((id) => id.toString()),
+    linkedRunIds: linkedRunIds.map((id) => id.toString()),
+    organizationId: task.organizationId,
+    outputType: task.outputType,
+    planningThreadId: task.planningThreadId?.toString(),
+    platforms: task.platforms,
+    priority: task.priority,
+    progress: serializeWorkspaceTaskProgress(task.progress),
+    qualityAssessment: task.qualityAssessment,
+    request: task.request,
+    requestedChangesReason: task.requestedChangesReason,
+    resultPreview: task.resultPreview,
+    reviewState: task.reviewState,
+    reviewTriggered: task.reviewTriggered,
+    routingSummary: task.routingSummary,
+    skillsUsed: task.skillsUsed,
+    skillVariantIds: skillVariantIds.map((id) => id.toString()),
+    status: task.status,
+    title: task.title,
+    updatedAt: serializeWorkspaceTaskDate(task.updatedAt),
+  };
+}


### PR DESCRIPTION
## Summary

`tasks.service.ts` was a 1,351-line `@Injectable` mixing CRUD, agent lifecycle, review/output actions, AI routing classification, planning/follow-up orchestration, and a **hand-rolled realtime serialization layer** (the last violating the repo rule that serializers live in `packages/serializers`).

Closes #837.

## The decomposition (all behavior-preserving)

| Unit | Responsibility |
|---|---|
| **`TaskRoutingService`** | Pure routing-decision engine. `inferOutputType` is now a `[regex, outputType]` table and the fallback is a per-outputType config map — no nested ternaries. |
| **`TaskActionsService`** | Review-gate transitions (approve/requestChanges/dismiss), output-array mutations (keep/unkeep/trash/attach), `recordTaskEvent`, and the realtime broadcast. The four copy-pasted output methods collapse into one `mutateOutputIdArray`; the review methods into one `applyReviewTransition`. |
| **`TaskPlanningService`** | Planning-thread + follow-up-task orchestration. |
| **`packages/serializers` realtime builder** | `buildWorkspaceTaskRealtimeSnapshot` + progress/event/date helpers, replacing the in-service `serialize*` methods. **Byte-compatible** with the previous wire shape (frontend still consumes `payload.task` as a flat object via `new Task(...)`, so the builder reproduces the exact flat object — including `brandId`/`organizationId` and ISO-string dates — rather than a JSON:API envelope). |

`TasksService` keeps only persistence/CRUD/lifecycle plus **thin delegators** to the extracted services, so the controller (and its HTTP contract) is unchanged. Renamed `requireAiTask` → `requireTask` (now public, reused by the extracted services) and `patchAiTaskAndReturn` → `patchTaskAndReturn`.

## Acceptance criteria

- [x] No file in `collections/tasks/services` exceeds 500 lines (was 1,351 → now 407 / 408 / 442 / 295); `TasksService` is persistence/CRUD/lifecycle only.
- [x] No method exceeds 80 lines; `inferOutputType` and the fallback routing are data-driven maps with no deep ternary nesting.
- [x] Zero in-service serialization of the task wire shape; the realtime payload is produced from the `packages/serializers` builder.
- [x] Output-array and review-action methods share a single helper each.
- [x] `requireAiTask` / `patchAiTaskAndReturn` renamed to generic names with all call sites updated.
- [x] Existing tasks controller/dto specs pass; new `task-routing.service.spec` + `task-planning.service.spec` cover the previously-untestable routing-decision and follow-up-extraction logic.
- [x] HTTP responses and emitted websocket payloads are unchanged (the snapshot builder reproduces the prior flat shape exactly).

## Verification

- `bun run test --filter=@genfeedai/api -- collections/tasks` → **36 passed (6 files)**
- `bunx turbo run type-check --filter=@genfeedai/api` → green (forwardRef triangle resolves)
- `bunx turbo run lint --filter=@genfeedai/api` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)