### PR TITLE
fix(posts): guard activity-FAILED patch so posts never stick in PROCESSING

### DIFF
--- a/apps/server/api/src/collections/posts/services/post-generation.service.ts
+++ b/apps/server/api/src/collections/posts/services/post-generation.service.ts
@@ -657,12 +657,22 @@ export class PostGenerationService {
       });
 
       if (activity) {
-        await this.activitiesService.patch(activity._id.toString(), {
-          key: ActivityKey.POST_FAILED,
-          value: JSON.stringify({
-            error: (error as Error)?.message || 'Generation failed',
-          }),
-        });
+        try {
+          await this.activitiesService.patch(activity._id.toString(), {
+            key: ActivityKey.POST_FAILED,
+            value: JSON.stringify({
+              error: (error as Error)?.message || 'Generation failed',
+            }),
+          });
+        } catch (activityError) {
+          // Never let an activity-update failure short-circuit the cleanup
+          // below — placeholder posts must still be marked FAILED, otherwise
+          // they stay stuck in PROCESSING forever.
+          this.logger.error(
+            'Failed to mark activity as failed during account content cleanup',
+            { activityError, platform: context.account.platform },
+          );
+        }
       }
 
       for (const post of createdPosts) {
@@ -837,12 +847,22 @@ export class PostGenerationService {
 
       // Update activity to FAILED
       if (activity) {
-        await this.activitiesService.patch(activity._id.toString(), {
-          key: ActivityKey.POST_FAILED,
-          value: JSON.stringify({
-            error: (error as Error)?.message || 'Thread expansion failed',
-          }),
-        });
+        try {
+          await this.activitiesService.patch(activity._id.toString(), {
+            key: ActivityKey.POST_FAILED,
+            value: JSON.stringify({
+              error: (error as Error)?.message || 'Thread expansion failed',
+            }),
+          });
+        } catch (activityError) {
+          // Never let an activity-update failure short-circuit the cleanup
+          // below — child posts must still be marked FAILED, otherwise they
+          // stay stuck in PROCESSING forever.
+          this.logger.error(
+            'Failed to mark activity as failed during thread expansion cleanup',
+            activityError,
+          );
+        }
       }
 
       for (const child of childPosts) {


### PR DESCRIPTION
## Problem (live on `master`)

In `post-generation.service.ts`, both `generateAccountContentAsync` and `expandThreadAsync` mark the parent activity `FAILED` inside their `catch` handler **before** the loop that marks each placeholder post `FAILED`:

```ts
if (activity) {
  await this.activitiesService.patch(...); // <-- if this throws, the loop below is skipped
}
for (const post of createdPosts) {
  await this.handleGeneratedPostFailure(...); // never runs -> posts stuck in PROCESSING
}
```

If `activitiesService.patch()` throws (DB timeout, already-deleted activity, transient failure), the exception escapes the catch and the post-failure cleanup loop never executes — leaving created posts **permanently stuck in PROCESSING**.

## Fix

Wrap each `activitiesService.patch()` call in its own `try/catch` (log + continue) so the FAILED-marking loop always runs regardless of the activity update outcome.

## Context

Surfaced during the merge-readiness review of #864. The bug is **live on master** — #877 ("failure-safe activity creation") moved `create()` inside the try and guarded `undefined` activity, but did **not** cover the unguarded patch in the catch blocks. #864 itself is now heavily conflicting/superseded, so this isolated fix is shipped directly off master.

## Verification

- Biome clean.
- Two-site change, no signature changes; CI Typecheck/Build/tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)