### PR TITLE
fix(posts): failure-safe activity creation, weighted thread limits, hook prompt-builder alignment (#861)

### DIFF
--- a/apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.ts
+++ b/apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.ts
@@ -828,10 +828,13 @@ export class PostsOperationsController {
     @Body() dto: GenerateHooksDto,
     @Req() _request: Request,
   ) {
-    const _publicMetadata = getPublicMetadata(user);
+    const publicMetadata = getPublicMetadata(user);
 
     try {
-      return await this.postGenerationService.generateHookVariations(dto);
+      return await this.postGenerationService.generateHookVariations(
+        dto,
+        publicMetadata,
+      );
     } catch (error: unknown) {
       const errorMessage = (error as Error)?.message || 'Unknown error';
       this.logger.error(`Hook generation failed: ${errorMessage}`);

--- a/apps/server/api/src/collections/posts/services/post-generation.service.spec.ts
+++ b/apps/server/api/src/collections/posts/services/post-generation.service.spec.ts
@@ -9,10 +9,15 @@ import { PostGenerationService } from '@api/collections/posts/services/post-gene
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { TemplatesService } from '@api/collections/templates/services/templates.service';
 import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
+import { TEXT_GENERATION_LIMITS } from '@api/constants/text-generation-limits.constant';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
-import { CredentialPlatform } from '@genfeedai/enums';
+import {
+  CredentialPlatform,
+  PostStatus,
+  SystemPromptKey,
+} from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -283,6 +288,94 @@ Tweet 3: Tech innovation is changing the world.`,
       expect(mockActivitiesService.patch).toHaveBeenCalled();
       expect(mockWebsocketService.emit).toHaveBeenCalled();
     });
+
+    it('marks every created post FAILED when activity creation throws (issue #861)', async () => {
+      mockActivitiesService.create.mockRejectedValueOnce(
+        new Error('activity store down'),
+      );
+      const secondPost = { ...mockPost, _id: '507f1f77bcf86cd799439015' };
+
+      await service.generateAccountContentAsync(
+        { count: 2, credential: credentialId, format: 'post', topic: 'AI' },
+        [mockPost, secondPost],
+        publicMetadata,
+        mockPublishingContext,
+      );
+
+      // No activity exists, so the failure branch must not attempt to patch it.
+      expect(mockActivitiesService.patch).not.toHaveBeenCalled();
+      // Both placeholder posts are driven out of PROCESSING into FAILED.
+      expect(mockPostsService.patch).toHaveBeenCalledWith(
+        String(mockPost._id),
+        expect.objectContaining({ status: PostStatus.FAILED }),
+      );
+      expect(mockPostsService.patch).toHaveBeenCalledWith(
+        String(secondPost._id),
+        expect.objectContaining({ status: PostStatus.FAILED }),
+      );
+    });
+  });
+
+  describe('expandThreadAsync', () => {
+    const originalPost = { ...mockPost, description: 'Original tweet content' };
+    const childPosts = [
+      { ...mockPost, _id: '507f1f77bcf86cd799439021' },
+      { ...mockPost, _id: '507f1f77bcf86cd799439022' },
+    ];
+
+    it('marks every child FAILED when activity creation throws (issue #861)', async () => {
+      mockActivitiesService.create.mockRejectedValueOnce(
+        new Error('activity store down'),
+      );
+
+      await service.expandThreadAsync(
+        originalPost,
+        childPosts,
+        { count: 3, tone: TweetTone.PROFESSIONAL },
+        publicMetadata,
+      );
+
+      expect(mockActivitiesService.patch).not.toHaveBeenCalled();
+      expect(mockPostsService.patch).toHaveBeenCalledWith(
+        String(childPosts[0]._id),
+        expect.objectContaining({ status: PostStatus.FAILED }),
+      );
+      expect(mockPostsService.patch).toHaveBeenCalledWith(
+        String(childPosts[1]._id),
+        expect.objectContaining({ status: PostStatus.FAILED }),
+      );
+    });
+
+    it('rejects thread replies over the 280 weighted-character limit (issue #861)', async () => {
+      // 300 plain characters exceeds the 280 weighted limit but would pass the
+      // old unweighted 560-char default — so this asserts the weighted gate.
+      const overLimitReply = 'a'.repeat(300);
+      mockReplicateService.generateTextCompletionSync.mockResolvedValueOnce(
+        JSON.stringify([overLimitReply, overLimitReply]),
+      );
+
+      await service.expandThreadAsync(
+        originalPost,
+        childPosts,
+        { count: 3, tone: TweetTone.PROFESSIONAL },
+        publicMetadata,
+      );
+
+      // No reply survives validation, so none is patched to DRAFT...
+      expect(mockPostsService.patch).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: PostStatus.DRAFT }),
+      );
+      // ...and every child is marked FAILED instead.
+      expect(mockPostsService.patch).toHaveBeenCalledWith(
+        String(childPosts[0]._id),
+        expect.objectContaining({ status: PostStatus.FAILED }),
+      );
+      expect(mockPostsService.patch).toHaveBeenCalledWith(
+        String(childPosts[1]._id),
+        expect.objectContaining({ status: PostStatus.FAILED }),
+      );
+    });
   });
 
   describe('parseTweetContent', () => {
@@ -373,16 +466,47 @@ Tweet 3: Tech innovation is changing the world.`,
         '["Hook one", "Hook two", "Hook three"]',
       );
 
-      const result = await service.generateHookVariations({
-        count: 3,
-        platform: 'twitter',
-        topic: 'AI technology',
-      });
+      const result = await service.generateHookVariations(
+        {
+          count: 3,
+          platform: 'twitter',
+          topic: 'AI technology',
+        },
+        publicMetadata,
+      );
 
       expect(result.hooks).toEqual(['Hook one', 'Hook two', 'Hook three']);
       expect(result.metadata.platform).toBe('twitter');
       expect(result.metadata.topic).toBe('AI technology');
       expect(result.metadata.count).toBe(3);
+    });
+
+    it('builds the Replicate input via the prompt builder with org context and the hook system prompt (issue #861)', async () => {
+      mockReplicateService.generateTextCompletionSync.mockResolvedValueOnce(
+        '[]',
+      );
+
+      await service.generateHookVariations(
+        { count: 2, platform: 'twitter', topic: 'AI' },
+        publicMetadata,
+      );
+
+      expect(mockPromptBuilderService.buildPrompt).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          maxTokens: TEXT_GENERATION_LIMITS.hookGeneration,
+          systemPromptTemplate: SystemPromptKey.HOOK_GENERATOR,
+          useTemplate: false,
+        }),
+        organizationId,
+      );
+      // The typed input object is forwarded to Replicate (no raw-string call).
+      expect(
+        mockReplicateService.generateTextCompletionSync,
+      ).toHaveBeenCalledWith(expect.any(String), {
+        max_tokens: 4096,
+        prompt: 'test prompt',
+      });
     });
   });
 });

--- a/apps/server/api/src/collections/posts/services/post-generation.service.ts
+++ b/apps/server/api/src/collections/posts/services/post-generation.service.ts
@@ -34,6 +34,7 @@ import {
   SystemPromptKey,
 } from '@genfeedai/enums';
 import type {
+  AccountPublishingConstraints,
   AccountPublishingContext,
   SocialGenerationFormat,
 } from '@genfeedai/interfaces';
@@ -50,6 +51,20 @@ type GenerationMetadata = Pick<
   IAuthPublicMetadata,
   'brand' | 'organization' | 'user'
 >;
+
+/**
+ * Thread expansion always targets X/Twitter, whose replies must respect the
+ * 280 weighted-character limit. Used to validate generated thread posts so
+ * over-limit replies are rejected instead of silently accepted (issue #861).
+ */
+const TWITTER_THREAD_CONSTRAINTS: AccountPublishingConstraints = {
+  maxWeightedCharacters: 280,
+  notes: ['Standard X posts use the 280 weighted-character limit.'],
+  supportsDirectPublishing: true,
+  supportsRichArticleCopy: false,
+  supportsThreads: true,
+  usesWeightedCharacters: true,
+};
 
 /**
  * Owns the AI generation engine for posts: account-content and thread-expansion
@@ -110,7 +125,7 @@ export class PostGenerationService {
   parseTweetContent(
     content: string,
     maxCount: number,
-    context?: Pick<AccountPublishingContext, 'account' | 'constraints'>,
+    context?: Pick<AccountPublishingContext, 'constraints'>,
   ): string[] {
     let tweetLines: string[] = [];
     const maxLength =
@@ -512,22 +527,27 @@ export class PostGenerationService {
     publicMetadata: GenerationMetadata,
     context: AccountPublishingContext,
   ): Promise<void> {
-    const activity = await this.activitiesService.create(
-      new ActivityEntity({
-        brand: publicMetadata.brand,
-        key: ActivityKey.POST_PROCESSING,
-        organization: publicMetadata.organization,
-        source: ActivitySource.POST_GENERATION,
-        user: publicMetadata.user,
-        value: JSON.stringify({
-          count: dto.count,
-          topic: dto.topic?.substring(0, 100),
-          type: `${dto.format}-generation`,
-        }),
-      }),
-    );
+    // Create the PROCESSING activity inside the try so a failure here cannot
+    // exit the method while leaving the already-created posts stuck in
+    // PROCESSING — the catch marks every post FAILED regardless (issue #861).
+    let activity: Awaited<ReturnType<ActivitiesService['create']>> | undefined;
 
     try {
+      activity = await this.activitiesService.create(
+        new ActivityEntity({
+          brand: publicMetadata.brand,
+          key: ActivityKey.POST_PROCESSING,
+          organization: publicMetadata.organization,
+          source: ActivitySource.POST_GENERATION,
+          user: publicMetadata.user,
+          value: JSON.stringify({
+            count: dto.count,
+            topic: dto.topic?.substring(0, 100),
+            type: `${dto.format}-generation`,
+          }),
+        }),
+      );
+
       const prompt = await this.buildAccountGenerationPrompt(
         dto,
         context,
@@ -636,12 +656,14 @@ export class PostGenerationService {
         platform: context.account.platform,
       });
 
-      await this.activitiesService.patch(activity._id.toString(), {
-        key: ActivityKey.POST_FAILED,
-        value: JSON.stringify({
-          error: (error as Error)?.message || 'Generation failed',
-        }),
-      });
+      if (activity) {
+        await this.activitiesService.patch(activity._id.toString(), {
+          key: ActivityKey.POST_FAILED,
+          value: JSON.stringify({
+            error: (error as Error)?.message || 'Generation failed',
+          }),
+        });
+      }
 
       for (const post of createdPosts) {
         await this.handleGeneratedPostFailure(
@@ -687,23 +709,27 @@ export class PostGenerationService {
     dto: ExpandToThreadDto,
     publicMetadata: GenerationMetadata,
   ): Promise<void> {
-    // Create PROCESSING activity at start
-    const activity = await this.activitiesService.create(
-      new ActivityEntity({
-        brand: publicMetadata.brand,
-        key: ActivityKey.POST_PROCESSING,
-        organization: publicMetadata.organization,
-        source: ActivitySource.POST_GENERATION,
-        user: publicMetadata.user,
-        value: JSON.stringify({
-          count: dto.count,
-          originalPostId: String(originalPost._id),
-          type: 'thread-expansion',
-        }),
-      }),
-    );
+    // Create the PROCESSING activity inside the try so a failure here cannot
+    // exit the method while leaving the child posts stuck in PROCESSING — the
+    // catch marks every child FAILED regardless (issue #861).
+    let activity: Awaited<ReturnType<ActivitiesService['create']>> | undefined;
 
     try {
+      activity = await this.activitiesService.create(
+        new ActivityEntity({
+          brand: publicMetadata.brand,
+          key: ActivityKey.POST_PROCESSING,
+          organization: publicMetadata.organization,
+          source: ActivitySource.POST_GENERATION,
+          user: publicMetadata.user,
+          value: JSON.stringify({
+            count: dto.count,
+            originalPostId: String(originalPost._id),
+            type: 'thread-expansion',
+          }),
+        }),
+      );
+
       const tone = dto.tone || TweetTone.PROFESSIONAL;
       const additionalCount = dto.count - 1;
 
@@ -744,8 +770,12 @@ export class PostGenerationService {
         throw new Error('No content generated from AI service');
       }
 
-      // Parse content into tweet lines using helper
-      const tweetLines = this.parseTweetContent(content, additionalCount);
+      // Parse content into tweet lines using helper. Thread expansion targets
+      // X/Twitter, so enforce the 280 weighted-character reply limit instead of
+      // the unweighted default (issue #861).
+      const tweetLines = this.parseTweetContent(content, additionalCount, {
+        constraints: TWITTER_THREAD_CONSTRAINTS,
+      });
 
       // Update child posts with generated content
       for (let i = 0; i < childPosts.length && i < tweetLines.length; i++) {
@@ -806,12 +836,14 @@ export class PostGenerationService {
       this.logger.error('Failed to expand thread asynchronously', error);
 
       // Update activity to FAILED
-      await this.activitiesService.patch(activity._id.toString(), {
-        key: ActivityKey.POST_FAILED,
-        value: JSON.stringify({
-          error: (error as Error)?.message || 'Thread expansion failed',
-        }),
-      });
+      if (activity) {
+        await this.activitiesService.patch(activity._id.toString(), {
+          key: ActivityKey.POST_FAILED,
+          value: JSON.stringify({
+            error: (error as Error)?.message || 'Thread expansion failed',
+          }),
+        });
+      }
 
       for (const child of childPosts) {
         await this.handleExpandPostFailure(String(child._id), error);
@@ -909,7 +941,10 @@ export class PostGenerationService {
    * Generate hook variations for a topic/platform. Throws on AI failure; the
    * caller maps the error onto the HTTP boundary.
    */
-  async generateHookVariations(dto: GenerateHooksDto): Promise<{
+  async generateHookVariations(
+    dto: GenerateHooksDto,
+    publicMetadata: Pick<IAuthPublicMetadata, 'organization'>,
+  ): Promise<{
     hooks: string[];
     metadata: {
       count: number;
@@ -932,8 +967,6 @@ export class PostGenerationService {
       platformToneMap[dto.platform] || platformToneMap.twitter;
     const toneInstruction = dto.tone ? `Tone: ${dto.tone}.` : '';
 
-    const systemPrompt = `You are an expert social media copywriter specializing in hooks that stop the scroll. Generate hook variations that are optimized for maximum engagement. Return ONLY a JSON array of strings, no other text.`;
-
     const userPrompt = `Generate ${count} different hook variations for this topic: "${dto.topic}"
 
 Platform: ${dto.platform} (${platformGuidance})
@@ -945,10 +978,26 @@ Requirements:
 - No hashtags in hooks
 - Return as JSON array: ["hook1", "hook2", ...]`;
 
+    // Route through the prompt builder so hooks inherit brand/org system-prompt
+    // context and a typed Replicate input, matching the other generation flows
+    // (issue #861). Replaces the prior raw-string call that needed a type
+    // suppression because generateTextCompletionSync expects an input object.
+    const { input } = await this.promptBuilderService.buildPrompt(
+      DEFAULT_MINI_TEXT_MODEL,
+      {
+        maxTokens: TEXT_GENERATION_LIMITS.hookGeneration,
+        modelCategory: ModelCategory.TEXT,
+        prompt: userPrompt,
+        systemPromptTemplate: SystemPromptKey.HOOK_GENERATOR,
+        temperature: 0.8,
+        useTemplate: false,
+      },
+      publicMetadata.organization,
+    );
+
     const result = await this.replicateService.generateTextCompletionSync(
       DEFAULT_MINI_TEXT_MODEL,
-      // @ts-expect-error TS2345
-      `${systemPrompt}\n\n${userPrompt}`,
+      input,
     );
 
     let hooks: string[] = [];

--- a/apps/server/api/src/constants/text-generation-limits.constant.ts
+++ b/apps/server/api/src/constants/text-generation-limits.constant.ts
@@ -2,6 +2,7 @@ export const TEXT_GENERATION_LIMITS = {
   articleEnhancement: 1000,
   articleImagePrompt: 400,
   articleVirality: 700,
+  hookGeneration: 900,
   newsletterDraft: 1400,
   newsletterTopicProposal: 700,
   postEnhancement: 500,


### PR DESCRIPTION
## Summary

Resolves the three deferred CodeRabbit findings from #857 in `apps/server/api/src/collections/posts/services/post-generation.service.ts`.

### 1. Failure-safe activity creation
`activitiesService.create()` ran **before** the `try` in both `generateAccountContentAsync` and `expandThreadAsync`. If it threw, the method exited before the catch, leaving the already-created `PROCESSING` posts/children stuck forever. Now the activity is created **inside** the `try`, and the catch's `activitiesService.patch()` is guarded with `if (activity)` — so every post/child is driven to `FAILED` even when activity creation itself fails.

### 2. Weighted thread-limit validation
Thread expansion called `parseTweetContent(content, additionalCount)` with no context, falling back to the **560 unweighted** char default — so thread replies exceeding X's **280 weighted-character** limit were silently accepted. It now passes a canonical `TWITTER_THREAD_CONSTRAINTS` (280 weighted). `parseTweetContent`'s context param is narrowed to the only field it reads (`constraints`).

### 3. Hook generation DTO/Replicate alignment
`generateHookVariations` passed a raw string to `replicateService.generateTextCompletionSync(version, input: Record<string, unknown>)` behind a `@ts-expect-error`, and the controller computed `publicMetadata` then **discarded it** (org never reached the service). It now routes through `promptBuilderService.buildPrompt` with the caller's organization and `SystemPromptKey.HOOK_GENERATOR`, forwarding a typed input object — matching the other generation flows (`enhanceDescription`, `buildAccountGenerationPrompt`). The `@ts-expect-error` is removed. A dedicated `hookGeneration` token limit (900) is added so the newly-introduced `max_tokens` cap does not truncate multi-hook output (the prior raw-string call had no cap).

## Verification
- `bunx biome check` — clean (+ pre-commit secretlint/biome hooks passed)
- `bunx vitest run src/collections/posts/services/post-generation.service.spec.ts` — **17/17 pass** (13 existing + 4 new covering all three paths: activity-creation-throws drives posts/children to FAILED without patching a missing activity; over-280-weighted thread replies rejected; hooks build input via the prompt builder with org + HOOK_GENERATOR)
- Adversarial multi-agent review of the diff (find → verify); the one confirmed actionable finding (a too-tight hook `max_tokens` cap) is fixed in this PR.
- Full workspace type-check deferred to CI: a standalone `tsc` can't resolve `@genfeedai/*` workspace packages without a full workspace build (excluded by the laptop-friendly resource policy); the Mac Studio heavy-validation host was unreachable. New symbols (`AccountPublishingConstraints`, `SystemPromptKey.HOOK_GENERATOR`, `TEXT_GENERATION_LIMITS.hookGeneration`) are confirmed exported/present.

Closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)