### PR TITLE
chore(memory): refresh Genfeed architecture context

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -5,12 +5,12 @@
 - [Project Overview](project_overview.md) — Genfeed.ai monorepo structure and key context
 - [One API Epic](project_one_api_epic.md) — Epic #95: consolidate self-hosted + cloud into one NestJS API, 20 issues, 8 phases
 - [Fallow Health](project_fallow.md) — Fallow codebase health analysis (#83), weekly CI, score 72/100
-- [BullMQ Refactor](project_bullmq.md) — 32 @Processor decorators in API need moving to Workers (#84)
+- [BullMQ Processor Placement](project_bullmq.md) — API no longer owns BullMQ processors; add new processors to workers or the owning runtime service
 - [Migration Status](project_migration.md) — cloud + core → genfeed.ai migration complete, all pages/tests present
 - [Settings Routing](project_settings_routing.md) — canonical personal/org/brand settings URL shapes
 - [Desktop BYOK Generation](project_desktop_byok_generation.md) — desktop local/BYOK generation is local-first; cloud connect is optional
 - [TS6.0/Prisma-7 build regression](project_ts6_prisma7_build_regression.md) — **BUILD REGRESSION RESOLVED 2026-06-03** (CI green @ 2e66b0aa8). Root cause was outdated turbo cache + mv-dist-src hack, not ~2020 real errors; removed the hack + fixed ~7 Prisma-7 Document interfaces. Stage 4 + migration-apply still pending.
-- **Deployment Modes & Auth Refactor (2026-06-22)** — canonical 3-mode model (SaaS / Community / Desktop as `deployment × client` axes) locked in [ADR-DEPLOYMENT-MODES](architecture/ADR-DEPLOYMENT-MODES.md). Two P0 epics: **#735** Better Auth across ALL modes incl. SaaS; phased rollout; headless API-keys UI+CLI #747 and **#740** deployment modes (canonical mode #742, switcher #743, CI rework #744, community-just-works #745, release QA #746). Multi-tenancy stays EE/SaaS; managed credits cloud-only; Community = funnel charter. Supersedes the auth half of #95.
+- **Deployment Modes & Auth Baseline (2026-06-29)** — canonical 3-mode model (SaaS / Community / Desktop as `deployment × client` axes) locked in [ADR-DEPLOYMENT-MODES](architecture/ADR-DEPLOYMENT-MODES.md). Better Auth is now the active auth baseline across modes after #769/#866; platform admin access uses `users.platformRole`; headless API keys remain tracked under #747/#878. Multi-tenancy stays EE/SaaS; managed credits cloud-only; Community = funnel charter. Supersedes the auth half of #95.
 
 ## Rules (user corrections — permanent)
 
@@ -56,7 +56,7 @@
 - [Project Brief](context/project-brief.md) — project brief
 - [Project Vision](context/project-vision.md) — long-term vision
 - [Tech Context](context/tech-context.md) — technology stack details
-- [E2E Architecture](context/e2e-architecture.md) — GitHub Actions e2e pipeline (4 jobs), Playwright + API E2E layers, triggers, DB provisioning, known debt
+- [E2E Architecture](context/e2e-architecture.md) — GitHub Actions E2E pipeline, API boot gate, sharded Playwright suite, triggers, DB provisioning, known debt
 
 ## Features
 
@@ -82,7 +82,7 @@
 - [PLG Boundary](architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md) — OSS vs cloud feature split
 - [Workflow-Backed Agents](architecture/ADR-WORKFLOW-BACKED-RECURRING-AGENT-AUTOMATION.md) — recurring agent automation
 - [Skills, Routines, and Memory Boundary](architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md) — OSS single-player loop vs cloud collaborative governance
-- [Deployment Modes & Auth](architecture/ADR-DEPLOYMENT-MODES.md) — 3 product modes (SaaS/Community/Desktop) as `deployment × client` axes; Better Auth everywhere; brand-always/org-SaaS-only switcher; multi-tenancy = EE/SaaS; managed credits cloud-only; Community funnel charter. Epics #735, #740. (contributor doc: `docs/deployment-modes.md`)
+- [Deployment Modes & Auth](architecture/ADR-DEPLOYMENT-MODES.md) — 3 product modes (SaaS/Community/Desktop) as `deployment × client` axes; Better Auth active baseline; brand-always/org-SaaS-only switcher; platform admin via `users.platformRole`; multi-tenancy = EE/SaaS; managed credits cloud-only; Community funnel charter. Epics #735, #740. (contributor doc: `docs/deployment-modes.md`)
 
 ## Rules (symlinked to .claude/rules/)
 

--- a/.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md
+++ b/.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md
@@ -6,11 +6,11 @@ Accepted
 
 ## Spec Version
 
-v1.1.0
+v1.2.0
 
 ## Last Updated
 
-2026-06-22
+2026-06-29
 
 ## Canonical Source
 
@@ -72,7 +72,7 @@ Better Auth ships **magic link, Google/GitHub OAuth, organizations/teams, and ad
 
 Client features gate on **mode**, never on raw auth signals.
 
-**Migration** is a phased rollout epic (#735). Better Auth organizations are implemented as an auth/session bridge while Genfeed `Organization`, `Member`, and `Role` remain the domain authorization and tenant-guard source. Use clean platform `role:superadmin` for SaaS control-plane access. Subscription state lives in DB-owned billing state.
+**Baseline:** Better Auth is the active auth path after the #735 cutover (#769) and hardening pass (#866). Better Auth organizations remain an auth/session bridge while Genfeed `Organization`, `Member`, and `Role` stay the domain authorization and tenant-guard source. SaaS control-plane access uses `users.platformRole` (for example `PLATFORM_SUPERADMIN`), not legacy superadmin flags. Subscription state lives in DB-owned billing state.
 
 ### 4. Tenancy
 
@@ -112,7 +112,7 @@ Community is a **funnel and credibility driver, not a revenue tier** (PostHog ki
 ## Consequences (implementation — tracked on epics #735 and #740)
 
 1. **Mode consolidation** → one canonical source, two axes (#742).
-2. **Auth** → Better Auth across all modes; phased rollout (#735), Better Auth organizations bridge (#792), platform `role:superadmin` (#806), and headless API-keys UI + CLI (#747).
+2. **Auth** → Better Auth across all modes; active baseline after #769/#866, Better Auth organizations bridge (#792), platform `users.platformRole` (#806), and headless API-keys UI + CLI (#747/#878).
 3. **Switcher rule** → brand always shown+populated; org SaaS-only (#743).
 4. **CI** → fast PRs; heavy gates at release-cut; self-hosted E2E nightly-only; community build split from SaaS deploy (#744).
 5. **Community "just works"** → fix docs/ports/compose + healthcheck (#745).
@@ -126,3 +126,10 @@ Community is a **funnel and credibility driver, not a revenue tier** (PostHog ki
 - **Epic #740** — Deployment modes (canonical split, switcher, CI, community, QA)
 - Supersedes the **auth half** of the closed One-API epic #95
 - Issue #87 — EE billing / multi-tenancy extraction
+
+## Revision Log
+
+| Version | Date       | Summary |
+| ------- | ---------- | ------- |
+| v1.1.0  | 2026-06-22 | Initial accepted deployment-mode and auth direction |
+| v1.2.0  | 2026-06-29 | Better Auth cutover is active baseline; platform admin access uses `users.platformRole` |

--- a/.agents/memory/architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md
+++ b/.agents/memory/architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Last Updated
+
+2026-06-29
+
 ## Decision
 
 Dynamic recurring automation must be workflow-backed by default.
@@ -51,6 +55,11 @@ The legacy product surface is retired:
 - `POST`/`PATCH`/pause/resume/delete/run-now cron-job API routes return `410`
 - SDK mutation methods fail before making HTTP calls
 - new product code must not create legacy cron rows or call legacy mutation APIs
+
+Recent migrations made this concrete for campaign orchestration, ad sync and
+optimization, agent autopilot, analytics sync, content production, reply
+polling, trend notifications, livestream bot scheduling, and default recurring
+workflows. Treat those migrations as the current pattern for tenant automation.
 
 Ad insights aggregation is explicitly classified as platform scheduling:
 

--- a/.agents/memory/context/e2e-architecture.md
+++ b/.agents/memory/context/e2e-architecture.md
@@ -1,6 +1,6 @@
 # E2E Architecture — Genfeed.ai
 
-> **Last verified:** 2026-06-19 (against `master`, live run #27803494712 — nightly, all 12 shards green)
+> **Last verified:** 2026-06-29 (against workflow files on `master`; latest live run not checked in this memory pass)
 > **Source of truth:** `.github/workflows/e2e.yml`, `playwright/`, `apps/server/api/test/`, `packages/prisma/`
 
 End-to-end testing runs **entirely on GitHub-hosted runners** (free for this public/OSS repo).
@@ -45,14 +45,14 @@ Top-level env: `TURBO_TOKEN` (secret) + `TURBO_TEAM` (var) enable Turborepo remo
 | Job id | Display name | Runner / timeout | Blocking? | What it runs |
 |---|---|---|---|---|
 | `e2e-route-coverage` | E2E Route Coverage Gate | ubuntu / 5m | **yes** (via gate) | `node scripts/e2e-route-coverage.mjs` |
-| `e2e-api` | API E2E Tests | ubuntu / 20m | **DISABLED** (`if: false`) | was `test:e2e:ci` — DI/path-alias broken, see §6 |
+| `e2e-api` | API E2E Tests | ubuntu / 20m | **yes** (via gate) | Postgres + Redis service containers, package build, Prisma migrate deploy, `test:e2e:ci` |
 | `e2e-frontend` | Frontend E2E (Shard N/12) | ubuntu / 45m | **yes** (via gate) | matrix 12 shards, `fail-fast:false`, `bun run test:e2e:sharded -- --reporter=blob` |
 | `e2e-merge-reports` | Merge E2E Reports | ubuntu / 10m | no (`if: always()`) | `playwright merge-reports` → single HTML report |
-| `e2e-gate` | E2E Gate (all shards) | ubuntu / 5m | **yes — the aggregator** | bash check of `e2e-route-coverage` + `e2e-frontend` results (fails on any shard failure OR cancellation) |
+| `e2e-gate` | E2E Gate (all shards) | ubuntu / 5m | **yes — the aggregator** | bash check of `e2e-route-coverage` + `e2e-frontend` + `e2e-api` results (fails on any required job failure OR cancellation) |
 | `e2e-frontend-authed` | Frontend Authenticated E2E | ubuntu / 40m | no (`continue-on-error`, gated by `E2E_AUTHED_ENABLED` var) | `bun run test:e2e:authed` |
 
-`e2e-gate` is the single job that represents the suite's pass/fail (it `needs:` route-coverage +
-frontend). It exits 1 if route coverage failed or any shard failed/was cancelled. Re-running only the
+`e2e-gate` is the single job that represents the required suite's pass/fail (it `needs:` route-coverage +
+frontend + API). It exits 1 if route coverage failed, API E2E failed, or any shard failed/was cancelled. Re-running only the
 failed shard + gate carries the green shards forward. **Frontend code-coverage moved out of this
 workflow** — it now lives in `coverage.yml` (weekly), not here. The old single `e2e-frontend` /
 `e2e-frontend-coverage` jobs in §2.3/§2.4 below are superseded by the sharded layout above.
@@ -75,11 +75,10 @@ workflow** — it now lives in `coverage.yml` (weekly), not here. The old single
 - **Job env:** `NODE_ENV=test`, `DATABASE_URL=postgresql://genfeed:genfeed_local@localhost:5432/test`,
   `REDIS_URL=redis://localhost:6379`. All external keys mocked
   (`REPLICATE_API_TOKEN`, `STRIPE_SECRET_KEY`, and auth secrets use test-safe values).
-- **Steps:** checkout → Node 22 → Bun 1.3.13 → cache bun/turbo → `bun install` →
+- **Steps:** checkout → Bun 1.3.14 via `.github/actions/setup-bun-env` → cache bun/turbo → `bun install` →
   `bunx turbo run build --filter="./packages/*"` →
   `bunx prisma migrate deploy` (cwd `packages/prisma`) → `test:e2e:ci` → codecov (flag `api-e2e`, non-fatal).
-- The API E2E job currently gates when enabled; keep workflow comments aligned with that behavior.
-  `continue-on-error`, so it DOES gate the run. (See §5.)
+- The API E2E job is enabled and required by `e2e-gate`; it has no `continue-on-error`.
 
 ### 2.3 `e2e-frontend` — Playwright core
 - **Steps:** checkout → Node 22 → Bun → cache bun/turbo/playwright-browsers → `bun install` →
@@ -196,7 +195,7 @@ Fixtures: `auth.fixture.ts` (`authenticatedPage`, `adminPage`, `automationPage`,
   `packages/prisma/generated/prisma/client/`, re-exported as `@genfeedai/prisma`).
   `DATABASE_URL` read via `packages/prisma/prisma.config.mjs` (not in schema), so `prisma generate` needs no DB.
 - **Migrations:** `packages/prisma/prisma/migrations/` — baseline `20260417050332_init` (all enums + ~140 tables)
-  + incremental migrations through `20260603083913_reconcile_filter_fields`.
+  + incremental migrations through `20260628200000_backfill_email_verified_for_migrated_users`.
 - **CI provisioning:** `e2e-api` job's `postgres` service container + `bunx prisma migrate deploy`
   (production-safe, applies pending migrations in order, no prompts). Suite then truncates/reseeds per test.
 - **Redis:** first-class dep — `RedisService` pub/sub (`packages/libs/redis/`) + BullMQ queues. Fault-tolerant
@@ -206,8 +205,6 @@ Fixtures: `auth.fixture.ts` (`authenticatedPage`, `adminPage`, `automationPage`,
 
 ## 6. Known risks / debt (gardening backlog)
 
-- **Stale "non-blocking" comment** on `e2e-api` — the job actually gates the run (no `continue-on-error`).
-  Either wire it as truly non-blocking or drop the comment.
 - **Hardcoded CI file list** in `test:e2e:ci` — rename/move any of the 3 files → CI silently runs fewer tests.
 - **Only 3 of ~11 API specs run in CI** — organizations/brands/auth/tasks never exercised by CI.
 - **`health.e2e-spec.ts`** (HTTP version) imports `@test/app.module` which does not exist — would fail if added.
@@ -216,8 +213,7 @@ Fixtures: `auth.fixture.ts` (`authenticatedPage`, `adminPage`, `automationPage`,
 - **`workers: 1` + `fullyParallel: true`** is contradictory; masks races that surface if workers increase.
 - **Playwright browser cache** has no restore-key fallback — any `bun.lock` change forces full Chromium re-download.
 - **Visual baselines** (`__screenshots__/`) are OS/font-sensitive — diffs across environments.
-- **Not a required PR gate** — runs nightly/manual only, so a regression can sit up to a day before
-  the nightly catches it.
+- **Not a regular PR gate** — the full E2E suite runs nightly/manual and through `full-suite.yml` / production QA, so an ordinary PR can merge before the nightly or release gate catches an E2E-only regression.
 
 ---
 

--- a/.agents/memory/context/progress.md
+++ b/.agents/memory/context/progress.md
@@ -1,13 +1,13 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-04-10T00:00:00Z
-version: 1.0
+last_updated: 2026-06-29T00:00:00Z
+version: 1.1
 author: Claude Code PM System
 ---
 
 # Progress — Genfeed.ai
 
-## Current State (2026-04-10)
+## Current State (2026-06-29)
 
 ### Migration Complete
 - Successfully migrated and consolidated from separate `cloud` + `core` repositories into a single `genfeed.ai` monorepo
@@ -16,22 +16,20 @@ author: Claude Code PM System
 - Enterprise features isolated into `ee/packages/` under commercial license
 
 ### CI/CD
-- GitHub Actions configured for CI/CD pipeline
-- Blacksmith runners removed — using standard GitHub Actions runners
-- Secret scanning set up
+- GitHub Actions configured for CI/CD, E2E, release QA, and production deploy pipelines
+- Standard GitHub Actions runners are the default execution environment
+- Secret scanning is set up (`gitleaks`, changed-file `secretlint`, local staged-content scan before commits)
 - Branch flow: trunk-based — short-lived branches off `master` → PR → `master`
 
 ### Recent Milestones
-- PR #116: Migrated raw HTML to UI primitives across the codebase
-- PR #120: Dynamic model registry implementation
-- PR #118: Thread context compaction for agent conversations
-- Root `/` redirect loop fixed for authenticated users with org/brand slug resolution; self-hosted onboarding loop tracked separately in issue #141
-- Default local ports regrouped: frontend `300x`, API core `3010-3014`, service/bot apps `3015-3019`, fleet services `3020-3022`
-- GitHub issue implementation workflow standardized on worktrees from `master` with PRs back to `master` (trunk-based)
+- Better Auth is the active auth baseline after the #735 cutover and hardening passes.
+- Default local ports remain grouped: frontend `300x`, API core `3010-3014`, service/bot apps `3015-3019`, fleet services `3020-3022`.
+- GitHub issue implementation workflow is trunk-based on `master` with short-lived worktrees/branches and PRs back to `master`.
+- Product recurring automation has been migrated toward workflow-backed scheduling; legacy `cron-jobs` is compatibility-only for new product work.
 
 ### Codebase Health
 - Fallow health score: 72/100 (tracked via issue #83)
-- BullMQ refactor ongoing: 32 `@Processor` decorators in API need moving to workers service (issue #84)
+- BullMQ processor placement refactor resolved for API: current source has no `@Processor(...)` decorators in `apps/server/api`; add new processors to workers or the owning runtime service.
 
 ### Active Development Areas
 - Stabilization post-migration
@@ -50,8 +48,7 @@ author: Claude Code PM System
 
 ## Known Issues / Debt
 
-- BullMQ processors still co-located in API instead of workers service
-- Some legacy patterns remain from pre-migration cloud/core split
+- Some legacy naming/comments remain from the pre-migration cloud/core and Mongo stacks; verify against current Prisma/Postgres source before acting.
 - Desktop and mobile apps in early stages
 - GPU pipeline services (images, videos, voices) need deployment documentation
 - Full `bun type-check` currently blocked by the existing `@genfeedai/ui` rootDir/file-list issue around `packages/client/src/schemas/*`

--- a/.agents/memory/context/project-overview.md
+++ b/.agents/memory/context/project-overview.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-04-10T00:00:00Z
-version: 1.0
+last_updated: 2026-06-29T00:00:00Z
+version: 1.1
 author: Claude Code PM System
 ---
 
@@ -23,8 +23,8 @@ Genfeed.ai is an open-source AI operating system for content creation — a self
 
 - **12 backend services** (NestJS): api, clips, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers
 - **6 app surfaces**: app (studio), docs, website, desktop, mobile, extensions
-- **~45 shared packages**: serializers, UI components, hooks, services, types, enums, workflow engine, integrations, etc.
-- **9 enterprise packages** (`ee/`): multi-tenancy, billing, analytics, SSO, teams, collaboration, scheduling, branding, admin-ee
+- **42 shared packages**: serializers, UI components, hooks, services, types, enums, workflow engine, integrations, Prisma, etc.
+- **5 enterprise packages** (`ee/`): analytics, billing, harness, multi-tenancy, teams
 - **Infrastructure**: Docker self-hosted, PostgreSQL (Prisma ORM), Redis + BullMQ, Better Auth
 
 ## Current State

--- a/.agents/memory/context/project-structure.md
+++ b/.agents/memory/context/project-structure.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-04-10T00:00:00Z
-version: 1.0
+last_updated: 2026-06-29T00:00:00Z
+version: 1.1
 author: Claude Code PM System
 ---
 
@@ -28,12 +28,12 @@ genfeed.ai/
 │   ├── app/                 # Main studio app (Next.js)
 │   ├── docs/                # Documentation site (Next.js)
 │   ├── website/             # Marketing site (Next.js)
-│   ├── desktop/             # Electron desktop app
-│   ├── mobile/              # React Native / Expo
+│   ├── desktop/app/         # Electron desktop app workspace
+│   ├── mobile/app/          # React Native / Expo workspace
 │   └── extensions/          # Browser & IDE extensions (v2 milestone)
-│       ├── browser/
-│       └── ide/
-├── packages/                # 43 shared packages (@genfeedai/*)
+│       ├── browser/app/
+│       └── ide/app/
+├── packages/                # 42 shared packages (@genfeedai/*)
 │   ├── agent/               # Agent logic
 │   ├── api-types/           # Generated API types
 │   ├── cli/                 # CLI tooling
@@ -42,37 +42,24 @@ genfeed.ai/
 │   ├── constants/           # Shared constants
 │   ├── contexts/            # React contexts
 │   ├── core/                # Core library
-│   ├── db/                  # Database utilities
-│   ├── deserializer/        # JSON:API deserializer
-│   ├── desktop-client/      # Desktop API client
 │   ├── desktop-contracts/   # Desktop IPC contracts
 │   ├── desktop-core/        # Desktop core logic
-│   ├── desktop-shell/       # Desktop shell
+│   ├── desktop-prisma/      # Desktop-local Prisma/PGlite schema + client
 │   ├── enums/               # Shared enums
 │   ├── errors/              # Error types
 │   ├── fonts/               # Font assets
 │   ├── helpers/             # Utility helpers
 │   ├── hooks/               # React hooks
-│   ├── integration-common/  # Integration base
 │   ├── integrations/        # Platform integrations
-│   │   ├── discord/
-│   │   ├── fanvue/
-│   │   ├── instagram/
-│   │   ├── linkedin/
-│   │   ├── slack/
-│   │   ├── telegram/
-│   │   ├── threads/
-│   │   ├── tiktok/
-│   │   ├── twitter/
-│   │   └── youtube/
 │   ├── interfaces/          # TypeScript interfaces
 │   ├── libs/                # Shared libraries
 │   ├── models/              # Domain data models
 │   ├── next-config/         # Shared Next.js config
 │   ├── pages/               # Shared page components
+│   ├── pricing/             # Pricing helpers
+│   ├── prisma/              # PostgreSQL Prisma schema, migrations, generated client
 │   ├── prompts/             # AI prompts
 │   ├── props/               # Component prop interfaces
-│   ├── providers/           # React providers
 │   ├── serializers/         # JSON:API serializers
 │   ├── services/            # Frontend services
 │   ├── storage/             # Storage abstraction
@@ -88,11 +75,11 @@ genfeed.ai/
 │   └── workflows/           # Workflow definitions
 ├── ee/                      # Enterprise features (commercial license)
 │   └── packages/
-│       ├── analytics/       # Advanced analytics (v2)
-│       ├── billing/         # Stripe billing & credits (Phase C extraction target)
+│       ├── analytics/       # Advanced analytics
+│       ├── billing/         # Stripe billing & credits
 │       ├── harness/         # @genfeedai/ee-harness — enterprise content-harness contributions
-│       ├── multi-tenancy/   # Multi-tenant org isolation (v2)
-│       └── teams/           # Team management (v2)
+│       ├── multi-tenancy/   # Multi-tenant org isolation
+│       └── teams/           # Team management
 ├── docker/                  # Docker configs
 ├── docs/                    # Documentation
 ├── e2e/                     # E2E test suites
@@ -107,7 +94,7 @@ genfeed.ai/
 - **Backend service structure**: `apps/server/{service}/src/` with NestJS modules
 - **API services**: `apps/server/api/src/services/{service-name}/` — 30+ domain services
 - **Integrations**: `apps/server/api/src/services/integrations/{platform}/` — 48+ platforms
-- **Frontend app structure**: `apps/{app}/app/` (Next.js App Router)
+- **Frontend app structure**: `apps/app/app/`, `apps/docs/app/`, and `apps/website/app/` use Next.js App Router. Admin routes are inside `apps/app/app/(protected)/admin`.
 - **Shared packages**: `packages/{name}/src/index.ts` barrel exports
 - **Serializers**: `packages/serializers/src/{attributes,configs,server}/{category}/`
 - **Enterprise packages**: `ee/packages/{name}/` — commercial license, multi-tenancy features

--- a/.agents/memory/context/project-style-guide.md
+++ b/.agents/memory/context/project-style-guide.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-04-07T00:00:00Z
-version: 1.0
+last_updated: 2026-06-29T00:00:00Z
+version: 1.1
 author: Claude Code PM System
 ---
 
@@ -49,8 +49,8 @@ author: Claude Code PM System
 - NestJS exceptions for errors (`NotFoundException`, `BadRequestException`)
 - `ConfigService` pattern — never `process.env` directly
 - Soft deletes: `isDeleted: boolean`
-- **Multi-tenant queries (enterprise only)**: `{ organization: orgId, isDeleted: false }` — this pattern lives in `ee/packages/multi-tenancy/`. Single-tenant deployments use `{ isDeleted: false }` only.
-- Compound indexes in module `useFactory`, simple via `@Prop`
+- **Multi-tenant queries (enterprise only)**: `{ organizationId: orgId, isDeleted: false }` — this pattern lives in `ee/packages/multi-tenancy/`. Single-tenant deployments use `{ isDeleted: false }` only unless the domain model already carries an organization id.
+- Compound indexes live in `packages/prisma/prisma/schema.prisma` via `@@index` or in explicit migrations.
 
 ## Naming
 

--- a/.agents/memory/context/system-patterns.md
+++ b/.agents/memory/context/system-patterns.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-04-07T00:00:00Z
-version: 1.0
+last_updated: 2026-06-29T00:00:00Z
+version: 1.1
 author: Claude Code PM System
 ---
 
@@ -28,8 +28,8 @@ Backend modules use `createServiceModule()` factory (auto-includes ConfigModule 
 ### Soft Deletes
 `isDeleted: boolean` field — never `deletedAt`. All queries filter `isDeleted: false`.
 
-### Queue Processing
-BullMQ queues with Redis. All cron jobs live in the workers service.
+### Queue Processing And Scheduling
+BullMQ queues use Redis. Product-facing recurring automation is workflow-backed through `WorkflowSchedulerService` and workflow trigger records. The legacy `cron-jobs` subsystem is retained for compatibility reads and workflow-adapter execution of migrated rows; do not add new product features to it. Static Nest `@Cron(...)` jobs are reserved for reviewed platform/maintenance responsibilities and are guarded by `bun run check:cron-boundary`.
 
 ## Frontend Patterns
 
@@ -57,7 +57,7 @@ Use `gen-*` design classes (`gen-card-spotlight`, `gen-contact-sheet`, `gen-divi
 ### Integration Services
 - Module: `createServiceModule()` factory
 - OAuth: `@Post('connect')` -> auth URL, `@Post('verify')` -> exchange code
-- Credentials scoped: `{ platform: CredentialPlatform.X, isDeleted: false }` (add `organization: orgId` only with enterprise multi-tenancy)
+- Credentials scoped: `{ platform: CredentialPlatform.X, isDeleted: false }` (add `organizationId` only with enterprise multi-tenancy)
 
 ### Agent Tools
 - Registration chain: tool def -> credit cost -> agent type config -> executor handler -> UI label -> test

--- a/.agents/memory/features/agent/COLLECTIONS.md
+++ b/.agents/memory/features/agent/COLLECTIONS.md
@@ -1,31 +1,38 @@
 # Agent Persistence Records
 
-## AgentRoom (Thread Metadata)
+> **Last verified:** 2026-06-29 against `packages/prisma/prisma/schema.prisma` and agent collection services.
 
-**File:** `apps/server/api/src/collections/agent-threads/schemas/agent-thread.schema.ts`
-**Collection:** `rooms`
+Storage source of truth is Prisma/Postgres. Files under `apps/server/api/src/collections/agent-*/schemas/` are TypeScript compatibility wrappers around Prisma types, not Mongoose schemas. Some wrappers still expose legacy aliases such as `_id`, `organization`, `user`, and `room`; service writes should use canonical Prisma fields (`id`, `organizationId`, `userId`, `threadId`, `brandId`, etc.).
+
+## AgentThread
+
+**Prisma model:** `AgentThread`
+**Table:** `agent_threads`
+**Compatibility type:** `AgentRoomDocument`
+
+Canonical fields:
 
 ```typescript
 {
-  user: ObjectId                     // thread owner
-  organization: ObjectId
+  id: string
+  mongoId?: string
+  userId: string
+  organizationId: string
   title?: string
-  source?: string                    // 'web', 'api', 'mobile'
-  status: AgentThreadStatus          // ACTIVE | ARCHIVED
-  systemPrompt?: string              // custom system prompt override
-  parentThreadId?: string            // for branched threads
-  memoryEntryIds?: string[]          // pinned agent memory references
+  status?: string
+  config: Json
   isDeleted: boolean
+  createdAt: Date
+  updatedAt: Date
 }
 ```
 
-**Index:** `idx_user_threads` on `{ isDeleted, organization, updatedAt, user }`
-
 **Service:** `AgentThreadsService`
-- `getUserThreads(userId, orgId, status?)` -- list threads
-- `archiveThread(threadId, orgId)` / `unarchiveThread()`
-- `updateThreadMetadata(threadId, orgId, { title, systemPrompt, memoryEntryIds })`
-- `branchThread(threadId, orgId, userId)` -- creates new thread + copies all messages
+
+- `getUserThreads(userId, organizationId, status?)`
+- `archiveThread(threadId, organizationId)` / `unarchiveThread()`
+- `updateThreadMetadata(threadId, organizationId, payload)`
+- `branchThread(threadId, organizationId, userId)` creates a new thread and copies messages
 
 **Controller endpoints:**
 
@@ -38,144 +45,137 @@
 | `POST` | `/:threadId/branches` | Branch thread |
 | `PATCH` | `/:threadId` | Update metadata or status |
 
----
-
 ## AgentMessage
 
-**File:** `apps/server/api/src/collections/agent-messages/schemas/agent-message.schema.ts`
-**Collection:** `messages`
+**Prisma model:** `AgentMessage`
+**Table:** `agent_messages`
+
+Canonical fields:
 
 ```typescript
 {
-  room: ObjectId                     // -> AgentRoom
-  organization: ObjectId
-  user: string
-  brand?: ObjectId
-  role: AgentMessageRole             // USER | ASSISTANT | SYSTEM | TOOL
+  id: string
+  mongoId?: string
+  threadId: string
+  organizationId: string
+  userId?: string
+  brandId?: string
+  role: string
   content?: string
-  toolCallId?: string
-  toolCalls?: ToolCall[]
-  metadata?: Record<string, unknown>
+  toolCalls?: Json
+  toolResults?: Json
+  metadata?: Json
   isDeleted: boolean
+  createdAt: Date
+  updatedAt: Date
 }
 ```
 
-**ToolCall sub-schema:**
-```typescript
-{
-  toolName: string
-  parameters?: Record<string, unknown>
-  result?: Record<string, unknown>
-  status?: string
-  creditsUsed?: number
-  durationMs?: number
-  error?: string
-}
-```
+**Indexes:** `@@index([organizationId, threadId, isDeleted, createdAt(sort: Desc), id])`, `@@index([threadId, isDeleted, id])`
 
 **Service:** `AgentMessagesService`
-- `addMessage(dto)` -- persist message with tool calls
-- `getMessagesByRoom(roomId, orgId, { limit, page })` -- default limit 50, page 1, sorted by createdAt desc
-- `getRecentMessages(roomId, limit?)` -- default limit 20, chronological (for LLM context)
-- `copyMessages(sourceRoom, targetRoom, orgId)` -- for thread branching
 
----
+- `addMessage(dto)` maps compatibility `room` to canonical `threadId`
+- `getMessagesByRoom(roomId, organizationId, { limit, page, cursor })`
+- `getRecentMessages(roomId, limit?)`
+- `copyMessages(sourceRoom, targetRoom, organizationId)`
 
-## AgentRun (Execution Tracking)
+## AgentRun
 
-**File:** `apps/server/api/src/collections/agent-runs/schemas/agent-run.schema.ts`
-**Collection:** `agent_runs`
+**Prisma model:** `AgentRun`
+**Table:** `agent_runs`
+
+Canonical fields:
 
 ```typescript
 {
-  organization: ObjectId
-  user: ObjectId
-  trigger: AgentExecutionTrigger     // MANUAL | SCHEDULED | EVENT | AUTO
-  status: AgentExecutionStatus       // PENDING | RUNNING | COMPLETED | FAILED | CANCELLED
-  strategy?: ObjectId
-  thread?: ObjectId                  // associated thread (optional)
-  parentRun?: ObjectId               // for nested runs
-  label: string                      // display name
+  id: string
+  mongoId?: string
+  organizationId: string
+  userId: string
+  strategyId?: string
+  threadId?: string
+  parentRunId?: string
+  status: AgentRunStatus
+  type?: string
+  config: Json
+  result?: Json
+  error?: string
+  metadata: Json
+  label?: string
   objective?: string
-  toolCalls: AgentRunToolCall[]      // completed tool invocations
-  summary?: string
+  trigger?: string
   creditsUsed: number
-  creditBudget?: number
-  startedAt?: Date
-  completedAt?: Date
   durationMs?: number
-  error?: string
-  retryCount: number
-  progress: number                   // 0-100
-  metadata?: Record<string, unknown>
   isDeleted: boolean
+  createdAt: Date
+  updatedAt: Date
 }
 ```
 
-**AgentRunToolCall sub-schema:**
-```typescript
-{
-  toolName: string
-  status: 'completed' | 'failed'
-  creditsUsed: number
-  durationMs: number
-  error?: string
-  executedAt: Date
-}
-```
+**Indexes:** organization/status/thread scoped Prisma indexes in `schema.prisma`.
 
 **Service:** `AgentRunsService`
-- `start(id, orgId)` -- sets status=RUNNING, startedAt=now
-- `getById(id, orgId)` -- retrieve single run
-- `isCancelled(id, orgId)` -- polled during streaming loop
-- `recordToolCall(id, orgId, toolCall)` -- appends to toolCalls array, increments creditsUsed
-- `updateProgress(id, orgId, progress)` -- clamps progress to [0, 100]
-- `getActiveRuns(orgId)` / `getByThread(threadId, orgId)`
-- `getStats(orgId)` -> `{ totalRuns, activeRuns, completedToday, failedToday, totalCreditsToday }`
-- `getRunContent(runId, orgId)` -> `{ posts, ingredients }`
 
----
+- `start(id, organizationId)` sets status to `RUNNING`
+- `getById(id, organizationId)`
+- `isCancelled(id, organizationId)`
+- `getActiveRuns(organizationId)` / `getByThread(threadId, organizationId)`
+- `getStats(organizationId)`
+- `getRunContent(runId, organizationId)`
 
 ## AgentMemory
 
-**File:** `apps/server/api/src/collections/agent-memories/schemas/agent-memory.schema.ts`
-**Collection:** `agent_memories`
+**Prisma model:** `AgentMemory`
+**Table:** `agent_memories`
+
+Canonical fields:
 
 ```typescript
 {
-  organization: ObjectId
-  user: string
-  content: string                    // memory text
-  kind: 'preference' | 'positive_example' | 'negative_example' | 'winner' | 'reference' | 'instruction' | 'pattern'
-  scope: 'user' | 'brand'           // default: 'user'
-  contentType: 'newsletter' | 'tweet' | 'thread' | 'article' | 'post' | 'generic'
-  sourceMessageId?: string
-  brand?: ObjectId
+  id: string
+  mongoId?: string
+  organizationId: string
+  userId: string
+  brandId?: string
+  campaignId?: string
+  content?: string
+  type?: string
+  metadata?: Json
+  scope?: string
+  kind?: string
+  contentType?: string
   platform?: string
+  summary?: string
+  tags: string[]
   sourceType?: string
   sourceUrl?: string
   sourceContentId?: string
-  importance: number                 // 0-1, default 0.5
-  confidence: number                 // 0-1, default 0.5
-  performanceSnapshot?: Record<string, unknown>
-  tags?: string[]
-  summary?: string
+  sourceMessageId?: string
+  importance?: number
+  confidence?: number
+  performanceSnapshot?: Json
+  createdAt: Date
+  updatedAt: Date
 }
 ```
 
 **Service:** `AgentMemoriesService`
-- `getMemoriesForPrompt(userId, orgId, { query?, contentType?, brandId?, pinnedMemoryIds?, limit? })`
-  - Fetches up to 200 candidates, ranks by multi-factor scoring, returns top K (default 8)
-  - Scoring: pinned (+100) > brand match (+5) > contentType exact (+8) or generic (+1) > kind bonus (winner/pattern +4, instruction/preference +3) > importance x 4 > confidence x 2 > query term matches (x 3 each) > minimum +1
-- `listForUser(userId, orgId, { limit? })` -- default limit 100, sorted by createdAt desc
-- `createMemory(userId, orgId, payload)` -- normalizes kind/scope/contentType, clamps importance/confidence to [0,1]
-- `removeMemory(memoryId, userId, orgId)`
 
-**Memory in system prompt** -- organized into 5 sections:
-1. User Preferences (kind: preference)
-2. Saved Instructions (kind: instruction, default)
-3. Winning Patterns (kind: winner, pattern)
-4. Reference Examples (kind: reference, positive_example)
-5. Avoid These Patterns (kind: negative_example)
+- `getMemoriesForPrompt(userId, organizationId, { query?, contentType?, brandId?, pinnedMemoryIds?, limit? })`
+  - Fetches candidates, ranks by pinned status, brand/content match, kind, importance/confidence, query terms, and recency.
+- `listForUser(userId, organizationId, { limit? })`
+- `createMemory(userId, organizationId, payload)`
+- `getCampaignMemories(campaignId, organizationId, contentType?)`
+- `saveCampaignMemory(userId, organizationId, campaignId, payload)`
+- `removeMemory(memoryId, userId, organizationId)`
+
+**Memory in system prompt** is organized into five sections:
+
+1. User Preferences (`kind: preference`)
+2. Saved Instructions (`kind: instruction`, default)
+3. Winning Patterns (`kind: winner`, `pattern`)
+4. Reference Examples (`kind: reference`, `positive_example`)
+5. Avoid These Patterns (`kind: negative_example`)
 
 Format: `- [content_type / platform / scope] snippet (max 220 chars)`

--- a/.agents/memory/features/agent/THREADING.md
+++ b/.agents/memory/features/agent/THREADING.md
@@ -1,26 +1,29 @@
 # Agent Threading & Event Sourcing
 
+> **Last verified:** 2026-06-29 against `apps/server/api/src/services/agent-threading/` and `packages/prisma/prisma/schema.prisma`.
+
 **Directory:** `apps/server/api/src/services/agent-threading/`
+
+Agent threading now persists through Prisma/Postgres. The `schemas/*.schema.ts` files in this directory are compatibility document types around Prisma rows and snapshot JSON, not Mongoose collection schemas.
 
 ## Module Exports
 
 - `AgentThreadEngineService` -- event appending + snapshot management
 - `AgentThreadProjectorService` -- event -> snapshot projection
-- `AgentRuntimeSessionService` -- session binding CRUD
+- `AgentRuntimeSessionService` -- session binding CRUD stored in `AgentThreadSnapshot.data.sessionBinding`
 - `AgentExecutionLaneService` -- in-memory concurrency control
 - `AgentProfileResolverService` -- agent profile resolution
+- `ThreadContextCompressorService` -- thread context compaction state
 
-## Collections
+## Persistence Records
 
-| Collection | Schema | Purpose |
-|-----------|--------|---------|
-| `agent_thread_events` | AgentThreadEvent | Immutable event log (event sourcing) |
-| `agent_thread_snapshots` | AgentThreadSnapshot | Projected state from events |
-| `agent_session_bindings` | AgentSessionBinding | Runtime/session state (runId, model, status, resumeCursor, activeCommandId) |
-| `agent_input_requests` | AgentInputRequest | Pending/resolved user input requests |
-| `agent_profile_snapshots` | AgentProfileSnapshot | Agent config snapshot (tools, prompts, memory policy) |
+| Prisma record | Backing table | Purpose |
+|---|---|---|
+| `AgentThreadEvent` | `agent_thread_events` | Immutable event log |
+| `AgentThreadSnapshot` | `agent_thread_snapshots` | Projected state from events; JSON payload holds runtime/session/profile/input state |
+| `ThreadContextState` | `thread_context_states` | Thread context compression state |
 
-All agent-threading records use the dedicated agent persistence connection.
+Runtime/session bindings, input requests, and profile snapshots are not standalone Prisma tables in the current schema. Current services adapt them into document-like shapes from `AgentThreadSnapshot.data`.
 
 ## Event Types (19)
 
@@ -41,13 +44,15 @@ error.raised
 **Key methods:**
 
 ### `appendEvent(params)`
-- Appends event to `agent_thread_events` with sequence guarantee
-- Uses `commandId` for idempotency (returns existing event if duplicate)
-- Increments `lastSequence` atomically on the snapshot
-- Projects event into snapshot via `AgentThreadProjectorService`
 
-**Side effects on session binding:**
-- `input.requested` -> status = `waiting_input`, creates `AgentInputRequest` doc
+- Appends an `AgentThreadEvent` row with a sequence guarantee.
+- Uses `commandId` for idempotency where supplied.
+- Increments `lastSequence` in projected snapshot data.
+- Projects the event into `AgentThreadSnapshot.data` via `AgentThreadProjectorService`.
+
+**Side effects on session binding stored in snapshot JSON:**
+
+- `input.requested` -> status = `waiting_input`, appends an input request to `data.inputRequests[]`
 - `thread.turn_started`, `work.started`, `tool.started`, `tool.progress` -> status = `running`
 - `input.resolved` -> status = `running`
 - `run.cancelled` -> status = `cancelled`
@@ -55,88 +60,102 @@ error.raised
 - `run.failed`, `error.raised` -> status = `failed`
 
 ### `resolveInputRequest(params)`
-Marks `AgentInputRequest` as resolved with answer + timestamp.
 
-### `recordProfileSnapshot(threadId, orgId, snapshot)`
-Upserts agent profile (tools, prompts, memory policy) for the thread.
+Marks an input request inside `AgentThreadSnapshot.data.inputRequests[]` as resolved with answer + timestamp.
 
-### `recordMemoryFlush(threadId, orgId, userId, content, tags)`
-Persists thread conversation summary to memory, returns memory ID.
+### `recordProfileSnapshot(threadId, organizationId, snapshot)`
+
+Stores agent profile data under `AgentThreadSnapshot.data.profileSnapshot`.
+
+### `recordMemoryFlush(threadId, organizationId, userId, content, tags)`
+
+Persists thread conversation summary to memory and returns a memory ID.
 
 ## AgentThreadProjectorService
 
 **Core method:** `applyEvent(snapshot, event) -> MutableSnapshot`
 
-Projects each event type into the snapshot state:
+Projects each event type into snapshot data:
 
 | Event | Snapshot Update |
 |-------|----------------|
 | `thread.turn_requested` | `activeRun = { status: 'queued' }` |
 | `thread.turn_started` / `work.started` | `activeRun = { status: 'running' }` |
 | `assistant.finalized` | `lastAssistantMessage = { messageId, content, metadata }` |
-| `input.requested` | Appends to `pendingInputRequests[]` |
+| `input.requested` | Appends to `pendingInputRequests[]` and `inputRequests[]` |
 | `input.resolved` | Removes matching `requestId` from `pendingInputRequests[]` |
 | `plan.upserted` | `latestProposedPlan = { id, content, steps }` |
 | `ui.blocks_updated` | `latestUiBlocks = { operation, blocks, blockIds }` |
 | `run.*` / `work.completed` / `error.raised` | `activeRun.completedAt` + status |
 | `memory.flushed` | Appends `memoryId` to `memorySummaryRefs[]` |
 | `tool.started` / `tool.progress` | `activeRun.status = 'running'` |
-| `tool.completed` | `activeRun.status = 'running'` (or `'failed'` if `payload.status='failed'`) |
+| `tool.completed` | `activeRun.status = 'running'` or `'failed'` if `payload.status='failed'` |
 
-**Timeline:** Max 250 entries (oldest dropped). Each entry has: `id`, `kind`, `label`, `detail`, `status`, `createdAt`, `sequence`, optional `runId`, `toolName`, `requestId`, `role`, `payload`.
+**Timeline:** Max 250 entries (oldest dropped). Each entry has `id`, `kind`, `label`, `detail`, `status`, `createdAt`, `sequence`, and optional `runId`, `toolName`, `requestId`, `role`, `payload`.
 
 **Timeline entry kinds:** `'assistant'`, `'input'`, `'message'`, `'plan'`, `'tool'`, `'work'`, `'system'`, `'error'`
 
-## AgentThreadSnapshot Schema
+## AgentThreadSnapshot
 
-**Collection:** `agent_thread_snapshots`
+**Prisma model:** `AgentThreadSnapshot`
+**Table:** `agent_thread_snapshots`
+
+Canonical row fields:
 
 ```typescript
 {
-  organization: ObjectId
-  thread: ObjectId          // unique with org
-  lastSequence: number      // highest event sequence processed
+  id: string
+  mongoId?: string
+  organizationId: string
+  threadId: string
+  data: Json
+  isDeleted: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+```
+
+**Index:** `@@unique([organizationId, threadId])`
+
+Snapshot `data` contains the projected thread state:
+
+```typescript
+{
+  lastSequence: number
   title?: string
   source?: string
   threadStatus?: string
   activeRun?: { runId, model, status, startedAt, completedAt }
-  pendingApprovals: AgentPendingApproval[]  // { requestId, requestKind, detail?, createdAt }
-  pendingInputRequests: AgentPendingInputRequest[]  // { requestId, title, prompt, allowFreeText?, recommendedOptionId?, options[], fieldId?, metadata?, createdAt }
+  pendingApprovals?: AgentPendingApproval[]
+  pendingInputRequests?: AgentPendingInputRequest[]
+  inputRequests?: Record<string, unknown>[]
   latestProposedPlan?: { id, content, explanation, steps, createdAt, updatedAt }
   latestUiBlocks?: { operation, blocks, blockIds, updatedAt }
   lastAssistantMessage?: { messageId, content, metadata, createdAt }
-  memorySummaryRefs: string[]
-  timeline: AgentThreadTimelineEntry[]  // max 250
+  memorySummaryRefs?: string[]
+  timeline?: AgentThreadTimelineEntry[]
   sessionBinding?: Record<string, unknown>
   profileSnapshot?: Record<string, unknown>
-  isDeleted: boolean
 }
 ```
 
-Index: `{ organization: 1, thread: 1 }` -- UNIQUE
+## AgentRuntimeSessionService
 
-## AgentSessionBinding Schema
-
-**Collection:** `agent_session_bindings`
-
-Stores runtime/session state for active agent execution. Does NOT store user/brand context -- that lives in the thread and profile snapshot.
+Stores runtime/session state inside `AgentThreadSnapshot.data.sessionBinding` and adapts it to `AgentSessionBindingDocument` for callers.
 
 ```typescript
 {
-  organization: ObjectId
-  thread: ObjectId
+  organizationId: string
+  threadId: string
   runId?: string
   model?: string
   status: 'idle' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'cancelled'
-  resumeCursor?: Record<string, unknown>   // checkpointing position
-  activeCommandId?: string                 // currently executing command
-  lastSeenAt?: string                      // last activity timestamp
+  resumeCursor?: Record<string, unknown>
+  activeCommandId?: string
+  lastSeenAt?: string
   metadata?: Record<string, unknown>
-  isDeleted: boolean
 }
 ```
-
-Index: `{ organization: 1, thread: 1 }` -- UNIQUE
 
 ## AgentExecutionLaneService
 
@@ -146,7 +165,7 @@ In-memory concurrency control using promise chains.
 async runExclusive<T>(laneKey: string, task: () => Promise<T>): Promise<T>
 ```
 
-Maintains `Map<string, Promise<unknown>>` -- tasks on the same lane execute sequentially. Used with key `thread:{threadId}` to serialize concurrent mutations on the same thread.
+Maintains `Map<string, Promise<unknown>>`; tasks on the same lane execute sequentially. Used with key `thread:{threadId}` to serialize concurrent mutations on the same thread.
 
 ## AgentProfileResolverService
 
@@ -155,9 +174,9 @@ Resolves agent configuration from context:
 ```typescript
 resolve(context: { agentType?, campaignId?, strategyId? }): {
   agentType?: string
-  campaign?: ObjectId
-  strategy?: ObjectId
-  routeKey: string              // "agentType:campaignId:strategyId"
+  campaignId?: string
+  strategyId?: string
+  routeKey: string
   enabledTools: string[]
   promptFragments: string[]
   hooks: { before_prompt_build, after_tool_call, before_tool_call, session_end }

--- a/.agents/memory/project_bullmq.md
+++ b/.agents/memory/project_bullmq.md
@@ -1,9 +1,11 @@
 ---
-name: BullMQ Refactor
-description: Issue #84 — move 32 @Processor decorators from API service to Workers service
+name: BullMQ Processor Placement
+description: API no longer owns BullMQ processors; put new processors in workers or the owning service
 type: project
+status: resolved
+last_verified: 2026-06-29
 ---
 
-**Why:** API process runs 32 BullMQ job processors alongside HTTP handlers. Heavy jobs (workflow execution, agent runs, content pipeline) eat CPU that should serve requests. Workers process has zero processors — only @Cron jobs.
+**Why:** The old #84 concern was API process contention from BullMQ processors running beside HTTP handlers. Current source has no `@Processor(...)` decorators in `apps/server/api`; most product processors now live under `apps/server/workers/src/processors/api/**`, while file/clip-specific processors remain in their owning services.
 
-**How to apply:** When adding new processors, put them in Workers (apps/server/workers), not API. Issue #84 tracks the migration of existing processors.
+**How to apply:** Do not add BullMQ processors to `apps/server/api`. Put new product/background processors in `apps/server/workers`, or in a dedicated owning runtime service when the queue is service-local (for example files/clips). Keep the API responsible for HTTP orchestration and queue enqueueing.

--- a/.agents/memory/project_migration.md
+++ b/.agents/memory/project_migration.md
@@ -6,7 +6,7 @@ type: project
 
 **Why:** Two repos (cloud SaaS + core open-source) were merged into genfeed.ai monorepo.
 
-**How to apply:** genfeed.ai is the canonical repo. cloud/ and core/ still exist on disk as reference but are no longer source of truth. The @genfeedai/create package still points to genfeedai/core — needs updating as part of epic #95.
+**How to apply:** genfeed.ai is the canonical repo. cloud/ and core/ may exist on disk as historical references but are no longer source of truth. Check current package metadata before publishing changes to `@genfeedai/create`.
 
 Migration stats: 114 web pages (105 cloud + 9 core), 3871 test files, all 12 NestJS services compile.
-Known issue: UI packages triplicated across apps/app, apps/admin, apps/website (same files, same hash). Tracked in #83 fallow report.
+Historical UI duplication should be re-verified from the current tree before acting on #83-era fallow notes; there is no standalone `apps/admin` workspace.

--- a/.agents/memory/reference_postgres_rds.md
+++ b/.agents/memory/reference_postgres_rds.md
@@ -1,6 +1,6 @@
 # Postgres RDS instances (us-west-1)
 
-last_verified: 2026-06-10
+last_verified: 2026-06-29
 
 | Instance | Role | Endpoint | Notes |
 |---|---|---|---|
@@ -9,8 +9,8 @@ last_verified: 2026-06-10
 
 ## Connection gotchas
 
-- **RDS PG 18 forces SSL** (`rds.force_ssl=1` system default). `@prisma/adapter-pg` sends no TLS by default → `P1010 "User was denied access on the database"` (looks like permissions, is actually missing TLS). Prisma CLI works regardless (auto-negotiates). Fix: `?sslmode=no-verify` in `DATABASE_URL` (TLS on, skip CA verify — RDS CA absent from node trust store).
-- **`PrismaService` reads raw `process.env.DATABASE_URL`** (`apps/server/api/src/shared/modules/prisma/prisma.service.ts`) — bypasses `BaseConfigService` file layering. Actual injection: bun auto-loads `apps/server/<service>/.env{,.local}` when turbo spawns package dev scripts.
+- **RDS PG 18 forces SSL** (`rds.force_ssl=1` system default). `PrismaService` resolves TLS explicitly for `@prisma/adapter-pg`: production server images bundle the AWS RDS CA at `/certs/rds-ca.pem`, and the service also honors `PRISMA_POSTGRES_CA_FILE` / `PGSSLROOTCERT`. `?sslmode=no-verify` remains a local escape hatch when no CA file is available.
+- **`PrismaService` reads `DATABASE_URL` through `ConfigService.get()`** (`apps/server/api/src/shared/modules/prisma/prisma.service.ts`) and passes an explicit `PrismaPg` adapter config. Prisma CLI and package scripts still read `process.env.DATABASE_URL` through `packages/prisma/prisma.config.mjs`.
 - `DATABASE_URL` lives in per-service `.env.local` files (api, files, mcp, notifications, workers) + `packages/prisma/prisma/.env`. Root `.env.local` has none.
 - Db/user/database all named `genfeed`. Prisma tables snake_case (`organizations`, `users`).
 

--- a/.agents/memory/rules/20-web-apps.md
+++ b/.agents/memory/rules/20-web-apps.md
@@ -2,7 +2,7 @@
 description: Frontend standards for Next.js apps.
 globs:
   - "apps/app/**"
-  - "apps/admin/**"
+  - "apps/docs/**"
   - "apps/website/**"
   - "apps/desktop/**"
   - "apps/mobile/**"

--- a/.agents/memory/system/AGENT-RUNTIME.md
+++ b/.agents/memory/system/AGENT-RUNTIME.md
@@ -79,7 +79,7 @@ Verification levels:
 
 Minimum checks by change type:
 
-- Frontend (`apps/app/*`, `apps/admin/*`, `packages/ui/*`, `packages/hooks/*`)
+- Frontend (`apps/app/*`, `apps/docs/*`, `apps/website/*`, `apps/desktop/app/*`, `apps/mobile/app/*`, `apps/extensions/*/app/*`, `packages/ui/*`, `packages/hooks/*`)
   - `fast`: lint/type checks
   - `strict`: add affected tests + QA flow
 

--- a/.agents/memory/system/ARCHITECTURE.md
+++ b/.agents/memory/system/ARCHITECTURE.md
@@ -5,7 +5,7 @@ Primary architecture references for planning/reporting.
 ## Repo Structure
 
 - **Apps (server):** `apps/server/{api,clips,discord,files,images,mcp,notifications,slack,telegram,videos,voices,workers}`
-- **Apps (frontend):** `apps/{app,admin,website,desktop,mobile,extensions}`
+- **Apps (frontend):** `apps/app`, `apps/docs`, `apps/website`, `apps/desktop/app`, `apps/mobile/app`, `apps/extensions/{browser,ide}/app`
 - **Packages:** `packages/*` (`@genfeedai/*` scope)
 - **Enterprise:** `ee/packages/*` (commercial license)
 

--- a/.agents/memory/system/CRITICAL-NEVER-DO.md
+++ b/.agents/memory/system/CRITICAL-NEVER-DO.md
@@ -19,11 +19,11 @@ All operations within the workspace root only. NEVER use `/tmp`, `/private/tmp`,
 
 ### NEVER DELETE Protected Root Files
 
-At repo root: `AGENTS.md`, `CLAUDE.md`, `README.md`. These are required for the Agentic Dashboard -- NOT duplicates of `.agents/` files.
+At repo root: `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `CONTRIBUTING.md`, `DESIGN.md`, `README.md`, and `RELEASING.md`. These are intentional root documentation surfaces -- NOT duplicates of `.agents/` files.
 
 ### NEVER Create Root-Level .md Files
 
-Only 3 allowed at root: `AGENTS.md`, `CLAUDE.md`, `README.md`. Everything else goes in `.agents/`.
+Only the current intentional root docs are allowed at root: `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `CONTRIBUTING.md`, `DESIGN.md`, `README.md`, and `RELEASING.md`. Everything else goes in `.agents/`.
 
 ### Session Files: ONE FILE PER DAY
 

--- a/.agents/memory/system/SELF-HOSTED-GUIDE.md
+++ b/.agents/memory/system/SELF-HOSTED-GUIDE.md
@@ -17,14 +17,14 @@ This file provides context for AI agents working on deployment-related tasks. It
 - **Single-tenant default:** One organization per deployment. No tenant isolation logic needed outside `ee/`.
 - **Enterprise multi-tenancy:** Available via `ee/packages/`. All multi-tenant data access code must live under `ee/` or import from `ee/packages/`.
 - **Server apps:** `apps/server/{api,clips,discord,files,images,mcp,notifications,slack,telegram,videos,voices,workers}`
-- **Frontend apps:** `apps/{app,admin,website,desktop,mobile}`
+- **Frontend apps:** `apps/app`, `apps/docs`, `apps/website`, `apps/desktop/app`, `apps/mobile/app`, and `apps/extensions/{browser,ide}/app`
 - **Database:** PostgreSQL via Prisma
 - **Queue:** BullMQ via Redis
 - **Real-time:** WebSocket via Redis pub/sub
 
 ## Key Invariants
 
-1. Self-hosted deployments must work with a single `docker compose up`.
+1. Self-hosted deployments must work with the documented self-host compose command: `docker compose -f docker-compose.selfhosted.yml up`.
 2. All required services must be documented in `docker/` configuration.
 3. BYOK (bring your own key) model execution must work without cloud dependencies.
 4. No external service dependencies should be hard requirements (social integrations are opt-in).

--- a/.agents/memory/system/SUMMARY.md
+++ b/.agents/memory/system/SUMMARY.md
@@ -7,9 +7,9 @@ Project planning/reporting summary.
 - Architecture: `./ARCHITECTURE.md`
 - Rules: `./RULES.md`
 - Agent runtime: `./AGENT-RUNTIME.md`
-- Critical rules: `./critical/CRITICAL-NEVER-DO.md`
-- Cross-project rules: `./critical/CROSS-PROJECT-RULES.md`
-- Priority reading: `./critical/PRIORITY-READING.md`
+- Critical rules: `./CRITICAL-NEVER-DO.md`
+- Cross-project rules: `./CROSS-PROJECT-RULES.md`
+- Priority reading: `./PRIORITY-READING.md`
 - Open-source context: `./OPEN-SOURCE-CONTEXT.md`
 - Self-hosted guide: `./SELF-HOSTED-GUIDE.md`
 
@@ -19,11 +19,10 @@ Project planning/reporting summary.
 apps/
   server/     api, clips, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers
   app/        Next.js studio UI
-  admin/      Admin panel
   website/    Marketing site
-  desktop/    Electron desktop shell embedding apps/app with local IPC backend actions
-  mobile/     React Native / Expo
-  extensions/ Browser + IDE extensions
+  desktop/app/ Electron desktop shell embedding apps/app with local IPC backend actions
+  mobile/app/  React Native / Expo
+  extensions/  Browser + IDE extensions
 packages/     Shared packages (@genfeedai/*)
 ee/packages/  Enterprise features (commercial license)
 docker/       Self-hosted deployment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,10 @@ Detailed docs: `.agents/README.md`
 2. Maintain strict TypeScript quality (no `any`/inline interface shortcuts).
 3. Use path aliases, not deep relative imports.
 4. Preserve semantic correctness in UI controls (navigation = `Link`, actions = `Button`).
-5. Treat MongoDB `users._id` as the canonical user reference. Never use AuthProvider `user.id` (`authProviderId`) as a DB foreign key.
+5. Treat Prisma `users.id` as the canonical user reference. Never use legacy auth provider IDs (`authProviderId`) as DB foreign keys.
 6. Do not manually edit generated `dist/` artifacts.
 7. Respect package boundaries: shared logic in `packages/*`, app-specific code in `apps/*`.
-8. Enterprise code (`ee/`): enforce multi-tenancy query guards (`{ organization: orgId, isDeleted: false }`).
+8. Enterprise code (`ee/`): enforce multi-tenancy query guards (`{ organizationId: orgId, isDeleted: false }`).
 
 ## Decorator Boundary Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 @.agents/memory/context/project-style-guide.md
 @.agents/memory/context/skills-architecture.md
 
-TypeScript monorepo: 6 app surfaces, 12 backend services, 43 shared packages.
+TypeScript monorepo: 6 app surfaces, 12 backend services, 42 shared packages.
 Stack: Next.js + NestJS + PostgreSQL (Prisma) + Redis + BullMQ
 
 ## Git Workflow
@@ -69,7 +69,7 @@ bun run test --filter=@genfeedai/[name]  # Run specific package tests
 ### Serializers (ALWAYS)
 - Serializers live in `packages/serializers/`, NEVER in API modules
 - Never return raw database records — serialize first
-- Flow: DB Document → Serializer → Client Response
+- Flow: DB record → Serializer → Client Response
 
 ### Frontend (ALWAYS)
 - AbortController in every useEffect with async calls
@@ -78,14 +78,14 @@ bun run test --filter=@genfeedai/[name]  # Run specific package tests
 - **Never raw HTML elements** — use `@ui/primitives/*` instead. `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>`, `<table>`, `<hr>`, etc. are blocked by `scripts/lint-no-raw-html.sh` pre-commit hook. For unstyled usage, use `Button` with `variant={ButtonVariant.UNSTYLED}` + `withWrapper={false}`. Never nest `Button` inside `Button` (invalid HTML) — restructure as siblings.
 
 ### Backend (ALWAYS)
-- Compound indexes in module `useFactory`, simple indexes via `@Prop` decorator
+- Compound indexes live in Prisma schema `@@index` directives or explicit migrations
 - NestJS exceptions for errors (`NotFoundException`, `BadRequestException`)
 - No backward compatibility wrappers — fix at the source
 - Soft deletes: `isDeleted: boolean` (NOT `deletedAt`)
 - ConfigService: `{ provide: ConfigService, useValue: new ConfigService() }` — never use `process.env` directly
 
 ### Multi-Tenancy (Enterprise `ee/` only)
-- Enterprise code under `ee/`: every MongoDB query MUST include `{ organization: orgId, isDeleted: false }`
+- Enterprise code under `ee/`: every tenant-scoped Prisma query MUST include `{ organizationId: orgId, isDeleted: false }`
 - Self-hosted single-tenant: organization filter is optional
 - **Repo invariant:** All multi-tenant data access code must live under `ee/` or import from `ee/packages/`
 
@@ -121,9 +121,9 @@ bun run test --filter=@genfeedai/[name]  # Run specific package tests
 | `apps/app/` | Main studio app |
 | `apps/docs/` | Documentation site |
 | `apps/website/` | Marketing site |
-| `apps/desktop/` | Electron desktop app |
-| `apps/mobile/` | React Native / Expo |
-| `apps/extensions/` | Browser + IDE extensions |
+| `apps/desktop/app/` | Electron desktop app |
+| `apps/mobile/app/` | React Native / Expo |
+| `apps/extensions/browser/app/`, `apps/extensions/ide/app/` | Browser + IDE extensions |
 
 ### Infrastructure
 - **Self-hosted**: Docker deployment (see `docs/self-hosting.md`)

--- a/CODEX.md
+++ b/CODEX.md
@@ -2,15 +2,16 @@
 
 ## Last Verified
 
-- **Date:** 2026-04-07
+- **Date:** 2026-06-29
 
 Codex-specific fast reference. See `AGENTS.md` for full project context.
 
 ## Reality Snapshot
 
-- Frontend apps: 4 (`app`, `admin`, `website`, `desktop`) + mobile + extensions
+- Frontend workspaces: `apps/app`, `apps/docs`, `apps/website`, `apps/desktop/app`, `apps/mobile/app`, `apps/extensions/browser/app`, `apps/extensions/ide/app`
 - Backend services: 12 on `apps/server/` (api, clips, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers)
-- Shared packages: 45+ directories under `packages/`
+- Shared packages: 42 directories under `packages/`
+- Admin routes live inside `apps/app/app/(protected)/admin`; there is no separate `apps/admin` workspace.
 - Enterprise features: `ee/packages/` (commercial license)
 
 ## Rules
@@ -33,7 +34,7 @@ Codex-specific fast reference. See `AGENTS.md` for full project context.
 - Keep serializers in `packages/serializers`; do not inline response shaping in controllers/services.
 - Preserve strict TypeScript quality (no `any` shortcuts for new code).
 - Use path aliases, not deep relative imports.
-- Treat MongoDB `users._id` as canonical user reference; do not use legacy auth provider `user.id` as DB foreign key.
+- Treat Prisma `users.id` as canonical user reference; do not use legacy auth provider IDs (`authProviderId`) as DB foreign keys.
 - Enterprise code (`ee/`): enforce multi-tenancy query guards.
 - Self-hosted (non-`ee/`): organization filter is optional for single-tenant deployments.
 - Soft deletes: `isDeleted: boolean` (NOT `deletedAt`).


### PR DESCRIPTION
## Summary

- Refreshes repo memory/instructions for current Prisma/Postgres architecture, Better Auth baseline, canonical `users.id`, `organizationId` tenant scoping, and actual app/package layout.
- Updates E2E memory for the current GitHub workflow: `e2e-api` is enabled and included in `e2e-gate`, with migrations current through `20260628200000_backfill_email_verified_for_migrated_users`.
- Rewrites agent persistence/threading memory from legacy Mongo/ObjectId collection shapes to current Prisma rows plus snapshot JSON compatibility boundaries.
- Fixes stale memory links, self-host compose command wording, BullMQ processor-placement status, workflow-backed scheduling notes, root markdown policy, and admin/workspace inventory.

## Evidence checked

- `package.json` workspace declarations and counts.
- `packages/prisma/prisma/schema.prisma` for user, org, agent, workflow, and migration architecture.
- `apps/server/api` auth, Prisma, agent, and collection services.
- `.github/workflows/e2e.yml` and `deploy-ecs.yml` for current CI/deploy gates.
- Recent merged PR/commit context for Better Auth, workflow scheduling, platform roles, and E2E/release changes.

## Validation

- `git diff --check`
- Relative markdown link/inline path existence check across 23 changed markdown files
- Focused stale-claim grep on changed files; remaining hits are intentional compatibility notes or trunk/deploy-environment warnings
- Commit hook `lint-staged` ran `bun scripts/run-secretlint.ts --no-glob` cleanly
- `bunx biome check` was attempted on changed markdown files; repo Biome config ignores these markdown paths, so no markdown files were processed

## Unresolved / out of writable scope

- Some non-memory source/task files still contain drift found during read-only inspection, including local `.agents/TODOS` task files, source references to `develop`, and Node 24 vs CI setup defaults. This automation only edited `.agents/memory/**`, `AGENTS.md`, `CLAUDE.md`, and `CODEX.md`.
