### PR TITLE
feat(content): add GEO optimizer

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,0 +1,29 @@
+# Genfeed.ai Docs
+
+> Technical documentation for Genfeed.ai, the open source AI OS for content creation.
+
+## Core
+
+- [Getting Started](https://docs.genfeed.ai/getting-started): Install and run Genfeed.
+- [Installation](https://docs.genfeed.ai/core/installation): Community and self-host setup.
+- [Configuration](https://docs.genfeed.ai/core/configuration): Environment, providers, and runtime settings.
+- [Self-hosted vs Cloud](https://docs.genfeed.ai/core/self-hosted-vs-cloud): Deployment mode boundaries.
+
+## API And Operations
+
+- [API Reference](https://docs.genfeed.ai/api-reference): Genfeed API reference.
+- [Provider Registry](https://docs.genfeed.ai/core/provider-registry): AI provider setup.
+- [Execution Boundaries](https://docs.genfeed.ai/core/execution-boundaries): Local, hosted, and managed execution.
+- [Production Readiness](https://docs.genfeed.ai/deployment/production-readiness): Deployment checks and release operations.
+
+## Content Loop
+
+- [Agent Orchestration](https://docs.genfeed.ai/core-loop/agent-orchestration): Agent and workflow execution model.
+- [Trend Ingestion](https://docs.genfeed.ai/core-loop/trend-ingestion): Reference and trend ingestion.
+- [Corpus Health](https://docs.genfeed.ai/core-loop/corpus-health): Corpus freshness and diagnostics.
+- [Prelaunch Corpus Backfill](https://docs.genfeed.ai/core-loop/prelaunch-corpus-backfill): Launch corpus preparation.
+
+## Optional
+
+- [Guides](https://docs.genfeed.ai/guides): Prompting, self-hosting, and workflow guides.
+- [Features](https://docs.genfeed.ai/features): Product capability overview.

--- a/apps/server/api/src/services/skill-executor/handlers/content-geo-optimizer.handler.spec.ts
+++ b/apps/server/api/src/services/skill-executor/handlers/content-geo-optimizer.handler.spec.ts
@@ -1,0 +1,145 @@
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import { ContentGeoOptimizerHandler } from '@api/services/skill-executor/handlers/content-geo-optimizer.handler';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ContentGeoOptimizerHandler', () => {
+  let handler: ContentGeoOptimizerHandler;
+
+  const mockLlmDispatcherService = {
+    chatCompletion: vi.fn(),
+  };
+
+  const mockLoggerService = {
+    warn: vi.fn(),
+  };
+
+  const baseContext = {
+    brandId: 'brand-id',
+    brandVoice: 'Evidence-led and plainspoken',
+    organizationId: 'org-id',
+    platforms: ['blog'],
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContentGeoOptimizerHandler,
+        { provide: LlmDispatcherService, useValue: mockLlmDispatcherService },
+        { provide: LoggerService, useValue: mockLoggerService },
+      ],
+    }).compile();
+
+    handler = module.get(ContentGeoOptimizerHandler);
+  });
+
+  it('returns a GEO scorecard and FAQ JSON-LD with LLM rewrite output', async () => {
+    mockLlmDispatcherService.chatCompletion.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              rewrittenContent:
+                '## Direct answer\n\nGEO-ready content gives answer engines short, source-backed answer blocks.',
+              suggestions: ['Add author credentials.'],
+            }),
+            role: 'assistant',
+          },
+        },
+      ],
+    });
+
+    const result = await handler.execute(baseContext, {
+      content:
+        '## How does GEO work?\n\nGEO-ready content gives answer engines concise answers in 2026. https://example.com/source',
+      faq: [
+        {
+          answer: 'Use concise answer blocks and source URLs.',
+          question: 'How do I optimize for answer engines?',
+        },
+      ],
+      sources: ['https://example.com/source'],
+      title: 'GEO Optimization Guide',
+      url: 'https://example.com/geo',
+    });
+
+    expect(result.skillSlug).toBe('content-geo-optimizer');
+    expect(result.type).toBe('text');
+    expect(result.content).toContain('## Direct answer');
+    expect(result.metadata.llmApplied).toBe(true);
+    expect(result.metadata.schemaType).toBe('FAQPage');
+    expect(result.metadata.geoScorecard).toMatchObject({
+      rating: expect.any(String),
+      score: expect.any(Number),
+    });
+    expect(result.metadata.jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        expect.objectContaining({
+          '@type': 'Question',
+          name: 'How do I optimize for answer engines?',
+        }),
+      ],
+    });
+  });
+
+  it('falls back deterministically and emits Article JSON-LD when the LLM fails', async () => {
+    mockLlmDispatcherService.chatCompletion.mockRejectedValue(
+      new Error('provider unavailable'),
+    );
+
+    const result = await handler.execute(baseContext, {
+      authorName: 'Genfeed',
+      content: 'GEO content should answer the user clearly. It needs sources.',
+      datePublished: '2026-06-28',
+      title: 'GEO Content',
+    });
+
+    expect(result.content).toContain('## Direct answer: GEO Content');
+    expect(result.metadata.llmApplied).toBe(false);
+    expect(result.metadata.schemaType).toBe('Article');
+    expect(result.metadata.jsonLd).toMatchObject({
+      '@type': 'Article',
+      author: { '@type': 'Person', name: 'Genfeed' },
+      headline: 'GEO Content',
+    });
+    expect(mockLoggerService.warn).toHaveBeenCalledWith(
+      'content-geo-optimizer LLM call failed, using fallback',
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+
+  it('emits HowTo JSON-LD for step-based GEO output', async () => {
+    mockLlmDispatcherService.chatCompletion.mockResolvedValue({
+      choices: [{ message: { content: '{}', role: 'assistant' } }],
+    });
+
+    const result = await handler.execute(baseContext, {
+      content: 'Step-by-step answer engine optimization.',
+      steps: ['Write a direct answer.', 'Add JSON-LD.'],
+      title: 'Optimize for answer engines',
+    });
+
+    expect(result.metadata.schemaType).toBe('HowTo');
+    expect(result.metadata.jsonLd).toMatchObject({
+      '@type': 'HowTo',
+      step: [
+        expect.objectContaining({
+          position: 1,
+          text: 'Write a direct answer.',
+        }),
+        expect.objectContaining({ position: 2, text: 'Add JSON-LD.' }),
+      ],
+    });
+  });
+
+  it('requires source content', async () => {
+    await expect(handler.execute(baseContext, {})).rejects.toThrow(
+      'content-geo-optimizer requires content',
+    );
+  });
+});

--- a/apps/server/api/src/services/skill-executor/handlers/content-geo-optimizer.handler.ts
+++ b/apps/server/api/src/services/skill-executor/handlers/content-geo-optimizer.handler.ts
@@ -1,0 +1,517 @@
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import {
+  type ContentDraft,
+  type SkillExecutionContext,
+  type SkillHandler,
+} from '@api/services/skill-executor/interfaces/skill-executor.interfaces';
+import {
+  buildArticleJsonLd,
+  buildFaqJsonLd,
+  buildHowToJsonLd,
+  type JsonLdValue,
+} from '@helpers/content/schema-org.helper';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+const GEO_SKILL_SLUG = 'content-geo-optimizer';
+const DEFAULT_MODEL = 'openai/gpt-4o-mini';
+const TRUSTED_GEO_MODELS = new Set([
+  'anthropic/claude-sonnet-4.5',
+  'openai/gpt-4o',
+  'openai/gpt-4o-mini',
+  'x-ai/grok-4-fast',
+]);
+
+interface GeoDimensionScore {
+  finding: string;
+  id: string;
+  label: string;
+  max: number;
+  score: number;
+}
+
+interface GeoScorecard {
+  dimensions: GeoDimensionScore[];
+  evidence: string[];
+  rating: 'excellent' | 'good' | 'needs_work' | 'poor';
+  schemaTypes: string[];
+  score: number;
+  suggestions: string[];
+}
+
+interface GeoLlmResult {
+  rewrittenContent?: string;
+  suggestions?: string[];
+}
+
+interface FaqParam {
+  answer: string;
+  question: string;
+}
+
+interface HowToStepParam {
+  name?: string;
+  text: string;
+}
+
+@Injectable()
+export class ContentGeoOptimizerHandler implements SkillHandler {
+  constructor(
+    private readonly llmDispatcherService: LlmDispatcherService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  async execute(
+    context: SkillExecutionContext,
+    params: Record<string, unknown>,
+  ): Promise<ContentDraft> {
+    const sourceContent = this.resolveContent(params);
+    if (!sourceContent) {
+      throw new Error(`${GEO_SKILL_SLUG} requires content`);
+    }
+
+    const title = this.getString(params.title) ?? 'Generated content';
+    const sources = this.getStringArray(params.sources);
+    const questions = this.getFaqParams(params.questions ?? params.faq);
+    const steps = this.getHowToSteps(params.steps);
+    const scorecard = this.buildGeoScorecard(sourceContent, {
+      questions,
+      sources,
+      steps,
+      title,
+    });
+
+    const fallbackContent = this.buildFallbackRewrite(
+      sourceContent,
+      title,
+      sources,
+    );
+    const llmResult = await this.runLlmRewrite(
+      context,
+      params,
+      sourceContent,
+      scorecard,
+    );
+    const rewrittenContent =
+      llmResult?.rewrittenContent?.trim() || fallbackContent;
+    const jsonLd = this.buildJsonLd(params, {
+      content: rewrittenContent,
+      questions,
+      steps,
+      title,
+    });
+
+    const suggestions = this.dedupe([
+      ...(llmResult?.suggestions ?? []),
+      ...scorecard.suggestions,
+    ]).slice(0, 8);
+
+    return {
+      confidence: scorecard.score >= 75 ? 0.84 : 0.68,
+      content: rewrittenContent,
+      metadata: {
+        geoScorecard: {
+          ...scorecard,
+          suggestions,
+        },
+        jsonLd,
+        llmApplied: Boolean(llmResult?.rewrittenContent),
+        schemaType: jsonLd['@type'],
+        sources,
+      },
+      platforms: context.platforms,
+      skillSlug: GEO_SKILL_SLUG,
+      type: 'text',
+    };
+  }
+
+  private async runLlmRewrite(
+    context: SkillExecutionContext,
+    params: Record<string, unknown>,
+    sourceContent: string,
+    scorecard: GeoScorecard,
+  ): Promise<GeoLlmResult | null> {
+    try {
+      const response = await this.llmDispatcherService.chatCompletion(
+        {
+          max_tokens: 1400,
+          messages: [
+            {
+              content:
+                'You optimize long-form content for generative answer engines. Return only JSON.',
+              role: 'system',
+            },
+            {
+              content: this.buildLlmPrompt(context, sourceContent, scorecard),
+              role: 'user',
+            },
+          ],
+          model: this.resolveModel(params.model),
+          temperature: 0.3,
+        },
+        context.organizationId,
+      );
+
+      const content = response.choices[0]?.message?.content;
+      if (!content) {
+        return null;
+      }
+
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return null;
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as GeoLlmResult;
+      return {
+        rewrittenContent: this.getString(parsed.rewrittenContent),
+        suggestions: this.getStringArray(parsed.suggestions),
+      };
+    } catch (error: unknown) {
+      this.loggerService.warn(
+        `${GEO_SKILL_SLUG} LLM call failed, using fallback`,
+        {
+          error,
+        },
+      );
+      return null;
+    }
+  }
+
+  private buildLlmPrompt(
+    context: SkillExecutionContext,
+    sourceContent: string,
+    scorecard: GeoScorecard,
+  ): string {
+    const weakFindings = scorecard.dimensions
+      .filter((dimension) => dimension.score < dimension.max)
+      .map((dimension) => `- ${dimension.label}: ${dimension.finding}`)
+      .join('\n');
+
+    return [
+      'Rewrite the content so ChatGPT, Perplexity, Claude, Google AI Overviews, and other answer engines can extract and cite it.',
+      'Return this exact JSON shape: {"rewrittenContent":"...","suggestions":["..."]}',
+      'Rules:',
+      '- Start with a direct answer block.',
+      '- Use question-led headings where natural.',
+      '- Preserve factual meaning and brand voice.',
+      '- Add source/citation placeholders only when the input provides source URLs.',
+      '- Do not invent facts, statistics, sources, dates, or quotes.',
+      `Brand voice: ${context.brandVoice || 'clear, useful, and evidence-led'}.`,
+      weakFindings ? `Weak GEO findings:\n${weakFindings}` : null,
+      `Content:\n${sourceContent.slice(0, 12000)}`,
+    ]
+      .filter((line): line is string => typeof line === 'string')
+      .join('\n\n');
+  }
+
+  private buildGeoScorecard(
+    content: string,
+    options: {
+      questions: FaqParam[];
+      sources: string[];
+      steps: HowToStepParam[];
+      title: string;
+    },
+  ): GeoScorecard {
+    const plainText = this.stripHtml(content);
+    const questionHeadingCount = (
+      content.match(
+        /(?:^|\n)\s*#{2,3}\s+(?:what|how|why|when|where|who|can|should|does|is|are)\b/gi,
+      ) ?? []
+    ).length;
+    const linkCount = (content.match(/https?:\/\//gi) ?? []).length;
+    const hasJsonLd = /application\/ld\+json|schema\.org/i.test(content);
+    const hasFreshness =
+      /\b(?:20\d{2}|updated|last modified|published)\b/i.test(content);
+    const sentences = plainText.split(/(?<=[.!?])\s+/).filter(Boolean);
+    const conciseSentences = sentences.filter((sentence) => {
+      const words = sentence.split(/\s+/).filter(Boolean).length;
+      return words >= 8 && words <= 35;
+    }).length;
+    const conciseRatio =
+      sentences.length > 0 ? conciseSentences / sentences.length : 0;
+    const titleTerms = options.title
+      .split(/\s+/)
+      .filter((term) => /^[A-Z][a-z0-9-]+/.test(term));
+
+    const dimensions: GeoDimensionScore[] = [
+      {
+        finding:
+          questionHeadingCount > 0
+            ? 'Question-led headings are present.'
+            : 'Add question-led H2/H3 headings that match answer-engine prompts.',
+        id: 'question_led_headings',
+        label: 'Question-led headings',
+        max: 18,
+        score:
+          questionHeadingCount >= 2 ? 18 : questionHeadingCount === 1 ? 12 : 4,
+      },
+      {
+        finding:
+          conciseRatio >= 0.6
+            ? 'Most sentences are extractable answer-length statements.'
+            : 'Use more concise answer blocks that can be quoted independently.',
+        id: 'extractable_answers',
+        label: 'Extractable answer blocks',
+        max: 20,
+        score: Math.round(Math.min(1, conciseRatio) * 20),
+      },
+      {
+        finding:
+          options.sources.length + linkCount >= 2
+            ? 'Source signals are available for attribution.'
+            : 'Add source URLs or citations for factual claims.',
+        id: 'source_attribution',
+        label: 'Source attribution',
+        max: 17,
+        score:
+          options.sources.length + linkCount >= 3
+            ? 17
+            : options.sources.length + linkCount >= 1
+              ? 10
+              : 2,
+      },
+      {
+        finding:
+          titleTerms.length > 0
+            ? 'Named entities are identifiable from title and copy.'
+            : 'Name the product, brand, entities, and topic explicitly.',
+        id: 'entity_clarity',
+        label: 'Entity clarity',
+        max: 15,
+        score: titleTerms.length >= 2 ? 15 : titleTerms.length === 1 ? 11 : 5,
+      },
+      {
+        finding:
+          hasJsonLd || options.questions.length > 0 || options.steps.length > 0
+            ? 'Structured-data candidates are present.'
+            : 'Add Article, FAQ, or HowTo JSON-LD for the generated content.',
+        id: 'schema_readiness',
+        label: 'Schema readiness',
+        max: 15,
+        score:
+          hasJsonLd || options.questions.length > 0 || options.steps.length > 0
+            ? 15
+            : 6,
+      },
+      {
+        finding: hasFreshness
+          ? 'Freshness signals are visible.'
+          : 'Add a published, updated, or current-year context signal.',
+        id: 'freshness',
+        label: 'Freshness signals',
+        max: 15,
+        score: hasFreshness ? 15 : 5,
+      },
+    ];
+
+    const score = dimensions.reduce(
+      (total, dimension) => total + dimension.score,
+      0,
+    );
+    return {
+      dimensions,
+      evidence: [
+        `${sentences.length} sentences inspected`,
+        `${questionHeadingCount} question-led headings`,
+        `${options.sources.length + linkCount} source signals`,
+      ],
+      rating:
+        score >= 85
+          ? 'excellent'
+          : score >= 70
+            ? 'good'
+            : score >= 45
+              ? 'needs_work'
+              : 'poor',
+      schemaTypes: this.resolveSchemaTypes(options.questions, options.steps),
+      score,
+      suggestions: dimensions
+        .filter((dimension) => dimension.score < dimension.max)
+        .map((dimension) => dimension.finding),
+    };
+  }
+
+  private buildFallbackRewrite(
+    sourceContent: string,
+    title: string,
+    sources: string[],
+  ): string {
+    const plainText = this.stripHtml(sourceContent);
+    const directAnswer =
+      this.firstSentence(plainText) || plainText.slice(0, 220);
+    const sourceSection =
+      sources.length > 0
+        ? ['## Sources', ...sources.map((source) => `- ${source}`)].join('\n')
+        : '';
+
+    return [
+      `## Direct answer: ${title}`,
+      directAnswer,
+      '## Citation-ready explanation',
+      sourceContent.trim(),
+      sourceSection,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+  }
+
+  private buildJsonLd(
+    params: Record<string, unknown>,
+    input: {
+      content: string;
+      questions: FaqParam[];
+      steps: HowToStepParam[];
+      title: string;
+    },
+  ): Record<string, JsonLdValue> {
+    const url = this.getString(params.url);
+    const description =
+      this.getString(params.description) ??
+      this.firstSentence(this.stripHtml(input.content));
+
+    if (input.steps.length > 0) {
+      return buildHowToJsonLd({
+        description,
+        name: input.title,
+        steps: input.steps,
+        url,
+      });
+    }
+
+    if (input.questions.length > 0) {
+      return buildFaqJsonLd({
+        items: input.questions,
+        name: input.title,
+        url,
+      });
+    }
+
+    return buildArticleJsonLd({
+      author: this.getString(params.authorName),
+      body: input.content,
+      dateModified: this.getString(params.dateModified),
+      datePublished: this.getString(params.datePublished),
+      description,
+      headline: input.title,
+      keywords: this.getStringArray(params.keywords),
+      mainEntityUrl: url,
+      publisher: this.getString(params.publisherName),
+      url,
+      wordCount: this.stripHtml(input.content).split(/\s+/).filter(Boolean)
+        .length,
+    });
+  }
+
+  private resolveSchemaTypes(
+    questions: FaqParam[],
+    steps: HowToStepParam[],
+  ): string[] {
+    if (steps.length > 0) {
+      return ['HowTo'];
+    }
+
+    if (questions.length > 0) {
+      return ['FAQPage'];
+    }
+
+    return ['Article'];
+  }
+
+  private resolveContent(params: Record<string, unknown>): string {
+    return (
+      this.getString(params.content) ??
+      this.getString(params.text) ??
+      this.getString(params.articleBody) ??
+      ''
+    );
+  }
+
+  private resolveModel(value: unknown): string {
+    if (typeof value === 'string' && TRUSTED_GEO_MODELS.has(value.trim())) {
+      return value.trim();
+    }
+
+    return DEFAULT_MODEL;
+  }
+
+  private getFaqParams(value: unknown): FaqParam[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .map((item): FaqParam | null => {
+        if (typeof item === 'string') {
+          return { answer: '', question: item.trim() };
+        }
+
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+          return null;
+        }
+
+        const record = item as Record<string, unknown>;
+        const question = this.getString(record.question);
+        const answer = this.getString(record.answer);
+
+        return question && answer ? { answer, question } : null;
+      })
+      .filter((item): item is FaqParam => item !== null);
+  }
+
+  private getHowToSteps(value: unknown): HowToStepParam[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .map((item): HowToStepParam | null => {
+        if (typeof item === 'string') {
+          const text = item.trim();
+          return text ? { text } : null;
+        }
+
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+          return null;
+        }
+
+        const record = item as Record<string, unknown>;
+        const text = this.getString(record.text);
+        return text ? { name: this.getString(record.name), text } : null;
+      })
+      .filter((item): item is HowToStepParam => item !== null);
+  }
+
+  private getString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0
+      ? value.trim()
+      : undefined;
+  }
+
+  private getStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  private stripHtml(value: string): string {
+    return value
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private firstSentence(value: string): string {
+    return value.split(/(?<=[.!?])\s+/)[0]?.trim() ?? '';
+  }
+
+  private dedupe(values: string[]): string[] {
+    return [...new Set(values.filter(Boolean))];
+  }
+}

--- a/apps/server/api/src/services/skill-executor/skill-executor.module.ts
+++ b/apps/server/api/src/services/skill-executor/skill-executor.module.ts
@@ -8,6 +8,7 @@ import { FalModule } from '@api/services/integrations/fal/fal.module';
 import { LeonardoAIModule } from '@api/services/integrations/leonardoai/leonardoai.module';
 import { LlmDispatcherModule } from '@api/services/integrations/llm/llm-dispatcher.module';
 import { ReplicateModule } from '@api/services/integrations/replicate/replicate.module';
+import { ContentGeoOptimizerHandler } from '@api/services/skill-executor/handlers/content-geo-optimizer.handler';
 import { ContentWritingHandler } from '@api/services/skill-executor/handlers/content-writing.handler';
 import { ImageGenerationHandler } from '@api/services/skill-executor/handlers/image-generation.handler';
 import { TrendDiscoveryHandler } from '@api/services/skill-executor/handlers/trend-discovery.handler';
@@ -30,6 +31,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => TrendsModule),
   ],
   providers: [
+    ContentGeoOptimizerHandler,
     ContentWritingHandler,
     ImageGenerationHandler,
     TrendDiscoveryHandler,

--- a/apps/server/api/src/services/skill-executor/skill-executor.service.spec.ts
+++ b/apps/server/api/src/services/skill-executor/skill-executor.service.spec.ts
@@ -1,6 +1,7 @@
 import { ContentRunsService } from '@api/collections/content-runs/services/content-runs.service';
 import { SkillsService } from '@api/collections/skills/services/skills.service';
 import { ByokProviderFactoryService } from '@api/services/byok/byok-provider-factory.service';
+import { ContentGeoOptimizerHandler } from '@api/services/skill-executor/handlers/content-geo-optimizer.handler';
 import { ContentWritingHandler } from '@api/services/skill-executor/handlers/content-writing.handler';
 import { ImageGenerationHandler } from '@api/services/skill-executor/handlers/image-generation.handler';
 import { TrendDiscoveryHandler } from '@api/services/skill-executor/handlers/trend-discovery.handler';
@@ -63,6 +64,7 @@ describe('SkillExecutorService', () => {
           provide: ByokProviderFactoryService,
           useValue: mockByokProviderFactoryService,
         },
+        { provide: ContentGeoOptimizerHandler, useValue: mockHandler },
         { provide: ContentWritingHandler, useValue: mockHandler },
         { provide: ImageGenerationHandler, useValue: mockHandler },
         { provide: TrendDiscoveryHandler, useValue: mockHandler },

--- a/apps/server/api/src/services/skill-executor/skill-executor.service.ts
+++ b/apps/server/api/src/services/skill-executor/skill-executor.service.ts
@@ -2,6 +2,7 @@ import { ContentRunsService } from '@api/collections/content-runs/services/conte
 import { SkillsService } from '@api/collections/skills/services/skills.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { ByokProviderFactoryService } from '@api/services/byok/byok-provider-factory.service';
+import { ContentGeoOptimizerHandler } from '@api/services/skill-executor/handlers/content-geo-optimizer.handler';
 import { ContentWritingHandler } from '@api/services/skill-executor/handlers/content-writing.handler';
 import { ImageGenerationHandler } from '@api/services/skill-executor/handlers/image-generation.handler';
 import { TrendDiscoveryHandler } from '@api/services/skill-executor/handlers/trend-discovery.handler';
@@ -33,12 +34,14 @@ export class SkillExecutorService {
     private readonly skillsService: SkillsService,
     private readonly contentRunsService: ContentRunsService,
     private readonly byokProviderFactoryService: ByokProviderFactoryService,
+    contentGeoOptimizerHandler: ContentGeoOptimizerHandler,
     contentWritingHandler: ContentWritingHandler,
     imageGenerationHandler: ImageGenerationHandler,
     trendDiscoveryHandler: TrendDiscoveryHandler,
     trendRemixHandler: TrendRemixHandler,
   ) {
     this.handlers = {
+      'content-geo-optimizer': contentGeoOptimizerHandler,
       'content-writing': contentWritingHandler,
       'image-generation': imageGenerationHandler,
       'trend-discovery': trendDiscoveryHandler,

--- a/apps/website/app/(content)/articles/[slug]/page.tsx
+++ b/apps/website/app/(content)/articles/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { stringifyJsonLd } from '@data/json-ld';
+import { buildArticleJsonLd } from '@genfeedai/helpers';
 import { metadata } from '@helpers/media/metadata/metadata.helper';
 import { EnvironmentService } from '@services/core/environment.service';
 import { PublicService } from '@services/external/public.service';
@@ -93,56 +94,28 @@ export default async function ArticleDetail({
 
   const articleJsonLd =
     article && article.id !== 'undefined'
-      ? {
-          '@context': 'https://schema.org',
-          '@type': 'BlogPosting',
-          articleBody: article.content || undefined,
-          author: article.author
-            ? {
-                '@type': 'Person',
-                name: article.author,
-                worksFor: {
-                  '@type': 'Organization',
-                  name: 'Genfeed',
-                  url: 'https://genfeed.ai',
-                },
-              }
-            : {
-                '@type': 'Organization',
-                name: 'Genfeed',
-                url: 'https://genfeed.ai',
-              },
+      ? buildArticleJsonLd({
+          author: article.author || {
+            name: 'Genfeed',
+            url: 'https://genfeed.ai',
+          },
+          body: article.content,
           dateModified: article.updatedAt || article.createdAt,
           datePublished: article.createdAt,
           description: article.summary,
           headline: article.label,
-          image: article.bannerUrl || metadata.cards.default,
+          imageUrls: [article.bannerUrl || metadata.cards.default],
           inLanguage: 'en-US',
-          isPartOf: {
-            '@type': 'Blog',
-            name: 'Genfeed Blog',
-            url: `${EnvironmentService.apps.website}/articles`,
-          },
-          keywords:
-            article.tags && article.tags.length > 0
-              ? article.tags.map((t) => t.label).join(', ')
-              : undefined,
-          mainEntityOfPage: {
-            '@id': `${EnvironmentService.apps.website}/articles/${slug}`,
-            '@type': 'WebPage',
-          },
+          keywords: article.tags?.map((tag) => tag.label),
+          mainEntityUrl: `${EnvironmentService.apps.website}/articles/${slug}`,
           publisher: {
-            '@type': 'Organization',
-            logo: {
-              '@type': 'ImageObject',
-              url: 'https://cdn.genfeed.ai/assets/logo.png',
-            },
+            logoUrl: 'https://cdn.genfeed.ai/assets/logo.png',
             name: 'Genfeed',
             url: 'https://genfeed.ai',
           },
           url: `${EnvironmentService.apps.website}/articles/${slug}`,
           wordCount: article.wordCount || undefined,
-        }
+        })
       : null;
 
   const breadcrumbJsonLd = {

--- a/apps/website/app/(public)/skills/_data.ts
+++ b/apps/website/app/(public)/skills/_data.ts
@@ -117,6 +117,13 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
       },
       {
         description:
+          'GEO scorecard, citation-ready rewrites, source attribution, and answer-engine schema guidance.',
+        icon: LuBrainCircuit,
+        name: 'GEO Optimizer',
+        slug: 'content-geo-optimizer',
+      },
+      {
+        description:
           'Operate content intake, briefs, production queues, review gates, and analytics loops.',
         icon: LuPackage,
         name: 'Factory Operator',

--- a/apps/website/scripts/generate-llms-txt.ts
+++ b/apps/website/scripts/generate-llms-txt.ts
@@ -206,6 +206,9 @@ function buildLlmsIndex(): string {
     '- [Open Source Core](https://github.com/genfeedai/genfeed.ai): Self-host Genfeed with your own AI keys',
   );
   lines.push(
+    `- [Generative Engine Optimization](${BASE_URL}/articles): Create citation-ready long-form content with answer blocks, source attribution, and Article/FAQ/HowTo structured data`,
+  );
+  lines.push(
     '- [Documentation](https://docs.genfeed.ai): API references, integration guides, and tutorials',
   );
   lines.push('');
@@ -260,6 +263,9 @@ function buildLlmsFull(): string {
   );
   s.push(
     '- **Analytics**: Track performance and revenue attribution across all channels',
+  );
+  s.push(
+    '- **Generative Engine Optimization**: Make long-form content citation-ready for AI answer engines with direct answer blocks, source attribution, and Article/FAQ/HowTo structured data',
   );
   s.push(
     '- **Open source core**: Self-host for free with your own AI keys (BYOK)',

--- a/packages/helpers/src/content/schema-org.helper.test.ts
+++ b/packages/helpers/src/content/schema-org.helper.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildArticleJsonLd,
+  buildFaqJsonLd,
+  buildGeneratedContentJsonLd,
+  buildHowToJsonLd,
+} from './schema-org.helper';
+
+describe('schema-org helpers', () => {
+  it('builds reusable Article JSON-LD for generated content', () => {
+    const jsonLd = buildArticleJsonLd({
+      author: { name: 'Ada Lovelace', url: 'https://example.com/ada' },
+      body: 'Direct answer with supporting evidence.',
+      datePublished: '2026-06-28',
+      description: 'Citation-ready answer for AI engines.',
+      headline: 'How to make content citation-ready',
+      imageUrls: ['https://example.com/cover.png'],
+      keywords: ['geo', 'structured data'],
+      mainEntityUrl: 'https://example.com/articles/geo',
+      publisher: {
+        logoUrl: 'https://example.com/logo.png',
+        name: 'Genfeed',
+        url: 'https://genfeed.ai',
+      },
+      wordCount: 512.8,
+    });
+
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      author: {
+        '@type': 'Person',
+        name: 'Ada Lovelace',
+      },
+      headline: 'How to make content citation-ready',
+      keywords: 'geo, structured data',
+      publisher: {
+        '@type': 'Organization',
+        logo: {
+          '@type': 'ImageObject',
+          url: 'https://example.com/logo.png',
+        },
+      },
+      wordCount: 513,
+    });
+  });
+
+  it('drops empty FAQ rows and emits Question/Answer entities', () => {
+    const jsonLd = buildFaqJsonLd({
+      items: [
+        {
+          answer: 'Use concise answer blocks and cite sources.',
+          question: 'How do AI engines cite content?',
+        },
+        { answer: '', question: 'Ignored question' },
+      ],
+      name: 'GEO FAQ',
+    });
+
+    expect(jsonLd.mainEntity).toEqual([
+      {
+        '@type': 'Question',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Use concise answer blocks and cite sources.',
+        },
+        name: 'How do AI engines cite content?',
+      },
+    ]);
+  });
+
+  it('builds HowTo steps with stable positions', () => {
+    const jsonLd = buildHowToJsonLd({
+      name: 'Optimize content for answer engines',
+      steps: [
+        { text: 'Write a direct answer block.' },
+        { name: 'Add schema', text: 'Emit Article, FAQ, or HowTo JSON-LD.' },
+      ],
+    });
+
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'HowTo',
+      name: 'Optimize content for answer engines',
+      step: [
+        { '@type': 'HowToStep', name: 'Step 1', position: 1 },
+        { '@type': 'HowToStep', name: 'Add schema', position: 2 },
+      ],
+    });
+  });
+
+  it('routes generated content by content type', () => {
+    expect(
+      buildGeneratedContentJsonLd({
+        contentType: 'faq',
+        items: [{ answer: 'A', question: 'Q' }],
+      })['@type'],
+    ).toBe('FAQPage');
+  });
+});

--- a/packages/helpers/src/content/schema-org.helper.ts
+++ b/packages/helpers/src/content/schema-org.helper.ts
@@ -1,0 +1,269 @@
+type JsonLdPrimitive = boolean | number | string | null;
+
+export type JsonLdValue =
+  | JsonLdPrimitive
+  | JsonLdValue[]
+  | { [key: string]: JsonLdValue | undefined };
+
+export interface SchemaOrgPersonInput {
+  name: string;
+  url?: string | null;
+}
+
+export interface SchemaOrgOrganizationInput {
+  logoUrl?: string | null;
+  name: string;
+  url?: string | null;
+}
+
+export interface ArticleJsonLdInput {
+  author?: SchemaOrgOrganizationInput | SchemaOrgPersonInput | string | null;
+  body?: string | null;
+  dateModified?: Date | string | null;
+  datePublished?: Date | string | null;
+  description?: string | null;
+  headline: string;
+  imageUrls?: string[];
+  inLanguage?: string | null;
+  keywords?: string[];
+  mainEntityUrl?: string | null;
+  publisher?: SchemaOrgOrganizationInput | string | null;
+  url?: string | null;
+  wordCount?: number | null;
+}
+
+export interface FaqJsonLdItemInput {
+  answer: string;
+  question: string;
+}
+
+export interface FaqJsonLdInput {
+  items: FaqJsonLdItemInput[];
+  name?: string | null;
+  url?: string | null;
+}
+
+export interface HowToJsonLdStepInput {
+  name?: string | null;
+  text: string;
+  url?: string | null;
+}
+
+export interface HowToJsonLdInput {
+  description?: string | null;
+  estimatedCost?: string | null;
+  name: string;
+  steps: HowToJsonLdStepInput[];
+  totalTime?: string | null;
+  url?: string | null;
+}
+
+export type GeneratedContentJsonLdInput =
+  | ({ contentType: 'article' } & ArticleJsonLdInput)
+  | ({ contentType: 'faq' } & FaqJsonLdInput)
+  | ({ contentType: 'howto' } & HowToJsonLdInput);
+
+export function buildArticleJsonLd(
+  input: ArticleJsonLdInput,
+): Record<string, JsonLdValue> {
+  return compactJsonLdRecord({
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    articleBody: normaliseText(input.body),
+    author: input.author ? buildAuthorEntity(input.author) : undefined,
+    dateModified: toIsoDate(input.dateModified),
+    datePublished: toIsoDate(input.datePublished),
+    description: normaliseText(input.description),
+    headline: input.headline.trim(),
+    image: normaliseStringArray(input.imageUrls),
+    inLanguage: normaliseText(input.inLanguage),
+    keywords: normaliseStringArray(input.keywords)?.join(', '),
+    mainEntityOfPage: input.mainEntityUrl
+      ? compactJsonLdRecord({
+          '@id': input.mainEntityUrl,
+          '@type': 'WebPage',
+        })
+      : undefined,
+    publisher: input.publisher
+      ? buildOrganizationEntity(input.publisher)
+      : undefined,
+    url: normaliseText(input.url),
+    wordCount:
+      typeof input.wordCount === 'number' && Number.isFinite(input.wordCount)
+        ? Math.max(0, Math.round(input.wordCount))
+        : undefined,
+  });
+}
+
+export function buildFaqJsonLd(
+  input: FaqJsonLdInput,
+): Record<string, JsonLdValue> {
+  const mainEntity = input.items
+    .map((item) => ({
+      answer: item.answer.trim(),
+      question: item.question.trim(),
+    }))
+    .filter((item) => item.answer.length > 0 && item.question.length > 0)
+    .map((item) =>
+      compactJsonLdRecord({
+        '@type': 'Question',
+        acceptedAnswer: compactJsonLdRecord({
+          '@type': 'Answer',
+          text: item.answer,
+        }),
+        name: item.question,
+      }),
+    );
+
+  return compactJsonLdRecord({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity,
+    name: normaliseText(input.name),
+    url: normaliseText(input.url),
+  });
+}
+
+export function buildHowToJsonLd(
+  input: HowToJsonLdInput,
+): Record<string, JsonLdValue> {
+  const steps = input.steps
+    .map((step) => ({
+      name: normaliseText(step.name),
+      text: step.text.trim(),
+      url: normaliseText(step.url),
+    }))
+    .filter((step) => step.text.length > 0)
+    .map((step, index) =>
+      compactJsonLdRecord({
+        '@type': 'HowToStep',
+        name: step.name ?? `Step ${index + 1}`,
+        position: index + 1,
+        text: step.text,
+        url: step.url,
+      }),
+    );
+
+  return compactJsonLdRecord({
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    description: normaliseText(input.description),
+    estimatedCost: normaliseText(input.estimatedCost),
+    name: input.name.trim(),
+    step: steps,
+    totalTime: normaliseText(input.totalTime),
+    url: normaliseText(input.url),
+  });
+}
+
+export function buildGeneratedContentJsonLd(
+  input: GeneratedContentJsonLdInput,
+): Record<string, JsonLdValue> {
+  if (input.contentType === 'faq') {
+    return buildFaqJsonLd(input);
+  }
+
+  if (input.contentType === 'howto') {
+    return buildHowToJsonLd(input);
+  }
+
+  return buildArticleJsonLd(input);
+}
+
+function buildAuthorEntity(
+  input: SchemaOrgOrganizationInput | SchemaOrgPersonInput | string,
+): Record<string, JsonLdValue> {
+  if (typeof input === 'string') {
+    return compactJsonLdRecord({
+      '@type': 'Person',
+      name: input.trim(),
+    });
+  }
+
+  return compactJsonLdRecord({
+    '@type': 'logoUrl' in input ? 'Organization' : 'Person',
+    logo:
+      'logoUrl' in input && input.logoUrl
+        ? compactJsonLdRecord({
+            '@type': 'ImageObject',
+            url: input.logoUrl,
+          })
+        : undefined,
+    name: input.name.trim(),
+    url: normaliseText(input.url),
+  });
+}
+
+function buildOrganizationEntity(
+  input: SchemaOrgOrganizationInput | string,
+): Record<string, JsonLdValue> {
+  if (typeof input === 'string') {
+    return compactJsonLdRecord({
+      '@type': 'Organization',
+      name: input.trim(),
+    });
+  }
+
+  return compactJsonLdRecord({
+    '@type': 'Organization',
+    logo: input.logoUrl
+      ? compactJsonLdRecord({
+          '@type': 'ImageObject',
+          url: input.logoUrl,
+        })
+      : undefined,
+    name: input.name.trim(),
+    url: normaliseText(input.url),
+  });
+}
+
+function compactJsonLdRecord(
+  value: Record<string, JsonLdValue | undefined>,
+): Record<string, JsonLdValue> {
+  const result: Record<string, JsonLdValue> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(entry) && entry.length === 0) {
+      continue;
+    }
+
+    if (typeof entry === 'string' && entry.trim().length === 0) {
+      continue;
+    }
+
+    result[key] = entry;
+  }
+
+  return result;
+}
+
+function normaliseText(value?: string | null): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normaliseStringArray(value?: string[]): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const items = value.map((item) => item.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+function toIsoDate(value?: Date | string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -4,6 +4,7 @@ export * from './auth/auth.helper';
 export * from './brand-completeness.helper';
 export * from './business/pricing/pricing.helper';
 export * from './business/tier-models/tier-models.helper';
+export * from './content/schema-org.helper';
 export * from './deserializer.helper';
 export * from './email/system-email.helper';
 export * from './formatting/cn/cn.util';

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,32 +4,33 @@ Genfeed.ai content and product skills — used by the application itself to powe
 
 ## Skills
 
-| Skill | Purpose |
-|-------|---------|
-| `ad-copy-creator` | Generate ad copy for campaigns |
-| `ad-performance-analyzer` | Analyze ad performance metrics |
-| `blog-content-creator` | Create blog posts and articles |
-| `brand-os-architect` | Create source-backed Brand OS systems |
-| `competitor-analyzer` | Analyze competitor content strategies |
-| `content-atomizer` | Break long-form content into social posts |
-| `content-reviewer` | Review and score content quality |
-| `content-seo-optimizer` | Optimize content for search engines |
-| `content-strategist` | Plan content calendars and strategy |
-| `genfeed-brand-os` | Apply the Genfeed.ai Brand OS |
-| `image-prompt-engineer` | Generate image prompts for AI models |
-| `instagram-content-creator` | Create Instagram-optimized content |
-| `linkedin-content-creator` | Create LinkedIn posts and articles |
-| `model-selector` | Select optimal AI model for a task |
-| `newsletter-creator` | Generate email newsletters |
-| `node-creator` | Create workflow nodes |
-| `onboarding` | Guide new user onboarding flows |
-| `openclaw-integration` | OpenClaw agent integration |
-| `prompt-generator` | Generate AI prompts for content |
-| `scope-validator` | Validate task scope and requirements |
-| `visual-brand-kit` | Maintain visual brand consistency |
-| `workflow-creator` | Build automation workflows |
-| `x-content-creator` | Create X/Twitter content |
-| `youtube-content-creator` | Create YouTube titles, descriptions, scripts |
+| Skill                       | Purpose                                        |
+| --------------------------- | ---------------------------------------------- |
+| `ad-copy-creator`           | Generate ad copy for campaigns                 |
+| `ad-performance-analyzer`   | Analyze ad performance metrics                 |
+| `blog-content-creator`      | Create blog posts and articles                 |
+| `brand-os-architect`        | Create source-backed Brand OS systems          |
+| `competitor-analyzer`       | Analyze competitor content strategies          |
+| `content-atomizer`          | Break long-form content into social posts      |
+| `content-geo-optimizer`     | Optimize content for generative answer engines |
+| `content-reviewer`          | Review and score content quality               |
+| `content-seo-optimizer`     | Optimize content for search engines            |
+| `content-strategist`        | Plan content calendars and strategy            |
+| `genfeed-brand-os`          | Apply the Genfeed.ai Brand OS                  |
+| `image-prompt-engineer`     | Generate image prompts for AI models           |
+| `instagram-content-creator` | Create Instagram-optimized content             |
+| `linkedin-content-creator`  | Create LinkedIn posts and articles             |
+| `model-selector`            | Select optimal AI model for a task             |
+| `newsletter-creator`        | Generate email newsletters                     |
+| `node-creator`              | Create workflow nodes                          |
+| `onboarding`                | Guide new user onboarding flows                |
+| `openclaw-integration`      | OpenClaw agent integration                     |
+| `prompt-generator`          | Generate AI prompts for content                |
+| `scope-validator`           | Validate task scope and requirements           |
+| `visual-brand-kit`          | Maintain visual brand consistency              |
+| `workflow-creator`          | Build automation workflows                     |
+| `x-content-creator`         | Create X/Twitter content                       |
+| `youtube-content-creator`   | Create YouTube titles, descriptions, scripts   |
 
 ## Adding a skill
 

--- a/skills/content-geo-optimizer/README.md
+++ b/skills/content-geo-optimizer/README.md
@@ -1,0 +1,31 @@
+# Content GEO Optimizer
+
+Optimize long-form content for generative answer engines: ChatGPT, Perplexity,
+Claude, Google AI Overviews, and retrieval-based assistants.
+
+## Installation
+
+```bash
+npx skills add genfeedai/skills/content-geo-optimizer
+```
+
+## Usage
+
+```text
+"Optimize this article for GEO"
+"Make this guide citation-ready for AI Overviews"
+"Score this content for ChatGPT and Perplexity citations"
+"Rewrite this FAQ for answer engines"
+```
+
+## What It Does
+
+- Scores content across six GEO dimensions with a 0-100 rubric.
+- Rewrites content into direct-answer, citation-ready structure.
+- Flags unsupported factual claims instead of inventing sources.
+- Recommends Article, FAQPage, or HowTo JSON-LD.
+- Pairs with the SEO optimizer when content needs both ranking and answer-engine readiness.
+
+## License
+
+MIT

--- a/skills/content-geo-optimizer/SKILL.md
+++ b/skills/content-geo-optimizer/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: content-geo-optimizer
+description: Optimize long-form content for generative answer engines with a GEO scorecard, citation-ready structure, source attribution, and schema recommendations. Triggers on "optimize for GEO", "AI answer engine optimization", "make this citation-ready", "improve AI Overviews", "optimize for ChatGPT citations".
+license: MIT
+metadata:
+  author: genfeedai
+  version: "1.0.0"
+---
+
+# Content GEO Optimizer
+
+You are an expert in Generative Engine Optimization: making content easy for
+answer engines such as ChatGPT, Perplexity, Claude, Google AI Overviews, and
+other retrieval-augmented systems to extract, quote, and cite accurately.
+
+When asked to optimize content for GEO, preserve the user's claims and sources.
+Do not invent citations, dates, quotes, statistics, or named entities.
+
+---
+
+## GEO Score Rubric (0-100)
+
+Score every piece of long-form content across six dimensions.
+
+| Dimension                 | Max | What to Check                                                              |
+| ------------------------- | --- | -------------------------------------------------------------------------- |
+| Question-led headings     | 18  | H2/H3 headings mirror likely user questions and People Also Ask prompts    |
+| Extractable answer blocks | 20  | Short direct answers appear under questions before explanation             |
+| Source attribution        | 17  | Factual claims cite public sources, studies, docs, or first-party evidence |
+| Entity clarity            | 15  | Product, brand, people, places, dates, tools, and categories are explicit  |
+| Schema readiness          | 15  | Article, FAQ, or HowTo JSON-LD can be emitted from the content             |
+| Freshness signals         | 15  | Published/updated date, current-year context, or recency caveat is visible |
+
+### Rating Bands
+
+| Score  | Rating     | Meaning                                                  |
+| ------ | ---------- | -------------------------------------------------------- |
+| 85-100 | Excellent  | Citation-ready with strong source and schema signals     |
+| 70-84  | Good       | Usable by answer engines with a few missing signals      |
+| 45-69  | Needs Work | Content has value but weak extractability or attribution |
+| 0-44   | Poor       | Rewrite before publishing for answer-engine discovery    |
+
+---
+
+## Required Output Format
+
+Always return:
+
+1. **GEO Score Card** with per-dimension score, finding, and total score.
+2. **Priority Fixes** ordered by answer-engine impact.
+3. **Citation-Ready Rewrite** that starts with a direct answer block.
+4. **Structured Data Recommendation**: Article, FAQPage, HowTo, or a combined pattern.
+5. **Source Notes** listing provided sources and claims that still need evidence.
+
+Use this score-card structure:
+
+```markdown
+## GEO Score Card
+
+| Dimension                 | Score | Max     | Finding    |
+| ------------------------- | ----- | ------- | ---------- |
+| Question-led headings     | X     | 18      | ...        |
+| Extractable answer blocks | X     | 20      | ...        |
+| Source attribution        | X     | 17      | ...        |
+| Entity clarity            | X     | 15      | ...        |
+| Schema readiness          | X     | 15      | ...        |
+| Freshness signals         | X     | 15      | ...        |
+| **TOTAL**                 | **X** | **100** | **Rating** |
+
+## Priority Fixes
+
+1. ...
+2. ...
+3. ...
+```
+
+---
+
+## Rewrite Rules
+
+- Start with a direct answer under a question-led heading.
+- Put the shortest complete answer before nuance, caveats, or examples.
+- Use descriptive entities instead of pronouns when a sentence may be quoted.
+- Cite source URLs inline or in a source list when the user provides them.
+- Add FAQ blocks for question clusters and HowTo steps for procedural content.
+- Mark unsupported claims as "needs source" instead of making them sound proven.
+- Keep brand voice, but bias toward clarity over cleverness.
+
+---
+
+## Schema Guidance
+
+Recommend JSON-LD based on content type:
+
+| Content Shape                              | Schema                                      |
+| ------------------------------------------ | ------------------------------------------- |
+| Explainer, opinion, analysis, announcement | `Article`                                   |
+| Question cluster or support page           | `FAQPage` with `Question` and `Answer`      |
+| Procedural guide                           | `HowTo` with ordered `HowToStep`            |
+| Article with FAQ section                   | `Article` plus nested or adjacent `FAQPage` |
+
+Required fields:
+
+- `Article`: `headline`, `description`, `author`, `datePublished`, `dateModified`, `mainEntityOfPage`
+- `FAQPage`: `mainEntity[].name`, `mainEntity[].acceptedAnswer.text`
+- `HowTo`: `name`, `step[].name`, `step[].text`, ordered `position`
+
+---
+
+## Genfeed Integration
+
+If Genfeed tools are available:
+
+- Use `content-geo-optimizer` for scorecard + rewrite output.
+- Use generated `Article`, `FAQPage`, or `HowTo` JSON-LD when publishing long-form content.
+- Pair this skill with `content-seo-optimizer` when the content must rank in both classic search and answer engines.
+- Use brand context for voice, but never let brand voice obscure factual attribution.
+
+---
+
+## Example
+
+```markdown
+## Citation-Ready Rewrite
+
+### How does Genfeed make content citation-ready?
+
+Genfeed makes content citation-ready by turning drafts into direct answer
+blocks, adding source-backed claims, naming entities explicitly, and emitting
+Article, FAQ, or HowTo JSON-LD for generated long-form content.
+
+### What still needs evidence?
+
+- The claim about conversion lift needs a source.
+- The model-comparison paragraph should cite the source benchmark or remove the number.
+```

--- a/skills/content-geo-optimizer/metadata.json
+++ b/skills/content-geo-optimizer/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "content-geo-optimizer",
+  "version": "1.0.0",
+  "description": "Optimize content for generative answer engines with GEO scoring, citation-ready rewrites, source attribution, and schema recommendations",
+  "author": "genfeedai",
+  "license": "MIT",
+  "triggers": [
+    "optimize for GEO",
+    "AI answer engine optimization",
+    "make this citation-ready",
+    "improve AI Overviews",
+    "optimize for ChatGPT citations",
+    "optimize for Perplexity",
+    "generative engine optimization",
+    "GEO score"
+  ],
+  "references": {},
+  "outputs": ["text"],
+  "tags": [
+    "geo",
+    "generative-engine-optimization",
+    "answer-engines",
+    "structured-data",
+    "schema",
+    "citation-ready"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the `content-geo-optimizer` skill charter, metadata, README, and public skills catalog entry.
- Implement a server-side GEO optimizer handler that rewrites content for answer engines, emits a GEO scorecard, and returns Article/FAQ/HowTo JSON-LD metadata.
- Add reusable schema.org helpers and use them for public article JSON-LD, plus update LLM discovery resources.

## Validation
- `bun run --cwd packages/helpers test src/content/schema-org.helper.test.ts`
- `bun run --cwd apps/server/api test:file src/services/skill-executor/handlers/content-geo-optimizer.handler.spec.ts src/services/skill-executor/skill-executor.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/helpers --filter=@genfeedai/api --filter=@genfeedai/website --filter=@genfeedai/docs`
- `bun run --cwd apps/website generate:llms`
- `bunx biome check --write packages/helpers/src/content/schema-org.helper.ts packages/helpers/src/content/schema-org.helper.test.ts apps/server/api/src/services/skill-executor/handlers/content-geo-optimizer.handler.ts apps/server/api/src/services/skill-executor/handlers/content-geo-optimizer.handler.spec.ts apps/server/api/src/services/skill-executor/skill-executor.service.ts apps/server/api/src/services/skill-executor/skill-executor.module.ts apps/server/api/src/services/skill-executor/skill-executor.service.spec.ts 'apps/website/app/(content)/articles/[slug]/page.tsx' 'apps/website/app/(public)/skills/_data.ts' apps/website/scripts/generate-llms-txt.ts`
- `bunx prettier --check skills/content-geo-optimizer/SKILL.md skills/content-geo-optimizer/README.md skills/content-geo-optimizer/metadata.json skills/README.md`
- `git diff --check`
- `git diff --cached --check`
- `bun scripts/run-secretlint.ts ...changed files...`

Closes #763
Related #757
