### PR TITLE
feat(auth): wire social login and email verification

### DIFF
--- a/apps/app/app/(public)/login/content.test.tsx
+++ b/apps/app/app/(public)/login/content.test.tsx
@@ -66,6 +66,9 @@ describe('LoginPage', () => {
       screen.getByRole('button', { name: 'Sign in with Google' }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Sign in with GitHub' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('link', { name: 'Sign in with a magic link' }),
     ).toHaveAttribute('href', '/login/magic-link');
     expect(
@@ -128,6 +131,21 @@ describe('LoginPage', () => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
         callbackURL: absoluteCallback('/onboarding'),
         provider: 'google',
+      });
+    });
+  });
+
+  it('starts GitHub sign-in with the default callback URL', async () => {
+    render(<LoginPage />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Sign in with GitHub' }),
+    );
+
+    await waitFor(() => {
+      expect(authClientMocks.social).toHaveBeenCalledWith({
+        callbackURL: absoluteCallback('/'),
+        provider: 'github',
       });
     });
   });

--- a/apps/app/app/(public)/login/login-better-auth.tsx
+++ b/apps/app/app/(public)/login/login-better-auth.tsx
@@ -15,6 +15,7 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
+import { FaGithub } from 'react-icons/fa6';
 import { FcGoogle } from 'react-icons/fc';
 import {
   getAuthCallbackURL,
@@ -129,7 +130,7 @@ export default function LoginBetterAuth({
     }
   }
 
-  async function handleGoogleSignIn() {
+  async function handleSocialSignIn(provider: 'github' | 'google') {
     setSocialErrorMessage(null);
     setErrorMessage(null);
     setPasswordErrorMessage(null);
@@ -138,17 +139,19 @@ export default function LoginBetterAuth({
     try {
       const result = await signIn.social({
         callbackURL: authCallbackURL,
-        provider: 'google',
+        provider,
       });
       if (result?.error) {
+        const label = provider === 'google' ? 'Google' : 'GitHub';
         setSocialErrorMessage(
           result.error.message ??
-            'Failed to continue with Google. Please try again.',
+            `Failed to continue with ${label}. Please try again.`,
         );
       }
     } catch {
+      const label = provider === 'google' ? 'Google' : 'GitHub';
       setSocialErrorMessage(
-        'Failed to continue with Google. Please try again.',
+        `Failed to continue with ${label}. Please try again.`,
       );
     } finally {
       setIsSocialSubmitting(false);
@@ -305,13 +308,25 @@ export default function LoginBetterAuth({
           <Button
             type="button"
             variant={ButtonVariant.OUTLINE}
-            onClick={handleGoogleSignIn}
+            onClick={() => handleSocialSignIn('google')}
             icon={<FcGoogle className="size-4" aria-hidden="true" />}
             isLoading={isSocialSubmitting}
             className={AUTH_BUTTON_CLASS_NAME}
             withWrapper={false}
           >
             Sign in with Google
+          </Button>
+
+          <Button
+            type="button"
+            variant={ButtonVariant.OUTLINE}
+            onClick={() => handleSocialSignIn('github')}
+            icon={<FaGithub className="size-4" aria-hidden="true" />}
+            isLoading={isSocialSubmitting}
+            className={AUTH_BUTTON_CLASS_NAME}
+            withWrapper={false}
+          >
+            Sign in with GitHub
           </Button>
 
           <Button

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -15,6 +15,7 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
+import { FaGithub } from 'react-icons/fa6';
 import { persistOnboardingHandoffParams } from '@/lib/onboarding/onboarding-access.util';
 import {
   getAuthCallbackURL,
@@ -69,9 +70,9 @@ export default function SignUpBetterAuth() {
     }
   }
 
-  async function handleGoogleSignUp() {
+  async function handleSocialSignUp(provider: 'github' | 'google') {
     setErrorMessage(null);
-    await signIn.social({ callbackURL: authCallbackURL, provider: 'google' });
+    await signIn.social({ callbackURL: authCallbackURL, provider });
   }
 
   if (!isMounted) {
@@ -137,11 +138,22 @@ export default function SignUpBetterAuth() {
         <Button
           type="button"
           variant={ButtonVariant.OUTLINE}
-          onClick={handleGoogleSignUp}
+          onClick={() => handleSocialSignUp('google')}
           className="w-full"
           withWrapper={false}
         >
           Continue with Google
+        </Button>
+
+        <Button
+          type="button"
+          variant={ButtonVariant.OUTLINE}
+          onClick={() => handleSocialSignUp('github')}
+          icon={<FaGithub className="size-4" aria-hidden="true" />}
+          className="w-full"
+          withWrapper={false}
+        >
+          Continue with GitHub
         </Button>
 
         <p className="text-center text-sm text-muted-foreground">

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -72,7 +72,20 @@ export default function SignUpBetterAuth() {
 
   async function handleSocialSignUp(provider: 'github' | 'google') {
     setErrorMessage(null);
-    await signIn.social({ callbackURL: authCallbackURL, provider });
+    try {
+      const result = await signIn.social({
+        callbackURL: authCallbackURL,
+        provider,
+      });
+      if (result?.error) {
+        setErrorMessage(
+          result.error.message ??
+            `Failed to sign up with ${provider}. Please try again.`,
+        );
+      }
+    } catch {
+      setErrorMessage(`Failed to sign up with ${provider}. Please try again.`);
+    }
   }
 
   if (!isMounted) {

--- a/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
@@ -75,6 +75,9 @@ describe('SignUpForm', () => {
     expect(
       screen.getByRole('button', { name: 'Continue with email' }),
     ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Continue with GitHub' }),
+    ).toBeInTheDocument();
   });
 
   it('sends a sign-up magic link with the callback URL', async () => {
@@ -128,6 +131,23 @@ describe('SignUpForm', () => {
     expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.source)).toBe(
       'oss-onboarding',
     );
+  });
+
+  it('starts GitHub sign-up with the callback URL', async () => {
+    window.history.replaceState({}, '', '/sign-up?callbackUrl=%2Fonboarding');
+
+    render(<SignUpForm />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with GitHub' }),
+    );
+
+    await waitFor(() => {
+      expect(authClientMocks.social).toHaveBeenCalledWith({
+        callbackURL: absoluteCallback('/onboarding'),
+        provider: 'github',
+      });
+    });
   });
 
   it('does not persist invalid access mode or malformed credit handoff params', async () => {

--- a/apps/mobile/app/ENV.md
+++ b/apps/mobile/app/ENV.md
@@ -16,6 +16,15 @@ EXPO_PUBLIC_API_URL=https://api.genfeed.ai
 ```
 The API base URL for backend requests.
 
+### Google Sign-In
+```bash
+EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your-default-google-client-id
+EXPO_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID=your-ios-google-client-id
+EXPO_PUBLIC_GOOGLE_OAUTH_ANDROID_CLIENT_ID=your-android-google-client-id
+EXPO_PUBLIC_GOOGLE_OAUTH_WEB_CLIENT_ID=your-web-google-client-id
+```
+OAuth client IDs used by Expo AuthSession for native Better Auth Google sign-in.
+
 ### Error Tracking (Sentry)
 ```bash
 EXPO_PUBLIC_SENTRY_DSN=https://your-dsn@sentry.io/project-id

--- a/apps/mobile/app/app.config.js
+++ b/apps/mobile/app/app.config.js
@@ -37,6 +37,13 @@ export default {
       enableAnalytics: process.env.EXPO_PUBLIC_ENABLE_ANALYTICS === 'true',
       enableErrorTracking:
         process.env.EXPO_PUBLIC_ENABLE_ERROR_TRACKING === 'true',
+      googleOAuthAndroidClientId:
+        process.env.EXPO_PUBLIC_GOOGLE_OAUTH_ANDROID_CLIENT_ID || '',
+      googleOAuthClientId: process.env.EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID || '',
+      googleOAuthIosClientId:
+        process.env.EXPO_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID || '',
+      googleOAuthWebClientId:
+        process.env.EXPO_PUBLIC_GOOGLE_OAUTH_WEB_CLIENT_ID || '',
       segmentWriteKey: process.env.EXPO_PUBLIC_SEGMENT_WRITE_KEY || '',
       sentryDsn: process.env.EXPO_PUBLIC_SENTRY_DSN || '',
     },

--- a/apps/mobile/app/app/(public)/login.tsx
+++ b/apps/mobile/app/app/(public)/login.tsx
@@ -1,3 +1,5 @@
+import * as Google from 'expo-auth-session/providers/google';
+import Constants from 'expo-constants';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
@@ -13,12 +15,33 @@ import { colors } from '@/constants';
 import { useMobileAuth } from '@/contexts/auth-context';
 
 export default function Login() {
-  const { isLoaded, signInWithEmail } = useMobileAuth();
+  const { isLoaded, signInWithEmail, signInWithGoogleIdToken } =
+    useMobileAuth();
   const router = useRouter();
+  const extra = Constants.expoConfig?.extra ?? {};
+  const [googleRequest, , promptGoogleAsync] = Google.useIdTokenAuthRequest({
+    androidClientId:
+      typeof extra.googleOAuthAndroidClientId === 'string'
+        ? extra.googleOAuthAndroidClientId
+        : undefined,
+    clientId:
+      typeof extra.googleOAuthClientId === 'string'
+        ? extra.googleOAuthClientId
+        : undefined,
+    iosClientId:
+      typeof extra.googleOAuthIosClientId === 'string'
+        ? extra.googleOAuthIosClientId
+        : undefined,
+    webClientId:
+      typeof extra.googleOAuthWebClientId === 'string'
+        ? extra.googleOAuthWebClientId
+        : undefined,
+  });
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 
   const handleSignIn = async () => {
     if (!isLoaded || isLoading) {
@@ -40,6 +63,40 @@ export default function Login() {
     }
   };
 
+  const handleGoogleSignIn = async () => {
+    if (!isLoaded || isGoogleLoading) {
+      return;
+    }
+
+    try {
+      setIsGoogleLoading(true);
+      const result = await promptGoogleAsync();
+      const auth = result.type === 'success' ? result.authentication : null;
+      const idToken =
+        result.type === 'success'
+          ? ((result.params?.id_token as string | undefined) ?? null)
+          : null;
+
+      if (!idToken) {
+        throw new Error('Google did not return an ID token.');
+      }
+
+      await signInWithGoogleIdToken({
+        accessToken: auth?.accessToken ?? null,
+        idToken,
+      });
+      router.replace('/content');
+    } catch (err: unknown) {
+      const error = err as { message?: string };
+      Alert.alert(
+        'Google sign in failed',
+        error.message || 'An error occurred',
+      );
+    } finally {
+      setIsGoogleLoading(false);
+    }
+  };
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -48,6 +105,27 @@ export default function Login() {
       </View>
 
       <View style={styles.form}>
+        <Pressable
+          disabled={isGoogleLoading || !googleRequest}
+          onPress={handleGoogleSignIn}
+          style={[
+            styles.googleButton,
+            isGoogleLoading && styles.signInButtonDisabled,
+          ]}
+        >
+          {isGoogleLoading ? (
+            <ActivityIndicator color={colors.textPrimary} size="small" />
+          ) : (
+            <Text style={styles.googleButtonText}>Continue with Google</Text>
+          )}
+        </Pressable>
+
+        <View style={styles.divider}>
+          <View style={styles.dividerLine} />
+          <Text style={styles.dividerText}>or</Text>
+          <View style={styles.dividerLine} />
+        </View>
+
         <View style={styles.inputContainer}>
           <Text style={styles.inputLabel}>Email</Text>
           <TextInput
@@ -103,6 +181,34 @@ const styles = StyleSheet.create({
   },
   form: {
     gap: 16,
+  },
+  divider: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 12,
+  },
+  dividerLine: {
+    backgroundColor: colors.bgBorder,
+    flex: 1,
+    height: 1,
+  },
+  dividerText: {
+    color: colors.textMuted,
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  googleButton: {
+    alignItems: 'center',
+    backgroundColor: colors.bgTertiary,
+    borderColor: colors.bgBorder,
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingVertical: 14,
+  },
+  googleButtonText: {
+    color: colors.textPrimary,
+    fontSize: 16,
+    fontWeight: '600',
   },
   header: {
     marginBottom: 32,

--- a/apps/mobile/app/app/(public)/login.tsx
+++ b/apps/mobile/app/app/(public)/login.tsx
@@ -72,18 +72,30 @@ export default function Login() {
       setIsGoogleLoading(true);
       const result = await promptGoogleAsync();
       const auth = result.type === 'success' ? result.authentication : null;
+      // Prefer the canonical OIDC field; fall back to the raw params entry.
       const idToken =
         result.type === 'success'
-          ? ((result.params?.id_token as string | undefined) ?? null)
+          ? (auth?.idToken ??
+            (result.params?.id_token as string | undefined) ??
+            null)
           : null;
 
       if (!idToken) {
-        throw new Error('Google did not return an ID token.');
+        Alert.alert(
+          'Google sign in failed',
+          'Google did not return an ID token. Please try again.',
+        );
+        return;
       }
+
+      // Forward the nonce so the server can verify it against the token claim.
+      const nonce =
+        result.type === 'success' ? (googleRequest?.nonce ?? null) : null;
 
       await signInWithGoogleIdToken({
         accessToken: auth?.accessToken ?? null,
         idToken,
+        nonce,
       });
       router.replace('/content');
     } catch (err: unknown) {

--- a/apps/mobile/app/contexts/auth-context.tsx
+++ b/apps/mobile/app/contexts/auth-context.tsx
@@ -8,8 +8,8 @@ import {
   useState,
 } from 'react';
 import {
-  mobileAuthService,
   type MobileAuthUser,
+  mobileAuthService,
 } from '@/services/auth.service';
 
 interface MobileAuthContextValue {
@@ -20,6 +20,11 @@ interface MobileAuthContextValue {
   signInWithEmail: (input: {
     email: string;
     password: string;
+  }) => Promise<void>;
+  signInWithGoogleIdToken: (input: {
+    accessToken?: string | null;
+    idToken: string;
+    nonce?: string | null;
   }) => Promise<void>;
   signOut: () => Promise<void>;
   user: MobileAuthUser | null;
@@ -107,6 +112,19 @@ export function MobileAuthProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  const signInWithGoogleIdToken = useCallback(
+    async (input: {
+      accessToken?: string | null;
+      idToken: string;
+      nonce?: string | null;
+    }) => {
+      const result = await mobileAuthService.signInWithGoogleIdToken(input);
+      setCookieHeader(result.cookieHeader);
+      setUser(result.user);
+    },
+    [],
+  );
+
   const signOut = useCallback(async () => {
     await mobileAuthService.signOut(cookieHeader);
     setCookieHeader(null);
@@ -120,6 +138,7 @@ export function MobileAuthProvider({ children }: { children: ReactNode }) {
       isSignedIn: Boolean(cookieHeader && user),
       refreshSession,
       signInWithEmail,
+      signInWithGoogleIdToken,
       signOut,
       user,
     }),
@@ -129,6 +148,7 @@ export function MobileAuthProvider({ children }: { children: ReactNode }) {
       isLoaded,
       refreshSession,
       signInWithEmail,
+      signInWithGoogleIdToken,
       signOut,
       user,
     ],

--- a/apps/mobile/app/package.json
+++ b/apps/mobile/app/package.json
@@ -7,6 +7,7 @@
     "@sentry/react-native": "8.16.0",
     "@shopify/flash-list": "2.3.2",
     "expo": "56.0.12",
+    "expo-auth-session": "^56.0.14",
     "expo-blur": "56.0.3",
     "expo-constants": "56.0.18",
     "expo-device": "56.0.4",

--- a/apps/mobile/app/services/auth.service.ts
+++ b/apps/mobile/app/services/auth.service.ts
@@ -31,6 +31,10 @@ interface BetterAuthSignInResponse {
   user?: BetterAuthUserResponse | null;
 }
 
+interface BetterAuthSocialSignInResponse extends BetterAuthSignInResponse {
+  token?: string;
+}
+
 function normalizeUser(
   data: BetterAuthUserResponse | null | undefined,
   organizationId: string | null = null,
@@ -78,7 +82,7 @@ function toCookieHeader(headers: Headers): string | null {
   const cookies = getSetCookieValues(headers)
     .map((cookie) => cookie.split(';')[0]?.trim())
     .filter((cookie): cookie is string => {
-      return Boolean(cookie && cookie.includes('better-auth.'));
+      return Boolean(cookie?.includes('better-auth.'));
     });
 
   return cookies.length > 0 ? cookies.join('; ') : null;
@@ -204,6 +208,40 @@ export const mobileAuthService = {
 
     if (!cookieHeader || !user) {
       throw new Error('Sign in did not return a usable Better Auth session.');
+    }
+
+    await Promise.all([
+      SecureStore.setItemAsync(SESSION_COOKIE_KEY, cookieHeader),
+      SecureStore.setItemAsync(USER_KEY, JSON.stringify(user)),
+    ]);
+
+    return { cookieHeader, user };
+  },
+
+  async signInWithGoogleIdToken(input: {
+    accessToken?: string | null;
+    idToken: string;
+    nonce?: string | null;
+  }): Promise<{ cookieHeader: string; user: MobileAuthUser }> {
+    const { cookieHeader, data } =
+      await authFetch<BetterAuthSocialSignInResponse>('/sign-in/social', {
+        body: JSON.stringify({
+          disableRedirect: true,
+          idToken: {
+            accessToken: input.accessToken ?? undefined,
+            nonce: input.nonce ?? undefined,
+            token: input.idToken,
+          },
+          provider: 'google',
+        }),
+        method: 'POST',
+      });
+    const user = normalizeUser(data?.user);
+
+    if (!cookieHeader || !user) {
+      throw new Error(
+        'Google sign in did not return a usable Better Auth session.',
+      );
     }
 
     await Promise.all([

--- a/apps/mobile/app/tests/services/auth.service.test.ts
+++ b/apps/mobile/app/tests/services/auth.service.test.ts
@@ -1,0 +1,72 @@
+import * as SecureStore from 'expo-secure-store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mobileAuthService } from '@/services/auth.service';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function mockJsonResponse(
+  body: unknown,
+  setCookie = 'better-auth.session_token=session-123; Path=/; HttpOnly',
+) {
+  mockFetch.mockResolvedValueOnce({
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'set-cookie' ? setCookie : null,
+    },
+    ok: true,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe('mobileAuthService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('signs in with a Google ID token through Better Auth and stores the session', async () => {
+    mockJsonResponse({
+      token: 'better-auth-jwt',
+      user: {
+        email: 'user@example.com',
+        id: 'user_123',
+        image: null,
+        name: 'User',
+      },
+    });
+
+    const result = await mobileAuthService.signInWithGoogleIdToken({
+      accessToken: 'google-access-token',
+      idToken: 'google-id-token',
+      nonce: 'nonce-123',
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.test.com/v1/auth/sign-in/social',
+      expect.objectContaining({
+        body: JSON.stringify({
+          disableRedirect: true,
+          idToken: {
+            accessToken: 'google-access-token',
+            nonce: 'nonce-123',
+            token: 'google-id-token',
+          },
+          provider: 'google',
+        }),
+        method: 'POST',
+      }),
+    );
+    expect(result.cookieHeader).toBe('better-auth.session_token=session-123');
+    expect(result.user).toEqual({
+      email: 'user@example.com',
+      id: 'user_123',
+      image: null,
+      name: 'User',
+      organizationId: null,
+    });
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+      'genfeed.better-auth.session-cookie',
+      'better-auth.session_token=session-123',
+    );
+  });
+});

--- a/apps/mobile/app/tests/setup.ts
+++ b/apps/mobile/app/tests/setup.ts
@@ -173,6 +173,14 @@ vi.mock('expo-web-browser', () => ({
   maybeCompleteAuthSession: vi.fn(),
 }));
 
+vi.mock('expo-auth-session/providers/google', () => ({
+  useIdTokenAuthRequest: vi.fn(() => [
+    { clientId: 'google-client' },
+    null,
+    vi.fn().mockResolvedValue({ type: 'cancel' }),
+  ]),
+}));
+
 vi.mock('expo-splash-screen', () => ({
   hideAsync: vi.fn(),
   preventAutoHideAsync: vi.fn(),
@@ -238,6 +246,7 @@ vi.mock('@/contexts/auth-context', () => ({
     isSignedIn: false,
     refreshSession: vi.fn(),
     signInWithEmail: vi.fn(),
+    signInWithGoogleIdToken: vi.fn(),
     signOut: vi.fn(),
     user: null,
   })),

--- a/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
@@ -3,8 +3,10 @@ import {
   parseCommaSeparated,
   parseTrustedOrigins,
   resolveBetterAuthBaseUrl,
+  resolveBooleanFlag,
   resolveCookieDomain,
   resolveExperimentalJoins,
+  resolveSocialProviderConfig,
 } from './better-auth.config';
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
 
@@ -59,6 +61,32 @@ describe('Better Auth config', () => {
       expect(resolveExperimentalJoins('false')).toBe(false);
       expect(resolveExperimentalJoins(undefined)).toBe(false);
       expect(resolveExperimentalJoins('1')).toBe(false);
+    });
+  });
+
+  describe('resolveBooleanFlag', () => {
+    it('parses explicit boolean strings and otherwise falls back', () => {
+      expect(resolveBooleanFlag('true')).toBe(true);
+      expect(resolveBooleanFlag(' false ')).toBe(false);
+      expect(resolveBooleanFlag(undefined, true)).toBe(true);
+      expect(resolveBooleanFlag('1', false)).toBe(false);
+    });
+  });
+
+  describe('resolveSocialProviderConfig', () => {
+    it('returns trimmed OAuth credentials when both values are configured', () => {
+      expect(
+        resolveSocialProviderConfig(' google-client ', ' google-secret '),
+      ).toEqual({
+        clientId: 'google-client',
+        clientSecret: 'google-secret',
+      });
+    });
+
+    it('omits the provider when either credential is missing', () => {
+      expect(resolveSocialProviderConfig('google-client', '')).toBeUndefined();
+      expect(resolveSocialProviderConfig('', 'google-secret')).toBeUndefined();
+      expect(resolveSocialProviderConfig(undefined, undefined)).toBeUndefined();
     });
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.config.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.ts
@@ -1,4 +1,4 @@
-import type { IBetterAuthGoogleConfig } from './better-auth.types';
+import type { IBetterAuthSocialProviderConfig } from './better-auth.types';
 
 /**
  * Pure config helpers shared by the Better Auth module (instance construction)
@@ -49,16 +49,31 @@ export function resolveCookieDomain(
   return trimmed ? trimmed : undefined;
 }
 
-/** Whether Better Auth's experimental Prisma joins are enabled via env. */
-export function resolveExperimentalJoins(value: string | undefined): boolean {
-  return value?.trim() === 'true';
+/** Whether a Better Auth boolean feature flag is enabled via env. */
+export function resolveBooleanFlag(
+  value: string | undefined,
+  fallback = false,
+): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === 'true') {
+    return true;
+  }
+  if (normalized === 'false') {
+    return false;
+  }
+  return fallback;
 }
 
-/** Build the Google social-provider config when both credentials are present. */
-export function resolveGoogleConfig(
+/** Whether Better Auth's experimental Prisma joins are enabled via env. */
+export function resolveExperimentalJoins(value: string | undefined): boolean {
+  return resolveBooleanFlag(value, false);
+}
+
+/** Build a social-provider config when both credentials are present. */
+export function resolveSocialProviderConfig(
   clientId: string | undefined,
   clientSecret: string | undefined,
-): IBetterAuthGoogleConfig | undefined {
+): IBetterAuthSocialProviderConfig | undefined {
   if (clientId?.trim() && clientSecret?.trim()) {
     return { clientId: clientId.trim(), clientSecret: clientSecret.trim() };
   }

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildBetterAuthOrganizationOptions,
   buildRateLimitStorage,
+  createBetterAuthInstance,
   resolveBetterAuthJwtAccess,
   resolveBetterAuthJwtIsSuperAdmin,
   resolveBetterAuthJwtOrganizationId,
@@ -380,5 +381,20 @@ describe('buildRateLimitStorage', () => {
     const storage = buildRateLimitStorage(createFakeRateLimitStore());
 
     expect(await storage.get('missing')).toBeNull();
+  });
+});
+
+describe('createBetterAuthInstance source', () => {
+  it('wires social provider and email-verification options into Better Auth', () => {
+    const source = createBetterAuthInstance.toString();
+
+    expect(source).toContain('socialProviders');
+    expect(source).toContain('github');
+    expect(source).toContain('google');
+    expect(source).toContain('requireEmailVerification');
+    expect(source).toContain('sendVerificationEmail');
+    expect(source).toContain('accountLinking');
+    expect(source).toContain('trustedProviders');
+    expect(source).toContain('enabled: true');
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -476,6 +476,16 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
       sendOnSignIn: requireEmailVerification,
       sendOnSignUp: requireEmailVerification,
       sendVerificationEmail: async ({ token, url, user }) => {
+        // Guard: this callback should only be invoked when email verification is
+        // required (SMTP is configured). If it fires without that flag, the
+        // deployment is misconfigured — throw so the error surfaces rather than
+        // silently swallowing a verification that was never sent.
+        if (!requireEmailVerification) {
+          throw new Error(
+            'sendVerificationEmail called but requireEmailVerification is false. ' +
+              'Configure SMTP and enable requireEmailVerification before sending verification emails.',
+          );
+        }
         await sendVerificationEmail({
           token,
           url,

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -423,13 +423,34 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     baseURL,
     trustedOrigins,
     google,
+    github,
+    requireEmailVerification = false,
     cookieDomain,
     ipAddressHeaders,
     experimentalJoins,
     rateLimitStore,
     sendMagicLink,
+    sendVerificationEmail,
     onUserCreated,
   } = options;
+  const socialProviders = {
+    ...(google
+      ? {
+          google: {
+            clientId: google.clientId,
+            clientSecret: google.clientSecret,
+          },
+        }
+      : {}),
+    ...(github
+      ? {
+          github: {
+            clientId: github.clientId,
+            clientSecret: github.clientSecret,
+          },
+        }
+      : {}),
+  };
 
   return betterAuth({
     appName: 'Genfeed.ai',
@@ -438,27 +459,44 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     secret,
     trustedOrigins,
     database: prismaAdapter(prisma, { provider: 'postgresql' }),
+    account: {
+      accountLinking: {
+        enabled: true,
+        requireLocalEmailVerified: true,
+        trustedProviders: ['google', 'github'],
+        updateUserInfoOnLink: true,
+      },
+    },
     emailAndPassword: {
       enabled: true,
-      // Email-verification flow lands in Phase 3 (#738); off for dual-run.
-      requireEmailVerification: false,
+      requireEmailVerification,
     },
-    ...(google
+    emailVerification: {
+      autoSignInAfterVerification: true,
+      sendOnSignIn: requireEmailVerification,
+      sendOnSignUp: requireEmailVerification,
+      sendVerificationEmail: async ({ token, url, user }) => {
+        await sendVerificationEmail({
+          token,
+          url,
+          user: { email: user.email },
+        });
+      },
+    },
+    ...(Object.keys(socialProviders).length > 0
       ? {
-          socialProviders: {
-            google: {
-              clientId: google.clientId,
-              clientSecret: google.clientSecret,
-            },
-          },
+          socialProviders,
         }
       : {}),
     // Share rate-limit counters across stateless API instances via Redis;
     // `customStorage` scopes Redis to rate limiting only (sessions stay in
     // Postgres). Omitted when no store is wired so the in-memory default holds.
-    ...(rateLimitStore
-      ? { rateLimit: { customStorage: buildRateLimitStorage(rateLimitStore) } }
-      : {}),
+    rateLimit: {
+      enabled: true,
+      ...(rateLimitStore
+        ? { customStorage: buildRateLimitStorage(rateLimitStore) }
+        : {}),
+    },
     // Experimental single-query joins (Prisma adapter). Env-gated; off unless
     // explicitly enabled after staging verification.
     ...(experimentalJoins ? { experimental: { joins: true } } : {}),

--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -17,9 +17,10 @@ import {
   parseCommaSeparated,
   parseTrustedOrigins,
   resolveBetterAuthBaseUrl,
+  resolveBooleanFlag,
   resolveCookieDomain,
   resolveExperimentalJoins,
-  resolveGoogleConfig,
+  resolveSocialProviderConfig,
 } from './better-auth.config';
 import {
   BETTER_AUTH_INSTANCE,
@@ -131,7 +132,11 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
           experimentalJoins: resolveExperimentalJoins(
             config.get('BETTER_AUTH_EXPERIMENTAL_JOINS'),
           ),
-          google: resolveGoogleConfig(
+          github: resolveSocialProviderConfig(
+            config.get('GITHUB_CLIENT_ID'),
+            config.get('GITHUB_CLIENT_SECRET'),
+          ),
+          google: resolveSocialProviderConfig(
             config.get('GOOGLE_CLIENT_ID'),
             config.get('GOOGLE_CLIENT_SECRET'),
           ),
@@ -139,6 +144,10 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
             config.get('BETTER_AUTH_IP_HEADERS'),
           ),
           rateLimitStore,
+          requireEmailVerification: resolveBooleanFlag(
+            config.get('BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION'),
+            false,
+          ),
           // Awaited so provisioning completes before the create resolves; the
           // UserProvisioningListener (@OnEvent) runs under Nest DI.
           onUserCreated: async (event) => {
@@ -147,6 +156,8 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
           prisma,
           secret,
           sendMagicLink: (params) => mailer.sendMagicLink(params),
+          sendVerificationEmail: (params) =>
+            mailer.sendVerificationEmail(params),
           trustedOrigins: parseTrustedOrigins(
             config.get('BETTER_AUTH_TRUSTED_ORIGINS'),
           ),

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -3,8 +3,8 @@
  */
 import type { PrismaClient } from '@genfeedai/prisma';
 
-/** Google OAuth credentials for the day-one social sign-in. */
-export interface IBetterAuthGoogleConfig {
+/** OAuth credentials for first-party social sign-in providers. */
+export interface IBetterAuthSocialProviderConfig {
   clientId: string;
   clientSecret: string;
 }
@@ -47,6 +47,15 @@ export interface IBetterAuthMagicLinkParams {
   token: string;
 }
 
+/** Arguments handed to Better Auth's email-verification delivery callback. */
+export interface IBetterAuthVerificationEmailParams {
+  token: string;
+  url: string;
+  user: {
+    email: string;
+  };
+}
+
 /**
  * Minimal shared KV (Redis) used to back Better Auth's rate-limit counters
  * across stateless API instances. Implementations must fail open — a Redis
@@ -71,7 +80,9 @@ export interface ICreateBetterAuthOptions {
   secret: string;
   baseURL: string;
   trustedOrigins: string[];
-  google?: IBetterAuthGoogleConfig;
+  google?: IBetterAuthSocialProviderConfig;
+  github?: IBetterAuthSocialProviderConfig;
+  requireEmailVerification?: boolean;
   /**
    * Root cookie domain (e.g. `.genfeed.ai`) for sharing the session cookie set
    * on the API host with sibling frontend subdomains. When set, enables
@@ -97,6 +108,9 @@ export interface ICreateBetterAuthOptions {
    */
   rateLimitStore?: IBetterAuthRateLimitStore;
   sendMagicLink: (params: IBetterAuthMagicLinkParams) => Promise<void>;
+  sendVerificationEmail: (
+    params: IBetterAuthVerificationEmailParams,
+  ) => Promise<void>;
   /**
    * Invoked (and awaited) from the `user.create.after` hook so a newly created
    * user is provisioned — org / settings / brand / member / credits — before the

--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.spec.ts
@@ -34,4 +34,35 @@ describe('BetterAuthMailerService', () => {
     );
     expect(html).toContain('If you did not request this sign-in link');
   });
+
+  it('sends email verification with the shared Genfeed system email shell', async () => {
+    const notificationsService = {
+      sendEmail: vi.fn().mockResolvedValue(undefined),
+    };
+    const logger = { log: vi.fn() };
+    const service = new BetterAuthMailerService(
+      notificationsService as never,
+      logger as never,
+    );
+    const url =
+      'https://api.genfeed.ai/v1/auth/verify-email?token=verify&callbackURL=https%3A%2F%2Fapp.genfeed.ai%2F';
+
+    await service.sendVerificationEmail({
+      token: 'verify',
+      url,
+      user: { email: 'user@example.com' },
+    });
+
+    expect(notificationsService.sendEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      'Verify your Genfeed.ai email',
+      expect.stringContaining('<!doctype html>'),
+    );
+    const html = notificationsService.sendEmail.mock.calls[0]?.[2] as string;
+    expect(html).toContain('Verify your email');
+    expect(html).toContain(
+      'https://api.genfeed.ai/v1/auth/verify-email?token=verify&amp;callbackURL=https%3A%2F%2Fapp.genfeed.ai%2F',
+    );
+    expect(html).toContain('If you did not create a Genfeed.ai account');
+  });
 });

--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
@@ -7,7 +7,10 @@ import {
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
-import type { IBetterAuthMagicLinkParams } from '../better-auth.types';
+import type {
+  IBetterAuthMagicLinkParams,
+  IBetterAuthVerificationEmailParams,
+} from '../better-auth.types';
 
 /**
  * Delivers Better Auth transactional emails through the existing notifications
@@ -39,6 +42,21 @@ export class BetterAuthMailerService {
     });
   }
 
+  async sendVerificationEmail({
+    url,
+    user,
+  }: IBetterAuthVerificationEmailParams): Promise<void> {
+    const subject = 'Verify your Genfeed.ai email';
+    const html = this.buildVerificationEmailHtml(url);
+
+    await this.notificationsService.sendEmail(user.email, subject, html);
+
+    this.logger.log('Verification email dispatched', {
+      ...this.context,
+      emailDomain: user.email.split('@')[1] ?? 'unknown',
+    });
+  }
+
   private buildMagicLinkHtml(url: string): string {
     const escapedUrl = escapeSystemEmailHtml(url);
 
@@ -55,6 +73,25 @@ export class BetterAuthMailerService {
         'If you did not request this sign-in link, you can safely ignore this email.',
       preheader: 'Use this one-time link to sign in to Genfeed.ai.',
       title: 'Sign in to Genfeed.ai',
+    });
+  }
+
+  private buildVerificationEmailHtml(url: string): string {
+    const escapedUrl = escapeSystemEmailHtml(url);
+
+    return buildSystemEmailHtml({
+      action: { label: 'Verify email', url },
+      bodyHtml: [
+        buildSystemEmailParagraph(
+          'Click the button below to verify your email address and finish securing your Genfeed.ai account.',
+        ),
+        '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
+        `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
+      ].join(''),
+      footerNote:
+        'If you did not create a Genfeed.ai account, you can safely ignore this email.',
+      preheader: 'Verify your email address for Genfeed.ai.',
+      title: 'Verify your email',
     });
   }
 }

--- a/apps/server/api/src/config/config.service.ts
+++ b/apps/server/api/src/config/config.service.ts
@@ -41,6 +41,9 @@ interface ApiEnvConfig extends IEnvConfig {
   BETTER_AUTH_SECRET?: string;
   BETTER_AUTH_URL?: string;
   BETTER_AUTH_TRUSTED_ORIGINS?: string;
+  BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION?: 'true' | 'false';
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
   API_PERFORMANCE_AUDIT?: 'true' | 'false';

--- a/bun.lock
+++ b/bun.lock
@@ -386,6 +386,7 @@
         "@sentry/react-native": "8.16.0",
         "@shopify/flash-list": "2.3.2",
         "expo": "56.0.12",
+        "expo-auth-session": "^56.0.14",
         "expo-blur": "56.0.3",
         "expo-constants": "56.0.18",
         "expo-device": "56.0.4",
@@ -521,6 +522,7 @@
         "@genfeedai/config": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
         "@genfeedai/tools": "workspace:*",
+        "@genfeedai/ui": "workspace:*",
       },
       "devDependencies": {
         "ts-loader": "9.6.2",
@@ -4954,9 +4956,13 @@
 
     "expo-asset": ["expo-asset@56.0.17", "", { "dependencies": { "@expo/image-utils": "^0.10.1", "expo-constants": "~56.0.18" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-GFN5j+8SPkyv0nfsiFHewmdB/D0tL237TsBE/gSfFOFy/J3a52py7IulcSqkA3sQE/u/UlD5BmvP5ssS4//nUg=="],
 
+    "expo-auth-session": ["expo-auth-session@56.0.14", "", { "dependencies": { "expo-application": "~56.0.3", "expo-constants": "~56.0.18", "expo-crypto": "~56.0.4", "expo-linking": "~56.0.14", "expo-web-browser": "~56.0.5", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-b6URDBKXVWBjHwypnbCPW6A3PrwYyFqzLXtTrrpTGpmDlsxk7xuz6wIA77sBNziz3hMxt11Nu70iY0fJZYT4jA=="],
+
     "expo-blur": ["expo-blur@56.0.3", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-KDDtrpWc2tYlm1WCPaOgBtv+YEGqe5ELheFPIgSNgHt28NQUDcfBcFsA9Us2StDh6osmSD6NbKxOt5bU6PcDbQ=="],
 
     "expo-constants": ["expo-constants@56.0.18", "", { "dependencies": { "@expo/env": "~2.3.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw=="],
+
+    "expo-crypto": ["expo-crypto@56.0.4", "", { "peerDependencies": { "expo": "*" } }, "sha512-fRNEhoXRXgAWBpe3/hq5X+KXTit3OZqdiAGts1YvNEUHQb+H5591mpPac0Yw+sZg9pXcrjRnzo5AxvZaENpc7g=="],
 
     "expo-device": ["expo-device@56.0.4", "", { "dependencies": { "ua-parser-js": "^0.7.33" }, "peerDependencies": { "expo": "*" } }, "sha512-ucVcGPkvBrl2QHuy7XcYex2Y6BETvJ6TREutZrwLGUDnlvbpKS8KfQoNZOpvkyo5Nmm9RrasYQ0CrXmBHho2mg=="],
 

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -53,6 +53,11 @@ export interface IEnvConfig {
   BETTER_AUTH_SECRET?: string;
   BETTER_AUTH_TRUSTED_ORIGINS?: string;
   BETTER_AUTH_URL?: string;
+  BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION?: 'true' | 'false';
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
 
   // === Sentry ===
   SENTRY_DSN?: string;

--- a/packages/config/src/schemas/better-auth.schema.ts
+++ b/packages/config/src/schemas/better-auth.schema.ts
@@ -44,6 +44,16 @@ export const betterAuthSchema = {
   BETTER_AUTH_TRUSTED_ORIGINS: Joi.string().optional().allow(''),
 
   /**
+   * Require users to verify their email before email/password sign-in.
+   * Disabled by default so Community/local installs without mailer config can
+   * still use password auth; SaaS/staging can enable it with Resend configured.
+   */
+  BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION: Joi.string()
+    .valid('true', 'false')
+    .optional()
+    .default('false'),
+
+  /**
    * Root cookie domain (e.g. `.genfeed.ai`) for sharing the session cookie
    * across sibling subdomains (api ↔ app). Leave unset for single-host /
    * Community deployments so the cookie stays host-scoped.
@@ -72,4 +82,6 @@ export const betterAuthSchema = {
    */
   GOOGLE_CLIENT_ID: Joi.string().optional().allow(''),
   GOOGLE_CLIENT_SECRET: Joi.string().optional().allow(''),
+  GITHUB_CLIENT_ID: Joi.string().optional().allow(''),
+  GITHUB_CLIENT_SECRET: Joi.string().optional().allow(''),
 };


### PR DESCRIPTION
## Summary
- add Better Auth social provider config for Google/GitHub with account linking and provider-scoped env validation
- add Better Auth email verification mailer hooks behind BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION
- add shared Better Auth rate limiting and wire mobile Google ID-token sign-in via Expo AuthSession

Closes #738
Refs #735

## Verification
- bun run --cwd apps/server/api test:file src/auth/better-auth/better-auth.config.spec.ts src/auth/better-auth/better-auth.factory.spec.ts src/auth/better-auth/services/better-auth-mailer.service.spec.ts
- bun run --cwd apps/app test -- "app/(public)/login/content.test.tsx" "app/(public)/sign-up/sign-up-form.test.tsx"
- bun run --cwd apps/mobile/app test -- tests/services/auth.service.test.ts
- bun run --cwd apps/mobile/app type-check
- bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/app --filter=@genfeedai/config
- git diff --check origin/master..HEAD

## Notes
- BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION defaults to false so existing self-hosted installs keep the current email/password behavior until SMTP and verification policy are configured.
- OAuth serving still requires deployment-specific GOOGLE_* and GITHUB_* client credentials plus Expo Google client IDs for mobile.
