### PR TITLE
fix(deploy): create default recurring workflows with prisma relations

### DIFF
--- a/apps/server/api/src/collections/brands/services/default-recurring-content.service.ts
+++ b/apps/server/api/src/collections/brands/services/default-recurring-content.service.ts
@@ -1,9 +1,8 @@
 import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { WorkflowTrigger } from '@genfeedai/enums';
+import { WorkflowStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 
 type DefaultRecurringContentType = 'image' | 'newsletter' | 'post';
 
@@ -46,7 +45,6 @@ export class DefaultRecurringContentService {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly moduleRef: ModuleRef,
     private readonly logger: LoggerService,
   ) {}
 
@@ -254,20 +252,14 @@ export class DefaultRecurringContentService {
       cronSchedule,
       timezone,
     );
-    const { WorkflowsService } = await import(
-      '@api/collections/workflows/services/workflows.service'
-    );
-    const workflowsService = this.moduleRef.get(WorkflowsService, {
-      strict: false,
-    });
-    const workflow = await workflowsService.createWorkflow(
-      params.userId,
-      params.organizationId,
-      {
-        brands: [brandId],
+    const workflow = await this.prisma.workflow.create({
+      data: {
+        brands: { connect: [{ id: brandId }] },
         description: workflowDescription,
         edges: [],
+        executionCount: 0,
         inputVariables: [],
+        isDeleted: false,
         isScheduleEnabled: true,
         label: workflowLabel,
         metadata: {
@@ -297,11 +289,15 @@ export class DefaultRecurringContentService {
             type: this.buildNodeType(params.contentType),
           },
         ],
+        organizationId: params.organizationId,
+        progress: 0,
         schedule: cronSchedule,
+        status: WorkflowStatus.ACTIVE,
+        steps: [],
         timezone,
-        trigger: WorkflowTrigger.SCHEDULED,
-      } as never,
-    );
+        userId: params.userId,
+      },
+    });
 
     const workflowId = String(
       (workflow as Record<string, unknown>)._id ??

--- a/apps/server/api/src/seeds/workflow-deployment-backfill.service.ts
+++ b/apps/server/api/src/seeds/workflow-deployment-backfill.service.ts
@@ -29,7 +29,7 @@ type WorkflowDeploymentBackfillOptions = {
   concurrency?: number;
 };
 
-const DEFAULT_BACKFILL_CONCURRENCY = 4;
+const DEFAULT_BACKFILL_CONCURRENCY = 1;
 const PROGRESS_LOG_INTERVAL = 25;
 
 @Injectable()


### PR DESCRIPTION
## Summary
- Create default recurring content workflows through Prisma directly with brands.connect instead of DTO-shaped brands arrays
- Remove the now-unused ModuleRef dependency from DefaultRecurringContentService
- Run deployment backfill serially to avoid serializable transaction write conflicts during org workflow seeding

## Verification
- bunx biome check --write --config-path=biome-staged.json --no-errors-on-unmatched apps/server/api/src/collections/brands/services/default-recurring-content.service.ts apps/server/api/src/seeds/workflow-deployment-backfill.service.ts
- bun run --cwd apps/server/api build
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js