### PR TITLE
fix(deploy): prevent workflow backfill timeout

### DIFF
--- a/apps/server/api/src/collections/brands/services/default-recurring-content.service.ts
+++ b/apps/server/api/src/collections/brands/services/default-recurring-content.service.ts
@@ -27,6 +27,7 @@ type ExistingDefaultRecurringWorkflow = {
 
 type EnsureDefaultRecurringContentParams = {
   brandId: string;
+  includeStatus?: boolean;
   organizationId: string;
   origin: 'brand-create' | 'empty-state' | 'manual' | 'onboarding' | 'system';
   userId: string;
@@ -198,6 +199,13 @@ export class DefaultRecurringContentService {
         origin: params.origin,
         userId: params.userId,
       });
+    }
+
+    if (params.includeStatus === false) {
+      return {
+        isConfigured: true,
+        items: [],
+      };
     }
 
     return await this.getStatus(params.organizationId, params.brandId);

--- a/apps/server/api/src/migrations/workflow-backfill.ts
+++ b/apps/server/api/src/migrations/workflow-backfill.ts
@@ -8,17 +8,20 @@ import process from 'node:process';
 import { AppModule } from '@api/app.module';
 import { WorkflowDeploymentBackfillService } from '@api/seeds/workflow-deployment-backfill.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Logger } from '@nestjs/common';
+import { type INestApplicationContext, Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
 const bootstrapLogger = new Logger('WorkflowBackfillMigration');
+const APP_CLOSE_TIMEOUT_MS = 10_000;
 
 async function main(): Promise<void> {
+  console.info('Workflow backfill migration booting');
   const app = await NestFactory.createApplicationContext(AppModule, {
     abortOnError: false,
     logger: ['error'],
     snapshot: true,
   });
+  console.info('Workflow backfill application context created');
 
   try {
     const logger = app.get<LoggerService>(LoggerService);
@@ -27,13 +30,59 @@ async function main(): Promise<void> {
       { strict: false },
     );
     const report = await workflowDeploymentBackfill.run();
+    console.info(
+      `Workflow backfill migration completed ${JSON.stringify(report)}`,
+    );
 
     logger.log('Workflow backfill migration completed', {
       report,
       service: 'WorkflowBackfillMigration',
     });
   } finally {
-    await app.close();
+    await closeApplicationContext(app);
+  }
+}
+
+async function closeApplicationContext(
+  app: INestApplicationContext,
+): Promise<void> {
+  try {
+    await withTimeout(
+      app.close(),
+      APP_CLOSE_TIMEOUT_MS,
+      `Workflow backfill app.close timed out after ${APP_CLOSE_TIMEOUT_MS}ms`,
+    );
+    console.info('Workflow backfill application context closed');
+  } catch (error: unknown) {
+    console.warn(
+      error instanceof Error
+        ? error.message
+        : `Workflow backfill app.close failed: ${String(error)}`,
+    );
+  }
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(timeoutMessage)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 

--- a/apps/server/api/src/seeds/workflow-deployment-backfill.service.ts
+++ b/apps/server/api/src/seeds/workflow-deployment-backfill.service.ts
@@ -25,6 +25,13 @@ type WorkflowDeploymentBackfillReport = {
   organizationsProcessed: number;
 };
 
+type WorkflowDeploymentBackfillOptions = {
+  concurrency?: number;
+};
+
+const DEFAULT_BACKFILL_CONCURRENCY = 4;
+const PROGRESS_LOG_INTERVAL = 25;
+
 @Injectable()
 export class WorkflowDeploymentBackfillService {
   private readonly context = 'WorkflowDeploymentBackfillService';
@@ -35,8 +42,13 @@ export class WorkflowDeploymentBackfillService {
     private readonly moduleRef: ModuleRef,
   ) {}
 
-  async run(): Promise<WorkflowDeploymentBackfillReport> {
-    this.logger.log('Starting deployment workflow backfill', this.context);
+  async run(
+    options: WorkflowDeploymentBackfillOptions = {},
+  ): Promise<WorkflowDeploymentBackfillReport> {
+    const concurrency = this.normalizeConcurrency(options.concurrency);
+    this.logProgress('Starting deployment workflow backfill', {
+      concurrency,
+    });
 
     const organizations = (await this.prisma.organization.findMany({
       orderBy: { createdAt: 'asc' },
@@ -46,26 +58,45 @@ export class WorkflowDeploymentBackfillService {
     const orgOwnerById = new Map<string, string>();
     let organizationsProcessed = 0;
     let orgFailures = 0;
+    const eligibleOrganizations: BackfillOrganization[] = [];
 
     for (const organization of organizations) {
       if (!organization.userId) {
         continue;
       }
       orgOwnerById.set(organization.id, organization.userId);
-      organizationsProcessed += 1;
-
-      try {
-        await this.provisionOrganizationWorkflows(
-          organization.userId,
-          organization.id,
-        );
-      } catch (error: unknown) {
-        orgFailures += 1;
-        this.logger.error('Failed to backfill organization workflows', error, {
-          organizationId: organization.id,
-        });
-      }
+      eligibleOrganizations.push(organization);
     }
+
+    await this.processWithConcurrency(
+      eligibleOrganizations,
+      concurrency,
+      async (organization) => {
+        try {
+          await this.provisionOrganizationWorkflows(
+            organization.userId as string,
+            organization.id,
+          );
+        } catch (error: unknown) {
+          orgFailures += 1;
+          this.logger.error(
+            'Failed to backfill organization workflows',
+            error,
+            {
+              organizationId: organization.id,
+            },
+          );
+        } finally {
+          organizationsProcessed += 1;
+          this.logProgressCheckpoint(
+            'Organization workflow backfill progress',
+            organizationsProcessed,
+            eligibleOrganizations.length,
+            orgFailures,
+          );
+        }
+      },
+    );
 
     const brands = (await this.prisma.brand.findMany({
       orderBy: { createdAt: 'asc' },
@@ -74,40 +105,55 @@ export class WorkflowDeploymentBackfillService {
     })) as BackfillBrand[];
     let brandsProcessed = 0;
     let brandFailures = 0;
+    const eligibleBrands = brands.filter(
+      (brand) => brand.userId ?? orgOwnerById.get(brand.organizationId),
+    );
 
-    for (const brand of brands) {
-      const userId = brand.userId ?? orgOwnerById.get(brand.organizationId);
-      if (!userId) {
-        continue;
-      }
-      brandsProcessed += 1;
+    await this.processWithConcurrency(
+      eligibleBrands,
+      concurrency,
+      async (brand) => {
+        const userId = brand.userId ?? orgOwnerById.get(brand.organizationId);
+        if (!userId) {
+          return;
+        }
 
-      try {
-        const { DefaultRecurringContentService } = await import(
-          '@api/collections/brands/services/default-recurring-content.service'
-        );
-        const defaultRecurringContentService = this.moduleRef.get(
-          DefaultRecurringContentService,
-          { strict: false },
-        );
-        await defaultRecurringContentService.ensureDefaultBundle({
-          brandId: brand.id,
-          organizationId: brand.organizationId,
-          origin: 'system',
-          userId,
-        });
-      } catch (error: unknown) {
-        brandFailures += 1;
-        this.logger.error(
-          'Failed to backfill default recurring workflows',
-          error,
-          {
+        try {
+          const { DefaultRecurringContentService } = await import(
+            '@api/collections/brands/services/default-recurring-content.service'
+          );
+          const defaultRecurringContentService = this.moduleRef.get(
+            DefaultRecurringContentService,
+            { strict: false },
+          );
+          await defaultRecurringContentService.ensureDefaultBundle({
             brandId: brand.id,
+            includeStatus: false,
             organizationId: brand.organizationId,
-          },
-        );
-      }
-    }
+            origin: 'system',
+            userId,
+          });
+        } catch (error: unknown) {
+          brandFailures += 1;
+          this.logger.error(
+            'Failed to backfill default recurring workflows',
+            error,
+            {
+              brandId: brand.id,
+              organizationId: brand.organizationId,
+            },
+          );
+        } finally {
+          brandsProcessed += 1;
+          this.logProgressCheckpoint(
+            'Brand workflow backfill progress',
+            brandsProcessed,
+            eligibleBrands.length,
+            brandFailures,
+          );
+        }
+      },
+    );
 
     const { CronJobsService } = await import(
       '@api/collections/cron-jobs/services/cron-jobs.service'
@@ -120,11 +166,20 @@ export class WorkflowDeploymentBackfillService {
       invalid: 0,
       migrated: 0,
       scanned: 0,
+      skipped: 0,
     };
 
     try {
+      this.logProgress('Starting legacy cron workflow migration');
       legacyCronReport = await cronJobsService.migrateLegacyJobsToWorkflows({
         dryRun: false,
+      });
+      this.logProgress('Legacy cron workflow migration completed', {
+        failed: legacyCronReport.failed,
+        invalid: legacyCronReport.invalid,
+        migrated: legacyCronReport.migrated,
+        scanned: legacyCronReport.scanned,
+        skipped: legacyCronReport.skipped,
       });
     } catch (error: unknown) {
       // Treat an unexpected throw the same way the org/brand loops above treat
@@ -152,7 +207,7 @@ export class WorkflowDeploymentBackfillService {
       organizationsProcessed,
     };
 
-    this.logger.log('Deployment workflow backfill completed', report);
+    this.logProgress('Deployment workflow backfill completed', report);
 
     const hardFailures =
       report.orgFailures + report.brandFailures + report.legacyCronFailed;
@@ -163,6 +218,68 @@ export class WorkflowDeploymentBackfillService {
     }
 
     return report;
+  }
+
+  private async processWithConcurrency<T>(
+    items: readonly T[],
+    concurrency: number,
+    worker: (item: T) => Promise<void>,
+  ): Promise<void> {
+    let nextIndex = 0;
+    const workerCount = Math.min(concurrency, Math.max(items.length, 1));
+
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (true) {
+          const index = nextIndex;
+          nextIndex += 1;
+
+          if (index >= items.length) {
+            return;
+          }
+
+          await worker(items[index] as T);
+        }
+      }),
+    );
+  }
+
+  private normalizeConcurrency(concurrency: number | undefined): number {
+    if (!Number.isSafeInteger(concurrency) || !concurrency) {
+      return DEFAULT_BACKFILL_CONCURRENCY;
+    }
+
+    return Math.min(Math.max(concurrency, 1), 10);
+  }
+
+  private logProgress(
+    message: string,
+    details?: Record<string, unknown>,
+  ): void {
+    const context = { ...(details ?? {}), service: this.context };
+    this.logger.log(message, context);
+    console.info(
+      `[${this.context}] ${message}${
+        details ? ` ${JSON.stringify(details)}` : ''
+      }`,
+    );
+  }
+
+  private logProgressCheckpoint(
+    message: string,
+    processed: number,
+    total: number,
+    failures: number,
+  ): void {
+    if (processed !== total && processed % PROGRESS_LOG_INTERVAL !== 0) {
+      return;
+    }
+
+    this.logProgress(message, {
+      failures,
+      processed,
+      total,
+    });
   }
 
   private async provisionOrganizationWorkflows(

--- a/apps/server/api/src/services/cache/services/cache-client.service.spec.ts
+++ b/apps/server/api/src/services/cache/services/cache-client.service.spec.ts
@@ -9,6 +9,7 @@ const mockPipeline = { exec: vi.fn().mockResolvedValue([]) };
 const mockRedisClient = {
   connect: vi.fn().mockResolvedValue(undefined),
   disconnect: vi.fn().mockResolvedValue(undefined),
+  destroy: vi.fn(),
   isReady: true,
   multi: vi.fn().mockReturnValue(mockPipeline),
   on: vi.fn().mockReturnThis(),
@@ -160,5 +161,23 @@ describe('CacheClientService', () => {
       expect.stringContaining('disconnect error'),
       expect.anything(),
     );
+  });
+
+  it('should force close when quit hangs on module destroy', async () => {
+    vi.useFakeTimers();
+    mockRedisClient.quit.mockImplementationOnce(
+      () => new Promise<never>(() => undefined),
+    );
+
+    const destroyPromise = service.onModuleDestroy();
+    await vi.advanceTimersByTimeAsync(3_000);
+    await destroyPromise;
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('disconnect error'),
+      expect.any(Error),
+    );
+    expect(mockRedisClient.destroy).toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/apps/server/api/src/services/cache/services/cache-client.service.ts
+++ b/apps/server/api/src/services/cache/services/cache-client.service.ts
@@ -15,6 +15,8 @@ export class CacheClientService implements OnModuleInit, OnModuleDestroy {
 
   private static readonly MAX_RECONNECT_RETRIES = 10;
   private static readonly MAX_RECONNECT_DELAY_MS = 30_000;
+  private static readonly DISCONNECT_TIMEOUT_MS = 3_000;
+  private static readonly FORCE_DISCONNECT_TIMEOUT_MS = 500;
 
   constructor(
     private readonly configService: ConfigService,
@@ -92,10 +94,66 @@ export class CacheClientService implements OnModuleInit, OnModuleDestroy {
     try {
       // Remove all event listeners to prevent memory leaks
       this.client.removeAllListeners();
-      await this.client.quit();
+      await this.withTimeout(
+        this.client.quit(),
+        CacheClientService.DISCONNECT_TIMEOUT_MS,
+        'Redis disconnect timeout',
+      );
       this.logger.log(`${this.constructorName} disconnected`);
     } catch (error: unknown) {
       this.logger.error(`${this.constructorName} disconnect error`, error);
+      await this.forceCloseClient();
+    }
+  }
+
+  private async forceCloseClient(): Promise<void> {
+    const client = this.client as RedisClientType & {
+      destroy?: () => void;
+      disconnect?: () => Promise<void> | void;
+    };
+
+    try {
+      if (typeof client.destroy === 'function') {
+        client.destroy();
+        return;
+      }
+
+      if (typeof client.disconnect === 'function') {
+        await this.withTimeout(
+          Promise.resolve(client.disconnect()),
+          CacheClientService.FORCE_DISCONNECT_TIMEOUT_MS,
+          'Redis force disconnect timeout',
+        );
+      }
+    } catch (error: unknown) {
+      this.logger.error(
+        `${this.constructorName} force disconnect error`,
+        error,
+      );
+    }
+  }
+
+  private async withTimeout<T>(
+    operation: Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error(timeoutMessage)),
+            timeoutMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bound Redis cache shutdown so workflow backfill cannot hang forever on app.close
- Add explicit CloudWatch-visible workflow backfill progress logs and bounded app.close in the one-off migration
- Run deployment workflow/org/brand backfills with small fixed concurrency and skip ignored per-brand status reloads

## Verification
- bunx biome check --write --config-path=biome-staged.json --no-errors-on-unmatched apps/server/api/src/services/cache/services/cache-client.service.ts apps/server/api/src/services/cache/services/cache-client.service.spec.ts apps/server/api/src/collections/brands/services/default-recurring-content.service.ts apps/server/api/src/migrations/workflow-backfill.ts apps/server/api/src/seeds/workflow-deployment-backfill.service.ts
- bun run --cwd apps/server/api test:file src/services/cache/services/cache-client.service.spec.ts
- bun run --cwd apps/server/api build
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js