### PR TITLE
docs(self-host): fix community quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Genfeed.ai is a self-hostable, AI-powered content creation platform. Generate im
 - **Editor** -- video and media composition timeline
 - **Desktop App** -- native Electron app for macOS, Windows, and Linux
 - **Mobile App** -- React Native / Expo for iOS and Android
-- **Admin Panel** -- model management, GPU configuration, system settings
 - **API + SDK** -- typed client library for programmatic access
 - **Self-Hosted GPU** -- bring your own GPU with ComfyUI integration
 
@@ -37,10 +36,11 @@ Genfeed.ai is a self-hostable, AI-powered content creation platform. Generate im
 git clone https://github.com/genfeedai/genfeed.ai.git
 cd genfeed.ai/docker
 cp .env.example .env
-docker compose up
+docker compose -f docker-compose.selfhosted.yml up
 ```
 
-The web UI will be available at `http://localhost:3000` and the API at `http://localhost:4000`.
+The web UI will be available at `http://localhost:3000`, the API at
+`http://localhost:3010`, and the local MCP surface at `http://localhost:3014`.
 
 ## Architecture
 
@@ -62,8 +62,7 @@ genfeed.ai/
       discord/        -- Discord bot integration
       slack/          -- Slack bot integration
       telegram/       -- Telegram bot integration
-    web/              -- Next.js studio UI
-    admin/            -- admin panel
+    app/              -- Next.js studio UI
     desktop/          -- Electron desktop app
     mobile/           -- React Native mobile app
     website/          -- marketing site

--- a/apps/docs/content/core/installation.mdx
+++ b/apps/docs/content/core/installation.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout } from 'nextra/components';
 
 # Self-Hosted Installation
 
@@ -8,24 +8,24 @@ Deploy Genfeed Core on your own infrastructure. This guide covers everything fro
 
 Before you begin, ensure you have:
 
-| Requirement | Version | Notes |
-|-------------|---------|-------|
-| **Node.js** | 18.0+ | [Download](https://nodejs.org/) |
-| **Bun** | 1.0+ | [Install](https://bun.sh/) (recommended) or use npm |
-| **PostgreSQL** | 17+ | [Install](https://www.postgresql.org/download/) |
-| **Redis** | 7.0+ | [Install](https://redis.io/download/) |
-| **Git** | Latest | [Download](https://git-scm.com/) |
+| Requirement    | Version | Notes                                               |
+| -------------- | ------- | --------------------------------------------------- |
+| **Node.js**    | 18.0+   | [Download](https://nodejs.org/)                     |
+| **Bun**        | 1.0+    | [Install](https://bun.sh/) (recommended) or use npm |
+| **PostgreSQL** | 17+     | [Install](https://www.postgresql.org/download/)     |
+| **Redis**      | 7.0+    | [Install](https://redis.io/download/)               |
+| **Git**        | Latest  | [Download](https://git-scm.com/)                    |
 
 ### API Keys (Optional but Recommended)
 
 To use AI generation features, you need API keys from at least one provider:
 
-| Provider | For | Get Key |
-|----------|-----|---------|
-| OpenAI | Text generation | [platform.openai.com](https://platform.openai.com/api-keys) |
-| Replicate | Image/Video models | [replicate.com](https://replicate.com/account/api-tokens) |
-| ElevenLabs | Voice synthesis | [elevenlabs.io](https://elevenlabs.io/app/settings/api-keys) |
-| Anthropic | Claude models | [console.anthropic.com](https://console.anthropic.com/) |
+| Provider   | For                | Get Key                                                      |
+| ---------- | ------------------ | ------------------------------------------------------------ |
+| OpenAI     | Text generation    | [platform.openai.com](https://platform.openai.com/api-keys)  |
+| Replicate  | Image/Video models | [replicate.com](https://replicate.com/account/api-tokens)    |
+| ElevenLabs | Voice synthesis    | [elevenlabs.io](https://elevenlabs.io/app/settings/api-keys) |
+| Anthropic  | Claude models      | [console.anthropic.com](https://console.anthropic.com/)      |
 
 ---
 
@@ -84,7 +84,7 @@ JWT_SECRET=your-secure-random-string
 ```
 
 <Callout type="warning">
-**Never commit API keys.** Add `.env.local` to your `.gitignore`. Never commit API keys or secrets to version control.
+  **Never commit API keys.** Add `.env.local` to your `.gitignore`. Never commit API keys or secrets to version control.
 </Callout>
 
 ### 4. Start Services
@@ -125,7 +125,7 @@ You should see:
 Open your browser and visit:
 
 ```
-http://localhost:3010/health
+http://localhost:3010/v1/health
 ```
 
 You should see a JSON response confirming the API, database, and Redis are connected and ready.
@@ -149,71 +149,47 @@ The app UI will be available at `http://localhost:3000`.
 
 ## Docker Deployment
 
-For production deployments, we recommend Docker:
+For Community self-hosting, use the published Docker image and the
+self-hosted compose file:
 
 ### Using Docker Compose
 
 ```bash
-# Clone with Docker config
 git clone https://github.com/genfeedai/genfeed.ai.git
-cd genfeed.ai
-
-# Copy environment file
+cd genfeed.ai/docker
 cp .env.example .env
-
-# Start all services
-docker-compose up -d
+docker compose -f docker-compose.selfhosted.yml up
 ```
 
-### docker-compose.yml
+This pulls `ghcr.io/genfeedai/genfeed.ai:latest`, starts Postgres, applies
+Prisma migrations, seeds one local workspace, and exposes:
 
-```yaml
-version: '3.8'
+| Service | URL                     |
+| ------- | ----------------------- |
+| Web UI  | `http://localhost:3000` |
+| API     | `http://localhost:3010` |
+| MCP     | `http://localhost:3014` |
 
-services:
-  api:
-    build: .
-    ports:
-      - "3010:3010"
-    environment:
-      - DATABASE_URL=postgresql://genfeed:genfeed_local@postgres:5432/genfeed
-      - REDIS_URL=redis://redis:6379
-    depends_on:
-      - postgres
-      - redis
+The default `docker/.env` starts without a login wall:
 
-  postgres:
-    image: postgres:17-alpine
-    environment:
-      - POSTGRES_DB=genfeed
-      - POSTGRES_USER=genfeed
-      - POSTGRES_PASSWORD=genfeed_local
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
-
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redis_data:/data
-    ports:
-      - "6379:6379"
-
-volumes:
-  postgres_data:
-  redis_data:
+```env
+BETTER_AUTH_ENABLED=false
+NEXT_PUBLIC_BETTER_AUTH_ENABLED=false
 ```
+
+To require local email/password sign-in, set both values to `true`. If
+`BETTER_AUTH_SECRET` is empty, the entrypoint generates and persists one under
+`/data/.better-auth-secret`.
 
 ---
 
 ## Resource Requirements
 
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| CPU | 2 cores | 4+ cores |
-| RAM | 4 GB | 8+ GB |
-| Storage | 20 GB | 100+ GB (for generated assets) |
+| Component | Minimum | Recommended                    |
+| --------- | ------- | ------------------------------ |
+| CPU       | 2 cores | 4+ cores                       |
+| RAM       | 4 GB    | 8+ GB                          |
+| Storage   | 20 GB   | 100+ GB (for generated assets) |
 
 ---
 
@@ -262,7 +238,7 @@ To upgrade to a new version:
 
 ```bash
 # Pull latest changes
-git pull origin main
+git pull origin master
 
 # Install new dependencies
 bun install

--- a/apps/docs/content/guides/self-host-quickstart.mdx
+++ b/apps/docs/content/guides/self-host-quickstart.mdx
@@ -1,20 +1,23 @@
 import { Callout, Steps, Tabs } from 'nextra/components';
 
-# Self-Host GenFeed in 5 Minutes
+# Self-Host Genfeed in 5 Minutes
 
-Get GenFeed Core running on your own infrastructure. Generate AI content with full control over models, data, and costs.
+Run Genfeed Community with the published Docker image, a local Postgres
+database, and a single seeded workspace.
 
 <Callout type="info">
-  **Just want to use GenFeed?** [GenFeed Cloud](https://genfeed.ai) is the fastest way to start — no setup required, all
-  features included, free tier available.
+  **Just want to use Genfeed?** [Genfeed Cloud](https://genfeed.ai) is the fastest way to start without running
+  infrastructure.
 </Callout>
 
 ## Prerequisites
 
-- Node.js 18+ (or Bun)
-- PostgreSQL 17+
-- Redis 7+
-- At least one AI provider API key (Replicate, fal.ai, or OpenAI)
+- Docker 24+
+- Docker Compose v2
+- At least one AI provider API key when you want to generate content
+
+No local Node.js, Bun, Postgres, Redis, or Better Auth account is required for
+the Community quick start.
 
 ## Quick Start
 
@@ -24,164 +27,127 @@ Get GenFeed Core running on your own infrastructure. Generate AI content with fu
 
 ```bash
 git clone https://github.com/genfeedai/genfeed.ai.git
-cd genfeed.ai
+cd genfeed.ai/docker
 ```
 
-### Install dependencies
-
-<Tabs items={['Bun (Recommended)', 'npm']}>
-  <Tabs.Tab>
+### Create the Community environment file
 
 ```bash
-bun install
+cp .env.example .env
 ```
 
-  </Tabs.Tab>
-  <Tabs.Tab>
+The default `.env` starts in single-user local mode with no login wall. Add
+provider keys such as `OPENAI_API_KEY`, `REPLICATE_KEY`, or `FAL_API_KEY` when
+you want generation enabled.
+
+### Start Genfeed Community
 
 ```bash
-npm install
+docker compose -f docker-compose.selfhosted.yml up
 ```
 
-  </Tabs.Tab>
-</Tabs>
+This pulls `ghcr.io/genfeedai/genfeed.ai:latest`, starts Postgres, applies
+Prisma migrations, and seeds one local user, organization, and brand.
 
-### Configure environment
+### Open the app
 
-```bash
-cp .env.example .env.local
-bun run env:sync local
+```text
+Web UI: http://localhost:3000
+API:    http://localhost:3010
+MCP:    http://localhost:3014
 ```
 
-Edit the root `.env.local` with your settings:
+### Verify the API
 
 ```bash
-# Required
-DATABASE_URL=postgresql://genfeed:genfeed_local@localhost:5432/genfeed
-REDIS_URL=redis://localhost:6379
-
-# AI Providers (at least one required)
-REPLICATE_KEY=your_token_here
-FAL_API_KEY=your_key_here
-
-# Optional
-PORT=3010
-NODE_ENV=development
-```
-
-### Start the server
-
-<Tabs items={['Bun', 'npm']}>
-  <Tabs.Tab>
-
-```bash
-bun run dev
-```
-
-  </Tabs.Tab>
-  <Tabs.Tab>
-
-```bash
-npm run dev
-```
-
-  </Tabs.Tab>
-</Tabs>
-
-### Generate your first image
-
-```bash
-curl -X POST http://localhost:3010/api/generate/image \
-  -H "Content-Type: application/json" \
-  -d '{
-    "prompt": "A modern tech startup office, minimalist design",
-    "model": "flux-schnell",
-    "width": 1024,
-    "height": 1024
-  }'
+curl http://localhost:3010/v1/health
 ```
 
 </Steps>
 
-## Docker Compose
+## What Starts
 
-For a production-ready setup with all dependencies:
+- Web UI on port 3000
+- API on port 3010
+- MCP on port 3014
+- Postgres on port 5432
+- Redis embedded in the Genfeed container and persisted under `/data`
 
-```yaml
-# docker-compose.yml
-version: '3.8'
+The compose file uses `docker/docker-compose.selfhosted.yml`. It is the
+Community path for self-hosters; the build-from-source compose files are for
+local development and CI.
 
-services:
-  genfeed:
-    build: .
-    ports:
-      - '3010:3010'
-    environment:
-      - DATABASE_URL=postgresql://genfeed:genfeed_local@postgres:5432/genfeed
-      - REDIS_URL=redis://redis:6379
-      - REPLICATE_KEY=${REPLICATE_KEY}
-    depends_on:
-      - postgres
-      - redis
+## Auth Modes
 
-  postgres:
-    image: postgres:17-alpine
-    environment:
-      - POSTGRES_DB=genfeed
-      - POSTGRES_USER=genfeed
-      - POSTGRES_PASSWORD=genfeed_local
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    ports:
-      - '5432:5432'
+<Tabs items={['Solo offline', 'Local login wall', 'Team invites']}>
+  <Tabs.Tab>
 
-  redis:
-    image: redis:7-alpine
-    ports:
-      - '6379:6379'
+Default Community installs run without a login wall:
 
-volumes:
-  postgres_data:
+```env
+BETTER_AUTH_ENABLED=false
+NEXT_PUBLIC_BETTER_AUTH_ENABLED=false
 ```
+
+The first boot seeds a local workspace. No email provider, OAuth app, or cloud
+account is needed.
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+Enable Better Auth when you want local email/password accounts:
+
+```env
+BETTER_AUTH_ENABLED=true
+NEXT_PUBLIC_BETTER_AUTH_ENABLED=true
+BETTER_AUTH_URL=http://localhost:3010
+BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
+BETTER_AUTH_SECRET=
+```
+
+Leaving `BETTER_AUTH_SECRET` empty is valid: the entrypoint generates and
+persists one under `/data/.better-auth-secret`.
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+Team invites, magic links, password resets, and email verification need an email
+provider:
+
+```env
+RESEND_API_KEY=re_...
+RESEND_FROM_EMAIL=updates@example.com
+RESEND_REPLY_TO_EMAIL=support@example.com
+```
+
+Google sign-in is optional. If enabled, use this local redirect URI:
+
+```text
+http://localhost:3010/v1/auth/callback/google
+```
+
+  </Tabs.Tab>
+</Tabs>
+
+## Optional GPU
+
+Point `GENFEED_GPU_URL` at your ComfyUI instance when you want local GPU-backed
+generation:
+
+```env
+GENFEED_GPU_URL=http://your-comfyui-host:8188
+```
+
+## Updating
 
 ```bash
-docker compose up -d
+cd genfeed.ai/docker
+docker compose -f docker-compose.selfhosted.yml pull
+docker compose -f docker-compose.selfhosted.yml up
 ```
-
-## What's Included
-
-- Image generation (Flux, SDXL, and more via Replicate/fal.ai)
-- Video generation (short-form, with captions)
-- Brand kit management
-- Job queue (BullMQ + Redis)
-- REST API
-- Webhook support
-
-## What's NOT Included (Cloud Only)
-
-Some features require the full GenFeed Cloud platform:
-
-| Feature                          | Core (OSS) | Cloud |
-| -------------------------------- | ---------- | ----- |
-| Image generation                 | Yes        | Yes   |
-| Video generation                 | Yes        | Yes   |
-| Brand kits                       | Yes        | Yes   |
-| Multi-tenancy                    | No         | Yes   |
-| Publisher (auto-post to socials) | No         | Yes   |
-| Analytics dashboard              | No         | Yes   |
-| Team collaboration               | No         | Yes   |
-| Managed infrastructure           | No         | Yes   |
-| SLA and support                  | No         | Yes   |
-
-<Callout type="info">
-  Need multi-tenancy, publishing, or analytics? [Try GenFeed Cloud](https://genfeed.ai) — same engine, fully managed,
-  with all the features your team needs.
-</Callout>
 
 ## Next Steps
 
-- [API Reference](/api-reference) — Full API documentation
-- [Models](/models) — Supported AI models and providers
-- [Execution Boundaries](/core/execution-boundaries) — Local, BYOK, managed, and Cloud runtime contract
-- [Deployment Options](/deployment) — Production deployment guides
-- [GenFeed Cloud](https://genfeed.ai) — Managed platform with all features
+- [Installation guide](/core/installation) -- Local development and Docker self-hosting
+- [Execution Boundaries](/core/execution-boundaries) -- Local, BYOK, managed, and Cloud runtime contract
+- [Deployment Options](/deployment) -- Cloud, Community, and Desktop modes

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -6,16 +6,16 @@ summary; the canonical, decision-of-record version is the ADR at
 
 ## The three modes
 
-| | **SaaS** | **Community** | **Desktop** |
-|---|---|---|---|
-| **For** | Customers using the hosted product | Self-hosters running the whole stack | Solo creators on their own machine |
-| **Get it** | app.genfeed.ai | `docker compose -f docker-compose.selfhosted.yml up` | Download the installer |
-| **Orgs** | many (isolated tenants) | **one** | one |
-| **Brands** | many per org | **many** | many |
-| **Auth** | Better Auth (email/password, magic link, Google) | Better Auth, self-hostable — none for solo, optional login wall | local-first sign-in |
-| **Storage** | S3 | local filesystem | local (PGlite) + optional cloud sync |
-| **Generation** | managed | your own provider keys (BYOK), free | BYOK local, free |
-| **Managed inference** | included | buy cloud credits, use via API | buy cloud credits, use via API |
+|                       | **SaaS**                                         | **Community**                                                     | **Desktop**                          |
+| --------------------- | ------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------ |
+| **For**               | Customers using the hosted product               | Self-hosters running the whole stack                              | Solo creators on their own machine   |
+| **Get it**            | app.genfeed.ai                                   | `cd docker && docker compose -f docker-compose.selfhosted.yml up` | Download the installer               |
+| **Orgs**              | many (isolated tenants)                          | **one**                                                           | one                                  |
+| **Brands**            | many per org                                     | **many**                                                          | many                                 |
+| **Auth**              | Better Auth (email/password, magic link, Google) | Better Auth, self-hostable — none for solo, optional login wall   | local-first sign-in                  |
+| **Storage**           | S3                                               | local filesystem                                                  | local (PGlite) + optional cloud sync |
+| **Generation**        | managed                                          | your own provider keys (BYOK), free                               | BYOK local, free                     |
+| **Managed inference** | included                                         | buy cloud credits, use via API                                    | buy cloud credits, use via API       |
 
 ## Choosing a mode (env)
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -5,8 +5,9 @@
 ```bash
 git clone https://github.com/genfeedai/genfeed.ai.git
 cd genfeed.ai
-cp docker/.env.example docker/.env
-docker compose --env-file docker/.env -f docker/docker-compose.selfhosted.yml up
+cd docker
+cp .env.example .env
+docker compose -f docker-compose.selfhosted.yml up
 ```
 
 This starts:


### PR DESCRIPTION
## Summary

- Point the root README and docs quick starts at the supported Community compose path: `docker/docker-compose.selfhosted.yml`.
- Replace stale build-from-source/self-host instructions with the published GHCR image path, real API/MCP ports, and Postgres/Prisma wording.
- Document the three Community auth journeys from #745: solo offline/no login wall, local Better Auth email/password login wall, and team invites/magic links with email provider setup.
- Remove the phantom admin app reference from the root README architecture snapshot.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd apps/docs type-check`
- `bun run --cwd apps/docs build`
- `bunx prettier --check README.md docs/self-hosting.md docs/deployment-modes.md apps/docs/content/guides/self-host-quickstart.mdx apps/docs/content/core/installation.mdx`
- `git diff --check`
- Ruby YAML assertion over `docker/docker-compose.selfhosted.yml` for GHCR image, Postgres health dependency, `.env` passthrough, 3000/3010 ports, and `/v1/health` healthcheck
- Static grep guards for stale `localhost:4000`, `docker compose up`, `docker-compose up`, phantom admin app text, port 3100, and user-facing MongoDB references in the touched docs
- Staged filename/diff secret scans and pre-commit `bun scripts/run-secretlint.ts --no-glob`

## Notes

- Docker CLI is not installed in this Codex worktree environment, so I could not run `docker compose config` or boot the stack locally. The compose contract was validated with a structured YAML assertion instead.

Closes #745
Related #740
