### PR TITLE
fix(deploy): use lean workflow backfill module

### DIFF
--- a/apps/server/api/src/migrations/workflow-backfill.module.ts
+++ b/apps/server/api/src/migrations/workflow-backfill.module.ts
@@ -1,0 +1,46 @@
+import type { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { DefaultRecurringContentService } from '@api/collections/brands/services/default-recurring-content.service';
+import type { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { CronJobsService } from '@api/collections/cron-jobs/services/cron-jobs.service';
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { ConfigModule } from '@api/config/config.module';
+import type { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
+import { WorkflowDeploymentBackfillService } from '@api/seeds/workflow-deployment-backfill.service';
+import type { CacheService } from '@api/services/cache/services/cache.service';
+import type { OpenRouterService } from '@api/services/integrations/openrouter/services/openrouter.service';
+import type { SubstackService } from '@api/services/integrations/substack/services/substack.service';
+import { PrismaModule } from '@api/shared/modules/prisma/prisma.module';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerModule } from '@libs/logger/logger.module';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [ConfigModule, LoggerModule, PrismaModule],
+  providers: [
+    WorkflowsService,
+    DefaultRecurringContentService,
+    WorkflowDeploymentBackfillService,
+    {
+      inject: [PrismaService, WorkflowsService, LoggerService],
+      provide: CronJobsService,
+      useFactory: (
+        prisma: PrismaService,
+        workflowsService: WorkflowsService,
+        logger: LoggerService,
+      ) =>
+        new CronJobsService(
+          prisma,
+          workflowsService,
+          {} as AgentRunsService,
+          {} as AgentRunQueueService,
+          {} as OpenRouterService,
+          {} as SubstackService,
+          {} as CacheService,
+          {} as CreditsUtilsService,
+          logger,
+        ),
+    },
+  ],
+})
+export class WorkflowBackfillModule {}

--- a/apps/server/api/src/migrations/workflow-backfill.ts
+++ b/apps/server/api/src/migrations/workflow-backfill.ts
@@ -5,7 +5,7 @@ import { bootstrap, setupGracefulShutdown } from '@libs/bootstrap';
 bootstrap({ app: 'api' });
 
 import process from 'node:process';
-import { AppModule } from '@api/app.module';
+import { WorkflowBackfillModule } from '@api/migrations/workflow-backfill.module';
 import { WorkflowDeploymentBackfillService } from '@api/seeds/workflow-deployment-backfill.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { type INestApplicationContext, Logger } from '@nestjs/common';
@@ -16,11 +16,14 @@ const APP_CLOSE_TIMEOUT_MS = 10_000;
 
 async function main(): Promise<void> {
   console.info('Workflow backfill migration booting');
-  const app = await NestFactory.createApplicationContext(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
+  const app = await NestFactory.createApplicationContext(
+    WorkflowBackfillModule,
+    {
+      abortOnError: false,
+      logger: ['error'],
+      snapshot: true,
+    },
+  );
   console.info('Workflow backfill application context created');
 
   try {


### PR DESCRIPTION
## Summary
- Replace full AppModule boot in workflow-backfill with a lean migration module
- Provide only Config, Logger, Prisma, WorkflowsService, DefaultRecurringContentService, CronJobsService, and WorkflowDeploymentBackfillService
- Stub unused CronJobsService runtime executor dependencies so the migration path avoids queues/integrations/schedulers/auth startup

## Verification
- bunx biome check --write --config-path=biome-staged.json --no-errors-on-unmatched apps/server/api/src/migrations/workflow-backfill.ts apps/server/api/src/migrations/workflow-backfill.module.ts
- bun run --cwd apps/server/api build
- bun run --cwd apps/server/api test:file src/services/cache/services/cache-client.service.spec.ts
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js