### PR TITLE
refactor(trends): extract source-item subsystem from TrendsService (#752)

### DIFF
--- a/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.spec.ts
@@ -1,0 +1,124 @@
+import { TrendPrelaunchCorpusService } from '@api/collections/trends/services/modules/trend-prelaunch-corpus.service';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { ApifyService } from '@api/services/integrations/apify/services/apify.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, TestingModule } from '@nestjs/testing';
+
+describe('TrendPrelaunchCorpusService', () => {
+  let service: TrendPrelaunchCorpusService;
+  let prisma: {
+    trend: {
+      create: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+  let referenceCorpus: {
+    countGlobalReferences: ReturnType<typeof vi.fn>;
+    syncTrendReferences: ReturnType<typeof vi.fn>;
+  };
+  let cache: { invalidateByTags: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    prisma = {
+      trend: {
+        create: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
+        update: vi.fn(),
+      },
+    };
+    referenceCorpus = {
+      countGlobalReferences: vi.fn().mockResolvedValue(7),
+      syncTrendReferences: vi
+        .fn()
+        .mockResolvedValue({ links: 0, references: 0, snapshots: 0 }),
+    };
+    cache = { invalidateByTags: vi.fn().mockResolvedValue(1) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrendPrelaunchCorpusService,
+        TrendSourceItemsService,
+        { provide: ApifyService, useValue: {} },
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: LoggerService,
+          useValue: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+        },
+        { provide: CacheService, useValue: cache },
+        { provide: TrendReferenceCorpusService, useValue: referenceCorpus },
+      ],
+    }).compile();
+
+    service = module.get(TrendPrelaunchCorpusService);
+  });
+
+  describe('getGlobalCorpusStats', () => {
+    it('counts only current, unexpired global trends', async () => {
+      const future = new Date(Date.now() + 3_600_000).toISOString();
+      const past = new Date(Date.now() - 3_600_000).toISOString();
+      prisma.trend.findMany.mockResolvedValue([
+        { data: { expiresAt: future, isCurrent: true } },
+        { data: { expiresAt: past, isCurrent: true } }, // expired
+        { data: { expiresAt: future, isCurrent: false } }, // not current
+      ]);
+
+      const result = await service.getGlobalCorpusStats();
+
+      expect(result).toEqual({ activeTrends: 1, referenceRecords: 7 });
+    });
+  });
+
+  describe('backfillPrelaunchReferenceCorpus', () => {
+    it('plans creates without writing in dry-run mode (the default)', async () => {
+      prisma.trend.findMany.mockResolvedValue([]);
+
+      const result = await service.backfillPrelaunchReferenceCorpus({
+        now: new Date('2026-06-09T00:00:00.000Z'),
+      });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.plannedCreates).toBe(result.seedTrends);
+      expect(result.plannedUpdates).toBe(0);
+      expect(result.createdTrends).toBe(0);
+      expect(prisma.trend.create).not.toHaveBeenCalled();
+      expect(prisma.trend.update).not.toHaveBeenCalled();
+      expect(referenceCorpus.syncTrendReferences).not.toHaveBeenCalled();
+      expect(cache.invalidateByTags).not.toHaveBeenCalled();
+    });
+
+    it('creates seeds, syncs references, and busts caches in live mode', async () => {
+      prisma.trend.findMany.mockResolvedValue([]);
+      prisma.trend.create.mockImplementation(async (input: unknown) => {
+        const payload = input as { data: { data: Record<string, unknown> } };
+        return {
+          brandId: null,
+          createdAt: new Date('2026-06-09T00:00:00.000Z'),
+          data: payload.data.data,
+          id: `created-${prisma.trend.create.mock.calls.length}`,
+          isDeleted: false,
+          organizationId: null,
+          updatedAt: new Date('2026-06-09T00:00:00.000Z'),
+        };
+      });
+
+      const result = await service.backfillPrelaunchReferenceCorpus({
+        dryRun: false,
+        now: new Date('2026-06-09T00:00:00.000Z'),
+      });
+
+      expect(result.dryRun).toBe(false);
+      expect(result.createdTrends).toBe(result.seedTrends);
+      expect(prisma.trend.create).toHaveBeenCalledTimes(result.seedTrends);
+      expect(prisma.trend.update).not.toHaveBeenCalled();
+      expect(referenceCorpus.syncTrendReferences).toHaveBeenCalledTimes(1);
+      expect(cache.invalidateByTags).toHaveBeenCalledWith([
+        'trends',
+        'trends:content',
+      ]);
+    });
+  });
+});

--- a/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.ts
@@ -1,0 +1,253 @@
+import {
+  buildPrelaunchReferenceCorpusSeeds,
+  PRELAUNCH_REFERENCE_CORPUS_MINIMUMS,
+  PRELAUNCH_REFERENCE_CORPUS_VERSION,
+  type PrelaunchReferenceCorpusSeed,
+} from '@api/collections/trends/data/prelaunch-reference-corpus.seed';
+import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
+import type { TrendDocument } from '@api/collections/trends/schemas/trend.schema';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+export interface PrelaunchReferenceCorpusBackfillOptions {
+  dryRun?: boolean;
+  now?: Date;
+}
+
+export interface PrelaunchReferenceCorpusBackfillResult {
+  createdTrends: number;
+  dryRun: boolean;
+  plannedCreates: number;
+  plannedUpdates: number;
+  referenceSync: {
+    links: number;
+    references: number;
+    snapshots: number;
+  };
+  seedReferences: number;
+  seedTrends: number;
+  updatedTrends: number;
+  version: string;
+}
+
+/**
+ * Owns prelaunch reference-corpus seeding/backfill and global corpus stats.
+ *
+ * Extracted from TrendsService (issue #752).
+ */
+@Injectable()
+export class TrendPrelaunchCorpusService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly loggerService: LoggerService,
+    private readonly cacheService: CacheService,
+    private readonly trendReferenceCorpusService: TrendReferenceCorpusService,
+    private readonly trendSourceItemsService: TrendSourceItemsService,
+  ) {}
+
+  async getGlobalCorpusStats(): Promise<{
+    activeTrends: number;
+    referenceRecords: number;
+  }> {
+    const now = new Date();
+    const [allGlobalTrends, referenceRecords] = await Promise.all([
+      this.prisma.trend.findMany({
+        where: { isDeleted: false, organizationId: null },
+      }),
+      this.trendReferenceCorpusService.countGlobalReferences(),
+    ]);
+    const activeTrends = allGlobalTrends.filter((doc) => {
+      const d = doc.data as unknown as Record<string, unknown>;
+      return (
+        d.isCurrent === true &&
+        d.expiresAt != null &&
+        new Date(d.expiresAt as string) > now
+      );
+    }).length;
+
+    return {
+      activeTrends,
+      referenceRecords,
+    };
+  }
+
+  async backfillPrelaunchReferenceCorpus(
+    options: PrelaunchReferenceCorpusBackfillOptions = {},
+  ): Promise<PrelaunchReferenceCorpusBackfillResult> {
+    const now = options.now ?? new Date();
+    const dryRun = options.dryRun ?? true;
+    const seeds = buildPrelaunchReferenceCorpusSeeds(now);
+    const seedReferences = seeds.reduce(
+      (total, seed) => total + seed.sourcePreview.length,
+      0,
+    );
+
+    const existingDocs = await this.findPrelaunchCorpusDocs();
+    const existingByKey = new Map(
+      existingDocs.flatMap((doc) => {
+        const key = this.getPrelaunchCorpusKey(doc);
+        return key ? [[key, doc] as const] : [];
+      }),
+    );
+    const plannedCreates = seeds.filter(
+      (seed) => !existingByKey.has(seed.key),
+    ).length;
+    const plannedUpdates = seeds.length - plannedCreates;
+
+    if (dryRun) {
+      return {
+        createdTrends: 0,
+        dryRun,
+        plannedCreates,
+        plannedUpdates,
+        referenceSync: { links: 0, references: 0, snapshots: 0 },
+        seedReferences,
+        seedTrends: seeds.length,
+        updatedTrends: 0,
+        version: PRELAUNCH_REFERENCE_CORPUS_VERSION,
+      };
+    }
+
+    const syncedTrends: TrendEntity[] = [];
+    let createdTrends = 0;
+    let updatedTrends = 0;
+
+    for (const seed of seeds) {
+      const trendData = this.buildPrelaunchTrendData(seed, now);
+      const existing = existingByKey.get(seed.key);
+
+      if (existing) {
+        const updated = await this.prisma.trend.update({
+          data: {
+            data: trendData,
+            isDeleted: false,
+          } as never,
+          where: { id: existing.id },
+        });
+        syncedTrends.push(this.toTrendEntity(updated));
+        updatedTrends += 1;
+        continue;
+      }
+
+      const created = await this.prisma.trend.create({
+        data: {
+          brandId: null,
+          data: trendData,
+          isDeleted: false,
+          organizationId: null,
+        } as never,
+      });
+      syncedTrends.push(this.toTrendEntity(created));
+      createdTrends += 1;
+    }
+
+    const referenceSync =
+      await this.trendReferenceCorpusService.syncTrendReferences(
+        syncedTrends.map((trend) =>
+          this.trendSourceItemsService.toSyncTrendInput(trend),
+        ),
+      );
+
+    await this.cacheService.invalidateByTags(['trends', 'trends:content']);
+
+    if (
+      seeds.length < PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends ||
+      seedReferences < PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.sourceReferences
+    ) {
+      this.loggerService.warn(
+        'Prelaunch reference corpus seed is below floor',
+        {
+          minimums: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS,
+          seedReferences,
+          seedTrends: seeds.length,
+        },
+      );
+    }
+
+    return {
+      createdTrends,
+      dryRun,
+      plannedCreates,
+      plannedUpdates,
+      referenceSync,
+      seedReferences,
+      seedTrends: seeds.length,
+      updatedTrends,
+      version: PRELAUNCH_REFERENCE_CORPUS_VERSION,
+    };
+  }
+
+  private async findPrelaunchCorpusDocs(): Promise<
+    Array<{ data: unknown; id: string } & Record<string, unknown>>
+  > {
+    const docs = await this.prisma.trend.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends * 2,
+      where: {
+        brandId: null,
+        isDeleted: false,
+        organizationId: null,
+      } as never,
+    });
+
+    return docs.filter((doc) => this.getPrelaunchCorpusKey(doc) != null);
+  }
+
+  private getPrelaunchCorpusKey(doc: { data: unknown }): string | null {
+    const data = doc.data as Record<string, unknown>;
+    const metadata = data.metadata as Record<string, unknown> | undefined;
+    const key = metadata?.prelaunchCorpusKey;
+
+    return typeof key === 'string' && key.length > 0 ? key : null;
+  }
+
+  private buildPrelaunchTrendData(
+    seed: PrelaunchReferenceCorpusSeed,
+    now: Date,
+  ): Record<string, unknown> {
+    const expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const sourceUrls = seed.sourcePreview.map((item) => item.sourceUrl);
+    const metadata = {
+      ...seed.metadata,
+      prelaunchCorpus: true,
+      prelaunchCorpusKey: seed.key,
+      source: 'curated',
+      sourcePreviewCache: seed.sourcePreview,
+      sourcePreviewCachedAt: now.toISOString(),
+      sourcePreviewState: 'fallback',
+      sourceSetVersion: PRELAUNCH_REFERENCE_CORPUS_VERSION,
+      trendType: seed.sourcePreview.some((item) => item.contentType === 'video')
+        ? 'video'
+        : 'topic',
+      urls: sourceUrls,
+    };
+
+    return {
+      expiresAt: expiresAt.toISOString(),
+      growthRate: seed.growthRate,
+      isCurrent: true,
+      isDeleted: false,
+      mentions: seed.mentions,
+      metadata,
+      platform: seed.platform,
+      requiresAuth: false,
+      topic: seed.topic,
+      viralityScore: seed.viralityScore,
+    };
+  }
+
+  private toTrendEntity(
+    doc: {
+      data: unknown;
+    } & Record<string, unknown>,
+  ): TrendEntity {
+    return new TrendEntity({
+      ...doc,
+      ...(doc.data as Record<string, unknown>),
+    } as unknown as TrendDocument);
+  }
+}

--- a/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.ts
@@ -185,8 +185,8 @@ export class TrendPrelaunchCorpusService {
     Array<{ data: unknown; id: string } & Record<string, unknown>>
   > {
     const docs = await this.prisma.trend.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends * 2,
+      // Scan the full seeded corpus: capping the lookup would let older rows
+      // fall out of existingByKey and create duplicate prelaunch trends.
       where: {
         brandId: null,
         isDeleted: false,

--- a/apps/server/api/src/collections/trends/services/modules/trend-query.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-query.service.spec.ts
@@ -1,0 +1,150 @@
+import { TrendQueryService } from '@api/collections/trends/services/modules/trend-query.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Test, TestingModule } from '@nestjs/testing';
+
+type PrismaMock = {
+  trend: {
+    findMany: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+};
+
+const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+const makeDoc = (
+  id: string,
+  data: Record<string, unknown>,
+  top: Record<string, unknown> = {},
+) => ({
+  brandId: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  data: {
+    expiresAt: future,
+    isCurrent: true,
+    platform: 'tiktok',
+    topic: data.topic ?? 'topic',
+    viralityScore: 50,
+    ...data,
+  },
+  id,
+  isDeleted: false,
+  organizationId: null,
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  ...top,
+});
+
+describe('TrendQueryService', () => {
+  let service: TrendQueryService;
+  let prisma: PrismaMock;
+
+  beforeEach(async () => {
+    prisma = {
+      trend: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrendQueryService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get(TrendQueryService);
+  });
+
+  describe('findActiveTrends', () => {
+    it('drops non-current and expired docs and sorts by virality desc', async () => {
+      prisma.trend.findMany.mockResolvedValue([
+        makeDoc('low', { viralityScore: 10 }),
+        makeDoc('expired', { expiresAt: past, viralityScore: 99 }),
+        makeDoc('stale', { isCurrent: false, viralityScore: 99 }),
+        makeDoc('high', { viralityScore: 90 }),
+      ]);
+
+      const result = await service.findActiveTrends({
+        brandId: null,
+        organizationId: null,
+      });
+
+      expect(result.map((t) => String(t.id))).toEqual(['high', 'low']);
+    });
+
+    it('filters by platform when supplied', async () => {
+      prisma.trend.findMany.mockResolvedValue([
+        makeDoc('a', { platform: 'tiktok' }),
+        makeDoc('b', { platform: 'youtube' }),
+      ]);
+
+      const result = await service.findActiveTrends({
+        brandId: null,
+        organizationId: null,
+        platform: 'youtube',
+      });
+
+      expect(result.map((t) => String(t.id))).toEqual(['b']);
+    });
+  });
+
+  describe('findLastGoodTrends', () => {
+    it('keeps expired/non-current docs and breaks virality ties by recency', async () => {
+      prisma.trend.findMany.mockResolvedValue([
+        makeDoc(
+          'older',
+          { expiresAt: past, isCurrent: false, viralityScore: 70 },
+          { createdAt: new Date('2026-01-01T00:00:00.000Z') },
+        ),
+        makeDoc(
+          'newer',
+          { expiresAt: past, isCurrent: false, viralityScore: 70 },
+          { createdAt: new Date('2026-02-01T00:00:00.000Z') },
+        ),
+      ]);
+
+      const result = await service.findLastGoodTrends({
+        brandId: null,
+        organizationId: null,
+      });
+
+      // both retained (no active filter); equal virality -> newer first
+      expect(result.map((t) => String(t.id))).toEqual(['newer', 'older']);
+    });
+  });
+
+  describe('getTrendById', () => {
+    it('returns null when the doc belongs to another org', async () => {
+      prisma.trend.findFirst.mockResolvedValue(
+        makeDoc('x', {}, { organizationId: 'other-org' }),
+      );
+
+      const result = await service.getTrendById('x', 'my-org');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the entity for a global trend', async () => {
+      prisma.trend.findFirst.mockResolvedValue(
+        makeDoc('x', { topic: 'global' }, { organizationId: null }),
+      );
+
+      const result = await service.getTrendById('x', 'my-org');
+
+      expect(result).not.toBeNull();
+      expect(String(result?.id)).toBe('x');
+    });
+  });
+
+  describe('getBootstrapTrends', () => {
+    it('returns the curated set, filtered by platform', () => {
+      const all = service.getBootstrapTrends();
+      const tiktok = service.getBootstrapTrends('tiktok');
+
+      expect(all.length).toBeGreaterThan(1);
+      expect(tiktok).toHaveLength(1);
+      expect(tiktok[0]?.platform).toBe('tiktok');
+    });
+  });
+});

--- a/apps/server/api/src/collections/trends/services/modules/trend-query.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-query.service.ts
@@ -70,7 +70,7 @@ export class TrendQueryService {
           'Instagram teams are turning dense strategy notes into swipeable carousel lessons and remixable Reel hooks.',
         source: 'curated',
         sourcePreviewState: 'fallback',
-        trendType: 'post',
+        trendType: 'topic',
         urls: ['https://genfeed.ai/studio'],
       },
       platform: 'instagram',
@@ -102,7 +102,7 @@ export class TrendQueryService {
           'Reddit discussions are comparing lightweight creator stacks for briefs, assets, scheduling, and analytics.',
         source: 'curated',
         sourcePreviewState: 'fallback',
-        trendType: 'discussion',
+        trendType: 'topic',
         urls: ['https://genfeed.ai/articles'],
       },
       platform: 'reddit',
@@ -150,7 +150,7 @@ export class TrendQueryService {
         isDeleted: false,
         ...(organizationId
           ? { OR: [{ organizationId }, { organizationId: null }] }
-          : {}),
+          : { organizationId: null }),
       },
     });
 

--- a/apps/server/api/src/collections/trends/services/modules/trend-query.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-query.service.ts
@@ -1,0 +1,293 @@
+import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
+import type { TrendDocument } from '@api/collections/trends/schemas/trend.schema';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Owns trend read queries against Prisma and the curated bootstrap fallback.
+ *
+ * Extracted from TrendsService (issue #752). The previously near-duplicate
+ * `findActiveTrends` / `findLastGoodTrends` helpers are unified behind a single
+ * parameterized {@link queryTrendsByFilter}.
+ */
+@Injectable()
+export class TrendQueryService {
+  private readonly BOOTSTRAP_TRENDS = [
+    {
+      growthRate: 68,
+      mentions: 42_000,
+      metadata: {
+        hashtags: ['#AIAgents', '#WorkflowAutomation'],
+        sampleContent:
+          'Creators are showing how AI agents turn recurring workflows into reusable content systems.',
+        source: 'curated',
+        sourcePreviewState: 'fallback',
+        trendType: 'topic',
+        urls: ['https://genfeed.ai/articles'],
+      },
+      platform: 'twitter',
+      topic: 'AI agent workflow demos',
+      viralityScore: 78,
+    },
+    {
+      growthRate: 55,
+      mentions: 31_000,
+      metadata: {
+        hashtags: ['#CreatorOps', '#ContentSystems'],
+        sampleContent:
+          'Teams are packaging trend research, briefs, reviews, and publishing into repeatable creator ops loops.',
+        source: 'curated',
+        sourcePreviewState: 'fallback',
+        trendType: 'topic',
+        urls: ['https://genfeed.ai/workflows'],
+      },
+      platform: 'linkedin',
+      topic: 'Creator ops playbooks',
+      viralityScore: 72,
+    },
+    {
+      growthRate: 49,
+      mentions: 27_500,
+      metadata: {
+        hashtags: ['#VideoRepurposing', '#ShortFormVideo'],
+        sampleContent:
+          'Short-form creators are remixing long-form clips into hooks, captions, and platform-native edits.',
+        source: 'curated',
+        sourcePreviewState: 'fallback',
+        trendType: 'video',
+        urls: ['https://genfeed.ai/studio'],
+      },
+      platform: 'youtube',
+      topic: 'Clip remix systems',
+      viralityScore: 69,
+    },
+    {
+      growthRate: 61,
+      mentions: 38_500,
+      metadata: {
+        hashtags: ['#CarouselDesign', '#CreatorStrategy'],
+        sampleContent:
+          'Instagram teams are turning dense strategy notes into swipeable carousel lessons and remixable Reel hooks.',
+        source: 'curated',
+        sourcePreviewState: 'fallback',
+        trendType: 'post',
+        urls: ['https://genfeed.ai/studio'],
+      },
+      platform: 'instagram',
+      topic: 'Carousel-to-Reel content systems',
+      viralityScore: 74,
+    },
+    {
+      growthRate: 64,
+      mentions: 44_200,
+      metadata: {
+        hashtags: ['#TikTokTrends', '#AICreators'],
+        sampleContent:
+          'TikTok creators are testing fast before-and-after demos that show a manual content workflow becoming automated.',
+        source: 'curated',
+        sourcePreviewState: 'fallback',
+        trendType: 'video',
+        urls: ['https://genfeed.ai/workflows'],
+      },
+      platform: 'tiktok',
+      topic: 'Automation before-and-after demos',
+      viralityScore: 76,
+    },
+    {
+      growthRate: 42,
+      mentions: 18_700,
+      metadata: {
+        hashtags: ['#CreatorTools', '#SaaS'],
+        sampleContent:
+          'Reddit discussions are comparing lightweight creator stacks for briefs, assets, scheduling, and analytics.',
+        source: 'curated',
+        sourcePreviewState: 'fallback',
+        trendType: 'discussion',
+        urls: ['https://genfeed.ai/articles'],
+      },
+      platform: 'reddit',
+      topic: 'Lean creator stack comparisons',
+      viralityScore: 63,
+    },
+  ] as const;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Find current (active) trends for a tenant/platform scope, sorted by
+   * virality.
+   */
+  findActiveTrends(filter: {
+    organizationId: string | null;
+    brandId: string | null;
+    platform?: string;
+  }): Promise<TrendEntity[]> {
+    return this.queryTrendsByFilter(filter, { activeOnly: true });
+  }
+
+  /**
+   * Find the most recent good trends regardless of expiry, used as a
+   * last-good fallback when no active trends exist.
+   */
+  findLastGoodTrends(filter: {
+    organizationId: string | null;
+    brandId: string | null;
+    platform?: string;
+  }): Promise<TrendEntity[]> {
+    return this.queryTrendsByFilter(filter, { activeOnly: false });
+  }
+
+  /**
+   * Get a single trend by ID, scoped to the organization or global trends.
+   */
+  async getTrendById(
+    trendId: string,
+    organizationId?: string,
+  ): Promise<TrendEntity | null> {
+    const doc = await this.prisma.trend.findFirst({
+      where: {
+        id: trendId,
+        isDeleted: false,
+        ...(organizationId
+          ? { OR: [{ organizationId }, { organizationId: null }] }
+          : {}),
+      },
+    });
+
+    if (!doc) {
+      return null;
+    }
+
+    // If organizationId provided, trend must belong to that org or be global
+    if (organizationId) {
+      const docOrgId = (doc as unknown as Record<string, unknown>)
+        .organizationId;
+      if (docOrgId !== organizationId && docOrgId !== null) {
+        return null;
+      }
+    }
+
+    return this.toTrendEntity(doc);
+  }
+
+  /**
+   * Curated bootstrap trends used as a final fallback when no data is cached.
+   */
+  getBootstrapTrends(platform?: string): TrendEntity[] {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 6 * 60 * 60 * 1000);
+
+    return this.BOOTSTRAP_TRENDS.filter(
+      (trend) => !platform || trend.platform === platform,
+    ).map((trend, index) => {
+      const id = `bootstrap-trend-${trend.platform}-${index + 1}`;
+      const metadata = {
+        ...trend.metadata,
+        sourcePreviewCache: [
+          {
+            contentType:
+              trend.platform === 'twitter'
+                ? 'tweet'
+                : trend.metadata.trendType === 'video'
+                  ? 'video'
+                  : 'post',
+            id: `${id}-fallback-1`,
+            platform: trend.platform,
+            sourceUrl: trend.metadata.urls[0],
+            text: trend.metadata.sampleContent,
+            title: trend.topic,
+          },
+        ],
+        sourcePreviewCachedAt: now.toISOString(),
+      };
+
+      return new TrendEntity({
+        brandId: null,
+        createdAt: now,
+        data: {
+          ...trend,
+          expiresAt,
+          isCurrent: true,
+          isDeleted: false,
+          metadata,
+          requiresAuth: false,
+        },
+        expiresAt,
+        growthRate: trend.growthRate,
+        id,
+        isCurrent: true,
+        isDeleted: false,
+        mentions: trend.mentions,
+        metadata,
+        organizationId: null,
+        platform: trend.platform,
+        requiresAuth: false,
+        topic: trend.topic,
+        updatedAt: now,
+        viralityScore: trend.viralityScore,
+      } as never);
+    });
+  }
+
+  /**
+   * Hydrate a Prisma trend document (with its nested `data` blob) into a
+   * flattened TrendEntity.
+   */
+  toTrendEntity(
+    doc: {
+      data: unknown;
+    } & Record<string, unknown>,
+  ): TrendEntity {
+    return new TrendEntity({
+      ...doc,
+      ...(doc.data as Record<string, unknown>),
+    } as unknown as TrendDocument);
+  }
+
+  private async queryTrendsByFilter(
+    filter: {
+      organizationId: string | null;
+      brandId: string | null;
+      platform?: string;
+    },
+    options: { activeOnly: boolean },
+  ): Promise<TrendEntity[]> {
+    const now = new Date();
+    const docs = await this.prisma.trend.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+      where: {
+        brandId: filter.brandId,
+        isDeleted: false,
+        organizationId: filter.organizationId,
+      },
+    });
+
+    return docs
+      .filter((doc) => {
+        const d = doc.data as unknown as Record<string, unknown>;
+        if (options.activeOnly) {
+          if (d.isCurrent !== true) return false;
+          if (d.expiresAt && new Date(d.expiresAt as string) <= now) {
+            return false;
+          }
+        }
+        if (filter.platform && d.platform !== filter.platform) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const ad = a.data as unknown as Record<string, number>;
+        const bd = b.data as unknown as Record<string, number>;
+        const viralityDelta = (bd.viralityScore ?? 0) - (ad.viralityScore ?? 0);
+        if (options.activeOnly) {
+          return viralityDelta;
+        }
+        return (
+          viralityDelta ||
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      })
+      .slice(0, 50)
+      .map((doc) => this.toTrendEntity(doc));
+  }
+}

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.spec.ts
@@ -1,0 +1,312 @@
+import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { ApifyService } from '@api/services/integrations/apify/services/apify.service';
+import { Test, TestingModule } from '@nestjs/testing';
+
+type ApifyMock = {
+  searchInstagramByHashtag: ReturnType<typeof vi.fn>;
+  searchRedditPosts: ReturnType<typeof vi.fn>;
+  searchTikTokByHashtag: ReturnType<typeof vi.fn>;
+  searchTwitterTweets: ReturnType<typeof vi.fn>;
+  searchYouTubeVideos: ReturnType<typeof vi.fn>;
+};
+
+const makeTrend = (overrides: Record<string, unknown> = {}): TrendEntity =>
+  ({
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    id: 'trend-1',
+    mentions: 1000,
+    metadata: { hashtags: ['#AI'] },
+    platform: 'instagram',
+    topic: 'AI trends',
+    viralityScore: 80,
+    ...overrides,
+  }) as unknown as TrendEntity;
+
+describe('TrendSourceItemsService', () => {
+  let service: TrendSourceItemsService;
+  let apify: ApifyMock;
+
+  beforeEach(async () => {
+    apify = {
+      searchInstagramByHashtag: vi.fn().mockResolvedValue([]),
+      searchRedditPosts: vi.fn().mockResolvedValue([]),
+      searchTikTokByHashtag: vi.fn().mockResolvedValue([]),
+      searchTwitterTweets: vi.fn().mockResolvedValue([]),
+      searchYouTubeVideos: vi.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrendSourceItemsService,
+        { provide: ApifyService, useValue: apify },
+      ],
+    }).compile();
+
+    service = module.get(TrendSourceItemsService);
+  });
+
+  describe('fetchTrendSourceItems', () => {
+    it('returns [] without calling Apify when no search term is resolvable', async () => {
+      const trend = makeTrend({ metadata: { hashtags: [] }, topic: '' });
+
+      const result = await service.fetchTrendSourceItems(trend, 5);
+
+      expect(result).toEqual([]);
+      expect(apify.searchInstagramByHashtag).not.toHaveBeenCalled();
+    });
+
+    it('returns [] for an unsupported platform', async () => {
+      const trend = makeTrend({ platform: 'pinterest' });
+
+      const result = await service.fetchTrendSourceItems(trend, 5);
+
+      expect(result).toEqual([]);
+      expect(apify.searchInstagramByHashtag).not.toHaveBeenCalled();
+    });
+
+    it('dispatches Instagram to the hashtag search and maps + filters null posts', async () => {
+      apify.searchInstagramByHashtag.mockResolvedValue([
+        {
+          caption: 'first',
+          id: 'ig-1',
+          imageUrl: 'https://img/1.jpg',
+          likesCount: 10,
+          ownerUsername: 'creator',
+          shortCode: 'abc',
+        },
+        // no shortCode / videoUrl / imageUrl -> mapper returns null -> filtered
+        { caption: 'second', id: 'ig-2' },
+      ]);
+
+      const result = await service.fetchTrendSourceItems(makeTrend(), 5);
+
+      expect(apify.searchInstagramByHashtag).toHaveBeenCalledWith('AI', {
+        limit: 5,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        contentType: 'image',
+        id: 'ig-1',
+        platform: 'instagram',
+        sourceUrl: 'https://www.instagram.com/p/abc/',
+      });
+    });
+
+    it('strips a leading # from the hashtag before searching', async () => {
+      await service.fetchTrendSourceItems(
+        makeTrend({ metadata: { hashtags: ['#ShortForm'] } }),
+        3,
+      );
+
+      expect(apify.searchInstagramByHashtag).toHaveBeenCalledWith('ShortForm', {
+        limit: 3,
+      });
+    });
+
+    it('dispatches Twitter and maps tweets (never null)', async () => {
+      apify.searchTwitterTweets.mockResolvedValue([
+        { authorUsername: 'jack', id: 'tw-1', text: 'hello' },
+      ]);
+
+      const result = await service.fetchTrendSourceItems(
+        makeTrend({ platform: 'twitter' }),
+        5,
+      );
+
+      expect(apify.searchTwitterTweets).toHaveBeenCalledWith('AI', {
+        limit: 5,
+      });
+      expect(result[0]).toMatchObject({
+        contentType: 'tweet',
+        platform: 'twitter',
+        sourceUrl: 'https://x.com/jack/status/tw-1',
+      });
+    });
+
+    it('falls back to the topic when no hashtag is present', async () => {
+      await service.fetchTrendSourceItems(
+        makeTrend({
+          metadata: {},
+          platform: 'reddit',
+          topic: 'creator stacks',
+        }),
+        5,
+      );
+
+      expect(apify.searchRedditPosts).toHaveBeenCalledWith('creator stacks', {
+        limit: 5,
+      });
+    });
+
+    it('dispatches TikTok and drops videos without a web url', async () => {
+      apify.searchTikTokByHashtag.mockResolvedValue([
+        {
+          authorMeta: { name: 'tk' },
+          desc: 'clip',
+          diggCount: 5,
+          id: 'tk-1',
+          webVideoUrl: 'https://tiktok.com/v/1',
+        },
+        { desc: 'no url', id: 'tk-2' }, // no webVideoUrl -> null -> filtered
+      ]);
+
+      const result = await service.fetchTrendSourceItems(
+        makeTrend({ platform: 'tiktok' }),
+        5,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        contentType: 'video',
+        platform: 'tiktok',
+        sourceUrl: 'https://tiktok.com/v/1',
+      });
+    });
+
+    it('dispatches YouTube and drops videos without a url', async () => {
+      apify.searchYouTubeVideos.mockResolvedValue([
+        {
+          channelName: 'chan',
+          id: 'yt-1',
+          title: 'A video',
+          url: 'https://youtu.be/1',
+        },
+        { id: 'yt-2', title: 'missing url' }, // no url -> null -> filtered
+      ]);
+
+      const result = await service.fetchTrendSourceItems(
+        makeTrend({ platform: 'youtube' }),
+        5,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        authorHandle: 'chan',
+        platform: 'youtube',
+        sourceUrl: 'https://youtu.be/1',
+        title: 'A video',
+      });
+    });
+
+    it('maps Reddit posts via permalink and drops urless posts', async () => {
+      apify.searchRedditPosts.mockResolvedValue([
+        {
+          author: 'redditor',
+          id: 'rd-1',
+          isVideo: false,
+          numComments: 3,
+          permalink: '/r/x/abc',
+          score: 12,
+          title: 'A thread',
+        },
+        { id: 'rd-2', title: 'no url' }, // no permalink/url -> null -> filtered
+      ]);
+
+      const result = await service.fetchTrendSourceItems(
+        makeTrend({ platform: 'reddit' }),
+        5,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        contentType: 'post',
+        platform: 'reddit',
+        sourceUrl: 'https://reddit.com/r/x/abc',
+      });
+    });
+  });
+
+  describe('buildFallbackTrendSourceItems', () => {
+    it('synthesizes one item per metadata url', () => {
+      const trend = makeTrend({
+        metadata: {
+          sampleContent: 'sample',
+          urls: ['https://a.com', 'https://b.com'],
+        },
+        platform: 'youtube',
+      });
+
+      const items = service.buildFallbackTrendSourceItems(trend);
+
+      expect(items).toHaveLength(2);
+      expect(items[0]).toMatchObject({
+        contentType: 'post',
+        id: 'trend-1-fallback-1',
+        sourceUrl: 'https://a.com',
+        text: 'sample',
+      });
+    });
+
+    it('returns [] when there are no urls or media', () => {
+      expect(
+        service.buildFallbackTrendSourceItems(makeTrend({ metadata: {} })),
+      ).toEqual([]);
+    });
+  });
+
+  describe('stored-preview accessors', () => {
+    it('reads, validates, and limits the cached preview', () => {
+      const trend = makeTrend({
+        metadata: {
+          sourcePreviewCache: [
+            {
+              contentType: 'post',
+              id: 'a',
+              platform: 'instagram',
+              sourceUrl: 'https://a',
+            },
+            { id: 'invalid' }, // fails the type guard -> filtered
+          ],
+        },
+      });
+
+      expect(service.getStoredTrendSourcePreview(trend, 5)).toHaveLength(1);
+    });
+
+    it('infers fallback vs live preview state from the first item id', () => {
+      expect(
+        service.getSourcePreviewState([{ id: 'x-fallback-1' } as never]),
+      ).toBe('fallback');
+      expect(service.getSourcePreviewState([{ id: 'x-1' } as never])).toBe(
+        'live',
+      );
+      expect(service.getSourcePreviewState([])).toBe('empty');
+    });
+
+    it('prefers the persisted state flag over inference', () => {
+      const trend = makeTrend({
+        metadata: { sourcePreviewState: 'live' },
+      });
+
+      expect(service.getStoredTrendSourcePreviewState(trend, [])).toBe('live');
+    });
+  });
+
+  describe('toSyncTrendInput', () => {
+    it('projects the trend with its stored preview and state', () => {
+      const trend = makeTrend({
+        metadata: {
+          sourcePreviewCache: [
+            {
+              contentType: 'post',
+              id: 'a',
+              platform: 'instagram',
+              sourceUrl: 'https://a',
+            },
+          ],
+          sourcePreviewState: 'fallback',
+        },
+      });
+
+      expect(service.toSyncTrendInput(trend)).toMatchObject({
+        id: 'trend-1',
+        mentions: 1000,
+        platform: 'instagram',
+        sourcePreviewState: 'fallback',
+        topic: 'AI trends',
+        viralityScore: 80,
+      });
+    });
+  });
+});

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.ts
@@ -1,0 +1,409 @@
+import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
+import type { TrendSourceItem } from '@api/collections/trends/interfaces/trend.interfaces';
+import { TREND_SOURCE_PREVIEW_LIMIT } from '@api/collections/trends/services/modules/trend-source.constants';
+import type {
+  ApifyInstagramPost,
+  ApifyNormalizedTweet,
+  ApifyRedditPost,
+  ApifyTikTokVideo,
+  ApifyYouTubeVideo,
+} from '@api/services/integrations/apify/interfaces/apify.interfaces';
+import { ApifyService } from '@api/services/integrations/apify/services/apify.service';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Owns the trend "source item" subsystem: live Apify fetch + per-platform
+ * normalization, fallback synthesis, and the stored source-preview accessors.
+ *
+ * Extracted from TrendsService (issue #752). The five previously copy-pasted
+ * per-platform fetchers are collapsed behind a single dispatch table in
+ * {@link fetchTrendSourceItems}.
+ */
+@Injectable()
+export class TrendSourceItemsService {
+  constructor(private readonly apifyService: ApifyService) {}
+
+  /**
+   * Build the source-reference sync input for a trend from its stored preview.
+   */
+  toSyncTrendInput(trend: TrendEntity): {
+    id: string;
+    mentions: number;
+    platform: string;
+    sourcePreview: TrendSourceItem[];
+    sourcePreviewState: 'live' | 'fallback' | 'empty';
+    topic: string;
+    viralityScore: number;
+  } {
+    const sourcePreview = this.getStoredTrendSourcePreview(
+      trend,
+      TREND_SOURCE_PREVIEW_LIMIT,
+    );
+
+    return {
+      id: String(trend.id),
+      mentions: trend.mentions,
+      platform: trend.platform,
+      sourcePreview,
+      sourcePreviewState: this.getStoredTrendSourcePreviewState(
+        trend,
+        sourcePreview,
+      ),
+      topic: trend.topic,
+      viralityScore: trend.viralityScore,
+    };
+  }
+
+  /**
+   * Fetch live source items for a trend from Apify, dispatching by platform.
+   *
+   * A single dispatch table replaces the previous five near-identical
+   * `fetch{Platform}SourceItems` methods: each shares the same shape of
+   * search-term guard, an Apify call, then `.map(mapper).filter(non-null)`.
+   */
+  async fetchTrendSourceItems(
+    trend: TrendEntity,
+    limit: number,
+  ): Promise<TrendSourceItem[]> {
+    const searchTerm = this.getTrendSearchTerm(trend);
+    if (!searchTerm) {
+      return [];
+    }
+
+    const fetchers: Record<string, () => Promise<TrendSourceItem[]>> = {
+      instagram: async () => {
+        const posts = await this.apifyService.searchInstagramByHashtag(
+          searchTerm,
+          { limit },
+        );
+        return this.normalizeSourceItems(posts, (post) =>
+          this.mapInstagramPostToSourceItem(post),
+        );
+      },
+      reddit: async () => {
+        const posts = await this.apifyService.searchRedditPosts(searchTerm, {
+          limit,
+        });
+        return this.normalizeSourceItems(posts, (post) =>
+          this.mapRedditPostToSourceItem(post),
+        );
+      },
+      tiktok: async () => {
+        const videos = await this.apifyService.searchTikTokByHashtag(
+          searchTerm,
+          { limit },
+        );
+        return this.normalizeSourceItems(videos, (video) =>
+          this.mapTikTokVideoToSourceItem(video),
+        );
+      },
+      twitter: async () => {
+        const tweets = await this.apifyService.searchTwitterTweets(searchTerm, {
+          limit,
+        });
+        return this.normalizeSourceItems(tweets, (tweet) =>
+          this.mapTweetToSourceItem(tweet),
+        );
+      },
+      youtube: async () => {
+        const videos = await this.apifyService.searchYouTubeVideos(searchTerm, {
+          limit,
+        });
+        return this.normalizeSourceItems(videos, (video) =>
+          this.mapYouTubeVideoToSourceItem(video),
+        );
+      },
+    };
+
+    const fetcher = fetchers[trend.platform];
+    return fetcher ? fetcher() : [];
+  }
+
+  /**
+   * Synthesize fallback source items from trend metadata when no live items
+   * are available.
+   */
+  buildFallbackTrendSourceItems(trend: TrendEntity): TrendSourceItem[] {
+    const mediaUrl =
+      typeof trend.metadata?.videoUrl === 'string'
+        ? trend.metadata.videoUrl
+        : undefined;
+    const sourceUrls = Array.isArray(trend.metadata?.urls)
+      ? trend.metadata.urls.filter(
+          (url): url is string => typeof url === 'string' && !!url,
+        )
+      : [];
+    const resolvedSourceUrls =
+      sourceUrls.length > 0 ? sourceUrls : mediaUrl ? [mediaUrl] : [];
+
+    return resolvedSourceUrls.map((sourceUrl, index) => ({
+      authorHandle:
+        typeof trend.metadata?.creatorHandle === 'string'
+          ? trend.metadata.creatorHandle
+          : undefined,
+      contentType:
+        trend.platform === 'twitter'
+          ? 'tweet'
+          : trend.metadata?.videoUrl
+            ? 'video'
+            : 'post',
+      id: `${trend.id}-fallback-${index + 1}`,
+      mediaUrl,
+      platform: trend.platform,
+      publishedAt: trend.createdAt?.toISOString(),
+      sourceUrl,
+      text:
+        typeof trend.metadata?.sampleContent === 'string'
+          ? trend.metadata.sampleContent
+          : trend.topic,
+      thumbnailUrl:
+        typeof trend.metadata?.thumbnailUrl === 'string'
+          ? trend.metadata.thumbnailUrl
+          : undefined,
+      title: trend.topic,
+    }));
+  }
+
+  /**
+   * Read the cached source-preview items stored on a trend's metadata.
+   */
+  getStoredTrendSourcePreview(
+    trend: TrendEntity,
+    limit: number = TREND_SOURCE_PREVIEW_LIMIT,
+  ): TrendSourceItem[] {
+    const cachedItems = trend.metadata?.sourcePreviewCache;
+    if (!Array.isArray(cachedItems)) {
+      return [];
+    }
+
+    return cachedItems
+      .filter((item): item is TrendSourceItem => this.isTrendSourceItem(item))
+      .slice(0, limit);
+  }
+
+  /**
+   * Resolve the stored preview state, preferring the persisted state flag and
+   * inferring from the items otherwise.
+   */
+  getStoredTrendSourcePreviewState(
+    trend: TrendEntity,
+    items: TrendSourceItem[],
+  ): 'live' | 'fallback' | 'empty' {
+    const storedState = trend.metadata?.sourcePreviewState;
+    if (
+      storedState === 'live' ||
+      storedState === 'fallback' ||
+      storedState === 'empty'
+    ) {
+      return storedState;
+    }
+
+    return this.getSourcePreviewState(items);
+  }
+
+  /**
+   * Infer whether a set of source items represents live, fallback, or empty
+   * data.
+   */
+  getSourcePreviewState(
+    items: TrendSourceItem[],
+  ): 'live' | 'fallback' | 'empty' {
+    if (items.length === 0) {
+      return 'empty';
+    }
+
+    return items[0]?.id.includes('-fallback') ? 'fallback' : 'live';
+  }
+
+  private normalizeSourceItems<TRaw>(
+    items: TRaw[],
+    map: (item: TRaw) => TrendSourceItem | null,
+  ): TrendSourceItem[] {
+    return items
+      .map((item) => map(item))
+      .filter((item): item is TrendSourceItem => item !== null);
+  }
+
+  private getTrendSearchTerm(trend: TrendEntity): string | null {
+    const primaryHashtag = Array.isArray(trend.metadata?.hashtags)
+      ? trend.metadata.hashtags.find((tag) => !!tag?.trim())
+      : null;
+
+    if (primaryHashtag) {
+      return primaryHashtag.replace(/^#/, '').trim();
+    }
+
+    const topic = trend.topic?.trim();
+    if (!topic) {
+      return null;
+    }
+
+    return topic.replace(/^#/, '').trim();
+  }
+
+  private mapInstagramPostToSourceItem(
+    post: ApifyInstagramPost,
+  ): TrendSourceItem | null {
+    const sourceUrl = post.shortCode
+      ? `https://www.instagram.com/p/${post.shortCode}/`
+      : post.videoUrl || post.imageUrl;
+
+    if (!sourceUrl) {
+      return null;
+    }
+
+    return {
+      authorHandle: post.ownerUsername || undefined,
+      contentType: post.videoUrl ? 'video' : 'image',
+      id: post.id,
+      mediaUrl: post.videoUrl || post.imageUrl,
+      metrics: {
+        comments: post.commentsCount,
+        likes: post.likesCount,
+        views: post.videoViewCount,
+      },
+      platform: 'instagram',
+      publishedAt: post.timestamp || undefined,
+      sourceUrl,
+      text: post.caption,
+      thumbnailUrl: post.imageUrl,
+      title: this.truncateText(post.caption, 100),
+    };
+  }
+
+  private mapTikTokVideoToSourceItem(
+    video: ApifyTikTokVideo,
+  ): TrendSourceItem | null {
+    if (!video.webVideoUrl) {
+      return null;
+    }
+
+    return {
+      authorHandle:
+        video.authorMeta?.name || video.authorMeta?.nickname || undefined,
+      contentType: 'video',
+      id: video.id,
+      mediaUrl: video.webVideoUrl,
+      metrics: {
+        comments: video.commentCount,
+        likes: video.diggCount,
+        shares: video.shareCount,
+        views: video.playCount,
+      },
+      platform: 'tiktok',
+      publishedAt: video.createTime
+        ? new Date(video.createTime * 1000).toISOString()
+        : undefined,
+      sourceUrl: video.webVideoUrl,
+      text: video.desc,
+      thumbnailUrl: video.authorMeta?.avatar || video.musicMeta?.coverUrl,
+      title: this.truncateText(video.desc, 100),
+    };
+  }
+
+  private mapTweetToSourceItem(tweet: ApifyNormalizedTweet): TrendSourceItem {
+    const sourceUrl = tweet.authorUsername
+      ? `https://x.com/${tweet.authorUsername}/status/${tweet.id}`
+      : `https://x.com/i/web/status/${tweet.id}`;
+
+    return {
+      authorHandle: tweet.authorUsername || undefined,
+      contentType: 'tweet',
+      id: tweet.id,
+      metrics: {
+        comments: tweet.metrics?.replies,
+        likes: tweet.metrics?.likes,
+        shares: tweet.metrics?.retweets,
+      },
+      platform: 'twitter',
+      publishedAt: tweet.createdAt?.toISOString(),
+      sourceUrl,
+      text: tweet.text,
+      thumbnailUrl: tweet.authorAvatarUrl,
+      title: this.truncateText(tweet.text, 100),
+    };
+  }
+
+  private mapYouTubeVideoToSourceItem(
+    video: ApifyYouTubeVideo,
+  ): TrendSourceItem | null {
+    if (!video.url) {
+      return null;
+    }
+
+    return {
+      authorHandle: video.channelName || undefined,
+      contentType: 'video',
+      id: video.id,
+      mediaUrl: video.url,
+      metrics: {
+        comments: video.commentCount,
+        likes: video.likeCount,
+        views: video.viewCount,
+      },
+      platform: 'youtube',
+      publishedAt: video.publishedAt || undefined,
+      sourceUrl: video.url,
+      text: video.description,
+      thumbnailUrl: video.thumbnailUrl,
+      title: video.title,
+    };
+  }
+
+  private mapRedditPostToSourceItem(
+    post: ApifyRedditPost,
+  ): TrendSourceItem | null {
+    const sourceUrl = post.permalink
+      ? `https://reddit.com${post.permalink}`
+      : post.url;
+
+    if (!sourceUrl) {
+      return null;
+    }
+
+    return {
+      authorHandle: post.author || undefined,
+      contentType: post.isVideo ? 'video' : 'post',
+      id: post.id,
+      mediaUrl: post.url,
+      metrics: {
+        comments: post.numComments,
+        likes: post.score,
+      },
+      platform: 'reddit',
+      publishedAt: post.createdUtc
+        ? new Date(post.createdUtc * 1000).toISOString()
+        : undefined,
+      sourceUrl,
+      text: post.title,
+      title: post.title,
+    };
+  }
+
+  private isTrendSourceItem(value: unknown): value is TrendSourceItem {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    const item = value as Record<string, unknown>;
+    return (
+      typeof item.id === 'string' &&
+      typeof item.platform === 'string' &&
+      typeof item.sourceUrl === 'string' &&
+      typeof item.contentType === 'string'
+    );
+  }
+
+  private truncateText(
+    value?: string,
+    maxLength: number = 100,
+  ): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    return value.length > maxLength
+      ? `${value.slice(0, maxLength - 1)}…`
+      : value;
+  }
+}

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.spec.ts
@@ -1,0 +1,263 @@
+import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { TrendSourcePreviewService } from '@api/collections/trends/services/modules/trend-source-preview.service';
+import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { ApifyService } from '@api/services/integrations/apify/services/apify.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, TestingModule } from '@nestjs/testing';
+
+const makeTrend = (overrides: Record<string, unknown> = {}): TrendEntity =>
+  ({
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    expiresAt: new Date('2026-02-01T00:00:00.000Z'),
+    id: 'trend-1',
+    mentions: 1000,
+    metadata: {},
+    platform: 'instagram',
+    requiresAuth: false,
+    topic: 'AI trends',
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    viralityScore: 80,
+    ...overrides,
+  }) as unknown as TrendEntity;
+
+describe('TrendSourcePreviewService', () => {
+  let service: TrendSourcePreviewService;
+  let sourceItems: TrendSourceItemsService;
+  let cache: {
+    generateKey: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    invalidateByTags: ReturnType<typeof vi.fn>;
+  };
+  let apify: { [key: string]: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    apify = {
+      searchInstagramByHashtag: vi.fn().mockResolvedValue([]),
+      searchRedditPosts: vi.fn().mockResolvedValue([]),
+      searchTikTokByHashtag: vi.fn().mockResolvedValue([]),
+      searchTwitterTweets: vi.fn().mockResolvedValue([]),
+      searchYouTubeVideos: vi.fn().mockResolvedValue([]),
+    };
+    cache = {
+      generateKey: vi.fn((...args: unknown[]) => args.join(':')),
+      get: vi.fn().mockResolvedValue(null),
+      invalidateByTags: vi.fn().mockResolvedValue(1),
+      set: vi.fn().mockResolvedValue(true),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrendSourcePreviewService,
+        TrendSourceItemsService,
+        { provide: ApifyService, useValue: apify },
+        {
+          provide: PrismaService,
+          useValue: {
+            trend: {
+              findFirst: vi.fn().mockResolvedValue(null),
+              update: vi.fn(),
+            },
+          },
+        },
+        {
+          provide: LoggerService,
+          useValue: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+        },
+        { provide: CacheService, useValue: cache },
+        {
+          provide: TrendReferenceCorpusService,
+          useValue: {
+            annotateSourceItemsWithReferenceIds: vi.fn(async (items) => items),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(TrendSourcePreviewService);
+    sourceItems = module.get(TrendSourceItemsService);
+  });
+
+  describe('getAnnotatedSourceItems', () => {
+    it('returns annotated live items when the fetch yields data', async () => {
+      vi.spyOn(sourceItems, 'fetchTrendSourceItems').mockResolvedValue([
+        {
+          contentType: 'post',
+          id: 'live-1',
+          platform: 'instagram',
+          sourceUrl: 'https://live',
+        },
+      ]);
+
+      const result = await service.getAnnotatedSourceItems(makeTrend(), 5);
+
+      expect(result.map((i) => i.id)).toEqual(['live-1']);
+    });
+
+    it('falls back to synthesized items when the live fetch throws', async () => {
+      vi.spyOn(sourceItems, 'fetchTrendSourceItems').mockRejectedValue(
+        new Error('apify down'),
+      );
+
+      const trend = makeTrend({
+        metadata: { sampleContent: 's', urls: ['https://fallback'] },
+      });
+
+      const result = await service.getAnnotatedSourceItems(trend, 5);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('trend-1-fallback-1');
+    });
+  });
+
+  describe('getTrendContent', () => {
+    const trendA = makeTrend({
+      id: 'a',
+      metadata: {
+        sourcePreviewCache: [
+          {
+            contentType: 'post',
+            id: 'a-1',
+            platform: 'instagram',
+            sourceUrl: 'https://a',
+          },
+        ],
+        sourcePreviewState: 'live',
+      },
+      viralityScore: 90,
+    });
+    const trendB = makeTrend({
+      id: 'b',
+      metadata: {
+        sourcePreviewCache: [
+          {
+            contentType: 'post',
+            id: 'b-1',
+            platform: 'instagram',
+            sourceUrl: 'https://b',
+          },
+        ],
+        sourcePreviewState: 'live',
+      },
+      viralityScore: 50,
+    });
+
+    it('returns the cached payload without loading access control', async () => {
+      cache.get.mockResolvedValue({ items: ['cached'] });
+      const loadAccessControl = vi.fn();
+
+      const result = await service.getTrendContent({}, {}, loadAccessControl);
+
+      expect(result).toEqual({ items: ['cached'] });
+      expect(loadAccessControl).not.toHaveBeenCalled();
+    });
+
+    it('builds, ranks, and caches the feed on a cache miss', async () => {
+      const loadAccessControl = vi.fn().mockResolvedValue({
+        connectedPlatforms: [],
+        lockedPlatforms: [],
+        trends: [trendB, trendA],
+      });
+
+      const result = await service.getTrendContent(
+        { organizationId: 'org' },
+        { limit: 10 },
+        loadAccessControl,
+      );
+
+      expect(result.items.map((i) => i.id)).toEqual(['a-1', 'b-1']);
+      expect(result.items.map((i) => i.contentRank)).toEqual([1, 2]);
+      expect(result.totalTrends).toBe(2);
+      expect(cache.set).toHaveBeenCalledOnce();
+    });
+
+    it('dedupes items that share a source url and unions matched trends', async () => {
+      const shared = (id: string, topic: string, virality: number) =>
+        makeTrend({
+          id,
+          metadata: {
+            sourcePreviewCache: [
+              {
+                contentType: 'post',
+                id: `${id}-1`,
+                platform: 'instagram',
+                sourceUrl: 'https://shared',
+              },
+            ],
+            sourcePreviewState: 'live',
+          },
+          topic,
+          viralityScore: virality,
+        });
+
+      const loadAccessControl = vi.fn().mockResolvedValue({
+        connectedPlatforms: [],
+        lockedPlatforms: [],
+        trends: [shared('a', 'Topic A', 90), shared('b', 'Topic B', 50)],
+      });
+
+      const result = await service.getTrendContent({}, {}, loadAccessControl);
+
+      expect(result.items).toHaveLength(1);
+      expect([...result.items[0].matchedTrends].sort()).toEqual([
+        'Topic A',
+        'Topic B',
+      ]);
+    });
+  });
+
+  describe('precomputeTrendSourcePreview', () => {
+    it('passes through trends on non-content-feed platforms untouched', async () => {
+      const trend = makeTrend({ platform: 'pinterest' });
+
+      const [result] = await service.precomputeTrendSourcePreview([trend]);
+
+      expect(result).toBe(trend);
+    });
+
+    it('skips a content-feed trend that already has a cached preview (no force)', async () => {
+      const fetchSpy = vi.spyOn(sourceItems, 'fetchTrendSourceItems');
+      const trend = makeTrend({
+        metadata: {
+          sourcePreviewCache: [
+            {
+              contentType: 'post',
+              id: 'cached-1',
+              platform: 'instagram',
+              sourceUrl: 'https://cached',
+            },
+          ],
+        },
+      });
+
+      const [result] = await service.precomputeTrendSourcePreview([trend]);
+
+      expect(result).toBe(trend);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('resolves and persists a preview when the cache is empty', async () => {
+      vi.spyOn(sourceItems, 'fetchTrendSourceItems').mockResolvedValue([
+        {
+          contentType: 'post',
+          id: 'live-1',
+          platform: 'instagram',
+          sourceUrl: 'https://live',
+        },
+      ]);
+      const trend = makeTrend({ metadata: { hashtags: ['#AI'] } });
+
+      const [result] = await service.precomputeTrendSourcePreview([trend], {
+        force: true,
+      });
+
+      expect(result.metadata?.sourcePreviewCache).toEqual([
+        expect.objectContaining({ id: 'live-1' }),
+      ]);
+      expect(result.metadata?.sourcePreviewState).toBe('live');
+    });
+  });
+});

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.ts
@@ -89,7 +89,9 @@ export class TrendSourcePreviewService {
     }
 
     return this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
-      this.trendSourceItemsService.buildFallbackTrendSourceItems(trend),
+      this.trendSourceItemsService
+        .buildFallbackTrendSourceItems(trend)
+        .slice(0, limit),
     );
   }
 
@@ -169,7 +171,9 @@ export class TrendSourcePreviewService {
       expiresAt:
         trend.expiresAt instanceof Date
           ? trend.expiresAt
-          : new Date(trend.expiresAt),
+          : trend.expiresAt
+            ? new Date(trend.expiresAt)
+            : undefined,
       sourcePreview,
       sourcePreviewState,
       sourcePreviewTotal: sourcePreview.length,
@@ -223,6 +227,11 @@ export class TrendSourcePreviewService {
           limit: TREND_SOURCE_PREVIEW_LIMIT,
         })
       : result.trends;
+    if (refresh) {
+      // Refresh repopulates only the current key; bust shared content tags so
+      // other trends:content:* variants don't keep serving stale previews.
+      await this.invalidateContentCache(['trends:content']);
+    }
 
     const contentItems =
       await this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.ts
@@ -171,9 +171,7 @@ export class TrendSourcePreviewService {
       expiresAt:
         trend.expiresAt instanceof Date
           ? trend.expiresAt
-          : trend.expiresAt
-            ? new Date(trend.expiresAt)
-            : undefined,
+          : new Date(trend.expiresAt),
       sourcePreview,
       sourcePreviewState,
       sourcePreviewTotal: sourcePreview.length,

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-preview.service.ts
@@ -1,0 +1,464 @@
+import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
+import type {
+  TrendContentItem,
+  TrendContentResult,
+  TrendDiscoveryItem,
+  TrendSourceItem,
+} from '@api/collections/trends/interfaces/trend.interfaces';
+import { TREND_SOURCE_PREVIEW_LIMIT } from '@api/collections/trends/services/modules/trend-source.constants';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+interface TrendsAccessControlResult {
+  trends: TrendEntity[];
+  connectedPlatforms: string[];
+  lockedPlatforms: string[];
+}
+
+/**
+ * Owns source-preview persistence/precompute/resolution, the content feed
+ * assembly, the cached content endpoint, and trend discovery items.
+ *
+ * Extracted from TrendsService (issue #752). Live fetch + normalization is
+ * delegated to {@link TrendSourceItemsService}.
+ */
+@Injectable()
+export class TrendSourcePreviewService {
+  private readonly CONTENT_CACHE_TTL_SECONDS = 600;
+  private readonly CONTENT_FEED_PLATFORMS = new Set([
+    'instagram',
+    'linkedin',
+    'reddit',
+    'tiktok',
+    'twitter',
+    'youtube',
+  ]);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly loggerService: LoggerService,
+    private readonly cacheService: CacheService,
+    private readonly trendReferenceCorpusService: TrendReferenceCorpusService,
+    private readonly trendSourceItemsService: TrendSourceItemsService,
+  ) {}
+
+  /**
+   * Build the source-reference sync input for a trend (delegates to the
+   * source-items service which owns the stored-preview accessors).
+   */
+  toSyncTrendInput(trend: TrendEntity): {
+    id: string;
+    mentions: number;
+    platform: string;
+    sourcePreview: TrendSourceItem[];
+    sourcePreviewState: 'live' | 'fallback' | 'empty';
+    topic: string;
+    viralityScore: number;
+  } {
+    return this.trendSourceItemsService.toSyncTrendInput(trend);
+  }
+
+  /**
+   * Fetch live source items for a trend (falling back to synthesized items)
+   * and annotate them with reference IDs.
+   */
+  async getAnnotatedSourceItems(
+    trend: TrendEntity,
+    limit: number,
+  ): Promise<TrendSourceItem[]> {
+    try {
+      const items = await this.trendSourceItemsService.fetchTrendSourceItems(
+        trend,
+        limit,
+      );
+      if (items.length > 0) {
+        return this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
+          items,
+        );
+      }
+    } catch (error: unknown) {
+      this.loggerService.warn('Failed to fetch live trend source items', {
+        error: error instanceof Error ? error.message : String(error),
+        platform: trend.platform,
+        trendId: trend.id,
+      });
+    }
+
+    return this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
+      this.trendSourceItemsService.buildFallbackTrendSourceItems(trend),
+    );
+  }
+
+  /**
+   * Precompute and persist source previews for a batch of trends, returning the
+   * hydrated trends.
+   */
+  async precomputeTrendSourcePreview(
+    trends: TrendEntity[],
+    options: {
+      force?: boolean;
+      limit?: number;
+    } = {},
+  ): Promise<TrendEntity[]> {
+    const limit = options.limit ?? TREND_SOURCE_PREVIEW_LIMIT;
+
+    return await Promise.all(
+      trends.map(async (trend) => {
+        if (!this.CONTENT_FEED_PLATFORMS.has(trend.platform)) {
+          return trend;
+        }
+
+        const cachedItems =
+          this.trendSourceItemsService.getStoredTrendSourcePreview(
+            trend,
+            limit,
+          );
+        if (!options.force && cachedItems.length > 0) {
+          return trend;
+        }
+
+        const resolvedItems = await this.resolveTrendSourcePreview(
+          trend,
+          undefined,
+          {
+            allowLiveFetch: true,
+            ignoreCached: options.force === true,
+            limit,
+          },
+        );
+
+        return this.persistTrendSourcePreview(trend, resolvedItems);
+      }),
+    );
+  }
+
+  /**
+   * Build a discovery item for a trend with an embedded (cache-only) preview.
+   */
+  async buildTrendDiscoveryItem(
+    trend: TrendEntity,
+    organizationId?: string,
+  ): Promise<TrendDiscoveryItem> {
+    const sourcePreview = await this.resolveTrendSourcePreview(
+      trend,
+      organizationId,
+      {
+        allowLiveFetch: false,
+        limit: 3,
+      },
+    );
+    const sourcePreviewState =
+      this.trendSourceItemsService.getStoredTrendSourcePreviewState(
+        trend,
+        sourcePreview,
+      );
+
+    return {
+      ...trend,
+      id: String(trend.id),
+      createdAt:
+        trend.createdAt instanceof Date
+          ? trend.createdAt
+          : trend.createdAt
+            ? new Date(trend.createdAt)
+            : undefined,
+      expiresAt:
+        trend.expiresAt instanceof Date
+          ? trend.expiresAt
+          : new Date(trend.expiresAt),
+      sourcePreview,
+      sourcePreviewState,
+      sourcePreviewTotal: sourcePreview.length,
+      updatedAt:
+        trend.updatedAt instanceof Date
+          ? trend.updatedAt
+          : trend.updatedAt
+            ? new Date(trend.updatedAt)
+            : undefined,
+    };
+  }
+
+  /**
+   * Resolve, dedupe, rank, and cache the content feed for a tenant scope.
+   *
+   * `loadAccessControl` is only invoked on a cache miss so callers don't pay
+   * the access-control cost when the feed is already cached.
+   */
+  async getTrendContent(
+    scope: { organizationId?: string; brandId?: string },
+    options: {
+      platform?: string;
+      limit?: number;
+      refresh?: boolean;
+    },
+    loadAccessControl: () => Promise<TrendsAccessControlResult>,
+  ): Promise<TrendContentResult> {
+    const limit = options.limit ?? 30;
+    const platform = options.platform;
+    const refresh = options.refresh ?? false;
+    const cacheKey = this.cacheService.generateKey(
+      'trends:content',
+      scope.organizationId || 'global',
+      scope.brandId || 'global',
+      platform || 'all',
+      limit,
+    );
+
+    if (!refresh) {
+      const cached = await this.cacheService.get<TrendContentResult>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+
+    const result = await loadAccessControl();
+
+    const trends = refresh
+      ? await this.precomputeTrendSourcePreview(result.trends, {
+          force: true,
+          limit: TREND_SOURCE_PREVIEW_LIMIT,
+        })
+      : result.trends;
+
+    const contentItems =
+      await this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
+        this.buildTrendContentItems(trends, limit),
+      );
+    const payload: TrendContentResult = {
+      connectedPlatforms: result.connectedPlatforms,
+      items: contentItems,
+      latestTrendAt: this.getLatestTrendAt(trends),
+      lockedPlatforms: result.lockedPlatforms,
+      totalTrends: trends.filter((trend) =>
+        this.CONTENT_FEED_PLATFORMS.has(trend.platform),
+      ).length,
+    };
+
+    await this.cacheService.set(cacheKey, payload, {
+      tags: [
+        'trends',
+        'trends:content',
+        platform ? `trends:content:${platform}` : 'trends:content:all',
+      ],
+      ttl: this.CONTENT_CACHE_TTL_SECONDS,
+    });
+
+    return payload;
+  }
+
+  /**
+   * Invalidate cached content-feed entries by tag.
+   */
+  invalidateContentCache(tags: string[]): Promise<number> {
+    return this.cacheService.invalidateByTags(tags);
+  }
+
+  private async persistTrendSourcePreview(
+    trend: TrendEntity,
+    items: TrendSourceItem[],
+  ): Promise<TrendEntity> {
+    const sourcePreviewState =
+      this.trendSourceItemsService.getSourcePreviewState(items);
+    const metadata = {
+      ...trend.metadata,
+      sourcePreviewCache: items,
+      sourcePreviewCachedAt: new Date().toISOString(),
+      sourcePreviewState,
+    };
+
+    const existingDoc = await this.prisma.trend.findFirst({
+      where: { id: String(trend.id), isDeleted: false } as never,
+    });
+    if (existingDoc) {
+      const existingData =
+        (existingDoc.data as unknown as Record<string, unknown>) ?? {};
+      await this.prisma.trend.update({
+        data: { data: { ...existingData, metadata } as never },
+        where: { id: String(trend.id) },
+      });
+    }
+
+    return new TrendEntity({
+      ...trend,
+      metadata,
+    });
+  }
+
+  private async resolveTrendSourcePreview(
+    trend: TrendEntity,
+    organizationId?: string,
+    options: {
+      allowLiveFetch?: boolean;
+      ignoreCached?: boolean;
+      limit?: number;
+    } = {},
+  ): Promise<TrendSourceItem[]> {
+    const limit = options.limit ?? TREND_SOURCE_PREVIEW_LIMIT;
+    const cachedItems =
+      options.ignoreCached === true
+        ? []
+        : this.trendSourceItemsService.getStoredTrendSourcePreview(
+            trend,
+            limit,
+          );
+    if (cachedItems.length > 0) {
+      return cachedItems;
+    }
+
+    const fallbackItems = this.trendSourceItemsService
+      .buildFallbackTrendSourceItems(trend)
+      .slice(0, limit);
+    if (!options.allowLiveFetch) {
+      return fallbackItems;
+    }
+
+    try {
+      const items = await this.trendSourceItemsService.fetchTrendSourceItems(
+        trend,
+        limit,
+      );
+      if (items.length > 0) {
+        return items;
+      }
+    } catch (error: unknown) {
+      this.loggerService.warn('Failed to build embedded trend source preview', {
+        error: error instanceof Error ? error.message : String(error),
+        organizationId,
+        platform: trend.platform,
+        trendId: trend.id,
+      });
+    }
+
+    return fallbackItems;
+  }
+
+  private buildTrendContentItems(
+    trends: TrendEntity[],
+    limit: number,
+  ): TrendContentItem[] {
+    const dedupedItems = new Map<string, TrendContentItem>();
+
+    for (const trend of trends) {
+      if (!this.CONTENT_FEED_PLATFORMS.has(trend.platform)) {
+        continue;
+      }
+
+      const storedItems =
+        this.trendSourceItemsService.getStoredTrendSourcePreview(
+          trend,
+          TREND_SOURCE_PREVIEW_LIMIT,
+        );
+      const sourceItems =
+        storedItems.length > 0
+          ? storedItems
+          : this.trendSourceItemsService.buildFallbackTrendSourceItems(trend);
+
+      for (const sourceItem of sourceItems) {
+        const contentItem: TrendContentItem = {
+          ...sourceItem,
+          contentRank: 0,
+          matchedTrends: [trend.topic],
+          requiresAuth: trend.requiresAuth,
+          sourcePreviewState:
+            this.trendSourceItemsService.getSourcePreviewState([sourceItem]),
+          trendId: String(trend.id),
+          trendMentions: trend.mentions,
+          trendTopic: trend.topic,
+          trendViralityScore: trend.viralityScore,
+        };
+        const dedupeKey = this.getTrendContentCacheKey(contentItem);
+        const existing = dedupedItems.get(dedupeKey);
+
+        if (!existing) {
+          dedupedItems.set(dedupeKey, contentItem);
+          continue;
+        }
+
+        const matchedTrends = Array.from(
+          new Set([...existing.matchedTrends, trend.topic]),
+        );
+        const preferred =
+          this.compareTrendContentItems(contentItem, existing) > 0
+            ? existing
+            : contentItem;
+
+        dedupedItems.set(dedupeKey, {
+          ...preferred,
+          matchedTrends,
+        });
+      }
+    }
+
+    return Array.from(dedupedItems.values())
+      .sort((left, right) => this.compareTrendContentItems(left, right))
+      .slice(0, limit)
+      .map((item, index) => ({
+        ...item,
+        contentRank: index + 1,
+      }));
+  }
+
+  private getLatestTrendAt(trends: TrendEntity[]): string | undefined {
+    const timestamps = trends
+      .map((trend) =>
+        trend.createdAt instanceof Date
+          ? trend.createdAt.getTime()
+          : trend.createdAt
+            ? new Date(trend.createdAt).getTime()
+            : 0,
+      )
+      .filter((value) => value > 0);
+
+    if (timestamps.length === 0) {
+      return undefined;
+    }
+
+    return new Date(Math.max(...timestamps)).toISOString();
+  }
+
+  private getTrendContentCacheKey(item: TrendContentItem): string {
+    return `${item.platform}:${item.sourceUrl || item.id}`;
+  }
+
+  private getTrendContentEngagementScore(item: TrendContentItem): number {
+    return (
+      (item.metrics?.views || 0) +
+      (item.metrics?.likes || 0) +
+      (item.metrics?.comments || 0) +
+      (item.metrics?.shares || 0)
+    );
+  }
+
+  private compareTrendContentItems(
+    left: TrendContentItem,
+    right: TrendContentItem,
+  ): number {
+    const liveStateDelta =
+      Number(right.sourcePreviewState === 'live') -
+      Number(left.sourcePreviewState === 'live');
+    if (liveStateDelta !== 0) {
+      return liveStateDelta;
+    }
+
+    const viralityDelta = right.trendViralityScore - left.trendViralityScore;
+    if (viralityDelta !== 0) {
+      return viralityDelta;
+    }
+
+    const engagementDelta =
+      this.getTrendContentEngagementScore(right) -
+      this.getTrendContentEngagementScore(left);
+    if (engagementDelta !== 0) {
+      return engagementDelta;
+    }
+
+    return (
+      new Date(right.publishedAt || 0).getTime() -
+      new Date(left.publishedAt || 0).getTime()
+    );
+  }
+}

--- a/apps/server/api/src/collections/trends/services/modules/trend-source.constants.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source.constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Default number of source-preview items retained per trend across the trend
+ * source-item subsystem. Shared by the source-items and source-preview services
+ * so the value cannot silently drift between them.
+ */
+export const TREND_SOURCE_PREVIEW_LIMIT = 5;

--- a/apps/server/api/src/collections/trends/services/trends.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trends.service.spec.ts
@@ -7,6 +7,10 @@ import { TrendAnalysisService } from '@api/collections/trends/services/modules/t
 import { TrendContentIdeasService } from '@api/collections/trends/services/modules/trend-content-ideas.service';
 import { TrendFetchService } from '@api/collections/trends/services/modules/trend-fetch.service';
 import { TrendFilteringService } from '@api/collections/trends/services/modules/trend-filtering.service';
+import { TrendPrelaunchCorpusService } from '@api/collections/trends/services/modules/trend-prelaunch-corpus.service';
+import { TrendQueryService } from '@api/collections/trends/services/modules/trend-query.service';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { TrendSourcePreviewService } from '@api/collections/trends/services/modules/trend-source-preview.service';
 import { TrendVideoService } from '@api/collections/trends/services/modules/trend-video.service';
 import { TrendPreferencesService } from '@api/collections/trends/services/trend-preferences.service';
 import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
@@ -113,6 +117,10 @@ describe('TrendsService', () => {
         TrendContentIdeasService,
         TrendFetchService,
         TrendFilteringService,
+        TrendPrelaunchCorpusService,
+        TrendQueryService,
+        TrendSourceItemsService,
+        TrendSourcePreviewService,
         TrendVideoService,
         TrendPreferencesService,
         {

--- a/apps/server/api/src/collections/trends/services/trends.service.ts
+++ b/apps/server/api/src/collections/trends/services/trends.service.ts
@@ -1,16 +1,9 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
-import {
-  buildPrelaunchReferenceCorpusSeeds,
-  PRELAUNCH_REFERENCE_CORPUS_MINIMUMS,
-  PRELAUNCH_REFERENCE_CORPUS_VERSION,
-  type PrelaunchReferenceCorpusSeed,
-} from '@api/collections/trends/data/prelaunch-reference-corpus.seed';
 import { TrendIdea } from '@api/collections/trends/dto/trend-ideas.dto';
 import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
 import type {
   HistoricalTrendsOptions,
-  TrendContentItem,
   TrendContentResult,
   TrendData,
   TrendDiscoveryItem,
@@ -23,7 +16,6 @@ import type {
   TrendTimelineEntry,
   TrendTurnoverStats,
 } from '@api/collections/trends/interfaces/trend-turnover.interface';
-import type { TrendDocument } from '@api/collections/trends/schemas/trend.schema';
 import type { TrendingHashtagDocument } from '@api/collections/trends/schemas/trending-hashtag.schema';
 import type { TrendingSoundDocument } from '@api/collections/trends/schemas/trending-sound.schema';
 import type { TrendingVideoDocument } from '@api/collections/trends/schemas/trending-video.schema';
@@ -31,159 +23,34 @@ import { TrendAnalysisService } from '@api/collections/trends/services/modules/t
 import { TrendContentIdeasService } from '@api/collections/trends/services/modules/trend-content-ideas.service';
 import { TrendFetchService } from '@api/collections/trends/services/modules/trend-fetch.service';
 import { TrendFilteringService } from '@api/collections/trends/services/modules/trend-filtering.service';
+import {
+  type PrelaunchReferenceCorpusBackfillOptions,
+  type PrelaunchReferenceCorpusBackfillResult,
+  TrendPrelaunchCorpusService,
+} from '@api/collections/trends/services/modules/trend-prelaunch-corpus.service';
+import { TrendQueryService } from '@api/collections/trends/services/modules/trend-query.service';
+import { TrendSourcePreviewService } from '@api/collections/trends/services/modules/trend-source-preview.service';
 import { TrendVideoService } from '@api/collections/trends/services/modules/trend-video.service';
 import { TrendPreferencesService } from '@api/collections/trends/services/trend-preferences.service';
 import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
-import { CacheService } from '@api/services/cache/services/cache.service';
-import type {
-  ApifyInstagramPost,
-  ApifyNormalizedTweet,
-  ApifyRedditPost,
-  ApifyTikTokVideo,
-  ApifyYouTubeVideo,
-} from '@api/services/integrations/apify/interfaces/apify.interfaces';
-import { ApifyService } from '@api/services/integrations/apify/services/apify.service';
-import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { Timeframe } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
-export interface PrelaunchReferenceCorpusBackfillOptions {
-  dryRun?: boolean;
-  now?: Date;
-}
+export type {
+  PrelaunchReferenceCorpusBackfillOptions,
+  PrelaunchReferenceCorpusBackfillResult,
+} from '@api/collections/trends/services/modules/trend-prelaunch-corpus.service';
 
-export interface PrelaunchReferenceCorpusBackfillResult {
-  createdTrends: number;
-  dryRun: boolean;
-  plannedCreates: number;
-  plannedUpdates: number;
-  referenceSync: {
-    links: number;
-    references: number;
-    snapshots: number;
-  };
-  seedReferences: number;
-  seedTrends: number;
-  updatedTrends: number;
-  version: string;
-}
-
+/**
+ * Orchestrates trend retrieval, access control, and discovery, delegating the
+ * source-item subsystem, preview persistence, read queries, and prelaunch
+ * corpus seeding to focused module services (issue #752).
+ */
 @Injectable()
 export class TrendsService {
-  private readonly CONTENT_CACHE_TTL_SECONDS = 600;
-  private readonly SOURCE_PREVIEW_LIMIT = 5;
-  private readonly CONTENT_FEED_PLATFORMS = new Set([
-    'instagram',
-    'linkedin',
-    'reddit',
-    'tiktok',
-    'twitter',
-    'youtube',
-  ]);
-  private readonly BOOTSTRAP_TRENDS = [
-    {
-      growthRate: 68,
-      mentions: 42_000,
-      metadata: {
-        hashtags: ['#AIAgents', '#WorkflowAutomation'],
-        sampleContent:
-          'Creators are showing how AI agents turn recurring workflows into reusable content systems.',
-        source: 'curated',
-        sourcePreviewState: 'fallback',
-        trendType: 'topic',
-        urls: ['https://genfeed.ai/articles'],
-      },
-      platform: 'twitter',
-      topic: 'AI agent workflow demos',
-      viralityScore: 78,
-    },
-    {
-      growthRate: 55,
-      mentions: 31_000,
-      metadata: {
-        hashtags: ['#CreatorOps', '#ContentSystems'],
-        sampleContent:
-          'Teams are packaging trend research, briefs, reviews, and publishing into repeatable creator ops loops.',
-        source: 'curated',
-        sourcePreviewState: 'fallback',
-        trendType: 'topic',
-        urls: ['https://genfeed.ai/workflows'],
-      },
-      platform: 'linkedin',
-      topic: 'Creator ops playbooks',
-      viralityScore: 72,
-    },
-    {
-      growthRate: 49,
-      mentions: 27_500,
-      metadata: {
-        hashtags: ['#VideoRepurposing', '#ShortFormVideo'],
-        sampleContent:
-          'Short-form creators are remixing long-form clips into hooks, captions, and platform-native edits.',
-        source: 'curated',
-        sourcePreviewState: 'fallback',
-        trendType: 'video',
-        urls: ['https://genfeed.ai/studio'],
-      },
-      platform: 'youtube',
-      topic: 'Clip remix systems',
-      viralityScore: 69,
-    },
-    {
-      growthRate: 61,
-      mentions: 38_500,
-      metadata: {
-        hashtags: ['#CarouselDesign', '#CreatorStrategy'],
-        sampleContent:
-          'Instagram teams are turning dense strategy notes into swipeable carousel lessons and remixable Reel hooks.',
-        source: 'curated',
-        sourcePreviewState: 'fallback',
-        trendType: 'post',
-        urls: ['https://genfeed.ai/studio'],
-      },
-      platform: 'instagram',
-      topic: 'Carousel-to-Reel content systems',
-      viralityScore: 74,
-    },
-    {
-      growthRate: 64,
-      mentions: 44_200,
-      metadata: {
-        hashtags: ['#TikTokTrends', '#AICreators'],
-        sampleContent:
-          'TikTok creators are testing fast before-and-after demos that show a manual content workflow becoming automated.',
-        source: 'curated',
-        sourcePreviewState: 'fallback',
-        trendType: 'video',
-        urls: ['https://genfeed.ai/workflows'],
-      },
-      platform: 'tiktok',
-      topic: 'Automation before-and-after demos',
-      viralityScore: 76,
-    },
-    {
-      growthRate: 42,
-      mentions: 18_700,
-      metadata: {
-        hashtags: ['#CreatorTools', '#SaaS'],
-        sampleContent:
-          'Reddit discussions are comparing lightweight creator stacks for briefs, assets, scheduling, and analytics.',
-        source: 'curated',
-        sourcePreviewState: 'fallback',
-        trendType: 'discussion',
-        urls: ['https://genfeed.ai/articles'],
-      },
-      platform: 'reddit',
-      topic: 'Lean creator stack comparisons',
-      viralityScore: 63,
-    },
-  ] as const;
-
   constructor(
-    private readonly prisma: PrismaService,
     private readonly loggerService: LoggerService,
-    private readonly cacheService: CacheService,
     private readonly brandsService: BrandsService,
     private readonly credentialsService: CredentialsService,
     private readonly trendPreferencesService: TrendPreferencesService,
@@ -193,59 +60,16 @@ export class TrendsService {
     private readonly trendAnalysisService: TrendAnalysisService,
     private readonly trendFilteringService: TrendFilteringService,
     private readonly trendVideoService: TrendVideoService,
-    private readonly apifyService: ApifyService,
+    private readonly trendQueryService: TrendQueryService,
+    private readonly trendSourcePreviewService: TrendSourcePreviewService,
+    private readonly trendPrelaunchCorpusService: TrendPrelaunchCorpusService,
   ) {}
 
-  private toSyncTrendInput(trend: TrendEntity): {
-    id: string;
-    mentions: number;
-    platform: string;
-    sourcePreview: TrendSourceItem[];
-    sourcePreviewState: 'live' | 'fallback' | 'empty';
-    topic: string;
-    viralityScore: number;
-  } {
-    return {
-      id: String(trend.id),
-      mentions: trend.mentions,
-      platform: trend.platform,
-      sourcePreview: this.getStoredTrendSourcePreview(
-        trend,
-        this.SOURCE_PREVIEW_LIMIT,
-      ),
-      sourcePreviewState: this.getStoredTrendSourcePreviewState(
-        trend,
-        this.getStoredTrendSourcePreview(trend, this.SOURCE_PREVIEW_LIMIT),
-      ),
-      topic: trend.topic,
-      viralityScore: trend.viralityScore,
-    };
-  }
-
-  async getGlobalCorpusStats(): Promise<{
+  getGlobalCorpusStats(): Promise<{
     activeTrends: number;
     referenceRecords: number;
   }> {
-    const now = new Date();
-    const [allGlobalTrends, referenceRecords] = await Promise.all([
-      this.prisma.trend.findMany({
-        where: { isDeleted: false, organizationId: null },
-      }),
-      this.trendReferenceCorpusService.countGlobalReferences(),
-    ]);
-    const activeTrends = allGlobalTrends.filter((doc) => {
-      const d = doc.data as unknown as Record<string, unknown>;
-      return (
-        d.isCurrent === true &&
-        d.expiresAt != null &&
-        new Date(d.expiresAt as string) > now
-      );
-    }).length;
-
-    return {
-      activeTrends,
-      referenceRecords,
-    };
+    return this.trendPrelaunchCorpusService.getGlobalCorpusStats();
   }
 
   // ==================== Orchestrator Methods ====================
@@ -291,14 +115,19 @@ export class TrendsService {
       brandId,
       (trend) => this.trendFilteringService.calculateViralityScore(trend),
     );
-    const hydratedTrends = await this.precomputeTrendSourcePreview(trends, {
-      force: true,
-      limit: this.SOURCE_PREVIEW_LIMIT,
-    });
+    const hydratedTrends =
+      await this.trendSourcePreviewService.precomputeTrendSourcePreview(
+        trends,
+        { force: true },
+      );
     await this.trendReferenceCorpusService.syncTrendReferences(
-      hydratedTrends.map((trend) => this.toSyncTrendInput(trend)),
+      hydratedTrends.map((trend) =>
+        this.trendSourcePreviewService.toSyncTrendInput(trend),
+      ),
     );
-    await this.cacheService.invalidateByTags(['trends:content']);
+    await this.trendSourcePreviewService.invalidateContentCache([
+      'trends:content',
+    ]);
     return hydratedTrends;
   }
 
@@ -314,7 +143,7 @@ export class TrendsService {
       allowFetchIfMissing?: boolean;
     } = {},
   ): Promise<TrendEntity[]> {
-    const cachedTrends = await this.findActiveTrends({
+    const cachedTrends = await this.trendQueryService.findActiveTrends({
       brandId: brandId ?? null,
       organizationId: organizationId ?? null,
       platform,
@@ -325,7 +154,7 @@ export class TrendsService {
     }
 
     if (organizationId || brandId) {
-      const globalTrends = await this.findActiveTrends({
+      const globalTrends = await this.trendQueryService.findActiveTrends({
         brandId: null,
         organizationId: null,
         platform,
@@ -338,7 +167,7 @@ export class TrendsService {
       }
     }
 
-    const lastGoodTrends = await this.findLastGoodTrends({
+    const lastGoodTrends = await this.trendQueryService.findLastGoodTrends({
       brandId: brandId ?? null,
       organizationId: organizationId ?? null,
       platform,
@@ -351,11 +180,12 @@ export class TrendsService {
     }
 
     if (organizationId || brandId) {
-      const globalLastGoodTrends = await this.findLastGoodTrends({
-        brandId: null,
-        organizationId: null,
-        platform,
-      });
+      const globalLastGoodTrends =
+        await this.trendQueryService.findLastGoodTrends({
+          brandId: null,
+          organizationId: null,
+          platform,
+        });
       if (globalLastGoodTrends.length > 0) {
         this.loggerService.log(
           'No tenant-scoped last-good trends found, falling back to global last-good trend dataset',
@@ -384,199 +214,7 @@ export class TrendsService {
     this.loggerService.log(
       'Fresh trend fetch returned no data, returning bootstrap trend fallback',
     );
-    return this.getBootstrapTrends(platform);
-  }
-
-  private toTrendEntity(
-    doc: {
-      data: unknown;
-    } & Record<string, unknown>,
-  ): TrendEntity {
-    return new TrendEntity({
-      ...doc,
-      ...(doc.data as Record<string, unknown>),
-    } as unknown as TrendDocument);
-  }
-
-  private async findPrelaunchCorpusDocs(): Promise<
-    Array<{ data: unknown; id: string } & Record<string, unknown>>
-  > {
-    const docs = await this.prisma.trend.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends * 2,
-      where: {
-        brandId: null,
-        isDeleted: false,
-        organizationId: null,
-      } as never,
-    });
-
-    return docs.filter((doc) => this.getPrelaunchCorpusKey(doc) != null);
-  }
-
-  private getPrelaunchCorpusKey(doc: { data: unknown }): string | null {
-    const data = doc.data as Record<string, unknown>;
-    const metadata = data.metadata as Record<string, unknown> | undefined;
-    const key = metadata?.prelaunchCorpusKey;
-
-    return typeof key === 'string' && key.length > 0 ? key : null;
-  }
-
-  private buildPrelaunchTrendData(
-    seed: PrelaunchReferenceCorpusSeed,
-    now: Date,
-  ): Record<string, unknown> {
-    const expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
-    const sourceUrls = seed.sourcePreview.map((item) => item.sourceUrl);
-    const metadata = {
-      ...seed.metadata,
-      prelaunchCorpus: true,
-      prelaunchCorpusKey: seed.key,
-      source: 'curated',
-      sourcePreviewCache: seed.sourcePreview,
-      sourcePreviewCachedAt: now.toISOString(),
-      sourcePreviewState: 'fallback',
-      sourceSetVersion: PRELAUNCH_REFERENCE_CORPUS_VERSION,
-      trendType: seed.sourcePreview.some((item) => item.contentType === 'video')
-        ? 'video'
-        : 'topic',
-      urls: sourceUrls,
-    };
-
-    return {
-      expiresAt: expiresAt.toISOString(),
-      growthRate: seed.growthRate,
-      isCurrent: true,
-      isDeleted: false,
-      mentions: seed.mentions,
-      metadata,
-      platform: seed.platform,
-      requiresAuth: false,
-      topic: seed.topic,
-      viralityScore: seed.viralityScore,
-    };
-  }
-
-  private async findActiveTrends(filter: {
-    organizationId: string | null;
-    brandId: string | null;
-    platform?: string;
-  }): Promise<TrendEntity[]> {
-    const now = new Date();
-    const docs = await this.prisma.trend.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: 200,
-      where: {
-        brandId: filter.brandId,
-        isDeleted: false,
-        organizationId: filter.organizationId,
-      },
-    });
-
-    return docs
-      .filter((doc) => {
-        const d = doc.data as unknown as Record<string, unknown>;
-        if (d.isCurrent !== true) return false;
-        if (d.expiresAt && new Date(d.expiresAt as string) <= now) return false;
-        if (filter.platform && d.platform !== filter.platform) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        const ad = a.data as unknown as Record<string, number>;
-        const bd = b.data as unknown as Record<string, number>;
-        return (bd.viralityScore ?? 0) - (ad.viralityScore ?? 0);
-      })
-      .slice(0, 50)
-      .map((doc) => this.toTrendEntity(doc));
-  }
-
-  private async findLastGoodTrends(filter: {
-    organizationId: string | null;
-    brandId: string | null;
-    platform?: string;
-  }): Promise<TrendEntity[]> {
-    const docs = await this.prisma.trend.findMany({
-      orderBy: { createdAt: 'desc' },
-      take: 200,
-      where: {
-        brandId: filter.brandId,
-        isDeleted: false,
-        organizationId: filter.organizationId,
-      },
-    });
-
-    return docs
-      .filter((doc) => {
-        const d = doc.data as unknown as Record<string, unknown>;
-        if (filter.platform && d.platform !== filter.platform) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        const ad = a.data as unknown as Record<string, number>;
-        const bd = b.data as unknown as Record<string, number>;
-        return (
-          (bd.viralityScore ?? 0) - (ad.viralityScore ?? 0) ||
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
-      })
-      .slice(0, 50)
-      .map((doc) => this.toTrendEntity(doc));
-  }
-
-  private getBootstrapTrends(platform?: string): TrendEntity[] {
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + 6 * 60 * 60 * 1000);
-
-    return this.BOOTSTRAP_TRENDS.filter(
-      (trend) => !platform || trend.platform === platform,
-    ).map((trend, index) => {
-      const id = `bootstrap-trend-${trend.platform}-${index + 1}`;
-      const metadata = {
-        ...trend.metadata,
-        sourcePreviewCache: [
-          {
-            contentType:
-              trend.platform === 'twitter'
-                ? 'tweet'
-                : trend.metadata.trendType === 'video'
-                  ? 'video'
-                  : 'post',
-            id: `${id}-fallback-1`,
-            platform: trend.platform,
-            sourceUrl: trend.metadata.urls[0],
-            text: trend.metadata.sampleContent,
-            title: trend.topic,
-          },
-        ],
-        sourcePreviewCachedAt: now.toISOString(),
-      };
-
-      return new TrendEntity({
-        brandId: null,
-        createdAt: now,
-        data: {
-          ...trend,
-          expiresAt,
-          isCurrent: true,
-          isDeleted: false,
-          metadata,
-          requiresAuth: false,
-        },
-        expiresAt,
-        growthRate: trend.growthRate,
-        id,
-        isCurrent: true,
-        isDeleted: false,
-        mentions: trend.mentions,
-        metadata,
-        organizationId: null,
-        platform: trend.platform,
-        requiresAuth: false,
-        topic: trend.topic,
-        updatedAt: now,
-        viralityScore: trend.viralityScore,
-      } as never);
-    });
+    return this.trendQueryService.getBootstrapTrends(platform);
   }
 
   /**
@@ -647,7 +285,7 @@ export class TrendsService {
     // through this wrapper and still need a curated set to render, so restore the
     // bootstrap fallback here when nothing is cached.
     if (trends.length === 0) {
-      trends = this.getBootstrapTrends(platform);
+      trends = this.trendQueryService.getBootstrapTrends(platform);
     }
 
     // Filter by brand description if brandId provided
@@ -734,7 +372,10 @@ export class TrendsService {
 
     const trends = await Promise.all(
       result.trends.map(async (trend) =>
-        this.buildTrendDiscoveryItem(trend, organizationId),
+        this.trendSourcePreviewService.buildTrendDiscoveryItem(
+          trend,
+          organizationId,
+        ),
       ),
     );
 
@@ -787,122 +428,35 @@ export class TrendsService {
 
   async precomputeGlobalTrendSourcePreview(): Promise<{ processed: number }> {
     const trends = await this.getTrends();
-    const hydratedTrends = await this.precomputeTrendSourcePreview(trends, {
-      force: true,
-      limit: this.SOURCE_PREVIEW_LIMIT,
-    });
+    const hydratedTrends =
+      await this.trendSourcePreviewService.precomputeTrendSourcePreview(
+        trends,
+        { force: true },
+      );
     await this.trendReferenceCorpusService.syncTrendReferences(
-      hydratedTrends.map((trend) => this.toSyncTrendInput(trend)),
+      hydratedTrends.map((trend) =>
+        this.trendSourcePreviewService.toSyncTrendInput(trend),
+      ),
     );
     const processed = hydratedTrends.length;
 
-    await this.cacheService.invalidateByTags(['trends:content']);
+    await this.trendSourcePreviewService.invalidateContentCache([
+      'trends:content',
+    ]);
 
     return { processed };
   }
 
-  async backfillPrelaunchReferenceCorpus(
-    options: PrelaunchReferenceCorpusBackfillOptions = {},
-  ): Promise<PrelaunchReferenceCorpusBackfillResult> {
-    const now = options.now ?? new Date();
-    const dryRun = options.dryRun ?? true;
-    const seeds = buildPrelaunchReferenceCorpusSeeds(now);
-    const seedReferences = seeds.reduce(
-      (total, seed) => total + seed.sourcePreview.length,
-      0,
+  backfillPrelaunchReferenceCorpus(
+    options: Parameters<
+      TrendPrelaunchCorpusService['backfillPrelaunchReferenceCorpus']
+    >[0] = {},
+  ): ReturnType<
+    TrendPrelaunchCorpusService['backfillPrelaunchReferenceCorpus']
+  > {
+    return this.trendPrelaunchCorpusService.backfillPrelaunchReferenceCorpus(
+      options,
     );
-
-    const existingDocs = await this.findPrelaunchCorpusDocs();
-    const existingByKey = new Map(
-      existingDocs.flatMap((doc) => {
-        const key = this.getPrelaunchCorpusKey(doc);
-        return key ? [[key, doc] as const] : [];
-      }),
-    );
-    const plannedCreates = seeds.filter(
-      (seed) => !existingByKey.has(seed.key),
-    ).length;
-    const plannedUpdates = seeds.length - plannedCreates;
-
-    if (dryRun) {
-      return {
-        createdTrends: 0,
-        dryRun,
-        plannedCreates,
-        plannedUpdates,
-        referenceSync: { links: 0, references: 0, snapshots: 0 },
-        seedReferences,
-        seedTrends: seeds.length,
-        updatedTrends: 0,
-        version: PRELAUNCH_REFERENCE_CORPUS_VERSION,
-      };
-    }
-
-    const syncedTrends: TrendEntity[] = [];
-    let createdTrends = 0;
-    let updatedTrends = 0;
-
-    for (const seed of seeds) {
-      const trendData = this.buildPrelaunchTrendData(seed, now);
-      const existing = existingByKey.get(seed.key);
-
-      if (existing) {
-        const updated = await this.prisma.trend.update({
-          data: {
-            data: trendData,
-            isDeleted: false,
-          } as never,
-          where: { id: existing.id },
-        });
-        syncedTrends.push(this.toTrendEntity(updated));
-        updatedTrends += 1;
-        continue;
-      }
-
-      const created = await this.prisma.trend.create({
-        data: {
-          brandId: null,
-          data: trendData,
-          isDeleted: false,
-          organizationId: null,
-        } as never,
-      });
-      syncedTrends.push(this.toTrendEntity(created));
-      createdTrends += 1;
-    }
-
-    const referenceSync =
-      await this.trendReferenceCorpusService.syncTrendReferences(
-        syncedTrends.map((trend) => this.toSyncTrendInput(trend)),
-      );
-
-    await this.cacheService.invalidateByTags(['trends', 'trends:content']);
-
-    if (
-      seeds.length < PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.trends ||
-      seedReferences < PRELAUNCH_REFERENCE_CORPUS_MINIMUMS.sourceReferences
-    ) {
-      this.loggerService.warn(
-        'Prelaunch reference corpus seed is below floor',
-        {
-          minimums: PRELAUNCH_REFERENCE_CORPUS_MINIMUMS,
-          seedReferences,
-          seedTrends: seeds.length,
-        },
-      );
-    }
-
-    return {
-      createdTrends,
-      dryRun,
-      plannedCreates,
-      plannedUpdates,
-      referenceSync,
-      seedReferences,
-      seedTrends: seeds.length,
-      updatedTrends,
-      version: PRELAUNCH_REFERENCE_CORPUS_VERSION,
-    };
   }
 
   async getReferenceCorpus(
@@ -961,42 +515,16 @@ export class TrendsService {
     );
   }
 
-  // ==================== Delegated: Filtering ====================
+  // ==================== Delegated: Read Queries ====================
 
   /**
    * Get a single trend by ID
    */
-  async getTrendById(
+  getTrendById(
     trendId: string,
     organizationId?: string,
   ): Promise<TrendEntity | null> {
-    const doc = await this.prisma.trend.findFirst({
-      where: {
-        id: trendId,
-        isDeleted: false,
-        ...(organizationId
-          ? { OR: [{ organizationId }, { organizationId: null }] }
-          : {}),
-      },
-    });
-
-    if (!doc) {
-      return null;
-    }
-
-    // If organizationId provided, trend must belong to that org or be global
-    if (organizationId) {
-      const docOrgId = (doc as unknown as Record<string, unknown>)
-        .organizationId;
-      if (docOrgId !== organizationId && docOrgId !== null) {
-        return null;
-      }
-    }
-
-    return new TrendEntity({
-      ...doc,
-      ...(doc.data as Record<string, unknown>),
-    } as unknown as TrendDocument);
+    return this.trendQueryService.getTrendById(trendId, organizationId);
   }
 
   async getTrendSourceItems(
@@ -1004,32 +532,18 @@ export class TrendsService {
     organizationId?: string,
     limit: number = 5,
   ): Promise<TrendSourceItem[]> {
-    const trend = await this.getTrendById(trendId, organizationId);
+    const trend = await this.trendQueryService.getTrendById(
+      trendId,
+      organizationId,
+    );
     if (!trend) {
       return [];
     }
 
-    try {
-      const items = await this.fetchTrendSourceItems(trend, limit);
-      if (items.length > 0) {
-        return this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
-          items,
-        );
-      }
-    } catch (error: unknown) {
-      this.loggerService.warn('Failed to fetch live trend source items', {
-        error: error instanceof Error ? error.message : String(error),
-        platform: trend.platform,
-        trendId,
-      });
-    }
-
-    return this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
-      this.buildFallbackTrendSourceItems(trend),
-    );
+    return this.trendSourcePreviewService.getAnnotatedSourceItems(trend, limit);
   }
 
-  async getTrendContent(
+  getTrendContent(
     organizationId?: string,
     brandId?: string,
     options: {
@@ -1038,61 +552,16 @@ export class TrendsService {
       refresh?: boolean;
     } = {},
   ): Promise<TrendContentResult> {
-    const limit = options.limit ?? 30;
-    const platform = options.platform;
-    const refresh = options.refresh ?? false;
-    const cacheKey = this.cacheService.generateKey(
-      'trends:content',
-      organizationId || 'global',
-      brandId || 'global',
-      platform || 'all',
-      limit,
+    return this.trendSourcePreviewService.getTrendContent(
+      { brandId, organizationId },
+      options,
+      () =>
+        this.getTrendsWithAccessControl(
+          organizationId,
+          brandId,
+          options.platform,
+        ),
     );
-
-    if (!refresh) {
-      const cached = await this.cacheService.get<TrendContentResult>(cacheKey);
-      if (cached) {
-        return cached;
-      }
-    }
-
-    const result = await this.getTrendsWithAccessControl(
-      organizationId,
-      brandId,
-      platform,
-    );
-
-    const trends = refresh
-      ? await this.precomputeTrendSourcePreview(result.trends, {
-          force: true,
-          limit: this.SOURCE_PREVIEW_LIMIT,
-        })
-      : result.trends;
-
-    const contentItems =
-      await this.trendReferenceCorpusService.annotateSourceItemsWithReferenceIds(
-        this.buildTrendContentItems(trends, limit),
-      );
-    const payload: TrendContentResult = {
-      connectedPlatforms: result.connectedPlatforms,
-      items: contentItems,
-      latestTrendAt: this.getLatestTrendAt(trends),
-      lockedPlatforms: result.lockedPlatforms,
-      totalTrends: trends.filter((trend) =>
-        this.CONTENT_FEED_PLATFORMS.has(trend.platform),
-      ).length,
-    };
-
-    await this.cacheService.set(cacheKey, payload, {
-      tags: [
-        'trends',
-        'trends:content',
-        platform ? `trends:content:${platform}` : 'trends:content:all',
-      ],
-      ttl: this.CONTENT_CACHE_TTL_SECONDS,
-    });
-
-    return payload;
   }
 
   /**
@@ -1211,649 +680,5 @@ export class TrendsService {
    */
   getTrendTimeline(days: 7 | 30 | 90): Promise<TrendTimelineEntry[]> {
     return this.trendVideoService.getTrendTimeline(days);
-  }
-
-  private async fetchTrendSourceItems(
-    trend: TrendEntity,
-    limit: number,
-  ): Promise<TrendSourceItem[]> {
-    switch (trend.platform) {
-      case 'instagram':
-        return this.fetchInstagramSourceItems(trend, limit);
-      case 'tiktok':
-        return this.fetchTikTokSourceItems(trend, limit);
-      case 'twitter':
-        return this.fetchTwitterSourceItems(trend, limit);
-      case 'youtube':
-        return this.fetchYouTubeSourceItems(trend, limit);
-      case 'reddit':
-        return this.fetchRedditSourceItems(trend, limit);
-      default:
-        return [];
-    }
-  }
-
-  private async fetchInstagramSourceItems(
-    trend: TrendEntity,
-    limit: number,
-  ): Promise<TrendSourceItem[]> {
-    const hashtag = this.getTrendSearchTerm(trend);
-    if (!hashtag) {
-      return [];
-    }
-
-    const posts = await this.apifyService.searchInstagramByHashtag(hashtag, {
-      limit,
-    });
-
-    return posts
-      .map((post) => this.mapInstagramPostToSourceItem(post))
-      .filter((item): item is TrendSourceItem => item !== null);
-  }
-
-  private async fetchTikTokSourceItems(
-    trend: TrendEntity,
-    limit: number,
-  ): Promise<TrendSourceItem[]> {
-    const hashtag = this.getTrendSearchTerm(trend);
-    if (!hashtag) {
-      return [];
-    }
-
-    const videos = await this.apifyService.searchTikTokByHashtag(hashtag, {
-      limit,
-    });
-
-    return videos
-      .map((video) => this.mapTikTokVideoToSourceItem(video))
-      .filter((item): item is TrendSourceItem => item !== null);
-  }
-
-  private async fetchTwitterSourceItems(
-    trend: TrendEntity,
-    limit: number,
-  ): Promise<TrendSourceItem[]> {
-    const query = this.getTrendSearchTerm(trend);
-    if (!query) {
-      return [];
-    }
-
-    const tweets = await this.apifyService.searchTwitterTweets(query, {
-      limit,
-    });
-
-    return tweets.map((tweet) => this.mapTweetToSourceItem(tweet));
-  }
-
-  private async fetchYouTubeSourceItems(
-    trend: TrendEntity,
-    limit: number,
-  ): Promise<TrendSourceItem[]> {
-    const query = this.getTrendSearchTerm(trend);
-    if (!query) {
-      return [];
-    }
-
-    const videos = await this.apifyService.searchYouTubeVideos(query, {
-      limit,
-    });
-
-    return videos
-      .map((video) => this.mapYouTubeVideoToSourceItem(video))
-      .filter((item): item is TrendSourceItem => item !== null);
-  }
-
-  private async fetchRedditSourceItems(
-    trend: TrendEntity,
-    limit: number,
-  ): Promise<TrendSourceItem[]> {
-    const query = this.getTrendSearchTerm(trend);
-    if (!query) {
-      return [];
-    }
-
-    const posts = await this.apifyService.searchRedditPosts(query, { limit });
-
-    return posts
-      .map((post) => this.mapRedditPostToSourceItem(post))
-      .filter((item): item is TrendSourceItem => item !== null);
-  }
-
-  private getTrendSearchTerm(trend: TrendEntity): string | null {
-    const primaryHashtag = Array.isArray(trend.metadata?.hashtags)
-      ? trend.metadata.hashtags.find((tag) => !!tag?.trim())
-      : null;
-
-    if (primaryHashtag) {
-      return primaryHashtag.replace(/^#/, '').trim();
-    }
-
-    const topic = trend.topic?.trim();
-    if (!topic) {
-      return null;
-    }
-
-    return topic.replace(/^#/, '').trim();
-  }
-
-  private mapInstagramPostToSourceItem(
-    post: ApifyInstagramPost,
-  ): TrendSourceItem | null {
-    const sourceUrl = post.shortCode
-      ? `https://www.instagram.com/p/${post.shortCode}/`
-      : post.videoUrl || post.imageUrl;
-
-    if (!sourceUrl) {
-      return null;
-    }
-
-    return {
-      authorHandle: post.ownerUsername || undefined,
-      contentType: post.videoUrl ? 'video' : 'image',
-      id: post.id,
-      mediaUrl: post.videoUrl || post.imageUrl,
-      metrics: {
-        comments: post.commentsCount,
-        likes: post.likesCount,
-        views: post.videoViewCount,
-      },
-      platform: 'instagram',
-      publishedAt: post.timestamp || undefined,
-      sourceUrl,
-      text: post.caption,
-      thumbnailUrl: post.imageUrl,
-      title: this.truncateText(post.caption, 100),
-    };
-  }
-
-  private mapTikTokVideoToSourceItem(
-    video: ApifyTikTokVideo,
-  ): TrendSourceItem | null {
-    if (!video.webVideoUrl) {
-      return null;
-    }
-
-    return {
-      authorHandle:
-        video.authorMeta?.name || video.authorMeta?.nickname || undefined,
-      contentType: 'video',
-      id: video.id,
-      mediaUrl: video.webVideoUrl,
-      metrics: {
-        comments: video.commentCount,
-        likes: video.diggCount,
-        shares: video.shareCount,
-        views: video.playCount,
-      },
-      platform: 'tiktok',
-      publishedAt: video.createTime
-        ? new Date(video.createTime * 1000).toISOString()
-        : undefined,
-      sourceUrl: video.webVideoUrl,
-      text: video.desc,
-      thumbnailUrl: video.authorMeta?.avatar || video.musicMeta?.coverUrl,
-      title: this.truncateText(video.desc, 100),
-    };
-  }
-
-  private mapTweetToSourceItem(tweet: ApifyNormalizedTweet): TrendSourceItem {
-    const sourceUrl = tweet.authorUsername
-      ? `https://x.com/${tweet.authorUsername}/status/${tweet.id}`
-      : `https://x.com/i/web/status/${tweet.id}`;
-
-    return {
-      authorHandle: tweet.authorUsername || undefined,
-      contentType: 'tweet',
-      id: tweet.id,
-      metrics: {
-        comments: tweet.metrics?.replies,
-        likes: tweet.metrics?.likes,
-        shares: tweet.metrics?.retweets,
-      },
-      platform: 'twitter',
-      publishedAt: tweet.createdAt?.toISOString(),
-      sourceUrl,
-      text: tweet.text,
-      thumbnailUrl: tweet.authorAvatarUrl,
-      title: this.truncateText(tweet.text, 100),
-    };
-  }
-
-  private mapYouTubeVideoToSourceItem(
-    video: ApifyYouTubeVideo,
-  ): TrendSourceItem | null {
-    if (!video.url) {
-      return null;
-    }
-
-    return {
-      authorHandle: video.channelName || undefined,
-      contentType: 'video',
-      id: video.id,
-      mediaUrl: video.url,
-      metrics: {
-        comments: video.commentCount,
-        likes: video.likeCount,
-        views: video.viewCount,
-      },
-      platform: 'youtube',
-      publishedAt: video.publishedAt || undefined,
-      sourceUrl: video.url,
-      text: video.description,
-      thumbnailUrl: video.thumbnailUrl,
-      title: video.title,
-    };
-  }
-
-  private mapRedditPostToSourceItem(
-    post: ApifyRedditPost,
-  ): TrendSourceItem | null {
-    const sourceUrl = post.permalink
-      ? `https://reddit.com${post.permalink}`
-      : post.url;
-
-    if (!sourceUrl) {
-      return null;
-    }
-
-    return {
-      authorHandle: post.author || undefined,
-      contentType: post.isVideo ? 'video' : 'post',
-      id: post.id,
-      mediaUrl: post.url,
-      metrics: {
-        comments: post.numComments,
-        likes: post.score,
-      },
-      platform: 'reddit',
-      publishedAt: post.createdUtc
-        ? new Date(post.createdUtc * 1000).toISOString()
-        : undefined,
-      sourceUrl,
-      text: post.title,
-      title: post.title,
-    };
-  }
-
-  private buildFallbackTrendSourceItems(trend: TrendEntity): TrendSourceItem[] {
-    const mediaUrl =
-      typeof trend.metadata?.videoUrl === 'string'
-        ? trend.metadata.videoUrl
-        : undefined;
-    const sourceUrls = Array.isArray(trend.metadata?.urls)
-      ? trend.metadata.urls.filter(
-          (url): url is string => typeof url === 'string' && !!url,
-        )
-      : [];
-    const resolvedSourceUrls =
-      sourceUrls.length > 0 ? sourceUrls : mediaUrl ? [mediaUrl] : [];
-
-    return resolvedSourceUrls.map((sourceUrl, index) => ({
-      authorHandle:
-        typeof trend.metadata?.creatorHandle === 'string'
-          ? trend.metadata.creatorHandle
-          : undefined,
-      contentType:
-        trend.platform === 'twitter'
-          ? 'tweet'
-          : trend.metadata?.videoUrl
-            ? 'video'
-            : 'post',
-      id: `${trend.id}-fallback-${index + 1}`,
-      mediaUrl,
-      platform: trend.platform,
-      publishedAt: trend.createdAt?.toISOString(),
-      sourceUrl,
-      text:
-        typeof trend.metadata?.sampleContent === 'string'
-          ? trend.metadata.sampleContent
-          : trend.topic,
-      thumbnailUrl:
-        typeof trend.metadata?.thumbnailUrl === 'string'
-          ? trend.metadata.thumbnailUrl
-          : undefined,
-      title: trend.topic,
-    }));
-  }
-
-  private getStoredTrendSourcePreview(
-    trend: TrendEntity,
-    limit: number = this.SOURCE_PREVIEW_LIMIT,
-  ): TrendSourceItem[] {
-    const cachedItems = trend.metadata?.sourcePreviewCache;
-    if (!Array.isArray(cachedItems)) {
-      return [];
-    }
-
-    return cachedItems
-      .filter((item): item is TrendSourceItem => this.isTrendSourceItem(item))
-      .slice(0, limit);
-  }
-
-  private getStoredTrendSourcePreviewState(
-    trend: TrendEntity,
-    items: TrendSourceItem[],
-  ): 'live' | 'fallback' | 'empty' {
-    const storedState = trend.metadata?.sourcePreviewState;
-    if (
-      storedState === 'live' ||
-      storedState === 'fallback' ||
-      storedState === 'empty'
-    ) {
-      return storedState;
-    }
-
-    return this.getSourcePreviewState(items);
-  }
-
-  private getSourcePreviewState(
-    items: TrendSourceItem[],
-  ): 'live' | 'fallback' | 'empty' {
-    if (items.length === 0) {
-      return 'empty';
-    }
-
-    return items[0]?.id.includes('-fallback') ? 'fallback' : 'live';
-  }
-
-  private isTrendSourceItem(value: unknown): value is TrendSourceItem {
-    if (!value || typeof value !== 'object') {
-      return false;
-    }
-
-    const item = value as Record<string, unknown>;
-    return (
-      typeof item.id === 'string' &&
-      typeof item.platform === 'string' &&
-      typeof item.sourceUrl === 'string' &&
-      typeof item.contentType === 'string'
-    );
-  }
-
-  private async persistTrendSourcePreview(
-    trend: TrendEntity,
-    items: TrendSourceItem[],
-  ): Promise<TrendEntity> {
-    const sourcePreviewState = this.getSourcePreviewState(items);
-    const metadata = {
-      ...trend.metadata,
-      sourcePreviewCache: items,
-      sourcePreviewCachedAt: new Date().toISOString(),
-      sourcePreviewState,
-    };
-
-    const existingDoc = await this.prisma.trend.findFirst({
-      where: { id: String(trend.id), isDeleted: false } as never,
-    });
-    if (existingDoc) {
-      const existingData =
-        (existingDoc.data as unknown as Record<string, unknown>) ?? {};
-      await this.prisma.trend.update({
-        data: { data: { ...existingData, metadata } as never },
-        where: { id: String(trend.id) },
-      });
-    }
-
-    return new TrendEntity({
-      ...trend,
-      metadata,
-    });
-  }
-
-  private async precomputeTrendSourcePreview(
-    trends: TrendEntity[],
-    options: {
-      force?: boolean;
-      limit?: number;
-    } = {},
-  ): Promise<TrendEntity[]> {
-    const limit = options.limit ?? this.SOURCE_PREVIEW_LIMIT;
-
-    return await Promise.all(
-      trends.map(async (trend) => {
-        if (!this.CONTENT_FEED_PLATFORMS.has(trend.platform)) {
-          return trend;
-        }
-
-        const cachedItems = this.getStoredTrendSourcePreview(trend, limit);
-        if (!options.force && cachedItems.length > 0) {
-          return trend;
-        }
-
-        const resolvedItems = await this.resolveTrendSourcePreview(
-          trend,
-          undefined,
-          {
-            allowLiveFetch: true,
-            ignoreCached: options.force === true,
-            limit,
-          },
-        );
-
-        return this.persistTrendSourcePreview(trend, resolvedItems);
-      }),
-    );
-  }
-
-  private getTrendContentCacheKey(item: TrendContentItem): string {
-    return `${item.platform}:${item.sourceUrl || item.id}`;
-  }
-
-  private getTrendContentEngagementScore(item: TrendContentItem): number {
-    return (
-      (item.metrics?.views || 0) +
-      (item.metrics?.likes || 0) +
-      (item.metrics?.comments || 0) +
-      (item.metrics?.shares || 0)
-    );
-  }
-
-  private compareTrendContentItems(
-    left: TrendContentItem,
-    right: TrendContentItem,
-  ): number {
-    const liveStateDelta =
-      Number(right.sourcePreviewState === 'live') -
-      Number(left.sourcePreviewState === 'live');
-    if (liveStateDelta !== 0) {
-      return liveStateDelta;
-    }
-
-    const viralityDelta = right.trendViralityScore - left.trendViralityScore;
-    if (viralityDelta !== 0) {
-      return viralityDelta;
-    }
-
-    const engagementDelta =
-      this.getTrendContentEngagementScore(right) -
-      this.getTrendContentEngagementScore(left);
-    if (engagementDelta !== 0) {
-      return engagementDelta;
-    }
-
-    return (
-      new Date(right.publishedAt || 0).getTime() -
-      new Date(left.publishedAt || 0).getTime()
-    );
-  }
-
-  private buildTrendContentItems(
-    trends: TrendEntity[],
-    limit: number,
-  ): TrendContentItem[] {
-    const dedupedItems = new Map<string, TrendContentItem>();
-
-    for (const trend of trends) {
-      if (!this.CONTENT_FEED_PLATFORMS.has(trend.platform)) {
-        continue;
-      }
-
-      const storedItems = this.getStoredTrendSourcePreview(
-        trend,
-        this.SOURCE_PREVIEW_LIMIT,
-      );
-      const sourceItems =
-        storedItems.length > 0
-          ? storedItems
-          : this.buildFallbackTrendSourceItems(trend);
-
-      for (const sourceItem of sourceItems) {
-        const contentItem: TrendContentItem = {
-          ...sourceItem,
-          contentRank: 0,
-          matchedTrends: [trend.topic],
-          requiresAuth: trend.requiresAuth,
-          sourcePreviewState: this.getSourcePreviewState([sourceItem]),
-          trendId: String(trend.id),
-          trendMentions: trend.mentions,
-          trendTopic: trend.topic,
-          trendViralityScore: trend.viralityScore,
-        };
-        const dedupeKey = this.getTrendContentCacheKey(contentItem);
-        const existing = dedupedItems.get(dedupeKey);
-
-        if (!existing) {
-          dedupedItems.set(dedupeKey, contentItem);
-          continue;
-        }
-
-        const matchedTrends = Array.from(
-          new Set([...existing.matchedTrends, trend.topic]),
-        );
-        const preferred =
-          this.compareTrendContentItems(contentItem, existing) > 0
-            ? existing
-            : contentItem;
-
-        dedupedItems.set(dedupeKey, {
-          ...preferred,
-          matchedTrends,
-        });
-      }
-    }
-
-    return Array.from(dedupedItems.values())
-      .sort((left, right) => this.compareTrendContentItems(left, right))
-      .slice(0, limit)
-      .map((item, index) => ({
-        ...item,
-        contentRank: index + 1,
-      }));
-  }
-
-  private getLatestTrendAt(trends: TrendEntity[]): string | undefined {
-    const timestamps = trends
-      .map((trend) =>
-        trend.createdAt instanceof Date
-          ? trend.createdAt.getTime()
-          : trend.createdAt
-            ? new Date(trend.createdAt).getTime()
-            : 0,
-      )
-      .filter((value) => value > 0);
-
-    if (timestamps.length === 0) {
-      return undefined;
-    }
-
-    return new Date(Math.max(...timestamps)).toISOString();
-  }
-
-  private truncateText(
-    value?: string,
-    maxLength: number = 100,
-  ): string | undefined {
-    if (!value) {
-      return undefined;
-    }
-
-    return value.length > maxLength
-      ? `${value.slice(0, maxLength - 1)}…`
-      : value;
-  }
-
-  private async buildTrendDiscoveryItem(
-    trend: TrendEntity,
-    organizationId?: string,
-  ): Promise<TrendDiscoveryItem> {
-    const sourcePreview = await this.resolveTrendSourcePreview(
-      trend,
-      organizationId,
-      {
-        allowLiveFetch: false,
-        limit: 3,
-      },
-    );
-    const sourcePreviewState = this.getStoredTrendSourcePreviewState(
-      trend,
-      sourcePreview,
-    );
-
-    return {
-      ...trend,
-      id: String(trend.id),
-      createdAt:
-        trend.createdAt instanceof Date
-          ? trend.createdAt
-          : trend.createdAt
-            ? new Date(trend.createdAt)
-            : undefined,
-      expiresAt:
-        trend.expiresAt instanceof Date
-          ? trend.expiresAt
-          : new Date(trend.expiresAt),
-      sourcePreview,
-      sourcePreviewState,
-      sourcePreviewTotal: sourcePreview.length,
-      updatedAt:
-        trend.updatedAt instanceof Date
-          ? trend.updatedAt
-          : trend.updatedAt
-            ? new Date(trend.updatedAt)
-            : undefined,
-    };
-  }
-
-  private async resolveTrendSourcePreview(
-    trend: TrendEntity,
-    organizationId?: string,
-    options: {
-      allowLiveFetch?: boolean;
-      ignoreCached?: boolean;
-      limit?: number;
-    } = {},
-  ): Promise<TrendSourceItem[]> {
-    const limit = options.limit ?? this.SOURCE_PREVIEW_LIMIT;
-    const cachedItems =
-      options.ignoreCached === true
-        ? []
-        : this.getStoredTrendSourcePreview(trend, limit);
-    if (cachedItems.length > 0) {
-      return cachedItems;
-    }
-
-    const fallbackItems = this.buildFallbackTrendSourceItems(trend).slice(
-      0,
-      limit,
-    );
-    if (!options.allowLiveFetch) {
-      return fallbackItems;
-    }
-
-    try {
-      const items = await this.fetchTrendSourceItems(trend, limit);
-      if (items.length > 0) {
-        return items;
-      }
-    } catch (error: unknown) {
-      this.loggerService.warn('Failed to build embedded trend source preview', {
-        error: error instanceof Error ? error.message : String(error),
-        organizationId,
-        platform: trend.platform,
-        trendId: trend.id,
-      });
-    }
-
-    return fallbackItems;
   }
 }

--- a/apps/server/api/src/collections/trends/trends.module.ts
+++ b/apps/server/api/src/collections/trends/trends.module.ts
@@ -7,6 +7,10 @@ import { TrendAnalysisService } from '@api/collections/trends/services/modules/t
 import { TrendContentIdeasService } from '@api/collections/trends/services/modules/trend-content-ideas.service';
 import { TrendFetchService } from '@api/collections/trends/services/modules/trend-fetch.service';
 import { TrendFilteringService } from '@api/collections/trends/services/modules/trend-filtering.service';
+import { TrendPrelaunchCorpusService } from '@api/collections/trends/services/modules/trend-prelaunch-corpus.service';
+import { TrendQueryService } from '@api/collections/trends/services/modules/trend-query.service';
+import { TrendSourceItemsService } from '@api/collections/trends/services/modules/trend-source-items.service';
+import { TrendSourcePreviewService } from '@api/collections/trends/services/modules/trend-source-preview.service';
 import { TrendVideoService } from '@api/collections/trends/services/modules/trend-video.service';
 import { TrendPreferencesService } from '@api/collections/trends/services/trend-preferences.service';
 import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
@@ -55,7 +59,11 @@ import { forwardRef, Module } from '@nestjs/common';
     TrendFetchService,
     TrendFilteringService,
     TrendPreferencesService,
+    TrendPrelaunchCorpusService,
+    TrendQueryService,
     TrendReferenceCorpusService,
+    TrendSourceItemsService,
+    TrendSourcePreviewService,
     TrendVideoService,
     TrendsService,
     TrendsWarmupService,


### PR DESCRIPTION
## Summary

Decomposes the 1,859-line `TrendsService` god object (issue #752) into focused, colocated module services, following the repo's existing `services/modules/` extraction pattern. **Behavior-preserving** — public method signatures and runtime behavior are unchanged.

## What changed

New services (each <500 lines, with colocated specs):

| Service | Responsibility | Deps |
|---|---|---|
| `TrendSourceItemsService` | Live Apify fetch + per-platform normalization + fallback synthesis + stored-preview accessors | apify |
| `TrendSourcePreviewService` | Preview persistence/precompute/resolution, content-feed assembly, cached `getTrendContent`, discovery items | prisma, cache, referenceCorpus, sourceItems |
| `TrendQueryService` | Trend read queries + bootstrap fallback | prisma |
| `TrendPrelaunchCorpusService` | Prelaunch reference-corpus seeding/backfill + global stats | prisma, cache, referenceCorpus, sourceItems |

- **Five-way fetcher duplication removed**: the five near-identical `fetch{Platform}SourceItems` methods collapse into a single dispatch table in `fetchTrendSourceItems`.
- **Read helpers unified**: `findActiveTrends` / `findLastGoodTrends` now share one parameterized `queryTrendsByFilter`.
- `TrendsService` is now a thin orchestrator: **1,859 → 684 lines**. `PrismaService`, `CacheService`, and `ApifyService` are no longer injected directly into it.
- Shared source-preview limit extracted to a single `TREND_SOURCE_PREVIEW_LIMIT` constant to prevent drift.

## Acceptance criteria

- ✅ Source-item subsystem extracted into cohesive module services.
- ✅ Five-way platform fetcher duplication gone (single dispatch path).
- ✅ `findActiveTrends`/`findLastGoodTrends` unified.
- ✅ Public method signatures and return shapes unchanged; existing `trends.service` integration spec still passes; new services have colocated specs.
- ✅ New files all <500 lines.
- ⚠️ **`TrendsService` constructor dependency count**: held at 13 (the three low-level infra deps — Prisma/Cache/Apify — were removed; three new module-service deps added). Dropping **below 10** is not reachable without removing the ~25 public forwarding methods that 6+ external files depend on (`TrendsController`, workflow services, workflow-engine-adapter, trend-inspiration processor, worker crons). That public-API change is out of scope for this behavior-preserving extraction and would be a separate cross-app PR.
- ⚠️ **`trends.service.ts` is 684 lines (>500)**: the residual is the public forwarding façade + the `getTrends` retrieval orchestration, which must stay for API stability. Pre-existing `trend-video.service.ts` (700) and `trend-reference-corpus.service.ts` (768) also exceed 500 and are out of scope.

## Adversarial review

Ran a multi-agent find→verify review over the diff (behavior parity, DI wiring, type safety, test gaps). Acted on the in-scope findings:
- Extracted the duplicated `SOURCE_PREVIEW_LIMIT` to a shared constant and removed the dead copy on the orchestrator.
- Added targeted coverage: TikTok/YouTube/Reddit dispatch + null-guard mappers, content-feed dedup-by-source-url, `precomputeTrendSourcePreview` cached-skip & cache-miss-persist branches, prelaunch live-mode backfill.

Findings left as **pre-existing / out of scope** (present on `master`, not introduced here): `pinterest` absent from `CONTENT_FEED_PLATFORMS` while present in `allPlatforms` (behavior preserved intentionally); `_loggerService` dead injection in `trend-filtering.service.ts`; `trend-fetch.service` test gaps.

## Verification

- `vitest` (scoped): **178 tests pass** across 15 trends-area files — orchestrator integration spec (43), four new colocated specs (39), adjacent module/warmup/controller/consumer specs.
- `biome check`: clean on all 48 trends files; pre-commit secretlint + biome passed.
- **Local typecheck limitation**: a full `tsc` requires the `@genfeedai/*` workspace packages to be built (a known TS6/Prisma-7 build-ordering constraint in this repo); `tsc` reports 0 errors in the new files and only the repo-wide unbuilt-`@genfeedai/*` resolution noise elsewhere. Mac Studio was unreachable this run, so the authoritative full typecheck/build is delegated to CI. The pre-existing `trends.module.spec.ts` failure (`@genfeedai/tools` entry resolution) reproduces on `master` and is the same unbuilt-package env issue.

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)