### PR TITLE
fix(workflows): write Prisma execution statuses with db casing

### DIFF
--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
@@ -1,0 +1,117 @@
+import { WorkflowExecutionStatus as PrismaWorkflowExecutionStatus } from '@genfeedai/prisma';
+import { WorkflowExecutionsService } from './workflow-executions.service';
+
+describe('WorkflowExecutionsService', () => {
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  const makeService = () => {
+    const workflowExecution = {
+      create: vi.fn().mockResolvedValue({ id: 'execution-1' }),
+      findFirst: vi.fn().mockResolvedValue({
+        id: 'execution-1',
+        result: {},
+        startedAt: new Date('2026-06-29T00:00:00.000Z'),
+        workflowId: 'workflow-1',
+      }),
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockResolvedValue({ id: 'execution-1' }),
+    };
+
+    const prisma = {
+      workflowExecution,
+    };
+
+    return {
+      prisma,
+      service: new WorkflowExecutionsService(prisma as never, logger as never),
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes Prisma workflow execution statuses with database enum casing', async () => {
+    const { prisma, service } = makeService();
+
+    await service.createExecution('user-1', 'org-1', {
+      trigger: 'scheduled',
+      workflow: 'workflow-1',
+    });
+    await service.startExecution('execution-1');
+    await service.completeExecution('execution-1');
+    await service.completeExecution('execution-1', 'failed');
+    await service.cancelExecution('execution-1');
+
+    expect(prisma.workflowExecution.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PrismaWorkflowExecutionStatus.PENDING,
+        }),
+      }),
+    );
+    expect(prisma.workflowExecution.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PrismaWorkflowExecutionStatus.RUNNING,
+        }),
+      }),
+    );
+    expect(prisma.workflowExecution.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PrismaWorkflowExecutionStatus.COMPLETED,
+        }),
+      }),
+    );
+    expect(prisma.workflowExecution.update).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PrismaWorkflowExecutionStatus.FAILED,
+        }),
+      }),
+    );
+    expect(prisma.workflowExecution.update).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PrismaWorkflowExecutionStatus.CANCELLED,
+        }),
+      }),
+    );
+  });
+
+  it('counts execution stats using Prisma enum casing from database rows', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findMany.mockResolvedValue([
+      {
+        result: { durationMs: 1000 },
+        status: PrismaWorkflowExecutionStatus.COMPLETED,
+      },
+      {
+        result: { durationMs: 3000 },
+        status: PrismaWorkflowExecutionStatus.COMPLETED,
+      },
+      {
+        result: {},
+        status: PrismaWorkflowExecutionStatus.FAILED,
+      },
+    ]);
+
+    await expect(
+      service.getExecutionStats('workflow-1', 'org-1'),
+    ).resolves.toEqual({
+      avgDurationMs: 2000,
+      completed: 2,
+      failed: 1,
+      total: 3,
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
@@ -10,8 +10,9 @@ import type {
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import { WorkflowExecutionStatus } from '@genfeedai/enums';
+import { WorkflowExecutionStatus as SharedWorkflowExecutionStatus } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
+import { WorkflowExecutionStatus as PrismaWorkflowExecutionStatus } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, Optional } from '@nestjs/common';
 
@@ -73,7 +74,7 @@ export class WorkflowExecutionsService extends BaseService<
           progress: 0,
           trigger: dto.trigger ?? null,
         } as never,
-        status: WorkflowExecutionStatus.PENDING,
+        status: PrismaWorkflowExecutionStatus.PENDING,
         userId,
         workflowId: dto.workflow,
       } as never,
@@ -89,7 +90,7 @@ export class WorkflowExecutionsService extends BaseService<
     const result = await this.prisma.workflowExecution.update({
       data: {
         startedAt: new Date(),
-        status: WorkflowExecutionStatus.RUNNING,
+        status: PrismaWorkflowExecutionStatus.RUNNING,
       } as never,
       where: { id: executionId },
     });
@@ -174,8 +175,8 @@ export class WorkflowExecutionsService extends BaseService<
         error,
         result: updatedResult as never,
         status: error
-          ? WorkflowExecutionStatus.FAILED
-          : WorkflowExecutionStatus.COMPLETED,
+          ? PrismaWorkflowExecutionStatus.FAILED
+          : PrismaWorkflowExecutionStatus.COMPLETED,
       } as never,
       where: { id: executionId },
     });
@@ -190,7 +191,7 @@ export class WorkflowExecutionsService extends BaseService<
     const result = await this.prisma.workflowExecution.update({
       data: {
         completedAt: new Date(),
-        status: WorkflowExecutionStatus.CANCELLED,
+        status: PrismaWorkflowExecutionStatus.CANCELLED,
       } as never,
       where: { id: executionId },
     });
@@ -235,8 +236,8 @@ export class WorkflowExecutionsService extends BaseService<
     const expectedNodes = totalNodes ?? nodeResults.length;
     const completedNodes = nodeResults.filter(
       (r) =>
-        r.status === WorkflowExecutionStatus.COMPLETED ||
-        r.status === WorkflowExecutionStatus.FAILED,
+        r.status === SharedWorkflowExecutionStatus.COMPLETED ||
+        r.status === SharedWorkflowExecutionStatus.FAILED,
     ).length;
     const progress =
       expectedNodes > 0
@@ -420,10 +421,10 @@ export class WorkflowExecutionsService extends BaseService<
 
     const total = typed.length;
     const completed = typed.filter(
-      (e) => e.status === WorkflowExecutionStatus.COMPLETED,
+      (e) => e.status === PrismaWorkflowExecutionStatus.COMPLETED,
     ).length;
     const failed = typed.filter(
-      (e) => e.status === WorkflowExecutionStatus.FAILED,
+      (e) => e.status === PrismaWorkflowExecutionStatus.FAILED,
     ).length;
 
     const durationsWithValue = typed

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -58,6 +58,14 @@ vi.mock('@genfeedai/prisma', () => {
     PENDING: 'PENDING',
   } as const;
 
+  const WorkflowExecutionStatus = {
+    CANCELLED: 'CANCELLED',
+    COMPLETED: 'COMPLETED',
+    FAILED: 'FAILED',
+    PENDING: 'PENDING',
+    RUNNING: 'RUNNING',
+  } as const;
+
   const Prisma = {
     empty: createSql(''),
     raw: (sql: string) => createSql(sql),
@@ -71,7 +79,13 @@ vi.mock('@genfeedai/prisma', () => {
     },
   };
 
-  return { McpApprovalStatus, Prisma, PrismaClient, VoiceProvider };
+  return {
+    McpApprovalStatus,
+    Prisma,
+    PrismaClient,
+    VoiceProvider,
+    WorkflowExecutionStatus,
+  };
 });
 
 // Mock @prisma/adapter-pg so PrismaService constructor doesn't require DATABASE_URL

--- a/apps/server/workers/src/processors/api/queues/workflow/workflow-execution.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/workflow/workflow-execution.processor.spec.ts
@@ -2,7 +2,8 @@ import { WorkflowExecutionsService } from '@api/collections/workflow-executions/
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { WorkflowQueueService } from '@api/queues/workflow/workflow-queue.service';
-import { WorkflowExecutionStatus } from '@genfeedai/enums';
+import { WorkflowExecutionStatus as SharedWorkflowExecutionStatus } from '@genfeedai/enums';
+import { WorkflowExecutionStatus as PrismaWorkflowExecutionStatus } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, type TestingModule } from '@nestjs/testing';
 import {
@@ -150,7 +151,7 @@ describe('WorkflowDelayProcessor', () => {
     mockExecutionsService = {
       findOne: vi.fn().mockResolvedValue({
         _id: 'exec-1',
-        status: WorkflowExecutionStatus.RUNNING,
+        status: PrismaWorkflowExecutionStatus.RUNNING,
       }),
     };
 
@@ -206,7 +207,31 @@ describe('WorkflowDelayProcessor', () => {
   it('should skip resume for cancelled execution', async () => {
     mockExecutionsService.findOne.mockResolvedValue({
       _id: 'exec-1',
-      status: WorkflowExecutionStatus.CANCELLED,
+      status: PrismaWorkflowExecutionStatus.CANCELLED,
+    });
+
+    const job = {
+      data: {
+        delayNodeId: 'delay-1',
+        executionId: 'exec-1',
+        organizationId: 'org-1',
+        resumeAt: new Date().toISOString(),
+        scheduledAt: new Date().toISOString(),
+        userId: 'user-1',
+        workflowId: 'wf-1',
+      },
+      name: 'delay-resume',
+    } as any;
+
+    await processor.process(job);
+
+    expect(mockQueueService.queueExecution).not.toHaveBeenCalled();
+  });
+
+  it('should skip resume for completed execution with legacy app casing', async () => {
+    mockExecutionsService.findOne.mockResolvedValue({
+      _id: 'exec-1',
+      status: SharedWorkflowExecutionStatus.COMPLETED,
     });
 
     const job = {

--- a/apps/server/workers/src/processors/api/queues/workflow/workflow-execution.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/workflow/workflow-execution.processor.ts
@@ -11,7 +11,8 @@ import type {
   WorkflowExecutionJobData,
 } from '@api/queues/workflow/workflow-queue.service';
 import { WorkflowQueueService } from '@api/queues/workflow/workflow-queue.service';
-import { WorkflowExecutionStatus } from '@genfeedai/enums';
+import { WorkflowExecutionStatus as SharedWorkflowExecutionStatus } from '@genfeedai/enums';
+import { WorkflowExecutionStatus as PrismaWorkflowExecutionStatus } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { forwardRef, Inject } from '@nestjs/common';
@@ -20,6 +21,15 @@ import { Job } from 'bullmq';
 type WorkflowExecutionResult = Awaited<
   ReturnType<WorkflowEngineAdapterService['executeWorkflow']>
 >;
+
+const TERMINAL_EXECUTION_STATUSES = new Set<string>([
+  PrismaWorkflowExecutionStatus.CANCELLED,
+  PrismaWorkflowExecutionStatus.COMPLETED,
+  PrismaWorkflowExecutionStatus.FAILED,
+  SharedWorkflowExecutionStatus.CANCELLED,
+  SharedWorkflowExecutionStatus.COMPLETED,
+  SharedWorkflowExecutionStatus.FAILED,
+]);
 
 @Processor('workflow-execution', {
   concurrency: 3,
@@ -121,10 +131,10 @@ export class WorkflowExecutionProcessor extends WorkerHost {
               startedAt: event.timestamp,
               status:
                 event.newStatus === 'completed'
-                  ? WorkflowExecutionStatus.COMPLETED
+                  ? SharedWorkflowExecutionStatus.COMPLETED
                   : event.newStatus === 'failed'
-                    ? WorkflowExecutionStatus.FAILED
-                    : WorkflowExecutionStatus.RUNNING,
+                    ? SharedWorkflowExecutionStatus.FAILED
+                    : SharedWorkflowExecutionStatus.RUNNING,
             },
             executable.nodes.length,
           );
@@ -198,11 +208,7 @@ export class WorkflowDelayProcessor extends WorkerHost {
 
     const executionStatus = String(execution.status);
 
-    if (
-      executionStatus === WorkflowExecutionStatus.CANCELLED ||
-      executionStatus === WorkflowExecutionStatus.FAILED ||
-      executionStatus === WorkflowExecutionStatus.COMPLETED
-    ) {
+    if (TERMINAL_EXECUTION_STATUSES.has(executionStatus)) {
       this.logger.warn(
         `${url} execution already ${executionStatus}, skipping delayed resume`,
         {


### PR DESCRIPTION
## Root cause
Production rollout failed after ECS service update because API/workers wrote lowercase `@genfeedai/enums` workflow execution statuses (`pending`, `running`, etc.) into the Prisma `WorkflowExecutionStatus` enum, whose database values are uppercase (`PENDING`, `RUNNING`, etc.). The new tasks repeatedly failed health checks while scheduled workflows retried.

## Fix
- Use Prisma-generated workflow execution status values for database writes and stats reads.
- Keep shared lowercase statuses for node-result JSON payloads.
- Treat both Prisma uppercase and legacy lowercase terminal statuses as terminal in the delay-resume worker.
- Add focused tests for DB enum casing and delay-resume terminal status handling.

## Verification
- `bunx vitest run src/collections/workflow-executions/services/workflow-executions.service.spec.ts --config vitest.config.ts` from `apps/server/api`
- `bunx vitest run src/processors/api/queues/workflow/workflow-execution.processor.spec.ts --config vitest.config.ts` from `apps/server/workers`
- `bunx biome check apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts apps/server/api/test/setup-unit.ts apps/server/workers/src/processors/api/queues/workflow/workflow-execution.processor.ts apps/server/workers/src/processors/api/queues/workflow/workflow-execution.processor.spec.ts`
- `git diff --check`