### PR TITLE
fix(deploy): exit boot smoke after init

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -365,6 +365,8 @@ jobs:
             if [ "$SECONDS" -ge "$DEADLINE" ]; then
               REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
                 --query 'tasks[0].stoppedReason' --output text)
+              aws ecs stop-task --cluster "$CLUSTER" --task "$TASK_ARN" \
+                --reason "deploy boot-smoke timed out before rollout" >/dev/null || true
               echo "::error::boot smoke task did not stop within 10m (last status: $STATUS, reason: $REASON)"; exit 1
             fi
             echo "  boot smoke task status: $STATUS ($((DEADLINE - SECONDS))s remaining)"

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -50,7 +50,6 @@ import helmet from 'helmet';
 import gptActionsSpec from './config/gpt-actions-openapi.json';
 
 const apiDir = dirname(fileURLToPath(import.meta.url));
-const BOOT_SMOKE_CLOSE_TIMEOUT_MS = 10_000;
 
 async function main() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -285,8 +284,7 @@ async function main() {
       // exit cleanly without listening. Any boot failure throws into the catch
       // below, which exits non-zero so the gate fails.
       await app.init();
-      await closeBootSmokeApplication(app, logger);
-      logger.debug('Boot smoke OK — API initialized cleanly.');
+      console.info('Boot smoke OK — API initialized cleanly.');
       process.exit(0);
     }
 
@@ -297,49 +295,6 @@ async function main() {
     if (process.env.BOOT_SMOKE === '1') {
       // Fail the boot-smoke gate loudly — never let a startup error pass as green.
       process.exit(1);
-    }
-  }
-}
-
-async function closeBootSmokeApplication(
-  app: NestExpressApplication,
-  logger: LoggerService,
-): Promise<void> {
-  try {
-    await withTimeout(
-      app.close(),
-      BOOT_SMOKE_CLOSE_TIMEOUT_MS,
-      `Boot smoke app.close timed out after ${BOOT_SMOKE_CLOSE_TIMEOUT_MS}ms`,
-    );
-  } catch (error: unknown) {
-    logger.warn(
-      error instanceof Error
-        ? error.message
-        : `Boot smoke app.close failed: ${String(error)}`,
-    );
-  }
-}
-
-async function withTimeout<T>(
-  operation: Promise<T>,
-  timeoutMs: number,
-  timeoutMessage: string,
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  try {
-    return await Promise.race([
-      operation,
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error(timeoutMessage)),
-          timeoutMs,
-        );
-      }),
-    ]);
-  } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Make BOOT_SMOKE exit immediately after successful app.init() instead of trying to close the full AppModule graph.
- Emit a visible console message before exiting so CloudWatch proves the boot-smoke branch was reached.
- Stop the boot-smoke ECS task if the workflow timeout fires, preventing orphaned one-off tasks.

## Deploy failure addressed
- Failed deploy run: https://github.com/genfeedai/genfeed.ai/actions/runs/28371994352
- Failed step: Boot smoke — verify new image boots
- Error: boot smoke task did not stop within 10m (last status: RUNNING, reason: None)
- AWS check showed two orphaned boot-smoke tasks left running from failed deploy attempts; both were stopped manually.
- Current production API service remains on task definition genfeed-production-api:17 from June 24; failed deploys did not roll services.

## Verification
- bunx biome check --write apps/server/api/src/main.ts .github/workflows/deploy-ecs.yml
- bun run --cwd apps/server/api build
- BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js
- aws ecs list-tasks --cluster genfeed-production --family genfeed-production-boot-smoke --desired-status RUNNING --region us-west-1

Note: no local gitleaks run.