### PR TITLE
fix(deploy): bound boot smoke shutdown

### DIFF
--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -50,6 +50,7 @@ import helmet from 'helmet';
 import gptActionsSpec from './config/gpt-actions-openapi.json';
 
 const apiDir = dirname(fileURLToPath(import.meta.url));
+const BOOT_SMOKE_CLOSE_TIMEOUT_MS = 10_000;
 
 async function main() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -284,7 +285,7 @@ async function main() {
       // exit cleanly without listening. Any boot failure throws into the catch
       // below, which exits non-zero so the gate fails.
       await app.init();
-      await app.close();
+      await closeBootSmokeApplication(app, logger);
       logger.debug('Boot smoke OK — API initialized cleanly.');
       process.exit(0);
     }
@@ -296,6 +297,49 @@ async function main() {
     if (process.env.BOOT_SMOKE === '1') {
       // Fail the boot-smoke gate loudly — never let a startup error pass as green.
       process.exit(1);
+    }
+  }
+}
+
+async function closeBootSmokeApplication(
+  app: NestExpressApplication,
+  logger: LoggerService,
+): Promise<void> {
+  try {
+    await withTimeout(
+      app.close(),
+      BOOT_SMOKE_CLOSE_TIMEOUT_MS,
+      `Boot smoke app.close timed out after ${BOOT_SMOKE_CLOSE_TIMEOUT_MS}ms`,
+    );
+  } catch (error: unknown) {
+    logger.warn(
+      error instanceof Error
+        ? error.message
+        : `Boot smoke app.close failed: ${String(error)}`,
+    );
+  }
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(timeoutMessage)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bound BOOT_SMOKE app.close() with a 10s timeout so a successful API init cannot leave the one-off ECS boot-smoke task running until the deploy deadline.
- Keep boot-smoke strict: app.init() failures still exit non-zero, while close-timeout warnings still allow the already-validated boot to exit 0.
- Matches the bounded close pattern already used by the workflow backfill migration entrypoint.

## Deploy failure addressed
- Production deploy run: https://github.com/genfeedai/genfeed.ai/actions/runs/28369178283
- Failed step: Boot smoke — verify new image boots
- Error: boot smoke task did not stop within 10m (last status: RUNNING, reason: None)
- Service rollout did not occur; failure happened before Tofu apply.

## Verification
- bunx biome check --write apps/server/api/src/main.ts
- bunx biome check apps/server/api/src/main.ts
- bun run --cwd apps/server/api build
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js

Note: no local gitleaks run.