### PR TITLE
refactor(mcp): decompose ClientService into BaseApiClient + domain clients (#709)

### DIFF
--- a/apps/server/mcp/src/services/client.service.ts
+++ b/apps/server/mcp/src/services/client.service.ts
@@ -1,21 +1,26 @@
 import type { AgentToolResult } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { ConfigService } from '@mcp/config/config.service';
+import { AdsClient } from '@mcp/services/client/ads.client';
+import { AgentClient } from '@mcp/services/client/agent.client';
+import { AnalyticsClient } from '@mcp/services/client/analytics.client';
+import { BaseApiClient } from '@mcp/services/client/base-api-client';
+import type {
+  BrandResponse,
+  CreateBatchParams,
+  ListBatchesParams,
+  PersonaResponse,
+} from '@mcp/services/client/client.types';
+import { ContentClient } from '@mcp/services/client/content.client';
+import { DarkroomClient } from '@mcp/services/client/darkroom.client';
+import { LinkedInClient } from '@mcp/services/client/linkedin.client';
+import { MediaClient } from '@mcp/services/client/media.client';
+import { WorkflowClient } from '@mcp/services/client/workflow.client';
+import { WorkspaceClient } from '@mcp/services/client/workspace.client';
 import type {
   Analytics,
   OrganizationAnalytics,
 } from '@mcp/shared/interfaces/analytics.interface';
-import type {
-  ArticleResource,
-  AvatarResource,
-  ImageResource,
-  MusicResource,
-  PostResource,
-  TrendResource,
-  VideoResource,
-  WorkflowResource,
-  WorkflowTemplateResource,
-} from '@mcp/shared/interfaces/api-response.interface';
 import type {
   McpApprovalDecision,
   McpApprovalResource,
@@ -46,7 +51,6 @@ import type {
   PostListParams,
   PostResponse,
   PublishContentParams,
-  SocialPlatform,
   TrendingTopic,
   TrendingTopicsParams,
   UsageStats,
@@ -64,1248 +68,326 @@ import type {
   WorkflowResponse,
   WorkflowTemplate,
 } from '@mcp/shared/interfaces/workflow.interface';
-import { resolveApiBaseUrl } from '@mcp/shared/utils/api-url.util';
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
-import type { AxiosInstance } from 'axios';
 
-interface ApiError {
-  response?: {
-    data?: { errors?: Array<{ detail?: string }> };
-  };
-  message?: string;
-}
-
-interface BrandResponse {
-  id: string;
-  name: string;
-  status?: string;
-  [key: string]: unknown;
-}
-
-interface PersonaResponse {
-  id: string;
-  name: string;
-  status?: string;
-  [key: string]: unknown;
-}
-
-interface CreateBatchParams {
-  brandId: string;
-  count: number;
-  platforms: string[];
-  topics?: string[];
-  dateRange?: { start: string; end: string };
-  style?: string;
-}
-
-interface ListBatchesParams {
-  batchId?: string;
-  status?: string;
-  limit?: number;
-  offset?: number;
-}
-
+/**
+ * Composition root for the MCP → Genfeed API client.
+ *
+ * The HTTP surface is decomposed into per-domain clients (media, content,
+ * workflows, ads, darkroom, analytics, workspace, agent, LinkedIn) that all
+ * share a single {@link BaseApiClient} — and therefore a single axios instance,
+ * so {@link setBearerToken} propagates to every sub-client. This class is a thin
+ * aggregator: it owns no request logic and only delegates, preserving the exact
+ * public method surface every MCP tool/resource consumes.
+ */
 @Injectable()
 export class ClientService {
-  private client: AxiosInstance;
-  private bearerToken: string;
+  private readonly base: BaseApiClient;
+  private readonly agent: AgentClient;
+  private readonly media: MediaClient;
+  private readonly analytics: AnalyticsClient;
+  private readonly content: ContentClient;
+  private readonly workflows: WorkflowClient;
+  private readonly workspace: WorkspaceClient;
+  private readonly ads: AdsClient;
+  private readonly darkroom: DarkroomClient;
+  // False positive below: the 14-char type name "LinkedInClient" next to the
+  // `linkedin` identifier matches the default gitleaks linkedin-client-id rule.
+  private readonly linkedin: LinkedInClient; // gitleaks:allow
 
   constructor(
-    private readonly logger: LoggerService,
-    private readonly httpService: HttpService,
-    private readonly configService: ConfigService,
+    logger: LoggerService,
+    httpService: HttpService,
+    configService: ConfigService,
   ) {
-    this.bearerToken =
-      (this.configService.get('GENFEEDAI_API_KEY') as string) || '';
-    const baseURL = resolveApiBaseUrl(
-      this.configService.get('GENFEEDAI_API_URL') as string | undefined,
-    );
-
-    this.client = this.httpService.axiosRef.create({
-      baseURL,
-      headers: {
-        Authorization: `Bearer ${this.bearerToken}`,
-        'Content-Type': 'application/json',
-      },
-      timeout: 30000,
-    });
+    this.base = new BaseApiClient(logger, httpService, configService);
+    this.agent = new AgentClient(this.base);
+    this.media = new MediaClient(this.base);
+    this.analytics = new AnalyticsClient(this.base);
+    this.content = new ContentClient(this.base);
+    this.workflows = new WorkflowClient(this.base);
+    this.workspace = new WorkspaceClient(this.base);
+    this.ads = new AdsClient(this.base);
+    this.darkroom = new DarkroomClient(this.base);
+    this.linkedin = new LinkedInClient(this.base);
   }
 
   setBearerToken(token: string): void {
-    this.bearerToken = token;
-    this.client.defaults.headers.Authorization = `Bearer ${token}`;
+    this.base.setBearerToken(token);
   }
 
-  async postAttributes<TResponse>(
+  postAttributes<TResponse>(
     endpoint: string,
     payload: Record<string, unknown>,
   ): Promise<TResponse> {
-    const response = await this.client.post(endpoint, payload);
-    return (response.data?.data?.attributes ??
-      response.data?.data) as TResponse;
+    return this.base.postAttributes<TResponse>(endpoint, payload);
   }
 
-  async executeAgentTool(
+  // ── Agent tools & approvals ──
+
+  executeAgentTool(
     name: string,
     parameters: Record<string, unknown>,
     context?: Record<string, unknown>,
   ): Promise<AgentToolResult> {
-    this.logger.debug(`Proxying agent tool ${name}`);
-
-    try {
-      const response = await this.client.post(
-        `/agent-tools/${encodeURIComponent(name)}/execute`,
-        { context, parameters },
-      );
-      return response.data as AgentToolResult;
-    } catch (error: unknown) {
-      this.logError(`executing agent tool ${name}`, error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, `Failed to execute ${name}`),
-      );
-    }
+    return this.agent.executeAgentTool(name, parameters, context);
   }
 
-  /**
-   * Persist a PENDING approval for a mutating MCP tool call. The API notifies a
-   * reviewer; nothing executes until the approval is resolved.
-   */
-  async createApproval(
+  createApproval(
     toolName: string,
     args: Record<string, unknown>,
   ): Promise<McpApprovalResource> {
-    try {
-      const response = await this.client.post('/mcp-approvals', {
-        arguments: args,
-        toolName,
-      });
-      return response.data?.data as McpApprovalResource;
-    } catch (error: unknown) {
-      this.logError(`creating approval for ${toolName}`, error as ApiError);
-      throw new Error(
-        this.getErrorMessage(
-          error as ApiError,
-          `Failed to create approval for ${toolName}`,
-        ),
-      );
-    }
+    return this.agent.createApproval(toolName, args);
   }
 
-  async getApproval(approvalId: string): Promise<McpApprovalResource | null> {
-    try {
-      const response = await this.client.get(
-        `/mcp-approvals/${encodeURIComponent(approvalId)}`,
-      );
-      return (response.data?.data as McpApprovalResource) ?? null;
-    } catch (error: unknown) {
-      this.logError(`fetching approval ${approvalId}`, error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to fetch approval'),
-      );
-    }
+  getApproval(approvalId: string): Promise<McpApprovalResource | null> {
+    return this.agent.getApproval(approvalId);
   }
 
-  /**
-   * Resolve an approval (atomic CLAIM on the API: PENDING -> APPROVED/DECLINED).
-   * Throws if the approval was already resolved, which is what lets the caller
-   * gate tool execution on a successful claim. The optional `result` is accepted
-   * for completeness, but the MCP flow persists the execution outcome separately
-   * via {@link attachApprovalResult} after the tool has run.
-   */
-  async resolveApproval(
+  resolveApproval(
     approvalId: string,
     decision: McpApprovalDecision,
     result?: Record<string, unknown>,
   ): Promise<McpApprovalResource> {
-    try {
-      const response = await this.client.post(
-        `/mcp-approvals/${encodeURIComponent(approvalId)}/resolve`,
-        { decision, ...(result ? { result } : {}) },
-      );
-      return response.data?.data as McpApprovalResource;
-    } catch (error: unknown) {
-      this.logError(`resolving approval ${approvalId}`, error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to resolve approval'),
-      );
-    }
+    return this.agent.resolveApproval(approvalId, decision, result);
   }
 
-  /**
-   * Attach the tool execution result (or error) to an already-APPROVED approval.
-   * Called after the approval has been atomically claimed via {@link resolveApproval}
-   * and the tool has run, so the audit record reflects the outcome.
-   */
-  async attachApprovalResult(
+  attachApprovalResult(
     approvalId: string,
     result: Record<string, unknown>,
   ): Promise<McpApprovalResource> {
-    try {
-      const response = await this.client.post(
-        `/mcp-approvals/${encodeURIComponent(approvalId)}/result`,
-        { result },
-      );
-      return response.data?.data as McpApprovalResource;
-    } catch (error: unknown) {
-      this.logError(
-        `attaching result to approval ${approvalId}`,
-        error as ApiError,
-      );
-      throw new Error(
-        this.getErrorMessage(
-          error as ApiError,
-          'Failed to attach approval result',
-        ),
-      );
-    }
+    return this.agent.attachApprovalResult(approvalId, result);
   }
 
-  private getErrorMessage(error: ApiError, defaultMessage: string): string {
-    return error.response?.data?.errors?.[0]?.detail || defaultMessage;
+  // ── Media (video / image / avatar / music) ──
+
+  createVideo(params: VideoCreationParams): Promise<VideoResponse> {
+    return this.media.createVideo(params);
   }
 
-  private logError(operation: string, error: ApiError): void {
-    this.logger.error(`Error ${operation}`, error.message, {
-      data: error.response?.data,
-    });
+  getVideoStatus(videoId: string): Promise<VideoStatus> {
+    return this.media.getVideoStatus(videoId);
   }
 
-  async createVideo(params: VideoCreationParams): Promise<VideoResponse> {
-    this.logger.debug('Creating video', { params });
-
-    try {
-      const response = await this.client.post('/videos', {
-        data: {
-          attributes: {
-            duration: params.duration,
-            height: 1080,
-            model: 'google/veo-2',
-            prompt: params.description,
-            style: params.style,
-            text: params.description,
-            title: params.title,
-            width: 1920,
-            ...(params.voiceOver?.enabled && { voiceOver: params.voiceOver }),
-          },
-          type: 'videos',
-        },
-      });
-
-      const video = response.data?.data;
-      return {
-        estimatedCompletion: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
-        id: video?.id || video?.attributes?.id,
-        status: video?.attributes?.status || 'processing',
-        url: video?.attributes?.url,
-      };
-    } catch (error: unknown) {
-      this.logError('creating video', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create video'),
-      );
-    }
+  listVideos(limit: number = 10, offset: number = 0): Promise<VideoResponse[]> {
+    return this.media.listVideos(limit, offset);
   }
 
-  async getVideoStatus(videoId: string): Promise<VideoStatus> {
-    this.logger.debug(`Getting video status for ID: ${videoId}`);
-
-    try {
-      const response = await this.client.get(`/videos/${videoId}`);
-      const video = response.data?.data;
-
-      return {
-        message: video?.attributes?.message || '',
-        progress: video?.attributes?.progress || 0,
-        status: video?.attributes?.status || 'unknown',
-        url: video?.attributes?.url,
-      };
-    } catch (error: unknown) {
-      this.logError('getting video status', error as ApiError);
-      throw new Error('Failed to get video status');
-    }
+  createImage(params: ImageCreationParams): Promise<ImageResponse> {
+    return this.media.createImage(params);
   }
 
-  async listVideos(
-    limit: number = 10,
-    offset: number = 0,
-  ): Promise<VideoResponse[]> {
-    this.logger.debug(`Listing videos: limit=${limit}, offset=${offset}`);
-
-    try {
-      const response = await this.client.get('/videos', {
-        params: { 'page[limit]': limit, 'page[offset]': offset },
-      });
-
-      return (
-        response.data?.data?.map((video: VideoResource) => ({
-          createdAt: video.attributes?.createdAt,
-          duration: video.attributes?.duration,
-          id: video.id,
-          status: video.attributes?.status || 'unknown',
-          title: video.attributes?.title || 'Untitled',
-          url: video.attributes?.url,
-          views: video.attributes?.views || 0,
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing videos', error as ApiError);
-      throw new Error('Failed to list videos');
-    }
+  listImages(params: ImageListParams = {}): Promise<ImageResponse[]> {
+    return this.media.listImages(params);
   }
 
-  async getVideoAnalytics(
+  createAvatar(params: AvatarCreationParams): Promise<AvatarResponse> {
+    return this.media.createAvatar(params);
+  }
+
+  listAvatars(params: AvatarListParams = {}): Promise<AvatarResponse[]> {
+    return this.media.listAvatars(params);
+  }
+
+  createMusic(params: MusicCreationParams): Promise<MusicResponse> {
+    return this.media.createMusic(params);
+  }
+
+  listMusic(params: MusicListParams = {}): Promise<MusicResponse[]> {
+    return this.media.listMusic(params);
+  }
+
+  // ── Analytics ──
+
+  getVideoAnalytics(
     videoId?: string,
     timeRange: string = '7d',
   ): Promise<Analytics> {
-    this.logger.debug(
-      `Getting video analytics: videoId=${videoId}, timeRange=${timeRange}`,
-    );
-
-    const emptyAnalytics: Analytics = {
-      averageWatchTime: 0,
-      comments: 0,
-      engagement: 0,
-      likes: 0,
-      shares: 0,
-      timeRange,
-      videoId: videoId || 'all',
-      views: 0,
-    };
-
-    try {
-      const endpoint = videoId
-        ? `/analytics/videos/${videoId}`
-        : '/analytics/videos';
-      const response = await this.client.get(endpoint, {
-        params: { timeRange },
-      });
-      const data = response.data?.data?.attributes || {};
-
-      return {
-        ...emptyAnalytics,
-        averageWatchTime: data.averageWatchTime || 0,
-        comments: data.comments || 0,
-        engagement: data.engagement || 0,
-        likes: data.likes || 0,
-        shares: data.shares || 0,
-        views: data.views || 0,
-      };
-    } catch (error: unknown) {
-      this.logError('getting video analytics', error as ApiError);
-      return emptyAnalytics;
-    }
+    return this.analytics.getVideoAnalytics(videoId, timeRange);
   }
 
-  async getOrganizationAnalytics(): Promise<OrganizationAnalytics> {
-    this.logger.debug('Getting organization analytics');
-
-    const emptyOrgAnalytics: OrganizationAnalytics = {
-      activeUsers: 0,
-      averageVideoLength: 0,
-      growthRate: 0,
-      topPerformingVideos: [],
-      totalEngagement: 0,
-      totalVideos: 0,
-      totalViews: 0,
-    };
-
-    try {
-      const response = await this.client.get('/analytics/organization');
-      const data = response.data?.data?.attributes || {};
-
-      return {
-        ...emptyOrgAnalytics,
-        activeUsers: data.activeUsers || 0,
-        averageVideoLength: data.averageVideoLength || 0,
-        growthRate: data.growthRate || 0,
-        topPerformingVideos: data.topPerformingVideos || [],
-        totalEngagement: data.totalEngagement || 0,
-        totalVideos: data.totalVideos || 0,
-        totalViews: data.totalViews || 0,
-      };
-    } catch (error: unknown) {
-      this.logError('getting organization analytics', error as ApiError);
-      return emptyOrgAnalytics;
-    }
+  getOrganizationAnalytics(): Promise<OrganizationAnalytics> {
+    return this.analytics.getOrganizationAnalytics();
   }
 
-  async createArticle(params: ArticleCreationParams): Promise<ArticleResponse> {
-    this.logger.debug('Creating article', { params });
+  // ── Content (articles / posts / trends) ──
 
-    try {
-      const response = await this.client.post('/articles/generations', {
-        data: {
-          attributes: {
-            keywords: params.keywords || [],
-            length: params.length || 'medium',
-            targetAudience: params.targetAudience,
-            tone: params.tone || 'professional',
-            topic: params.topic,
-          },
-          type: 'articles',
-        },
-      });
-
-      const article = response.data?.data;
-      return {
-        content: article?.attributes?.content || '',
-        createdAt: article?.attributes?.createdAt || new Date().toISOString(),
-        id: article?.id || article?.attributes?.id,
-        status: article?.attributes?.status || 'processing',
-        title: article?.attributes?.title || params.topic,
-        wordCount: article?.attributes?.wordCount || 0,
-      };
-    } catch (error: unknown) {
-      this.logError('creating article', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create article'),
-      );
-    }
+  createArticle(params: ArticleCreationParams): Promise<ArticleResponse> {
+    return this.content.createArticle(params);
   }
 
-  async searchArticles(
-    params: ArticleSearchParams,
-  ): Promise<ArticleSearchResult[]> {
-    this.logger.debug('Searching articles', { params });
-
-    try {
-      const response = await this.client.get('/articles', {
-        params: {
-          'filter[category]': params.category,
-          'filter[search]': params.query,
-          'page[limit]': params.limit || 10,
-          'page[offset]': params.offset || 0,
-        },
-      });
-
-      return (
-        response.data?.data?.map((article: ArticleResource) => ({
-          category: article.attributes?.category,
-          createdAt: article.attributes?.createdAt,
-          excerpt:
-            article.attributes?.excerpt ||
-            article.attributes?.content?.substring(0, 200),
-          id: article.id,
-          title: article.attributes?.title,
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('searching articles', error as ApiError);
-      throw new Error('Failed to search articles');
-    }
+  searchArticles(params: ArticleSearchParams): Promise<ArticleSearchResult[]> {
+    return this.content.searchArticles(params);
   }
 
-  async getArticle(articleId: string): Promise<ArticleResponse> {
-    this.logger.debug(`Getting article: ${articleId}`);
-
-    try {
-      const response = await this.client.get(`/articles/${articleId}`);
-      const article = response.data?.data;
-
-      return {
-        content: article?.attributes?.content || '',
-        createdAt: article?.attributes?.createdAt,
-        id: article?.id,
-        status: article?.attributes?.status || 'published',
-        title: article?.attributes?.title,
-        updatedAt: article?.attributes?.updatedAt,
-        wordCount: article?.attributes?.wordCount || 0,
-      };
-    } catch (error: unknown) {
-      this.logError('getting article', error as ApiError);
-      throw new Error('Failed to get article');
-    }
+  getArticle(articleId: string): Promise<ArticleResponse> {
+    return this.content.getArticle(articleId);
   }
 
-  async createImage(params: ImageCreationParams): Promise<ImageResponse> {
-    this.logger.debug('Creating image', { params });
-
-    try {
-      const response = await this.client.post('/images', {
-        data: {
-          attributes: {
-            prompt: params.prompt,
-            quality: params.quality || 'standard',
-            size: params.size || 'square',
-            style: params.style || 'realistic',
-          },
-          type: 'images',
-        },
-      });
-
-      const image = response.data?.data;
-      return {
-        createdAt: image?.attributes?.createdAt || new Date().toISOString(),
-        id: image?.id || image?.attributes?.id,
-        prompt: params.prompt,
-        size: params.size || 'square',
-        status: image?.attributes?.status || 'processing',
-        style: params.style || 'realistic',
-        url: image?.attributes?.url || '',
-      };
-    } catch (error: unknown) {
-      this.logError('creating image', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create image'),
-      );
-    }
+  publishContent(params: PublishContentParams): Promise<PostResponse[]> {
+    return this.content.publishContent(params);
   }
 
-  async listImages(params: ImageListParams = {}): Promise<ImageResponse[]> {
-    this.logger.debug('Listing images', { params });
-
-    try {
-      const response = await this.client.get('/images', {
-        params: {
-          'page[limit]': params.limit || 10,
-          'page[offset]': params.offset || 0,
-        },
-      });
-
-      return (
-        response.data?.data?.map((image: ImageResource) => ({
-          createdAt: image.attributes?.createdAt,
-          id: image.id,
-          prompt: image.attributes?.prompt || '',
-          size: image.attributes?.size || 'square',
-          status: image.attributes?.status || 'completed',
-          style: image.attributes?.style || 'realistic',
-          url: image.attributes?.url || '',
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing images', error as ApiError);
-      throw new Error('Failed to list images');
-    }
+  listPosts(params: PostListParams = {}): Promise<PostResponse[]> {
+    return this.content.listPosts(params);
   }
 
-  async createAvatar(params: AvatarCreationParams): Promise<AvatarResponse> {
-    this.logger.debug('Creating avatar', { params });
-
-    try {
-      const response = await this.client.post('/avatars/generate', {
-        data: {
-          attributes: {
-            age: params.age || 'middle-aged',
-            gender: params.gender,
-            name: params.name,
-            style: params.style || 'realistic',
-          },
-          type: 'avatars',
-        },
-      });
-
-      const avatar = response.data?.data;
-      return {
-        age: params.age || 'middle-aged',
-        createdAt: avatar?.attributes?.createdAt || new Date().toISOString(),
-        gender: params.gender,
-        id: avatar?.id || avatar?.attributes?.id,
-        name: params.name,
-        status: avatar?.attributes?.status || 'processing',
-        style: params.style || 'realistic',
-        thumbnailUrl: avatar?.attributes?.thumbnailUrl,
-        videoUrl: avatar?.attributes?.videoUrl,
-      };
-    } catch (error: unknown) {
-      this.logError('creating avatar', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create avatar'),
-      );
-    }
-  }
-
-  async listAvatars(params: AvatarListParams = {}): Promise<AvatarResponse[]> {
-    this.logger.debug('Listing avatars', { params });
-
-    try {
-      const response = await this.client.get('/avatars', {
-        params: {
-          'page[limit]': params.limit || 10,
-          'page[offset]': params.offset || 0,
-        },
-      });
-
-      return (
-        response.data?.data?.map((avatar: AvatarResource) => ({
-          age: avatar.attributes?.age,
-          createdAt: avatar.attributes?.createdAt,
-          gender: avatar.attributes?.gender,
-          id: avatar.id,
-          name: avatar.attributes?.name || 'Unnamed',
-          status: avatar.attributes?.status || 'completed',
-          style: avatar.attributes?.style,
-          thumbnailUrl: avatar.attributes?.thumbnailUrl,
-          videoUrl: avatar.attributes?.videoUrl,
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing avatars', error as ApiError);
-      throw new Error('Failed to list avatars');
-    }
-  }
-
-  async createMusic(params: MusicCreationParams): Promise<MusicResponse> {
-    this.logger.debug('Creating music', { params });
-
-    try {
-      const response = await this.client.post('/musics', {
-        data: {
-          attributes: {
-            duration: params.duration || 60,
-            genre: params.genre,
-            mood: params.mood,
-            prompt: params.prompt,
-          },
-          type: 'musics',
-        },
-      });
-
-      const music = response.data?.data;
-      return {
-        createdAt: music?.attributes?.createdAt || new Date().toISOString(),
-        duration: params.duration || 60,
-        genre: params.genre,
-        id: music?.id || music?.attributes?.id,
-        mood: params.mood,
-        prompt: params.prompt,
-        status: music?.attributes?.status || 'processing',
-        url: music?.attributes?.url,
-      };
-    } catch (error: unknown) {
-      this.logError('creating music', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create music'),
-      );
-    }
-  }
-
-  async listMusic(params: MusicListParams = {}): Promise<MusicResponse[]> {
-    this.logger.debug('Listing music', { params });
-
-    try {
-      const response = await this.client.get('/musics', {
-        params: {
-          'page[limit]': params.limit || 10,
-          'page[offset]': params.offset || 0,
-        },
-      });
-
-      return (
-        response.data?.data?.map((music: MusicResource) => ({
-          createdAt: music.attributes?.createdAt,
-          duration: music.attributes?.duration || 0,
-          genre: music.attributes?.genre,
-          id: music.id,
-          mood: music.attributes?.mood,
-          prompt: music.attributes?.prompt || '',
-          status: music.attributes?.status || 'completed',
-          url: music.attributes?.url,
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing music', error as ApiError);
-      throw new Error('Failed to list music');
-    }
-  }
-
-  async publishContent(params: PublishContentParams): Promise<PostResponse[]> {
-    this.logger.debug('Publishing content', { params });
-
-    try {
-      const response = await this.client.post('/posts', {
-        data: {
-          attributes: {
-            contentId: params.contentId,
-            customMessage: params.customMessage,
-            platforms: params.platforms,
-            scheduleAt: params.scheduleAt,
-          },
-          type: 'posts',
-        },
-      });
-
-      const posts = response.data?.data;
-      if (Array.isArray(posts)) {
-        return posts.map((post: PostResource, index: number) => ({
-          contentId: params.contentId,
-          createdAt: post.attributes?.createdAt || new Date().toISOString(),
-          id: post.id,
-          platform:
-            (post.attributes?.platform as SocialPlatform) ||
-            params.platforms[index] ||
-            params.platforms[0],
-          publishedAt: post.attributes?.publishedAt,
-          publishedUrl: post.attributes?.publishedUrl,
-          scheduledAt: post.attributes?.scheduledAt,
-          status:
-            (post.attributes?.status as PostResponse['status']) || 'pending',
-        }));
-      }
-
-      return [
-        {
-          contentId: params.contentId,
-          createdAt: posts?.attributes?.createdAt || new Date().toISOString(),
-          id: posts?.id,
-          platform:
-            (posts?.attributes?.platform as SocialPlatform) ||
-            params.platforms[0],
-          publishedAt: posts?.attributes?.publishedAt,
-          publishedUrl: posts?.attributes?.publishedUrl,
-          scheduledAt: posts?.attributes?.scheduledAt,
-          status:
-            (posts?.attributes?.status as PostResponse['status']) || 'pending',
-        },
-      ];
-    } catch (error: unknown) {
-      this.logError('publishing content', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to publish content'),
-      );
-    }
-  }
-
-  async listPosts(params: PostListParams = {}): Promise<PostResponse[]> {
-    this.logger.debug('Listing posts', { params });
-
-    try {
-      const queryParams: Record<string, string | number> = {
-        'page[limit]': params.limit || 10,
-        'page[offset]': params.offset || 0,
-      };
-
-      if (params.platform && params.platform !== 'all') {
-        queryParams['filter[platform]'] = params.platform;
-      }
-
-      const response = await this.client.get('/posts', { params: queryParams });
-
-      return (
-        response.data?.data?.map((post: PostResource) => ({
-          contentId: post.attributes?.contentId,
-          createdAt: post.attributes?.createdAt,
-          id: post.id,
-          platform: post.attributes?.platform,
-          publishedAt: post.attributes?.publishedAt,
-          publishedUrl: post.attributes?.publishedUrl,
-          scheduledAt: post.attributes?.scheduledAt,
-          status: post.attributes?.status || 'published',
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing posts', error as ApiError);
-      throw new Error('Failed to list posts');
-    }
-  }
-
-  async getTrendingTopics(
+  getTrendingTopics(
     params: TrendingTopicsParams = {},
   ): Promise<TrendingTopic[]> {
-    this.logger.debug('Getting trending topics', { params });
-
-    try {
-      const response = await this.client.get('/trends', {
-        params: {
-          category: params.category || 'all',
-          timeframe: params.timeframe || '24h',
-        },
-      });
-
-      return (
-        response.data?.data?.map((trend: TrendResource) => ({
-          category: trend.attributes?.category || params.category || 'all',
-          growth: trend.attributes?.growth || 0,
-          relatedKeywords: trend.attributes?.relatedKeywords || [],
-          topic: trend.attributes?.topic || trend.attributes?.name,
-          volume: trend.attributes?.volume || 0,
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('getting trending topics', error as ApiError);
-      throw new Error('Failed to get trending topics');
-    }
+    return this.content.getTrendingTopics(params);
   }
 
-  async getCredits(): Promise<CreditsUsage> {
-    this.logger.debug('Getting credits usage');
+  // ── Workspace (credits / usage / brands / personas / batches / account / chat) ──
 
-    try {
-      const response = await this.client.get('/credits/usage');
-      const data = response.data?.data?.attributes || response.data?.data || {};
-
-      return {
-        available: data.available || 0,
-        breakdown: {
-          articles: data.breakdown?.articles || 0,
-          avatars: data.breakdown?.avatars || 0,
-          images: data.breakdown?.images || 0,
-          music: data.breakdown?.music || 0,
-          videos: data.breakdown?.videos || 0,
-        },
-        resetDate: data.resetDate,
-        total: data.total || 0,
-        used: data.used || 0,
-      };
-    } catch (error: unknown) {
-      this.logError('getting credits', error as ApiError);
-      throw new Error('Failed to get credits usage');
-    }
+  getCredits(): Promise<CreditsUsage> {
+    return this.workspace.getCredits();
   }
 
-  async getUsageStats(timeRange: string = '30d'): Promise<UsageStats> {
-    this.logger.debug(`Getting usage stats for timeRange: ${timeRange}`);
-
-    try {
-      const response = await this.client.get('/usage/stats', {
-        params: { timeRange },
-      });
-      const data = response.data?.data?.attributes || response.data?.data || {};
-
-      return {
-        contentCreated: {
-          articles: data.contentCreated?.articles || 0,
-          avatars: data.contentCreated?.avatars || 0,
-          images: data.contentCreated?.images || 0,
-          music: data.contentCreated?.music || 0,
-          videos: data.contentCreated?.videos || 0,
-        },
-        creditsUsed: data.creditsUsed || 0,
-        postsPublished: data.postsPublished || 0,
-        timeRange,
-        totalEngagement: data.totalEngagement || 0,
-      };
-    } catch (error: unknown) {
-      this.logError('getting usage stats', error as ApiError);
-      throw new Error('Failed to get usage stats');
-    }
+  getUsageStats(timeRange: string = '30d'): Promise<UsageStats> {
+    return this.workspace.getUsageStats(timeRange);
   }
 
-  async createWorkflow(
-    params: WorkflowCreateParams,
-  ): Promise<WorkflowResponse> {
-    this.logger.debug('Creating workflow', { params });
-
-    try {
-      const response = await this.client.post('/workflows', {
-        data: {
-          attributes: {
-            description: params.description,
-            name: params.name,
-            schedule: params.schedule,
-            steps: params.steps,
-            templateId: params.templateId,
-          },
-          type: 'workflows',
-        },
-      });
-
-      const workflow = response.data?.data;
-      return {
-        createdAt: workflow?.attributes?.createdAt || new Date().toISOString(),
-        description: workflow?.attributes?.description || params.description,
-        id: workflow?.id || workflow?.attributes?.id,
-        lastRunAt: workflow?.attributes?.lastRunAt,
-        name: workflow?.attributes?.name || params.name,
-        nextRunAt: workflow?.attributes?.nextRunAt,
-        status: workflow?.attributes?.status || 'draft',
-        steps: workflow?.attributes?.steps || params.steps || [],
-        updatedAt: workflow?.attributes?.updatedAt,
-      };
-    } catch (error: unknown) {
-      this.logError('creating workflow', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create workflow'),
-      );
-    }
+  listBrands(): Promise<BrandResponse[]> {
+    return this.workspace.listBrands();
   }
 
-  async executeWorkflow(
-    params: WorkflowExecuteParams,
-  ): Promise<WorkflowExecutionResult> {
-    this.logger.debug('Executing workflow', { params });
-
-    try {
-      const response = await this.client.post('/workflow-executions', {
-        inputValues: params.variables,
-        workflow: params.workflowId,
-      });
-
-      const execution = response.data?.data;
-      return {
-        completedAt: execution?.attributes?.completedAt,
-        error: execution?.attributes?.error,
-        executionId: execution?.id || execution?.attributes?.id,
-        results: execution?.attributes?.results,
-        startedAt: execution?.attributes?.startedAt || new Date().toISOString(),
-        status: execution?.attributes?.status || 'started',
-        workflowId: params.workflowId,
-      };
-    } catch (error: unknown) {
-      this.logError('executing workflow', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to execute workflow'),
-      );
-    }
-  }
-
-  async getWorkflowStatus(workflowId: string): Promise<WorkflowResponse> {
-    this.logger.debug(`Getting workflow status for ID: ${workflowId}`);
-
-    try {
-      const response = await this.client.get(`/workflows/${workflowId}`);
-      const workflow = response.data?.data;
-
-      return {
-        createdAt: workflow?.attributes?.createdAt,
-        currentStepIndex: workflow?.attributes?.currentStepIndex,
-        description: workflow?.attributes?.description,
-        id: workflow?.id,
-        lastRunAt: workflow?.attributes?.lastRunAt,
-        name: workflow?.attributes?.name,
-        nextRunAt: workflow?.attributes?.nextRunAt,
-        status: workflow?.attributes?.status || 'draft',
-        steps: workflow?.attributes?.steps || [],
-        updatedAt: workflow?.attributes?.updatedAt,
-      };
-    } catch (error: unknown) {
-      this.logError('getting workflow status', error as ApiError);
-      throw new Error('Failed to get workflow status');
-    }
-  }
-
-  async listWorkflows(
-    params: WorkflowListParams = {},
-  ): Promise<WorkflowResponse[]> {
-    this.logger.debug('Listing workflows', { params });
-
-    try {
-      const queryParams: Record<string, string | number> = {
-        'page[limit]': params.limit || 10,
-        'page[offset]': params.offset || 0,
-      };
-
-      if (params.status) {
-        queryParams['filter[status]'] = params.status;
-      }
-
-      const response = await this.client.get('/workflows', {
-        params: queryParams,
-      });
-
-      return (
-        response.data?.data?.map((workflow: WorkflowResource) => ({
-          createdAt: workflow.attributes?.createdAt,
-          currentStepIndex: workflow.attributes?.currentStepIndex,
-          description: workflow.attributes?.description,
-          id: workflow.id,
-          lastRunAt: workflow.attributes?.lastRunAt,
-          name: workflow.attributes?.name,
-          nextRunAt: workflow.attributes?.nextRunAt,
-          status: workflow.attributes?.status || 'draft',
-          steps: workflow.attributes?.steps || [],
-          updatedAt: workflow.attributes?.updatedAt,
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing workflows', error as ApiError);
-      throw new Error('Failed to list workflows');
-    }
-  }
-
-  async listWorkflowTemplates(): Promise<WorkflowTemplate[]> {
-    this.logger.debug('Listing workflow templates');
-
-    try {
-      const response = await this.client.get('/workflows/templates');
-
-      return (
-        response.data?.data?.map((template: WorkflowTemplateResource) => ({
-          category: template.attributes?.category || 'general',
-          creditsRequired: template.attributes?.creditsRequired,
-          description:
-            template.attributes?.description || 'No description available',
-          estimatedDuration: template.attributes?.estimatedDuration,
-          id: template.id,
-          name: template.attributes?.name,
-          steps: template.attributes?.steps || [],
-        })) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing workflow templates', error as ApiError);
-      throw new Error('Failed to list workflow templates');
-    }
-  }
-
-  async listBrands(): Promise<BrandResponse[]> {
-    this.logger.debug('Listing brands');
-
-    try {
-      const response = await this.client.get('/brands');
-      return (
-        response.data?.data?.map(
-          (brand: { id?: string; attributes?: Record<string, unknown> }) => ({
-            id: brand.id || String(brand.attributes?.id || ''),
-            name: String(brand.attributes?.name || 'Unnamed'),
-            status: brand.attributes?.status
-              ? String(brand.attributes.status)
-              : undefined,
-            ...(brand.attributes || {}),
-          }),
-        ) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing brands', error as ApiError);
-      throw new Error('Failed to list brands');
-    }
-  }
-
-  async listPersonas(
+  listPersonas(
     params: { status?: string; limit?: number; offset?: number } = {},
   ): Promise<PersonaResponse[]> {
-    this.logger.debug('Listing personas', { params });
-
-    try {
-      const response = await this.client.get('/personas', {
-        params: {
-          'filter[status]': params.status,
-          'page[limit]': params.limit || 10,
-          'page[offset]': params.offset || 0,
-        },
-      });
-
-      return (
-        response.data?.data?.map(
-          (persona: { id?: string; attributes?: Record<string, unknown> }) => ({
-            id: persona.id || String(persona.attributes?.id || ''),
-            name: String(persona.attributes?.name || 'Unnamed'),
-            status: persona.attributes?.status
-              ? String(persona.attributes.status)
-              : undefined,
-            ...(persona.attributes || {}),
-          }),
-        ) || []
-      );
-    } catch (error: unknown) {
-      this.logError('listing personas', error as ApiError);
-      throw new Error('Failed to list personas');
-    }
+    return this.workspace.listPersonas(params);
   }
 
-  async createBatch(
-    params: CreateBatchParams,
-  ): Promise<Record<string, unknown>> {
-    this.logger.debug('Creating content batch', { params });
-
-    try {
-      const response = await this.client.post('/batches', {
-        data: {
-          attributes: params,
-          type: 'batches',
-        },
-      });
-
-      return (response.data?.data?.attributes ||
-        response.data?.data ||
-        {}) as Record<string, unknown>;
-    } catch (error: unknown) {
-      this.logError('creating batch', error as ApiError);
-      throw new Error(
-        this.getErrorMessage(error as ApiError, 'Failed to create batch'),
-      );
-    }
+  createBatch(params: CreateBatchParams): Promise<Record<string, unknown>> {
+    return this.workspace.createBatch(params);
   }
 
-  async listBatches(
+  listBatches(
     params: ListBatchesParams = {},
   ): Promise<Array<Record<string, unknown>>> {
-    this.logger.debug('Listing content batches', { params });
-
-    try {
-      const response = await this.client.get('/batches', {
-        params: {
-          'filter[batchId]': params.batchId,
-          'filter[status]': params.status,
-          'page[limit]': params.limit || 20,
-          'page[offset]': params.offset || 0,
-        },
-      });
-
-      if (!Array.isArray(response.data?.data)) {
-        return [];
-      }
-
-      return response.data.data.map(
-        (item: { id?: string; attributes?: Record<string, unknown> }) => ({
-          id: item.id || String(item.attributes?.id || ''),
-          ...(item.attributes || {}),
-        }),
-      );
-    } catch (error: unknown) {
-      this.logError('listing batches', error as ApiError);
-      throw new Error('Failed to list batches');
-    }
+    return this.workspace.listBatches(params);
   }
 
-  // ── Meta Ads Methods ──
-
-  async listMetaAdAccounts(): Promise<unknown[]> {
-    try {
-      const response = await this.client.get('/integrations/meta-ads/accounts');
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing Meta ad accounts', error as ApiError);
-      throw new Error('Failed to list Meta ad accounts');
-    }
+  getAccountInfo(): Promise<Record<string, unknown>> {
+    return this.workspace.getAccountInfo();
   }
 
-  async listMetaCampaigns(
+  getJobStatus(jobId: string): Promise<Record<string, unknown>> {
+    return this.workspace.getJobStatus(jobId);
+  }
+
+  createChat(): Promise<Record<string, unknown>> {
+    return this.workspace.createChat();
+  }
+
+  sendChatMessage(
+    threadId: string,
+    message: string,
+  ): Promise<Record<string, unknown>> {
+    return this.workspace.sendChatMessage(threadId, message);
+  }
+
+  // ── Workflows ──
+
+  createWorkflow(params: WorkflowCreateParams): Promise<WorkflowResponse> {
+    return this.workflows.createWorkflow(params);
+  }
+
+  executeWorkflow(
+    params: WorkflowExecuteParams,
+  ): Promise<WorkflowExecutionResult> {
+    return this.workflows.executeWorkflow(params);
+  }
+
+  getWorkflowStatus(workflowId: string): Promise<WorkflowResponse> {
+    return this.workflows.getWorkflowStatus(workflowId);
+  }
+
+  listWorkflows(params: WorkflowListParams = {}): Promise<WorkflowResponse[]> {
+    return this.workflows.listWorkflows(params);
+  }
+
+  listWorkflowTemplates(): Promise<WorkflowTemplate[]> {
+    return this.workflows.listWorkflowTemplates();
+  }
+
+  // ── Meta Ads ──
+
+  listMetaAdAccounts(): Promise<unknown[]> {
+    return this.ads.listMetaAdAccounts();
+  }
+
+  listMetaCampaigns(
     adAccountId: string,
     status?: string,
     limit?: number,
   ): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        '/integrations/meta-ads/campaigns',
-        { params: { adAccountId, limit, status } },
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing Meta campaigns', error as ApiError);
-      throw new Error('Failed to list Meta campaigns');
-    }
+    return this.ads.listMetaCampaigns(adAccountId, status, limit);
   }
 
-  async getMetaCampaignInsights(
+  getMetaCampaignInsights(
     campaignId: string,
     datePreset?: string,
     since?: string,
     until?: string,
   ): Promise<unknown> {
-    try {
-      const response = await this.client.get(
-        `/integrations/meta-ads/campaigns/${campaignId}/insights`,
-        { params: { datePreset, since, until } },
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('getting Meta campaign insights', error as ApiError);
-      throw new Error('Failed to get Meta campaign insights');
-    }
+    return this.ads.getMetaCampaignInsights(
+      campaignId,
+      datePreset,
+      since,
+      until,
+    );
   }
 
-  async getMetaAdSetInsights(
-    adSetId: string,
-    datePreset?: string,
-  ): Promise<unknown> {
-    try {
-      const response = await this.client.get(
-        `/integrations/meta-ads/adsets/${adSetId}/insights`,
-        { params: { datePreset } },
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('getting Meta ad set insights', error as ApiError);
-      throw new Error('Failed to get Meta ad set insights');
-    }
+  getMetaAdSetInsights(adSetId: string, datePreset?: string): Promise<unknown> {
+    return this.ads.getMetaAdSetInsights(adSetId, datePreset);
   }
 
-  async getMetaAdInsights(adId: string, datePreset?: string): Promise<unknown> {
-    try {
-      const response = await this.client.get(
-        `/integrations/meta-ads/ads/${adId}/insights`,
-        { params: { datePreset } },
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('getting Meta ad insights', error as ApiError);
-      throw new Error('Failed to get Meta ad insights');
-    }
+  getMetaAdInsights(adId: string, datePreset?: string): Promise<unknown> {
+    return this.ads.getMetaAdInsights(adId, datePreset);
   }
 
-  async listMetaAdCreatives(
-    adAccountId: string,
-    limit?: number,
-  ): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        '/integrations/meta-ads/creatives',
-        { params: { adAccountId, limit } },
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing Meta ad creatives', error as ApiError);
-      throw new Error('Failed to list Meta ad creatives');
-    }
+  listMetaAdCreatives(adAccountId: string, limit?: number): Promise<unknown[]> {
+    return this.ads.listMetaAdCreatives(adAccountId, limit);
   }
 
-  async compareMetaCampaigns(
+  compareMetaCampaigns(
     campaignIds: string[],
     datePreset?: string,
   ): Promise<unknown> {
-    try {
-      const response = await this.client.get(
-        '/integrations/meta-ads/campaigns/compare',
-        { params: { campaignIds: campaignIds.join(','), datePreset } },
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('comparing Meta campaigns', error as ApiError);
-      throw new Error('Failed to compare Meta campaigns');
-    }
+    return this.ads.compareMetaCampaigns(campaignIds, datePreset);
   }
 
-  async getMetaTopPerformers(
+  getMetaTopPerformers(
     adAccountId: string,
     metric: string,
     limit?: number,
   ): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        '/integrations/meta-ads/top-performers',
-        { params: { adAccountId, limit, metric } },
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('getting Meta top performers', error as ApiError);
-      throw new Error('Failed to get Meta top performers');
-    }
+    return this.ads.getMetaTopPerformers(adAccountId, metric, limit);
   }
 
-  // ── Google Ads Methods ──
+  // ── Google Ads ──
 
-  async listGoogleAdsCustomers(): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        '/integrations/google-ads/customers',
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing Google Ads customers', error as ApiError);
-      throw new Error('Failed to list Google Ads customers');
-    }
+  listGoogleAdsCustomers(): Promise<unknown[]> {
+    return this.ads.listGoogleAdsCustomers();
   }
 
-  async listGoogleAdsCampaigns(
+  listGoogleAdsCampaigns(
     customerId: string,
     status?: string,
     limit?: number,
     loginCustomerId?: string,
   ): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        '/integrations/google-ads/campaigns',
-        { params: { customerId, limit, loginCustomerId, status } },
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing Google Ads campaigns', error as ApiError);
-      throw new Error('Failed to list Google Ads campaigns');
-    }
+    return this.ads.listGoogleAdsCampaigns(
+      customerId,
+      status,
+      limit,
+      loginCustomerId,
+    );
   }
 
-  async getGoogleAdsCampaignMetrics(
+  getGoogleAdsCampaignMetrics(
     customerId: string,
     campaignId: string,
     startDate?: string,
@@ -1313,72 +395,49 @@ export class ClientService {
     segmentByDate?: boolean,
     loginCustomerId?: string,
   ): Promise<unknown> {
-    try {
-      const response = await this.client.get(
-        `/integrations/google-ads/campaigns/${campaignId}/metrics`,
-        {
-          params: {
-            customerId,
-            endDate,
-            loginCustomerId,
-            segmentByDate,
-            startDate,
-          },
-        },
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('getting Google Ads campaign metrics', error as ApiError);
-      throw new Error('Failed to get Google Ads campaign metrics');
-    }
+    return this.ads.getGoogleAdsCampaignMetrics(
+      customerId,
+      campaignId,
+      startDate,
+      endDate,
+      segmentByDate,
+      loginCustomerId,
+    );
   }
 
-  async getGoogleAdsAdGroupInsights(
+  getGoogleAdsAdGroupInsights(
     customerId: string,
     adGroupId: string,
     startDate?: string,
     endDate?: string,
     loginCustomerId?: string,
   ): Promise<unknown> {
-    try {
-      const response = await this.client.get(
-        `/integrations/google-ads/ad-groups/${adGroupId}/insights`,
-        {
-          params: { customerId, endDate, loginCustomerId, startDate },
-        },
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('getting Google Ads ad group insights', error as ApiError);
-      throw new Error('Failed to get Google Ads ad group insights');
-    }
+    return this.ads.getGoogleAdsAdGroupInsights(
+      customerId,
+      adGroupId,
+      startDate,
+      endDate,
+      loginCustomerId,
+    );
   }
 
-  async getGoogleAdsKeywordPerformance(
+  getGoogleAdsKeywordPerformance(
     customerId: string,
     startDate?: string,
     endDate?: string,
     limit?: number,
     loginCustomerId?: string,
   ): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        '/integrations/google-ads/keywords',
-        {
-          params: { customerId, endDate, limit, loginCustomerId, startDate },
-        },
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError(
-        'getting Google Ads keyword performance',
-        error as ApiError,
-      );
-      throw new Error('Failed to get Google Ads keyword performance');
-    }
+    return this.ads.getGoogleAdsKeywordPerformance(
+      customerId,
+      startDate,
+      endDate,
+      limit,
+      loginCustomerId,
+    );
   }
 
-  async getGoogleAdsSearchTerms(
+  getGoogleAdsSearchTerms(
     customerId: string,
     campaignId: string,
     startDate?: string,
@@ -1386,305 +445,121 @@ export class ClientService {
     limit?: number,
     loginCustomerId?: string,
   ): Promise<unknown[]> {
-    try {
-      const response = await this.client.get(
-        `/integrations/google-ads/search-terms/${campaignId}`,
-        {
-          params: { customerId, endDate, limit, loginCustomerId, startDate },
-        },
-      );
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('getting Google Ads search terms', error as ApiError);
-      throw new Error('Failed to get Google Ads search terms');
-    }
+    return this.ads.getGoogleAdsSearchTerms(
+      customerId,
+      campaignId,
+      startDate,
+      endDate,
+      limit,
+      loginCustomerId,
+    );
   }
 
-  // ── Account Management Methods (CLI Parity) ──
+  // ── Ad Insights (Content Loop) ──
 
-  async getAccountInfo(): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.get('/accounts');
-      const account = response.data?.data?.[0] || response.data?.data;
-      return {
-        id: account?.id,
-        ...(account?.attributes || account || {}),
-      };
-    } catch (error: unknown) {
-      this.logError('getting account info', error as ApiError);
-      throw new Error('Failed to get account info');
-    }
-  }
-
-  async getJobStatus(jobId: string): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.get(`/ingredients/${jobId}`);
-      const data = response.data?.data;
-      return {
-        id: data?.id,
-        ...(data?.attributes || data || {}),
-      };
-    } catch (error: unknown) {
-      this.logError('getting job status', error as ApiError);
-      throw new Error('Failed to get job status');
-    }
-  }
-
-  // ── Admin / Infrastructure Methods (CLI Parity) ──
-
-  async getDarkroomHealth(): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.get('/darkroom/health');
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('getting darkroom health', error as ApiError);
-      throw new Error('Failed to get darkroom health');
-    }
-  }
-
-  async controlComfyUi(
-    action: string,
-    confirm?: boolean,
-  ): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.post('/darkroom/comfyui/control', {
-        action,
-        confirm,
-      });
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('controlling ComfyUI', error as ApiError);
-      throw new Error('Failed to control ComfyUI');
-    }
-  }
-
-  async listLoras(): Promise<unknown[]> {
-    try {
-      const response = await this.client.get('/darkroom/loras');
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing LoRAs', error as ApiError);
-      throw new Error('Failed to list LoRAs');
-    }
-  }
-
-  async listGpuPersonas(): Promise<unknown[]> {
-    try {
-      const response = await this.client.get('/darkroom/personas');
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('listing GPU personas', error as ApiError);
-      throw new Error('Failed to list GPU personas');
-    }
-  }
-
-  // ── Training Pipeline Methods (CLI Parity) ──
-
-  async startTraining(params: {
-    handle: string;
-    steps?: number;
-    rank?: number;
-    learningRate?: number;
-  }): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.post('/training/start', params);
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('starting training', error as ApiError);
-      throw new Error('Failed to start training');
-    }
-  }
-
-  async getTrainingStatus(jobId: string): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.get(`/training/status/${jobId}`);
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('getting training status', error as ApiError);
-      throw new Error('Failed to get training status');
-    }
-  }
-
-  async getDatasetInfo(handle: string): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.get(`/datasets/${handle}`);
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('getting dataset info', error as ApiError);
-      throw new Error('Failed to get dataset info');
-    }
-  }
-
-  async deleteDataset(
-    handle: string,
-    confirm: boolean,
-  ): Promise<Record<string, unknown>> {
-    if (!confirm) {
-      return {
-        message: `This will permanently delete dataset "${handle}". Pass confirm: true to proceed.`,
-        preview: true,
-      };
-    }
-    try {
-      const response = await this.client.delete(`/datasets/${handle}`);
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('deleting dataset', error as ApiError);
-      throw new Error('Failed to delete dataset');
-    }
-  }
-
-  async runCaptioning(handle: string): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.post(`/datasets/${handle}/caption`);
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('running captioning', error as ApiError);
-      throw new Error('Failed to run captioning');
-    }
-  }
-
-  // ── Darkroom Generation Methods (CLI Parity) ──
-
-  async generateDarkroomContent(params: {
-    type: string;
-    prompt?: string;
-    count?: number;
-    personaHandle?: string;
-  }): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.post('/darkroom/generate', params);
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('generating darkroom content', error as ApiError);
-      throw new Error('Failed to generate darkroom content');
-    }
-  }
-
-  async getDarkroomJobStatus(jobId: string): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.get(
-        `/darkroom/generate/status/${jobId}`,
-      );
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('getting darkroom job status', error as ApiError);
-      throw new Error('Failed to get darkroom job status');
-    }
-  }
-
-  // ── Agent Chat Methods (CLI Parity) ──
-
-  async createChat(): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.post('/threads');
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('creating chat', error as ApiError);
-      throw new Error('Failed to create chat');
-    }
-  }
-
-  async sendChatMessage(
-    threadId: string,
-    message: string,
-  ): Promise<Record<string, unknown>> {
-    try {
-      const response = await this.client.post(`/threads/${threadId}/messages`, {
-        content: message,
-      });
-      return response.data?.data || response.data || {};
-    } catch (error: unknown) {
-      this.logError('sending chat message', error as ApiError);
-      throw new Error('Failed to send chat message');
-    }
-  }
-
-  // ── Ad Insights Methods (Content Loop) ──
-
-  async getAdPerformanceInsights(params?: {
+  getAdPerformanceInsights(params?: {
     industry?: string;
     platform?: string;
   }): Promise<unknown> {
-    try {
-      const response = await this.client.get('/ad-insights/benchmarks', {
-        params,
-      });
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('getting ad performance insights', error as ApiError);
-      throw new Error('Failed to get ad performance insights');
-    }
+    return this.ads.getAdPerformanceInsights(params);
   }
 
-  async getTopHeadlines(params?: {
+  getTopHeadlines(params?: {
     industry?: string;
     platform?: string;
   }): Promise<unknown[]> {
-    try {
-      const response = await this.client.get('/ad-insights/top-headlines', {
-        params,
-      });
-      return response.data?.data || response.data || [];
-    } catch (error: unknown) {
-      this.logError('getting top headlines', error as ApiError);
-      throw new Error('Failed to get top headlines');
-    }
+    return this.ads.getTopHeadlines(params);
   }
 
-  async suggestAdHeadlines(params: {
+  suggestAdHeadlines(params: {
     industry?: string;
     platform?: string;
     product?: string;
   }): Promise<unknown> {
-    try {
-      const response = await this.client.post(
-        '/ad-insights/suggest-headlines',
-        params,
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('suggesting ad headlines', error as ApiError);
-      throw new Error('Failed to suggest ad headlines');
-    }
+    return this.ads.suggestAdHeadlines(params);
   }
 
-  async generateAdVariations(params: {
+  generateAdVariations(params: {
     headline?: string;
     body?: string;
     platform?: string;
     count?: number;
   }): Promise<unknown> {
-    try {
-      const response = await this.client.post(
-        '/ad-insights/generate-variations',
-        params,
-      );
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('generating ad variations', error as ApiError);
-      throw new Error('Failed to generate ad variations');
-    }
+    return this.ads.generateAdVariations(params);
   }
 
-  async benchmarkAdPerformance(params?: {
+  benchmarkAdPerformance(params?: {
     industry?: string;
     platform?: string;
   }): Promise<unknown> {
-    try {
-      const response = await this.client.get('/ad-insights/benchmarks', {
-        params,
-      });
-      return response.data?.data || response.data;
-    } catch (error: unknown) {
-      this.logError('benchmarking ad performance', error as ApiError);
-      throw new Error('Failed to benchmark ad performance');
-    }
+    return this.ads.benchmarkAdPerformance(params);
   }
 
-  // ── LinkedIn Tools ──
+  // ── Darkroom / Training ──
 
-  async generateLinkedInContent(params: {
+  getDarkroomHealth(): Promise<Record<string, unknown>> {
+    return this.darkroom.getDarkroomHealth();
+  }
+
+  controlComfyUi(
+    action: string,
+    confirm?: boolean,
+  ): Promise<Record<string, unknown>> {
+    return this.darkroom.controlComfyUi(action, confirm);
+  }
+
+  listLoras(): Promise<unknown[]> {
+    return this.darkroom.listLoras();
+  }
+
+  listGpuPersonas(): Promise<unknown[]> {
+    return this.darkroom.listGpuPersonas();
+  }
+
+  startTraining(params: {
+    handle: string;
+    steps?: number;
+    rank?: number;
+    learningRate?: number;
+  }): Promise<Record<string, unknown>> {
+    return this.darkroom.startTraining(params);
+  }
+
+  getTrainingStatus(jobId: string): Promise<Record<string, unknown>> {
+    return this.darkroom.getTrainingStatus(jobId);
+  }
+
+  getDatasetInfo(handle: string): Promise<Record<string, unknown>> {
+    return this.darkroom.getDatasetInfo(handle);
+  }
+
+  deleteDataset(
+    handle: string,
+    confirm: boolean,
+  ): Promise<Record<string, unknown>> {
+    return this.darkroom.deleteDataset(handle, confirm);
+  }
+
+  runCaptioning(handle: string): Promise<Record<string, unknown>> {
+    return this.darkroom.runCaptioning(handle);
+  }
+
+  generateDarkroomContent(params: {
+    type: string;
+    prompt?: string;
+    count?: number;
+    personaHandle?: string;
+  }): Promise<Record<string, unknown>> {
+    return this.darkroom.generateDarkroomContent(params);
+  }
+
+  getDarkroomJobStatus(jobId: string): Promise<Record<string, unknown>> {
+    return this.darkroom.getDarkroomJobStatus(jobId);
+  }
+
+  // ── LinkedIn ──
+
+  generateLinkedInContent(params: {
     brandId?: string;
     topic: string;
     variationsCount?: number;
@@ -1697,104 +572,23 @@ export class ClientService {
       hook: string;
     }>
   > {
-    this.logger.debug('Generating LinkedIn content', { params });
-
-    try {
-      const response = await this.client.post(
-        '/content-intelligence/generate',
-        {
-          brandId: params.brandId,
-          platform: 'linkedin',
-          topic: params.topic,
-          variationsCount: params.variationsCount || 3,
-        },
-      );
-
-      return (
-        response.data?.data?.map(
-          (item: {
-            attributes?: {
-              body?: string;
-              content?: string;
-              cta?: string;
-              hashtags?: string[];
-              hook?: string;
-            };
-          }) => ({
-            body: item.attributes?.body || '',
-            content: item.attributes?.content || '',
-            cta: item.attributes?.cta || '',
-            hashtags: item.attributes?.hashtags || [],
-            hook: item.attributes?.hook || '',
-          }),
-        ) || []
-      );
-    } catch (error: unknown) {
-      this.logError('generating LinkedIn content', error as ApiError);
-      throw new Error('Failed to generate LinkedIn content');
-    }
+    return this.linkedin.generateLinkedInContent(params);
   }
 
-  async getLinkedInConnectionStatus(): Promise<{
+  getLinkedInConnectionStatus(): Promise<{
     avatar: string | null;
     connected: boolean;
     handle: string | null;
     name: string | null;
     platform: string;
   }> {
-    this.logger.debug('Getting LinkedIn connection status');
-
-    try {
-      const response = await this.client.get('/credentials/mentions');
-      const mentions = response.data?.mentions || [];
-      const linkedin = mentions.find(
-        (m: { platform?: string }) => m.platform === 'linkedin',
-      );
-
-      if (linkedin) {
-        return {
-          avatar: linkedin.avatar || null,
-          connected: true,
-          handle: linkedin.handle || null,
-          name: linkedin.name || null,
-          platform: 'linkedin',
-        };
-      }
-
-      return {
-        avatar: null,
-        connected: false,
-        handle: null,
-        name: null,
-        platform: 'linkedin',
-      };
-    } catch (error: unknown) {
-      this.logError('getting LinkedIn connection status', error as ApiError);
-      throw new Error('Failed to get LinkedIn connection status');
-    }
+    return this.linkedin.getLinkedInConnectionStatus();
   }
 
-  async getLinkedInAnalytics(
+  getLinkedInAnalytics(
     contentId: string,
     timeRange: string = '7d',
   ): Promise<Record<string, unknown>> {
-    this.logger.debug('Getting LinkedIn analytics', { contentId, timeRange });
-
-    try {
-      const response = await this.client.get(
-        `/content-performance/${contentId}`,
-        {
-          params: {
-            platform: 'linkedin',
-            timeRange,
-          },
-        },
-      );
-
-      return response.data?.data?.attributes || response.data?.data || {};
-    } catch (error: unknown) {
-      this.logError('getting LinkedIn analytics', error as ApiError);
-      throw new Error('Failed to get LinkedIn analytics');
-    }
+    return this.linkedin.getLinkedInAnalytics(contentId, timeRange);
   }
 }

--- a/apps/server/mcp/src/services/client/ads.client.ts
+++ b/apps/server/mcp/src/services/client/ads.client.ts
@@ -1,0 +1,330 @@
+import type { BaseApiClient } from './base-api-client';
+
+/** Meta Ads, Google Ads, and ad-insights (content-loop) read/generate methods. */
+export class AdsClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  // ── Meta Ads ──
+
+  listMetaAdAccounts(): Promise<unknown[]> {
+    return this.base.request(
+      'listing Meta ad accounts',
+      async (http) =>
+        this.base.unwrapList(await http.get('/integrations/meta-ads/accounts')),
+      this.base.failWith('Failed to list Meta ad accounts'),
+    );
+  }
+
+  listMetaCampaigns(
+    adAccountId: string,
+    status?: string,
+    limit?: number,
+  ): Promise<unknown[]> {
+    return this.base.request(
+      'listing Meta campaigns',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/integrations/meta-ads/campaigns', {
+            params: { adAccountId, limit, status },
+          }),
+        ),
+      this.base.failWith('Failed to list Meta campaigns'),
+    );
+  }
+
+  getMetaCampaignInsights(
+    campaignId: string,
+    datePreset?: string,
+    since?: string,
+    until?: string,
+  ): Promise<unknown> {
+    return this.base.request(
+      'getting Meta campaign insights',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get(
+            `/integrations/meta-ads/campaigns/${campaignId}/insights`,
+            { params: { datePreset, since, until } },
+          ),
+        ),
+      this.base.failWith('Failed to get Meta campaign insights'),
+    );
+  }
+
+  getMetaAdSetInsights(adSetId: string, datePreset?: string): Promise<unknown> {
+    return this.base.request(
+      'getting Meta ad set insights',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get(`/integrations/meta-ads/adsets/${adSetId}/insights`, {
+            params: { datePreset },
+          }),
+        ),
+      this.base.failWith('Failed to get Meta ad set insights'),
+    );
+  }
+
+  getMetaAdInsights(adId: string, datePreset?: string): Promise<unknown> {
+    return this.base.request(
+      'getting Meta ad insights',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get(`/integrations/meta-ads/ads/${adId}/insights`, {
+            params: { datePreset },
+          }),
+        ),
+      this.base.failWith('Failed to get Meta ad insights'),
+    );
+  }
+
+  listMetaAdCreatives(adAccountId: string, limit?: number): Promise<unknown[]> {
+    return this.base.request(
+      'listing Meta ad creatives',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/integrations/meta-ads/creatives', {
+            params: { adAccountId, limit },
+          }),
+        ),
+      this.base.failWith('Failed to list Meta ad creatives'),
+    );
+  }
+
+  compareMetaCampaigns(
+    campaignIds: string[],
+    datePreset?: string,
+  ): Promise<unknown> {
+    return this.base.request(
+      'comparing Meta campaigns',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get('/integrations/meta-ads/campaigns/compare', {
+            params: { campaignIds: campaignIds.join(','), datePreset },
+          }),
+        ),
+      this.base.failWith('Failed to compare Meta campaigns'),
+    );
+  }
+
+  getMetaTopPerformers(
+    adAccountId: string,
+    metric: string,
+    limit?: number,
+  ): Promise<unknown[]> {
+    return this.base.request(
+      'getting Meta top performers',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/integrations/meta-ads/top-performers', {
+            params: { adAccountId, limit, metric },
+          }),
+        ),
+      this.base.failWith('Failed to get Meta top performers'),
+    );
+  }
+
+  // ── Google Ads ──
+
+  listGoogleAdsCustomers(): Promise<unknown[]> {
+    return this.base.request(
+      'listing Google Ads customers',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/integrations/google-ads/customers'),
+        ),
+      this.base.failWith('Failed to list Google Ads customers'),
+    );
+  }
+
+  listGoogleAdsCampaigns(
+    customerId: string,
+    status?: string,
+    limit?: number,
+    loginCustomerId?: string,
+  ): Promise<unknown[]> {
+    return this.base.request(
+      'listing Google Ads campaigns',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/integrations/google-ads/campaigns', {
+            params: { customerId, limit, loginCustomerId, status },
+          }),
+        ),
+      this.base.failWith('Failed to list Google Ads campaigns'),
+    );
+  }
+
+  getGoogleAdsCampaignMetrics(
+    customerId: string,
+    campaignId: string,
+    startDate?: string,
+    endDate?: string,
+    segmentByDate?: boolean,
+    loginCustomerId?: string,
+  ): Promise<unknown> {
+    return this.base.request(
+      'getting Google Ads campaign metrics',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get(
+            `/integrations/google-ads/campaigns/${campaignId}/metrics`,
+            {
+              params: {
+                customerId,
+                endDate,
+                loginCustomerId,
+                segmentByDate,
+                startDate,
+              },
+            },
+          ),
+        ),
+      this.base.failWith('Failed to get Google Ads campaign metrics'),
+    );
+  }
+
+  getGoogleAdsAdGroupInsights(
+    customerId: string,
+    adGroupId: string,
+    startDate?: string,
+    endDate?: string,
+    loginCustomerId?: string,
+  ): Promise<unknown> {
+    return this.base.request(
+      'getting Google Ads ad group insights',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get(
+            `/integrations/google-ads/ad-groups/${adGroupId}/insights`,
+            {
+              params: { customerId, endDate, loginCustomerId, startDate },
+            },
+          ),
+        ),
+      this.base.failWith('Failed to get Google Ads ad group insights'),
+    );
+  }
+
+  getGoogleAdsKeywordPerformance(
+    customerId: string,
+    startDate?: string,
+    endDate?: string,
+    limit?: number,
+    loginCustomerId?: string,
+  ): Promise<unknown[]> {
+    return this.base.request(
+      'getting Google Ads keyword performance',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/integrations/google-ads/keywords', {
+            params: { customerId, endDate, limit, loginCustomerId, startDate },
+          }),
+        ),
+      this.base.failWith('Failed to get Google Ads keyword performance'),
+    );
+  }
+
+  getGoogleAdsSearchTerms(
+    customerId: string,
+    campaignId: string,
+    startDate?: string,
+    endDate?: string,
+    limit?: number,
+    loginCustomerId?: string,
+  ): Promise<unknown[]> {
+    return this.base.request(
+      'getting Google Ads search terms',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get(
+            `/integrations/google-ads/search-terms/${campaignId}`,
+            {
+              params: {
+                customerId,
+                endDate,
+                limit,
+                loginCustomerId,
+                startDate,
+              },
+            },
+          ),
+        ),
+      this.base.failWith('Failed to get Google Ads search terms'),
+    );
+  }
+
+  // ── Ad Insights (Content Loop) ──
+
+  getAdPerformanceInsights(params?: {
+    industry?: string;
+    platform?: string;
+  }): Promise<unknown> {
+    return this.base.request(
+      'getting ad performance insights',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get('/ad-insights/benchmarks', { params }),
+        ),
+      this.base.failWith('Failed to get ad performance insights'),
+    );
+  }
+
+  getTopHeadlines(params?: {
+    industry?: string;
+    platform?: string;
+  }): Promise<unknown[]> {
+    return this.base.request(
+      'getting top headlines',
+      async (http) =>
+        this.base.unwrapList(
+          await http.get('/ad-insights/top-headlines', { params }),
+        ),
+      this.base.failWith('Failed to get top headlines'),
+    );
+  }
+
+  suggestAdHeadlines(params: {
+    industry?: string;
+    platform?: string;
+    product?: string;
+  }): Promise<unknown> {
+    return this.base.request(
+      'suggesting ad headlines',
+      async (http) =>
+        this.base.unwrapData(
+          await http.post('/ad-insights/suggest-headlines', params),
+        ),
+      this.base.failWith('Failed to suggest ad headlines'),
+    );
+  }
+
+  generateAdVariations(params: {
+    headline?: string;
+    body?: string;
+    platform?: string;
+    count?: number;
+  }): Promise<unknown> {
+    return this.base.request(
+      'generating ad variations',
+      async (http) =>
+        this.base.unwrapData(
+          await http.post('/ad-insights/generate-variations', params),
+        ),
+      this.base.failWith('Failed to generate ad variations'),
+    );
+  }
+
+  benchmarkAdPerformance(params?: {
+    industry?: string;
+    platform?: string;
+  }): Promise<unknown> {
+    return this.base.request(
+      'benchmarking ad performance',
+      async (http) =>
+        this.base.unwrapData(
+          await http.get('/ad-insights/benchmarks', { params }),
+        ),
+      this.base.failWith('Failed to benchmark ad performance'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/agent.client.ts
+++ b/apps/server/mcp/src/services/client/agent.client.ts
@@ -1,0 +1,115 @@
+import type { AgentToolResult } from '@genfeedai/interfaces';
+import type {
+  McpApprovalDecision,
+  McpApprovalResource,
+} from '@mcp/shared/interfaces/approval.interface';
+import type { BaseApiClient } from './base-api-client';
+
+/**
+ * Agent-tool proxying and the human-in-the-loop approval lifecycle for mutating
+ * MCP tool calls.
+ */
+export class AgentClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  executeAgentTool(
+    name: string,
+    parameters: Record<string, unknown>,
+    context?: Record<string, unknown>,
+  ): Promise<AgentToolResult> {
+    this.base.logger.debug(`Proxying agent tool ${name}`);
+
+    return this.base.request(
+      `executing agent tool ${name}`,
+      async (http) => {
+        const response = await http.post(
+          `/agent-tools/${encodeURIComponent(name)}/execute`,
+          { context, parameters },
+        );
+        return response.data as AgentToolResult;
+      },
+      this.base.failWithDetail(`Failed to execute ${name}`),
+    );
+  }
+
+  /**
+   * Persist a PENDING approval for a mutating MCP tool call. The API notifies a
+   * reviewer; nothing executes until the approval is resolved.
+   */
+  createApproval(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<McpApprovalResource> {
+    return this.base.request(
+      `creating approval for ${toolName}`,
+      async (http) => {
+        const response = await http.post('/mcp-approvals', {
+          arguments: args,
+          toolName,
+        });
+        return response.data?.data as McpApprovalResource;
+      },
+      this.base.failWithDetail(`Failed to create approval for ${toolName}`),
+    );
+  }
+
+  getApproval(approvalId: string): Promise<McpApprovalResource | null> {
+    return this.base.request(
+      `fetching approval ${approvalId}`,
+      async (http) => {
+        const response = await http.get(
+          `/mcp-approvals/${encodeURIComponent(approvalId)}`,
+        );
+        return (response.data?.data as McpApprovalResource) ?? null;
+      },
+      this.base.failWithDetail('Failed to fetch approval'),
+    );
+  }
+
+  /**
+   * Resolve an approval (atomic CLAIM on the API: PENDING -> APPROVED/DECLINED).
+   * Throws if the approval was already resolved, which is what lets the caller
+   * gate tool execution on a successful claim. The optional `result` is accepted
+   * for completeness, but the MCP flow persists the execution outcome separately
+   * via {@link attachApprovalResult} after the tool has run.
+   */
+  resolveApproval(
+    approvalId: string,
+    decision: McpApprovalDecision,
+    result?: Record<string, unknown>,
+  ): Promise<McpApprovalResource> {
+    return this.base.request(
+      `resolving approval ${approvalId}`,
+      async (http) => {
+        const response = await http.post(
+          `/mcp-approvals/${encodeURIComponent(approvalId)}/resolve`,
+          { decision, ...(result ? { result } : {}) },
+        );
+        return response.data?.data as McpApprovalResource;
+      },
+      this.base.failWithDetail('Failed to resolve approval'),
+    );
+  }
+
+  /**
+   * Attach the tool execution result (or error) to an already-APPROVED approval.
+   * Called after the approval has been atomically claimed via {@link resolveApproval}
+   * and the tool has run, so the audit record reflects the outcome.
+   */
+  attachApprovalResult(
+    approvalId: string,
+    result: Record<string, unknown>,
+  ): Promise<McpApprovalResource> {
+    return this.base.request(
+      `attaching result to approval ${approvalId}`,
+      async (http) => {
+        const response = await http.post(
+          `/mcp-approvals/${encodeURIComponent(approvalId)}/result`,
+          { result },
+        );
+        return response.data?.data as McpApprovalResource;
+      },
+      this.base.failWithDetail('Failed to attach approval result'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/analytics.client.ts
+++ b/apps/server/mcp/src/services/client/analytics.client.ts
@@ -1,0 +1,92 @@
+import type {
+  Analytics,
+  OrganizationAnalytics,
+} from '@mcp/shared/interfaces/analytics.interface';
+import type { BaseApiClient } from './base-api-client';
+
+/**
+ * Read-only analytics rollups. Unlike most client methods, these never throw —
+ * on error they log and return an empty-but-shaped result so dashboards degrade
+ * gracefully.
+ */
+export class AnalyticsClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  getVideoAnalytics(
+    videoId?: string,
+    timeRange: string = '7d',
+  ): Promise<Analytics> {
+    this.base.logger.debug(
+      `Getting video analytics: videoId=${videoId}, timeRange=${timeRange}`,
+    );
+
+    const emptyAnalytics: Analytics = {
+      averageWatchTime: 0,
+      comments: 0,
+      engagement: 0,
+      likes: 0,
+      shares: 0,
+      timeRange,
+      videoId: videoId || 'all',
+      views: 0,
+    };
+
+    return this.base.request<Analytics>(
+      'getting video analytics',
+      async (http) => {
+        const endpoint = videoId
+          ? `/analytics/videos/${videoId}`
+          : '/analytics/videos';
+        const response = await http.get(endpoint, {
+          params: { timeRange },
+        });
+        const data = response.data?.data?.attributes || {};
+
+        return {
+          ...emptyAnalytics,
+          averageWatchTime: data.averageWatchTime || 0,
+          comments: data.comments || 0,
+          engagement: data.engagement || 0,
+          likes: data.likes || 0,
+          shares: data.shares || 0,
+          views: data.views || 0,
+        };
+      },
+      () => emptyAnalytics,
+    );
+  }
+
+  getOrganizationAnalytics(): Promise<OrganizationAnalytics> {
+    this.base.logger.debug('Getting organization analytics');
+
+    const emptyOrgAnalytics: OrganizationAnalytics = {
+      activeUsers: 0,
+      averageVideoLength: 0,
+      growthRate: 0,
+      topPerformingVideos: [],
+      totalEngagement: 0,
+      totalVideos: 0,
+      totalViews: 0,
+    };
+
+    return this.base.request<OrganizationAnalytics>(
+      'getting organization analytics',
+      async (http) => {
+        const response = await http.get('/analytics/organization');
+        const data = response.data?.data?.attributes || {};
+
+        return {
+          ...emptyOrgAnalytics,
+          activeUsers: data.activeUsers || 0,
+          averageVideoLength: data.averageVideoLength || 0,
+          growthRate: data.growthRate || 0,
+          topPerformingVideos: data.topPerformingVideos || [],
+          totalEngagement: data.totalEngagement || 0,
+          totalVideos: data.totalVideos || 0,
+          totalViews: data.totalViews || 0,
+        };
+      },
+      () => emptyOrgAnalytics,
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/base-api-client.ts
+++ b/apps/server/mcp/src/services/client/base-api-client.ts
@@ -1,0 +1,126 @@
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { ConfigService } from '@mcp/config/config.service';
+import { resolveApiBaseUrl } from '@mcp/shared/utils/api-url.util';
+import type { HttpService } from '@nestjs/axios';
+import type { AxiosInstance, AxiosResponse } from 'axios';
+import type { ApiError } from './client.types';
+
+/**
+ * Low-level HTTP foundation shared by every domain client.
+ *
+ * Owns the single axios instance — so {@link setBearerToken} propagates to all
+ * sub-clients that compose this base — plus the canonical request/error shell
+ * and the JSON:API response-unwrap helpers. Domain clients receive one instance
+ * of this class and route every call through {@link request}, which replaces the
+ * ~52 copies of try/catch/logError/throw that previously lived inline.
+ */
+export class BaseApiClient {
+  private readonly http: AxiosInstance;
+  private bearerToken: string;
+
+  constructor(
+    readonly logger: LoggerService,
+    httpService: HttpService,
+    configService: ConfigService,
+  ) {
+    this.bearerToken = (configService.get('GENFEEDAI_API_KEY') as string) || '';
+    const baseURL = resolveApiBaseUrl(
+      configService.get('GENFEEDAI_API_URL') as string | undefined,
+    );
+
+    this.http = httpService.axiosRef.create({
+      baseURL,
+      headers: {
+        Authorization: `Bearer ${this.bearerToken}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 30000,
+    });
+  }
+
+  setBearerToken(token: string): void {
+    this.bearerToken = token;
+    this.http.defaults.headers.Authorization = `Bearer ${token}`;
+  }
+
+  /**
+   * Canonical request shell. Runs `call` against the shared axios instance and,
+   * on failure, logs once via {@link logError} then hands the error to
+   * `onError` — which either throws (see {@link failWith} / {@link failWithDetail})
+   * or returns a fallback value (e.g. an empty-analytics object).
+   */
+  async request<T>(
+    operation: string,
+    call: (http: AxiosInstance) => Promise<T>,
+    onError: (error: ApiError) => T,
+  ): Promise<T> {
+    try {
+      return await call(this.http);
+    } catch (error: unknown) {
+      this.logError(operation, error as ApiError);
+      return onError(error as ApiError);
+    }
+  }
+
+  /** `onError` factory: throw a fixed message (the bare-throw methods). */
+  failWith(message: string): (error: ApiError) => never {
+    return () => {
+      throw new Error(message);
+    };
+  }
+
+  /** `onError` factory: prefer the API-supplied error detail, else `defaultMessage`. */
+  failWithDetail(defaultMessage: string): (error: ApiError) => never {
+    return (error: ApiError) => {
+      throw new Error(this.getErrorMessage(error, defaultMessage));
+    };
+  }
+
+  getErrorMessage(error: ApiError, defaultMessage: string): string {
+    return error.response?.data?.errors?.[0]?.detail || defaultMessage;
+  }
+
+  logError(operation: string, error: ApiError): void {
+    this.logger.error(`Error ${operation}`, error.message, {
+      data: error.response?.data,
+    });
+  }
+
+  // ── Response unwrap helpers (JSON:API `{ data: { ... } }` envelope) ──
+
+  /** `data.data` → `data` → `[]`. */
+  unwrapList<T = unknown>(response: AxiosResponse): T[] {
+    return (response.data?.data || response.data || []) as T[];
+  }
+
+  /** `data.data` → `data` (no fallback). */
+  unwrapData<T = unknown>(response: AxiosResponse): T {
+    return (response.data?.data || response.data) as T;
+  }
+
+  /** `data.data` → `data` → `{}`. */
+  unwrapObject<T = Record<string, unknown>>(response: AxiosResponse): T {
+    return (response.data?.data || response.data || {}) as T;
+  }
+
+  /** `data.data.attributes` → `data.data` → `{}`. */
+  unwrapAttributes<T = Record<string, unknown>>(response: AxiosResponse): T {
+    return (response.data?.data?.attributes || response.data?.data || {}) as T;
+  }
+
+  /**
+   * Generic attribute POST proxy: posts `payload` and returns the created
+   * resource's attributes. Intentionally unguarded — raw axios errors
+   * propagate to the caller, matching prior behavior. Note the nullish (`??`)
+   * unwrap here is deliberately distinct from {@link unwrapAttributes}'s `||`
+   * form: callers expect `null`/empty attributes to pass through untouched.
+   */
+  async postAttributes<TResponse>(
+    endpoint: string,
+    payload: Record<string, unknown>,
+  ): Promise<TResponse> {
+    const response = await this.http.post(endpoint, payload);
+    return (response.data?.data?.attributes ??
+      response.data?.data) as TResponse;
+  }
+}

--- a/apps/server/mcp/src/services/client/client.types.ts
+++ b/apps/server/mcp/src/services/client/client.types.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared types and constants for the MCP API client family.
+ *
+ * The client surface used to live in a single 1,800-line `client.service.ts`.
+ * It is now split into a {@link BaseApiClient} foundation plus per-domain
+ * client classes; these types are the small shared vocabulary between them.
+ */
+
+/** Shape of an axios error carrying a JSON:API error envelope. */
+export interface ApiError {
+  response?: {
+    data?: { errors?: Array<{ detail?: string }> };
+  };
+  message?: string;
+}
+
+export interface BrandResponse {
+  id: string;
+  name: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface PersonaResponse {
+  id: string;
+  name: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface CreateBatchParams {
+  brandId: string;
+  count: number;
+  platforms: string[];
+  topics?: string[];
+  dateRange?: { start: string; end: string };
+  style?: string;
+}
+
+export interface ListBatchesParams {
+  batchId?: string;
+  status?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Canonical fallback status strings for resource responses. Centralized here so
+ * the defaults no longer drift across methods (e.g. a created resource is
+ * `processing`, a listed one is `completed`). Values are unchanged from the
+ * previous inline literals.
+ */
+export const CONTENT_STATUS = {
+  COMPLETED: 'completed',
+  DRAFT: 'draft',
+  PENDING: 'pending',
+  PROCESSING: 'processing',
+  PUBLISHED: 'published',
+  UNKNOWN: 'unknown',
+} as const;

--- a/apps/server/mcp/src/services/client/content.client.ts
+++ b/apps/server/mcp/src/services/client/content.client.ts
@@ -1,0 +1,233 @@
+import type {
+  ArticleResource,
+  PostResource,
+  TrendResource,
+} from '@mcp/shared/interfaces/api-response.interface';
+import type {
+  ArticleCreationParams,
+  ArticleResponse,
+  ArticleSearchParams,
+  ArticleSearchResult,
+} from '@mcp/shared/interfaces/article.interface';
+import type {
+  PostListParams,
+  PostResponse,
+  PublishContentParams,
+  SocialPlatform,
+  TrendingTopic,
+  TrendingTopicsParams,
+} from '@mcp/shared/interfaces/post.interface';
+import type { BaseApiClient } from './base-api-client';
+import { CONTENT_STATUS } from './client.types';
+
+/** Articles, social posts/publishing, and trending topics. */
+export class ContentClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  createArticle(params: ArticleCreationParams): Promise<ArticleResponse> {
+    this.base.logger.debug('Creating article', { params });
+
+    return this.base.request(
+      'creating article',
+      async (http) => {
+        const response = await http.post('/articles/generations', {
+          data: {
+            attributes: {
+              keywords: params.keywords || [],
+              length: params.length || 'medium',
+              targetAudience: params.targetAudience,
+              tone: params.tone || 'professional',
+              topic: params.topic,
+            },
+            type: 'articles',
+          },
+        });
+
+        const article = response.data?.data;
+        return {
+          content: article?.attributes?.content || '',
+          createdAt: article?.attributes?.createdAt || new Date().toISOString(),
+          id: article?.id || article?.attributes?.id,
+          status: article?.attributes?.status || CONTENT_STATUS.PROCESSING,
+          title: article?.attributes?.title || params.topic,
+          wordCount: article?.attributes?.wordCount || 0,
+        };
+      },
+      this.base.failWithDetail('Failed to create article'),
+    );
+  }
+
+  searchArticles(params: ArticleSearchParams): Promise<ArticleSearchResult[]> {
+    this.base.logger.debug('Searching articles', { params });
+
+    return this.base.request(
+      'searching articles',
+      async (http) => {
+        const response = await http.get('/articles', {
+          params: {
+            'filter[category]': params.category,
+            'filter[search]': params.query,
+            'page[limit]': params.limit || 10,
+            'page[offset]': params.offset || 0,
+          },
+        });
+
+        return (
+          response.data?.data?.map((article: ArticleResource) => ({
+            category: article.attributes?.category,
+            createdAt: article.attributes?.createdAt,
+            excerpt:
+              article.attributes?.excerpt ||
+              article.attributes?.content?.substring(0, 200),
+            id: article.id,
+            title: article.attributes?.title,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to search articles'),
+    );
+  }
+
+  getArticle(articleId: string): Promise<ArticleResponse> {
+    this.base.logger.debug(`Getting article: ${articleId}`);
+
+    return this.base.request(
+      'getting article',
+      async (http) => {
+        const response = await http.get(`/articles/${articleId}`);
+        const article = response.data?.data;
+
+        return {
+          content: article?.attributes?.content || '',
+          createdAt: article?.attributes?.createdAt,
+          id: article?.id,
+          status: article?.attributes?.status || CONTENT_STATUS.PUBLISHED,
+          title: article?.attributes?.title,
+          updatedAt: article?.attributes?.updatedAt,
+          wordCount: article?.attributes?.wordCount || 0,
+        };
+      },
+      this.base.failWith('Failed to get article'),
+    );
+  }
+
+  publishContent(params: PublishContentParams): Promise<PostResponse[]> {
+    this.base.logger.debug('Publishing content', { params });
+
+    return this.base.request(
+      'publishing content',
+      async (http) => {
+        const response = await http.post('/posts', {
+          data: {
+            attributes: {
+              contentId: params.contentId,
+              customMessage: params.customMessage,
+              platforms: params.platforms,
+              scheduleAt: params.scheduleAt,
+            },
+            type: 'posts',
+          },
+        });
+
+        const posts = response.data?.data;
+        if (Array.isArray(posts)) {
+          return posts.map((post: PostResource, index: number) => ({
+            contentId: params.contentId,
+            createdAt: post.attributes?.createdAt || new Date().toISOString(),
+            id: post.id,
+            platform:
+              (post.attributes?.platform as SocialPlatform) ||
+              params.platforms[index] ||
+              params.platforms[0],
+            publishedAt: post.attributes?.publishedAt,
+            publishedUrl: post.attributes?.publishedUrl,
+            scheduledAt: post.attributes?.scheduledAt,
+            status:
+              (post.attributes?.status as PostResponse['status']) || 'pending',
+          }));
+        }
+
+        return [
+          {
+            contentId: params.contentId,
+            createdAt: posts?.attributes?.createdAt || new Date().toISOString(),
+            id: posts?.id,
+            platform:
+              (posts?.attributes?.platform as SocialPlatform) ||
+              params.platforms[0],
+            publishedAt: posts?.attributes?.publishedAt,
+            publishedUrl: posts?.attributes?.publishedUrl,
+            scheduledAt: posts?.attributes?.scheduledAt,
+            status:
+              (posts?.attributes?.status as PostResponse['status']) ||
+              'pending',
+          },
+        ];
+      },
+      this.base.failWithDetail('Failed to publish content'),
+    );
+  }
+
+  listPosts(params: PostListParams = {}): Promise<PostResponse[]> {
+    this.base.logger.debug('Listing posts', { params });
+
+    return this.base.request(
+      'listing posts',
+      async (http) => {
+        const queryParams: Record<string, string | number> = {
+          'page[limit]': params.limit || 10,
+          'page[offset]': params.offset || 0,
+        };
+
+        if (params.platform && params.platform !== 'all') {
+          queryParams['filter[platform]'] = params.platform;
+        }
+
+        const response = await http.get('/posts', { params: queryParams });
+
+        return (
+          response.data?.data?.map((post: PostResource) => ({
+            contentId: post.attributes?.contentId,
+            createdAt: post.attributes?.createdAt,
+            id: post.id,
+            platform: post.attributes?.platform,
+            publishedAt: post.attributes?.publishedAt,
+            publishedUrl: post.attributes?.publishedUrl,
+            scheduledAt: post.attributes?.scheduledAt,
+            status: post.attributes?.status || CONTENT_STATUS.PUBLISHED,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list posts'),
+    );
+  }
+
+  getTrendingTopics(
+    params: TrendingTopicsParams = {},
+  ): Promise<TrendingTopic[]> {
+    this.base.logger.debug('Getting trending topics', { params });
+
+    return this.base.request(
+      'getting trending topics',
+      async (http) => {
+        const response = await http.get('/trends', {
+          params: {
+            category: params.category || 'all',
+            timeframe: params.timeframe || '24h',
+          },
+        });
+
+        return (
+          response.data?.data?.map((trend: TrendResource) => ({
+            category: trend.attributes?.category || params.category || 'all',
+            growth: trend.attributes?.growth || 0,
+            relatedKeywords: trend.attributes?.relatedKeywords || [],
+            topic: trend.attributes?.topic || trend.attributes?.name,
+            volume: trend.attributes?.volume || 0,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to get trending topics'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/darkroom.client.ts
+++ b/apps/server/mcp/src/services/client/darkroom.client.ts
@@ -1,0 +1,139 @@
+import type { BaseApiClient } from './base-api-client';
+
+/**
+ * Darkroom (GPU pipeline) admin/infrastructure, LoRA training, and on-box
+ * generation methods — CLI parity surface.
+ */
+export class DarkroomClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  // ── Admin / Infrastructure ──
+
+  getDarkroomHealth(): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'getting darkroom health',
+      async (http) =>
+        this.base.unwrapObject(await http.get('/darkroom/health')),
+      this.base.failWith('Failed to get darkroom health'),
+    );
+  }
+
+  controlComfyUi(
+    action: string,
+    confirm?: boolean,
+  ): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'controlling ComfyUI',
+      async (http) =>
+        this.base.unwrapObject(
+          await http.post('/darkroom/comfyui/control', { action, confirm }),
+        ),
+      this.base.failWith('Failed to control ComfyUI'),
+    );
+  }
+
+  listLoras(): Promise<unknown[]> {
+    return this.base.request(
+      'listing LoRAs',
+      async (http) => this.base.unwrapList(await http.get('/darkroom/loras')),
+      this.base.failWith('Failed to list LoRAs'),
+    );
+  }
+
+  listGpuPersonas(): Promise<unknown[]> {
+    return this.base.request(
+      'listing GPU personas',
+      async (http) =>
+        this.base.unwrapList(await http.get('/darkroom/personas')),
+      this.base.failWith('Failed to list GPU personas'),
+    );
+  }
+
+  // ── Training Pipeline ──
+
+  startTraining(params: {
+    handle: string;
+    steps?: number;
+    rank?: number;
+    learningRate?: number;
+  }): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'starting training',
+      async (http) =>
+        this.base.unwrapObject(await http.post('/training/start', params)),
+      this.base.failWith('Failed to start training'),
+    );
+  }
+
+  getTrainingStatus(jobId: string): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'getting training status',
+      async (http) =>
+        this.base.unwrapObject(await http.get(`/training/status/${jobId}`)),
+      this.base.failWith('Failed to get training status'),
+    );
+  }
+
+  getDatasetInfo(handle: string): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'getting dataset info',
+      async (http) =>
+        this.base.unwrapObject(await http.get(`/datasets/${handle}`)),
+      this.base.failWith('Failed to get dataset info'),
+    );
+  }
+
+  deleteDataset(
+    handle: string,
+    confirm: boolean,
+  ): Promise<Record<string, unknown>> {
+    if (!confirm) {
+      return Promise.resolve({
+        message: `This will permanently delete dataset "${handle}". Pass confirm: true to proceed.`,
+        preview: true,
+      });
+    }
+    return this.base.request(
+      'deleting dataset',
+      async (http) =>
+        this.base.unwrapObject(await http.delete(`/datasets/${handle}`)),
+      this.base.failWith('Failed to delete dataset'),
+    );
+  }
+
+  runCaptioning(handle: string): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'running captioning',
+      async (http) =>
+        this.base.unwrapObject(await http.post(`/datasets/${handle}/caption`)),
+      this.base.failWith('Failed to run captioning'),
+    );
+  }
+
+  // ── Darkroom Generation ──
+
+  generateDarkroomContent(params: {
+    type: string;
+    prompt?: string;
+    count?: number;
+    personaHandle?: string;
+  }): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'generating darkroom content',
+      async (http) =>
+        this.base.unwrapObject(await http.post('/darkroom/generate', params)),
+      this.base.failWith('Failed to generate darkroom content'),
+    );
+  }
+
+  getDarkroomJobStatus(jobId: string): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'getting darkroom job status',
+      async (http) =>
+        this.base.unwrapObject(
+          await http.get(`/darkroom/generate/status/${jobId}`),
+        ),
+      this.base.failWith('Failed to get darkroom job status'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/linkedin.client.ts
+++ b/apps/server/mcp/src/services/client/linkedin.client.ts
@@ -1,0 +1,120 @@
+import type { BaseApiClient } from './base-api-client';
+
+/** LinkedIn content generation, connection status, and analytics tools. */
+export class LinkedInClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  generateLinkedInContent(params: {
+    brandId?: string;
+    topic: string;
+    variationsCount?: number;
+  }): Promise<
+    Array<{
+      body: string;
+      content: string;
+      cta: string;
+      hashtags: string[];
+      hook: string;
+    }>
+  > {
+    this.base.logger.debug('Generating LinkedIn content', { params });
+
+    return this.base.request(
+      'generating LinkedIn content',
+      async (http) => {
+        const response = await http.post('/content-intelligence/generate', {
+          brandId: params.brandId,
+          platform: 'linkedin',
+          topic: params.topic,
+          variationsCount: params.variationsCount || 3,
+        });
+
+        return (
+          response.data?.data?.map(
+            (item: {
+              attributes?: {
+                body?: string;
+                content?: string;
+                cta?: string;
+                hashtags?: string[];
+                hook?: string;
+              };
+            }) => ({
+              body: item.attributes?.body || '',
+              content: item.attributes?.content || '',
+              cta: item.attributes?.cta || '',
+              hashtags: item.attributes?.hashtags || [],
+              hook: item.attributes?.hook || '',
+            }),
+          ) || []
+        );
+      },
+      this.base.failWith('Failed to generate LinkedIn content'),
+    );
+  }
+
+  getLinkedInConnectionStatus(): Promise<{
+    avatar: string | null;
+    connected: boolean;
+    handle: string | null;
+    name: string | null;
+    platform: string;
+  }> {
+    this.base.logger.debug('Getting LinkedIn connection status');
+
+    return this.base.request(
+      'getting LinkedIn connection status',
+      async (http) => {
+        const response = await http.get('/credentials/mentions');
+        const mentions = response.data?.mentions || [];
+        const linkedin = mentions.find(
+          (m: { platform?: string }) => m.platform === 'linkedin',
+        );
+
+        if (linkedin) {
+          return {
+            avatar: linkedin.avatar || null,
+            connected: true,
+            handle: linkedin.handle || null,
+            name: linkedin.name || null,
+            platform: 'linkedin',
+          };
+        }
+
+        return {
+          avatar: null,
+          connected: false,
+          handle: null,
+          name: null,
+          platform: 'linkedin',
+        };
+      },
+      this.base.failWith('Failed to get LinkedIn connection status'),
+    );
+  }
+
+  getLinkedInAnalytics(
+    contentId: string,
+    timeRange: string = '7d',
+  ): Promise<Record<string, unknown>> {
+    this.base.logger.debug('Getting LinkedIn analytics', {
+      contentId,
+      timeRange,
+    });
+
+    return this.base.request(
+      'getting LinkedIn analytics',
+      async (http) => {
+        const response = await http.get(`/content-performance/${contentId}`, {
+          params: {
+            platform: 'linkedin',
+            timeRange,
+          },
+        });
+
+        return this.base.unwrapAttributes(response);
+      },
+      this.base.failWith('Failed to get LinkedIn analytics'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/media.client.ts
+++ b/apps/server/mcp/src/services/client/media.client.ts
@@ -1,0 +1,308 @@
+import type {
+  AvatarResource,
+  ImageResource,
+  MusicResource,
+  VideoResource,
+} from '@mcp/shared/interfaces/api-response.interface';
+import type {
+  AvatarCreationParams,
+  AvatarListParams,
+  AvatarResponse,
+} from '@mcp/shared/interfaces/avatar.interface';
+import type {
+  ImageCreationParams,
+  ImageListParams,
+  ImageResponse,
+} from '@mcp/shared/interfaces/image.interface';
+import type {
+  MusicCreationParams,
+  MusicListParams,
+  MusicResponse,
+} from '@mcp/shared/interfaces/music.interface';
+import type {
+  VideoCreationParams,
+  VideoResponse,
+  VideoStatus,
+} from '@mcp/shared/interfaces/video.interface';
+import type { BaseApiClient } from './base-api-client';
+import { CONTENT_STATUS } from './client.types';
+
+/** Media generation + listing: videos, images, avatars, and music. */
+export class MediaClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  createVideo(params: VideoCreationParams): Promise<VideoResponse> {
+    this.base.logger.debug('Creating video', { params });
+
+    return this.base.request(
+      'creating video',
+      async (http) => {
+        const response = await http.post('/videos', {
+          data: {
+            attributes: {
+              duration: params.duration,
+              height: 1080,
+              model: 'google/veo-2',
+              prompt: params.description,
+              style: params.style,
+              text: params.description,
+              title: params.title,
+              width: 1920,
+              ...(params.voiceOver?.enabled && { voiceOver: params.voiceOver }),
+            },
+            type: 'videos',
+          },
+        });
+
+        const video = response.data?.data;
+        return {
+          estimatedCompletion: new Date(
+            Date.now() + 5 * 60 * 1000,
+          ).toISOString(),
+          id: video?.id || video?.attributes?.id,
+          status: video?.attributes?.status || CONTENT_STATUS.PROCESSING,
+          url: video?.attributes?.url,
+        };
+      },
+      this.base.failWithDetail('Failed to create video'),
+    );
+  }
+
+  getVideoStatus(videoId: string): Promise<VideoStatus> {
+    this.base.logger.debug(`Getting video status for ID: ${videoId}`);
+
+    return this.base.request(
+      'getting video status',
+      async (http) => {
+        const response = await http.get(`/videos/${videoId}`);
+        const video = response.data?.data;
+
+        return {
+          message: video?.attributes?.message || '',
+          progress: video?.attributes?.progress || 0,
+          status: video?.attributes?.status || CONTENT_STATUS.UNKNOWN,
+          url: video?.attributes?.url,
+        };
+      },
+      this.base.failWith('Failed to get video status'),
+    );
+  }
+
+  listVideos(limit: number = 10, offset: number = 0): Promise<VideoResponse[]> {
+    this.base.logger.debug(`Listing videos: limit=${limit}, offset=${offset}`);
+
+    return this.base.request(
+      'listing videos',
+      async (http) => {
+        const response = await http.get('/videos', {
+          params: { 'page[limit]': limit, 'page[offset]': offset },
+        });
+
+        return (
+          response.data?.data?.map((video: VideoResource) => ({
+            createdAt: video.attributes?.createdAt,
+            duration: video.attributes?.duration,
+            id: video.id,
+            status: video.attributes?.status || CONTENT_STATUS.UNKNOWN,
+            title: video.attributes?.title || 'Untitled',
+            url: video.attributes?.url,
+            views: video.attributes?.views || 0,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list videos'),
+    );
+  }
+
+  createImage(params: ImageCreationParams): Promise<ImageResponse> {
+    this.base.logger.debug('Creating image', { params });
+
+    return this.base.request(
+      'creating image',
+      async (http) => {
+        const response = await http.post('/images', {
+          data: {
+            attributes: {
+              prompt: params.prompt,
+              quality: params.quality || 'standard',
+              size: params.size || 'square',
+              style: params.style || 'realistic',
+            },
+            type: 'images',
+          },
+        });
+
+        const image = response.data?.data;
+        return {
+          createdAt: image?.attributes?.createdAt || new Date().toISOString(),
+          id: image?.id || image?.attributes?.id,
+          prompt: params.prompt,
+          size: params.size || 'square',
+          status: image?.attributes?.status || CONTENT_STATUS.PROCESSING,
+          style: params.style || 'realistic',
+          url: image?.attributes?.url || '',
+        };
+      },
+      this.base.failWithDetail('Failed to create image'),
+    );
+  }
+
+  listImages(params: ImageListParams = {}): Promise<ImageResponse[]> {
+    this.base.logger.debug('Listing images', { params });
+
+    return this.base.request(
+      'listing images',
+      async (http) => {
+        const response = await http.get('/images', {
+          params: {
+            'page[limit]': params.limit || 10,
+            'page[offset]': params.offset || 0,
+          },
+        });
+
+        return (
+          response.data?.data?.map((image: ImageResource) => ({
+            createdAt: image.attributes?.createdAt,
+            id: image.id,
+            prompt: image.attributes?.prompt || '',
+            size: image.attributes?.size || 'square',
+            status: image.attributes?.status || CONTENT_STATUS.COMPLETED,
+            style: image.attributes?.style || 'realistic',
+            url: image.attributes?.url || '',
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list images'),
+    );
+  }
+
+  createAvatar(params: AvatarCreationParams): Promise<AvatarResponse> {
+    this.base.logger.debug('Creating avatar', { params });
+
+    return this.base.request(
+      'creating avatar',
+      async (http) => {
+        const response = await http.post('/avatars/generate', {
+          data: {
+            attributes: {
+              age: params.age || 'middle-aged',
+              gender: params.gender,
+              name: params.name,
+              style: params.style || 'realistic',
+            },
+            type: 'avatars',
+          },
+        });
+
+        const avatar = response.data?.data;
+        return {
+          age: params.age || 'middle-aged',
+          createdAt: avatar?.attributes?.createdAt || new Date().toISOString(),
+          gender: params.gender,
+          id: avatar?.id || avatar?.attributes?.id,
+          name: params.name,
+          status: avatar?.attributes?.status || CONTENT_STATUS.PROCESSING,
+          style: params.style || 'realistic',
+          thumbnailUrl: avatar?.attributes?.thumbnailUrl,
+          videoUrl: avatar?.attributes?.videoUrl,
+        };
+      },
+      this.base.failWithDetail('Failed to create avatar'),
+    );
+  }
+
+  listAvatars(params: AvatarListParams = {}): Promise<AvatarResponse[]> {
+    this.base.logger.debug('Listing avatars', { params });
+
+    return this.base.request(
+      'listing avatars',
+      async (http) => {
+        const response = await http.get('/avatars', {
+          params: {
+            'page[limit]': params.limit || 10,
+            'page[offset]': params.offset || 0,
+          },
+        });
+
+        return (
+          response.data?.data?.map((avatar: AvatarResource) => ({
+            age: avatar.attributes?.age,
+            createdAt: avatar.attributes?.createdAt,
+            gender: avatar.attributes?.gender,
+            id: avatar.id,
+            name: avatar.attributes?.name || 'Unnamed',
+            status: avatar.attributes?.status || CONTENT_STATUS.COMPLETED,
+            style: avatar.attributes?.style,
+            thumbnailUrl: avatar.attributes?.thumbnailUrl,
+            videoUrl: avatar.attributes?.videoUrl,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list avatars'),
+    );
+  }
+
+  createMusic(params: MusicCreationParams): Promise<MusicResponse> {
+    this.base.logger.debug('Creating music', { params });
+
+    return this.base.request(
+      'creating music',
+      async (http) => {
+        const response = await http.post('/musics', {
+          data: {
+            attributes: {
+              duration: params.duration || 60,
+              genre: params.genre,
+              mood: params.mood,
+              prompt: params.prompt,
+            },
+            type: 'musics',
+          },
+        });
+
+        const music = response.data?.data;
+        return {
+          createdAt: music?.attributes?.createdAt || new Date().toISOString(),
+          duration: params.duration || 60,
+          genre: params.genre,
+          id: music?.id || music?.attributes?.id,
+          mood: params.mood,
+          prompt: params.prompt,
+          status: music?.attributes?.status || CONTENT_STATUS.PROCESSING,
+          url: music?.attributes?.url,
+        };
+      },
+      this.base.failWithDetail('Failed to create music'),
+    );
+  }
+
+  listMusic(params: MusicListParams = {}): Promise<MusicResponse[]> {
+    this.base.logger.debug('Listing music', { params });
+
+    return this.base.request(
+      'listing music',
+      async (http) => {
+        const response = await http.get('/musics', {
+          params: {
+            'page[limit]': params.limit || 10,
+            'page[offset]': params.offset || 0,
+          },
+        });
+
+        return (
+          response.data?.data?.map((music: MusicResource) => ({
+            createdAt: music.attributes?.createdAt,
+            duration: music.attributes?.duration || 0,
+            genre: music.attributes?.genre,
+            id: music.id,
+            mood: music.attributes?.mood,
+            prompt: music.attributes?.prompt || '',
+            status: music.attributes?.status || CONTENT_STATUS.COMPLETED,
+            url: music.attributes?.url,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list music'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/workflow.client.ts
+++ b/apps/server/mcp/src/services/client/workflow.client.ts
@@ -1,0 +1,174 @@
+import type {
+  WorkflowResource,
+  WorkflowTemplateResource,
+} from '@mcp/shared/interfaces/api-response.interface';
+import type {
+  WorkflowCreateParams,
+  WorkflowExecuteParams,
+  WorkflowExecutionResult,
+  WorkflowListParams,
+  WorkflowResponse,
+  WorkflowTemplate,
+} from '@mcp/shared/interfaces/workflow.interface';
+import type { BaseApiClient } from './base-api-client';
+import { CONTENT_STATUS } from './client.types';
+
+/** Workflow authoring, execution, and template discovery. */
+export class WorkflowClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  createWorkflow(params: WorkflowCreateParams): Promise<WorkflowResponse> {
+    this.base.logger.debug('Creating workflow', { params });
+
+    return this.base.request(
+      'creating workflow',
+      async (http) => {
+        const response = await http.post('/workflows', {
+          data: {
+            attributes: {
+              description: params.description,
+              name: params.name,
+              schedule: params.schedule,
+              steps: params.steps,
+              templateId: params.templateId,
+            },
+            type: 'workflows',
+          },
+        });
+
+        const workflow = response.data?.data;
+        return {
+          createdAt:
+            workflow?.attributes?.createdAt || new Date().toISOString(),
+          description: workflow?.attributes?.description || params.description,
+          id: workflow?.id || workflow?.attributes?.id,
+          lastRunAt: workflow?.attributes?.lastRunAt,
+          name: workflow?.attributes?.name || params.name,
+          nextRunAt: workflow?.attributes?.nextRunAt,
+          status: workflow?.attributes?.status || CONTENT_STATUS.DRAFT,
+          steps: workflow?.attributes?.steps || params.steps || [],
+          updatedAt: workflow?.attributes?.updatedAt,
+        };
+      },
+      this.base.failWithDetail('Failed to create workflow'),
+    );
+  }
+
+  executeWorkflow(
+    params: WorkflowExecuteParams,
+  ): Promise<WorkflowExecutionResult> {
+    this.base.logger.debug('Executing workflow', { params });
+
+    return this.base.request(
+      'executing workflow',
+      async (http) => {
+        const response = await http.post('/workflow-executions', {
+          inputValues: params.variables,
+          workflow: params.workflowId,
+        });
+
+        const execution = response.data?.data;
+        return {
+          completedAt: execution?.attributes?.completedAt,
+          error: execution?.attributes?.error,
+          executionId: execution?.id || execution?.attributes?.id,
+          results: execution?.attributes?.results,
+          startedAt:
+            execution?.attributes?.startedAt || new Date().toISOString(),
+          status: execution?.attributes?.status || 'started',
+          workflowId: params.workflowId,
+        };
+      },
+      this.base.failWithDetail('Failed to execute workflow'),
+    );
+  }
+
+  getWorkflowStatus(workflowId: string): Promise<WorkflowResponse> {
+    this.base.logger.debug(`Getting workflow status for ID: ${workflowId}`);
+
+    return this.base.request(
+      'getting workflow status',
+      async (http) => {
+        const response = await http.get(`/workflows/${workflowId}`);
+        const workflow = response.data?.data;
+
+        return {
+          createdAt: workflow?.attributes?.createdAt,
+          currentStepIndex: workflow?.attributes?.currentStepIndex,
+          description: workflow?.attributes?.description,
+          id: workflow?.id,
+          lastRunAt: workflow?.attributes?.lastRunAt,
+          name: workflow?.attributes?.name,
+          nextRunAt: workflow?.attributes?.nextRunAt,
+          status: workflow?.attributes?.status || CONTENT_STATUS.DRAFT,
+          steps: workflow?.attributes?.steps || [],
+          updatedAt: workflow?.attributes?.updatedAt,
+        };
+      },
+      this.base.failWith('Failed to get workflow status'),
+    );
+  }
+
+  listWorkflows(params: WorkflowListParams = {}): Promise<WorkflowResponse[]> {
+    this.base.logger.debug('Listing workflows', { params });
+
+    return this.base.request(
+      'listing workflows',
+      async (http) => {
+        const queryParams: Record<string, string | number> = {
+          'page[limit]': params.limit || 10,
+          'page[offset]': params.offset || 0,
+        };
+
+        if (params.status) {
+          queryParams['filter[status]'] = params.status;
+        }
+
+        const response = await http.get('/workflows', {
+          params: queryParams,
+        });
+
+        return (
+          response.data?.data?.map((workflow: WorkflowResource) => ({
+            createdAt: workflow.attributes?.createdAt,
+            currentStepIndex: workflow.attributes?.currentStepIndex,
+            description: workflow.attributes?.description,
+            id: workflow.id,
+            lastRunAt: workflow.attributes?.lastRunAt,
+            name: workflow.attributes?.name,
+            nextRunAt: workflow.attributes?.nextRunAt,
+            status: workflow.attributes?.status || CONTENT_STATUS.DRAFT,
+            steps: workflow.attributes?.steps || [],
+            updatedAt: workflow.attributes?.updatedAt,
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list workflows'),
+    );
+  }
+
+  listWorkflowTemplates(): Promise<WorkflowTemplate[]> {
+    this.base.logger.debug('Listing workflow templates');
+
+    return this.base.request(
+      'listing workflow templates',
+      async (http) => {
+        const response = await http.get('/workflows/templates');
+
+        return (
+          response.data?.data?.map((template: WorkflowTemplateResource) => ({
+            category: template.attributes?.category || 'general',
+            creditsRequired: template.attributes?.creditsRequired,
+            description:
+              template.attributes?.description || 'No description available',
+            estimatedDuration: template.attributes?.estimatedDuration,
+            id: template.id,
+            name: template.attributes?.name,
+            steps: template.attributes?.steps || [],
+          })) || []
+        );
+      },
+      this.base.failWith('Failed to list workflow templates'),
+    );
+  }
+}

--- a/apps/server/mcp/src/services/client/workspace.client.ts
+++ b/apps/server/mcp/src/services/client/workspace.client.ts
@@ -1,0 +1,244 @@
+import type {
+  CreditsUsage,
+  UsageStats,
+} from '@mcp/shared/interfaces/post.interface';
+import type { BaseApiClient } from './base-api-client';
+import type {
+  BrandResponse,
+  CreateBatchParams,
+  ListBatchesParams,
+  PersonaResponse,
+} from './client.types';
+
+/**
+ * Account-scoped reads and content-batch orchestration: credits/usage, brands,
+ * personas, batches, account/job status, and agent chat threads.
+ */
+export class WorkspaceClient {
+  constructor(private readonly base: BaseApiClient) {}
+
+  getCredits(): Promise<CreditsUsage> {
+    this.base.logger.debug('Getting credits usage');
+
+    return this.base.request(
+      'getting credits',
+      async (http) => {
+        const response = await http.get('/credits/usage');
+        // Inline unwrap: the result is destructured below, so it must keep the
+        // axios `any` shape rather than the helper's typed return.
+        const data =
+          response.data?.data?.attributes || response.data?.data || {};
+
+        return {
+          available: data.available || 0,
+          breakdown: {
+            articles: data.breakdown?.articles || 0,
+            avatars: data.breakdown?.avatars || 0,
+            images: data.breakdown?.images || 0,
+            music: data.breakdown?.music || 0,
+            videos: data.breakdown?.videos || 0,
+          },
+          resetDate: data.resetDate,
+          total: data.total || 0,
+          used: data.used || 0,
+        };
+      },
+      this.base.failWith('Failed to get credits usage'),
+    );
+  }
+
+  getUsageStats(timeRange: string = '30d'): Promise<UsageStats> {
+    this.base.logger.debug(`Getting usage stats for timeRange: ${timeRange}`);
+
+    return this.base.request(
+      'getting usage stats',
+      async (http) => {
+        const response = await http.get('/usage/stats', {
+          params: { timeRange },
+        });
+        const data =
+          response.data?.data?.attributes || response.data?.data || {};
+
+        return {
+          contentCreated: {
+            articles: data.contentCreated?.articles || 0,
+            avatars: data.contentCreated?.avatars || 0,
+            images: data.contentCreated?.images || 0,
+            music: data.contentCreated?.music || 0,
+            videos: data.contentCreated?.videos || 0,
+          },
+          creditsUsed: data.creditsUsed || 0,
+          postsPublished: data.postsPublished || 0,
+          timeRange,
+          totalEngagement: data.totalEngagement || 0,
+        };
+      },
+      this.base.failWith('Failed to get usage stats'),
+    );
+  }
+
+  listBrands(): Promise<BrandResponse[]> {
+    this.base.logger.debug('Listing brands');
+
+    return this.base.request(
+      'listing brands',
+      async (http) => {
+        const response = await http.get('/brands');
+        return (
+          response.data?.data?.map(
+            (brand: { id?: string; attributes?: Record<string, unknown> }) => ({
+              id: brand.id || String(brand.attributes?.id || ''),
+              name: String(brand.attributes?.name || 'Unnamed'),
+              status: brand.attributes?.status
+                ? String(brand.attributes.status)
+                : undefined,
+              ...(brand.attributes || {}),
+            }),
+          ) || []
+        );
+      },
+      this.base.failWith('Failed to list brands'),
+    );
+  }
+
+  listPersonas(
+    params: { status?: string; limit?: number; offset?: number } = {},
+  ): Promise<PersonaResponse[]> {
+    this.base.logger.debug('Listing personas', { params });
+
+    return this.base.request(
+      'listing personas',
+      async (http) => {
+        const response = await http.get('/personas', {
+          params: {
+            'filter[status]': params.status,
+            'page[limit]': params.limit || 10,
+            'page[offset]': params.offset || 0,
+          },
+        });
+
+        return (
+          response.data?.data?.map(
+            (persona: {
+              id?: string;
+              attributes?: Record<string, unknown>;
+            }) => ({
+              id: persona.id || String(persona.attributes?.id || ''),
+              name: String(persona.attributes?.name || 'Unnamed'),
+              status: persona.attributes?.status
+                ? String(persona.attributes.status)
+                : undefined,
+              ...(persona.attributes || {}),
+            }),
+          ) || []
+        );
+      },
+      this.base.failWith('Failed to list personas'),
+    );
+  }
+
+  createBatch(params: CreateBatchParams): Promise<Record<string, unknown>> {
+    this.base.logger.debug('Creating content batch', { params });
+
+    return this.base.request(
+      'creating batch',
+      async (http) => {
+        const response = await http.post('/batches', {
+          data: {
+            attributes: params,
+            type: 'batches',
+          },
+        });
+
+        return this.base.unwrapAttributes(response);
+      },
+      this.base.failWithDetail('Failed to create batch'),
+    );
+  }
+
+  listBatches(
+    params: ListBatchesParams = {},
+  ): Promise<Array<Record<string, unknown>>> {
+    this.base.logger.debug('Listing content batches', { params });
+
+    return this.base.request(
+      'listing batches',
+      async (http) => {
+        const response = await http.get('/batches', {
+          params: {
+            'filter[batchId]': params.batchId,
+            'filter[status]': params.status,
+            'page[limit]': params.limit || 20,
+            'page[offset]': params.offset || 0,
+          },
+        });
+
+        if (!Array.isArray(response.data?.data)) {
+          return [];
+        }
+
+        return response.data.data.map(
+          (item: { id?: string; attributes?: Record<string, unknown> }) => ({
+            id: item.id || String(item.attributes?.id || ''),
+            ...(item.attributes || {}),
+          }),
+        );
+      },
+      this.base.failWith('Failed to list batches'),
+    );
+  }
+
+  getAccountInfo(): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'getting account info',
+      async (http) => {
+        const response = await http.get('/accounts');
+        const account = response.data?.data?.[0] || response.data?.data;
+        return {
+          id: account?.id,
+          ...(account?.attributes || account || {}),
+        };
+      },
+      this.base.failWith('Failed to get account info'),
+    );
+  }
+
+  getJobStatus(jobId: string): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'getting job status',
+      async (http) => {
+        const response = await http.get(`/ingredients/${jobId}`);
+        const data = response.data?.data;
+        return {
+          id: data?.id,
+          ...(data?.attributes || data || {}),
+        };
+      },
+      this.base.failWith('Failed to get job status'),
+    );
+  }
+
+  createChat(): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'creating chat',
+      async (http) => this.base.unwrapObject(await http.post('/threads')),
+      this.base.failWith('Failed to create chat'),
+    );
+  }
+
+  sendChatMessage(
+    threadId: string,
+    message: string,
+  ): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'sending chat message',
+      async (http) =>
+        this.base.unwrapObject(
+          await http.post(`/threads/${threadId}/messages`, {
+            content: message,
+          }),
+        ),
+      this.base.failWith('Failed to send chat message'),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Decomposes the 1,800-line `apps/server/mcp/src/services/client.service.ts` god-class (~52 methods spanning ~17 domains, with the `try/catch → logError → throw` shell copied ~52 times verbatim) into a thin composition root plus per-domain clients that all compose a single `BaseApiClient`. Closes #709.

Behavior-preserving only — no endpoint, payload, response-shape, status-default, or error-handling change.

## What changed

- **`client/base-api-client.ts`** — owns the single axios instance (so `setBearerToken` propagates to every sub-client), the canonical `request<T>(operation, call, onError)` shell that replaces the ~52 try/catch copies, the `failWith` / `failWithDetail` onError factories (the two original throw forms), `logError`, `getErrorMessage`, the JSON:API unwrap helpers (`unwrapList` / `unwrapData` / `unwrapObject` / `unwrapAttributes`), and the unguarded `postAttributes` proxy.
- **`client/{agent,media,analytics,content,workflow,workspace,ads,darkroom,linkedin}.client.ts`** — per-domain clients composing the base, matching the issue's named groupings (`AdsClient` = meta/google/ad-insights, `MediaClient` = video/image/avatar/music, etc.).
- **`client/client.types.ts`** — shared `ApiError` / `BrandResponse` / `PersonaResponse` / `CreateBatchParams` / `ListBatchesParams` plus the `CONTENT_STATUS` map centralizing the previously-drifting status-default literals.
- **`client.service.ts`** — now a thin composition root. Keeps its exact `(logger, httpService, configService)` constructor and full public method surface; only delegates. Every MCP tool/resource/registry consumer, `mcp.module.ts`, and the existing specs are untouched.

## Acceptance criteria (#709)

- ✅ Each domain client small & cohesive; `ClientService` is a thin aggregator (–1,610 lines of bodies, all delegations).
- ✅ The try/catch shell and the response-unwrap idioms each exist in exactly one place (`BaseApiClient`).
- ✅ Status defaults come from a single `CONTENT_STATUS` map (no drifting magic strings).
- ✅ `setBearerToken` propagates to the shared axios instance across all sub-clients (single `BaseApiClient`).
- ✅ Public method surface unchanged → `client.service.spec.ts` and all ClientService consumers unaffected.

## Verification

- **Method-surface parity**: `diff` of public method names new-vs-`origin/master` is **empty** (73 incl. constructor).
- **Error-form parity (numeric)**: original had **70** `try/catch` sites, each calling `logError` → mapped 1:1 to **70** `request()` calls = **14** `failWithDetail` (matches original 14 `getErrorMessage` uses) + **2** analytics return-fallback (matches original 2) + **54** `failWith`.
- **Adversarial multi-agent review** of the full diff (behavior × type × spec-wiring × completeness, find→verify): **0 confirmed findings**. The only flagged items were a false `.js`-extension/TS2835 concern, independently refuted (pattern is pervasive on `master`; `tsc --noEmit` reports zero TS2835).
- **Lint**: pre-commit `biome check` + `secretlint` green on all 12 files.
- ⚠️ **Local typecheck/tests not run**: this environment has no installed `node_modules` and the Mac Studio validation host was unreachable, so the workspace `bun type-check` / `vitest` scoped runs were deferred to CI per the repo's local-verification policy. CI's required checks are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)