### PR TITLE
fix(deploy): unblock prod deploys — break tasks DI-cycle TDZ, backfill emailVerified, bun x

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,7 @@ jobs:
       # The E2E suite assumes a migrated DB (it truncates + reseeds per test,
       # it does not create the schema itself).
       - name: Apply Prisma migrations to test DB
-        run: bunx prisma migrate deploy
+        run: bun x prisma migrate deploy
         working-directory: packages/prisma
 
       - name: Run API E2E smoke tests

--- a/apps/server/api/src/collections/tasks/services/task-actions.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-actions.service.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { type TaskDocument } from '@api/collections/tasks/schemas/task.schema';
-import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import type { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { TASKS_SERVICE } from '@api/collections/tasks/tasks.tokens';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -11,12 +12,7 @@ import {
   serializeWorkspaceTaskProgress,
   type WorkspaceTaskProgressSnapshot,
 } from '@genfeedai/serializers';
-import {
-  BadRequestException,
-  forwardRef,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 export type TaskEventInput = {
   payload?: Record<string, unknown>;
@@ -58,7 +54,7 @@ type TaskDelegate = {
 @Injectable()
 export class TaskActionsService {
   constructor(
-    @Inject(forwardRef(() => TasksService))
+    @Inject(TASKS_SERVICE)
     private readonly tasksService: TasksService,
     private readonly prisma: PrismaService,
     private readonly ingredientsService: IngredientsService,

--- a/apps/server/api/src/collections/tasks/services/task-planning.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-planning.service.ts
@@ -5,14 +5,10 @@ import { OrganizationsService } from '@api/collections/organizations/services/or
 import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
 import { CreateTaskDto } from '@api/collections/tasks/dto/create-task.dto';
 import { type TaskDocument } from '@api/collections/tasks/schemas/task.schema';
-import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import type { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { TASKS_SERVICE } from '@api/collections/tasks/tasks.tokens';
 import { serializeWorkspaceTaskDate } from '@genfeedai/serializers';
-import {
-  BadRequestException,
-  forwardRef,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 const PLANNING_THREAD_SOURCE_PREFIX = 'workspace-planning:';
 const PLANNING_THREAD_TITLE_PREFIX = 'Plan next steps: ';
@@ -37,7 +33,7 @@ type FollowUpPlanStep = {
 @Injectable()
 export class TaskPlanningService {
   constructor(
-    @Inject(forwardRef(() => TasksService))
+    @Inject(TASKS_SERVICE)
     private readonly tasksService: TasksService,
     private readonly agentThreadsService: AgentThreadsService,
     private readonly agentMessagesService: AgentMessagesService,

--- a/apps/server/api/src/collections/tasks/tasks.module.ts
+++ b/apps/server/api/src/collections/tasks/tasks.module.ts
@@ -11,6 +11,7 @@ import { TaskActionsService } from '@api/collections/tasks/services/task-actions
 import { TaskPlanningService } from '@api/collections/tasks/services/task-planning.service';
 import { TaskRoutingService } from '@api/collections/tasks/services/task-routing.service';
 import { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { TASKS_SERVICE } from '@api/collections/tasks/tasks.tokens';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { AgentOrchestratorModule } from '@api/services/agent-orchestrator/agent-orchestrator.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
@@ -39,6 +40,10 @@ import { forwardRef, Module } from '@nestjs/common';
     TaskPlanningService,
     TaskRoutingService,
     TasksService,
+    // Token alias so TaskActionsService/TaskPlanningService inject TasksService
+    // without a load-time class reference (breaks the bundle TDZ — see
+    // tasks.tokens.ts). Resolves to the same singleton instance.
+    { provide: TASKS_SERVICE, useExisting: TasksService },
   ],
 })
 export class TasksModule {}

--- a/apps/server/api/src/collections/tasks/tasks.tokens.ts
+++ b/apps/server/api/src/collections/tasks/tasks.tokens.ts
@@ -1,0 +1,16 @@
+/**
+ * DI token aliasing {@link TasksService}.
+ *
+ * `TaskActionsService` and `TaskPlanningService` inject it through this token
+ * instead of `@Inject(forwardRef(() => TasksService))`, so the compiled files no
+ * longer reference the `TasksService` *class value* at module-evaluation time
+ * (emitDecoratorMetadata would otherwise emit it into `design:paramtypes`).
+ *
+ * Those services and `TasksService` import each other, so that load-time value
+ * reference triggered a temporal-dead-zone crash in the bundled output —
+ * `ReferenceError: Cannot access 'TasksService' before initialization` — which
+ * took down the `api-workflow-backfill` boot (and was a latent risk for the api
+ * bundle). With `import type` + this token, the cycle has no load-time value
+ * edge; DI still resolves the singleton via `useExisting` in {@link TasksModule}.
+ */
+export const TASKS_SERVICE = Symbol('TASKS_SERVICE');

--- a/docker/selfhosted-entrypoint.sh
+++ b/docker/selfhosted-entrypoint.sh
@@ -69,7 +69,10 @@ echo "[entrypoint] Running Prisma migrations..."
 MIGRATE_RETRIES=5
 MIGRATE_DELAY=5
 for i in $(seq 1 $MIGRATE_RETRIES); do
-  if (cd packages/prisma && bunx prisma migrate deploy); then
+  # `bun x` (not `bunx`): some runtime images ship only the `bun` binary, and a
+  # bare `bunx` first-arg falls through to the node entrypoint as `node bunx`
+  # (MODULE_NOT_FOUND). Mirrors the ECS migrate task + deploy-common.sh.
+  if (cd packages/prisma && bun x prisma migrate deploy); then
     echo "[entrypoint] Prisma migrations applied successfully"
     break
   fi

--- a/packages/prisma/prisma/migrations/20260628200000_backfill_email_verified_for_migrated_users/migration.sql
+++ b/packages/prisma/prisma/migrations/20260628200000_backfill_email_verified_for_migrated_users/migration.sql
@@ -1,0 +1,17 @@
+-- Backfill emailVerified for users migrated from the legacy auth provider (Clerk).
+--
+-- These accounts were email-verified in the prior IdP but carry Prisma's column
+-- default (emailVerified = false). Better Auth's account-linking gate
+-- (account.accountLinking.requireLocalEmailVerified, default true) refuses to
+-- implicitly link a social provider (Google) onto a local user whose
+-- emailVerified is false, surfacing as `account_not_linked` on first Google
+-- sign-in. Migrated users are identified by a non-null authProviderId (the legacy
+-- IdP user id); new Better Auth users have a null authProviderId and get their
+-- emailVerified set correctly at sign-up, so they are intentionally excluded.
+--
+-- Idempotent: only flips rows still sitting on the default. Safe to re-run.
+UPDATE "users"
+SET "emailVerified" = true
+WHERE "authProviderId" IS NOT NULL
+  AND "emailVerified" = false
+  AND "isDeleted" = false;


### PR DESCRIPTION
## Why

Production deploy run [28333678787](https://github.com/genfeedai/genfeed.ai/actions/runs/28333678787) applied the pending migrations (fixing the Better Auth `internal_server_error` — prod was missing `users.authProviderId`) but then **aborted before rolling services** when the `workflow-backfill` step crashed. This PR fixes that crash so deploys can complete again, plus the second-order Google blocker.

## Changes

### 1. Break the tasks DI-cycle TDZ (unblocks every deploy)
`workflow-backfill` (`migrate:workflows`) crashed at module-load:
```
ReferenceError: Cannot access 'TasksService' before initialization
  at TaskActionsService (api-workflow-backfill bundle)
```
`TaskActionsService` and `TaskPlanningService` injected `TasksService` via `@Inject(forwardRef(() => TasksService))` **with a value import**, so `emitDecoratorMetadata` emitted `TasksService` into `design:paramtypes` at class-definition time. The three services import each other, so in the webpack bundle's module order that value reference hit the TDZ — crashing the boot before the service roll (and a latent risk for the api bundle).

**Fix:** the two child services now `import type { TasksService }` and inject `@Inject(TASKS_SERVICE)` (new `tasks.tokens.ts`); `TasksModule` aliases it via `{ provide: TASKS_SERVICE, useExisting: TasksService }`. The cycle no longer has a load-time class edge. `forwardRef` stays on the `TasksService → children` side, which resolves the runtime DI cycle.

**Verified** (this is a runtime-load bug invisible to tsc — which is why CI missed it):
- Built **both** `api` and `api-workflow-backfill` bundles → boot past the old crash point (`Cannot access 'TasksService'` count = `0`).
- With `BETTER_AUTH_ENABLED=false`, the backfill **bootstraps fully and runs to SIGTERM with no Nest DI resolution error** — the token + one-sided `forwardRef` resolves the cycle at runtime.

### 2. Backfill `emailVerified` for migrated users (finishes Google sign-in)
Even with `authProviderId` restored, ex-Clerk users carry the `emailVerified=false` default, which trips Better Auth's `requireLocalEmailVerified` gate → `account_not_linked` on Google sign-in. New migration sets `emailVerified=true` for `authProviderId IS NOT NULL` (idempotent; new Better-Auth users excluded). Runs in the deploy's migrate step (before `workflow-backfill`).

### 3. `bunx` → `bun x` for `prisma migrate deploy`
`docker/selfhosted-entrypoint.sh` + `.github/workflows/e2e.yml` — a bare `bunx` first-arg falls through to `node bunx` (`MODULE_NOT_FOUND`) on bun-only images. Matches the ECS migrate task + `deploy-common.sh`.

## Deploy sequence after merge
Merge → image builds → deploy: migrate applies the `emailVerified` backfill → `workflow-backfill` now succeeds → **services roll to master** (code catches up to the DB) → Google fully works for migrated users.

## Out of scope (tracked separately)
- The **CI deploy gap** — `deploy-ecs.yml` is `workflow_dispatch`-only and `/release` never triggers it (root cause of the 5-day freeze). Needs a decision on release→deploy wiring.
- Better Auth hardening (separate PR #866).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
