### PR TITLE
fix(api): bound startup redis hooks

### DIFF
--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -46,13 +46,42 @@ import helmet from 'helmet';
 import gptActionsSpec from './config/gpt-actions-openapi.json';
 
 const apiDir = dirname(fileURLToPath(import.meta.url));
+const API_LISTEN_TIMEOUT_MS = Number(
+  process.env.API_LISTEN_TIMEOUT_MS ?? 120_000,
+);
+
+async function withStartupTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(timeoutMessage)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
 
 async function main() {
+  console.info('API bootstrap: creating Nest application');
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     abortOnError: false,
     logger: ['error'],
     snapshot: true,
   });
+  console.info('API bootstrap: Nest application created');
 
   const configService = app.get(ConfigService);
   const logger = app.get<LoggerService>(LoggerService);
@@ -276,14 +305,20 @@ async function main() {
       process.exit(0);
     }
 
-    await app.listen(port);
+    console.info(`API bootstrap: starting listener on port ${port}`);
+    await withStartupTimeout(
+      app.listen(port),
+      API_LISTEN_TIMEOUT_MS,
+      `API listen timed out after ${API_LISTEN_TIMEOUT_MS}ms before serving port ${port}`,
+    );
+    console.info(`API bootstrap: listener ready on port ${port}`);
     logger.debug(`API service is running on port ${port}`);
   } catch (error: unknown) {
     logger.error('Failed to start API service:', error);
-    if (process.env.BOOT_SMOKE === '1') {
-      // Fail the boot-smoke gate loudly — never let a startup error pass as green.
-      process.exit(1);
-    }
+    console.error('API bootstrap failed:', error);
+    // A failed bootstrap leaves the process alive but unbound if Redis/BullMQ
+    // handles remain open. Exit loudly so ECS and boot-smoke fail fast.
+    process.exit(1);
   }
 }
 

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -46,9 +46,15 @@ import helmet from 'helmet';
 import gptActionsSpec from './config/gpt-actions-openapi.json';
 
 const apiDir = dirname(fileURLToPath(import.meta.url));
-const API_LISTEN_TIMEOUT_MS = Number(
-  process.env.API_LISTEN_TIMEOUT_MS ?? 120_000,
-);
+const DEFAULT_API_LISTEN_TIMEOUT_MS = 120_000;
+
+function parsePositiveTimeoutMs(
+  value: string | undefined,
+  fallbackMs: number,
+): number {
+  const timeoutMs = Number(value ?? fallbackMs);
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : fallbackMs;
+}
 
 async function withStartupTimeout<T>(
   operation: Promise<T>,
@@ -75,19 +81,25 @@ async function withStartupTimeout<T>(
 }
 
 async function main() {
-  console.info('API bootstrap: creating Nest application');
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-  console.info('API bootstrap: Nest application created');
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
+  let logger: LoggerService | undefined;
 
   try {
+    console.info('API bootstrap: creating Nest application');
+    const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+      abortOnError: false,
+      logger: ['error'],
+      snapshot: true,
+    });
+    console.info('API bootstrap: Nest application created');
+
+    const configService = app.get(ConfigService);
+    logger = app.get<LoggerService>(LoggerService);
+    const port = configService.get('PORT');
+    const apiListenTimeoutMs = parsePositiveTimeoutMs(
+      configService.get('API_LISTEN_TIMEOUT_MS'),
+      DEFAULT_API_LISTEN_TIMEOUT_MS,
+    );
+
     app.set('trust proxy', 1);
     app.enableShutdownHooks();
 
@@ -308,13 +320,13 @@ async function main() {
     console.info(`API bootstrap: starting listener on port ${port}`);
     await withStartupTimeout(
       app.listen(port),
-      API_LISTEN_TIMEOUT_MS,
-      `API listen timed out after ${API_LISTEN_TIMEOUT_MS}ms before serving port ${port}`,
+      apiListenTimeoutMs,
+      `API listen timed out after ${apiListenTimeoutMs}ms before serving port ${port}`,
     );
     console.info(`API bootstrap: listener ready on port ${port}`);
     logger.debug(`API service is running on port ${port}`);
   } catch (error: unknown) {
-    logger.error('Failed to start API service:', error);
+    logger?.error('Failed to start API service:', error);
     console.error('API bootstrap failed:', error);
     // A failed bootstrap leaves the process alive but unbound if Redis/BullMQ
     // handles remain open. Exit loudly so ECS and boot-smoke fail fast.

--- a/apps/server/api/src/services/microservices/microservices.service.ts
+++ b/apps/server/api/src/services/microservices/microservices.service.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { ConfigService } from '@api/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
@@ -23,6 +24,7 @@ export interface ServiceHealth {
 @Injectable()
 export class MicroservicesService implements OnModuleInit {
   private readonly constructorName: string = String(this.constructor.name);
+  private static readonly REDIS_CONNECT_TIMEOUT_MS = 5_000;
   private redisClient: RedisClientType | null = null;
   private servicesConfig!: Map<string, { url: string; required: boolean }>;
 
@@ -94,7 +96,8 @@ export class MicroservicesService implements OnModuleInit {
     try {
       this.redisClient = createClient({
         socket: {
-          connectTimeout: 3_000,
+          connectTimeout: MicroservicesService.REDIS_CONNECT_TIMEOUT_MS,
+          reconnectStrategy: () => false as const,
           ...(config.tls ? { tls: true as const } : {}),
         },
         url: config.url,
@@ -108,15 +111,44 @@ export class MicroservicesService implements OnModuleInit {
         this.loggerService.log('Redis Client Connected');
       });
 
-      await this.redisClient.connect();
+      await this.withTimeout(
+        this.redisClient.connect(),
+        MicroservicesService.REDIS_CONNECT_TIMEOUT_MS,
+        `${this.constructorName} initializeRedis: Redis connect timed out after ${MicroservicesService.REDIS_CONNECT_TIMEOUT_MS}ms`,
+      );
       this.loggerService.log(
         `${this.constructorName} initializeRedis: Successfully connected to Redis`,
       );
     } catch (error: unknown) {
+      this.redisClient = null;
       this.loggerService.error(
         `${this.constructorName} initializeRedis: Failed to connect to Redis at ${config.url}`,
         error,
       );
+    }
+  }
+
+  private async withTimeout<T>(
+    operation: Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error(timeoutMessage)),
+            timeoutMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 
@@ -126,7 +158,11 @@ export class MicroservicesService implements OnModuleInit {
     }
 
     try {
-      await this.redisClient.ping();
+      await this.withTimeout(
+        this.redisClient.ping(),
+        MicroservicesService.REDIS_CONNECT_TIMEOUT_MS,
+        'Redis health check timed out',
+      );
       return true;
     } catch (error: unknown) {
       this.loggerService.error('Redis health check failed', error);

--- a/apps/server/api/src/services/microservices/microservices.service.ts
+++ b/apps/server/api/src/services/microservices/microservices.service.ts
@@ -79,8 +79,18 @@ export class MicroservicesService implements OnModuleInit {
     ]);
   }
 
+  private getRedisLogTarget(redisUrl: string): string {
+    try {
+      const url = new URL(redisUrl);
+      return `${url.protocol}//${url.host}`;
+    } catch {
+      return '[invalid Redis URL]';
+    }
+  }
+
   private async initializeRedis() {
-    if (!process.env.REDIS_URL) {
+    const redisUrl = this.configService.get('REDIS_URL');
+    if (!redisUrl) {
       this.loggerService.warn(
         `${this.constructorName} initializeRedis: REDIS_URL not set — skipping (offline/self-hosted mode)`,
       );
@@ -88,9 +98,10 @@ export class MicroservicesService implements OnModuleInit {
     }
 
     const config = parseRedisConnection(this.configService);
+    const redisLogTarget = this.getRedisLogTarget(config.url);
 
     this.loggerService.log(
-      `${this.constructorName} initializeRedis: Connecting to Redis at ${config.url}`,
+      `${this.constructorName} initializeRedis: Connecting to Redis at ${redisLogTarget}`,
     );
 
     try {
@@ -122,7 +133,7 @@ export class MicroservicesService implements OnModuleInit {
     } catch (error: unknown) {
       this.redisClient = null;
       this.loggerService.error(
-        `${this.constructorName} initializeRedis: Failed to connect to Redis at ${config.url}`,
+        `${this.constructorName} initializeRedis: Failed to connect to Redis at ${redisLogTarget}`,
         error,
       );
     }
@@ -244,7 +255,7 @@ export class MicroservicesService implements OnModuleInit {
 
     this.loggerService.log(`${url} checking services in ${nodeEnv} mode`);
 
-    if (process.env.REDIS_URL) {
+    if (this.configService.get('REDIS_URL')) {
       const redisHealthy = await this.checkRedisHealth();
       if (!redisHealthy) {
         const message =

--- a/apps/server/api/src/services/notifications/notifications.service.spec.ts
+++ b/apps/server/api/src/services/notifications/notifications.service.spec.ts
@@ -91,10 +91,32 @@ describe('NotificationsService', () => {
 
       await service.onModuleInit();
 
-      expect(loggerService.error).toHaveBeenCalledWith(
+      expect(loggerService.warn).toHaveBeenCalledWith(
         expect.stringContaining('failed to connect'),
         error,
       );
+    });
+
+    it('should not block startup when Redis connect hangs', async () => {
+      vi.useFakeTimers();
+      try {
+        (mockPublisher.connect as vi.Mock).mockReturnValue(
+          new Promise(() => {}),
+        );
+
+        const init = service.onModuleInit();
+        await vi.advanceTimersByTimeAsync(5_000);
+        await init;
+
+        expect(loggerService.warn).toHaveBeenCalledWith(
+          expect.stringContaining('failed to connect'),
+          expect.objectContaining({
+            message: expect.stringContaining('timed out'),
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/apps/server/api/src/services/notifications/notifications.service.ts
+++ b/apps/server/api/src/services/notifications/notifications.service.ts
@@ -23,6 +23,7 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
   private publisher: RedisClientType;
   private isShuttingDown = false;
   private readonly constructorName = this.constructor.name;
+  private static readonly CONNECT_TIMEOUT_MS = 5_000;
 
   constructor(
     private readonly configService: ConfigService,
@@ -31,7 +32,8 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
     const config = parseRedisConnection(this.configService);
     this.publisher = createClient({
       socket: {
-        connectTimeout: 10_000,
+        connectTimeout: NotificationsService.CONNECT_TIMEOUT_MS,
+        reconnectStrategy: () => false as const,
         ...(config.tls ? { tls: true as const } : {}),
       },
       url: config.url,
@@ -48,10 +50,13 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
 
   async onModuleInit() {
     try {
-      await this.publisher.connect();
+      await this.connectPublisher('initial connect');
       this.logger.log(`${this.constructorName} initialized successfully`);
     } catch (error: unknown) {
-      this.logger.error(`${this.constructorName} failed to connect`, error);
+      this.logger.warn(
+        `${this.constructorName} failed to connect - notifications disabled`,
+        error,
+      );
     }
   }
 
@@ -123,7 +128,7 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
     }
 
     try {
-      await this.publisher.connect();
+      await this.connectPublisher('reconnect');
       return this.publisher.isReady;
     } catch (error: unknown) {
       this.logger.error(`${this.constructorName} failed to reconnect`, error);
@@ -136,6 +141,31 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
       error instanceof Error &&
       error.message.toLowerCase().includes('client is closed')
     );
+  }
+
+  private async connectPublisher(reason: string): Promise<void> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      await Promise.race([
+        this.publisher.connect(),
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `${this.constructorName} Redis publisher ${reason} timed out after ${NotificationsService.CONNECT_TIMEOUT_MS}ms`,
+                ),
+              ),
+            NotificationsService.CONNECT_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   // Helper methods for specific notification types

--- a/packages/libs/redis/redis.service.spec.ts
+++ b/packages/libs/redis/redis.service.spec.ts
@@ -134,8 +134,12 @@ describe('RedisService', () => {
     createService();
     await service.onModuleInit();
 
-    await expect(service.publish('test-channel', { ok: true })).rejects.toThrow(
-      'Redis service not initialized',
+    await expect(
+      service.publish('test-channel', { ok: true }),
+    ).resolves.toBeUndefined();
+    expect(mockLoggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Redis not initialized'),
+      expect.objectContaining({ service: 'RedisService' }),
     );
 
     expect(mockLoggerService.warn).toHaveBeenCalledWith(
@@ -164,12 +168,16 @@ describe('RedisService', () => {
     );
   });
 
-  it('should throw on publish before initialization', async () => {
+  it('should no-op on publish before initialization', async () => {
     createService();
 
     await expect(
       service.publish('test-channel', { test: 'data' }),
-    ).rejects.toThrow('Redis service not initialized');
+    ).resolves.toBeUndefined();
+    expect(mockLoggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Redis not initialized'),
+      expect.objectContaining({ service: 'RedisService' }),
+    );
   });
 
   it('should unsubscribe and clear handlers', async () => {

--- a/packages/libs/redis/redis.service.spec.ts
+++ b/packages/libs/redis/redis.service.spec.ts
@@ -233,4 +233,35 @@ describe('RedisService', () => {
 
     expect(eventSpy).toHaveBeenCalledWith('test-channel', payload);
   });
+
+  it('should retry Redis subscription after a failed subscribe attempt', async () => {
+    const publisher = buildMockClient();
+    const subscriber = buildMockClient();
+    subscriber.subscribe
+      .mockRejectedValueOnce(new Error('subscribe timeout'))
+      .mockResolvedValueOnce(undefined);
+
+    createClientSpy = vi
+      .spyOn(redis, 'createClient')
+      .mockReturnValueOnce(publisher as unknown as RedisClientType)
+      .mockReturnValueOnce(subscriber as unknown as RedisClientType);
+
+    createService();
+    await service.onModuleInit();
+
+    await expect(service.subscribe('flaky-channel', vi.fn())).rejects.toThrow(
+      'subscribe timeout',
+    );
+
+    const handler = vi.fn();
+    await service.subscribe('flaky-channel', handler);
+
+    expect(subscriber.subscribe).toHaveBeenCalledTimes(2);
+    const callback = subscriber.subscribe.mock.calls[1]?.[1] as
+      | ((payload: string) => void)
+      | undefined;
+    callback?.(JSON.stringify({ retried: true }));
+
+    expect(handler).toHaveBeenCalledWith({ retried: true });
+  });
 });

--- a/packages/libs/redis/redis.service.ts
+++ b/packages/libs/redis/redis.service.ts
@@ -144,20 +144,25 @@ export class RedisService
   ) {
     if (!this.handlers.has(channel)) {
       this.handlers.set(channel, []);
-      await this.withTimeout(
-        this.subscriber.subscribe(channel, (message) => {
-          const parsedMessage = JSON.parse(message);
-          // Emit for EventEmitter listeners
-          this.emit('message', channel, message);
-          // Call specific handlers
-          const handlers = this.handlers.get(channel) || [];
-          for (const h of handlers) {
-            h(parsedMessage);
-          }
-        }),
-        RedisService.SUBSCRIBE_TIMEOUT_MS,
-        `Redis subscribe to ${channel} timed out after ${RedisService.SUBSCRIBE_TIMEOUT_MS}ms`,
-      );
+      try {
+        await this.withTimeout(
+          this.subscriber.subscribe(channel, (message) => {
+            const parsedMessage = JSON.parse(message);
+            // Emit for EventEmitter listeners
+            this.emit('message', channel, message);
+            // Call specific handlers
+            const handlers = this.handlers.get(channel) || [];
+            for (const h of handlers) {
+              h(parsedMessage);
+            }
+          }),
+          RedisService.SUBSCRIBE_TIMEOUT_MS,
+          `Redis subscribe to ${channel} timed out after ${RedisService.SUBSCRIBE_TIMEOUT_MS}ms`,
+        );
+      } catch (error) {
+        this.handlers.delete(channel);
+        throw error;
+      }
       this.logger.log(`Subscribed to channel: ${channel}`, this.context);
     }
     if (handler) {

--- a/packages/libs/redis/redis.service.ts
+++ b/packages/libs/redis/redis.service.ts
@@ -15,6 +15,8 @@ export class RedisService
   extends EventEmitter
   implements OnModuleInit, OnModuleDestroy
 {
+  private static readonly CONNECT_TIMEOUT_MS = 3_000;
+  private static readonly SUBSCRIBE_TIMEOUT_MS = 5_000;
   private readonly context = { service: RedisService.name };
   private publisher!: RedisClientType;
   private subscriber!: RedisClientType;
@@ -46,9 +48,8 @@ export class RedisService
     }
 
     const config = parseRedisConnection(this.configService);
-    const CONNECT_TIMEOUT = 3_000;
     const socketOptions = {
-      connectTimeout: CONNECT_TIMEOUT,
+      connectTimeout: RedisService.CONNECT_TIMEOUT_MS,
       reconnectStrategy: () => false as const, // Don't retry - fail fast
       ...(config.tls ? { tls: true as const } : {}),
     };
@@ -66,7 +67,7 @@ export class RedisService
         new Promise((_, reject) =>
           setTimeout(
             () => reject(new Error('Redis publisher connection timeout')),
-            CONNECT_TIMEOUT,
+            RedisService.CONNECT_TIMEOUT_MS,
           ),
         ),
       ]);
@@ -83,7 +84,7 @@ export class RedisService
         new Promise((_, reject) =>
           setTimeout(
             () => reject(new Error('Redis subscriber connection timeout')),
-            CONNECT_TIMEOUT,
+            RedisService.CONNECT_TIMEOUT_MS,
           ),
         ),
       ]);
@@ -143,16 +144,20 @@ export class RedisService
   ) {
     if (!this.handlers.has(channel)) {
       this.handlers.set(channel, []);
-      await this.subscriber.subscribe(channel, (message) => {
-        const parsedMessage = JSON.parse(message);
-        // Emit for EventEmitter listeners
-        this.emit('message', channel, message);
-        // Call specific handlers
-        const handlers = this.handlers.get(channel) || [];
-        for (const h of handlers) {
-          h(parsedMessage);
-        }
-      });
+      await this.withTimeout(
+        this.subscriber.subscribe(channel, (message) => {
+          const parsedMessage = JSON.parse(message);
+          // Emit for EventEmitter listeners
+          this.emit('message', channel, message);
+          // Call specific handlers
+          const handlers = this.handlers.get(channel) || [];
+          for (const h of handlers) {
+            h(parsedMessage);
+          }
+        }),
+        RedisService.SUBSCRIBE_TIMEOUT_MS,
+        `Redis subscribe to ${channel} timed out after ${RedisService.SUBSCRIBE_TIMEOUT_MS}ms`,
+      );
       this.logger.log(`Subscribed to channel: ${channel}`, this.context);
     }
     if (handler) {
@@ -175,5 +180,29 @@ export class RedisService
       return null;
     }
     return this.publisher;
+  }
+
+  private async withTimeout<T>(
+    operation: Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error(timeoutMessage)),
+            timeoutMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add API startup progress markers and fail-fast exit on bootstrap failure
- bound Redis startup/reconnect paths in notifications and microservices services
- bound shared Redis pub/sub subscription startup and align tests with fail-open publish behavior

## Verification
- bunx biome check --write apps/server/api/src/main.ts apps/server/api/src/services/notifications/notifications.service.ts apps/server/api/src/services/notifications/notifications.service.spec.ts apps/server/api/src/services/microservices/microservices.service.ts packages/libs/redis/redis.service.ts packages/libs/redis/redis.service.spec.ts
- bunx vitest run src/services/notifications/notifications.service.spec.ts src/services/microservices/microservices.service.spec.ts --config vitest.config.ts
- bunx vitest run packages/libs/redis/redis.service.spec.ts --config vitest.config.ts
- bun --filter @genfeedai/api build
- bun type-check --filter=@genfeedai/api
- git diff --check

Notes: local start:prod/BOOT_CHECK cannot resolve tsconfig-paths/register in this checkout; the production container does resolve it, as shown by boot-smoke logs from run 28390091674.