### PR TITLE
refactor(ui): single-source radius + consolidate cards onto one Card surface

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,6 +85,7 @@ typography:
     letterSpacing: -0.03em
 
 rounded:
+  none: 0px
   sm: 2px
   md: 6px
   lg: 8px
@@ -117,7 +118,7 @@ components:
   card:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.text-primary}"
-    rounded: "{rounded.sm}"
+    rounded: "{rounded.none}"
     shadow: "inset 0 0 0 1px {colors.border}"
   dialog:
     backgroundColor: "{colors.bg-primary}"
@@ -163,7 +164,7 @@ components:
   stat-card:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.text-primary}"
-    rounded: "{rounded.sm}"
+    rounded: "{rounded.none}"
   input:
     backgroundColor: "{colors.bg-tertiary}"
     textColor: "{colors.text-primary}"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,7 +117,7 @@ components:
   card:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.text-primary}"
-    rounded: "{rounded.md}"
+    rounded: "{rounded.sm}"
     shadow: "inset 0 0 0 1px {colors.border}"
   dialog:
     backgroundColor: "{colors.bg-primary}"
@@ -163,7 +163,7 @@ components:
   stat-card:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.text-primary}"
-    rounded: "{rounded.md}"
+    rounded: "{rounded.sm}"
   input:
     backgroundColor: "{colors.bg-tertiary}"
     textColor: "{colors.text-primary}"

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-hero-card.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-hero-card.tsx
@@ -25,10 +25,7 @@ export default function ProactiveHeroCard({
   onContinueSelfServe,
 }: Props) {
   return (
-    <Card
-      bodyClassName="gap-0 p-8"
-      className="rounded-3xl border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.14),rgba(255,255,255,0.03)_45%,rgba(0,0,0,0.2))]"
-    >
+    <Card bodyClassName="gap-0 p-8" className="border-white/10 bg-white/[0.06]">
       <div className="flex flex-wrap items-start justify-between gap-6">
         <div className="max-w-2xl">
           <Badge

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
@@ -108,7 +108,7 @@ export default function ClipResultCard({
   }, [videoUrl, clip.title]);
 
   return (
-    <div className="group relative flex flex-col rounded-xl border border-zinc-800 bg-zinc-900/50 p-4 transition-all hover:border-zinc-700 hover:bg-zinc-900">
+    <div className="group relative flex flex-col rounded-card border border-zinc-800 bg-zinc-900/50 p-4 transition-all hover:border-zinc-700 hover:bg-zinc-900">
       {/* Header */}
       <div className="mb-3 flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -20,7 +20,7 @@ function BrandCard({ brand, orgSlug }: { brand: Brand; orgSlug: string }) {
   return (
     <Link
       href={cardHref}
-      className="group flex flex-col gap-4 rounded-lg border border-border bg-card p-5 transition hover:border-border-strong hover:bg-foreground/[0.04]"
+      className="group flex flex-col gap-4 rounded-card border border-border bg-card p-5 transition hover:border-border-strong hover:bg-foreground/[0.04]"
     >
       <div className="flex items-center gap-3">
         {brand.logoUrl ? (

--- a/apps/app/app/(protected)/admin/overview/analytics/business/business-dashboard.tsx
+++ b/apps/app/app/(protected)/admin/overview/analytics/business/business-dashboard.tsx
@@ -372,7 +372,7 @@ export default function BusinessDashboard() {
 
       {/* Category Breakdown */}
       {data.ingredients.categoryBreakdown.length > 0 && (
-        <div className="rounded-lg border border-border bg-card p-4">
+        <div className="rounded-card border border-border bg-card p-4">
           <h3 className="mb-3 text-sm font-semibold text-foreground">
             Ingredient Category Breakdown
           </h3>

--- a/apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
+++ b/apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
@@ -43,7 +43,7 @@ export function AdGridCard({
       variant={ButtonVariant.UNSTYLED}
       onClick={() => onSelect(item)}
       className={cn(
-        'group rounded-xl border border-white/[0.06] bg-card p-4 text-left transition-all duration-200 hover:border-white/[0.10]',
+        'group rounded-card border border-white/[0.06] bg-card p-4 text-left transition-all duration-200 hover:border-white/[0.10]',
         isSelected && 'border-primary/45 shadow-lg shadow-primary/10',
       )}
     >

--- a/apps/app/src/components/models/ModelCard.tsx
+++ b/apps/app/src/components/models/ModelCard.tsx
@@ -31,7 +31,7 @@ export function ModelCard({ model, onSelect, isRecent }: ModelCardProps) {
       variant={ButtonVariant.UNSTYLED}
       withWrapper={false}
       onClick={() => onSelect(model)}
-      className="group w-full rounded-xl border border-border bg-card text-left transition hover:border-primary overflow-hidden"
+      className="group w-full rounded-card border border-border bg-card text-left transition hover:border-primary overflow-hidden"
     >
       <div className="flex items-stretch">
         {/* Thumbnail or placeholder - full height */}

--- a/apps/app/src/components/ui/card.tsx
+++ b/apps/app/src/components/ui/card.tsx
@@ -3,11 +3,17 @@
 import type * as React from 'react';
 import { cn } from '@/lib/utils';
 
+/**
+ * shadcn-API surface that shares the canonical card chrome from
+ * packages/ui (rounded-card = near-sharp 2px + inset hairline border).
+ * Kept only as a Card/CardContent composition shim for the few public
+ * pages that use that API; styling is NOT a second card system.
+ */
 export function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'rounded-xl border border-border bg-card text-card-foreground shadow-sm',
+        'rounded-card bg-card text-card-foreground shadow-border',
         className,
       )}
       {...props}

--- a/apps/app/src/components/ui/link-card.tsx
+++ b/apps/app/src/components/ui/link-card.tsx
@@ -23,7 +23,7 @@ export function LinkCard({
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        'flex items-center gap-3 rounded-xl border border-border transition hover:border-primary/50 hover:bg-secondary/30',
+        'flex items-center gap-3 rounded-card border border-border transition hover:border-primary/50 hover:bg-secondary/30',
         prominent ? 'p-4' : 'p-3',
       )}
     >

--- a/apps/app/src/features/workflows/components/ui/card/NodeCard.tsx
+++ b/apps/app/src/features/workflows/components/ui/card/NodeCard.tsx
@@ -19,7 +19,7 @@ export function NodeCard({
   return (
     <div
       className={cn(
-        'space-y-3 border border-[var(--border)] bg-card p-4',
+        'space-y-3 rounded-card border border-[var(--border)] bg-card p-4',
         className,
       )}
       style={{ minWidth }}

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -528,7 +528,7 @@ textarea {
 .global-banner-warning {
   background: color-mix(in srgb, var(--warning) 14%, transparent);
   border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
-  border-radius: var(--radius-card);
+  border-radius: var(--radius-lg);
   color: var(--warning);
   padding: 12px 16px;
 }
@@ -642,7 +642,7 @@ textarea {
   align-items: flex-start;
   background: var(--tertiary);
   border: 1px solid transparent;
-  border-radius: var(--radius-card);
+  border-radius: var(--radius-lg);
   color: var(--text);
   cursor: pointer;
   display: flex;
@@ -768,7 +768,7 @@ textarea {
 .conversation-messages {
   background: var(--panel);
   border: 1px solid var(--card-border);
-  border-radius: var(--radius-card);
+  border-radius: var(--radius-xl);
   flex: 1;
   overflow-y: auto;
   padding: 24px;
@@ -1001,7 +1001,7 @@ textarea {
   backdrop-filter: blur(16px);
   background: var(--panel);
   border: 1px solid var(--card-border);
-  border-radius: var(--radius-card);
+  border-radius: var(--radius-xl);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -1398,7 +1398,7 @@ textarea {
   align-items: flex-start;
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
-  border-radius: var(--radius-card);
+  border-radius: var(--radius-2xl);
   color: var(--danger);
   display: flex;
   flex-direction: column;
@@ -1837,7 +1837,7 @@ textarea {
 .auth-error {
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
-  border-radius: var(--radius-card);
+  border-radius: var(--radius-2xl);
   color: var(--danger);
   font-size: 13px;
   padding: 12px;

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -20,6 +20,17 @@
   --tertiary: #131518;
   --warning: #f59e0b;
   --sidebar-width: 260px;
+  --radius-none: 0px;
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 10px;
+  --radius-2xl: 12px;
+  --radius-3xl: 16px;
+  --radius-full: 9999px;
+  /* Canonical near-sharp card radius */
+  --radius-card: 2px;
 }
 
 * {
@@ -91,7 +102,7 @@ textarea {
   align-items: center;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--muted);
   cursor: pointer;
   display: flex;
@@ -151,7 +162,7 @@ textarea {
   align-items: center;
   background: transparent;
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--muted);
   cursor: pointer;
   display: flex;
@@ -180,7 +191,7 @@ textarea {
   align-items: center;
   background: transparent;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--muted);
   cursor: pointer;
   display: flex;
@@ -208,7 +219,7 @@ textarea {
 .logo-mark {
   align-items: center;
   background: var(--accent);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--accent-foreground);
   display: flex;
   font-size: 18px;
@@ -219,7 +230,7 @@ textarea {
 }
 
 .logo-mark.large {
-  border-radius: 12px;
+  border-radius: var(--radius-2xl);
   font-size: 36px;
   height: 72px;
   width: 72px;
@@ -236,7 +247,7 @@ textarea {
   align-items: center;
   background: var(--accent);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--accent-foreground);
   cursor: pointer;
   display: flex;
@@ -267,7 +278,7 @@ textarea {
   align-items: center;
   background: transparent;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--muted);
   cursor: pointer;
   display: flex;
@@ -353,7 +364,7 @@ textarea {
   align-items: flex-start;
   background: transparent;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--text);
   cursor: pointer;
   display: flex;
@@ -395,7 +406,7 @@ textarea {
 
 .thread-status-badge {
   background: color-mix(in srgb, var(--warning) 15%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--warning);
   font-size: 10px;
   font-weight: 600;
@@ -430,7 +441,7 @@ textarea {
 .sync-dot {
   animation: pulse 2s infinite;
   background: var(--accent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   height: 8px;
   width: 8px;
 }
@@ -455,7 +466,7 @@ textarea {
 .user-avatar {
   align-items: center;
   background: var(--accent-soft);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--accent);
   display: flex;
   font-size: 14px;
@@ -517,7 +528,7 @@ textarea {
 .global-banner-warning {
   background: color-mix(in srgb, var(--warning) 14%, transparent);
   border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   color: var(--warning);
   padding: 12px 16px;
 }
@@ -600,7 +611,7 @@ textarea {
 .composer-control-group select {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--text);
   padding: 10px 12px;
 }
@@ -631,7 +642,7 @@ textarea {
   align-items: flex-start;
   background: var(--tertiary);
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   color: var(--text);
   cursor: pointer;
   display: flex;
@@ -688,7 +699,7 @@ textarea {
 .provider-preset {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   color: var(--muted);
   cursor: pointer;
   font-size: 11px;
@@ -717,7 +728,7 @@ textarea {
 .provider-field input {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   color: var(--text);
   font-size: 12px;
   letter-spacing: 0;
@@ -747,7 +758,7 @@ textarea {
 .generating-badge {
   animation: pulse 1.5s infinite;
   background: var(--accent-soft);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--accent);
   font-size: 12px;
   font-weight: 600;
@@ -757,7 +768,7 @@ textarea {
 .conversation-messages {
   background: var(--panel);
   border: 1px solid var(--card-border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   flex: 1;
   overflow-y: auto;
   padding: 24px;
@@ -766,7 +777,7 @@ textarea {
 .brief-handoff-card {
   background: color-mix(in srgb, var(--accent) 7%, var(--tertiary));
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -806,7 +817,7 @@ textarea {
 .empty-logo {
   align-items: center;
   background: var(--accent);
-  border-radius: 12px;
+  border-radius: var(--radius-2xl);
   color: var(--accent-foreground);
   display: flex;
   font-size: 36px;
@@ -842,7 +853,7 @@ textarea {
 .message-avatar {
   align-items: center;
   background: var(--accent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--accent-foreground);
   display: flex;
   flex-shrink: 0;
@@ -859,20 +870,20 @@ textarea {
 }
 
 .message-bubble {
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   max-width: 600px;
   padding: 12px 16px;
 }
 
 .bubble-user {
   background: color-mix(in srgb, var(--agent) 12%, var(--tertiary));
-  border-bottom-right-radius: 6px;
+  border-bottom-right-radius: var(--radius-md);
 }
 
 .bubble-ai {
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-bottom-left-radius: 6px;
+  border-bottom-left-radius: var(--radius-md);
 }
 
 .message-text {
@@ -900,7 +911,7 @@ textarea {
 .typing-indicator .dot {
   animation: typing 1.4s infinite;
   background: var(--agent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   height: 8px;
   width: 8px;
 }
@@ -931,7 +942,7 @@ textarea {
 .generated-card {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   margin-top: 10px;
   padding: 14px;
 }
@@ -944,7 +955,7 @@ textarea {
 
 .generated-card-content {
   background: var(--panel);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-family: inherit;
   font-size: 13px;
   margin: 0;
@@ -990,7 +1001,7 @@ textarea {
   backdrop-filter: blur(16px);
   background: var(--panel);
   border: 1px solid var(--card-border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -1000,7 +1011,7 @@ textarea {
 .conversation-input {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--text);
   flex: 1;
   min-height: 44px;
@@ -1015,7 +1026,7 @@ textarea {
 
 .send-button {
   align-self: flex-end;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 12px 24px;
 }
 
@@ -1064,7 +1075,7 @@ textarea {
 .panel-card {
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   padding: 18px;
 }
 
@@ -1076,7 +1087,7 @@ textarea {
 .primary-button,
 .ghost-button {
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   padding: 12px 18px;
 }
@@ -1109,7 +1120,7 @@ textarea {
 
 .sidebar-action-button {
   align-items: center;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   gap: 8px;
   justify-content: center;
@@ -1120,7 +1131,7 @@ textarea {
 .sidebar-workspace-card {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -1137,7 +1148,7 @@ textarea {
 .workspace-switch-item {
   align-items: center;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--text);
   display: grid;
   gap: 8px;
@@ -1167,7 +1178,7 @@ textarea {
 }
 
 .status-dot {
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   height: 8px;
   width: 8px;
 }
@@ -1197,7 +1208,7 @@ textarea {
   align-items: flex-start;
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   display: grid;
   gap: 14px;
   grid-template-columns: 38px minmax(0, 1fr) auto;
@@ -1224,7 +1235,7 @@ textarea {
   align-items: center;
   background: var(--accent-soft);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--text);
   display: flex;
   height: 38px;
@@ -1278,7 +1289,7 @@ textarea {
 .pill-button {
   background: var(--tertiary);
   border: 1px solid var(--card-border);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--muted);
   cursor: pointer;
   font-size: 13px;
@@ -1302,7 +1313,7 @@ textarea {
 
 .platform-badge {
   background: var(--accent-soft);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--accent);
   font-size: 11px;
   font-weight: 600;
@@ -1313,7 +1324,7 @@ textarea {
 /* Status badges */
 
 .status-badge {
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   font-size: 11px;
   font-weight: 600;
   padding: 2px 10px;
@@ -1373,7 +1384,7 @@ textarea {
 
 .content-type-badge {
   background: color-mix(in srgb, var(--info) 14%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--info);
   font-size: 11px;
   font-weight: 600;
@@ -1387,7 +1398,7 @@ textarea {
   align-items: flex-start;
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   color: var(--danger);
   display: flex;
   flex-direction: column;
@@ -1415,7 +1426,7 @@ textarea {
   align-items: center;
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1530,7 +1541,7 @@ textarea {
   animation: pulse 1.5s infinite;
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   height: 140px;
 }
 
@@ -1584,14 +1595,14 @@ textarea {
 
 .score-track {
   background: var(--tertiary);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   flex: 1;
   height: 6px;
   overflow: hidden;
 }
 
 .score-fill {
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   height: 100%;
   transition: width 0.3s;
 }
@@ -1640,7 +1651,7 @@ textarea {
 .agent-avatar {
   align-items: center;
   background: var(--accent-soft);
-  border-radius: 12px;
+  border-radius: var(--radius-2xl);
   display: flex;
   font-size: 24px;
   height: 44px;
@@ -1649,7 +1660,7 @@ textarea {
 }
 
 .agent-avatar-img {
-  border-radius: 12px;
+  border-radius: var(--radius-2xl);
   height: 100%;
   object-fit: cover;
   width: 100%;
@@ -1693,7 +1704,7 @@ textarea {
 .agent-run-output {
   background: var(--surface-muted);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1773,7 +1784,7 @@ textarea {
 
 .node-count-badge {
   background: color-mix(in srgb, var(--info) 14%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--info);
   font-size: 11px;
   font-weight: 600;
@@ -1799,7 +1810,7 @@ textarea {
   align-items: center;
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -1826,7 +1837,7 @@ textarea {
 .auth-error {
   background: color-mix(in srgb, var(--danger) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   color: var(--danger);
   font-size: 13px;
   padding: 12px;
@@ -1947,7 +1958,7 @@ textarea {
 .terminal-preset {
   background: transparent;
   border: 1px solid var(--card-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--muted);
   cursor: pointer;
   font: inherit;

--- a/apps/extensions/browser/app/src/styles/theme.css
+++ b/apps/extensions/browser/app/src/styles/theme.css
@@ -37,7 +37,8 @@
   background: var(--color-base-100);
   border: 1px solid var(--color-base-300);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-  border-radius: 8px;
+  /* Near-sharp card radius — matches the canonical --radius-card (2px). */
+  border-radius: 2px;
   transition: all 300ms;
 
   &:hover {

--- a/apps/extensions/browser/app/src/styles/theme.css
+++ b/apps/extensions/browser/app/src/styles/theme.css
@@ -37,8 +37,8 @@
   background: var(--color-base-100);
   border: 1px solid var(--color-base-300);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-  /* Near-sharp card radius — matches the canonical --radius-card (2px). */
-  border-radius: 2px;
+  /* Sharp card radius — matches the canonical --radius-card (0px). */
+  border-radius: 0px;
   transition: all 300ms;
 
   &:hover {

--- a/apps/mobile/app/app/(protected)/_layout.tsx
+++ b/apps/mobile/app/app/(protected)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Tabs, useRouter } from 'expo-router';
 import { useEffect } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useMobileAuth } from '@/contexts/auth-context';
 import { usePendingApprovalCount } from '@/hooks/use-approvals';
 
@@ -28,7 +28,7 @@ const badgeStyles = StyleSheet.create({
   container: {
     alignItems: 'center',
     backgroundColor: colors.error,
-    borderRadius: 10,
+    borderRadius: borderRadius.xl,
     height: 20,
     justifyContent: 'center',
     minWidth: 20,

--- a/apps/mobile/app/app/(protected)/analytics.tsx
+++ b/apps/mobile/app/app/(protected)/analytics.tsx
@@ -11,7 +11,7 @@ import {
   ErrorScreen,
   LoadingScreen,
 } from '@/components/ScreenStates';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useAnalytics } from '@/hooks/use-analytics';
 import { formatNumber, formatPercentage } from '@/utils/format-date';
 
@@ -343,7 +343,7 @@ const styles = StyleSheet.create({
     paddingBottom: 32,
   },
   engagementBar: {
-    borderRadius: 4,
+    borderRadius: borderRadius.sm,
     flexDirection: 'row',
     height: 8,
     marginBottom: 16,
@@ -359,7 +359,7 @@ const styles = StyleSheet.create({
   },
   engagementSection: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     padding: 16,
   },
   engagementSegment: {
@@ -408,7 +408,7 @@ const styles = StyleSheet.create({
   platformCard: {
     alignItems: 'center',
     backgroundColor: colors.bgTertiary,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     flexDirection: 'row',
     marginBottom: 8,
     padding: 14,
@@ -424,7 +424,7 @@ const styles = StyleSheet.create({
   platformIconContainer: {
     alignItems: 'center',
     backgroundColor: colors.bgBorder,
-    borderRadius: 10,
+    borderRadius: borderRadius.xl,
     height: 40,
     justifyContent: 'center',
     width: 40,
@@ -449,7 +449,7 @@ const styles = StyleSheet.create({
   rankBadge: {
     alignItems: 'center',
     backgroundColor: colors.indigo,
-    borderRadius: 8,
+    borderRadius: borderRadius.lg,
     height: 32,
     justifyContent: 'center',
     width: 32,
@@ -485,7 +485,7 @@ const styles = StyleSheet.create({
   },
   statIcon: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 8,
+    borderRadius: borderRadius.lg,
     color: colors.indigo,
     fontSize: 20,
     height: 36,
@@ -514,7 +514,7 @@ const styles = StyleSheet.create({
   topContentCard: {
     alignItems: 'center',
     backgroundColor: colors.bgTertiary,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     flexDirection: 'row',
     marginBottom: 8,
     padding: 14,

--- a/apps/mobile/app/app/(protected)/approval/[id].tsx
+++ b/apps/mobile/app/app/(protected)/approval/[id].tsx
@@ -14,7 +14,7 @@ import {
   View,
 } from 'react-native';
 import { ErrorScreen, LoadingScreen } from '@/components/ScreenStates';
-import { CONTENT_TYPE_LABELS, colors } from '@/constants';
+import { borderRadius, CONTENT_TYPE_LABELS, colors } from '@/constants';
 import { useApproval, useApprovalActions } from '@/hooks/use-approvals';
 import { formatShortDate } from '@/utils/format-date';
 
@@ -248,7 +248,7 @@ export default function ApprovalDetail() {
 const styles = StyleSheet.create({
   actionButton: {
     alignItems: 'center',
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     flex: 1,
     paddingVertical: 16,
   },
@@ -282,7 +282,7 @@ const styles = StyleSheet.create({
   badge: {
     alignSelf: 'flex-start',
     backgroundColor: colors.bgTertiary,
-    borderRadius: 8,
+    borderRadius: borderRadius.lg,
     paddingHorizontal: 12,
     paddingVertical: 4,
   },
@@ -341,7 +341,7 @@ const styles = StyleSheet.create({
   },
   metadata: {
     backgroundColor: colors.bgSecondary,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     gap: 12,
     marginTop: 8,
     padding: 16,
@@ -367,7 +367,7 @@ const styles = StyleSheet.create({
   },
   modalButton: {
     alignItems: 'center',
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     minWidth: 80,
     paddingHorizontal: 20,
     paddingVertical: 12,

--- a/apps/mobile/app/app/(protected)/approvals.tsx
+++ b/apps/mobile/app/app/(protected)/approvals.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { EmptyState, LoadingScreen } from '@/components/ScreenStates';
-import { CONTENT_TYPE_LABELS, colors } from '@/constants';
+import { borderRadius, CONTENT_TYPE_LABELS, colors } from '@/constants';
 import {
   useApprovalActions,
   useApprovals,
@@ -443,7 +443,7 @@ const styles = StyleSheet.create({
   },
   badge: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 6,
+    borderRadius: borderRadius.md,
     paddingHorizontal: 8,
     paddingVertical: 2,
   },
@@ -456,7 +456,7 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: colors.bgSecondary,
     borderColor: colors.bgTertiary,
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     borderWidth: 1,
     flexDirection: 'row',
     gap: 12,
@@ -495,7 +495,7 @@ const styles = StyleSheet.create({
   checkbox: {
     alignItems: 'center',
     borderColor: colors.textSubtle,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     borderWidth: 2,
     height: 24,
     justifyContent: 'center',
@@ -576,7 +576,7 @@ const styles = StyleSheet.create({
   },
   selectionButton: {
     backgroundColor: colors.bgBorder,
-    borderRadius: 8,
+    borderRadius: borderRadius.lg,
     paddingHorizontal: 16,
     paddingVertical: 8,
   },
@@ -599,7 +599,7 @@ const styles = StyleSheet.create({
   },
   swipeAction: {
     alignItems: 'center',
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     justifyContent: 'center',
     marginBottom: 12,
     width: 80,
@@ -613,7 +613,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   thumbnail: {
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     height: 64,
     width: 64,
   },

--- a/apps/mobile/app/app/(protected)/content.tsx
+++ b/apps/mobile/app/app/(protected)/content.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'expo-router';
 import type { ReactNode } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { EmptyState, LoadingScreen } from '@/components/ScreenStates';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useIngredients } from '@/hooks/use-ingredients';
 import type { Ingredient } from '@/services/api/ingredients.service';
 import { formatRelativeDateVerbose } from '@/utils/format-date';
@@ -179,7 +179,7 @@ const styles = StyleSheet.create({
   articleBadge: {
     alignSelf: 'flex-start',
     backgroundColor: colors.agent,
-    borderRadius: 999,
+    borderRadius: borderRadius.full,
     paddingHorizontal: 10,
     paddingVertical: 4,
   },
@@ -191,7 +191,7 @@ const styles = StyleSheet.create({
   },
   articleCard: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     gap: 12,
     padding: 20,
   },
@@ -200,7 +200,7 @@ const styles = StyleSheet.create({
   },
   card: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     flexDirection: 'row',
     gap: 16,
     padding: 16,
@@ -237,7 +237,7 @@ const styles = StyleSheet.create({
   },
   hero: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     gap: 12,
     padding: 24,
   },
@@ -276,12 +276,12 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   squareThumbnail: {
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     height: 72,
     width: 72,
   },
   videoThumbnail: {
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     height: 72,
     width: 128,
   },

--- a/apps/mobile/app/app/(protected)/ideas.tsx
+++ b/apps/mobile/app/app/(protected)/ideas.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from 'react-native';
 import { EmptyState, ErrorScreen } from '@/components/ScreenStates';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useIdeaActions, useIdeas } from '@/hooks/use-ideas';
 import type { Idea } from '@/services/api/ideas.service';
 import { formatRelativeDateVerbose } from '@/utils/format-date';
@@ -217,7 +217,7 @@ export default function Ideas() {
 const styles = StyleSheet.create({
   actionButton: {
     backgroundColor: colors.bgTertiary,
-    borderRadius: 8,
+    borderRadius: borderRadius.lg,
     paddingHorizontal: 12,
     paddingVertical: 6,
   },
@@ -229,7 +229,7 @@ const styles = StyleSheet.create({
   addButton: {
     alignItems: 'center',
     backgroundColor: colors.agent,
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     paddingVertical: 14,
   },
   addButtonLabel: {
@@ -273,7 +273,7 @@ const styles = StyleSheet.create({
   ideaCard: {
     backgroundColor: colors.bgSecondary,
     borderColor: colors.bgTertiary,
-    borderRadius: 16,
+    borderRadius: borderRadius.xxxl,
     borderWidth: 1,
     gap: 12,
     padding: 16,
@@ -320,7 +320,7 @@ const styles = StyleSheet.create({
   },
   modalButton: {
     alignItems: 'center',
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     minWidth: 80,
     paddingHorizontal: 20,
     paddingVertical: 12,

--- a/apps/mobile/app/app/(protected)/ingredient/[id].tsx
+++ b/apps/mobile/app/app/(protected)/ingredient/[id].tsx
@@ -2,7 +2,7 @@ import { Image } from 'expo-image';
 import { useLocalSearchParams } from 'expo-router';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { ErrorScreen, LoadingScreen } from '@/components/ScreenStates';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useIngredient } from '@/hooks/use-ingredients';
 import { formatFullDate } from '@/utils/format-date';
 
@@ -94,7 +94,7 @@ const styles = StyleSheet.create({
   categoryBadge: {
     alignSelf: 'flex-start',
     backgroundColor: colors.agent,
-    borderRadius: 999,
+    borderRadius: borderRadius.full,
     color: colors.bgSecondary,
     fontSize: 12,
     fontWeight: '600',

--- a/apps/mobile/app/app/(public)/login.tsx
+++ b/apps/mobile/app/app/(public)/login.tsx
@@ -9,7 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useMobileAuth } from '@/contexts/auth-context';
 
 export default function Login() {
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
   input: {
     backgroundColor: colors.bgTertiary,
     borderColor: colors.bgBorder,
-    borderRadius: 10,
+    borderRadius: borderRadius.xl,
     borderWidth: 1,
     color: colors.textPrimary,
     fontSize: 16,
@@ -127,7 +127,7 @@ const styles = StyleSheet.create({
   signInButton: {
     alignItems: 'center',
     backgroundColor: colors.indigo,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     marginTop: 8,
     paddingVertical: 14,
   },

--- a/apps/mobile/app/components/ErrorBoundary.tsx
+++ b/apps/mobile/app/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -109,7 +109,7 @@ const styles = StyleSheet.create({
   },
   detailsContainer: {
     backgroundColor: colors.bgSecondary,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     marginBottom: 24,
     maxHeight: 200,
     padding: 16,
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
   },
   retryButton: {
     backgroundColor: colors.indigo,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     paddingHorizontal: 32,
     paddingVertical: 14,
   },

--- a/apps/mobile/app/components/OfflineIndicator.tsx
+++ b/apps/mobile/app/components/OfflineIndicator.tsx
@@ -5,7 +5,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 import { useNetworkStatus } from '@/hooks/use-network-status';
 import { useOfflineQueue } from '@/hooks/use-offline-queue';
 
@@ -74,7 +74,7 @@ const styles = StyleSheet.create({
   content: {
     alignItems: 'center',
     backgroundColor: colors.bgTertiary,
-    borderRadius: 10,
+    borderRadius: borderRadius.xl,
     flexDirection: 'row',
     gap: 10,
     paddingHorizontal: 16,
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
   },
   dot: {
     backgroundColor: colors.error,
-    borderRadius: 4,
+    borderRadius: borderRadius.sm,
     height: 8,
     width: 8,
   },

--- a/apps/mobile/app/components/ScreenErrorBoundary.tsx
+++ b/apps/mobile/app/components/ScreenErrorBoundary.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'expo-router';
 import React, { type ReactNode } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { colors } from '@/constants';
+import { borderRadius, colors } from '@/constants';
 
 interface ScreenErrorFallbackProps {
   onRetry: () => void;
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: colors.transparent,
     borderColor: colors.bgTertiary,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     borderWidth: 2,
     paddingVertical: 14,
   },
@@ -115,7 +115,7 @@ const styles = StyleSheet.create({
   retryButton: {
     alignItems: 'center',
     backgroundColor: colors.indigo,
-    borderRadius: 12,
+    borderRadius: borderRadius.xxl,
     paddingVertical: 14,
   },
   retryButtonPressed: {

--- a/apps/server/mcp/src/mcp/setup-page.ts
+++ b/apps/server/mcp/src/mcp/setup-page.ts
@@ -113,13 +113,6 @@ body::before {
   content: "";
   opacity: 0.55;
 }
-body::after {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  background: linear-gradient(180deg, rgba(0,0,0,0.18), #000 86%);
-  content: "";
-}
 button, input { font: inherit; }
 button { cursor: pointer; }
 a { color: inherit; text-decoration: none; }
@@ -147,7 +140,7 @@ a { color: inherit; text-decoration: none; }
   height: 24px;
   place-items: center;
   border: 1px solid var(--gf-border);
-  border-radius: var(--gf-radius-sm);
+  border-radius: var(--gf-surface-radius);
   background: var(--gf-bg-primary);
   color: var(--gf-text-primary);
   font-size: 12px;

--- a/bun.lock
+++ b/bun.lock
@@ -521,6 +521,7 @@
         "@genfeedai/config": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
         "@genfeedai/tools": "workspace:*",
+        "@genfeedai/ui": "workspace:*",
       },
       "devDependencies": {
         "ts-loader": "9.6.2",

--- a/packages/next-config/tailwind.config.base.ts
+++ b/packages/next-config/tailwind.config.base.ts
@@ -40,9 +40,10 @@ export const PLATFORM_TOKEN_COLORS = Object.fromEntries(
  * Use as a preset in each app's tailwind.config.ts:
  *   presets: [baseTailwindConfig]
  *
- * Design: subtle border radius (4px) on interactive elements.
- * Use `rounded-none` explicitly for sharp-edge layout containers.
- * `rounded-full` (9999px) preserved for intentionally circular elements.
+ * Radius is owned entirely by the v4 `@theme` block in
+ * packages/styles/globals.css (single source of truth, mirrors
+ * packages/ui/web-tokens.css). `rounded-none`/`rounded-full`/`rounded`
+ * fall back to Tailwind v4 built-ins. Do not redefine borderRadius here.
  */
 export const baseTailwindConfig: Config = {
   content: [
@@ -54,17 +55,6 @@ export const baseTailwindConfig: Config = {
     '../../../node_modules/@genfeedai/workflow-ui/dist/**/*.mjs',
   ],
   theme: {
-    borderRadius: {
-      '2xl': '0.75rem',
-      '3xl': '1rem',
-      DEFAULT: '0.25rem',
-      full: '9999px',
-      lg: '0.5rem',
-      md: '0.375rem',
-      none: '0',
-      sm: '0.25rem',
-      xl: '0.625rem',
-    },
     extend: {
       animation: {
         'collapsible-down': 'collapsible-down 200ms ease-out',

--- a/packages/styles/genfeed.css
+++ b/packages/styles/genfeed.css
@@ -434,7 +434,7 @@
 .gen-card-spotlight {
   position: relative;
   overflow: hidden;
-  border-radius: 1.5rem;
+  border-radius: var(--radius-card);
   border: 1px solid var(--gen-accent-border);
   background: color-mix(
     in srgb,
@@ -447,28 +447,10 @@
     box-shadow 0.3s ease,
     transform 0.3s ease;
 
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(
-      circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-      var(--gen-accent-bg),
-      transparent 60%
-    );
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    pointer-events: none;
-  }
-
   &:hover {
     border-color: var(--gen-accent-hover);
     box-shadow: 0 28px 64px -34px rgba(0, 0, 0, 0.68);
     transform: translateY(-2px);
-
-    &::before {
-      opacity: 1;
-    }
   }
 }
 
@@ -577,13 +559,9 @@
 
 /* Cards */
 .gen-card-featured {
-  border-radius: 0;
+  border-radius: var(--radius-card);
   border: 1px solid color-mix(in srgb, hsl(var(--gen-accent)) 72%, white 28%);
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, hsl(var(--gen-accent)) 88%, white 12%),
-    color-mix(in srgb, hsl(var(--gen-accent)) 68%, black 32%)
-  );
+  background: color-mix(in srgb, hsl(var(--gen-accent)) 82%, black 18%);
   box-shadow: 0 28px 64px -34px
     color-mix(in srgb, hsl(var(--gen-accent)) 45%, black 55%);
   color: hsl(var(--background));

--- a/packages/styles/globals.css
+++ b/packages/styles/globals.css
@@ -57,15 +57,19 @@
   --color-info-content: hsl(var(--info-foreground));
   --color-error-content: hsl(var(--destructive-foreground));
 
-  /* Radius scale */
-  --radius-sm: 2px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
-  --radius-xl: 10px;
-  --radius-2xl: 12px;
-  --radius-3xl: 16px;
-  --radius-xxl: 12px;
-  --radius-xxxl: 16px;
+  /* Radius — references the canonical scale in packages/ui/web-tokens.css.
+     Holds NO values; this block only registers the tokens so Tailwind emits
+     the rounded-* utilities. Values live once in web-tokens.css. */
+  --radius-none: var(--radius-none);
+  --radius-xs: var(--radius-xs);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+  --radius-2xl: var(--radius-2xl);
+  --radius-3xl: var(--radius-3xl);
+  --radius-full: var(--radius-full);
+  --radius-card: var(--radius-card);
 
   /* Semantic colors layered on shipshitdev/ui ship-* tokens */
   --color-border-strong: var(--ship-border-strong);
@@ -549,7 +553,7 @@ a {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid hsl(var(--border));
   background: hsl(var(--background) / 0.44);
   color: hsl(var(--foreground) / 0.66);

--- a/packages/styles/shadcn-theme.css
+++ b/packages/styles/shadcn-theme.css
@@ -51,8 +51,6 @@
   --accent-pink: #ec4899;
   --accent-rose: #f472b6;
   --accent-orange: #f97316;
-
-  --radius: 0.25rem;
 }
 
 @layer base {

--- a/packages/ui/src/components/card/Card.tsx
+++ b/packages/ui/src/components/card/Card.tsx
@@ -32,7 +32,7 @@ const Card = memo(function Card({
   onClick,
 }: CardProps) {
   const cardClasses = cn(
-    'relative overflow-hidden rounded-md text-left transition-[border-color,background-color] duration-150 ease-out',
+    'relative overflow-hidden rounded-card text-left transition-[border-color,background-color] duration-150 ease-out',
     VARIANT_CLASSES[variant],
     figure && 'flex flex-row',
     onClick && 'cursor-pointer',

--- a/packages/ui/src/components/card/empty/CardEmpty.tsx
+++ b/packages/ui/src/components/card/empty/CardEmpty.tsx
@@ -37,7 +37,7 @@ export function CardEmptyContent({
       aria-live="polite"
       className={cn(
         'flex flex-col items-center justify-center text-center py-12',
-        'bg-gradient-radial from-white/[0.02] to-transparent',
+        'bg-white/[0.02]',
         className,
       )}
     >

--- a/packages/ui/src/components/cards/generated-prompt-card/GeneratedPromptCard.tsx
+++ b/packages/ui/src/components/cards/generated-prompt-card/GeneratedPromptCard.tsx
@@ -6,6 +6,7 @@ import type {
   GeneratedPromptCardProps,
   PromptMetadataTagProps,
 } from '@genfeedai/props/studio/prompt-generator.props';
+import Card from '@ui/card/Card';
 import { Button } from '@ui/primitives/button';
 import { memo, useCallback } from 'react';
 import {
@@ -55,14 +56,15 @@ const GeneratedPromptCard = memo(function GeneratedPromptCard({
   const isCurrentlyGenerating = isGenerating && generatingType !== null;
 
   return (
-    <article
+    <Card
       className={cn(
-        'relative group',
+        'group',
         'bg-white/[0.03] border border-white/[0.08]',
         'transition-all duration-300 ease-out',
         'hover:border-white/[0.15] hover:bg-white/[0.05]',
         prompt.isRejected && 'opacity-40 pointer-events-none',
       )}
+      bodyClassName="gap-0 p-0"
     >
       {/* Reject button */}
       <Button
@@ -157,7 +159,7 @@ const GeneratedPromptCard = memo(function GeneratedPromptCard({
           <span className="capitalize">{prompt.format}</span>
         </div>
       </div>
-    </article>
+    </Card>
   );
 });
 

--- a/packages/ui/src/components/cards/setup-card/SetupCard.tsx
+++ b/packages/ui/src/components/cards/setup-card/SetupCard.tsx
@@ -17,7 +17,7 @@ export default function SetupCard() {
 
   return (
     <Card
-      className="mx-3 mb-3 border border-white/[0.06] bg-white/[0.03]"
+      className="mx-3 mb-3 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)] bg-white/[0.03]"
       bodyClassName="gap-0 p-3"
     >
       {/* Header */}

--- a/packages/ui/src/components/cards/setup-card/SetupCard.tsx
+++ b/packages/ui/src/components/cards/setup-card/SetupCard.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import { useSetupCard } from '@genfeedai/hooks/utils/use-setup-card/use-setup-card';
+import Card from '@ui/card/Card';
 import Link from 'next/link';
 import { HiCheck, HiChevronRight } from 'react-icons/hi2';
 
@@ -15,7 +16,10 @@ export default function SetupCard() {
   const progress = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
 
   return (
-    <div className="mx-3 mb-3 border border-white/[0.06] bg-white/[0.03] p-3">
+    <Card
+      className="mx-3 mb-3 border border-white/[0.06] bg-white/[0.03]"
+      bodyClassName="gap-0 p-3"
+    >
       {/* Header */}
       <div className="flex items-center justify-between mb-2">
         <span className="text-[11px] font-semibold text-white/60">
@@ -58,6 +62,6 @@ export default function SetupCard() {
           </Link>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/packages/ui/src/components/cards/streak-card/StreakCard.tsx
+++ b/packages/ui/src/components/cards/streak-card/StreakCard.tsx
@@ -48,7 +48,7 @@ export default function StreakCard() {
 
   return (
     <Card
-      className="mx-3 mb-3 overflow-visible border border-orange-500/15 bg-orange-500/[0.06]"
+      className="mx-3 mb-3 overflow-visible shadow-[inset_0_0_0_1px_rgba(249,115,22,0.15)] bg-orange-500/[0.06]"
       bodyClassName="gap-0 p-3"
     >
       <StreakCelebrationBurst isVisible={isCelebrating} />

--- a/packages/ui/src/components/cards/streak-card/StreakCard.tsx
+++ b/packages/ui/src/components/cards/streak-card/StreakCard.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import { useStreak } from '@genfeedai/hooks/data/streaks/use-streak/use-streak';
 import { STREAK_CELEBRATION_EVENT } from '@genfeedai/services/engagement/streak-events';
+import Card from '@ui/card/Card';
 import StreakCelebrationBurst from '@ui/feedback/streak-celebration/StreakCelebrationBurst';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
@@ -46,7 +47,10 @@ export default function StreakCard() {
   );
 
   return (
-    <div className="relative mx-3 mb-3 border border-orange-500/15 bg-orange-500/[0.06] p-3">
+    <Card
+      className="mx-3 mb-3 overflow-visible border border-orange-500/15 bg-orange-500/[0.06]"
+      bodyClassName="gap-0 p-3"
+    >
       <StreakCelebrationBurst isVisible={isCelebrating} />
       <div className="mb-2 flex items-center justify-between">
         <div>
@@ -99,6 +103,6 @@ export default function StreakCard() {
         </span>
         <span className="text-white/40">View</span>
       </Link>
-    </div>
+    </Card>
   );
 }

--- a/packages/ui/src/components/evaluation/card/EvaluationCard.tsx
+++ b/packages/ui/src/components/evaluation/card/EvaluationCard.tsx
@@ -237,7 +237,6 @@ export default function EvaluationCard({
     <Card
       label="Quality Evaluation"
       headerAction={getHeaderAction()}
-      className="border border-white/[0.08] bg-card"
       bodyClassName={
         !evaluation || evaluation.status !== Status.COMPLETED
           ? undefined

--- a/packages/ui/src/components/evaluation/seo-scorecard/SeoScorecard.tsx
+++ b/packages/ui/src/components/evaluation/seo-scorecard/SeoScorecard.tsx
@@ -197,7 +197,7 @@ export default function SeoScorecard({
       <Card
         label="SEO Scorecard"
         headerAction={headerAction}
-        className={cn('border border-white/[0.08] bg-card', className)}
+        className={className}
       >
         <div className="flex items-start gap-3">
           <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">

--- a/packages/ui/src/components/folders/card/FolderCard.tsx
+++ b/packages/ui/src/components/folders/card/FolderCard.tsx
@@ -1,27 +1,17 @@
 'use client';
 
 import type { FolderCardProps } from '@genfeedai/props/ui/content/folder.props';
-import type { KeyboardEvent } from 'react';
+import Card from '@ui/card/Card';
 import { HiFolder } from 'react-icons/hi2';
 
 export default function FolderCard({ folder, onClick }: FolderCardProps) {
   const activateFolder = () => onClick?.(folder);
-  const activateFolderFromKeyboard = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Enter' && event.key !== ' ') {
-      return;
-    }
-
-    event.preventDefault();
-    activateFolder();
-  };
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <Card
       onClick={activateFolder}
-      onKeyDown={activateFolderFromKeyboard}
-      className="group cursor-pointer bg-card border border-white/[0.08] transition-all p-4 hover:scale-105"
+      className="group cursor-pointer border border-white/[0.08] transition-all hover:scale-105"
+      bodyClassName="gap-0 p-4"
     >
       <div className="flex flex-col items-center gap-3">
         <HiFolder className="text-6xl text-primary/60 group-hover:text-primary transition-colors" />
@@ -34,6 +24,6 @@ export default function FolderCard({ folder, onClick }: FolderCardProps) {
           )}
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/packages/ui/src/components/marketing/EditorialPoster.tsx
+++ b/packages/ui/src/components/marketing/EditorialPoster.tsx
@@ -32,13 +32,11 @@ export default function EditorialPoster({
   return (
     <article
       className={cn(
-        'relative overflow-hidden border border-[var(--gen-accent-border)] bg-[linear-gradient(160deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02)_45%,rgba(255,255,255,0.01))] p-8 sm:p-10 lg:p-12',
-        'shadow-[0_24px_80px_rgba(0,0,0,0.28)]',
+        'relative overflow-hidden rounded-card border border-[var(--gen-accent-border)] bg-white/[0.04] p-8 sm:p-10 lg:p-12',
         className,
       )}
       data-testid={testId}
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,var(--gen-accent-glow),transparent_45%),linear-gradient(to_bottom,transparent,rgba(0,0,0,0.45))]" />
       <div className="pointer-events-none absolute inset-0 opacity-40 mix-blend-screen">
         <div className="absolute inset-y-0 left-[14%] w-px bg-[var(--gen-accent-border)]" />
         <div className="absolute inset-y-0 right-[18%] w-px bg-[var(--gen-accent-border)]" />

--- a/packages/ui/src/components/modals/onboarding/steps/OnboardingStepWelcome.tsx
+++ b/packages/ui/src/components/modals/onboarding/steps/OnboardingStepWelcome.tsx
@@ -50,9 +50,9 @@ export default function OnboardingStepWelcome() {
         {features.map((feature) => (
           <div
             key={feature.title}
-            className="group relative flex items-start gap-4 p-5 bg-gradient-to-br from-white/[0.07] to-white/[0.03] border border-white/[0.08] hover:border-white/[0.15] transition-all duration-300 hover:-translate-y-0.5"
+            className="group relative flex items-start gap-4 p-5 bg-white/[0.05] border border-white/[0.08] hover:border-white/[0.15] transition-all duration-300 hover:-translate-y-0.5"
           >
-            <div className="flex-shrink-0 size-12 bg-gradient-to-br from-primary/20 via-primary/10 to-primary/5 border border-primary/10 group-hover:border-primary/20 transition-colors flex items-center justify-center">
+            <div className="flex-shrink-0 size-12 bg-primary/10 border border-primary/10 group-hover:border-primary/20 transition-colors flex items-center justify-center">
               <feature.icon className="size-6 text-primary" />
             </div>
             <div>

--- a/packages/ui/src/core/radius.ts
+++ b/packages/ui/src/core/radius.ts
@@ -1,20 +1,22 @@
 export type RadiusTokenName =
   | 'none'
+  | 'xs'
   | 'sm'
   | 'md'
   | 'lg'
   | 'xl'
-  | 'xxl'
-  | 'xxxl'
+  | '2xl'
+  | '3xl'
   | 'full';
 
 export const radiusTokens = {
+  '2xl': '12px',
+  '3xl': '16px',
   full: '9999px',
   lg: '8px',
   md: '6px',
   none: '0px',
   sm: '4px',
   xl: '10px',
-  xxl: '12px',
-  xxxl: '16px',
+  xs: '2px',
 } as const satisfies Record<RadiusTokenName, string>;

--- a/packages/ui/src/dashboard/MetricCard.tsx
+++ b/packages/ui/src/dashboard/MetricCard.tsx
@@ -1,6 +1,5 @@
 import { ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn';
-import Card from '@ui/card/Card';
 import type { ComponentType, ReactNode } from 'react';
 import { Button } from '../primitives/button';
 
@@ -31,12 +30,11 @@ export function MetricCard({
   const isClickable = !!(href || onClick);
 
   const inner = (
-    <Card
+    <div
       className={cn(
-        'h-full',
+        'h-full rounded-card bg-card px-4 py-4 shadow-border transition-[border-color,background-color] duration-150 ease-out sm:px-5 sm:py-5',
         isClickable && 'cursor-pointer hover:bg-accent/50',
       )}
-      bodyClassName="gap-0 px-4 py-4 sm:px-5 sm:py-5"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
@@ -54,7 +52,7 @@ export function MetricCard({
         </div>
         <Icon className="mt-1.5 size-4 shrink-0 text-muted-foreground/50" />
       </div>
-    </Card>
+    </div>
   );
 
   if (href && LinkComponent) {

--- a/packages/ui/src/dashboard/MetricCard.tsx
+++ b/packages/ui/src/dashboard/MetricCard.tsx
@@ -1,5 +1,6 @@
 import { ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn';
+import Card from '@ui/card/Card';
 import type { ComponentType, ReactNode } from 'react';
 import { Button } from '../primitives/button';
 
@@ -30,11 +31,12 @@ export function MetricCard({
   const isClickable = !!(href || onClick);
 
   const inner = (
-    <div
+    <Card
       className={cn(
-        'h-full rounded-lg bg-card px-4 py-4 shadow-border transition-colors sm:px-5 sm:py-5',
-        isClickable && 'hover:bg-accent/50 cursor-pointer',
+        'h-full',
+        isClickable && 'cursor-pointer hover:bg-accent/50',
       )}
+      bodyClassName="gap-0 px-4 py-4 sm:px-5 sm:py-5"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
@@ -52,7 +54,7 @@ export function MetricCard({
         </div>
         <Icon className="mt-1.5 size-4 shrink-0 text-muted-foreground/50" />
       </div>
-    </div>
+    </Card>
   );
 
   if (href && LinkComponent) {

--- a/packages/ui/src/generators/webview-css.ts
+++ b/packages/ui/src/generators/webview-css.ts
@@ -1,3 +1,4 @@
+import { radiusTokens } from '@ui/core/radius';
 import { webviewSemanticTokenMap } from '@ui/semantic/webview';
 
 export function generateWebviewTokenCss(): string {
@@ -14,7 +15,7 @@ ${semanticLines.join('\n')}
     --badge: var(--vscode-badge-background);
     --badge-foreground: var(--vscode-badge-foreground);
     --container-padding: 12px;
-    --radius: 4px;
+    --radius: ${radiusTokens.sm};
     --space-md: 12px;
     --space-lg: 16px;
   }

--- a/packages/ui/src/static/surface.test.ts
+++ b/packages/ui/src/static/surface.test.ts
@@ -12,8 +12,8 @@ describe('static surface primitives', () => {
   });
 
   it('drives every surface from the single sharp-radius knob', () => {
-    // Near-sharp borders: one knob, mirroring the canonical --radius-card (2px).
-    expect(staticSurfaceCss).toContain('--gf-surface-radius: 2px');
+    // Sharp borders: one knob, mirroring the canonical --radius-card (0px).
+    expect(staticSurfaceCss).toContain('--gf-surface-radius: 0px');
     expect(staticSurfaceCss).toContain(
       'border-radius: var(--gf-surface-radius)',
     );

--- a/packages/ui/src/static/surface.test.ts
+++ b/packages/ui/src/static/surface.test.ts
@@ -3,13 +3,29 @@ import { describe, expect, it } from 'vitest';
 import { staticSurfaceClassNames, staticSurfaceCss } from './surface';
 
 describe('static surface primitives', () => {
-  it('uses the shared card radius for HTML-only surfaces', () => {
+  it('exposes the card class names for HTML-only surfaces', () => {
     expect(staticSurfaceClassNames.card).toBe('gf-card');
     expect(staticSurfaceClassNames.featureCard).toBe('gf-card gf-feature-card');
     expect(staticSurfaceClassNames.infoCard).toBe('gf-card gf-info-card');
-    expect(staticSurfaceCss).toContain('border-radius: var(--gf-radius-md)');
-    expect(staticSurfaceCss).toContain('--gf-radius-md: 6px');
     expect(staticSurfaceCss).toContain('.gf-feature-card');
     expect(staticSurfaceCss).toContain('.gf-info-card');
+  });
+
+  it('drives every surface from the single sharp-radius knob', () => {
+    // Near-sharp borders: one knob, mirroring the canonical --radius-card (2px).
+    expect(staticSurfaceCss).toContain('--gf-surface-radius: 2px');
+    expect(staticSurfaceCss).toContain(
+      'border-radius: var(--gf-surface-radius)',
+    );
+    // No surface should pin the old fixed card radius any more.
+    expect(staticSurfaceCss).not.toContain(
+      'border-radius: var(--gf-radius-md)',
+    );
+  });
+
+  it('keeps card/surface fills free of tonal gradients', () => {
+    // The feature card must use a flat fill, not the old diagonal sheen.
+    expect(staticSurfaceCss).not.toContain('linear-gradient(160deg');
+    expect(staticSurfaceCss).toContain('.gf-feature-card {');
   });
 });

--- a/packages/ui/src/static/surface.ts
+++ b/packages/ui/src/static/surface.ts
@@ -49,6 +49,10 @@ export const staticSurfaceCss = `
   --gf-radius-md: ${radiusTokens.md};
   --gf-radius-lg: ${radiusTokens.lg};
   --gf-radius-xl: ${radiusTokens.xl};
+  /* Single knob for the editorial "sharp border" surface language. Mirrors the
+     canonical --radius-card (near-sharp 2px). Set to ${radiusTokens.none} for
+     perfectly sharp corners or a larger token to soften every surface at once. */
+  --gf-surface-radius: ${radiusTokens.xs};
   --gf-shadow-border: inset 0 0 0 1px var(--gf-border);
   --gf-shadow-border-strong: inset 0 0 0 1px var(--gf-border-strong);
 }
@@ -56,7 +60,7 @@ export const staticSurfaceCss = `
   position: relative;
   overflow: hidden;
   border: 0;
-  border-radius: var(--gf-radius-md);
+  border-radius: var(--gf-surface-radius);
   background: var(--gf-bg-secondary);
   color: var(--gf-text-primary);
   box-shadow: var(--gf-shadow-border);
@@ -68,11 +72,8 @@ export const staticSurfaceCss = `
 }
 .gf-feature-card {
   min-height: 430px;
-  background:
-    linear-gradient(160deg, rgba(255,255,255,0.075), rgba(255,255,255,0.018) 46%, rgba(255,255,255,0.008)),
-    var(--gf-bg-primary);
+  background: var(--gf-bg-tertiary);
   padding: 34px;
-  box-shadow: 0 24px 80px rgba(0,0,0,0.32);
 }
 .gf-feature-card::before {
   position: absolute;
@@ -151,7 +152,7 @@ export const staticSurfaceCss = `
   align-items: center;
   justify-content: center;
   border: 1px solid var(--gf-border-strong);
-  border-radius: var(--gf-radius-md);
+  border-radius: var(--gf-surface-radius);
   background: transparent;
   color: var(--gf-text-primary);
   padding: 0 14px;
@@ -185,7 +186,7 @@ export const staticSurfaceCss = `
   display: inline-flex;
   align-items: center;
   border: 1px solid var(--gf-border);
-  border-radius: var(--gf-radius-md);
+  border-radius: var(--gf-surface-radius);
   background: rgba(255, 255, 255, 0.025);
   color: var(--gf-text-muted);
   font-size: 10px;
@@ -211,7 +212,7 @@ export const staticSurfaceCss = `
 }
 .gf-inline-code {
   border: 1px solid var(--gf-border);
-  border-radius: var(--gf-radius-sm);
+  border-radius: var(--gf-surface-radius);
   background: rgba(255, 255, 255, 0.035);
   color: var(--gf-text-secondary);
   padding: 1px 5px;
@@ -221,7 +222,7 @@ export const staticSurfaceCss = `
   max-width: 100%;
   overflow-x: auto;
   border: 0;
-  border-radius: var(--gf-radius-md);
+  border-radius: var(--gf-surface-radius);
   background: var(--gf-bg-primary);
   color: #dbeafe;
   box-shadow: var(--gf-shadow-border);
@@ -235,7 +236,7 @@ export const staticSurfaceCss = `
   grid-template-columns: 20px minmax(0, 1fr);
   gap: 12px;
   border: 1px solid rgba(245, 158, 11, 0.26);
-  border-radius: var(--gf-radius-md);
+  border-radius: var(--gf-surface-radius);
   background: rgba(245, 158, 11, 0.08);
   color: var(--gf-text-secondary);
   padding: 14px;

--- a/packages/ui/src/static/surface.ts
+++ b/packages/ui/src/static/surface.ts
@@ -50,9 +50,9 @@ export const staticSurfaceCss = `
   --gf-radius-lg: ${radiusTokens.lg};
   --gf-radius-xl: ${radiusTokens.xl};
   /* Single knob for the editorial "sharp border" surface language. Mirrors the
-     canonical --radius-card (near-sharp 2px). Set to ${radiusTokens.none} for
-     perfectly sharp corners or a larger token to soften every surface at once. */
-  --gf-surface-radius: ${radiusTokens.xs};
+     canonical --radius-card (sharp 0px). Raise to a token (e.g. ${radiusTokens.xs})
+     to soften every surface at once. */
+  --gf-surface-radius: ${radiusTokens.none};
   --gf-shadow-border: inset 0 0 0 1px var(--gf-border);
   --gf-shadow-border-strong: inset 0 0 0 1px var(--gf-border-strong);
 }

--- a/packages/ui/web-tokens.css
+++ b/packages/ui/web-tokens.css
@@ -35,14 +35,21 @@
   --space-xxxl: 32px;
   --space-xxxxl: 48px;
 
+  /* Canonical radius scale — THE single source of truth for radius values.
+     Mirrored 1:1 in packages/ui/src/core/radius.ts (TS consumers) and locked
+     by scripts/check-design-system.ts. globals.css @theme only references
+     these vars; it never re-declares the values. */
   --radius-none: 0px;
+  --radius-xs: 2px;
   --radius-sm: 4px;
   --radius-md: 6px;
   --radius-lg: 8px;
   --radius-xl: 10px;
-  --radius-xxl: 12px;
-  --radius-xxxl: 16px;
+  --radius-2xl: 12px;
+  --radius-3xl: 16px;
   --radius-full: 9999px;
+  /* Semantic: canonical card/surface radius (near-sharp). Retune here once. */
+  --radius-card: 2px;
 
   --motion-duration-fast: 200ms;
   --motion-duration-normal: 300ms;

--- a/packages/ui/web-tokens.css
+++ b/packages/ui/web-tokens.css
@@ -48,8 +48,9 @@
   --radius-2xl: 12px;
   --radius-3xl: 16px;
   --radius-full: 9999px;
-  /* Semantic: canonical card/surface radius (near-sharp). Retune here once. */
-  --radius-card: 2px;
+  /* Semantic: canonical card/surface radius — sharp 0px, matching the Brand OS
+     editorial direction. This single knob drives every card; retune here once. */
+  --radius-card: 0px;
 
   --motion-duration-fast: 200ms;
   --motion-duration-normal: 300ms;


### PR DESCRIPTION
## Summary

Fixes the MCP setup-page card UI and eliminates duplicate card code / conflicting radius definitions across the monorepo, per the request to consolidate cards and stop defining radius three times.

### MCP card UI
- Sharp **2px** corners via one `--gf-surface-radius` knob.
- Removed gradient fills (diagonal sheen on the feature card + page tonal vignette). Kept the hairline blueprint grid (it's 1px rules, not a tonal gradient).

### Radius — now a single source per language (was defined 3×)
Three files used to carry radius values (`core/radius.ts`, `web-tokens.css`, `globals.css @theme`) because three systems consume them (TS code / runtime CSS vars / Tailwind utilities), and `@theme inline` doesn't emit runtime vars — which let `sm` drift to `2px` in one file and `4px` in another.
- **Values now live once**: `packages/ui/web-tokens.css` (CSS) + `packages/ui/src/core/radius.ts` (TS), locked identical by `check-design-system`.
- `globals.css @theme` only **references** the vars (`--radius-md: var(--radius-md)`) — holds zero values, so it can't drift. Verified the var-ref pattern still generates `rounded-*` utilities via a Tailwind v4 compile.
- Fixed the `sm` 2px/4px conflict, renamed `xxl/xxxl → 2xl/3xl` (dropped duplicate aliases), removed the dead v3 `borderRadius` block and the orphaned shadcn `--radius`, tokenized the webview generator. Added semantic `--radius-card` (2px).

### Cards — consolidated onto the canonical `@ui` Card
- `Card` now uses `rounded-card`. Folded **MetricCard, SetupCard, StreakCard, GeneratedPromptCard, FolderCard** onto `<Card>` so the chrome (radius/border/bg/shadow) lives in **one** component; intentional accents (e.g. Streak's orange) preserved via `className`.
- Aligned the shadcn `card.tsx`, `LinkCard`, and app card containers (ModelCard, AdGridCard, ClipResultCard, workflow `NodeCard`, org-landing, business-dashboard) to `rounded-card`. Removed redundant chrome classes on `EvaluationCard`/`SeoScorecard`.

### Gradients
Removed card/surface fill gradients (`gen-card-featured`, `gen-card-spotlight` radial, `CardEmpty`, `EditorialPoster`, onboarding) → flat. Kept functional gradients (image scrims, chart fills, skeleton shimmer, page vignettes).

### Non-main frontends tokenized
Desktop renderer CSS (52 radii → tokens, 14 cards → `--radius-card`), mobile RN (37 raw `borderRadius` ints → constants; 6 off-scale left), browser extension `.gf-card`.

## Validation
- `bun run check:design-system` — pass (token drift, design.md lint, platform coverage).
- `bunx turbo run type-check --filter=@genfeedai/ui --filter=@genfeedai/next-config` — pass.
- `packages/ui` tests — 76 pass (surface + card components).
- `apps/server/mcp` setup-page test — 5 pass.
- Tailwind v4 compile confirms `@theme` var-ref radius generates `rounded-card`/`rounded-2xl`/`rounded-full`.

## Reviewer notes (visual)
A few cards changed treatment toward consistency and warrant a visual glance: cards folded onto `<Card>` now carry the canonical inset hairline in addition to any accent border (minor double-edge on tinted cards), and desktop/mobile radii shifted to the token scale (desktop cards → 2px). The hand-rolled `<article>` on GeneratedPromptCard became a `<div>` (Card renders a div). `StatCard` keeps its `@shipshitdev/ui` Card (intentional shared lib, not folded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)