### PR TITLE
fix(images): harden generation create() path — multi-output credits, fan-out attribution, non-batch outputs (#859)

### DIFF
--- a/apps/server/api/src/collections/images/services/image-generation.service.spec.ts
+++ b/apps/server/api/src/collections/images/services/image-generation.service.spec.ts
@@ -1,0 +1,390 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { CreateImageDto } from '@api/collections/images/dto/create-image.dto';
+import { ImageGenerationService } from '@api/collections/images/services/image-generation.service';
+import type { RequestWithContext as ExpressRequest } from '@api/common/middleware/request-context.middleware';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for the three #859 hardening fixes carried into
+ * {@link ImageGenerationService} by the #778 refactor (mirror of the videos set
+ * in #853):
+ *  - F1: the deferred credit authorization scales with the real number of
+ *    billable provider calls (Fal + non-batch Replicate fan out; batch Replicate
+ *    and single-output providers do not).
+ *  - F2: a failed fan-out output is attributed to that specific output, never to
+ *    the primary.
+ *  - F3: non-batch Replicate requests exactly one output per call.
+ */
+
+const ORG = 'org-1';
+const RESOLVED_BRAND = 'brand-resolved';
+
+// REPLICATE_BYTEDANCE_SEEDREAM_5_LITE / _4_5 and REPLICATE_FAST_FLUX_TRAINER are
+// the batch-capable IMAGE models in MODEL_OUTPUT_CAPABILITIES; everything else is
+// non-batch. Use the `seedream-5-lite` key (no dot) so classifyProvider's
+// owner/model regex resolves it to the Replicate provider.
+const BATCH_MODEL = MODEL_KEYS.REPLICATE_BYTEDANCE_SEEDREAM_5_LITE;
+const NON_BATCH_REPLICATE_MODEL = MODEL_KEYS.REPLICATE_GOOGLE_IMAGEN_4;
+const FAL_MODEL = MODEL_KEYS.FAL_NANO_BANANA_2;
+const SINGLE_OUTPUT_MODEL = MODEL_KEYS.LEONARDOAI;
+
+const buildUser = (organization: string = ORG): User =>
+  ({
+    id: 'auth-user-1',
+    publicMetadata: {
+      brand: 'brand-from-token',
+      organization,
+      user: 'user-1',
+    },
+  }) as unknown as User;
+
+const buildRequest = (
+  overrides: Record<string, unknown> = {},
+): ExpressRequest =>
+  ({
+    originalUrl: '/api/images',
+    params: {},
+    query: {},
+    ...overrides,
+  }) as unknown as ExpressRequest;
+
+const baseDto = (overrides: Partial<CreateImageDto> = {}): CreateImageDto =>
+  ({
+    height: 1080,
+    model: NON_BATCH_REPLICATE_MODEL,
+    text: 'a sunset over the ocean',
+    width: 1920,
+    ...overrides,
+  }) as CreateImageDto;
+
+const createService = () => {
+  let savedDocCount = 0;
+  const sharedService = {
+    saveDocuments: vi.fn().mockImplementation(() => {
+      const n = savedDocCount++;
+      return Promise.resolve({
+        ingredientData: {
+          _id: `ing-${n}`,
+          toString: () => `ing-${n}`,
+        },
+        metadataData: { _id: `meta-${n}` },
+      });
+    }),
+  };
+
+  const brandsService = {
+    findOne: vi.fn().mockResolvedValue({
+      _id: RESOLVED_BRAND,
+      description: 'desc',
+      label: 'Brand',
+      organization: ORG,
+      primaryColor: '#fff',
+      secondaryColor: '#000',
+      text: 'text',
+    }),
+  };
+  const organizationSettingsService = {
+    findOne: vi.fn().mockResolvedValue(null),
+  };
+  const modelRegistrationService = {
+    validateModelForOrg: vi.fn().mockResolvedValue(undefined),
+  };
+  const modelsService = {
+    findOne: vi.fn().mockResolvedValue({ cost: 10 }),
+  };
+  const creditsUtilsService = {
+    checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
+    getOrganizationCreditsBalance: vi.fn().mockResolvedValue(1000),
+  };
+  const promptsService = {
+    create: vi.fn().mockResolvedValue({ _id: 'prompt-doc', original: 'built' }),
+  };
+  const promptBuilderService = {
+    buildPrompt: vi.fn().mockResolvedValue({
+      input: { prompt: 'built-prompt' },
+      templateUsed: 'template',
+      templateVersion: '1.0.0',
+    }),
+  };
+  const comfyUIService = { generateImage: vi.fn() };
+  const klingAIService = { queueGenerateImage: vi.fn() };
+  const leonardoaiService = {
+    generateImage: vi.fn().mockResolvedValue('leo-gen'),
+  };
+  const falService = {
+    generateImage: vi.fn().mockResolvedValue({ url: 'https://fal/0.png' }),
+  };
+  const replicateService = {
+    generateTextToImage: vi.fn().mockResolvedValue('rep-gen'),
+  };
+  const metadataService = { patch: vi.fn().mockResolvedValue(undefined) };
+  const imagesService = {
+    findOne: vi.fn().mockResolvedValue({ _id: 'ing-0', status: 'completed' }),
+    patch: vi.fn().mockResolvedValue(undefined),
+  };
+  const activitiesService = {
+    create: vi.fn().mockResolvedValue({ _id: { toString: () => 'act' } }),
+  };
+  const websocketService = {
+    publishBackgroundTaskUpdate: vi.fn().mockResolvedValue(undefined),
+    publishVideoComplete: vi.fn().mockResolvedValue(undefined),
+  };
+  const failedGenerationService = {
+    handleFailedImageGeneration: vi.fn().mockResolvedValue(undefined),
+  };
+  const routerService = {
+    getDefaultModel: vi.fn().mockResolvedValue(NON_BATCH_REPLICATE_MODEL),
+    selectModel: vi.fn(),
+  };
+  const pollingService = {
+    waitForMultipleIngredientsCompletion: vi
+      .fn()
+      .mockResolvedValue([{ _id: 'ing-0', status: 'completed' }]),
+    waitForIngredientCompletion: vi
+      .fn()
+      .mockResolvedValue({ _id: 'ing-0', status: 'completed' }),
+  };
+  const filesClientService = { uploadToS3: vi.fn() };
+  const assetsService = {};
+  const ingredientsService = {};
+  const configService = {};
+  const loggerService = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggerService;
+
+  const service = new ImageGenerationService(
+    configService as never,
+    activitiesService as never,
+    assetsService as never,
+    brandsService as never,
+    comfyUIService as never,
+    creditsUtilsService as never,
+    failedGenerationService as never,
+    filesClientService as never,
+    falService as never,
+    pollingService as never,
+    imagesService as never,
+    ingredientsService as never,
+    organizationSettingsService as never,
+    klingAIService as never,
+    leonardoaiService as never,
+    loggerService,
+    metadataService as never,
+    modelRegistrationService as never,
+    modelsService as never,
+    promptBuilderService as never,
+    promptsService as never,
+    replicateService as never,
+    routerService as never,
+    sharedService as never,
+    websocketService as never,
+  );
+
+  return {
+    creditsUtilsService,
+    failedGenerationService,
+    falService,
+    metadataService,
+    promptBuilderService,
+    replicateService,
+    service,
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ImageGenerationService', () => {
+  describe('deferred credit authorization (multi-output, F1)', () => {
+    it('multiplies the authorized amount by outputs for Fal (always fans out)', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateImage(
+        buildUser(),
+        baseDto({ model: FAL_MODEL, outputs: 2 }),
+        buildRequest({ creditsConfig: { deferred: true } }),
+      );
+
+      // base 10 x 2 fan-out outputs = 20
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(ORG, 20);
+    });
+
+    it('multiplies the authorized amount by outputs for non-batch Replicate', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateImage(
+        buildUser(),
+        baseDto({ model: NON_BATCH_REPLICATE_MODEL, outputs: 3 }),
+        buildRequest({ creditsConfig: { deferred: true } }),
+      );
+
+      // base 10 x 3 separate provider calls = 30
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(ORG, 30);
+    });
+
+    it('does not multiply for batch-capable Replicate models', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateImage(
+        buildUser(),
+        baseDto({ model: BATCH_MODEL, outputs: 3 }),
+        buildRequest({ creditsConfig: { deferred: true } }),
+      );
+
+      // batch model yields all outputs from a single call -> single base cost
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(ORG, 10);
+    });
+
+    it('does not multiply for single-output providers (e.g. Leonardo)', async () => {
+      const { service, creditsUtilsService } = createService();
+
+      await service.generateImage(
+        buildUser(),
+        baseDto({ model: SINGLE_OUTPUT_MODEL, outputs: 4 }),
+        buildRequest({ creditsConfig: { deferred: true } }),
+      );
+
+      // single-output providers ignore `outputs` -> never over-charge by N
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(ORG, 10);
+    });
+  });
+
+  describe('non-batch Replicate outputs (F3)', () => {
+    it('requests exactly one output per call for non-batch models', async () => {
+      const { service, promptBuilderService, replicateService } =
+        createService();
+
+      await service.generateImage(
+        buildUser(),
+        baseDto({
+          model: NON_BATCH_REPLICATE_MODEL,
+          outputs: 3,
+          waitForCompletion: true,
+        }),
+        buildRequest(),
+      );
+
+      // The dispatch-time buildPrompt (last call) must request a single output;
+      // the N images come from N separate provider calls.
+      const dispatchCall = promptBuilderService.buildPrompt.mock.calls.at(-1);
+      expect(
+        (dispatchCall?.[1] as { outputs?: number } | undefined)?.outputs,
+      ).toBe(1);
+      expect(replicateService.generateTextToImage).toHaveBeenCalledTimes(3);
+    });
+
+    it('requests all outputs in a single call for batch-capable models', async () => {
+      const {
+        service,
+        promptBuilderService,
+        replicateService,
+        metadataService,
+      } = createService();
+      replicateService.generateTextToImage.mockResolvedValue('rep');
+
+      await service.generateImage(
+        buildUser(),
+        baseDto({ model: BATCH_MODEL, outputs: 3, waitForCompletion: true }),
+        buildRequest(),
+      );
+
+      const dispatchCall = promptBuilderService.buildPrompt.mock.calls.at(-1);
+      expect(
+        (dispatchCall?.[1] as { outputs?: number } | undefined)?.outputs,
+      ).toBe(3);
+      // Batch model -> one provider call, indexed external ids on each placeholder.
+      expect(replicateService.generateTextToImage).toHaveBeenCalledTimes(1);
+      const externalIds = metadataService.patch.mock.calls.map(
+        ([, entity]) => (entity as { externalId?: string }).externalId,
+      );
+      expect(externalIds).toContain('rep_0');
+      expect(externalIds).toContain('rep_1');
+      expect(externalIds).toContain('rep_2');
+    });
+  });
+
+  describe('fan-out failure attribution (F2)', () => {
+    it('marks the specific failed additional output, not the primary', async () => {
+      const { service, replicateService, failedGenerationService } =
+        createService();
+      // Primary call succeeds (ing-0); the additional output's call fails (ing-1).
+      replicateService.generateTextToImage
+        .mockResolvedValueOnce('rep-gen-0')
+        .mockRejectedValueOnce(new Error('boom'));
+
+      const error = await service
+        .generateImage(
+          buildUser(),
+          baseDto({
+            model: NON_BATCH_REPLICATE_MODEL,
+            outputs: 2,
+            waitForCompletion: true,
+          }),
+          buildRequest(),
+        )
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+
+      const markedIds =
+        failedGenerationService.handleFailedImageGeneration.mock.calls.map(
+          (call) => call[1],
+        );
+      // The failed additional output (ing-1) is marked; the primary (ing-0) is not.
+      expect(markedIds).toContain('ing-1');
+      expect(markedIds).not.toContain('ing-0');
+
+      // The websocket path targets the failed output, not the primary.
+      const markedWsPaths =
+        failedGenerationService.handleFailedImageGeneration.mock.calls.map(
+          (call) => call[2],
+        );
+      expect(markedWsPaths).toContain('/images/ing-1');
+    });
+
+    it('marks the specific failed Fal additional output, not the primary', async () => {
+      const { service, falService, failedGenerationService } = createService();
+      // Primary output succeeds (ing-0); the additional output fails (ing-1).
+      falService.generateImage
+        .mockResolvedValueOnce({ url: 'https://fal/0.png' })
+        .mockRejectedValueOnce(new Error('boom'));
+
+      // Fal is background-only: generateImage returns the placeholder
+      // immediately, so the fan-out failure is attributed asynchronously.
+      await service.generateImage(
+        buildUser(),
+        baseDto({ model: FAL_MODEL, outputs: 2 }),
+        buildRequest(),
+      );
+
+      await vi.waitFor(() => {
+        expect(
+          failedGenerationService.handleFailedImageGeneration,
+        ).toHaveBeenCalled();
+      });
+
+      const markedIds =
+        failedGenerationService.handleFailedImageGeneration.mock.calls.map(
+          (call) => call[1],
+        );
+      // The failed additional output (ing-1) is marked; the already-succeeded
+      // primary (ing-0) is not.
+      expect(markedIds).toContain('ing-1');
+      expect(markedIds).not.toContain('ing-0');
+    });
+  });
+});

--- a/apps/server/api/src/collections/images/services/image-generation.service.ts
+++ b/apps/server/api/src/collections/images/services/image-generation.service.ts
@@ -1150,10 +1150,20 @@ export class ImageGenerationService {
         }),
       ]);
 
-      await this.createImagePlaceholderActivity(
-        context,
-        additionalIngredient._id,
-      );
+      // Activity creation + websocket publishing is post-success bookkeeping:
+      // a failure here must not mark the already-generated additional output as
+      // failed, so swallow (and log) instead of letting it reach the catch.
+      try {
+        await this.createImagePlaceholderActivity(
+          context,
+          additionalIngredient._id,
+        );
+      } catch (activityError: unknown) {
+        this.loggerService.error(
+          'Failed to publish placeholder activity for additional output',
+          { error: activityError },
+        );
+      }
 
       context.pendingIngredientIds.push(additionalIngredient._id.toString());
     } catch (error: unknown) {
@@ -1448,6 +1458,9 @@ export class ImageGenerationService {
             destination,
             promptParams,
           );
+        if (!additionalGenerationId) {
+          throw new Error('No generation ID returned from Replicate');
+        }
 
         await Promise.all([
           this.metadataService.patch(

--- a/apps/server/api/src/collections/images/services/image-generation.service.ts
+++ b/apps/server/api/src/collections/images/services/image-generation.service.ts
@@ -589,6 +589,28 @@ export class ImageGenerationService {
       requiredCredits = 5; // Fallback default cost
     }
 
+    // This route always defers (CreditsGuard defers until the model resolves),
+    // so this is the sole authorizer and must charge for the real number of
+    // billable provider calls — the single figure CreditsInterceptor deducts on
+    // success. `calculateDynamicImageCost` returns the per-output base. Only the
+    // providers that fan out into one provider call per output multiply: Fal
+    // always loops per output, and non-batch Replicate makes a separate call per
+    // output. Batch-capable Replicate yields N images in one call, and the
+    // single-output providers (genfeedai/klingai/leonardo/sdxl) ignore `outputs`
+    // entirely, so neither multiplies. Mirrors the videos hardening in #853 and
+    // matches the dispatch logic below.
+    const requestedOutputs = Number(createImageDto.outputs) || 1;
+    if (requestedOutputs > 1) {
+      const provider = this.classifyProvider(model);
+      const isBatchSupported =
+        MODEL_OUTPUT_CAPABILITIES[model]?.isBatchSupported ?? false;
+      const fansOutPerOutput =
+        provider === 'fal' || (provider === 'replicate' && !isBatchSupported);
+      if (fansOutPerOutput) {
+        requiredCredits *= requestedOutputs;
+      }
+    }
+
     const hasCredits =
       await this.creditsUtilsService.checkOrganizationCreditsAvailable(
         organization,
@@ -805,14 +827,20 @@ export class ImageGenerationService {
     context: GenerationContext,
     error: unknown,
     label: string,
+    ingredientId: SavedIngredient['_id'] = context.ingredientData._id,
   ): Promise<never> {
     this.loggerService.error(`${label} failed`, error);
     const errorMessage = getErrorMessage(error);
 
+    // Attribute the failure to the specific output that failed, not always the
+    // primary ingredient. The websocket path is derived from the same id so the
+    // matching placeholder (not the first) receives the failure update. The
+    // default keeps every single-output provider call site on the primary id —
+    // and for the primary `WebSocketPaths.image(_id)` equals `context.websocketUrl`.
     await this.failedGenerationService.handleFailedImageGeneration(
       this.imagesService,
-      context.ingredientData._id,
-      context.websocketUrl,
+      ingredientId,
+      WebSocketPaths.image(ingredientId),
       context.publicMetadata,
       getUserRoomName(context.user.id),
       errorMessage,
@@ -1037,27 +1065,41 @@ export class ImageGenerationService {
     });
 
     const generationPromise = (async () => {
-      const falResult = await this.falService.generateImage(
-        context.model,
-        buildFalInput(),
-      );
+      // Primary output: a failure here is attributed to the primary ingredient.
+      let primaryUrl: string;
+      try {
+        const falResult = await this.falService.generateImage(
+          context.model,
+          buildFalInput(),
+        );
+        await this.metadataService.patch(
+          metadataData._id,
+          new MetadataEntity({
+            externalId: falResult.url,
+            prompt: promptData._id,
+          }),
+        );
+        primaryUrl = falResult.url;
+      } catch (error: unknown) {
+        return this.handleProviderFailure(
+          context,
+          error,
+          'FalService generateImage',
+          context.ingredientData._id,
+        );
+      }
 
-      await this.metadataService.patch(
-        metadataData._id,
-        new MetadataEntity({
-          externalId: falResult.url,
-          prompt: promptData._id,
-        }),
-      );
-
+      // Additional outputs sit outside the primary's catch: each owns its own
+      // failure attribution (see createFalAdditionalOutput), so a failed fan-out
+      // output marks that output rather than the already-succeeded primary.
+      // finishGeneration attaches an empty catch to the background promise, so a
+      // rejection after marking is intentional and not an unhandled rejection.
       for (let i = 1; i < context.outputs; i++) {
         await this.createFalAdditionalOutput(context, buildFalInput);
       }
 
-      return falResult.url;
-    })().catch((error: unknown) =>
-      this.handleProviderFailure(context, error, 'FalService generateImage'),
-    );
+      return primaryUrl;
+    })();
 
     return { generationPromise, kind: 'background-only' };
   }
@@ -1069,45 +1111,71 @@ export class ImageGenerationService {
   ): Promise<void> {
     const { createImageDto, brand, promptData, publicMetadata } = context;
 
-    const {
-      metadataData: additionalMetadata,
-      ingredientData: additionalIngredient,
-    } = await this.sharedService.saveDocuments(context.user, {
-      ...createImageDto,
-      brand: brand._id,
-      category: IngredientCategory.IMAGE,
-      extension: MetadataExtension.JPG,
-      model: context.model,
-      organization: publicMetadata.organization,
-      parent: context.ingredientData.parent,
-      prompt: promptData._id,
-      status: IngredientStatus.PROCESSING,
-    });
+    // Capture the additional output's id as soon as its placeholder exists so a
+    // generation/patch failure marks that specific output, not the (already
+    // succeeded) primary.
+    let additionalIngredientId: SavedIngredient['_id'] | null = null;
+    try {
+      const {
+        metadataData: additionalMetadata,
+        ingredientData: additionalIngredient,
+      } = await this.sharedService.saveDocuments(context.user, {
+        ...createImageDto,
+        brand: brand._id,
+        category: IngredientCategory.IMAGE,
+        extension: MetadataExtension.JPG,
+        model: context.model,
+        organization: publicMetadata.organization,
+        parent: context.ingredientData.parent,
+        prompt: promptData._id,
+        status: IngredientStatus.PROCESSING,
+      });
+      additionalIngredientId = additionalIngredient._id;
 
-    const additionalResult = await this.falService.generateImage(
-      context.model,
-      buildFalInput(),
-    );
+      const additionalResult = await this.falService.generateImage(
+        context.model,
+        buildFalInput(),
+      );
 
-    await Promise.all([
-      this.metadataService.patch(
-        additionalMetadata._id,
-        new MetadataEntity({
-          externalId: additionalResult.url,
+      await Promise.all([
+        this.metadataService.patch(
+          additionalMetadata._id,
+          new MetadataEntity({
+            externalId: additionalResult.url,
+            prompt: promptData._id,
+          }),
+        ),
+        this.imagesService.patch(additionalIngredient._id, {
           prompt: promptData._id,
         }),
-      ),
-      this.imagesService.patch(additionalIngredient._id, {
-        prompt: promptData._id,
-      }),
-    ]);
+      ]);
 
-    await this.createImagePlaceholderActivity(
-      context,
-      additionalIngredient._id,
-    );
+      await this.createImagePlaceholderActivity(
+        context,
+        additionalIngredient._id,
+      );
 
-    context.pendingIngredientIds.push(additionalIngredient._id.toString());
+      context.pendingIngredientIds.push(additionalIngredient._id.toString());
+    } catch (error: unknown) {
+      // Mark the specific additional output that failed; never fall back to the
+      // primary, which is a different (already-succeeded) output.
+      if (additionalIngredientId) {
+        return this.handleProviderFailure(
+          context,
+          error,
+          'FalService generateImage (additional output)',
+          additionalIngredientId,
+        );
+      }
+      // The placeholder was never created (saveDocuments failed), so there is
+      // nothing to mark. Log so the dropped output is observable, then propagate
+      // to fail the request rather than swallowing it silently.
+      this.loggerService.error(
+        'Fal additional output failed before its placeholder was created',
+        error,
+      );
+      throw error;
+    }
   }
 
   /**
@@ -1124,8 +1192,16 @@ export class ImageGenerationService {
       promptData,
     } = context;
 
-    // Build provider-specific prompt using universal prompt builder with template
-    // support. NOTE: This must complete before we can start generation.
+    const destination = context.model;
+    const modelCapability = MODEL_OUTPUT_CAPABILITIES[destination];
+    const isBatchSupported = modelCapability?.isBatchSupported ?? false;
+
+    // Build provider-specific prompt using the universal prompt builder with
+    // template support. NOTE: This must complete before we can start generation.
+    // Only batch-capable models yield every output from a single call, so they
+    // request `context.outputs`; non-batch models make a separate call per output
+    // (see createReplicateSequentialOutputs) and must request exactly one output
+    // per call — otherwise every one of those N calls over-requests N images.
     const { input: promptParams } = await this.promptBuilderService.buildPrompt(
       context.model,
       {
@@ -1142,7 +1218,7 @@ export class ImageGenerationService {
         // Use model's category from DB (set by ModelsGuard), fallback to IMAGE
         modelCategory: ModelCategory.IMAGE,
         mood: createImageDto.mood,
-        outputs: context.outputs,
+        outputs: isBatchSupported ? context.outputs : 1,
         prompt: promptData.original,
         // Template support
         promptTemplate: createImageDto.promptTemplate,
@@ -1157,54 +1233,80 @@ export class ImageGenerationService {
       context.publicMetadata.organization,
     );
 
-    const destination = context.model;
-    const modelCapability = MODEL_OUTPUT_CAPABILITIES[destination];
-    const isBatchSupported = modelCapability?.isBatchSupported ?? false;
-
     // Track all placeholder ingredient IDs - start with first one
     const pollIds: string[] = [context.ingredientData._id.toString()];
 
-    const generationPromise = this.replicateService
-      .generateTextToImage(destination, promptParams)
-      .then(async (generationId) => {
-        if (!generationId) {
+    const generationPromise = (async () => {
+      // Primary generation: a failure here is attributed to the primary
+      // ingredient.
+      let generationId: string;
+      try {
+        const id = await this.replicateService.generateTextToImage(
+          destination,
+          promptParams,
+        );
+        if (!id) {
           throw new Error('No generation ID returned from Replicate');
         }
+        generationId = id;
+      } catch (error: unknown) {
+        return this.handleProviderFailure(
+          context,
+          error,
+          'ReplicateService generateImage',
+          context.ingredientData._id,
+        );
+      }
 
-        if (isBatchSupported && context.outputs > 1) {
+      // Multi-output fan-out. createReplicateSequentialOutputs owns its own
+      // per-output failure attribution (a failed additional output marks that
+      // output, never the primary); the batch and single-output branches wrap
+      // their DB work here so a failure still tears down the primary placeholder.
+      if (isBatchSupported && context.outputs > 1) {
+        try {
           await this.createReplicateBatchOutputs(
             context,
             destination,
             generationId,
             pollIds,
           );
-        } else if (context.outputs > 1) {
-          await this.createReplicateSequentialOutputs(
+        } catch (error: unknown) {
+          return this.handleProviderFailure(
             context,
-            destination,
-            generationId,
-            promptParams,
-            pollIds,
+            error,
+            'ReplicateService generateImage',
+            context.ingredientData._id,
           );
-        } else {
-          // Single output - use original external ID
+        }
+      } else if (context.outputs > 1) {
+        await this.createReplicateSequentialOutputs(
+          context,
+          destination,
+          generationId,
+          promptParams,
+          pollIds,
+        );
+      } else {
+        // Single output - use original external ID
+        try {
           await this.metadataService.patch(
             context.metadataData._id,
             new MetadataEntity({
               externalId: generationId,
             }),
           );
+        } catch (error: unknown) {
+          return this.handleProviderFailure(
+            context,
+            error,
+            'ReplicateService generateImage',
+            context.ingredientData._id,
+          );
         }
+      }
 
-        return generationId;
-      })
-      .catch((error: unknown) =>
-        this.handleProviderFailure(
-          context,
-          error,
-          'ReplicateService generateImage',
-        ),
-      );
+      return generationId;
+    })();
 
     return { generationPromise, kind: 'poll-multiple', pollIds };
   }
@@ -1301,57 +1403,91 @@ export class ImageGenerationService {
   ): Promise<void> {
     const { createImageDto, brand, promptData, publicMetadata } = context;
 
-    await this.metadataService.patch(
-      context.metadataData._id,
-      new MetadataEntity({
-        externalId: generationId,
-      }),
-    );
+    try {
+      await this.metadataService.patch(
+        context.metadataData._id,
+        new MetadataEntity({
+          externalId: generationId,
+        }),
+      );
+    } catch (error: unknown) {
+      await this.handleProviderFailure(
+        context,
+        error,
+        'ReplicateService generateImage',
+        context.ingredientData._id,
+      );
+    }
 
     // Make additional API calls for remaining outputs
     // NOTE: Sequential because each needs unique generationId
     for (let i = 1; i < context.outputs; i++) {
-      const {
-        metadataData: additionalMetadata,
-        ingredientData: additionalIngredient,
-      } = await this.sharedService.saveDocuments(context.user, {
-        ...createImageDto,
-        brand: brand._id,
-        category: IngredientCategory.IMAGE,
-        extension: MetadataExtension.JPG,
-        model: context.model,
-        organization: publicMetadata.organization,
-        parent: context.ingredientData.parent,
-        prompt: promptData._id,
-        status: IngredientStatus.PROCESSING,
-      });
+      // Capture the additional output's id as soon as its placeholder exists so
+      // a generation/patch failure marks that specific output, not the primary.
+      let additionalIngredientId: SavedIngredient['_id'] | null = null;
+      try {
+        const {
+          metadataData: additionalMetadata,
+          ingredientData: additionalIngredient,
+        } = await this.sharedService.saveDocuments(context.user, {
+          ...createImageDto,
+          brand: brand._id,
+          category: IngredientCategory.IMAGE,
+          extension: MetadataExtension.JPG,
+          model: context.model,
+          organization: publicMetadata.organization,
+          parent: context.ingredientData.parent,
+          prompt: promptData._id,
+          status: IngredientStatus.PROCESSING,
+        });
+        additionalIngredientId = additionalIngredient._id;
 
-      // Make separate API call for each output
-      const additionalGenerationId =
-        await this.replicateService.generateTextToImage(
-          destination,
-          promptParams,
+        // Make separate API call for each output
+        const additionalGenerationId =
+          await this.replicateService.generateTextToImage(
+            destination,
+            promptParams,
+          );
+
+        await Promise.all([
+          this.metadataService.patch(
+            additionalMetadata._id,
+            new MetadataEntity({
+              externalId: additionalGenerationId,
+            }),
+          ),
+          this.imagesService.patch(additionalIngredient._id, {
+            prompt: promptData._id,
+          }),
+        ]);
+
+        await this.createImagePlaceholderActivity(
+          context,
+          additionalIngredient._id,
         );
 
-      await Promise.all([
-        this.metadataService.patch(
-          additionalMetadata._id,
-          new MetadataEntity({
-            externalId: additionalGenerationId,
-          }),
-        ),
-        this.imagesService.patch(additionalIngredient._id, {
-          prompt: promptData._id,
-        }),
-      ]);
-
-      await this.createImagePlaceholderActivity(
-        context,
-        additionalIngredient._id,
-      );
-
-      // Push this additional ingredient ID to tracking array for polling
-      pollIds.push(additionalIngredient._id.toString());
+        // Push this additional ingredient ID to tracking array for polling
+        pollIds.push(additionalIngredient._id.toString());
+      } catch (error: unknown) {
+        // Mark the specific additional output that failed; never fall back to
+        // the primary, which is a different output.
+        if (additionalIngredientId) {
+          return this.handleProviderFailure(
+            context,
+            error,
+            'ReplicateService generateImage (additional output)',
+            additionalIngredientId,
+          );
+        }
+        // The placeholder was never created (saveDocuments failed), so there is
+        // nothing to mark. Log so the dropped output is observable, then
+        // propagate to fail the request rather than swallowing it silently.
+        this.loggerService.error(
+          'Replicate additional output failed before its placeholder was created',
+          error,
+        );
+        throw error;
+      }
     }
 
     this.loggerService.log(


### PR DESCRIPTION
## Summary

Fixes the three pre-existing findings carried verbatim into `ImageGenerationService` when `create()` was extracted by the #778 refactor (behavior-preserving). Each is now a scoped change with a regression test. Mirror of the videos hardening in #853.

File: `apps/server/api/src/collections/images/services/image-generation.service.ts`

| # | Area | Fix |
|---|------|-----|
| **F1** | Billing / multi-output | `ensureDeferredCredits` now scales the deferred authorization by the **real number of billable provider calls** — the single figure `CreditsInterceptor` deducts on success. `calculateDynamicImageCost` returns the per-output base; only providers that fan out one provider call per output multiply: **Fal** (always loops) and **non-batch Replicate**. **Batch-capable Replicate** yields N images in one call, and the **single-output providers** (genfeedai/klingai/leonardo/sdxl) ignore `outputs` — neither multiplies. The predicate is provider-aware (`classifyProvider`) rather than a blind `!isBatchSupported`, so single-output providers are never over-charged. |
| **F2** | Fan-out failure attribution | `handleProviderFailure` now takes the failed ingredient id (defaulting to the primary) and derives the websocket path from it. `dispatchFal`/`dispatchReplicate` are restructured so the fan-out helpers own their own attribution — a failed **additional** output marks **that specific output** instead of always marking the first (already-succeeded) primary. A `saveDocuments` failure before a placeholder exists is now logged rather than silently swallowed. |
| **F3** | Non-batch outputs | `isBatchSupported` is computed **before** `buildPrompt`, and the prompt requests `isBatchSupported ? context.outputs : 1`. Non-batch Replicate makes N separate calls, so each must request exactly **one** output (previously every call over-requested N). Batch-capable models still request all N in their single call. |

## Why provider-aware (not a blind mirror of #853)

The videos pipeline used a blind `!isBatchSupported` multiplier. Images has single-output providers (Leonardo/Kling/GenfeedAi/SDXL) that ignore `outputs`; a blind predicate would over-charge them N×. The fix scopes the multiplier to the providers whose dispatch logic actually fans out (`fal`, non-batch `replicate`), matching the real cost incurred.

## Tests

New `apps/server/api/src/collections/images/services/image-generation.service.spec.ts` (8 tests):
- F1: Fal ×N, non-batch Replicate ×N, batch Replicate ×1, single-output provider ×1 (no over-charge)
- F2: specific failed additional output marked (Replicate sequential **and** Fal background fan-out), primary never marked
- F3: non-batch requests `outputs: 1` per call; batch requests `outputs: N` in one call

## Verification

- `vitest` image-generation.service.spec.ts — **8 passed**
- `vitest` images-operations.controller.spec.ts (existing) — **38 passed** (no regression)
- `biome check` — clean
- `tsc --noEmit` (api package) — no errors in changed files
- Adversarial multi-agent review of the diff (find → verify): F1/F2/F3 logic confirmed correct; review-surfaced silent-swallow + missing Fal test addressed in this PR. One **pre-existing, out-of-scope** defect was surfaced — `classifyProvider` can't route dot-versioned Replicate keys (e.g. `bytedance/seedream-4.5`) because `isReplicateDestination`'s regex excludes `.` — filed separately, not touched here.

Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)