### PR TITLE
feat(seo): canonical SEOScorerService spine + score_seo agent tool (#758)

### DIFF
--- a/apps/server/api/src/app.module.ts
+++ b/apps/server/api/src/app.module.ts
@@ -176,6 +176,7 @@ import { NotificationsModule } from '@api/services/notifications/notifications.m
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
 import { PreflightModule } from '@api/services/preflight/preflight.module';
 import { RouterModule as ModelRouterModule } from '@api/services/router/router.module';
+import { SeoModule } from '@api/services/seo/seo.module';
 import { SkillExecutorModule } from '@api/services/skill-executor/skill-executor.module';
 import { DesktopSyncModule } from '@api/services/sync/desktop-sync.module';
 import { SyncModule } from '@api/services/sync/sync.module';
@@ -391,6 +392,9 @@ import { SentryModule } from '@sentry/nestjs/setup';
 
     // Content Optimization (closed-loop feedback)
     ContentOptimizationModule,
+
+    // SEO scoring (canonical SEOScorerService, #758)
+    SeoModule,
 
     // Higgsfield (multi-model I2V)
     HiggsFieldModule,

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -40,6 +40,7 @@ import { AgentThreadingModule } from '@api/services/agent-threading/agent-thread
 import { BatchGenerationModule } from '@api/services/batch-generation/batch-generation.module';
 import { ContentQualityModule } from '@api/services/content-quality/content-quality.module';
 import { LlmDispatcherModule } from '@api/services/integrations/llm/llm-dispatcher.module';
+import { SeoModule } from '@api/services/seo/seo.module';
 import { SkillRuntimeModule } from '@api/services/skill-runtime/skill-runtime.module';
 import { LoggerModule } from '@libs/logger/logger.module';
 import { HttpModule } from '@nestjs/axios';
@@ -86,6 +87,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => WorkflowExecutionsModule),
     forwardRef(() => WorkflowsModule),
     forwardRef(() => AgentSpawnModule),
+    SeoModule,
     forwardRef(() => SkillRuntimeModule),
   ],
   providers: [

--- a/apps/server/api/src/services/agent-orchestrator/constants/agent-type-config.constant.ts
+++ b/apps/server/api/src/services/agent-orchestrator/constants/agent-type-config.constant.ts
@@ -41,6 +41,7 @@ const SHARED_READ_TOOLS: AgentToolName[] = [
   GENERATE_AD_PACK_TOOL,
   PREPARE_AD_LAUNCH_REVIEW_TOOL,
   'rate_content' as AgentToolName,
+  AgentToolName.SCORE_SEO,
   'rate_ingredient' as AgentToolName,
   'get_top_ingredients' as AgentToolName,
   'replicate_top_ingredient' as AgentToolName,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -48,6 +48,7 @@ import { AgentStreamPublisherService } from '@api/services/agent-orchestrator/ag
 import { AgentSpawnService } from '@api/services/agent-spawn/agent-spawn.service';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { ContentQualityScorerService } from '@api/services/content-quality/content-quality-scorer.service';
+import { SeoScorerService } from '@api/services/seo/seo-scorer.service';
 import { isEEEnabled } from '@genfeedai/config';
 import {
   AgentType,
@@ -389,6 +390,8 @@ export class AgentToolExecutorService {
     private readonly voicesService: VoicesService,
     @Optional()
     private readonly contentQualityScorerService: ContentQualityScorerService,
+    @Optional()
+    private readonly seoScorerService: SeoScorerService,
     @Optional()
     private readonly agentGoalsService: AgentGoalsService,
     @Optional()
@@ -1129,6 +1132,10 @@ export class AgentToolExecutorService {
       // Content quality scoring
       case 'rate_content':
         return this.rateContent(params, ctx);
+
+      // SEO scoring
+      case 'score_seo':
+        return this.scoreSeo(params, ctx);
 
       // Ingredient voting & replication tools
       case 'rate_ingredient':
@@ -8334,6 +8341,79 @@ export class AgentToolExecutorService {
       return {
         creditsUsed: 0,
         error: `Rate content failed: ${errorMessage}`,
+        success: false,
+      };
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // SEO SCORING
+  // ──────────────────────────────────────────────
+
+  private async scoreSeo(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.seoScorerService) {
+      return {
+        creditsUsed: 0,
+        error: 'SeoScorerService not available',
+        success: false,
+      };
+    }
+
+    const contentId = params.contentId ? String(params.contentId) : undefined;
+    const contentType =
+      String(params.contentType ?? 'article') === 'post' ? 'post' : 'article';
+    const targetKeyword = params.targetKeyword
+      ? String(params.targetKeyword)
+      : undefined;
+
+    if (!contentId) {
+      return {
+        creditsUsed: 0,
+        error: 'contentId is required',
+        success: false,
+      };
+    }
+
+    try {
+      const result =
+        contentType === 'post'
+          ? await this.seoScorerService.scorePost(
+              contentId,
+              ctx.organizationId,
+              targetKeyword,
+            )
+          : await this.seoScorerService.scoreArticle(
+              contentId,
+              ctx.organizationId,
+              targetKeyword,
+            );
+
+      return {
+        creditsUsed: 0,
+        data: {
+          breakdown: result.breakdown,
+          message: `SEO score: ${result.score}/100 (${result.rating}). ${result.suggestions[0] ?? ''}`,
+          rating: result.rating,
+          score: result.score,
+          suggestions: result.suggestions,
+        },
+        success: true,
+      };
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      this.loggerService.error(`${this.constructorName} SCORE_SEO failed`, {
+        contentId,
+        error: errorMessage,
+      });
+
+      return {
+        creditsUsed: 0,
+        error: `Score SEO failed: ${errorMessage}`,
         success: false,
       };
     }

--- a/apps/server/api/src/services/seo/seo-scorer.service.spec.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.service.spec.ts
@@ -364,7 +364,11 @@ describe('SeoScorerService', () => {
     });
     expect(prisma.article.update).toHaveBeenCalledTimes(1);
     const updateArg = prisma.article.update.mock.calls[0][0];
-    expect(updateArg.where).toEqual({ id: 'art_1', isDeleted: false });
+    expect(updateArg.where).toEqual({
+      id: 'art_1',
+      isDeleted: false,
+      organizationId: 'org_1',
+    });
     expect(typeof updateArg.data.seoScore).toBe('number');
     expect(updateArg.data.seoBreakdown).toBeTruthy();
     expect(card.score).toBe(updateArg.data.seoScore);
@@ -372,7 +376,7 @@ describe('SeoScorerService', () => {
 
   it('throws NotFound when the article is missing', async () => {
     prisma.article.findFirst.mockResolvedValue(null);
-    await expect(service.scoreArticle('missing')).rejects.toThrow(
+    await expect(service.scoreArticle('missing', 'org_1')).rejects.toThrow(
       'Article not found',
     );
   });
@@ -389,7 +393,11 @@ describe('SeoScorerService', () => {
     const card = await service.scorePost('post_1', 'org_1', 'email marketing');
     expect(prisma.post.update).toHaveBeenCalledTimes(1);
     const updateArg = prisma.post.update.mock.calls[0][0];
-    expect(updateArg.where).toEqual({ id: 'post_1', isDeleted: false });
+    expect(updateArg.where).toEqual({
+      id: 'post_1',
+      isDeleted: false,
+      organizationId: 'org_1',
+    });
     expect(typeof updateArg.data.seoScore).toBe('number');
     expect(updateArg.data.seoBreakdown).toBeTruthy();
     expect(card.score).toBe(updateArg.data.seoScore);
@@ -397,7 +405,7 @@ describe('SeoScorerService', () => {
 
   it('throws NotFound when the post is missing', async () => {
     prisma.post.findFirst.mockResolvedValue(null);
-    await expect(service.scorePost('missing')).rejects.toThrow(
+    await expect(service.scorePost('missing', 'org_1')).rejects.toThrow(
       'Post not found',
     );
   });

--- a/apps/server/api/src/services/seo/seo-scorer.service.spec.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.service.spec.ts
@@ -1,0 +1,404 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub the global PrismaService class so importing the service never tries to
+// construct the real (adapter-backed) client. We inject a plain mock anyway.
+vi.mock('@api/shared/modules/prisma/prisma.service', () => ({
+  PrismaService: class {},
+}));
+
+import type { ConfigService } from '@api/config/config.service';
+import type { OpenRouterService } from '@api/services/integrations/openrouter/services/openrouter.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+
+import { SeoScorerService } from './seo-scorer.service';
+import type { SeoScorableContent } from './seo-scorer.types';
+import {
+  assembleScorecard,
+  buildSeoChecks,
+  computeKeywordDensity,
+  countWords,
+  fleschReadingEase,
+  splitSentences,
+} from './seo-scorer.util';
+
+function check(checks: ReturnType<typeof buildSeoChecks>, id: string) {
+  const found = checks.find((c) => c.id === id);
+  if (!found) {
+    throw new Error(`check ${id} not found`);
+  }
+  return found;
+}
+
+// ─── Pure text helpers ─────────────────────────────────────────────────────
+
+describe('seo-scorer.util text helpers', () => {
+  it('countWords counts whitespace-separated tokens', () => {
+    expect(countWords('one two three')).toBe(3);
+    expect(countWords('  ')).toBe(0);
+    expect(countWords('')).toBe(0);
+  });
+
+  it('splitSentences splits on terminal punctuation', () => {
+    expect(splitSentences('A cat. A dog! A bird?')).toHaveLength(3);
+    expect(splitSentences('')).toHaveLength(0);
+  });
+
+  it('fleschReadingEase returns a clamped 0-100 score', () => {
+    const easy = fleschReadingEase('The cat sat on the mat. The dog ran fast.');
+    expect(easy).toBeGreaterThan(60);
+    expect(easy).toBeLessThanOrEqual(100);
+    expect(fleschReadingEase('')).toBe(0);
+  });
+
+  it('computeKeywordDensity returns null without a keyword and a percent with one', () => {
+    expect(computeKeywordDensity('any text here', null)).toBeNull();
+    const words = `${'word '.repeat(98)}seo seo`.trim();
+    expect(computeKeywordDensity(words, 'seo')).toBeCloseTo(2, 1);
+  });
+});
+
+// ─── Deterministic dimension checks ─────────────────────────────────────────
+
+describe('buildSeoChecks deterministic scoring', () => {
+  it('scores title length by band', () => {
+    expect(
+      check(buildSeoChecks({ title: 'a'.repeat(55) }), 'title_length').points,
+    ).toBe(4);
+    expect(
+      check(buildSeoChecks({ title: 'a'.repeat(40) }), 'title_length').points,
+    ).toBe(3);
+    expect(check(buildSeoChecks({ title: '' }), 'title_length').points).toBe(0);
+  });
+
+  it('scores meta description length by band', () => {
+    expect(
+      check(buildSeoChecks({ metaDescription: 'm'.repeat(155) }), 'meta_length')
+        .points,
+    ).toBe(4);
+    expect(
+      check(buildSeoChecks({ metaDescription: '' }), 'meta_length').points,
+    ).toBe(0);
+  });
+
+  it('scores slug format', () => {
+    expect(
+      check(
+        buildSeoChecks({ slug: 'best-email-marketing-tools' }),
+        'slug_format',
+      ).points,
+    ).toBe(3);
+    expect(
+      check(buildSeoChecks({ slug: 'post-12345' }), 'slug_format').points,
+    ).toBe(2);
+    expect(
+      check(buildSeoChecks({ slug: '2026-01-01' }), 'slug_format').points,
+    ).toBe(0);
+    expect(
+      check(buildSeoChecks({ slug: 'Bad_Slug' }), 'slug_format').points,
+    ).toBe(0);
+  });
+
+  it('rewards a clean heading hierarchy and penalises skips / missing H1', () => {
+    expect(
+      check(
+        buildSeoChecks({ content: '<h1>A</h1><h2>B</h2><h3>C</h3>' }),
+        'heading_hierarchy',
+      ).points,
+    ).toBe(5);
+    expect(
+      check(
+        buildSeoChecks({ content: '<h1>A</h1><h3>C</h3>' }),
+        'heading_hierarchy',
+      ).points,
+    ).toBe(3);
+    expect(
+      check(
+        buildSeoChecks({ content: '<p>no headings</p>' }),
+        'heading_hierarchy',
+      ).points,
+    ).toBe(0);
+  });
+
+  it('counts internal links and bullet lists', () => {
+    const html =
+      '<a href="/a">x</a><a href="/b">y</a><a href="/c">z</a><ul><li>1</li></ul>';
+    const checks = buildSeoChecks({ content: html });
+    expect(check(checks, 'internal_links').points).toBe(3);
+    expect(check(checks, 'lists_used').points).toBe(3);
+  });
+
+  it('scores image alt-text coverage', () => {
+    const html =
+      '<img src="email-funnel.webp" alt="email funnel"/><img src="cta.webp" alt="cta"/>';
+    const checks = buildSeoChecks({ content: html });
+    expect(check(checks, 'image_alt_text').points).toBe(3);
+    expect(check(checks, 'image_compression').points).toBe(2);
+  });
+
+  it('penalises keyword stuffing (density > 3%)', () => {
+    const stuffed = `<p>${'seo '.repeat(8)}${'word '.repeat(12)}</p>`;
+    const c = check(
+      buildSeoChecks({ content: stuffed, targetKeyword: 'seo' }),
+      'kw_density',
+    );
+    expect(c.points).toBe(0);
+    expect(c.note.toLowerCase()).toContain('stuffing');
+  });
+
+  it('treats link-free content and valid #anchor links as non-broken', () => {
+    expect(
+      check(
+        buildSeoChecks({ content: '<p>no links here</p>' }),
+        'no_broken_links',
+      ).points,
+    ).toBe(1);
+    const withToc = buildSeoChecks({
+      content: '<a href="#intro">Introduction</a><p>body</p>',
+    });
+    expect(check(withToc, 'no_broken_links').points).toBe(1);
+    // In-page anchors are not counted as content internal links.
+    expect(check(withToc, 'internal_links').points).toBe(0);
+  });
+
+  it('detects JSON-LD schema markup', () => {
+    const withSchema = '<script type="application/ld+json">{}</script>';
+    expect(
+      check(buildSeoChecks({ content: withSchema }), 'schema_markup').points,
+    ).toBe(3);
+    expect(
+      check(buildSeoChecks({ content: '<p>x</p>' }), 'schema_markup').points,
+    ).toBe(0);
+  });
+
+  it('audits keyword placement when a target keyword is supplied', () => {
+    const input: SeoScorableContent = {
+      content:
+        '<h2>Email Marketing basics</h2><p>Email marketing is a channel.</p>',
+      metaDescription: 'A guide to email marketing for teams.',
+      slug: 'email-marketing-guide',
+      targetKeyword: 'email marketing',
+      title: 'The Email Marketing Playbook',
+    };
+    const checks = buildSeoChecks(input);
+    expect(check(checks, 'kw_in_title').points).toBe(4);
+    expect(check(checks, 'kw_in_slug').points).toBe(3);
+    expect(check(checks, 'kw_in_meta').points).toBe(3);
+    expect(check(checks, 'kw_in_h2').points).toBe(3);
+  });
+
+  it('marks keyword checks unavailable when no target keyword is given', () => {
+    const checks = buildSeoChecks({
+      title: 'Some Title',
+      content: '<p>Body</p>',
+    });
+    expect(check(checks, 'kw_in_title').available).toBe(false);
+    expect(check(checks, 'kw_in_title').points).toBe(0);
+  });
+
+  it('marks head-only signals (canonical, OG, page speed) unavailable', () => {
+    const checks = buildSeoChecks({ content: '<p>x</p>' });
+    expect(check(checks, 'canonical_tag').available).toBe(false);
+    expect(check(checks, 'open_graph').available).toBe(false);
+    expect(check(checks, 'page_speed').available).toBe(false);
+  });
+});
+
+// ─── Assembly ──────────────────────────────────────────────────────────────
+
+describe('assembleScorecard', () => {
+  it('aggregates per-dimension breakdown and overall rating', () => {
+    const checks = buildSeoChecks({
+      content:
+        '<h1>Email Marketing</h1><h2>Email Marketing tips</h2><p>Email marketing is great.</p>',
+      metaDescription: 'm'.repeat(155),
+      slug: 'email-marketing-guide',
+      targetKeyword: 'email marketing',
+      title: 'a'.repeat(55),
+    });
+    const card = assembleScorecard(checks, {
+      fleschReadingEase: 65,
+      keywordDensity: 1.5,
+      llmApplied: false,
+      scoredAt: '2026-06-26T00:00:00.000Z',
+      targetKeyword: 'email marketing',
+      wordCount: 5,
+    });
+    expect(card.score).toBeGreaterThanOrEqual(0);
+    expect(card.score).toBeLessThanOrEqual(100);
+    const summed = Object.values(card.breakdown).reduce((a, b) => a + b, 0);
+    expect(card.score).toBe(summed);
+    // Unavailable in this fixture: canonical(2) + OG(2) + mobile(3) +
+    // pageSpeed(2) + secondaryKw(2, none given) + https(1, no url) = 12.
+    expect(card.meta.maxAvailable).toBe(88);
+    expect(['excellent', 'good', 'needs_work', 'poor', 'critical']).toContain(
+      card.rating,
+    );
+  });
+});
+
+// ─── Service ───────────────────────────────────────────────────────────────
+
+describe('SeoScorerService', () => {
+  let configService: ConfigService;
+  let logger: LoggerService;
+  let openRouter: { chatCompletion: ReturnType<typeof vi.fn> };
+  let prisma: {
+    article: {
+      findFirst: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+    post: {
+      findFirst: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+  let service: SeoScorerService;
+
+  const goodInput: SeoScorableContent = {
+    content:
+      '<h1>Email Marketing</h1><p>Email marketing helps teams reach inboxes.</p>' +
+      '<h2>Email Marketing tactics</h2><ul><li>Segment</li><li>Automate</li></ul>' +
+      '<a href="/guide">read the guide</a>',
+    metaDescription: 'd'.repeat(155),
+    slug: 'email-marketing-guide',
+    targetKeyword: 'email marketing',
+    title: 'a'.repeat(55),
+  };
+
+  beforeEach(() => {
+    configService = {
+      get: vi.fn().mockReturnValue(undefined),
+    } as unknown as ConfigService;
+    logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as LoggerService;
+    openRouter = { chatCompletion: vi.fn() };
+    prisma = {
+      article: { findFirst: vi.fn(), update: vi.fn() },
+      post: { findFirst: vi.fn(), update: vi.fn() },
+    };
+    service = new SeoScorerService(
+      configService,
+      logger,
+      prisma as unknown as PrismaService,
+      openRouter as unknown as OpenRouterService,
+    );
+  });
+
+  it('produces a reproducible deterministic score (same input → same number)', async () => {
+    const a = await service.scoreContent(goodInput, { useLlm: false });
+    const b = await service.scoreContent(goodInput, { useLlm: false });
+    expect(a.score).toBe(b.score);
+    expect(a.breakdown).toEqual(b.breakdown);
+    expect(openRouter.chatCompletion).not.toHaveBeenCalled();
+    expect(a.meta.llmApplied).toBe(false);
+  });
+
+  it('lets the LLM move only the qualitative checks, leaving deterministic ones intact', async () => {
+    const baseline = await service.scoreContent(goodInput, { useLlm: false });
+    const baselineTitle = baseline.checks.find(
+      (c) => c.id === 'title_length',
+    )?.points;
+
+    openRouter.chatCompletion.mockResolvedValue({
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: {
+            content: JSON.stringify({
+              activeVoicePoints: 3,
+              conclusionCtaPoints: 1,
+              faqPoints: 3,
+              jargonPoints: 2,
+              suggestions: ['Add an author bio for E-E-A-T.'],
+            }),
+            role: 'assistant',
+          },
+        },
+      ],
+    });
+
+    const withLlm = await service.scoreContent(goodInput);
+    expect(withLlm.meta.llmApplied).toBe(true);
+    expect(withLlm.checks.find((c) => c.id === 'faq_section')?.points).toBe(3);
+    expect(withLlm.checks.find((c) => c.id === 'conclusion_cta')?.points).toBe(
+      1,
+    );
+    expect(withLlm.checks.find((c) => c.id === 'title_length')?.points).toBe(
+      baselineTitle,
+    );
+    expect(withLlm.suggestions).toContain('Add an author bio for E-E-A-T.');
+  });
+
+  it('falls back to deterministic-only when the LLM call fails', async () => {
+    openRouter.chatCompletion.mockRejectedValue(new Error('boom'));
+    const result = await service.scoreContent(goodInput);
+    expect(result.meta.llmApplied).toBe(false);
+    expect(result.score).toBeGreaterThan(0);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('scores and persists an article', async () => {
+    prisma.article.findFirst.mockResolvedValue({
+      content: goodInput.content,
+      excerpt: goodInput.metaDescription,
+      id: 'art_1',
+      organizationId: 'org_1',
+      slug: goodInput.slug,
+      title: goodInput.title,
+    });
+    prisma.article.update.mockResolvedValue({});
+
+    const card = await service.scoreArticle(
+      'art_1',
+      'org_1',
+      'email marketing',
+    );
+
+    expect(prisma.article.findFirst).toHaveBeenCalledWith({
+      where: { id: 'art_1', isDeleted: false, organizationId: 'org_1' },
+    });
+    expect(prisma.article.update).toHaveBeenCalledTimes(1);
+    const updateArg = prisma.article.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ id: 'art_1', isDeleted: false });
+    expect(typeof updateArg.data.seoScore).toBe('number');
+    expect(updateArg.data.seoBreakdown).toBeTruthy();
+    expect(card.score).toBe(updateArg.data.seoScore);
+  });
+
+  it('throws NotFound when the article is missing', async () => {
+    prisma.article.findFirst.mockResolvedValue(null);
+    await expect(service.scoreArticle('missing')).rejects.toThrow(
+      'Article not found',
+    );
+  });
+
+  it('scores and persists a post with seoScore + seoBreakdown', async () => {
+    prisma.post.findFirst.mockResolvedValue({
+      description: '<p>Email marketing is great for reach.</p>',
+      id: 'post_1',
+      label: 'Email Marketing',
+      organizationId: 'org_1',
+    });
+    prisma.post.update.mockResolvedValue({});
+
+    const card = await service.scorePost('post_1', 'org_1', 'email marketing');
+    expect(prisma.post.update).toHaveBeenCalledTimes(1);
+    const updateArg = prisma.post.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ id: 'post_1', isDeleted: false });
+    expect(typeof updateArg.data.seoScore).toBe('number');
+    expect(updateArg.data.seoBreakdown).toBeTruthy();
+    expect(card.score).toBe(updateArg.data.seoScore);
+  });
+
+  it('throws NotFound when the post is missing', async () => {
+    prisma.post.findFirst.mockResolvedValue(null);
+    await expect(service.scorePost('missing')).rejects.toThrow(
+      'Post not found',
+    );
+  });
+});

--- a/apps/server/api/src/services/seo/seo-scorer.service.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.service.ts
@@ -154,6 +154,7 @@ export class SeoScorerService {
       slug: null,
       targetKeyword: targetKeyword ?? null,
       title: post.label,
+      url: post.url,
     });
 
     await this.persist('post', post.id, organizationId, scorecard);

--- a/apps/server/api/src/services/seo/seo-scorer.service.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.service.ts
@@ -1,0 +1,314 @@
+import { ConfigService } from '@api/config/config.service';
+import type {
+  OpenRouterChatCompletionParams,
+  OpenRouterChatCompletionResponse,
+} from '@api/services/integrations/openrouter/dto/openrouter.dto';
+import { OpenRouterService } from '@api/services/integrations/openrouter/services/openrouter.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Prisma } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable, NotFoundException, Optional } from '@nestjs/common';
+
+import {
+  type ScoreContentOptions,
+  type SeoCheck,
+  type SeoQualitativeLlmResult,
+  type SeoScorableContent,
+  type SeoScorableType,
+  type SeoScorecard,
+} from './seo-scorer.types';
+import {
+  assembleScorecard,
+  buildSeoChecks,
+  computeKeywordDensity,
+  countWords,
+  fleschReadingEase,
+  stripHtmlToText,
+} from './seo-scorer.util';
+
+/** Qualitative checks the LLM layer is allowed to refine, keyed by check id. */
+const QUALITATIVE_LLM_FIELDS: Record<string, keyof SeoQualitativeLlmResult> = {
+  active_voice: 'activeVoicePoints',
+  conclusion_cta: 'conclusionCtaPoints',
+  faq_section: 'faqPoints',
+  jargon_controlled: 'jargonPoints',
+};
+
+const MAX_LLM_CONTENT_CHARS = 12000;
+
+/**
+ * Canonical SEO scorer (#758).
+ *
+ * Scores a piece of long-form content (article / post) against the 7-dimension
+ * rubric in `skills/content-seo-optimizer/SKILL.md`. Deterministic checks are
+ * computed in code (reproducible: same input → same number); the LLM only
+ * refines the qualitative dimensions. Results are persisted on the entity.
+ */
+@Injectable()
+export class SeoScorerService {
+  private readonly constructorName = String(this.constructor.name);
+  private readonly defaultModel: string;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly logger: LoggerService,
+    private readonly prisma: PrismaService,
+    @Optional()
+    private readonly openRouterService?: OpenRouterService,
+  ) {
+    this.defaultModel =
+      this.configService.get('XAI_MODEL') || 'x-ai/grok-4-fast';
+  }
+
+  /**
+   * Score a piece of content. Deterministic by construction; the LLM layer
+   * (when available and not disabled) refines only the qualitative checks.
+   */
+  async scoreContent(
+    input: SeoScorableContent,
+    options?: ScoreContentOptions,
+  ): Promise<SeoScorecard> {
+    const checks = buildSeoChecks(input);
+    const plainText = stripHtmlToText(input.content ?? '');
+    const targetKeyword = (input.targetKeyword ?? '').trim() || null;
+    let llmApplied = false;
+    let llmSuggestions: string[] = [];
+
+    if (options?.useLlm !== false && this.openRouterService) {
+      const llm = await this.runQualitativeLlm(input);
+      if (llm) {
+        this.applyQualitativeScores(checks, llm);
+        llmSuggestions = Array.isArray(llm.suggestions) ? llm.suggestions : [];
+        llmApplied = true;
+      }
+    }
+
+    const scorecard = assembleScorecard(checks, {
+      fleschReadingEase: fleschReadingEase(plainText),
+      keywordDensity: computeKeywordDensity(plainText, targetKeyword),
+      llmApplied,
+      scoredAt: new Date().toISOString(),
+      targetKeyword,
+      wordCount: countWords(plainText),
+    });
+
+    if (llmSuggestions.length > 0) {
+      scorecard.suggestions = dedupe([
+        ...llmSuggestions,
+        ...scorecard.suggestions,
+      ]).slice(0, 8);
+    }
+
+    return scorecard;
+  }
+
+  /** Score an article by id and persist the result. */
+  async scoreArticle(
+    articleId: string,
+    organizationId?: string,
+    targetKeyword?: string,
+  ): Promise<SeoScorecard> {
+    const article = await this.prisma.article.findFirst({
+      where: {
+        id: articleId,
+        isDeleted: false,
+        ...(organizationId ? { organizationId } : {}),
+      },
+    });
+    if (!article) {
+      throw new NotFoundException('Article not found');
+    }
+
+    const scorecard = await this.scoreContent({
+      content: article.content,
+      metaDescription: article.excerpt,
+      slug: article.slug,
+      targetKeyword: targetKeyword ?? null,
+      title: article.title,
+    });
+
+    await this.persist('article', article.id, scorecard);
+    return scorecard;
+  }
+
+  /** Score a post by id and persist the result. */
+  async scorePost(
+    postId: string,
+    organizationId?: string,
+    targetKeyword?: string,
+  ): Promise<SeoScorecard> {
+    const post = await this.prisma.post.findFirst({
+      where: {
+        id: postId,
+        isDeleted: false,
+        ...(organizationId ? { organizationId } : {}),
+      },
+    });
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+
+    const scorecard = await this.scoreContent({
+      content: post.description,
+      metaDescription: null,
+      slug: null,
+      targetKeyword: targetKeyword ?? null,
+      title: post.label,
+    });
+
+    await this.persist('post', post.id, scorecard);
+    return scorecard;
+  }
+
+  // ─── Persistence ────────────────────────────────────────────────────────
+
+  private async persist(
+    type: SeoScorableType,
+    id: string,
+    scorecard: SeoScorecard,
+  ): Promise<void> {
+    const data = {
+      seoBreakdown: this.toJsonValue({
+        breakdown: scorecard.breakdown,
+        checks: scorecard.checks,
+        meta: scorecard.meta,
+        rating: scorecard.rating,
+        suggestions: scorecard.suggestions,
+      }),
+      seoScore: scorecard.score,
+    };
+
+    // Guard against a soft-delete racing between findFirst and persist.
+    if (type === 'article') {
+      await this.prisma.article.update({
+        data,
+        where: { id, isDeleted: false },
+      });
+    } else {
+      await this.prisma.post.update({ data, where: { id, isDeleted: false } });
+    }
+  }
+
+  private toJsonValue(value: unknown): Prisma.InputJsonValue {
+    return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
+  }
+
+  // ─── LLM qualitative layer ────────────────────────────────────────────────
+
+  private applyQualitativeScores(
+    checks: SeoCheck[],
+    llm: SeoQualitativeLlmResult,
+  ): void {
+    for (const check of checks) {
+      const field = QUALITATIVE_LLM_FIELDS[check.id];
+      if (!field) {
+        continue;
+      }
+      const value = llm[field];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        check.points = Math.max(0, Math.min(check.max, Math.round(value)));
+      }
+    }
+  }
+
+  private async runQualitativeLlm(
+    input: SeoScorableContent,
+  ): Promise<SeoQualitativeLlmResult | null> {
+    if (!this.openRouterService) {
+      return null;
+    }
+    const plainText = (input.content ?? '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, MAX_LLM_CONTENT_CHARS);
+
+    if (!plainText) {
+      return null;
+    }
+
+    const prompt = buildQualitativePrompt(input, plainText);
+
+    try {
+      const params: OpenRouterChatCompletionParams = {
+        max_tokens: 1024,
+        messages: [{ content: prompt, role: 'user' }],
+        model: this.defaultModel,
+        temperature: 0.2,
+      };
+      const response: OpenRouterChatCompletionResponse =
+        await this.openRouterService.chatCompletion(params);
+      return this.parseQualitativeResponse(response);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `${this.constructorName} qualitative LLM call failed: ${message}`,
+      );
+      return null;
+    }
+  }
+
+  private parseQualitativeResponse(
+    response: OpenRouterChatCompletionResponse,
+  ): SeoQualitativeLlmResult | null {
+    const content = response.choices?.[0]?.message?.content;
+    if (!content) {
+      return null;
+    }
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(jsonMatch[0]) as SeoQualitativeLlmResult;
+      return {
+        activeVoicePoints: clampNumber(parsed.activeVoicePoints, 0, 3),
+        conclusionCtaPoints: clampNumber(parsed.conclusionCtaPoints, 0, 1),
+        faqPoints: clampNumber(parsed.faqPoints, 0, 3),
+        jargonPoints: clampNumber(parsed.jargonPoints, 0, 2),
+        suggestions: Array.isArray(parsed.suggestions)
+          ? parsed.suggestions.filter((s): s is string => typeof s === 'string')
+          : [],
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+function clampNumber(
+  value: number | undefined,
+  min: number,
+  max: number,
+): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(min, Math.min(max, value));
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function buildQualitativePrompt(
+  input: SeoScorableContent,
+  plainText: string,
+): string {
+  return `You are an expert SEO analyst. Score ONLY the four qualitative criteria below for the content. Return ONLY valid JSON with no markdown.
+
+Return this exact shape:
+{ "faqPoints": <0-3>, "conclusionCtaPoints": <0-1>, "activeVoicePoints": <0-3>, "jargonPoints": <0-2>, "suggestions": ["..."] }
+
+Criteria:
+- faqPoints (0-3): Does the content include an FAQ section answering likely "People Also Ask" questions?
+- conclusionCtaPoints (0-1): Does it end with a clear call to action / next step?
+- activeVoicePoints (0-3): Is it written predominantly in active voice (≥80% = 3)?
+- jargonPoints (0-2): Are technical terms defined on first use (no unexplained jargon = 2)?
+- suggestions: up to 3 short, specific improvements.
+
+Title: ${(input.title ?? '').slice(0, 200)}
+
+Content:
+${plainText}`;
+}

--- a/apps/server/api/src/services/seo/seo-scorer.service.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.service.ts
@@ -105,14 +105,14 @@ export class SeoScorerService {
   /** Score an article by id and persist the result. */
   async scoreArticle(
     articleId: string,
-    organizationId?: string,
+    organizationId: string,
     targetKeyword?: string,
   ): Promise<SeoScorecard> {
     const article = await this.prisma.article.findFirst({
       where: {
         id: articleId,
         isDeleted: false,
-        ...(organizationId ? { organizationId } : {}),
+        organizationId,
       },
     });
     if (!article) {
@@ -127,21 +127,21 @@ export class SeoScorerService {
       title: article.title,
     });
 
-    await this.persist('article', article.id, scorecard);
+    await this.persist('article', article.id, organizationId, scorecard);
     return scorecard;
   }
 
   /** Score a post by id and persist the result. */
   async scorePost(
     postId: string,
-    organizationId?: string,
+    organizationId: string,
     targetKeyword?: string,
   ): Promise<SeoScorecard> {
     const post = await this.prisma.post.findFirst({
       where: {
         id: postId,
         isDeleted: false,
-        ...(organizationId ? { organizationId } : {}),
+        organizationId,
       },
     });
     if (!post) {
@@ -156,7 +156,7 @@ export class SeoScorerService {
       title: post.label,
     });
 
-    await this.persist('post', post.id, scorecard);
+    await this.persist('post', post.id, organizationId, scorecard);
     return scorecard;
   }
 
@@ -165,6 +165,7 @@ export class SeoScorerService {
   private async persist(
     type: SeoScorableType,
     id: string,
+    organizationId: string,
     scorecard: SeoScorecard,
   ): Promise<void> {
     const data = {
@@ -178,14 +179,18 @@ export class SeoScorerService {
       seoScore: scorecard.score,
     };
 
-    // Guard against a soft-delete racing between findFirst and persist.
+    // Scope the write by organization (defense-in-depth beyond the org-scoped
+    // read) and guard against a soft-delete racing between findFirst and persist.
     if (type === 'article') {
       await this.prisma.article.update({
         data,
-        where: { id, isDeleted: false },
+        where: { id, isDeleted: false, organizationId },
       });
     } else {
-      await this.prisma.post.update({ data, where: { id, isDeleted: false } });
+      await this.prisma.post.update({
+        data,
+        where: { id, isDeleted: false, organizationId },
+      });
     }
   }
 

--- a/apps/server/api/src/services/seo/seo-scorer.types.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.types.ts
@@ -1,0 +1,132 @@
+/**
+ * Canonical SEO scorer contract (#758).
+ *
+ * Mirrors the 7-dimension, 100-point rubric defined in
+ * `skills/content-seo-optimizer/SKILL.md`. The scorer mixes deterministic
+ * checks (computed in code, fully reproducible) with LLM qualitative
+ * sub-scores for the criteria that cannot be derived from the content alone.
+ */
+
+export const SEO_DIMENSIONS = [
+  'keywordPlacement',
+  'contentStructure',
+  'readability',
+  'metaOptimization',
+  'links',
+  'media',
+  'technicalSignals',
+] as const;
+
+export type SeoDimension = (typeof SEO_DIMENSIONS)[number];
+
+/** Per-dimension maximum points — sums to 100. */
+export const SEO_DIMENSION_MAX: Record<SeoDimension, number> = {
+  contentStructure: 20,
+  keywordPlacement: 20,
+  links: 10,
+  media: 10,
+  metaOptimization: 15,
+  readability: 15,
+  technicalSignals: 10,
+};
+
+/**
+ * `deterministic` checks are computed purely in code (same input → same
+ * points). `qualitative` checks carry a deterministic heuristic baseline but
+ * may be refined by the LLM layer.
+ */
+export type SeoCheckKind = 'deterministic' | 'qualitative';
+
+export interface SeoCheck {
+  /** Stable identifier (e.g. `kw_in_title`). */
+  id: string;
+  dimension: SeoDimension;
+  label: string;
+  kind: SeoCheckKind;
+  /** Maximum points this check contributes to its dimension. */
+  max: number;
+  /** Points earned (0..max). */
+  points: number;
+  /**
+   * `false` when the signal cannot be derived from the supplied input (e.g.
+   * canonical/OG tags live in <head>, page-speed needs a render environment).
+   * Unavailable checks still count 0 toward the raw score but are surfaced so
+   * the caller can renormalise against `maxAvailable`.
+   */
+  available: boolean;
+  /** Actionable, human-readable finding used to build suggestions. */
+  note: string;
+}
+
+/**
+ * Normalised, source-agnostic content the scorer operates on. Decoupled from
+ * the Article/Post DB shape so the deterministic core is trivially testable.
+ */
+export interface SeoScorableContent {
+  /** Page title / H1 (Article.title, Post.label). */
+  title?: string | null;
+  /** Meta description / excerpt (Article.excerpt). */
+  metaDescription?: string | null;
+  /** URL slug. */
+  slug?: string | null;
+  /** Body, stored as HTML in this codebase. */
+  content?: string | null;
+  /** Full page URL — only used for HTTPS / technical signals. */
+  url?: string | null;
+  /** Primary keyword to audit placement against. */
+  targetKeyword?: string | null;
+  /** Supporting keywords audited in subheadings. */
+  secondaryKeywords?: string[];
+}
+
+export type SeoRating =
+  | 'excellent'
+  | 'good'
+  | 'needs_work'
+  | 'poor'
+  | 'critical';
+
+export interface SeoScorecardMeta {
+  wordCount: number;
+  fleschReadingEase: number;
+  targetKeyword: string | null;
+  /**
+   * Word-coverage density: (occurrences × phrase_word_count) / total_words ×
+   * 100, or null when no keyword given.
+   */
+  keywordDensity: number | null;
+  /** Whether the LLM qualitative layer was applied. */
+  llmApplied: boolean;
+  /** Sum of `max` across available checks (for UI renormalisation). */
+  maxAvailable: number;
+  scoredAt: string;
+}
+
+export interface SeoScorecard {
+  /** Overall 0-100 score (sum of all checks, rounded). */
+  score: number;
+  rating: SeoRating;
+  /** Earned points per dimension. */
+  breakdown: Record<SeoDimension, number>;
+  /** Prioritised, actionable improvement suggestions. */
+  suggestions: string[];
+  /** Per-check detail (deterministic + qualitative). */
+  checks: SeoCheck[];
+  meta: SeoScorecardMeta;
+}
+
+/** Qualitative sub-scores returned by the LLM layer (each 0..check max). */
+export interface SeoQualitativeLlmResult {
+  faqPoints?: number;
+  conclusionCtaPoints?: number;
+  activeVoicePoints?: number;
+  jargonPoints?: number;
+  suggestions?: string[];
+}
+
+export interface ScoreContentOptions {
+  /** Set `false` to skip the LLM layer (deterministic-only). Defaults to true. */
+  useLlm?: boolean;
+}
+
+export type SeoScorableType = 'article' | 'post';

--- a/apps/server/api/src/services/seo/seo-scorer.util.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.util.ts
@@ -109,7 +109,7 @@ export function computeKeywordDensity(
     return 0;
   }
   const escaped = normalisedKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const matches = text.toLowerCase().match(new RegExp(escaped, 'g'));
+  const matches = text.toLowerCase().match(new RegExp(`\\b${escaped}\\b`, 'g'));
   const occurrences = matches ? matches.length : 0;
   const keywordWordSpan = normalisedKeyword.split(/\s+/).filter(Boolean).length;
   return (
@@ -226,8 +226,11 @@ export function parseSeoHtml(html?: string | null): ParsedSeoHtml {
     links.push({
       href,
       isExternal: isAbsolute,
-      // In-page anchors are jump links, not content internal links.
-      isInternal: isWellFormed && !isAbsolute && !isAnchorOnly,
+      // Internal links are same-document relative paths only. In-page anchors
+      // are jump links, and scheme URIs (mailto:, tel:, …) are neither internal
+      // nor page links, so exclude both from the internal count.
+      isInternal:
+        isWellFormed && !isAnchorOnly && !/^[a-z][a-z0-9+.-]*:/i.test(href),
       isWellFormed,
       opensNewTab: ($(el).attr('target') ?? '') === '_blank',
       text,
@@ -242,13 +245,17 @@ export function parseSeoHtml(html?: string | null): ParsedSeoHtml {
     });
   });
 
+  // Capture JSON-LD presence before stripping non-visible nodes, then exclude
+  // script/style/noscript text from the scored plain text.
+  const hasJsonLd = $('script[type="application/ld+json"]').length > 0;
+  $('script, style, noscript').remove();
   const plainText = $.root().text().replace(/\s+/g, ' ').trim();
 
   return {
     h1Count: $('h1').length,
     hasCaptionTrack: $('track').length > 0,
     hasInPageAnchors: $('a[href^="#"]').length > 0,
-    hasJsonLd: $('script[type="application/ld+json"]').length > 0,
+    hasJsonLd,
     hasList: $('ul, ol').length > 0,
     hasVideoEmbed: $('iframe, video').length > 0,
     headings,

--- a/apps/server/api/src/services/seo/seo-scorer.util.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.util.ts
@@ -1,0 +1,995 @@
+import * as cheerio from 'cheerio';
+
+import {
+  SEO_DIMENSION_MAX,
+  type SeoCheck,
+  type SeoDimension,
+  type SeoRating,
+  type SeoScorableContent,
+  type SeoScorecard,
+  type SeoScorecardMeta,
+} from './seo-scorer.types';
+
+// ─── Text helpers (deterministic) ────────────────────────────────────────
+
+/** Strip HTML tags and collapse whitespace into plain text. */
+export function stripHtmlToText(html: string): string {
+  if (!html) {
+    return '';
+  }
+  // cheerio gives accurate text extraction; fall back to regex if parse fails.
+  try {
+    return cheerio.load(html).root().text().replace(/\s+/g, ' ').trim();
+  } catch {
+    return html
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+}
+
+/** Count words in plain text. */
+export function countWords(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+/** Split plain text into sentences. */
+export function splitSentences(text: string): string[] {
+  if (!text) {
+    return [];
+  }
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => /[a-z0-9]/i.test(sentence));
+}
+
+/** Estimate syllables in a single word (heuristic, English). */
+export function countSyllablesInWord(word: string): number {
+  const normalised = word.toLowerCase().replace(/[^a-z]/g, '');
+  if (!normalised) {
+    return 0;
+  }
+  if (normalised.length <= 3) {
+    return 1;
+  }
+  const groups = normalised
+    .replace(/(?:[^laeiouy]es|ed|[^laeiouy]e)$/, '')
+    .replace(/^y/, '')
+    .match(/[aeiouy]{1,2}/g);
+  return groups ? groups.length : 1;
+}
+
+/**
+ * Flesch Reading Ease (0-100, higher = easier).
+ * `206.835 − 1.015 × (words/sentences) − 84.6 × (syllables/words)`.
+ *
+ * NOTE: the only existing implementation lives in the frontend-only
+ * `@genfeedai/services` package (a private class behind a Bearer-token
+ * factory, with no tsconfig alias inside the NestJS API), so it cannot be
+ * imported here. We re-implement the same canonical formula deterministically.
+ */
+export function fleschReadingEase(text: string): number {
+  const sentences = splitSentences(text);
+  const words = text.split(/\s+/).filter(Boolean);
+  if (sentences.length === 0 || words.length === 0) {
+    return 0;
+  }
+  const syllables = words.reduce(
+    (total, word) => total + countSyllablesInWord(word),
+    0,
+  );
+  const avgWordsPerSentence = words.length / sentences.length;
+  const avgSyllablesPerWord = syllables / words.length;
+  const score =
+    206.835 - 1.015 * avgWordsPerSentence - 84.6 * avgSyllablesPerWord;
+  return Math.max(0, Math.min(100, Math.round(score * 10) / 10));
+}
+
+/**
+ * Keyword density as a word-coverage percentage:
+ * `(occurrences × phrase_word_count) / total_words × 100`.
+ * For a single-word keyword this is the usual occurrences/total*100; for a
+ * multi-word phrase it reflects the share of words the phrase occupies.
+ * Returns null when no keyword is supplied.
+ */
+export function computeKeywordDensity(
+  text: string,
+  keyword?: string | null,
+): number | null {
+  const normalisedKeyword = (keyword ?? '').trim().toLowerCase();
+  if (!normalisedKeyword) {
+    return null;
+  }
+  const totalWords = countWords(text);
+  if (totalWords === 0) {
+    return 0;
+  }
+  const escaped = normalisedKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matches = text.toLowerCase().match(new RegExp(escaped, 'g'));
+  const occurrences = matches ? matches.length : 0;
+  const keywordWordSpan = normalisedKeyword.split(/\s+/).filter(Boolean).length;
+  return (
+    Math.round(((occurrences * keywordWordSpan) / totalWords) * 10000) / 100
+  );
+}
+
+const GENERIC_ANCHORS = new Set([
+  'click here',
+  'here',
+  'read more',
+  'learn more',
+  'this',
+  'link',
+  'this link',
+  'more',
+  'click',
+  'go',
+]);
+
+const CTA_TERMS = [
+  'subscribe',
+  'sign up',
+  'signup',
+  'get started',
+  'contact',
+  'download',
+  'try ',
+  'learn more',
+  'buy',
+  'book a',
+  'join',
+  'start ',
+  'register',
+];
+
+const TRANSITION_WORDS = [
+  'however',
+  'therefore',
+  'additionally',
+  'furthermore',
+  'moreover',
+  'for example',
+  'for instance',
+  'in addition',
+  'consequently',
+  'meanwhile',
+  'nevertheless',
+  'on the other hand',
+  'as a result',
+  'in contrast',
+  'similarly',
+  'finally',
+  'first',
+  'second',
+  'next',
+  'then',
+  'because',
+  'although',
+  'while',
+  'in conclusion',
+];
+
+interface ParsedSeoHtml {
+  plainText: string;
+  wordCount: number;
+  headings: Array<{ level: number; text: string }>;
+  paragraphs: string[];
+  links: Array<{
+    href: string;
+    text: string;
+    isInternal: boolean;
+    isExternal: boolean;
+    opensNewTab: boolean;
+    isWellFormed: boolean;
+  }>;
+  images: Array<{ src: string; alt: string }>;
+  hasList: boolean;
+  hasInPageAnchors: boolean;
+  hasJsonLd: boolean;
+  hasVideoEmbed: boolean;
+  hasCaptionTrack: boolean;
+  h1Count: number;
+}
+
+/** Parse HTML body into the structured signals the scorer needs. */
+export function parseSeoHtml(html?: string | null): ParsedSeoHtml {
+  const $ = cheerio.load(html ?? '');
+
+  const headings: Array<{ level: number; text: string }> = [];
+  $('h1, h2, h3, h4, h5, h6').each((_i, el) => {
+    const level = Number((el as { tagName?: string }).tagName?.charAt(1) ?? 0);
+    headings.push({ level, text: $(el).text().trim() });
+  });
+
+  const paragraphs: string[] = [];
+  $('p').each((_i, el) => {
+    const text = $(el).text().trim();
+    if (text) {
+      paragraphs.push(text);
+    }
+  });
+
+  const links: ParsedSeoHtml['links'] = [];
+  $('a[href]').each((_i, el) => {
+    const href = ($(el).attr('href') ?? '').trim();
+    const text = $(el).text().trim();
+    const isAbsolute = /^https?:\/\//i.test(href);
+    const isAnchorOnly = href.startsWith('#');
+    // Named fragment links (#section) are valid HTML; only bare '#' and
+    // javascript: URIs are malformed.
+    const isWellFormed =
+      href.length > 0 && !href.startsWith('javascript:') && href !== '#';
+    links.push({
+      href,
+      isExternal: isAbsolute,
+      // In-page anchors are jump links, not content internal links.
+      isInternal: isWellFormed && !isAbsolute && !isAnchorOnly,
+      isWellFormed,
+      opensNewTab: ($(el).attr('target') ?? '') === '_blank',
+      text,
+    });
+  });
+
+  const images: ParsedSeoHtml['images'] = [];
+  $('img').each((_i, el) => {
+    images.push({
+      alt: ($(el).attr('alt') ?? '').trim(),
+      src: ($(el).attr('src') ?? '').trim(),
+    });
+  });
+
+  const plainText = $.root().text().replace(/\s+/g, ' ').trim();
+
+  return {
+    h1Count: $('h1').length,
+    hasCaptionTrack: $('track').length > 0,
+    hasInPageAnchors: $('a[href^="#"]').length > 0,
+    hasJsonLd: $('script[type="application/ld+json"]').length > 0,
+    hasList: $('ul, ol').length > 0,
+    hasVideoEmbed: $('iframe, video').length > 0,
+    headings,
+    images,
+    links,
+    paragraphs,
+    plainText,
+    wordCount: countWords(plainText),
+  };
+}
+
+// ─── Scoring band helpers ────────────────────────────────────────────────
+
+/** Award `full` inside the ideal band, decaying toward 0 further out. */
+function bandScore(
+  value: number,
+  ideal: [number, number],
+  full: number,
+): number {
+  const [lo, hi] = ideal;
+  if (value >= lo && value <= hi) {
+    return full;
+  }
+  const width = Math.max(1, hi - lo);
+  const distance = value < lo ? lo - value : value - hi;
+  const steps = Math.ceil(distance / width);
+  return Math.max(0, full - steps);
+}
+
+function ratio(numerator: number, denominator: number): number {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+function includesCaseInsensitive(haystack: string, needle: string): boolean {
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+// ─── Deterministic + heuristic check engine ──────────────────────────────
+
+/**
+ * Build the full set of scored checks for a piece of content. Deterministic
+ * checks are scored exactly; qualitative checks carry a deterministic
+ * heuristic baseline that the LLM layer may later refine.
+ */
+export function buildSeoChecks(input: SeoScorableContent): SeoCheck[] {
+  const html = input.content ?? '';
+  const parsed = parseSeoHtml(html);
+  const plainText = parsed.plainText;
+  const title = (input.title ?? '').trim();
+  const meta = (input.metaDescription ?? '').trim();
+  const slug = (input.slug ?? '').trim();
+  const keyword = (input.targetKeyword ?? '').trim();
+  const hasKeyword = keyword.length > 0;
+  const keywordLower = keyword.toLowerCase();
+  const secondaryKeywords = (input.secondaryKeywords ?? [])
+    .map((k) => k.trim().toLowerCase())
+    .filter(Boolean);
+
+  const checks: SeoCheck[] = [];
+  const add = (
+    dimension: SeoDimension,
+    id: string,
+    label: string,
+    max: number,
+    points: number,
+    note: string,
+    options?: { kind?: 'deterministic' | 'qualitative'; available?: boolean },
+  ): void => {
+    checks.push({
+      available: options?.available ?? true,
+      dimension,
+      id,
+      kind: options?.kind ?? 'deterministic',
+      label,
+      max,
+      note,
+      points: Math.max(0, Math.min(max, Math.round(points))),
+    });
+  };
+
+  // ── Dimension 1: Keyword Placement (20) ──
+  const firstHundredWords = plainText.split(/\s+/).slice(0, 100).join(' ');
+  const h2Texts = parsed.headings
+    .filter((h) => h.level === 2)
+    .map((h) => h.text.toLowerCase());
+  const subheadingTexts = parsed.headings
+    .filter((h) => h.level >= 2)
+    .map((h) => h.text.toLowerCase());
+  const density = computeKeywordDensity(plainText, keyword);
+
+  add(
+    'keywordPlacement',
+    'kw_in_title',
+    'Primary keyword in title/H1',
+    4,
+    hasKeyword && includesCaseInsensitive(title, keyword) ? 4 : 0,
+    hasKeyword
+      ? 'Include the primary keyword in the title.'
+      : 'Provide a target keyword to audit keyword placement.',
+    { available: hasKeyword },
+  );
+  add(
+    'keywordPlacement',
+    'kw_in_first_100',
+    'Primary keyword in first 100 words',
+    3,
+    hasKeyword && includesCaseInsensitive(firstHundredWords, keyword) ? 3 : 0,
+    'Mention the primary keyword naturally in the opening paragraph.',
+    { available: hasKeyword },
+  );
+  add(
+    'keywordPlacement',
+    'kw_in_slug',
+    'Primary keyword in URL slug',
+    3,
+    hasKeyword && includesCaseInsensitive(slug.replace(/-/g, ' '), keyword)
+      ? 3
+      : 0,
+    'Add the primary keyword to the URL slug.',
+    { available: hasKeyword },
+  );
+  add(
+    'keywordPlacement',
+    'kw_in_meta',
+    'Primary keyword in meta description',
+    3,
+    hasKeyword && includesCaseInsensitive(meta, keyword) ? 3 : 0,
+    'Include the primary keyword in the meta description.',
+    { available: hasKeyword },
+  );
+  add(
+    'keywordPlacement',
+    'kw_in_h2',
+    'Primary keyword in at least one H2',
+    3,
+    hasKeyword && h2Texts.some((t) => t.includes(keywordLower)) ? 3 : 0,
+    'Use the primary keyword in at least one H2 heading.',
+    { available: hasKeyword },
+  );
+  add(
+    'keywordPlacement',
+    'secondary_kw_in_subheadings',
+    'Secondary keywords in subheadings',
+    2,
+    secondaryKeywords.length > 0 &&
+      secondaryKeywords.some((k) => subheadingTexts.some((t) => t.includes(k)))
+      ? 2
+      : 0,
+    'Work supporting keywords into H2/H3 subheadings.',
+    { available: secondaryKeywords.length > 0 },
+  );
+  add(
+    'keywordPlacement',
+    'kw_density',
+    'Keyword density 1-2%',
+    2,
+    density === null
+      ? 0
+      : density >= 1 && density <= 2
+        ? 2
+        : (density >= 0.5 && density < 1) || (density > 2 && density <= 3)
+          ? 1
+          : 0,
+    density !== null && density > 3
+      ? `Keyword density is ${density}% — reduce to avoid keyword stuffing.`
+      : 'Target a keyword density of 1-2%.',
+    { available: hasKeyword },
+  );
+
+  // ── Dimension 2: Content Structure (20) ──
+  add(
+    'contentStructure',
+    'heading_hierarchy',
+    'Proper heading hierarchy (H1→H2→H3)',
+    5,
+    scoreHeadingHierarchy(parsed),
+    'Use a single H1 and avoid skipping heading levels.',
+  );
+  add(
+    'contentStructure',
+    'paragraph_length',
+    'Paragraph length (2-3 sentences)',
+    3,
+    scoreParagraphLength(parsed.paragraphs),
+    'Keep paragraphs to 2-3 sentences for scannability.',
+  );
+  const tocRequired = parsed.wordCount >= 2000;
+  add(
+    'contentStructure',
+    'table_of_contents',
+    'Table of contents for 2000+ words',
+    3,
+    !tocRequired ? 3 : parsed.hasInPageAnchors ? 3 : 0,
+    tocRequired
+      ? 'Add a table of contents with jump links for long-form content.'
+      : 'Table of contents not required at this length.',
+  );
+  add(
+    'contentStructure',
+    'lists_used',
+    'Bullet/numbered lists used',
+    3,
+    parsed.hasList ? 3 : 0,
+    'Use bullet or numbered lists for parallel items.',
+  );
+  add(
+    'contentStructure',
+    'faq_section',
+    'FAQ section present',
+    3,
+    heuristicFaqPresent(parsed) ? 3 : 0,
+    'Add an FAQ section answering "People Also Ask" questions.',
+    { kind: 'qualitative' },
+  );
+  const introWordCount = countWords(parsed.paragraphs[0] ?? '');
+  add(
+    'contentStructure',
+    'intro_length',
+    'Introduction under 150 words',
+    2,
+    parsed.paragraphs.length === 0
+      ? 0
+      : introWordCount <= 150
+        ? 2
+        : introWordCount <= 250
+          ? 1
+          : 0,
+    'Tighten the introduction to under 150 words.',
+  );
+  add(
+    'contentStructure',
+    'conclusion_cta',
+    'Conclusion with CTA',
+    1,
+    heuristicConclusionCta(parsed.paragraphs) ? 1 : 0,
+    'End with a clear call to action.',
+    { kind: 'qualitative' },
+  );
+
+  // ── Dimension 3: Readability (15) ──
+  const flesch = fleschReadingEase(plainText);
+  add(
+    'readability',
+    'flesch',
+    'Flesch Reading Ease 60-70',
+    4,
+    plainText.length === 0 ? 0 : bandScore(flesch, [60, 70], 4),
+    `Flesch Reading Ease is ${flesch}; aim for 60-70 (standard web readability).`,
+  );
+  add(
+    'readability',
+    'active_voice',
+    'Active voice 80%+',
+    3,
+    scoreActiveVoice(plainText),
+    'Favour active voice over passive constructions.',
+    { kind: 'qualitative' },
+  );
+  add(
+    'readability',
+    'sentence_variance',
+    'Sentence length variance',
+    3,
+    scoreSentenceVariance(plainText),
+    'Vary sentence length — mix short and medium sentences.',
+  );
+  add(
+    'readability',
+    'transition_words',
+    'Transition words in 30%+ sentences',
+    3,
+    scoreTransitionWords(plainText),
+    'Add transition words ("however", "for example") to improve flow.',
+  );
+  add(
+    'readability',
+    'jargon_controlled',
+    'No jargon without explanation',
+    2,
+    2,
+    'Define technical terms on first use.',
+    { kind: 'qualitative' },
+  );
+
+  // ── Dimension 4: Meta Optimization (15) ──
+  add(
+    'metaOptimization',
+    'title_length',
+    'Title tag 50-60 characters',
+    4,
+    title.length === 0 ? 0 : bandScore(title.length, [50, 60], 4),
+    `Title is ${title.length} characters; aim for 50-60.`,
+  );
+  add(
+    'metaOptimization',
+    'meta_length',
+    'Meta description 150-160 characters',
+    4,
+    meta.length === 0 ? 0 : bandScore(meta.length, [150, 160], 4),
+    meta.length === 0
+      ? 'Add a 150-160 character meta description.'
+      : `Meta description is ${meta.length} characters; aim for 150-160.`,
+  );
+  add(
+    'metaOptimization',
+    'slug_format',
+    'URL slug 3-5 words, hyphenated',
+    3,
+    scoreSlug(slug),
+    'Use a clean 3-5 word hyphenated slug (no IDs or dates).',
+  );
+  add(
+    'metaOptimization',
+    'canonical_tag',
+    'Canonical tag set',
+    2,
+    0,
+    'Canonical tags are rendered outside content; verify at the page level.',
+    { available: false },
+  );
+  add(
+    'metaOptimization',
+    'open_graph',
+    'Open Graph tags present',
+    2,
+    0,
+    'Open Graph tags are rendered outside content; verify at the page level.',
+    { available: false },
+  );
+
+  // ── Dimension 5: Internal/External Links (10) ──
+  const internalLinks = parsed.links.filter((l) => l.isInternal).length;
+  const externalLinks = parsed.links.filter((l) => l.isExternal).length;
+  const descriptiveLinks = parsed.links.filter(
+    (l) => l.text.length > 0 && !GENERIC_ANCHORS.has(l.text.toLowerCase()),
+  ).length;
+  add(
+    'links',
+    'internal_links',
+    '3-5 internal links',
+    3,
+    internalLinks >= 3 && internalLinks <= 5
+      ? 3
+      : (internalLinks >= 1 && internalLinks <= 2) ||
+          (internalLinks >= 6 && internalLinks <= 8)
+        ? 2
+        : internalLinks > 8
+          ? 1
+          : 0,
+    'Add 3-5 internal links to related content.',
+  );
+  add(
+    'links',
+    'external_links',
+    '2-3 authoritative external links',
+    2,
+    externalLinks >= 2 && externalLinks <= 3
+      ? 2
+      : externalLinks === 1 || (externalLinks >= 4 && externalLinks <= 5)
+        ? 1
+        : 0,
+    'Cite 2-3 authoritative external sources.',
+  );
+  add(
+    'links',
+    'descriptive_anchors',
+    'Descriptive anchor text',
+    3,
+    parsed.links.length === 0
+      ? 0
+      : bandScoreRatio(ratio(descriptiveLinks, parsed.links.length), 3),
+    'Use descriptive anchor text instead of "click here".',
+  );
+  add(
+    'links',
+    'no_broken_links',
+    'No malformed links',
+    1,
+    // No links trivially satisfies "no malformed links".
+    parsed.links.length === 0 || parsed.links.every((l) => l.isWellFormed)
+      ? 1
+      : 0,
+    'Fix empty or malformed link targets.',
+  );
+  add(
+    'links',
+    'links_open_appropriately',
+    'External links open in a new tab',
+    1,
+    externalLinks === 0
+      ? 1
+      : parsed.links.filter((l) => l.isExternal).every((l) => l.opensNewTab)
+        ? 1
+        : 0,
+    'Open external links in a new tab.',
+  );
+
+  // ── Dimension 6: Media Optimization (10) ──
+  const imageCount = parsed.images.length;
+  const withAlt = parsed.images.filter((img) => img.alt.length > 0).length;
+  const descriptiveNames = parsed.images.filter((img) =>
+    hasDescriptiveFilename(img.src),
+  ).length;
+  const compressed = parsed.images.filter((img) =>
+    /\.(webp|avif)(\?|#|$)/i.test(img.src),
+  ).length;
+  add(
+    'media',
+    'image_alt_text',
+    'Images have descriptive alt text',
+    3,
+    imageCount === 0 ? 0 : bandScoreRatio(ratio(withAlt, imageCount), 3),
+    imageCount === 0
+      ? 'Add images with descriptive, keyword-aware alt text.'
+      : 'Add alt text to all images.',
+  );
+  add(
+    'media',
+    'image_filenames',
+    'Descriptive image file names',
+    2,
+    imageCount === 0
+      ? 0
+      : bandScoreRatio(ratio(descriptiveNames, imageCount), 2),
+    'Use descriptive image file names (not IMG_1234.png).',
+  );
+  add(
+    'media',
+    'image_compression',
+    'Images compressed (WebP/AVIF)',
+    2,
+    imageCount === 0 ? 0 : bandScoreRatio(ratio(compressed, imageCount), 2),
+    'Serve images as WebP/AVIF for faster loads.',
+  );
+  add(
+    'media',
+    'video_embed',
+    'Video embed present',
+    2,
+    parsed.hasVideoEmbed ? 2 : 0,
+    'Embed a relevant video to increase dwell time.',
+  );
+  add(
+    'media',
+    'media_captions',
+    'Captions/transcripts for media',
+    1,
+    !parsed.hasVideoEmbed ? 1 : parsed.hasCaptionTrack ? 1 : 0,
+    'Provide captions or transcripts for embedded media.',
+  );
+
+  // ── Dimension 7: Technical Signals (10) ──
+  add(
+    'technicalSignals',
+    'schema_markup',
+    'Schema markup (JSON-LD) present',
+    3,
+    parsed.hasJsonLd ? 3 : 0,
+    'Add JSON-LD schema markup appropriate to the content type.',
+  );
+  add(
+    'technicalSignals',
+    'mobile_friendly',
+    'Mobile-friendly layout',
+    3,
+    0,
+    'Mobile-friendliness requires a render environment to verify.',
+    { available: false },
+  );
+  add(
+    'technicalSignals',
+    'page_speed',
+    'Page speed considerations',
+    2,
+    0,
+    'Page speed requires a render environment to verify.',
+    { available: false },
+  );
+  const url = (input.url ?? '').trim();
+  add(
+    'technicalSignals',
+    'https',
+    'HTTPS',
+    1,
+    url.length === 0 ? 0 : /^https:\/\//i.test(url) ? 1 : 0,
+    url.length === 0
+      ? 'Provide the page URL to verify HTTPS.'
+      : 'Serve the page over HTTPS.',
+    { available: url.length > 0 },
+  );
+  add(
+    'technicalSignals',
+    'clean_html',
+    'Clean HTML structure',
+    1,
+    parsed.headings.length > 0 && parsed.wordCount > 0 ? 1 : 0,
+    'Use semantic HTML with a clear heading structure.',
+  );
+
+  return checks;
+}
+
+function bandScoreRatio(value: number, max: number): number {
+  if (value >= 0.9) {
+    return max;
+  }
+  if (value >= 0.6) {
+    return Math.max(0, max - 1);
+  }
+  if (value >= 0.3) {
+    return Math.max(0, max - 2);
+  }
+  return value > 0 ? Math.max(0, max - 3) : 0;
+}
+
+function scoreHeadingHierarchy(parsed: ParsedSeoHtml): number {
+  if (parsed.headings.length === 0) {
+    return 0;
+  }
+  let points = 5;
+  if (parsed.h1Count !== 1) {
+    points -= 2;
+  }
+  let previousLevel = 0;
+  let skipped = false;
+  for (const heading of parsed.headings) {
+    if (previousLevel > 0 && heading.level > previousLevel + 1) {
+      skipped = true;
+    }
+    previousLevel = heading.level;
+  }
+  if (skipped) {
+    points -= 2;
+  }
+  return Math.max(0, points);
+}
+
+function scoreParagraphLength(paragraphs: string[]): number {
+  if (paragraphs.length === 0) {
+    return 0;
+  }
+  const maxSentences = paragraphs.reduce(
+    (max, paragraph) => Math.max(max, splitSentences(paragraph).length),
+    0,
+  );
+  if (maxSentences <= 3) {
+    return 3;
+  }
+  if (maxSentences <= 4) {
+    return 2;
+  }
+  if (maxSentences <= 6) {
+    return 1;
+  }
+  return 0;
+}
+
+function heuristicFaqPresent(parsed: ParsedSeoHtml): boolean {
+  const hasFaqHeading = parsed.headings.some(
+    (h) =>
+      h.text.toLowerCase().includes('faq') ||
+      h.text.toLowerCase().includes('frequently asked'),
+  );
+  const questionHeadings = parsed.headings.filter((h) =>
+    h.text.trim().endsWith('?'),
+  ).length;
+  return hasFaqHeading || questionHeadings >= 2;
+}
+
+function heuristicConclusionCta(paragraphs: string[]): boolean {
+  if (paragraphs.length === 0) {
+    return false;
+  }
+  const tail = paragraphs.slice(-2).join(' ').toLowerCase();
+  return CTA_TERMS.some((term) => tail.includes(term));
+}
+
+function scoreActiveVoice(text: string): number {
+  const sentences = splitSentences(text);
+  if (sentences.length === 0) {
+    return 0;
+  }
+  const passivePattern = /\b(was|were|is|are|been|being|be)\b\s+\w+(ed|en)\b/i;
+  const passive = sentences.filter((s) => passivePattern.test(s)).length;
+  const activeRatio = 1 - ratio(passive, sentences.length);
+  if (activeRatio >= 0.8) {
+    return 3;
+  }
+  if (activeRatio >= 0.6) {
+    return 2;
+  }
+  if (activeRatio >= 0.4) {
+    return 1;
+  }
+  return 0;
+}
+
+function scoreSentenceVariance(text: string): number {
+  const sentences = splitSentences(text);
+  if (sentences.length < 2) {
+    return sentences.length === 1 ? 1 : 0;
+  }
+  const lengths = sentences.map((s) => countWords(s));
+  const mean = lengths.reduce((sum, n) => sum + n, 0) / lengths.length;
+  const variance =
+    lengths.reduce((sum, n) => sum + (n - mean) ** 2, 0) / lengths.length;
+  const stdev = Math.sqrt(variance);
+  const hasShort = lengths.some((n) => n <= 12);
+  const hasLong = lengths.some((n) => n >= 18);
+  if (stdev >= 5 && hasShort && hasLong) {
+    return 3;
+  }
+  if (stdev >= 3) {
+    return 2;
+  }
+  return 1;
+}
+
+function scoreTransitionWords(text: string): number {
+  const sentences = splitSentences(text);
+  if (sentences.length === 0) {
+    return 0;
+  }
+  const withTransition = sentences.filter((sentence) => {
+    const lower = sentence.toLowerCase();
+    return TRANSITION_WORDS.some((word) => lower.includes(word));
+  }).length;
+  const transitionRatio = ratio(withTransition, sentences.length);
+  if (transitionRatio >= 0.3) {
+    return 3;
+  }
+  if (transitionRatio >= 0.2) {
+    return 2;
+  }
+  if (transitionRatio >= 0.1) {
+    return 1;
+  }
+  return 0;
+}
+
+function scoreSlug(slug: string): number {
+  if (!slug) {
+    return 0;
+  }
+  const isHyphenated = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug);
+  if (!isHyphenated) {
+    return 0;
+  }
+  const tokens = slug.split('-').filter(Boolean);
+  const isDateOrIdHeavy = tokens.every((t) => /^\d+$/.test(t));
+  if (isDateOrIdHeavy) {
+    return 0;
+  }
+  if (tokens.length >= 3 && tokens.length <= 5) {
+    return 3;
+  }
+  if (tokens.length === 2 || tokens.length === 6 || tokens.length === 7) {
+    return 2;
+  }
+  return 1;
+}
+
+function hasDescriptiveFilename(src: string): boolean {
+  if (!src) {
+    return false;
+  }
+  const filename = (src.split('/').pop() ?? '').split(/[?#]/)[0];
+  if (!filename) {
+    return false;
+  }
+  const base = filename.replace(/\.[a-z0-9]+$/i, '');
+  if (base.length < 4) {
+    return false;
+  }
+  const genericPattern =
+    /^(img|image|dsc|dscn|photo|screenshot|untitled|pic)[-_]?\d*$/i;
+  const numericOnly = /^\d+$/;
+  const hashLike = /^[a-f0-9]{16,}$/i;
+  return (
+    !genericPattern.test(base) &&
+    !numericOnly.test(base) &&
+    !hashLike.test(base)
+  );
+}
+
+// ─── Assembly ────────────────────────────────────────────────────────────
+
+function ratingFor(score: number): SeoRating {
+  if (score >= 90) {
+    return 'excellent';
+  }
+  if (score >= 75) {
+    return 'good';
+  }
+  if (score >= 60) {
+    return 'needs_work';
+  }
+  if (score >= 40) {
+    return 'poor';
+  }
+  return 'critical';
+}
+
+/** Aggregate scored checks into a full scorecard. */
+export function assembleScorecard(
+  checks: SeoCheck[],
+  meta: Omit<SeoScorecardMeta, 'maxAvailable'>,
+): SeoScorecard {
+  const breakdown = Object.fromEntries(
+    (Object.keys(SEO_DIMENSION_MAX) as SeoDimension[]).map((d) => [d, 0]),
+  ) as Record<SeoDimension, number>;
+
+  let total = 0;
+  let maxAvailable = 0;
+  for (const check of checks) {
+    breakdown[check.dimension] += check.points;
+    total += check.points;
+    if (check.available) {
+      maxAvailable += check.max;
+    }
+  }
+
+  const score = Math.max(0, Math.min(100, Math.round(total)));
+
+  const suggestions = checks
+    .filter((check) => check.available && check.points < check.max)
+    .sort((a, b) => {
+      const lostB = b.max - b.points;
+      const lostA = a.max - a.points;
+      // Highest points-lost first; tie-break by larger dimension weight.
+      return lostB - lostA || b.max - a.max;
+    })
+    .slice(0, 8)
+    .map((check) => check.note);
+
+  return {
+    breakdown,
+    checks,
+    meta: { ...meta, maxAvailable },
+    rating: ratingFor(score),
+    score,
+    suggestions,
+  };
+}

--- a/apps/server/api/src/services/seo/seo.module.ts
+++ b/apps/server/api/src/services/seo/seo.module.ts
@@ -1,0 +1,13 @@
+import { OpenRouterModule } from '@api/services/integrations/openrouter/openrouter.module';
+import { createServiceModule } from '@api/shared/service-module.factory';
+import { forwardRef } from '@nestjs/common';
+
+import { SeoScorerService } from './seo-scorer.service';
+
+/**
+ * Canonical SEO scorer module (#758). PrismaService is provided globally;
+ * OpenRouterModule supplies the LLM client for the qualitative layer.
+ */
+export const SeoModule = createServiceModule(SeoScorerService, {
+  additionalImports: [forwardRef(() => OpenRouterModule)],
+});

--- a/packages/agent/src/components/agent-tool-call-display.helpers.ts
+++ b/packages/agent/src/components/agent-tool-call-display.helpers.ts
@@ -38,6 +38,7 @@ export const TOOL_LABELS: Record<string, string> = {
   prepare_workflow_trigger: 'Prepare Workflow Trigger',
   present_payment_options: 'Payment Options',
   rate_content: 'Rate Content',
+  score_seo: 'Score SEO',
   rate_ingredient: 'Rate Ingredient',
   reframe_image: 'Reframe Image',
   resolve_handle: 'Resolve Handle',

--- a/packages/interfaces/src/ai/agent-tool.interface.ts
+++ b/packages/interfaces/src/ai/agent-tool.interface.ts
@@ -44,6 +44,7 @@ export enum AgentToolName {
   UPDATE_STRATEGY_STATE = 'update_strategy_state',
   CAPTURE_MEMORY = 'capture_memory',
   RATE_CONTENT = 'rate_content',
+  SCORE_SEO = 'score_seo',
   RATE_INGREDIENT = 'rate_ingredient',
   GET_TOP_INGREDIENTS = 'get_top_ingredients',
   REPLICATE_TOP_INGREDIENT = 'replicate_top_ingredient',

--- a/packages/prisma/prisma/migrations/20260626120000_add_seo_score_fields/migration.sql
+++ b/packages/prisma/prisma/migrations/20260626120000_add_seo_score_fields/migration.sql
@@ -1,0 +1,10 @@
+-- Canonical SEO scorer (#758): per-entity SEO score + structured scorecard.
+-- Additive and backward-compatible (both columns nullable, no defaults).
+
+-- AlterTable
+ALTER TABLE "articles" ADD COLUMN     "seoScore" DOUBLE PRECISION;
+ALTER TABLE "articles" ADD COLUMN     "seoBreakdown" JSONB;
+
+-- AlterTable
+ALTER TABLE "posts" ADD COLUMN     "seoScore" DOUBLE PRECISION;
+ALTER TABLE "posts" ADD COLUMN     "seoBreakdown" JSONB;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1760,6 +1760,9 @@ model Post {
   sourceWorkflowName    String?
   // Origin label for the post (e.g. agent, fastlane, manual). Free-form string.
   source                String?
+  // Canonical SEO score (0-100) + structured scorecard, set by SEOScorerService (#758).
+  seoScore              Float?
+  seoBreakdown          Json?
   isDeleted             Boolean         @default(false)
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
@@ -2089,6 +2092,11 @@ model Article {
 
   category String?
   scope    String?
+
+  // Canonical SEO score (0-100) + structured scorecard, set by SEOScorerService (#758).
+  // Distinct from the virality sub-factor `seoScore` (in-memory virality blob only).
+  seoScore     Float?
+  seoBreakdown Json?
 
   @@map("articles")
 }

--- a/packages/tools/src/registry/source/agent-only/content.tools.ts
+++ b/packages/tools/src/registry/source/agent-only/content.tools.ts
@@ -219,4 +219,32 @@ export const AGENT_CONTENT_TOOLS: SourceTool[] = [
     requiredRole: 'user',
     surfaces: { agent: true, cliAgentVisible: true, mcp: false },
   },
+  {
+    creditCost: 0,
+    description:
+      'Score a piece of content (article or post) for SEO against a 7-dimension rubric. Returns a 0-100 score, per-dimension breakdown, and prioritized improvement suggestions. Persists the result on the entity.',
+    name: 'score_seo',
+    parameters: {
+      properties: {
+        contentId: {
+          description: 'ID of the article or post to score',
+          type: 'string',
+        },
+        contentType: {
+          description: 'Type of content to score (defaults to article)',
+          enum: ['article', 'post'],
+          type: 'string',
+        },
+        targetKeyword: {
+          description:
+            'Optional primary keyword to audit placement against (title, slug, meta, headings, density)',
+          type: 'string',
+        },
+      },
+      required: ['contentId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: true, cliAgentVisible: true, mcp: false },
+  },
 ];


### PR DESCRIPTION
## Summary

Implements the **canonical `SEOScorerService`** — the spine of the SEO/GEO foundation epic (#757). Promotes the prose-only `content-seo-optimizer` rubric into deterministic, reproducible code, with an LLM layer for the genuinely qualitative criteria, persistence on `Article`/`Post`, and a `score_seo` agent tool.

Closes #758

## What changed

**New service** — `apps/server/api/src/services/seo/`
- `seo-scorer.types.ts` — 7-dimension / 100-point contract (`SeoScorecard`, `SeoCheck`, `SeoScorableContent`).
- `seo-scorer.util.ts` — pure, deterministic engine: HTML parsing (cheerio), Flesch Reading Ease, keyword density (penalises >3% stuffing), heading-hierarchy validation, slug format, title/meta length bands, internal/external links, anchor descriptiveness, image alt/filename/compression, lists, transition words, sentence variance, JSON-LD schema, HTTPS. **Same input → same score.**
- `seo-scorer.service.ts` — orchestrator. Computes the deterministic scorecard, then (when OpenRouter is available) runs a single LLM call that refines **only** the four qualitative checks (FAQ, conclusion CTA, active voice, jargon); degrades gracefully to deterministic-only on any failure. `scoreArticle` / `scorePost` load, score, and persist.
- `seo.module.ts` — `createServiceModule()` wiring (OpenRouter; Prisma is global).
- `seo-scorer.service.spec.ts` — 24 unit tests.

**Persistence** — `seoScore Float?` + `seoBreakdown Json?` added to `Article` and `Post` (additive, nullable migration `20260626120000_add_seo_score_fields`). Distinct from the existing virality sub-factor `seoScore` (in-memory only).

**Agent tool** — `score_seo` parallel to `rate_content`: `SourceTool` def in `content.tools.ts`, `AgentToolName.SCORE_SEO`, `SHARED_READ_TOOLS`, `TOOL_LABELS`, executor handler + `@Optional()` injection, wired via `SeoModule` into the orchestrator + `app.module`.

## Design notes (decisions made autonomously)

- **Flesch re-implemented locally.** The only existing `calculateReadability()` lives in the frontend-only `@genfeedai/services` package (a private class behind a Bearer-token factory, with no tsconfig alias inside the NestJS API), so it cannot be imported. The canonical formula is re-implemented as a small pure helper — documented in a JSDoc note rather than risking a refactor of the frontend service.
- **Content-only signals.** Head-/render-only criteria (canonical, Open Graph, mobile-friendly, page-speed) are flagged `available: false` and surfaced via `meta.maxAvailable` rather than silently zeroed — honest about what a content scorer can determine. Per the issue's non-goals, SERP/GSC/render data are separate child issues.
- **`creditCost: 0`** — matches `rate_content`; SEO scoring is a read/analysis tool.

## Verification (scoped — laptop policy; full build/typecheck + migration apply run in CI)

- `bun run test` (seo spec): **24/24 pass** — every deterministic check, reproducibility, LLM-only-moves-qualitative, persistence (incl. `seoScore`+`seoBreakdown`), and not-found paths.
- Targeted `tsc` over the API: **0 type errors** in any changed file (remaining repo-wide diagnostics are the known `rootDir`/ad-hoc-tsc artifacts resolved by `nest build`).
- `turbo run type-check` for `@genfeedai/tools`, `@genfeedai/interfaces`, `@genfeedai/agent`: **green**.
- `biome check`: **clean**.
- Prisma client regenerated; migration is additive/backward-compatible. **No live migration applied** — CI/deploy applies it.

## Adversarial review

Ran a multi-agent find→verify review of the diff; fixed all confirmed findings: in-page `#anchor` links no longer fail `no_broken_links` (and aren't miscounted as internal links), link-free content is no longer penalised, `image_alt_text` correctly typed `deterministic`, density JSDoc corrected, and a soft-delete `isDeleted: false` guard added to the persist path. Coverage gaps closed with new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)