### PR TITLE
feat(brands): brand context interview — AI gap-detection Q&A across agent, MCP & settings

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentDetailPage.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentDetailPage.tsx
@@ -47,6 +47,7 @@ const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   [AgentType.SHORT_FORM_WRITER]: 'Short-Form Writer',
   [AgentType.CTA_CONTENT]: 'CTA / Conversion',
   [AgentType.YOUTUBE_SCRIPT]: 'YouTube Script',
+  [AgentType.BRAND_INTERVIEW]: 'Brand Interview',
 };
 
 const AGENT_TYPE_ICONS: Record<AgentType, React.ReactNode> = {
@@ -61,6 +62,7 @@ const AGENT_TYPE_ICONS: Record<AgentType, React.ReactNode> = {
   [AgentType.SHORT_FORM_WRITER]: <HiOutlineBolt className="size-5" />,
   [AgentType.CTA_CONTENT]: <HiOutlineSparkles className="size-5" />,
   [AgentType.YOUTUBE_SCRIPT]: <FaYoutube className="size-4" />,
+  [AgentType.BRAND_INTERVIEW]: <HiOutlineSparkles className="size-5" />,
 };
 
 function AgentDetailPageContent({ agentId }: AgentDetailPageProps) {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/useAgentStrategiesColumns.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/useAgentStrategiesColumns.tsx
@@ -34,6 +34,7 @@ const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   [AgentType.SHORT_FORM_WRITER]: 'Short-Form Writer',
   [AgentType.CTA_CONTENT]: 'CTA / Conversion',
   [AgentType.YOUTUBE_SCRIPT]: 'YouTube Script',
+  [AgentType.BRAND_INTERVIEW]: 'Brand Interview',
 };
 
 const AGENT_TYPE_ICONS: Record<AgentType, React.ReactNode> = {
@@ -48,6 +49,7 @@ const AGENT_TYPE_ICONS: Record<AgentType, React.ReactNode> = {
   [AgentType.SHORT_FORM_WRITER]: <HiOutlineBolt className="size-4" />,
   [AgentType.CTA_CONTENT]: <HiOutlineSparkles className="size-4" />,
   [AgentType.YOUTUBE_SCRIPT]: <FaYoutube className="size-4" />,
+  [AgentType.BRAND_INTERVIEW]: <HiOutlineSparkles className="size-4" />,
 };
 
 const AUTONOMY_MODE_LABELS: Record<AgentAutonomyMode, string> = {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/library/AgentHubPage.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/library/AgentHubPage.tsx
@@ -40,6 +40,7 @@ const AGENT_TYPE_ICONS: Record<AgentType, React.ReactNode> = {
   [AgentType.SHORT_FORM_WRITER]: <HiOutlineBolt className="size-5" />,
   [AgentType.CTA_CONTENT]: <HiOutlineSparkles className="size-5" />,
   [AgentType.YOUTUBE_SCRIPT]: <FaYoutube className="size-4" />,
+  [AgentType.BRAND_INTERVIEW]: <HiOutlineSparkles className="size-5" />,
 };
 
 const AGENT_TYPE_LABELS: Record<AgentType, string> = {
@@ -54,6 +55,7 @@ const AGENT_TYPE_LABELS: Record<AgentType, string> = {
   [AgentType.SHORT_FORM_WRITER]: 'Short-Form Writer',
   [AgentType.CTA_CONTENT]: 'CTA / Conversion',
   [AgentType.YOUTUBE_SCRIPT]: 'YouTube Script',
+  [AgentType.BRAND_INTERVIEW]: 'Brand Interview',
 };
 
 function AgentCard({

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.test.tsx
@@ -1,0 +1,308 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BrandSettingsInterviewPage from './content';
+
+const mocks = vi.hoisted(() => ({
+  brandDetail: {
+    brand: { id: 'brand-1', label: 'Test Brand' },
+    brandId: 'brand-1',
+    handleRefreshBrand: vi.fn(),
+    hasBrandId: true,
+    isLoading: false,
+  },
+  getCompletenessService: vi.fn(),
+  getInterviewService: vi.fn(),
+  loggerError: vi.fn(),
+  useBrandInterview: {
+    completenessScore: 0,
+    currentQuestion: null,
+    error: null,
+    interviewId: null,
+    isLoading: false,
+    progress: null,
+    skipQuestion: vi.fn(),
+    startInterview: vi.fn(),
+    status: 'idle' as 'idle' | 'in_progress' | 'complete',
+    submitAnswer: vi.fn(),
+  },
+}));
+
+vi.mock('@hooks/pages/use-brand-detail/use-brand-detail', () => ({
+  useBrandDetail: () => mocks.brandDetail,
+}));
+
+vi.mock('@hooks/utils/use-brand-interview/use-brand-interview', () => ({
+  useBrandInterview: () => mocks.useBrandInterview,
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getInterviewService,
+}));
+
+vi.mock('@services/social/brand-interview.service', () => ({
+  BrandInterviewService: {
+    getInstance: vi.fn(),
+  },
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: {
+    error: mocks.loggerError,
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@ui/card/Card', () => ({
+  default: ({
+    children,
+    className,
+  }: {
+    children?: ReactNode;
+    className?: string;
+  }) => <section className={className}>{children}</section>,
+}));
+
+vi.mock('@ui/loading/default/Loading', () => ({
+  default: () => <div>Loading…</div>,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    isDisabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    isDisabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={isDisabled} type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}));
+
+vi.mock('@ui/primitives/textarea', () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea {...props} />
+  ),
+}));
+
+vi.mock('@ui/primitives/select', () => ({
+  Select: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children?: ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+}));
+
+describe('BrandSettingsInterviewPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.brandDetail = {
+      brand: { id: 'brand-1', label: 'Test Brand' },
+      brandId: 'brand-1',
+      handleRefreshBrand: vi.fn(),
+      hasBrandId: true,
+      isLoading: false,
+    };
+
+    mocks.useBrandInterview = {
+      completenessScore: 0,
+      currentQuestion: null,
+      error: null,
+      interviewId: null,
+      isLoading: false,
+      progress: null,
+      skipQuestion: vi.fn(),
+      startInterview: vi.fn(),
+      status: 'idle',
+      submitAnswer: vi.fn(),
+    };
+
+    mocks.getInterviewService.mockResolvedValue({
+      getCompleteness: vi.fn().mockResolvedValue({
+        incompleteFieldKeys: [],
+        interviewableGapCount: 3,
+        overallScore: 42,
+      }),
+    });
+  });
+
+  it('renders "Start interview" button in idle state', () => {
+    render(<BrandSettingsInterviewPage />);
+
+    expect(screen.getByText('Start interview')).toBeVisible();
+  });
+
+  it('shows credit disclosure in idle state', () => {
+    render(<BrandSettingsInterviewPage />);
+
+    expect(screen.getByText(/10 credits/)).toBeVisible();
+  });
+
+  it('calls startInterview when "Start interview" button is clicked', async () => {
+    render(<BrandSettingsInterviewPage />);
+
+    fireEvent.click(screen.getByText('Start interview'));
+
+    await waitFor(() => {
+      expect(mocks.useBrandInterview.startInterview).toHaveBeenCalled();
+    });
+  });
+
+  it('shows question after start (in_progress state)', () => {
+    mocks.useBrandInterview = {
+      ...mocks.useBrandInterview,
+      currentQuestion: {
+        answerType: 'text',
+        enumOptions: undefined,
+        examples: undefined,
+        fieldKey: 'label',
+        group: 'identity',
+        hint: 'The name of your brand',
+        isRequired: true,
+        questionText: 'What is the name of your brand?',
+        weight: 10,
+      },
+      interviewId: 'iv-123',
+      progress: { answeredFields: 1, percentComplete: 10, totalFields: 10 },
+      status: 'in_progress',
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    expect(screen.getByText('What is the name of your brand?')).toBeVisible();
+    expect(screen.getByText('Submit')).toBeVisible();
+    expect(screen.getByText('Skip')).toBeVisible();
+  });
+
+  it('calls submitAnswer with typed text when Submit is clicked', async () => {
+    mocks.useBrandInterview = {
+      ...mocks.useBrandInterview,
+      currentQuestion: {
+        answerType: 'text',
+        fieldKey: 'label',
+        group: 'identity',
+        isRequired: true,
+        questionText: 'What is the name of your brand?',
+        weight: 10,
+      },
+      interviewId: 'iv-123',
+      progress: { answeredFields: 0, percentComplete: 0, totalFields: 5 },
+      status: 'in_progress',
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    fireEvent.change(screen.getByPlaceholderText('Type your answer…'), {
+      target: { value: 'Acme Corp' },
+    });
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mocks.useBrandInterview.submitAnswer).toHaveBeenCalledWith(
+        'Acme Corp',
+      );
+    });
+  });
+
+  it('calls skipQuestion when Skip is clicked', async () => {
+    mocks.useBrandInterview = {
+      ...mocks.useBrandInterview,
+      currentQuestion: {
+        answerType: 'text',
+        fieldKey: 'label',
+        group: 'identity',
+        isRequired: false,
+        questionText: 'Optional question?',
+        weight: 5,
+      },
+      interviewId: 'iv-123',
+      progress: { answeredFields: 0, percentComplete: 0, totalFields: 5 },
+      status: 'in_progress',
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    fireEvent.click(screen.getByText('Skip'));
+
+    await waitFor(() => {
+      expect(mocks.useBrandInterview.skipQuestion).toHaveBeenCalled();
+    });
+  });
+
+  it('shows complete state when status is complete', () => {
+    mocks.useBrandInterview = {
+      ...mocks.useBrandInterview,
+      completenessScore: 85,
+      status: 'complete',
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    expect(screen.getByText('Interview complete')).toBeVisible();
+    expect(screen.getByText(/85%/)).toBeVisible();
+  });
+
+  it('calls handleRefreshBrand when interview completes', async () => {
+    mocks.useBrandInterview = {
+      ...mocks.useBrandInterview,
+      completenessScore: 85,
+      status: 'complete',
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    await waitFor(() => {
+      expect(mocks.brandDetail.handleRefreshBrand).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('shows loading state', () => {
+    mocks.brandDetail = {
+      ...mocks.brandDetail,
+      hasBrandId: false,
+      isLoading: true,
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    expect(screen.getByText('Loading…')).toBeVisible();
+  });
+
+  it('shows not-found state', () => {
+    mocks.brandDetail = {
+      ...mocks.brandDetail,
+      brand: null,
+      hasBrandId: true,
+      isLoading: false,
+    };
+
+    render(<BrandSettingsInterviewPage />);
+
+    expect(screen.getByText('Brand not found.')).toBeVisible();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import type { IBrandInterviewQuestion } from '@genfeedai/interfaces';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useBrandDetail } from '@hooks/pages/use-brand-detail/use-brand-detail';
+import { useBrandInterview } from '@hooks/utils/use-brand-interview/use-brand-interview';
+import { BrandInterviewService } from '@services/social/brand-interview.service';
+import Card from '@ui/card/Card';
+import Loading from '@ui/loading/default/Loading';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ui/primitives/select';
+import { Textarea } from '@ui/primitives/textarea';
+import { useCallback, useEffect, useState } from 'react';
+
+const INTERVIEW_CREDIT_COST = 10;
+
+function QuestionInput({
+  question,
+  value,
+  onChange,
+}: {
+  question: IBrandInterviewQuestion;
+  value: string;
+  onChange: (val: string) => void;
+}) {
+  if (question.answerType === 'enum' && question.enumOptions?.length) {
+    return (
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id="interview-answer-enum">
+          <SelectValue placeholder="Select an option…" />
+        </SelectTrigger>
+        <SelectContent>
+          {question.enumOptions.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  if (question.answerType === 'list') {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Textarea
+          id="interview-answer-list"
+          placeholder="Enter values separated by commas or new lines…"
+          rows={4}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Separate multiple values with commas or new lines.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      id="interview-answer-text"
+      placeholder="Type your answer…"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+export default function BrandSettingsInterviewPage() {
+  const { brand, brandId, hasBrandId, isLoading, handleRefreshBrand } =
+    useBrandDetail();
+
+  const {
+    status,
+    currentQuestion,
+    progress,
+    completenessScore,
+    isLoading: isInterviewLoading,
+    error,
+    startInterview,
+    submitAnswer,
+    skipQuestion,
+  } = useBrandInterview(brandId || null);
+
+  const getInterviewService = useAuthedService((token: string) =>
+    BrandInterviewService.getInstance(token),
+  );
+
+  const [idleScore, setIdleScore] = useState<number | null>(null);
+  const [answerDraft, setAnswerDraft] = useState('');
+
+  // Fetch completeness on idle mount
+  useEffect(() => {
+    if (!brandId || status !== 'idle') {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const fetchCompleteness = async () => {
+      try {
+        const service = await getInterviewService();
+        const result = await service.getCompleteness(
+          brandId,
+          controller.signal,
+        );
+
+        if (!controller.signal.aborted) {
+          setIdleScore(result.overallScore);
+        }
+      } catch (err: unknown) {
+        const e = err as Error;
+
+        if (e?.name !== 'AbortError') {
+          // Silently fail — score is decorative on the idle screen
+        }
+      }
+    };
+
+    fetchCompleteness();
+
+    return () => {
+      controller.abort();
+    };
+  }, [brandId, status, getInterviewService]);
+
+  // Refresh brand data when interview completes so completeness card updates
+  const handleInterviewComplete = useCallback(() => {
+    handleRefreshBrand(true);
+  }, [handleRefreshBrand]);
+
+  useEffect(() => {
+    if (status === 'complete') {
+      handleInterviewComplete();
+    }
+  }, [status, handleInterviewComplete]);
+
+  if (!hasBrandId || isLoading) {
+    return <Loading isFullSize={false} />;
+  }
+
+  if (!brand) {
+    return (
+      <Card className="p-6">
+        <p className="text-sm text-muted-foreground">Brand not found.</p>
+      </Card>
+    );
+  }
+
+  // Idle state — show completeness + credit disclosure + start button
+  if (status === 'idle') {
+    return (
+      <Card className="p-6">
+        <div className="flex flex-col gap-4 max-w-lg">
+          <div>
+            <h2 className="text-base font-semibold">Brand Context Interview</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Answer a set of targeted questions to help Genfeed understand your
+              brand&apos;s identity, voice, and strategy. Better context means
+              better AI content.
+            </p>
+          </div>
+
+          {idleScore !== null && (
+            <div className="flex items-center gap-3">
+              <div className="h-2 flex-1 rounded-full bg-white/[0.06] overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-500"
+                  style={{ width: `${idleScore}%` }}
+                />
+              </div>
+              <span className="text-sm font-medium text-muted-foreground w-10 text-right">
+                {idleScore}%
+              </span>
+            </div>
+          )}
+
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+            <p className="text-sm text-amber-400/90">
+              Starting a new interview uses{' '}
+              <strong>{INTERVIEW_CREDIT_COST} credits</strong>. Resuming an
+              existing session is free.
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div>
+            <Button
+              isDisabled={isInterviewLoading}
+              variant={ButtonVariant.DEFAULT}
+              onClick={startInterview}
+            >
+              {isInterviewLoading ? 'Starting…' : 'Start interview'}
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  // Complete state
+  if (status === 'complete') {
+    return (
+      <Card className="p-6">
+        <div className="flex flex-col gap-4 max-w-lg">
+          <div>
+            <h2 className="text-base font-semibold text-green-400">
+              Interview complete
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Your brand context has been updated. Overall completeness is now{' '}
+              <strong>{completenessScore}%</strong>. The AI will use this
+              context when generating content.
+            </p>
+          </div>
+
+          <div>
+            <Button
+              variant={ButtonVariant.DEFAULT}
+              onClick={() => {
+                window.location.reload();
+              }}
+            >
+              Start another interview
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  // In progress state
+  return (
+    <Card className="p-6">
+      <div className="flex flex-col gap-5 max-w-lg">
+        {/* Progress indicator */}
+        {progress && (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Progress</span>
+              <span className="text-xs font-medium text-muted-foreground">
+                {progress.answeredFields} / {progress.totalFields} fields (
+                {progress.percentComplete}%)
+              </span>
+            </div>
+            <div className="h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary transition-all duration-500"
+                style={{ width: `${progress.percentComplete}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Current question */}
+        {currentQuestion ? (
+          <div className="flex flex-col gap-3">
+            <div>
+              <label
+                className="text-sm font-medium leading-snug"
+                htmlFor={
+                  currentQuestion.answerType === 'enum'
+                    ? 'interview-answer-enum'
+                    : currentQuestion.answerType === 'list'
+                      ? 'interview-answer-list'
+                      : 'interview-answer-text'
+                }
+              >
+                {currentQuestion.questionText}
+                {currentQuestion.isRequired && (
+                  <span className="ml-1 text-destructive">*</span>
+                )}
+              </label>
+
+              {currentQuestion.hint && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {currentQuestion.hint}
+                </p>
+              )}
+            </div>
+
+            <QuestionInput
+              question={currentQuestion}
+              value={answerDraft}
+              onChange={setAnswerDraft}
+            />
+
+            {currentQuestion.examples &&
+              currentQuestion.examples.length > 0 && (
+                <div className="rounded-md bg-white/[0.03] px-3 py-2">
+                  <p className="text-[11px] text-muted-foreground font-medium mb-1">
+                    Examples
+                  </p>
+                  <ul className="flex flex-col gap-0.5">
+                    {currentQuestion.examples.map((ex) => (
+                      <li
+                        key={ex}
+                        className="text-[11px] text-muted-foreground/70"
+                      >
+                        {ex}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+
+            <div className="flex items-center gap-2 pt-1">
+              <Button
+                isDisabled={isInterviewLoading || !answerDraft.trim()}
+                variant={ButtonVariant.DEFAULT}
+                onClick={() => {
+                  submitAnswer(answerDraft.trim());
+                  setAnswerDraft('');
+                }}
+              >
+                {isInterviewLoading ? 'Submitting…' : 'Submit'}
+              </Button>
+
+              <Button
+                isDisabled={isInterviewLoading}
+                variant={ButtonVariant.GHOST}
+                onClick={() => {
+                  skipQuestion();
+                  setAnswerDraft('');
+                }}
+              >
+                Skip
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Loading isFullSize={false} />
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/page.test.tsx
@@ -1,0 +1,5 @@
+import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+
+assertSourceHasExport(
+  'app/(protected)/[orgSlug]/[brandSlug]/settings/interview/page.tsx',
+);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/page.tsx
@@ -1,0 +1,14 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import { Suspense } from 'react';
+import BrandSettingsInterviewPage from './content';
+
+export const generateMetadata = createPageMetadata('Brand Interview');
+
+export default function BrandSettingsInterviewRoute() {
+  return (
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+      <BrandSettingsInterviewPage />
+    </Suspense>
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/layout.tsx
@@ -35,6 +35,11 @@ export default function BrandSettingsLayout({ children }: LayoutProps) {
       label: 'Harness',
     },
     {
+      href: settingsHref('/interview'),
+      id: 'interview',
+      label: 'Interview',
+    },
+    {
       href: settingsHref('/publishing'),
       id: 'publishing',
       label: 'Publishing',

--- a/apps/server/api/src/app.module.ts
+++ b/apps/server/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { AvatarsModule } from '@api/collections/avatars/avatars.module';
 import { BookmarksModule } from '@api/collections/bookmarks/bookmarks.module';
 import { BotsModule } from '@api/collections/bots/bots.module';
 import { BrandMemoryModule } from '@api/collections/brand-memory/brand-memory.module';
+import { BrandInterviewModule } from '@api/collections/brands/brand-interview/brand-interview.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { BusinessAnalyticsModule } from '@api/collections/business-analytics/business-analytics.module';
 import { CaptionsModule } from '@api/collections/captions/captions.module';
@@ -240,6 +241,7 @@ import { SentryModule } from '@sentry/nestjs/setup';
     // BusinessAnalyticsModule — EE (gated below)
     BotsModule,
     BrandMemoryModule,
+    BrandInterviewModule,
     BrandsModule,
     OutreachCampaignsModule,
     CronJobsModule,

--- a/apps/server/api/src/collections/brands/brand-interview/brand-interview.module.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/brand-interview.module.ts
@@ -1,0 +1,25 @@
+/**
+ * BrandInterviewModule — stateful brand context interview engine.
+ * Detects in-scope gaps (identity/voice/strategy) and asks targeted questions
+ * to fill them. Credits are charged once at session start.
+ *
+ * NOTE: Uses an explicit @Module (not createServiceModule) because this module
+ * registers a controller in addition to providers.
+ */
+import { BrandInterviewController } from '@api/collections/brands/brand-interview/controllers/brand-interview.controller';
+import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
+import { CreditsModule } from '@api/collections/credits/credits.module';
+import { forwardRef, Module } from '@nestjs/common';
+
+@Module({
+  controllers: [BrandInterviewController],
+  exports: [BrandInterviewService],
+  imports: [
+    // CreditsUtilsService — swapped to OSS no-op in community mode
+    forwardRef(() => CreditsModule),
+    // PrismaService, CacheInvalidationService, and LoggerService are all @Global
+    // (PrismaModule, CacheModule, LoggerModule) so no local import needed.
+  ],
+  providers: [BrandInterviewService],
+})
+export class BrandInterviewModule {}

--- a/apps/server/api/src/collections/brands/brand-interview/constants/brand-interview-question-catalog.constant.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/constants/brand-interview-question-catalog.constant.ts
@@ -1,0 +1,260 @@
+import type {
+  BrandInterviewAnswerType,
+  BrandInterviewGroup,
+  IBrandInterviewQuestion,
+} from '@genfeedai/interfaces';
+
+export const BRAND_INTERVIEW_CREDIT_COST = 10;
+
+/**
+ * In-scope storage location for a field: which sub-object on the Brand holds it.
+ */
+export type BrandFieldStorage = 'brand' | 'voice' | 'strategy';
+
+export interface BrandFieldMeta {
+  group: BrandInterviewGroup;
+  answerType: BrandInterviewAnswerType;
+  storage: BrandFieldStorage;
+}
+
+/**
+ * Lookup map from fieldKey → group, answerType, storage.
+ * Derived directly from the canonical field map in the spec.
+ */
+export const BRAND_FIELD_META: Record<string, BrandFieldMeta> = {
+  // identity → Brand columns
+  description: { answerType: 'text', group: 'identity', storage: 'brand' },
+  text: { answerType: 'text', group: 'identity', storage: 'brand' },
+
+  // voice → agentConfig.voice.*
+  tone: { answerType: 'text', group: 'voice', storage: 'voice' },
+  style: { answerType: 'text', group: 'voice', storage: 'voice' },
+  audience: { answerType: 'list', group: 'voice', storage: 'voice' },
+  values: { answerType: 'list', group: 'voice', storage: 'voice' },
+  messagingPillars: { answerType: 'list', group: 'voice', storage: 'voice' },
+  sampleOutput: { answerType: 'text', group: 'voice', storage: 'voice' },
+  doNotSoundLike: { answerType: 'list', group: 'voice', storage: 'voice' },
+
+  // strategy → agentConfig.strategy.*
+  goals: { answerType: 'list', group: 'strategy', storage: 'strategy' },
+  contentTypes: { answerType: 'list', group: 'strategy', storage: 'strategy' },
+  platforms: { answerType: 'list', group: 'strategy', storage: 'strategy' },
+  frequency: { answerType: 'text', group: 'strategy', storage: 'strategy' },
+} as const;
+
+/**
+ * Ordered catalog of all 13 in-scope interview questions.
+ * Order = catalog order from spec: identity → voice → strategy.
+ * This order determines the sequence in which gaps are asked.
+ */
+export const BRAND_INTERVIEW_QUESTION_CATALOG: IBrandInterviewQuestion[] = [
+  // ── IDENTITY ──────────────────────────────────────────────────────────────
+  {
+    answerType: 'text',
+    examples: [
+      'We help indie makers ship faster by automating content distribution.',
+      'A B2B SaaS that removes manual data entry from finance teams.',
+    ],
+    fieldKey: 'description',
+    group: 'identity',
+    hint: 'One to three sentences. Focus on who you help and what problem you solve.',
+    isRequired: true,
+    questionText:
+      "What does your brand do? Give a short description of your brand's purpose and audience.",
+    weight: 10,
+  },
+  {
+    answerType: 'text',
+    examples: [
+      'You are a knowledgeable but approachable assistant for Acme Inc., a startup that helps e-commerce brands automate their social media. Keep your tone friendly, concise, and data-driven.',
+      'You represent BoldCraft Studio. Your writing is bold, slightly edgy, and always action-oriented. Prioritize short sentences and strong verbs.',
+    ],
+    fieldKey: 'text',
+    group: 'identity',
+    hint: "This is the system-level instruction that shapes all AI-generated content. Think of it as the brand's personality brief — include your brand name, core mission, content style, and any absolute do-nots.",
+    isRequired: false,
+    questionText:
+      "Write your brand's AI system prompt. This text tells the AI exactly how to write as your brand across all content types.",
+    weight: 9,
+  },
+
+  // ── VOICE ─────────────────────────────────────────────────────────────────
+  {
+    answerType: 'text',
+    examples: [
+      'Professional yet warm',
+      'Playful and irreverent',
+      'Authoritative and concise',
+    ],
+    fieldKey: 'tone',
+    group: 'voice',
+    hint: 'Use a short phrase — adjectives work well here.',
+    isRequired: true,
+    questionText:
+      "What is your brand's communication tone? Describe the overall feel of how your brand speaks.",
+    weight: 8,
+  },
+  {
+    answerType: 'text',
+    examples: [
+      'Short punchy sentences, always ends with a clear call-to-action',
+      'Storytelling-first, long-form, lots of data and citations',
+    ],
+    fieldKey: 'style',
+    group: 'voice',
+    hint: 'Think about sentence length, structure, and any signature writing habits.',
+    isRequired: false,
+    questionText:
+      'How would you describe your writing style? Explain how your brand structures and delivers its message.',
+    weight: 7,
+  },
+  {
+    answerType: 'list',
+    examples: [
+      'Startup founders',
+      'Marketing managers at SMBs',
+      'Freelance designers aged 25-40',
+    ],
+    fieldKey: 'audience',
+    group: 'voice',
+    hint: 'Enter one audience segment per line. Be as specific as possible.',
+    isRequired: true,
+    questionText:
+      'Who is your target audience? List the main groups of people you create content for.',
+    weight: 8,
+  },
+  {
+    answerType: 'list',
+    examples: ['Transparency', 'Customer empowerment', 'Speed over perfection'],
+    fieldKey: 'values',
+    group: 'voice',
+    hint: 'Enter one value per line. Limit to 3-6 core values for best results.',
+    isRequired: false,
+    questionText:
+      "What are your brand's core values? List the principles that guide how your brand behaves and communicates.",
+    weight: 7,
+  },
+  {
+    answerType: 'list',
+    examples: [
+      'We believe AI should be a co-creator, not a replacement',
+      'Simple beats complex, always',
+      'Your brand voice is your competitive moat',
+    ],
+    fieldKey: 'messagingPillars',
+    group: 'voice',
+    hint: 'Enter one pillar per line. These become recurring themes in your content.',
+    isRequired: false,
+    questionText:
+      'What are your key messaging pillars? List the core ideas or beliefs you want to communicate consistently.',
+    weight: 6,
+  },
+  {
+    answerType: 'text',
+    examples: [
+      '5 AI tools that doubled our content output (without the cringe)',
+      'Thread: Everything we learned building our first $10k MRR, the hard way.',
+    ],
+    fieldKey: 'sampleOutput',
+    group: 'voice',
+    hint: "Paste a tweet, hook, or opening paragraph — whatever captures your brand's voice best.",
+    isRequired: false,
+    questionText:
+      'Share a sample of your best content. Paste an example of writing that perfectly captures how your brand sounds.',
+    weight: 6,
+  },
+  {
+    answerType: 'list',
+    examples: [
+      'Corporate jargon and buzzwords',
+      'Overly casual slang',
+      'Negative or fear-based language',
+    ],
+    fieldKey: 'doNotSoundLike',
+    group: 'voice',
+    hint: 'Enter one item per line — brands, styles, or phrases to avoid.',
+    isRequired: false,
+    questionText:
+      'What should your brand NOT sound like? List styles, tones, or examples of writing you want to avoid.',
+    weight: 5,
+  },
+
+  // ── STRATEGY ──────────────────────────────────────────────────────────────
+  {
+    answerType: 'list',
+    examples: [
+      'Grow newsletter to 10k subscribers',
+      'Increase LinkedIn engagement by 30%',
+      'Establish thought leadership in AI tools',
+    ],
+    fieldKey: 'goals',
+    group: 'strategy',
+    hint: 'Enter one goal per line. Focus on outcomes, not activities.',
+    isRequired: false,
+    questionText:
+      'What are your content strategy goals? List what you want your content to achieve over the next 3-6 months.',
+    weight: 7,
+  },
+  {
+    answerType: 'list',
+    examples: [
+      'Short-form social posts',
+      'Long-form blog articles',
+      'Email newsletters',
+      'Video scripts',
+    ],
+    fieldKey: 'contentTypes',
+    group: 'strategy',
+    hint: 'Enter one content type per line.',
+    isRequired: false,
+    questionText:
+      'What types of content do you create? List the formats you publish or plan to publish.',
+    weight: 6,
+  },
+  {
+    answerType: 'list',
+    examples: [
+      'LinkedIn',
+      'X (Twitter)',
+      'Instagram',
+      'Newsletter (Substack)',
+      'YouTube',
+    ],
+    fieldKey: 'platforms',
+    group: 'strategy',
+    hint: 'Enter one platform per line.',
+    isRequired: false,
+    questionText:
+      'Which platforms do you publish on? List the channels where your audience finds your content.',
+    weight: 6,
+  },
+  {
+    answerType: 'text',
+    examples: [
+      '5 posts per week on social, 1 newsletter monthly',
+      'Daily short-form, 2x weekly long-form',
+    ],
+    fieldKey: 'frequency',
+    group: 'strategy',
+    hint: 'Include both the cadence and format where relevant.',
+    isRequired: false,
+    questionText:
+      'How often do you publish content? Describe your target publishing frequency.',
+    weight: 5,
+  },
+];
+
+/**
+ * Ordered list of all in-scope fieldKeys in catalog order.
+ * Used to determine question sequence efficiently.
+ */
+export const IN_SCOPE_FIELD_KEYS: string[] =
+  BRAND_INTERVIEW_QUESTION_CATALOG.map((q) => q.fieldKey);
+
+/**
+ * Quick lookup: fieldKey → IBrandInterviewQuestion
+ */
+export const CATALOG_BY_FIELD_KEY: Record<string, IBrandInterviewQuestion> =
+  Object.fromEntries(
+    BRAND_INTERVIEW_QUESTION_CATALOG.map((q) => [q.fieldKey, q]),
+  );

--- a/apps/server/api/src/collections/brands/brand-interview/controllers/brand-interview.controller.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/controllers/brand-interview.controller.ts
@@ -1,0 +1,165 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { StartBrandInterviewDto } from '@api/collections/brands/brand-interview/dto/start-brand-interview.dto';
+import { SubmitBrandInterviewAnswerDto } from '@api/collections/brands/brand-interview/dto/submit-brand-interview-answer.dto';
+import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import type {
+  IBrandInterviewAnswerResult,
+  IBrandInterviewCompleteness,
+  IBrandInterviewStartResult,
+} from '@genfeedai/interfaces';
+import type { BrandInterview } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { BRAND_INTERVIEW_CREDIT_COST } from '../constants/brand-interview-question-catalog.constant';
+
+@AutoSwagger()
+@Controller('brands')
+export class BrandInterviewController {
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly brandInterviewService: BrandInterviewService,
+  ) {}
+
+  /**
+   * Extract org context or throw 403.
+   */
+  private requireOrganizationId(user: User): string {
+    const publicMetadata = getPublicMetadata(user);
+    const orgId = publicMetadata.organization?.toString();
+
+    if (!orgId) {
+      throw new HttpException(
+        {
+          detail: 'Organization context is required',
+          title: 'Forbidden',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    return orgId;
+  }
+
+  /**
+   * POST /brands/:brandId/interview
+   * Start (or resume) a brand context interview.
+   */
+  @Post(':brandId/interview')
+  async start(
+    @Param('brandId') brandId: string,
+    @CurrentUser() user: User,
+    @Body() dto: StartBrandInterviewDto,
+  ): Promise<IBrandInterviewStartResult> {
+    const organizationId = this.requireOrganizationId(user);
+    const publicMetadata = getPublicMetadata(user);
+    const userId = publicMetadata.user?.toString() ?? '';
+
+    return this.brandInterviewService.start(
+      brandId,
+      organizationId,
+      userId,
+      dto.creditAmount ?? BRAND_INTERVIEW_CREDIT_COST,
+    );
+  }
+
+  /**
+   * GET /brands/:brandId/interview/active
+   * Return the active (in_progress) interview for a brand, or 404.
+   */
+  @Get(':brandId/interview/active')
+  async getActiveForBrand(
+    @Param('brandId') brandId: string,
+    @CurrentUser() user: User,
+  ): Promise<BrandInterview | null> {
+    const organizationId = this.requireOrganizationId(user);
+    return this.brandInterviewService.getActiveForBrand(
+      brandId,
+      organizationId,
+    );
+  }
+
+  /**
+   * GET /brands/:brandId/completeness
+   * Return brand completeness scores (interviewable gaps only).
+   */
+  @Get(':brandId/completeness')
+  async getCompleteness(
+    @Param('brandId') brandId: string,
+    @CurrentUser() user: User,
+  ): Promise<IBrandInterviewCompleteness> {
+    const organizationId = this.requireOrganizationId(user);
+    return this.brandInterviewService.getCompleteness(brandId, organizationId);
+  }
+
+  /**
+   * GET /brands/interview/:interviewId
+   * Fetch a specific interview session.
+   */
+  @Get('interview/:interviewId')
+  async getById(
+    @Param('interviewId') interviewId: string,
+    @CurrentUser() user: User,
+  ): Promise<BrandInterview> {
+    const organizationId = this.requireOrganizationId(user);
+    return this.brandInterviewService.getById(interviewId, organizationId);
+  }
+
+  /**
+   * POST /brands/interview/:interviewId/answer
+   * Submit an answer to the current question.
+   */
+  @Post('interview/:interviewId/answer')
+  async submitAnswer(
+    @Param('interviewId') interviewId: string,
+    @CurrentUser() user: User,
+    @Body() dto: SubmitBrandInterviewAnswerDto,
+  ): Promise<IBrandInterviewAnswerResult> {
+    const organizationId = this.requireOrganizationId(user);
+    const publicMetadata = getPublicMetadata(user);
+    const userId = publicMetadata.user?.toString() ?? '';
+
+    return this.brandInterviewService.submitAnswer(
+      interviewId,
+      organizationId,
+      userId,
+      dto.answer,
+    );
+  }
+
+  /**
+   * POST /brands/interview/:interviewId/skip
+   * Skip the current question and advance.
+   */
+  @Post('interview/:interviewId/skip')
+  async skipField(
+    @Param('interviewId') interviewId: string,
+    @CurrentUser() user: User,
+  ): Promise<IBrandInterviewAnswerResult> {
+    const organizationId = this.requireOrganizationId(user);
+    return this.brandInterviewService.skipField(interviewId, organizationId);
+  }
+
+  /**
+   * POST /brands/interview/:interviewId/abandon
+   * Abandon an in-progress interview.
+   */
+  @Post('interview/:interviewId/abandon')
+  async abandon(
+    @Param('interviewId') interviewId: string,
+    @CurrentUser() user: User,
+  ): Promise<BrandInterview> {
+    const organizationId = this.requireOrganizationId(user);
+    return this.brandInterviewService.abandon(interviewId, organizationId);
+  }
+}

--- a/apps/server/api/src/collections/brands/brand-interview/controllers/brand-interview.controller.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/controllers/brand-interview.controller.ts
@@ -6,6 +6,7 @@ import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decora
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import type {
+  IActiveBrandInterview,
   IBrandInterviewAnswerResult,
   IBrandInterviewCompleteness,
   IBrandInterviewStartResult,
@@ -21,7 +22,6 @@ import {
   Param,
   Post,
 } from '@nestjs/common';
-import { BRAND_INTERVIEW_CREDIT_COST } from '../constants/brand-interview-question-catalog.constant';
 
 @AutoSwagger()
 @Controller('brands')
@@ -65,12 +65,7 @@ export class BrandInterviewController {
     const publicMetadata = getPublicMetadata(user);
     const userId = publicMetadata.user?.toString() ?? '';
 
-    return this.brandInterviewService.start(
-      brandId,
-      organizationId,
-      userId,
-      dto.creditAmount ?? BRAND_INTERVIEW_CREDIT_COST,
-    );
+    return this.brandInterviewService.start(brandId, organizationId, userId);
   }
 
   /**
@@ -81,7 +76,7 @@ export class BrandInterviewController {
   async getActiveForBrand(
     @Param('brandId') brandId: string,
     @CurrentUser() user: User,
-  ): Promise<BrandInterview | null> {
+  ): Promise<IActiveBrandInterview | null> {
     const organizationId = this.requireOrganizationId(user);
     return this.brandInterviewService.getActiveForBrand(
       brandId,

--- a/apps/server/api/src/collections/brands/brand-interview/dto/start-brand-interview.dto.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/dto/start-brand-interview.dto.ts
@@ -1,18 +1,1 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsOptional, Max, Min } from 'class-validator';
-
-import { BRAND_INTERVIEW_CREDIT_COST } from '../constants/brand-interview-question-catalog.constant';
-
-export class StartBrandInterviewDto {
-  @ApiPropertyOptional({
-    default: BRAND_INTERVIEW_CREDIT_COST,
-    description:
-      'Credits to charge for starting this interview session. Defaults to the standard cost.',
-    example: BRAND_INTERVIEW_CREDIT_COST,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(0)
-  @Max(1000)
-  creditAmount?: number;
-}
+export class StartBrandInterviewDto {}

--- a/apps/server/api/src/collections/brands/brand-interview/dto/start-brand-interview.dto.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/dto/start-brand-interview.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+import { BRAND_INTERVIEW_CREDIT_COST } from '../constants/brand-interview-question-catalog.constant';
+
+export class StartBrandInterviewDto {
+  @ApiPropertyOptional({
+    default: BRAND_INTERVIEW_CREDIT_COST,
+    description:
+      'Credits to charge for starting this interview session. Defaults to the standard cost.',
+    example: BRAND_INTERVIEW_CREDIT_COST,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  creditAmount?: number;
+}

--- a/apps/server/api/src/collections/brands/brand-interview/dto/submit-brand-interview-answer.dto.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/dto/submit-brand-interview-answer.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class SubmitBrandInterviewAnswerDto {
+  @ApiProperty({
+    description:
+      'The answer to the current interview question. For list fields, separate items with newlines or commas.',
+    example: 'Professional yet warm, with a touch of wit.',
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(10_000)
+  answer!: string;
+}

--- a/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.spec.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.spec.ts
@@ -1,0 +1,509 @@
+/**
+ * BrandInterviewService unit tests.
+ *
+ * All Prisma delegates and external services are mocked so no DB or Redis is needed.
+ */
+
+vi.mock('@genfeedai/prisma', () => ({ PrismaClient: class {} }));
+
+import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import { InsufficientCreditsException } from '@api/helpers/exceptions/business/business-logic.exception';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BRAND_INTERVIEW_CREDIT_COST,
+  IN_SCOPE_FIELD_KEYS,
+} from '../constants/brand-interview-question-catalog.constant';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeLogger(): LoggerService {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggerService;
+}
+
+function makeSession(
+  overrides: Partial<{
+    id: string;
+    brandId: string;
+    organizationId: string;
+    userId: string;
+    status: string;
+    answeredFields: Record<string, unknown>;
+    askedFieldKeys: string[];
+    currentFieldKey: string | null;
+    completenessBefore: number;
+    completenessAfter: number | null;
+    creditsCharged: number;
+    isDeleted: boolean;
+  }> = {},
+) {
+  return {
+    id: 'interview-1',
+    brandId: 'brand-1',
+    organizationId: 'org-1',
+    userId: 'user-1',
+    status: 'in_progress',
+    answeredFields: {},
+    askedFieldKeys: [],
+    currentFieldKey: 'description',
+    completenessBefore: 0,
+    completenessAfter: null,
+    creditsCharged: BRAND_INTERVIEW_CREDIT_COST,
+    isDeleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeEmptyBrand(agentConfig: Record<string, unknown> = {}) {
+  return {
+    id: 'brand-1',
+    organizationId: 'org-1',
+    label: 'Test Brand',
+    description: null,
+    text: null,
+    agentConfig,
+    isDeleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+describe('BrandInterviewService', () => {
+  let service: BrandInterviewService;
+  let brandDelegate: Record<string, ReturnType<typeof vi.fn>>;
+  let interviewDelegate: Record<string, ReturnType<typeof vi.fn>>;
+  let creditsService: {
+    checkOrganizationCreditsAvailable: ReturnType<typeof vi.fn>;
+    deductCreditsFromOrganization: ReturnType<typeof vi.fn>;
+    getOrganizationCreditsBalance: ReturnType<typeof vi.fn>;
+  };
+  let cacheService: { invalidate: ReturnType<typeof vi.fn> };
+  let logger: LoggerService;
+
+  beforeEach(() => {
+    brandDelegate = {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    };
+    interviewDelegate = {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    };
+    creditsService = {
+      checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
+      deductCreditsFromOrganization: vi.fn().mockResolvedValue(undefined),
+      getOrganizationCreditsBalance: vi.fn().mockResolvedValue(1000),
+    };
+    cacheService = {
+      invalidate: vi.fn().mockResolvedValue(undefined),
+    };
+    logger = makeLogger();
+
+    const prisma = {
+      brand: brandDelegate,
+      brandInterview: interviewDelegate,
+    } as unknown as PrismaService;
+
+    service = new BrandInterviewService(
+      prisma,
+      creditsService as unknown as CreditsUtilsService,
+      cacheService as unknown as CacheInvalidationService,
+      logger,
+    );
+  });
+
+  // ── start() ───────────────────────────────────────────────────────────────
+
+  describe('start()', () => {
+    it('charges credits once for a new session', async () => {
+      const session = makeSession();
+      brandDelegate.findFirst.mockResolvedValue(makeEmptyBrand());
+      interviewDelegate.findFirst.mockResolvedValue(null); // no existing session
+      interviewDelegate.create.mockResolvedValue(session);
+
+      const result = await service.start('brand-1', 'org-1', 'user-1');
+
+      expect(
+        creditsService.deductCreditsFromOrganization,
+      ).toHaveBeenCalledOnce();
+      expect(creditsService.deductCreditsFromOrganization).toHaveBeenCalledWith(
+        'org-1',
+        'user-1',
+        BRAND_INTERVIEW_CREDIT_COST,
+        'Brand context interview',
+        expect.any(String), // ActivitySource.BRAND_INTERVIEW
+      );
+      expect(result.interviewId).toBe('interview-1');
+      expect(result.creditsCharged).toBe(BRAND_INTERVIEW_CREDIT_COST);
+    });
+
+    it('returns existing session without re-charging (idempotent)', async () => {
+      const existingSession = makeSession({ id: 'existing-123' });
+      brandDelegate.findFirst.mockResolvedValue(makeEmptyBrand());
+      interviewDelegate.findFirst.mockResolvedValue(existingSession); // existing session found
+
+      const result = await service.start('brand-1', 'org-1', 'user-1');
+
+      expect(
+        creditsService.deductCreditsFromOrganization,
+      ).not.toHaveBeenCalled();
+      expect(
+        creditsService.checkOrganizationCreditsAvailable,
+      ).not.toHaveBeenCalled();
+      expect(result.interviewId).toBe('existing-123');
+      expect(result.creditsCharged).toBe(0); // no charge on re-entry
+    });
+
+    it('handles P2002 unique violation on concurrent start — returns active session without charging', async () => {
+      const raceSession = makeSession({ id: 'race-session' });
+      brandDelegate.findFirst.mockResolvedValue(makeEmptyBrand());
+      interviewDelegate.findFirst
+        .mockResolvedValueOnce(null) // first check: no existing
+        .mockResolvedValueOnce(raceSession); // second check after P2002
+
+      const p2002 = Object.assign(new Error('Unique constraint'), {
+        code: 'P2002',
+      });
+      interviewDelegate.create.mockRejectedValue(p2002);
+
+      const result = await service.start('brand-1', 'org-1', 'user-1');
+
+      expect(
+        creditsService.deductCreditsFromOrganization,
+      ).not.toHaveBeenCalled();
+      expect(result.interviewId).toBe('race-session');
+      expect(result.creditsCharged).toBe(0);
+    });
+
+    it('throws InsufficientCreditsException when balance is too low', async () => {
+      brandDelegate.findFirst.mockResolvedValue(makeEmptyBrand());
+      interviewDelegate.findFirst.mockResolvedValue(null);
+      creditsService.checkOrganizationCreditsAvailable.mockResolvedValue(false);
+      creditsService.getOrganizationCreditsBalance.mockResolvedValue(3);
+
+      await expect(
+        service.start('brand-1', 'org-1', 'user-1'),
+      ).rejects.toBeInstanceOf(InsufficientCreditsException);
+
+      expect(interviewDelegate.create).not.toHaveBeenCalled();
+    });
+
+    it('compensates (soft-abandons session) when deduct throws', async () => {
+      const session = makeSession();
+      brandDelegate.findFirst.mockResolvedValue(makeEmptyBrand());
+      interviewDelegate.findFirst.mockResolvedValue(null);
+      interviewDelegate.create.mockResolvedValue(session);
+      creditsService.deductCreditsFromOrganization.mockRejectedValue(
+        new Error('deduct failed'),
+      );
+      interviewDelegate.update.mockResolvedValue({
+        ...session,
+        isDeleted: true,
+        status: 'abandoned',
+      });
+
+      await expect(service.start('brand-1', 'org-1', 'user-1')).rejects.toThrow(
+        'deduct failed',
+      );
+
+      expect(interviewDelegate.update).toHaveBeenCalledWith({
+        data: { isDeleted: true, status: 'abandoned' },
+        where: { id: session.id },
+      });
+    });
+
+    it('OSS no-op path (deduct resolves) still returns a session', async () => {
+      const session = makeSession();
+      brandDelegate.findFirst.mockResolvedValue(makeEmptyBrand());
+      interviewDelegate.findFirst.mockResolvedValue(null);
+      interviewDelegate.create.mockResolvedValue(session);
+      // OSS: deduct always resolves without side effects
+      creditsService.deductCreditsFromOrganization.mockResolvedValue(undefined);
+
+      const result = await service.start('brand-1', 'org-1', 'user-1');
+
+      expect(result.interviewId).toBe('interview-1');
+      expect(result.creditsCharged).toBe(BRAND_INTERVIEW_CREDIT_COST);
+    });
+
+    it('throws NotFoundException when brand does not exist', async () => {
+      brandDelegate.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.start('nonexistent', 'org-1', 'user-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  // ── writeFieldToBrand (tested via submitAnswer) ────────────────────────────
+
+  describe('submitAnswer() — field writes', () => {
+    it('writes identity field directly to brand row (description)', async () => {
+      const session = makeSession({ currentFieldKey: 'description' });
+      const emptyBrand = makeEmptyBrand();
+      const filledBrand = { ...emptyBrand, description: 'My brand does X.' };
+
+      interviewDelegate.findFirst.mockResolvedValue(session);
+      brandDelegate.findFirst.mockResolvedValueOnce(filledBrand); // reload after write
+      brandDelegate.update.mockResolvedValue(filledBrand);
+      interviewDelegate.update.mockResolvedValue({
+        ...session,
+        answeredFields: { description: 'My brand does X.' },
+        currentFieldKey: 'text',
+      });
+
+      await service.submitAnswer(
+        'interview-1',
+        'org-1',
+        'user-1',
+        'My brand does X.',
+      );
+
+      expect(brandDelegate.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ description: 'My brand does X.' }),
+        }),
+      );
+    });
+
+    it('deep-merges agentConfig — preserves sibling voice fields', async () => {
+      // Pre-existing: voice.tone = 'Bold' already set
+      const agentConfig = { voice: { tone: 'Bold' } };
+      const session = makeSession({
+        currentFieldKey: 'style',
+        answeredFields: { tone: 'Bold' },
+      });
+      const brandWithTone = makeEmptyBrand(agentConfig);
+
+      // After write the brand has both tone and style
+      const brandAfterWrite = makeEmptyBrand({
+        voice: { style: 'Punchy sentences', tone: 'Bold' },
+      });
+
+      interviewDelegate.findFirst.mockResolvedValue(session);
+      brandDelegate.findFirst
+        .mockResolvedValueOnce(brandWithTone) // read for agentConfig merge
+        .mockResolvedValueOnce(brandAfterWrite); // reload after write for completeness
+      brandDelegate.update.mockResolvedValue(brandAfterWrite);
+      interviewDelegate.update.mockResolvedValue({
+        ...session,
+        answeredFields: { style: 'Punchy sentences', tone: 'Bold' },
+        currentFieldKey: 'audience',
+      });
+
+      await service.submitAnswer(
+        'interview-1',
+        'org-1',
+        'user-1',
+        'Punchy sentences',
+      );
+
+      // The update call must preserve tone as well as writing style
+      const updateCall = brandDelegate.update.mock.calls[0][0];
+      const writtenCfg = updateCall.data.agentConfig as Record<string, unknown>;
+      const voiceGrp = writtenCfg.voice as Record<string, unknown>;
+      expect(voiceGrp.tone).toBe('Bold');
+      expect(voiceGrp.style).toBe('Punchy sentences');
+    });
+
+    it('advances to next in-scope gap after answering', async () => {
+      // Only description is answered; next should be 'text'
+      const session = makeSession({ currentFieldKey: 'description' });
+      // Brand after write: description set but text still empty
+      const updatedBrand = makeEmptyBrand();
+      Object.assign(updatedBrand, { description: 'Test' });
+
+      interviewDelegate.findFirst.mockResolvedValue(session);
+      brandDelegate.findFirst.mockResolvedValue(updatedBrand);
+      brandDelegate.update.mockResolvedValue(updatedBrand);
+      interviewDelegate.update.mockImplementation((args) =>
+        Promise.resolve({ ...session, ...args.data }),
+      );
+
+      const result = await service.submitAnswer(
+        'interview-1',
+        'org-1',
+        'user-1',
+        'Test',
+      );
+
+      // Next question should be 'text' (next in catalog after 'description')
+      expect(result.nextQuestion?.fieldKey).toBe('text');
+      expect(result.isComplete).toBe(false);
+    });
+
+    it('marks session completed when all in-scope fields are answered', async () => {
+      // Simulate a brand that has ALL in-scope fields filled (completeness returns no incomplete)
+      const fullyFilledBrand = makeEmptyBrand({
+        strategy: {
+          contentTypes: ['posts'],
+          frequency: 'daily',
+          goals: ['growth'],
+          platforms: ['LinkedIn'],
+        },
+        voice: {
+          audience: ['founders'],
+          doNotSoundLike: ['corporate'],
+          messagingPillars: ['simplicity'],
+          sampleOutput: 'Example text.',
+          style: 'Direct',
+          tone: 'Bold',
+          values: ['transparency'],
+        },
+      });
+      Object.assign(fullyFilledBrand, {
+        description: 'We help brands.',
+        text: 'You are Acme...',
+      });
+
+      // Session that just answered the last field
+      const session = makeSession({
+        answeredFields: Object.fromEntries(
+          IN_SCOPE_FIELD_KEYS.map((k) => [k, 'answered']),
+        ),
+        currentFieldKey: 'frequency',
+      });
+
+      interviewDelegate.findFirst.mockResolvedValue({
+        ...session,
+        answeredFields: Object.fromEntries(
+          IN_SCOPE_FIELD_KEYS.filter((k) => k !== 'frequency').map((k) => [
+            k,
+            'answered',
+          ]),
+        ),
+        currentFieldKey: 'frequency',
+      });
+      brandDelegate.findFirst.mockResolvedValue(fullyFilledBrand);
+      brandDelegate.update.mockResolvedValue(fullyFilledBrand);
+      interviewDelegate.update.mockImplementation((args) =>
+        Promise.resolve({ ...session, ...args.data }),
+      );
+
+      const result = await service.submitAnswer(
+        'interview-1',
+        'org-1',
+        'user-1',
+        'daily',
+      );
+
+      expect(result.isComplete).toBe(true);
+      expect(result.status).toBe('completed');
+      expect(result.nextQuestion).toBeNull();
+    });
+  });
+
+  // ── skipField() ────────────────────────────────────────────────────────────
+
+  describe('skipField()', () => {
+    it('advances to next in-scope gap without writing to brand', async () => {
+      const session = makeSession({ currentFieldKey: 'description' });
+      const emptyBrand = makeEmptyBrand();
+
+      interviewDelegate.findFirst.mockResolvedValue(session);
+      brandDelegate.findFirst.mockResolvedValue(emptyBrand);
+      interviewDelegate.update.mockImplementation((args) =>
+        Promise.resolve({ ...session, ...args.data }),
+      );
+
+      const result = await service.skipField('interview-1', 'org-1');
+
+      // Brand must NOT be written
+      expect(brandDelegate.update).not.toHaveBeenCalled();
+      // Next question should be 'text' (next in catalog after description)
+      expect(result.nextQuestion?.fieldKey).toBe('text');
+      expect(result.isComplete).toBe(false);
+    });
+
+    it('completes when no more non-skipped gaps remain', async () => {
+      // All fields skipped except one, and that one is being skipped now
+      const askedFieldKeys = IN_SCOPE_FIELD_KEYS.filter(
+        (k) => k !== 'frequency',
+      );
+      const session = makeSession({
+        askedFieldKeys,
+        currentFieldKey: 'frequency',
+      });
+      const emptyBrand = makeEmptyBrand();
+
+      interviewDelegate.findFirst.mockResolvedValue(session);
+      brandDelegate.findFirst.mockResolvedValue(emptyBrand);
+      interviewDelegate.update.mockImplementation((args) =>
+        Promise.resolve({ ...session, ...args.data }),
+      );
+
+      const result = await service.skipField('interview-1', 'org-1');
+
+      expect(result.isComplete).toBe(true);
+      expect(result.status).toBe('completed');
+    });
+  });
+
+  // ── getCompleteness() ──────────────────────────────────────────────────────
+
+  describe('getCompleteness()', () => {
+    it('excludes visual fields from interviewableGapCount', async () => {
+      // An empty brand: all fields including visual are incomplete
+      // computeBrandCompleteness will return label (always set), logo, primaryColor as missing
+      // but those should NOT be in interviewableGapCount
+      const emptyBrand = makeEmptyBrand();
+      brandDelegate.findFirst.mockResolvedValue(emptyBrand);
+
+      const result = await service.getCompleteness('brand-1', 'org-1');
+
+      // Only the 13 in-scope keys should appear in incompleteFieldKeys
+      const unexpectedKeys = result.incompleteFieldKeys.filter(
+        (k) => !IN_SCOPE_FIELD_KEYS.includes(k),
+      );
+      expect(unexpectedKeys).toHaveLength(0);
+      // All 13 in-scope fields should be incomplete for an empty brand
+      expect(result.interviewableGapCount).toBe(IN_SCOPE_FIELD_KEYS.length);
+    });
+  });
+
+  // ── abandon() ─────────────────────────────────────────────────────────────
+
+  describe('abandon()', () => {
+    it('marks session as abandoned', async () => {
+      const session = makeSession();
+      interviewDelegate.findFirst.mockResolvedValue(session);
+      interviewDelegate.update.mockResolvedValue({
+        ...session,
+        status: 'abandoned',
+      });
+
+      await service.abandon('interview-1', 'org-1');
+
+      expect(interviewDelegate.update).toHaveBeenCalledWith({
+        data: { status: 'abandoned' },
+        where: { id: 'interview-1' },
+      });
+    });
+
+    it('throws BadRequestException when session is already completed', async () => {
+      interviewDelegate.findFirst.mockResolvedValue(
+        makeSession({ status: 'completed' }),
+      );
+
+      await expect(
+        service.abandon('interview-1', 'org-1'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.spec.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.spec.ts
@@ -477,6 +477,50 @@ describe('BrandInterviewService', () => {
     });
   });
 
+  // ── getActiveForBrand() ────────────────────────────────────────────────────
+
+  describe('getActiveForBrand()', () => {
+    it('returns null when no active session exists', async () => {
+      interviewDelegate.findFirst.mockResolvedValue(null);
+
+      const result = await service.getActiveForBrand('brand-1', 'org-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('maps currentFieldKey → currentQuestion and completenessBefore → completenessScore', async () => {
+      const session = makeSession({
+        currentFieldKey: 'description',
+        completenessBefore: 42,
+        answeredFields: { tone: 'Bold' },
+      });
+      interviewDelegate.findFirst.mockResolvedValue(session);
+
+      const result = await service.getActiveForBrand('brand-1', 'org-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('interview-1');
+      expect(result!.status).toBe('in_progress');
+      // currentFieldKey 'description' must resolve to a question object
+      expect(result!.currentQuestion).not.toBeNull();
+      expect(result!.currentQuestion?.fieldKey).toBe('description');
+      // completenessBefore must surface as completenessScore
+      expect(result!.completenessScore).toBe(42);
+      // answeredCount reflects answered fields in session
+      expect(result!.answeredCount).toBe(1);
+      expect(result!.totalCount).toBe(IN_SCOPE_FIELD_KEYS.length);
+    });
+
+    it('sets currentQuestion to null when currentFieldKey is null', async () => {
+      const session = makeSession({ currentFieldKey: null });
+      interviewDelegate.findFirst.mockResolvedValue(session);
+
+      const result = await service.getActiveForBrand('brand-1', 'org-1');
+
+      expect(result!.currentQuestion).toBeNull();
+    });
+  });
+
   // ── abandon() ─────────────────────────────────────────────────────────────
 
   describe('abandon()', () => {

--- a/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.ts
@@ -7,6 +7,7 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { ActivitySource } from '@genfeedai/enums';
 import { computeBrandCompleteness } from '@genfeedai/helpers';
 import type {
+  IActiveBrandInterview,
   IBrandInterviewAnswerResult,
   IBrandInterviewCompleteness,
   IBrandInterviewProgress,
@@ -345,8 +346,8 @@ export class BrandInterviewService {
   async getActiveForBrand(
     brandId: string,
     organizationId: string,
-  ): Promise<BrandInterview | null> {
-    return this.prisma.brandInterview.findFirst({
+  ): Promise<IActiveBrandInterview | null> {
+    const session = await this.prisma.brandInterview.findFirst({
       where: {
         brandId,
         isDeleted: false,
@@ -354,6 +355,12 @@ export class BrandInterviewService {
         status: 'in_progress',
       },
     });
+
+    if (!session) {
+      return null;
+    }
+
+    return this.buildActiveResult(session);
   }
 
   async getCompleteness(
@@ -520,6 +527,32 @@ export class BrandInterviewService {
       interviewId: session.id,
       progress,
       status: session.status as IBrandInterviewStartResult['status'],
+    };
+  }
+
+  /**
+   * Map a raw BrandInterview row to the IActiveBrandInterview shape consumed
+   * by the frontend resume hook. Resolves currentFieldKey → currentQuestion and
+   * surfaces completenessBefore as completenessScore.
+   */
+  private buildActiveResult(session: BrandInterview): IActiveBrandInterview {
+    const currentQuestion: IBrandInterviewQuestion | null =
+      session.currentFieldKey
+        ? (CATALOG_BY_FIELD_KEY[session.currentFieldKey] ?? null)
+        : null;
+
+    const answeredCount = Object.keys(
+      (session.answeredFields as Record<string, unknown>) ?? {},
+    ).length;
+
+    return {
+      answeredCount,
+      brandId: session.brandId,
+      completenessScore: session.completenessBefore,
+      currentQuestion,
+      id: session.id,
+      status: session.status as IActiveBrandInterview['status'],
+      totalCount: IN_SCOPE_FIELD_KEYS.length,
     };
   }
 

--- a/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.ts
@@ -13,7 +13,7 @@ import type {
   IBrandInterviewQuestion,
   IBrandInterviewStartResult,
 } from '@genfeedai/interfaces';
-import type { BrandInterview } from '@genfeedai/prisma';
+import { type BrandInterview, Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
 
@@ -214,7 +214,7 @@ export class BrandInterviewService {
 
     const updated = await this.prisma.brandInterview.update({
       data: {
-        answeredFields: updatedAnsweredFields,
+        answeredFields: updatedAnsweredFields as Prisma.InputJsonValue,
         askedFieldKeys,
         completenessAfter,
         currentFieldKey: nextFieldKey,
@@ -476,7 +476,7 @@ export class BrandInterviewService {
       cfg[grpKey] = { ...grp, [fieldKey]: value };
 
       await this.prisma.brand.update({
-        data: { agentConfig: cfg },
+        data: { agentConfig: cfg as Prisma.InputJsonValue },
         where: { id: brandId },
       });
     }

--- a/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.ts
+++ b/apps/server/api/src/collections/brands/brand-interview/services/brand-interview.service.ts
@@ -1,0 +1,534 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { CACHE_PATTERNS } from '@api/common/constants/cache-patterns.constants';
+import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import { InsufficientCreditsException } from '@api/helpers/exceptions/business/business-logic.exception';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { ActivitySource } from '@genfeedai/enums';
+import { computeBrandCompleteness } from '@genfeedai/helpers';
+import type {
+  IBrandInterviewAnswerResult,
+  IBrandInterviewCompleteness,
+  IBrandInterviewProgress,
+  IBrandInterviewQuestion,
+  IBrandInterviewStartResult,
+} from '@genfeedai/interfaces';
+import type { BrandInterview } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+import {
+  BRAND_FIELD_META,
+  BRAND_INTERVIEW_CREDIT_COST,
+  CATALOG_BY_FIELD_KEY,
+  IN_SCOPE_FIELD_KEYS,
+} from '../constants/brand-interview-question-catalog.constant';
+
+@Injectable()
+export class BrandInterviewService {
+  private readonly constructorName = this.constructor.name;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly creditsUtilsService: CreditsUtilsService,
+    private readonly cacheInvalidationService: CacheInvalidationService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  async start(
+    brandId: string,
+    organizationId: string,
+    userId: string,
+    creditAmount: number = BRAND_INTERVIEW_CREDIT_COST,
+  ): Promise<IBrandInterviewStartResult> {
+    // 1. Load brand — must belong to org and not be deleted
+    const brand = await this.prisma.brand.findFirst({
+      where: { id: brandId, isDeleted: false, organizationId },
+    });
+
+    if (!brand) {
+      throw new NotFoundException('Brand', brandId);
+    }
+
+    // 2. Idempotency: return existing active session without re-charging
+    const existing = await this.prisma.brandInterview.findFirst({
+      where: {
+        brandId,
+        isDeleted: false,
+        organizationId,
+        status: 'in_progress',
+      },
+    });
+
+    if (existing) {
+      this.logger.debug(
+        `${this.constructorName} returning existing interview`,
+        {
+          interviewId: existing.id,
+        },
+      );
+      return this.buildStartResult(existing, 0);
+    }
+
+    // 3. Compute completeness before the interview starts
+    const completeness = computeBrandCompleteness(
+      brand as Parameters<typeof computeBrandCompleteness>[0],
+    );
+    const completenessBefore = completeness.overallScore;
+    const incompleteKeys = new Set(
+      completeness.incompleteFields.map((f) => f.key),
+    );
+
+    // 4. Determine the first in-scope incomplete field
+    const firstFieldKey =
+      IN_SCOPE_FIELD_KEYS.find((k) => incompleteKeys.has(k)) ?? null;
+
+    // 5. Credits preflight
+    const hasCredits =
+      await this.creditsUtilsService.checkOrganizationCreditsAvailable(
+        organizationId,
+        creditAmount,
+      );
+    if (!hasCredits) {
+      const balance =
+        await this.creditsUtilsService.getOrganizationCreditsBalance(
+          organizationId,
+        );
+      throw new InsufficientCreditsException(creditAmount, balance);
+    }
+
+    // 6. Create session — wrap in try/catch for P2002 (concurrent start race)
+    let session: BrandInterview;
+    try {
+      session = await this.prisma.brandInterview.create({
+        data: {
+          answeredFields: {},
+          askedFieldKeys: [],
+          brandId,
+          completenessBefore,
+          completenessAfter: null,
+          creditsCharged: creditAmount,
+          currentFieldKey: firstFieldKey,
+          isDeleted: false,
+          organizationId,
+          status: 'in_progress',
+          userId,
+        },
+      });
+    } catch (error: unknown) {
+      if (this.isPrismaUniqueViolation(error)) {
+        // Concurrent request already created the session — return it without charging
+        const race = await this.prisma.brandInterview.findFirst({
+          where: {
+            brandId,
+            isDeleted: false,
+            organizationId,
+            status: 'in_progress',
+          },
+        });
+        if (race) {
+          return this.buildStartResult(race, 0);
+        }
+      }
+      throw error;
+    }
+
+    // 7. Deduct credits — compensate (soft-abandon) if deduction fails
+    try {
+      await this.creditsUtilsService.deductCreditsFromOrganization(
+        organizationId,
+        userId,
+        creditAmount,
+        'Brand context interview',
+        ActivitySource.BRAND_INTERVIEW,
+      );
+    } catch (error: unknown) {
+      // Compensate: soft-delete the session so the unique index is freed
+      await this.prisma.brandInterview.update({
+        data: { isDeleted: true, status: 'abandoned' },
+        where: { id: session.id },
+      });
+      throw error;
+    }
+
+    return this.buildStartResult(session, creditAmount);
+  }
+
+  async submitAnswer(
+    interviewId: string,
+    organizationId: string,
+    _userId: string,
+    answer: string,
+  ): Promise<IBrandInterviewAnswerResult> {
+    const session = await this.loadActiveSession(interviewId, organizationId);
+    const { brandId } = session;
+
+    const fieldKey = session.currentFieldKey;
+    if (!fieldKey) {
+      throw new BadRequestException(
+        'No current question — this interview is already complete or has no remaining gaps.',
+      );
+    }
+
+    const question = CATALOG_BY_FIELD_KEY[fieldKey];
+    if (!question) {
+      throw new BadRequestException(`Unknown field key: ${fieldKey}`);
+    }
+
+    // Normalize the answer
+    const normalized = this.normalizeAnswer(answer, question);
+
+    // Write to brand
+    await this.writeFieldToBrand(brandId, organizationId, fieldKey, normalized);
+
+    // Update session state
+    const answeredFields =
+      (session.answeredFields as Record<string, unknown>) ?? {};
+    const updatedAnsweredFields = { ...answeredFields, [fieldKey]: normalized };
+    const askedFieldKeys = [...(session.askedFieldKeys ?? []), fieldKey];
+
+    // Reload brand to recompute completeness after write
+    const updatedBrand = await this.prisma.brand.findFirst({
+      where: { id: brandId, isDeleted: false },
+    });
+
+    const completeness = computeBrandCompleteness(
+      (updatedBrand ?? {}) as Parameters<typeof computeBrandCompleteness>[0],
+    );
+    const incompleteKeys = new Set(
+      completeness.incompleteFields.map((f) => f.key),
+    );
+
+    // Next field: in-scope, incomplete, not already answered in this session
+    const answeredInSession = new Set(Object.keys(updatedAnsweredFields));
+    const nextFieldKey =
+      IN_SCOPE_FIELD_KEYS.find(
+        (k) => incompleteKeys.has(k) && !answeredInSession.has(k),
+      ) ?? null;
+
+    const isComplete = nextFieldKey === null;
+    const newStatus = isComplete ? 'completed' : 'in_progress';
+    const completenessAfter = isComplete ? completeness.overallScore : null;
+
+    const updated = await this.prisma.brandInterview.update({
+      data: {
+        answeredFields: updatedAnsweredFields,
+        askedFieldKeys,
+        completenessAfter,
+        currentFieldKey: nextFieldKey,
+        status: newStatus,
+      },
+      where: { id: interviewId },
+    });
+
+    const progress = this.buildProgress(updated);
+
+    return {
+      completenessScore: completeness.overallScore,
+      interviewId,
+      isComplete,
+      nextQuestion: nextFieldKey
+        ? (CATALOG_BY_FIELD_KEY[nextFieldKey] ?? null)
+        : null,
+      progress,
+      status: newStatus,
+    };
+  }
+
+  async skipField(
+    interviewId: string,
+    organizationId: string,
+  ): Promise<IBrandInterviewAnswerResult> {
+    const session = await this.loadActiveSession(interviewId, organizationId);
+
+    const fieldKey = session.currentFieldKey;
+    if (!fieldKey) {
+      throw new BadRequestException('No current question to skip.');
+    }
+
+    const askedFieldKeys = [...(session.askedFieldKeys ?? []), fieldKey];
+    const answeredFields =
+      (session.answeredFields as Record<string, unknown>) ?? {};
+    const answeredInSession = new Set(Object.keys(answeredFields));
+
+    // Reload brand completeness to find the next gap
+    const brand = await this.prisma.brand.findFirst({
+      where: { id: session.brandId, isDeleted: false },
+    });
+
+    const completeness = computeBrandCompleteness(
+      (brand ?? {}) as Parameters<typeof computeBrandCompleteness>[0],
+    );
+    const incompleteKeys = new Set(
+      completeness.incompleteFields.map((f) => f.key),
+    );
+    const skippedSet = new Set(askedFieldKeys);
+
+    // Next field: in-scope, incomplete, not already answered or skipped in this session
+    const nextFieldKey =
+      IN_SCOPE_FIELD_KEYS.find(
+        (k) =>
+          incompleteKeys.has(k) &&
+          !answeredInSession.has(k) &&
+          !skippedSet.has(k),
+      ) ?? null;
+
+    const isComplete = nextFieldKey === null;
+    const newStatus = isComplete ? 'completed' : 'in_progress';
+    const completenessAfter = isComplete ? completeness.overallScore : null;
+
+    const updated = await this.prisma.brandInterview.update({
+      data: {
+        askedFieldKeys,
+        completenessAfter,
+        currentFieldKey: nextFieldKey,
+        status: newStatus,
+      },
+      where: { id: interviewId },
+    });
+
+    const progress = this.buildProgress(updated);
+
+    return {
+      completenessScore: completeness.overallScore,
+      interviewId,
+      isComplete,
+      nextQuestion: nextFieldKey
+        ? (CATALOG_BY_FIELD_KEY[nextFieldKey] ?? null)
+        : null,
+      progress,
+      status: newStatus,
+    };
+  }
+
+  async abandon(
+    interviewId: string,
+    organizationId: string,
+  ): Promise<BrandInterview> {
+    const session = await this.prisma.brandInterview.findFirst({
+      where: { id: interviewId, isDeleted: false, organizationId },
+    });
+
+    if (!session) {
+      throw new NotFoundException('BrandInterview', interviewId);
+    }
+
+    if (session.status !== 'in_progress') {
+      throw new BadRequestException(
+        'Only in-progress interviews can be abandoned.',
+      );
+    }
+
+    return this.prisma.brandInterview.update({
+      data: { status: 'abandoned' },
+      where: { id: interviewId },
+    });
+  }
+
+  async getById(
+    interviewId: string,
+    organizationId: string,
+  ): Promise<BrandInterview> {
+    const session = await this.prisma.brandInterview.findFirst({
+      where: { id: interviewId, isDeleted: false, organizationId },
+    });
+
+    if (!session) {
+      throw new NotFoundException('BrandInterview', interviewId);
+    }
+
+    return session;
+  }
+
+  async getActiveForBrand(
+    brandId: string,
+    organizationId: string,
+  ): Promise<BrandInterview | null> {
+    return this.prisma.brandInterview.findFirst({
+      where: {
+        brandId,
+        isDeleted: false,
+        organizationId,
+        status: 'in_progress',
+      },
+    });
+  }
+
+  async getCompleteness(
+    brandId: string,
+    organizationId: string,
+  ): Promise<IBrandInterviewCompleteness> {
+    const brand = await this.prisma.brand.findFirst({
+      where: { id: brandId, isDeleted: false, organizationId },
+    });
+
+    if (!brand) {
+      throw new NotFoundException('Brand', brandId);
+    }
+
+    const result = computeBrandCompleteness(
+      brand as Parameters<typeof computeBrandCompleteness>[0],
+    );
+    const incompleteInScope = result.incompleteFields.filter((f) =>
+      IN_SCOPE_FIELD_KEYS.includes(f.key),
+    );
+
+    return {
+      incompleteFieldKeys: incompleteInScope.map((f) => f.key),
+      interviewableGapCount: incompleteInScope.length,
+      overallScore: result.overallScore,
+    };
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async loadActiveSession(
+    interviewId: string,
+    organizationId: string,
+  ): Promise<BrandInterview> {
+    const session = await this.prisma.brandInterview.findFirst({
+      where: { id: interviewId, isDeleted: false, organizationId },
+    });
+
+    if (!session) {
+      throw new NotFoundException('BrandInterview', interviewId);
+    }
+
+    if (session.status !== 'in_progress') {
+      throw new BadRequestException(
+        `Interview is not in progress (current status: ${session.status}).`,
+      );
+    }
+
+    return session;
+  }
+
+  private normalizeAnswer(
+    raw: string,
+    question: IBrandInterviewQuestion,
+  ): string | string[] {
+    if (question.answerType === 'list') {
+      const items = raw
+        .split(/[\n,]+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (items.length === 0) {
+        throw new BadRequestException('Answer must contain at least one item.');
+      }
+      return items;
+    }
+
+    if (question.answerType === 'enum') {
+      const trimmed = raw.trim();
+      if (!question.enumOptions?.includes(trimmed)) {
+        throw new BadRequestException(
+          `Invalid option "${trimmed}". Valid options: ${question.enumOptions?.join(', ')}.`,
+        );
+      }
+      return trimmed;
+    }
+
+    // text
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      throw new BadRequestException('Answer cannot be empty.');
+    }
+    return trimmed;
+  }
+
+  /**
+   * Write a single field value back to the Brand record.
+   * Uses a read-modify-write for nested agentConfig fields to preserve siblings.
+   * Never calls BrandsService.updateAgentConfig (it shallow-overwrites the group).
+   */
+  private async writeFieldToBrand(
+    brandId: string,
+    organizationId: string,
+    fieldKey: string,
+    value: string | string[],
+  ): Promise<void> {
+    const meta = BRAND_FIELD_META[fieldKey];
+    if (!meta) {
+      throw new BadRequestException(`No field metadata for key: ${fieldKey}`);
+    }
+
+    if (meta.storage === 'brand') {
+      // Direct column update
+      await this.prisma.brand.update({
+        data: { [fieldKey]: value },
+        where: { id: brandId },
+      });
+    } else {
+      // Nested agentConfig update — must read first to preserve sibling fields
+      const brand = await this.prisma.brand.findFirst({
+        where: { id: brandId, isDeleted: false, organizationId },
+      });
+
+      if (!brand) {
+        throw new NotFoundException('Brand', brandId);
+      }
+
+      const cfg = (brand.agentConfig as Record<string, unknown>) ?? {};
+      const grpKey = meta.storage; // 'voice' | 'strategy'
+      const grp = (cfg[grpKey] as Record<string, unknown>) ?? {};
+      cfg[grpKey] = { ...grp, [fieldKey]: value };
+
+      await this.prisma.brand.update({
+        data: { agentConfig: cfg },
+        where: { id: brandId },
+      });
+    }
+
+    // Invalidate brand caches after write
+    await this.cacheInvalidationService.invalidate(
+      CACHE_PATTERNS.BRANDS_SINGLE(brandId),
+      CACHE_PATTERNS.BRANDS_LIST(organizationId),
+    );
+  }
+
+  private buildProgress(session: BrandInterview): IBrandInterviewProgress {
+    const answered = Object.keys(
+      (session.answeredFields as Record<string, unknown>) ?? {},
+    ).length;
+    const total = IN_SCOPE_FIELD_KEYS.length;
+
+    return {
+      answeredFields: answered,
+      percentComplete: total > 0 ? Math.round((answered / total) * 100) : 100,
+      totalFields: total,
+    };
+  }
+
+  private buildStartResult(
+    session: BrandInterview,
+    creditsCharged: number,
+  ): IBrandInterviewStartResult {
+    const currentQuestion: IBrandInterviewQuestion | null =
+      session.currentFieldKey
+        ? (CATALOG_BY_FIELD_KEY[session.currentFieldKey] ?? null)
+        : null;
+
+    const progress = this.buildProgress(session);
+
+    return {
+      brandId: session.brandId,
+      completenessScore: session.completenessBefore,
+      creditsCharged,
+      currentQuestion,
+      interviewId: session.id,
+      progress,
+      status: session.status as IBrandInterviewStartResult['status'],
+    };
+  }
+
+  private isPrismaUniqueViolation(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code: string }).code === 'P2002'
+    );
+  }
+}

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -8,6 +8,7 @@ import { AgentThreadsModule } from '@api/collections/agent-threads/agent-threads
 import { BotsModule } from '@api/collections/bots/bots.module';
 import { BotsService } from '@api/collections/bots/services/bots.service';
 import { BotsLivestreamService } from '@api/collections/bots/services/bots-livestream.service';
+import { BrandInterviewModule } from '@api/collections/brands/brand-interview/brand-interview.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { ContentIntelligenceModule } from '@api/collections/content-intelligence/content-intelligence.module';
@@ -64,6 +65,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => AgentStreamPublisherModule),
     forwardRef(() => AnalyticsModule),
     forwardRef(() => BatchGenerationModule),
+    forwardRef(() => BrandInterviewModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => BotsModule),
     forwardRef(() => OutreachCampaignsModule),

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -2725,4 +2725,69 @@ describe('AgentOrchestratorService', () => {
     );
     expect(response.message.content).toBe('Approved plan executed.');
   });
+
+  // ──────────────────────────────────────────────
+  // BRAND CONTEXT INTERVIEW — agent-type routing
+  // ──────────────────────────────────────────────
+
+  it('uses BRAND_INTERVIEW_SYSTEM_PROMPT when agentType is BRAND_INTERVIEW', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+
+    await service.chat(
+      {
+        agentType: AgentType.BRAND_INTERVIEW,
+        content: 'Start my brand interview',
+      },
+      {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+      },
+    );
+
+    expect(llmDispatcher.chatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('brand context facilitator'),
+            role: 'system',
+          }),
+        ]),
+      }),
+      ORG_ID,
+    );
+  });
+
+  it('does not charge per-turn credits for BRAND_INTERVIEW agentType', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+
+    await service.chat(
+      {
+        agentType: AgentType.BRAND_INTERVIEW,
+        content: 'Start my brand interview',
+      },
+      {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+      },
+    );
+
+    // With turnCost = 0 the service checks credits with 0 (so it never blocks)
+    // and deducts 0 — the net effect is no credits billed for the turn.
+    expect(
+      creditsUtilsService.checkOrganizationCreditsAvailable,
+    ).toHaveBeenCalledWith(ORG_ID, 0);
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).toHaveBeenCalledWith(
+      ORG_ID,
+      USER_ID,
+      0,
+      expect.stringContaining('Agent chat turn'),
+      expect.anything(),
+    );
+  });
 });

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -33,6 +33,7 @@ import {
   detectPlatformIntentSuffix,
   getAgentTypeConfig,
 } from '@api/services/agent-orchestrator/constants/agent-type-config.constant';
+import { BRAND_INTERVIEW_SYSTEM_PROMPT } from '@api/services/agent-orchestrator/constants/brand-interview-system-prompt.constant';
 import { ONBOARDING_SYSTEM_PROMPT } from '@api/services/agent-orchestrator/constants/onboarding-system-prompt.constant';
 import {
   type AgentGenerationPriority,
@@ -61,7 +62,7 @@ import {
   AgentAutonomyMode,
   AgentExecutionTrigger,
   AgentMessageRole,
-  type AgentType,
+  AgentType,
   SubscriptionTier,
 } from '@genfeedai/enums';
 import {
@@ -519,8 +520,12 @@ export class AgentOrchestratorService {
 
       const model = request.model || DEFAULT_AGENT_CHAT_MODEL;
 
-      // Check minimum credits for the turn based on selected model
-      const turnCost = getAgentTurnCost(model);
+      // Brand interview turns are free — the engine charges 10 credits once via
+      // BrandInterviewService.start(). Never double-bill the per-turn cost.
+      const turnCost =
+        request.agentType === AgentType.BRAND_INTERVIEW
+          ? 0
+          : getAgentTurnCost(model);
       const hasCredits =
         await this.creditsUtilsService.checkOrganizationCreditsAvailable(
           context.organizationId,
@@ -1299,8 +1304,12 @@ export class AgentOrchestratorService {
 
     const model = request.model || DEFAULT_AGENT_CHAT_MODEL;
 
-    // Check minimum credits for the turn based on selected model
-    const turnCost = getAgentTurnCost(model);
+    // Brand interview turns are free — the engine charges 10 credits once via
+    // BrandInterviewService.start(). Never double-bill the per-turn cost.
+    const turnCost =
+      request.agentType === AgentType.BRAND_INTERVIEW
+        ? 0
+        : getAgentTurnCost(model);
     const hasCredits =
       await this.creditsUtilsService.checkOrganizationCreditsAvailable(
         context.organizationId,
@@ -3670,6 +3679,16 @@ export class AgentOrchestratorService {
         policy,
         resolvedSkills,
         systemPrompt: ONBOARDING_SYSTEM_PROMPT,
+      };
+    }
+
+    if (request.agentType === AgentType.BRAND_INTERVIEW) {
+      return {
+        memories,
+        model: resolveModel(),
+        policy,
+        resolvedSkills,
+        systemPrompt: BRAND_INTERVIEW_SYSTEM_PROMPT,
       };
     }
 

--- a/apps/server/api/src/services/agent-orchestrator/constants/agent-type-config.constant.ts
+++ b/apps/server/api/src/services/agent-orchestrator/constants/agent-type-config.constant.ts
@@ -412,6 +412,19 @@ YouTube-specific guidelines:
 - For Shorts: hook in first 2 seconds, single idea, end with rewatch trigger`,
   },
 
+  [AgentType.BRAND_INTERVIEW]: {
+    defaultDailyCreditBudget: 50,
+    defaultModel: 'deepseek/deepseek-chat',
+    defaultTools: [
+      AgentToolName.GET_CURRENT_BRAND,
+      AgentToolName.START_BRAND_INTERVIEW,
+      AgentToolName.SUBMIT_BRAND_INTERVIEW_ANSWER,
+      AgentToolName.SKIP_BRAND_INTERVIEW_QUESTION,
+      AgentToolName.GET_BRAND_COMPLETENESS,
+    ],
+    systemPromptSuffix: '',
+  },
+
   [ORCHESTRATOR_AGENT_TYPE]: {
     defaultDailyCreditBudget: 250,
     defaultModel: 'deepseek/deepseek-chat',

--- a/apps/server/api/src/services/agent-orchestrator/constants/brand-interview-system-prompt.constant.ts
+++ b/apps/server/api/src/services/agent-orchestrator/constants/brand-interview-system-prompt.constant.ts
@@ -1,0 +1,33 @@
+export const BRAND_INTERVIEW_SYSTEM_PROMPT = `You are the Genfeed brand context facilitator. Your job is to guide the user through a structured interview that fills in missing brand context so AI-generated content is more accurate and on-brand.
+
+## Critical rules — read before acting
+
+1. **Never invent or assume answers.** Every answer must come from the human. Do not pre-fill, guess, or fabricate brand information.
+2. **One question at a time.** Ask exactly the question returned in currentQuestion.questionText. Do not batch multiple questions in a single message.
+3. **Always relay exact words.** Pass the user's exact wording to submit_brand_interview_answer — do not paraphrase, clean up, or rewrite it.
+4. **Store the interviewId.** Call start_brand_interview exactly once at the start. Keep the returned interviewId and pass it to every subsequent submit or skip call.
+5. **Skip on uncertainty.** If the user says "skip", "don't know", "pass", "not sure", or similar — call skip_brand_interview_question immediately without asking follow-up questions.
+6. **Do not editorialize during the interview.** Between questions, only echo the next question. Do not provide feedback, coaching, or suggestions on the user's answers mid-interview.
+7. **When isComplete is true** — congratulate the user briefly and give a one-sentence summary of the brand context that was collected. Do not prompt for more information.
+
+## Flow
+
+### Start
+- Call start_brand_interview with the brandId.
+- If currentQuestion is null, the brand context is already complete — tell the user and stop.
+- Otherwise, introduce yourself briefly (one sentence), then ask the first question using the exact questionText.
+
+### Each turn
+- After the user responds, call submit_brand_interview_answer with the interviewId and the user's exact answer.
+- If the user wants to skip, call skip_brand_interview_question instead.
+- Present the next question (nextQuestion.questionText) immediately. Do not add commentary between questions.
+
+### Completion
+- When a tool returns isComplete: true, acknowledge the completion.
+- Briefly summarize what was captured (e.g. "I've recorded your brand's tone, target audience, and messaging pillars.").
+- Offer to run get_brand_completeness if the user wants to see the full score.
+
+## Style
+- Conversational and concise. No emoji. No filler phrases like "Great answer!" or "Wonderful!".
+- Do not reveal internal tool names or technical details to the user.
+- Today's date: {{date}}`;

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -546,6 +546,48 @@ describe('AgentToolExecutorService', () => {
       }),
     };
 
+    const brandInterviewService = {
+      getCompleteness: vi.fn().mockResolvedValue({
+        incompleteFieldKeys: ['audience', 'tone'],
+        interviewableGapCount: 2,
+        overallScore: 40,
+      }),
+      skipField: vi.fn().mockResolvedValue({
+        completenessScore: 45,
+        interviewId: 'interview-1',
+        isComplete: false,
+        nextQuestion: {
+          fieldKey: 'tone',
+          questionText: "What is your brand's tone?",
+        },
+        progress: { answeredCount: 1, skippedCount: 1, totalCount: 10 },
+        status: 'in_progress',
+      }),
+      start: vi.fn().mockResolvedValue({
+        brandId: '67a123456789012345678901',
+        completenessScore: 40,
+        creditsCharged: 10,
+        currentQuestion: {
+          fieldKey: 'audience',
+          questionText: 'Who is your target audience?',
+        },
+        interviewId: 'interview-1',
+        progress: { answeredCount: 0, skippedCount: 0, totalCount: 10 },
+        status: 'in_progress',
+      }),
+      submitAnswer: vi.fn().mockResolvedValue({
+        completenessScore: 50,
+        interviewId: 'interview-1',
+        isComplete: false,
+        nextQuestion: {
+          fieldKey: 'tone',
+          questionText: "What is your brand's tone?",
+        },
+        progress: { answeredCount: 1, skippedCount: 0, totalCount: 10 },
+        status: 'in_progress',
+      }),
+    };
+
     const service = new AgentToolExecutorService(
       loggerService,
       configService as never,
@@ -582,6 +624,7 @@ describe('AgentToolExecutorService', () => {
       ingredientsService as never,
       {} as never, // votesService
       adsResearchService as never,
+      brandInterviewService as never,
     );
 
     return {
@@ -589,6 +632,7 @@ describe('AgentToolExecutorService', () => {
       agentGoalsService,
       agentMemoryCaptureService,
       aiActionsService,
+      brandInterviewService,
       analyticsService,
       batchGenerationService,
       botsLivestreamService,
@@ -3340,5 +3384,119 @@ describe('AgentToolExecutorService', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('not found');
+  });
+
+  // ──────────────────────────────────────────────
+  // BRAND CONTEXT INTERVIEW TOOLS
+  // ──────────────────────────────────────────────
+
+  it('start_brand_interview calls engine start and returns interview data', async () => {
+    const { brandInterviewService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.START_BRAND_INTERVIEW,
+      { brandId: '67a123456789012345678901' },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(brandInterviewService.start).toHaveBeenCalledWith(
+      '67a123456789012345678901',
+      CTX.organizationId,
+      CTX.userId,
+    );
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        interviewId: 'interview-1',
+        status: 'in_progress',
+        completenessScore: 40,
+      }),
+    );
+    expect(result.creditsUsed).toBe(10);
+  });
+
+  it('start_brand_interview returns error when brandId is missing', async () => {
+    const { service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.START_BRAND_INTERVIEW,
+      {},
+      CTX,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('brandId');
+  });
+
+  it('submit_brand_interview_answer calls engine submitAnswer and returns next question', async () => {
+    const { brandInterviewService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.SUBMIT_BRAND_INTERVIEW_ANSWER,
+      { interviewId: 'interview-1', answer: 'Developers and startup founders' },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(brandInterviewService.submitAnswer).toHaveBeenCalledWith(
+      'interview-1',
+      CTX.organizationId,
+      CTX.userId,
+      'Developers and startup founders',
+    );
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        interviewId: 'interview-1',
+        isComplete: false,
+        completenessScore: 50,
+      }),
+    );
+    expect(result.creditsUsed).toBe(0);
+  });
+
+  it('skip_brand_interview_question calls engine skipField and returns next question', async () => {
+    const { brandInterviewService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.SKIP_BRAND_INTERVIEW_QUESTION,
+      { interviewId: 'interview-1' },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(brandInterviewService.skipField).toHaveBeenCalledWith(
+      'interview-1',
+      CTX.organizationId,
+    );
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        interviewId: 'interview-1',
+        isComplete: false,
+      }),
+    );
+    expect(result.creditsUsed).toBe(0);
+  });
+
+  it('get_brand_completeness calls engine getCompleteness and returns score', async () => {
+    const { brandInterviewService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.GET_BRAND_COMPLETENESS,
+      { brandId: '67a123456789012345678901' },
+      CTX,
+    );
+
+    expect(result.success).toBe(true);
+    expect(brandInterviewService.getCompleteness).toHaveBeenCalledWith(
+      '67a123456789012345678901',
+      CTX.organizationId,
+    );
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        overallScore: 40,
+        incompleteFieldKeys: expect.arrayContaining(['audience', 'tone']),
+      }),
+    );
+    expect(result.creditsUsed).toBe(0);
   });
 });

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -8,6 +8,7 @@ import type {
   AgentMemoryScope,
 } from '@api/collections/agent-memories/schemas/agent-memory.schema';
 import { AgentMemoryCaptureService } from '@api/collections/agent-memories/services/agent-memory-capture.service';
+import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
 import { resolveEffectiveBrandAgentConfig } from '@api/collections/brands/utils/brand-agent-config-resolution.util';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
@@ -400,6 +401,8 @@ export class AgentToolExecutorService {
     private readonly votesService: VotesService,
     @Optional()
     private readonly adsResearchService: AdsResearchService | undefined,
+    @Optional()
+    private readonly brandInterviewService: BrandInterviewService | undefined,
   ) {
     this.apiBaseUrl =
       this.configService.get('API_BASE_URL') || 'http://localhost:3010';
@@ -1158,6 +1161,19 @@ export class AgentToolExecutorService {
 
       case 'update_goal':
         return this.updateGoal(params, ctx);
+
+      // Brand context interview tools
+      case AgentToolName.START_BRAND_INTERVIEW:
+        return this.startBrandInterview(params, ctx);
+
+      case AgentToolName.SUBMIT_BRAND_INTERVIEW_ANSWER:
+        return this.submitBrandInterviewAnswer(params, ctx);
+
+      case AgentToolName.SKIP_BRAND_INTERVIEW_QUESTION:
+        return this.skipBrandInterviewQuestion(params, ctx);
+
+      case AgentToolName.GET_BRAND_COMPLETENESS:
+        return this.getBrandCompleteness(params, ctx);
 
       default:
         return {
@@ -8690,5 +8706,206 @@ export class AgentToolExecutorService {
       default:
         return undefined;
     }
+  }
+
+  // ──────────────────────────────────────────────
+  // BRAND CONTEXT INTERVIEW TOOLS
+  // ──────────────────────────────────────────────
+
+  private async startBrandInterview(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.brandInterviewService) {
+      return {
+        creditsUsed: 0,
+        error: 'Brand interview service is not available in this environment.',
+        success: false,
+      };
+    }
+
+    const brandId = this.readOptionalString(params.brandId);
+    if (!brandId) {
+      return {
+        creditsUsed: 0,
+        error: 'start_brand_interview requires a brandId.',
+        success: false,
+      };
+    }
+
+    const result = await this.brandInterviewService.start(
+      brandId,
+      ctx.organizationId,
+      ctx.userId,
+    );
+
+    const nextActions: AgentUiAction[] =
+      result.currentQuestion === null
+        ? [
+            {
+              data: {
+                completenessScore: result.completenessScore,
+                interviewId: result.interviewId,
+              },
+              description:
+                'Your brand context is already complete — no more questions needed.',
+              id: `brand-interview-complete-${brandId}`,
+              title: 'Brand Context Complete',
+              type: 'brand_interview_complete_card',
+            } as never,
+          ]
+        : [];
+
+    return {
+      creditsUsed: result.creditsCharged,
+      data: {
+        brandId: result.brandId,
+        completenessScore: result.completenessScore,
+        currentQuestion: result.currentQuestion,
+        interviewId: result.interviewId,
+        progress: result.progress,
+        status: result.status,
+      },
+      nextActions,
+      success: true,
+    };
+  }
+
+  private async submitBrandInterviewAnswer(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.brandInterviewService) {
+      return {
+        creditsUsed: 0,
+        error: 'Brand interview service is not available in this environment.',
+        success: false,
+      };
+    }
+
+    const interviewId = this.readOptionalString(params.interviewId);
+    const answer = this.readOptionalString(params.answer);
+
+    if (!interviewId || !answer) {
+      return {
+        creditsUsed: 0,
+        error: 'submit_brand_interview_answer requires interviewId and answer.',
+        success: false,
+      };
+    }
+
+    const result = await this.brandInterviewService.submitAnswer(
+      interviewId,
+      ctx.organizationId,
+      ctx.userId,
+      answer,
+    );
+
+    const nextActions: AgentUiAction[] = result.isComplete
+      ? [
+          {
+            data: {
+              completenessScore: result.completenessScore,
+              interviewId: result.interviewId,
+            },
+            description:
+              'All brand context questions have been answered. Your brand profile is now more complete.',
+            id: `brand-interview-complete-${result.interviewId}`,
+            title: 'Brand Context Complete',
+            type: 'brand_interview_complete_card',
+          } as never,
+        ]
+      : [];
+
+    return {
+      creditsUsed: 0,
+      data: {
+        completenessScore: result.completenessScore,
+        interviewId: result.interviewId,
+        isComplete: result.isComplete,
+        nextQuestion: result.nextQuestion,
+        progress: result.progress,
+        status: result.status,
+      },
+      nextActions,
+      success: true,
+    };
+  }
+
+  private async skipBrandInterviewQuestion(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.brandInterviewService) {
+      return {
+        creditsUsed: 0,
+        error: 'Brand interview service is not available in this environment.',
+        success: false,
+      };
+    }
+
+    const interviewId = this.readOptionalString(params.interviewId);
+    if (!interviewId) {
+      return {
+        creditsUsed: 0,
+        error: 'skip_brand_interview_question requires an interviewId.',
+        success: false,
+      };
+    }
+
+    const result = await this.brandInterviewService.skipField(
+      interviewId,
+      ctx.organizationId,
+    );
+
+    return {
+      creditsUsed: 0,
+      data: {
+        completenessScore: result.completenessScore,
+        interviewId: result.interviewId,
+        isComplete: result.isComplete,
+        nextQuestion: result.nextQuestion,
+        progress: result.progress,
+        status: result.status,
+      },
+      success: true,
+    };
+  }
+
+  private async getBrandCompleteness(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.brandInterviewService) {
+      return {
+        creditsUsed: 0,
+        error: 'Brand interview service is not available in this environment.',
+        success: false,
+      };
+    }
+
+    const brandId = this.readOptionalString(params.brandId);
+    if (!brandId) {
+      return {
+        creditsUsed: 0,
+        error: 'get_brand_completeness requires a brandId.',
+        success: false,
+      };
+    }
+
+    const result = await this.brandInterviewService.getCompleteness(
+      brandId,
+      ctx.organizationId,
+    );
+
+    return {
+      creditsUsed: 0,
+      data: {
+        incompleteFieldKeys: result.incompleteFieldKeys,
+        interviewableGapCount: result.interviewableGapCount,
+        overallScore: result.overallScore,
+      },
+      success: true,
+    };
   }
 }

--- a/apps/server/mcp/src/services/tool-registry.service.ts
+++ b/apps/server/mcp/src/services/tool-registry.service.ts
@@ -56,6 +56,10 @@ const APPROVAL_REQUIRED_TOOLS: ReadonlySet<string> = new Set<string>([
   'generate_bootstrap',
   'generate_pulid',
   'generate_darkroom_content',
+  // Brand context interview — mutating tools require user confirmation
+  'start_brand_interview',
+  'submit_brand_interview_answer',
+  'skip_brand_interview_question',
 ]);
 
 @Injectable()

--- a/packages/agent/src/components/BrandInterviewCompleteCard.tsx
+++ b/packages/agent/src/components/BrandInterviewCompleteCard.tsx
@@ -1,0 +1,43 @@
+import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
+import type { ReactElement } from 'react';
+import { HiCheckCircle } from 'react-icons/hi2';
+
+interface BrandInterviewCompleteCardProps {
+  action: AgentUiAction;
+}
+
+export function BrandInterviewCompleteCard({
+  action,
+}: BrandInterviewCompleteCardProps): ReactElement {
+  const data = action.data ?? {};
+  const completenessScore =
+    typeof data.completenessScore === 'number' ? data.completenessScore : null;
+
+  return (
+    <div className="my-2 border border-emerald-500/20 bg-background p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <HiCheckCircle className="size-5 text-emerald-600" />
+        <h3 className="text-sm font-semibold text-foreground">
+          {action.title || 'Brand Context Complete'}
+        </h3>
+      </div>
+
+      {action.description ? (
+        <p className="mb-3 text-xs text-muted-foreground">
+          {action.description}
+        </p>
+      ) : null}
+
+      {completenessScore !== null ? (
+        <div className="border border-emerald-500/20 bg-emerald-500/5 p-3">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Brand context completeness
+          </p>
+          <p className="mt-1 text-sm font-semibold text-emerald-600">
+            {completenessScore}%
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/agent/src/components/BrandInterviewOfferCard.tsx
+++ b/packages/agent/src/components/BrandInterviewOfferCard.tsx
@@ -1,0 +1,113 @@
+import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
+import { ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
+import { type ReactElement, useCallback, useState } from 'react';
+import { HiCheckCircle, HiSparkles } from 'react-icons/hi2';
+
+interface BrandInterviewOfferCardProps {
+  action: AgentUiAction;
+  onUiAction?: (
+    action: string,
+    payload?: Record<string, unknown>,
+  ) => void | Promise<void>;
+}
+
+export function BrandInterviewOfferCard({
+  action,
+  onUiAction,
+}: BrandInterviewOfferCardProps): ReactElement {
+  const [isStarting, setIsStarting] = useState(false);
+  const [isStarted, setIsStarted] = useState(false);
+
+  const data = action.data ?? {};
+  const completenessScore =
+    typeof data.completenessScore === 'number' ? data.completenessScore : null;
+  const currentQuestion =
+    data.currentQuestion &&
+    typeof data.currentQuestion === 'object' &&
+    'questionText' in (data.currentQuestion as Record<string, unknown>)
+      ? (data.currentQuestion as { questionText: string })
+      : null;
+
+  const startCta = action.ctas?.find((cta) => cta.action === 'start_interview');
+
+  const handleStart = useCallback(async () => {
+    if (!startCta?.action || !onUiAction || isStarting || isStarted) {
+      return;
+    }
+
+    setIsStarting(true);
+
+    try {
+      await onUiAction(startCta.action, startCta.payload);
+      setIsStarted(true);
+    } finally {
+      setIsStarting(false);
+    }
+  }, [isStarted, isStarting, onUiAction, startCta?.action, startCta?.payload]);
+
+  if (isStarted) {
+    return (
+      <div className="my-2 border border-emerald-500/20 bg-background p-4">
+        <div className="flex items-center gap-2 text-emerald-600">
+          <HiCheckCircle className="size-5" />
+          <span className="text-sm font-medium">Interview started.</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2 border border-border bg-background p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <HiSparkles className="size-5 text-amber-500" />
+        <h3 className="text-sm font-semibold text-foreground">
+          {action.title || 'Brand Context Interview'}
+        </h3>
+      </div>
+
+      {action.description ? (
+        <p className="mb-3 text-xs text-muted-foreground">
+          {action.description}
+        </p>
+      ) : null}
+
+      {completenessScore !== null ? (
+        <div className="mb-3 border border-border bg-card/40 p-3">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Current completeness
+          </p>
+          <p className="mt-1 text-sm font-semibold text-foreground">
+            {completenessScore}%
+          </p>
+        </div>
+      ) : null}
+
+      {currentQuestion ? (
+        <div className="mb-3 border border-border bg-card/40 p-3">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            First question
+          </p>
+          <p className="mt-1 text-sm text-foreground">
+            {currentQuestion.questionText}
+          </p>
+        </div>
+      ) : null}
+
+      {startCta?.action ? (
+        <Button
+          variant={ButtonVariant.DEFAULT}
+          isDisabled={isStarting}
+          isLoading={isStarting}
+          onClick={() => {
+            void handleStart();
+          }}
+          icon={<HiSparkles className="size-4" />}
+          className="mt-4 w-full justify-center"
+        >
+          {isStarting ? 'Starting...' : (startCta.label ?? 'Start interview')}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/agent/src/components/UiActionRenderer.tsx
+++ b/packages/agent/src/components/UiActionRenderer.tsx
@@ -14,6 +14,8 @@ import { AnalyticsSnapshotCard } from '@genfeedai/agent/components/AnalyticsSnap
 import { BatchGenerationCard } from '@genfeedai/agent/components/BatchGenerationCard';
 import { BatchGenerationResultCard } from '@genfeedai/agent/components/BatchGenerationResultCard';
 import { BrandCreateCard } from '@genfeedai/agent/components/BrandCreateCard';
+import { BrandInterviewCompleteCard } from '@genfeedai/agent/components/BrandInterviewCompleteCard';
+import { BrandInterviewOfferCard } from '@genfeedai/agent/components/BrandInterviewOfferCard';
 import { BrandVoiceProfileCard } from '@genfeedai/agent/components/BrandVoiceProfileCard';
 import {
   CampaignControlCard,
@@ -163,6 +165,12 @@ export function UiActionRenderer({
       return <LivestreamBotCard action={action} onUiAction={onUiAction} />;
     case 'livestream_bot_status_card':
       return <LivestreamBotCard action={action} onUiAction={onUiAction} />;
+    case 'brand_interview_offer_card':
+      return (
+        <BrandInterviewOfferCard action={action} onUiAction={onUiAction} />
+      );
+    case 'brand_interview_complete_card':
+      return <BrandInterviewCompleteCard action={action} />;
     case 'ai_text_action_card':
       return (
         <AiTextActionCard

--- a/packages/agent/src/models/agent-chat.model.ts
+++ b/packages/agent/src/models/agent-chat.model.ts
@@ -151,7 +151,9 @@ export interface AgentUiAction {
     | 'campaign_launch_prep_card'
     | 'workflow_created_card'
     | 'bot_created_card'
-    | 'livestream_bot_status_card';
+    | 'livestream_bot_status_card'
+    | 'brand_interview_offer_card'
+    | 'brand_interview_complete_card';
   title: string;
   description?: string;
   platform?: string;

--- a/packages/enums/src/activity.enum.ts
+++ b/packages/enums/src/activity.enum.ts
@@ -34,6 +34,7 @@ export enum ActivitySource {
   BOT_GENERATION = 'bot-generate',
   VOICE_GENERATION = 'voice-generate',
   TREND_SCAN = 'trend-scan',
+  BRAND_INTERVIEW = 'brand-interview',
 }
 
 export enum ActivityKey {

--- a/packages/enums/src/agent-strategy.enum.ts
+++ b/packages/enums/src/agent-strategy.enum.ts
@@ -22,6 +22,7 @@ export enum AgentType {
   SHORT_FORM_WRITER = 'short_form_writer',
   CTA_CONTENT = 'cta_content',
   YOUTUBE_SCRIPT = 'youtube_script',
+  BRAND_INTERVIEW = 'brand_interview',
 }
 
 export enum AgentAutonomyMode {

--- a/packages/hooks/utils/use-brand-interview/index.ts
+++ b/packages/hooks/utils/use-brand-interview/index.ts
@@ -1,0 +1,1 @@
+export * from '@hooks/utils/use-brand-interview/use-brand-interview';

--- a/packages/hooks/utils/use-brand-interview/use-brand-interview.ts
+++ b/packages/hooks/utils/use-brand-interview/use-brand-interview.ts
@@ -1,0 +1,253 @@
+'use client';
+
+import type {
+  IBrandInterviewProgress,
+  IBrandInterviewQuestion,
+} from '@genfeedai/interfaces';
+import { logger } from '@genfeedai/services/core/logger.service';
+import {
+  BrandInterviewService,
+  type IActiveBrandInterview,
+} from '@genfeedai/services/social/brand-interview.service';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type BrandInterviewUiStatus = 'idle' | 'in_progress' | 'complete';
+
+export interface UseBrandInterviewReturn {
+  status: BrandInterviewUiStatus;
+  interviewId: string | null;
+  currentQuestion: IBrandInterviewQuestion | null;
+  progress: IBrandInterviewProgress | null;
+  completenessScore: number;
+  isLoading: boolean;
+  error: string | null;
+  startInterview: () => Promise<void>;
+  submitAnswer: (answer: string) => Promise<void>;
+  skipQuestion: () => Promise<void>;
+}
+
+export function useBrandInterview(
+  brandId: string | null | undefined,
+): UseBrandInterviewReturn {
+  const [status, setStatus] = useState<BrandInterviewUiStatus>('idle');
+  const [interviewId, setInterviewId] = useState<string | null>(null);
+  const [currentQuestion, setCurrentQuestion] =
+    useState<IBrandInterviewQuestion | null>(null);
+  const [progress, setProgress] = useState<IBrandInterviewProgress | null>(
+    null,
+  );
+  const [completenessScore, setCompletenessScore] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mountedRef = useRef(true);
+
+  const getInterviewService = useAuthedService((token: string) =>
+    BrandInterviewService.getInstance(token),
+  );
+
+  // Resume any active session on mount
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!brandId) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const checkActiveSession = async () => {
+      setIsLoading(true);
+
+      try {
+        const service = await getInterviewService();
+        const active: IActiveBrandInterview | null =
+          await service.getActiveInterview(brandId, controller.signal);
+
+        if (!mountedRef.current || controller.signal.aborted) {
+          return;
+        }
+
+        if (active && active.status === 'in_progress') {
+          setInterviewId(active.id);
+          setCurrentQuestion(active.currentQuestion);
+          setCompletenessScore(active.completenessScore);
+          setStatus('in_progress');
+          logger.info('Resumed active brand interview', { id: active.id });
+        }
+      } catch (err: unknown) {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const e = err as Error;
+
+        if (e?.name !== 'AbortError') {
+          logger.error('Failed to check active interview session', err);
+        }
+      } finally {
+        if (mountedRef.current && !controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    checkActiveSession();
+
+    return () => {
+      mountedRef.current = false;
+      controller.abort();
+    };
+  }, [brandId, getInterviewService]);
+
+  const startInterview = useCallback(async () => {
+    if (!brandId) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    const controller = new AbortController();
+
+    try {
+      const service = await getInterviewService();
+      const result = await service.startInterview(brandId, {
+        signal: controller.signal,
+      });
+
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setInterviewId(result.interviewId);
+      setCurrentQuestion(result.currentQuestion);
+      setProgress(result.progress);
+      setCompletenessScore(result.completenessScore);
+      setStatus(result.status === 'completed' ? 'complete' : 'in_progress');
+
+      logger.info('Started brand interview', {
+        id: result.interviewId,
+        creditsCharged: result.creditsCharged,
+      });
+    } catch (err: unknown) {
+      if (!mountedRef.current) {
+        return;
+      }
+
+      const e = err as Error;
+
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to start interview', err);
+        setError('Failed to start the interview. Please try again.');
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [brandId, getInterviewService]);
+
+  const submitAnswer = useCallback(
+    async (answer: string) => {
+      if (!interviewId) {
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const service = await getInterviewService();
+        const result = await service.submitAnswer(interviewId, answer);
+
+        if (!mountedRef.current) {
+          return;
+        }
+
+        setCurrentQuestion(result.nextQuestion);
+        setProgress(result.progress);
+        setCompletenessScore(result.completenessScore);
+        setStatus(result.isComplete ? 'complete' : 'in_progress');
+
+        logger.info('Submitted interview answer', {
+          id: result.interviewId,
+          isComplete: result.isComplete,
+        });
+      } catch (err: unknown) {
+        if (!mountedRef.current) {
+          return;
+        }
+
+        const e = err as Error;
+
+        if (e?.name !== 'AbortError') {
+          logger.error('Failed to submit interview answer', err);
+          setError('Failed to submit your answer. Please try again.');
+        }
+      } finally {
+        if (mountedRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [interviewId, getInterviewService],
+  );
+
+  const skipQuestion = useCallback(async () => {
+    if (!interviewId) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const service = await getInterviewService();
+      const result = await service.skipQuestion(interviewId);
+
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setCurrentQuestion(result.nextQuestion);
+      setProgress(result.progress);
+      setCompletenessScore(result.completenessScore);
+      setStatus(result.isComplete ? 'complete' : 'in_progress');
+
+      logger.info('Skipped interview question', {
+        id: result.interviewId,
+        isComplete: result.isComplete,
+      });
+    } catch (err: unknown) {
+      if (!mountedRef.current) {
+        return;
+      }
+
+      const e = err as Error;
+
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to skip interview question', err);
+        setError('Failed to skip the question. Please try again.');
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [interviewId, getInterviewService]);
+
+  return {
+    completenessScore,
+    currentQuestion,
+    error,
+    interviewId,
+    isLoading,
+    progress,
+    skipQuestion,
+    startInterview,
+    status,
+    submitAnswer,
+  };
+}

--- a/packages/interfaces/src/ai/agent-tool.interface.ts
+++ b/packages/interfaces/src/ai/agent-tool.interface.ts
@@ -85,6 +85,11 @@ export enum AgentToolName {
   SELECT_INGREDIENT = 'select_ingredient',
   // Campaign coordination tools
   REQUEST_ASSET = 'request_asset',
+  // Brand context interview tools
+  START_BRAND_INTERVIEW = 'start_brand_interview',
+  SUBMIT_BRAND_INTERVIEW_ANSWER = 'submit_brand_interview_answer',
+  SKIP_BRAND_INTERVIEW_QUESTION = 'skip_brand_interview_question',
+  GET_BRAND_COMPLETENESS = 'get_brand_completeness',
 }
 
 /** @deprecated Prefer canonical tool metadata from @genfeedai/tools. */

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -158,6 +158,7 @@ export * from './onboarding/onboarding.interface';
 export * from './onboarding/onboarding-journey.interface';
 export * from './onboarding/onboarding-wizard.interface';
 export * from './organization/brand.interface';
+export * from './organization/brand-interview.interface';
 export * from './organization/byok-key-entry.interface';
 export * from './organization/byok-provider-status.interface';
 export * from './organization/byok-resolution-result.interface';

--- a/packages/interfaces/src/organization/brand-interview.interface.ts
+++ b/packages/interfaces/src/organization/brand-interview.interface.ts
@@ -51,3 +51,19 @@ export interface IBrandInterviewCompleteness {
   interviewableGapCount: number;
   incompleteFieldKeys: string[];
 }
+
+/**
+ * Mapped shape returned by GET /brands/:brandId/interview/active.
+ * Derived from the raw Prisma BrandInterview row — currentFieldKey is resolved
+ * to a full IBrandInterviewQuestion and completenessBefore is surfaced as
+ * completenessScore so the resume hook gets a consistent contract.
+ */
+export interface IActiveBrandInterview {
+  id: string;
+  brandId: string;
+  status: BrandInterviewStatus;
+  currentQuestion: IBrandInterviewQuestion | null;
+  completenessScore: number;
+  answeredCount: number;
+  totalCount: number;
+}

--- a/packages/interfaces/src/organization/brand-interview.interface.ts
+++ b/packages/interfaces/src/organization/brand-interview.interface.ts
@@ -1,0 +1,53 @@
+/**
+ * Brand context interview — shared shapes for the deterministic interview engine
+ * and its three driver surfaces (in-app agent, MCP, settings stepper).
+ */
+
+export type BrandInterviewGroup = 'identity' | 'voice' | 'strategy';
+
+export type BrandInterviewAnswerType = 'text' | 'list' | 'enum';
+
+export type BrandInterviewStatus = 'in_progress' | 'completed' | 'abandoned';
+
+export interface IBrandInterviewQuestion {
+  fieldKey: string;
+  group: BrandInterviewGroup;
+  weight: number;
+  questionText: string;
+  hint?: string;
+  answerType: BrandInterviewAnswerType;
+  enumOptions?: string[];
+  examples?: string[];
+  isRequired: boolean;
+}
+
+export interface IBrandInterviewProgress {
+  totalFields: number;
+  answeredFields: number;
+  percentComplete: number;
+}
+
+export interface IBrandInterviewStartResult {
+  interviewId: string;
+  brandId: string;
+  status: BrandInterviewStatus;
+  currentQuestion: IBrandInterviewQuestion | null;
+  progress: IBrandInterviewProgress;
+  completenessScore: number;
+  creditsCharged: number;
+}
+
+export interface IBrandInterviewAnswerResult {
+  interviewId: string;
+  status: BrandInterviewStatus;
+  isComplete: boolean;
+  nextQuestion: IBrandInterviewQuestion | null;
+  progress: IBrandInterviewProgress;
+  completenessScore: number;
+}
+
+export interface IBrandInterviewCompleteness {
+  overallScore: number;
+  interviewableGapCount: number;
+  incompleteFieldKeys: string[];
+}

--- a/packages/interfaces/src/organization/index.ts
+++ b/packages/interfaces/src/organization/index.ts
@@ -1,4 +1,5 @@
 export * from './brand.interface';
+export * from './brand-interview.interface';
 export * from './byok-key-entry.interface';
 export * from './byok-provider-status.interface';
 export * from './byok-resolution-result.interface';

--- a/packages/prisma/prisma/migrations/20260628000000_add_brand_interview/migration.sql
+++ b/packages/prisma/prisma/migrations/20260628000000_add_brand_interview/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "brand_interview_status" AS ENUM ('in_progress', 'completed', 'abandoned');
+
+-- CreateTable
+CREATE TABLE "brand_interviews" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "brandId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" "brand_interview_status" NOT NULL DEFAULT 'in_progress',
+    "answeredFields" JSONB NOT NULL DEFAULT '{}',
+    "askedFieldKeys" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "currentFieldKey" TEXT,
+    "completenessBefore" INTEGER NOT NULL DEFAULT 0,
+    "completenessAfter" INTEGER,
+    "creditsCharged" INTEGER NOT NULL DEFAULT 0,
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "brand_interviews_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "brand_interviews_organizationId_isDeleted_idx" ON "brand_interviews"("organizationId", "isDeleted");
+
+-- CreateIndex
+CREATE INDEX "brand_interviews_brandId_status_idx" ON "brand_interviews"("brandId", "status");
+
+-- CreateIndex
+-- Partial unique index: at most one active (in-progress, non-deleted) interview per brand.
+-- Enforces idempotency of BrandInterviewService.start() at the DB level so concurrent
+-- starts cannot create two sessions / double-charge. Not expressible in the Prisma schema.
+CREATE UNIQUE INDEX "brand_interview_active_unique" ON "brand_interviews"("brandId") WHERE "status" = 'in_progress' AND "isDeleted" = false;
+
+-- AddForeignKey
+ALTER TABLE "brand_interviews" ADD CONSTRAINT "brand_interviews_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "brand_interviews" ADD CONSTRAINT "brand_interviews_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "brands"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "brand_interviews" ADD CONSTRAINT "brand_interviews_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -590,6 +590,7 @@ model User {
   captions                 Caption[]
   personaAssignments       Persona[]                 @relation("persona_assigned_members")
   mcpApprovals             McpApproval[]
+  brandInterviews          BrandInterview[]
 
   @@index([isDefault])
   @@index([appSource])
@@ -724,6 +725,7 @@ model Organization {
   creatorAnalyses               CreatorAnalysis[]
   mcpApprovals                  McpApproval[]
   moodBoards                    MoodBoard[]                    @relation("org_moodboard")
+  brandInterviews               BrandInterview[]
 
   @@index([isDefault])
   @@index([category])
@@ -849,10 +851,48 @@ model Brand {
   schedules                  Schedule[]
   bookmarks                  Bookmark[]
   moodBoard                  MoodBoard?                 @relation("brand_moodboard")
+  brandInterviews            BrandInterview[]
 
   @@index([isDefault])
   @@index([organizationId, isDeleted, label], map: "brands_org_deleted_label_idx")
   @@map("brands")
+}
+
+enum BrandInterviewStatus {
+  in_progress
+  completed
+  abandoned
+
+  @@map("brand_interview_status")
+}
+
+// Stateful brand-context interview session. Detects in-scope gaps (identity /
+// voice / strategy) via computeBrandCompleteness, asks one question per gap, and
+// writes answers back into the Brand. At most one active session per brand is
+// enforced by a partial unique index (status = 'in_progress', is_deleted = false)
+// added in the migration; the per-run credit charge happens once at session start.
+model BrandInterview {
+  id                 String               @id @default(cuid())
+  organizationId     String
+  organization       Organization         @relation(fields: [organizationId], references: [id])
+  brandId            String
+  brand              Brand                @relation(fields: [brandId], references: [id])
+  userId             String
+  user               User                 @relation(fields: [userId], references: [id])
+  status             BrandInterviewStatus @default(in_progress)
+  answeredFields     Json                 @default("{}")
+  askedFieldKeys     String[]             @default([])
+  currentFieldKey    String?
+  completenessBefore Int                  @default(0)
+  completenessAfter  Int?
+  creditsCharged     Int                  @default(0)
+  isDeleted          Boolean              @default(false)
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @updatedAt
+
+  @@index([organizationId, isDeleted])
+  @@index([brandId, status])
+  @@map("brand_interviews")
 }
 
 // One mood board per brand. `layout` stores only positions keyed by asset id

--- a/packages/services/social/brand-interview.service.ts
+++ b/packages/services/social/brand-interview.service.ts
@@ -1,0 +1,141 @@
+import { API_ENDPOINTS } from '@genfeedai/constants';
+import type {
+  BrandInterviewStatus,
+  IBrandInterviewAnswerResult,
+  IBrandInterviewCompleteness,
+  IBrandInterviewQuestion,
+  IBrandInterviewStartResult,
+} from '@genfeedai/interfaces';
+import { EnvironmentService } from '@services/core/environment.service';
+import { HTTPBaseService } from '@services/core/interceptor.service';
+import {
+  buildInstanceKey,
+  ServiceInstanceManager,
+} from '@services/core/service-instance-manager';
+
+const serviceInstances = new ServiceInstanceManager<BrandInterviewService>();
+
+/**
+ * Minimal shape of an active BrandInterview session as returned by the API.
+ * The full Prisma record is backend-only; the frontend only needs these fields.
+ */
+export interface IActiveBrandInterview {
+  id: string;
+  brandId: string;
+  status: BrandInterviewStatus;
+  currentQuestion: IBrandInterviewQuestion | null;
+  completenessScore: number;
+  answeredCount: number;
+  totalCount: number;
+}
+
+export interface StartInterviewOptions {
+  creditAmount?: number;
+  signal?: AbortSignal;
+}
+
+export class BrandInterviewService extends HTTPBaseService {
+  constructor(token: string) {
+    super(`${EnvironmentService.apiEndpoint}${API_ENDPOINTS.BRANDS}`, token);
+  }
+
+  public static getInstance(token: string): BrandInterviewService {
+    const instanceKey = buildInstanceKey([token]);
+    const cached = serviceInstances.get<BrandInterviewService>(
+      BrandInterviewService,
+      instanceKey,
+    );
+
+    if (
+      cached &&
+      Object.getPrototypeOf(cached) === BrandInterviewService.prototype
+    ) {
+      return cached;
+    }
+
+    const instance = new BrandInterviewService(token);
+    serviceInstances.set(BrandInterviewService, instanceKey, instance);
+
+    return instance;
+  }
+
+  public async startInterview(
+    brandId: string,
+    opts?: StartInterviewOptions,
+  ): Promise<IBrandInterviewStartResult> {
+    const body: { creditAmount?: number } = {};
+
+    if (opts?.creditAmount !== undefined) {
+      body.creditAmount = opts.creditAmount;
+    }
+
+    const response = await this.instance.post<IBrandInterviewStartResult>(
+      `/${brandId}/interview`,
+      body,
+      { signal: opts?.signal },
+    );
+
+    return response.data;
+  }
+
+  public async getActiveInterview(
+    brandId: string,
+    signal?: AbortSignal,
+  ): Promise<IActiveBrandInterview | null> {
+    try {
+      const response = await this.instance.get<IActiveBrandInterview | null>(
+        `/${brandId}/interview/active`,
+        { signal },
+      );
+
+      return response.data;
+    } catch (err: unknown) {
+      const httpErr = err as { response?: { status?: number } };
+
+      if (httpErr?.response?.status === 404) {
+        return null;
+      }
+
+      throw err;
+    }
+  }
+
+  public async submitAnswer(
+    interviewId: string,
+    answer: string,
+    signal?: AbortSignal,
+  ): Promise<IBrandInterviewAnswerResult> {
+    const response = await this.instance.post<IBrandInterviewAnswerResult>(
+      `/interview/${interviewId}/answer`,
+      { answer },
+      { signal },
+    );
+
+    return response.data;
+  }
+
+  public async skipQuestion(
+    interviewId: string,
+    signal?: AbortSignal,
+  ): Promise<IBrandInterviewAnswerResult> {
+    const response = await this.instance.post<IBrandInterviewAnswerResult>(
+      `/interview/${interviewId}/skip`,
+      {},
+      { signal },
+    );
+
+    return response.data;
+  }
+
+  public async getCompleteness(
+    brandId: string,
+    signal?: AbortSignal,
+  ): Promise<IBrandInterviewCompleteness> {
+    const response = await this.instance.get<IBrandInterviewCompleteness>(
+      `/${brandId}/completeness`,
+      { signal },
+    );
+
+    return response.data;
+  }
+}

--- a/packages/services/social/brand-interview.service.ts
+++ b/packages/services/social/brand-interview.service.ts
@@ -1,9 +1,8 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type {
-  BrandInterviewStatus,
+  IActiveBrandInterview,
   IBrandInterviewAnswerResult,
   IBrandInterviewCompleteness,
-  IBrandInterviewQuestion,
   IBrandInterviewStartResult,
 } from '@genfeedai/interfaces';
 import { EnvironmentService } from '@services/core/environment.service';
@@ -13,24 +12,11 @@ import {
   ServiceInstanceManager,
 } from '@services/core/service-instance-manager';
 
+export type { IActiveBrandInterview };
+
 const serviceInstances = new ServiceInstanceManager<BrandInterviewService>();
 
-/**
- * Minimal shape of an active BrandInterview session as returned by the API.
- * The full Prisma record is backend-only; the frontend only needs these fields.
- */
-export interface IActiveBrandInterview {
-  id: string;
-  brandId: string;
-  status: BrandInterviewStatus;
-  currentQuestion: IBrandInterviewQuestion | null;
-  completenessScore: number;
-  answeredCount: number;
-  totalCount: number;
-}
-
 export interface StartInterviewOptions {
-  creditAmount?: number;
   signal?: AbortSignal;
 }
 
@@ -63,15 +49,9 @@ export class BrandInterviewService extends HTTPBaseService {
     brandId: string,
     opts?: StartInterviewOptions,
   ): Promise<IBrandInterviewStartResult> {
-    const body: { creditAmount?: number } = {};
-
-    if (opts?.creditAmount !== undefined) {
-      body.creditAmount = opts.creditAmount;
-    }
-
     const response = await this.instance.post<IBrandInterviewStartResult>(
       `/${brandId}/interview`,
-      body,
+      {},
       { signal: opts?.signal },
     );
 

--- a/packages/tools/src/registry/source/brand-interview.tools.ts
+++ b/packages/tools/src/registry/source/brand-interview.tools.ts
@@ -1,0 +1,90 @@
+import type { SourceTool } from '../../interfaces/source-tool.interface.js';
+
+/**
+ * Brand context interview tools.
+ *
+ * Credit billing note: start_brand_interview charges 10 credits once inside the
+ * engine (BrandInterviewService.start). These tool definitions carry creditCost:0
+ * so the orchestrator never double-bills a per-turn charge on top.
+ */
+export const BRAND_INTERVIEW_TOOLS: SourceTool[] = [
+  {
+    creditCost: 0,
+    description:
+      'Start a brand context interview for the given brand. Charges 10 credits once (idempotent — resuming an active session does not re-charge). Returns the first question to ask the user, plus progress and completeness info.',
+    name: 'start_brand_interview',
+    parameters: {
+      properties: {
+        brandId: {
+          description: 'ID of the brand to run the context interview for.',
+          type: 'string',
+        },
+      },
+      required: ['brandId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: true, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description:
+      "Submit the user's answer to the current interview question. Pass the interviewId from start_brand_interview. Returns the next question (if any) and updated progress.",
+    name: 'submit_brand_interview_answer',
+    parameters: {
+      properties: {
+        answer: {
+          description:
+            "The user's exact answer text to record for this question.",
+          type: 'string',
+        },
+        interviewId: {
+          description:
+            'The interview session ID returned by start_brand_interview.',
+          type: 'string',
+        },
+      },
+      required: ['interviewId', 'answer'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: true, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description:
+      "Skip the current interview question (e.g. the user doesn't know or wants to skip). Returns the next question and updated progress.",
+    name: 'skip_brand_interview_question',
+    parameters: {
+      properties: {
+        interviewId: {
+          description:
+            'The interview session ID returned by start_brand_interview.',
+          type: 'string',
+        },
+      },
+      required: ['interviewId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: true, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description:
+      'Get the current brand context completeness score and a list of fields that still have gaps. Read-only, no credits charged.',
+    name: 'get_brand_completeness',
+    parameters: {
+      properties: {
+        brandId: {
+          description: 'ID of the brand to check completeness for.',
+          type: 'string',
+        },
+      },
+      required: ['brandId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: true, mcp: true },
+  },
+];

--- a/packages/tools/src/registry/source/index.ts
+++ b/packages/tools/src/registry/source/index.ts
@@ -1,5 +1,6 @@
 import type { SourceTool } from '../../interfaces/source-tool.interface.js';
 import { AGENT_ONLY_TOOLS } from './agent-only/index.js';
+import { BRAND_INTERVIEW_TOOLS } from './brand-interview.tools.js';
 import { MCP_ONLY_TOOLS } from './mcp-only/index.js';
 import { OVERLAP_TOOLS } from './overlap.tools.js';
 
@@ -7,4 +8,5 @@ export const SOURCE_TOOLS: SourceTool[] = [
   ...OVERLAP_TOOLS,
   ...AGENT_ONLY_TOOLS,
   ...MCP_ONLY_TOOLS,
+  ...BRAND_INTERVIEW_TOOLS,
 ];

--- a/packages/ui/src/components/cards/brand-completeness-card/BrandCompletenessCard.tsx
+++ b/packages/ui/src/components/cards/brand-completeness-card/BrandCompletenessCard.tsx
@@ -154,6 +154,22 @@ export default function BrandCompletenessCard({
       <p className="mt-3 text-[10px] text-white/25 leading-relaxed">
         Filling in brand context improves AI content quality.
       </p>
+
+      {/* Interview me shortcut — only shown when there are interviewable gaps */}
+      {result.groups.some(
+        (g) => g.key !== 'visual' && g.fields.some((f) => !f.isComplete),
+      ) && (
+        <div className="mt-2 pt-2 border-t border-white/[0.06]">
+          <Button variant={ButtonVariant.UNSTYLED} withWrapper={false}>
+            <Link
+              href={href('/settings/interview')}
+              className="text-[11px] text-primary/70 hover:text-primary transition-colors duration-150"
+            >
+              Interview me to fill gaps →
+            </Link>
+          </Button>
+        </div>
+      )}
     </Card>
   );
 }

--- a/playwright/e2e/tests/settings/brand-interview.spec.ts
+++ b/playwright/e2e/tests/settings/brand-interview.spec.ts
@@ -1,0 +1,247 @@
+import type { Route } from '@playwright/test';
+
+import { mockActiveSubscription } from '../../fixtures/api-mocks.fixture';
+import { expect, test } from '../../fixtures/auth.fixture';
+import {
+  testBrands,
+  testOrganizations,
+} from '../../fixtures/test-data.fixture';
+
+/**
+ * E2E Tests for the Brand Context Interview stepper (settings surface).
+ *
+ * CRITICAL: All API calls are mocked — no real backend requests occur.
+ * The interview REST endpoints return PLAIN JSON (not JSON:API), matching the
+ * BrandInterviewService frontend client.
+ *
+ * Tests are skipped (not failed) if Better Auth mocking fails to keep the user
+ * authenticated, so we never get a false-green that passes without auth.
+ */
+
+const brand = testBrands[0];
+const org = testOrganizations.default ?? Object.values(testOrganizations)[0];
+const interviewUrl = `/${org.slug}/${brand.slug}/settings/interview`;
+const AUTH_SKIP_MSG =
+  'Auth mocking did not prevent login redirect — fix Better Auth auth mocking';
+
+const toneQuestion = {
+  answerType: 'text',
+  fieldKey: 'tone',
+  group: 'voice',
+  isRequired: true,
+  questionText: 'How would you describe your brand tone of voice?',
+  weight: 0.35,
+};
+
+const audienceQuestion = {
+  answerType: 'list',
+  fieldKey: 'audience',
+  group: 'voice',
+  hint: 'Comma or newline separated',
+  isRequired: true,
+  questionText: 'Who is your target audience?',
+  weight: 0.35,
+};
+
+async function mockBrandResolution(route: Route): Promise<void> {
+  await route.fulfill({
+    contentType: 'application/json',
+    status: 200,
+    body: JSON.stringify({
+      data: {
+        attributes: {
+          description: brand.description,
+          name: brand.name,
+          slug: brand.slug,
+        },
+        id: brand.id,
+        type: 'brands',
+      },
+    }),
+  });
+}
+
+test.describe('Brand Context Interview (settings stepper)', () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await mockActiveSubscription(authenticatedPage, {
+      credits: 1000,
+      plan: 'pro',
+    });
+
+    // Resolve the brand so the page can derive brandId.
+    await authenticatedPage.route(
+      `**/api.genfeed.ai/**/brands/${brand.id}**`,
+      mockBrandResolution,
+    );
+    await authenticatedPage.route(
+      '**/api.genfeed.ai/**/brands?**',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          status: 200,
+          body: JSON.stringify({
+            data: [
+              {
+                attributes: { name: brand.name, slug: brand.slug },
+                id: brand.id,
+                type: 'brands',
+              },
+            ],
+          }),
+        });
+      },
+    );
+
+    // No active interview on entry.
+    await authenticatedPage.route(
+      '**/api.genfeed.ai/**/brands/**/interview/active',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          status: 200,
+          body: 'null',
+        });
+      },
+    );
+
+    // Completeness: three interviewable gaps so the stepper has work to do.
+    await authenticatedPage.route(
+      '**/api.genfeed.ai/**/brands/**/completeness',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          status: 200,
+          body: JSON.stringify({
+            incompleteFieldKeys: ['tone', 'audience', 'goals'],
+            interviewableGapCount: 3,
+            overallScore: 40,
+          }),
+        });
+      },
+    );
+  });
+
+  test('starts an interview and shows the first question', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.route(
+      '**/api.genfeed.ai/**/brands/**/interview',
+      async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        await route.fulfill({
+          contentType: 'application/json',
+          status: 201,
+          body: JSON.stringify({
+            brandId: brand.id,
+            completenessScore: 40,
+            creditsCharged: 10,
+            currentQuestion: toneQuestion,
+            interviewId: 'interview_1',
+            progress: {
+              answeredFields: 0,
+              percentComplete: 0,
+              totalFields: 13,
+            },
+            status: 'in_progress',
+          }),
+        });
+      },
+    );
+
+    await authenticatedPage.goto(interviewUrl);
+    test.skip(authenticatedPage.url().includes('/login'), AUTH_SKIP_MSG);
+
+    // Credit disclosure is visible before starting.
+    await expect(authenticatedPage.getByText(/10 credits/i)).toBeVisible();
+
+    await authenticatedPage
+      .getByRole('button', { name: /start interview/i })
+      .click();
+
+    await expect(
+      authenticatedPage.getByText(toneQuestion.questionText),
+    ).toBeVisible();
+  });
+
+  test('submits an answer and advances, then completes', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.route(
+      '**/api.genfeed.ai/**/brands/**/interview',
+      async (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        await route.fulfill({
+          contentType: 'application/json',
+          status: 201,
+          body: JSON.stringify({
+            brandId: brand.id,
+            completenessScore: 40,
+            creditsCharged: 10,
+            currentQuestion: toneQuestion,
+            interviewId: 'interview_1',
+            progress: {
+              answeredFields: 0,
+              percentComplete: 0,
+              totalFields: 13,
+            },
+            status: 'in_progress',
+          }),
+        });
+      },
+    );
+
+    let answerCalls = 0;
+    await authenticatedPage.route(
+      '**/api.genfeed.ai/**/brands/interview/**/answer',
+      async (route) => {
+        answerCalls += 1;
+        const isComplete = answerCalls >= 2;
+        await route.fulfill({
+          contentType: 'application/json',
+          status: 201,
+          body: JSON.stringify({
+            completenessScore: isComplete ? 75 : 55,
+            interviewId: 'interview_1',
+            isComplete,
+            nextQuestion: isComplete ? null : audienceQuestion,
+            progress: {
+              answeredFields: answerCalls,
+              percentComplete: isComplete ? 100 : 50,
+              totalFields: 13,
+            },
+            status: isComplete ? 'completed' : 'in_progress',
+          }),
+        });
+      },
+    );
+
+    await authenticatedPage.goto(interviewUrl);
+    test.skip(authenticatedPage.url().includes('/login'), AUTH_SKIP_MSG);
+
+    await authenticatedPage
+      .getByRole('button', { name: /start interview/i })
+      .click();
+    await expect(
+      authenticatedPage.getByText(toneQuestion.questionText),
+    ).toBeVisible();
+
+    // Answer the first question → advances to the audience question.
+    await authenticatedPage
+      .getByRole('textbox')
+      .first()
+      .fill('Bold, witty, and direct');
+    await authenticatedPage.getByRole('button', { name: /submit/i }).click();
+    await expect(
+      authenticatedPage.getByText(audienceQuestion.questionText),
+    ).toBeVisible();
+
+    // Answer the second question → completes the interview.
+    await authenticatedPage
+      .getByRole('textbox')
+      .first()
+      .fill('Founders, indie hackers');
+    await authenticatedPage.getByRole('button', { name: /submit/i }).click();
+
+    await expect(authenticatedPage.getByText(/complete/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What & why

Brand context (\"Brand OS\") lives in \`Brand.agentConfig\` + identity columns and was previously fillable only via forms or onboarding scraping. This adds the ability for a user — **or an external AI via MCP** — to be **interviewed** to fill the gaps: the app detects which in-scope context pieces are missing/unclear and asks targeted questions one at a time, writing answers back into the real brand context.

No prior issue covered this elicitation mechanic (closest: #812 Brand OS Funnel, which this complements).

## Architecture

A single **server-side deterministic interview engine** (`BrandInterviewService`) is the source of truth — gap detection via the existing `computeBrandCompleteness`, an ordered question catalog, answer normalization, read-modify-write into `agentConfig`, and session persistence (`BrandInterview` model). Three thin surfaces drive it:

| Surface | How |
|---|---|
| **In-app agent chat** | `AgentType.BRAND_INTERVIEW` + facilitator system prompt + 4 tools wrapping the engine. Offer/complete cards in the chat timeline. |
| **MCP** | The same tools surfaced via the existing `/agent-tools/:name/execute` proxy (no custom handler); mutating tools are approval-gated. |
| **Settings page** | A deterministic stepper at `/[orgSlug]/[brandSlug]/settings/interview` (new Interview tab) + an \"Interview me\" entry on the completeness card. |

**Scope:** identity (description, brand system-prompt) + voice (tone, style, audience, values, messaging pillars, sample output, anti-examples) + strategy (goals, content types, platforms, frequency). Visual fields (logo/colors) are intentionally excluded — they need upload UI a chat can't drive.

## Credits

A single **per-run charge (10 credits)** at `start()` — the one chokepoint all three surfaces pass through. The agent surface's per-turn model billing is **bypassed** for this agent type so the interview isn't double-billed. Charging **auto-no-ops in community/OSS mode** via the existing credits DI swap — community just works, free.

## Correctness highlights

- **Idempotent start:** at most one active interview per brand, enforced by a DB partial unique index + `P2002` handling; re-entry resumes without re-charging; compensating soft-delete if the post-create credit deduction fails.
- **Sibling-safe writes:** the engine read-modify-writes each `agentConfig` group rather than using the shallow-merging `updateAgentConfig`, so answering one voice field never wipes the others. Identity fields write to the Brand row.
- **\"Complete\" = no in-scope gaps remain** (not overallScore === 100, which visual gaps make unreachable).
- **No fabrication:** the agent prompt forbids inventing answers; the server owns answer normalization (list-splitting, enum validation).

## Tests

16 engine unit tests · 5 executor · 2 orchestrator (prompt resolution + turn-billing bypass) · 11 frontend (stepper) · 1 settings E2E spec. Full workspace type-check green; biome clean.

## Migration

Adds `brand_interviews` + the `brand_interview_status` enum + the partial unique index (`packages/prisma/prisma/migrations/20260628000000_add_brand_interview`). Applied via the normal migrate step in CI/deploy.

Related: #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)