### PR TITLE
feat(services): thread AbortSignal through BaseService.findOne (#637)

### DIFF
--- a/apps/app/app/(protected)/admin/automation/trainings/[id]/training-detail.tsx
+++ b/apps/app/app/(protected)/admin/automation/trainings/[id]/training-detail.tsx
@@ -68,7 +68,7 @@ export default function TrainingDetail({
 
         controller.signal.throwIfAborted();
 
-        const data = await service.findOne(trainingId);
+        const data = await service.findOne(trainingId, {}, controller.signal);
 
         controller.signal.throwIfAborted();
 

--- a/packages/services/core/base.service.test.ts
+++ b/packages/services/core/base.service.test.ts
@@ -475,6 +475,21 @@ describe('BaseService', () => {
       expect(result).toBeInstanceOf(TestModel);
     });
 
+    it('forwards an AbortSignal to the request config so the fetch is cancellable', async () => {
+      const mockResponse = {
+        data: { data: { id: '123', name: 'Test' } },
+      };
+      service.getInstanceForTest().get.mockResolvedValue(mockResponse);
+      const controller = new AbortController();
+
+      await service.findOne('123', { include: 'relations' }, controller.signal);
+
+      expect(service.getInstanceForTest().get).toHaveBeenCalledWith('/123', {
+        params: { include: 'relations' },
+        signal: controller.signal,
+      });
+    });
+
     it('should throw on error', async () => {
       service
         .getInstanceForTest()

--- a/packages/services/core/base.service.ts
+++ b/packages/services/core/base.service.ts
@@ -258,11 +258,15 @@ export abstract class BaseService<
     );
   }
 
-  public findOne(id: string, query: Record<string, unknown> = {}): Promise<T> {
+  public findOne(
+    id: string,
+    query: Record<string, unknown> = {},
+    signal?: AbortSignal,
+  ): Promise<T> {
     return this.executeWithErrorHandling(
       `GET ${this.baseURL}/${id}`,
       this.instance
-        .get<JsonApiResponseDocument>(`/${id}`, { params: query })
+        .get<JsonApiResponseDocument>(`/${id}`, { params: query, signal })
         .then((res) => res.data)
         .then(async (res) => await this.mapOne(res)),
     );


### PR DESCRIPTION
## What

`BaseService.findAll` already forwards an `AbortSignal` into the Axios request config (`{ params, signal }`), so list fetches are genuinely cancellable. `findOne` did not — it only accepted query params. The training-detail screen therefore aborted its `AbortController` and skipped stale state updates, but the underlying `GET /trainings/:id` request kept running to completion (the immediate UI bug from PR #620 was masked, the network-layer debt remained).

This threads the signal the rest of the way down.

## Changes

- **`packages/services/core/base.service.ts`** — add an optional `signal?: AbortSignal` parameter to `findOne`, forwarded as `{ params: query, signal }`, mirroring the existing `findAll` signature exactly. Optional + last-positional → backward compatible for every existing caller and subclass.
- **`apps/app/.../trainings/[id]/training-detail.tsx`** — pass the already-present `controller.signal` into `service.findOne(trainingId, {}, controller.signal)` so a superseded load aborts the in-flight request, not just the post-response state write.
- **`packages/services/core/base.service.test.ts`** — focused test asserting `findOne` forwards the signal into the request config (mirrors the existing `findAll` signal test).

## Scope notes

- Mutation helpers (`post`/`patch`/`delete`) are intentionally untouched — the issue scopes this to the fetch helpers and the `findOne` consumer. No gratuitous refactoring.
- `TrainingsService` inherits `BaseService.findOne` (no override), so the 3-arg call resolves directly.

## Verification

- `bun run test --filter=@genfeedai/services` → `core/base.service.test.ts` **53 passed** (incl. new signal-forwarding case).
- `@genfeedai/services` `tsc --noEmit` clean for changed files (only unrelated pre-existing error: `@genfeedai/auth-client` unresolved in `packages/helpers` — an unbuilt-workspace-dep artifact from the Better Auth cutover #769, untouched here; resolves under CI's dependency-ordered build).
- `biome lint` on the 3 changed files → exit 0; pre-commit secretlint + no-raw-html hooks green.
- Adversarial multi-agent review of the diff: one confirmed finding (a tautological abort test) was removed; signal forwarding is verified by the retained focused test.
- Full `apps/app` typecheck deferred to CI (heavy; the consumer change is a type-safe optional 3rd arg).

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)