### PR TITLE
feat(auth): bridge Better Auth organizations

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -1,6 +1,7 @@
 import type { RateLimit } from 'better-auth';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  buildBetterAuthOrganizationOptions,
   buildRateLimitStorage,
   resolveBetterAuthJwtAccess,
   resolveBetterAuthJwtIsSuperAdmin,
@@ -19,6 +20,9 @@ function createPrismaMock() {
       findFirst: vi.fn(),
     },
     organization: {
+      findFirst: vi.fn(),
+    },
+    role: {
       findFirst: vi.fn(),
     },
     user: {
@@ -214,6 +218,115 @@ describe('resolveBetterAuthJwtAccess', () => {
 
     expect(prisma.organization.findFirst).not.toHaveBeenCalled();
     expect(prisma.member.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildBetterAuthOrganizationOptions', () => {
+  it('maps Better Auth organization tables onto Genfeed ownership fields', () => {
+    const options = buildBetterAuthOrganizationOptions(
+      createPrismaMock() as unknown as PrismaForBetterAuth,
+    );
+
+    expect(options.creatorRole).toBe('admin');
+    expect(options.disableOrganizationDeletion).toBe(true);
+    expect(options.requireEmailVerificationOnInvitation).toBe(true);
+    expect(options.schema?.session?.fields?.activeOrganizationId).toBe(
+      'activeOrganizationId',
+    );
+    expect(options.schema?.organization?.modelName).toBe('organization');
+    expect(options.schema?.organization?.fields?.name).toBe('label');
+    expect(options.schema?.organization?.fields?.logo).toBe(
+      'authProviderLogoUrl',
+    );
+    expect(options.schema?.member?.modelName).toBe('member');
+    expect(options.schema?.member?.fields?.role).toBe('roleKey');
+    expect(options.schema?.member?.additionalFields?.roleId).toMatchObject({
+      references: { field: 'id', model: 'role' },
+      required: true,
+      type: 'string',
+    });
+    expect(options.schema?.invitation?.modelName).toBe('invitation');
+    expect(options.schema?.invitation?.fields?.role).toBe('roleKey');
+    expect(options.schema?.invitation?.fields?.status).toBe('status');
+  });
+
+  it('fills required Genfeed organization fields before plugin organization creation', async () => {
+    const options = buildBetterAuthOrganizationOptions(
+      createPrismaMock() as unknown as PrismaForBetterAuth,
+    );
+
+    const result = await options.organizationHooks?.beforeCreateOrganization?.({
+      organization: { name: 'Acme', slug: 'acme' },
+      user: { id: 'user_1' } as never,
+    });
+
+    expect(result).toEqual({
+      data: {
+        category: 'BUSINESS',
+        isDeleted: false,
+        isSelected: false,
+        name: 'Acme',
+        slug: 'acme',
+        userId: 'user_1',
+      },
+    });
+  });
+
+  it('resolves Better Auth string roles to Genfeed role ids before member writes', async () => {
+    const prisma = createPrismaMock();
+    prisma.role.findFirst.mockResolvedValueOnce({
+      id: 'role_admin',
+      key: 'admin',
+    });
+    const options = buildBetterAuthOrganizationOptions(
+      prisma as unknown as PrismaForBetterAuth,
+    );
+
+    const result = await options.organizationHooks?.beforeAddMember?.({
+      member: {
+        organizationId: 'org_1',
+        role: 'owner',
+        userId: 'user_1',
+      },
+      organization: { id: 'org_1' } as never,
+      user: { id: 'user_1' } as never,
+    });
+
+    expect(result).toEqual({
+      data: {
+        isActive: true,
+        isDeleted: false,
+        organizationId: 'org_1',
+        role: 'admin',
+        roleId: 'role_admin',
+        userId: 'user_1',
+      },
+    });
+    expect(prisma.role.findFirst).toHaveBeenCalledWith({
+      select: { id: true, key: true },
+      where: { isDeleted: false, key: 'admin' },
+    });
+  });
+
+  it('rejects Better Auth invitation creation because Genfeed owns invites', async () => {
+    const options = buildBetterAuthOrganizationOptions(
+      createPrismaMock() as unknown as PrismaForBetterAuth,
+    );
+
+    await expect(
+      options.organizationHooks?.beforeCreateInvitation?.({
+        invitation: {
+          email: 'user@example.com',
+          inviterId: 'user_1',
+          organizationId: 'org_1',
+          role: 'member',
+        },
+        inviter: { id: 'user_1' } as never,
+        organization: { id: 'org_1' } as never,
+      }),
+    ).rejects.toThrow(
+      'Genfeed InvitationService owns organization invitations',
+    );
   });
 });
 

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -3,7 +3,12 @@ import { dash } from '@better-auth/infra';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
 import { betterAuth, type RateLimit } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
-import { jwt, magicLink } from 'better-auth/plugins';
+import {
+  jwt,
+  magicLink,
+  type OrganizationOptions,
+  organization,
+} from 'better-auth/plugins';
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
 import type {
   IBetterAuthRateLimitStore,
@@ -17,6 +22,22 @@ import { isPlatformSuperAdmin } from './better-auth-access.util';
  */
 const RATE_LIMIT_KEY_PREFIX = 'ba:ratelimit:';
 const RATE_LIMIT_TTL_SECONDS = 86_400;
+const BETTER_AUTH_CREATOR_ROLE = 'admin';
+const BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY = 'BUSINESS';
+
+const BETTER_AUTH_ROLE_KEY_FALLBACKS: Record<string, string[]> = {
+  admin: ['admin', 'user'],
+  member: ['member', 'user'],
+  owner: ['admin', 'user'],
+  user: ['user'],
+};
+
+function normalizeBetterAuthOrganizationRole(role: string | undefined): string {
+  const normalized = role?.trim().toLowerCase();
+  return normalized && normalized in BETTER_AUTH_ROLE_KEY_FALLBACKS
+    ? normalized
+    : 'member';
+}
 
 /**
  * Adapt the shared Redis KV into Better Auth's `rateLimit.customStorage` shape
@@ -45,6 +66,207 @@ export function buildRateLimitStorage(store: IBetterAuthRateLimitStore): {
 
 function getString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getRequiredString(value: unknown, label: string): string {
+  const resolved = getString(value);
+  if (!resolved) {
+    throw new Error(`${label} is required for Better Auth organization bridge`);
+  }
+  return resolved;
+}
+
+async function resolveGenfeedRoleForBetterAuthRole(
+  prisma: ICreateBetterAuthOptions['prisma'],
+  role: string | undefined,
+): Promise<{ roleId: string; roleKey: string }> {
+  const roleKey = normalizeBetterAuthOrganizationRole(role);
+  const fallbackKeys = BETTER_AUTH_ROLE_KEY_FALLBACKS[roleKey] ?? ['user'];
+
+  for (const key of fallbackKeys) {
+    const genfeedRole = await prisma.role.findFirst({
+      select: { id: true, key: true },
+      where: { isDeleted: false, key },
+    });
+    if (genfeedRole) {
+      return { roleId: genfeedRole.id, roleKey: genfeedRole.key };
+    }
+  }
+
+  throw new Error(
+    `No Genfeed Role found for Better Auth organization role "${roleKey}"`,
+  );
+}
+
+/**
+ * Maps Better Auth's organization plugin onto Genfeed's existing domain tables.
+ *
+ * BA gets string role/session compatibility (`roleKey`,
+ * `Session.activeOrganizationId`), but Genfeed authorization keeps validating
+ * against Organization/Member/Role rows. Invitation creation stays owned by
+ * `InvitationService`; BA invite creation is rejected so there is one source of
+ * token/email/status behavior.
+ */
+export function buildBetterAuthOrganizationOptions(
+  prisma: ICreateBetterAuthOptions['prisma'],
+): OrganizationOptions {
+  return {
+    creatorRole: BETTER_AUTH_CREATOR_ROLE,
+    disableOrganizationDeletion: true,
+    requireEmailVerificationOnInvitation: true,
+    schema: {
+      session: {
+        fields: {
+          activeOrganizationId: 'activeOrganizationId',
+        },
+      },
+      organization: {
+        modelName: 'organization',
+        fields: {
+          createdAt: 'createdAt',
+          logo: 'authProviderLogoUrl',
+          name: 'label',
+          slug: 'slug',
+          updatedAt: 'updatedAt',
+        },
+        additionalFields: {
+          category: {
+            defaultValue: BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY,
+            input: false,
+            required: true,
+            type: 'string',
+          },
+          isDeleted: {
+            defaultValue: false,
+            input: false,
+            required: true,
+            type: 'boolean',
+          },
+          isSelected: {
+            defaultValue: false,
+            input: false,
+            required: true,
+            type: 'boolean',
+          },
+          userId: {
+            input: false,
+            references: { field: 'id', model: 'user' },
+            required: true,
+            type: 'string',
+          },
+        },
+      },
+      member: {
+        modelName: 'member',
+        fields: {
+          createdAt: 'createdAt',
+          organizationId: 'organizationId',
+          role: 'roleKey',
+          userId: 'userId',
+        },
+        additionalFields: {
+          isActive: {
+            defaultValue: true,
+            input: false,
+            required: true,
+            type: 'boolean',
+          },
+          isDeleted: {
+            defaultValue: false,
+            input: false,
+            required: true,
+            type: 'boolean',
+          },
+          roleId: {
+            input: false,
+            references: { field: 'id', model: 'role' },
+            required: true,
+            type: 'string',
+          },
+          updatedAt: {
+            input: false,
+            onUpdate: () => new Date(),
+            required: false,
+            type: 'date',
+          },
+        },
+      },
+      invitation: {
+        modelName: 'invitation',
+        fields: {
+          createdAt: 'createdAt',
+          email: 'email',
+          expiresAt: 'expiresAt',
+          inviterId: 'invitedByUserId',
+          organizationId: 'organizationId',
+          role: 'roleKey',
+          status: 'status',
+        },
+        additionalFields: {
+          roleId: {
+            input: false,
+            references: { field: 'id', model: 'role' },
+            required: true,
+            type: 'string',
+          },
+          tokenHash: {
+            input: false,
+            required: true,
+            type: 'string',
+            unique: true,
+          },
+          updatedAt: {
+            input: false,
+            onUpdate: () => new Date(),
+            required: false,
+            type: 'date',
+          },
+        },
+      },
+    },
+    organizationHooks: {
+      beforeCreateOrganization: async ({ organization, user }) => {
+        return {
+          data: {
+            ...organization,
+            category: BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY,
+            isDeleted: false,
+            isSelected: false,
+            userId: getRequiredString(user.id, 'user.id'),
+          },
+        };
+      },
+      beforeAddMember: async ({ member }) => {
+        const role = await resolveGenfeedRoleForBetterAuthRole(
+          prisma,
+          member.role,
+        );
+        return {
+          data: {
+            ...member,
+            isActive: true,
+            isDeleted: false,
+            role: role.roleKey,
+            roleId: role.roleId,
+          },
+        };
+      },
+      beforeUpdateMemberRole: async ({ newRole }) => {
+        const role = await resolveGenfeedRoleForBetterAuthRole(prisma, newRole);
+        return {
+          data: {
+            role: role.roleKey,
+            roleId: role.roleId,
+          },
+        };
+      },
+      beforeCreateInvitation: async () => {
+        throw new Error(
+          'Genfeed InvitationService owns organization invitations; Better Auth invite creation is disabled.',
+        );
+      },
+    },
+  };
 }
 
 /**
@@ -187,10 +409,11 @@ export async function resolveBetterAuthJwtIsSuperAdmin(
  *
  * Runs against the existing Postgres via the Prisma adapter. Better Auth's `user`
  * model maps onto the existing `User` table (`image` → `avatar`; `handle` filled
- * by a create hook). Plugins: magic-link + jwt now; the organization and admin
- * plugins are deferred (they require remapping the custom Organization/Member/Role
- * models). The jwt plugin issues short-lived JWTs (sub = `User.id`) and publishes
- * a JWKS at `${baseURL}${BETTER_AUTH_BASE_PATH}/jwks`.
+ * by a create hook). Plugins: magic-link, organization bridge, and jwt. The
+ * organization plugin is compatibility-only: active org / string-role session
+ * state maps onto existing Organization/Member rows while Genfeed remains the
+ * tenant authorization source. The jwt plugin issues short-lived JWTs (sub =
+ * `User.id`) and publishes a JWKS at `${baseURL}${BETTER_AUTH_BASE_PATH}/jwks`.
  */
 export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
   const {
@@ -303,6 +526,7 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
           await sendMagicLink({ email, url, token });
         },
       }),
+      organization(buildBetterAuthOrganizationOptions(prisma)),
       jwt({
         jwt: {
           issuer: baseURL,

--- a/apps/server/api/src/collections/members/schemas/member.schema.ts
+++ b/apps/server/api/src/collections/members/schemas/member.schema.ts
@@ -6,6 +6,5 @@ export interface MemberDocument extends Member {
   _id: string;
   organization?: string | null;
   role?: string | null;
-  roleKey?: string | null;
   user?: string | null;
 }

--- a/apps/server/api/src/collections/members/schemas/member.schema.ts
+++ b/apps/server/api/src/collections/members/schemas/member.schema.ts
@@ -6,5 +6,6 @@ export interface MemberDocument extends Member {
   _id: string;
   organization?: string | null;
   role?: string | null;
+  roleKey?: string | null;
   user?: string | null;
 }

--- a/apps/server/api/src/collections/members/services/invitation.service.spec.ts
+++ b/apps/server/api/src/collections/members/services/invitation.service.spec.ts
@@ -14,6 +14,7 @@ const now = new Date('2026-06-23T12:00:00.000Z');
 const orgId = 'org_123';
 const userId = 'user_123';
 const roleId = 'role_user';
+const roleKey = 'member';
 const memberId = 'member_123';
 
 type MockFn = ReturnType<typeof vi.fn>;
@@ -66,6 +67,8 @@ interface InvitationRow {
   redirectUrl: string | null;
   revokedAt: Date | null;
   roleId: string;
+  roleKey: string;
+  status: string;
   tokenHash: string;
   updatedAt: Date;
 }
@@ -83,6 +86,7 @@ interface MemberRow {
   isDeleted: boolean;
   organizationId: string;
   roleId: string;
+  roleKey: string;
   userId: string;
 }
 
@@ -108,6 +112,8 @@ function makeInvitation(overrides: Partial<InvitationRow> = {}): InvitationRow {
     redirectUrl: null,
     revokedAt: null,
     roleId,
+    roleKey,
+    status: 'pending',
     tokenHash: hashToken('token-123'),
     updatedAt: now,
     ...overrides,
@@ -131,6 +137,7 @@ function makeMember(overrides: Partial<MemberRow> = {}): MemberRow {
     isDeleted: false,
     organizationId: orgId,
     roleId,
+    roleKey,
     userId,
     ...overrides,
   };
@@ -227,7 +234,7 @@ describe('InvitationService', () => {
   describe('createInvitation', () => {
     it('creates a hashed invitation token and sends an accept email', async () => {
       const { notificationsService, prisma, service } = buildService();
-      prisma.role.findFirst.mockResolvedValue({ id: roleId });
+      prisma.role.findFirst.mockResolvedValue({ id: roleId, key: roleKey });
       prisma.organization.findFirst.mockResolvedValue({
         id: orgId,
         label: 'Acme',
@@ -248,7 +255,7 @@ describe('InvitationService', () => {
       });
 
       expect(prisma.invitation.updateMany).toHaveBeenCalledWith({
-        data: { isDeleted: true, revokedAt: now },
+        data: { isDeleted: true, revokedAt: now, status: 'canceled' },
         where: {
           acceptedAt: null,
           email: 'new@example.com',
@@ -263,6 +270,8 @@ describe('InvitationService', () => {
           invitedByUserId: userId,
           organizationId: orgId,
           roleId,
+          roleKey,
+          status: 'pending',
           tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
         }),
       });
@@ -281,7 +290,7 @@ describe('InvitationService', () => {
 
     it('rejects invitations for users already active in the organization', async () => {
       const { prisma, service } = buildService();
-      prisma.role.findFirst.mockResolvedValue({ id: roleId });
+      prisma.role.findFirst.mockResolvedValue({ id: roleId, key: roleKey });
       prisma.organization.findFirst.mockResolvedValue({
         id: orgId,
         label: 'Acme',
@@ -338,7 +347,7 @@ describe('InvitationService', () => {
       const result = await service.revokeInvitation('inv_123', orgId);
 
       expect(prisma.invitation.update).toHaveBeenCalledWith({
-        data: { isDeleted: true, revokedAt: now },
+        data: { isDeleted: true, revokedAt: now, status: 'canceled' },
         where: { id: 'inv_123' },
       });
       expect(result.status).toBe('revoked');
@@ -395,6 +404,7 @@ describe('InvitationService', () => {
         data: {
           isActive: true,
           roleId,
+          roleKey,
         },
         where: { id: memberId },
       });
@@ -438,6 +448,7 @@ describe('InvitationService', () => {
           isActive: true,
           organizationId: orgId,
           roleId,
+          roleKey,
           userId,
         },
       });

--- a/apps/server/api/src/collections/members/services/invitation.service.ts
+++ b/apps/server/api/src/collections/members/services/invitation.service.ts
@@ -67,6 +67,7 @@ type InvitationWithOrganization = Invitation & {
 };
 
 type InvitationTransaction = Prisma.TransactionClient;
+type RoleAssignment = { roleId: string; roleKey: string };
 
 function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
@@ -142,7 +143,7 @@ export class InvitationService {
     input: CreateInvitationInput,
   ): Promise<InvitationView> {
     const email = normalizeEmail(input.email);
-    const roleId = await this.resolveRoleId(
+    const role = await this.resolveRoleAssignment(
       input.roleId,
       input.defaultRoleKey ?? 'member',
     );
@@ -165,7 +166,7 @@ export class InvitationService {
 
     const invitation = await this.prisma.$transaction(async (tx) => {
       await tx.invitation.updateMany({
-        data: { isDeleted: true, revokedAt: new Date() },
+        data: { isDeleted: true, revokedAt: new Date(), status: 'canceled' },
         where: {
           acceptedAt: null,
           email,
@@ -184,7 +185,9 @@ export class InvitationService {
           lastName: input.lastName,
           organizationId: input.organizationId,
           redirectUrl: input.redirectUrl,
-          roleId,
+          roleId: role.roleId,
+          roleKey: role.roleKey,
+          status: 'pending',
           tokenHash,
         },
       });
@@ -234,7 +237,7 @@ export class InvitationService {
     }
 
     const revoked = await this.prisma.invitation.update({
-      data: { isDeleted: true, revokedAt: new Date() },
+      data: { isDeleted: true, revokedAt: new Date(), status: 'canceled' },
       where: { id: invitation.id },
     });
 
@@ -293,7 +296,7 @@ export class InvitationService {
       this.assertInvitationAcceptable(invitation);
 
       const consumeResult = await tx.invitation.updateMany({
-        data: { acceptedAt: new Date() },
+        data: { acceptedAt: new Date(), status: 'accepted' },
         where: {
           acceptedAt: null,
           id: invitation.id,
@@ -341,28 +344,28 @@ export class InvitationService {
     return url.toString();
   }
 
-  private async resolveRoleId(
+  private async resolveRoleAssignment(
     roleId: string | undefined,
     defaultRoleKey: 'member' | 'user',
-  ): Promise<string> {
+  ): Promise<RoleAssignment> {
     if (roleId) {
       const role = await this.prisma.role.findFirst({
-        select: { id: true },
+        select: { id: true, key: true },
         where: { id: roleId, isDeleted: false },
       });
       if (!role) {
         throw new BadRequestException('Role not found');
       }
-      return role.id;
+      return { roleId: role.id, roleKey: role.key };
     }
 
     const role =
       (await this.prisma.role.findFirst({
-        select: { id: true },
+        select: { id: true, key: true },
         where: { isDeleted: false, key: defaultRoleKey },
       })) ??
       (await this.prisma.role.findFirst({
-        select: { id: true },
+        select: { id: true, key: true },
         where: { isDeleted: false, key: 'user' },
       }));
 
@@ -370,7 +373,7 @@ export class InvitationService {
       throw new BadRequestException('Default role not found');
     }
 
-    return role.id;
+    return { roleId: role.id, roleKey: role.key };
   }
 
   private async assertNoActiveMember(
@@ -499,6 +502,7 @@ export class InvitationService {
         data: {
           isActive: true,
           roleId: invitation.roleId,
+          roleKey: invitation.roleKey,
         },
         where: { id: existing.id },
       });
@@ -509,6 +513,7 @@ export class InvitationService {
         isActive: true,
         organizationId: invitation.organizationId,
         roleId: invitation.roleId,
+        roleKey: invitation.roleKey,
         userId,
       },
     });

--- a/apps/server/api/src/collections/users/services/user-setup.service.spec.ts
+++ b/apps/server/api/src/collections/users/services/user-setup.service.spec.ts
@@ -223,6 +223,14 @@ describe('UserSetupService', () => {
       await service.initializeUserResources(userId);
 
       expect(mockMembersService.create).toHaveBeenCalledTimes(1);
+      expect(mockMembersService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: orgId,
+          roleId,
+          roleKey: 'admin',
+          userId,
+        }),
+      );
     });
 
     it('should provision default recurring workflows for a newly created organization', async () => {
@@ -265,7 +273,9 @@ describe('UserSetupService', () => {
 
       // Both role lookups should have been attempted
       expect(mockRolesService.findOne).toHaveBeenCalledTimes(2);
-      expect(mockMembersService.create).toHaveBeenCalledTimes(1);
+      expect(mockMembersService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ roleKey: 'user' }),
+      );
     });
 
     it('should throw if no role found at all', async () => {

--- a/apps/server/api/src/collections/users/services/user-setup.service.ts
+++ b/apps/server/api/src/collections/users/services/user-setup.service.ts
@@ -414,6 +414,7 @@ export class UserSetupService {
       isActive: true,
       organizationId,
       roleId: String(roleToAssign._id),
+      roleKey: roleToAssign.key,
       userId,
     } as unknown as Parameters<typeof this.membersService.create>[0]);
 

--- a/docs/better-auth-organization-bridge.md
+++ b/docs/better-auth-organization-bridge.md
@@ -1,0 +1,28 @@
+# Better Auth Organization Bridge
+
+Genfeed uses Better Auth organizations as an identity/session compatibility
+layer, not as the authorization source of truth.
+
+## Ownership
+
+- `Organization`, `Member`, `Role`, and `Invitation` remain Genfeed domain rows.
+- Tenant access continues to validate live Genfeed `Organization` and `Member`
+  records, including soft-delete and active-membership checks.
+- `Member.roleId -> Role` remains the authorization boundary.
+- `Member.roleKey` is denormalized Better Auth compatibility state for string
+  role checks.
+- `Session.activeOrganizationId` is Better Auth session state. Genfeed still
+  resolves request authority through `User.lastUsedOrganizationId` and validated
+  membership/ownership.
+
+## Invitations
+
+Genfeed `InvitationService` owns organization invitations, tokens, emails,
+expiry, accept/revoke behavior, and accepted-member creation. Better Auth
+invitation creation is disabled by the organization bridge hook so the system
+does not run two incompatible invitation sources.
+
+The `Invitation.roleKey` and `Invitation.status` fields exist only to keep rows
+readable by Better Auth organization compatibility paths. Genfeed API responses
+derive user-facing invitation status from `acceptedAt`, `revokedAt`, and
+`expiresAt`.

--- a/packages/prisma/prisma/migrations/20260629100000_better_auth_organization_bridge/migration.sql
+++ b/packages/prisma/prisma/migrations/20260629100000_better_auth_organization_bridge/migration.sql
@@ -1,0 +1,44 @@
+-- Better Auth organization compatibility bridge (#792).
+--
+-- Genfeed Organization/Member/Role/Invitation rows remain the authorization
+-- source of truth. These nullable/string compatibility columns let the Better
+-- Auth organization plugin map onto existing tables without replacing
+-- Member.roleId -> Role or Genfeed InvitationService ownership.
+
+ALTER TABLE "sessions" ADD COLUMN "activeOrganizationId" TEXT;
+
+ALTER TABLE "organizations" ADD COLUMN "authProviderLogoUrl" TEXT;
+
+ALTER TABLE "members" ADD COLUMN "roleKey" TEXT;
+
+ALTER TABLE "invitations" ADD COLUMN "roleKey" TEXT;
+ALTER TABLE "invitations" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'pending';
+
+UPDATE "sessions"
+SET "activeOrganizationId" = "users"."lastUsedOrganizationId"
+FROM "users"
+WHERE "sessions"."userId" = "users"."id"
+  AND "users"."lastUsedOrganizationId" IS NOT NULL;
+
+UPDATE "members"
+SET "roleKey" = "roles"."key"
+FROM "roles"
+WHERE "members"."roleId" = "roles"."id"
+  AND "members"."roleKey" IS NULL;
+
+UPDATE "invitations"
+SET "roleKey" = "roles"."key"
+FROM "roles"
+WHERE "invitations"."roleId" = "roles"."id"
+  AND "invitations"."roleKey" IS NULL;
+
+UPDATE "invitations"
+SET "status" = CASE
+  WHEN "acceptedAt" IS NOT NULL THEN 'accepted'
+  WHEN "revokedAt" IS NOT NULL OR "isDeleted" = true THEN 'canceled'
+  WHEN "expiresAt" <= CURRENT_TIMESTAMP THEN 'canceled'
+  ELSE 'pending'
+END;
+
+CREATE INDEX "sessions_activeOrganizationId_idx" ON "sessions"("activeOrganizationId");
+CREATE INDEX "members_organizationId_roleKey_isDeleted_idx" ON "members"("organizationId", "roleKey", "isDeleted");

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -492,7 +492,7 @@ enum PlatformRole {
 model User {
   id                       String          @id @default(cuid())
   mongoId                  String?         @unique
-  authProviderId                  String?         @unique
+  authProviderId           String?         @unique
   handle                   String          @unique
   firstName                String?
   lastName                 String?
@@ -528,8 +528,8 @@ model User {
   organizations            Organization[]
   brands                   Brand[]
   members                  Member[]
-  invitationsSent          Invitation[]            @relation("invitation_invited_by")
-  invitationsAccepted      Invitation[]            @relation("invitation_accepted_by")
+  invitationsSent          Invitation[]              @relation("invitation_invited_by")
+  invitationsAccepted      Invitation[]              @relation("invitation_accepted_by")
   sessions                 Session[]
   accounts                 Account[]
   settings                 Setting?
@@ -598,24 +598,25 @@ model User {
 }
 
 model Organization {
-  id                        String                @id @default(cuid())
-  mongoId                   String?               @unique
-  authProviderOrganizationId       String?               @unique
-  userId                    String
-  user                      User                  @relation(fields: [userId], references: [id])
-  label                     String
-  slug                      String                @unique
-  prefix                    String?
-  isSelected                Boolean               @default(false)
-  isDefault                 Boolean               @default(false)
-  isDeleted                 Boolean               @default(false)
-  category                  OrganizationCategory  @default(BUSINESS)
-  accountType               OrganizationCategory?
-  onboardingCompleted       Boolean               @default(false)
-  isProactiveOnboarding     Boolean               @default(false)
-  proactiveWelcomeDismissed Boolean               @default(false)
-  createdAt                 DateTime              @default(now())
-  updatedAt                 DateTime              @updatedAt
+  id                         String                @id @default(cuid())
+  mongoId                    String?               @unique
+  authProviderOrganizationId String?               @unique
+  authProviderLogoUrl        String?
+  userId                     String
+  user                       User                  @relation(fields: [userId], references: [id])
+  label                      String
+  slug                       String                @unique
+  prefix                     String?
+  isSelected                 Boolean               @default(false)
+  isDefault                  Boolean               @default(false)
+  isDeleted                  Boolean               @default(false)
+  category                   OrganizationCategory  @default(BUSINESS)
+  accountType                OrganizationCategory?
+  onboardingCompleted        Boolean               @default(false)
+  isProactiveOnboarding      Boolean               @default(false)
+  proactiveWelcomeDismissed  Boolean               @default(false)
+  createdAt                  DateTime              @default(now())
+  updatedAt                  DateTime              @updatedAt
 
   // Ownership relations
   brands                        Brand[]
@@ -875,22 +876,26 @@ model MoodBoard {
 }
 
 model Member {
-  id                String       @id @default(cuid())
-  mongoId           String?      @unique
+  id                       String       @id @default(cuid())
+  mongoId                  String?      @unique
   authProviderMembershipId String?      @unique
-  organizationId    String
-  organization      Organization @relation(fields: [organizationId], references: [id])
-  userId            String
-  user              User         @relation(fields: [userId], references: [id])
-  roleId            String
-  role              Role         @relation(fields: [roleId], references: [id])
-  brands            Brand[]      @relation("member_brands")
-  lastUsedBrandId   String?
-  lastUsedBrand     Brand?       @relation("member_last_used_brand", fields: [lastUsedBrandId], references: [id])
-  isActive          Boolean      @default(true)
-  isDeleted         Boolean      @default(false)
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  organizationId           String
+  organization             Organization @relation(fields: [organizationId], references: [id])
+  userId                   String
+  user                     User         @relation(fields: [userId], references: [id])
+  roleId                   String
+  role                     Role         @relation(fields: [roleId], references: [id])
+  // Better Auth organization-plugin compatibility. This is a denormalized role
+  // key for BA's string-role checks only; Genfeed authorization remains
+  // Member.roleId -> Role.
+  roleKey                  String?
+  brands                   Brand[]      @relation("member_brands")
+  lastUsedBrandId          String?
+  lastUsedBrand            Brand?       @relation("member_last_used_brand", fields: [lastUsedBrandId], references: [id])
+  isActive                 Boolean      @default(true)
+  isDeleted                Boolean      @default(false)
+  createdAt                DateTime     @default(now())
+  updatedAt                DateTime     @updatedAt
 
   @@index([organizationId, userId, isDeleted], map: "members_org_user_deleted_idx")
   @@map("members")
@@ -908,6 +913,11 @@ model Invitation {
   invitedByUser    User         @relation("invitation_invited_by", fields: [invitedByUserId], references: [id])
   roleId           String
   role             Role         @relation(fields: [roleId], references: [id])
+  // Better Auth organization-plugin compatibility. Genfeed InvitationService
+  // owns invitation lifecycle and keeps these fields in sync for read-only BA
+  // compatibility; BA invite creation is blocked by factory hooks.
+  roleKey          String?
+  status           String       @default("pending")
   tokenHash        String       @unique
   redirectUrl      String?
   expiresAt        DateTime
@@ -949,24 +959,28 @@ model Role {
 //   Account      → user_credentials  (password hash + linked OAuth accounts)
 //   Verification → auth_tokens        (magic-link + email-verification tokens)
 //   Jwks         → auth_jwks          (jwt-plugin signing keys; JWKS source)
-// The BA `user` model maps onto the existing `User` model above. The org/member
-// and admin plugins are deferred (they require remapping the custom
-// Organization/Member/Role models); Phase 1 resolves org/brand from the existing
-// tables, matching the legacy auth provider path.
+// The BA `user` model maps onto the existing `User` model above. The
+// organization plugin maps onto existing Organization/Member/Invitation tables
+// through compatibility fields while Genfeed keeps Member.roleId -> Role and
+// InvitationService as the authorization/invitation source of truth.
 // ═══════════════════════════════════════════════════════════════
 
 model Session {
-  id        String   @id @default(cuid())
-  expiresAt DateTime
-  token     String   @unique
-  ipAddress String?
-  userAgent String?
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                   String   @id @default(cuid())
+  expiresAt            DateTime
+  token                String   @unique
+  ipAddress            String?
+  userAgent            String?
+  userId               String
+  user                 User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // Better Auth organization-plugin session state. Genfeed request
+  // authorization still validates organization access from User/Member rows.
+  activeOrganizationId String?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
 
   @@index([userId])
+  @@index([activeOrganizationId])
   @@map("sessions")
 }
 

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -898,6 +898,7 @@ model Member {
   updatedAt                DateTime     @updatedAt
 
   @@index([organizationId, userId, isDeleted], map: "members_org_user_deleted_idx")
+  @@index([organizationId, roleKey, isDeleted], map: "members_organizationId_roleKey_isDeleted_idx")
   @@map("members")
 }
 


### PR DESCRIPTION
## Summary
- map Better Auth organization/session/member/invitation compatibility onto existing Genfeed Prisma tables
- add the organization plugin bridge with Genfeed-owned role resolution and disabled BA invite creation
- keep Genfeed InvitationService/UserSetup writes synchronized with BA role/status compatibility fields
- document the bridge ownership boundary

Closes #792
Refs #735

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bunx biome check --write apps/server/api/src/auth/better-auth/better-auth.factory.ts apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts apps/server/api/src/collections/members/schemas/member.schema.ts apps/server/api/src/collections/members/services/invitation.service.ts apps/server/api/src/collections/members/services/invitation.service.spec.ts apps/server/api/src/collections/users/services/user-setup.service.ts apps/server/api/src/collections/users/services/user-setup.service.spec.ts docs/better-auth-organization-bridge.md`
- `bunx prisma format --schema packages/prisma/prisma/schema.prisma`
- `bun run --cwd apps/server/api test:file src/auth/better-auth/better-auth.factory.spec.ts`
- `bun run --cwd apps/server/api test:file src/collections/members/services/invitation.service.spec.ts`
- `bun run --cwd apps/server/api test:file src/collections/users/services/user-setup.service.spec.ts`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/prisma`
- `bunx biome check apps/server/api/src/auth/better-auth/better-auth.factory.ts apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts apps/server/api/src/collections/members/schemas/member.schema.ts apps/server/api/src/collections/members/services/invitation.service.ts apps/server/api/src/collections/members/services/invitation.service.spec.ts apps/server/api/src/collections/users/services/user-setup.service.ts apps/server/api/src/collections/users/services/user-setup.service.spec.ts`
- `git diff --cached --name-only | xargs bunx secretlint`