### PR TITLE
feat(desktop): define local cloud identity

### DIFF
--- a/apps/desktop/app/src/main.ts
+++ b/apps/desktop/app/src/main.ts
@@ -6,6 +6,7 @@ import type {
   DesktopSyncCursorScope,
   IDesktopAssetGenerationRequest,
   IDesktopAssetSyncUpdate,
+  IDesktopAuthoritySummary,
   IDesktopBootstrap,
   IDesktopBrandManifest,
   IDesktopContentRunDraft,
@@ -15,6 +16,7 @@ import type {
   IDesktopSyncOpAck,
   IDesktopTerminalCreateOptions,
   IDesktopWorkflowGenerationOptions,
+  IDesktopWorkspaceCloudLinkInput,
 } from '@genfeedai/desktop-contracts';
 import { DESKTOP_IPC_CHANNELS } from '@genfeedai/desktop-contracts';
 import {
@@ -40,6 +42,7 @@ import { DesktopFilesService } from './main/files.service';
 import { DesktopGenerationService } from './main/generation.service';
 import { DesktopKvService } from './main/kv.service';
 import { DesktopLocalService } from './main/local.service';
+import { LocalIdentityService } from './main/local-identity.service';
 import { buildDesktopMenu } from './main/menu.service';
 import { DesktopPgliteService } from './main/pglite.service';
 import { DesktopPrismaService } from './main/prisma.service';
@@ -61,6 +64,7 @@ let bootstrapCache: IDesktopBootstrap | null = null;
 let pgliteService: DesktopPgliteService | null = null;
 let prismaService: DesktopPrismaService | null = null;
 let kvService: DesktopKvService;
+let localIdentityService: LocalIdentityService;
 let sessionService: DesktopSessionService;
 let workspaceService: DesktopWorkspaceService;
 let filesService: DesktopFilesService;
@@ -106,15 +110,21 @@ const LOCAL_ORGANIZATION = {
   slug: 'local-workspace',
 } as const;
 const LOCAL_USER = {
-  id: 'local-user',
   name: 'Local Desktop User',
   organizationId: LOCAL_ORGANIZATION.id,
 } as const;
+const DESKTOP_AUTHORITY: IDesktopAuthoritySummary = {
+  cloud: ['organization-membership', 'roles', 'shared-brand-settings'],
+  local: [
+    'private-drafts',
+    'local-generation',
+    'imported-files',
+    'unsynced-assets',
+  ],
+};
 const OFFLINE_MODE_KEY = 'desktop.offline.mode';
 const ONBOARDING_COMPLETED_KEY = 'onboarding.completed';
 const SYNC_THREADS_CURSOR_KEY = 'sync.threads.cursor';
-const LOCAL_BETTER_AUTH_ID_KEY = 'local.user.betterAuthId';
-const LEGACY_LOCAL_AUTH_ID_KEY = ['local.user.', 'auth', 'ProviderId'].join('');
 const ACTIVE_WORKSPACE_ID_KEY = 'desktop.workspace.activeId';
 
 function getSyncCursorKey(scope: DesktopSyncCursorScope = 'threads'): string {
@@ -122,11 +132,66 @@ function getSyncCursorKey(scope: DesktopSyncCursorScope = 'threads'): string {
 }
 
 function getBetterAuthId(): string | null {
-  return (
-    kvService.getValueSync(LOCAL_BETTER_AUTH_ID_KEY) ??
-    kvService.getValueSync(LEGACY_LOCAL_AUTH_ID_KEY)
-  );
+  return localIdentityService.getBetterAuthId();
 }
+
+function getLocalCloudIdentityContext() {
+  return {
+    cloudUserId: getBetterAuthId(),
+    localDeviceId: localIdentityService.getLocalDeviceId(),
+    localUserId: localIdentityService.getLocalUserId(),
+  };
+}
+
+const getCloudIdentityStatus = (
+  session: IDesktopBootstrap['session'],
+  betterAuthId: string | null,
+) => (session ? 'connected' : betterAuthId ? 'signed-out' : 'never-connected');
+
+const persistDeviceIdentity = async (
+  session: IDesktopBootstrap['session'],
+): Promise<void> => {
+  const client = prismaService?.getClient();
+
+  if (!client) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const localDeviceId = localIdentityService.getLocalDeviceId();
+  const betterAuthId = getBetterAuthId();
+  const existing = await client.desktopDeviceIdentity.findUnique({
+    where: {
+      id: localDeviceId,
+    },
+  });
+
+  await client.desktopDeviceIdentity.upsert({
+    create: {
+      cloudUserEmail: session?.userEmail ?? null,
+      cloudUserId: betterAuthId,
+      connectedAt: session?.issuedAt ?? null,
+      createdAt: now,
+      id: localDeviceId,
+      lastSeenAt: now,
+      localUserId: localIdentityService.getLocalUserId(),
+      status: getCloudIdentityStatus(session, betterAuthId),
+      updatedAt: now,
+    },
+    update: {
+      cloudUserEmail: session?.userEmail ?? existing?.cloudUserEmail ?? null,
+      cloudUserId: betterAuthId ?? existing?.cloudUserId ?? null,
+      connectedAt: session?.issuedAt ?? existing?.connectedAt ?? null,
+      lastSeenAt: now,
+      localUserId: localIdentityService.getLocalUserId(),
+      status: getCloudIdentityStatus(session, betterAuthId),
+      updatedAt: now,
+    },
+    where: {
+      id: localDeviceId,
+    },
+  });
+};
 
 const getActiveWorkspaceId = (
   workspaces = workspaceService.listRecentWorkspaces(),
@@ -176,23 +241,37 @@ const getBootstrap = (): IDesktopBootstrap => {
   }
 
   const workspaces = workspaceService.listRecentWorkspaces();
+  const session = sessionService.getSession();
+  const betterAuthId = getBetterAuthId();
+  const localUserId = localIdentityService.getLocalUserId();
   const bootstrap: IDesktopBootstrap = {
     activeWorkspaceId: getActiveWorkspaceId(workspaces),
-    betterAuthId: getBetterAuthId(),
+    authority: DESKTOP_AUTHORITY,
+    betterAuthId,
+    cloudIdentity: {
+      cloudUserEmail: session?.userEmail,
+      cloudUserId: betterAuthId ?? undefined,
+      connectedAt: session?.issuedAt,
+      localDeviceId: localIdentityService.getLocalDeviceId(),
+      localUserId,
+      status: getCloudIdentityStatus(session, betterAuthId),
+    },
+    cloudOrganizations: syncService.listCloudOrganizations(),
     environment: sessionService.getEnvironment(),
     isOfflineMode,
     localOrganization: { ...LOCAL_ORGANIZATION },
     localUser: {
       ...LOCAL_USER,
-      userEmail: sessionService.getSession()?.userEmail,
+      id: localUserId,
+      userEmail: session?.userEmail,
     },
-    localUserId: LOCAL_USER.id,
+    localUserId,
     preferences: {
       nativeNotificationsEnabled: Notification.isSupported(),
     },
     brands: syncService.listBrands(),
     recents: workspaceService.listRecents(),
-    session: sessionService.getSession(),
+    session,
     syncState: syncService.getState(),
     workspaces,
   };
@@ -370,7 +449,8 @@ const handleAuthCallback = async (rawUrl: string): Promise<void> => {
     return;
   }
 
-  await kvService.setValue(LOCAL_BETTER_AUTH_ID_KEY, session.userId);
+  await localIdentityService.setBetterAuthId(session.userId);
+  await persistDeviceIdentity(session);
   isOfflineMode = false;
   await kvService.setValue(OFFLINE_MODE_KEY, '0');
   await emitSession();
@@ -419,6 +499,7 @@ const registerIpcHandlers = (): void => {
   });
   ipcMain.handle(DESKTOP_IPC_CHANNELS.authLogout, async () => {
     await sessionService.clearSession();
+    await persistDeviceIdentity(null);
     await emitSession();
     await emitBootstrap();
   });
@@ -498,7 +579,24 @@ const registerIpcHandlers = (): void => {
     async (_event: unknown, workspaceId: string, projectId: string) => {
       const workspace = await workspaceService.linkProject(
         workspaceId,
-        projectId,
+        projectId || null,
+        getLocalCloudIdentityContext(),
+      );
+      await emitBootstrap();
+      return workspace;
+    },
+  );
+  ipcMain.handle(
+    DESKTOP_IPC_CHANNELS.workspaceLinkCloudContext,
+    async (
+      _event: unknown,
+      workspaceId: string,
+      input: IDesktopWorkspaceCloudLinkInput,
+    ) => {
+      const workspace = await workspaceService.linkCloudContext(
+        workspaceId,
+        input,
+        getLocalCloudIdentityContext(),
       );
       await emitBootstrap();
       return workspace;
@@ -841,14 +939,19 @@ app.whenReady().then(async () => {
   const pglite = await pgliteService.init();
   prismaService = new DesktopPrismaService(pglite);
   const prismaClient = prismaService.getClient();
-  await prismaService.bootstrapLocalIdentity();
   kvService = new DesktopKvService(prismaClient);
   await kvService.init();
+  localIdentityService = new LocalIdentityService(kvService);
+  await localIdentityService.initialize();
+  await prismaService.bootstrapLocalIdentity(
+    localIdentityService.getLocalUserId(),
+  );
   sessionService = new DesktopSessionService(kvService, environment);
   const session = await sessionService.validateStoredSession();
   if (session) {
-    await kvService.setValue(LOCAL_BETTER_AUTH_ID_KEY, session.userId);
+    await localIdentityService.setBetterAuthId(session.userId);
   }
+  await persistDeviceIdentity(session);
   workspaceService = new DesktopWorkspaceService(prismaClient);
   await workspaceService.init();
   syncService = new DesktopSyncService(prismaClient);

--- a/apps/desktop/app/src/main/local-identity.service.test.ts
+++ b/apps/desktop/app/src/main/local-identity.service.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import type { DesktopKvService } from './kv.service';
+import { LocalIdentityService } from './local-identity.service';
+
+const createKvMock = (initialValues: Record<string, string> = {}) => {
+  const values = new Map(Object.entries(initialValues));
+
+  return {
+    getValue: async (key: string) => values.get(key) ?? null,
+    setValue: async (key: string, value: string) => {
+      values.set(key, value);
+    },
+    values,
+  } as unknown as DesktopKvService & { values: Map<string, string> };
+};
+
+describe('LocalIdentityService', () => {
+  it('creates stable local user and device ids on first boot', async () => {
+    const kv = createKvMock();
+    const service = new LocalIdentityService(kv);
+
+    await service.initialize();
+
+    expect(service.getLocalUserId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(service.getLocalDeviceId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(kv.values.get('local.user.id')).toBe(service.getLocalUserId());
+    expect(kv.values.get('local.device.id')).toBe(service.getLocalDeviceId());
+  });
+
+  it('loads existing identity and persists Better Auth user id separately', async () => {
+    const kv = createKvMock({
+      'local.device.id': 'device-1',
+      'local.user.id': 'user-1',
+    });
+    const service = new LocalIdentityService(kv);
+
+    await service.initialize();
+    await service.setBetterAuthId('cloud-user-1');
+
+    expect(service.getLocalUserId()).toBe('user-1');
+    expect(service.getLocalDeviceId()).toBe('device-1');
+    expect(service.getBetterAuthId()).toBe('cloud-user-1');
+    expect(kv.values.get('local.user.betterAuthId')).toBe('cloud-user-1');
+  });
+});

--- a/apps/desktop/app/src/main/local-identity.service.ts
+++ b/apps/desktop/app/src/main/local-identity.service.ts
@@ -6,6 +6,7 @@ import type { DesktopKvService } from './kv.service';
  *
  * KV keys — permanent, never rename:
  *   local.user.id          — stable UUID set on first boot, never changes
+ *   local.device.id        — stable UUID for this installed desktop device
  *   local.user.betterAuthId     — Better Auth user ID persisted after first cloud sign-in,
  *                            survives sign-out and token expiry
  *   onboarding.completed   — '1' once the onboarding wizard is dismissed
@@ -15,6 +16,7 @@ import type { DesktopKvService } from './kv.service';
  * synchronously while persistence stays async on the PGlite layer.
  */
 const LOCAL_USER_ID_KEY = 'local.user.id';
+const LOCAL_DEVICE_ID_KEY = 'local.device.id';
 const LOCAL_BETTER_AUTH_ID_KEY = 'local.user.betterAuthId';
 const LEGACY_LOCAL_AUTH_ID_KEY = ['local.user.', 'auth', 'ProviderId'].join('');
 const ONBOARDING_COMPLETED_KEY = 'onboarding.completed';
@@ -22,6 +24,7 @@ const SYNC_THREADS_CURSOR_KEY = 'sync.threads.cursor';
 
 export class LocalIdentityService {
   private betterAuthId: string | null = null;
+  private localDeviceId: string | null = null;
   private localUserId: string | null = null;
   private onboardingCompleted = false;
   private syncCursor: string | null = null;
@@ -31,12 +34,14 @@ export class LocalIdentityService {
   async initialize(): Promise<void> {
     const [
       storedLocalUserId,
+      storedLocalDeviceId,
       storedBetterAuthId,
       storedLegacyAuthId,
       storedOnboardingCompleted,
       storedSyncCursor,
     ] = await Promise.all([
       this.database.getValue(LOCAL_USER_ID_KEY),
+      this.database.getValue(LOCAL_DEVICE_ID_KEY),
       this.database.getValue(LOCAL_BETTER_AUTH_ID_KEY),
       this.database.getValue(LEGACY_LOCAL_AUTH_ID_KEY),
       this.database.getValue(ONBOARDING_COMPLETED_KEY),
@@ -44,6 +49,7 @@ export class LocalIdentityService {
     ]);
 
     this.localUserId = storedLocalUserId ?? randomUUID();
+    this.localDeviceId = storedLocalDeviceId ?? randomUUID();
     this.betterAuthId = storedBetterAuthId ?? storedLegacyAuthId ?? null;
     this.onboardingCompleted = storedOnboardingCompleted === '1';
     this.syncCursor = storedSyncCursor ?? null;
@@ -51,6 +57,18 @@ export class LocalIdentityService {
     if (!storedLocalUserId) {
       await this.database.setValue(LOCAL_USER_ID_KEY, this.localUserId);
     }
+
+    if (!storedLocalDeviceId) {
+      await this.database.setValue(LOCAL_DEVICE_ID_KEY, this.localDeviceId);
+    }
+  }
+
+  getLocalDeviceId(): string {
+    if (!this.localDeviceId) {
+      throw new Error('Local identity service not initialized');
+    }
+
+    return this.localDeviceId;
   }
 
   getLocalUserId(): string {

--- a/apps/desktop/app/src/main/pglite.service.test.ts
+++ b/apps/desktop/app/src/main/pglite.service.test.ts
@@ -34,7 +34,10 @@ describe('DesktopPgliteService', () => {
     );
 
     expect(service.getDataDir()).toBe(dataDir);
-    expect(migrationRows.rows).toEqual([{ migration_name: '0001_init' }]);
+    expect(migrationRows.rows).toEqual([
+      { migration_name: '0001_init' },
+      { migration_name: '0002_local_cloud_identity' },
+    ]);
     expect(workspaceRows.rows).toEqual([{ name: 'desktop_workspace' }]);
 
     await service.close();

--- a/apps/desktop/app/src/main/prisma.service.ts
+++ b/apps/desktop/app/src/main/prisma.service.ts
@@ -4,7 +4,7 @@ import { createDesktopPrismaClient } from '@genfeedai/desktop-prisma';
 import { toIso } from './time.util';
 
 const LOCAL_ORGANIZATION_ID = 'local-org';
-const LOCAL_USER_ID = 'local-user';
+const DEFAULT_LOCAL_USER_ID = 'local-user';
 
 export class DesktopPrismaService {
   private client: PrismaClient | null = null;
@@ -19,7 +19,9 @@ export class DesktopPrismaService {
     return this.client;
   }
 
-  async bootstrapLocalIdentity(): Promise<void> {
+  async bootstrapLocalIdentity(
+    localUserId = DEFAULT_LOCAL_USER_ID,
+  ): Promise<void> {
     const client = this.getClient();
     const now = toIso();
 
@@ -43,7 +45,7 @@ export class DesktopPrismaService {
     await client.user.upsert({
       create: {
         createdAt: now,
-        id: LOCAL_USER_ID,
+        id: localUserId,
         name: 'Local Desktop User',
         organizationId: LOCAL_ORGANIZATION_ID,
         updatedAt: now,
@@ -53,7 +55,7 @@ export class DesktopPrismaService {
         updatedAt: now,
       },
       where: {
-        id: LOCAL_USER_ID,
+        id: localUserId,
       },
     });
   }

--- a/apps/desktop/app/src/main/release-qa.test.ts
+++ b/apps/desktop/app/src/main/release-qa.test.ts
@@ -30,15 +30,14 @@ describe('desktop release QA', () => {
     expect(scripts?.['release:mac']).toContain('bun run release:manifest');
   });
 
-  it('runs macOS desktop QA on pull requests that can affect the shell', () => {
+  it('exposes macOS desktop QA as a reusable/manual workflow', () => {
     const workflow = readText('.github/workflows/desktop-qa.yml');
 
     expect(workflow).toContain('name: Desktop QA');
-    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('workflow_call:');
     expect(workflow).toContain('runs-on: macos-latest');
-    expect(workflow).toContain("'apps/desktop/**'");
-    expect(workflow).toContain("'apps/app/**'");
-    expect(workflow).toContain("'packages/desktop-*/**'");
+    expect(workflow).toContain('Setup Bun environment');
     expect(workflow).toContain(
       'bun run --filter=@genfeedai/desktop qa:release',
     );

--- a/apps/desktop/app/src/main/sync.service.test.ts
+++ b/apps/desktop/app/src/main/sync.service.test.ts
@@ -4,10 +4,32 @@ import { DesktopSyncService } from './sync.service';
 const createPrismaMock = (rows: Array<Record<string, unknown>> = []) => {
   const assets = new Map<string, Record<string, unknown>>();
   const brands = new Map<string, Record<string, unknown>>();
+  const cloudOrganizations = new Map<string, Record<string, unknown>>();
   const syncJobs = new Map(rows.map((row) => [String(row.id), row]));
   const syncOps = new Map<string, Record<string, unknown>>();
 
   return {
+    desktopCloudOrganization: {
+      findMany: async () =>
+        Array.from(cloudOrganizations.values()).sort((left, right) =>
+          String(right.updatedAt).localeCompare(String(left.updatedAt)),
+        ),
+      upsert: async ({
+        create,
+        update,
+        where,
+      }: {
+        create: Record<string, unknown>;
+        update: Record<string, unknown>;
+        where: { cloudId: string };
+      }) => {
+        cloudOrganizations.set(where.cloudId, {
+          ...(cloudOrganizations.get(where.cloudId) ?? create),
+          ...update,
+          cloudId: where.cloudId,
+        });
+      },
+    },
     desktopAsset: {
       findMany: async () =>
         Array.from(assets.values()).sort((left, right) =>
@@ -117,6 +139,7 @@ const createPrismaMock = (rows: Array<Record<string, unknown>> = []) => {
     },
     assets,
     brands,
+    cloudOrganizations,
     syncJobs,
     syncOps,
   };
@@ -188,6 +211,61 @@ describe('DesktopSyncService', () => {
       pendingCount: 1,
       retryingCount: 0,
       runningCount: 1,
+    });
+  });
+
+  it('persists cloud organization and brand mappings from a manifest', async () => {
+    const prisma = createPrismaMock();
+    const service = new DesktopSyncService(prisma as never);
+    await service.init();
+
+    await service.applyBrandManifest({
+      assets: [],
+      brands: [
+        {
+          id: 'brand-cloud-1',
+          label: 'Moonrise Studio',
+          organizationId: 'org-cloud-1',
+          slug: 'moonrise',
+          updatedAt: '2026-04-01T09:00:00.000Z',
+        },
+      ],
+      ingredients: [],
+      organization: {
+        id: 'org-cloud-1',
+        label: 'Acme Cloud',
+        slug: 'acme',
+        updatedAt: '2026-04-01T08:00:00.000Z',
+      },
+      updatedCursor: 'cursor-1',
+    });
+
+    expect(service.listCloudOrganizations()).toEqual([
+      {
+        cloudId: 'org-cloud-1',
+        lastPulledAt: expect.any(String),
+        name: 'Acme Cloud',
+        slug: 'acme',
+        updatedAt: '2026-04-01T08:00:00.000Z',
+      },
+    ]);
+    expect(service.listBrands()).toEqual([
+      expect.objectContaining({
+        cloudId: 'brand-cloud-1',
+        cloudOrganizationId: 'org-cloud-1',
+        id: 'brand-cloud-1',
+        name: 'Moonrise Studio',
+        organizationId: 'local-org',
+        syncPolicy: 'metadata-sync',
+      }),
+    ]);
+    expect(prisma.cloudOrganizations.get('org-cloud-1')).toMatchObject({
+      name: 'Acme Cloud',
+      slug: 'acme',
+    });
+    expect(prisma.brands.get('brand-cloud-1')).toMatchObject({
+      cloudOrganizationId: 'org-cloud-1',
+      organizationId: 'local-org',
     });
   });
 });

--- a/apps/desktop/app/src/main/sync.service.ts
+++ b/apps/desktop/app/src/main/sync.service.ts
@@ -8,6 +8,7 @@ import type {
   IDesktopAssetSyncUpdate,
   IDesktopBrand,
   IDesktopBrandManifest,
+  IDesktopCloudOrganization,
   IDesktopSyncJob,
   IDesktopSyncOp,
   IDesktopSyncOpAck,
@@ -42,34 +43,44 @@ const isOneOf = <T extends string>(
 export class DesktopSyncService {
   private readonly assets = new Map<string, IDesktopAsset>();
   private readonly brands = new Map<string, IDesktopBrand>();
+  private readonly cloudOrganizations = new Map<
+    string,
+    IDesktopCloudOrganization
+  >();
   private readonly jobs = new Map<string, IDesktopSyncJob>();
   private readonly ops = new Map<string, IDesktopSyncOp>();
 
   constructor(private readonly prisma: PrismaClient) {}
 
   async init(): Promise<void> {
-    const [assetRows, brandRows, jobRows, opRows] = await Promise.all([
-      this.prisma.desktopAsset.findMany({
-        orderBy: {
-          updatedAt: 'desc',
-        },
-      }),
-      this.prisma.desktopBrand.findMany({
-        orderBy: {
-          updatedAt: 'desc',
-        },
-      }),
-      this.prisma.desktopSyncJob.findMany({
-        orderBy: {
-          updatedAt: 'desc',
-        },
-      }),
-      this.prisma.desktopSyncOp.findMany({
-        orderBy: {
-          updatedAt: 'desc',
-        },
-      }),
-    ]);
+    const [assetRows, brandRows, cloudOrganizationRows, jobRows, opRows] =
+      await Promise.all([
+        this.prisma.desktopAsset.findMany({
+          orderBy: {
+            updatedAt: 'desc',
+          },
+        }),
+        this.prisma.desktopBrand.findMany({
+          orderBy: {
+            updatedAt: 'desc',
+          },
+        }),
+        this.prisma.desktopCloudOrganization.findMany({
+          orderBy: {
+            updatedAt: 'desc',
+          },
+        }),
+        this.prisma.desktopSyncJob.findMany({
+          orderBy: {
+            updatedAt: 'desc',
+          },
+        }),
+        this.prisma.desktopSyncOp.findMany({
+          orderBy: {
+            updatedAt: 'desc',
+          },
+        }),
+      ]);
 
     this.assets.clear();
     for (const row of assetRows) {
@@ -79,6 +90,11 @@ export class DesktopSyncService {
     this.brands.clear();
     for (const row of brandRows) {
       this.brands.set(row.id, this.toBrand(row));
+    }
+
+    this.cloudOrganizations.clear();
+    for (const row of cloudOrganizationRows) {
+      this.cloudOrganizations.set(row.cloudId, this.toCloudOrganization(row));
     }
 
     this.jobs.clear();
@@ -98,6 +114,7 @@ export class DesktopSyncService {
 
   private toBrand(row: {
     cloudId: string | null;
+    cloudOrganizationId: string | null;
     cloudVersion: string | null;
     createdAt: string;
     id: string;
@@ -110,6 +127,7 @@ export class DesktopSyncService {
   }): IDesktopBrand {
     return {
       cloudId: row.cloudId ?? undefined,
+      cloudOrganizationId: row.cloudOrganizationId ?? undefined,
       cloudVersion: row.cloudVersion ?? undefined,
       createdAt: row.createdAt,
       id: row.id,
@@ -118,6 +136,24 @@ export class DesktopSyncService {
       organizationId: row.organizationId,
       slug: row.slug,
       syncPolicy: row.syncPolicy as IDesktopBrand['syncPolicy'],
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  private toCloudOrganization(row: {
+    cloudId: string;
+    lastPulledAt: string | null;
+    name: string;
+    role: string | null;
+    slug: string;
+    updatedAt: string;
+  }): IDesktopCloudOrganization {
+    return {
+      cloudId: row.cloudId,
+      lastPulledAt: row.lastPulledAt ?? undefined,
+      name: row.name,
+      role: row.role ?? undefined,
+      slug: row.slug,
       updatedAt: row.updatedAt,
     };
   }
@@ -200,6 +236,12 @@ export class DesktopSyncService {
 
   listBrands(): IDesktopBrand[] {
     return Array.from(this.brands.values()).sort((left, right) =>
+      right.updatedAt.localeCompare(left.updatedAt),
+    );
+  }
+
+  listCloudOrganizations(): IDesktopCloudOrganization[] {
+    return Array.from(this.cloudOrganizations.values()).sort((left, right) =>
       right.updatedAt.localeCompare(left.updatedAt),
     );
   }
@@ -337,6 +379,38 @@ export class DesktopSyncService {
   async applyBrandManifest(manifest: IDesktopBrandManifest): Promise<void> {
     const pulledAt = toIso();
 
+    if (manifest.organization) {
+      const organization: IDesktopCloudOrganization = {
+        cloudId: manifest.organization.id,
+        lastPulledAt: pulledAt,
+        name: manifest.organization.label,
+        slug: manifest.organization.slug,
+        updatedAt: manifest.organization.updatedAt,
+      };
+
+      await this.prisma.desktopCloudOrganization.upsert({
+        create: {
+          cloudId: organization.cloudId,
+          lastPulledAt: organization.lastPulledAt ?? null,
+          name: organization.name,
+          role: organization.role ?? null,
+          slug: organization.slug,
+          updatedAt: organization.updatedAt,
+        },
+        update: {
+          lastPulledAt: organization.lastPulledAt ?? null,
+          name: organization.name,
+          role: organization.role ?? null,
+          slug: organization.slug,
+          updatedAt: organization.updatedAt,
+        },
+        where: {
+          cloudId: organization.cloudId,
+        },
+      });
+      this.cloudOrganizations.set(organization.cloudId, organization);
+    }
+
     for (const cloudBrand of manifest.brands) {
       if (cloudBrand.isDeleted) {
         await this.prisma.desktopBrand.deleteMany({
@@ -358,6 +432,8 @@ export class DesktopSyncService {
         id: cloudBrand.id,
         lastPulledAt: pulledAt,
         name: cloudBrand.label,
+        cloudOrganizationId:
+          cloudBrand.organizationId ?? manifest.organization?.id,
         organizationId: LOCAL_ORGANIZATION_ID,
         slug: cloudBrand.slug,
         syncPolicy: 'metadata-sync',
@@ -367,6 +443,7 @@ export class DesktopSyncService {
       await this.prisma.desktopBrand.upsert({
         create: {
           cloudId: brand.cloudId ?? null,
+          cloudOrganizationId: brand.cloudOrganizationId ?? null,
           cloudVersion: brand.cloudVersion ?? null,
           createdAt: brand.createdAt,
           id: brand.id,
@@ -379,6 +456,7 @@ export class DesktopSyncService {
         },
         update: {
           cloudId: brand.cloudId ?? null,
+          cloudOrganizationId: brand.cloudOrganizationId ?? null,
           cloudVersion: brand.cloudVersion ?? null,
           lastPulledAt: brand.lastPulledAt ?? null,
           name: brand.name,

--- a/apps/desktop/app/src/main/workspace.service.test.ts
+++ b/apps/desktop/app/src/main/workspace.service.test.ts
@@ -10,10 +10,29 @@ import {
 const { DesktopWorkspaceService } = await import('./workspace.service');
 
 const createPrismaMock = () => {
+  const cloudLinksByWorkspaceId = new Map<string, Record<string, unknown>>();
   const workspacesById = new Map<string, Record<string, unknown>>();
   const recentItemsById = new Map<string, Record<string, unknown>>();
 
   return {
+    desktopWorkspaceCloudLink: {
+      findMany: async () => Array.from(cloudLinksByWorkspaceId.values()),
+      upsert: async ({
+        create,
+        update,
+        where,
+      }: {
+        create: Record<string, unknown>;
+        update: Record<string, unknown>;
+        where: { workspaceId: string };
+      }) => {
+        cloudLinksByWorkspaceId.set(where.workspaceId, {
+          ...(cloudLinksByWorkspaceId.get(where.workspaceId) ?? create),
+          ...update,
+          workspaceId: where.workspaceId,
+        });
+      },
+    },
     desktopRecentItem: {
       findMany: async () =>
         Array.from(recentItemsById.values()).sort((left, right) =>
@@ -58,6 +77,7 @@ const createPrismaMock = () => {
         });
       },
     },
+    cloudLinksByWorkspaceId,
     recentItemsById,
     workspacesById,
   };
@@ -129,6 +149,7 @@ describe('DesktopWorkspaceService', () => {
       indexingState: 'idle',
       lastOpenedAt: now,
       linkedBrandId: null,
+      linkedOrganizationId: null,
       linkedProjectId: null,
       localDraftCount: 0,
       name: 'Linked Workspace',
@@ -156,5 +177,69 @@ describe('DesktopWorkspaceService', () => {
 
     await service.revealInFinder('workspace-1');
     expect(electronMockState.shell.revealedPaths).toEqual([workspaceDir]);
+  });
+
+  it('links a workspace to explicit cloud org, brand, and project context', async () => {
+    const workspaceDir = path.join(temporaryRoot, 'cloud-linked-workspace');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+
+    const now = '2026-04-01T10:00:00.000Z';
+    const prisma = createPrismaMock();
+    prisma.workspacesById.set('workspace-1', {
+      createdAt: now,
+      fileIndex: '[]',
+      id: 'workspace-1',
+      indexingState: 'idle',
+      lastOpenedAt: now,
+      linkedBrandId: null,
+      linkedOrganizationId: null,
+      linkedProjectId: null,
+      localDraftCount: 0,
+      name: 'Cloud Linked Workspace',
+      path: workspaceDir,
+      pendingSyncCount: 0,
+      syncPolicy: 'local-only',
+      updatedAt: now,
+    });
+
+    const service = new DesktopWorkspaceService(prisma as never);
+    await service.init();
+
+    const workspace = await service.linkCloudContext(
+      'workspace-1',
+      {
+        cloudBrandId: 'brand-cloud-1',
+        cloudOrganizationId: 'org-cloud-1',
+        cloudProjectId: 'project-cloud-1',
+        syncPolicy: 'metadata-sync',
+      },
+      {
+        cloudUserId: 'cloud-user-1',
+        localDeviceId: 'device-1',
+        localUserId: 'local-user-1',
+      },
+    );
+
+    expect(workspace).toMatchObject({
+      linkedBrandId: 'brand-cloud-1',
+      linkedOrganizationId: 'org-cloud-1',
+      linkedProjectId: 'project-cloud-1',
+      syncPolicy: 'metadata-sync',
+    });
+    expect(workspace.cloudLink).toMatchObject({
+      cloudBrandId: 'brand-cloud-1',
+      cloudOrganizationId: 'org-cloud-1',
+      cloudProjectId: 'project-cloud-1',
+      cloudUserId: 'cloud-user-1',
+      localDeviceId: 'device-1',
+      localUserId: 'local-user-1',
+      syncPolicy: 'metadata-sync',
+      workspaceId: 'workspace-1',
+    });
+    expect(prisma.cloudLinksByWorkspaceId.get('workspace-1')).toMatchObject({
+      cloudBrandId: 'brand-cloud-1',
+      cloudOrganizationId: 'org-cloud-1',
+      cloudProjectId: 'project-cloud-1',
+    });
   });
 });

--- a/apps/desktop/app/src/main/workspace.service.ts
+++ b/apps/desktop/app/src/main/workspace.service.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import type {
   IDesktopRecentItem,
   IDesktopWorkspace,
+  IDesktopWorkspaceCloudLink,
+  IDesktopWorkspaceCloudLinkInput,
   IDesktopWorkspaceFile,
 } from '@genfeedai/desktop-contracts';
 import {
@@ -29,14 +31,24 @@ const SKIPPED_INDEX_DIRECTORIES = new Set([
   'release',
 ]);
 
+export interface DesktopLocalCloudIdentityContext {
+  cloudUserId?: string | null;
+  localDeviceId: string;
+  localUserId: string;
+}
+
+const normalizeNullableString = (value: string | null | undefined) =>
+  value && value.length > 0 ? value : null;
+
 export class DesktopWorkspaceService {
+  private readonly cloudLinks = new Map<string, IDesktopWorkspaceCloudLink>();
   private readonly recents = new Map<string, IDesktopRecentItem>();
   private readonly workspaces = new Map<string, IDesktopWorkspace>();
 
   constructor(private readonly prisma: PrismaClient) {}
 
   async init(): Promise<void> {
-    const [workspaceRows, recentRows] = await Promise.all([
+    const [workspaceRows, recentRows, cloudLinkRows] = await Promise.all([
       this.prisma.desktopWorkspace.findMany({
         orderBy: {
           lastOpenedAt: 'desc',
@@ -47,7 +59,13 @@ export class DesktopWorkspaceService {
           openedAt: 'desc',
         },
       }),
+      this.prisma.desktopWorkspaceCloudLink.findMany(),
     ]);
+
+    this.cloudLinks.clear();
+    for (const row of cloudLinkRows) {
+      this.cloudLinks.set(row.workspaceId, this.toCloudLink(row));
+    }
 
     this.workspaces.clear();
     for (const row of workspaceRows) {
@@ -123,6 +141,7 @@ export class DesktopWorkspaceService {
     indexingState: string;
     lastOpenedAt: string;
     linkedBrandId: string | null;
+    linkedOrganizationId: string | null;
     linkedProjectId: string | null;
     localDraftCount: number;
     name: string;
@@ -131,20 +150,52 @@ export class DesktopWorkspaceService {
     syncPolicy: string;
     updatedAt: string;
   }): IDesktopWorkspace {
+    const cloudLink = this.cloudLinks.get(row.id);
+
     return {
       createdAt: row.createdAt,
       fileIndex: JSON.parse(row.fileIndex) as IDesktopWorkspaceFile[],
+      ...(cloudLink ? { cloudLink } : {}),
       id: row.id,
       indexingState: row.indexingState as 'idle' | 'indexing',
       lastOpenedAt: row.lastOpenedAt,
-      linkedBrandId: row.linkedBrandId ?? undefined,
-      linkedProjectId: row.linkedProjectId ?? undefined,
+      linkedBrandId: row.linkedBrandId ?? cloudLink?.cloudBrandId ?? undefined,
+      linkedOrganizationId:
+        row.linkedOrganizationId ?? cloudLink?.cloudOrganizationId ?? undefined,
+      linkedProjectId:
+        row.linkedProjectId ?? cloudLink?.cloudProjectId ?? undefined,
       localDraftCount: row.localDraftCount,
       name: row.name,
       path: row.path,
       pendingSyncCount: row.pendingSyncCount,
       syncPolicy: row.syncPolicy as IDesktopWorkspace['syncPolicy'],
       updatedAt: row.updatedAt,
+    };
+  }
+
+  private toCloudLink(row: {
+    cloudBrandId: string | null;
+    cloudOrganizationId: string | null;
+    cloudProjectId: string | null;
+    cloudUserId: string | null;
+    linkedAt: string;
+    localDeviceId: string;
+    localUserId: string;
+    syncPolicy: string;
+    updatedAt: string;
+    workspaceId: string;
+  }): IDesktopWorkspaceCloudLink {
+    return {
+      cloudBrandId: row.cloudBrandId ?? undefined,
+      cloudOrganizationId: row.cloudOrganizationId ?? undefined,
+      cloudProjectId: row.cloudProjectId ?? undefined,
+      cloudUserId: row.cloudUserId ?? undefined,
+      linkedAt: row.linkedAt,
+      localDeviceId: row.localDeviceId,
+      localUserId: row.localUserId,
+      syncPolicy: row.syncPolicy as IDesktopWorkspaceCloudLink['syncPolicy'],
+      updatedAt: row.updatedAt,
+      workspaceId: row.workspaceId,
     };
   }
 
@@ -162,10 +213,13 @@ export class DesktopWorkspaceService {
 
   private async persistWorkspace(input: {
     id?: string;
-    linkedProjectId?: string;
+    linkedBrandId?: string | null;
+    linkedOrganizationId?: string | null;
+    linkedProjectId?: string | null;
     name: string;
     path: string;
     reindex?: boolean;
+    syncPolicy?: IDesktopWorkspace['syncPolicy'];
   }): Promise<IDesktopWorkspace> {
     this.ensureWorkspaceMetadataFolder(input.path);
     const now = toIso();
@@ -184,14 +238,23 @@ export class DesktopWorkspaceService {
       id: existing?.id ?? input.id ?? randomUUID(),
       indexingState: 'idle',
       lastOpenedAt: now,
-      linkedBrandId: existing?.linkedBrandId ?? null,
+      linkedBrandId:
+        input.linkedBrandId !== undefined
+          ? input.linkedBrandId
+          : (existing?.linkedBrandId ?? null),
+      linkedOrganizationId:
+        input.linkedOrganizationId !== undefined
+          ? input.linkedOrganizationId
+          : (existing?.linkedOrganizationId ?? null),
       linkedProjectId:
-        input.linkedProjectId ?? existing?.linkedProjectId ?? null,
+        input.linkedProjectId !== undefined
+          ? input.linkedProjectId
+          : (existing?.linkedProjectId ?? null),
       localDraftCount: existing?.localDraftCount ?? 0,
       name: input.name,
       path: input.path,
       pendingSyncCount: existing?.pendingSyncCount ?? 0,
-      syncPolicy: existing?.syncPolicy ?? 'local-only',
+      syncPolicy: input.syncPolicy ?? existing?.syncPolicy ?? 'local-only',
       updatedAt: now,
     };
 
@@ -270,17 +333,102 @@ export class DesktopWorkspaceService {
 
   async linkProject(
     workspaceId: string,
-    projectId: string,
+    projectId: string | null,
+    identity?: DesktopLocalCloudIdentityContext,
   ): Promise<IDesktopWorkspace> {
+    if (identity) {
+      return this.linkCloudContext(
+        workspaceId,
+        { cloudProjectId: projectId },
+        identity,
+      );
+    }
+
     const workspace = this.getWorkspace(workspaceId);
 
     return this.persistWorkspace({
       id: workspace.id,
-      linkedProjectId: projectId,
+      linkedProjectId: normalizeNullableString(projectId),
       name: workspace.name,
       path: workspace.path,
       reindex: false,
     });
+  }
+
+  async linkCloudContext(
+    workspaceId: string,
+    input: IDesktopWorkspaceCloudLinkInput,
+    identity: DesktopLocalCloudIdentityContext,
+  ): Promise<IDesktopWorkspace> {
+    const workspace = this.getWorkspace(workspaceId);
+    const existingLink = this.cloudLinks.get(workspaceId);
+    const cloudOrganizationId =
+      input.cloudOrganizationId !== undefined
+        ? normalizeNullableString(input.cloudOrganizationId)
+        : (existingLink?.cloudOrganizationId ??
+          workspace.linkedOrganizationId ??
+          null);
+    const cloudBrandId =
+      input.cloudBrandId !== undefined
+        ? normalizeNullableString(input.cloudBrandId)
+        : (existingLink?.cloudBrandId ?? workspace.linkedBrandId ?? null);
+    const cloudProjectId =
+      input.cloudProjectId !== undefined
+        ? normalizeNullableString(input.cloudProjectId)
+        : (existingLink?.cloudProjectId ?? workspace.linkedProjectId ?? null);
+    const syncPolicy =
+      input.syncPolicy ?? existingLink?.syncPolicy ?? workspace.syncPolicy;
+    const now = toIso();
+    const linkedAt = existingLink?.linkedAt ?? now;
+
+    const nextWorkspace = await this.persistWorkspace({
+      id: workspace.id,
+      linkedBrandId: cloudBrandId,
+      linkedOrganizationId: cloudOrganizationId,
+      linkedProjectId: cloudProjectId,
+      name: workspace.name,
+      path: workspace.path,
+      reindex: false,
+      syncPolicy,
+    });
+
+    const row = {
+      cloudBrandId,
+      cloudOrganizationId,
+      cloudProjectId,
+      cloudUserId:
+        normalizeNullableString(identity.cloudUserId) ??
+        existingLink?.cloudUserId ??
+        null,
+      linkedAt,
+      localDeviceId: identity.localDeviceId,
+      localUserId: identity.localUserId,
+      syncPolicy,
+      updatedAt: now,
+      workspaceId,
+    };
+
+    await this.prisma.desktopWorkspaceCloudLink.upsert({
+      create: row,
+      update: row,
+      where: {
+        workspaceId,
+      },
+    });
+
+    const cloudLink = this.toCloudLink(row);
+    this.cloudLinks.set(workspaceId, cloudLink);
+    const linkedWorkspace = {
+      ...nextWorkspace,
+      cloudLink,
+      linkedBrandId: cloudBrandId ?? undefined,
+      linkedOrganizationId: cloudOrganizationId ?? undefined,
+      linkedProjectId: cloudProjectId ?? undefined,
+      syncPolicy,
+    };
+    this.workspaces.set(workspaceId, linkedWorkspace);
+
+    return linkedWorkspace;
   }
 
   async revealInFinder(workspaceId: string): Promise<void> {

--- a/apps/desktop/app/src/preload.ts
+++ b/apps/desktop/app/src/preload.ts
@@ -266,6 +266,12 @@ const desktopBridge: IGenfeedDesktopBridge = {
   workspace: {
     getRecentWorkspaces: async () =>
       ipcRenderer.invoke(DESKTOP_IPC_CHANNELS.workspaceRecent),
+    linkCloudContext: async (workspaceId, input) =>
+      ipcRenderer.invoke(
+        DESKTOP_IPC_CHANNELS.workspaceLinkCloudContext,
+        workspaceId,
+        input,
+      ),
     linkProject: async (workspaceId, projectId) =>
       ipcRenderer.invoke(
         DESKTOP_IPC_CHANNELS.workspaceLinkProject,

--- a/apps/desktop/app/src/renderer/App.tsx
+++ b/apps/desktop/app/src/renderer/App.tsx
@@ -19,6 +19,21 @@ import type { DesktopAgentRunHandoff } from './views/AgentsView';
 
 const emptyBootstrap: IDesktopBootstrap = {
   betterAuthId: null,
+  authority: {
+    cloud: ['organization-membership', 'roles', 'shared-brand-settings'],
+    local: [
+      'private-drafts',
+      'local-generation',
+      'imported-files',
+      'unsynced-assets',
+    ],
+  },
+  cloudIdentity: {
+    localDeviceId: '',
+    localUserId: '',
+    status: 'never-connected',
+  },
+  cloudOrganizations: [],
   environment: {
     apiEndpoint: '',
     appEndpoint: '',
@@ -435,6 +450,8 @@ export const App = () => {
             activeThread={activeThread}
             isOnline={isOnline}
             pendingTrend={pendingTrend}
+            brands={bootstrap.brands}
+            cloudOrganizations={bootstrap.cloudOrganizations}
             selectedWorkspace={selectedWorkspace}
             selectedWorkspaceId={selectedWorkspaceId}
             onCreateThread={createThread}

--- a/apps/desktop/app/src/renderer/MainView.tsx
+++ b/apps/desktop/app/src/renderer/MainView.tsx
@@ -1,4 +1,6 @@
 import type {
+  IDesktopBrand,
+  IDesktopCloudOrganization,
   IDesktopMessage,
   IDesktopThread,
   IDesktopTrendHandoff,
@@ -52,6 +54,8 @@ const WorkflowsView = lazy(() =>
 interface MainViewProps {
   activeView: NavView;
   activeThread: IDesktopThread | null;
+  brands: IDesktopBrand[];
+  cloudOrganizations: IDesktopCloudOrganization[];
   isOnline: boolean;
   pendingTrend: IDesktopTrendHandoff | null;
   selectedWorkspace: IDesktopWorkspace | null;
@@ -68,6 +72,8 @@ interface MainViewProps {
 function MainView({
   activeView,
   activeThread,
+  brands,
+  cloudOrganizations,
   isOnline,
   pendingTrend,
   selectedWorkspace,
@@ -87,6 +93,8 @@ function MainView({
       onSetStatus={onSetStatus}
       onTrendConsumed={onTrendConsumed}
       pendingTrend={pendingTrend}
+      brands={brands}
+      cloudOrganizations={cloudOrganizations}
       thread={activeThread}
       workspaceId={selectedWorkspaceId}
     />

--- a/apps/desktop/app/src/renderer/offline/OfflineShell.test.tsx
+++ b/apps/desktop/app/src/renderer/offline/OfflineShell.test.tsx
@@ -5,8 +5,23 @@ import OfflineShell from './OfflineShell';
 
 const bootstrap: IDesktopBootstrap = {
   activeWorkspaceId: 'workspace-1',
+  authority: {
+    cloud: ['organization-membership', 'roles', 'shared-brand-settings'],
+    local: [
+      'private-drafts',
+      'local-generation',
+      'imported-files',
+      'unsynced-assets',
+    ],
+  },
   brands: [],
   betterAuthId: null,
+  cloudIdentity: {
+    localDeviceId: 'device-1',
+    localUserId: 'local-user',
+    status: 'never-connected',
+  },
+  cloudOrganizations: [],
   environment: {
     apiEndpoint: '',
     appEndpoint: '',

--- a/apps/desktop/app/src/renderer/views/ConversationComposerToolbar.tsx
+++ b/apps/desktop/app/src/renderer/views/ConversationComposerToolbar.tsx
@@ -2,6 +2,8 @@ import type {
   DesktopContentPlatform,
   DesktopContentType,
   DesktopPublishIntent,
+  IDesktopBrand,
+  IDesktopCloudOrganization,
   IDesktopCloudProject,
   IDesktopWorkspace,
 } from '@genfeedai/desktop-contracts';
@@ -61,17 +63,21 @@ const PUBLISH_INTENT_OPTIONS: Array<{
 ];
 
 const UNLINKED_PROJECT_VALUE = '__not_linked__';
+const UNLINKED_BRAND_VALUE = '__no_cloud_brand__';
 
 type ConversationComposerToolbarProps = {
   contentType: DesktopContentType;
   input: string;
   onContentTypeChange: (value: DesktopContentType) => void;
+  onBrandLink: (brandId: string, organizationId?: string) => Promise<void>;
   onImportAssets: () => Promise<void>;
   onPlatformChange: (value: DesktopContentPlatform) => void;
   onProjectLink: (projectId: string) => Promise<void>;
   onPublishIntentChange: (value: DesktopPublishIntent) => void;
   onSaveDraft: () => Promise<void>;
   platform: DesktopContentPlatform;
+  brands: IDesktopBrand[];
+  cloudOrganizations: IDesktopCloudOrganization[];
   projects: IDesktopCloudProject[];
   publishIntent: DesktopPublishIntent;
   workspace: IDesktopWorkspace | null;
@@ -81,7 +87,10 @@ type ConversationComposerToolbarProps = {
 export function ConversationComposerToolbar({
   contentType,
   input,
+  brands,
+  cloudOrganizations,
   onContentTypeChange,
+  onBrandLink,
   onImportAssets,
   onPlatformChange,
   onProjectLink,
@@ -93,6 +102,13 @@ export function ConversationComposerToolbar({
   workspace,
   workspaceId,
 }: ConversationComposerToolbarProps) {
+  const cloudOrgNamesById = new Map(
+    cloudOrganizations.map((organization) => [
+      organization.cloudId,
+      organization.name,
+    ]),
+  );
+
   return (
     <div className="composer-toolbar panel-card">
       <div className="composer-control-group">
@@ -158,6 +174,52 @@ export function ConversationComposerToolbar({
             {PUBLISH_INTENT_OPTIONS.map((option) => (
               <SelectItem key={option.value} value={option.value}>
                 {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="composer-control-group composer-project-group">
+        <label className="composer-label" htmlFor="desktop-brand-link">
+          Cloud brand
+        </label>
+        <Select
+          onValueChange={(value) => {
+            if (value === UNLINKED_BRAND_VALUE) {
+              void onBrandLink('');
+              return;
+            }
+
+            const brand = brands.find((item) => item.id === value);
+            void onBrandLink(
+              brand?.cloudId ?? value,
+              brand?.cloudOrganizationId,
+            );
+          }}
+          value={
+            workspace?.linkedBrandId
+              ? (brands.find(
+                  (brand) =>
+                    brand.cloudId === workspace.linkedBrandId ||
+                    brand.id === workspace.linkedBrandId,
+                )?.id ?? workspace.linkedBrandId)
+              : UNLINKED_BRAND_VALUE
+          }
+        >
+          <SelectTrigger id="desktop-brand-link">
+            <SelectValue placeholder="Local only" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNLINKED_BRAND_VALUE}>Local only</SelectItem>
+            {brands.map((brand) => (
+              <SelectItem key={brand.id} value={brand.id}>
+                {brand.cloudOrganizationId
+                  ? `${brand.name} - ${
+                      cloudOrgNamesById.get(brand.cloudOrganizationId) ??
+                      brand.cloudOrganizationId
+                    }`
+                  : brand.name}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/desktop/app/src/renderer/views/ConversationView.tsx
+++ b/apps/desktop/app/src/renderer/views/ConversationView.tsx
@@ -2,6 +2,8 @@ import type {
   DesktopContentPlatform,
   DesktopContentType,
   DesktopPublishIntent,
+  IDesktopBrand,
+  IDesktopCloudOrganization,
   IDesktopMessage,
   IDesktopThread,
   IDesktopTrendHandoff,
@@ -17,6 +19,8 @@ import { useConversationSend } from './useConversationSend';
 import { useConversationState } from './useConversationState';
 
 interface ConversationViewProps {
+  brands: IDesktopBrand[];
+  cloudOrganizations: IDesktopCloudOrganization[];
   onCreateThread: () => IDesktopThread;
   onSendMessage: (threadId: string, message: IDesktopMessage) => void;
   onSetStatus: (threadId: string, status: 'awaiting-response' | 'idle') => void;
@@ -30,6 +34,8 @@ export const ConversationView = ({
   onCreateThread,
   onSendMessage,
   onSetStatus,
+  brands,
+  cloudOrganizations,
   pendingTrend,
   onTrendConsumed,
   thread,
@@ -53,6 +59,7 @@ export const ConversationView = ({
     handleOpenCreditsCheckout,
     handleOpenProviderKeys,
     handleProjectLink,
+    handleBrandLink,
     handleSaveDraft,
     handleSaveProvider,
     handleTestProvider,
@@ -162,11 +169,14 @@ export const ConversationView = ({
               setPlatform as (v: DesktopContentPlatform) => void
             }
             onProjectLink={handleProjectLink}
+            onBrandLink={handleBrandLink}
             onPublishIntentChange={
               setPublishIntent as (v: DesktopPublishIntent) => void
             }
             onSaveDraft={handleSaveDraft}
             platform={platform}
+            brands={brands}
+            cloudOrganizations={cloudOrganizations}
             projects={projects}
             publishIntent={publishIntent}
             workspace={workspace}

--- a/apps/desktop/app/src/renderer/views/useConversationState.ts
+++ b/apps/desktop/app/src/renderer/views/useConversationState.ts
@@ -458,6 +458,22 @@ export function useConversationState({
     [workspaceId],
   );
 
+  const handleBrandLink = useCallback(
+    async (brandId: string, organizationId?: string) => {
+      if (!workspaceId) {
+        return;
+      }
+
+      const nextWorkspace =
+        await window.genfeedDesktop.workspace.linkCloudContext(workspaceId, {
+          cloudBrandId: brandId || null,
+          cloudOrganizationId: brandId ? (organizationId ?? null) : null,
+        });
+      setWorkspace(nextWorkspace);
+    },
+    [workspaceId],
+  );
+
   const applyProviderPreset = useCallback(
     (nextProviderKind: DesktopGenerationProviderKind) => {
       const preset = PROVIDER_PRESETS[nextProviderKind];
@@ -573,6 +589,7 @@ export function useConversationState({
     handleNewDraft,
     handleOpenCreditsCheckout,
     handleOpenProviderKeys,
+    handleBrandLink,
     handleProjectLink,
     handleSaveDraft,
     handleSaveProvider,

--- a/apps/desktop/app/src/shared/desktop-contracts.test.ts
+++ b/apps/desktop/app/src/shared/desktop-contracts.test.ts
@@ -17,6 +17,9 @@ describe('desktop shared packages', () => {
     expect(DESKTOP_IPC_CHANNELS.workspaceSelect).toBe(
       'desktop:workspace:select',
     );
+    expect(DESKTOP_IPC_CHANNELS.workspaceLinkCloudContext).toBe(
+      'desktop:workspace:linkCloudContext',
+    );
     expect(DESKTOP_IPC_CHANNELS.filesRevealAsset).toBe(
       'desktop:files:revealAsset',
     );

--- a/packages/desktop-contracts/src/index.ts
+++ b/packages/desktop-contracts/src/index.ts
@@ -67,6 +67,7 @@ export const DESKTOP_IPC_CHANNELS = {
   terminalResize: 'desktop:terminal:resize',
   terminalWrite: 'desktop:terminal:write',
   toggleSidebar: 'desktop:view:toggleSidebar',
+  workspaceLinkCloudContext: 'desktop:workspace:linkCloudContext',
   workspaceLinkProject: 'desktop:workspace:linkProject',
   workspaceOpen: 'desktop:workspace:open',
   workspaceRead: 'desktop:workspace:read',
@@ -154,10 +155,12 @@ export interface IDesktopWorkspaceFile {
 export interface IDesktopWorkspace {
   createdAt: string;
   fileIndex: IDesktopWorkspaceFile[];
+  cloudLink?: IDesktopWorkspaceCloudLink;
   id: string;
   indexingState: 'idle' | 'indexing';
   lastOpenedAt: string;
   linkedBrandId?: string;
+  linkedOrganizationId?: string;
   linkedProjectId?: string;
   localDraftCount: number;
   name: string;
@@ -195,8 +198,68 @@ export type DesktopSyncCursorScope = 'brandManifest' | 'threads';
 
 export type DesktopAssetUploadMode = 'api-proxy' | 'presigned-put';
 
+export type DesktopCloudLinkStatus =
+  | 'connected'
+  | 'never-connected'
+  | 'signed-out';
+
+export type DesktopCloudAuthority =
+  | 'organization-membership'
+  | 'roles'
+  | 'shared-brand-settings';
+
+export type DesktopLocalAuthority =
+  | 'imported-files'
+  | 'local-generation'
+  | 'private-drafts'
+  | 'unsynced-assets';
+
+export interface IDesktopCloudIdentity {
+  cloudUserEmail?: string;
+  cloudUserId?: string;
+  connectedAt?: string;
+  localDeviceId: string;
+  localUserId: string;
+  status: DesktopCloudLinkStatus;
+}
+
+export interface IDesktopCloudOrganization {
+  cloudId: string;
+  lastPulledAt?: string;
+  name: string;
+  role?: string;
+  slug: string;
+  updatedAt: string;
+}
+
+export interface IDesktopWorkspaceCloudLink {
+  cloudBrandId?: string;
+  cloudOrganizationId?: string;
+  cloudProjectId?: string;
+  cloudUserId?: string;
+  linkedAt: string;
+  localDeviceId: string;
+  localUserId: string;
+  syncPolicy: DesktopSyncPolicy;
+  updatedAt: string;
+  workspaceId: string;
+}
+
+export interface IDesktopWorkspaceCloudLinkInput {
+  cloudBrandId?: string | null;
+  cloudOrganizationId?: string | null;
+  cloudProjectId?: string | null;
+  syncPolicy?: DesktopSyncPolicy;
+}
+
+export interface IDesktopAuthoritySummary {
+  cloud: DesktopCloudAuthority[];
+  local: DesktopLocalAuthority[];
+}
+
 export interface IDesktopBrand {
   cloudId?: string;
+  cloudOrganizationId?: string;
   cloudVersion?: string;
   createdAt: string;
   id: string;
@@ -505,6 +568,9 @@ export interface IDesktopBootstrap {
   activeWorkspaceId: string | null;
   /** Better Auth user ID persisted locally after first cloud sign-in; null if never signed in */
   betterAuthId: string | null;
+  authority: IDesktopAuthoritySummary;
+  cloudIdentity: IDesktopCloudIdentity;
+  cloudOrganizations: IDesktopCloudOrganization[];
   environment: IDesktopEnvironment;
   isOfflineMode: boolean;
   localOrganization: IDesktopLocalOrganization;
@@ -877,6 +943,10 @@ export interface IGenfeedDesktopBridge {
   };
   workspace: {
     getRecentWorkspaces: () => Promise<IDesktopWorkspace[]>;
+    linkCloudContext: (
+      workspaceId: string,
+      input: IDesktopWorkspaceCloudLinkInput,
+    ) => Promise<IDesktopWorkspace>;
     linkProject: (
       workspaceId: string,
       projectId: string,

--- a/packages/desktop-prisma/prisma/migrations/0002_local_cloud_identity/migration.sql
+++ b/packages/desktop-prisma/prisma/migrations/0002_local_cloud_identity/migration.sql
@@ -1,0 +1,53 @@
+ALTER TABLE desktop_workspace
+  ADD COLUMN IF NOT EXISTS linked_organization_id TEXT;
+
+ALTER TABLE desktop_brand
+  ADD COLUMN IF NOT EXISTS cloud_organization_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_desktop_brand_cloud_org_updated
+  ON desktop_brand (cloud_organization_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS desktop_device_identity (
+  id TEXT PRIMARY KEY,
+  local_user_id TEXT NOT NULL,
+  cloud_user_id TEXT,
+  cloud_user_email TEXT,
+  status TEXT NOT NULL DEFAULT 'never-connected',
+  connected_at TEXT,
+  last_seen_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_desktop_device_identity_cloud_user
+  ON desktop_device_identity (cloud_user_id);
+
+CREATE TABLE IF NOT EXISTS desktop_cloud_organization (
+  cloud_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  role TEXT,
+  last_pulled_at TEXT,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_desktop_cloud_organization_slug
+  ON desktop_cloud_organization (slug);
+
+CREATE TABLE IF NOT EXISTS desktop_workspace_cloud_link (
+  workspace_id TEXT PRIMARY KEY
+    REFERENCES desktop_workspace (id) ON DELETE CASCADE,
+  local_user_id TEXT NOT NULL,
+  local_device_id TEXT NOT NULL,
+  cloud_user_id TEXT,
+  cloud_organization_id TEXT,
+  cloud_brand_id TEXT,
+  cloud_project_id TEXT,
+  sync_policy TEXT NOT NULL DEFAULT 'local-only',
+  linked_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_desktop_workspace_cloud_link_cloud_org
+  ON desktop_workspace_cloud_link (cloud_organization_id);
+CREATE INDEX IF NOT EXISTS idx_desktop_workspace_cloud_link_cloud_brand
+  ON desktop_workspace_cloud_link (cloud_brand_id);
+CREATE INDEX IF NOT EXISTS idx_desktop_workspace_cloud_link_cloud_project
+  ON desktop_workspace_cloud_link (cloud_project_id);

--- a/packages/desktop-prisma/prisma/schema.prisma
+++ b/packages/desktop-prisma/prisma/schema.prisma
@@ -8,54 +8,54 @@ datasource db {
 }
 
 model User {
-  id             String         @id
-  organizationId String         @map("organization_id")
-  authProviderId        String?        @unique @map("authProvider_id")
+  id             String       @id
+  organizationId String       @map("organization_id")
+  authProviderId String?      @unique @map("authProvider_id")
   email          String?
   name           String
-  createdAt      String         @map("created_at")
-  updatedAt      String         @map("updated_at")
-  organization   Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  createdAt      String       @map("created_at")
+  updatedAt      String       @map("updated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId])
   @@map("users")
 }
 
 model Organization {
-  id        String          @id
-  name      String
-  slug      String          @unique
-  createdAt String          @map("created_at")
-  updatedAt String          @map("updated_at")
-  users     User[]
-  posts     Post[]
-  trends    Trend[]
-  ingredients Ingredient[]
+  id              String          @id
+  name            String
+  slug            String          @unique
+  createdAt       String          @map("created_at")
+  updatedAt       String          @map("updated_at")
+  users           User[]
+  posts           Post[]
+  trends          Trend[]
+  ingredients     Ingredient[]
   agentStrategies AgentStrategy[]
-  workflows Workflow[]
+  workflows       Workflow[]
 
   @@map("organizations")
 }
 
 model Post {
-  id               String        @id
-  organizationId   String        @map("organization_id")
-  workspaceId      String?       @map("workspace_id")
+  id               String       @id
+  organizationId   String       @map("organization_id")
+  workspaceId      String?      @map("workspace_id")
   platform         String
   type             String
   prompt           String
   content          String
   status           String
-  publishIntent    String?       @map("publish_intent")
-  sourceDraftId    String?       @unique @map("source_draft_id")
-  sourceTrendId    String?       @map("source_trend_id")
-  sourceTrendTopic String?       @map("source_trend_topic")
-  publishedAt      String?       @map("published_at")
-  views            Int           @default(0)
-  engagements      Int           @default(0)
-  createdAt        String        @map("created_at")
-  updatedAt        String        @map("updated_at")
-  organization     Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  publishIntent    String?      @map("publish_intent")
+  sourceDraftId    String?      @unique @map("source_draft_id")
+  sourceTrendId    String?      @map("source_trend_id")
+  sourceTrendTopic String?      @map("source_trend_topic")
+  publishedAt      String?      @map("published_at")
+  views            Int          @default(0)
+  engagements      Int          @default(0)
+  createdAt        String       @map("created_at")
+  updatedAt        String       @map("updated_at")
+  organization     Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId, updatedAt(sort: Desc)])
   @@index([status, publishedAt(sort: Desc)])
@@ -64,16 +64,16 @@ model Post {
 }
 
 model Ingredient {
-  id                  String        @id
-  organizationId      String        @map("organization_id")
-  title               String
-  content             String
-  platform            String?
-  totalVotes          Int           @default(0) @map("total_votes")
-  sourcePostId        String?       @map("source_post_id")
-  createdAt           String        @map("created_at")
-  updatedAt           String        @map("updated_at")
-  organization        Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String       @id
+  organizationId String       @map("organization_id")
+  title          String
+  content        String
+  platform       String?
+  totalVotes     Int          @default(0) @map("total_votes")
+  sourcePostId   String?      @map("source_post_id")
+  createdAt      String       @map("created_at")
+  updatedAt      String       @map("updated_at")
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId, updatedAt(sort: Desc)])
   @@index([platform, totalVotes(sort: Desc)])
@@ -81,32 +81,32 @@ model Ingredient {
 }
 
 model Trend {
-  id              String        @id
-  organizationId  String        @map("organization_id")
+  id              String       @id
+  organizationId  String       @map("organization_id")
   platform        String
   topic           String
   summary         String?
-  viralityScore   Int           @map("virality_score")
-  engagementScore Int           @map("engagement_score")
-  createdAt       String        @map("created_at")
-  organization    Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  viralityScore   Int          @map("virality_score")
+  engagementScore Int          @map("engagement_score")
+  createdAt       String       @map("created_at")
+  organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId, platform, topic])
   @@map("trends")
 }
 
 model AgentStrategy {
-  id             String               @id
-  organizationId String               @map("organization_id")
+  id             String              @id
+  organizationId String              @map("organization_id")
   name           String
   avatar         String?
-  platformsJson  String               @default("[]") @map("platforms_json")
+  platformsJson  String              @default("[]") @map("platforms_json")
   status         String
-  isActive       Boolean              @default(true) @map("is_active")
-  lastRunAt      String?              @map("last_run_at")
-  createdAt      String               @map("created_at")
-  updatedAt      String               @map("updated_at")
-  organization   Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  isActive       Boolean             @default(true) @map("is_active")
+  lastRunAt      String?             @map("last_run_at")
+  createdAt      String              @map("created_at")
+  updatedAt      String              @map("updated_at")
+  organization   Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   workflows      WorkflowExecution[]
 
   @@index([organizationId, updatedAt(sort: Desc)])
@@ -114,17 +114,17 @@ model AgentStrategy {
 }
 
 model Workflow {
-  id             String               @id
-  organizationId String               @map("organization_id")
+  id             String              @id
+  organizationId String              @map("organization_id")
   name           String
   description    String?
   lifecycle      String
-  nodeCount      Int                  @map("node_count")
-  supportsBatch  Boolean              @default(false) @map("supports_batch")
-  lastExecutedAt String?              @map("last_executed_at")
-  createdAt      String               @map("created_at")
-  updatedAt      String               @map("updated_at")
-  organization   Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  nodeCount      Int                 @map("node_count")
+  supportsBatch  Boolean             @default(false) @map("supports_batch")
+  lastExecutedAt String?             @map("last_executed_at")
+  createdAt      String              @map("created_at")
+  updatedAt      String              @map("updated_at")
+  organization   Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   executions     WorkflowExecution[]
 
   @@index([organizationId, updatedAt(sort: Desc)])
@@ -155,39 +155,89 @@ model DesktopKv {
 }
 
 model DesktopWorkspace {
-  id               String  @id
-  name             String
-  path             String  @unique
-  linkedProjectId  String? @map("linked_project_id")
-  linkedBrandId    String? @map("linked_brand_id")
-  syncPolicy       String  @default("local-only") @map("sync_policy")
-  fileIndex        String  @default("[]") @map("file_index")
-  indexingState    String  @default("idle") @map("indexing_state")
-  localDraftCount  Int     @default(0) @map("local_draft_count")
-  pendingSyncCount Int     @default(0) @map("pending_sync_count")
-  createdAt        String  @map("created_at")
-  updatedAt        String  @map("updated_at")
-  lastOpenedAt     String  @map("last_opened_at")
+  id                   String                     @id
+  name                 String
+  path                 String                     @unique
+  linkedOrganizationId String?                    @map("linked_organization_id")
+  linkedProjectId      String?                    @map("linked_project_id")
+  linkedBrandId        String?                    @map("linked_brand_id")
+  syncPolicy           String                     @default("local-only") @map("sync_policy")
+  fileIndex            String                     @default("[]") @map("file_index")
+  indexingState        String                     @default("idle") @map("indexing_state")
+  localDraftCount      Int                        @default(0) @map("local_draft_count")
+  pendingSyncCount     Int                        @default(0) @map("pending_sync_count")
+  createdAt            String                     @map("created_at")
+  updatedAt            String                     @map("updated_at")
+  lastOpenedAt         String                     @map("last_opened_at")
+  cloudLink            DesktopWorkspaceCloudLink?
 
   @@index([lastOpenedAt(sort: Desc)])
   @@map("desktop_workspace")
 }
 
 model DesktopBrand {
-  id             String  @id
-  organizationId String  @map("organization_id")
-  cloudId        String? @unique @map("cloud_id")
-  name           String
-  slug           String
-  syncPolicy     String  @default("none") @map("sync_policy")
-  cloudVersion   String? @map("cloud_version")
-  lastPulledAt   String? @map("last_pulled_at")
-  createdAt      String  @map("created_at")
-  updatedAt      String  @map("updated_at")
+  id                  String  @id
+  organizationId      String  @map("organization_id")
+  cloudOrganizationId String? @map("cloud_organization_id")
+  cloudId             String? @unique @map("cloud_id")
+  name                String
+  slug                String
+  syncPolicy          String  @default("none") @map("sync_policy")
+  cloudVersion        String? @map("cloud_version")
+  lastPulledAt        String? @map("last_pulled_at")
+  createdAt           String  @map("created_at")
+  updatedAt           String  @map("updated_at")
 
   @@unique([organizationId, slug])
   @@index([organizationId, updatedAt(sort: Desc)])
+  @@index([cloudOrganizationId, updatedAt(sort: Desc)])
   @@map("desktop_brand")
+}
+
+model DesktopDeviceIdentity {
+  id             String  @id
+  localUserId    String  @map("local_user_id")
+  cloudUserId    String? @map("cloud_user_id")
+  cloudUserEmail String? @map("cloud_user_email")
+  status         String  @default("never-connected")
+  connectedAt    String? @map("connected_at")
+  lastSeenAt     String? @map("last_seen_at")
+  createdAt      String  @map("created_at")
+  updatedAt      String  @map("updated_at")
+
+  @@index([cloudUserId])
+  @@map("desktop_device_identity")
+}
+
+model DesktopCloudOrganization {
+  cloudId      String  @id @map("cloud_id")
+  name         String
+  slug         String
+  role         String?
+  lastPulledAt String? @map("last_pulled_at")
+  updatedAt    String  @map("updated_at")
+
+  @@index([slug])
+  @@map("desktop_cloud_organization")
+}
+
+model DesktopWorkspaceCloudLink {
+  workspaceId         String           @id @map("workspace_id")
+  localUserId         String           @map("local_user_id")
+  localDeviceId       String           @map("local_device_id")
+  cloudUserId         String?          @map("cloud_user_id")
+  cloudOrganizationId String?          @map("cloud_organization_id")
+  cloudBrandId        String?          @map("cloud_brand_id")
+  cloudProjectId      String?          @map("cloud_project_id")
+  syncPolicy          String           @default("local-only") @map("sync_policy")
+  linkedAt            String           @map("linked_at")
+  updatedAt           String           @map("updated_at")
+  workspace           DesktopWorkspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([cloudOrganizationId])
+  @@index([cloudBrandId])
+  @@index([cloudProjectId])
+  @@map("desktop_workspace_cloud_link")
 }
 
 model DesktopAsset {
@@ -241,15 +291,15 @@ model DesktopSyncOp {
 }
 
 model DesktopSyncJob {
-  id         String  @id
+  id          String  @id
   workspaceId String? @map("workspace_id")
-  type       String
-  payload    String
-  status     String
-  error      String?
-  retryCount Int     @default(0) @map("retry_count")
-  createdAt  String  @map("created_at")
-  updatedAt  String  @map("updated_at")
+  type        String
+  payload     String
+  status      String
+  error       String?
+  retryCount  Int     @default(0) @map("retry_count")
+  createdAt   String  @map("created_at")
+  updatedAt   String  @map("updated_at")
 
   @@index([workspaceId, updatedAt(sort: Desc)])
   @@index([status, updatedAt(sort: Desc)])


### PR DESCRIPTION
## Summary
- add durable desktop local user/device identity and expose cloud/local authority in desktop bootstrap
- persist cloud organization, brand, and project links for workspaces through Prisma/PGlite and desktop IPC
- reconcile cloud organization/brand manifest metadata and add a desktop Cloud brand selector

Closes #315
Refs #735

## Validation
- `bunx biome check --write apps/desktop/app/src/main.ts apps/desktop/app/src/main/local-identity.service.ts apps/desktop/app/src/main/local-identity.service.test.ts apps/desktop/app/src/main/pglite.service.test.ts apps/desktop/app/src/main/prisma.service.ts apps/desktop/app/src/main/release-qa.test.ts apps/desktop/app/src/main/sync.service.ts apps/desktop/app/src/main/sync.service.test.ts apps/desktop/app/src/main/workspace.service.ts apps/desktop/app/src/main/workspace.service.test.ts apps/desktop/app/src/preload.ts apps/desktop/app/src/renderer/App.tsx apps/desktop/app/src/renderer/MainView.tsx apps/desktop/app/src/renderer/offline/OfflineShell.test.tsx apps/desktop/app/src/renderer/views/ConversationComposerToolbar.tsx apps/desktop/app/src/renderer/views/ConversationView.tsx apps/desktop/app/src/renderer/views/useConversationState.ts apps/desktop/app/src/shared/desktop-contracts.test.ts packages/desktop-contracts/src/index.ts`
- `bunx prisma generate --schema packages/desktop-prisma/prisma/schema.prisma`
- `bunx prisma validate --schema packages/desktop-prisma/prisma/schema.prisma`
- `bun run --cwd apps/desktop/app type-check`
- `bun run --cwd apps/desktop/app test`
- `git diff HEAD~1 --check`
- `git diff --cached --name-only -z | xargs -0 bun scripts/run-secretlint.ts`

## Notes
- `bun run --cwd packages/desktop-prisma db:generate` still cannot find a package-local `prisma` binary in this workspace, so generation was verified with `bunx prisma generate`.
