### PR TITLE
fix(auth): expose cache client to Better Auth module

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -4,6 +4,7 @@ import { OrganizationsModule } from '@api/collections/organizations/organization
 import { UserSetupModule } from '@api/collections/users/user-setup.module';
 import { UsersModule } from '@api/collections/users/users.module';
 import { ConfigService } from '@api/config/config.service';
+import { CacheModule } from '@api/services/cache/cache.module';
 import { CacheClientService } from '@api/services/cache/services/cache-client.service';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -52,6 +53,7 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
     forwardRef(() => BrandsModule),
     forwardRef(() => MembersModule),
     forwardRef(() => UserSetupModule),
+    CacheModule,
     NotificationsModule,
   ],
   providers: [

--- a/apps/server/api/src/services/cache/cache.module.ts
+++ b/apps/server/api/src/services/cache/cache.module.ts
@@ -17,6 +17,7 @@ import { Global, Module } from '@nestjs/common';
 @Module({
   exports: [
     CacheInvalidationService,
+    CacheClientService,
     CacheService,
     CacheStrategies,
     RedisCacheInterceptor,


### PR DESCRIPTION
## Summary
- export CacheClientService from CacheModule
- import CacheModule into BetterAuthModule so BETTER_AUTH_INSTANCE can resolve its rate-limit cache dependency in the workflow backfill Nest application context

## Verification
- bun run --cwd apps/server/api build
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js

No release/tag cut; this is only to unblock the production deploy backfill gate.