### PR TITLE
fix(videos): harden generation create() path — 7 CodeRabbit findings (#853)

### DIFF
--- a/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
@@ -52,7 +52,7 @@ import {
   ModelCategory,
 } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
-import { HttpException, StreamableFile } from '@nestjs/common';
+import { HttpException, HttpStatus, StreamableFile } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type {
   Request as ExpressRequest,
@@ -230,7 +230,9 @@ describe('VideosController', () => {
         {
           provide: CreditsUtilsService,
           useValue: {
+            checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
             deductCreditsFromOrganization: vi.fn().mockResolvedValue(undefined),
+            getOrganizationCreditsBalance: vi.fn().mockResolvedValue(1000),
           },
         },
         {
@@ -285,6 +287,7 @@ describe('VideosController', () => {
           provide: ModelRegistrationService,
           useValue: {
             registerGeneratedOutput: vi.fn().mockResolvedValue(undefined),
+            validateModelForOrg: vi.fn().mockResolvedValue(mockModelData),
           },
         },
         {
@@ -976,73 +979,52 @@ describe('VideosController', () => {
       ).rejects.toThrow(HttpException);
     });
 
-    it('should deduct credits after successful generation', async () => {
-      await controller.create(mockRequest, baseCreateDto, mockUser);
+    // Credit deduction is owned by CreditsInterceptor (overridden in this spec).
+    // The service no longer deducts directly; instead ensureDeferredCredits
+    // authorizes the single amount the interceptor later deducts. These tests
+    // assert that authorized amount via the deferred-credits availability check.
+    const deferredRequest = () =>
+      ({
+        ...mockRequest,
+        creditsConfig: { deferred: true },
+      }) as unknown as ExpressRequest;
+
+    it('authorizes the base credit amount for a successful generation', async () => {
+      await controller.create(deferredRequest(), baseCreateDto, mockUser);
 
       expect(
-        creditsUtilsService.deductCreditsFromOrganization,
-      ).toHaveBeenCalledWith(
-        mockOrgId.toString(),
-        mockUserId.toString(),
-        expect.any(Number),
-        expect.stringContaining('Video generation'),
-        expect.any(String),
-      );
-    });
-
-    it('should double credits for high resolution', async () => {
-      const mockBuilderResult = {
-        ...mockPromptBuilderResult,
-        input: {
-          ...mockPromptBuilderResult.input,
-          resolution: 'high',
-        },
-      };
-      (
-        testingModule.get(PromptBuilderService).buildPrompt as vi.Mock
-      ).mockResolvedValue(mockBuilderResult);
-
-      await controller.create(mockRequest, baseCreateDto, mockUser);
-
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(mockOrgId.toString(), 10);
       expect(
         creditsUtilsService.deductCreditsFromOrganization,
-      ).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        20, // 10 * 2 for high resolution
-        expect.stringContaining('high resolution'),
-        expect.any(String),
-      );
+      ).not.toHaveBeenCalled();
     });
 
-    it('should multiply credits by outputs count', async () => {
-      const mockBuilderResult = {
-        ...mockPromptBuilderResult,
-        input: {
-          ...mockPromptBuilderResult.input,
-          resolution: 'standard',
-        },
+    it('doubles the authorized amount for high resolution', async () => {
+      const dto: CreateVideoDto = {
+        ...baseCreateDto,
+        resolution: 'high',
       };
-      (
-        testingModule.get(PromptBuilderService).buildPrompt as vi.Mock
-      ).mockResolvedValueOnce(mockBuilderResult);
 
+      await controller.create(deferredRequest(), dto, mockUser);
+
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(mockOrgId.toString(), 20); // 10 * 2 for high resolution
+    });
+
+    it('multiplies the authorized amount by outputs for non-batch models', async () => {
       const dto: CreateVideoDto = {
         ...baseCreateDto,
         outputs: 3,
+        resolution: 'standard',
       };
 
-      await controller.create(mockRequest, dto, mockUser);
+      await controller.create(deferredRequest(), dto, mockUser);
 
       expect(
-        creditsUtilsService.deductCreditsFromOrganization,
-      ).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        30, // 10 * 3 outputs
-        expect.stringContaining('3 outputs'),
-        expect.any(String),
-      );
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(mockOrgId.toString(), 30); // 10 * 3 outputs
     });
 
     it('should handle auto model selection', async () => {
@@ -1156,13 +1138,19 @@ describe('VideosController', () => {
       ).toHaveBeenCalled();
     });
 
-    it('should handle null generation ID', async () => {
+    it('should fail and clean up on a null generation ID', async () => {
       klingAIService.queueGenerateTextToVideo.mockResolvedValue(
         null as unknown as string,
       );
 
-      await controller.create(mockRequest, baseCreateDto, mockUser);
+      // A generation that never started must fail the request so
+      // CreditsInterceptor does not charge for it.
+      const error = await controller
+        .create(mockRequest, baseCreateDto, mockUser)
+        .catch((e) => e);
 
+      expect(error).toBeInstanceOf(HttpException);
+      expect(error.getStatus()).toBe(HttpStatus.BAD_GATEWAY);
       expect(
         failedGenerationService.handleFailedVideoGeneration,
       ).toHaveBeenCalled();
@@ -1234,6 +1222,7 @@ describe('VideosController', () => {
       expect(promptsService.findOne).toHaveBeenCalledWith({
         _id: mockPromptId.toString(),
         isDeleted: false,
+        organization: mockOrgId.toString(),
       });
     });
 

--- a/apps/server/api/src/collections/videos/services/video-generation.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation.service.spec.ts
@@ -1,0 +1,427 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { CreateVideoDto } from '@api/collections/videos/dto/create-video.dto';
+import { VideoGenerationService } from '@api/collections/videos/services/video-generation.service';
+import type { RequestWithContext as ExpressRequest } from '@api/common/middleware/request-context.middleware';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Focused regression tests for the seven CodeRabbit findings tracked in #853.
+ * Each finding is exercised through the public generateVideo() entry point with
+ * the collaborators mocked, so the new contracts are pinned without standing up
+ * the full NestJS module.
+ */
+describe('VideoGenerationService', () => {
+  const ORG = 'org-1';
+  const RESOLVED_BRAND = 'brand-resolved';
+  const BATCH_MODEL = MODEL_KEYS.REPLICATE_BYTEDANCE_SEEDREAM_4_5;
+  const NON_BATCH_MODEL = MODEL_KEYS.KLINGAI_V2;
+
+  const buildUser = (organization: string = ORG): User =>
+    ({
+      id: 'auth-user-1',
+      publicMetadata: {
+        brand: 'brand-from-token',
+        organization,
+        user: 'user-1',
+      },
+    }) as unknown as User;
+
+  const buildRequest = (
+    overrides: Record<string, unknown> = {},
+  ): ExpressRequest =>
+    ({
+      originalUrl: '/api/videos',
+      params: {},
+      query: {},
+      ...overrides,
+    }) as unknown as ExpressRequest;
+
+  const createService = () => {
+    let savedDocCount = 0;
+    const sharedService = {
+      saveDocuments: vi.fn().mockImplementation(() => {
+        const n = savedDocCount++;
+        return Promise.resolve({
+          ingredientData: {
+            _id: `ing-${n}`,
+            toString: () => `ing-${n}`,
+          },
+          metadataData: { _id: `meta-${n}` },
+        });
+      }),
+    };
+
+    const brandsService = {
+      findOne: vi.fn().mockResolvedValue({
+        _id: RESOLVED_BRAND,
+        defaultVideoModel: NON_BATCH_MODEL,
+        description: 'desc',
+        label: 'Brand',
+        organization: ORG,
+        primaryColor: '#fff',
+        secondaryColor: '#000',
+        text: 'text',
+      }),
+    };
+    const organizationSettingsService = {
+      findOne: vi.fn().mockResolvedValue(null),
+    };
+    const modelRegistrationService = {
+      validateModelForOrg: vi.fn().mockResolvedValue(undefined),
+    };
+    const modelsService = {
+      findOne: vi.fn().mockResolvedValue({ cost: 10 }),
+    };
+    const creditsUtilsService = {
+      checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
+      deductCreditsFromOrganization: vi.fn().mockResolvedValue(undefined),
+      getOrganizationCreditsBalance: vi.fn().mockResolvedValue(1000),
+    };
+    const promptsService = {
+      create: vi.fn().mockResolvedValue({ _id: 'prompt-doc' }),
+      findOne: vi.fn(),
+    };
+    const promptBuilderService = {
+      buildPrompt: vi.fn().mockResolvedValue({
+        input: { prompt: 'built-prompt' },
+        templateUsed: 'template',
+        templateVersion: '1.0.0',
+      }),
+    };
+    const klingAIService = {
+      queueGenerateTextToVideo: vi.fn().mockResolvedValue('kling-gen'),
+    };
+    const replicateService = {
+      generateTextToVideo: vi.fn().mockResolvedValue('replicate-gen'),
+    };
+    const falService = { generateVideo: vi.fn() };
+    const metadataService = { patch: vi.fn().mockResolvedValue(undefined) };
+    const videosService = {
+      findOne: vi.fn(),
+      patch: vi.fn().mockResolvedValue(undefined),
+    };
+    const activitiesService = {
+      create: vi.fn().mockResolvedValue({ _id: { toString: () => 'act' } }),
+    };
+    const websocketService = {
+      publishBackgroundTaskUpdate: vi.fn().mockResolvedValue(undefined),
+    };
+    const cacheService = {
+      invalidateByTags: vi.fn().mockResolvedValue(0),
+    };
+    const failedGenerationService = {
+      handleFailedVideoGeneration: vi.fn().mockResolvedValue(undefined),
+    };
+    const routerService = {
+      getDefaultModel: vi.fn().mockResolvedValue(NON_BATCH_MODEL),
+      selectModel: vi.fn(),
+    };
+    const bookmarksService = { addGeneratedIngredient: vi.fn() };
+    const videoMusicOrchestrationService = {
+      orchestrateVideoWithMusic: vi.fn(),
+    };
+    const pollingService = {
+      waitForMultipleIngredientsCompletion: vi.fn(),
+    };
+    const assetsService = {};
+    const ingredientsService = {};
+    const configService = {};
+    const loggerService = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as LoggerService;
+
+    const service = new VideoGenerationService(
+      configService as never,
+      activitiesService as never,
+      brandsService as never,
+      assetsService as never,
+      bookmarksService as never,
+      creditsUtilsService as never,
+      falService as never,
+      failedGenerationService as never,
+      ingredientsService as never,
+      pollingService as never,
+      klingAIService as never,
+      loggerService,
+      metadataService as never,
+      modelRegistrationService as never,
+      modelsService as never,
+      organizationSettingsService as never,
+      promptsService as never,
+      promptBuilderService as never,
+      replicateService as never,
+      sharedService as never,
+      videoMusicOrchestrationService as never,
+      videosService as never,
+      cacheService as never,
+      routerService as never,
+      websocketService as never,
+    );
+
+    return {
+      brandsService,
+      cacheService,
+      creditsUtilsService,
+      failedGenerationService,
+      klingAIService,
+      metadataService,
+      modelRegistrationService,
+      promptsService,
+      replicateService,
+      service,
+    };
+  };
+
+  const baseDto = (overrides: Partial<CreateVideoDto> = {}): CreateVideoDto =>
+    ({
+      height: 1080,
+      model: NON_BATCH_MODEL,
+      text: 'a sunset over the ocean',
+      width: 1920,
+      ...overrides,
+    }) as CreateVideoDto;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Finding 1 — org model validation must run even without request context.
+  describe('model org validation (finding 1)', () => {
+    it('validates the resolved model against the token org when request context is absent', async () => {
+      const { service, modelRegistrationService } = createService();
+
+      await service.generateVideo(buildUser(), baseDto(), buildRequest());
+
+      expect(modelRegistrationService.validateModelForOrg).toHaveBeenCalledWith(
+        NON_BATCH_MODEL,
+        ORG,
+      );
+    });
+
+    it('skips validation for single-tenant deployments without an organization', async () => {
+      const { service, modelRegistrationService } = createService();
+
+      await service.generateVideo(buildUser(''), baseDto(), buildRequest());
+
+      expect(
+        modelRegistrationService.validateModelForOrg,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  // Finding 2 — prompt lookup is org-scoped and fails closed.
+  describe('saved-prompt lookup (finding 2)', () => {
+    it('scopes the prompt lookup to the caller organization', async () => {
+      const { service, promptsService } = createService();
+      promptsService.findOne.mockResolvedValue({
+        _id: 'prompt-id',
+        original: 'stored prompt',
+      });
+
+      await service.generateVideo(
+        buildUser(),
+        baseDto({ prompt: 'prompt-id' }),
+        buildRequest(),
+      );
+
+      expect(promptsService.findOne).toHaveBeenCalledWith({
+        _id: 'prompt-id',
+        isDeleted: false,
+        organization: ORG,
+      });
+    });
+
+    it('throws 404 and does not dispatch when the referenced prompt is missing', async () => {
+      const { service, promptsService, klingAIService } = createService();
+      promptsService.findOne.mockResolvedValue(null);
+
+      const error = await service
+        .generateVideo(
+          buildUser(),
+          baseDto({ prompt: 'missing-id' }),
+          buildRequest(),
+        )
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(HttpException);
+      expect(error.getStatus()).toBe(HttpStatus.NOT_FOUND);
+      expect(klingAIService.queueGenerateTextToVideo).not.toHaveBeenCalled();
+    });
+
+    it('omits the org filter for single-tenant deployments', async () => {
+      const { service, promptsService } = createService();
+      promptsService.findOne.mockResolvedValue({
+        _id: 'prompt-id',
+        original: 'stored prompt',
+      });
+
+      await service.generateVideo(
+        buildUser(''),
+        baseDto({ prompt: 'prompt-id' }),
+        buildRequest(),
+      );
+
+      expect(promptsService.findOne).toHaveBeenCalledWith({
+        _id: 'prompt-id',
+        isDeleted: false,
+      });
+    });
+  });
+
+  // Finding 3 — persist the prompt against the resolved brand.
+  it('persists the prompt against the resolved brand id (finding 3)', async () => {
+    const { service, promptsService } = createService();
+
+    await service.generateVideo(
+      buildUser(),
+      baseDto({ brand: 'brand-from-token' }),
+      buildRequest(),
+    );
+
+    expect(promptsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ brand: RESOLVED_BRAND }),
+    );
+  });
+
+  // Finding 4 — a single credit calculation feeds authorization and deduction.
+  describe('credit accounting (finding 4)', () => {
+    it('never deducts directly — deduction is owned by CreditsInterceptor', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateVideo(buildUser(), baseDto(), buildRequest());
+
+      expect(
+        creditsUtilsService.deductCreditsFromOrganization,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('authorizes the fully-multiplied amount on the deferred path', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateVideo(
+        buildUser(),
+        baseDto({ outputs: 2, resolution: 'high' }),
+        buildRequest({ creditsConfig: { deferred: true } }),
+      );
+
+      // base 10 x2 (high res) x2 (two non-batch outputs) = 40
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(ORG, 40);
+    });
+
+    it('does not multiply authorization by outputs for batch-capable models', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateVideo(
+        buildUser(),
+        baseDto({ model: BATCH_MODEL, outputs: 3, resolution: 'standard' }),
+        buildRequest({ creditsConfig: { deferred: true } }),
+      );
+
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(ORG, 10);
+    });
+
+    it('throws 502 and cleans up when the first output never starts (no charge)', async () => {
+      const { service, klingAIService, failedGenerationService, cacheService } =
+        createService();
+      klingAIService.queueGenerateTextToVideo.mockResolvedValue(
+        null as unknown as string,
+      );
+
+      const error = await service
+        .generateVideo(buildUser(), baseDto(), buildRequest())
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(HttpException);
+      expect(error.getStatus()).toBe(HttpStatus.BAD_GATEWAY);
+      // The single placeholder is torn down and the success-only cache bust
+      // (which the CreditsInterceptor keys deduction off) is never reached.
+      expect(
+        failedGenerationService.handleFailedVideoGeneration,
+      ).toHaveBeenCalled();
+      expect(cacheService.invalidateByTags).not.toHaveBeenCalled();
+    });
+  });
+
+  // Finding 5 — every batch placeholder gets its own indexed external id.
+  it('patches an indexed external id onto every batch placeholder (finding 5)', async () => {
+    const { service, replicateService, metadataService } = createService();
+    replicateService.generateTextToVideo.mockResolvedValue('gen');
+
+    await service.generateVideo(
+      buildUser(),
+      baseDto({ model: BATCH_MODEL, outputs: 3 }),
+      buildRequest(),
+    );
+
+    const externalIds = metadataService.patch.mock.calls.map(
+      ([, entity]) => (entity as { externalId?: string }).externalId,
+    );
+    expect(externalIds).toContain('gen_0');
+    expect(externalIds).toContain('gen_1');
+    expect(externalIds).toContain('gen_2');
+  });
+
+  // Finding 6 — non-batch outputs are tracked before the call and fail on null.
+  describe('non-batch multi-output (finding 6)', () => {
+    it('tracks the placeholder before dispatch and cleans it up when the id is null', async () => {
+      const { service, klingAIService, failedGenerationService } =
+        createService();
+      klingAIService.queueGenerateTextToVideo
+        .mockResolvedValueOnce('kling-gen-0')
+        .mockResolvedValueOnce(null);
+
+      const error = await service
+        .generateVideo(buildUser(), baseDto({ outputs: 2 }), buildRequest())
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(HttpException);
+      expect(error.getStatus()).toBe(HttpStatus.BAD_GATEWAY);
+
+      const cleanedIds =
+        failedGenerationService.handleFailedVideoGeneration.mock.calls.map(
+          (call) => call[1],
+        );
+      // Both the first and the additional placeholder are torn down.
+      expect(cleanedIds).toContain('ing-0');
+      expect(cleanedIds).toContain('ing-1');
+    });
+
+    it('persists the real external id for additional non-batch outputs', async () => {
+      const { service, klingAIService, metadataService } = createService();
+      klingAIService.queueGenerateTextToVideo
+        .mockResolvedValueOnce('kling-gen-0')
+        .mockResolvedValueOnce('kling-gen-1');
+
+      await service.generateVideo(
+        buildUser(),
+        baseDto({ outputs: 2 }),
+        buildRequest(),
+      );
+
+      const externalIds = metadataService.patch.mock.calls.map(
+        ([, entity]) => (entity as { externalId?: string }).externalId,
+      );
+      expect(externalIds).toContain('kling-gen-1');
+      expect(externalIds).not.toContain('');
+    });
+  });
+
+  // Finding 7 — bust the shared video cache tag after the write.
+  it('invalidates the video cache tag (finding 7)', async () => {
+    const { service, cacheService } = createService();
+
+    await service.generateVideo(buildUser(), baseDto(), buildRequest());
+
+    expect(cacheService.invalidateByTags).toHaveBeenCalledWith(['videos']);
+  });
+});

--- a/apps/server/api/src/collections/videos/services/video-generation.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation.service.ts
@@ -62,6 +62,17 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { getUserRoomName } from '@libs/websockets/room-name.util';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 
+/**
+ * HTTP cache tags busted after a video write so newly-created placeholders are
+ * visible immediately. Every cached video endpoint (`GET /latest`, `GET /`,
+ * `GET /:videoId`) is registered under the single `videos` tag, so busting it
+ * invalidates list, latest, and single-record responses alike. The aggregate
+ * tag set for the underlying ingredient collection (`agg:ingredient`,
+ * `agg:paginated`, …) is invalidated automatically by BaseService when
+ * saveDocuments/patch run during generation, so it is not duplicated here.
+ */
+const VIDEO_WRITE_CACHE_TAGS: readonly string[] = ['videos'];
+
 type PromptInput = Record<string, unknown> & {
   prompt?: string;
   resolution?: string;
@@ -186,12 +197,18 @@ export class VideoGenerationService {
       referenceIds,
     );
 
-    // Validate resolved model against org (catches default-resolution bypassing ModelsGuard)
-    if (request.context?.organizationId) {
-      const authenticatedOrgId = request.context.organizationId;
+    // Validate the resolved model against the authenticated organization. This
+    // catches a default/auto-selected model bypassing ModelsGuard. Prefer the
+    // organization claim from the verified token (publicMetadata) so validation
+    // still runs when request-context middleware did not populate
+    // organizationId; fall back to the request context. Only single-tenant
+    // deployments (no organization present) skip this check.
+    const validationOrgId =
+      publicMetadata.organization || request.context?.organizationId;
+    if (validationOrgId) {
       await this.modelRegistrationService.validateModelForOrg(
         model,
-        authenticatedOrgId,
+        validationOrgId,
       );
     }
 
@@ -231,14 +248,31 @@ export class VideoGenerationService {
     }
 
     if (createVideoDto.prompt) {
+      // Scope the saved-prompt lookup to the caller's organization and fail
+      // closed: an unknown or cross-organization prompt id must reject the
+      // request rather than silently continuing with an empty prompt. The org
+      // filter is only applied when an organization is present — single-tenant
+      // deployments store prompts with a null organization, so passing an empty
+      // string would never match.
       const prompt = await this.promptsService.findOne({
         _id: createVideoDto.prompt.toString(),
         isDeleted: false,
+        ...(publicMetadata.organization
+          ? { organization: publicMetadata.organization }
+          : {}),
       });
 
-      if (prompt?._id) {
-        promptText = prompt?.enhanced || prompt?.original || '';
+      if (!prompt?._id) {
+        throw new HttpException(
+          {
+            detail: 'The referenced prompt could not be found',
+            title: 'Prompt not found',
+          },
+          HttpStatus.NOT_FOUND,
+        );
       }
+
+      promptText = prompt.enhanced || prompt.original || '';
     }
 
     // First build prompt to get template info
@@ -296,7 +330,10 @@ export class VideoGenerationService {
     const promptData = await this.promptsService.create(
       new PromptEntity({
         blacklists: createVideoDto.blacklist,
-        brand: publicMetadata.brand,
+        // Persist against the resolved brand (which honors createVideoDto.brand)
+        // rather than the token default, matching the brand used everywhere else
+        // in this flow (saveDocuments, activities, cleanup).
+        brand: brand._id,
         camera: createVideoDto.camera,
         category: PromptCategory.MODELS_PROMPT_VIDEO,
         mood: createVideoDto.mood,
@@ -347,7 +384,6 @@ export class VideoGenerationService {
       user: publicMetadata.user,
     });
 
-    const websocketUrl = WebSocketPaths.video(ingredientData._id);
     const outputs = createVideoDto.outputs || 1;
 
     this.loggerService.debug('Video generation request received', {
@@ -372,62 +408,12 @@ export class VideoGenerationService {
       });
 
       if (generationId) {
-        // Deduct credits after successful generation trigger
-        // Credits were already verified by CreditsGuard before processing started
-        const modelData = await this.modelsService.findOne({ key: model });
-        let creditsToDeduct = modelData?.cost || 0;
-
-        // Multiply credits by resolution multiplier (high/1080p = 2x, standard/720p = 1x)
-        if (
-          promptInput.resolution === 'high' ||
-          promptInput.resolution === '1080p'
-        ) {
-          creditsToDeduct *= 2;
-        }
-
-        // Multiply credits by outputs for multi-output requests
-        if (outputs > 1) {
-          creditsToDeduct *= outputs;
-        }
-
-        if (creditsToDeduct > 0) {
-          // Build description with resolution and outputs info
-          let resolutionText = '';
-          if (
-            promptInput.resolution === 'high' ||
-            promptInput.resolution === '1080p'
-          ) {
-            resolutionText = ' (high resolution)';
-          } else if (
-            promptInput.resolution === 'standard' ||
-            promptInput.resolution === '720p'
-          ) {
-            resolutionText = ' (standard resolution)';
-          }
-          const outputsText = outputs > 1 ? ` (${outputs} outputs)` : '';
-          const description = `Video generation - ${model}${resolutionText}${outputsText}`;
-
-          await this.creditsUtilsService.deductCreditsFromOrganization(
-            publicMetadata.organization,
-            publicMetadata.user,
-            creditsToDeduct,
-            description,
-            ActivitySource.VIDEO_GENERATION,
-          );
-
-          this.loggerService.log(
-            'Credits deducted after video generation triggered',
-            {
-              credits: creditsToDeduct,
-              generationId,
-              model,
-              organizationId: publicMetadata.organization,
-              outputs,
-              resolution: promptInput.resolution || undefined,
-              userId: publicMetadata.user,
-            },
-          );
-        }
+        // Credit deduction is owned by CreditsInterceptor, which deducts the
+        // single authorized amount recorded on request.creditsConfig.amount by
+        // ensureDeferredCredits (resolution + output multipliers already
+        // applied). The service no longer performs a second, separately-computed
+        // deduction — that diverged from the authorized figure and double-charged
+        // the request. Matches the images generation pipeline.
 
         // Check if model supports batch generation (single API call with multiple outputs)
         const modelCapability = MODEL_OUTPUT_CAPABILITIES[model];
@@ -471,10 +457,27 @@ export class VideoGenerationService {
             }),
           );
 
-          // Add all ingredient IDs to pending list
+          // Track every additional placeholder before any further async work so
+          // the outer catch tears them down if a subsequent patch throws.
           pendingIngredientIds.push(
             ...additionalDocuments.map(({ ingredientData }) =>
               ingredientData._id.toString(),
+            ),
+          );
+
+          // Patch the indexed external id onto every additional placeholder so
+          // each batch output resolves to its own result (`_1`, `_2`, …). The
+          // first output already received `${generationId}_0` above; without
+          // this, only the first placeholder was ever reconciled.
+          await Promise.all(
+            additionalDocuments.map(
+              ({ metadataData: additionalMetadata }, index) =>
+                this.metadataService.patch(
+                  additionalMetadata._id,
+                  new MetadataEntity({
+                    externalId: `${generationId}_${index + 1}`,
+                  }),
+                ),
             ),
           );
 
@@ -538,6 +541,10 @@ export class VideoGenerationService {
               width,
             });
 
+            // Track the placeholder before the external call so the outer catch
+            // cleans it up if the provider call below throws.
+            pendingIngredientIds.push(additionalIngredient._id.toString());
+
             // Make separate API call for each output based on model
             const additionalGenerationId: string | null =
               await this.dispatchVideoGeneration({
@@ -550,20 +557,31 @@ export class VideoGenerationService {
                 width,
               });
 
+            // Fail closed on a null generation id rather than persisting an
+            // empty externalId that can never be reconciled. The outer catch
+            // tears down every tracked placeholder.
+            if (!additionalGenerationId) {
+              throw new HttpException(
+                {
+                  detail: `Video generation failed to start for output ${i + 1}`,
+                  title: 'Generation failed',
+                },
+                HttpStatus.BAD_GATEWAY,
+              );
+            }
+
             // Parallelize the patch operations
             await Promise.all([
               this.metadataService.patch(
                 additionalMetadata._id,
                 new MetadataEntity({
-                  externalId: additionalGenerationId || '',
+                  externalId: additionalGenerationId,
                 }),
               ),
               this.videosService.patch(additionalIngredient._id, {
                 prompt: promptData._id,
               }),
             ]);
-
-            pendingIngredientIds.push(additionalIngredient._id.toString());
 
             // Create activity for this additional output (non-batch path)
             await this.createVideoPlaceholderActivity({
@@ -595,24 +613,16 @@ export class VideoGenerationService {
           );
         }
       } else {
-        // Clean up all placeholders on failure
-        await this.failedGenerationService.handleFailedVideoGeneration(
-          this.videosService,
-          ingredientData._id,
-          websocketUrl,
-          user.id,
-          getUserRoomName(user.id),
+        // Generation never started. Throw so the outer catch tears down every
+        // tracked placeholder and the request fails — this prevents
+        // CreditsInterceptor (which deducts the authorized amount on HTTP
+        // success) from charging for a generation that never began.
+        throw new HttpException(
           {
-            brand: brand._id.toString(),
-            key: ActivityKey.VIDEO_FAILED,
-            organization: publicMetadata.organization,
-            source: ActivitySource.VIDEO_GENERATION,
-            user: publicMetadata.user,
-            value: JSON.stringify({
-              error: 'Generation failed to start',
-              ingredientId: ingredientData._id.toString(),
-            }),
+            detail: 'Video generation failed to start',
+            title: 'Generation failed',
           },
+          HttpStatus.BAD_GATEWAY,
         );
       }
     } catch (error: unknown) {
@@ -667,8 +677,10 @@ export class VideoGenerationService {
       }
     }
 
-    // Invalidate cached video listings so placeholders appear immediately
-    await this.cacheService.invalidateByTags(['videos']);
+    // Invalidate cached video listings so placeholders appear immediately.
+    // Busts the full tag set (list + single-record + aggregate) so no cached
+    // view can serve a stale response after the write.
+    await this.cacheService.invalidateByTags([...VIDEO_WRITE_CACHE_TAGS]);
 
     // Handle background music orchestration (runs in background)
     if (createVideoDto.backgroundMusic) {
@@ -860,6 +872,29 @@ export class VideoGenerationService {
       );
     } else {
       requiredCredits = 5; // Fallback default cost
+    }
+
+    // Apply the same resolution and output multipliers CreditsGuard applies on
+    // the non-deferred path. This deferred authorization amount is the single
+    // figure CreditsInterceptor deducts on success, so it must equal the full
+    // cost of the request (per-output base x resolution x outputs).
+    if (
+      createVideoDto.resolution === 'high' ||
+      createVideoDto.resolution === '1080p'
+    ) {
+      requiredCredits *= 2;
+    }
+    const requestedOutputs = createVideoDto.outputs || 1;
+    const isBatchSupported =
+      MODEL_OUTPUT_CAPABILITIES[model]?.isBatchSupported ?? false;
+    // This route always defers (see @DeferCreditsUntilModelResolution), so this
+    // is the sole authorizer and must charge for the real number of billable
+    // provider calls. generateVideo() fans out into separate dispatch calls
+    // exactly when the model is NOT batch-capable, so `isBatchSupported` — not
+    // CreditsGuard's training-key heuristic — is the predicate that matches the
+    // actual cost incurred below.
+    if (!isBatchSupported && requestedOutputs > 1) {
+      requiredCredits *= requestedOutputs;
     }
 
     const hasCredits =

--- a/apps/server/api/src/collections/videos/services/video-generation.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation.service.ts
@@ -257,9 +257,7 @@ export class VideoGenerationService {
       const prompt = await this.promptsService.findOne({
         _id: createVideoDto.prompt.toString(),
         isDeleted: false,
-        ...(publicMetadata.organization
-          ? { organization: publicMetadata.organization }
-          : {}),
+        ...(validationOrgId ? { organization: validationOrgId } : {}),
       });
 
       if (!prompt?._id) {


### PR DESCRIPTION
## Summary

Fixes the seven pre-existing CodeRabbit "Major" findings carried into `VideoGenerationService` when `create()` was extracted from `videos.controller.ts` in #842 (behavior-preserving). Each is now fixed as a scoped change with regression tests.

File: `apps/server/api/src/collections/videos/services/video-generation.service.ts`

| # | Area | Fix |
|---|------|-----|
| F1 | Security / multi-tenancy | Validate the resolved model against the org whenever one is present (token claim → request-context fallback), not only when `request.context.organizationId` was populated. Closes the default/auto-selected-model `ModelsGuard` bypass; single-tenant (no org) still skips. |
| F2 | Security / multi-tenancy | Org-scope the saved-prompt lookup **and fail closed** (404) on an unknown/foreign prompt id instead of silently generating with an empty prompt. The org filter is omitted when no org is present so single-tenant (null `organizationId`) still resolves prompts. |
| F3 | Data integrity | Persist the prompt against the resolved `brand._id` (honors `createVideoDto.brand`) instead of the token-default brand — matches `saveDocuments`/activities/cleanup. |
| F4 | Data integrity / billing | Remove the service's second, separately-computed credit deduction. Deduction is now owned solely by `CreditsInterceptor` (matching the images pipeline); `ensureDeferredCredits` authorizes the full multiplied amount (`base × resolution × outputs` for non-batch) the interceptor deducts. A null `generationId` on the first output now fails the request so a generation that never started is not charged. |
| F5 | Data integrity | Patch an indexed `externalId` (`_1`, `_2`, …) onto **every** additional batch placeholder (previously only the first got `_0`). Placeholders are tracked before patching so they are cleaned up on failure. |
| F6 | Stability | Track each additional non-batch placeholder **before** its provider call and fail closed on a null id instead of persisting `externalId: ''`. |
| F7 | Caching | All video GET endpoints register the single `videos` cache tag, so busting it already covers list/latest/single; aggregate tags are invalidated by `BaseService` on the underlying ingredient writes. Kept as `['videos']` with documentation (the original premise of separate single-record/agg tags did not hold). |

### Notable behavior changes (intentional, tested)
- **No more double-charge.** Previously the route deducted credits twice with divergent amounts — once via `CreditsInterceptor` (`creditsConfig.amount`) and once via a manual `deductCreditsFromOrganization` call. The manual call is removed; the interceptor is the single source, fed by the single `ensureDeferredCredits` calculation.
- **Failed-to-start generations now fail the request** (`502`) instead of returning success, preventing the interceptor from charging for a generation that never began.
- The output multiplier in `ensureDeferredCredits` keys on `isBatchSupported` (the real number of billable provider calls this route fans out into), since this route is always deferred and `ensureDeferredCredits` is its sole authorizer.

## Review

Diff was put through an adversarial multi-agent review (security/multi-tenancy, billing, control-flow, cache, tests) with per-finding verification. Confirmed issues were fixed:
- Single-tenant prompt lookup regression (empty-string org filter) → conditional org filter.
- Batch-placeholder leak window (push tracked before patch) → reordered tracking before the patch.
- Phantom cache tags → reverted to the correct `['videos']`.
- Added HTTP status-code assertions and a first-output null-generation test.

## Verification
- `bun run test` (scoped, vitest): `video-generation.service.spec.ts` (new, all 7 findings) + `videos.controller.spec.ts` — **62 passed**.
- `biome check` — clean.
- Scoped `tsc` on the api package shows **no type errors in the changed files** (the unbuilt-`@genfeedai/*`-package `TS2307` resolution errors affect the whole tree uniformly and are an environment artifact; full workspace typecheck/build left to CI).

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)