### PR TITLE
[codex] Upgrade CI actions to Node 24 runtime

### DIFF
--- a/.github/actions/build-unified-image/action.yml
+++ b/.github/actions/build-unified-image/action.yml
@@ -53,7 +53,7 @@ runs:
         df -h / | tail -1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Container Registry
       uses: docker/login-action@v4
@@ -64,7 +64,7 @@ runs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ inputs.registry }}/${{ inputs.image_prefix }}/server
         # github.sha is the immutable tag every deploy actually pulls (see

--- a/.github/workflows/browser-extension-submit.yml
+++ b/.github/workflows/browser-extension-submit.yml
@@ -51,7 +51,7 @@ jobs:
         working-directory: apps/extensions/browser/app
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: browser-extension-build
           path: apps/extensions/browser/app/build/chrome-mv3-prod.zip
@@ -63,7 +63,7 @@ jobs:
     needs: [build]
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: browser-extension-build
           path: apps/extensions/browser/app/build

--- a/.github/workflows/build-verify-selfhosted.yml
+++ b/.github/workflows/build-verify-selfhosted.yml
@@ -69,7 +69,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build self-hosted image (no push)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -65,7 +65,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build unified server image (no push)
         uses: docker/build-push-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/claude-pattern-miner.yml
+++ b/.github/workflows/claude-pattern-miner.yml
@@ -64,7 +64,7 @@ jobs:
             --out docs/claude-pattern-miner-report.md
 
       - name: Upload reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: claude-pattern-miner-report
           path: |

--- a/.github/workflows/codebase-health.yml
+++ b/.github/workflows/codebase-health.yml
@@ -43,7 +43,7 @@ jobs:
         # not fallow.sarif — the old path silently never existed, which only
         # surfaced once the health step stopped erroring on the bad CLI command.
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: fallow-results.sarif
 

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -115,7 +115,7 @@ jobs:
           echo "explicit=$EXPLICIT_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -86,7 +86,7 @@ jobs:
         run: bun run --filter=@genfeedai/desktop release:mac
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: genfeed-desktop-macos
           path: apps/desktop/app/release/*
@@ -101,13 +101,13 @@ jobs:
       contents: write
     steps:
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: genfeed-desktop-macos
           path: release
 
       - name: Attach macOS artifacts to GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           make_latest: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -72,7 +72,7 @@ jobs:
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/.github/workflows/e2e-selfhosted-release.yml
+++ b/.github/workflows/e2e-selfhosted-release.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload container logs (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-e2e-compose-logs
           path: compose-logs.txt
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-e2e-playwright-report
           path: playwright/artifacts/report/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -152,7 +152,7 @@ jobs:
           NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
 
       - name: Upload blob report (shard ${{ matrix.shard }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         # Always upload so the merge job has every shard, even failed ones.
         if: always()
         with:
@@ -177,7 +177,7 @@ jobs:
           cache-turbo: "false"
 
       - name: Download all blob reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: blob-report-*
           merge-multiple: true
@@ -187,7 +187,7 @@ jobs:
         run: bunx playwright merge-reports --reporter=html,github ./all-blob-reports
 
       - name: Upload merged HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-merged
           path: playwright-report/
@@ -301,7 +301,7 @@ jobs:
           E2E_BETTER_AUTH_SESSION_TOKEN: ${{ secrets.E2E_BETTER_AUTH_SESSION_TOKEN }}
 
       - name: Upload authed Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always() && steps.authed_secrets.outputs.ready == 'true'
         with:
           name: playwright-report-authed
@@ -309,7 +309,7 @@ jobs:
           retention-days: 7
 
       - name: Upload authed traces (on failure)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure() && steps.authed_secrets.outputs.ready == 'true'
         with:
           name: playwright-traces-authed

--- a/.github/workflows/ide-extension-ci.yml
+++ b/.github/workflows/ide-extension-ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: bun run package
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ide-extension-vsix
           path: apps/extensions/ide/app/*.vsix

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: "24.x"
 
       - name: Setup EAS
-        uses: expo/expo-github-action@v8
+        uses: expo/expo-github-action@v9
         with:
           eas-version: latest
 


### PR DESCRIPTION
## Summary

Updates GitHub Actions dependencies that still declared deprecated Node 20 runtimes so the CI gate no longer emits Node 20 deprecation warnings while `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is enabled.

## Changes

- Bumped Gitleaks from `gitleaks/gitleaks-action@v2` to `@v3`.
- Bumped artifact upload/download actions to existing Node 24 runtime releases.
- Bumped Docker, AWS credentials, CodeQL SARIF upload, Expo, and GitHub release actions to Node 24-compatible releases.
- Preserved existing SHA-pinning style where the workflow already used exact action SHAs.

## Notes

`PlasmoHQ/bpp` still declares `node20` upstream on its latest tag and `main`, so that workflow action remains the only known Node 20 metadata source. Replacing it would require a behavioral rewrite of the browser extension publishing step or vendoring the action bundle.

## Validation

- `git diff --check`
- `actionlint` on changed workflow files
- metadata scan of external action `runs.using` declarations
- diff-scoped secret filename and token-pattern checks