### PR TITLE
feat(content): add inline SEO scorecard

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-detail.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-detail.test.tsx
@@ -78,9 +78,11 @@ const defaultArticleDetailState = () => ({
   handleEnhance: vi.fn(),
   handlePublish: vi.fn(),
   handleSave: vi.fn(),
+  handleScoreSeo: vi.fn(),
   isDirty: false,
   isEnhancing: false,
   isLoading: false,
+  isScoringSeo: false,
   isSaving: false,
   pathname: '/org-123/brand-123/compose/article',
   setFormField: vi.fn(),
@@ -146,5 +148,62 @@ describe('ArticleDetail', () => {
     });
 
     expect(pushMock).toHaveBeenCalledWith('/org-123/brand-123/posts/post-1');
+  });
+
+  it('forwards article SEO scoring from the sidebar', () => {
+    const handleScoreSeo = vi.fn();
+    useArticleDetailMock.mockReturnValue({
+      ...defaultArticleDetailState(),
+      article: {
+        id: 'article-1',
+        category: 'blog',
+        content: '<p>Article body</p>',
+        label: 'SEO Article',
+        readingTime: 4,
+        seoBreakdown: {
+          breakdown: {
+            contentStructure: 16,
+            keywordPlacement: 18,
+            links: 5,
+            media: 7,
+            metaOptimization: 10,
+            readability: 12,
+            technicalSignals: 8,
+          },
+          checks: [],
+          meta: {
+            fleschReadingEase: 61,
+            keywordDensity: null,
+            llmApplied: false,
+            maxAvailable: 100,
+            scoredAt: '2026-06-28T12:00:00.000Z',
+            targetKeyword: null,
+            wordCount: 820,
+          },
+          rating: 'good',
+          suggestions: ['Add an internal link.'],
+        },
+        seoScore: 76,
+        status: 'draft',
+        summary: 'Article summary',
+        wordCount: 820,
+      },
+      form: {
+        category: 'blog',
+        content: '<p>Article body</p>',
+        label: 'SEO Article',
+        status: 'draft',
+        summary: 'Article summary',
+        tags: '',
+      },
+      handleScoreSeo,
+    });
+
+    render(<ArticleDetail articleId="article-1" />);
+
+    expect(screen.getByText('SEO Scorecard')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Re-score SEO' }));
+
+    expect(handleScoreSeo).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-detail.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-detail.tsx
@@ -109,6 +109,7 @@ export default function ArticleDetail({
     isLoading,
     isSaving,
     isEnhancing,
+    isScoringSeo,
     isDirty,
     error,
     form,
@@ -118,6 +119,7 @@ export default function ArticleDetail({
     handleArchive,
     handleDelete,
     handleEnhance,
+    handleScoreSeo,
     pathname,
   } = useArticleDetail({ articleId });
 
@@ -322,7 +324,13 @@ export default function ArticleDetail({
         </div>
 
         {/* Right column */}
-        <ArticleSidebar form={form} article={article} />
+        <ArticleSidebar
+          form={form}
+          article={article}
+          isDirty={isDirty}
+          isScoringSeo={isScoringSeo}
+          onScoreSeo={handleScoreSeo}
+        />
       </div>
     </div>
   );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-sidebar.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-sidebar.tsx
@@ -3,6 +3,7 @@
 import type { Article } from '@genfeedai/models/content/article.model';
 import type { ArticleFormState } from '@props/content/article-editor.props';
 import Card from '@ui/card/Card';
+import SeoScorecard from '@ui/evaluation/seo-scorecard/SeoScorecard';
 import ContentPreviewSidebar from '@ui/preview/ContentPreviewSidebar';
 
 type ArticleSidebarProps = {
@@ -11,9 +12,18 @@ type ArticleSidebarProps = {
     'label' | 'summary' | 'content' | 'status' | 'category'
   >;
   article: Article | null;
+  isDirty?: boolean;
+  isScoringSeo?: boolean;
+  onScoreSeo?: () => void | Promise<void>;
 };
 
-export default function ArticleSidebar({ form, article }: ArticleSidebarProps) {
+export default function ArticleSidebar({
+  form,
+  article,
+  isDirty = false,
+  isScoringSeo = false,
+  onScoreSeo,
+}: ArticleSidebarProps) {
   return (
     <div className="space-y-4">
       <ContentPreviewSidebar
@@ -22,6 +32,17 @@ export default function ArticleSidebar({ form, article }: ArticleSidebarProps) {
         content={form.content}
         platform="article"
       />
+
+      {article && (
+        <SeoScorecard
+          score={article.seoScore}
+          scorecard={article.seoBreakdown}
+          contentTypeLabel="article"
+          isScoring={isScoringSeo}
+          hasUnsavedChanges={isDirty}
+          onScore={onScoreSeo}
+        />
+      )}
 
       {/* Article stats */}
       {article && (

--- a/apps/server/api/src/collections/articles/articles.module.ts
+++ b/apps/server/api/src/collections/articles/articles.module.ts
@@ -28,6 +28,7 @@ import { ReplicateModule } from '@api/services/integrations/replicate/replicate.
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { PromptBuilderModule } from '@api/services/prompt-builder/prompt-builder.module';
 import { RouterModule } from '@api/services/router/router.module';
+import { SeoModule } from '@api/services/seo/seo.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
@@ -50,6 +51,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => PromptsModule),
     forwardRef(() => ReplicateModule),
     forwardRef(() => RouterModule),
+    forwardRef(() => SeoModule),
     forwardRef(() => TemplatesModule),
     forwardRef(() => UsersModule),
     forwardRef(() => ContentHarnessModule),

--- a/apps/server/api/src/collections/articles/controllers/articles.controller.spec.ts
+++ b/apps/server/api/src/collections/articles/controllers/articles.controller.spec.ts
@@ -18,8 +18,10 @@ import { SubscriptionGuard } from '@api/helpers/guards/subscription/subscription
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { RouterService } from '@api/services/router/router.service';
+import { SeoScorerService } from '@api/services/seo/seo-scorer.service';
 import { ArticleCategory, AssetScope } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
+import { HttpException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
 
@@ -96,6 +98,10 @@ describe('ArticlesController', () => {
     getDefaultModel: vi.fn(),
   };
 
+  const mockSeoScorerService = {
+    scoreArticle: vi.fn(),
+  };
+
   const mockLoggerService = {
     debug: vi.fn(),
     error: vi.fn(),
@@ -104,6 +110,12 @@ describe('ArticlesController', () => {
   };
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+    mockArticlesService.findAll.mockResolvedValue({ docs: [mockArticle] });
+    mockSeoScorerService.scoreArticle.mockResolvedValue({
+      score: 84,
+    });
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ArticlesController],
       providers: [
@@ -143,6 +155,10 @@ describe('ArticlesController', () => {
         {
           provide: RouterService,
           useValue: mockRouterService,
+        },
+        {
+          provide: SeoScorerService,
+          useValue: mockSeoScorerService,
         },
         {
           provide: LoggerService,
@@ -304,6 +320,75 @@ describe('ArticlesController', () => {
         mockUser.publicMetadata.brand,
       );
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('scoreSeo', () => {
+    const id = '507f1f77bcf86cd799439014';
+
+    it('should score article SEO and return the refreshed article', async () => {
+      const scoredArticle = {
+        ...mockArticle,
+        seoBreakdown: { rating: 'good' },
+        seoScore: 84,
+      };
+      mockArticlesService.findAll
+        .mockResolvedValueOnce({ docs: [mockArticle] })
+        .mockResolvedValueOnce({ docs: [scoredArticle] });
+
+      const result = await controller.scoreSeo(
+        mockRequest,
+        id,
+        { targetKeyword: 'content automation' },
+        mockUser,
+      );
+
+      expect(service.findAll).toHaveBeenNthCalledWith(
+        1,
+        {
+          where: {
+            _id: id,
+            isDeleted: false,
+          },
+        },
+        {
+          pagination: false,
+        },
+      );
+      expect(mockSeoScorerService.scoreArticle).toHaveBeenCalledWith(
+        id,
+        mockUser.publicMetadata.organization,
+        'content automation',
+      );
+      expect(service.findAll).toHaveBeenCalledTimes(2);
+      expect(result).toBeDefined();
+    });
+
+    it('should throw NOT_FOUND when article is missing', async () => {
+      mockArticlesService.findAll.mockResolvedValueOnce({ docs: [] });
+
+      await expect(
+        controller.scoreSeo(mockRequest, id, {}, mockUser),
+      ).rejects.toThrow(HttpException);
+
+      expect(mockSeoScorerService.scoreArticle).not.toHaveBeenCalled();
+    });
+
+    it('should throw NOT_FOUND when article belongs to another organization', async () => {
+      mockArticlesService.findAll.mockResolvedValueOnce({
+        docs: [
+          {
+            ...mockArticle,
+            organization: '507f191e810c19729de860ee',
+          },
+        ],
+      });
+
+      await expect(
+        controller.scoreSeo(mockRequest, id, {}, mockUser),
+      ).rejects.toThrow(HttpException);
+
+      expect(mockSeoScorerService.scoreArticle).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/collections/articles/controllers/articles.controller.ts
+++ b/apps/server/api/src/collections/articles/controllers/articles.controller.ts
@@ -48,6 +48,8 @@ import {
 import { getMinimumTextCredits } from '@api/helpers/utils/text-pricing/text-pricing.util';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { RouterService } from '@api/services/router/router.service';
+import { ScoreSeoDto } from '@api/services/seo/dto/score-seo.dto';
+import { SeoScorerService } from '@api/services/seo/seo-scorer.service';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
 import {
   ActivityEntityModel,
@@ -97,6 +99,7 @@ export class ArticlesController extends BaseCRUDController<
     private readonly organizationSettingsService: OrganizationSettingsService,
     public readonly loggerService: LoggerService,
     public readonly routerService: RouterService,
+    private readonly seoScorerService: SeoScorerService,
   ) {
     // ArticleSerializer would need to be created, using null for now
     super(loggerService, articlesService, ArticleSerializer, 'Article', [
@@ -447,6 +450,66 @@ export class ArticlesController extends BaseCRUDController<
     );
 
     return serializeSingle(request, ArticleSerializer, updatedArticle);
+  }
+
+  @Post(':articleId/seo-scores')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async scoreSeo(
+    @Req() request: Request,
+    @Param('articleId') articleId: string,
+    @Body() dto: ScoreSeoDto,
+    @CurrentUser() user: User,
+  ): Promise<JsonApiSingleResponse> {
+    const publicMetadata = getPublicMetadata(user);
+    const results = await this.articlesService.findAll(
+      {
+        where: {
+          _id: articleId,
+          isDeleted: false,
+        },
+      },
+      {
+        pagination: false,
+      },
+    );
+
+    if (!results || !results.docs || results.docs.length === 0) {
+      ErrorResponse.notFound(this.entityName, articleId);
+    }
+
+    const article = results.docs[0];
+
+    if (
+      String(article.organization ?? article.organizationId) !==
+        publicMetadata.organization.toString() &&
+      !getIsSuperAdmin(user, request)
+    ) {
+      ErrorResponse.notFound(this.entityName, articleId);
+    }
+
+    await this.seoScorerService.scoreArticle(
+      articleId,
+      publicMetadata.organization,
+      dto.targetKeyword,
+    );
+
+    const updatedResults = await this.articlesService.findAll(
+      {
+        where: {
+          _id: articleId,
+          isDeleted: false,
+        },
+      },
+      {
+        pagination: false,
+      },
+    );
+
+    return serializeSingle(
+      request,
+      ArticleSerializer,
+      updatedResults?.docs?.[0] ?? article,
+    );
   }
 
   @Post(':articleId/reviews')

--- a/apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.spec.ts
+++ b/apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.spec.ts
@@ -40,6 +40,7 @@ import { ReplicateService } from '@api/services/integrations/replicate/replicate
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
 import { QuotaService } from '@api/services/quota/quota.service';
+import { SeoScorerService } from '@api/services/seo/seo-scorer.service';
 import {
   CredentialPlatform,
   IngredientCategory,
@@ -201,6 +202,12 @@ describe('PostsOperationsController', () => {
     verifyQuota: vi.fn().mockResolvedValue(true),
   };
 
+  const mockSeoScorerService = {
+    scorePost: vi.fn().mockResolvedValue({
+      score: 82,
+    }),
+  };
+
   const mockReplicateService = {
     generateTextCompletionSync: vi.fn().mockResolvedValue(
       `Tweet 1: This is a great tweet about technology.
@@ -244,6 +251,9 @@ Tweet 3: Tech innovation is changing the world.`,
       input: { max_tokens: 4096, prompt: 'test prompt' },
     });
     mockQuotaService.verifyQuota.mockResolvedValue(true);
+    mockSeoScorerService.scorePost.mockResolvedValue({
+      score: 82,
+    });
     mockReplicateService.generateTextCompletionSync.mockResolvedValue(
       `Tweet 1: This is a great tweet about technology.
 Tweet 2: Here's another insightful post.
@@ -275,6 +285,7 @@ Tweet 3: Tech innovation is changing the world.`,
         { provide: PromptBuilderService, useValue: mockPromptBuilderService },
         { provide: QuotaService, useValue: mockQuotaService },
         { provide: ReplicateService, useValue: mockReplicateService },
+        { provide: SeoScorerService, useValue: mockSeoScorerService },
         { provide: TemplatesService, useValue: mockTemplatesService },
         {
           provide: TrendReferenceCorpusService,
@@ -1062,6 +1073,73 @@ Tweet 3: Tech innovation is changing the world.`,
         }),
         organizationId,
       );
+    });
+  });
+
+  // ==========================================================================
+  // POST /posts/:postId/seo-scores - scoreSeo
+  // ==========================================================================
+  describe('scoreSeo', () => {
+    beforeEach(() => {
+      mockPostsService.findOne.mockResolvedValue(mockPost);
+    });
+
+    it('scores post SEO and returns the refreshed post', async () => {
+      const scoredPost = {
+        ...mockPost,
+        seoBreakdown: { rating: 'good' },
+        seoScore: 82,
+      };
+      mockPostsService.findOne
+        .mockResolvedValueOnce(mockPost)
+        .mockResolvedValueOnce(scoredPost);
+
+      const result = await controller.scoreSeo(
+        mockRequest,
+        postId,
+        { targetKeyword: 'workflow automation' },
+        mockUser,
+      );
+
+      expect(mockPostsService.findOne).toHaveBeenNthCalledWith(
+        1,
+        { _id: postId },
+        expect.any(Array),
+      );
+      expect(mockSeoScorerService.scorePost).toHaveBeenCalledWith(
+        postId,
+        organizationId,
+        'workflow automation',
+      );
+      expect(mockPostsService.findOne).toHaveBeenNthCalledWith(
+        2,
+        { _id: postId },
+        expect.any(Array),
+      );
+      expect(result).toEqual({ data: scoredPost });
+    });
+
+    it('throws NOT_FOUND when post is missing', async () => {
+      mockPostsService.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        controller.scoreSeo(mockRequest, postId, {}, mockUser),
+      ).rejects.toThrow(HttpException);
+
+      expect(mockSeoScorerService.scorePost).not.toHaveBeenCalled();
+    });
+
+    it('throws FORBIDDEN when post belongs to another organization', async () => {
+      mockPostsService.findOne.mockResolvedValueOnce({
+        ...mockPost,
+        organization: '507f191e810c19729de860ee',
+      });
+
+      await expect(
+        controller.scoreSeo(mockRequest, postId, {}, mockUser),
+      ).rejects.toThrow(HttpException);
+
+      expect(mockSeoScorerService.scorePost).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.ts
+++ b/apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.ts
@@ -33,6 +33,8 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { QuotaService } from '@api/services/quota/quota.service';
+import { ScoreSeoDto } from '@api/services/seo/dto/score-seo.dto';
+import { SeoScorerService } from '@api/services/seo/seo-scorer.service';
 import { PopulatePatterns } from '@api/shared/utils/populate/populate.util';
 import {
   ActivityEntityModel,
@@ -77,6 +79,7 @@ export class PostsOperationsController {
     private readonly postGenerationService: PostGenerationService,
     private readonly postsService: PostsService,
     private readonly quotaService: QuotaService,
+    private readonly seoScorerService: SeoScorerService,
   ) {}
 
   // ============================================================================
@@ -811,6 +814,59 @@ export class PostsOperationsController {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
+  }
+
+  @Post(':postId/seo-scores')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async scoreSeo(
+    @Req() request: Request,
+    @Param('postId') postId: string,
+    @Body() dto: ScoreSeoDto,
+    @CurrentUser() user: User,
+  ): Promise<JsonApiSingleResponse> {
+    const publicMetadata = getPublicMetadata(user);
+
+    const post = await this.postsService.findOne({ _id: postId }, [
+      PopulatePatterns.ingredientsMinimal,
+      PopulatePatterns.credentialMinimal,
+    ]);
+
+    if (!post) {
+      throw new HttpException(
+        {
+          detail: 'Post not found',
+          title: `Post ${postId} not found`,
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    if (
+      post.organization.toString() !== publicMetadata.organization.toString()
+    ) {
+      throw new HttpException(
+        {
+          detail: 'You do not have access to this post',
+          title: 'Access denied',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    await this.seoScorerService.scorePost(
+      postId,
+      publicMetadata.organization,
+      dto.targetKeyword,
+    );
+
+    const updatedPost = await this.postsService.findOne({ _id: postId }, [
+      PopulatePatterns.ingredientsMinimal,
+      PopulatePatterns.credentialMinimal,
+      PopulatePatterns.userMinimal,
+      PopulatePatterns.brandMinimal,
+    ]);
+
+    return serializeSingle(request, this.serializer, updatedPost ?? post);
   }
 
   // ============================================================================

--- a/apps/server/api/src/collections/posts/posts.module.ts
+++ b/apps/server/api/src/collections/posts/posts.module.ts
@@ -26,6 +26,7 @@ import { ReplicateModule } from '@api/services/integrations/replicate/replicate.
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
 import { PromptBuilderModule } from '@api/services/prompt-builder/prompt-builder.module';
 import { QuotaModule } from '@api/services/quota/quota.module';
+import { SeoModule } from '@api/services/seo/seo.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
@@ -47,6 +48,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => PromptBuilderModule),
     forwardRef(() => QuotaModule),
     forwardRef(() => ReplicateModule),
+    forwardRef(() => SeoModule),
     forwardRef(() => TemplatesModule),
     forwardRef(() => TrendsModule),
   ],

--- a/apps/server/api/src/services/seo/dto/score-seo.dto.ts
+++ b/apps/server/api/src/services/seo/dto/score-seo.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ScoreSeoDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  targetKeyword?: string;
+}

--- a/packages/client/src/models/content/article.model.ts
+++ b/packages/client/src/models/content/article.model.ts
@@ -12,6 +12,7 @@ import type {
   ITag,
   IUser,
   IXArticleMetadata,
+  SeoScorecardSnapshot,
 } from '@genfeedai/interfaces';
 
 export class Article extends BaseEntity implements IArticle {
@@ -29,6 +30,8 @@ export class Article extends BaseEntity implements IArticle {
   public declare publishedAt?: string;
   public declare scope: AssetScope;
   public declare generationPrompt?: string;
+  public declare seoScore?: number | null;
+  public declare seoBreakdown?: SeoScorecardSnapshot | null;
   public declare xArticleMetadata?: IXArticleMetadata;
 
   constructor(data: Partial<IArticle> = {}) {

--- a/packages/client/src/models/content/post.model.ts
+++ b/packages/client/src/models/content/post.model.ts
@@ -13,6 +13,7 @@ import type {
   IPostAnalyticsSummary,
   ITag,
   IUser,
+  SeoScorecardSnapshot,
 } from '@genfeedai/interfaces';
 
 export class Post extends BaseEntity implements IPost {
@@ -47,6 +48,8 @@ export class Post extends BaseEntity implements IPost {
   public declare children?: IPost[];
   public declare order?: number;
   public declare isShareToFeedSelected?: boolean;
+  public declare seoScore?: number | null;
+  public declare seoBreakdown?: SeoScorecardSnapshot | null;
 
   constructor(data: Partial<IPost> = {}) {
     super(data);

--- a/packages/hooks/pages/use-article-detail/use-article-detail.test.ts
+++ b/packages/hooks/pages/use-article-detail/use-article-detail.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const pushMock = vi.fn();
 const postMock = vi.fn();
 const findOneMock = vi.fn();
+const scoreSeoMock = vi.fn();
 const notificationsServiceMock = {
   error: vi.fn(),
   success: vi.fn(),
@@ -12,6 +13,7 @@ const notificationsServiceMock = {
 const articlesServiceMock = {
   findOne: findOneMock,
   post: postMock,
+  scoreSeo: scoreSeoMock,
 };
 const getArticlesServiceMock = vi.fn(async () => articlesServiceMock);
 
@@ -58,6 +60,17 @@ describe('useArticleDetail', () => {
       tags: [],
     });
     postMock.mockResolvedValue({ id: 'article-created-1' });
+    scoreSeoMock.mockResolvedValue({
+      category: 'post',
+      content: '',
+      id: 'article-1',
+      label: 'Existing article',
+      seoScore: 82,
+      slug: 'existing-article',
+      status: 'draft',
+      summary: '',
+      tags: [],
+    });
     getArticlesServiceMock.mockResolvedValue(articlesServiceMock);
   });
 
@@ -67,6 +80,7 @@ describe('useArticleDetail', () => {
     expect(result.current).toHaveProperty('isLoading');
     expect(result.current).toHaveProperty('isSaving');
     expect(result.current).toHaveProperty('isEnhancing');
+    expect(result.current).toHaveProperty('isScoringSeo');
     expect(result.current).toHaveProperty('isDirty');
     expect(result.current).toHaveProperty('error');
     expect(result.current).toHaveProperty('form');
@@ -76,6 +90,7 @@ describe('useArticleDetail', () => {
     expect(result.current).toHaveProperty('handleArchive');
     expect(result.current).toHaveProperty('handleDelete');
     expect(result.current).toHaveProperty('handleEnhance');
+    expect(result.current).toHaveProperty('handleScoreSeo');
   });
 
   it('initializes with null article', () => {
@@ -110,7 +125,28 @@ describe('useArticleDetail', () => {
     expect(typeof result.current.handleArchive).toBe('function');
     expect(typeof result.current.handleDelete).toBe('function');
     expect(typeof result.current.handleEnhance).toBe('function');
+    expect(typeof result.current.handleScoreSeo).toBe('function');
     expect(typeof result.current.setFormField).toBe('function');
+  });
+
+  it('scores SEO for the current article', async () => {
+    const { result } = renderHook(() =>
+      useArticleDetail({ articleId: 'article-1' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.handleScoreSeo();
+    });
+
+    expect(scoreSeoMock).toHaveBeenCalledWith('article-1');
+    expect(result.current.article?.seoScore).toBe(82);
+    expect(notificationsServiceMock.success).toHaveBeenCalledWith(
+      'SEO score updated',
+    );
   });
 
   it('navigates to the generic composer route after creating a new article', async () => {

--- a/packages/hooks/pages/use-article-detail/use-article-detail.ts
+++ b/packages/hooks/pages/use-article-detail/use-article-detail.ts
@@ -21,6 +21,7 @@ export interface UseArticleDetailReturn {
   isLoading: boolean;
   isSaving: boolean;
   isEnhancing: boolean;
+  isScoringSeo: boolean;
   isDirty: boolean;
   error: string | null;
   form: ArticleFormState;
@@ -33,6 +34,7 @@ export interface UseArticleDetailReturn {
   handleArchive: () => Promise<void>;
   handleDelete: () => Promise<void>;
   handleEnhance: (prompt: string) => Promise<void>;
+  handleScoreSeo: () => Promise<void>;
   pathname: string;
   notificationsService: NotificationsService;
   getArticlesService: () => Promise<ArticlesService>;
@@ -76,6 +78,7 @@ export function useArticleDetail({
   const [isLoading, setIsLoading] = useState(!!articleId);
   const [isSaving, setIsSaving] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
+  const [isScoringSeo, setIsScoringSeo] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const initialFormRef = useRef<ArticleFormState>(DEFAULT_FORM_STATE);
@@ -281,6 +284,32 @@ export function useArticleDetail({
     [resolvedId, isEnhancing, getArticlesService, notificationsService, form],
   );
 
+  const handleScoreSeo = useCallback(async () => {
+    if (!resolvedId || isScoringSeo || isDirty) {
+      return;
+    }
+
+    setIsScoringSeo(true);
+
+    try {
+      const service = await getArticlesService();
+      const updated = await service.scoreSeo(resolvedId);
+      setArticle(updated);
+      notificationsService.success('SEO score updated');
+    } catch (err) {
+      logger.error('Failed to score article SEO', err);
+      notificationsService.error('Failed to score SEO');
+    } finally {
+      setIsScoringSeo(false);
+    }
+  }, [
+    resolvedId,
+    isScoringSeo,
+    isDirty,
+    getArticlesService,
+    notificationsService,
+  ]);
+
   return {
     article,
     error,
@@ -291,9 +320,11 @@ export function useArticleDetail({
     handleEnhance,
     handlePublish,
     handleSave,
+    handleScoreSeo,
     isDirty,
     isEnhancing,
     isLoading,
+    isScoringSeo,
     isSaving,
     notificationsService,
     pathname,

--- a/packages/interfaces/src/content/article.interface.ts
+++ b/packages/interfaces/src/content/article.interface.ts
@@ -12,6 +12,7 @@ import type {
   ITag,
   IUser,
 } from '../index';
+import type { SeoScorecardSnapshot } from './seo-scorecard.interface';
 import type { IXArticleMetadata } from './x-article-metadata.interface';
 
 export interface IArticle extends IBaseEntity {
@@ -34,6 +35,8 @@ export interface IArticle extends IBaseEntity {
   generationPrompt?: string;
   bannerUrl?: string;
   evaluation?: IEvaluation | null;
+  seoScore?: number | null;
+  seoBreakdown?: SeoScorecardSnapshot | null;
   xArticleMetadata?: IXArticleMetadata;
 }
 

--- a/packages/interfaces/src/content/index.ts
+++ b/packages/interfaces/src/content/index.ts
@@ -14,6 +14,7 @@ export * from './post-quick-action.interface';
 export * from './prompt.interface';
 export * from './prompts-content.interface';
 export * from './publication-card.interface';
+export * from './seo-scorecard.interface';
 export * from './studio-edit-detail.interface';
 export * from './tag.interface';
 export * from './template.interface';

--- a/packages/interfaces/src/content/post.interface.ts
+++ b/packages/interfaces/src/content/post.interface.ts
@@ -10,6 +10,7 @@ import type {
   ITag,
   IUser,
 } from '../index';
+import type { SeoScorecardSnapshot } from './seo-scorecard.interface';
 
 export interface IPost extends IBaseEntity {
   ingredients: IIngredient[];
@@ -41,6 +42,8 @@ export interface IPost extends IBaseEntity {
   avgEngagementRate?: number;
   evalScore?: number | null;
   evaluation?: IEvaluation | null;
+  seoScore?: number | null;
+  seoBreakdown?: SeoScorecardSnapshot | null;
   parent?: string;
   children?: IPost[];
   order?: number;

--- a/packages/interfaces/src/content/seo-scorecard.interface.ts
+++ b/packages/interfaces/src/content/seo-scorecard.interface.ts
@@ -1,0 +1,68 @@
+export const SEO_DIMENSIONS = [
+  'keywordPlacement',
+  'contentStructure',
+  'readability',
+  'metaOptimization',
+  'links',
+  'media',
+  'technicalSignals',
+] as const;
+
+export type SeoDimension = (typeof SEO_DIMENSIONS)[number];
+
+export const SEO_DIMENSION_MAX: Record<SeoDimension, number> = {
+  contentStructure: 20,
+  keywordPlacement: 20,
+  links: 10,
+  media: 10,
+  metaOptimization: 15,
+  readability: 15,
+  technicalSignals: 10,
+};
+
+export type SeoCheckKind = 'deterministic' | 'qualitative';
+
+export interface SeoCheck {
+  id: string;
+  dimension: SeoDimension;
+  label: string;
+  kind: SeoCheckKind;
+  max: number;
+  points: number;
+  available: boolean;
+  note: string;
+}
+
+export type SeoRating =
+  | 'excellent'
+  | 'good'
+  | 'needs_work'
+  | 'poor'
+  | 'critical';
+
+export interface SeoScorecardMeta {
+  wordCount: number;
+  fleschReadingEase: number;
+  targetKeyword: string | null;
+  keywordDensity: number | null;
+  llmApplied: boolean;
+  maxAvailable: number;
+  scoredAt: string;
+}
+
+export interface SeoScorecard {
+  score: number;
+  rating: SeoRating;
+  breakdown: Record<SeoDimension, number>;
+  suggestions: string[];
+  checks: SeoCheck[];
+  meta: SeoScorecardMeta;
+}
+
+export type SeoScorecardSnapshot = Omit<SeoScorecard, 'score'> & {
+  score?: number;
+};
+
+export interface ScoreSeoRequest {
+  targetKeyword?: string;
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -92,6 +92,7 @@ export * from './content/post-quick-action.interface';
 export * from './content/prompt.interface';
 export * from './content/prompts-content.interface';
 export * from './content/publication-card.interface';
+export * from './content/seo-scorecard.interface';
 export * from './content/studio-edit-detail.interface';
 export * from './content/tag.interface';
 export * from './content/template.interface';

--- a/packages/pages/posts/detail/post-detail.tsx
+++ b/packages/pages/posts/detail/post-detail.tsx
@@ -16,7 +16,7 @@ import Breadcrumb from '@ui/navigation/breadcrumb/Breadcrumb';
 import EngagementPreview from '@ui/posts/engagement-preview/EngagementPreview';
 import PostDetailSidebar from '@ui/posts/post-detail-sidebar/PostDetailSidebar';
 import { useRouter } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 export interface PostDetailProps {
   postId: string;
@@ -47,7 +47,6 @@ export default function PostDetail({
     childDescriptions,
     scheduleDraft,
     selectedIngredients,
-    isUpdating,
     isSavingDescription,
     isSavingSchedule,
     isSavingIngredients,
@@ -56,7 +55,6 @@ export default function PostDetail({
     isTogglingGrok,
     isTogglingFirstComment,
     isExpandingToThread,
-    isEditable,
     isPublished,
     analyticsStats,
     carouselValidation,
@@ -98,8 +96,10 @@ export default function PostDetail({
     performAutoSaveForPost,
     getPostsService,
     notificationsService,
+    refreshPost,
     pathname,
   } = hookData;
+  const [isScoringSeo, setIsScoringSeo] = useState(false);
   const reviewSummary: PostReviewSummary | undefined = post
     ? {
         generationId: (post as { generationId?: string }).generationId,
@@ -175,6 +175,32 @@ export default function PostDetail({
       notificationsService.error('Failed to duplicate post');
     }
   }, [post, getPostsService, notificationsService, router, href]);
+
+  const handleScoreSeo = useCallback(async () => {
+    if (!post || isScoringSeo || isContentDirty) {
+      return;
+    }
+
+    setIsScoringSeo(true);
+
+    try {
+      const service = await getPostsService();
+      await service.scoreSeo(post.id);
+      await refreshPost(true);
+      notificationsService.success('SEO score updated');
+    } catch {
+      notificationsService.error('Failed to score SEO');
+    } finally {
+      setIsScoringSeo(false);
+    }
+  }, [
+    post,
+    isScoringSeo,
+    isContentDirty,
+    getPostsService,
+    refreshPost,
+    notificationsService,
+  ]);
 
   const isPagePresentation = presentation === 'page';
   const wrapperClassName = isPagePresentation ? 'container mx-auto p-6' : '';
@@ -311,10 +337,13 @@ export default function PostDetail({
             scheduleDraft={scheduleDraft}
             isSavingSchedule={isSavingSchedule}
             isScheduleDirty={isScheduleDirty}
+            isScoringSeo={isScoringSeo}
+            isSeoDirty={isContentDirty}
             analyticsStats={analyticsStats}
             reviewSummary={reviewSummary}
             onScheduleChange={(value) => setScheduleDraft(value)}
             onScheduleSave={handleScheduleSave}
+            onScoreSeo={handleScoreSeo}
           />
 
           {/* Engagement Preview - shown for unpublished posts */}

--- a/packages/props/components/post-detail-sidebar.props.ts
+++ b/packages/props/components/post-detail-sidebar.props.ts
@@ -25,9 +25,12 @@ export interface PostDetailSidebarProps {
   scheduleDraft: string;
   isSavingSchedule: boolean;
   isScheduleDirty: boolean;
+  isScoringSeo?: boolean;
+  isSeoDirty?: boolean;
   analyticsStats: AnalyticsStat[];
   reviewSummary?: PostReviewSummary;
   onScheduleChange: (value: string) => void;
   onScheduleSave: () => void;
+  onScoreSeo?: () => void | Promise<void>;
   className?: string;
 }

--- a/packages/serializers/src/attributes/content/article.attributes.ts
+++ b/packages/serializers/src/attributes/content/article.attributes.ts
@@ -19,6 +19,8 @@ export const articleAttributes = createEntityAttributes([
   'viralityAnalysis',
   'performanceMetrics',
   'evaluation',
+  'seoScore',
+  'seoBreakdown',
   'generationPrompt',
   'xArticleMetadata',
 ]);

--- a/packages/serializers/src/attributes/content/post.attributes.ts
+++ b/packages/serializers/src/attributes/content/post.attributes.ts
@@ -54,5 +54,7 @@ export const postAttributes = createEntityAttributes([
   'avgEngagementRate',
   'evalScore',
   'evaluation',
+  'seoScore',
+  'seoBreakdown',
   'persona',
 ]);

--- a/packages/services/content/articles.service.test.ts
+++ b/packages/services/content/articles.service.test.ts
@@ -43,6 +43,11 @@ describe('ArticlesService', () => {
       expect(service.delete).toBeDefined();
       expect(typeof service.delete).toBe('function');
     });
+
+    it('has scoreSeo method for scoring article SEO', () => {
+      expect(service.scoreSeo).toBeDefined();
+      expect(typeof service.scoreSeo).toBe('function');
+    });
   });
 
   describe('article-specific operations', () => {

--- a/packages/services/content/articles.service.ts
+++ b/packages/services/content/articles.service.ts
@@ -1,6 +1,7 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type { ArticleCategory } from '@genfeedai/enums';
 import { PublishStatus } from '@genfeedai/enums';
+import type { ScoreSeoRequest } from '@genfeedai/interfaces';
 import { Article } from '@genfeedai/models/content/article.model';
 import { ArticleSerializer } from '@genfeedai/serializers';
 import {
@@ -171,6 +172,15 @@ export class ArticlesService extends BaseService<Article> {
         // on the response object. The frontend handles extracting these in the component.
         return article;
       });
+  }
+
+  public async scoreSeo(
+    id: string,
+    data: ScoreSeoRequest = {},
+  ): Promise<Article> {
+    return await this.instance
+      .post<JsonApiResponseDocument>(`/${id}/seo-scores`, data)
+      .then((res) => this.mapOne(res.data));
   }
 
   public async review(

--- a/packages/services/content/posts.service.test.ts
+++ b/packages/services/content/posts.service.test.ts
@@ -3,6 +3,36 @@ import { Post } from '@genfeedai/models/content/post.model';
 import { PostSerializer } from '@genfeedai/serializers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@genfeedai/pricing', () => ({
+  AVATAR_CREDIT_COSTS: {},
+  BYOK_CREDIT_VALUE_DOLLARS: 0.01,
+  BYOK_FEE_PERCENTAGE: 0,
+  BYOK_FEE_PER_CREDIT: 0,
+  BYOK_FREE_THRESHOLD_CREDITS: 0,
+  INTERNAL_CREDIT_COSTS: {},
+  PAYG_CREDIT_PACKS: [],
+  TRAINING_PACKAGES: [],
+  VIDEO_CREDIT_COSTS: {},
+  WEBSITE_CREDIT_PACKS: [],
+  applyMargin: (value: number) => value,
+  contentServiceOffering: {},
+  creatorPlan: {},
+  creditPackPrice: () => 0,
+  creditPackTotalCredits: () => 0,
+  creditsToOutputEstimate: () => '',
+  dedicatedServerPlan: {},
+  formatOutputs: () => '',
+  formatPrice: () => '',
+  getCloudTeamsPlan: () => null,
+  getCreatorPlan: () => null,
+  getEnterprisePlan: () => null,
+  getHostedPlan: () => null,
+  getPlanByLabel: () => null,
+  getProPlan: () => null,
+  getScalePlan: () => null,
+  websitePlans: [],
+}));
+
 // Mock EnvironmentService
 vi.mock('@services/core/environment.service', () => ({
   EnvironmentService: {
@@ -54,14 +84,16 @@ vi.mock('@services/core/base.service', () => {
       return new ServiceClass(token);
     }
 
-    protected async mapOne(data: any): Promise<Post> {
-      return new Post(data.data || data);
+    protected async mapOne(data: unknown): Promise<Post> {
+      const payload = data as { data?: unknown };
+      return new Post((payload.data ?? data) as Partial<Post>);
     }
 
-    protected async mapMany(data: any): Promise<Post[]> {
-      const items = data.data || data;
+    protected async mapMany(data: unknown): Promise<Post[]> {
+      const payload = data as { data?: unknown };
+      const items = payload.data ?? data;
       return Array.isArray(items)
-        ? items.map((item: any) => new Post(item))
+        ? items.map((item) => new Post(item as Partial<Post>))
         : [];
     }
   }
@@ -107,11 +139,13 @@ describe('PostsService', () => {
 
   describe('constructor', () => {
     it('should initialize with correct endpoint', () => {
-      expect((service as any).endpoint).toBe(API_ENDPOINTS.POSTS);
+      expect((service as unknown as { endpoint: string }).endpoint).toBe(
+        API_ENDPOINTS.POSTS,
+      );
     });
 
     it('should initialize with provided token', () => {
-      expect((service as any).token).toBe(mockToken);
+      expect((service as unknown as { token: string }).token).toBe(mockToken);
     });
   });
 
@@ -169,6 +203,21 @@ describe('PostsService', () => {
           },
         );
       }
+    });
+  });
+
+  describe('scoreSeo', () => {
+    it('should score post SEO with an optional target keyword', async () => {
+      mockInstance.post.mockResolvedValue({ data: mockPostData });
+
+      const result = await service.scoreSeo('post-123', {
+        targetKeyword: 'workflow automation',
+      });
+
+      expect(mockInstance.post).toHaveBeenCalledWith('/post-123/seo-scores', {
+        targetKeyword: 'workflow automation',
+      });
+      expect(result).toBeInstanceOf(Post);
     });
   });
 

--- a/packages/services/content/posts.service.ts
+++ b/packages/services/content/posts.service.ts
@@ -1,6 +1,7 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type {
   AccountPublishingContext,
+  ScoreSeoRequest,
   SocialGenerationFormat,
 } from '@genfeedai/interfaces';
 import { Post } from '@genfeedai/models/content/post.model';
@@ -70,6 +71,14 @@ export class PostsService extends BaseService<Post> {
     const response = await this.instance.post<JsonApiResponseDocument>(
       `/${id}/enhancements`,
       { prompt, tone },
+    );
+    return this.mapOne(response.data);
+  }
+
+  public async scoreSeo(id: string, data: ScoreSeoRequest = {}): Promise<Post> {
+    const response = await this.instance.post<JsonApiResponseDocument>(
+      `/${id}/seo-scores`,
+      data,
     );
     return this.mapOne(response.data);
   }

--- a/packages/ui/src/components/evaluation/seo-scorecard/SeoScorecard.test.tsx
+++ b/packages/ui/src/components/evaluation/seo-scorecard/SeoScorecard.test.tsx
@@ -1,0 +1,87 @@
+import type { SeoScorecardSnapshot } from '@genfeedai/interfaces';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SeoScorecard from '@ui/evaluation/seo-scorecard/SeoScorecard';
+import { describe, expect, it, vi } from 'vitest';
+
+const scorecard: SeoScorecardSnapshot = {
+  breakdown: {
+    contentStructure: 16,
+    keywordPlacement: 18,
+    links: 4,
+    media: 6,
+    metaOptimization: 12,
+    readability: 13,
+    technicalSignals: 8,
+  },
+  checks: [
+    {
+      available: true,
+      dimension: 'metaOptimization',
+      id: 'title_length',
+      kind: 'deterministic',
+      label: 'Title length',
+      max: 3,
+      note: 'Title length is within range.',
+      points: 3,
+    },
+    {
+      available: true,
+      dimension: 'links',
+      id: 'internal_links',
+      kind: 'deterministic',
+      label: 'Internal links',
+      max: 3,
+      note: 'Add internal links.',
+      points: 1,
+    },
+  ],
+  meta: {
+    fleschReadingEase: 58,
+    keywordDensity: 1.4,
+    llmApplied: true,
+    maxAvailable: 100,
+    scoredAt: '2026-06-28T12:00:00.000Z',
+    targetKeyword: 'workflow automation',
+    wordCount: 842,
+  },
+  rating: 'good',
+  score: 77,
+  suggestions: ['Add more internal links.', 'Tighten the meta description.'],
+};
+
+describe('SeoScorecard', () => {
+  it('renders score, breakdown, checks, and suggestions', () => {
+    render(<SeoScorecard score={77} scorecard={scorecard} />);
+
+    expect(screen.getByText('77')).toBeInTheDocument();
+    expect(screen.getByText('/100')).toBeInTheDocument();
+    expect(screen.getByText('Good')).toBeInTheDocument();
+    expect(screen.getByText('workflow automation')).toBeInTheDocument();
+    expect(screen.getByText('Keyword')).toBeInTheDocument();
+    expect(screen.getByText('18/20')).toBeInTheDocument();
+    expect(screen.getByText('Title length')).toBeInTheDocument();
+    expect(screen.getByText('Internal links')).toBeInTheDocument();
+    expect(screen.getByText('Add more internal links.')).toBeInTheDocument();
+  });
+
+  it('renders an empty state and calls onScore', () => {
+    const onScore = vi.fn();
+    render(<SeoScorecard contentTypeLabel="article" onScore={onScore} />);
+
+    expect(screen.getByText('No SEO score yet')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Score SEO' }));
+
+    expect(onScore).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables scoring when the content has unsaved changes', () => {
+    const onScore = vi.fn();
+    render(<SeoScorecard hasUnsavedChanges={true} onScore={onScore} />);
+
+    expect(screen.getByRole('button', { name: 'Score SEO' })).toBeDisabled();
+    expect(
+      screen.getByText('Save your changes before scoring.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/evaluation/seo-scorecard/SeoScorecard.tsx
+++ b/packages/ui/src/components/evaluation/seo-scorecard/SeoScorecard.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
+import type {
+  SeoCheck,
+  SeoDimension,
+  SeoScorecardSnapshot,
+} from '@genfeedai/interfaces';
+import Card from '@ui/card/Card';
+import { Badge } from '@ui/primitives/badge';
+import { Button } from '@ui/primitives/button';
+import { Progress } from '@ui/primitives/progress';
+import { Separator } from '@ui/primitives/separator';
+import {
+  AlertCircle,
+  CheckCircle2,
+  CircleDot,
+  Gauge,
+  RefreshCw,
+} from 'lucide-react';
+
+const DETERMINISTIC_CHECK_IDS = [
+  'title_length',
+  'meta_length',
+  'slug_format',
+  'heading_hierarchy',
+  'image_alt_text',
+  'internal_links',
+] as const;
+
+const SEO_DIMENSIONS: SeoDimension[] = [
+  'keywordPlacement',
+  'contentStructure',
+  'readability',
+  'metaOptimization',
+  'links',
+  'media',
+  'technicalSignals',
+];
+
+const SEO_DIMENSION_MAX: Record<SeoDimension, number> = {
+  contentStructure: 20,
+  keywordPlacement: 20,
+  links: 10,
+  media: 10,
+  metaOptimization: 15,
+  readability: 15,
+  technicalSignals: 10,
+};
+
+const DIMENSION_LABELS: Record<SeoDimension, string> = {
+  contentStructure: 'Structure',
+  keywordPlacement: 'Keyword',
+  links: 'Links',
+  media: 'Media',
+  metaOptimization: 'Metadata',
+  readability: 'Readability',
+  technicalSignals: 'Technical',
+};
+
+const RATING_LABELS: Record<string, string> = {
+  critical: 'Critical',
+  excellent: 'Excellent',
+  good: 'Good',
+  needs_work: 'Needs work',
+  poor: 'Poor',
+};
+
+type CheckState = 'pass' | 'partial' | 'fix' | 'unavailable';
+
+export interface SeoScorecardProps {
+  score?: number | null;
+  scorecard?: SeoScorecardSnapshot | null;
+  contentTypeLabel?: string;
+  isScoring?: boolean;
+  isDisabled?: boolean;
+  hasUnsavedChanges?: boolean;
+  onScore?: () => void | Promise<void>;
+  className?: string;
+}
+
+function getScoreTone(score: number): string {
+  if (score >= 85) {
+    return 'text-success';
+  }
+  if (score >= 70) {
+    return 'text-info';
+  }
+  if (score >= 50) {
+    return 'text-warning';
+  }
+  return 'text-error';
+}
+
+function getCheckState(check: SeoCheck): CheckState {
+  if (!check.available) {
+    return 'unavailable';
+  }
+
+  const ratio = check.max > 0 ? check.points / check.max : 0;
+  if (ratio >= 0.9) {
+    return 'pass';
+  }
+  if (ratio >= 0.5) {
+    return 'partial';
+  }
+  return 'fix';
+}
+
+function getCheckIcon(state: CheckState) {
+  switch (state) {
+    case 'pass':
+      return <CheckCircle2 className="size-3.5" />;
+    case 'partial':
+      return <CircleDot className="size-3.5" />;
+    case 'fix':
+      return <AlertCircle className="size-3.5" />;
+    case 'unavailable':
+      return <CircleDot className="size-3.5" />;
+  }
+}
+
+function getCheckVariant(state: CheckState) {
+  switch (state) {
+    case 'pass':
+      return 'success';
+    case 'partial':
+      return 'warning';
+    case 'fix':
+      return 'destructive';
+    case 'unavailable':
+      return 'outline';
+  }
+}
+
+function formatPercent(value: number, max: number): number {
+  if (max <= 0) {
+    return 0;
+  }
+  return Math.round((value / max) * 100);
+}
+
+function formatScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+export default function SeoScorecard({
+  score,
+  scorecard,
+  contentTypeLabel = 'content',
+  isScoring = false,
+  isDisabled = false,
+  hasUnsavedChanges = false,
+  onScore,
+  className,
+}: SeoScorecardProps) {
+  const resolvedScore =
+    typeof score === 'number'
+      ? formatScore(score)
+      : typeof scorecard?.score === 'number'
+        ? formatScore(scorecard.score)
+        : null;
+  const hasScore = resolvedScore !== null;
+  const actionLabel = hasScore ? 'Re-score' : 'Score';
+  const scoreDisabled =
+    isDisabled || isScoring || hasUnsavedChanges || !onScore;
+  const deterministicChecks =
+    scorecard?.checks?.filter((check) =>
+      DETERMINISTIC_CHECK_IDS.includes(
+        check.id as (typeof DETERMINISTIC_CHECK_IDS)[number],
+      ),
+    ) ?? [];
+
+  const headerAction = onScore ? (
+    <Button
+      ariaLabel={`${actionLabel} SEO`}
+      icon={<RefreshCw className="size-4" />}
+      isDisabled={scoreDisabled}
+      isLoading={isScoring}
+      label={isScoring ? 'Scoring' : actionLabel}
+      onClick={() => {
+        void onScore();
+      }}
+      size={ButtonSize.SM}
+      tooltip={
+        hasUnsavedChanges
+          ? 'Save changes before scoring SEO'
+          : `${actionLabel} SEO`
+      }
+      variant={ButtonVariant.GENERATE}
+    />
+  ) : undefined;
+
+  if (!hasScore || !scorecard) {
+    return (
+      <Card
+        label="SEO Scorecard"
+        headerAction={headerAction}
+        className={cn('border border-white/[0.08] bg-card', className)}
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <Gauge className="size-4" />
+          </div>
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm font-medium">No SEO score yet</p>
+            <p className="text-xs leading-relaxed text-foreground/60">
+              Score this {contentTypeLabel.toLowerCase()} to check keywords,
+              metadata, links, media, structure, and readability.
+            </p>
+            {hasUnsavedChanges ? (
+              <p className="text-xs text-warning">
+                Save your changes before scoring.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      label="SEO Scorecard"
+      headerAction={headerAction}
+      className={cn('border border-white/[0.08] bg-card', className)}
+      bodyClassName="space-y-4"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div
+            className={cn(
+              'text-4xl font-semibold',
+              getScoreTone(resolvedScore),
+            )}
+          >
+            {resolvedScore}
+            <span className="text-base font-medium text-foreground/40">
+              /100
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={resolvedScore >= 70 ? 'success' : 'warning'}>
+              {RATING_LABELS[scorecard.rating] ?? scorecard.rating}
+            </Badge>
+            {scorecard.meta?.targetKeyword ? (
+              <Badge variant="outline">{scorecard.meta.targetKeyword}</Badge>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="text-right text-xs text-foreground/60">
+          <p>{scorecard.meta?.wordCount ?? 0} words</p>
+          <p>Flesch {Math.round(scorecard.meta?.fleschReadingEase ?? 0)}</p>
+          {scorecard.meta?.keywordDensity !== null &&
+          scorecard.meta?.keywordDensity !== undefined ? (
+            <p>{scorecard.meta.keywordDensity.toFixed(1)}% keyword</p>
+          ) : null}
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        {SEO_DIMENSIONS.map((dimension) => {
+          const value = scorecard.breakdown?.[dimension] ?? 0;
+          const max = SEO_DIMENSION_MAX[dimension];
+          return (
+            <div key={dimension} className="space-y-1.5">
+              <div className="flex items-center justify-between gap-3 text-xs">
+                <span className="font-medium text-foreground/70">
+                  {DIMENSION_LABELS[dimension]}
+                </span>
+                <span className="text-foreground/50">
+                  {value}/{max}
+                </span>
+              </div>
+              <Progress value={formatPercent(value, max)} />
+            </div>
+          );
+        })}
+      </div>
+
+      {deterministicChecks.length > 0 ? (
+        <>
+          <Separator />
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold text-foreground/60 uppercase">
+              Checks
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {deterministicChecks.map((check) => {
+                const state = getCheckState(check);
+                return (
+                  <Badge
+                    key={check.id}
+                    variant={getCheckVariant(state)}
+                    title={check.note}
+                    className="inline-flex items-center gap-1.5"
+                  >
+                    {getCheckIcon(state)}
+                    {check.label}
+                  </Badge>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      ) : null}
+
+      {scorecard.suggestions.length > 0 ? (
+        <>
+          <Separator />
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold text-foreground/60 uppercase">
+              Suggestions
+            </h4>
+            <ul className="space-y-1.5">
+              {scorecard.suggestions.slice(0, 4).map((suggestion) => (
+                <li
+                  key={suggestion}
+                  className="text-xs leading-relaxed text-foreground/70"
+                >
+                  {suggestion}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      ) : null}
+    </Card>
+  );
+}

--- a/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.test.tsx
+++ b/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { PostStatus } from '@genfeedai/enums';
 import type { PostDetailSidebarProps } from '@genfeedai/props/components/post-detail-sidebar.props';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import PostDetailSidebar from '@ui/posts/post-detail-sidebar/PostDetailSidebar';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -85,5 +85,55 @@ describe('PostDetailSidebar', () => {
     expect(screen.getByText('Review State')).toBeInTheDocument();
     expect(screen.getAllByText('Changes requested')).toHaveLength(2);
     expect(screen.getAllByText('Needs a stronger hook.')).toHaveLength(2);
+  });
+
+  it('renders SEO scorecard and forwards score action', () => {
+    const onScoreSeo = vi.fn();
+
+    render(
+      <PostDetailSidebar
+        {...baseProps}
+        post={
+          {
+            id: 'post-1',
+            platform: 'twitter',
+            seoBreakdown: {
+              breakdown: {
+                contentStructure: 16,
+                keywordPlacement: 18,
+                links: 5,
+                media: 7,
+                metaOptimization: 10,
+                readability: 12,
+                technicalSignals: 8,
+              },
+              checks: [],
+              meta: {
+                fleschReadingEase: 61,
+                keywordDensity: null,
+                llmApplied: false,
+                maxAvailable: 100,
+                scoredAt: '2026-06-28T12:00:00.000Z',
+                targetKeyword: null,
+                wordCount: 120,
+              },
+              rating: 'good',
+              suggestions: ['Add a more specific title.'],
+            },
+            seoScore: 76,
+            status: PostStatus.DRAFT,
+          } as never
+        }
+        onScoreSeo={onScoreSeo}
+      />,
+    );
+
+    expect(screen.getByText('SEO Scorecard')).toBeInTheDocument();
+    expect(screen.getByText('76')).toBeInTheDocument();
+    expect(screen.getByText('Add a more specific title.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-score SEO' }));
+
+    expect(onScoreSeo).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.tsx
+++ b/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@genfeedai/utils/media/ingredient-type.util';
 import Card from '@ui/card/Card';
 import EvaluationCard from '@ui/evaluation/card/EvaluationCard';
+import SeoScorecard from '@ui/evaluation/seo-scorecard/SeoScorecard';
 import {
   LazyMasonryImage,
   LazyMasonryVideo,
@@ -29,10 +30,13 @@ export default function PostDetailSidebar({
   scheduleDraft,
   isSavingSchedule,
   isScheduleDirty,
+  isScoringSeo = false,
+  isSeoDirty = false,
   analyticsStats,
   reviewSummary,
   onScheduleChange,
   onScheduleSave,
+  onScoreSeo,
   className = '',
 }: PostDetailSidebarProps) {
   // Get browser timezone for consistent date display
@@ -102,6 +106,15 @@ export default function PostDetailSidebar({
         onEvaluate={async () => {
           await evaluate();
         }}
+      />
+
+      <SeoScorecard
+        score={post.seoScore}
+        scorecard={post.seoBreakdown}
+        contentTypeLabel="post"
+        isScoring={isScoringSeo}
+        hasUnsavedChanges={isSeoDirty}
+        onScore={onScoreSeo}
       />
 
       {isPublished && post.ingredients?.length > 0 && (


### PR DESCRIPTION
## Summary
- Adds org-scoped SEO scoring endpoints for posts and articles using the canonical SeoScorerService.
- Serializes seoScore and seoBreakdown through shared interfaces, client models, and services.
- Adds a reusable inline SEO scorecard in post and article sidebars with score, dimension breakdown, checks, suggestions, and dirty-state guards.

Closes #760
Refs #757

## Validation
- bun run test:file src/collections/posts/controllers/operations/posts-operations.controller.spec.ts src/collections/articles/controllers/articles.controller.spec.ts
- bun run test src/components/evaluation/seo-scorecard/SeoScorecard.test.tsx src/components/posts/post-detail-sidebar/PostDetailSidebar.test.tsx
- bun run test pages/use-article-detail/use-article-detail.test.ts
- bun run test content/posts.service.test.ts content/articles.service.test.ts
- bun run test app/(protected)/[orgSlug]/[brandSlug]/compose/article/article-detail.test.tsx
- bunx turbo run type-check --filter=@genfeedai/interfaces --filter=@genfeedai/client --filter=@genfeedai/serializers --filter=@genfeedai/props --filter=@genfeedai/services --filter=@genfeedai/hooks --filter=@genfeedai/ui --filter=@genfeedai/app --filter=@genfeedai/api
- bun scripts/run-secretlint.ts on staged files
