### PR TITLE
feat(auth): harden Better Auth — hashed magic-link tokens, Redis rate limiting, env-gated cross-subdomain cookies + IP headers + joins

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  parseCommaSeparated,
   parseTrustedOrigins,
   resolveBetterAuthBaseUrl,
+  resolveCookieDomain,
+  resolveExperimentalJoins,
 } from './better-auth.config';
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
 
@@ -20,5 +23,42 @@ describe('Better Auth config', () => {
         'https://genfeed.ai, https://app.genfeed.ai, https://console.genfeed.ai',
       ),
     ).toContain('https://console.genfeed.ai');
+  });
+
+  describe('parseCommaSeparated', () => {
+    it('trims, splits, and drops empty entries', () => {
+      expect(
+        parseCommaSeparated(' x-forwarded-for , cf-connecting-ip ,'),
+      ).toEqual(['x-forwarded-for', 'cf-connecting-ip']);
+    });
+
+    it('returns an empty list for unset / blank values', () => {
+      expect(parseCommaSeparated(undefined)).toEqual([]);
+      expect(parseCommaSeparated('')).toEqual([]);
+    });
+  });
+
+  describe('resolveCookieDomain', () => {
+    it('returns the trimmed root domain when set', () => {
+      expect(resolveCookieDomain('  .genfeed.ai ')).toBe('.genfeed.ai');
+    });
+
+    it('returns undefined for unset / blank so the cookie stays host-scoped', () => {
+      expect(resolveCookieDomain(undefined)).toBeUndefined();
+      expect(resolveCookieDomain('   ')).toBeUndefined();
+    });
+  });
+
+  describe('resolveExperimentalJoins', () => {
+    it('enables only on the exact string "true"', () => {
+      expect(resolveExperimentalJoins('true')).toBe(true);
+      expect(resolveExperimentalJoins(' true ')).toBe(true);
+    });
+
+    it('stays off for any other / unset value', () => {
+      expect(resolveExperimentalJoins('false')).toBe(false);
+      expect(resolveExperimentalJoins(undefined)).toBe(false);
+      expect(resolveExperimentalJoins('1')).toBe(false);
+    });
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.config.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.ts
@@ -21,15 +21,37 @@ export function resolveBetterAuthBaseUrl(
   return `http://localhost:${port ?? 3010}`;
 }
 
-/** Parse the comma-separated trusted-origins env value into a clean list. */
-export function parseTrustedOrigins(value: string | undefined): string[] {
+/** Split a comma-separated env value into a clean, trimmed, non-empty list. */
+export function parseCommaSeparated(value: string | undefined): string[] {
   if (!value) {
     return [];
   }
   return value
     .split(',')
-    .map((origin) => origin.trim())
-    .filter((origin) => origin.length > 0);
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/** Parse the comma-separated trusted-origins env value into a clean list. */
+export function parseTrustedOrigins(value: string | undefined): string[] {
+  return parseCommaSeparated(value);
+}
+
+/**
+ * Resolve the optional cross-subdomain cookie domain (e.g. `.genfeed.ai`).
+ * Returns `undefined` when unset so single-host / Community deployments keep
+ * the default host-scoped session cookie.
+ */
+export function resolveCookieDomain(
+  value: string | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/** Whether Better Auth's experimental Prisma joins are enabled via env. */
+export function resolveExperimentalJoins(value: string | undefined): boolean {
+  return value?.trim() === 'true';
 }
 
 /** Build the Google social-provider config when both credentials are present. */

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -1,10 +1,15 @@
+import type { RateLimit } from 'better-auth';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  buildRateLimitStorage,
   resolveBetterAuthJwtAccess,
   resolveBetterAuthJwtIsSuperAdmin,
   resolveBetterAuthJwtOrganizationId,
 } from './better-auth.factory';
-import type { ICreateBetterAuthOptions } from './better-auth.types';
+import type {
+  IBetterAuthRateLimitStore,
+  ICreateBetterAuthOptions,
+} from './better-auth.types';
 
 type PrismaForBetterAuth = ICreateBetterAuthOptions['prisma'];
 
@@ -209,5 +214,58 @@ describe('resolveBetterAuthJwtAccess', () => {
 
     expect(prisma.organization.findFirst).not.toHaveBeenCalled();
     expect(prisma.member.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+/** In-memory stand-in for the Redis KV that records the args it was called with. */
+function createFakeRateLimitStore(): IBetterAuthRateLimitStore & {
+  readonly entries: Map<string, string>;
+  readonly setCalls: Array<{ key: string; value: string; ttlSeconds: number }>;
+} {
+  const entries = new Map<string, string>();
+  const setCalls: Array<{ key: string; value: string; ttlSeconds: number }> =
+    [];
+  return {
+    entries,
+    get: async (key) => entries.get(key) ?? null,
+    set: async (key, value, ttlSeconds) => {
+      entries.set(key, value);
+      setCalls.push({ key, ttlSeconds, value });
+    },
+    setCalls,
+  };
+}
+
+const sampleRateLimit: RateLimit = {
+  count: 3,
+  key: 'ip:1.2.3.4',
+  lastRequest: 1700,
+};
+
+describe('buildRateLimitStorage', () => {
+  it('round-trips a rate-limit record through the shared store', async () => {
+    const storage = buildRateLimitStorage(createFakeRateLimitStore());
+
+    await storage.set('ip:1.2.3.4', sampleRateLimit);
+
+    expect(await storage.get('ip:1.2.3.4')).toEqual(sampleRateLimit);
+  });
+
+  it('namespaces keys and applies a TTL so idle counters self-expire', async () => {
+    const store = createFakeRateLimitStore();
+    const storage = buildRateLimitStorage(store);
+
+    await storage.set('ip:1.2.3.4', sampleRateLimit);
+
+    const [call] = store.setCalls;
+    expect(call.key).toBe('ba:ratelimit:ip:1.2.3.4');
+    expect(call.value).toBe(JSON.stringify(sampleRateLimit));
+    expect(call.ttlSeconds).toBeGreaterThan(0);
+  });
+
+  it('returns null when the counter is absent (fail-open path)', async () => {
+    const storage = buildRateLimitStorage(createFakeRateLimitStore());
+
+    expect(await storage.get('missing')).toBeNull();
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,12 +1,47 @@
 import { randomUUID } from 'node:crypto';
 import { dash } from '@better-auth/infra';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
-import { betterAuth } from 'better-auth';
+import { betterAuth, type RateLimit } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { jwt, magicLink } from 'better-auth/plugins';
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
-import type { ICreateBetterAuthOptions } from './better-auth.types';
+import type {
+  IBetterAuthRateLimitStore,
+  ICreateBetterAuthOptions,
+} from './better-auth.types';
 import { isPlatformSuperAdmin } from './better-auth-access.util';
+
+/**
+ * Prefix + GC window for Better Auth rate-limit counters in Redis. Active keys
+ * refresh their TTL on each write, so the TTL only reclaims idle counters.
+ */
+const RATE_LIMIT_KEY_PREFIX = 'ba:ratelimit:';
+const RATE_LIMIT_TTL_SECONDS = 86_400;
+
+/**
+ * Adapt the shared Redis KV into Better Auth's `rateLimit.customStorage` shape
+ * so all API instances share one counter window (per-process memory would let
+ * the effective limit scale with instance count). Reads/writes are JSON; the
+ * underlying store fails open, so a Redis blip degrades limiting, never auth.
+ */
+export function buildRateLimitStorage(store: IBetterAuthRateLimitStore): {
+  get: (key: string) => Promise<RateLimit | null>;
+  set: (key: string, value: RateLimit) => Promise<void>;
+} {
+  return {
+    get: async (key) => {
+      const raw = await store.get(`${RATE_LIMIT_KEY_PREFIX}${key}`);
+      return raw ? (JSON.parse(raw) as RateLimit) : null;
+    },
+    set: async (key, value) => {
+      await store.set(
+        `${RATE_LIMIT_KEY_PREFIX}${key}`,
+        JSON.stringify(value),
+        RATE_LIMIT_TTL_SECONDS,
+      );
+    },
+  };
+}
 
 function getString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
@@ -165,6 +200,10 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     baseURL,
     trustedOrigins,
     google,
+    cookieDomain,
+    ipAddressHeaders,
+    experimentalJoins,
+    rateLimitStore,
     sendMagicLink,
     onUserCreated,
   } = options;
@@ -191,6 +230,28 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
           },
         }
       : {}),
+    // Share rate-limit counters across stateless API instances via Redis;
+    // `customStorage` scopes Redis to rate limiting only (sessions stay in
+    // Postgres). Omitted when no store is wired so the in-memory default holds.
+    ...(rateLimitStore
+      ? { rateLimit: { customStorage: buildRateLimitStorage(rateLimitStore) } }
+      : {}),
+    // Experimental single-query joins (Prisma adapter). Env-gated; off unless
+    // explicitly enabled after staging verification.
+    ...(experimentalJoins ? { experimental: { joins: true } } : {}),
+    advanced: {
+      // Pin the client-IP header(s) only when configured (e.g. `x-forwarded-for`
+      // behind the production ALB); unset keeps Better Auth's default detection
+      // for proxy-less / differently-fronted deployment modes.
+      ...(ipAddressHeaders && ipAddressHeaders.length > 0
+        ? { ipAddress: { ipAddressHeaders } }
+        : {}),
+      // Share the session cookie across sibling subdomains (api ↔ app) when a
+      // root domain is configured; host-scoped otherwise.
+      ...(cookieDomain
+        ? { crossSubDomainCookies: { enabled: true, domain: cookieDomain } }
+        : {}),
+    },
     user: {
       // Better Auth's `image` field maps onto the existing `User.avatar` column.
       fields: { image: 'avatar' },
@@ -234,6 +295,10 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     plugins: [
       ...(apiKey ? [dash({ apiKey })] : []),
       magicLink({
+        // Persist only the hash of magic-link tokens so a DB read cannot replay
+        // them. Lookup re-hashes the incoming token, so any in-flight plaintext
+        // links issued before this change fail until they expire (~min TTL).
+        storeToken: 'hashed',
         sendMagicLink: async ({ email, url, token }) => {
           await sendMagicLink({ email, url, token });
         },

--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -4,6 +4,7 @@ import { OrganizationsModule } from '@api/collections/organizations/organization
 import { UserSetupModule } from '@api/collections/users/user-setup.module';
 import { UsersModule } from '@api/collections/users/users.module';
 import { ConfigService } from '@api/config/config.service';
+import { CacheClientService } from '@api/services/cache/services/cache-client.service';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { IS_BETTER_AUTH_ENABLED } from '@genfeedai/config';
@@ -12,8 +13,11 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PassportModule } from '@nestjs/passport';
 
 import {
+  parseCommaSeparated,
   parseTrustedOrigins,
   resolveBetterAuthBaseUrl,
+  resolveCookieDomain,
+  resolveExperimentalJoins,
   resolveGoogleConfig,
 } from './better-auth.config';
 import {
@@ -25,6 +29,7 @@ import {
   createBetterAuthInstance,
 } from './better-auth.factory';
 import { BetterAuthService } from './better-auth.service';
+import type { IBetterAuthRateLimitStore } from './better-auth.types';
 import { UserProvisioningListener } from './listeners/user-provisioning.listener';
 import { BetterAuthStrategy } from './passport/better-auth.strategy';
 import { BetterAuthIdentityResolverService } from './services/better-auth-identity-resolver.service';
@@ -61,6 +66,7 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
         ConfigService,
         BetterAuthMailerService,
         EventEmitter2,
+        CacheClientService,
       ],
       provide: BETTER_AUTH_INSTANCE,
       useFactory: (
@@ -68,6 +74,7 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
         config: ConfigService,
         mailer: BetterAuthMailerService,
         eventEmitter: EventEmitter2,
+        cacheClient: CacheClientService,
       ): BetterAuthInstance | null => {
         // Enabled by default; explicit offline/local runs can set
         // BETTER_AUTH_ENABLED=false to skip the auth handler.
@@ -84,16 +91,52 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
           );
         }
 
+        // Shared Redis KV for rate-limit counters. Fails open — a Redis outage
+        // degrades cross-instance limiting rather than breaking authentication.
+        const rateLimitStore: IBetterAuthRateLimitStore = {
+          get: async (key) => {
+            if (!cacheClient.isReady) {
+              return null;
+            }
+            try {
+              return (await cacheClient.instance.get(key)) ?? null;
+            } catch {
+              return null;
+            }
+          },
+          set: async (key, value, ttlSeconds) => {
+            if (!cacheClient.isReady) {
+              return;
+            }
+            try {
+              await cacheClient.instance.set(key, value, { EX: ttlSeconds });
+            } catch {
+              // Fail open: never let a Redis error break auth rate limiting.
+              return;
+            }
+          },
+        };
+
         return createBetterAuthInstance({
           apiKey: config.get('BETTER_AUTH_API_KEY'),
           baseURL: resolveBetterAuthBaseUrl(
             config.get('BETTER_AUTH_URL'),
             config.get('PORT'),
           ),
+          cookieDomain: resolveCookieDomain(
+            config.get('BETTER_AUTH_COOKIE_DOMAIN'),
+          ),
+          experimentalJoins: resolveExperimentalJoins(
+            config.get('BETTER_AUTH_EXPERIMENTAL_JOINS'),
+          ),
           google: resolveGoogleConfig(
             config.get('GOOGLE_CLIENT_ID'),
             config.get('GOOGLE_CLIENT_SECRET'),
           ),
+          ipAddressHeaders: parseCommaSeparated(
+            config.get('BETTER_AUTH_IP_HEADERS'),
+          ),
+          rateLimitStore,
           // Awaited so provisioning completes before the create resolves; the
           // UserProvisioningListener (@OnEvent) runs under Nest DI.
           onUserCreated: async (event) => {

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -47,6 +47,17 @@ export interface IBetterAuthMagicLinkParams {
   token: string;
 }
 
+/**
+ * Minimal shared KV (Redis) used to back Better Auth's rate-limit counters
+ * across stateless API instances. Implementations must fail open — a Redis
+ * outage must degrade rate limiting, never break authentication. The factory
+ * adapts this into Better Auth's `rateLimit.customStorage` shape.
+ */
+export interface IBetterAuthRateLimitStore {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, ttlSeconds: number) => Promise<void>;
+}
+
 /** Payload emitted after Better Auth creates a new user row. */
 export interface IBetterAuthUserCreatedEvent {
   userId: string;
@@ -61,6 +72,30 @@ export interface ICreateBetterAuthOptions {
   baseURL: string;
   trustedOrigins: string[];
   google?: IBetterAuthGoogleConfig;
+  /**
+   * Root cookie domain (e.g. `.genfeed.ai`) for sharing the session cookie set
+   * on the API host with sibling frontend subdomains. When set, enables
+   * `advanced.crossSubDomainCookies`. Unset (single-host / Community) keeps the
+   * default host-scoped cookie.
+   */
+  cookieDomain?: string;
+  /**
+   * Ordered client-IP headers for Better Auth's rate limiting + session
+   * tracking (e.g. `['x-forwarded-for']` behind the production ALB). Unset
+   * keeps Better Auth's default header detection — important for deployment
+   * modes with a different (or no) edge proxy.
+   */
+  ipAddressHeaders?: string[];
+  /**
+   * Enable Better Auth's experimental single-query joins on the Prisma adapter.
+   * Gated off by default; flip per environment after staging verification.
+   */
+  experimentalJoins?: boolean;
+  /**
+   * Shared KV (Redis) backing rate-limit counters across instances. When
+   * provided, rate limiting uses it instead of per-process memory.
+   */
+  rateLimitStore?: IBetterAuthRateLimitStore;
   sendMagicLink: (params: IBetterAuthMagicLinkParams) => Promise<void>;
   /**
    * Invoked (and awaited) from the `user.create.after` hook so a newly created

--- a/packages/config/src/schemas/better-auth.schema.ts
+++ b/packages/config/src/schemas/better-auth.schema.ts
@@ -44,6 +44,29 @@ export const betterAuthSchema = {
   BETTER_AUTH_TRUSTED_ORIGINS: Joi.string().optional().allow(''),
 
   /**
+   * Root cookie domain (e.g. `.genfeed.ai`) for sharing the session cookie
+   * across sibling subdomains (api ↔ app). Leave unset for single-host /
+   * Community deployments so the cookie stays host-scoped.
+   */
+  BETTER_AUTH_COOKIE_DOMAIN: Joi.string().optional().allow(''),
+
+  /**
+   * Comma-separated client-IP headers Better Auth reads for rate limiting and
+   * session tracking (e.g. `x-forwarded-for` behind the production ALB). Unset
+   * keeps Better Auth's default detection for proxy-less / other edges.
+   */
+  BETTER_AUTH_IP_HEADERS: Joi.string().optional().allow(''),
+
+  /**
+   * Enable Better Auth's experimental single-query Prisma joins. Off by
+   * default; flip per environment after staging verification.
+   */
+  BETTER_AUTH_EXPERIMENTAL_JOINS: Joi.string()
+    .valid('true', 'false')
+    .optional()
+    .default('false'),
+
+  /**
    * Google OAuth credentials for the day-one social sign-in. Optional so the
    * provider is simply absent when unset; presence enables the Google button.
    */


### PR DESCRIPTION
## Summary

Production hardening for the Better Auth runtime, verified against the **installed** `better-auth@1.6.21` types (not just docs). Every environment-dependent change is **env-gated** so it's a no-op for single-host / Community / Desktop deployment modes and only activates where configured.

> **Scope note:** this PR does **not** fix the Google `internal_server_error`. That was traced through the installed source to a different cause (see *What this does not fix* below) that needs a prod log line + a data backfill, tracked separately.

## Changes

| Change | Why | Risk / gating |
|---|---|---|
| `magicLink({ storeToken: 'hashed' })` | `auth_tokens.value` stored magic-link tokens in **plaintext** — a DB read could replay them | Cutover invalidates in-flight plaintext links (~min TTL); deploy off-peak |
| `rateLimit.customStorage` → shared Redis KV | BA's rate-limit counters were per-process memory; across Fargate tasks the effective limit scaled with instance count | `customStorage` scopes Redis to **rate limiting only** (sessions stay in Postgres); **fails open** — a Redis blip degrades limiting, never auth |
| `advanced.crossSubDomainCookies` | Session cookie is set on `api.genfeed.ai` but read by `app.genfeed.ai` middleware — host-scoped cookies never make the hop | Gated on `BETTER_AUTH_COOKIE_DOMAIN`; **no-op unless set** |
| `advanced.ipAddress.ipAddressHeaders` | Pin the client-IP header behind the prod ALB | Gated on `BETTER_AUTH_IP_HEADERS`; unset keeps BA's default detection |
| `experimental.joins` | Optional single-query Prisma joins | Gated on `BETTER_AUTH_EXPERIMENTAL_JOINS` (**off by default**); flip after staging verification |

New env vars (all optional, declared in `packages/config/src/schemas/better-auth.schema.ts`):
`BETTER_AUTH_COOKIE_DOMAIN`, `BETTER_AUTH_IP_HEADERS`, `BETTER_AUTH_EXPERIMENTAL_JOINS`.

## To activate in prod (separate from merge)

- `BETTER_AUTH_COOKIE_DOMAIN=.genfeed.ai`
- `BETTER_AUTH_IP_HEADERS=x-forwarded-for`
- (leave `BETTER_AUTH_EXPERIMENTAL_JOINS` unset/`false` until verified in staging)

## What this does **not** fix (tracked separately)

The Google sign-in `internal_server_error` is emitted by `better-auth/dist/oauth2/link-account.mjs:11-13` **only when the `findOAuthUser` Prisma query throws** ("Better auth was unable to query your database"). That's a DB-layer failure, not config — its exact Prisma error is in Sentry/CloudWatch.

Behind it sits a second blocker: the `requireLocalEmailVerified` gate (default `true`, source-confirmed independent of `trustedProviders`) blocks linking for migrated users whose `User.emailVerified=false`. Fix there is an `emailVerified=true` backfill for ex-Clerk users, not a config flag.

## Verification

- `bunx biome check` — clean (pre-commit hooks green: Biome + secretlint)
- `bun run --cwd apps/server/api test better-auth.config.spec.ts better-auth.factory.spec.ts` — **19/19 pass** (added: comma-parser, cookie-domain, experimental-joins resolvers; Redis rate-limit adapter round-trip / key-prefix+TTL / null-path)
- `tsc --noEmit` on `@genfeedai/api` + `@genfeedai/config` — clean against `better-auth@1.6.21` (only the pre-existing tsconfig `baseUrl` TS5101 deprecation, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
