### PR TITLE
fix(shell): apply deployment-mode switcher rules

### DIFF
--- a/apps/server/api/src/common/middleware/request-context.middleware.spec.ts
+++ b/apps/server/api/src/common/middleware/request-context.middleware.spec.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const configState = vi.hoisted(() => ({
+  isSelfHosted: false,
+}));
+
 vi.mock('@genfeedai/config', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@genfeedai/config')>();
 
   return {
     ...actual,
-    IS_SELF_HOSTED: false,
+    get IS_SELF_HOSTED() {
+      return configState.isSelfHosted;
+    },
   };
 });
 
@@ -89,11 +95,26 @@ function buildSubscriptionsService(status: string | null = 'active') {
   };
 }
 
+function buildPrismaService() {
+  return {
+    brand: {
+      findFirst: vi.fn().mockResolvedValue({ id: 'brand_default' }),
+    },
+    organization: {
+      findFirst: vi.fn().mockResolvedValue({ id: 'org_default' }),
+    },
+    user: {
+      findFirst: vi.fn().mockResolvedValue({ id: 'user_default' }),
+    },
+  };
+}
+
 describe('RequestContextMiddleware', () => {
   let middleware: RequestContextMiddleware;
   let redisService: { getPublisher: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    configState.isSelfHosted = false;
     redisService = { getPublisher: vi.fn() };
     middleware = new RequestContextMiddleware(
       redisService as unknown as RedisService,
@@ -250,5 +271,48 @@ describe('RequestContextMiddleware', () => {
       unknown
     >;
     expect(ctx.isSuperAdmin).toBe(false);
+  });
+
+  it('hydrates self-hosted context with the default brand', async () => {
+    configState.isSelfHosted = true;
+    const publisher = buildPublisher();
+    redisService.getPublisher.mockReturnValue(publisher);
+    const prisma = buildPrismaService();
+
+    middleware = new RequestContextMiddleware(
+      redisService as unknown as RedisService,
+      buildLogger(),
+      buildOrgSettingsService('free') as never,
+      buildSubscriptionsService('active') as never,
+      prisma as never,
+    );
+
+    const req = {} as never;
+    const next: NextFunction = vi.fn();
+
+    await middleware.use(req, {} as Response, next);
+
+    expect(prisma.brand.findFirst).toHaveBeenCalledWith({
+      where: {
+        isDefault: true,
+        isDeleted: false,
+        organizationId: 'org_default',
+      },
+    });
+    expect((req as { context: unknown }).context).toEqual(
+      expect.objectContaining({
+        brandId: 'brand_default',
+        isSuperAdmin: true,
+        organizationId: 'org_default',
+        subscriptionTier: 'free',
+        userId: 'user_default',
+      }),
+    );
+    expect(publisher.setEx).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Number),
+      expect.stringContaining('"brandId":"brand_default"'),
+    );
+    expect(next).toHaveBeenCalledOnce();
   });
 });

--- a/apps/server/api/src/common/middleware/request-context.middleware.ts
+++ b/apps/server/api/src/common/middleware/request-context.middleware.ts
@@ -147,9 +147,16 @@ export class RequestContextMiddleware implements NestMiddleware {
         isDeleted: false,
         organization: defaultOrg.id,
       });
+      const defaultBrand = await this.prisma.brand.findFirst({
+        where: {
+          isDefault: true,
+          isDeleted: false,
+          organizationId: defaultOrg.id,
+        },
+      });
 
       const requestContext: IRequestContext = {
-        brandId: undefined,
+        brandId: defaultBrand?.id,
         hydratedAt: Date.now(),
         isSuperAdmin: true,
         organizationId: defaultOrg.id,

--- a/packages/contexts/user/brand-context/brand-context.test.tsx
+++ b/packages/contexts/user/brand-context/brand-context.test.tsx
@@ -15,10 +15,20 @@ const useAuthMock = vi.fn();
 const useParamsMock = vi.fn();
 const useUserMock = vi.fn();
 const useAuthedServiceMock = vi.fn();
+const loadClientProtectedBootstrapMock = vi.hoisted(() => vi.fn());
+const authServiceGetInstanceMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@genfeedai/auth-client/react', () => ({
   useAuth: () => useAuthMock(),
   useUser: () => useUserMock(),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => useAuthMock(),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-user/use-auth-user', () => ({
+  useAuthUser: () => useUserMock(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -52,7 +62,7 @@ vi.mock('@genfeedai/services/organization/users.service', () => ({
 
 vi.mock('@genfeedai/services/auth/auth.service', () => ({
   AuthService: {
-    getInstance: vi.fn(),
+    getInstance: authServiceGetInstanceMock,
   },
 }));
 
@@ -71,7 +81,7 @@ vi.mock('@genfeedai/services/core/logger.service', () => ({
 vi.mock(
   '../../providers/protected-bootstrap/client-protected-bootstrap',
   () => ({
-    loadClientProtectedBootstrap: vi.fn().mockResolvedValue(null),
+    loadClientProtectedBootstrap: loadClientProtectedBootstrapMock,
   }),
 );
 
@@ -130,6 +140,10 @@ describe('BrandProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+    delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    loadClientProtectedBootstrapMock.mockResolvedValue(null);
+    authServiceGetInstanceMock.mockReturnValue({});
     useParamsMock.mockReturnValue({});
     useAuthMock.mockReturnValue({
       isLoaded: true,
@@ -409,5 +423,85 @@ describe('BrandProvider', () => {
       );
       expect(screen.getByTestId('is-ready')).toHaveTextContent('true');
     });
+  });
+
+  it('loads self-hosted brands through local bootstrap without a signed-in session', async () => {
+    process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'false';
+    useAuthMock.mockReturnValue({
+      getToken: vi.fn().mockResolvedValue(null),
+      isLoaded: true,
+      isSignedIn: false,
+      orgId: null,
+      userId: null,
+    });
+    useUserMock.mockReturnValue({ user: null });
+    useParamsMock.mockReturnValue({
+      brandSlug: 'default',
+      orgSlug: 'default',
+    });
+    loadClientProtectedBootstrapMock.mockImplementation(
+      async (
+        _cacheKey: string | undefined,
+        getAuthService: () => Promise<unknown>,
+      ) => {
+        await getAuthService();
+
+        return {
+          ...initialBootstrap,
+          brandId: 'brand_default',
+          brands: [
+            {
+              id: 'brand_default',
+              label: 'Default Brand',
+              organization: {
+                id: 'org_default',
+                slug: 'default',
+              },
+              slug: 'default',
+            },
+          ],
+          organizationId: 'org_default',
+        };
+      },
+    );
+
+    function Consumer() {
+      const { brandId, brands, isReady, organizationId, selectedBrand } =
+        useBrand();
+
+      return (
+        <div>
+          <span data-testid="brand-id">{brandId}</span>
+          <span data-testid="organization-id">{organizationId}</span>
+          <span data-testid="brand-count">{String(brands.length)}</span>
+          <span data-testid="selected-brand">{selectedBrand?.label}</span>
+          <span data-testid="is-ready">{String(isReady)}</span>
+        </div>
+      );
+    }
+
+    const Wrapper = createWrapper();
+
+    render(
+      <Wrapper>
+        <BrandProvider initialBootstrap={null}>
+          <Consumer />
+        </BrandProvider>
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('brand-id')).toHaveTextContent('brand_default');
+      expect(screen.getByTestId('organization-id')).toHaveTextContent(
+        'org_default',
+      );
+      expect(screen.getByTestId('brand-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('selected-brand')).toHaveTextContent(
+        'Default Brand',
+      );
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('true');
+    });
+    expect(authServiceGetInstanceMock).toHaveBeenCalledWith('');
+    expect(useAuthedServiceMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/contexts/user/brand-context/useBrandProviderState.ts
+++ b/packages/contexts/user/brand-context/useBrandProviderState.ts
@@ -34,6 +34,23 @@ import {
   getBrandOrganizationSlug,
 } from './brand-context.helpers';
 
+interface GenfeedRuntimeConfig {
+  betterAuthEnabled?: boolean;
+}
+
+function isLocalBootstrapEnabled(): boolean {
+  const runtimeConfig = (
+    globalThis as typeof globalThis & {
+      __GENFEED_RUNTIME_CONFIG__?: GenfeedRuntimeConfig;
+    }
+  ).__GENFEED_RUNTIME_CONFIG__;
+  const betterAuthEnabled =
+    runtimeConfig?.betterAuthEnabled ??
+    process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED !== 'false';
+
+  return !process.env.NEXT_PUBLIC_GENFEED_CLOUD && !betterAuthEnabled;
+}
+
 interface UseBrandProviderStateParams {
   initialBootstrap?: ProtectedBootstrapData | null;
 }
@@ -48,11 +65,13 @@ export function useBrandProviderState({
     userId,
     orgId,
   } = useAuthIdentity();
+  const localBootstrapEnabled = isLocalBootstrapEnabled();
   const { user } = useAuthUser();
   const playwrightAuth = getPlaywrightAuthState();
   const effectiveIsAuthLoaded =
-    isAuthLoaded || playwrightAuth?.isLoaded === true;
-  const effectiveIsSignedIn = isSignedIn || playwrightAuth?.isSignedIn === true;
+    isAuthLoaded || playwrightAuth?.isLoaded === true || localBootstrapEnabled;
+  const effectiveIsSignedIn =
+    isSignedIn || playwrightAuth?.isSignedIn === true || localBootstrapEnabled;
   const effectiveUserId = userId ?? playwrightAuth?.userId ?? null;
   const effectiveOrgId = orgId ?? playwrightAuth?.orgId ?? null;
 
@@ -65,6 +84,10 @@ export function useBrandProviderState({
   );
   const getAuthService = useContextAuthedService((token: string) =>
     AuthService.getInstance(token),
+  );
+  const getLocalAuthService = useCallback(
+    async () => AuthService.getInstance(''),
+    [],
   );
 
   const sessionKey = `${effectiveUserId ?? 'none'}:${effectiveOrgId ?? 'none'}`;
@@ -160,7 +183,7 @@ export function useBrandProviderState({
       try {
         const bootstrap = await loadClientProtectedBootstrap(
           clientBootstrapCacheKey,
-          getAuthService,
+          localBootstrapEnabled ? getLocalAuthService : getAuthService,
         );
 
         if (bootstrap) {
@@ -171,6 +194,10 @@ export function useBrandProviderState({
           error,
           reportToSentry: false,
         });
+      }
+
+      if (localBootstrapEnabled) {
+        return [];
       }
 
       const service = await getUsersService();
@@ -308,7 +335,7 @@ export function useBrandProviderState({
       try {
         const bootstrap = await loadClientProtectedBootstrap(
           clientBootstrapCacheKey,
-          getAuthService,
+          localBootstrapEnabled ? getLocalAuthService : getAuthService,
         );
 
         if (bootstrap?.organizationId === scopedOrganizationId) {
@@ -321,6 +348,10 @@ export function useBrandProviderState({
           error,
           reportToSentry: false,
         });
+      }
+
+      if (localBootstrapEnabled) {
+        return null;
       }
 
       try {

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -66,6 +66,33 @@ vi.mock('@genfeedai/auth-client/react', () => {
   };
 });
 
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({
+    getToken: vi.fn().mockResolvedValue('mock-token'),
+    isLoaded: true,
+    isSignedIn: true,
+    orgId: 'org_test123',
+    sessionId: 'sess_test123',
+    userId: 'user_test123',
+  }),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-user/use-auth-user', () => ({
+  useAuthUser: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    user: {
+      emailAddresses: [{ emailAddress: 'test@example.com', id: 'email_1' }],
+      firstName: 'Test',
+      fullName: 'Test User',
+      id: 'user_test123',
+      imageUrl: 'https://example.com/avatar.png',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+    },
+  }),
+}));
+
 vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
   useBrand: () => ({
     brandId: null,
@@ -167,6 +194,11 @@ describe('MenuShared', () => {
     mockBrandState.selectedBrand = null;
     mockLogoUrl.value = '';
     mockPathname.value = '/settings/personal';
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
   });
 
   const config: MenuConfig = {
@@ -225,6 +257,17 @@ describe('MenuShared', () => {
 
     expect(screen.getByTestId('sidebar-header-shell')).toBeInTheDocument();
     expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
+  });
+
+  it('hides the organization switcher outside SaaS cloud mode', () => {
+    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+
+    render(<MenuShared config={config} />);
+
+    expect(screen.getByTestId('sidebar-header-shell')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('organization-switcher'),
+    ).not.toBeInTheDocument();
   });
 
   it('attaches the actionable inbox count to the workspace inbox row', () => {

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -77,6 +77,8 @@ export default function MenuShared({
     ? (prefixHref({ href: backHref }) ?? backHref)
     : undefined;
   const prefetchBackHref = useNavigationPrefetch(resolvedBackHref);
+  const shouldRenderOrganizationSwitcher =
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true';
 
   const secondaryNavigationContent =
     secondaryItems.length > 0 ? (
@@ -213,7 +215,7 @@ export default function MenuShared({
           )}
         >
           {sharedCollapseControl}
-          <OrganizationSwitcher />
+          {shouldRenderOrganizationSwitcher ? <OrganizationSwitcher /> : null}
         </div>
 
         {/* Body — fades out when collapsed, pointer-events disabled */}


### PR DESCRIPTION
## Summary
- Hydrate self-hosted request context with the default brand ID so protected bootstrap can populate brand state.
- Allow self-hosted local bootstrap to load brands/settings without a signed Better Auth session when Better Auth is disabled.
- Hide the organization switcher outside SaaS cloud mode while preserving the brand switcher path.

## Validation
- bun run --cwd apps/server/api test:file src/common/middleware/request-context.middleware.spec.ts
- bun run --cwd packages/contexts test user/brand-context/brand-context.test.tsx
- bun run --cwd packages/ui test src/components/menus/shared/MenuShared.test.tsx
- bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/contexts --filter=@genfeedai/ui
- pre-commit hook: Biome staged check, raw HTML lint, secretlint

Closes #743
Related #740