### PR TITLE
feat(brand): define brand kit contract

### DIFF
--- a/packages/helpers/src/brand-kit-contract.helper.test.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.test.ts
@@ -1,0 +1,204 @@
+import type {
+  IBrandKitAssetValue,
+  IBrandKitSocialLink,
+} from '@genfeedai/interfaces';
+import {
+  type BrandKitSourceBrand,
+  buildBrandKitDraftFromBrand,
+  computeBrandKitReadiness,
+} from '@helpers/brand-kit-contract.helper';
+
+function createCompleteBrand(): BrandKitSourceBrand {
+  return {
+    agentConfig: {
+      strategy: {
+        contentTypes: ['post', 'article'],
+        frequency: 'weekly',
+        goals: ['pipeline'],
+        platforms: ['linkedin', 'x'],
+      },
+      voice: {
+        audience: ['founders', 'operators'],
+        doNotSoundLike: ['generic'],
+        messagingPillars: ['speed', 'taste'],
+        sampleOutput: 'Ship the sharp version.',
+        style: 'concise',
+        tone: 'direct',
+        values: ['clarity', 'momentum'],
+      },
+    },
+    backgroundColor: '#ffffff',
+    banner: {
+      id: 'banner-asset',
+      label: 'Launch banner',
+      url: 'https://cdn.example.com/banner.png',
+    },
+    description: 'An operator-first content OS.',
+    fontFamily: 'Inter',
+    id: 'brand-1',
+    label: 'Acme',
+    links: [
+      {
+        category: 'website',
+        label: 'Website',
+        url: 'https://acme.example',
+      },
+    ],
+    logo: {
+      id: 'logo-asset',
+      label: 'Primary logo',
+      mimeType: 'image/png',
+      url: 'https://cdn.example.com/logo.png',
+    },
+    organization: { id: 'org-1' },
+    primaryColor: '#ff5500',
+    references: [
+      {
+        id: 'ref-asset',
+        label: 'Reference',
+        url: 'https://cdn.example.com/ref.png',
+      },
+    ],
+    secondaryColor: '#111827',
+    text: 'Use short, grounded copy with explicit proof.',
+    twitterUrl: 'https://x.com/acme',
+  };
+}
+
+describe('brand kit contract helpers', () => {
+  it('maps an existing brand into the shared brand kit draft contract', () => {
+    const draft = buildBrandKitDraftFromBrand(createCompleteBrand(), {
+      draftId: 'draft-1',
+    });
+
+    expect(draft.id).toBe('draft-1');
+    expect(draft.brandId).toBe('brand-1');
+    expect(draft.organizationId).toBe('org-1');
+    expect(draft.status).toBe('ready');
+    expect(draft.readiness.status).toBe('complete');
+    expect(draft.readiness.score).toBe(100);
+
+    expect(draft.fields.label?.currentValue).toBe('Acme');
+    expect(draft.fields.promptGuidelines?.ownerPath).toBe('brand.text');
+    expect(draft.fields.promptGuidelines?.currentValue).toBe(
+      'Use short, grounded copy with explicit proof.',
+    );
+    expect(draft.fields.voiceAudience?.currentValue).toEqual([
+      'founders',
+      'operators',
+    ]);
+
+    const logo = draft.fields.logo?.currentValue as
+      | IBrandKitAssetValue
+      | undefined;
+    expect(logo).toMatchObject({
+      id: 'logo-asset',
+      role: 'logo',
+      sourceType: 'current_brand',
+      url: 'https://cdn.example.com/logo.png',
+    });
+
+    const references = draft.fields.references?.currentValue as
+      | IBrandKitAssetValue[]
+      | undefined;
+    expect(references).toHaveLength(1);
+    expect(references?.[0]).toMatchObject({
+      id: 'ref-asset',
+      role: 'reference',
+    });
+
+    const socialLinks = draft.fields.socialLinks?.currentValue as
+      | IBrandKitSocialLink[]
+      | undefined;
+    expect(socialLinks).toEqual([
+      {
+        platform: 'twitter',
+        sourceType: 'current_brand',
+        url: 'https://x.com/acme',
+      },
+      {
+        label: 'Website',
+        platform: 'website',
+        sourceType: 'current_brand',
+        url: 'https://acme.example',
+      },
+    ]);
+  });
+
+  it('documents every field owner and preserves existing data by default', () => {
+    const draft = buildBrandKitDraftFromBrand(createCompleteBrand());
+    const fields = Object.values(draft.fields);
+
+    expect(fields).toHaveLength(22);
+    expect(
+      fields.every((field) => field.applyActionDefault === 'preserve'),
+    ).toBe(true);
+    expect(draft.fields.primaryColor?.ownerPath).toBe('brand.primaryColor');
+    expect(draft.fields.voiceTone?.ownerPath).toBe(
+      'brand.agentConfig.voice.tone',
+    );
+    expect(draft.fields.references?.ownerPath).toBe('brand.references');
+  });
+
+  it('reports partial readiness and field diagnostics for missing kit data', () => {
+    const readiness = computeBrandKitReadiness({
+      id: 'brand-2',
+      label: 'Partial',
+      primaryColor: '#000000',
+    });
+
+    expect(readiness.status).toBe('partial');
+    expect(readiness.score).toBeLessThan(100);
+    expect(readiness.missingFields).toEqual(
+      expect.arrayContaining([
+        'description',
+        'primaryColor',
+        'fontFamily',
+        'promptGuidelines',
+        'voiceTone',
+        'voiceStyle',
+        'logo',
+        'references',
+      ]),
+    );
+    expect(
+      readiness.diagnostics.some(
+        (diagnostic) => diagnostic.code === 'brand_kit_missing_primaryColor',
+      ),
+    ).toBe(true);
+  });
+
+  it('marks an empty brand kit as missing', () => {
+    const draft = buildBrandKitDraftFromBrand({ id: 'brand-3' });
+
+    expect(draft.status).toBe('missing');
+    expect(draft.readiness.status).toBe('missing');
+    expect(draft.readiness.score).toBe(0);
+    expect(draft.readiness.missingFields).toHaveLength(9);
+  });
+
+  it('carries blocking diagnostics into the draft readiness state', () => {
+    const draft = buildBrandKitDraftFromBrand(createCompleteBrand(), {
+      diagnostics: [
+        {
+          code: 'brand_kit_private_source_blocked',
+          fieldKey: 'logo',
+          message: 'Private source URL rejected.',
+          severity: 'error',
+        },
+      ],
+    });
+
+    expect(draft.status).toBe('blocked');
+    expect(draft.readiness.status).toBe('blocked');
+    expect(draft.readiness.score).toBe(100);
+    expect(draft.readiness.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'brand_kit_private_source_blocked',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/helpers/src/brand-kit-contract.helper.test.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.test.ts
@@ -177,6 +177,43 @@ describe('brand kit contract helpers', () => {
     expect(draft.readiness.missingFields).toHaveLength(9);
   });
 
+  it('deduplicates reference asset URLs across references, primaryReferenceUrl, and referenceImages', () => {
+    const sharedUrl = 'https://cdn.example.com/shared.png';
+    const draft = buildBrandKitDraftFromBrand({
+      id: 'brand-dedup',
+      primaryReferenceUrl: sharedUrl,
+      referenceImages: [sharedUrl, 'https://cdn.example.com/unique.png'],
+      references: [{ id: 'ref-1', url: sharedUrl }],
+    });
+
+    const references = draft.fields.references?.currentValue as
+      | IBrandKitAssetValue[]
+      | undefined;
+    const urls = references?.map((r) => r.url);
+    const uniqueUrls = [...new Set(urls)];
+    expect(urls).toHaveLength(uniqueUrls.length);
+    expect(references?.some((r) => r.url === sharedUrl)).toBe(true);
+    expect(
+      references?.some((r) => r.url === 'https://cdn.example.com/unique.png'),
+    ).toBe(true);
+  });
+
+  it('preserves primaryReferenceUrl as a reference asset when not already in references[]', () => {
+    const draft = buildBrandKitDraftFromBrand({
+      id: 'brand-primary-ref',
+      primaryReferenceUrl: 'https://cdn.example.com/primary.png',
+      references: [{ id: 'ref-1', url: 'https://cdn.example.com/other.png' }],
+    });
+
+    const references = draft.fields.references?.currentValue as
+      | IBrandKitAssetValue[]
+      | undefined;
+    expect(references).toHaveLength(2);
+    expect(
+      references?.some((r) => r.url === 'https://cdn.example.com/primary.png'),
+    ).toBe(true);
+  });
+
   it('carries blocking diagnostics into the draft readiness state', () => {
     const draft = buildBrandKitDraftFromBrand(createCompleteBrand(), {
       diagnostics: [

--- a/packages/helpers/src/brand-kit-contract.helper.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.ts
@@ -173,22 +173,40 @@ function readReferenceAssets(
   const references = brand.references ?? [];
   const referenceImages = brand.referenceImages ?? [];
   const values: IBrandKitAssetValue[] = [];
+  const seenUrls = new Set<string>();
 
   for (const reference of references) {
     const value = toAssetValue('reference', reference);
     if (value) {
+      if (value.url) {
+        if (seenUrls.has(value.url)) {
+          continue;
+        }
+        seenUrls.add(value.url);
+      }
       values.push(value);
     }
   }
 
   const primaryReference = toAssetValue('reference', brand.primaryReferenceUrl);
   if (primaryReference) {
-    values.push(primaryReference);
+    if (!primaryReference.url || !seenUrls.has(primaryReference.url)) {
+      if (primaryReference.url) {
+        seenUrls.add(primaryReference.url);
+      }
+      values.push(primaryReference);
+    }
   }
 
   for (const referenceImage of referenceImages) {
     const value = toAssetValue('reference', referenceImage);
     if (value) {
+      if (value.url) {
+        if (seenUrls.has(value.url)) {
+          continue;
+        }
+        seenUrls.add(value.url);
+      }
       values.push(value);
     }
   }

--- a/packages/helpers/src/brand-kit-contract.helper.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.ts
@@ -1,0 +1,437 @@
+import {
+  BRAND_KIT_FIELD_OWNERSHIP,
+  type BrandKitAssetRole,
+  type BrandKitFieldKey,
+  type BrandKitSourceType,
+  type IBrandKitAssetValue,
+  type IBrandKitDiagnostic,
+  type IBrandKitDraft,
+  type IBrandKitDraftField,
+  type IBrandKitFieldOwner,
+  type IBrandKitReadiness,
+  type IBrandKitSocialLink,
+  type IBrandKitSourceEvidence,
+} from '@genfeedai/interfaces';
+
+interface BrandKitAssetSource {
+  id?: string;
+  url?: string;
+  label?: string;
+  mimeType?: string;
+  width?: number;
+  height?: number;
+}
+
+interface BrandKitLinkSource {
+  label?: string;
+  category?: string;
+  url?: string;
+}
+
+export interface BrandKitSourceBrand {
+  id: string;
+  organization?: string | { id?: string | null } | null;
+  label?: string | null;
+  description?: string | null;
+  text?: string | null;
+  fontFamily?: string | null;
+  primaryColor?: string | null;
+  secondaryColor?: string | null;
+  backgroundColor?: string | null;
+  logo?: BrandKitAssetSource | null;
+  banner?: BrandKitAssetSource | null;
+  references?: BrandKitAssetSource[] | null;
+  logoUrl?: string | null;
+  bannerUrl?: string | null;
+  primaryReferenceUrl?: string | null;
+  referenceImages?: Array<string | BrandKitAssetSource> | null;
+  links?: BrandKitLinkSource[] | null;
+  youtubeUrl?: string | null;
+  tiktokUrl?: string | null;
+  instagramUrl?: string | null;
+  twitterUrl?: string | null;
+  linkedinUrl?: string | null;
+  agentConfig?: {
+    voice?: {
+      tone?: string | null;
+      style?: string | null;
+      audience?: string[] | null;
+      values?: string[] | null;
+      messagingPillars?: string[] | null;
+      doNotSoundLike?: string[] | null;
+      sampleOutput?: string | null;
+    } | null;
+    strategy?: {
+      contentTypes?: string[] | null;
+      platforms?: string[] | null;
+      goals?: string[] | null;
+      frequency?: string | null;
+    } | null;
+  } | null;
+}
+
+export interface BuildBrandKitDraftOptions {
+  draftId?: string;
+  sourceType?: BrandKitSourceType;
+  evidence?: IBrandKitSourceEvidence[];
+  diagnostics?: IBrandKitDiagnostic[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+const REQUIRED_BRAND_KIT_FIELDS: readonly BrandKitFieldKey[] = [
+  'label',
+  'description',
+  'primaryColor',
+  'fontFamily',
+  'promptGuidelines',
+  'voiceTone',
+  'voiceStyle',
+  'logo',
+  'references',
+];
+
+const DEFAULT_PRIMARY_COLORS = new Set(['#000', '#000000']);
+
+const SOCIAL_URL_FIELDS: ReadonlyArray<{
+  platform: string;
+  key:
+    | 'youtubeUrl'
+    | 'tiktokUrl'
+    | 'instagramUrl'
+    | 'twitterUrl'
+    | 'linkedinUrl';
+}> = [
+  { key: 'youtubeUrl', platform: 'youtube' },
+  { key: 'tiktokUrl', platform: 'tiktok' },
+  { key: 'instagramUrl', platform: 'instagram' },
+  { key: 'twitterUrl', platform: 'twitter' },
+  { key: 'linkedinUrl', platform: 'linkedin' },
+];
+
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function getOrganizationId(
+  organization: BrandKitSourceBrand['organization'],
+): string | undefined {
+  if (typeof organization === 'string') {
+    return organization;
+  }
+  if (organization && hasText(organization.id)) {
+    return organization.id;
+  }
+  return undefined;
+}
+
+function findOwner(key: BrandKitFieldKey): IBrandKitFieldOwner {
+  const owner = BRAND_KIT_FIELD_OWNERSHIP.find((entry) => entry.key === key);
+  if (!owner) {
+    throw new Error(`Missing brand kit owner mapping for ${key}`);
+  }
+  return owner;
+}
+
+function toAssetValue(
+  role: BrandKitAssetRole,
+  asset: BrandKitAssetSource | string | null | undefined,
+): IBrandKitAssetValue | undefined {
+  if (!asset) {
+    return undefined;
+  }
+
+  if (typeof asset === 'string') {
+    return hasText(asset)
+      ? {
+          role,
+          sourceType: 'current_brand',
+          url: asset,
+        }
+      : undefined;
+  }
+
+  if (!hasText(asset.id) && !hasText(asset.url)) {
+    return undefined;
+  }
+
+  return {
+    height: asset.height,
+    id: asset.id,
+    label: asset.label,
+    mimeType: asset.mimeType,
+    role,
+    sourceType: 'current_brand',
+    url: asset.url,
+    width: asset.width,
+  };
+}
+
+function readReferenceAssets(
+  brand: BrandKitSourceBrand,
+): IBrandKitAssetValue[] {
+  const references = brand.references ?? [];
+  const referenceImages = brand.referenceImages ?? [];
+  const values: IBrandKitAssetValue[] = [];
+
+  for (const reference of references) {
+    const value = toAssetValue('reference', reference);
+    if (value) {
+      values.push(value);
+    }
+  }
+
+  const primaryReference = toAssetValue('reference', brand.primaryReferenceUrl);
+  if (primaryReference) {
+    values.push(primaryReference);
+  }
+
+  for (const referenceImage of referenceImages) {
+    const value = toAssetValue('reference', referenceImage);
+    if (value) {
+      values.push(value);
+    }
+  }
+
+  return values;
+}
+
+function readSocialLinks(brand: BrandKitSourceBrand): IBrandKitSocialLink[] {
+  const links: IBrandKitSocialLink[] = [];
+  const seenUrls = new Set<string>();
+
+  for (const field of SOCIAL_URL_FIELDS) {
+    const url = brand[field.key];
+    if (!hasText(url) || seenUrls.has(url)) {
+      continue;
+    }
+    seenUrls.add(url);
+    links.push({
+      platform: field.platform,
+      sourceType: 'current_brand',
+      url,
+    });
+  }
+
+  for (const link of brand.links ?? []) {
+    if (!hasText(link.url) || seenUrls.has(link.url)) {
+      continue;
+    }
+    seenUrls.add(link.url);
+    links.push({
+      label: link.label,
+      platform: link.category ?? 'link',
+      sourceType: 'current_brand',
+      url: link.url,
+    });
+  }
+
+  return links;
+}
+
+function readCurrentValue(
+  brand: BrandKitSourceBrand,
+  key: BrandKitFieldKey,
+): unknown {
+  switch (key) {
+    case 'label':
+      return brand.label ?? undefined;
+    case 'description':
+      return brand.description ?? undefined;
+    case 'primaryColor':
+      return brand.primaryColor ?? undefined;
+    case 'secondaryColor':
+      return brand.secondaryColor ?? undefined;
+    case 'backgroundColor':
+      return brand.backgroundColor ?? undefined;
+    case 'fontFamily':
+      return brand.fontFamily ?? undefined;
+    case 'promptGuidelines':
+      return brand.text ?? undefined;
+    case 'voiceTone':
+      return brand.agentConfig?.voice?.tone ?? undefined;
+    case 'voiceStyle':
+      return brand.agentConfig?.voice?.style ?? undefined;
+    case 'voiceAudience':
+      return brand.agentConfig?.voice?.audience ?? undefined;
+    case 'voiceValues':
+      return brand.agentConfig?.voice?.values ?? undefined;
+    case 'voiceMessagingPillars':
+      return brand.agentConfig?.voice?.messagingPillars ?? undefined;
+    case 'voiceDoNotSoundLike':
+      return brand.agentConfig?.voice?.doNotSoundLike ?? undefined;
+    case 'voiceSampleOutput':
+      return brand.agentConfig?.voice?.sampleOutput ?? undefined;
+    case 'strategyContentTypes':
+      return brand.agentConfig?.strategy?.contentTypes ?? undefined;
+    case 'strategyPlatforms':
+      return brand.agentConfig?.strategy?.platforms ?? undefined;
+    case 'strategyGoals':
+      return brand.agentConfig?.strategy?.goals ?? undefined;
+    case 'strategyFrequency':
+      return brand.agentConfig?.strategy?.frequency ?? undefined;
+    case 'socialLinks':
+      return readSocialLinks(brand);
+    case 'logo':
+      return (
+        toAssetValue('logo', brand.logo) ?? toAssetValue('logo', brand.logoUrl)
+      );
+    case 'banner':
+      return (
+        toAssetValue('banner', brand.banner) ??
+        toAssetValue('banner', brand.bannerUrl)
+      );
+    case 'references':
+      return readReferenceAssets(brand);
+  }
+}
+
+function hasMeaningfulFieldValue(
+  key: BrandKitFieldKey,
+  value: unknown,
+): boolean {
+  if (key === 'primaryColor' && hasText(value)) {
+    return !DEFAULT_PRIMARY_COLORS.has(value.trim().toLowerCase());
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.keys(value).length > 0;
+  }
+  return hasText(value);
+}
+
+function createMissingFieldDiagnostic(
+  key: BrandKitFieldKey,
+): IBrandKitDiagnostic {
+  const owner = findOwner(key);
+  return {
+    code: `brand_kit_missing_${key}`,
+    fieldKey: key,
+    message: `${owner.label} is missing from the current brand kit.`,
+    severity: 'warning',
+  };
+}
+
+function buildReadiness(
+  fields: Partial<Record<BrandKitFieldKey, IBrandKitDraftField>>,
+  diagnostics: IBrandKitDiagnostic[],
+): IBrandKitReadiness {
+  const missingFields = REQUIRED_BRAND_KIT_FIELDS.filter((key) => {
+    const field = fields[key];
+    const value = field?.proposedValue ?? field?.currentValue;
+    return !hasMeaningfulFieldValue(key, value);
+  });
+
+  const missingDiagnostics = missingFields.map(createMissingFieldDiagnostic);
+  const blockingDiagnostics = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === 'error',
+  );
+  const readinessDiagnostics = [...diagnostics, ...missingDiagnostics];
+  const completedFields =
+    REQUIRED_BRAND_KIT_FIELDS.length - missingFields.length;
+  const score = Math.round(
+    (completedFields / REQUIRED_BRAND_KIT_FIELDS.length) * 100,
+  );
+
+  if (blockingDiagnostics.length > 0) {
+    return {
+      diagnostics: readinessDiagnostics,
+      missingFields,
+      requiredFields: [...REQUIRED_BRAND_KIT_FIELDS],
+      score,
+      status: 'blocked',
+    };
+  }
+
+  if (missingFields.length === 0) {
+    return {
+      diagnostics: readinessDiagnostics,
+      missingFields,
+      requiredFields: [...REQUIRED_BRAND_KIT_FIELDS],
+      score: 100,
+      status: 'complete',
+    };
+  }
+
+  return {
+    diagnostics: readinessDiagnostics,
+    missingFields,
+    requiredFields: [...REQUIRED_BRAND_KIT_FIELDS],
+    score,
+    status:
+      missingFields.length === REQUIRED_BRAND_KIT_FIELDS.length
+        ? 'missing'
+        : 'partial',
+  };
+}
+
+function buildDraftField(
+  brand: BrandKitSourceBrand,
+  owner: IBrandKitFieldOwner,
+  evidence: IBrandKitSourceEvidence[],
+): IBrandKitDraftField {
+  return {
+    applyActionDefault: owner.applyActionDefault,
+    currentValue: readCurrentValue(brand, owner.key),
+    diagnostics: [],
+    evidence,
+    group: owner.group,
+    key: owner.key,
+    label: owner.label,
+    ownerPath: owner.ownerPath,
+  };
+}
+
+export function buildBrandKitDraftFromBrand(
+  brand: BrandKitSourceBrand,
+  options: BuildBrandKitDraftOptions = {},
+): IBrandKitDraft {
+  const sourceType = options.sourceType ?? 'current_brand';
+  const evidence: IBrandKitSourceEvidence[] =
+    options.evidence && options.evidence.length > 0
+      ? options.evidence
+      : [
+          {
+            label: 'Current brand record',
+            sourceId: brand.id,
+            sourceType,
+          },
+        ];
+  const fields: Partial<Record<BrandKitFieldKey, IBrandKitDraftField>> = {};
+
+  for (const owner of BRAND_KIT_FIELD_OWNERSHIP) {
+    fields[owner.key] = buildDraftField(brand, owner, evidence);
+  }
+
+  const diagnostics = options.diagnostics ?? [];
+  const readiness = buildReadiness(fields, diagnostics);
+
+  return {
+    assetCandidates: [],
+    brandId: brand.id,
+    createdAt: options.createdAt,
+    diagnostics,
+    evidence,
+    fields,
+    id: options.draftId,
+    organizationId: getOrganizationId(brand.organization),
+    readiness,
+    sourceType,
+    status: readiness.status === 'complete' ? 'ready' : readiness.status,
+    updatedAt: options.updatedAt,
+  };
+}
+
+export function computeBrandKitReadiness(
+  brand: BrandKitSourceBrand,
+): IBrandKitReadiness {
+  return buildBrandKitDraftFromBrand(brand).readiness;
+}
+
+export function getBrandKitFieldOwner(
+  key: BrandKitFieldKey,
+): IBrandKitFieldOwner {
+  return findOwner(key);
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -2,6 +2,7 @@ export * from './aspect-ratio.helper';
 export * from './async/sleep.helper';
 export * from './auth/auth.helper';
 export * from './brand-completeness.helper';
+export * from './brand-kit-contract.helper';
 export * from './business/pricing/pricing.helper';
 export * from './business/tier-models/tier-models.helper';
 export * from './content/schema-org.helper';

--- a/packages/helpers/vitest.config.ts
+++ b/packages/helpers/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
       '@genfeedai/pricing': path.resolve(__dirname, '../pricing/src/index.ts'),
       '@genfeedai/enums': path.resolve(__dirname, '../enums/src/index.ts'),
       '@genfeedai/helpers': path.resolve(__dirname, './src/index.ts'),
+      '@genfeedai/interfaces': path.resolve(
+        __dirname,
+        '../interfaces/src/index.ts',
+      ),
       '@helpers': path.resolve(__dirname, './src'),
       '@hooks': path.resolve(__dirname, '../hooks'),
       '@props': path.resolve(__dirname, '../props'),

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -160,6 +160,7 @@ export * from './onboarding/onboarding-journey.interface';
 export * from './onboarding/onboarding-wizard.interface';
 export * from './organization/brand.interface';
 export * from './organization/brand-interview.interface';
+export * from './organization/brand-kit.interface';
 export * from './organization/byok-key-entry.interface';
 export * from './organization/byok-provider-status.interface';
 export * from './organization/byok-resolution-result.interface';

--- a/packages/interfaces/src/organization/brand-kit.interface.ts
+++ b/packages/interfaces/src/organization/brand-kit.interface.ts
@@ -1,0 +1,373 @@
+import type { IBrandAgentStrategy, IBrandAgentVoice } from './brand.interface';
+
+export type BrandKitDraftStatus =
+  | 'ready'
+  | 'partial'
+  | 'missing'
+  | 'blocked'
+  | 'accepted'
+  | 'discarded';
+
+export type BrandKitReadinessStatus =
+  | 'complete'
+  | 'partial'
+  | 'blocked'
+  | 'missing';
+
+export type BrandKitFieldGroup =
+  | 'profile'
+  | 'visual'
+  | 'voice'
+  | 'strategy'
+  | 'links'
+  | 'assets';
+
+export type BrandKitSourceType =
+  | 'current_brand'
+  | 'website'
+  | 'manual'
+  | 'uploaded_guidance'
+  | 'system';
+
+export type BrandKitAssetRole = 'logo' | 'banner' | 'reference';
+
+export type BrandKitApplyAction = 'accept' | 'reject' | 'preserve';
+
+export type BrandKitDiagnosticSeverity = 'info' | 'warning' | 'error';
+
+export type BrandKitFieldKey =
+  | 'label'
+  | 'description'
+  | 'primaryColor'
+  | 'secondaryColor'
+  | 'backgroundColor'
+  | 'fontFamily'
+  | 'promptGuidelines'
+  | 'voiceTone'
+  | 'voiceStyle'
+  | 'voiceAudience'
+  | 'voiceValues'
+  | 'voiceMessagingPillars'
+  | 'voiceDoNotSoundLike'
+  | 'voiceSampleOutput'
+  | 'strategyContentTypes'
+  | 'strategyPlatforms'
+  | 'strategyGoals'
+  | 'strategyFrequency'
+  | 'socialLinks'
+  | 'logo'
+  | 'banner'
+  | 'references';
+
+export type BrandKitFieldOwnerPath =
+  | 'brand.label'
+  | 'brand.description'
+  | 'brand.primaryColor'
+  | 'brand.secondaryColor'
+  | 'brand.backgroundColor'
+  | 'brand.fontFamily'
+  | 'brand.text'
+  | 'brand.agentConfig.voice.tone'
+  | 'brand.agentConfig.voice.style'
+  | 'brand.agentConfig.voice.audience'
+  | 'brand.agentConfig.voice.values'
+  | 'brand.agentConfig.voice.messagingPillars'
+  | 'brand.agentConfig.voice.doNotSoundLike'
+  | 'brand.agentConfig.voice.sampleOutput'
+  | 'brand.agentConfig.strategy.contentTypes'
+  | 'brand.agentConfig.strategy.platforms'
+  | 'brand.agentConfig.strategy.goals'
+  | 'brand.agentConfig.strategy.frequency'
+  | 'brand.links'
+  | 'brand.logo'
+  | 'brand.banner'
+  | 'brand.references';
+
+export interface IBrandKitFieldOwner {
+  key: BrandKitFieldKey;
+  label: string;
+  group: BrandKitFieldGroup;
+  ownerPath: BrandKitFieldOwnerPath;
+  valueKind: 'string' | 'string[]' | 'socialLinks' | 'asset' | 'asset[]';
+  applyActionDefault: BrandKitApplyAction;
+}
+
+export interface IBrandKitSourceEvidence {
+  sourceType: BrandKitSourceType;
+  label: string;
+  sourceId?: string;
+  url?: string;
+  excerpt?: string;
+  confidence?: number;
+}
+
+export interface IBrandKitDiagnostic {
+  code: string;
+  severity: BrandKitDiagnosticSeverity;
+  message: string;
+  fieldKey?: BrandKitFieldKey;
+}
+
+export interface IBrandKitSocialLink {
+  platform: string;
+  url: string;
+  label?: string;
+  sourceType: BrandKitSourceType;
+}
+
+export interface IBrandKitAssetValue {
+  role: BrandKitAssetRole;
+  id?: string;
+  url?: string;
+  label?: string;
+  mimeType?: string;
+  width?: number;
+  height?: number;
+  sourceType: BrandKitSourceType;
+}
+
+export interface IBrandKitAssetCandidate extends IBrandKitAssetValue {
+  candidateId: string;
+  sourceUrl?: string;
+  diagnostics?: IBrandKitDiagnostic[];
+}
+
+export interface IBrandKitDraftField<TValue = unknown> {
+  key: BrandKitFieldKey;
+  label: string;
+  group: BrandKitFieldGroup;
+  ownerPath: BrandKitFieldOwnerPath;
+  currentValue?: TValue;
+  proposedValue?: TValue;
+  evidence: IBrandKitSourceEvidence[];
+  diagnostics: IBrandKitDiagnostic[];
+  confidence?: number;
+  applyActionDefault: BrandKitApplyAction;
+}
+
+export interface IBrandKitReadiness {
+  status: BrandKitReadinessStatus;
+  score: number;
+  requiredFields: BrandKitFieldKey[];
+  missingFields: BrandKitFieldKey[];
+  diagnostics: IBrandKitDiagnostic[];
+}
+
+export interface IBrandKitDraft {
+  id?: string;
+  brandId: string;
+  organizationId?: string;
+  status: BrandKitDraftStatus;
+  sourceType: BrandKitSourceType;
+  fields: Partial<Record<BrandKitFieldKey, IBrandKitDraftField>>;
+  assetCandidates: IBrandKitAssetCandidate[];
+  evidence: IBrandKitSourceEvidence[];
+  diagnostics: IBrandKitDiagnostic[];
+  readiness: IBrandKitReadiness;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface IBrandKitApplyFieldDecision<TValue = unknown> {
+  action: BrandKitApplyAction;
+  value?: TValue;
+  assetCandidateId?: string;
+  replaceExisting?: boolean;
+}
+
+export interface IBrandKitApplyRequest {
+  brandId: string;
+  draftId?: string;
+  fields: Partial<Record<BrandKitFieldKey, IBrandKitApplyFieldDecision>>;
+}
+
+export interface IBrandKitApplyResult {
+  brandId: string;
+  status: Extract<BrandKitDraftStatus, 'accepted' | 'partial' | 'blocked'>;
+  appliedFields: BrandKitFieldKey[];
+  preservedFields: BrandKitFieldKey[];
+  diagnostics: IBrandKitDiagnostic[];
+}
+
+export type IBrandKitVoiceSnapshot = IBrandAgentVoice;
+
+export type IBrandKitStrategySnapshot = IBrandAgentStrategy;
+
+export const BRAND_KIT_FIELD_OWNERSHIP: readonly IBrandKitFieldOwner[] = [
+  {
+    applyActionDefault: 'preserve',
+    group: 'profile',
+    key: 'label',
+    label: 'Brand name',
+    ownerPath: 'brand.label',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'profile',
+    key: 'description',
+    label: 'Description',
+    ownerPath: 'brand.description',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'visual',
+    key: 'primaryColor',
+    label: 'Primary color',
+    ownerPath: 'brand.primaryColor',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'visual',
+    key: 'secondaryColor',
+    label: 'Secondary color',
+    ownerPath: 'brand.secondaryColor',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'visual',
+    key: 'backgroundColor',
+    label: 'Background color',
+    ownerPath: 'brand.backgroundColor',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'visual',
+    key: 'fontFamily',
+    label: 'Font family',
+    ownerPath: 'brand.fontFamily',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'promptGuidelines',
+    label: 'Prompt guidelines',
+    ownerPath: 'brand.text',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceTone',
+    label: 'Voice tone',
+    ownerPath: 'brand.agentConfig.voice.tone',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceStyle',
+    label: 'Voice style',
+    ownerPath: 'brand.agentConfig.voice.style',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceAudience',
+    label: 'Voice audience',
+    ownerPath: 'brand.agentConfig.voice.audience',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceValues',
+    label: 'Voice values',
+    ownerPath: 'brand.agentConfig.voice.values',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceMessagingPillars',
+    label: 'Messaging pillars',
+    ownerPath: 'brand.agentConfig.voice.messagingPillars',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceDoNotSoundLike',
+    label: 'Avoid sounding like',
+    ownerPath: 'brand.agentConfig.voice.doNotSoundLike',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'voice',
+    key: 'voiceSampleOutput',
+    label: 'Sample output',
+    ownerPath: 'brand.agentConfig.voice.sampleOutput',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'strategy',
+    key: 'strategyContentTypes',
+    label: 'Content types',
+    ownerPath: 'brand.agentConfig.strategy.contentTypes',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'strategy',
+    key: 'strategyPlatforms',
+    label: 'Platforms',
+    ownerPath: 'brand.agentConfig.strategy.platforms',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'strategy',
+    key: 'strategyGoals',
+    label: 'Goals',
+    ownerPath: 'brand.agentConfig.strategy.goals',
+    valueKind: 'string[]',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'strategy',
+    key: 'strategyFrequency',
+    label: 'Posting frequency',
+    ownerPath: 'brand.agentConfig.strategy.frequency',
+    valueKind: 'string',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'links',
+    key: 'socialLinks',
+    label: 'Social links',
+    ownerPath: 'brand.links',
+    valueKind: 'socialLinks',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'assets',
+    key: 'logo',
+    label: 'Logo',
+    ownerPath: 'brand.logo',
+    valueKind: 'asset',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'assets',
+    key: 'banner',
+    label: 'Banner',
+    ownerPath: 'brand.banner',
+    valueKind: 'asset',
+  },
+  {
+    applyActionDefault: 'preserve',
+    group: 'assets',
+    key: 'references',
+    label: 'Reference assets',
+    ownerPath: 'brand.references',
+    valueKind: 'asset[]',
+  },
+];

--- a/packages/interfaces/src/organization/brand-kit.interface.ts
+++ b/packages/interfaces/src/organization/brand-kit.interface.ts
@@ -168,12 +168,25 @@ export interface IBrandKitDraft {
   updatedAt?: string;
 }
 
-export interface IBrandKitApplyFieldDecision<TValue = unknown> {
-  action: BrandKitApplyAction;
+export interface IBrandKitApplyFieldDecisionAccept<TValue = unknown> {
+  action: 'accept';
   value?: TValue;
   assetCandidateId?: string;
   replaceExisting?: boolean;
 }
+
+export interface IBrandKitApplyFieldDecisionPreserve {
+  action: 'preserve';
+}
+
+export interface IBrandKitApplyFieldDecisionReject {
+  action: 'reject';
+}
+
+export type IBrandKitApplyFieldDecision<TValue = unknown> =
+  | IBrandKitApplyFieldDecisionAccept<TValue>
+  | IBrandKitApplyFieldDecisionPreserve
+  | IBrandKitApplyFieldDecisionReject;
 
 export interface IBrandKitApplyRequest {
   brandId: string;

--- a/packages/interfaces/src/organization/index.ts
+++ b/packages/interfaces/src/organization/index.ts
@@ -1,5 +1,6 @@
 export * from './brand.interface';
 export * from './brand-interview.interface';
+export * from './brand-kit.interface';
 export * from './byok-key-entry.interface';
 export * from './byok-provider-status.interface';
 export * from './byok-resolution-result.interface';


### PR DESCRIPTION
## Summary
- Add shared Brand Kit draft/apply/readiness contract types for profile, visual identity, voice, strategy, links, assets, evidence, and diagnostics.
- Add deterministic helpers to map current brand records into that contract without mutating storage.
- Add focused coverage proving owner mapping, preserve-by-default apply semantics, readiness diagnostics, missing states, and blocking diagnostics.

Closes #771
Refs #770

## Validation
- bunx biome check --write packages/interfaces/src/organization/brand-kit.interface.ts packages/interfaces/src/organization/index.ts packages/interfaces/src/index.ts packages/helpers/src/brand-kit-contract.helper.ts packages/helpers/src/brand-kit-contract.helper.test.ts packages/helpers/src/index.ts packages/helpers/vitest.config.ts
- bun run --cwd packages/helpers test -- src/brand-kit-contract.helper.test.ts
- bunx turbo run type-check --filter=@genfeedai/interfaces --filter=@genfeedai/helpers
- bun run --cwd packages/helpers test
- git diff --check
- bun scripts/run-secretlint.ts packages/helpers/src/brand-kit-contract.helper.test.ts packages/helpers/src/brand-kit-contract.helper.ts packages/helpers/src/index.ts packages/helpers/vitest.config.ts packages/interfaces/src/index.ts packages/interfaces/src/organization/brand-kit.interface.ts packages/interfaces/src/organization/index.ts
- pre-commit lint-staged Secretlint/Biome hooks