### PR TITLE
fix(deploy): keep API health off Swagger startup path

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -279,7 +279,7 @@ jobs:
           # Bound the wait: bare 'aws ecs wait tasks-stopped' polls silently for
           # up to ~10 min then fails opaquely. Poll describe-tasks with a deadline
           # and surface lastStatus / stoppedReason for fast diagnosis.
-          DEADLINE=$((SECONDS + 600))
+          DEADLINE=$((SECONDS + 900))
           while :; do
             STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
               --query 'tasks[0].lastStatus' --output text)
@@ -335,11 +335,9 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
-          # Run the api with BOOT_CHECK=1 as a one-off task: it loads the compiled
-          # entrypoint (catching crash-on-boot like the #711 circular-dep TDZ)
-          # then exits before opening long-lived prod connections. If it can't
-          # load, fail HERE — before any service rolls — so a bad image never
-          # reaches traffic (vs. rolling then circuit-breaker rollback).
+          # Run the api as a one-off task and require localhost /v1/health to
+          # answer. This catches both crash-on-boot failures and "loads but never
+          # binds the port" failures before any service rolls.
           CLUSTER=$(tofu output -raw cluster_name)
           TASK_DEFINITION=$(tofu output -raw boot_smoke_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
@@ -368,7 +366,7 @@ jobs:
                 --query 'tasks[0].stoppedReason' --output text)
               aws ecs stop-task --cluster "$CLUSTER" --task "$TASK_ARN" \
                 --reason "deploy boot-smoke timed out before rollout" >/dev/null || true
-              echo "::error::boot smoke task did not stop within 10m (last status: $STATUS, reason: $REASON)"; exit 1
+              echo "::error::boot smoke task did not stop within 15m (last status: $STATUS, reason: $REASON)"; exit 1
             fi
             echo "  boot smoke task status: $STATUS ($((DEADLINE - SECONDS))s remaining)"
             sleep 6

--- a/apps/server/api/src/endpoints/docs/docs.service.spec.ts
+++ b/apps/server/api/src/endpoints/docs/docs.service.spec.ts
@@ -71,6 +71,43 @@ describe('DocsService', () => {
       expect(result.components?.schemas?.User).toBeDefined();
       expect(result.tags).toHaveLength(1);
     });
+
+    it('should lazily build and cache the OpenAPI document from a factory', () => {
+      const doc = {
+        info: { title: 'Lazy API', version: '1.0.0' },
+        openapi: '3.0.0',
+        paths: {},
+      } as OpenAPIObject;
+      const factory = vi.fn(() => doc);
+
+      service.setOpenApiDocumentFactory(factory);
+
+      expect(service.getOpenApiDocument()).toBe(doc);
+      expect(service.getOpenApiDocument()).toBe(doc);
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear a lazy factory when a document is set directly', () => {
+      const factory = vi.fn(
+        () =>
+          ({
+            info: { title: 'Factory API', version: '1.0.0' },
+            openapi: '3.0.0',
+            paths: {},
+          }) as OpenAPIObject,
+      );
+      const doc = {
+        info: { title: 'Direct API', version: '1.0.0' },
+        openapi: '3.0.0',
+        paths: {},
+      } as OpenAPIObject;
+
+      service.setOpenApiDocumentFactory(factory);
+      service.setOpenApiDocument(doc);
+
+      expect(service.getOpenApiDocument()).toBe(doc);
+      expect(factory).not.toHaveBeenCalled();
+    });
   });
 
   describe('setGptActionsSpec / getGptActionsSpec', () => {

--- a/apps/server/api/src/endpoints/docs/docs.service.ts
+++ b/apps/server/api/src/endpoints/docs/docs.service.ts
@@ -3,11 +3,19 @@ import type { OpenAPIObject } from '@nestjs/swagger';
 
 @Injectable()
 export class DocsService {
-  private openApiDocument: OpenAPIObject | Record<string, unknown> = {};
+  private openApiDocument: OpenAPIObject | Record<string, unknown> | null =
+    null;
+  private openApiDocumentFactory: (() => OpenAPIObject) | null = null;
   private gptActionsSpec: Record<string, unknown> = {};
 
   setOpenApiDocument(doc: OpenAPIObject): void {
     this.openApiDocument = doc;
+    this.openApiDocumentFactory = null;
+  }
+
+  setOpenApiDocumentFactory(factory: () => OpenAPIObject): void {
+    this.openApiDocument = null;
+    this.openApiDocumentFactory = factory;
   }
 
   setGptActionsSpec(spec: Record<string, unknown>): void {
@@ -15,7 +23,16 @@ export class DocsService {
   }
 
   getOpenApiDocument(): OpenAPIObject | Record<string, unknown> {
-    return this.openApiDocument;
+    if (this.openApiDocument) {
+      return this.openApiDocument;
+    }
+
+    if (this.openApiDocumentFactory) {
+      this.openApiDocument = this.openApiDocumentFactory();
+      return this.openApiDocument;
+    }
+
+    return {};
   }
 
   getGptActionsSpec(): Record<string, unknown> {

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -35,11 +35,7 @@ import {
 } from '@libs/redis/redis-connection.utils';
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
-import {
-  DocumentBuilder,
-  type OpenAPIObject,
-  SwaggerModule,
-} from '@nestjs/swagger';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Queue } from 'bullmq';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
@@ -82,18 +78,10 @@ async function main() {
       .addServer('/v1')
       .build();
 
-    let document: OpenAPIObject | null = null;
-    try {
-      document = SwaggerModule.createDocument(app, options);
-    } catch (swaggerError) {
-      logger.error('Swagger document generation failed', swaggerError);
-    }
-
     const docsService = app.get(DocsService);
-    if (document) {
-      docsService.setOpenApiDocument(document);
-    }
-
+    docsService.setOpenApiDocumentFactory(() =>
+      SwaggerModule.createDocument(app, options),
+    );
     docsService.setGptActionsSpec(gptActionsSpec);
 
     app.enableCors(

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -59,8 +59,8 @@ locals {
   # at 0. Core set (api + its boot-required deps files/mcp/notifications, +
   # workers) runs at 1.
   services = {
-    api           = { filter = "@genfeedai/api", port = 3010, cpu = 1024, mem = 2048, alb = true, health_grace = 120, desired = 1 }
-    workers       = { filter = "@genfeedai/workers", port = 3013, cpu = 512, mem = 2048, alb = false, health_grace = 60, desired = 1 }
+    api           = { filter = "@genfeedai/api", port = 3010, cpu = 1024, mem = 2048, alb = true, health_grace = 600, desired = 1 }
+    workers       = { filter = "@genfeedai/workers", port = 3013, cpu = 512, mem = 2048, alb = false, health_grace = 600, desired = 1 }
     files         = { filter = "@genfeedai/files", port = 3012, cpu = 256, mem = 512, alb = false, health_grace = 60, desired = 1 }
     mcp           = { filter = "@genfeedai/mcp", port = 3014, cpu = 256, mem = 512, alb = true, health_grace = 60, desired = 1 }
     notifications = { filter = "@genfeedai/notifications", port = 3011, cpu = 256, mem = 512, alb = true, health_grace = 60, desired = 1 }

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -127,10 +127,9 @@ resource "aws_ecs_task_definition" "workflow_backfill" {
 }
 
 # ── One-off boot smoke (run via `aws ecs run-task` BEFORE services roll) ─
-# Boots the compiled api entrypoint with BOOT_CHECK=1 so module evaluation catches
-# crash-on-boot bugs like the circular-dependency TDZ in #711, then exits before
-# opening long-lived production connections. If the new image can't load, the
-# deploy fails HERE, before any service rolls.
+# Starts the production api command and requires localhost /v1/health to answer.
+# This catches both crash-on-boot bugs and "loads but never binds the port"
+# failures before any service rolls.
 resource "aws_cloudwatch_log_group" "boot_smoke" {
   name              = "/ecs/${local.name_prefix}/boot-smoke"
   retention_in_days = 30
@@ -149,12 +148,15 @@ resource "aws_ecs_task_definition" "boot_smoke" {
     name      = "boot-smoke"
     image     = local.image
     essential = true
-    command   = ["bun", "--filter", local.services.api.filter, "start:prod"]
-    secrets   = local.task_secrets
+    command = [
+      "bash",
+      "-lc",
+      "set -euo pipefail; bun --filter ${local.services.api.filter} start:prod & pid=$!; trap 'kill $pid 2>/dev/null || true' EXIT; for i in $(seq 1 48); do if ! kill -0 $pid 2>/dev/null; then wait $pid; exit $?; fi; if curl -fsS http://127.0.0.1:${local.services.api.port}/v1/health >/dev/null; then echo 'Boot smoke OK — API served /v1/health.'; exit 0; fi; sleep 10; done; echo 'API did not serve /v1/health within boot-smoke window' >&2; exit 1",
+    ]
+    secrets = local.task_secrets
     environment = concat(local.internal_env, [
       { name = "PORT", value = tostring(local.services.api.port) },
       { name = "SERVICE_NAME", value = "api" },
-      { name = "BOOT_CHECK", value = "1" },
     ])
     logConfiguration = {
       logDriver = "awslogs"


### PR DESCRIPTION
## Summary
- defer OpenAPI/Swagger document generation until `/v1/openapi.json` is requested, so API startup can bind `/v1/health` before docs graph traversal
- make the ECS boot-smoke task start the production API command and require localhost `/v1/health` before service rollout
- widen API/workers ECS startup grace to 600s to avoid premature kills during production bootstrap

## Failure evidence
- Deploy run 28385127702 failed at `Wait for services stable` on SHA 960a612b8913cafdd793438e2c881e84c76b2acc
- ECS rolled API/workers back to June 25 task definitions (`fcfa441...` image)
- Standalone `api:19` task never opened port 3010; internal Fargate curl to `http://10.0.11.138:3010/v1/health` returned `Connection refused` for several minutes
- API logs stopped after Redis/BullMQ startup warnings, before `app.listen()`

## Verification
- `bunx vitest run src/endpoints/docs/docs.service.spec.ts src/endpoints/docs/docs.controller.spec.ts --config vitest.config.ts`
- `bunx biome check apps/server/api/src/endpoints/docs/docs.service.ts apps/server/api/src/endpoints/docs/docs.service.spec.ts apps/server/api/src/main.ts .github/workflows/deploy-ecs.yml`
- `tofu fmt -check infra/terraform/genfeed-prod/services.tf infra/terraform/genfeed-prod/locals.tf`
- `git diff --check`
- `bun --filter @genfeedai/api build`
- `BOOT_CHECK=1 timeout 120 node apps/server/dist/apps/api/main.js`

No local gitleaks run.