### PR TITLE
feat(admin): add warm-up account provisioning

### DIFF
--- a/apps/app/app/(protected)/admin/administration/warmup-accounts/page.test.tsx
+++ b/apps/app/app/(protected)/admin/administration/warmup-accounts/page.test.tsx
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('app/(protected)/admin/administration/warmup-accounts/page.tsx', () => {
+  it('keeps the warm-up accounts route exported', () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        'app/(protected)/admin/administration/warmup-accounts/page.tsx',
+      ),
+      'utf8',
+    );
+
+    expect(source).toContain('WarmupAccountsPage');
+    expect(source).toContain('createPageMetadata');
+  });
+});

--- a/apps/app/app/(protected)/admin/administration/warmup-accounts/page.tsx
+++ b/apps/app/app/(protected)/admin/administration/warmup-accounts/page.tsx
@@ -1,0 +1,14 @@
+import { SkeletonLoadingFallback } from '@components/loading/skeleton/SkeletonFallbacks';
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import WarmupAccountsPage from '@protected/administration/warmup-accounts/warmup-accounts-page';
+import { Suspense } from 'react';
+
+export const generateMetadata = createPageMetadata('Warm-up accounts');
+
+export default function WarmupAccountsRoutePage() {
+  return (
+    <Suspense fallback={<SkeletonLoadingFallback />}>
+      <WarmupAccountsPage />
+    </Suspense>
+  );
+}

--- a/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.test.tsx
+++ b/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import WarmupAccountsPage from './warmup-accounts-page';
+
+const mocks = vi.hoisted(() => ({
+  createWarmupAccount: vi.fn(),
+  getWarmupAccounts: vi.fn(),
+  notifications: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: (factory: (token: string) => unknown) => async () =>
+    factory('test-token'),
+}));
+
+vi.mock('@services/admin/warmup-accounts.service', () => ({
+  AdminWarmupAccountsService: {
+    getInstance: () => ({
+      createWarmupAccount: mocks.createWarmupAccount,
+      getWarmupAccounts: mocks.getWarmupAccounts,
+    }),
+  },
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@services/core/notifications.service', () => ({
+  NotificationsService: {
+    getInstance: () => mocks.notifications,
+  },
+}));
+
+vi.mock('@ui/layout/container/Container', () => ({
+  default: ({
+    activeTab,
+    children,
+    label,
+    onTabChange,
+    tabs,
+  }: {
+    activeTab: string;
+    children: ReactNode;
+    label: string;
+    onTabChange: (tab: string) => void;
+    tabs: Array<{ id: string; label: string }>;
+  }) => (
+    <section>
+      <h1>{label}</h1>
+      <nav>
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            aria-pressed={activeTab === tab.id}
+            onClick={() => onTabChange(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+      {children}
+    </section>
+  ),
+}));
+
+const account = {
+  auditEvents: [],
+  brandId: 'brand_1',
+  brandName: 'Acme',
+  createdAt: '2026-06-29T10:00:00.000Z',
+  customerUserId: 'customer_1',
+  diagnostics: {
+    steps: [
+      {
+        message: 'Created pending customer invitation.',
+        status: 'done' as const,
+        timestamp: '2026-06-29T10:01:00.000Z',
+      },
+    ],
+  },
+  id: 'warmup_1',
+  invitationId: 'invite_1',
+  leadEmail: 'lead@example.com',
+  operatorUserId: 'operator_1',
+  organizationId: 'org_1',
+  organizationName: 'Acme Growth',
+  status: 'INVITED' as const,
+  updatedAt: '2026-06-29T10:01:00.000Z',
+};
+
+describe('WarmupAccountsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getWarmupAccounts.mockResolvedValue([account]);
+    mocks.createWarmupAccount.mockResolvedValue(account);
+  });
+
+  it('loads and renders account progress on the accounts tab', async () => {
+    render(<WarmupAccountsPage defaultTab="accounts" />);
+
+    await waitFor(() => {
+      expect(mocks.getWarmupAccounts).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getAllByText('Acme Growth').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Invited').length).toBeGreaterThan(0);
+    expect(screen.getByText('org_1')).toBeDefined();
+    expect(
+      screen.getByText('Created pending customer invitation.'),
+    ).toBeDefined();
+  });
+
+  it('submits the create form and selects the returned account', async () => {
+    render(<WarmupAccountsPage />);
+
+    fireEvent.change(screen.getByLabelText(/Lead email/), {
+      target: { value: 'lead@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/Organization/), {
+      target: { value: 'Acme Growth' },
+    });
+    fireEvent.change(screen.getByLabelText(/First brand/), {
+      target: { value: 'Acme' },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Provision warm-up account/i }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.createWarmupAccount).toHaveBeenCalledWith({
+        brandName: 'Acme',
+        guidance: undefined,
+        leadEmail: 'lead@example.com',
+        leadFirstName: undefined,
+        leadLastName: undefined,
+        organizationName: 'Acme Growth',
+        websiteUrl: undefined,
+      });
+    });
+
+    expect(mocks.notifications.success).toHaveBeenCalledWith(
+      'Warm-up account provisioned',
+    );
+    expect(screen.getByText('invite_1')).toBeDefined();
+  });
+});

--- a/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.tsx
+++ b/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.tsx
@@ -1,0 +1,566 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import type {
+  IWarmupAccount,
+  IWarmupAccountStatus,
+} from '@genfeedai/interfaces';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import type {
+  WarmupAccountFormState,
+  WarmupAccountsPageProps,
+} from '@props/admin/warmup-accounts.props';
+import { AdminWarmupAccountsService } from '@services/admin/warmup-accounts.service';
+import { logger } from '@services/core/logger.service';
+import { NotificationsService } from '@services/core/notifications.service';
+import CardEmpty from '@ui/card/empty/CardEmpty';
+import Badge from '@ui/display/badge/Badge';
+import { SkeletonCard } from '@ui/display/skeleton/skeleton';
+import Container from '@ui/layout/container/Container';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import { Textarea } from '@ui/primitives/textarea';
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import {
+  HiArrowPath,
+  HiOutlineCheckCircle,
+  HiOutlineRocketLaunch,
+} from 'react-icons/hi2';
+
+const TABS = [
+  { id: 'create', label: 'Create' },
+  { id: 'accounts', label: 'Accounts' },
+];
+
+const INITIAL_FORM: WarmupAccountFormState = {
+  brandName: '',
+  guidance: '',
+  leadEmail: '',
+  leadFirstName: '',
+  leadLastName: '',
+  organizationName: '',
+  websiteUrl: '',
+};
+
+const WARMUP_SKELETON_KEYS = [
+  'warmup-account-skeleton-1',
+  'warmup-account-skeleton-2',
+  'warmup-account-skeleton-3',
+] as const;
+
+const STATUS_META: Record<
+  IWarmupAccountStatus,
+  {
+    label: string;
+    variant: 'error' | 'ghost' | 'info' | 'outline' | 'success' | 'warning';
+  }
+> = {
+  ARCHIVED: { label: 'Archived', variant: 'ghost' },
+  CLAIMED: { label: 'Claimed', variant: 'success' },
+  DRAFT: { label: 'Draft', variant: 'outline' },
+  FAILED: { label: 'Failed', variant: 'error' },
+  INVITED: { label: 'Invited', variant: 'success' },
+  PROVISIONED: { label: 'Provisioned', variant: 'info' },
+  PROVISIONING: { label: 'Provisioning', variant: 'warning' },
+};
+
+type PageState = {
+  accounts: IWarmupAccount[];
+  activeTab: 'accounts' | 'create';
+  form: WarmupAccountFormState;
+  isLoading: boolean;
+  isSubmitting: boolean;
+  selectedAccountId?: string;
+};
+
+type PageAction =
+  | { type: 'SET_TAB'; tab: 'accounts' | 'create' }
+  | { type: 'SET_LOADING'; isLoading: boolean }
+  | { type: 'SET_SUBMITTING'; isSubmitting: boolean }
+  | { type: 'SET_ACCOUNTS'; accounts: IWarmupAccount[] }
+  | {
+      type: 'SET_FIELD';
+      field: keyof WarmupAccountFormState;
+      value: string;
+    }
+  | { type: 'SET_SELECTED'; accountId: string }
+  | { type: 'CREATE_SUCCESS'; account: IWarmupAccount };
+
+function pageReducer(state: PageState, action: PageAction): PageState {
+  switch (action.type) {
+    case 'CREATE_SUCCESS': {
+      const remaining = state.accounts.filter(
+        (account) => account.id !== action.account.id,
+      );
+      return {
+        ...state,
+        accounts: [action.account, ...remaining],
+        activeTab: 'accounts',
+        form: INITIAL_FORM,
+        selectedAccountId: action.account.id,
+      };
+    }
+    case 'SET_ACCOUNTS':
+      return {
+        ...state,
+        accounts: action.accounts,
+        selectedAccountId:
+          state.selectedAccountId ?? action.accounts[0]?.id ?? undefined,
+      };
+    case 'SET_FIELD':
+      return {
+        ...state,
+        form: { ...state.form, [action.field]: action.value },
+      };
+    case 'SET_LOADING':
+      return { ...state, isLoading: action.isLoading };
+    case 'SET_SELECTED':
+      return { ...state, selectedAccountId: action.accountId };
+    case 'SET_SUBMITTING':
+      return { ...state, isSubmitting: action.isSubmitting };
+    case 'SET_TAB':
+      return {
+        ...state,
+        activeTab: action.tab,
+        isLoading: action.tab === 'accounts' ? true : state.isLoading,
+      };
+    default:
+      return state;
+  }
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleString('en-US', {
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function getStatusMeta(status: IWarmupAccountStatus) {
+  return STATUS_META[status] ?? { label: status, variant: 'outline' as const };
+}
+
+export default function WarmupAccountsPage({
+  defaultTab = 'create',
+}: WarmupAccountsPageProps) {
+  const [state, dispatch] = useReducer(pageReducer, {
+    accounts: [],
+    activeTab: defaultTab,
+    form: INITIAL_FORM,
+    isLoading: defaultTab === 'accounts',
+    isSubmitting: false,
+  });
+
+  const { accounts, activeTab, form, isLoading, isSubmitting } = state;
+  const notificationsService = NotificationsService.getInstance();
+
+  const getWarmupAccountsService = useAuthedService((token: string) =>
+    AdminWarmupAccountsService.getInstance(token),
+  );
+
+  const selectedAccount = useMemo(
+    () =>
+      accounts.find((account) => account.id === state.selectedAccountId) ??
+      accounts[0],
+    [accounts, state.selectedAccountId],
+  );
+
+  const loadAccounts = useCallback(
+    async (signal: AbortSignal) => {
+      try {
+        const service = await getWarmupAccountsService();
+        const data = await service.getWarmupAccounts();
+
+        if (!signal.aborted) {
+          dispatch({ type: 'SET_ACCOUNTS', accounts: data });
+          logger.info('Warm-up accounts loaded', { count: data.length });
+        }
+      } catch (error) {
+        if (signal.aborted) {
+          return;
+        }
+        logger.error('Failed to load warm-up accounts', error);
+        notificationsService.error('Failed to load warm-up accounts');
+      } finally {
+        if (!signal.aborted) {
+          dispatch({ type: 'SET_LOADING', isLoading: false });
+        }
+      }
+    },
+    [getWarmupAccountsService, notificationsService],
+  );
+
+  useEffect(() => {
+    if (activeTab !== 'accounts') {
+      return;
+    }
+
+    const controller = new AbortController();
+    loadAccounts(controller.signal);
+
+    return () => controller.abort();
+  }, [activeTab, loadAccounts]);
+
+  function handleFieldChange(
+    field: keyof WarmupAccountFormState,
+    value: string,
+  ): void {
+    dispatch({ type: 'SET_FIELD', field, value });
+  }
+
+  async function handleSubmit(
+    event: React.FormEvent<HTMLFormElement>,
+  ): Promise<void> {
+    event.preventDefault();
+
+    if (!form.leadEmail.trim()) {
+      notificationsService.warning('Lead email is required');
+      return;
+    }
+
+    if (!form.organizationName.trim() || !form.brandName.trim()) {
+      notificationsService.warning('Organization and brand are required');
+      return;
+    }
+
+    dispatch({ type: 'SET_SUBMITTING', isSubmitting: true });
+
+    try {
+      const service = await getWarmupAccountsService();
+      const account = await service.createWarmupAccount({
+        brandName: form.brandName.trim(),
+        guidance: form.guidance.trim() || undefined,
+        leadEmail: form.leadEmail.trim(),
+        leadFirstName: form.leadFirstName.trim() || undefined,
+        leadLastName: form.leadLastName.trim() || undefined,
+        organizationName: form.organizationName.trim(),
+        websiteUrl: form.websiteUrl.trim() || undefined,
+      });
+
+      dispatch({ type: 'CREATE_SUCCESS', account });
+
+      if (account.status === 'FAILED') {
+        notificationsService.warning('Warm-up account needs attention');
+      } else {
+        notificationsService.success('Warm-up account provisioned');
+      }
+    } catch (error) {
+      logger.error('Failed to create warm-up account', error);
+      notificationsService.error('Failed to create warm-up account');
+    } finally {
+      dispatch({ type: 'SET_SUBMITTING', isSubmitting: false });
+    }
+  }
+
+  return (
+    <Container
+      label="Warm-up accounts"
+      description="Provision lead accounts for operator-prepared customer demos"
+      icon={HiOutlineRocketLaunch}
+      tabs={TABS}
+      activeTab={activeTab}
+      onTabChange={(tab) =>
+        dispatch({ type: 'SET_TAB', tab: tab as 'accounts' | 'create' })
+      }
+    >
+      {activeTab === 'create' && (
+        <form onSubmit={handleSubmit} className="max-w-3xl space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <Field label="Lead email" required htmlFor="warmup-lead-email">
+              <Input
+                id="warmup-lead-email"
+                type="email"
+                value={form.leadEmail}
+                onChange={(event) =>
+                  handleFieldChange('leadEmail', event.target.value)
+                }
+                disabled={isSubmitting}
+                placeholder="founder@example.com"
+                required
+              />
+            </Field>
+
+            <Field label="Website" htmlFor="warmup-website-url">
+              <Input
+                id="warmup-website-url"
+                type="url"
+                value={form.websiteUrl}
+                onChange={(event) =>
+                  handleFieldChange('websiteUrl', event.target.value)
+                }
+                disabled={isSubmitting}
+                placeholder="https://example.com"
+              />
+            </Field>
+
+            <Field label="First name" htmlFor="warmup-lead-first-name">
+              <Input
+                id="warmup-lead-first-name"
+                value={form.leadFirstName}
+                onChange={(event) =>
+                  handleFieldChange('leadFirstName', event.target.value)
+                }
+                disabled={isSubmitting}
+                placeholder="Ada"
+              />
+            </Field>
+
+            <Field label="Last name" htmlFor="warmup-lead-last-name">
+              <Input
+                id="warmup-lead-last-name"
+                value={form.leadLastName}
+                onChange={(event) =>
+                  handleFieldChange('leadLastName', event.target.value)
+                }
+                disabled={isSubmitting}
+                placeholder="Lovelace"
+              />
+            </Field>
+
+            <Field
+              label="Organization"
+              required
+              htmlFor="warmup-organization-name"
+            >
+              <Input
+                id="warmup-organization-name"
+                value={form.organizationName}
+                onChange={(event) =>
+                  handleFieldChange('organizationName', event.target.value)
+                }
+                disabled={isSubmitting}
+                placeholder="Acme Growth"
+                required
+              />
+            </Field>
+
+            <Field label="First brand" required htmlFor="warmup-brand-name">
+              <Input
+                id="warmup-brand-name"
+                value={form.brandName}
+                onChange={(event) =>
+                  handleFieldChange('brandName', event.target.value)
+                }
+                disabled={isSubmitting}
+                placeholder="Acme"
+                required
+              />
+            </Field>
+          </div>
+
+          <Field label="Operator guidance" htmlFor="warmup-guidance">
+            <Textarea
+              id="warmup-guidance"
+              className="min-h-[140px]"
+              value={form.guidance}
+              onChange={(event) =>
+                handleFieldChange('guidance', event.target.value)
+              }
+              disabled={isSubmitting}
+              placeholder="Context to preserve for the operator before starter content is prepared"
+            />
+          </Field>
+
+          <Button
+            type="submit"
+            isDisabled={isSubmitting}
+            className="inline-flex items-center gap-2"
+          >
+            {isSubmitting ? (
+              <HiArrowPath className="size-4 animate-spin" />
+            ) : (
+              <HiOutlineCheckCircle className="size-4" />
+            )}
+            {isSubmitting ? 'Provisioning' : 'Provision warm-up account'}
+          </Button>
+        </form>
+      )}
+
+      {activeTab === 'accounts' && (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,0.95fr)_minmax(360px,0.75fr)]">
+          <WarmupAccountList
+            accounts={accounts}
+            isLoading={isLoading}
+            selectedAccountId={selectedAccount?.id}
+            onSelectAccount={(accountId) =>
+              dispatch({ type: 'SET_SELECTED', accountId })
+            }
+          />
+          <WarmupAccountDetail account={selectedAccount} />
+        </div>
+      )}
+    </Container>
+  );
+}
+
+function Field({
+  children,
+  htmlFor,
+  label,
+  required = false,
+}: {
+  children: React.ReactNode;
+  htmlFor: string;
+  label: string;
+  required?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={htmlFor} className="text-sm font-medium text-foreground">
+        {label}
+        {required ? <span className="text-rose-400"> *</span> : null}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function WarmupAccountList({
+  accounts,
+  isLoading,
+  onSelectAccount,
+  selectedAccountId,
+}: {
+  accounts: IWarmupAccount[];
+  isLoading: boolean;
+  onSelectAccount: (accountId: string) => void;
+  selectedAccountId?: string;
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {WARMUP_SKELETON_KEYS.map((key) => (
+          <SkeletonCard key={key} showImage={false} />
+        ))}
+      </div>
+    );
+  }
+
+  if (accounts.length === 0) {
+    return <CardEmpty label="No warm-up accounts yet" />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {accounts.map((account) => {
+        const status = getStatusMeta(account.status);
+        const isSelected = selectedAccountId === account.id;
+
+        return (
+          <Button
+            key={account.id}
+            type="button"
+            variant={ButtonVariant.UNSTYLED}
+            withWrapper={false}
+            onClick={() => onSelectAccount(account.id)}
+            className={`w-full border p-4 text-left transition-colors ${
+              isSelected
+                ? 'border-primary/50 bg-primary/5'
+                : 'border-white/5 bg-card hover:border-white/15'
+            }`}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">
+                  {account.organizationName}
+                </h3>
+                <p className="mt-1 text-xs text-foreground/60">
+                  {account.leadEmail}
+                </p>
+              </div>
+              <Badge variant={status.variant}>{status.label}</Badge>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs text-foreground/50">
+              <span>{account.brandName}</span>
+              <span>{formatDate(account.createdAt)}</span>
+            </div>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+function WarmupAccountDetail({ account }: { account?: IWarmupAccount }) {
+  if (!account) {
+    return (
+      <div className="border border-white/5 bg-card p-5">
+        <CardEmpty label="Select a warm-up account" />
+      </div>
+    );
+  }
+
+  const status = getStatusMeta(account.status);
+  const diagnostics = account.diagnostics?.steps ?? [];
+
+  return (
+    <aside className="border border-white/5 bg-card p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">
+            {account.brandName}
+          </h2>
+          <p className="mt-1 text-sm text-foreground/60">
+            {account.organizationName}
+          </p>
+        </div>
+        <Badge variant={status.variant}>{status.label}</Badge>
+      </div>
+
+      <dl className="mt-5 grid gap-3 text-sm">
+        <DetailRow label="Lead" value={account.leadEmail} />
+        <DetailRow label="Organization ID" value={account.organizationId} />
+        <DetailRow label="Brand ID" value={account.brandId} />
+        <DetailRow label="Invitation ID" value={account.invitationId} />
+        <DetailRow label="Operator ID" value={account.operatorUserId} />
+      </dl>
+
+      <div className="mt-6 border-t border-white/5 pt-5">
+        <h3 className="text-sm font-semibold text-foreground">Diagnostics</h3>
+        {diagnostics.length === 0 ? (
+          <p className="mt-2 text-sm text-foreground/50">
+            No diagnostic events recorded.
+          </p>
+        ) : (
+          <ol className="mt-3 space-y-3">
+            {diagnostics.map((step) => (
+              <li
+                key={`${step.timestamp}-${step.message}`}
+                className="flex gap-3 text-sm"
+              >
+                <Badge variant={step.status === 'failed' ? 'error' : 'outline'}>
+                  {step.status}
+                </Badge>
+                <div>
+                  <p className="text-foreground">{step.message}</p>
+                  <p className="text-xs text-foreground/50">
+                    {formatDate(step.timestamp)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+        {account.diagnostics?.error ? (
+          <p className="mt-4 border border-rose-500/20 bg-rose-500/5 p-3 text-sm text-rose-200">
+            {account.diagnostics.error}
+          </p>
+        ) : null}
+      </div>
+    </aside>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value?: string }) {
+  return (
+    <div className="grid gap-1">
+      <dt className="text-xs uppercase tracking-wide text-foreground/40">
+        {label}
+      </dt>
+      <dd className="break-all text-foreground">{value ?? 'Pending'}</dd>
+    </div>
+  );
+}

--- a/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.tsx
+++ b/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.tsx
@@ -70,6 +70,7 @@ type PageState = {
   form: WarmupAccountFormState;
   isLoading: boolean;
   isSubmitting: boolean;
+  loadTrigger: number;
   selectedAccountId?: string;
 };
 
@@ -97,6 +98,7 @@ function pageReducer(state: PageState, action: PageAction): PageState {
         accounts: [action.account, ...remaining],
         activeTab: 'accounts',
         form: INITIAL_FORM,
+        loadTrigger: state.loadTrigger + 1,
         selectedAccountId: action.account.id,
       };
     }
@@ -123,6 +125,8 @@ function pageReducer(state: PageState, action: PageAction): PageState {
         ...state,
         activeTab: action.tab,
         isLoading: action.tab === 'accounts' ? true : state.isLoading,
+        loadTrigger:
+          action.tab === 'accounts' ? state.loadTrigger + 1 : state.loadTrigger,
       };
     default:
       return state;
@@ -152,9 +156,11 @@ export default function WarmupAccountsPage({
     form: INITIAL_FORM,
     isLoading: defaultTab === 'accounts',
     isSubmitting: false,
+    loadTrigger: 0,
   });
 
-  const { accounts, activeTab, form, isLoading, isSubmitting } = state;
+  const { accounts, activeTab, form, isLoading, isSubmitting, loadTrigger } =
+    state;
   const notificationsService = NotificationsService.getInstance();
 
   const getWarmupAccountsService = useAuthedService((token: string) =>
@@ -193,6 +199,7 @@ export default function WarmupAccountsPage({
     [getWarmupAccountsService, notificationsService],
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: loadTrigger is an intentional re-fire signal incremented on every accounts-tab selection, including re-selections of the already-active tab
   useEffect(() => {
     if (activeTab !== 'accounts') {
       return;
@@ -202,7 +209,7 @@ export default function WarmupAccountsPage({
     loadAccounts(controller.signal);
 
     return () => controller.abort();
-  }, [activeTab, loadAccounts]);
+  }, [activeTab, loadAccounts, loadTrigger]);
 
   function handleFieldChange(
     field: keyof WarmupAccountFormState,
@@ -526,9 +533,10 @@ function WarmupAccountDetail({ account }: { account?: IWarmupAccount }) {
           </p>
         ) : (
           <ol className="mt-3 space-y-3">
-            {diagnostics.map((step) => (
+            {diagnostics.map((step, index) => (
               <li
-                key={`${step.timestamp}-${step.message}`}
+                // biome-ignore lint/suspicious/noArrayIndexKey: timestamp+message collide on same-ms duplicate steps; index is the correct disambiguator
+                key={`${step.timestamp}-${step.message}-${index}`}
                 className="flex gap-3 text-sm"
               >
                 <Badge variant={step.status === 'failed' ? 'error' : 'outline'}>

--- a/apps/app/packages/config/admin-menu-items.config.test.ts
+++ b/apps/app/packages/config/admin-menu-items.config.test.ts
@@ -22,6 +22,7 @@ describe('ADMIN_MENU_ITEMS', () => {
 
     expect(hrefs).toContain('/admin/organization');
     expect(hrefs).toContain('/admin/administration/users');
+    expect(hrefs).toContain('/admin/administration/warmup-accounts');
     expect(hrefs).toContain('/admin/administration/subscriptions');
     expect(hrefs).toContain('/admin/overview/analytics/all');
   });

--- a/apps/app/packages/config/admin-menu-items.config.ts
+++ b/apps/app/packages/config/admin-menu-items.config.ts
@@ -195,6 +195,14 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
   },
   {
     group: 'Administration',
+    href: APP_ROUTES.ADMIN.ADMINISTRATION.WARMUP_ACCOUNTS,
+    label: 'Warm-up accounts',
+    matchPaths: [APP_ROUTES.ADMIN.ADMINISTRATION.WARMUP_ACCOUNTS],
+    outline: HiOutlineUserGroup,
+    solid: HiUserGroup,
+  },
+  {
+    group: 'Administration',
     href: APP_ROUTES.ADMIN.ADMINISTRATION.ROLES,
     label: 'Roles',
     matchPaths: [APP_ROUTES.ADMIN.ADMINISTRATION.ROLES],

--- a/apps/server/api/src/endpoints/admin/admin.module.ts
+++ b/apps/server/api/src/endpoints/admin/admin.module.ts
@@ -1,11 +1,13 @@
 import { AdminAnnouncementsModule } from '@api/endpoints/admin/announcements/announcements.module';
 import { AdminFleetModule } from '@api/endpoints/admin/fleet/fleet.module';
+import { AdminWarmupAccountsModule } from '@api/endpoints/admin/warmup-accounts/warmup-accounts.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   imports: [
     forwardRef(() => AdminFleetModule),
     forwardRef(() => AdminAnnouncementsModule),
+    forwardRef(() => AdminWarmupAccountsModule),
   ],
 })
 export class AdminModule {}

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/dto/create-warmup-account.dto.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/dto/create-warmup-account.dto.ts
@@ -1,0 +1,41 @@
+import {
+  IsEmail,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
+
+export class CreateWarmupAccountDto {
+  @IsEmail()
+  @MaxLength(320)
+  leadEmail!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(80)
+  leadFirstName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(80)
+  leadLastName?: string;
+
+  @IsString()
+  @MaxLength(120)
+  organizationName!: string;
+
+  @IsString()
+  @MaxLength(120)
+  brandName!: string;
+
+  @IsOptional()
+  @IsUrl({ require_protocol: false })
+  @MaxLength(512)
+  websiteUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  guidance?: string;
+}

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.controller.spec.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.controller.spec.ts
@@ -1,0 +1,175 @@
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
+import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
+import { LoggerService } from '@libs/logger/logger.service';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WarmupAccountsController } from './warmup-accounts.controller';
+import { AdminWarmupAccountsService } from './warmup-accounts.service';
+
+const mockGetPublicMetadata = vi.fn();
+
+vi.mock('@api/endpoints/admin/guards/ip-whitelist.guard', () => ({
+  IpWhitelistGuard: vi.fn().mockImplementation(function () {
+    return { canActivate: vi.fn().mockReturnValue(true) };
+  }),
+}));
+
+vi.mock('@api/helpers/decorators/user/current-user.decorator', () => ({
+  CurrentUser:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+vi.mock('@api/helpers/utils/auth/auth.util', () => ({
+  getPublicMetadata: () => mockGetPublicMetadata(),
+}));
+
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  serializeCollection: vi.fn(
+    (_req: unknown, _serializer: unknown, data: unknown) => ({
+      data,
+      serialized: true,
+    }),
+  ),
+  serializeSingle: vi.fn(
+    (_req: unknown, _serializer: unknown, item: unknown) => ({
+      data: item,
+      serialized: true,
+    }),
+  ),
+}));
+
+vi.mock('@genfeedai/serializers', () => ({
+  WarmupAccountSerializer: {},
+}));
+
+const makeRequest = () => ({
+  url: 'https://api.genfeed.ai/admin/warmup-accounts',
+});
+
+const makeUser = () => ({
+  id: 'auth_provider_user_1',
+  publicMetadata: { user: 'db_user_1' },
+});
+
+const makeWarmupAccount = () => ({
+  _id: 'warmup_1',
+  brandName: 'Acme',
+  diagnostics: { steps: [] },
+  id: 'warmup_1',
+  leadEmail: 'lead@example.com',
+  operatorUserId: 'db_user_1',
+  organizationName: 'Acme Growth',
+  status: 'INVITED',
+});
+
+describe('WarmupAccountsController', () => {
+  let controller: WarmupAccountsController;
+
+  const warmupAccountsService = {
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+  };
+
+  const loggerService = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetPublicMetadata.mockReturnValue({ user: 'db_user_1' });
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WarmupAccountsController],
+      providers: [
+        {
+          provide: AdminWarmupAccountsService,
+          useValue: warmupAccountsService,
+        },
+        { provide: LoggerService, useValue: loggerService },
+      ],
+    })
+      .overrideGuard('IpWhitelistGuard')
+      .useValue({ canActivate: () => true })
+      .overrideGuard(SuperAdminGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<WarmupAccountsController>(WarmupAccountsController);
+  });
+
+  it('requires IP whitelist and platform superadmin guards', () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      WarmupAccountsController,
+    );
+
+    expect(guards).toEqual([IpWhitelistGuard, SuperAdminGuard]);
+  });
+
+  it('creates warm-up accounts with the local DB user id', async () => {
+    const account = makeWarmupAccount();
+    warmupAccountsService.create.mockResolvedValue(account);
+
+    const dto = {
+      brandName: 'Acme',
+      leadEmail: 'lead@example.com',
+      organizationName: 'Acme Growth',
+    };
+
+    const result = await controller.create(
+      dto,
+      makeUser() as never,
+      makeRequest() as never,
+    );
+
+    expect(warmupAccountsService.create).toHaveBeenCalledWith('db_user_1', dto);
+    expect(result).toMatchObject({ data: account, serialized: true });
+  });
+
+  it('rejects create requests when local DB user id is missing', async () => {
+    mockGetPublicMetadata.mockReturnValue({ user: '' });
+
+    await expect(
+      controller.create(
+        {
+          brandName: 'Acme',
+          leadEmail: 'lead@example.com',
+          organizationName: 'Acme Growth',
+        },
+        makeUser() as never,
+        makeRequest() as never,
+      ),
+    ).rejects.toThrow('Local user id is required');
+  });
+
+  it('serializes list responses with pagination metadata', async () => {
+    const account = makeWarmupAccount();
+    warmupAccountsService.list.mockResolvedValue([account]);
+
+    const result = await controller.list(makeRequest() as never);
+
+    expect(warmupAccountsService.list).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      data: expect.objectContaining({
+        docs: [account],
+        totalDocs: 1,
+      }),
+      serialized: true,
+    });
+  });
+
+  it('serializes detail responses', async () => {
+    const account = makeWarmupAccount();
+    warmupAccountsService.get.mockResolvedValue(account);
+
+    const result = await controller.get('warmup_1', makeRequest() as never);
+
+    expect(warmupAccountsService.get).toHaveBeenCalledWith('warmup_1');
+    expect(result).toMatchObject({ data: account, serialized: true });
+  });
+});

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.controller.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.controller.ts
@@ -1,0 +1,102 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
+import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
+import { CreateWarmupAccountDto } from '@api/endpoints/admin/warmup-accounts/dto/create-warmup-account.dto';
+import { AdminWarmupAccountsService } from '@api/endpoints/admin/warmup-accounts/warmup-accounts.service';
+import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { ErrorResponse } from '@api/helpers/utils/error-response/error-response.util';
+import {
+  serializeCollection,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
+import { WarmupAccountSerializer } from '@genfeedai/serializers';
+import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+
+@ApiTags('Admin / Warm-up Accounts')
+@Controller('admin/warmup-accounts')
+@UseGuards(IpWhitelistGuard, SuperAdminGuard)
+export class WarmupAccountsController {
+  constructor(
+    private readonly warmupAccountsService: AdminWarmupAccountsService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Provision a lead warm-up account' })
+  async create(
+    @Body() dto: CreateWarmupAccountDto,
+    @CurrentUser() user: User,
+    @Req() request: Request,
+  ) {
+    try {
+      const account = await this.warmupAccountsService.create(
+        this.getActorUserId(user),
+        dto,
+      );
+      return serializeSingle(request, WarmupAccountSerializer, account);
+    } catch (error) {
+      return ErrorResponse.handle(error, this.loggerService, 'createWarmup');
+    }
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List warm-up accounts' })
+  async list(@Req() request: Request) {
+    try {
+      const accounts = await this.warmupAccountsService.list();
+      return serializeCollection(request, WarmupAccountSerializer, {
+        docs: accounts,
+        hasNextPage: false,
+        hasPrevPage: false,
+        limit: accounts.length,
+        nextPage: null,
+        page: 1,
+        pagingCounter: 1,
+        prevPage: null,
+        totalDocs: accounts.length,
+        totalPages: 1,
+      });
+    } catch (error) {
+      return ErrorResponse.handle(error, this.loggerService, 'listWarmups');
+    }
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get warm-up account details' })
+  async get(@Param('id') id: string, @Req() request: Request) {
+    try {
+      const account = await this.warmupAccountsService.get(id);
+      return serializeSingle(request, WarmupAccountSerializer, account);
+    } catch (error) {
+      return ErrorResponse.handle(error, this.loggerService, 'getWarmup');
+    }
+  }
+
+  private getActorUserId(user: User): string {
+    const actorUserId = getPublicMetadata(user).user?.toString().trim();
+
+    if (!actorUserId) {
+      throw new BadRequestException(
+        'Local user id is required to provision warm-up accounts',
+      );
+    }
+
+    return actorUserId;
+  }
+}

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.module.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.module.ts
@@ -1,0 +1,13 @@
+import { MembersModule } from '@api/collections/members/members.module';
+import { SuperAdminGuard } from '@api/common/guards/super-admin.guard';
+import { IpWhitelistGuard } from '@api/endpoints/admin/guards/ip-whitelist.guard';
+import { WarmupAccountsController } from '@api/endpoints/admin/warmup-accounts/warmup-accounts.controller';
+import { AdminWarmupAccountsService } from '@api/endpoints/admin/warmup-accounts/warmup-accounts.service';
+import { forwardRef, Module } from '@nestjs/common';
+
+@Module({
+  controllers: [WarmupAccountsController],
+  imports: [forwardRef(() => MembersModule)],
+  providers: [AdminWarmupAccountsService, IpWhitelistGuard, SuperAdminGuard],
+})
+export class AdminWarmupAccountsModule {}

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.spec.ts
@@ -1,0 +1,233 @@
+import { InvitationService } from '@api/collections/members/services/invitation.service';
+import { AdminWarmupAccountsService } from '@api/endpoints/admin/warmup-accounts/warmup-accounts.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { WarmupAccountStatus } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createdAt = new Date('2026-06-29T10:00:00.000Z');
+const updatedAt = new Date('2026-06-29T10:01:00.000Z');
+
+function makeWarmupAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    auditEvents: [],
+    brandId: 'brand_1',
+    brandName: 'Acme',
+    createdAt,
+    customerUserId: 'customer_1',
+    diagnostics: { steps: [] },
+    guidance: null,
+    id: 'warmup_1',
+    invitationId: null,
+    isDeleted: false,
+    leadEmail: 'lead@example.com',
+    leadFirstName: 'Ada',
+    leadLastName: 'Lovelace',
+    operatorUserId: 'operator_1',
+    organizationId: 'org_1',
+    organizationName: 'Acme Growth',
+    status: WarmupAccountStatus.PROVISIONED,
+    updatedAt,
+    websiteUrl: 'https://example.com',
+    ...overrides,
+  };
+}
+
+describe('AdminWarmupAccountsService', () => {
+  let service: AdminWarmupAccountsService;
+  let prisma: {
+    $transaction: ReturnType<typeof vi.fn>;
+    warmupAccount: {
+      findFirst: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+  let tx: {
+    brand: {
+      create: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+    };
+    member: {
+      create: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+    organization: {
+      create: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+    };
+    role: {
+      findFirst: ReturnType<typeof vi.fn>;
+    };
+    user: {
+      create: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+    };
+    warmupAccount: {
+      create: ReturnType<typeof vi.fn>;
+    };
+  };
+  let invitationService: {
+    createInvitation: ReturnType<typeof vi.fn>;
+  };
+  let logger: {
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  const dto = {
+    brandName: 'Acme',
+    leadEmail: 'LEAD@example.com',
+    leadFirstName: 'Ada',
+    leadLastName: 'Lovelace',
+    organizationName: 'Acme Growth',
+    websiteUrl: 'https://example.com',
+  };
+
+  beforeEach(() => {
+    tx = {
+      brand: {
+        create: vi.fn().mockResolvedValue({ id: 'brand_1' }),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      member: {
+        create: vi.fn().mockResolvedValue({ id: 'member_1' }),
+        findFirst: vi.fn().mockResolvedValue(null),
+        update: vi.fn(),
+      },
+      organization: {
+        create: vi.fn().mockResolvedValue({ id: 'org_1' }),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      role: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValue({ id: 'role_admin', key: 'admin' }),
+      },
+      user: {
+        create: vi.fn().mockResolvedValue({ id: 'customer_1' }),
+        findFirst: vi
+          .fn()
+          .mockResolvedValueOnce({ id: 'operator_1' })
+          .mockResolvedValueOnce(null),
+      },
+      warmupAccount: {
+        create: vi
+          .fn()
+          .mockResolvedValue(makeWarmupAccount({ status: 'PROVISIONED' })),
+      },
+    };
+
+    prisma = {
+      $transaction: vi.fn((callback: (client: typeof tx) => Promise<unknown>) =>
+        callback(tx),
+      ),
+      warmupAccount: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue(
+          makeWarmupAccount({
+            invitationId: 'invite_1',
+            status: WarmupAccountStatus.INVITED,
+          }),
+        ),
+      },
+    };
+
+    invitationService = {
+      createInvitation: vi.fn().mockResolvedValue({
+        id: 'invite_1',
+      }),
+    };
+
+    logger = {
+      error: vi.fn(),
+    };
+
+    service = new AdminWarmupAccountsService(
+      prisma as unknown as PrismaService,
+      invitationService as unknown as InvitationService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  it('returns an existing active warm-up account for duplicate lead email', async () => {
+    prisma.warmupAccount.findFirst.mockResolvedValue(
+      makeWarmupAccount({ status: WarmupAccountStatus.INVITED }),
+    );
+
+    const result = await service.create('operator_1', dto);
+
+    expect(result.status).toBe('INVITED');
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(invitationService.createInvitation).not.toHaveBeenCalled();
+  });
+
+  it('provisions the account resources and creates a pending invitation', async () => {
+    const result = await service.create('operator_1', dto);
+
+    expect(tx.organization.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          label: 'Acme Growth',
+          userId: 'customer_1',
+        }),
+      }),
+    );
+    expect(tx.brand.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          label: 'Acme',
+          organizationId: 'org_1',
+          userId: 'customer_1',
+        }),
+      }),
+    );
+    expect(tx.member.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organizationId: 'org_1',
+          roleKey: 'admin',
+          userId: 'operator_1',
+        }),
+      }),
+    );
+    expect(invitationService.createInvitation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'lead@example.com',
+        invitedByUserId: 'operator_1',
+        organizationId: 'org_1',
+        sendEmail: false,
+      }),
+    );
+    expect(result.status).toBe('INVITED');
+    expect(result.invitationId).toBe('invite_1');
+  });
+
+  it('records a failed status with diagnostics when invitation creation fails', async () => {
+    invitationService.createInvitation.mockRejectedValue(
+      new Error('Invitation disabled'),
+    );
+    prisma.warmupAccount.update.mockResolvedValue(
+      makeWarmupAccount({
+        diagnostics: {
+          error: 'Invitation disabled',
+          steps: [
+            {
+              message: 'Failed to create pending customer invitation.',
+              status: 'failed',
+              timestamp: '2026-06-29T10:02:00.000Z',
+            },
+          ],
+        },
+        status: WarmupAccountStatus.FAILED,
+      }),
+    );
+
+    const result = await service.create('operator_1', dto);
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(result.status).toBe('FAILED');
+    expect(result.diagnostics.error).toBe('Invitation disabled');
+  });
+});

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.ts
@@ -1,0 +1,503 @@
+import { randomUUID } from 'node:crypto';
+import { InvitationService } from '@api/collections/members/services/invitation.service';
+import { CreateWarmupAccountDto } from '@api/endpoints/admin/warmup-accounts/dto/create-warmup-account.dto';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type {
+  IWarmupAccount,
+  IWarmupAccountAuditEvent,
+  IWarmupAccountDiagnosticStep,
+  IWarmupAccountDiagnostics,
+} from '@genfeedai/interfaces';
+import {
+  OrganizationCategory,
+  type Prisma,
+  type Role,
+  type User,
+  type WarmupAccount,
+  WarmupAccountStatus,
+} from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+type WarmupAccountView = IWarmupAccount & { _id: string };
+type WarmupTransaction = Prisma.TransactionClient;
+type RoleAssignment = Pick<Role, 'id' | 'key'>;
+type CustomerUser = Pick<User, 'id'>;
+
+const ACTIVE_WARMUP_STATUSES: WarmupAccountStatus[] = [
+  WarmupAccountStatus.DRAFT,
+  WarmupAccountStatus.PROVISIONING,
+  WarmupAccountStatus.PROVISIONED,
+  WarmupAccountStatus.INVITED,
+  WarmupAccountStatus.FAILED,
+];
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function trimOptional(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function makeTimestamp(): string {
+  return new Date().toISOString();
+}
+
+function createSlugSeed(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 48) || 'warmup'
+  );
+}
+
+function createHandle(email: string): string {
+  const seed = createSlugSeed(email.split('@')[0] ?? 'lead').slice(0, 24);
+  return `${seed}-${randomUUID().slice(0, 8)}`;
+}
+
+function createAuditEvent(
+  actorUserId: string,
+  message: string,
+): IWarmupAccountAuditEvent {
+  return {
+    actorUserId,
+    message,
+    timestamp: makeTimestamp(),
+  };
+}
+
+function createDiagnosticStep(
+  status: IWarmupAccountDiagnosticStep['status'],
+  message: string,
+): IWarmupAccountDiagnosticStep {
+  return {
+    message,
+    status,
+    timestamp: makeTimestamp(),
+  };
+}
+
+@Injectable()
+export class AdminWarmupAccountsService {
+  private readonly context = { service: AdminWarmupAccountsService.name };
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly invitationService: InvitationService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async create(
+    operatorUserId: string,
+    dto: CreateWarmupAccountDto,
+  ): Promise<WarmupAccountView> {
+    const leadEmail = normalizeEmail(dto.leadEmail);
+    const existing = await this.prisma.warmupAccount.findFirst({
+      orderBy: { createdAt: 'desc' },
+      where: {
+        isDeleted: false,
+        leadEmail,
+        status: { in: ACTIVE_WARMUP_STATUSES },
+      },
+    });
+
+    if (existing) {
+      return this.toView(existing);
+    }
+
+    const provisioned = await this.prisma.$transaction((tx) =>
+      this.provisionWarmupAccount(tx, operatorUserId, leadEmail, dto),
+    );
+
+    return this.createInvitation(provisioned, operatorUserId);
+  }
+
+  async get(id: string): Promise<WarmupAccountView> {
+    const account = await this.prisma.warmupAccount.findFirst({
+      where: { id, isDeleted: false },
+    });
+
+    if (!account) {
+      throw new NotFoundException('Warm-up account not found');
+    }
+
+    return this.toView(account);
+  }
+
+  async list(): Promise<WarmupAccountView[]> {
+    const accounts = await this.prisma.warmupAccount.findMany({
+      orderBy: { createdAt: 'desc' },
+      where: { isDeleted: false },
+    });
+
+    return accounts.map((account) => this.toView(account));
+  }
+
+  private async provisionWarmupAccount(
+    tx: WarmupTransaction,
+    operatorUserId: string,
+    leadEmail: string,
+    dto: CreateWarmupAccountDto,
+  ): Promise<WarmupAccount> {
+    await this.assertOperatorUser(tx, operatorUserId);
+
+    const customerUser = await this.findOrCreateCustomerUser(
+      tx,
+      leadEmail,
+      dto,
+    );
+    const organizationSlug = await this.createUniqueOrganizationSlug(
+      tx,
+      dto.organizationName,
+    );
+    const brandSlug = await this.createUniqueBrandSlug(tx, dto.brandName);
+
+    const organization = await tx.organization.create({
+      data: {
+        accountType: OrganizationCategory.BUSINESS,
+        category: OrganizationCategory.BUSINESS,
+        isProactiveOnboarding: true,
+        label: dto.organizationName.trim(),
+        onboardingCompleted: false,
+        slug: organizationSlug,
+        userId: customerUser.id,
+      },
+      select: { id: true },
+    });
+
+    const brand = await tx.brand.create({
+      data: {
+        description: trimOptional(dto.websiteUrl),
+        isSelected: true,
+        label: dto.brandName.trim(),
+        organizationId: organization.id,
+        slug: brandSlug,
+        text: trimOptional(dto.guidance),
+        userId: customerUser.id,
+      },
+      select: { id: true },
+    });
+
+    await this.ensureOperatorMember(tx, {
+      brandId: brand.id,
+      operatorUserId,
+      organizationId: organization.id,
+    });
+
+    return tx.warmupAccount.create({
+      data: {
+        auditEvents: [
+          createAuditEvent(
+            operatorUserId,
+            'Provisioned warm-up organization and first brand.',
+          ),
+        ] as Prisma.InputJsonValue,
+        brandId: brand.id,
+        brandName: dto.brandName.trim(),
+        customerUserId: customerUser.id,
+        diagnostics: {
+          steps: [
+            createDiagnosticStep('done', 'Created or reused lead user.'),
+            createDiagnosticStep('done', 'Created warm-up organization.'),
+            createDiagnosticStep('done', 'Created first brand workspace.'),
+            createDiagnosticStep('done', 'Granted operator member access.'),
+          ],
+        } as Prisma.InputJsonValue,
+        guidance: trimOptional(dto.guidance),
+        leadEmail,
+        leadFirstName: trimOptional(dto.leadFirstName),
+        leadLastName: trimOptional(dto.leadLastName),
+        operatorUserId,
+        organizationId: organization.id,
+        organizationName: dto.organizationName.trim(),
+        status: WarmupAccountStatus.PROVISIONED,
+        websiteUrl: trimOptional(dto.websiteUrl),
+      },
+    });
+  }
+
+  private async createInvitation(
+    account: WarmupAccount,
+    operatorUserId: string,
+  ): Promise<WarmupAccountView> {
+    if (!account.organizationId) {
+      throw new BadRequestException('Warm-up organization is missing');
+    }
+
+    try {
+      const invitation = await this.invitationService.createInvitation({
+        defaultRoleKey: 'member',
+        email: account.leadEmail,
+        firstName: account.leadFirstName ?? undefined,
+        invitedByUserId: operatorUserId,
+        lastName: account.leadLastName ?? undefined,
+        organizationId: account.organizationId,
+        redirectUrl: `/login?warmupAccountId=${account.id}`,
+        sendEmail: false,
+      });
+
+      const updated = await this.prisma.warmupAccount.update({
+        data: {
+          auditEvents: this.appendAuditEvent(
+            account,
+            operatorUserId,
+            `Created pending invitation ${invitation.id}.`,
+          ) as Prisma.InputJsonValue,
+          diagnostics: this.appendDiagnosticStep(
+            account,
+            'done',
+            'Created pending customer invitation.',
+          ) as Prisma.InputJsonValue,
+          invitationId: invitation.id,
+          status: WarmupAccountStatus.INVITED,
+        },
+        where: { id: account.id },
+      });
+
+      return this.toView(updated);
+    } catch (error) {
+      this.logger.error('Warm-up invitation provisioning failed', {
+        ...this.context,
+        error: getErrorMessage(error),
+        warmupAccountId: account.id,
+      });
+
+      const failed = await this.prisma.warmupAccount.update({
+        data: {
+          auditEvents: this.appendAuditEvent(
+            account,
+            operatorUserId,
+            'Invitation provisioning failed.',
+          ) as Prisma.InputJsonValue,
+          diagnostics: this.appendDiagnosticStep(
+            account,
+            'failed',
+            'Failed to create pending customer invitation.',
+            error,
+          ) as Prisma.InputJsonValue,
+          status: WarmupAccountStatus.FAILED,
+        },
+        where: { id: account.id },
+      });
+
+      return this.toView(failed);
+    }
+  }
+
+  private async assertOperatorUser(
+    tx: WarmupTransaction,
+    operatorUserId: string,
+  ): Promise<void> {
+    const operator = await tx.user.findFirst({
+      select: { id: true },
+      where: { id: operatorUserId, isDeleted: false },
+    });
+
+    if (!operator) {
+      throw new BadRequestException('Operator user not found');
+    }
+  }
+
+  private async findOrCreateCustomerUser(
+    tx: WarmupTransaction,
+    leadEmail: string,
+    dto: CreateWarmupAccountDto,
+  ): Promise<CustomerUser> {
+    const existing = await tx.user.findFirst({
+      select: { id: true },
+      where: { email: leadEmail, isDeleted: false },
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    const name = [
+      trimOptional(dto.leadFirstName),
+      trimOptional(dto.leadLastName),
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return tx.user.create({
+      data: {
+        email: leadEmail,
+        firstName: trimOptional(dto.leadFirstName),
+        handle: createHandle(leadEmail),
+        isInvited: true,
+        lastName: trimOptional(dto.leadLastName),
+        name: name || undefined,
+      },
+      select: { id: true },
+    });
+  }
+
+  private async ensureOperatorMember(
+    tx: WarmupTransaction,
+    input: {
+      brandId: string;
+      operatorUserId: string;
+      organizationId: string;
+    },
+  ): Promise<void> {
+    const existing = await tx.member.findFirst({
+      select: { id: true },
+      where: {
+        isDeleted: false,
+        organizationId: input.organizationId,
+        userId: input.operatorUserId,
+      },
+    });
+
+    if (existing) {
+      await tx.member.update({
+        data: {
+          isActive: true,
+          lastUsedBrandId: input.brandId,
+        },
+        where: { id: existing.id },
+      });
+      return;
+    }
+
+    const role = await this.resolveOperatorRole(tx);
+    await tx.member.create({
+      data: {
+        isActive: true,
+        lastUsedBrandId: input.brandId,
+        organizationId: input.organizationId,
+        roleId: role.id,
+        roleKey: role.key,
+        userId: input.operatorUserId,
+      },
+    });
+  }
+
+  private async resolveOperatorRole(
+    tx: WarmupTransaction,
+  ): Promise<RoleAssignment> {
+    const role = await tx.role.findFirst({
+      select: { id: true, key: true },
+      where: {
+        isDeleted: false,
+        key: { in: ['admin', 'member', 'user'] },
+      },
+      orderBy: [
+        {
+          key: 'asc',
+        },
+      ],
+    });
+
+    if (!role) {
+      throw new BadRequestException('No member role is available');
+    }
+
+    return role;
+  }
+
+  private async createUniqueOrganizationSlug(
+    tx: WarmupTransaction,
+    value: string,
+  ): Promise<string> {
+    const seed = createSlugSeed(value);
+    return this.createUniqueSlug(seed, (slug) =>
+      tx.organization.findFirst({
+        select: { id: true },
+        where: { slug },
+      }),
+    );
+  }
+
+  private async createUniqueBrandSlug(
+    tx: WarmupTransaction,
+    value: string,
+  ): Promise<string> {
+    const seed = createSlugSeed(value);
+    return this.createUniqueSlug(seed, (slug) =>
+      tx.brand.findFirst({
+        select: { id: true },
+        where: { slug },
+      }),
+    );
+  }
+
+  private async createUniqueSlug(
+    seed: string,
+    findExisting: (slug: string) => Promise<{ id: string } | null>,
+  ): Promise<string> {
+    for (let index = 0; index < 10; index += 1) {
+      const candidate = index === 0 ? seed : `${seed}-${index + 1}`;
+      const existing = await findExisting(candidate);
+
+      if (!existing) {
+        return candidate;
+      }
+    }
+
+    return `${seed}-${randomUUID().slice(0, 8)}`;
+  }
+
+  private appendAuditEvent(
+    account: WarmupAccount,
+    actorUserId: string,
+    message: string,
+  ): IWarmupAccountAuditEvent[] {
+    return [
+      ...(account.auditEvents as unknown as IWarmupAccountAuditEvent[]),
+      createAuditEvent(actorUserId, message),
+    ];
+  }
+
+  private appendDiagnosticStep(
+    account: WarmupAccount,
+    status: IWarmupAccountDiagnosticStep['status'],
+    message: string,
+    error?: unknown,
+  ): IWarmupAccountDiagnostics {
+    return {
+      ...(account.diagnostics as unknown as IWarmupAccountDiagnostics),
+      error: error ? getErrorMessage(error) : undefined,
+      steps: [
+        ...((account.diagnostics as unknown as IWarmupAccountDiagnostics)
+          .steps ?? []),
+        createDiagnosticStep(status, message),
+      ],
+    };
+  }
+
+  private toView(account: WarmupAccount): WarmupAccountView {
+    return {
+      _id: account.id,
+      auditEvents: account.auditEvents as unknown as IWarmupAccountAuditEvent[],
+      brandId: account.brandId ?? undefined,
+      brandName: account.brandName,
+      createdAt: account.createdAt.toISOString(),
+      customerUserId: account.customerUserId ?? undefined,
+      diagnostics: account.diagnostics as unknown as IWarmupAccountDiagnostics,
+      guidance: account.guidance ?? undefined,
+      id: account.id,
+      invitationId: account.invitationId ?? undefined,
+      leadEmail: account.leadEmail,
+      leadFirstName: account.leadFirstName ?? undefined,
+      leadLastName: account.leadLastName ?? undefined,
+      operatorUserId: account.operatorUserId,
+      organizationId: account.organizationId ?? undefined,
+      organizationName: account.organizationName,
+      status: account.status,
+      updatedAt: account.updatedAt.toISOString(),
+      websiteUrl: account.websiteUrl ?? undefined,
+    };
+  }
+}

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.ts
@@ -34,7 +34,6 @@ const ACTIVE_WARMUP_STATUSES: WarmupAccountStatus[] = [
   WarmupAccountStatus.PROVISIONING,
   WarmupAccountStatus.PROVISIONED,
   WarmupAccountStatus.INVITED,
-  WarmupAccountStatus.FAILED,
 ];
 
 function normalizeEmail(email: string): string {
@@ -178,7 +177,6 @@ export class AdminWarmupAccountsService {
 
     const brand = await tx.brand.create({
       data: {
-        description: trimOptional(dto.websiteUrl),
         isSelected: true,
         label: dto.brandName.trim(),
         organizationId: organization.id,
@@ -391,17 +389,14 @@ export class AdminWarmupAccountsService {
       select: { id: true, key: true },
       where: {
         isDeleted: false,
-        key: { in: ['admin', 'member', 'user'] },
+        key: 'admin',
       },
-      orderBy: [
-        {
-          key: 'asc',
-        },
-      ],
     });
 
     if (!role) {
-      throw new BadRequestException('No member role is available');
+      throw new BadRequestException(
+        'Admin role is not configured — warm-up provisioning requires an admin role',
+      );
     }
 
     return role;

--- a/apps/server/api/test/setup-unit.ts
+++ b/apps/server/api/test/setup-unit.ts
@@ -58,6 +58,21 @@ vi.mock('@genfeedai/prisma', () => {
     PENDING: 'PENDING',
   } as const;
 
+  const OrganizationCategory = {
+    BUSINESS: 'BUSINESS',
+    PERSONAL: 'PERSONAL',
+  } as const;
+
+  const WarmupAccountStatus = {
+    ARCHIVED: 'ARCHIVED',
+    CLAIMED: 'CLAIMED',
+    DRAFT: 'DRAFT',
+    FAILED: 'FAILED',
+    INVITED: 'INVITED',
+    PROVISIONED: 'PROVISIONED',
+    PROVISIONING: 'PROVISIONING',
+  } as const;
+
   const WorkflowExecutionStatus = {
     CANCELLED: 'CANCELLED',
     COMPLETED: 'COMPLETED',
@@ -81,9 +96,11 @@ vi.mock('@genfeedai/prisma', () => {
 
   return {
     McpApprovalStatus,
+    OrganizationCategory,
     Prisma,
     PrismaClient,
     VoiceProvider,
+    WarmupAccountStatus,
     WorkflowExecutionStatus,
   };
 });

--- a/packages/constants/src/routes.constant.ts
+++ b/packages/constants/src/routes.constant.ts
@@ -13,6 +13,7 @@ export const APP_ROUTES = {
       ROLES: '/admin/administration/roles',
       SUBSCRIPTIONS: '/admin/administration/subscriptions',
       USERS: '/admin/administration/users',
+      WARMUP_ACCOUNTS: '/admin/administration/warmup-accounts',
     },
     AGENT: '/admin/agent',
     AUTOMATION: {

--- a/packages/interfaces/src/admin/index.ts
+++ b/packages/interfaces/src/admin/index.ts
@@ -1,3 +1,4 @@
 export * from './announcements.interface';
 export * from './darkroom.interface';
 export * from './fleet.interface';
+export * from './warmup-accounts.interface';

--- a/packages/interfaces/src/admin/warmup-accounts.interface.ts
+++ b/packages/interfaces/src/admin/warmup-accounts.interface.ts
@@ -1,0 +1,56 @@
+export type IWarmupAccountStatus =
+  | 'DRAFT'
+  | 'PROVISIONING'
+  | 'PROVISIONED'
+  | 'INVITED'
+  | 'FAILED'
+  | 'CLAIMED'
+  | 'ARCHIVED';
+
+export interface IWarmupAccountDiagnosticStep {
+  message: string;
+  status: 'blocked' | 'done' | 'failed' | 'pending';
+  timestamp: string;
+}
+
+export interface IWarmupAccountDiagnostics {
+  error?: string;
+  steps: IWarmupAccountDiagnosticStep[];
+}
+
+export interface IWarmupAccountAuditEvent {
+  actorUserId: string;
+  message: string;
+  timestamp: string;
+}
+
+export interface IWarmupAccountCreateRequest {
+  leadEmail: string;
+  leadFirstName?: string;
+  leadLastName?: string;
+  organizationName: string;
+  brandName: string;
+  websiteUrl?: string;
+  guidance?: string;
+}
+
+export interface IWarmupAccount {
+  id: string;
+  leadEmail: string;
+  leadFirstName?: string;
+  leadLastName?: string;
+  organizationName: string;
+  brandName: string;
+  websiteUrl?: string;
+  guidance?: string;
+  status: IWarmupAccountStatus;
+  operatorUserId: string;
+  customerUserId?: string;
+  organizationId?: string;
+  brandId?: string;
+  invitationId?: string;
+  diagnostics: IWarmupAccountDiagnostics;
+  auditEvents: IWarmupAccountAuditEvent[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -1,6 +1,7 @@
 export * from './admin/announcements.interface';
 export * from './admin/darkroom.interface';
 export * from './admin/fleet.interface';
+export * from './admin/warmup-accounts.interface';
 export * from './ai/agent-campaign.interface';
 export * from './ai/agent-run.interface';
 export * from './ai/agent-strategy.interface';

--- a/packages/prisma/prisma/migrations/20260629182552_add_warmup_accounts/migration.sql
+++ b/packages/prisma/prisma/migrations/20260629182552_add_warmup_accounts/migration.sql
@@ -1,0 +1,51 @@
+-- CreateEnum
+CREATE TYPE "WarmupAccountStatus" AS ENUM ('DRAFT', 'PROVISIONING', 'PROVISIONED', 'INVITED', 'FAILED', 'CLAIMED', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "warmup_accounts" (
+    "id" TEXT NOT NULL,
+    "leadEmail" TEXT NOT NULL,
+    "leadFirstName" TEXT,
+    "leadLastName" TEXT,
+    "organizationName" TEXT NOT NULL,
+    "brandName" TEXT NOT NULL,
+    "websiteUrl" TEXT,
+    "guidance" TEXT,
+    "status" "WarmupAccountStatus" NOT NULL DEFAULT 'DRAFT',
+    "operatorUserId" TEXT NOT NULL,
+    "customerUserId" TEXT,
+    "organizationId" TEXT,
+    "brandId" TEXT,
+    "invitationId" TEXT,
+    "diagnostics" JSONB NOT NULL DEFAULT '{}',
+    "auditEvents" JSONB NOT NULL DEFAULT '[]',
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "warmup_accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "warmup_accounts_lead_status_idx" ON "warmup_accounts"("leadEmail", "isDeleted", "status");
+
+-- CreateIndex
+CREATE INDEX "warmup_accounts_status_created_idx" ON "warmup_accounts"("status", "isDeleted", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "warmup_accounts_org_deleted_idx" ON "warmup_accounts"("organizationId", "isDeleted");
+
+-- AddForeignKey
+ALTER TABLE "warmup_accounts" ADD CONSTRAINT "warmup_accounts_operatorUserId_fkey" FOREIGN KEY ("operatorUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "warmup_accounts" ADD CONSTRAINT "warmup_accounts_customerUserId_fkey" FOREIGN KEY ("customerUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "warmup_accounts" ADD CONSTRAINT "warmup_accounts_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "warmup_accounts" ADD CONSTRAINT "warmup_accounts_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "brands"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "warmup_accounts" ADD CONSTRAINT "warmup_accounts_invitationId_fkey" FOREIGN KEY ("invitationId") REFERENCES "invitations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -485,6 +485,16 @@ enum PlatformRole {
   SUPERADMIN
 }
 
+enum WarmupAccountStatus {
+  DRAFT
+  PROVISIONING
+  PROVISIONED
+  INVITED
+  FAILED
+  CLAIMED
+  ARCHIVED
+}
+
 // ═══════════════════════════════════════════════════════════════
 // CORE IDENTITY — The ownership chain
 // User → Organization → Brand → Member
@@ -592,6 +602,8 @@ model User {
   personaAssignments       Persona[]                 @relation("persona_assigned_members")
   mcpApprovals             McpApproval[]
   brandInterviews          BrandInterview[]
+  warmupAccountsOperated   WarmupAccount[]           @relation("warmup_account_operator")
+  warmupAccountsCustomer   WarmupAccount[]           @relation("warmup_account_customer")
 
   @@index([isDefault])
   @@index([appSource])
@@ -728,6 +740,7 @@ model Organization {
   mcpApprovals                  McpApproval[]
   moodBoards                    MoodBoard[]                    @relation("org_moodboard")
   brandInterviews               BrandInterview[]
+  warmupAccounts                WarmupAccount[]
 
   @@index([isDefault])
   @@index([category])
@@ -854,6 +867,7 @@ model Brand {
   bookmarks                  Bookmark[]
   moodBoard                  MoodBoard?                 @relation("brand_moodboard")
   brandInterviews            BrandInterview[]
+  warmupAccounts             WarmupAccount[]
 
   @@index([isDefault])
   @@index([organizationId, isDeleted, label], map: "brands_org_deleted_label_idx")
@@ -966,6 +980,7 @@ model Invitation {
   acceptedAt       DateTime?
   acceptedByUserId String?
   acceptedByUser   User?        @relation("invitation_accepted_by", fields: [acceptedByUserId], references: [id])
+  warmupAccounts   WarmupAccount[]
   revokedAt        DateTime?
   isDeleted        Boolean      @default(false)
   createdAt        DateTime     @default(now())
@@ -976,6 +991,38 @@ model Invitation {
   @@index([email, isDeleted], map: "invitations_email_deleted_idx")
   @@index([expiresAt, acceptedAt, revokedAt, isDeleted], map: "invitations_expiry_status_idx")
   @@map("invitations")
+}
+
+model WarmupAccount {
+  id               String              @id @default(cuid())
+  leadEmail        String
+  leadFirstName    String?
+  leadLastName     String?
+  organizationName String
+  brandName        String
+  websiteUrl       String?
+  guidance         String?
+  status           WarmupAccountStatus @default(DRAFT)
+  operatorUserId   String
+  operatorUser     User                @relation("warmup_account_operator", fields: [operatorUserId], references: [id])
+  customerUserId   String?
+  customerUser     User?               @relation("warmup_account_customer", fields: [customerUserId], references: [id], onDelete: SetNull)
+  organizationId   String?
+  organization     Organization?       @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  brandId          String?
+  brand            Brand?              @relation(fields: [brandId], references: [id], onDelete: SetNull)
+  invitationId     String?
+  invitation       Invitation?         @relation(fields: [invitationId], references: [id], onDelete: SetNull)
+  diagnostics      Json                @default("{}")
+  auditEvents      Json                @default("[]")
+  isDeleted        Boolean             @default(false)
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
+
+  @@index([leadEmail, isDeleted, status], map: "warmup_accounts_lead_status_idx")
+  @@index([status, isDeleted, createdAt(sort: Desc)], map: "warmup_accounts_status_created_idx")
+  @@index([organizationId, isDeleted], map: "warmup_accounts_org_deleted_idx")
+  @@map("warmup_accounts")
 }
 
 model Role {

--- a/packages/props/admin/warmup-accounts.props.ts
+++ b/packages/props/admin/warmup-accounts.props.ts
@@ -1,0 +1,22 @@
+import type {
+  IWarmupAccount,
+  IWarmupAccountCreateRequest,
+} from '@genfeedai/interfaces';
+
+export interface WarmupAccountFormState extends IWarmupAccountCreateRequest {
+  guidance: string;
+  leadFirstName: string;
+  leadLastName: string;
+  websiteUrl: string;
+}
+
+export interface WarmupAccountsPageProps {
+  defaultTab?: 'create' | 'accounts';
+}
+
+export interface WarmupAccountListProps {
+  accounts: IWarmupAccount[];
+  isLoading: boolean;
+  selectedAccountId?: string;
+  onSelectAccount: (accountId: string) => void;
+}

--- a/packages/serializers/src/attributes/admin/index.ts
+++ b/packages/serializers/src/attributes/admin/index.ts
@@ -14,3 +14,4 @@ export * from '@serializers/attributes/admin/darkroom-pipeline-stats.attributes'
 export * from '@serializers/attributes/admin/darkroom-service-status.attributes';
 export * from '@serializers/attributes/admin/darkroom-upload-dataset-result.attributes';
 export * from '@serializers/attributes/admin/darkroom-voice.attributes';
+export * from '@serializers/attributes/admin/warmup-account.attributes';

--- a/packages/serializers/src/attributes/admin/warmup-account.attributes.ts
+++ b/packages/serializers/src/attributes/admin/warmup-account.attributes.ts
@@ -1,0 +1,21 @@
+import { createEntityAttributes } from '@genfeedai/helpers';
+
+export const warmupAccountAttributes = createEntityAttributes([
+  'leadEmail',
+  'leadFirstName',
+  'leadLastName',
+  'organizationName',
+  'brandName',
+  'websiteUrl',
+  'guidance',
+  'status',
+  'operatorUserId',
+  'customerUserId',
+  'organizationId',
+  'brandId',
+  'invitationId',
+  'diagnostics',
+  'auditEvents',
+  'createdAt',
+  'updatedAt',
+]);

--- a/packages/serializers/src/configs/admin/index.ts
+++ b/packages/serializers/src/configs/admin/index.ts
@@ -14,3 +14,4 @@ export * from '@serializers/configs/admin/darkroom-pipeline-stats.config';
 export * from '@serializers/configs/admin/darkroom-service-status.config';
 export * from '@serializers/configs/admin/darkroom-upload-dataset-result.config';
 export * from '@serializers/configs/admin/darkroom-voice.config';
+export * from '@serializers/configs/admin/warmup-account.config';

--- a/packages/serializers/src/configs/admin/warmup-account.config.ts
+++ b/packages/serializers/src/configs/admin/warmup-account.config.ts
@@ -1,0 +1,7 @@
+import { warmupAccountAttributes } from '@serializers/attributes/admin/warmup-account.attributes';
+import { simpleConfig } from '@serializers/builders';
+
+export const warmupAccountSerializerConfig = simpleConfig(
+  'warmup-account',
+  warmupAccountAttributes,
+);

--- a/packages/serializers/src/server/admin/index.ts
+++ b/packages/serializers/src/server/admin/index.ts
@@ -28,3 +28,4 @@ export * from '@serializers/server/admin/darkroom-upload-dataset-result.serializ
 export { DarkroomUploadDatasetResultSerializer as FleetUploadDatasetResultSerializer } from '@serializers/server/admin/darkroom-upload-dataset-result.serializer';
 export * from '@serializers/server/admin/darkroom-voice.serializer';
 export { DarkroomVoiceSerializer as FleetVoiceSerializer } from '@serializers/server/admin/darkroom-voice.serializer';
+export * from '@serializers/server/admin/warmup-account.serializer';

--- a/packages/serializers/src/server/admin/warmup-account.serializer.ts
+++ b/packages/serializers/src/server/admin/warmup-account.serializer.ts
@@ -1,0 +1,7 @@
+import { buildSerializer } from '@serializers/builders';
+import { warmupAccountSerializerConfig } from '@serializers/configs';
+
+export const { WarmupAccountSerializer } = buildSerializer(
+  'server',
+  warmupAccountSerializerConfig,
+);

--- a/packages/services/admin/warmup-accounts.service.test.ts
+++ b/packages/services/admin/warmup-accounts.service.test.ts
@@ -1,0 +1,113 @@
+import { AdminWarmupAccountsService } from '@services/admin/warmup-accounts.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock('@services/core/json-api', () => ({
+  deserializeCollection: vi.fn(
+    (document: { data: unknown[] }) => document.data,
+  ),
+  deserializeResource: vi.fn((document: { data: unknown }) => {
+    const resource = document.data as
+      | { id?: string; attributes?: Record<string, unknown> }
+      | undefined;
+
+    return {
+      id: resource?.id,
+      ...(resource?.attributes ?? {}),
+    };
+  }),
+}));
+
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    apiEndpoint: 'https://api.genfeed.ai/v1',
+  },
+}));
+
+vi.mock('@services/core/interceptor.service', () => {
+  class MockHTTPBaseService {
+    protected instance = {
+      get: mockGet,
+      post: mockPost,
+    };
+
+    static getBaseServiceInstance<T>(
+      ServiceClass: new (...args: never[]) => T,
+      ...args: never[]
+    ): T {
+      return new ServiceClass(...args);
+    }
+  }
+
+  return { HTTPBaseService: MockHTTPBaseService };
+});
+
+describe('AdminWarmupAccountsService', () => {
+  let service: AdminWarmupAccountsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AdminWarmupAccountsService('test-token');
+  });
+
+  it('deserializes warm-up account collections', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            attributes: {
+              leadEmail: 'lead@example.com',
+              status: 'INVITED',
+            },
+            id: 'warmup-1',
+          },
+        ],
+      },
+    });
+
+    await expect(service.getWarmupAccounts()).resolves.toEqual([
+      {
+        attributes: {
+          leadEmail: 'lead@example.com',
+          status: 'INVITED',
+        },
+        id: 'warmup-1',
+      },
+    ]);
+  });
+
+  it('posts create requests and deserializes the created resource', async () => {
+    mockPost.mockResolvedValue({
+      data: {
+        data: {
+          attributes: {
+            leadEmail: 'founder@example.com',
+            organizationName: 'Founder Co',
+            status: 'INVITED',
+          },
+          id: 'warmup-2',
+        },
+      },
+    });
+
+    await expect(
+      service.createWarmupAccount({
+        brandName: 'Founder Brand',
+        leadEmail: 'founder@example.com',
+        organizationName: 'Founder Co',
+      }),
+    ).resolves.toEqual({
+      id: 'warmup-2',
+      leadEmail: 'founder@example.com',
+      organizationName: 'Founder Co',
+      status: 'INVITED',
+    });
+    expect(mockPost).toHaveBeenCalledWith('', {
+      brandName: 'Founder Brand',
+      leadEmail: 'founder@example.com',
+      organizationName: 'Founder Co',
+    });
+  });
+});

--- a/packages/services/admin/warmup-accounts.service.ts
+++ b/packages/services/admin/warmup-accounts.service.ts
@@ -1,0 +1,44 @@
+import type {
+  IWarmupAccount,
+  IWarmupAccountCreateRequest,
+} from '@genfeedai/interfaces';
+import { EnvironmentService } from '@services/core/environment.service';
+import { HTTPBaseService } from '@services/core/interceptor.service';
+import {
+  deserializeCollection,
+  deserializeResource,
+  type JsonApiResponseDocument,
+} from '@services/core/json-api';
+
+export class AdminWarmupAccountsService extends HTTPBaseService {
+  constructor(token: string) {
+    super(`${EnvironmentService.apiEndpoint}/admin/warmup-accounts`, token);
+  }
+
+  public static getInstance(token: string): AdminWarmupAccountsService {
+    return HTTPBaseService.getBaseServiceInstance(
+      AdminWarmupAccountsService,
+      token,
+    ) as AdminWarmupAccountsService;
+  }
+
+  async createWarmupAccount(
+    data: IWarmupAccountCreateRequest,
+  ): Promise<IWarmupAccount> {
+    const response = await this.instance.post<JsonApiResponseDocument>(
+      '',
+      data,
+    );
+    return deserializeResource<IWarmupAccount>(response.data);
+  }
+
+  async getWarmupAccount(id: string): Promise<IWarmupAccount> {
+    const response = await this.instance.get<JsonApiResponseDocument>(`/${id}`);
+    return deserializeResource<IWarmupAccount>(response.data);
+  }
+
+  async getWarmupAccounts(): Promise<IWarmupAccount[]> {
+    const response = await this.instance.get<JsonApiResponseDocument>('');
+    return deserializeCollection<IWarmupAccount>(response.data);
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Prisma warm-up account lifecycle model, migration, shared interface, and JSON:API serializer.
- Add guarded superadmin API endpoints for list/detail/create with idempotent lead email provisioning and invitation failure diagnostics.
- Add an admin Warm-up accounts page with create/list/detail/progress states and focused unit tests.

## Validation
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bun run --cwd packages/services test admin/warmup-accounts.service.test.ts`
- `bun run --cwd apps/server/api test:file src/endpoints/admin/warmup-accounts/warmup-accounts.service.spec.ts src/endpoints/admin/warmup-accounts/warmup-accounts.controller.spec.ts`
- `bun run --cwd apps/app test app/'(protected)'/admin/administration/warmup-accounts/warmup-accounts-page.test.tsx app/'(protected)'/admin/administration/warmup-accounts/page.test.tsx packages/config/admin-menu-items.config.test.ts`
- `bunx turbo run type-check --filter=@genfeedai/constants --filter=@genfeedai/interfaces --filter=@genfeedai/serializers --filter=@genfeedai/services --filter=@genfeedai/props --filter=@genfeedai/app`
- `bunx turbo run type-check --filter=@genfeedai/app`
- `bun run --cwd apps/server/api build`
- `bun run design:lint`
- `bun run check:ui-guards`
- `git diff --check origin/master..HEAD`
- `git diff --cached --check`
- `git diff --cached --name-only -z | xargs -0 bunx secretlint`

## Notes
- Direct API `tsc --noEmit` is not a usable standalone check in this repo: after bypassing the existing TypeScript 6 `baseUrl` deprecation it reports thousands of existing alias-resolution errors for `@api/*` modules. The supported Nest build path passed instead.
- `design:lint` returned zero errors and existing warnings.
- UI guard required checks passed; advisory raw-button findings are existing debt outside this change.

Closes #904
Refs #801
