### PR TITLE
feat(workflows): add SEO workflow nodes (seoScore, seoRewrite, iterativeSeoRefine, postPublishTrigger) (#761)

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -792,6 +792,8 @@ export class WorkflowEngineAdapterService {
     platforms: SocialPlatform[];
     caption: string;
     targetKeyword: string | null;
+    /** Publish status forwarded to PostPublishTriggerExecutor's `status` output field. */
+    status?: string;
   }): Promise<void> {
     if (!this.workflowExecutionQueueService) {
       return;
@@ -804,6 +806,7 @@ export class WorkflowEngineAdapterService {
         content: params.caption,
         platforms: params.platforms,
         postIds: params.postIds,
+        status: params.status ?? 'queued',
         targetKeyword: params.targetKeyword,
         title: null,
       },
@@ -1599,6 +1602,7 @@ export class WorkflowEngineAdapterService {
         targetKeyword,
         triggerSeoOptimization,
         userId,
+        workflowId,
       }) => {
         if (!postsService || !credentialsService) {
           return {
@@ -1648,15 +1652,47 @@ export class WorkflowEngineAdapterService {
         // Opt-in, loop-safe: only emit for immediate publishes that actually
         // created posts, so an SEO-optimization workflow can run on the content.
         if (triggerSeoOptimization && !scheduledFor && postIds.length > 0) {
-          await this.emitPostPublishedEvent({
-            brandId,
-            caption,
-            organizationId,
-            platforms: publishedPlatforms,
-            postIds,
-            targetKeyword: targetKeyword ?? null,
-            userId,
-          });
+          // Guard: if the current workflow is itself rooted at a
+          // `postPublishTrigger` node, re-emitting `post-published` would route
+          // back to the same workflow and create an infinite trigger loop.
+          // Fetch the workflow's node list and skip the emit when a
+          // postPublishTrigger node is present.
+          let isPostPublishWorkflow = false;
+          if (this.prismaService && workflowId) {
+            try {
+              const workflowDoc = await this.prismaService.workflow.findFirst({
+                select: { nodes: true },
+                where: { id: workflowId, isDeleted: false },
+              });
+              const nodes = Array.isArray(workflowDoc?.nodes)
+                ? (workflowDoc.nodes as Array<{ type?: string }>)
+                : [];
+              isPostPublishWorkflow = nodes.some(
+                (n) => n.type === 'postPublishTrigger',
+              );
+            } catch {
+              // Non-fatal: if the lookup fails, default to safe (no re-emit).
+              isPostPublishWorkflow = true;
+            }
+          }
+
+          if (isPostPublishWorkflow) {
+            this.loggerService.debug(
+              `${this.logContext} skipping post-published re-emit — workflow ${workflowId} is itself a postPublishTrigger workflow`,
+              { organizationId, workflowId },
+            );
+          } else {
+            await this.emitPostPublishedEvent({
+              brandId,
+              caption,
+              organizationId,
+              platforms: publishedPlatforms,
+              postIds,
+              status: 'queued',
+              targetKeyword: targetKeyword ?? null,
+              userId,
+            });
+          }
         }
 
         return {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -37,6 +37,8 @@ import { ContentProductionWorkflowService } from '@api/collections/workflows/ser
 import { LivestreamBotWorkflowService } from '@api/collections/workflows/services/livestream-bot-workflow.service';
 import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
+import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
+import type { TriggerEvent } from '@api/collections/workflows/services/workflow-executor.service';
 import type { TrendNotificationCadence } from '@api/collections/workflows/templates/trend-notification-workflows.template';
 import { ConfigService } from '@api/config/config.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -48,6 +50,7 @@ import { OpenRouterService } from '@api/services/integrations/openrouter/service
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
+import { SeoScorerService } from '@api/services/seo/seo-scorer.service';
 import { WhisperService } from '@api/services/whisper/whisper.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { SharedService } from '@api/shared/services/shared/shared.service';
@@ -82,23 +85,29 @@ import {
   createBrandAssetExecutor,
   createBrandContextExecutor,
   createImageGenExecutor,
+  createIterativeSeoRefineExecutor,
   createLipSyncExecutor,
   createMentionTriggerExecutor,
   createNewFollowerTriggerExecutor,
   createNewLikeTriggerExecutor,
   createNewRepostTriggerExecutor,
+  createPostPublishTriggerExecutor,
   createPostReplyExecutor,
   createPromptConstructorExecutor,
   createPublishExecutor,
   createReframeExecutor,
   createSendDmExecutor,
   createSendEmailExecutor,
+  createSeoRewriteExecutor,
+  createSeoScoreExecutor,
   createTextToSpeechExecutor,
   createTrendDigestExecutor,
   createTrendTriggerExecutor,
   createUpscaleExecutor,
   type KeywordTriggerPlatform,
   type NodeExecutor,
+  type SeoRewriteResolver,
+  type SeoScoreResolver,
   type SocialPlatform,
   type TrendDigestEntry,
   type TrendPlatform,
@@ -288,6 +297,9 @@ export class WorkflowEngineAdapterService {
     private readonly legacyCronJobExecutor?: LegacyCronJobExecutor,
     @Optional()
     private readonly livestreamBotWorkflowService?: LivestreamBotWorkflowService,
+    @Optional() private readonly seoScorerService?: SeoScorerService,
+    @Optional()
+    private readonly workflowExecutionQueueService?: WorkflowExecutionQueueService,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -313,6 +325,7 @@ export class WorkflowEngineAdapterService {
     this.registerBrandAssetExecutor();
     this.registerBrandContextExecutor();
     this.registerAnalyticsFeedbackExecutor();
+    this.registerSeoExecutors();
     this.registerAdAutomationExecutors();
     this.registerCampaignOrchestrationExecutors();
     this.registerAgentAutopilotExecutors();
@@ -651,6 +664,166 @@ export class WorkflowEngineAdapterService {
       executor.nodeType,
       this.wrapEngineExecutor(executor),
     );
+  }
+
+  /**
+   * Registers the SEO workflow nodes (#761):
+   * - `seoScore`: scores content via SeoScorerService, emitting score + suggestions.
+   * - `seoRewrite`: rewrites content to address suggestions via the LLM client.
+   * - `iterativeSeoRefine`: runs an internal score -> rewrite -> re-score loop
+   *   (no graph cycle) until the target score is reached.
+   * - `postPublishTrigger`: root trigger node; output is injected from the
+   *   `post-published` event when a workflow is started by a publish.
+   *
+   * The score + rewrite resolvers are shared between the standalone nodes and
+   * the iterative node so behavior stays identical across both composition styles.
+   */
+  private registerSeoExecutors(): void {
+    const seoScorerService = this.seoScorerService;
+    const openRouterService = this.openRouterService;
+
+    const scoreResolver: SeoScoreResolver = async ({ content, useLlm }) => {
+      if (!seoScorerService) {
+        return {
+          breakdown: {},
+          rating: 'critical',
+          score: 0,
+          suggestions: ['SEO scorer service unavailable'],
+        };
+      }
+      const scorecard = await seoScorerService.scoreContent(content, {
+        useLlm,
+      });
+      return {
+        breakdown: scorecard.breakdown,
+        rating: scorecard.rating,
+        score: scorecard.score,
+        suggestions: scorecard.suggestions,
+      };
+    };
+
+    const rewriteResolver: SeoRewriteResolver = async ({
+      content,
+      suggestions,
+      targetKeyword,
+      title,
+      model,
+    }) => {
+      if (!openRouterService) {
+        // Graceful degradation: return content unchanged so the loop terminates
+        // rather than throwing in environments without an LLM client.
+        return { model: null, text: content };
+      }
+
+      const systemPrompt =
+        'You are an expert SEO editor. Rewrite the provided content to address ' +
+        'the listed SEO suggestions while preserving the original meaning, tone, ' +
+        'and factual accuracy. Return ONLY the rewritten content body (plain text ' +
+        'or HTML matching the input) with no preamble or commentary.';
+
+      const userPrompt = [
+        title ? `Title: ${title}` : null,
+        targetKeyword ? `Target keyword: ${targetKeyword}` : null,
+        suggestions.length > 0
+          ? `SEO suggestions to address:\n${suggestions
+              .map((suggestion, index) => `${index + 1}. ${suggestion}`)
+              .join('\n')}`
+          : null,
+        `Content:\n${content}`,
+      ]
+        .filter((section): section is string => section !== null)
+        .join('\n\n');
+
+      const response = await openRouterService.chatCompletion({
+        max_tokens: 2000,
+        messages: [
+          { content: systemPrompt, role: 'system' },
+          { content: userPrompt, role: 'user' },
+        ],
+        model: model ?? 'openai/gpt-4o-mini',
+        temperature: 0.4,
+      });
+
+      const rewritten = response.choices[0]?.message?.content?.trim() ?? '';
+      return {
+        model: response.model,
+        text: rewritten.length > 0 ? rewritten : content,
+      };
+    };
+
+    const seoScoreExecutor = createSeoScoreExecutor(scoreResolver);
+    this.engine.registerExecutor(
+      seoScoreExecutor.nodeType,
+      this.wrapEngineExecutor(seoScoreExecutor),
+    );
+
+    const seoRewriteExecutor = createSeoRewriteExecutor(rewriteResolver);
+    this.engine.registerExecutor(
+      seoRewriteExecutor.nodeType,
+      this.wrapEngineExecutor(seoRewriteExecutor),
+    );
+
+    const iterativeSeoRefineExecutor = createIterativeSeoRefineExecutor(
+      scoreResolver,
+      rewriteResolver,
+    );
+    this.engine.registerExecutor(
+      iterativeSeoRefineExecutor.nodeType,
+      this.wrapEngineExecutor(iterativeSeoRefineExecutor),
+    );
+
+    const postPublishTriggerExecutor = createPostPublishTriggerExecutor();
+    this.engine.registerExecutor(
+      postPublishTriggerExecutor.nodeType,
+      this.wrapEngineExecutor(postPublishTriggerExecutor),
+    );
+  }
+
+  /**
+   * Emits a `post-published` trigger event so any workflow rooted at a
+   * `postPublishTrigger` node runs an SEO-optimization pass on the published
+   * content. Best-effort: failures are logged and never block publishing.
+   */
+  private async emitPostPublishedEvent(params: {
+    organizationId: string;
+    userId: string;
+    brandId: string;
+    postIds: string[];
+    platforms: SocialPlatform[];
+    caption: string;
+    targetKeyword: string | null;
+  }): Promise<void> {
+    if (!this.workflowExecutionQueueService) {
+      return;
+    }
+
+    const event: TriggerEvent = {
+      data: {
+        brandId: params.brandId,
+        caption: params.caption,
+        content: params.caption,
+        platforms: params.platforms,
+        postIds: params.postIds,
+        targetKeyword: params.targetKeyword,
+        title: null,
+      },
+      organizationId: params.organizationId,
+      platform: params.platforms[0] ?? 'multi',
+      type: 'post-published',
+      userId: params.userId,
+    };
+
+    try {
+      await this.workflowExecutionQueueService.queueTriggerEvent(event);
+    } catch (error) {
+      this.loggerService.error(
+        `${this.logContext} failed to emit post-published event`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+          organizationId: params.organizationId,
+        },
+      );
+    }
   }
 
   private registerAdAutomationExecutors(): void {
@@ -1423,6 +1596,8 @@ export class WorkflowEngineAdapterService {
         organizationId,
         platforms,
         scheduledFor,
+        targetKeyword,
+        triggerSeoOptimization,
         userId,
       }) => {
         if (!postsService || !credentialsService) {
@@ -1468,6 +1643,20 @@ export class WorkflowEngineAdapterService {
 
           postIds.push(post._id.toString());
           publishedPlatforms.push(platform);
+        }
+
+        // Opt-in, loop-safe: only emit for immediate publishes that actually
+        // created posts, so an SEO-optimization workflow can run on the content.
+        if (triggerSeoOptimization && !scheduledFor && postIds.length > 0) {
+          await this.emitPostPublishedEvent({
+            brandId,
+            caption,
+            organizationId,
+            platforms: publishedPlatforms,
+            postIds,
+            targetKeyword: targetKeyword ?? null,
+            userId,
+          });
         }
 
         return {

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
@@ -125,6 +125,7 @@ const TRIGGER_NODE_TYPES = new Set([
   'newFollowerTrigger',
   'newLikeTrigger',
   'newRepostTrigger',
+  'postPublishTrigger',
   'trendTrigger',
 ]);
 
@@ -141,6 +142,8 @@ const EVENT_TYPE_TO_NODE_TYPE: Record<string, string> = {
   newLikeTrigger: 'newLikeTrigger',
   newRepost: 'newRepostTrigger',
   newRepostTrigger: 'newRepostTrigger',
+  'post-published': 'postPublishTrigger',
+  postPublishTrigger: 'postPublishTrigger',
   trend: 'trendTrigger',
   trendTrigger: 'trendTrigger',
 };

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -76,6 +76,7 @@ import { TwitterModule } from '@api/services/integrations/twitter/twitter.module
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
 import { ReplyBotModule } from '@api/services/reply-bot/reply-bot.module';
+import { SeoModule } from '@api/services/seo/seo.module';
 import { WhisperModule } from '@api/services/whisper/whisper.module';
 import { WorkflowExecutorModule } from '@api/services/workflow-executor/workflow-executor.module';
 import { SharedModule } from '@api/shared/shared.module';
@@ -150,6 +151,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => QueuesModule),
     forwardRef(() => ReplyBotConfigsModule),
     forwardRef(() => ReplyBotModule),
+    forwardRef(() => SeoModule),
     forwardRef(() => SharedModule),
     forwardRef(() => TikTokAdsModule),
     forwardRef(() => TrendsModule),

--- a/packages/workflow-engine/src/executors/executor-registry.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.ts
@@ -52,6 +52,10 @@ import {
   ImageGenExecutor,
 } from '@workflow-engine/executors/saas/image-gen-executor';
 import {
+  createIterativeSeoRefineExecutor,
+  IterativeSeoRefineExecutor,
+} from '@workflow-engine/executors/saas/iterative-seo-refine-executor';
+import {
   createKeywordTriggerExecutor,
   KeywordTriggerExecutor,
 } from '@workflow-engine/executors/saas/keyword-trigger-executor';
@@ -88,6 +92,10 @@ import {
   PatternContextExecutor,
 } from '@workflow-engine/executors/saas/pattern-context-executor';
 import {
+  createPostPublishTriggerExecutor,
+  PostPublishTriggerExecutor,
+} from '@workflow-engine/executors/saas/post-publish-trigger-executor';
+import {
   createPostReplyExecutor,
   PostReplyExecutor,
 } from '@workflow-engine/executors/saas/post-reply-executor';
@@ -115,6 +123,14 @@ import {
   createSendEmailExecutor,
   SendEmailExecutor,
 } from '@workflow-engine/executors/saas/send-email-executor';
+import {
+  createSeoRewriteExecutor,
+  SeoRewriteExecutor,
+} from '@workflow-engine/executors/saas/seo-rewrite-executor';
+import {
+  createSeoScoreExecutor,
+  SeoScoreExecutor,
+} from '@workflow-engine/executors/saas/seo-score-executor';
 import {
   createSocialPublishExecutor,
   SocialPublishExecutor,
@@ -299,6 +315,14 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     nodeType: 'imageGen',
     requiresResolver: true,
   },
+  iterativeSeoRefine: {
+    description:
+      'Runs an internal SEO score -> rewrite -> re-score loop until the target score is reached (no graph cycle)',
+    executorClass: IterativeSeoRefineExecutor,
+    factory: () => createIterativeSeoRefineExecutor(),
+    nodeType: 'iterativeSeoRefine',
+    requiresResolver: true,
+  },
   keywordTrigger: {
     description:
       'Starts workflow when a keyword or phrase is detected in social posts',
@@ -376,6 +400,14 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     nodeType: 'patternContext',
     requiresResolver: true,
   },
+  postPublishTrigger: {
+    description:
+      'Starts an SEO-optimization workflow when content is published (post-published event)',
+    executorClass: PostPublishTriggerExecutor,
+    factory: () => createPostPublishTriggerExecutor(),
+    nodeType: 'postPublishTrigger',
+    requiresResolver: false,
+  },
   postReply: {
     description: 'Replies to a social media post on the specified platform',
     executorClass: PostReplyExecutor,
@@ -424,6 +456,22 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     executorClass: SendEmailExecutor,
     factory: () => createSendEmailExecutor(),
     nodeType: 'sendEmail',
+    requiresResolver: true,
+  },
+  seoRewrite: {
+    description:
+      'Rewrites content to address SEO suggestions from an upstream seoScore node',
+    executorClass: SeoRewriteExecutor,
+    factory: () => createSeoRewriteExecutor(),
+    nodeType: 'seoRewrite',
+    requiresResolver: true,
+  },
+  seoScore: {
+    description:
+      'Scores content against the canonical SEO rubric; emits score, breakdown, and suggestions',
+    executorClass: SeoScoreExecutor,
+    factory: () => createSeoScoreExecutor(),
+    nodeType: 'seoScore',
     requiresResolver: true,
   },
   socialPublish: {

--- a/packages/workflow-engine/src/executors/saas/index.ts
+++ b/packages/workflow-engine/src/executors/saas/index.ts
@@ -14,6 +14,8 @@ export * from '@workflow-engine/executors/saas/engagement-trigger-executor';
 export * from '@workflow-engine/executors/saas/film-grain-executor';
 // AI generation executors
 export * from '@workflow-engine/executors/saas/image-gen-executor';
+// SEO score -> rewrite -> re-score loop executor
+export * from '@workflow-engine/executors/saas/iterative-seo-refine-executor';
 export * from '@workflow-engine/executors/saas/keyword-trigger-executor';
 export * from '@workflow-engine/executors/saas/lens-effects-executor';
 // Lip sync executor
@@ -23,6 +25,8 @@ export * from '@workflow-engine/executors/saas/music-source-executor';
 export * from '@workflow-engine/executors/saas/new-follower-trigger-executor';
 export * from '@workflow-engine/executors/saas/new-like-trigger-executor';
 export * from '@workflow-engine/executors/saas/new-repost-trigger-executor';
+// Post-publish SEO trigger executor
+export * from '@workflow-engine/executors/saas/post-publish-trigger-executor';
 // Social action executors
 export * from '@workflow-engine/executors/saas/post-reply-executor';
 // Prompt construction executor
@@ -33,6 +37,9 @@ export * from '@workflow-engine/executors/saas/reframe-executor';
 export * from '@workflow-engine/executors/saas/rss-input-executor';
 export * from '@workflow-engine/executors/saas/send-dm-executor';
 export * from '@workflow-engine/executors/saas/send-email-executor';
+// SEO scoring + rewrite executors
+export * from '@workflow-engine/executors/saas/seo-rewrite-executor';
+export * from '@workflow-engine/executors/saas/seo-score-executor';
 export {
   createSocialPublishExecutor,
   SocialPublishExecutor,

--- a/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.spec.ts
@@ -203,7 +203,7 @@ describe('IterativeSeoRefineExecutor', () => {
     });
   });
 
-  it('estimates cost proportional to maxIterations', () => {
+  it('estimates cost proportional to maxIterations (initial score + iterations)', () => {
     const node: ExecutableNode = {
       config: { maxIterations: 3 },
       id: 'r',
@@ -211,6 +211,37 @@ describe('IterativeSeoRefineExecutor', () => {
       label: 'R',
       type: 'iterativeSeoRefine',
     };
-    expect(executor.estimateCost(node)).toBe(15);
+    // 2 (initial score) + 3 × 5 (score + rewrite per iteration) = 17
+    expect(executor.estimateCost(node)).toBe(17);
+  });
+
+  it('returns the best-scoring candidate, not the last, when a rewrite lowers the score', async () => {
+    // Scores: initial=60, after rewrite-1=80 (best), after rewrite-2=50 (regression)
+    const score = scoreSequence([60, 80, 50]);
+    executor.setScoreResolver(score as unknown as SeoScoreResolver);
+
+    let rewriteCall = 0;
+    rewrite.mockImplementation(async () => {
+      rewriteCall += 1;
+      return {
+        model: 'm',
+        text: rewriteCall === 1 ? 'best body' : 'worse body',
+      };
+    });
+
+    const result = await executor.execute(
+      makeInput(
+        { maxIterations: 3, targetScore: 90 },
+        { content: 'original body' },
+      ),
+    );
+    const data = result.data as IterativeSeoRefineOutput;
+
+    // Should return the best candidate (score 80, after first rewrite), not the last (50)
+    expect(data.score).toBe(80);
+    expect(data.text).toBe('best body');
+    expect(data.converged).toBe(false);
+    // History still records all iterations
+    expect(data.history).toHaveLength(4); // initial + 3 rewrites (loop runs until maxIterations)
   });
 });

--- a/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.spec.ts
@@ -1,0 +1,216 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createIterativeSeoRefineExecutor,
+  type IterativeSeoRefineExecutor,
+  type IterativeSeoRefineOutput,
+} from '@workflow-engine/executors/saas/iterative-seo-refine-executor';
+import type { SeoRewriteResolver } from '@workflow-engine/executors/saas/seo-rewrite-executor';
+import type { SeoScoreResolver } from '@workflow-engine/executors/saas/seo-score-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeInput(
+  config: Record<string, unknown>,
+  upstream?: Record<string, unknown>,
+): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'refine-1',
+    inputs: [],
+    label: 'Iterative SEO Refine',
+    type: 'iterativeSeoRefine',
+  };
+  const inputs = new Map<string, unknown>();
+  if (upstream !== undefined) {
+    inputs.set('in', upstream);
+  }
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs, node };
+}
+
+/** Score resolver that returns the next score from a queue on each call. */
+function scoreSequence(scores: number[]): ReturnType<typeof vi.fn> {
+  let call = 0;
+  return vi.fn().mockImplementation(async () => {
+    const score = scores[Math.min(call, scores.length - 1)] ?? 0;
+    call += 1;
+    return {
+      breakdown: { keywordPlacement: score / 4 },
+      rating: score >= 80 ? 'good' : 'needs_work',
+      score,
+      suggestions: ['improve'],
+    };
+  });
+}
+
+describe('IterativeSeoRefineExecutor', () => {
+  let executor: IterativeSeoRefineExecutor;
+  let rewrite: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executor = createIterativeSeoRefineExecutor();
+    rewrite = vi
+      .fn()
+      .mockImplementation(async () => ({ model: 'm', text: 'rewritten body' }));
+    executor.setRewriteResolver(rewrite as unknown as SeoRewriteResolver);
+  });
+
+  it('throws when resolvers are not configured', async () => {
+    const fresh = createIterativeSeoRefineExecutor();
+    await expect(fresh.execute(makeInput({ content: 'x' }))).rejects.toThrow(
+      'Iterative SEO refine resolvers not configured',
+    );
+  });
+
+  it('throws when content is missing', async () => {
+    executor.setScoreResolver(
+      scoreSequence([90]) as unknown as SeoScoreResolver,
+    );
+    await expect(executor.execute(makeInput({}))).rejects.toThrow(
+      'Missing required input: content',
+    );
+  });
+
+  it('returns immediately with zero rewrites when the input already passes', async () => {
+    const score = scoreSequence([85]);
+    executor.setScoreResolver(score as unknown as SeoScoreResolver);
+
+    const result = await executor.execute(
+      makeInput({ targetScore: 80 }, { content: '<p>good</p>' }),
+    );
+    const data = result.data as IterativeSeoRefineOutput;
+
+    expect(data.converged).toBe(true);
+    expect(data.iterations).toBe(0);
+    expect(data.score).toBe(85);
+    expect(data.text).toBe('<p>good</p>');
+    expect(rewrite).not.toHaveBeenCalled();
+    expect(data.history).toEqual([
+      { iteration: 0, rewritten: false, score: 85 },
+    ]);
+  });
+
+  it('rewrites and re-scores until the target score is reached', async () => {
+    // initial 50 -> rewrite -> 70 -> rewrite -> 82 (converges on 2nd pass)
+    const score = scoreSequence([50, 70, 82]);
+    executor.setScoreResolver(score as unknown as SeoScoreResolver);
+
+    const result = await executor.execute(
+      makeInput(
+        { maxIterations: 5, targetScore: 80 },
+        { content: '<p>weak</p>', targetKeyword: 'kw', title: 'T' },
+      ),
+    );
+    const data = result.data as IterativeSeoRefineOutput;
+
+    expect(data.converged).toBe(true);
+    expect(data.iterations).toBe(2);
+    expect(data.score).toBe(82);
+    expect(data.text).toBe('rewritten body');
+    expect(rewrite).toHaveBeenCalledTimes(2);
+    expect(score).toHaveBeenCalledTimes(3);
+    expect(data.history).toEqual([
+      { iteration: 0, rewritten: false, score: 50 },
+      { iteration: 1, rewritten: true, score: 70 },
+      { iteration: 2, rewritten: true, score: 82 },
+    ]);
+  });
+
+  it('stops at maxIterations without converging when the target is never met', async () => {
+    const score = scoreSequence([10, 20, 30]);
+    executor.setScoreResolver(score as unknown as SeoScoreResolver);
+
+    const result = await executor.execute(
+      makeInput({ maxIterations: 2, targetScore: 90 }, { content: 'low' }),
+    );
+    const data = result.data as IterativeSeoRefineOutput;
+
+    expect(data.converged).toBe(false);
+    expect(data.iterations).toBe(2);
+    expect(rewrite).toHaveBeenCalledTimes(2);
+    expect(data.history).toHaveLength(3);
+  });
+
+  it('forwards the latest suggestions into each rewrite call', async () => {
+    executor.setScoreResolver(
+      scoreSequence([40, 95]) as unknown as SeoScoreResolver,
+    );
+    await executor.execute(makeInput({ targetScore: 80 }, { content: 'body' }));
+    expect(rewrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'body',
+        suggestions: ['improve'],
+      }),
+    );
+  });
+
+  it('stops refining when the rewrite resolver returns empty content', async () => {
+    executor.setScoreResolver(
+      scoreSequence([40, 40, 40]) as unknown as SeoScoreResolver,
+    );
+    rewrite.mockResolvedValueOnce({ model: 'm', text: '' });
+
+    const result = await executor.execute(
+      makeInput({ maxIterations: 3, targetScore: 80 }, { content: 'body' }),
+    );
+    const data = result.data as IterativeSeoRefineOutput;
+
+    expect(data.iterations).toBe(0);
+    expect(data.text).toBe('body');
+    expect(data.converged).toBe(false);
+    expect(rewrite).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads content from a ConditionResult passthrough', async () => {
+    executor.setScoreResolver(
+      scoreSequence([95]) as unknown as SeoScoreResolver,
+    );
+    const result = await executor.execute(
+      makeInput(
+        { targetScore: 80 },
+        {
+          actualValue: 60,
+          data: { content: '<p>from condition</p>' },
+          operator: 'greaterThanOrEquals',
+          result: false,
+        },
+      ),
+    );
+    expect((result.data as IterativeSeoRefineOutput).text).toBe(
+      '<p>from condition</p>',
+    );
+  });
+
+  describe('validate', () => {
+    it('rejects out-of-range targetScore and maxIterations', () => {
+      const node: ExecutableNode = {
+        config: { maxIterations: 99, targetScore: 150 },
+        id: 'r',
+        inputs: [],
+        label: 'R',
+        type: 'iterativeSeoRefine',
+      };
+      const result = executor.validate(node);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('targetScore must be between 0 and 100');
+      expect(result.errors).toContain('maxIterations must be between 1 and 10');
+    });
+  });
+
+  it('estimates cost proportional to maxIterations', () => {
+    const node: ExecutableNode = {
+      config: { maxIterations: 3 },
+      id: 'r',
+      inputs: [],
+      label: 'R',
+      type: 'iterativeSeoRefine',
+    };
+    expect(executor.estimateCost(node)).toBe(15);
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.ts
@@ -1,0 +1,246 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { SeoRewriteResolver } from '@workflow-engine/executors/saas/seo-rewrite-executor';
+import {
+  pickSeoString,
+  resolveSeoUpstream,
+  type SeoScorableContentLike,
+  type SeoScoreResolver,
+} from '@workflow-engine/executors/saas/seo-score-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const DEFAULT_TARGET_SCORE = 80;
+const DEFAULT_MAX_ITERATIONS = 3;
+const MAX_ALLOWED_ITERATIONS = 10;
+/** Per-iteration credit estimate: one score (2) + one rewrite (3). */
+const CREDITS_PER_ITERATION = 5;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SeoRefineIteration {
+  /** 0 = initial score, 1..n = score after each rewrite. */
+  iteration: number;
+  score: number;
+  /** Whether a rewrite was performed before this score. */
+  rewritten: boolean;
+}
+
+export interface IterativeSeoRefineOutput {
+  /** Best/final content after refinement. */
+  text: string;
+  /** Final score for `text`. */
+  score: number;
+  rating: string | null;
+  /** Number of rewrite passes performed (0 if the input already passed). */
+  iterations: number;
+  /** Whether the target score was reached. */
+  converged: boolean;
+  /** Per-iteration score history (oldest first). */
+  history: SeoRefineIteration[];
+  breakdown: Record<string, number> | null;
+  suggestions: string[];
+  targetKeyword: string | null;
+  title: string | null;
+}
+
+// =============================================================================
+// EXECUTOR
+// =============================================================================
+
+/**
+ * Iterative SEO Refine Executor
+ *
+ * Runs a score -> rewrite -> re-score loop INTERNALLY, up to `maxIterations`
+ * passes, until the content reaches `targetScore`. Emitting the loop as a
+ * single node keeps the workflow a pure DAG — the validator hard-rejects graph
+ * cycles (`CYCLE_DETECTED`), so an iterate-until pattern cannot be modelled as
+ * a back-edge in the graph itself.
+ *
+ * Node Type: iterativeSeoRefine
+ */
+export class IterativeSeoRefineExecutor extends BaseExecutor {
+  readonly nodeType = 'iterativeSeoRefine';
+  private scoreResolver: SeoScoreResolver | null = null;
+  private rewriteResolver: SeoRewriteResolver | null = null;
+
+  setScoreResolver(resolver: SeoScoreResolver): void {
+    this.scoreResolver = resolver;
+  }
+
+  setRewriteResolver(resolver: SeoRewriteResolver): void {
+    this.rewriteResolver = resolver;
+  }
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+
+    const targetScore = node.config.targetScore;
+    if (
+      targetScore !== undefined &&
+      (typeof targetScore !== 'number' || targetScore < 0 || targetScore > 100)
+    ) {
+      errors.push('targetScore must be between 0 and 100');
+    }
+
+    const maxIterations = node.config.maxIterations;
+    if (
+      maxIterations !== undefined &&
+      (typeof maxIterations !== 'number' ||
+        maxIterations < 1 ||
+        maxIterations > MAX_ALLOWED_ITERATIONS)
+    ) {
+      errors.push(
+        `maxIterations must be between 1 and ${MAX_ALLOWED_ITERATIONS}`,
+      );
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  estimateCost(node: ExecutableNode): number {
+    const maxIterations = this.resolveMaxIterations(node);
+    return maxIterations * CREDITS_PER_ITERATION;
+  }
+
+  private resolveMaxIterations(node: ExecutableNode): number {
+    const raw = this.getOptionalConfig<number>(
+      node.config,
+      'maxIterations',
+      DEFAULT_MAX_ITERATIONS,
+    );
+    return Math.min(Math.max(Math.floor(raw), 1), MAX_ALLOWED_ITERATIONS);
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, inputs, context } = input;
+
+    if (!this.scoreResolver || !this.rewriteResolver) {
+      throw new Error('Iterative SEO refine resolvers not configured');
+    }
+
+    const upstream = resolveSeoUpstream(inputs);
+
+    let text =
+      pickSeoString(inputs, upstream, node, 'content') ??
+      pickSeoString(inputs, upstream, node, 'text') ??
+      '';
+
+    if (!text || text.trim().length === 0) {
+      throw new Error('Missing required input: content');
+    }
+
+    const title = pickSeoString(inputs, upstream, node, 'title');
+    const targetKeyword = pickSeoString(
+      inputs,
+      upstream,
+      node,
+      'targetKeyword',
+    );
+
+    const targetScore = this.getOptionalConfig<number>(
+      node.config,
+      'targetScore',
+      DEFAULT_TARGET_SCORE,
+    );
+    const maxIterations = this.resolveMaxIterations(node);
+    const useLlm = this.getOptionalConfig<boolean>(node.config, 'useLlm', true);
+    const model = this.getOptionalConfig<string | null>(
+      node.config,
+      'model',
+      null,
+    );
+
+    const buildScorable = (body: string): SeoScorableContentLike => ({
+      content: body,
+      secondaryKeywords: [],
+      targetKeyword,
+      title,
+    });
+
+    const history: SeoRefineIteration[] = [];
+
+    let current = await this.scoreResolver({
+      content: buildScorable(text),
+      organizationId: context.organizationId,
+      useLlm,
+    });
+    history.push({ iteration: 0, rewritten: false, score: current.score });
+
+    let iterations = 0;
+    while (current.score < targetScore && iterations < maxIterations) {
+      const rewrite = await this.rewriteResolver({
+        content: text,
+        model,
+        organizationId: context.organizationId,
+        suggestions: current.suggestions ?? [],
+        targetKeyword,
+        title,
+      });
+
+      // Guard against a resolver that returns empty content: keep the best text
+      // and stop refining rather than re-scoring an empty body to zero.
+      if (!rewrite.text || rewrite.text.trim().length === 0) {
+        break;
+      }
+      text = rewrite.text;
+      iterations += 1;
+
+      current = await this.scoreResolver({
+        content: buildScorable(text),
+        organizationId: context.organizationId,
+        useLlm,
+      });
+      history.push({
+        iteration: iterations,
+        rewritten: true,
+        score: current.score,
+      });
+    }
+
+    const output: IterativeSeoRefineOutput = {
+      breakdown: current.breakdown ?? null,
+      converged: current.score >= targetScore,
+      history,
+      iterations,
+      rating: current.rating ?? null,
+      score: current.score,
+      suggestions: current.suggestions ?? [],
+      targetKeyword: targetKeyword ?? null,
+      text,
+      title: title ?? null,
+    };
+
+    return {
+      data: output,
+      metadata: {
+        converged: output.converged,
+        iterations,
+        score: current.score,
+      },
+    };
+  }
+}
+
+export function createIterativeSeoRefineExecutor(
+  scoreResolver?: SeoScoreResolver,
+  rewriteResolver?: SeoRewriteResolver,
+): IterativeSeoRefineExecutor {
+  const executor = new IterativeSeoRefineExecutor();
+  if (scoreResolver) {
+    executor.setScoreResolver(scoreResolver);
+  }
+  if (rewriteResolver) {
+    executor.setRewriteResolver(rewriteResolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/iterative-seo-refine-executor.ts
@@ -109,7 +109,8 @@ export class IterativeSeoRefineExecutor extends BaseExecutor {
 
   estimateCost(node: ExecutableNode): number {
     const maxIterations = this.resolveMaxIterations(node);
-    return maxIterations * CREDITS_PER_ITERATION;
+    // 2 credits for the initial score + up to maxIterations × 5 (1 rewrite + 1 rescore each).
+    return 2 + maxIterations * CREDITS_PER_ITERATION;
   }
 
   private resolveMaxIterations(node: ExecutableNode): number {
@@ -176,6 +177,12 @@ export class IterativeSeoRefineExecutor extends BaseExecutor {
     });
     history.push({ iteration: 0, rewritten: false, score: current.score });
 
+    // Track the best-scoring candidate across iterations so a rewrite that
+    // lowers the score does not cause the executor to return worse content.
+    let bestText = text;
+    let bestScore = current.score;
+    let bestResult = current;
+
     let iterations = 0;
     while (current.score < targetScore && iterations < maxIterations) {
       const rewrite = await this.rewriteResolver({
@@ -205,18 +212,25 @@ export class IterativeSeoRefineExecutor extends BaseExecutor {
         rewritten: true,
         score: current.score,
       });
+
+      // Only promote this iteration's candidate if it improves on the best seen so far.
+      if (current.score > bestScore) {
+        bestText = text;
+        bestScore = current.score;
+        bestResult = current;
+      }
     }
 
     const output: IterativeSeoRefineOutput = {
-      breakdown: current.breakdown ?? null,
-      converged: current.score >= targetScore,
+      breakdown: bestResult.breakdown ?? null,
+      converged: bestScore >= targetScore,
       history,
       iterations,
-      rating: current.rating ?? null,
-      score: current.score,
-      suggestions: current.suggestions ?? [],
+      rating: bestResult.rating ?? null,
+      score: bestScore,
+      suggestions: bestResult.suggestions ?? [],
       targetKeyword: targetKeyword ?? null,
-      text,
+      text: bestText,
       title: title ?? null,
     };
 
@@ -225,7 +239,7 @@ export class IterativeSeoRefineExecutor extends BaseExecutor {
       metadata: {
         converged: output.converged,
         iterations,
-        score: current.score,
+        score: bestScore,
       },
     };
   }

--- a/packages/workflow-engine/src/executors/saas/post-publish-trigger-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/post-publish-trigger-executor.spec.ts
@@ -1,0 +1,85 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createPostPublishTriggerExecutor,
+  type PostPublishTriggerExecutor,
+  type PostPublishTriggerOutput,
+} from '@workflow-engine/executors/saas/post-publish-trigger-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+function makeInput(
+  config: Record<string, unknown>,
+  injected?: Record<string, unknown>,
+): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'pp-1',
+    inputs: [],
+    label: 'On Publish',
+    type: 'postPublishTrigger',
+  };
+  const inputs = new Map<string, unknown>();
+  if (injected !== undefined) {
+    inputs.set('event', injected);
+  }
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs, node };
+}
+
+describe('PostPublishTriggerExecutor', () => {
+  let executor: PostPublishTriggerExecutor;
+
+  beforeEach(() => {
+    executor = createPostPublishTriggerExecutor();
+  });
+
+  it('normalizes injected publish event data', async () => {
+    const result = await executor.execute(
+      makeInput(
+        {},
+        {
+          brandId: 'brand-1',
+          caption: 'Launch day!',
+          platforms: ['twitter', 'linkedin'],
+          postIds: ['p1', 'p2'],
+          status: 'queued',
+          targetKeyword: 'launch',
+        },
+      ),
+    );
+    const data = result.data as PostPublishTriggerOutput;
+    expect(data.postIds).toEqual(['p1', 'p2']);
+    expect(data.platforms).toEqual(['twitter', 'linkedin']);
+    expect(data.content).toBe('Launch day!');
+    expect(data.targetKeyword).toBe('launch');
+    expect(data.brandId).toBe('brand-1');
+    expect(result.metadata?.postCount).toBe(2);
+    expect(result.metadata?.platformCount).toBe(2);
+  });
+
+  it('defaults to safe empty values when no event data is present', async () => {
+    const result = await executor.execute(makeInput({}));
+    const data = result.data as PostPublishTriggerOutput;
+    expect(data.postIds).toEqual([]);
+    expect(data.platforms).toEqual([]);
+    expect(data.content).toBeNull();
+    expect(data.targetKeyword).toBeNull();
+  });
+
+  it('is a free node', () => {
+    const node: ExecutableNode = {
+      config: {},
+      id: 'pp',
+      inputs: [],
+      label: 'On Publish',
+      type: 'postPublishTrigger',
+    };
+    expect(executor.estimateCost(node)).toBe(0);
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/post-publish-trigger-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/post-publish-trigger-executor.ts
@@ -1,0 +1,101 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Output shape of the postPublishTrigger node. When a workflow is rooted at
+ * this trigger, the engine injects the `post-published` event payload directly
+ * into the node's output (trigger nodes are not re-executed — their output is
+ * populated from `TriggerEvent.data`). This executor's `execute()` runs only
+ * when the node is invoked directly (e.g. unit tests, or manual runs); it
+ * normalises inputs/config into the same stable shape so downstream `seoScore`
+ * / `iterativeSeoRefine` nodes can consume it identically in both paths.
+ */
+export interface PostPublishTriggerOutput {
+  /** IDs of the posts that were published. */
+  postIds: string[];
+  /** Platforms the content was published to. */
+  platforms: string[];
+  /** Publish status reported by the publish node. */
+  status: string | null;
+  /** Published body/caption — the content downstream SEO nodes score. */
+  content: string | null;
+  /** Title/label of the published content. */
+  title: string | null;
+  /** Target keyword to optimise against, if configured. */
+  targetKeyword: string | null;
+  /** Brand the content belongs to. */
+  brandId: string | null;
+}
+
+// =============================================================================
+// EXECUTOR
+// =============================================================================
+
+/**
+ * Post Publish Trigger Executor
+ *
+ * Root trigger node that starts an SEO-optimisation workflow when content is
+ * published. A `post-published` TriggerEvent is routed to workflows rooted at
+ * this node via `EVENT_TYPE_TO_NODE_TYPE` in WorkflowExecutorService; the
+ * publish node opts into emitting that event with `triggerSeoOptimization`.
+ *
+ * Node Type: postPublishTrigger
+ */
+export class PostPublishTriggerExecutor extends BaseExecutor {
+  readonly nodeType = 'postPublishTrigger';
+
+  estimateCost(_node: ExecutableNode): number {
+    return 0;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, inputs } = input;
+
+    const upstream = inputs.values().next().value as
+      | Record<string, unknown>
+      | undefined;
+
+    const read = <T>(key: string, fallback: T): T =>
+      (inputs.get(key) as T | undefined) ??
+      (upstream?.[key] as T | undefined) ??
+      (node.config[key] as T | undefined) ??
+      fallback;
+
+    const postIdsRaw = read<unknown>('postIds', []);
+    const platformsRaw = read<unknown>('platforms', []);
+
+    const content =
+      read<string | null>('content', null) ??
+      read<string | null>('caption', null);
+
+    const output: PostPublishTriggerOutput = {
+      brandId: read<string | null>('brandId', null),
+      content,
+      platforms: Array.isArray(platformsRaw) ? (platformsRaw as string[]) : [],
+      postIds: Array.isArray(postIdsRaw) ? (postIdsRaw as string[]) : [],
+      status: read<string | null>('status', null),
+      targetKeyword: read<string | null>('targetKeyword', null),
+      title: read<string | null>('title', null),
+    };
+
+    return {
+      data: output,
+      metadata: {
+        platformCount: output.platforms.length,
+        postCount: output.postIds.length,
+      },
+    };
+  }
+}
+
+export function createPostPublishTriggerExecutor(): PostPublishTriggerExecutor {
+  return new PostPublishTriggerExecutor();
+}

--- a/packages/workflow-engine/src/executors/saas/publish-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/publish-executor.spec.ts
@@ -120,6 +120,18 @@ describe('PublishExecutor', () => {
       );
     });
 
+    it('forwards workflowId from context to the resolver', async () => {
+      const input = makeInput(
+        { caption: 'Test', platforms: { twitter: true } },
+        { brand: { brandId: 'b-1' }, media: 'img.png' },
+      );
+      await executor.execute(input);
+      // context.workflowId is 'wf-1' in makeInput
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowId: 'wf-1' }),
+      );
+    });
+
     it('prefers caption from input over config', async () => {
       const input = makeInput(
         { caption: 'config', platforms: { twitter: true } },

--- a/packages/workflow-engine/src/executors/saas/publish-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/publish-executor.ts
@@ -38,6 +38,9 @@ export type PublishResolver = (params: {
   brandId: string;
   organizationId: string;
   userId: string;
+  /** ID of the currently executing workflow — used by the resolver to detect
+   * trigger loops when `triggerSeoOptimization` is true. */
+  workflowId: string;
   media?: unknown;
   caption: string;
   platforms: SocialPlatform[];
@@ -166,6 +169,7 @@ export class PublishExecutor extends BaseExecutor {
       targetKeyword,
       triggerSeoOptimization,
       userId: context.userId,
+      workflowId: context.workflowId,
     });
 
     return {

--- a/packages/workflow-engine/src/executors/saas/publish-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/publish-executor.ts
@@ -42,6 +42,14 @@ export type PublishResolver = (params: {
   caption: string;
   platforms: SocialPlatform[];
   scheduledFor: Date | null;
+  /**
+   * Opt-in: when true, the resolver should emit a `post-published` event after a
+   * successful publish so workflows rooted at a `postPublishTrigger` node can run
+   * an SEO-optimization pass. Off by default to avoid trigger loops.
+   */
+  triggerSeoOptimization?: boolean;
+  /** Target keyword forwarded to the downstream SEO-optimization workflow. */
+  targetKeyword?: string | null;
 }) => Promise<PublishOutput>;
 
 export class PublishExecutor extends BaseExecutor {
@@ -137,6 +145,17 @@ export class PublishExecutor extends BaseExecutor {
         ? new Date(schedule.datetime)
         : null;
 
+    const triggerSeoOptimization = this.getOptionalConfig<boolean>(
+      node.config,
+      'triggerSeoOptimization',
+      false,
+    );
+    const targetKeyword = this.getOptionalConfig<string | null>(
+      node.config,
+      'targetKeyword',
+      null,
+    );
+
     const result = await this.resolver({
       brandId: brandContext.brandId,
       caption,
@@ -144,6 +163,8 @@ export class PublishExecutor extends BaseExecutor {
       organizationId: context.organizationId,
       platforms: enabledPlatforms,
       scheduledFor,
+      targetKeyword,
+      triggerSeoOptimization,
       userId: context.userId,
     });
 

--- a/packages/workflow-engine/src/executors/saas/seo-optimization-workflow.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/seo-optimization-workflow.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Composed end-to-end coverage for the SEO-optimization workflow (#761):
+ * - the graph (seoScore -> condition -> seoRewrite) passes validation with no cycle,
+ * - the same shape with a back-edge is rejected (CYCLE_DETECTED), proving why the
+ *   iterate-until loop lives inside `iterativeSeoRefine` rather than the graph,
+ * - the executors, run in dependency order, produce the score -> branch -> rewrite path.
+ */
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import { createConditionExecutor } from '@workflow-engine/executors/saas/condition-executor';
+import {
+  createSeoRewriteExecutor,
+  type SeoRewriteOutput,
+  type SeoRewriteResolver,
+} from '@workflow-engine/executors/saas/seo-rewrite-executor';
+import {
+  createSeoScoreExecutor,
+  type SeoScoreOutput,
+  type SeoScoreResolver,
+} from '@workflow-engine/executors/saas/seo-score-executor';
+import type {
+  ExecutableNode,
+  ExecutableWorkflow,
+} from '@workflow-engine/types';
+import { validateWorkflow } from '@workflow-engine/validation/workflow-validator';
+import { describe, expect, it } from 'vitest';
+
+const CONTEXT: ExecutionContext = {
+  organizationId: 'org-1',
+  runId: 'run-1',
+  userId: 'user-1',
+  workflowId: 'wf-1',
+};
+
+function node(type: string, config: Record<string, unknown>): ExecutableNode {
+  return { config, id: `${type}-1`, inputs: [], label: type, type };
+}
+
+describe('SEO optimization workflow (composed)', () => {
+  it('validates seoScore -> condition -> seoRewrite as an acyclic graph', () => {
+    const workflow: ExecutableWorkflow = {
+      edges: [
+        {
+          id: 'e1',
+          source: 'seoScore-1',
+          sourceHandle: 'data',
+          target: 'condition-1',
+          targetHandle: 'data',
+        },
+        {
+          id: 'e2',
+          source: 'condition-1',
+          sourceHandle: 'false',
+          target: 'seoRewrite-1',
+          targetHandle: 'content',
+        },
+      ],
+      id: 'wf-seo',
+      lockedNodeIds: [],
+      nodes: [
+        node('seoScore', {}),
+        node('condition', {
+          customField: 'score',
+          field: 'custom',
+          operator: 'greaterThanOrEquals',
+          value: 80,
+        }),
+        node('seoRewrite', {}),
+      ],
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+
+    const result = validateWorkflow(workflow);
+    expect(result.isValid).toBe(true);
+    expect(result.errors.map((error) => error.code)).not.toContain(
+      'CYCLE_DETECTED',
+    );
+  });
+
+  it('rejects a score<->rewrite back-edge as a cycle', () => {
+    const workflow: ExecutableWorkflow = {
+      edges: [
+        { id: 'e1', source: 'seoScore-1', target: 'seoRewrite-1' },
+        // Back-edge: turns the iterate-until into a graph cycle.
+        { id: 'e2', source: 'seoRewrite-1', target: 'seoScore-1' },
+      ],
+      id: 'wf-cycle',
+      lockedNodeIds: [],
+      nodes: [node('seoScore', {}), node('seoRewrite', {})],
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+
+    const result = validateWorkflow(workflow);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.map((error) => error.code)).toContain(
+      'CYCLE_DETECTED',
+    );
+  });
+
+  it('runs score -> branch (below target) -> rewrite end to end', async () => {
+    const scoreResolver: SeoScoreResolver = async () => ({
+      breakdown: { keywordPlacement: 10 },
+      rating: 'needs_work',
+      score: 60,
+      suggestions: ['Add the target keyword to the first paragraph'],
+    });
+    const rewriteResolver: SeoRewriteResolver = async ({ content }) => ({
+      model: 'm',
+      text: `improved: ${content}`,
+    });
+
+    const scoreExecutor = createSeoScoreExecutor(scoreResolver);
+    const conditionExecutor = createConditionExecutor();
+    const rewriteExecutor = createSeoRewriteExecutor(rewriteResolver);
+
+    // 1. score the content
+    const scoreOut = await scoreExecutor.execute({
+      context: CONTEXT,
+      inputs: new Map([
+        ['in', { content: '<p>thin</p>', targetKeyword: 'kw', title: 'T' }],
+      ]),
+      node: node('seoScore', {}),
+    });
+    const scoreData = scoreOut.data as SeoScoreOutput;
+    expect(scoreData.score).toBe(60);
+
+    // 2. branch on the emitted score
+    const conditionOut = await conditionExecutor.execute({
+      context: CONTEXT,
+      inputs: new Map([['in', scoreData]]),
+      node: node('condition', {
+        customField: 'score',
+        field: 'custom',
+        operator: 'greaterThanOrEquals',
+        value: 80,
+      }),
+    });
+    expect(conditionOut.metadata?.branch).toBe('false');
+
+    // 3. low-score branch rewrites using the upstream score output
+    const rewriteOut = await rewriteExecutor.execute({
+      context: CONTEXT,
+      inputs: new Map([['in', scoreData]]),
+      node: node('seoRewrite', {}),
+    });
+    const rewriteData = rewriteOut.data as SeoRewriteOutput;
+    expect(rewriteData.text).toBe('improved: <p>thin</p>');
+    expect(rewriteData.appliedSuggestions).toEqual([
+      'Add the target keyword to the first paragraph',
+    ]);
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/seo-rewrite-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/seo-rewrite-executor.spec.ts
@@ -1,0 +1,133 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createSeoRewriteExecutor,
+  type SeoRewriteExecutor,
+  type SeoRewriteOutput,
+  type SeoRewriteResolver,
+} from '@workflow-engine/executors/saas/seo-rewrite-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeInput(
+  config: Record<string, unknown>,
+  upstream?: Record<string, unknown>,
+): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'seo-rewrite-1',
+    inputs: [],
+    label: 'SEO Rewrite',
+    type: 'seoRewrite',
+  };
+  const inputs = new Map<string, unknown>();
+  if (upstream !== undefined) {
+    inputs.set('in', upstream);
+  }
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs, node };
+}
+
+describe('SeoRewriteExecutor', () => {
+  let executor: SeoRewriteExecutor;
+  let resolver: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executor = createSeoRewriteExecutor();
+    resolver = vi
+      .fn()
+      .mockResolvedValue({ model: 'openai/gpt-4o-mini', text: 'rewritten' });
+    executor.setResolver(resolver as unknown as SeoRewriteResolver);
+  });
+
+  it('throws when no resolver is configured', async () => {
+    const fresh = createSeoRewriteExecutor();
+    await expect(fresh.execute(makeInput({ content: 'x' }))).rejects.toThrow(
+      'SEO rewrite resolver not configured',
+    );
+  });
+
+  it('throws when content is missing', async () => {
+    await expect(executor.execute(makeInput({}))).rejects.toThrow(
+      'Missing required input: content',
+    );
+  });
+
+  it('rewrites content using upstream seoScore output', async () => {
+    const result = await executor.execute(
+      makeInput(
+        {},
+        {
+          content: '<p>original</p>',
+          suggestions: ['Add an H2', 'Shorten sentences'],
+          targetKeyword: 'kw',
+          title: 'Title',
+        },
+      ),
+    );
+    const data = result.data as SeoRewriteOutput;
+    expect(data.text).toBe('rewritten');
+    expect(data.model).toBe('openai/gpt-4o-mini');
+    expect(data.appliedSuggestions).toEqual(['Add an H2', 'Shorten sentences']);
+    expect(data.title).toBe('Title');
+    expect(data.targetKeyword).toBe('kw');
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: '<p>original</p>',
+        organizationId: 'org-1',
+        suggestions: ['Add an H2', 'Shorten sentences'],
+        targetKeyword: 'kw',
+        title: 'Title',
+      }),
+    );
+  });
+
+  it('defaults model to null and suggestions to empty when absent', async () => {
+    resolver.mockResolvedValueOnce({ text: 'done' });
+    const result = await executor.execute(makeInput({ content: 'body' }));
+    const data = result.data as SeoRewriteOutput;
+    expect(data.model).toBeNull();
+    expect(data.appliedSuggestions).toEqual([]);
+  });
+
+  it('reads content from a ConditionResult passthrough (downstream of a condition)', async () => {
+    await executor.execute(
+      makeInput(
+        {},
+        {
+          actualValue: 60,
+          data: {
+            content: '<p>real content</p>',
+            suggestions: ['Add an H2'],
+            targetKeyword: 'kw',
+          },
+          operator: 'greaterThanOrEquals',
+          result: false,
+        },
+      ),
+    );
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: '<p>real content</p>',
+        suggestions: ['Add an H2'],
+        targetKeyword: 'kw',
+      }),
+    );
+  });
+
+  it('estimates a flat cost', () => {
+    const node = {
+      config: {},
+      id: 'r',
+      inputs: [],
+      label: 'R',
+      type: 'seoRewrite',
+    };
+    expect(executor.estimateCost(node)).toBe(3);
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/seo-rewrite-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/seo-rewrite-executor.ts
@@ -1,0 +1,136 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import {
+  pickSeoString,
+  resolveSeoUpstream,
+} from '@workflow-engine/executors/saas/seo-score-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SeoRewriteOutput {
+  /** Rewritten content body. */
+  text: string;
+  /** Model that produced the rewrite, when known. */
+  model: string | null;
+  /** Suggestions the rewrite was asked to address. */
+  appliedSuggestions: string[];
+  /** Target keyword carried through for downstream re-scoring. */
+  targetKeyword: string | null;
+  /** Title carried through unchanged for downstream re-scoring. */
+  title: string | null;
+}
+
+export type SeoRewriteResolver = (params: {
+  content: string;
+  suggestions: string[];
+  organizationId: string;
+  title?: string | null;
+  targetKeyword?: string | null;
+  model?: string | null;
+}) => Promise<{ text: string; model?: string | null }>;
+
+// =============================================================================
+// EXECUTOR
+// =============================================================================
+
+/**
+ * SEO Rewrite Executor
+ *
+ * Rewrites content to address SEO suggestions emitted by an upstream `seoScore`
+ * node. The rewrite itself (an LLM call) is injected at runtime from the NestJS
+ * service layer.
+ *
+ * Node Type: seoRewrite
+ */
+export class SeoRewriteExecutor extends BaseExecutor {
+  readonly nodeType = 'seoRewrite';
+  private resolver: SeoRewriteResolver | null = null;
+
+  setResolver(resolver: SeoRewriteResolver): void {
+    this.resolver = resolver;
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 3;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, inputs, context } = input;
+
+    if (!this.resolver) {
+      throw new Error('SEO rewrite resolver not configured');
+    }
+
+    const upstream = resolveSeoUpstream(inputs);
+
+    const content = pickSeoString(inputs, upstream, node, 'content') ?? '';
+
+    if (!content || content.trim().length === 0) {
+      throw new Error('Missing required input: content');
+    }
+
+    const suggestionsRaw =
+      (inputs.get('suggestions') as unknown) ??
+      (upstream?.suggestions as unknown) ??
+      node.config.suggestions ??
+      [];
+    const suggestions = Array.isArray(suggestionsRaw)
+      ? (suggestionsRaw as string[])
+      : [];
+
+    const title = pickSeoString(inputs, upstream, node, 'title');
+    const targetKeyword = pickSeoString(
+      inputs,
+      upstream,
+      node,
+      'targetKeyword',
+    );
+
+    const model = this.getOptionalConfig<string | null>(
+      node.config,
+      'model',
+      null,
+    );
+
+    const result = await this.resolver({
+      content,
+      model,
+      organizationId: context.organizationId,
+      suggestions,
+      targetKeyword,
+      title,
+    });
+
+    const output: SeoRewriteOutput = {
+      appliedSuggestions: suggestions,
+      model: result.model ?? null,
+      targetKeyword: targetKeyword ?? null,
+      text: result.text,
+      title: title ?? null,
+    };
+
+    return {
+      data: output,
+      metadata: {
+        model: result.model ?? null,
+        suggestionCount: suggestions.length,
+      },
+    };
+  }
+}
+
+export function createSeoRewriteExecutor(
+  resolver?: SeoRewriteResolver,
+): SeoRewriteExecutor {
+  const executor = new SeoRewriteExecutor();
+  if (resolver) {
+    executor.setResolver(resolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/executors/saas/seo-score-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/seo-score-executor.spec.ts
@@ -1,0 +1,156 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createSeoScoreExecutor,
+  type SeoScoreExecutor,
+  type SeoScoreOutput,
+  type SeoScoreResolver,
+} from '@workflow-engine/executors/saas/seo-score-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeInput(
+  config: Record<string, unknown>,
+  upstream?: Record<string, unknown>,
+): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'seo-score-1',
+    inputs: [],
+    label: 'SEO Score',
+    type: 'seoScore',
+  };
+  const inputs = new Map<string, unknown>();
+  if (upstream !== undefined) {
+    inputs.set('in', upstream);
+  }
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs, node };
+}
+
+describe('SeoScoreExecutor', () => {
+  let executor: SeoScoreExecutor;
+  let resolver: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executor = createSeoScoreExecutor();
+    resolver = vi.fn().mockResolvedValue({
+      breakdown: { keywordPlacement: 12 },
+      rating: 'needs_work',
+      score: 64,
+      suggestions: ['Add the target keyword to the title'],
+    });
+    executor.setResolver(resolver as unknown as SeoScoreResolver);
+  });
+
+  it('throws when no resolver is configured', async () => {
+    const fresh = createSeoScoreExecutor();
+    await expect(fresh.execute(makeInput({}))).rejects.toThrow(
+      'SEO score resolver not configured',
+    );
+  });
+
+  it('surfaces score at the top level for downstream condition nodes', async () => {
+    const result = await executor.execute(
+      makeInput(
+        {},
+        {
+          content: '<p>body</p>',
+          targetKeyword: 'ai workflows',
+          title: 'My Title',
+        },
+      ),
+    );
+    const data = result.data as SeoScoreOutput;
+    expect(data.score).toBe(64);
+    expect(data.suggestions).toEqual(['Add the target keyword to the title']);
+    expect(data.content).toBe('<p>body</p>');
+    expect(data.title).toBe('My Title');
+    expect(data.targetKeyword).toBe('ai workflows');
+    expect(result.metadata?.score).toBe(64);
+  });
+
+  it('builds scorable content from upstream output and defaults useLlm to true', async () => {
+    await executor.execute(
+      makeInput(
+        {},
+        { content: '<p>body</p>', targetKeyword: 'kw', title: 'T' },
+      ),
+    );
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          content: '<p>body</p>',
+          targetKeyword: 'kw',
+          title: 'T',
+        }),
+        organizationId: 'org-1',
+        useLlm: true,
+      }),
+    );
+  });
+
+  it('falls back to node config and forwards useLlm:false', async () => {
+    await executor.execute(
+      makeInput({
+        content: '<p>from config</p>',
+        targetKeyword: 'cfg-kw',
+        useLlm: false,
+      }),
+    );
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          content: '<p>from config</p>',
+          targetKeyword: 'cfg-kw',
+        }),
+        useLlm: false,
+      }),
+    );
+  });
+
+  it('defaults suggestions to an empty array when the resolver omits them', async () => {
+    resolver.mockResolvedValueOnce({ score: 90 });
+    const result = await executor.execute(makeInput({ content: 'x' }));
+    expect((result.data as SeoScoreOutput).suggestions).toEqual([]);
+  });
+
+  it('unwraps a ConditionResult passthrough when placed downstream of a condition', async () => {
+    // A `condition` node forwards its inbound payload under `.data`.
+    await executor.execute(
+      makeInput(
+        {},
+        {
+          actualValue: 60,
+          data: { content: '<p>via condition</p>', targetKeyword: 'kw' },
+          operator: 'greaterThanOrEquals',
+          result: false,
+        },
+      ),
+    );
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          content: '<p>via condition</p>',
+          targetKeyword: 'kw',
+        }),
+      }),
+    );
+  });
+
+  it('estimates a flat cost', () => {
+    const node = {
+      config: {},
+      id: 's',
+      inputs: [],
+      label: 'S',
+      type: 'seoScore',
+    };
+    expect(executor.estimateCost(node)).toBe(2);
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/seo-score-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/seo-score-executor.ts
@@ -145,7 +145,11 @@ export class SeoScoreExecutor extends BaseExecutor {
       [];
 
     return {
-      content: pickSeoString(inputs, upstream, node, 'content'),
+      // `seoRewrite` emits `text`, not `content` — fall back so a
+      // seoRewrite→seoScore wiring scores the rewritten body rather than null.
+      content:
+        pickSeoString(inputs, upstream, node, 'content') ??
+        pickSeoString(inputs, upstream, node, 'text'),
       metaDescription: pickSeoString(inputs, upstream, node, 'metaDescription'),
       secondaryKeywords: Array.isArray(secondary)
         ? (secondary as string[])

--- a/packages/workflow-engine/src/executors/saas/seo-score-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/seo-score-executor.ts
@@ -1,0 +1,204 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Source-agnostic content the SEO scorer operates on. Kept local to the engine
+ * package so the executor stays decoupled from the backend SEO service types
+ * (mirrors `SeoScorableContent` in apps/server/api/src/services/seo).
+ */
+export interface SeoScorableContentLike {
+  title?: string | null;
+  metaDescription?: string | null;
+  slug?: string | null;
+  /** Body, stored as HTML in this codebase. */
+  content?: string | null;
+  url?: string | null;
+  targetKeyword?: string | null;
+  secondaryKeywords?: string[];
+}
+
+/** Minimal scorecard shape the node forwards downstream. */
+export interface SeoScoreResolverResult {
+  /** Overall 0-100 score. */
+  score: number;
+  /** Coarse rating label. */
+  rating?: string;
+  /** Earned points per dimension. */
+  breakdown?: Record<string, number>;
+  /** Prioritised, actionable improvement suggestions. */
+  suggestions?: string[];
+}
+
+/**
+ * Output emitted by the seoScore node. `score` is surfaced at the top level so
+ * a downstream `condition` node can branch on it via
+ * `{ field: 'custom', customField: 'score', operator: 'greaterThanOrEquals' }`.
+ * The scored `content`/`title`/`targetKeyword` are passed through so a
+ * `seoRewrite` node downstream can act on the same content + suggestions.
+ */
+export interface SeoScoreOutput extends SeoScoreResolverResult {
+  score: number;
+  suggestions: string[];
+  content: string | null;
+  title: string | null;
+  targetKeyword: string | null;
+}
+
+export type SeoScoreResolver = (params: {
+  content: SeoScorableContentLike;
+  organizationId: string;
+  useLlm?: boolean;
+}) => Promise<SeoScoreResolverResult>;
+
+// =============================================================================
+// SHARED UPSTREAM RESOLUTION
+// =============================================================================
+
+/**
+ * Returns the upstream node's output as a plain object. A `condition` node
+ * forwards its inbound payload under `.data` (its own output is a
+ * `ConditionResult`), so when an SEO node is wired downstream of a `condition`
+ * we unwrap `.data` to recover the original `seoScore` output. This keeps the
+ * "score -> branch -> rewrite" pattern working without the SEO nodes seeing a
+ * `ConditionResult` where they expect content.
+ */
+export function resolveSeoUpstream(
+  inputs: Map<string, unknown>,
+): Record<string, unknown> | undefined {
+  const first = inputs.values().next().value;
+  if (!first || typeof first !== 'object') {
+    return undefined;
+  }
+  const obj = first as Record<string, unknown>;
+  // ConditionResult signature: { result: boolean, ..., data: <passthrough> }
+  if (
+    typeof obj.result === 'boolean' &&
+    obj.data !== null &&
+    typeof obj.data === 'object'
+  ) {
+    return obj.data as Record<string, unknown>;
+  }
+  return obj;
+}
+
+/** Reads a string value from a named input, falling back to the upstream
+ * object then node config; ignores non-string values (e.g. a ConditionResult
+ * delivered under a control handle). */
+export function pickSeoString(
+  inputs: Map<string, unknown>,
+  upstream: Record<string, unknown> | undefined,
+  node: ExecutableNode,
+  key: string,
+): string | null {
+  const candidates = [inputs.get(key), upstream?.[key], node.config[key]];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+// =============================================================================
+// EXECUTOR
+// =============================================================================
+
+/**
+ * SEO Score Executor
+ *
+ * Scores a piece of content against the canonical SEO rubric and emits the
+ * score, per-dimension breakdown, and prioritised suggestions. The actual
+ * scoring is injected at runtime from the NestJS service layer (SeoScorerService).
+ *
+ * Node Type: seoScore
+ */
+export class SeoScoreExecutor extends BaseExecutor {
+  readonly nodeType = 'seoScore';
+  private resolver: SeoScoreResolver | null = null;
+
+  setResolver(resolver: SeoScoreResolver): void {
+    this.resolver = resolver;
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 2;
+  }
+
+  private buildContent(
+    inputs: Map<string, unknown>,
+    node: ExecutableNode,
+  ): SeoScorableContentLike {
+    const upstream = resolveSeoUpstream(inputs);
+
+    const secondary =
+      (inputs.get('secondaryKeywords') as unknown) ??
+      (upstream?.secondaryKeywords as unknown) ??
+      (node.config.secondaryKeywords as unknown) ??
+      [];
+
+    return {
+      content: pickSeoString(inputs, upstream, node, 'content'),
+      metaDescription: pickSeoString(inputs, upstream, node, 'metaDescription'),
+      secondaryKeywords: Array.isArray(secondary)
+        ? (secondary as string[])
+        : [],
+      slug: pickSeoString(inputs, upstream, node, 'slug'),
+      targetKeyword: pickSeoString(inputs, upstream, node, 'targetKeyword'),
+      title: pickSeoString(inputs, upstream, node, 'title'),
+      url: pickSeoString(inputs, upstream, node, 'url'),
+    };
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, inputs, context } = input;
+
+    if (!this.resolver) {
+      throw new Error('SEO score resolver not configured');
+    }
+
+    const content = this.buildContent(inputs, node);
+    const useLlm = this.getOptionalConfig<boolean>(node.config, 'useLlm', true);
+
+    const result = await this.resolver({
+      content,
+      organizationId: context.organizationId,
+      useLlm,
+    });
+
+    const output: SeoScoreOutput = {
+      breakdown: result.breakdown,
+      content: content.content ?? null,
+      rating: result.rating,
+      score: result.score,
+      suggestions: result.suggestions ?? [],
+      targetKeyword: content.targetKeyword ?? null,
+      title: content.title ?? null,
+    };
+
+    return {
+      data: output,
+      metadata: {
+        rating: result.rating,
+        score: result.score,
+      },
+    };
+  }
+}
+
+export function createSeoScoreExecutor(
+  resolver?: SeoScoreResolver,
+): SeoScoreExecutor {
+  const executor = new SeoScoreExecutor();
+  if (resolver) {
+    executor.setResolver(resolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/utils/credit-calculator.ts
+++ b/packages/workflow-engine/src/utils/credit-calculator.ts
@@ -27,6 +27,7 @@ export const DEFAULT_CREDIT_COSTS: CreditCostConfig = {
   newRepostTrigger: 0,
   noop: 0,
   patternContext: 0,
+  postPublishTrigger: 0, // trigger node — the optimization workflow it starts bills itself
   promptConstructor: 0,
   rssInput: 0,
   trendTrigger: 0,
@@ -53,7 +54,10 @@ export const DEFAULT_CREDIT_COSTS: CreditCostConfig = {
   // ----- text / content generation -----
   caption: 1, // legacy alias
   generateArticle: 3, // legacy alias
+  iterativeSeoRefine: 15, // [ESTIMATED] default maxIterations(3) x (score 2 + rewrite 3) -> ~15; the engine reads this flat value for budgeting, while executor.estimateCost scales with the configured maxIterations
   postReply: 1, // [ESTIMATED] comparable to caption
+  seoRewrite: 3, // [ESTIMATED] LLM rewrite; comparable to generateArticle
+  seoScore: 2, // [ESTIMATED] LLM-assisted scoring pass; lighter than a full rewrite
   tweetRemix: 1,
 
   // ----- image generation / processing -----
@@ -231,6 +235,7 @@ const NODE_CATEGORY_MAP: Record<string, string> = {
   newRepostTrigger: 'input',
   noop: 'input',
   patternContext: 'input',
+  postPublishTrigger: 'input',
   rssInput: 'input',
   trendTrigger: 'input',
   tweetInput: 'input',
@@ -255,7 +260,10 @@ const NODE_CATEGORY_MAP: Record<string, string> = {
   generateMusic: 'ai',
   generateVideo: 'ai',
   imageGen: 'ai',
+  iterativeSeoRefine: 'ai',
   lipSync: 'ai',
+  seoRewrite: 'ai',
+  seoScore: 'ai',
   textToSpeech: 'ai',
   videoGen: 'ai',
   voiceChange: 'ai',

--- a/skills/workflow-creator/SKILL.md
+++ b/skills/workflow-creator/SKILL.md
@@ -67,6 +67,9 @@ Place at x: 300-500
 | `textToSpeech` | Text to Speech | text (text, required) | audio | Convert text to speech using ElevenLabs |
 | `transcribe` | Transcribe | video (video), audio (audio) | text | Convert video/audio to text transcript |
 | `motionControl` | Motion Control | image (image, required), prompt (text) | video | Generate video with motion control (Kling AI) |
+| `seoScore` | SEO Score | content (text/object) | object (`score`, `breakdown`, `suggestions`) | Score content against the canonical SEO rubric |
+| `seoRewrite` | SEO Rewrite | content (text, required), suggestions (text, multiple) | text | Rewrite content to address SEO suggestions |
+| `iterativeSeoRefine` | Iterative SEO Refine | content (text, required) | object (`text`, `score`, `iterations`, `converged`) | Internal score → rewrite → re-score loop until `targetScore` (no graph cycle) |
 
 ### Processing Nodes (Category: processing)
 
@@ -92,6 +95,29 @@ Place at x: 800-1000
 | Type | Label | Inputs | Description |
 |------|-------|--------|-------------|
 | `output` | Output | media (image/video, required) | Final workflow output |
+
+### Control Flow Nodes (Category: control)
+
+| Type | Label | Inputs | Outputs | Description |
+|------|-------|--------|---------|-------------|
+| `condition` | Condition | data (object) | true / false branches | Branch on a field. Use `field: 'custom'` + `customField` (dot-notation path into the upstream output) + an operator such as `greaterThanOrEquals` to branch on a numeric key (e.g. an SEO `score`). |
+| `delay` | Delay | any | any | Pause execution for a duration or until an optimal time |
+
+> The validator hard-rejects graph cycles (`CYCLE_DETECTED`). To iterate
+> (score → rewrite → re-score until a threshold), use the single
+> `iterativeSeoRefine` node — never a back-edge.
+
+### Trigger Nodes (Category: input)
+
+| Type | Label | Outputs | Description |
+|------|-------|---------|-------------|
+| `postPublishTrigger` | On Publish | object (`postIds`, `platforms`, `content`, `title`, `targetKeyword`) | Root trigger; starts the workflow when content is published with `triggerSeoOptimization` enabled on the `publish` node (`post-published` event). |
+
+> **Loop safety:** the `post-published` event only fires when a `publish` node sets
+> `triggerSeoOptimization: true` (off by default). Do **not** put a `publish` node
+> with that flag inside a workflow that is itself rooted at `postPublishTrigger` —
+> that would re-emit the event and re-trigger the workflow. Keep SEO-optimization
+> workflows publish-free, or leave the flag off on any publish node they contain.
 
 ### Composition Nodes (Category: composition)
 
@@ -579,6 +605,45 @@ Connections must match handle types:
       "sourceHandle": "video",
       "targetHandle": "media"
     }
+  ]
+}
+```
+
+### SEO Optimization (score → branch → rewrite → converge)
+
+Express a "keep improving until the score is good enough" loop **without a graph
+cycle**. Two valid shapes:
+
+**A. Single-node loop (preferred).** `iterativeSeoRefine` runs the
+score → rewrite → re-score loop internally up to `maxIterations`:
+
+```json
+{
+  "nodes": [
+    { "id": "trigger", "type": "postPublishTrigger", "position": { "x": 0, "y": 0 }, "data": { "label": "On Publish" } },
+    { "id": "refine", "type": "iterativeSeoRefine", "position": { "x": 300, "y": 0 }, "data": { "label": "Refine SEO", "targetScore": 80, "maxIterations": 3, "targetKeyword": "ai content workflows" } },
+    { "id": "out", "type": "output", "position": { "x": 600, "y": 0 }, "data": { "label": "Optimized" } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger", "target": "refine", "sourceHandle": "content", "targetHandle": "content" },
+    { "id": "e2", "source": "refine", "target": "out", "sourceHandle": "text", "targetHandle": "media" }
+  ]
+}
+```
+
+**B. Explicit single-pass branch.** `seoScore` → `condition` (branch on the
+emitted `score`) → `seoRewrite` on the low-score branch:
+
+```json
+{
+  "nodes": [
+    { "id": "score", "type": "seoScore", "position": { "x": 0, "y": 0 }, "data": { "label": "Score", "targetKeyword": "ai content workflows" } },
+    { "id": "gate", "type": "condition", "position": { "x": 300, "y": 0 }, "data": { "label": "Score >= 80?", "field": "custom", "customField": "score", "operator": "greaterThanOrEquals", "value": 80 } },
+    { "id": "rewrite", "type": "seoRewrite", "position": { "x": 600, "y": 120 }, "data": { "label": "Rewrite" } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "score", "target": "gate", "sourceHandle": "data", "targetHandle": "data" },
+    { "id": "e2", "source": "gate", "target": "rewrite", "sourceHandle": "false", "targetHandle": "content" }
   ]
 }
 ```


### PR DESCRIPTION
## Summary

Adds the workflow-engine node types to compose an **SEO-optimization workflow** on top of the canonical SEO scorer (#758), plus an on-publish trigger. Closes #761.

### New nodes (`packages/workflow-engine`, `BaseExecutor` + resolver pattern)
- **`seoScore`** (ai) — scores content via `SeoScorerService`; emits `{ score, breakdown, suggestions }` with `score` at the **top level** so a downstream `condition` node can branch on it (`field: 'custom'`, `customField: 'score'`, `greaterThanOrEquals`).
- **`seoRewrite`** (ai) — rewrites content to address suggestions (LLM via OpenRouter).
- **`iterativeSeoRefine`** (ai) — runs an **internal** `score → rewrite → re-score` loop up to `maxIterations` until `targetScore`. Single node ⇒ the workflow stays a **pure DAG** (the validator hard-rejects back-edges with `CYCLE_DETECTED`). This is the headline acceptance criterion.
- **`postPublishTrigger`** (trigger) — root trigger; a `publish` node opting in via `triggerSeoOptimization` emits a `post-published` event that routes here.

### Wiring
- Registered in `EXECUTOR_REGISTRY` + `DEFAULT_CREDIT_COSTS` (+ `NODE_CATEGORY_MAP`); credit-coverage spec satisfied.
- `WorkflowEngineAdapterService.registerSeoExecutors()` injects `SeoScorerService` + OpenRouter; `emitPostPublishedEvent()` enqueues via `WorkflowExecutionQueueService` (no circular dep — the adapter does **not** inject `WorkflowExecutorService`).
- `TRIGGER_NODE_TYPES` + `EVENT_TYPE_TO_NODE_TYPE` route `post-published → postPublishTrigger`.
- `SeoModule` added to `WorkflowsModule`.
- `skills/workflow-creator/SKILL.md`: added the `condition` node to the registry table (it was missing), the new SEO/trigger nodes, two SEO-optimization example workflows, and loop-safety guidance.

SEO nodes **unwrap a `ConditionResult` passthrough**, so they work correctly when placed downstream of a `condition`. `iterativeSeoRefine` guards against empty rewrites.

## Deviations from the issue (codebase reality)
- The issue references the `@genfeedai/sdk` `node-creator` builder — that's the **external plugin** API. Internal engine nodes use the `BaseExecutor`/resolver/`EXECUTOR_REGISTRY` pattern (image-gen, analytics-feedback), which this PR follows.
- The issue describes post-publish firing "off the PublishExecutor output event (BullMQ) through `WorkflowSchedulerService`". In reality `PublishExecutor` emits no BullMQ event and `WorkflowSchedulerService` is cron-only, so this uses the existing **trigger-event** model instead (the consistent, root-cause-correct mechanism).

## Known follow-up
- Post-publish **loop safety** currently relies on the opt-in `triggerSeoOptimization` flag (off by default) + documented guidance. A structural depth / trigger-source guard in `ExecutionContext` would be a broader engine change and is intentionally out of scope here.

## Verification
- `bunx vitest run` (workflow-engine, touched specs): **72 passing** — 29 new SEO specs (per-node + composed validator/sequential E2E) + `publish-executor`/`condition-executor` (no regressions).
- `bunx tsc --noEmit` — **workflow-engine: 0 errors**; **api (`tsconfig.typecheck.json`): 0 source errors** (only the pre-existing `baseUrl` deprecation notice).
- `biome check` clean; pre-commit secretlint passed.
- Credit-coverage invariant verified: all 43 registered nodeTypes (incl. the 4 new) have credit entries.
- Adversarial multi-agent review (find → verify) run on the diff; 5 confirmed findings fixed (ConditionResult passthrough, credit cost 4→15, empty-rewrite guard, estimateCost test coverage, loop-safety docs).

> Note: full workspace tests/build were not run locally (laptop-scoped); CI covers the registry/credit-coverage specs that need built workspace deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)