### PR TITLE
fix(docker): include ui workspace in server image

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -41,7 +41,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/auth-client','packages/client','packages/config','packages/constants','packages/enums','packages/harness','packages/helpers','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/auth-client','packages/client','packages/config','packages/constants','packages/contexts','packages/enums','packages/harness','packages/helpers','packages/hooks','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/ui','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -65,9 +65,11 @@ RUN --mount=type=bind,source=.,target=/ctx \
       /ctx/packages/client/package.json \
       /ctx/packages/config/package.json \
       /ctx/packages/constants/package.json \
+      /ctx/packages/contexts/package.json \
       /ctx/packages/enums/package.json \
       /ctx/packages/harness/package.json \
       /ctx/packages/helpers/package.json \
+      /ctx/packages/hooks/package.json \
       /ctx/packages/integrations/package.json \
       /ctx/packages/interfaces/package.json \
       /ctx/packages/models/package.json \
@@ -79,6 +81,7 @@ RUN --mount=type=bind,source=.,target=/ctx \
       /ctx/packages/storage/package.json \
       /ctx/packages/tools/package.json \
       /ctx/packages/types/package.json \
+      /ctx/packages/ui/package.json \
       /ctx/packages/utils/package.json \
       /ctx/packages/workflow-engine/package.json \
       /ctx/packages/workflow-saas/package.json \


### PR DESCRIPTION
## Summary
- Add packages/ui to Dockerfile.server's reduced server workspace graph.
- Add packages/contexts and packages/hooks because they are recursive workspace deps of @genfeedai/ui.
- Copy those package manifests into the manifest-only install layer.

## Failure addressed
- Current master Build Server Image run: https://github.com/genfeedai/genfeed.ai/actions/runs/28374985833
- Failed at Dockerfile.server bun install with: Workspace dependency "@genfeedai/ui" not found.
- Triggered by current master server-side MCP code importing @genfeedai/ui/static/surface.

## Verification
- git diff --check
- Recursive workspace closure check for the reduced server image graph: no missing workspace deps

Note: no local gitleaks run, and no local Docker build to avoid CPU load.