### PR TITLE
refactor(serializers): remove unused CredentialFullSerializer

### DIFF
--- a/packages/serializers/__tests__/all-attributes.test.ts
+++ b/packages/serializers/__tests__/all-attributes.test.ts
@@ -103,7 +103,6 @@ import { tagAttributes } from '@serializers/attributes/management/tag.attributes
 import { brandAttributes } from '@serializers/attributes/organizations/brand.attributes';
 import {
   credentialAttributes,
-  credentialFullAttributes,
   credentialInstagramAttributes,
   credentialOAuthAttributes,
 } from '@serializers/attributes/organizations/credential.attributes';
@@ -436,15 +435,6 @@ describe('Serializer Attributes', () => {
       expect(Array.isArray(organizationSettingsAttributes)).toBe(true);
       expect(organizationSettingsAttributes.length).toBeGreaterThan(0);
       for (const attr of organizationSettingsAttributes)
-        expect(typeof attr).toBe('string');
-    });
-  });
-
-  describe('credentialFullAttributes', () => {
-    it('should be a non-empty array of strings', () => {
-      expect(Array.isArray(credentialFullAttributes)).toBe(true);
-      expect(credentialFullAttributes.length).toBeGreaterThan(0);
-      for (const attr of credentialFullAttributes)
         expect(typeof attr).toBe('string');
     });
   });

--- a/packages/serializers/__tests__/attributes.test.ts
+++ b/packages/serializers/__tests__/attributes.test.ts
@@ -103,7 +103,6 @@ import { tagAttributes } from '@serializers/attributes/management/tag.attributes
 import { brandAttributes } from '@serializers/attributes/organizations/brand.attributes';
 import {
   credentialAttributes,
-  credentialFullAttributes,
   credentialInstagramAttributes,
   credentialOAuthAttributes,
 } from '@serializers/attributes/organizations/credential.attributes';
@@ -661,21 +660,6 @@ describe('Serializer Attributes', () => {
     it('should not contain duplicates', () => {
       const unique = new Set(organizationSettingsAttributes);
       expect(unique.size).toBe(organizationSettingsAttributes.length);
-    });
-  });
-
-  describe('credentialFullAttributes', () => {
-    it('should be a non-empty array of strings', () => {
-      expect(Array.isArray(credentialFullAttributes)).toBe(true);
-      expect(credentialFullAttributes.length).toBeGreaterThan(0);
-      for (const attr of credentialFullAttributes) {
-        expect(typeof attr).toBe('string');
-      }
-    });
-
-    it('should not contain duplicates', () => {
-      const unique = new Set(credentialFullAttributes);
-      expect(unique.size).toBe(credentialFullAttributes.length);
     });
   });
 

--- a/packages/serializers/__tests__/server-serializers.test.ts
+++ b/packages/serializers/__tests__/server-serializers.test.ts
@@ -98,7 +98,6 @@ import { PromptSerializer } from '@serializers/server/management/prompt.serializ
 import { TagSerializer } from '@serializers/server/management/tag.serializer';
 import { BrandSerializer } from '@serializers/server/organizations/brand.serializer';
 import {
-  CredentialFullSerializer,
   CredentialInstagramPagesSerializer,
   CredentialOAuthSerializer,
   CredentialSerializer,
@@ -447,16 +446,6 @@ describe('Server Serializers', () => {
 
     it('should have a serialize method', () => {
       expect(typeof CredentialSerializer.serialize).toBe('function');
-    });
-  });
-
-  describe('CredentialFullSerializer', () => {
-    it('should be a function (serializer)', () => {
-      expect(typeof CredentialFullSerializer).toBe('object');
-    });
-
-    it('should have a serialize method', () => {
-      expect(typeof CredentialFullSerializer.serialize).toBe('function');
     });
   });
 

--- a/packages/serializers/src/attributes/organizations/credential.attributes.ts
+++ b/packages/serializers/src/attributes/organizations/credential.attributes.ts
@@ -1,14 +1,5 @@
 import { createEntityAttributes } from '@genfeedai/helpers';
 
-const sensitiveFields = [
-  'oauthToken',
-  'oauthTokenSecret',
-  'accessToken',
-  'accessTokenSecret',
-  'refreshToken',
-  'refreshTokenExpiry',
-];
-
 const publicFields = [
   'organization',
   'brand',
@@ -22,11 +13,6 @@ const publicFields = [
   'description',
   'isConnected',
 ];
-
-export const credentialFullAttributes = createEntityAttributes([
-  ...publicFields,
-  ...sensitiveFields,
-]);
 
 export const credentialAttributes = createEntityAttributes(publicFields);
 

--- a/packages/serializers/src/configs/organizations/credential.config.ts
+++ b/packages/serializers/src/configs/organizations/credential.config.ts
@@ -1,6 +1,5 @@
 import {
   credentialAttributes,
-  credentialFullAttributes,
   credentialInstagramAttributes,
   credentialOAuthAttributes,
 } from '@serializers/attributes/organizations/credential.attributes';
@@ -22,12 +21,6 @@ const baseRelationships = {
 export const credentialSerializerConfig = {
   attributes: credentialAttributes,
   type: 'credential',
-  ...baseRelationships,
-};
-
-export const credentialFullSerializerConfig = {
-  attributes: credentialFullAttributes,
-  type: 'credential-full',
   ...baseRelationships,
 };
 

--- a/packages/serializers/src/server/organizations/credential.serializer.ts
+++ b/packages/serializers/src/server/organizations/credential.serializer.ts
@@ -1,6 +1,5 @@
 import { buildSerializer } from '@serializers/builders';
 import {
-  credentialFullSerializerConfig,
   credentialInstagramPagesSerializerConfig,
   credentialOAuthSerializerConfig,
   credentialSerializerConfig,
@@ -10,12 +9,6 @@ import {
 export const { CredentialSerializer } = buildSerializer(
   'server',
   credentialSerializerConfig,
-);
-
-/** Includes sensitive data */
-export const { CredentialFullSerializer } = buildSerializer(
-  'server',
-  credentialFullSerializerConfig,
 );
 
 export const { CredentialOAuthSerializer } = buildSerializer(


### PR DESCRIPTION
## What

Removes the unused `CredentialFullSerializer` and its entire supporting chain from `@genfeedai/serializers`.

`CredentialFullSerializer` serialized **all** Credential secret fields — `accessToken`, `refreshToken`, `oauthToken`, `oauthTokenSecret`, `accessTokenSecret` (plus `refreshTokenExpiry`). It was exported from the serializers barrel but referenced only in unit tests. That made it a latent footgun: one stray import in a controller and it would leak plaintext tokens in an API response.

The default `CredentialSerializer` used by every controller already excludes these fields, so this is **hardening, not a behavior fix** — no production code path changes.

## Removed

- `CredentialFullSerializer` — `packages/serializers/src/server/organizations/credential.serializer.ts`
- `credentialFullSerializerConfig` (`type: 'credential-full'`) — `packages/serializers/src/configs/organizations/credential.config.ts`
- `credentialFullAttributes` + the now-unused `sensitiveFields` const — `packages/serializers/src/attributes/organizations/credential.attributes.ts`
- Corresponding `describe` blocks + imports in the three serializer test files (`server-serializers.test.ts`, `attributes.test.ts`, `all-attributes.test.ts`)

All serializer barrels are `export *`, so no named re-exports needed updating. A full-monorepo grep confirms zero remaining references to any removed symbol, and `sensitiveFields` had no other consumer.

## Verification

- `bunx turbo run type-check --filter=@genfeedai/serializers` ✅
- `bunx turbo run lint --filter=@genfeedai/serializers` ✅
- `bunx biome check` on all 6 touched files ✅
- `bun run test --filter=@genfeedai/serializers` → **734 passed** (8 files) ✅

Pure deletion: 6 files, −64 lines, 0 additions.