### PR TITLE
ci: focused app tests on PR + master push (vitest --changed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
+    # Runs on every event: workflow_call (release/full-suite) AND pull_request /
+    # push so the focused `test-app-changed` gate below can read its outputs. The
+    # heavy sharded test-* jobs keep their own `&& workflow_call` gate, so
+    # broadening this does not trigger the full matrix on PRs.
+    if: needs.trust.outputs.is-trusted == 'true'
     outputs:
       app: ${{ steps.scope.outputs.app }}
       api: ${{ steps.scope.outputs.api }}
@@ -484,6 +488,45 @@ jobs:
         run: bunx turbo run build --filter='./apps/app...'
       - name: Run app test shard
         run: cd apps/app && bunx vitest run --config ./vitest.config.mts --maxWorkers=2 --shard=${{ matrix.shard }}/4
+        env:
+          NODE_ENV: test
+
+  # Focused, blocking app tests on every PR and master push: runs only the
+  # @genfeedai/app tests whose module graph touches the diff (vitest --changed),
+  # so it stays fast while pinning any regression to the single PR/merge that
+  # introduced it. The full sharded `test-app` matrix above still runs the whole
+  # suite via workflow_call (full-suite / release), which catches cross-cutting
+  # tests that --changed's static graph can miss (e.g. filesystem-scan contracts).
+  test-app-changed:
+    name: Test App (changed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [trust, test-scope]
+    if: >-
+      needs.trust.outputs.is-trusted == 'true'
+      && needs.test-scope.outputs.app == 'true'
+      && (github.event_name == 'pull_request' || github.event_name == 'push')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+      - name: Build app workspace
+        run: bunx turbo run build --filter='./apps/app...'
+      - name: Run changed app tests
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          # Force-push / new-branch pushes report an all-zero "before"; fall back
+          # to the previous commit so --changed always has a valid diff base.
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="HEAD~1"
+          fi
+          echo "Running app tests changed since $BASE"
+          cd apps/app && bunx vitest run --config ./vitest.config.mts \
+            --maxWorkers=2 --passWithNoTests --changed "$BASE"
         env:
           NODE_ENV: test
 


### PR DESCRIPTION
## Why

App unit tests only run via `workflow_call` (full-suite / release). So per-PR and per-merge CI **never exercised them** — which is exactly how the Clerk → Better Auth cutover landed **16 broken app tests on master** that sat red until a full-suite run, and pinning them to a cause meant bisecting weeks of merges (see #844).

## What

Adds a focused, **blocking** `test-app-changed` job that runs on every **pull_request** and **master push**:

- `vitest run --changed <base>` — only the `@genfeedai/app` tests whose module graph touches the diff. Base = PR base SHA, or the push's previous commit (`github.event.before`, with an all-zero fallback to `HEAD~1`).
- `--passWithNoTests` so changes that don't touch app code stay green.
- Fast: scopes to the diff (validated locally — a proxy-test-touching diff selected 165/448 files, not the whole suite), and pins any regression to the **single PR/merge** that introduced it.

The existing sharded `test-app` matrix is unchanged — it still runs the **whole** suite via `workflow_call` (full-suite / release), catching cross-cutting tests `--changed`'s static graph can miss (e.g. the filesystem-scan `protected-pages-source-contract` test).

`test-scope` now runs on all events (was `workflow_call`-only) so the new job can read its change-detection outputs. The heavy sharded `test-*` jobs keep their own `&& workflow_call` gate, so **the full matrix is not triggered on PRs** — only the focused job is.

## Layering

| Stage | Runs | Speed |
|---|---|---|
| PR / master push | focused `--changed` app tests (this PR) | fast, blocking |
| full-suite / release (`workflow_call`) | full sharded `test-app` + `test-api` | slow, complete |

## Verification

- `actionlint` / YAML parse clean; job wiring confirmed.
- `--changed` smoke: no app changes → `No test files found, exiting with code 0`. App-touching diff → focused 165-file / 582-test subset, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)