### PR TITLE
[codex] Publish branded MCP setup docs with shared UI surfaces

### DIFF
--- a/apps/docs/content/api-reference/_meta.ts
+++ b/apps/docs/content/api-reference/_meta.ts
@@ -1,4 +1,5 @@
 export default {
   index: 'Overview',
+  mcp: 'MCP Server',
   reference: 'Endpoint Reference',
 };

--- a/apps/docs/content/api-reference/mcp.mdx
+++ b/apps/docs/content/api-reference/mcp.mdx
@@ -1,11 +1,11 @@
 ---
 title: MCP Server
-description: Connect Genfeed.ai to Claude Code, Codex, and any Streamable HTTP MCP client.
+description: Connect Genfeed.ai to Claude Code, Codex, or any Streamable HTTP MCP client.
 ---
 
 # MCP Server
 
-Genfeed.ai runs a hosted Model Context Protocol server so AI clients can work with Genfeed content, media generation, workflows, publishing, analytics, ads, and agent threads using your own API key permissions.
+Use the hosted Genfeed MCP server to give AI clients API-key scoped access to content, workflows, publishing, analytics, and ads.
 
 **Endpoint:** `https://mcp.genfeed.ai/mcp`
 
@@ -13,11 +13,11 @@ Genfeed.ai runs a hosted Model Context Protocol server so AI clients can work wi
 
 **Authentication:** `Authorization: Bearer <gf_... API key>`.
 
-Visit [`https://mcp.genfeed.ai`](https://mcp.genfeed.ai) in a browser for a short connection page with Claude Code and Codex setup tabs.
+Open [`https://mcp.genfeed.ai`](https://mcp.genfeed.ai) for Claude Code and Codex setup.
 
 ## Create an API Key
 
-Create a Genfeed API key in app settings, then export it where your MCP client runs:
+Create a key in Genfeed app settings and export it where your MCP client runs:
 
 ```bash
 export GENFEED_API_KEY=gf_live_xxx
@@ -43,7 +43,7 @@ You can also open `/mcp` inside Claude Code and inspect the `genfeed` server.
 
 ## Connect Codex
 
-Codex CLI and the Codex IDE extension share MCP configuration through `~/.codex/config.toml`. Add the server with:
+Codex CLI and the Codex IDE share `~/.codex/config.toml`. Add the server with:
 
 ```bash
 codex mcp add genfeed --url https://mcp.genfeed.ai/mcp --bearer-token-env-var GENFEED_API_KEY
@@ -57,30 +57,29 @@ url = "https://mcp.genfeed.ai/mcp"
 bearer_token_env_var = "GENFEED_API_KEY"
 ```
 
-## What the Agent Can Do
+## Tools
 
-The MCP server exposes Genfeed as a set of tools and resources. Each call runs with the API key permissions attached to the request.
+Each call uses the permissions on the API key.
 
-- **Content and media:** create and inspect articles, images, videos, music, avatars, darkroom jobs, and batch generation.
-- **Workflows:** list templates, create workflows, execute workflows, and inspect run status.
-- **Publishing:** list social posts, publish content, and inspect publishing state.
-- **Analytics and ads:** read analytics, ad insights, campaign data, Google Ads, and Meta Ads surfaces.
-- **Agent control:** create and inspect agent threads, run agent chat, and resolve approval-gated actions.
-- **Admin tools:** superadmin-only infrastructure and approval tools stay role-gated.
+- **Content and media:** articles, images, videos, music, avatars, batches.
+- **Workflows:** list, create, execute, inspect status.
+- **Publishing:** list and publish social posts.
+- **Analytics and ads:** analytics, campaigns, Google Ads, Meta Ads.
+- **Agents and admin:** threads, approvals, role-gated admin tools.
 
 ## HTTP Details
 
-The MCP endpoint accepts `POST`, `GET`, and `DELETE` per the Streamable HTTP transport. Production requests must include:
+The endpoint accepts `POST`, `GET`, and `DELETE`. Production requests must include:
 
 ```http
 Authorization: Bearer gf_live_xxx
 ```
 
-Unauthenticated requests return a JSON-RPC unauthorized error. Invalid or expired keys return a 401 with the API authentication error.
+Missing, invalid, or expired keys return 401 errors.
 
 ## Local Self-Hosted Surface
 
-Self-hosted Genfeed exposes the same MCP surface locally at `http://localhost:3014/mcp` when the MCP service is running. The hosted cloud endpoint remains:
+Self-hosted Genfeed uses `http://localhost:3014/mcp` when the MCP service is running. Cloud uses:
 
 ```text
 https://mcp.genfeed.ai/mcp
@@ -88,6 +87,6 @@ https://mcp.genfeed.ai/mcp
 
 ## Troubleshooting
 
-- **Client cannot discover the server:** confirm the URL is exactly `https://mcp.genfeed.ai/mcp` and that your client supports Streamable HTTP.
-- **Unauthorized errors:** confirm `GENFEED_API_KEY` is set in the environment where the client runs, starts with `gf_`, and is sent as a bearer token.
-- **Wrong endpoint in docs or config:** use `/v1/config` on the MCP host and verify it returns `https://mcp.genfeed.ai/mcp`.
+- **Discovery fails:** use exactly `https://mcp.genfeed.ai/mcp` and a Streamable HTTP client.
+- **401 errors:** confirm `GENFEED_API_KEY` is set and sent as a bearer token.
+- **Wrong endpoint:** check `/v1/config` on the MCP host.

--- a/apps/docs/content/api-reference/mcp.mdx
+++ b/apps/docs/content/api-reference/mcp.mdx
@@ -1,0 +1,93 @@
+---
+title: MCP Server
+description: Connect Genfeed.ai to Claude Code, Codex, and any Streamable HTTP MCP client.
+---
+
+# MCP Server
+
+Genfeed.ai runs a hosted Model Context Protocol server so AI clients can work with Genfeed content, media generation, workflows, publishing, analytics, ads, and agent threads using your own API key permissions.
+
+**Endpoint:** `https://mcp.genfeed.ai/mcp`
+
+**Transport:** Streamable HTTP.
+
+**Authentication:** `Authorization: Bearer <gf_... API key>`.
+
+Visit [`https://mcp.genfeed.ai`](https://mcp.genfeed.ai) in a browser for a short connection page with Claude Code and Codex setup tabs.
+
+## Create an API Key
+
+Create a Genfeed API key in app settings, then export it where your MCP client runs:
+
+```bash
+export GENFEED_API_KEY=gf_live_xxx
+```
+
+Treat API keys like passwords. Do not commit them or paste them into shared logs.
+
+## Connect Claude Code
+
+Claude Code can connect remote HTTP MCP servers from the terminal:
+
+```bash
+claude mcp add --transport http genfeed --scope user https://mcp.genfeed.ai/mcp --header "Authorization: Bearer $GENFEED_API_KEY"
+```
+
+Verify with:
+
+```bash
+claude mcp list
+```
+
+You can also open `/mcp` inside Claude Code and inspect the `genfeed` server.
+
+## Connect Codex
+
+Codex CLI and the Codex IDE extension share MCP configuration through `~/.codex/config.toml`. Add the server with:
+
+```bash
+codex mcp add genfeed --url https://mcp.genfeed.ai/mcp --bearer-token-env-var GENFEED_API_KEY
+```
+
+Equivalent `config.toml`:
+
+```toml
+[mcp_servers.genfeed]
+url = "https://mcp.genfeed.ai/mcp"
+bearer_token_env_var = "GENFEED_API_KEY"
+```
+
+## What the Agent Can Do
+
+The MCP server exposes Genfeed as a set of tools and resources. Each call runs with the API key permissions attached to the request.
+
+- **Content and media:** create and inspect articles, images, videos, music, avatars, darkroom jobs, and batch generation.
+- **Workflows:** list templates, create workflows, execute workflows, and inspect run status.
+- **Publishing:** list social posts, publish content, and inspect publishing state.
+- **Analytics and ads:** read analytics, ad insights, campaign data, Google Ads, and Meta Ads surfaces.
+- **Agent control:** create and inspect agent threads, run agent chat, and resolve approval-gated actions.
+- **Admin tools:** superadmin-only infrastructure and approval tools stay role-gated.
+
+## HTTP Details
+
+The MCP endpoint accepts `POST`, `GET`, and `DELETE` per the Streamable HTTP transport. Production requests must include:
+
+```http
+Authorization: Bearer gf_live_xxx
+```
+
+Unauthenticated requests return a JSON-RPC unauthorized error. Invalid or expired keys return a 401 with the API authentication error.
+
+## Local Self-Hosted Surface
+
+Self-hosted Genfeed exposes the same MCP surface locally at `http://localhost:3014/mcp` when the MCP service is running. The hosted cloud endpoint remains:
+
+```text
+https://mcp.genfeed.ai/mcp
+```
+
+## Troubleshooting
+
+- **Client cannot discover the server:** confirm the URL is exactly `https://mcp.genfeed.ai/mcp` and that your client supports Streamable HTTP.
+- **Unauthorized errors:** confirm `GENFEED_API_KEY` is set in the environment where the client runs, starts with `gf_`, and is sent as a bearer token.
+- **Wrong endpoint in docs or config:** use `/v1/config` on the MCP host and verify it returns `https://mcp.genfeed.ai/mcp`.

--- a/apps/server/mcp/package.json
+++ b/apps/server/mcp/package.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "@genfeedai/config": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",
-    "@genfeedai/tools": "workspace:*"
+    "@genfeedai/tools": "workspace:*",
+    "@genfeedai/ui": "workspace:*"
   },
   "description": "Genfeed MCP Server",
   "devDependencies": {

--- a/apps/server/mcp/src/config/app-metadata.json
+++ b/apps/server/mcp/src/config/app-metadata.json
@@ -32,9 +32,12 @@
   "icon": "https://api.genfeed.ai/favicon.ico",
   "mcp": {
     "server": {
-      "args": ["-y", "@genfeedai/mcp-client"],
-      "command": "npx",
-      "type": "stdio"
+      "headers": {
+        "Authorization": "Bearer ${GENFEED_API_KEY}"
+      },
+      "transport": "streamable-http",
+      "type": "http",
+      "url": "https://mcp.genfeed.ai/mcp"
     }
   },
   "name": "Genfeed AI",

--- a/apps/server/mcp/src/main.ts
+++ b/apps/server/mcp/src/main.ts
@@ -8,6 +8,7 @@ import { getGenfeedCorsOptions } from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
 import { AppModule } from '@mcp/app.module';
 import { ConfigService } from '@mcp/config/config.service';
+import { renderSetupPage } from '@mcp/mcp/setup-page';
 import { AuthService, type McpRole } from '@mcp/services/auth.service';
 import { ServerService } from '@mcp/services/server.service';
 import { StreamableHttpService } from '@mcp/services/streamable-http.service';
@@ -25,6 +26,19 @@ interface AuthenticatedRequest extends Request {
   };
 }
 
+const MCP_CORS_ALLOWED_HEADERS = [
+  'Authorization',
+  'Content-Type',
+  'Last-Event-ID',
+  'Mcp-Protocol-Version',
+  'Mcp-Session-Id',
+].join(', ');
+
+const MCP_CORS_EXPOSED_HEADERS = [
+  'Mcp-Protocol-Version',
+  'Mcp-Session-Id',
+].join(', ');
+
 async function main(): Promise<void> {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     abortOnError: false,
@@ -40,13 +54,15 @@ async function main(): Promise<void> {
 
   const port = configService.get('PORT');
 
-  app.enableCors(
-    getGenfeedCorsOptions({
+  app.enableCors({
+    ...getGenfeedCorsOptions({
       additionalOrigins: ['https://mcp.genfeed.ai'],
       chromeExtensionId: configService.get('CHROME_EXTENSION_ID'),
       isDevelopment: configService.get('NODE_ENV') === 'development',
     }),
-  );
+    allowedHeaders: MCP_CORS_ALLOWED_HEADERS,
+    exposedHeaders: MCP_CORS_EXPOSED_HEADERS,
+  });
 
   const expressApp = app.getHttpAdapter().getInstance();
 
@@ -58,16 +74,30 @@ async function main(): Promise<void> {
     const token = authService.extractBearerToken(req.headers.authorization);
 
     if (!token) {
-      res
-        .status(401)
-        .json({ error: 'Authorization header with Bearer token required' });
+      res.setHeader('WWW-Authenticate', 'Bearer');
+      res.status(401).json({
+        error: {
+          code: -32001,
+          message: 'Unauthorized. Connect with a Genfeed API key bearer token.',
+        },
+        id: null,
+        jsonrpc: '2.0',
+      });
       return;
     }
 
     const authResult = await authService.authenticateRequest(token);
 
     if (!authResult.valid) {
-      res.status(401).json({ error: authResult.error || 'Invalid token' });
+      res.setHeader('WWW-Authenticate', 'Bearer');
+      res.status(401).json({
+        error: {
+          code: -32001,
+          message: authResult.error || 'Invalid token',
+        },
+        id: null,
+        jsonrpc: '2.0',
+      });
       return;
     }
 
@@ -113,8 +143,23 @@ async function main(): Promise<void> {
   );
 
   app.use('/', (req: Request, res: Response, next: NextFunction) => {
-    const redirectPaths = ['/', '/docs', '/v1'];
-    if (redirectPaths.includes(req.path)) {
+    if (req.path === '/' || req.path === '/docs') {
+      const preferred = req.accepts(['html', 'json']);
+      if (preferred === 'json') {
+        res.json({
+          endpoint: '/mcp',
+          service: 'mcp',
+          status: 'healthy',
+          transport: 'streamable-http',
+        });
+        return;
+      }
+
+      res.type('html').send(renderSetupPage());
+      return;
+    }
+
+    if (req.path === '/v1') {
       res.redirect('/v1/docs');
     } else {
       next();

--- a/apps/server/mcp/src/main.ts
+++ b/apps/server/mcp/src/main.ts
@@ -8,7 +8,7 @@ import { getGenfeedCorsOptions } from '@libs/config/cors.config';
 import { LoggerService } from '@libs/logger/logger.service';
 import { AppModule } from '@mcp/app.module';
 import { ConfigService } from '@mcp/config/config.service';
-import { renderSetupPage } from '@mcp/mcp/setup-page';
+import { getPublicMcpUrl, renderSetupPage } from '@mcp/mcp/setup-page';
 import { AuthService, type McpRole } from '@mcp/services/auth.service';
 import { ServerService } from '@mcp/services/server.service';
 import { StreamableHttpService } from '@mcp/services/streamable-http.service';
@@ -147,7 +147,7 @@ async function main(): Promise<void> {
       const preferred = req.accepts(['html', 'json']);
       if (preferred === 'json') {
         res.json({
-          endpoint: '/mcp',
+          endpoint: getPublicMcpUrl(),
           service: 'mcp',
           status: 'healthy',
           transport: 'streamable-http',

--- a/apps/server/mcp/src/mcp/controllers/mcp.controller.spec.ts
+++ b/apps/server/mcp/src/mcp/controllers/mcp.controller.spec.ts
@@ -115,8 +115,13 @@ describe('McpController', () => {
     controller = module.get<McpController>(McpController);
   });
 
+  beforeEach(() => {
+    vi.stubEnv('GENFEED_MCP_RESOURCE_URL', '');
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('should be defined', () => {

--- a/apps/server/mcp/src/mcp/controllers/mcp.controller.spec.ts
+++ b/apps/server/mcp/src/mcp/controllers/mcp.controller.spec.ts
@@ -5,12 +5,59 @@ import { ClientService } from '@mcp/services/client.service';
 import { ServerService } from '@mcp/services/server.service';
 import { Test, TestingModule } from '@nestjs/testing';
 
+type AuthenticatedControllerRequest = Parameters<McpController['callTool']>[2];
+
+vi.mock('@genfeedai/tools', () => ({
+  getToolsForSurface: vi.fn(() => [
+    {
+      inputSchema: { type: 'object' },
+      name: 'generate_video',
+    },
+    {
+      inputSchema: { type: 'object' },
+      name: 'get_video_status',
+    },
+    {
+      inputSchema: { type: 'object' },
+      name: 'list_videos',
+    },
+    {
+      inputSchema: { type: 'object' },
+      name: 'get_video_analytics',
+    },
+  ]),
+  toMcpTools: vi.fn((tools: unknown) => tools),
+}));
+
+vi.mock('@mcp/services/client.service', () => ({
+  ClientService: class ClientService {},
+}));
+
+vi.mock('@mcp/services/server.service', () => ({
+  ServerService: class ServerService {},
+}));
+
+vi.mock('@mcp/guards/mcp-auth.guard', () => ({
+  McpAuthGuard: class McpAuthGuard {},
+  Public: () => () => undefined,
+}));
+
 describe('McpController', () => {
   let controller: McpController;
 
   const mockMcpService = {
     getHello: vi.fn().mockReturnValue('Genfeed MCP Server'),
-    getMcpConfiguration: vi.fn().mockReturnValue({ version: '1.0.0' }),
+    getMcpConfiguration: vi.fn().mockReturnValue({
+      mcpServers: {
+        genfeed: {
+          headers: { Authorization: 'Bearer ${GENFEED_API_KEY}' },
+          transport: 'streamable-http',
+          type: 'http',
+          url: 'https://mcp.genfeed.ai/mcp',
+        },
+      },
+      version: '1.0.0',
+    }),
     getMcpExample: vi.fn().mockReturnValue({ example: 'data' }),
   };
 
@@ -92,6 +139,11 @@ describe('McpController', () => {
     it('should return MCP configuration', () => {
       const result = controller.getMcpConfiguration();
       expect(result).toHaveProperty('version', '1.0.0');
+      expect(result.mcpServers).toHaveProperty('genfeed');
+      expect(result.mcpServers.genfeed).toMatchObject({
+        type: 'http',
+        url: 'https://mcp.genfeed.ai/mcp',
+      });
       expect(result).toHaveProperty('streamableHttp');
       expect(result.streamableHttp).toHaveProperty(
         'endpoint',
@@ -110,6 +162,30 @@ describe('McpController', () => {
       const result = controller.getMcpExample();
       expect(result).toEqual({ example: 'data' });
       expect(mockMcpService.getMcpExample).toHaveBeenCalled();
+    });
+  });
+
+  describe('getMcpDocumentation', () => {
+    it('returns the production setup page for Claude Code and Codex', () => {
+      const response = {
+        send: vi.fn(),
+        setHeader: vi.fn(),
+      } as unknown as {
+        send: ReturnType<typeof vi.fn>;
+        setHeader: ReturnType<typeof vi.fn>;
+      };
+
+      controller.getMcpDocumentation(response as never);
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Content-Type',
+        'text/html',
+      );
+      const html = response.send.mock.calls[0]?.[0] as string;
+      expect(html).toContain('https://mcp.genfeed.ai/mcp');
+      expect(html).toContain('Claude Code setup');
+      expect(html).toContain('Codex setup');
+      expect(html).not.toContain('http://localhost:3014');
     });
   });
 
@@ -133,7 +209,7 @@ describe('McpController', () => {
 
       // Check canonical video tool exists
       const createVideoTool = result.tools.find(
-        (t: any) => t.name === 'generate_video',
+        (tool) => tool.name === 'generate_video',
       );
       expect(createVideoTool).toBeDefined();
       expect(createVideoTool?.inputSchema).toBeDefined();
@@ -148,7 +224,7 @@ describe('McpController', () => {
       expect(result.resources.length).toBe(2);
 
       const videoAnalytics = result.resources.find(
-        (r: any) => r.uri === 'genfeed://analytics/videos',
+        (resource) => resource.uri === 'genfeed://analytics/videos',
       );
       expect(videoAnalytics).toBeDefined();
     });
@@ -161,7 +237,7 @@ describe('McpController', () => {
         token: 'test-token',
         userId: 'user-456',
       },
-    } as any;
+    } as AuthenticatedControllerRequest;
 
     it('should call generate_video tool', async () => {
       const args = {
@@ -254,7 +330,7 @@ describe('McpController', () => {
         token: 'test-token',
         userId: 'user-456',
       },
-    } as any;
+    } as AuthenticatedControllerRequest;
 
     it('should read video analytics resource', async () => {
       mockClientService.getVideoAnalytics.mockResolvedValue({

--- a/apps/server/mcp/src/mcp/controllers/mcp.controller.ts
+++ b/apps/server/mcp/src/mcp/controllers/mcp.controller.ts
@@ -71,6 +71,13 @@ export class McpController {
   getManifest() {
     return {
       ...appMetadata,
+      mcp: {
+        ...appMetadata.mcp,
+        server: {
+          ...appMetadata.mcp.server,
+          url: getPublicMcpUrl(),
+        },
+      },
       mcp_version: '1.18.1',
       server_running: this.serverService.isServerRunning(),
       server_version: '1.0.0',

--- a/apps/server/mcp/src/mcp/controllers/mcp.controller.ts
+++ b/apps/server/mcp/src/mcp/controllers/mcp.controller.ts
@@ -3,6 +3,7 @@ import { LoggerService } from '@libs/logger/logger.service';
 import * as appMetadata from '@mcp/config/app-metadata.json';
 import { Public } from '@mcp/guards/mcp-auth.guard';
 import { MCPService } from '@mcp/mcp/services/mcp.service';
+import { getPublicMcpUrl, renderSetupPage } from '@mcp/mcp/setup-page';
 import { ClientService } from '@mcp/services/client.service';
 import { ServerService } from '@mcp/services/server.service';
 import { Body, Controller, Get, Param, Post, Req, Res } from '@nestjs/common';
@@ -31,11 +32,12 @@ export class McpController {
   @Get('config')
   getMcpConfiguration() {
     const config = this.mcpService.getMcpConfiguration();
+    const endpoint = getPublicMcpUrl();
     return {
       ...config,
       streamableHttp: {
         auth: 'Bearer token (API key starting with gf_)',
-        endpoint: 'https://mcp.genfeed.ai/mcp',
+        endpoint,
         methods: ['POST', 'GET', 'DELETE'],
         protocol: 'MCP 2025-03-26',
         transport: 'streamable-http',
@@ -46,9 +48,11 @@ export class McpController {
   @Public()
   @Get('mcp-info')
   getMcpInfo() {
+    const endpoint = getPublicMcpUrl();
+
     return {
       auth: 'Bearer token (API key starting with gf_)',
-      endpoint: 'https://mcp.genfeed.ai/mcp',
+      endpoint,
       methods: ['POST', 'GET', 'DELETE'],
       protocol: 'MCP 2025-03-26',
       serverRunning: this.serverService.isServerRunning(),
@@ -292,344 +296,7 @@ export class McpController {
   @Public()
   @Get('docs')
   getMcpDocumentation(@Res() res: Response) {
-    const html = this.getHomePageHtml();
     res.setHeader('Content-Type', 'text/html');
-    res.send(html);
-  }
-
-  private getHomePageHtml(): string {
-    return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Genfeed MCP Server</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            padding: 20px;
-        }
-        .container {
-            max-width: 900px;
-            background: white;
-            border-radius: 20px;
-            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-            overflow: hidden;
-        }
-        .header {
-            background: linear-gradient(135deg, #764ba2 0%, #667eea 100%);
-            color: white;
-            padding: 40px;
-            text-align: center;
-        }
-        .header h1 {
-            font-size: 2.5em;
-            margin-bottom: 10px;
-        }
-        .header p {
-            font-size: 1.2em;
-            opacity: 0.9;
-        }
-        .content {
-            padding: 40px;
-        }
-        .section {
-            margin-bottom: 40px;
-        }
-        .section h2 {
-            color: #667eea;
-            margin-bottom: 20px;
-            font-size: 1.8em;
-        }
-        .code-block {
-            background: #f4f4f4;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            padding: 20px;
-            margin: 15px 0;
-            font-family: 'Courier New', monospace;
-            overflow-x: auto;
-        }
-        .endpoint {
-            background: #e8f4fd;
-            border-left: 4px solid #667eea;
-            padding: 15px;
-            margin: 15px 0;
-            border-radius: 4px;
-        }
-        .endpoint strong {
-            color: #667eea;
-        }
-        .tools-list, .resources-list {
-            list-style: none;
-            padding: 0;
-        }
-        .tools-list li, .resources-list li {
-            background: #f8f9fa;
-            padding: 15px;
-            margin: 10px 0;
-            border-radius: 8px;
-            border-left: 4px solid #667eea;
-        }
-        .tools-list li strong, .resources-list li strong {
-            color: #667eea;
-            display: block;
-            margin-bottom: 5px;
-        }
-        .status {
-            display: inline-block;
-            padding: 5px 15px;
-            background: #4caf50;
-            color: white;
-            border-radius: 20px;
-            font-weight: bold;
-            margin-top: 10px;
-        }
-        .warning {
-            background: #fff3cd;
-            border: 1px solid #ffc107;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-            color: #856404;
-        }
-        .footer {
-            text-align: center;
-            padding: 20px;
-            background: #f8f9fa;
-            color: #666;
-        }
-        .config-section {
-            background: #f0f9ff;
-            border: 1px solid #0ea5e9;
-            border-radius: 8px;
-            padding: 20px;
-            margin: 20px 0;
-        }
-        .config-section h3 {
-            color: #0ea5e9;
-            margin-bottom: 15px;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>🎬 Genfeed MCP Server</h1>
-            <p>Model Context Protocol for AI Video Generation & Analytics</p>
-            <div class="status">Active</div>
-        </div>
-
-        <div class="content">
-            <div class="section">
-                <h2>🔌 Connection Details</h2>
-                <div class="endpoint">
-                    <strong>Server Endpoint:</strong> http://localhost:3014
-                </div>
-                <div class="endpoint">
-                    <strong>Health Check:</strong> GET http://localhost:3014/v1/health
-                </div>
-                <div class="endpoint">
-                    <strong>Configuration:</strong> GET http://localhost:3014/config
-                </div>
-                <div class="endpoint">
-                    <strong>Example:</strong> GET http://localhost:3014/example
-                </div>
-            </div>
-
-            <div class="section">
-                <h2>🔐 Authentication</h2>
-                <p>This MCP server requires a Genfeed.ai API key for authentication:</p>
-                <div class="code-block">
-GENFEED_API_KEY=your-api-key-here
-GENFEEDAI_API_URL=https://api.genfeed.ai
-                </div>
-                <p>Set these environment variables when running the server or configure them in your Claude Desktop settings.</p>
-            </div>
-
-            <div class="section">
-                <h2>🤖 Connect from Claude Desktop</h2>
-                <p>Add this server to your Claude Desktop configuration:</p>
-
-                <div class="config-section">
-                    <h3>Claude Desktop Configuration</h3>
-                    <p><strong>Config file location:</strong></p>
-                    <ul style="margin-left: 20px; margin-top: 10px;">
-                        <li><strong>macOS:</strong> ~/Library/Application Support/Claude/claude_desktop_config.json</li>
-                        <li><strong>Windows:</strong> %APPDATA%\\Claude\\claude_desktop_config.json</li>
-                        <li><strong>Linux:</strong> ~/.config/claude-desktop/config.json</li>
-                    </ul>
-
-                    <p style="margin-top: 15px;"><strong>Add this configuration:</strong></p>
-                    <div class="code-block">{
-  "mcpServers": {
-    "genfeed-ai": {
-      "command": "node",
-      "args": ["/path/to/genfeed/dist/mcp/main.js"],
-      "env": {
-        "NODE_ENV": "production",
-        "MCP_PORT": "3014",
-        "GENFEEDAI_API_URL": "https://api.genfeed.ai",
-        "GENFEED_API_KEY": "your-api-key-here"
-      }
-    }
-  }
-}</div>
-                </div>
-
-                <ol style="margin-left: 20px; margin-top: 15px;">
-                    <li style="margin: 10px 0;">Install and build the Genfeed.ai MCP server</li>
-                    <li style="margin: 10px 0;">Add the configuration above to your Claude Desktop config file</li>
-                    <li style="margin: 10px 0;">Replace the path and API key with your actual values</li>
-                    <li style="margin: 10px 0;">Restart Claude Desktop and start using the tools!</li>
-                </ol>
-            </div>
-
-            <div class="section">
-                <h2>🌐 Connect via Streamable HTTP (Remote Agents)</h2>
-                <p>For remote AI agents (OpenClaw, custom agents), connect via the Streamable HTTP transport:</p>
-
-                <div class="config-section">
-                    <h3>Streamable HTTP Endpoint</h3>
-                    <div class="endpoint">
-                        <strong>Endpoint:</strong> https://mcp.genfeed.ai/mcp
-                    </div>
-                    <div class="endpoint">
-                        <strong>Protocol:</strong> MCP 2025-03-26 (Streamable HTTP)
-                    </div>
-                    <div class="endpoint">
-                        <strong>Methods:</strong> POST, GET, DELETE
-                    </div>
-                    <div class="endpoint">
-                        <strong>Auth:</strong> Bearer token (API key starting with gf_)
-                    </div>
-                </div>
-
-                <p style="margin-top: 15px;"><strong>Connect from any MCP client:</strong></p>
-                <div class="code-block">import { Client } from "@modelcontextprotocol/sdk/client";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-
-const transport = new StreamableHTTPClientTransport(
-  new URL("https://mcp.genfeed.ai/mcp"),
-  { requestInit: { headers: { Authorization: "Bearer gf_live_xxx" } } }
-);
-
-const client = new Client({ name: "my-agent", version: "1.0.0" });
-await client.connect(transport);
-
-const tools = await client.listTools();
-const result = await client.callTool({
-  name: "generate_image",
-  arguments: { prompt: "A sunset over mountains" }
-});</div>
-
-                <p style="margin-top: 15px;"><strong>OpenClaw / Agent Configuration:</strong></p>
-                <div class="code-block">{
-  "mcpServers": {
-    "genfeed": {
-      "url": "https://mcp.genfeed.ai/mcp",
-      "headers": {
-        "Authorization": "Bearer gf_live_xxx"
-      }
-    }
-  }
-}</div>
-            </div>
-
-            <div class="section">
-                <h2>🛠️ Available Tools</h2>
-                <ul class="tools-list">
-                    <li>
-                        <strong>generate_video</strong>
-                        Create AI-generated videos with customizable styles, duration, and voice-over options. Supports professional, casual, animated, documentary, and tutorial styles.
-                    </li>
-                    <li>
-                        <strong>get_video_status</strong>
-                        Check the processing status and progress of your video creation jobs. Returns real-time updates on video generation progress.
-                    </li>
-                    <li>
-                        <strong>list_videos</strong>
-                        Get a paginated list of all videos in your organization with optional limit and offset parameters.
-                    </li>
-                    <li>
-                        <strong>get_video_analytics</strong>
-                        Retrieve detailed analytics for specific videos including views, engagement metrics, and performance data across different time ranges.
-                    </li>
-                </ul>
-            </div>
-
-            <div class="section">
-                <h2>📊 Available Resources</h2>
-                <ul class="resources-list">
-                    <li>
-                        <strong>genfeed://analytics/videos</strong>
-                        Comprehensive analytics data for all videos in your organization, accessible directly through MCP resources.
-                    </li>
-                    <li>
-                        <strong>genfeed://analytics/organization</strong>
-                        Organization-wide performance metrics, statistics, and aggregated analytics data.
-                    </li>
-                </ul>
-            </div>
-
-            <div class="section">
-                <h2>💻 Example Usage</h2>
-                <p>Once connected to Claude Desktop, you can use natural language to interact with Genfeed.ai:</p>
-                <div class="code-block">
-# Create a professional video
-"Create a professional video about AI trends with a 30-second duration and female voice-over"
-
-# Check video status
-"Check the status of video ID abc123"
-
-# List recent videos
-"Show me my last 5 videos"
-
-# Get analytics
-"Get analytics for video ID abc123 for the last 7 days"
-
-# Access organization analytics
-"Show me our organization's video performance metrics"
-                </div>
-            </div>
-
-            <div class="section">
-                <h2>🚀 Installation Steps</h2>
-                <ol style="margin-left: 20px;">
-                    <li style="margin: 10px 0;"><strong>Clone Repository:</strong> git clone https://github.com/genfeedai/api.genfeed.ai.git</li>
-                    <li style="margin: 10px 0;"><strong>Install Dependencies:</strong> npm install</li>
-                    <li style="margin: 10px 0;"><strong>Build Project:</strong> npm run build</li>
-                    <li style="margin: 10px 0;"><strong>Set Environment Variables:</strong> Configure GENFEED_API_KEY and other required env vars</li>
-                    <li style="margin: 10px 0;"><strong>Configure Claude Desktop:</strong> Add the MCP server configuration</li>
-                    <li style="margin: 10px 0;"><strong>Restart Claude Desktop:</strong> The server will be available in your AI assistant</li>
-                </ol>
-            </div>
-
-            <div class="warning">
-                <strong>⚠️ Important:</strong> This server requires a valid Genfeed.ai API key. Make sure to set the GENFEED_API_KEY environment variable or configure it in your Claude Desktop settings.
-            </div>
-        </div>
-
-        <div class="footer">
-            <p>Genfeed MCP Server v1.0.0 | Powered by Model Context Protocol</p>
-            <p><a href="https://genfeed.ai" style="color: #667eea;">genfeed.ai</a> | <a href="https://docs.genfeed.ai/api" style="color: #667eea;">API Documentation</a></p>
-        </div>
-    </div>
-</body>
-</html>
-    `;
+    res.send(renderSetupPage());
   }
 }

--- a/apps/server/mcp/src/mcp/services/mcp.service.spec.ts
+++ b/apps/server/mcp/src/mcp/services/mcp.service.spec.ts
@@ -12,8 +12,13 @@ describe('MCPService', () => {
     service = module.get<MCPService>(MCPService);
   });
 
+  beforeEach(() => {
+    vi.stubEnv('GENFEED_MCP_RESOURCE_URL', '');
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('should be defined', () => {

--- a/apps/server/mcp/src/mcp/services/mcp.service.spec.ts
+++ b/apps/server/mcp/src/mcp/services/mcp.service.spec.ts
@@ -32,25 +32,31 @@ describe('MCPService', () => {
   describe('getMcpConfiguration', () => {
     it('should return MCP configuration', () => {
       const config = service.getMcpConfiguration();
+      const serverConfig = config.mcpServers.genfeed;
 
       expect(config).toBeDefined();
       expect(config.mcpServers).toBeDefined();
-      expect(config.mcpServers['genfeed-ai']).toBeDefined();
-      expect(config.mcpServers['genfeed-ai'].command).toBe('node');
-      expect(config.mcpServers['genfeed-ai'].args).toEqual([
-        'dist/mcp/main.js',
-      ]);
-      expect(config.mcpServers['genfeed-ai'].env).toBeDefined();
+      expect(serverConfig).toBeDefined();
+      expect(serverConfig).toMatchObject({
+        headers: {
+          Authorization: 'Bearer ${GENFEED_API_KEY}',
+        },
+        transport: 'streamable-http',
+        type: 'http',
+        url: 'https://mcp.genfeed.ai/mcp',
+      });
     });
 
-    it('should include required environment variables', () => {
+    it('should include hosted Streamable HTTP auth details', () => {
       const config = service.getMcpConfiguration();
-      const env = config.mcpServers['genfeed-ai'].env;
+      const serverConfig = config.mcpServers.genfeed;
 
-      expect(env?.NODE_ENV).toBe('production');
-      expect(env?.MCP_PORT).toBe('3014');
-      expect(env?.GENFEEDAI_API_URL).toBe('https://api.genfeed.ai');
-      expect(env?.GENFEED_API_KEY).toBeDefined();
+      expect(serverConfig).toMatchObject({
+        headers: {
+          Authorization: 'Bearer ${GENFEED_API_KEY}',
+        },
+        url: 'https://mcp.genfeed.ai/mcp',
+      });
     });
   });
 
@@ -63,6 +69,12 @@ describe('MCPService', () => {
       expect(example.version).toBe('1.0.0');
       expect(example.description).toContain('AI-powered video generation');
       expect(example.capabilities).toBeDefined();
+      expect(example.installation.clientExamples.claudeCode.command).toContain(
+        'claude mcp add --transport http genfeed',
+      );
+      expect(example.installation.clientExamples.codex.command).toContain(
+        'codex mcp add genfeed --url https://mcp.genfeed.ai/mcp',
+      );
       expect(example.tools).toBeDefined();
     });
 

--- a/apps/server/mcp/src/mcp/services/mcp.service.ts
+++ b/apps/server/mcp/src/mcp/services/mcp.service.ts
@@ -1,4 +1,8 @@
-import type { McpConfiguration } from '@mcp/shared/interfaces/mcp-config.interface';
+import { getPublicMcpUrl } from '@mcp/mcp/setup-page';
+import type {
+  McpClientExamples,
+  McpConfiguration,
+} from '@mcp/shared/interfaces/mcp-config.interface';
 import { Injectable } from '@nestjs/common';
 
 export interface McpExample {
@@ -8,12 +12,7 @@ export interface McpExample {
   };
   description: string;
   installation: {
-    configuration: {
-      claudeDesktop: {
-        example: McpConfiguration;
-        path: string;
-      };
-    };
+    clientExamples: McpClientExamples;
     description: string;
     steps: string[];
   };
@@ -43,23 +42,25 @@ export class MCPService {
   }
 
   getMcpConfiguration(): McpConfiguration {
+    const mcpUrl = getPublicMcpUrl();
+
     return {
       mcpServers: {
-        'genfeed-ai': {
-          args: ['dist/mcp/main.js'],
-          command: 'node',
-          env: {
-            GENFEED_API_KEY: 'your-api-key-here',
-            GENFEEDAI_API_URL: 'https://api.genfeed.ai',
-            MCP_PORT: '3014',
-            NODE_ENV: 'production',
+        genfeed: {
+          headers: {
+            Authorization: 'Bearer ${GENFEED_API_KEY}',
           },
+          transport: 'streamable-http',
+          type: 'http',
+          url: mcpUrl,
         },
       },
     };
   }
 
   getMcpExample(): McpExample {
+    const mcpUrl = getPublicMcpUrl();
+
     return {
       capabilities: {
         resources: {
@@ -71,32 +72,36 @@ export class MCPService {
       },
       description: 'AI-powered video generation and analytics MCP server',
       installation: {
-        configuration: {
-          claudeDesktop: {
-            example: {
-              mcpServers: {
-                'genfeed-ai': {
-                  args: ['/path/to/genfeed/dist/mcp/main.js'],
-                  command: 'node',
-                  env: {
-                    GENFEED_API_KEY: 'your-api-key-here',
-                    GENFEEDAI_API_URL: 'https://api.genfeed.ai',
-                    MCP_PORT: '3014',
-                    NODE_ENV: 'production',
-                  },
-                },
+        clientExamples: {
+          claudeCode: {
+            command: `claude mcp add --transport http genfeed --scope user ${mcpUrl} --header "Authorization: Bearer $GENFEED_API_KEY"`,
+          },
+          codex: {
+            command: `codex mcp add genfeed --url ${mcpUrl} --bearer-token-env-var GENFEED_API_KEY`,
+            configToml: `[mcp_servers.genfeed]
+url = "${mcpUrl}"
+bearer_token_env_var = "GENFEED_API_KEY"`,
+          },
+          mcpServers: {
+            genfeed: {
+              env: {
+                GENFEED_API_KEY: 'gf_live_xxx',
               },
+              headers: {
+                Authorization: 'Bearer ${GENFEED_API_KEY}',
+              },
+              transport: 'streamable-http',
+              type: 'http',
+              url: mcpUrl,
             },
-            path: '~/.config/claude-desktop/config.json',
           },
         },
-        description: 'Install Genfeed.ai MCP Server',
+        description: 'Connect the hosted Genfeed.ai MCP server',
         steps: [
-          '1. Clone the Genfeed.ai repository',
-          '2. Install dependencies: npm install',
-          '3. Set up environment variables',
-          '4. Build the project: npm run build',
-          '5. Add the MCP server configuration to your Claude Desktop settings',
+          '1. Create a Genfeed API key in app settings',
+          '2. Export GENFEED_API_KEY in your shell or client environment',
+          '3. Add the hosted Streamable HTTP endpoint to Claude Code or Codex',
+          '4. Verify the server with your client MCP list command',
         ],
       },
       name: 'Genfeed.ai MCP Server',

--- a/apps/server/mcp/src/mcp/setup-page.spec.ts
+++ b/apps/server/mcp/src/mcp/setup-page.spec.ts
@@ -20,9 +20,12 @@ describe('MCP setup page', () => {
   it('uses shared static UI surface primitives instead of local card CSS', () => {
     const html = renderSetupPage();
 
-    expect(html).toContain('gf-card mcp-hero-card');
+    expect(html).toContain('gf-card gf-feature-card');
+    expect(html).toContain('gf-card gf-info-card');
     expect(html).toContain('gf-button gf-button-primary');
     expect(html).toContain('gf-code-block command');
+    expect(html).not.toContain('mcp-hero-card');
+    expect(html).not.toContain('mcp-meta-card');
     expect(html).not.toContain('class="poster"');
     expect(html).not.toContain('class="client-shell"');
     expect(html).not.toContain('class="meta-card"');

--- a/apps/server/mcp/src/mcp/setup-page.spec.ts
+++ b/apps/server/mcp/src/mcp/setup-page.spec.ts
@@ -17,6 +17,17 @@ describe('MCP setup page', () => {
     expect(html).not.toContain('http://localhost:3014');
   });
 
+  it('uses shared static UI surface primitives instead of local card CSS', () => {
+    const html = renderSetupPage();
+
+    expect(html).toContain('gf-card mcp-hero-card');
+    expect(html).toContain('gf-button gf-button-primary');
+    expect(html).toContain('gf-code-block command');
+    expect(html).not.toContain('class="poster"');
+    expect(html).not.toContain('class="client-shell"');
+    expect(html).not.toContain('class="meta-card"');
+  });
+
   it('escapes an overridden endpoint before rendering it into HTML', () => {
     vi.stubEnv(
       'GENFEED_MCP_RESOURCE_URL',

--- a/apps/server/mcp/src/mcp/setup-page.spec.ts
+++ b/apps/server/mcp/src/mcp/setup-page.spec.ts
@@ -1,0 +1,33 @@
+import { getPublicMcpUrl, renderSetupPage } from '@mcp/mcp/setup-page';
+
+describe('MCP setup page', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the production MCP endpoint by default', () => {
+    vi.stubEnv('GENFEED_MCP_RESOURCE_URL', '');
+
+    expect(getPublicMcpUrl()).toBe('https://mcp.genfeed.ai/mcp');
+
+    const html = renderSetupPage();
+    expect(html).toContain('https://mcp.genfeed.ai/mcp');
+    expect(html).toContain('claude mcp add --transport http genfeed');
+    expect(html).toContain('codex mcp add genfeed --url');
+    expect(html).not.toContain('http://localhost:3014');
+  });
+
+  it('escapes an overridden endpoint before rendering it into HTML', () => {
+    vi.stubEnv(
+      'GENFEED_MCP_RESOURCE_URL',
+      'https://preview-mcp.genfeed.ai/mcp?x=<script>',
+    );
+
+    const html = renderSetupPage();
+
+    expect(html).toContain(
+      'https://preview-mcp.genfeed.ai/mcp?x=&lt;script&gt;',
+    );
+    expect(html).not.toContain('x=<script>');
+  });
+});

--- a/apps/server/mcp/src/mcp/setup-page.spec.ts
+++ b/apps/server/mcp/src/mcp/setup-page.spec.ts
@@ -41,4 +41,22 @@ describe('MCP setup page', () => {
     );
     expect(html).not.toContain('x=<script>');
   });
+
+  it('falls back to the default when override scheme is not http/https', () => {
+    // Concatenate to prevent biome from misinterpreting the scheme token.
+    const dangerousScheme = ['java', 'script:alert(1)'].join('');
+    vi.stubEnv('GENFEED_MCP_RESOURCE_URL', dangerousScheme);
+
+    expect(getPublicMcpUrl()).toBe('https://mcp.genfeed.ai/mcp');
+
+    const html = renderSetupPage();
+    expect(html).toContain('https://mcp.genfeed.ai/mcp');
+    expect(html).not.toContain(dangerousScheme);
+  });
+
+  it('falls back to the default URL when override is malformed', () => {
+    vi.stubEnv('GENFEED_MCP_RESOURCE_URL', 'not a url %%');
+
+    expect(getPublicMcpUrl()).toBe('https://mcp.genfeed.ai/mcp');
+  });
 });

--- a/apps/server/mcp/src/mcp/setup-page.ts
+++ b/apps/server/mcp/src/mcp/setup-page.ts
@@ -1,5 +1,10 @@
 import process from 'node:process';
 
+import {
+  staticSurfaceClassNames,
+  staticSurfaceCss,
+} from '@genfeedai/ui/static/surface';
+
 const DEFAULT_APP_URL = 'https://app.genfeed.ai';
 const DEFAULT_DOCS_URL = 'https://docs.genfeed.ai';
 const DEFAULT_MCP_URL = 'https://mcp.genfeed.ai/mcp';
@@ -39,6 +44,7 @@ export function getPublicAppUrl(): string {
 }
 
 export function renderSetupPage(): string {
+  const ui = staticSurfaceClassNames;
   const mcpUrl = getPublicMcpUrl();
   const appUrl = getPublicAppUrl();
   const docsUrl = getPublicDocsUrl();
@@ -69,33 +75,15 @@ bearer_token_env_var = "GENFEED_API_KEY"`);
 <style>
 :root {
   color-scheme: dark;
-  --bg: #000000;
-  --bg-soft: #050607;
-  --surface: rgba(255, 255, 255, 0.025);
-  --surface-strong: rgba(255, 255, 255, 0.055);
-  --edge: rgba(255, 255, 255, 0.08);
-  --edge-strong: rgba(255, 255, 255, 0.16);
-  --text: #f4f4f5;
-  --text-soft: rgba(244, 244, 245, 0.72);
-  --text-muted: rgba(244, 244, 245, 0.42);
-  --text-faint: rgba(244, 244, 245, 0.22);
-  --accent: #fafafa;
-  --accent-foreground: #050607;
-  --success: #10b981;
-  --warning: #f59e0b;
-  --agent: #38bdf8;
-  --done: #a855f7;
-  --youtube: #ff0000;
-  --tiktok: #fe2c55;
-  --linkedin: #0a66c2;
 }
+${staticSurfaceCss}
 * { box-sizing: border-box; }
-html { min-height: 100%; background: var(--bg); }
+html { min-height: 100%; background: #050607; }
 body {
   min-height: 100vh;
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--gf-bg-primary);
+  color: var(--gf-text-primary);
   font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   letter-spacing: 0;
   -webkit-font-smoothing: antialiased;
@@ -131,7 +119,7 @@ a { color: inherit; text-decoration: none; }
   align-items: center;
   justify-content: space-between;
   gap: 18px;
-  border-bottom: 1px solid var(--edge);
+  border-bottom: 1px solid var(--gf-border);
 }
 .brand {
   display: inline-flex;
@@ -144,14 +132,15 @@ a { color: inherit; text-decoration: none; }
   width: 24px;
   height: 24px;
   place-items: center;
-  border: 1px solid var(--edge);
-  background: #050607;
-  color: var(--text);
+  border: 1px solid var(--gf-border);
+  border-radius: var(--gf-radius-sm);
+  background: var(--gf-bg-primary);
+  color: var(--gf-text-primary);
   font-size: 12px;
   font-weight: 800;
 }
 .brand-name {
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.18em;
@@ -165,43 +154,28 @@ a { color: inherit; text-decoration: none; }
   gap: 16px;
 }
 .nav-link {
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
-.nav-link:hover { color: var(--text); }
-.nav-button {
-  display: inline-flex;
-  min-height: 30px;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--accent);
-  border-radius: 4px;
-  background: var(--accent);
-  color: var(--accent-foreground);
-  padding: 0 14px;
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
+.nav-link:hover { color: var(--gf-text-primary); }
 .hero {
   display: grid;
   min-height: 540px;
   grid-template-columns: minmax(0, 1fr) minmax(340px, 460px);
   gap: 56px;
   align-items: center;
-  border-bottom: 1px solid var(--edge);
+  border-bottom: 1px solid var(--gf-border);
   padding: 58px 0 64px;
 }
 .eyebrow,
 .section-kicker,
-.poster-kicker,
+.mcp-hero-card-kicker,
 .meta-label {
   margin: 0;
-  color: var(--text-faint);
+  color: var(--gf-text-faint);
   font-size: 10px;
   font-weight: 900;
   letter-spacing: 0.2em;
@@ -210,7 +184,7 @@ a { color: inherit; text-decoration: none; }
 .hero h1 {
   max-width: 680px;
   margin: 18px 0 0;
-  color: var(--text);
+  color: var(--gf-text-primary);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 72px;
   font-weight: 700;
@@ -219,14 +193,14 @@ a { color: inherit; text-decoration: none; }
 }
 .hero h1 em {
   display: block;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-style: italic;
   font-weight: 400;
 }
 .lede {
   max-width: 600px;
   margin: 22px 0 0;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 14px;
   line-height: 1.8;
 }
@@ -236,41 +210,15 @@ a { color: inherit; text-decoration: none; }
   gap: 10px;
   margin-top: 30px;
 }
-.button {
-  display: inline-flex;
-  min-height: 36px;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--edge-strong);
-  border-radius: 4px;
-  background: #050607;
-  color: var(--text);
-  padding: 0 14px;
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-.button.primary {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: var(--accent-foreground);
-}
-.button:hover { border-color: rgba(255,255,255,0.28); }
-.button.primary:hover { background: #e4e4e7; }
-.poster {
-  position: relative;
-  overflow: hidden;
+.mcp-hero-card {
   min-height: 430px;
-  border: 1px solid var(--edge);
   background:
     linear-gradient(160deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018) 46%, rgba(255,255,255,0.008)),
-    #050607;
+    var(--gf-bg-primary);
   padding: 34px;
   box-shadow: 0 24px 80px rgba(0,0,0,0.32);
 }
-.poster::before {
+.mcp-hero-card::before {
   position: absolute;
   inset: 0;
   background-image:
@@ -280,7 +228,7 @@ a { color: inherit; text-decoration: none; }
   content: "";
   opacity: 0.28;
 }
-.poster-inner {
+.mcp-hero-card-inner {
   position: relative;
   z-index: 1;
   display: flex;
@@ -289,7 +237,7 @@ a { color: inherit; text-decoration: none; }
   justify-content: space-between;
   gap: 28px;
 }
-.poster-title {
+.mcp-hero-card-title {
   max-width: 350px;
   margin: 18px 0 0;
   font-family: Georgia, "Times New Roman", serif;
@@ -298,17 +246,17 @@ a { color: inherit; text-decoration: none; }
   line-height: 0.98;
   letter-spacing: 0;
 }
-.poster-copy {
+.mcp-hero-card-copy {
   max-width: 330px;
   margin: 14px 0 0;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 13px;
   line-height: 1.65;
 }
 .flow {
   display: grid;
   gap: 8px;
-  border-top: 1px solid var(--edge);
+  border-top: 1px solid var(--gf-border);
   padding-top: 18px;
 }
 .flow-row {
@@ -321,14 +269,14 @@ a { color: inherit; text-decoration: none; }
 }
 .flow-row:last-child { border-bottom: 0; }
 .flow-name {
-  color: var(--text);
+  color: var(--gf-text-primary);
   font-size: 12px;
   font-weight: 750;
 }
 .flow-copy {
   min-width: 0;
   overflow: hidden;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -337,7 +285,7 @@ a { color: inherit; text-decoration: none; }
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.1em;
@@ -347,26 +295,15 @@ a { color: inherit; text-decoration: none; }
   width: 7px;
   height: 7px;
   border-radius: 999px;
-  background: var(--success);
+  background: var(--gf-success);
   content: "";
 }
 .platforms {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  border-top: 1px solid var(--edge);
+  border-top: 1px solid var(--gf-border);
   padding-top: 18px;
-}
-.platform {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  border: 1px solid var(--edge);
-  background: rgba(0,0,0,0.24);
-  padding: 6px 8px;
-  color: var(--text-soft);
-  font-size: 11px;
-  font-weight: 700;
 }
 .platform::before {
   width: 6px;
@@ -374,15 +311,15 @@ a { color: inherit; text-decoration: none; }
   border-radius: 999px;
   content: "";
 }
-.platform.youtube::before { background: var(--youtube); }
-.platform.tiktok::before { background: var(--tiktok); }
-.platform.linkedin::before { background: var(--linkedin); }
+.platform.youtube::before { background: var(--gf-platform-youtube); }
+.platform.tiktok::before { background: var(--gf-platform-tiktok); }
+.platform.linkedin::before { background: var(--gf-platform-linkedin); }
 .endpoint-band {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, auto) auto;
   gap: 18px;
   align-items: end;
-  border-bottom: 1px solid var(--edge);
+  border-bottom: 1px solid var(--gf-border);
   padding: 30px 0;
 }
 .endpoint-band > div {
@@ -393,39 +330,21 @@ a { color: inherit; text-decoration: none; }
 }
 .endpoint-copy p {
   margin: 8px 0 0;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 13px;
 }
 .endpoint-code {
   min-width: 0;
-  overflow-x: auto;
-  border: 1px solid var(--edge);
-  background: rgba(255,255,255,0.025);
-  color: var(--text);
-  font-family: "SF Mono", SFMono-Regular, Consolas, Menlo, monospace;
-  font-size: 12px;
+  color: var(--gf-text-primary);
   line-height: 1.6;
-  padding: 10px 12px;
   white-space: nowrap;
 }
 .copy {
   align-self: end;
   justify-self: start;
-  min-height: 36px;
-  border: 1px solid var(--edge-strong);
-  border-radius: 4px;
-  background: #050607;
-  color: var(--text-soft);
-  padding: 0 12px;
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  white-space: nowrap;
 }
-.copy:hover { border-color: rgba(255,255,255,0.28); color: var(--text); }
 .section {
-  border-bottom: 1px solid var(--edge);
+  border-bottom: 1px solid var(--gf-border);
   padding: 82px 0;
 }
 .section-head {
@@ -444,32 +363,28 @@ a { color: inherit; text-decoration: none; }
   letter-spacing: 0;
 }
 .section-title em {
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-style: italic;
   font-weight: 400;
 }
 .section-copy {
   margin: 0;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 14px;
   line-height: 1.8;
-}
-.client-shell {
-  border: 1px solid var(--edge);
-  background: var(--surface);
 }
 .tablist {
   display: flex;
   flex-wrap: wrap;
   gap: 0;
-  border-bottom: 1px solid var(--edge);
+  border-bottom: 1px solid var(--gf-border);
 }
 .tab {
   min-height: 46px;
   border: 0;
-  border-right: 1px solid var(--edge);
+  border-right: 1px solid var(--gf-border);
   background: transparent;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   padding: 0 18px;
   font-size: 10px;
   font-weight: 900;
@@ -477,8 +392,8 @@ a { color: inherit; text-decoration: none; }
   text-transform: uppercase;
 }
 .tab[aria-selected="true"] {
-  background: var(--surface-strong);
-  color: var(--text);
+  background: var(--gf-bg-hover);
+  color: var(--gf-text-primary);
 }
 .tabpanel {
   display: none;
@@ -491,28 +406,16 @@ a { color: inherit; text-decoration: none; }
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  border-bottom: 1px solid var(--edge);
+  border-bottom: 1px solid var(--gf-border);
   padding: 22px 0;
 }
 .instruction-title {
   margin: 0;
-  color: var(--text);
+  color: var(--gf-text-primary);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 28px;
   font-weight: 700;
   letter-spacing: 0;
-}
-.badge {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--edge);
-  background: rgba(255,255,255,0.025);
-  color: var(--text-muted);
-  padding: 5px 8px;
-  font-size: 10px;
-  font-weight: 900;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
 }
 .steps {
   display: grid;
@@ -532,7 +435,7 @@ a { color: inherit; text-decoration: none; }
 }
 .step:last-child { border-bottom: 0; }
 .step-number {
-  color: var(--text-faint);
+  color: var(--gf-text-faint);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 34px;
   font-weight: 700;
@@ -540,85 +443,58 @@ a { color: inherit; text-decoration: none; }
 }
 .step-title {
   margin: 0;
-  color: var(--text);
+  color: var(--gf-text-primary);
   font-size: 14px;
   font-weight: 750;
 }
 .step-copy {
   margin: 5px 0 0;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 13px;
   line-height: 1.6;
 }
 code, pre {
   font-family: "SF Mono", SFMono-Regular, Consolas, Menlo, monospace;
 }
-code.inline {
-  border: 1px solid var(--edge);
-  background: rgba(255,255,255,0.035);
-  padding: 1px 5px;
-  color: var(--text-soft);
-  font-size: 11px;
-}
 pre.command {
   margin: 12px 0 0;
-  max-width: 100%;
-  overflow-x: auto;
-  border: 1px solid var(--edge);
-  background: #030303;
-  color: #dbeafe;
-  font-size: 12px;
-  line-height: 1.7;
-  padding: 13px;
-  white-space: pre;
 }
 .meta-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
 }
-.meta-card {
+.mcp-meta-card {
   min-height: 190px;
-  border: 1px solid var(--edge);
-  background: var(--surface);
   padding: 22px;
 }
-.meta-card h3 {
+.mcp-meta-card h3 {
   margin: 14px 0 0;
-  color: var(--text);
+  color: var(--gf-text-primary);
   font-size: 15px;
   font-weight: 750;
 }
-.meta-card p {
+.mcp-meta-card p {
   margin: 9px 0 0;
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 13px;
   line-height: 1.65;
 }
-.meta-card a {
+.mcp-meta-card a {
   display: inline-flex;
   margin-top: 16px;
-  color: var(--text-soft);
+  color: var(--gf-text-secondary);
   font-size: 10px;
   font-weight: 900;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
-.meta-card a:hover { color: var(--text); }
-.warning-note {
-  display: grid;
-  grid-template-columns: 20px minmax(0, 1fr);
-  gap: 12px;
+.mcp-meta-card a:hover { color: var(--gf-text-primary); }
+.mcp-warning-note {
   margin-top: 14px;
-  border: 1px solid rgba(245,158,11,0.26);
-  background: rgba(245,158,11,0.08);
-  padding: 14px;
-  color: var(--text-soft);
-  font-size: 12px;
-  line-height: 1.6;
 }
 .warning-mark {
-  color: var(--warning);
+  color: var(--gf-warning);
   font-weight: 900;
 }
 .site-footer {
@@ -627,7 +503,7 @@ pre.command {
   gap: 18px;
   align-items: center;
   padding: 36px 0 44px;
-  color: var(--text-faint);
+  color: var(--gf-text-faint);
   font-size: 11px;
 }
 .footer-links {
@@ -637,13 +513,13 @@ pre.command {
   gap: 16px;
 }
 .footer-links a {
-  color: var(--text-muted);
+  color: var(--gf-text-muted);
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
-.footer-links a:hover { color: var(--text); }
+.footer-links a:hover { color: var(--gf-text-primary); }
 @media (max-width: 920px) {
   .hero,
   .section-head,
@@ -657,7 +533,7 @@ pre.command {
     padding: 48px 0 54px;
   }
   .hero h1 { font-size: 58px; }
-  .poster { min-height: 360px; }
+  .mcp-hero-card { min-height: 360px; }
   .copy { justify-self: start; }
 }
 @media (max-width: 640px) {
@@ -666,8 +542,8 @@ pre.command {
   .nav-links { gap: 10px; }
   .nav-link { display: none; }
   .hero h1 { font-size: 42px; }
-  .poster { padding: 22px; }
-  .poster-title { font-size: 34px; }
+  .mcp-hero-card { padding: 22px; }
+  .mcp-hero-card-title { font-size: 34px; }
   .flow-row { grid-template-columns: 1fr; gap: 3px; }
   .flow-copy { white-space: normal; }
   .section { padding: 56px 0; }
@@ -675,7 +551,7 @@ pre.command {
   .tabpanel { padding: 0 16px 4px; }
   .tab {
     flex: 1 1 50%;
-    border-bottom: 1px solid var(--edge);
+    border-bottom: 1px solid var(--gf-border);
     padding: 0 10px;
   }
   .step { grid-template-columns: 1fr; gap: 8px; }
@@ -685,7 +561,7 @@ pre.command {
 }
 </style>
 </head>
-<body>
+<body class="${ui.root}">
 <main class="page">
   <nav class="site-nav" aria-label="Genfeed MCP">
     <a class="brand" href="https://genfeed.ai" rel="noopener noreferrer">
@@ -696,7 +572,7 @@ pre.command {
       <a class="nav-link" href="${docsGuideUrlSafe}" rel="noopener noreferrer">Docs</a>
       <a class="nav-link" href="/v1/config" rel="noopener noreferrer">Config</a>
       <a class="nav-link" href="/v1/health" rel="noopener noreferrer">Health</a>
-      <a class="nav-button" href="${apiKeysUrlSafe}" rel="noopener noreferrer">API keys</a>
+      <a class="${ui.buttonPrimary}" href="${apiKeysUrlSafe}" rel="noopener noreferrer">API keys</a>
     </div>
   </nav>
 
@@ -706,17 +582,17 @@ pre.command {
       <h1>Genfeed MCP.<em>Claude + Codex.</em></h1>
       <p class="lede">Connect AI clients to Genfeed content, workflows, publishing, analytics, and ads with an API key.</p>
       <div class="hero-actions">
-        <a class="button primary" href="${apiKeysUrlSafe}" rel="noopener noreferrer">Create API key</a>
-        <a class="button" href="${docsGuideUrlSafe}" rel="noopener noreferrer">Read MCP docs</a>
+        <a class="${ui.buttonPrimary}" href="${apiKeysUrlSafe}" rel="noopener noreferrer">Create API key</a>
+        <a class="${ui.buttonSecondary}" href="${docsGuideUrlSafe}" rel="noopener noreferrer">Read MCP docs</a>
       </div>
     </div>
 
-    <aside class="poster" aria-label="Genfeed MCP workflow preview">
-      <div class="poster-inner">
+    <aside class="${ui.card} mcp-hero-card" aria-label="Genfeed MCP workflow preview">
+      <div class="mcp-hero-card-inner">
         <div>
-          <p class="poster-kicker">AI model context protocol</p>
-          <h2 class="poster-title">Agent workspace access.</h2>
-          <p class="poster-copy">Read, create, publish, and measure from your AI client.</p>
+          <p class="mcp-hero-card-kicker">AI model context protocol</p>
+          <h2 class="mcp-hero-card-title">Agent workspace access.</h2>
+          <p class="mcp-hero-card-copy">Read, create, publish, and measure from your AI client.</p>
         </div>
         <div class="flow" aria-label="Content operating loop">
           <div class="flow-row">
@@ -736,9 +612,9 @@ pre.command {
           </div>
         </div>
         <div class="platforms" aria-label="Platform publishing preview">
-          <span class="platform youtube">YouTube</span>
-          <span class="platform tiktok">TikTok</span>
-          <span class="platform linkedin">LinkedIn</span>
+          <span class="${ui.chip} platform youtube">YouTube</span>
+          <span class="${ui.chip} platform tiktok">TikTok</span>
+          <span class="${ui.chip} platform linkedin">LinkedIn</span>
         </div>
       </div>
     </aside>
@@ -750,9 +626,9 @@ pre.command {
       <p>Hosted Streamable HTTP. Use localhost only for self-hosting.</p>
     </div>
     <div>
-      <div class="endpoint-code" id="mcp-url">${mcpUrlSafe}</div>
+      <div class="${ui.codeBlock} endpoint-code" id="mcp-url">${mcpUrlSafe}</div>
     </div>
-    <button class="copy" type="button" data-copy="${mcpUrlSafe}" aria-label="Copy MCP endpoint">Copy</button>
+    <button class="${ui.buttonSecondary} copy" type="button" data-copy="${mcpUrlSafe}" aria-label="Copy MCP endpoint">Copy</button>
   </section>
 
   <section class="section" aria-labelledby="setup-title">
@@ -764,7 +640,7 @@ pre.command {
       <p class="section-copy">Export a Genfeed API key, then add the remote HTTP server to your client.</p>
     </div>
 
-    <div class="client-shell">
+    <div class="${ui.card}">
       <div class="tablist" role="tablist" aria-label="Client setup instructions">
         <button class="tab" id="tab-claude-code" type="button" role="tab" aria-selected="true" aria-controls="panel-claude-code" data-tab="claude-code">Claude Code</button>
         <button class="tab" id="tab-codex" type="button" role="tab" aria-selected="false" aria-controls="panel-codex" data-tab="codex">Codex</button>
@@ -773,15 +649,15 @@ pre.command {
       <section class="tabpanel is-active" id="panel-claude-code" role="tabpanel" aria-labelledby="tab-claude-code" data-panel="claude-code">
         <div class="setup-title-row">
           <h3 class="instruction-title">Claude Code setup</h3>
-          <span class="badge">HTTP transport</span>
+          <span class="${ui.badge}">HTTP transport</span>
         </div>
         <ol class="steps">
           <li class="step">
             <span class="step-number">01</span>
             <div>
               <p class="step-title">Export API key</p>
-              <p class="step-copy">Create a <code class="inline">gf_</code> key in Genfeed settings.</p>
-              <pre class="command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
+              <p class="step-copy">Create a <code class="${ui.inlineCode}">gf_</code> key in Genfeed settings.</p>
+              <pre class="${ui.codeBlock} command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
             </div>
           </li>
           <li class="step">
@@ -789,14 +665,14 @@ pre.command {
             <div>
               <p class="step-title">Add MCP server</p>
               <p class="step-copy">Register the hosted endpoint in user scope.</p>
-              <pre class="command"><code>${claudeCommandSafe}</code></pre>
+              <pre class="${ui.codeBlock} command"><code>${claudeCommandSafe}</code></pre>
             </div>
           </li>
           <li class="step">
             <span class="step-number">03</span>
             <div>
               <p class="step-title">Verify</p>
-              <p class="step-copy">Run <code class="inline">claude mcp list</code> or open <code class="inline">/mcp</code>.</p>
+              <p class="step-copy">Run <code class="${ui.inlineCode}">claude mcp list</code> or open <code class="${ui.inlineCode}">/mcp</code>.</p>
             </div>
           </li>
         </ol>
@@ -805,7 +681,7 @@ pre.command {
       <section class="tabpanel" id="panel-codex" role="tabpanel" aria-labelledby="tab-codex" data-panel="codex">
         <div class="setup-title-row">
           <h3 class="instruction-title">Codex setup</h3>
-          <span class="badge">CLI and IDE config</span>
+          <span class="${ui.badge}">CLI and IDE config</span>
         </div>
         <ol class="steps">
           <li class="step">
@@ -813,15 +689,15 @@ pre.command {
             <div>
               <p class="step-title">Export API key</p>
               <p class="step-copy">Codex reads this env var for the bearer token.</p>
-              <pre class="command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
+              <pre class="${ui.codeBlock} command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
             </div>
           </li>
           <li class="step">
             <span class="step-number">02</span>
             <div>
               <p class="step-title">Add MCP server</p>
-              <p class="step-copy">The CLI and IDE share <code class="inline">~/.codex/config.toml</code>.</p>
-              <pre class="command"><code>${codexCommandSafe}</code></pre>
+              <p class="step-copy">The CLI and IDE share <code class="${ui.inlineCode}">~/.codex/config.toml</code>.</p>
+              <pre class="${ui.codeBlock} command"><code>${codexCommandSafe}</code></pre>
             </div>
           </li>
           <li class="step">
@@ -829,7 +705,7 @@ pre.command {
             <div>
               <p class="step-title">Manual config</p>
               <p class="step-copy">Paste this into a user or trusted project config.</p>
-              <pre class="command"><code>${codexTomlSafe}</code></pre>
+              <pre class="${ui.codeBlock} command"><code>${codexTomlSafe}</code></pre>
             </div>
           </li>
         </ol>
@@ -843,23 +719,23 @@ pre.command {
         <p class="section-kicker">Details</p>
         <h2 class="section-title" id="details-title">Endpoint. <em>API auth.</em></h2>
       </div>
-      <p class="section-copy">MCP calls go to <code class="inline">${mcpUrlSafe}</code> and use the permissions on the API key.</p>
+      <p class="section-copy">MCP calls go to <code class="${ui.inlineCode}">${mcpUrlSafe}</code> and use the permissions on the API key.</p>
     </div>
 
     <div class="meta-grid">
-      <article class="meta-card">
+      <article class="${ui.card} mcp-meta-card">
         <p class="meta-label">Authentication</p>
         <h3>Bearer token</h3>
-        <p>Send <code class="inline">Authorization: Bearer gf_live_xxx</code> with every request.</p>
+        <p>Send <code class="${ui.inlineCode}">Authorization: Bearer gf_live_xxx</code> with every request.</p>
         <a href="${apiKeysUrlSafe}" rel="noopener noreferrer">Manage keys</a>
       </article>
-      <article class="meta-card">
+      <article class="${ui.card} mcp-meta-card">
         <p class="meta-label">Transport</p>
         <h3>HTTP transport</h3>
-        <p>Register Genfeed as a remote MCP server. No <code class="inline">npx</code> or localhost for cloud.</p>
+        <p>Register Genfeed as a remote MCP server. No <code class="${ui.inlineCode}">npx</code> or localhost for cloud.</p>
         <a href="/v1/config" rel="noopener noreferrer">View config</a>
       </article>
-      <article class="meta-card">
+      <article class="${ui.card} mcp-meta-card">
         <p class="meta-label">Status</p>
         <h3>Health checks</h3>
         <p>Use health and config to debug routing or stale client settings.</p>
@@ -867,7 +743,7 @@ pre.command {
       </article>
     </div>
 
-    <div class="warning-note" role="note">
+    <div class="${ui.warningNote} mcp-warning-note" role="note">
       <span class="warning-mark">!</span>
       <span>Keep API keys out of commits and shared logs.</span>
     </div>
@@ -912,7 +788,7 @@ pre.command {
     });
   });
 
-  document.querySelectorAll('button.copy').forEach(function (btn) {
+  document.querySelectorAll('button[data-copy]').forEach(function (btn) {
     btn.addEventListener('click', function () {
       var text = btn.getAttribute('data-copy') || '';
       navigator.clipboard.writeText(text).then(function () {

--- a/apps/server/mcp/src/mcp/setup-page.ts
+++ b/apps/server/mcp/src/mcp/setup-page.ts
@@ -703,8 +703,8 @@ pre.command {
   <header class="hero">
     <div>
       <p class="eyebrow">&lt; MCP server &gt;</p>
-      <h1>Connect AI agents to your content operating system.<em>From Claude Code to Codex.</em></h1>
-      <p class="lede">Genfeed MCP gives compatible AI clients API-key scoped access to content, media generation, workflows, publishing, analytics, ads, and agent threads.</p>
+      <h1>Genfeed MCP.<em>Claude + Codex.</em></h1>
+      <p class="lede">Connect AI clients to Genfeed content, workflows, publishing, analytics, and ads with an API key.</p>
       <div class="hero-actions">
         <a class="button primary" href="${apiKeysUrlSafe}" rel="noopener noreferrer">Create API key</a>
         <a class="button" href="${docsGuideUrlSafe}" rel="noopener noreferrer">Read MCP docs</a>
@@ -715,23 +715,23 @@ pre.command {
       <div class="poster-inner">
         <div>
           <p class="poster-kicker">AI model context protocol</p>
-          <h2 class="poster-title">Workspace context for every agent.</h2>
-          <p class="poster-copy">Research, create, publish, and measure without copying data between Genfeed and your AI client.</p>
+          <h2 class="poster-title">Agent workspace access.</h2>
+          <p class="poster-copy">Read, create, publish, and measure from your AI client.</p>
         </div>
         <div class="flow" aria-label="Content operating loop">
           <div class="flow-row">
             <span class="flow-name">Research</span>
-            <span class="flow-copy">Trending topics, analytics, audience signals</span>
+            <span class="flow-copy">Topics, analytics, audience signals</span>
             <span class="status-dot">Live</span>
           </div>
           <div class="flow-row">
             <span class="flow-name">Generate</span>
-            <span class="flow-copy">Video, image, music, article, campaign assets</span>
+            <span class="flow-copy">Media and campaign assets</span>
             <span class="status-dot">Ready</span>
           </div>
           <div class="flow-row">
             <span class="flow-name">Publish</span>
-            <span class="flow-copy">Schedule posts and trigger workflows</span>
+            <span class="flow-copy">Posts and workflows</span>
             <span class="status-dot">Guarded</span>
           </div>
         </div>
@@ -746,8 +746,8 @@ pre.command {
 
   <section class="endpoint-band" aria-labelledby="endpoint-title">
     <div class="endpoint-copy">
-      <p class="meta-label" id="endpoint-title">Production endpoint</p>
-      <p>Use the hosted Streamable HTTP endpoint. Localhost belongs only in self-hosted development config.</p>
+      <p class="meta-label" id="endpoint-title">Endpoint</p>
+      <p>Hosted Streamable HTTP. Use localhost only for self-hosting.</p>
     </div>
     <div>
       <div class="endpoint-code" id="mcp-url">${mcpUrlSafe}</div>
@@ -758,10 +758,10 @@ pre.command {
   <section class="section" aria-labelledby="setup-title">
     <div class="section-head">
       <div>
-        <p class="section-kicker">Client setup</p>
-        <h2 class="section-title" id="setup-title">One server. <em>Two agent clients.</em></h2>
+        <p class="section-kicker">Setup</p>
+        <h2 class="section-title" id="setup-title">One server. <em>Any client.</em></h2>
       </div>
-      <p class="section-copy">Claude Code and Codex both connect to the same production MCP server with the same bearer-token model. Create a Genfeed API key, export it locally, then register the remote HTTP server.</p>
+      <p class="section-copy">Export a Genfeed API key, then add the remote HTTP server to your client.</p>
     </div>
 
     <div class="client-shell">
@@ -779,24 +779,24 @@ pre.command {
           <li class="step">
             <span class="step-number">01</span>
             <div>
-              <p class="step-title">Export a Genfeed API key</p>
-              <p class="step-copy">Create a <code class="inline">gf_</code> key in Genfeed settings, then export it before adding the server.</p>
+              <p class="step-title">Export API key</p>
+              <p class="step-copy">Create a <code class="inline">gf_</code> key in Genfeed settings.</p>
               <pre class="command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
             </div>
           </li>
           <li class="step">
             <span class="step-number">02</span>
             <div>
-              <p class="step-title">Add the remote HTTP server</p>
-              <p class="step-copy">User scope makes Genfeed available across local Claude Code sessions.</p>
+              <p class="step-title">Add MCP server</p>
+              <p class="step-copy">Register the hosted endpoint in user scope.</p>
               <pre class="command"><code>${claudeCommandSafe}</code></pre>
             </div>
           </li>
           <li class="step">
             <span class="step-number">03</span>
             <div>
-              <p class="step-title">Verify the connection</p>
-              <p class="step-copy">Run <code class="inline">claude mcp list</code> or open <code class="inline">/mcp</code> inside Claude Code.</p>
+              <p class="step-title">Verify</p>
+              <p class="step-copy">Run <code class="inline">claude mcp list</code> or open <code class="inline">/mcp</code>.</p>
             </div>
           </li>
         </ol>
@@ -811,24 +811,24 @@ pre.command {
           <li class="step">
             <span class="step-number">01</span>
             <div>
-              <p class="step-title">Export a Genfeed API key</p>
-              <p class="step-copy">Codex reads the bearer token from the environment variable configured for this server.</p>
+              <p class="step-title">Export API key</p>
+              <p class="step-copy">Codex reads this env var for the bearer token.</p>
               <pre class="command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
             </div>
           </li>
           <li class="step">
             <span class="step-number">02</span>
             <div>
-              <p class="step-title">Add the Streamable HTTP server</p>
-              <p class="step-copy">The CLI and IDE extension share the server definition through <code class="inline">~/.codex/config.toml</code>.</p>
+              <p class="step-title">Add MCP server</p>
+              <p class="step-copy">The CLI and IDE share <code class="inline">~/.codex/config.toml</code>.</p>
               <pre class="command"><code>${codexCommandSafe}</code></pre>
             </div>
           </li>
           <li class="step">
             <span class="step-number">03</span>
             <div>
-              <p class="step-title">Or edit config.toml directly</p>
-              <p class="step-copy">Use the same settings in a user or trusted project config.</p>
+              <p class="step-title">Manual config</p>
+              <p class="step-copy">Paste this into a user or trusted project config.</p>
               <pre class="command"><code>${codexTomlSafe}</code></pre>
             </div>
           </li>
@@ -840,36 +840,36 @@ pre.command {
   <section class="section" aria-labelledby="details-title">
     <div class="section-head">
       <div>
-        <p class="section-kicker">Server details</p>
-        <h2 class="section-title" id="details-title">Production by default. <em>Guarded by API keys.</em></h2>
+        <p class="section-kicker">Details</p>
+        <h2 class="section-title" id="details-title">Endpoint. <em>API auth.</em></h2>
       </div>
-      <p class="section-copy">The browser page is documentation. Actual MCP calls use the hosted <code class="inline">${mcpUrlSafe}</code> endpoint and the permissions attached to the API key on each request.</p>
+      <p class="section-copy">MCP calls go to <code class="inline">${mcpUrlSafe}</code> and use the permissions on the API key.</p>
     </div>
 
     <div class="meta-grid">
       <article class="meta-card">
         <p class="meta-label">Authentication</p>
-        <h3>Bearer token required</h3>
-        <p>Send <code class="inline">Authorization: Bearer gf_live_xxx</code> with every MCP request. Keys can be created and revoked from Genfeed app settings.</p>
+        <h3>Bearer token</h3>
+        <p>Send <code class="inline">Authorization: Bearer gf_live_xxx</code> with every request.</p>
         <a href="${apiKeysUrlSafe}" rel="noopener noreferrer">Manage keys</a>
       </article>
       <article class="meta-card">
         <p class="meta-label">Transport</p>
-        <h3>Streamable HTTP</h3>
-        <p>Clients should register Genfeed as a remote HTTP MCP server, not an <code class="inline">npx</code> stdio process and not localhost.</p>
+        <h3>HTTP transport</h3>
+        <p>Register Genfeed as a remote MCP server. No <code class="inline">npx</code> or localhost for cloud.</p>
         <a href="/v1/config" rel="noopener noreferrer">View config</a>
       </article>
       <article class="meta-card">
         <p class="meta-label">Status</p>
-        <h3>Service discovery</h3>
-        <p>Use the health and config endpoints when debugging client discovery, deployment routing, or stale MCP client settings.</p>
+        <h3>Health checks</h3>
+        <p>Use health and config to debug routing or stale client settings.</p>
         <a href="/v1/health" rel="noopener noreferrer">View health</a>
       </article>
     </div>
 
     <div class="warning-note" role="note">
       <span class="warning-mark">!</span>
-      <span>Treat API keys like passwords. Do not commit them or paste them into shared logs.</span>
+      <span>Keep API keys out of commits and shared logs.</span>
     </div>
   </section>
 

--- a/apps/server/mcp/src/mcp/setup-page.ts
+++ b/apps/server/mcp/src/mcp/setup-page.ts
@@ -1,0 +1,928 @@
+import process from 'node:process';
+
+const DEFAULT_APP_URL = 'https://app.genfeed.ai';
+const DEFAULT_DOCS_URL = 'https://docs.genfeed.ai';
+const DEFAULT_MCP_URL = 'https://mcp.genfeed.ai/mcp';
+const API_KEY_SETTINGS_PATH = '/settings/api-keys';
+const DOCS_GUIDE_PATH = '/api-reference/mcp';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/$/, '');
+}
+
+function readEnv(name: string): string | undefined {
+  // biome-ignore lint/style/noProcessEnv: MCP setup docs need deploy-time endpoint overrides before Nest config is available.
+  return process.env[name];
+}
+
+export function getPublicMcpUrl(): string {
+  return trimTrailingSlash(
+    readEnv('GENFEED_MCP_RESOURCE_URL') || DEFAULT_MCP_URL,
+  );
+}
+
+export function getPublicDocsUrl(): string {
+  return trimTrailingSlash(readEnv('GENFEED_DOCS_URL') || DEFAULT_DOCS_URL);
+}
+
+export function getPublicAppUrl(): string {
+  return trimTrailingSlash(readEnv('GENFEED_APP_URL') || DEFAULT_APP_URL);
+}
+
+export function renderSetupPage(): string {
+  const mcpUrl = getPublicMcpUrl();
+  const appUrl = getPublicAppUrl();
+  const docsUrl = getPublicDocsUrl();
+  const apiKeysUrl = `${appUrl}${API_KEY_SETTINGS_PATH}`;
+  const docsGuideUrl = `${docsUrl}${DOCS_GUIDE_PATH}`;
+
+  const mcpUrlSafe = escapeHtml(mcpUrl);
+  const apiKeysUrlSafe = escapeHtml(apiKeysUrl);
+  const docsUrlSafe = escapeHtml(docsUrl);
+  const docsGuideUrlSafe = escapeHtml(docsGuideUrl);
+  const claudeCommandSafe = escapeHtml(
+    `claude mcp add --transport http genfeed --scope user ${mcpUrl} --header "Authorization: Bearer $GENFEED_API_KEY"`,
+  );
+  const codexCommandSafe = escapeHtml(
+    `codex mcp add genfeed --url ${mcpUrl} --bearer-token-env-var GENFEED_API_KEY`,
+  );
+  const codexTomlSafe = escapeHtml(`[mcp_servers.genfeed]
+url = "${mcpUrl}"
+bearer_token_env_var = "GENFEED_API_KEY"`);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Genfeed MCP Server</title>
+<style>
+:root {
+  color-scheme: dark;
+  --bg: #000000;
+  --bg-soft: #050607;
+  --surface: rgba(255, 255, 255, 0.025);
+  --surface-strong: rgba(255, 255, 255, 0.055);
+  --edge: rgba(255, 255, 255, 0.08);
+  --edge-strong: rgba(255, 255, 255, 0.16);
+  --text: #f4f4f5;
+  --text-soft: rgba(244, 244, 245, 0.72);
+  --text-muted: rgba(244, 244, 245, 0.42);
+  --text-faint: rgba(244, 244, 245, 0.22);
+  --accent: #fafafa;
+  --accent-foreground: #050607;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --agent: #38bdf8;
+  --done: #a855f7;
+  --youtube: #ff0000;
+  --tiktok: #fe2c55;
+  --linkedin: #0a66c2;
+}
+* { box-sizing: border-box; }
+html { min-height: 100%; background: var(--bg); }
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  letter-spacing: 0;
+  -webkit-font-smoothing: antialiased;
+}
+body::before {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px);
+  background-size: 80px 80px;
+  content: "";
+  opacity: 0.55;
+}
+body::after {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(180deg, rgba(0,0,0,0.18), #000 86%);
+  content: "";
+}
+button, input { font: inherit; }
+button { cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+.page {
+  width: min(1120px, calc(100vw - 32px));
+  margin: 0 auto;
+}
+.site-nav {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid var(--edge);
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.mark {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 1px solid var(--edge);
+  background: #050607;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 800;
+}
+.brand-name {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+}
+.nav-link {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.nav-link:hover { color: var(--text); }
+.nav-button {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  padding: 0 14px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.hero {
+  display: grid;
+  min-height: 540px;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 460px);
+  gap: 56px;
+  align-items: center;
+  border-bottom: 1px solid var(--edge);
+  padding: 58px 0 64px;
+}
+.eyebrow,
+.section-kicker,
+.poster-kicker,
+.meta-label {
+  margin: 0;
+  color: var(--text-faint);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.hero h1 {
+  max-width: 680px;
+  margin: 18px 0 0;
+  color: var(--text);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 72px;
+  font-weight: 700;
+  line-height: 0.94;
+  letter-spacing: 0;
+}
+.hero h1 em {
+  display: block;
+  color: var(--text-muted);
+  font-style: italic;
+  font-weight: 400;
+}
+.lede {
+  max-width: 600px;
+  margin: 22px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.8;
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 30px;
+}
+.button {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--edge-strong);
+  border-radius: 4px;
+  background: #050607;
+  color: var(--text);
+  padding: 0 14px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.button.primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.button:hover { border-color: rgba(255,255,255,0.28); }
+.button.primary:hover { background: #e4e4e7; }
+.poster {
+  position: relative;
+  overflow: hidden;
+  min-height: 430px;
+  border: 1px solid var(--edge);
+  background:
+    linear-gradient(160deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018) 46%, rgba(255,255,255,0.008)),
+    #050607;
+  padding: 34px;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.32);
+}
+.poster::before {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.08) 1px, transparent 1px);
+  background-size: 96px 96px;
+  content: "";
+  opacity: 0.28;
+}
+.poster-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: 360px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 28px;
+}
+.poster-title {
+  max-width: 350px;
+  margin: 18px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+.poster-copy {
+  max-width: 330px;
+  margin: 14px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+.flow {
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid var(--edge);
+  padding-top: 18px;
+}
+.flow-row {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  border-bottom: 1px solid rgba(255,255,255,0.055);
+  padding: 10px 0;
+}
+.flow-row:last-child { border-bottom: 0; }
+.flow-name {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 750;
+}
+.flow-copy {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.status-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.status-dot::before {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--success);
+  content: "";
+}
+.platforms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  border-top: 1px solid var(--edge);
+  padding-top: 18px;
+}
+.platform {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--edge);
+  background: rgba(0,0,0,0.24);
+  padding: 6px 8px;
+  color: var(--text-soft);
+  font-size: 11px;
+  font-weight: 700;
+}
+.platform::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  content: "";
+}
+.platform.youtube::before { background: var(--youtube); }
+.platform.tiktok::before { background: var(--tiktok); }
+.platform.linkedin::before { background: var(--linkedin); }
+.endpoint-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, auto) auto;
+  gap: 18px;
+  align-items: end;
+  border-bottom: 1px solid var(--edge);
+  padding: 30px 0;
+}
+.endpoint-band > div {
+  min-width: 0;
+}
+.endpoint-copy {
+  min-width: 0;
+}
+.endpoint-copy p {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.endpoint-code {
+  min-width: 0;
+  overflow-x: auto;
+  border: 1px solid var(--edge);
+  background: rgba(255,255,255,0.025);
+  color: var(--text);
+  font-family: "SF Mono", SFMono-Regular, Consolas, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  padding: 10px 12px;
+  white-space: nowrap;
+}
+.copy {
+  align-self: end;
+  justify-self: start;
+  min-height: 36px;
+  border: 1px solid var(--edge-strong);
+  border-radius: 4px;
+  background: #050607;
+  color: var(--text-soft);
+  padding: 0 12px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.copy:hover { border-color: rgba(255,255,255,0.28); color: var(--text); }
+.section {
+  border-bottom: 1px solid var(--edge);
+  padding: 82px 0;
+}
+.section-head {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  gap: 42px;
+  align-items: end;
+  margin-bottom: 32px;
+}
+.section-title {
+  margin: 14px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 44px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+}
+.section-title em {
+  color: var(--text-muted);
+  font-style: italic;
+  font-weight: 400;
+}
+.section-copy {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.8;
+}
+.client-shell {
+  border: 1px solid var(--edge);
+  background: var(--surface);
+}
+.tablist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+  border-bottom: 1px solid var(--edge);
+}
+.tab {
+  min-height: 46px;
+  border: 0;
+  border-right: 1px solid var(--edge);
+  background: transparent;
+  color: var(--text-muted);
+  padding: 0 18px;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.tab[aria-selected="true"] {
+  background: var(--surface-strong);
+  color: var(--text);
+}
+.tabpanel {
+  display: none;
+  padding: 0 26px 6px;
+}
+.tabpanel.is-active { display: block; }
+.setup-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border-bottom: 1px solid var(--edge);
+  padding: 22px 0;
+}
+.instruction-title {
+  margin: 0;
+  color: var(--text);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--edge);
+  background: rgba(255,255,255,0.025);
+  color: var(--text-muted);
+  padding: 5px 8px;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.steps {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.step {
+  display: grid;
+  grid-template-columns: 68px minmax(0, 1fr);
+  gap: 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  padding: 24px 0;
+}
+.step > div {
+  min-width: 0;
+}
+.step:last-child { border-bottom: 0; }
+.step-number {
+  color: var(--text-faint);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 34px;
+  font-weight: 700;
+  line-height: 1;
+}
+.step-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 750;
+}
+.step-copy {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+code, pre {
+  font-family: "SF Mono", SFMono-Regular, Consolas, Menlo, monospace;
+}
+code.inline {
+  border: 1px solid var(--edge);
+  background: rgba(255,255,255,0.035);
+  padding: 1px 5px;
+  color: var(--text-soft);
+  font-size: 11px;
+}
+pre.command {
+  margin: 12px 0 0;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--edge);
+  background: #030303;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.7;
+  padding: 13px;
+  white-space: pre;
+}
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+.meta-card {
+  min-height: 190px;
+  border: 1px solid var(--edge);
+  background: var(--surface);
+  padding: 22px;
+}
+.meta-card h3 {
+  margin: 14px 0 0;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 750;
+}
+.meta-card p {
+  margin: 9px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+.meta-card a {
+  display: inline-flex;
+  margin-top: 16px;
+  color: var(--text-soft);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.meta-card a:hover { color: var(--text); }
+.warning-note {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 12px;
+  margin-top: 14px;
+  border: 1px solid rgba(245,158,11,0.26);
+  background: rgba(245,158,11,0.08);
+  padding: 14px;
+  color: var(--text-soft);
+  font-size: 12px;
+  line-height: 1.6;
+}
+.warning-mark {
+  color: var(--warning);
+  font-weight: 900;
+}
+.site-footer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 18px;
+  align-items: center;
+  padding: 36px 0 44px;
+  color: var(--text-faint);
+  font-size: 11px;
+}
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 16px;
+}
+.footer-links a {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.footer-links a:hover { color: var(--text); }
+@media (max-width: 920px) {
+  .hero,
+  .section-head,
+  .meta-grid,
+  .endpoint-band {
+    grid-template-columns: 1fr;
+  }
+  .hero {
+    min-height: auto;
+    gap: 34px;
+    padding: 48px 0 54px;
+  }
+  .hero h1 { font-size: 58px; }
+  .poster { min-height: 360px; }
+  .copy { justify-self: start; }
+}
+@media (max-width: 640px) {
+  .page { width: min(100vw - 24px, 1120px); }
+  .site-nav { align-items: flex-start; padding: 12px 0; }
+  .nav-links { gap: 10px; }
+  .nav-link { display: none; }
+  .hero h1 { font-size: 42px; }
+  .poster { padding: 22px; }
+  .poster-title { font-size: 34px; }
+  .flow-row { grid-template-columns: 1fr; gap: 3px; }
+  .flow-copy { white-space: normal; }
+  .section { padding: 56px 0; }
+  .section-title { font-size: 34px; }
+  .tabpanel { padding: 0 16px 4px; }
+  .tab {
+    flex: 1 1 50%;
+    border-bottom: 1px solid var(--edge);
+    padding: 0 10px;
+  }
+  .step { grid-template-columns: 1fr; gap: 8px; }
+  .step-number { font-size: 26px; }
+  .site-footer { grid-template-columns: 1fr; }
+  .footer-links { justify-content: flex-start; }
+}
+</style>
+</head>
+<body>
+<main class="page">
+  <nav class="site-nav" aria-label="Genfeed MCP">
+    <a class="brand" href="https://genfeed.ai" rel="noopener noreferrer">
+      <span class="mark" aria-hidden="true">G</span>
+      <span class="brand-name">Genfeed MCP</span>
+    </a>
+    <div class="nav-links" aria-label="MCP navigation">
+      <a class="nav-link" href="${docsGuideUrlSafe}" rel="noopener noreferrer">Docs</a>
+      <a class="nav-link" href="/v1/config" rel="noopener noreferrer">Config</a>
+      <a class="nav-link" href="/v1/health" rel="noopener noreferrer">Health</a>
+      <a class="nav-button" href="${apiKeysUrlSafe}" rel="noopener noreferrer">API keys</a>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div>
+      <p class="eyebrow">&lt; MCP server &gt;</p>
+      <h1>Connect AI agents to your content operating system.<em>From Claude Code to Codex.</em></h1>
+      <p class="lede">Genfeed MCP gives compatible AI clients API-key scoped access to content, media generation, workflows, publishing, analytics, ads, and agent threads.</p>
+      <div class="hero-actions">
+        <a class="button primary" href="${apiKeysUrlSafe}" rel="noopener noreferrer">Create API key</a>
+        <a class="button" href="${docsGuideUrlSafe}" rel="noopener noreferrer">Read MCP docs</a>
+      </div>
+    </div>
+
+    <aside class="poster" aria-label="Genfeed MCP workflow preview">
+      <div class="poster-inner">
+        <div>
+          <p class="poster-kicker">AI model context protocol</p>
+          <h2 class="poster-title">Workspace context for every agent.</h2>
+          <p class="poster-copy">Research, create, publish, and measure without copying data between Genfeed and your AI client.</p>
+        </div>
+        <div class="flow" aria-label="Content operating loop">
+          <div class="flow-row">
+            <span class="flow-name">Research</span>
+            <span class="flow-copy">Trending topics, analytics, audience signals</span>
+            <span class="status-dot">Live</span>
+          </div>
+          <div class="flow-row">
+            <span class="flow-name">Generate</span>
+            <span class="flow-copy">Video, image, music, article, campaign assets</span>
+            <span class="status-dot">Ready</span>
+          </div>
+          <div class="flow-row">
+            <span class="flow-name">Publish</span>
+            <span class="flow-copy">Schedule posts and trigger workflows</span>
+            <span class="status-dot">Guarded</span>
+          </div>
+        </div>
+        <div class="platforms" aria-label="Platform publishing preview">
+          <span class="platform youtube">YouTube</span>
+          <span class="platform tiktok">TikTok</span>
+          <span class="platform linkedin">LinkedIn</span>
+        </div>
+      </div>
+    </aside>
+  </header>
+
+  <section class="endpoint-band" aria-labelledby="endpoint-title">
+    <div class="endpoint-copy">
+      <p class="meta-label" id="endpoint-title">Production endpoint</p>
+      <p>Use the hosted Streamable HTTP endpoint. Localhost belongs only in self-hosted development config.</p>
+    </div>
+    <div>
+      <div class="endpoint-code" id="mcp-url">${mcpUrlSafe}</div>
+    </div>
+    <button class="copy" type="button" data-copy="${mcpUrlSafe}" aria-label="Copy MCP endpoint">Copy</button>
+  </section>
+
+  <section class="section" aria-labelledby="setup-title">
+    <div class="section-head">
+      <div>
+        <p class="section-kicker">Client setup</p>
+        <h2 class="section-title" id="setup-title">One server. <em>Two agent clients.</em></h2>
+      </div>
+      <p class="section-copy">Claude Code and Codex both connect to the same production MCP server with the same bearer-token model. Create a Genfeed API key, export it locally, then register the remote HTTP server.</p>
+    </div>
+
+    <div class="client-shell">
+      <div class="tablist" role="tablist" aria-label="Client setup instructions">
+        <button class="tab" id="tab-claude-code" type="button" role="tab" aria-selected="true" aria-controls="panel-claude-code" data-tab="claude-code">Claude Code</button>
+        <button class="tab" id="tab-codex" type="button" role="tab" aria-selected="false" aria-controls="panel-codex" data-tab="codex">Codex</button>
+      </div>
+
+      <section class="tabpanel is-active" id="panel-claude-code" role="tabpanel" aria-labelledby="tab-claude-code" data-panel="claude-code">
+        <div class="setup-title-row">
+          <h3 class="instruction-title">Claude Code setup</h3>
+          <span class="badge">HTTP transport</span>
+        </div>
+        <ol class="steps">
+          <li class="step">
+            <span class="step-number">01</span>
+            <div>
+              <p class="step-title">Export a Genfeed API key</p>
+              <p class="step-copy">Create a <code class="inline">gf_</code> key in Genfeed settings, then export it before adding the server.</p>
+              <pre class="command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
+            </div>
+          </li>
+          <li class="step">
+            <span class="step-number">02</span>
+            <div>
+              <p class="step-title">Add the remote HTTP server</p>
+              <p class="step-copy">User scope makes Genfeed available across local Claude Code sessions.</p>
+              <pre class="command"><code>${claudeCommandSafe}</code></pre>
+            </div>
+          </li>
+          <li class="step">
+            <span class="step-number">03</span>
+            <div>
+              <p class="step-title">Verify the connection</p>
+              <p class="step-copy">Run <code class="inline">claude mcp list</code> or open <code class="inline">/mcp</code> inside Claude Code.</p>
+            </div>
+          </li>
+        </ol>
+      </section>
+
+      <section class="tabpanel" id="panel-codex" role="tabpanel" aria-labelledby="tab-codex" data-panel="codex">
+        <div class="setup-title-row">
+          <h3 class="instruction-title">Codex setup</h3>
+          <span class="badge">CLI and IDE config</span>
+        </div>
+        <ol class="steps">
+          <li class="step">
+            <span class="step-number">01</span>
+            <div>
+              <p class="step-title">Export a Genfeed API key</p>
+              <p class="step-copy">Codex reads the bearer token from the environment variable configured for this server.</p>
+              <pre class="command"><code>export GENFEED_API_KEY=gf_live_xxx</code></pre>
+            </div>
+          </li>
+          <li class="step">
+            <span class="step-number">02</span>
+            <div>
+              <p class="step-title">Add the Streamable HTTP server</p>
+              <p class="step-copy">The CLI and IDE extension share the server definition through <code class="inline">~/.codex/config.toml</code>.</p>
+              <pre class="command"><code>${codexCommandSafe}</code></pre>
+            </div>
+          </li>
+          <li class="step">
+            <span class="step-number">03</span>
+            <div>
+              <p class="step-title">Or edit config.toml directly</p>
+              <p class="step-copy">Use the same settings in a user or trusted project config.</p>
+              <pre class="command"><code>${codexTomlSafe}</code></pre>
+            </div>
+          </li>
+        </ol>
+      </section>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="details-title">
+    <div class="section-head">
+      <div>
+        <p class="section-kicker">Server details</p>
+        <h2 class="section-title" id="details-title">Production by default. <em>Guarded by API keys.</em></h2>
+      </div>
+      <p class="section-copy">The browser page is documentation. Actual MCP calls use the hosted <code class="inline">${mcpUrlSafe}</code> endpoint and the permissions attached to the API key on each request.</p>
+    </div>
+
+    <div class="meta-grid">
+      <article class="meta-card">
+        <p class="meta-label">Authentication</p>
+        <h3>Bearer token required</h3>
+        <p>Send <code class="inline">Authorization: Bearer gf_live_xxx</code> with every MCP request. Keys can be created and revoked from Genfeed app settings.</p>
+        <a href="${apiKeysUrlSafe}" rel="noopener noreferrer">Manage keys</a>
+      </article>
+      <article class="meta-card">
+        <p class="meta-label">Transport</p>
+        <h3>Streamable HTTP</h3>
+        <p>Clients should register Genfeed as a remote HTTP MCP server, not an <code class="inline">npx</code> stdio process and not localhost.</p>
+        <a href="/v1/config" rel="noopener noreferrer">View config</a>
+      </article>
+      <article class="meta-card">
+        <p class="meta-label">Status</p>
+        <h3>Service discovery</h3>
+        <p>Use the health and config endpoints when debugging client discovery, deployment routing, or stale MCP client settings.</p>
+        <a href="/v1/health" rel="noopener noreferrer">View health</a>
+      </article>
+    </div>
+
+    <div class="warning-note" role="note">
+      <span class="warning-mark">!</span>
+      <span>Treat API keys like passwords. Do not commit them or paste them into shared logs.</span>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <span>Genfeed.ai MCP</span>
+    <div class="footer-links">
+      <a href="${docsUrlSafe}" rel="noopener noreferrer">Documentation</a>
+      <a href="${docsGuideUrlSafe}" rel="noopener noreferrer">MCP guide</a>
+      <a href="/v1/config" rel="noopener noreferrer">Config</a>
+      <a href="/v1/health" rel="noopener noreferrer">Health</a>
+    </div>
+  </footer>
+</main>
+<script>
+  function setActiveTab(next) {
+    document.querySelectorAll('[role="tab"][data-tab]').forEach(function (tab) {
+      var active = tab.getAttribute('data-tab') === next;
+      tab.setAttribute('aria-selected', active ? 'true' : 'false');
+      tab.tabIndex = active ? 0 : -1;
+    });
+    document.querySelectorAll('[role="tabpanel"][data-panel]').forEach(function (panel) {
+      panel.classList.toggle('is-active', panel.getAttribute('data-panel') === next);
+    });
+  }
+
+  document.querySelectorAll('[role="tab"][data-tab]').forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      setActiveTab(tab.getAttribute('data-tab') || 'claude-code');
+    });
+    tab.addEventListener('keydown', function (event) {
+      if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+      var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"][data-tab]'));
+      var index = tabs.indexOf(tab);
+      var nextIndex = event.key === 'ArrowRight'
+        ? (index + 1) % tabs.length
+        : (index - 1 + tabs.length) % tabs.length;
+      event.preventDefault();
+      tabs[nextIndex].focus();
+      setActiveTab(tabs[nextIndex].getAttribute('data-tab') || 'claude-code');
+    });
+  });
+
+  document.querySelectorAll('button.copy').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var text = btn.getAttribute('data-copy') || '';
+      navigator.clipboard.writeText(text).then(function () {
+        var previous = btn.textContent;
+        btn.textContent = 'Copied';
+        setTimeout(function () { btn.textContent = previous; }, 1500);
+      });
+    });
+  });
+</script>
+</body>
+</html>`;
+}

--- a/apps/server/mcp/src/mcp/setup-page.ts
+++ b/apps/server/mcp/src/mcp/setup-page.ts
@@ -186,7 +186,6 @@ a { color: inherit; text-decoration: none; }
 }
 .eyebrow,
 .section-kicker,
-.mcp-hero-card-kicker,
 .meta-label {
   margin: 0;
   color: var(--gf-text-faint);
@@ -223,49 +222,6 @@ a { color: inherit; text-decoration: none; }
   flex-wrap: wrap;
   gap: 10px;
   margin-top: 30px;
-}
-.mcp-hero-card {
-  min-height: 430px;
-  background:
-    linear-gradient(160deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018) 46%, rgba(255,255,255,0.008)),
-    var(--gf-bg-primary);
-  padding: 34px;
-  box-shadow: 0 24px 80px rgba(0,0,0,0.32);
-}
-.mcp-hero-card::before {
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(255,255,255,0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,0.08) 1px, transparent 1px);
-  background-size: 96px 96px;
-  content: "";
-  opacity: 0.28;
-}
-.mcp-hero-card-inner {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  min-height: 360px;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 28px;
-}
-.mcp-hero-card-title {
-  max-width: 350px;
-  margin: 18px 0 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 42px;
-  font-weight: 700;
-  line-height: 0.98;
-  letter-spacing: 0;
-}
-.mcp-hero-card-copy {
-  max-width: 330px;
-  margin: 14px 0 0;
-  color: var(--gf-text-muted);
-  font-size: 13px;
-  line-height: 1.65;
 }
 .flow {
   display: grid;
@@ -478,32 +434,6 @@ pre.command {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
 }
-.mcp-meta-card {
-  min-height: 190px;
-  padding: 22px;
-}
-.mcp-meta-card h3 {
-  margin: 14px 0 0;
-  color: var(--gf-text-primary);
-  font-size: 15px;
-  font-weight: 750;
-}
-.mcp-meta-card p {
-  margin: 9px 0 0;
-  color: var(--gf-text-muted);
-  font-size: 13px;
-  line-height: 1.65;
-}
-.mcp-meta-card a {
-  display: inline-flex;
-  margin-top: 16px;
-  color: var(--gf-text-secondary);
-  font-size: 10px;
-  font-weight: 900;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-.mcp-meta-card a:hover { color: var(--gf-text-primary); }
 .mcp-warning-note {
   margin-top: 14px;
 }
@@ -547,7 +477,6 @@ pre.command {
     padding: 48px 0 54px;
   }
   .hero h1 { font-size: 58px; }
-  .mcp-hero-card { min-height: 360px; }
   .copy { justify-self: start; }
 }
 @media (max-width: 640px) {
@@ -556,8 +485,6 @@ pre.command {
   .nav-links { gap: 10px; }
   .nav-link { display: none; }
   .hero h1 { font-size: 42px; }
-  .mcp-hero-card { padding: 22px; }
-  .mcp-hero-card-title { font-size: 34px; }
   .flow-row { grid-template-columns: 1fr; gap: 3px; }
   .flow-copy { white-space: normal; }
   .section { padding: 56px 0; }
@@ -601,12 +528,12 @@ pre.command {
       </div>
     </div>
 
-    <aside class="${ui.card} mcp-hero-card" aria-label="Genfeed MCP workflow preview">
-      <div class="mcp-hero-card-inner">
+    <aside class="${ui.featureCard}" aria-label="Genfeed MCP workflow preview">
+      <div class="${ui.featureCardInner}">
         <div>
-          <p class="mcp-hero-card-kicker">AI model context protocol</p>
-          <h2 class="mcp-hero-card-title">Agent workspace access.</h2>
-          <p class="mcp-hero-card-copy">Read, create, publish, and measure from your AI client.</p>
+          <p class="${ui.featureCardKicker}">AI model context protocol</p>
+          <h2 class="${ui.featureCardTitle}">Agent workspace access.</h2>
+          <p class="${ui.featureCardCopy}">Read, create, publish, and measure from your AI client.</p>
         </div>
         <div class="flow" aria-label="Content operating loop">
           <div class="flow-row">
@@ -737,19 +664,19 @@ pre.command {
     </div>
 
     <div class="meta-grid">
-      <article class="${ui.card} mcp-meta-card">
+      <article class="${ui.infoCard}">
         <p class="meta-label">Authentication</p>
         <h3>Bearer token</h3>
         <p>Send <code class="${ui.inlineCode}">Authorization: Bearer gf_live_xxx</code> with every request.</p>
         <a href="${apiKeysUrlSafe}" rel="noopener noreferrer">Manage keys</a>
       </article>
-      <article class="${ui.card} mcp-meta-card">
+      <article class="${ui.infoCard}">
         <p class="meta-label">Transport</p>
         <h3>HTTP transport</h3>
         <p>Register Genfeed as a remote MCP server. No <code class="${ui.inlineCode}">npx</code> or localhost for cloud.</p>
         <a href="/v1/config" rel="noopener noreferrer">View config</a>
       </article>
-      <article class="${ui.card} mcp-meta-card">
+      <article class="${ui.infoCard}">
         <p class="meta-label">Status</p>
         <h3>Health checks</h3>
         <p>Use health and config to debug routing or stale client settings.</p>

--- a/apps/server/mcp/src/mcp/setup-page.ts
+++ b/apps/server/mcp/src/mcp/setup-page.ts
@@ -29,18 +29,32 @@ function readEnv(name: string): string | undefined {
   return process.env[name];
 }
 
+function readPublicUrl(name: string, fallback: string): string {
+  const raw = readEnv(name);
+  if (!raw) return trimTrailingSlash(fallback);
+  let protocol: string;
+  try {
+    ({ protocol } = new URL(raw));
+  } catch {
+    return trimTrailingSlash(fallback);
+  }
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    return trimTrailingSlash(fallback);
+  }
+  // Return raw (not URL#toString) to preserve original encoding.
+  return trimTrailingSlash(raw);
+}
+
 export function getPublicMcpUrl(): string {
-  return trimTrailingSlash(
-    readEnv('GENFEED_MCP_RESOURCE_URL') || DEFAULT_MCP_URL,
-  );
+  return readPublicUrl('GENFEED_MCP_RESOURCE_URL', DEFAULT_MCP_URL);
 }
 
 export function getPublicDocsUrl(): string {
-  return trimTrailingSlash(readEnv('GENFEED_DOCS_URL') || DEFAULT_DOCS_URL);
+  return readPublicUrl('GENFEED_DOCS_URL', DEFAULT_DOCS_URL);
 }
 
 export function getPublicAppUrl(): string {
-  return trimTrailingSlash(readEnv('GENFEED_APP_URL') || DEFAULT_APP_URL);
+  return readPublicUrl('GENFEED_APP_URL', DEFAULT_APP_URL);
 }
 
 export function renderSetupPage(): string {

--- a/apps/server/mcp/src/shared/interfaces/mcp-config.interface.ts
+++ b/apps/server/mcp/src/shared/interfaces/mcp-config.interface.ts
@@ -1,9 +1,35 @@
 export interface McpConfiguration {
   mcpServers: {
+    [key: string]:
+      | {
+          args: string[];
+          command: string;
+          env?: Record<string, string>;
+        }
+      | {
+          headers?: Record<string, string>;
+          transport?: string;
+          type: 'http';
+          url: string;
+        };
+  };
+}
+
+export interface McpClientExamples {
+  claudeCode: {
+    command: string;
+  };
+  codex: {
+    command: string;
+    configToml: string;
+  };
+  mcpServers: {
     [key: string]: {
-      command: string;
-      args: string[];
       env?: Record<string, string>;
+      headers?: Record<string, string>;
+      transport?: string;
+      type: 'http';
+      url: string;
     };
   };
 }

--- a/apps/server/mcp/tsconfig.app.json
+++ b/apps/server/mcp/tsconfig.app.json
@@ -7,8 +7,10 @@
     "moduleResolution": "node16",
     "outDir": "../dist/apps/mcp",
     "paths": {
+      "@genfeedai/ui/*": ["../../../packages/ui/src/*"],
       "@libs/*": ["../../../packages/libs/*"],
-      "@mcp/*": ["./src/*"]
+      "@mcp/*": ["./src/*"],
+      "@ui/*": ["../../../packages/ui/src/*"]
     },
     "resolveJsonModule": true
   },

--- a/apps/server/mcp/tsconfig.json
+++ b/apps/server/mcp/tsconfig.json
@@ -4,8 +4,10 @@
     "moduleResolution": "node16",
     "outDir": "../../dist/apps/mcp",
     "paths": {
+      "@genfeedai/ui/*": ["../../../packages/ui/src/*"],
       "@libs/*": ["../../../packages/libs/*"],
-      "@mcp/*": ["./src/*"]
+      "@mcp/*": ["./src/*"],
+      "@ui/*": ["../../../packages/ui/src/*"]
     },
     "resolveJsonModule": true,
     "types": ["node", "vitest/globals"]

--- a/apps/server/mcp/vitest.config.ts
+++ b/apps/server/mcp/vitest.config.ts
@@ -42,6 +42,14 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@genfeedai\/ui\/(.*)$/,
+        replacement: path.resolve(mcpDir, '../../../packages/ui/src/$1'),
+      },
+      {
+        find: /^@ui\/(.*)$/,
+        replacement: path.resolve(mcpDir, '../../../packages/ui/src/$1'),
+      },
+      {
         find: '@genfeedai/config',
         replacement: path.resolve(mcpDir, '../../../packages/config/src'),
       },

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -42,6 +42,10 @@ export const designTokens: DesignTokens = {
 };
 
 export {
+  staticSurfaceClassNames,
+  staticSurfaceCss,
+} from './static/surface';
+export {
   generateNativeTokens,
   generateWebTokenCss,
   generateWebviewTokenCss,

--- a/packages/ui/src/static/surface.test.ts
+++ b/packages/ui/src/static/surface.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { staticSurfaceClassNames, staticSurfaceCss } from './surface';
+
+describe('static surface primitives', () => {
+  it('uses the shared card radius for HTML-only surfaces', () => {
+    expect(staticSurfaceClassNames.card).toBe('gf-card');
+    expect(staticSurfaceCss).toContain('border-radius: var(--gf-radius-md)');
+    expect(staticSurfaceCss).toContain('--gf-radius-md: 6px');
+  });
+});

--- a/packages/ui/src/static/surface.test.ts
+++ b/packages/ui/src/static/surface.test.ts
@@ -5,7 +5,11 @@ import { staticSurfaceClassNames, staticSurfaceCss } from './surface';
 describe('static surface primitives', () => {
   it('uses the shared card radius for HTML-only surfaces', () => {
     expect(staticSurfaceClassNames.card).toBe('gf-card');
+    expect(staticSurfaceClassNames.featureCard).toBe('gf-card gf-feature-card');
+    expect(staticSurfaceClassNames.infoCard).toBe('gf-card gf-info-card');
     expect(staticSurfaceCss).toContain('border-radius: var(--gf-radius-md)');
     expect(staticSurfaceCss).toContain('--gf-radius-md: 6px');
+    expect(staticSurfaceCss).toContain('.gf-feature-card');
+    expect(staticSurfaceCss).toContain('.gf-info-card');
   });
 });

--- a/packages/ui/src/static/surface.ts
+++ b/packages/ui/src/static/surface.ts
@@ -11,6 +11,12 @@ export const staticSurfaceClassNames = {
   card: 'gf-card',
   chip: 'gf-chip',
   codeBlock: 'gf-code-block',
+  featureCard: 'gf-card gf-feature-card',
+  featureCardCopy: 'gf-feature-card-copy',
+  featureCardInner: 'gf-feature-card-inner',
+  featureCardKicker: 'gf-feature-card-kicker',
+  featureCardTitle: 'gf-feature-card-title',
+  infoCard: 'gf-card gf-info-card',
   inlineCode: 'gf-inline-code',
   root: 'gf-ui',
   warningNote: 'gf-warning-note',
@@ -59,6 +65,85 @@ export const staticSurfaceCss = `
 }
 .gf-card:hover {
   box-shadow: var(--gf-shadow-border-strong);
+}
+.gf-feature-card {
+  min-height: 430px;
+  background:
+    linear-gradient(160deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018) 46%, rgba(255,255,255,0.008)),
+    var(--gf-bg-primary);
+  padding: 34px;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.32);
+}
+.gf-feature-card::before {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.08) 1px, transparent 1px);
+  background-size: 96px 96px;
+  content: "";
+  opacity: 0.28;
+}
+.gf-feature-card-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: 360px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 28px;
+}
+.gf-feature-card-kicker {
+  margin: 0;
+  color: var(--gf-text-faint);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.gf-feature-card-title {
+  max-width: 350px;
+  margin: 18px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+.gf-feature-card-copy {
+  max-width: 330px;
+  margin: 14px 0 0;
+  color: var(--gf-text-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+.gf-info-card {
+  min-height: 190px;
+  padding: 22px;
+}
+.gf-info-card h3 {
+  margin: 14px 0 0;
+  color: var(--gf-text-primary);
+  font-size: 15px;
+  font-weight: 750;
+}
+.gf-info-card p {
+  margin: 9px 0 0;
+  color: var(--gf-text-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+.gf-info-card a {
+  display: inline-flex;
+  margin-top: 16px;
+  color: var(--gf-text-secondary);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.gf-info-card a:hover {
+  color: var(--gf-text-primary);
 }
 .gf-button {
   display: inline-flex;
@@ -156,5 +241,18 @@ export const staticSurfaceCss = `
   padding: 14px;
   font-size: 12px;
   line-height: 1.6;
+}
+@media (max-width: 920px) {
+  .gf-feature-card {
+    min-height: 360px;
+  }
+}
+@media (max-width: 640px) {
+  .gf-feature-card {
+    padding: 22px;
+  }
+  .gf-feature-card-title {
+    font-size: 34px;
+  }
 }
 `;

--- a/packages/ui/src/static/surface.ts
+++ b/packages/ui/src/static/surface.ts
@@ -1,0 +1,160 @@
+import { semanticColorTokens } from '../core/colors';
+import { radiusTokens } from '../core/radius';
+
+const darkColors = semanticColorTokens.dark;
+
+export const staticSurfaceClassNames = {
+  badge: 'gf-badge',
+  button: 'gf-button',
+  buttonPrimary: 'gf-button gf-button-primary',
+  buttonSecondary: 'gf-button gf-button-secondary',
+  card: 'gf-card',
+  chip: 'gf-chip',
+  codeBlock: 'gf-code-block',
+  inlineCode: 'gf-inline-code',
+  root: 'gf-ui',
+  warningNote: 'gf-warning-note',
+} as const;
+
+export const staticSurfaceCss = `
+.gf-ui {
+  --gf-bg-primary: ${darkColors.background.hex};
+  --gf-bg-secondary: ${darkColors.card.hex};
+  --gf-bg-tertiary: ${darkColors.backgroundSecondary.hex};
+  --gf-bg-elevated: ${darkColors.popover.hex};
+  --gf-bg-hover: ${darkColors.backgroundTertiary.hex};
+  --gf-border: ${darkColors.border.hex};
+  --gf-border-strong: rgba(255, 255, 255, 0.18);
+  --gf-text-primary: ${darkColors.foreground.hex};
+  --gf-text-secondary: ${darkColors.secondaryForeground.hex};
+  --gf-text-muted: ${darkColors.mutedForeground.hex};
+  --gf-text-faint: rgba(244, 244, 245, 0.22);
+  --gf-accent: ${darkColors.primary.hex};
+  --gf-accent-foreground: ${darkColors.primaryForeground.hex};
+  --gf-accent-hover: #e4e4e7;
+  --gf-success: ${darkColors.success.hex};
+  --gf-warning: ${darkColors.warning.hex};
+  --gf-danger: ${darkColors.destructive.hex};
+  --gf-info: ${darkColors.info.hex};
+  --gf-platform-youtube: #ff0000;
+  --gf-platform-tiktok: #fe2c55;
+  --gf-platform-linkedin: #0a66c2;
+  --gf-radius-sm: ${radiusTokens.sm};
+  --gf-radius-md: ${radiusTokens.md};
+  --gf-radius-lg: ${radiusTokens.lg};
+  --gf-radius-xl: ${radiusTokens.xl};
+  --gf-shadow-border: inset 0 0 0 1px var(--gf-border);
+  --gf-shadow-border-strong: inset 0 0 0 1px var(--gf-border-strong);
+}
+.gf-card {
+  position: relative;
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--gf-radius-md);
+  background: var(--gf-bg-secondary);
+  color: var(--gf-text-primary);
+  box-shadow: var(--gf-shadow-border);
+  text-align: left;
+  transition: background-color 150ms ease-out, box-shadow 150ms ease-out;
+}
+.gf-card:hover {
+  box-shadow: var(--gf-shadow-border-strong);
+}
+.gf-button {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--gf-border-strong);
+  border-radius: var(--gf-radius-md);
+  background: transparent;
+  color: var(--gf-text-primary);
+  padding: 0 14px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: background-color 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out;
+}
+.gf-button:hover {
+  border-color: var(--gf-text-muted);
+  background: var(--gf-bg-hover);
+}
+.gf-button-primary {
+  border-color: var(--gf-accent);
+  background: var(--gf-accent);
+  color: var(--gf-accent-foreground);
+}
+.gf-button-primary:hover {
+  border-color: var(--gf-accent-hover);
+  background: var(--gf-accent-hover);
+  color: var(--gf-accent-foreground);
+}
+.gf-button-secondary {
+  background: var(--gf-bg-secondary);
+  color: var(--gf-text-secondary);
+}
+.gf-badge,
+.gf-chip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--gf-border);
+  border-radius: var(--gf-radius-md);
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--gf-text-muted);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.gf-badge {
+  padding: 5px 8px;
+}
+.gf-chip {
+  gap: 7px;
+  padding: 6px 8px;
+  color: var(--gf-text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.gf-inline-code,
+.gf-code-block {
+  font-family: "SF Mono", SFMono-Regular, Consolas, Menlo, monospace;
+}
+.gf-inline-code {
+  border: 1px solid var(--gf-border);
+  border-radius: var(--gf-radius-sm);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--gf-text-secondary);
+  padding: 1px 5px;
+  font-size: 11px;
+}
+.gf-code-block {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 0;
+  border-radius: var(--gf-radius-md);
+  background: var(--gf-bg-primary);
+  color: #dbeafe;
+  box-shadow: var(--gf-shadow-border);
+  font-size: 12px;
+  line-height: 1.7;
+  padding: 13px;
+  white-space: pre;
+}
+.gf-warning-note {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 12px;
+  border: 1px solid rgba(245, 158, 11, 0.26);
+  border-radius: var(--gf-radius-md);
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--gf-text-secondary);
+  padding: 14px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+`;


### PR DESCRIPTION
## Summary

- Switch MCP client configuration and metadata from localhost/stdio-style setup to the hosted Streamable HTTP endpoint at `https://mcp.genfeed.ai/mcp`.
- Add the hosted MCP setup page with Genfeed.ai visual treatment, Claude Code and Codex setup tabs, API-key guidance, and health/config links.
- Move the MCP setup page card treatments into shared static UI primitives: `gf-feature-card` and `gf-info-card`.
- Remove MCP-only card classes like `mcp-hero-card` and `mcp-meta-card` so the page consumes shared UI surfaces instead of owning card implementations.

## Why

The live MCP docs/setup surface was still presenting local connection details and a generic connector-page design. The first pass also put reusable card styling in the MCP page itself. This updates the public endpoint and client setup while keeping the card surface system owned by `@genfeedai/ui`.

## Validation

- `bun run --cwd apps/server/mcp test` passes: 17 files, 144 tests.
- `bun run --cwd apps/server/mcp build` passes.
- `bun run --cwd packages/ui test -- src/static/surface.test.ts` passes.
- `bun run --cwd packages/ui build` passes.
- `bun run design:lint` passes with 0 errors; existing DESIGN.md warnings remain.
- Previous docs build and Playwright smoke coverage on this PR passed for desktop/mobile endpoint text, no localhost leak, tab behavior, and no horizontal overflow.
