### PR TITLE
fix(deploy): use entrypoint check for ECS boot smoke

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -335,10 +335,11 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
-          # Run the api with BOOT_SMOKE=1 as a one-off task: it fully initializes
-          # (catching crash-on-boot like the #711 circular-dep TDZ) then exits 0.
-          # If it can't boot, fail HERE — before any service rolls — so a bad
-          # image never reaches traffic (vs. rolling then circuit-breaker rollback).
+          # Run the api with BOOT_CHECK=1 as a one-off task: it loads the compiled
+          # entrypoint (catching crash-on-boot like the #711 circular-dep TDZ)
+          # then exits before opening long-lived prod connections. If it can't
+          # load, fail HERE — before any service rolls — so a bad image never
+          # reaches traffic (vs. rolling then circuit-breaker rollback).
           CLUSTER=$(tofu output -raw cluster_name)
           TASK_DEFINITION=$(tofu output -raw boot_smoke_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -127,11 +127,10 @@ resource "aws_ecs_task_definition" "workflow_backfill" {
 }
 
 # ── One-off boot smoke (run via `aws ecs run-task` BEFORE services roll) ─
-# Boots the api with BOOT_SMOKE=1 so it fully initializes (catching crash-on-boot
-# bugs like the circular-dependency TDZ in #711 that CI's lack of a boot test let
-# ship) then exits 0 — without listening. Uses the api service's full env so the
-# boot path is realistic. If the new image can't boot, the deploy fails HERE,
-# before any service rolls.
+# Boots the compiled api entrypoint with BOOT_CHECK=1 so module evaluation catches
+# crash-on-boot bugs like the circular-dependency TDZ in #711, then exits before
+# opening long-lived production connections. If the new image can't load, the
+# deploy fails HERE, before any service rolls.
 resource "aws_cloudwatch_log_group" "boot_smoke" {
   name              = "/ecs/${local.name_prefix}/boot-smoke"
   retention_in_days = 30
@@ -155,7 +154,7 @@ resource "aws_ecs_task_definition" "boot_smoke" {
     environment = concat(local.internal_env, [
       { name = "PORT", value = tostring(local.services.api.port) },
       { name = "SERVICE_NAME", value = "api" },
-      { name = "BOOT_SMOKE", value = "1" },
+      { name = "BOOT_CHECK", value = "1" },
     ])
     logConfiguration = {
       logDriver = "awslogs"


### PR DESCRIPTION
## Summary
- changes the pre-roll ECS boot-smoke task from full BOOT_SMOKE app init to the existing compiled-entrypoint BOOT_CHECK path
- keeps the gate before Tofu service rollout, but avoids long-lived Redis/BullMQ/prod connection handles that kept the one-off task RUNNING until timeout
- updates deploy comments to match the actual gate behavior

## Evidence
- Failed deploy: https://github.com/genfeedai/genfeed.ai/actions/runs/28377083132/job/84073141177
- Failure point: Boot smoke task stayed RUNNING for 10m, then workflow stopped it before Tofu apply
- Production rollout was skipped in the failed run

## Local verification
- git diff --check
- tofu fmt -check infra/terraform/genfeed-prod/services.tf
- static wiring check: boot-smoke task sets BOOT_CHECK=1 and BOOT_CHECK exits before main() is called

No local gitleaks run.