### PR TITLE
feat(api): add public media provenance routes

### DIFF
--- a/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
@@ -9,7 +9,10 @@ import { Test, type TestingModule } from '@nestjs/testing';
 
 const makeVideo = (overrides: Record<string, unknown> = {}) => ({
   _id: 'video-1',
-  category: IngredientCategory.VIDEO,
+  // Prisma returns IngredientCategory as its UPPERCASE stored form ('VIDEO'),
+  // not the JS enum lowercase value ('video'). The mock reflects what the DB layer
+  // actually returns so the guard comparison in buildPackageFromVideoQuery is valid.
+  category: 'VIDEO',
   cdnUrl: 'https://cdn.example.com/video-1.mp4',
   fileSize: 2048,
   generationCompletedAt: new Date('2026-06-20T10:00:00.000Z'),
@@ -136,7 +139,9 @@ describe('VideoProvenanceService', () => {
     expect(pkg.assetId).toBe('video-1');
     expect(videosService.findOne).toHaveBeenCalledWith({
       _id: 'video-1',
-      category: IngredientCategory.VIDEO,
+      // CategoryPrismaUtil.toIngredientCategory converts the JS enum ('video') to
+      // the Prisma UPPERCASE form ('VIDEO') required by findFirst WHERE clauses.
+      category: 'VIDEO',
       isDeleted: false,
       scope: 'public',
       status: 'generated',

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
@@ -126,6 +126,32 @@ describe('VideoProvenanceService', () => {
     });
   });
 
+  it('builds public provenance only from generated public videos', async () => {
+    videosService.findOne.mockResolvedValue(makeVideo());
+    metadataService.findOne.mockResolvedValue(null);
+    captionsService.find.mockResolvedValue([{ content: 'Public transcript' }]);
+
+    const pkg = await service.buildPublicProvenance('video-1');
+
+    expect(pkg.assetId).toBe('video-1');
+    expect(videosService.findOne).toHaveBeenCalledWith({
+      _id: 'video-1',
+      category: IngredientCategory.VIDEO,
+      isDeleted: false,
+      scope: 'public',
+      status: 'generated',
+    });
+    expect(pkg.transcriptSidecar.segmentCount).toBe(1);
+  });
+
+  it('does not build public provenance for non-public videos', async () => {
+    videosService.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.buildPublicProvenance('video-1'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
   it('throws NotFound when the video does not exist', async () => {
     videosService.findOne.mockResolvedValue(null);
 

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.spec.ts
@@ -139,12 +139,13 @@ describe('VideoProvenanceService', () => {
     expect(pkg.assetId).toBe('video-1');
     expect(videosService.findOne).toHaveBeenCalledWith({
       _id: 'video-1',
-      // CategoryPrismaUtil.toIngredientCategory converts the JS enum ('video') to
-      // the Prisma UPPERCASE form ('VIDEO') required by findFirst WHERE clauses.
+      // All three enum fields are converted to the Prisma UPPERCASE form by
+      // CategoryPrismaUtil before being passed to findFirst. The JS enum values
+      // are lowercase ('video', 'public', 'generated'); Prisma stores UPPERCASE.
       category: 'VIDEO',
       isDeleted: false,
-      scope: 'public',
-      status: 'generated',
+      scope: 'PUBLIC',
+      status: 'GENERATED',
     });
     expect(pkg.transcriptSidecar.segmentCount).toBe(1);
   });

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.ts
@@ -1,6 +1,7 @@
 import { CaptionsService } from '@api/collections/captions/services/captions.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import {
   AssetScope,
   IngredientCategory,
@@ -87,7 +88,13 @@ export class VideoProvenanceService {
 
     return this.buildPackageFromVideoQuery(videoId, {
       _id: videoId,
-      category: IngredientCategory.VIDEO,
+      // buildWhereFromParams passes the value directly to Prisma which stores
+      // IngredientCategory as uppercase (e.g. 'VIDEO'). The JS enum value is
+      // lowercase ('video'), so we convert via CategoryPrismaUtil to avoid a
+      // silent mismatch that would cause findOne to return null on valid records.
+      category: CategoryPrismaUtil.toIngredientCategory(
+        IngredientCategory.VIDEO,
+      ),
       isDeleted: false,
       scope: AssetScope.PUBLIC,
       status: IngredientStatus.GENERATED,
@@ -102,7 +109,19 @@ export class VideoProvenanceService {
       where,
     )) as unknown as IVideoProvenanceRecord | null;
 
-    if (!video || video.category !== IngredientCategory.VIDEO) {
+    // Prisma returns IngredientCategory as its UPPERCASE stored form (e.g. 'VIDEO'),
+    // while IngredientCategory.VIDEO in the JS enum is lowercase ('video').
+    // Compare against the Prisma form to avoid rejecting valid video records.
+    // Only reject when the category field is explicitly present AND is not VIDEO —
+    // a missing category is already ruled out by the WHERE clause in the callers
+    // that filter by category, but we keep the null-check for defensive coverage.
+    const prismaVideoCategory = CategoryPrismaUtil.toIngredientCategory(
+      IngredientCategory.VIDEO,
+    );
+    if (
+      !video ||
+      (video.category !== undefined && video.category !== prismaVideoCategory)
+    ) {
       throw new NotFoundException(
         `${this.constructorName}: video ${videoId} not found`,
       );

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.ts
@@ -1,7 +1,11 @@
 import { CaptionsService } from '@api/collections/captions/services/captions.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
-import { IngredientCategory } from '@genfeedai/enums';
+import {
+  AssetScope,
+  IngredientCategory,
+  IngredientStatus,
+} from '@genfeedai/enums';
 import { buildMediaProvenancePackage } from '@genfeedai/helpers';
 import type {
   IMediaProvenanceInput,
@@ -71,6 +75,29 @@ export class VideoProvenanceService {
       isDeleted: false,
     };
 
+    return this.buildPackageFromVideoQuery(videoId, where);
+  }
+
+  async buildPublicProvenance(
+    videoId: string,
+  ): Promise<IMediaProvenancePackage> {
+    this.loggerService.debug(`${this.constructorName} buildPublicProvenance`, {
+      videoId,
+    });
+
+    return this.buildPackageFromVideoQuery(videoId, {
+      _id: videoId,
+      category: IngredientCategory.VIDEO,
+      isDeleted: false,
+      scope: AssetScope.PUBLIC,
+      status: IngredientStatus.GENERATED,
+    });
+  }
+
+  private async buildPackageFromVideoQuery(
+    videoId: string,
+    where: Record<string, unknown>,
+  ): Promise<IMediaProvenancePackage> {
     const video = (await this.videosService.findOne(
       where,
     )) as unknown as IVideoProvenanceRecord | null;

--- a/apps/server/api/src/collections/videos/services/video-provenance.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-provenance.service.ts
@@ -96,8 +96,10 @@ export class VideoProvenanceService {
         IngredientCategory.VIDEO,
       ),
       isDeleted: false,
-      scope: AssetScope.PUBLIC,
-      status: IngredientStatus.GENERATED,
+      // scope and status are also Prisma enums stored as UPPERCASE. Convert from
+      // the lowercase JS enum values to avoid the same silent WHERE mismatch.
+      scope: CategoryPrismaUtil.toAssetScope(AssetScope.PUBLIC),
+      status: CategoryPrismaUtil.toIngredientStatus(IngredientStatus.GENERATED),
     });
   }
 

--- a/apps/server/api/src/endpoints/public/controllers/media/public-media.controller.spec.ts
+++ b/apps/server/api/src/endpoints/public/controllers/media/public-media.controller.spec.ts
@@ -1,0 +1,108 @@
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  returnNotFound: vi.fn((type, id) => {
+    const { HttpException, HttpStatus } = require('@nestjs/common');
+    throw new HttpException(
+      { detail: `${type} ${id} doesn't exist`, title: `${type} not found` },
+      HttpStatus.NOT_FOUND,
+    );
+  }),
+}));
+vi.mock('@api/endpoints/public/services/public-media.service', () => ({
+  PublicMediaService: class {},
+}));
+
+import { PublicMediaController } from '@api/endpoints/public/controllers/media/public-media.controller';
+import { PublicMediaService } from '@api/endpoints/public/services/public-media.service';
+import type {
+  IMediaProvenanceManifest,
+  IPublicMediaRouteReference,
+} from '@genfeedai/interfaces';
+import { HttpException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+const assetId = 'cvideo123456789';
+
+const routeReference = {
+  assetId,
+  canonicalUrl: 'https://cdn.example.com/videos/cvideo123456789.mp4',
+  kind: 'video',
+  manifestFilename: 'cvideo123456789.manifest.json',
+  manifestPath: `/public/media/${assetId}/manifest.json`,
+  mediaPath: `/public/videos/${assetId}/video.mp4`,
+  provenancePath: `/public/media/${assetId}`,
+  publicPagePath: `/public/videos/${assetId}`,
+  transcriptFilename: 'cvideo123456789.transcript.vtt',
+  transcriptPath: `/public/media/${assetId}/transcript.vtt`,
+} satisfies IPublicMediaRouteReference;
+
+const manifest = {
+  assetId,
+  canonicalUrl: 'https://cdn.example.com/videos/cvideo123456789.mp4',
+  kind: 'video',
+} as IMediaProvenanceManifest;
+
+describe('PublicMediaController', () => {
+  let controller: PublicMediaController;
+  let publicMediaService: {
+    getManifest: ReturnType<typeof vi.fn>;
+    getRouteReference: ReturnType<typeof vi.fn>;
+    getTranscriptVtt: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    publicMediaService = {
+      getManifest: vi.fn().mockResolvedValue(manifest),
+      getRouteReference: vi.fn().mockResolvedValue(routeReference),
+      getTranscriptVtt: vi.fn().mockResolvedValue('WEBVTT\n'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PublicMediaController],
+      providers: [
+        {
+          provide: PublicMediaService,
+          useValue: publicMediaService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<PublicMediaController>(PublicMediaController);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns media route references in a data envelope', async () => {
+    await expect(controller.resolveMedia(assetId)).resolves.toEqual({
+      data: routeReference,
+    });
+    expect(publicMediaService.getRouteReference).toHaveBeenCalledWith(assetId);
+  });
+
+  it('returns the raw manifest artifact', async () => {
+    await expect(controller.getManifest(assetId)).resolves.toBe(manifest);
+    expect(publicMediaService.getManifest).toHaveBeenCalledWith(assetId);
+  });
+
+  it('returns the raw WebVTT transcript artifact', async () => {
+    await expect(controller.getTranscript(assetId)).resolves.toBe('WEBVTT\n');
+    expect(publicMediaService.getTranscriptVtt).toHaveBeenCalledWith(assetId);
+  });
+
+  it('rejects invalid media ids before resolving route references', async () => {
+    await expect(controller.resolveMedia('not-an-id')).rejects.toThrow(
+      HttpException,
+    );
+    expect(publicMediaService.getRouteReference).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid media ids before returning artifacts', async () => {
+    await expect(controller.getManifest('not-an-id')).rejects.toThrow(
+      HttpException,
+    );
+    await expect(controller.getTranscript('not-an-id')).rejects.toThrow(
+      HttpException,
+    );
+    expect(publicMediaService.getManifest).not.toHaveBeenCalled();
+    expect(publicMediaService.getTranscriptVtt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/endpoints/public/controllers/media/public-media.controller.ts
+++ b/apps/server/api/src/endpoints/public/controllers/media/public-media.controller.ts
@@ -1,0 +1,70 @@
+import { PublicMediaService } from '@api/endpoints/public/services/public-media.service';
+import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { returnNotFound } from '@api/helpers/utils/response/response.util';
+import { isEntityId } from '@api/helpers/validation/entity-id.validator';
+import type {
+  IMediaProvenanceManifest,
+  IPublicMediaRouteReference,
+} from '@genfeedai/interfaces';
+import { Public } from '@libs/decorators/public.decorator';
+import { Controller, Get, Header, Param } from '@nestjs/common';
+
+@AutoSwagger()
+@Public()
+@Controller('public/media')
+export class PublicMediaController {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(private readonly publicMediaService: PublicMediaService) {}
+
+  @Get(':assetId')
+  @Cache({
+    keyGenerator: (req) => `public:media:${req.params?.assetId ?? 'unknown'}`,
+    tags: ['media', 'public'],
+    ttl: 1800,
+  })
+  async resolveMedia(
+    @Param('assetId') assetId: string,
+  ): Promise<{ data: IPublicMediaRouteReference }> {
+    if (!isEntityId(assetId)) {
+      return returnNotFound(this.constructorName, assetId);
+    }
+
+    return { data: await this.publicMediaService.getRouteReference(assetId) };
+  }
+
+  @Get(':assetId/manifest.json')
+  @Header('Content-Type', 'application/json; charset=utf-8')
+  @Cache({
+    keyGenerator: (req) =>
+      `public:media:${req.params?.assetId ?? 'unknown'}:manifest`,
+    tags: ['media', 'public'],
+    ttl: 1800,
+  })
+  async getManifest(
+    @Param('assetId') assetId: string,
+  ): Promise<IMediaProvenanceManifest> {
+    if (!isEntityId(assetId)) {
+      return returnNotFound(this.constructorName, assetId);
+    }
+
+    return this.publicMediaService.getManifest(assetId);
+  }
+
+  @Get(':assetId/transcript.vtt')
+  @Header('Content-Type', 'text/vtt; charset=utf-8')
+  @Cache({
+    keyGenerator: (req) =>
+      `public:media:${req.params?.assetId ?? 'unknown'}:transcript`,
+    tags: ['media', 'public'],
+    ttl: 1800,
+  })
+  async getTranscript(@Param('assetId') assetId: string): Promise<string> {
+    if (!isEntityId(assetId)) {
+      return returnNotFound(this.constructorName, assetId);
+    }
+
+    return this.publicMediaService.getTranscriptVtt(assetId);
+  }
+}

--- a/apps/server/api/src/endpoints/public/public.module.ts
+++ b/apps/server/api/src/endpoints/public/public.module.ts
@@ -9,10 +9,12 @@ import { VideosModule } from '@api/collections/videos/videos.module';
 import { PublicArticlesController } from '@api/endpoints/public/controllers/articles/public.articles.controller';
 import { PublicBrandsController } from '@api/endpoints/public/controllers/brands/public.brands.controller';
 import { PublicImagesController } from '@api/endpoints/public/controllers/images/public.images.controller';
+import { PublicMediaController } from '@api/endpoints/public/controllers/media/public-media.controller';
 import { PublicMusicsController } from '@api/endpoints/public/controllers/musics/public.musics.controller';
 import { PublicPostsController } from '@api/endpoints/public/controllers/posts/public.posts.controller';
 import { PublicRSSController } from '@api/endpoints/public/controllers/rss/rss.controller';
 import { PublicVideosController } from '@api/endpoints/public/controllers/videos/public.videos.controller';
+import { PublicMediaService } from '@api/endpoints/public/services/public-media.service';
 import { RssService } from '@api/endpoints/public/services/rss.service';
 import { FilesClientModule } from '@api/services/files-microservice/client/files-client.module';
 import { forwardRef, Module } from '@nestjs/common';
@@ -22,6 +24,7 @@ import { forwardRef, Module } from '@nestjs/common';
     PublicArticlesController,
     PublicBrandsController,
     PublicImagesController,
+    PublicMediaController,
     PublicMusicsController,
     PublicPostsController,
     PublicRSSController,
@@ -39,6 +42,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => PostsModule),
     forwardRef(() => VideosModule),
   ],
-  providers: [RssService],
+  providers: [PublicMediaService, RssService],
 })
 export class PublicModule {}

--- a/apps/server/api/src/endpoints/public/services/public-media.service.spec.ts
+++ b/apps/server/api/src/endpoints/public/services/public-media.service.spec.ts
@@ -1,0 +1,72 @@
+import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
+import { PublicMediaService } from '@api/endpoints/public/services/public-media.service';
+import type { IMediaProvenancePackage } from '@genfeedai/interfaces';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+const mediaPackage = {
+  assetId: 'cvideo123456789',
+  manifest: {
+    assetId: 'cvideo123456789',
+    canonicalUrl: 'https://cdn.example.com/videos/cvideo123456789.mp4',
+    kind: 'video',
+  },
+  manifestFilename: 'cvideo123456789.manifest.json',
+  transcriptSidecar: {
+    filename: 'cvideo123456789.transcript.vtt',
+    vtt: 'WEBVTT\n\n00:00.000 --> 00:01.000\nHello\n',
+  },
+} as unknown as IMediaProvenancePackage;
+
+describe('PublicMediaService', () => {
+  let service: PublicMediaService;
+  let videoProvenanceService: {
+    buildPublicProvenance: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    videoProvenanceService = {
+      buildPublicProvenance: vi.fn().mockResolvedValue(mediaPackage),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PublicMediaService,
+        {
+          provide: VideoProvenanceService,
+          useValue: videoProvenanceService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PublicMediaService>(PublicMediaService);
+  });
+
+  it('builds canonical public route references for a media asset', async () => {
+    const result = await service.getRouteReference('cvideo123456789');
+
+    expect(result).toEqual({
+      assetId: 'cvideo123456789',
+      canonicalUrl: 'https://cdn.example.com/videos/cvideo123456789.mp4',
+      kind: 'video',
+      manifestFilename: 'cvideo123456789.manifest.json',
+      manifestPath: '/public/media/cvideo123456789/manifest.json',
+      mediaPath: '/public/videos/cvideo123456789/video.mp4',
+      provenancePath: '/public/media/cvideo123456789',
+      publicPagePath: '/public/videos/cvideo123456789',
+      transcriptFilename: 'cvideo123456789.transcript.vtt',
+      transcriptPath: '/public/media/cvideo123456789/transcript.vtt',
+    });
+  });
+
+  it('returns the raw manifest for the manifest route', async () => {
+    await expect(service.getManifest('cvideo123456789')).resolves.toBe(
+      mediaPackage.manifest,
+    );
+  });
+
+  it('returns the raw WebVTT transcript for the transcript route', async () => {
+    await expect(service.getTranscriptVtt('cvideo123456789')).resolves.toBe(
+      mediaPackage.transcriptSidecar.vtt,
+    );
+  });
+});

--- a/apps/server/api/src/endpoints/public/services/public-media.service.ts
+++ b/apps/server/api/src/endpoints/public/services/public-media.service.ts
@@ -1,0 +1,53 @@
+import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
+import type {
+  IMediaProvenanceManifest,
+  IPublicMediaRouteReference,
+} from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+const publicMediaPath = (assetId: string): string => `/public/media/${assetId}`;
+
+@Injectable()
+export class PublicMediaService {
+  constructor(
+    private readonly videoProvenanceService: VideoProvenanceService,
+  ) {}
+
+  async getRouteReference(
+    assetId: string,
+  ): Promise<IPublicMediaRouteReference> {
+    const mediaPackage =
+      await this.videoProvenanceService.buildPublicProvenance(assetId);
+    const basePath = publicMediaPath(mediaPackage.assetId);
+
+    return {
+      assetId: mediaPackage.assetId,
+      canonicalUrl: mediaPackage.manifest.canonicalUrl,
+      kind: mediaPackage.manifest.kind,
+      manifestFilename: mediaPackage.manifestFilename,
+      manifestPath: `${basePath}/manifest.json`,
+      mediaPath:
+        mediaPackage.manifest.kind === 'video'
+          ? `/public/videos/${mediaPackage.assetId}/video.mp4`
+          : null,
+      provenancePath: basePath,
+      publicPagePath: `/public/videos/${mediaPackage.assetId}`,
+      transcriptFilename: mediaPackage.transcriptSidecar.filename,
+      transcriptPath: `${basePath}/transcript.vtt`,
+    };
+  }
+
+  async getManifest(assetId: string): Promise<IMediaProvenanceManifest> {
+    const mediaPackage =
+      await this.videoProvenanceService.buildPublicProvenance(assetId);
+
+    return mediaPackage.manifest;
+  }
+
+  async getTranscriptVtt(assetId: string): Promise<string> {
+    const mediaPackage =
+      await this.videoProvenanceService.buildPublicProvenance(assetId);
+
+    return mediaPackage.transcriptSidecar.vtt;
+  }
+}

--- a/apps/server/api/src/endpoints/public/services/public-media.service.ts
+++ b/apps/server/api/src/endpoints/public/services/public-media.service.ts
@@ -20,18 +20,19 @@ export class PublicMediaService {
       await this.videoProvenanceService.buildPublicProvenance(assetId);
     const basePath = publicMediaPath(mediaPackage.assetId);
 
+    const isVideo = mediaPackage.manifest.kind === 'video';
+
     return {
       assetId: mediaPackage.assetId,
       canonicalUrl: mediaPackage.manifest.canonicalUrl,
       kind: mediaPackage.manifest.kind,
       manifestFilename: mediaPackage.manifestFilename,
       manifestPath: `${basePath}/manifest.json`,
-      mediaPath:
-        mediaPackage.manifest.kind === 'video'
-          ? `/public/videos/${mediaPackage.assetId}/video.mp4`
-          : null,
+      mediaPath: isVideo
+        ? `/public/videos/${mediaPackage.assetId}/video.mp4`
+        : null,
       provenancePath: basePath,
-      publicPagePath: `/public/videos/${mediaPackage.assetId}`,
+      publicPagePath: isVideo ? `/public/videos/${mediaPackage.assetId}` : null,
       transcriptFilename: mediaPackage.transcriptSidecar.filename,
       transcriptPath: `${basePath}/transcript.vtt`,
     };

--- a/apps/server/api/src/helpers/utils/category-prisma/category-prisma.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/category-prisma/category-prisma.util.spec.ts
@@ -1,7 +1,38 @@
-import { IngredientCategory, OrganizationCategory } from '@genfeedai/enums';
+import {
+  AssetScope,
+  IngredientCategory,
+  IngredientStatus,
+  OrganizationCategory,
+} from '@genfeedai/enums';
 import { BadRequestException } from '@nestjs/common';
 import { describe, expect, it } from 'vitest';
 import { CategoryPrismaUtil } from './category-prisma.util';
+
+/**
+ * Valid Prisma AssetScope values — must stay in sync with
+ * packages/prisma/prisma/schema.prisma enum AssetScope.
+ */
+const PRISMA_ASSET_SCOPE_MEMBERS = [
+  'USER',
+  'BRAND',
+  'ORGANIZATION',
+  'PUBLIC',
+] as const;
+
+/**
+ * Valid Prisma IngredientStatus values — must stay in sync with
+ * packages/prisma/prisma/schema.prisma enum IngredientStatus.
+ */
+const PRISMA_INGREDIENT_STATUS_MEMBERS = [
+  'DRAFT',
+  'PROCESSING',
+  'UPLOADED',
+  'GENERATED',
+  'VALIDATED',
+  'FAILED',
+  'ARCHIVED',
+  'REJECTED',
+] as const;
 
 /**
  * Valid Prisma IngredientCategory values — must stay in sync with
@@ -209,6 +240,98 @@ describe('CategoryPrismaUtil', () => {
     });
   });
 
+  describe('toAssetScope', () => {
+    it('maps AssetScope.PUBLIC (app-form) to Prisma PUBLIC', () => {
+      expect(CategoryPrismaUtil.toAssetScope(AssetScope.PUBLIC)).toBe('PUBLIC');
+    });
+
+    it('maps AssetScope.USER to Prisma USER', () => {
+      expect(CategoryPrismaUtil.toAssetScope(AssetScope.USER)).toBe('USER');
+    });
+
+    it('maps AssetScope.BRAND to Prisma BRAND', () => {
+      expect(CategoryPrismaUtil.toAssetScope(AssetScope.BRAND)).toBe('BRAND');
+    });
+
+    it('maps AssetScope.ORGANIZATION to Prisma ORGANIZATION', () => {
+      expect(CategoryPrismaUtil.toAssetScope(AssetScope.ORGANIZATION)).toBe(
+        'ORGANIZATION',
+      );
+    });
+
+    it('passes through an already-Prisma-form value idempotently', () => {
+      expect(CategoryPrismaUtil.toAssetScope('PUBLIC')).toBe('PUBLIC');
+      expect(CategoryPrismaUtil.toAssetScope('USER')).toBe('USER');
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(CategoryPrismaUtil.toAssetScope(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(CategoryPrismaUtil.toAssetScope('')).toBeUndefined();
+    });
+
+    it('throws BadRequestException for a non-empty unmappable value', () => {
+      expect(() => CategoryPrismaUtil.toAssetScope('unknown')).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequestException with the offending value in the message', () => {
+      expect(() => CategoryPrismaUtil.toAssetScope('private')).toThrow(
+        'Unknown AssetScope: private',
+      );
+    });
+  });
+
+  describe('toIngredientStatus', () => {
+    it('maps IngredientStatus.GENERATED (app-form) to Prisma GENERATED', () => {
+      expect(
+        CategoryPrismaUtil.toIngredientStatus(IngredientStatus.GENERATED),
+      ).toBe('GENERATED');
+    });
+
+    it('maps IngredientStatus.DRAFT to Prisma DRAFT', () => {
+      expect(
+        CategoryPrismaUtil.toIngredientStatus(IngredientStatus.DRAFT),
+      ).toBe('DRAFT');
+    });
+
+    it('maps IngredientStatus.FAILED to Prisma FAILED', () => {
+      expect(
+        CategoryPrismaUtil.toIngredientStatus(IngredientStatus.FAILED),
+      ).toBe('FAILED');
+    });
+
+    it('passes through an already-Prisma-form value idempotently', () => {
+      expect(CategoryPrismaUtil.toIngredientStatus('GENERATED')).toBe(
+        'GENERATED',
+      );
+      expect(CategoryPrismaUtil.toIngredientStatus('DRAFT')).toBe('DRAFT');
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(CategoryPrismaUtil.toIngredientStatus(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(CategoryPrismaUtil.toIngredientStatus('')).toBeUndefined();
+    });
+
+    it('throws BadRequestException for a non-empty unmappable value', () => {
+      expect(() => CategoryPrismaUtil.toIngredientStatus('unknown')).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequestException with the offending value in the message', () => {
+      expect(() => CategoryPrismaUtil.toIngredientStatus('active')).toThrow(
+        'Unknown IngredientStatus: active',
+      );
+    });
+  });
+
   describe('toOrganizationCategoryFilter', () => {
     it('returns { category: "BUSINESS" } for OrganizationCategory.BUSINESS', () => {
       expect(
@@ -295,6 +418,60 @@ describe('CategoryPrismaUtil', () => {
         expect(
           allMappedOrgOutputs,
           `Prisma member '${prismaValue}' is not the output of any app-enum mapping — stale Prisma member list or missing production map entry`,
+        ).toContain(prismaValue);
+      }
+    });
+
+    it('every AssetScope app-enum member maps to a valid Prisma AssetScope member', () => {
+      const prismaSet = new Set<string>(PRISMA_ASSET_SCOPE_MEMBERS);
+      for (const appValue of Object.values(AssetScope)) {
+        const prismaValue = CategoryPrismaUtil.toAssetScope(appValue);
+        expect(
+          prismaValue,
+          `AssetScope.${appValue} produced undefined — add it to APP_TO_PRISMA_ASSET_SCOPE`,
+        ).toBeDefined();
+        expect(
+          prismaSet.has(prismaValue as string),
+          `AssetScope.${appValue} mapped to "${prismaValue}" which is not a valid Prisma AssetScope member`,
+        ).toBe(true);
+      }
+    });
+
+    it('every Prisma AssetScope member is the output of some app-enum mapping', () => {
+      const allMapped = Object.values(AssetScope).map((v) =>
+        CategoryPrismaUtil.toAssetScope(v),
+      );
+      for (const prismaValue of PRISMA_ASSET_SCOPE_MEMBERS) {
+        expect(
+          allMapped,
+          `Prisma AssetScope member '${prismaValue}' is not the output of any app-enum mapping`,
+        ).toContain(prismaValue);
+      }
+    });
+
+    it('every IngredientStatus app-enum member maps to a valid Prisma IngredientStatus member', () => {
+      const prismaSet = new Set<string>(PRISMA_INGREDIENT_STATUS_MEMBERS);
+      for (const appValue of Object.values(IngredientStatus)) {
+        const prismaValue = CategoryPrismaUtil.toIngredientStatus(appValue);
+        expect(
+          prismaValue,
+          `IngredientStatus.${appValue} produced undefined — add it to APP_TO_PRISMA_INGREDIENT_STATUS`,
+        ).toBeDefined();
+        expect(
+          prismaSet.has(prismaValue as string),
+          `IngredientStatus.${appValue} mapped to "${prismaValue}" which is not a valid Prisma IngredientStatus member`,
+        ).toBe(true);
+      }
+    });
+
+    it('every Prisma IngredientStatus member is the output of some app-enum mapping', () => {
+      const allMapped = Object.values(IngredientStatus).map((v) =>
+        CategoryPrismaUtil.toIngredientStatus(v),
+      );
+      for (const prismaValue of PRISMA_INGREDIENT_STATUS_MEMBERS) {
+        expect(
+          allMapped,
+          `Prisma IngredientStatus member '${prismaValue}' is not the output of any app-enum mapping`,
         ).toContain(prismaValue);
       }
     });

--- a/apps/server/api/src/helpers/utils/category-prisma/category-prisma.util.ts
+++ b/apps/server/api/src/helpers/utils/category-prisma/category-prisma.util.ts
@@ -1,4 +1,9 @@
-import { IngredientCategory, OrganizationCategory } from '@genfeedai/enums';
+import {
+  AssetScope,
+  IngredientCategory,
+  IngredientStatus,
+  OrganizationCategory,
+} from '@genfeedai/enums';
 import { BadRequestException } from '@nestjs/common';
 
 /**
@@ -24,6 +29,30 @@ export type PrismaIngredientCategoryValue =
  * These string literals must match the Prisma schema exactly.
  */
 export type PrismaOrganizationCategoryValue = 'CREATOR' | 'BUSINESS' | 'AGENCY';
+
+/**
+ * Prisma UPPERCASE enum values for AssetScope.
+ * These string literals must match the Prisma schema exactly.
+ */
+export type PrismaAssetScopeValue =
+  | 'USER'
+  | 'BRAND'
+  | 'ORGANIZATION'
+  | 'PUBLIC';
+
+/**
+ * Prisma UPPERCASE enum values for IngredientStatus.
+ * These string literals must match the Prisma schema exactly.
+ */
+export type PrismaIngredientStatusValue =
+  | 'DRAFT'
+  | 'PROCESSING'
+  | 'UPLOADED'
+  | 'GENERATED'
+  | 'VALIDATED'
+  | 'FAILED'
+  | 'ARCHIVED'
+  | 'REJECTED';
 
 /**
  * Explicit app→Prisma mapping for IngredientCategory.
@@ -83,6 +112,57 @@ const PRISMA_INGREDIENT_CATEGORY_VALUES = new Set<string>(
  */
 const PRISMA_ORGANIZATION_CATEGORY_VALUES = new Set<string>(
   Object.values(APP_TO_PRISMA_ORGANIZATION_CATEGORY),
+);
+
+/**
+ * Explicit app→Prisma mapping for AssetScope.
+ *
+ * App-level enum values are lowercase (e.g. 'public'); Prisma stores UPPERCASE
+ * (e.g. 'PUBLIC'). The Prisma 7 PG driver adapter does not populate
+ * `_runtimeDataModel` so BaseService.normalizeEnumScalarValue() cannot rescue
+ * these values at runtime. This map is the canonical, exhaustive boundary.
+ *
+ * If you add a member to @genfeedai/enums AssetScope you MUST add it here too —
+ * the guard test in category-prisma.util.spec.ts will fail otherwise.
+ */
+const APP_TO_PRISMA_ASSET_SCOPE: Record<AssetScope, PrismaAssetScopeValue> = {
+  [AssetScope.USER]: 'USER',
+  [AssetScope.BRAND]: 'BRAND',
+  [AssetScope.ORGANIZATION]: 'ORGANIZATION',
+  [AssetScope.PUBLIC]: 'PUBLIC',
+};
+
+/**
+ * Explicit app→Prisma mapping for IngredientStatus.
+ *
+ * App-level enum values are lowercase (e.g. 'generated'); Prisma stores UPPERCASE
+ * (e.g. 'GENERATED'). Same rationale as AssetScope above.
+ *
+ * If you add a member to @genfeedai/enums IngredientStatus you MUST add it here
+ * too — the guard test in category-prisma.util.spec.ts will fail otherwise.
+ */
+const APP_TO_PRISMA_INGREDIENT_STATUS: Record<
+  IngredientStatus,
+  PrismaIngredientStatusValue
+> = {
+  [IngredientStatus.DRAFT]: 'DRAFT',
+  [IngredientStatus.PROCESSING]: 'PROCESSING',
+  [IngredientStatus.UPLOADED]: 'UPLOADED',
+  [IngredientStatus.GENERATED]: 'GENERATED',
+  [IngredientStatus.VALIDATED]: 'VALIDATED',
+  [IngredientStatus.FAILED]: 'FAILED',
+  [IngredientStatus.ARCHIVED]: 'ARCHIVED',
+  [IngredientStatus.REJECTED]: 'REJECTED',
+};
+
+/** The set of valid Prisma AssetScope UPPERCASE strings. */
+const PRISMA_ASSET_SCOPE_VALUES = new Set<string>(
+  Object.values(APP_TO_PRISMA_ASSET_SCOPE),
+);
+
+/** The set of valid Prisma IngredientStatus UPPERCASE strings. */
+const PRISMA_INGREDIENT_STATUS_VALUES = new Set<string>(
+  Object.values(APP_TO_PRISMA_INGREDIENT_STATUS),
 );
 
 export class CategoryPrismaUtil {
@@ -171,5 +251,61 @@ export class CategoryPrismaUtil {
       return {};
     }
     return { category: CategoryPrismaUtil.toOrganizationCategory(category) };
+  }
+
+  /**
+   * Map a single AssetScope app-enum value to its Prisma UPPERCASE form.
+   *
+   * - App-form values (lowercase, e.g. 'public') → mapped to 'PUBLIC'.
+   * - Already-Prisma-form values (UPPERCASE, e.g. 'PUBLIC') → passed through
+   *   idempotently.
+   * - `undefined` / empty string → returns `undefined`.
+   * - Non-empty unmappable value → throws BadRequestException.
+   */
+  static toAssetScope(
+    value?: AssetScope | string,
+  ): PrismaAssetScopeValue | undefined {
+    if (value === undefined || value === '') {
+      return undefined;
+    }
+
+    const mapped = APP_TO_PRISMA_ASSET_SCOPE[value as AssetScope];
+    if (mapped !== undefined) {
+      return mapped;
+    }
+
+    if (PRISMA_ASSET_SCOPE_VALUES.has(value as string)) {
+      return value as PrismaAssetScopeValue;
+    }
+
+    throw new BadRequestException(`Unknown AssetScope: ${value}`);
+  }
+
+  /**
+   * Map a single IngredientStatus app-enum value to its Prisma UPPERCASE form.
+   *
+   * - App-form values (lowercase, e.g. 'generated') → mapped to 'GENERATED'.
+   * - Already-Prisma-form values (UPPERCASE, e.g. 'GENERATED') → passed through
+   *   idempotently.
+   * - `undefined` / empty string → returns `undefined`.
+   * - Non-empty unmappable value → throws BadRequestException.
+   */
+  static toIngredientStatus(
+    value?: IngredientStatus | string,
+  ): PrismaIngredientStatusValue | undefined {
+    if (value === undefined || value === '') {
+      return undefined;
+    }
+
+    const mapped = APP_TO_PRISMA_INGREDIENT_STATUS[value as IngredientStatus];
+    if (mapped !== undefined) {
+      return mapped;
+    }
+
+    if (PRISMA_INGREDIENT_STATUS_VALUES.has(value as string)) {
+      return value as PrismaIngredientStatusValue;
+    }
+
+    throw new BadRequestException(`Unknown IngredientStatus: ${value}`);
   }
 }

--- a/packages/interfaces/src/content/media-provenance.interface.ts
+++ b/packages/interfaces/src/content/media-provenance.interface.ts
@@ -134,7 +134,12 @@ export interface IPublicMediaRouteReference {
   assetId: string;
   kind: string;
   canonicalUrl: string | null;
-  publicPagePath: string;
+  /**
+   * Path to the public page for this asset. `null` for media kinds that do not
+   * have a dedicated public page (mirrors the nullability of `mediaPath`).
+   * Currently only `'video'` produces a non-null value.
+   */
+  publicPagePath: string | null;
   mediaPath: string | null;
   provenancePath: string;
   manifestPath: string;

--- a/packages/interfaces/src/content/media-provenance.interface.ts
+++ b/packages/interfaces/src/content/media-provenance.interface.ts
@@ -129,6 +129,20 @@ export interface IMediaProvenancePackage {
   transcriptSidecar: IMediaTranscriptSidecar;
 }
 
+/** Public API route references for a generated media provenance package. */
+export interface IPublicMediaRouteReference {
+  assetId: string;
+  kind: string;
+  canonicalUrl: string | null;
+  publicPagePath: string;
+  mediaPath: string | null;
+  provenancePath: string;
+  manifestPath: string;
+  transcriptPath: string;
+  manifestFilename: string;
+  transcriptFilename: string;
+}
+
 /*
  * Read shapes consumed by the API provenance export service. They describe the
  * narrow projection of DB rows the service reads when assembling a package, kept


### PR DESCRIPTION
## Summary

Closes #33
Refs #30

Adds public media provenance routes for generated public video assets:

- `GET /public/media/:assetId` resolves the asset ID to the public video metadata route, media stream route, manifest route, and transcript route.
- `GET /public/media/:assetId/manifest.json` returns the canonical provenance manifest.
- `GET /public/media/:assetId/transcript.vtt` returns the WebVTT transcript sidecar.

The public lookup path reuses `VideoProvenanceService` but requires `scope=public`, `status=generated`, and `category=video`, so it does not fall back to unscoped tenant data.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bunx biome check --write` on touched files
- `bun run --cwd apps/server/api test:file src/collections/videos/services/video-provenance.service.spec.ts src/endpoints/public/services/public-media.service.spec.ts src/endpoints/public/controllers/media/public-media.controller.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/interfaces`
- `bun run audit:api` (passed; reported existing SQL audit findings)
- `bunx turbo run lint --filter=@genfeedai/api --filter=@genfeedai/interfaces`
- `bun run --cwd packages/prisma db:generate`
- `bunx turbo run build --filter=@genfeedai/api`
- `git diff --check`
- `git diff --cached --check`
- `bunx secretlint` on touched files

Skipped manual live API smoke because this local worktree does not have a seeded generated public video asset; the success/error paths are covered by focused controller/service tests and the API build.

Note: the first API build attempt failed because the local Prisma generated client was missing in this fresh worktree. After running `bun run --cwd packages/prisma db:generate`, the same API build passed.
