### PR TITLE
fix(telegram): collect audio video workflow inputs

### DIFF
--- a/apps/server/api/src/services/telegram-bot/__tests__/telegram-bot.service.spec.ts
+++ b/apps/server/api/src/services/telegram-bot/__tests__/telegram-bot.service.spec.ts
@@ -1,16 +1,19 @@
 import { TelegramBotService } from '@api/services/telegram-bot/telegram-bot.service';
+import { Bot } from 'grammy';
 
 // Mock grammy
 vi.mock('grammy', () => ({
-  Bot: vi.fn().mockImplementation(() => ({
-    command: vi.fn(),
-    handleUpdate: vi.fn(),
-    on: vi.fn(),
-    start: vi.fn(),
-    stop: vi.fn(),
-    token: 'test-token',
-    use: vi.fn(),
-  })),
+  Bot: vi.fn().mockImplementation(function Bot() {
+    return {
+      command: vi.fn(),
+      handleUpdate: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      token: 'test-token',
+      use: vi.fn(),
+    };
+  }),
   InlineKeyboard: vi.fn().mockImplementation(() => ({
     row: vi.fn().mockReturnThis(),
     text: vi.fn().mockReturnThis(),
@@ -141,6 +144,31 @@ describe('TelegramBotService', () => {
       expect(startPollingSpy).not.toHaveBeenCalled();
       expect(mockLoggerService.log).toHaveBeenCalledWith(
         'TelegramBotService: polling disabled for local development',
+      );
+    });
+
+    it('registers audio and video workflow input handlers', async () => {
+      await service.onModuleInit();
+
+      const botInstance = vi.mocked(Bot).mock.results.at(-1)?.value as
+        | { on: ReturnType<typeof vi.fn> }
+        | undefined;
+
+      expect(botInstance?.on).toHaveBeenCalledWith(
+        'message:audio',
+        expect.any(Function),
+      );
+      expect(botInstance?.on).toHaveBeenCalledWith(
+        'message:voice',
+        expect.any(Function),
+      );
+      expect(botInstance?.on).toHaveBeenCalledWith(
+        'message:video',
+        expect.any(Function),
+      );
+      expect(botInstance?.on).toHaveBeenCalledWith(
+        'message:document',
+        expect.any(Function),
       );
     });
   });

--- a/apps/server/api/src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts
+++ b/apps/server/api/src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts
@@ -1,0 +1,224 @@
+import type { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import type {
+  ConversationState,
+  WorkflowInput,
+} from '@api/services/telegram-bot/telegram-bot.types';
+import type { TelegramConversationService } from '@api/services/telegram-bot/telegram-conversation.service';
+import { TelegramMessageHandlerService } from '@api/services/telegram-bot/telegram-message-handler.service';
+import type { TelegramRunCommandsService } from '@api/services/telegram-bot/telegram-run-commands.service';
+import { FileInputType } from '@genfeedai/enums';
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { Context } from 'grammy';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MessageShape = {
+  audio?: { file_id: string; file_name?: string; mime_type?: string };
+  document?: { file_id: string; file_name?: string; mime_type?: string };
+  video?: { file_id: string; file_name?: string; mime_type?: string };
+  voice?: { file_id: string; mime_type?: string };
+};
+
+type ContextFixture = {
+  ctx: Context;
+  getFile: ReturnType<typeof vi.fn>;
+  reply: ReturnType<typeof vi.fn>;
+};
+
+function createState(input: WorkflowInput): ConversationState {
+  return {
+    collectedInputs: new Map(),
+    currentInputIndex: 0,
+    requiredInputs: [input],
+    startedAt: Date.now(),
+    step: 'collecting_inputs',
+  };
+}
+
+function createMediaInput(
+  inputType: Extract<WorkflowInput['inputType'], 'audio' | 'video'>,
+): WorkflowInput {
+  return {
+    inputType,
+    label: inputType === 'audio' ? 'Narration' : 'Reference video',
+    nodeId: `${inputType}-node`,
+    nodeType: `${inputType}Input`,
+    required: true,
+  };
+}
+
+function createContextFixture(
+  message: MessageShape,
+  filePath: string,
+): ContextFixture {
+  const reply = vi.fn();
+  const getFile = vi.fn().mockResolvedValue({ file_path: filePath });
+  const ctx = {
+    api: { getFile },
+    chat: { id: 42 },
+    message,
+    reply,
+  } as unknown as Context;
+
+  return { ctx, getFile, reply };
+}
+
+function stubFetch(contentType: string | null): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue({
+    arrayBuffer: vi.fn().mockResolvedValue(Uint8Array.from([1, 2, 3]).buffer),
+    headers: { get: vi.fn().mockReturnValue(contentType) },
+    ok: true,
+    status: 200,
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('TelegramMessageHandlerService media inputs', () => {
+  let logger: LoggerService;
+  let conversation: TelegramConversationService;
+  let filesClientService: FilesClientService;
+  let promptNextInput: ReturnType<typeof vi.fn>;
+  let uploadToS3: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    logger = {
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as LoggerService;
+    promptNextInput = vi.fn();
+    uploadToS3 = vi.fn().mockResolvedValue({
+      publicUrl: 'https://cdn.genfeed.ai/telegram-media',
+    });
+    filesClientService = {
+      uploadToS3,
+    } as unknown as FilesClientService;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('collects Telegram audio input as a token-free workflow URL', async () => {
+    const state = createState(createMediaInput('audio'));
+    conversation = {
+      getState: vi.fn().mockReturnValue(state),
+      promptNextInput,
+    } as unknown as TelegramConversationService;
+    const service = new TelegramMessageHandlerService(
+      logger,
+      conversation,
+      {} as unknown as TelegramRunCommandsService,
+      filesClientService,
+    );
+    service.setBotToken('bot-token');
+    stubFetch('audio/mpeg');
+    const { ctx } = createContextFixture(
+      {
+        audio: {
+          file_id: 'audio-file',
+          file_name: 'sample.mp3',
+          mime_type: 'audio/mpeg',
+        },
+      },
+      'voice/sample.mp3',
+    );
+
+    await service.handleAudio(ctx);
+
+    expect(uploadToS3).toHaveBeenCalledWith(
+      expect.stringMatching(/^telegram-uploads\/42-audio-node-\d+\.mp3$/),
+      'musics',
+      expect.objectContaining({
+        contentType: 'audio/mpeg',
+        data: expect.any(Buffer),
+        type: FileInputType.BUFFER,
+      }),
+    );
+    expect(state.collectedInputs.get('audio-node')).toBe(
+      'https://cdn.genfeed.ai/telegram-media',
+    );
+    expect(state.currentInputIndex).toBe(1);
+    expect(promptNextInput).toHaveBeenCalledWith(ctx, 42);
+  });
+
+  it('collects Telegram video input as a token-free workflow URL', async () => {
+    const state = createState(createMediaInput('video'));
+    conversation = {
+      getState: vi.fn().mockReturnValue(state),
+      promptNextInput,
+    } as unknown as TelegramConversationService;
+    const service = new TelegramMessageHandlerService(
+      logger,
+      conversation,
+      {} as unknown as TelegramRunCommandsService,
+      filesClientService,
+    );
+    service.setBotToken('bot-token');
+    stubFetch(null);
+    const { ctx } = createContextFixture(
+      {
+        video: {
+          file_id: 'video-file',
+          file_name: 'clip.mp4',
+          mime_type: 'video/mp4',
+        },
+      },
+      'video/clip.mp4',
+    );
+
+    await service.handleVideo(ctx);
+
+    expect(uploadToS3).toHaveBeenCalledWith(
+      expect.stringMatching(/^telegram-uploads\/42-video-node-\d+\.mp4$/),
+      'videos',
+      expect.objectContaining({
+        contentType: 'video/mp4',
+        data: expect.any(Buffer),
+        type: FileInputType.BUFFER,
+      }),
+    );
+    expect(state.collectedInputs.get('video-node')).toBe(
+      'https://cdn.genfeed.ai/telegram-media',
+    );
+    expect(state.currentInputIndex).toBe(1);
+    expect(promptNextInput).toHaveBeenCalledWith(ctx, 42);
+  });
+
+  it('accepts document uploads for the current audio or video step', async () => {
+    const state = createState(createMediaInput('audio'));
+    conversation = {
+      getState: vi.fn().mockReturnValue(state),
+      promptNextInput,
+    } as unknown as TelegramConversationService;
+    const service = new TelegramMessageHandlerService(
+      logger,
+      conversation,
+      {} as unknown as TelegramRunCommandsService,
+      filesClientService,
+    );
+    service.setBotToken('bot-token');
+    stubFetch('audio/wav');
+    const { ctx } = createContextFixture(
+      {
+        document: {
+          file_id: 'document-audio',
+          file_name: 'source.wav',
+          mime_type: 'audio/wav',
+        },
+      },
+      'documents/source.wav',
+    );
+
+    await service.handleDocument(ctx);
+
+    expect(uploadToS3).toHaveBeenCalledWith(
+      expect.stringMatching(/^telegram-uploads\/42-audio-node-\d+\.wav$/),
+      'musics',
+      expect.objectContaining({ contentType: 'audio/wav' }),
+    );
+    expect(state.collectedInputs.get('audio-node')).toBe(
+      'https://cdn.genfeed.ai/telegram-media',
+    );
+  });
+});

--- a/apps/server/api/src/services/telegram-bot/telegram-bot.service.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-bot.service.ts
@@ -255,6 +255,14 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
     // Photo messages (for image inputs)
     this.bot.on('message:photo', (ctx) => this.messageHandler.handlePhoto(ctx));
 
+    // Audio/video messages (for workflow media inputs)
+    this.bot.on('message:audio', (ctx) => this.messageHandler.handleAudio(ctx));
+    this.bot.on('message:voice', (ctx) => this.messageHandler.handleAudio(ctx));
+    this.bot.on('message:video', (ctx) => this.messageHandler.handleVideo(ctx));
+    this.bot.on('message:document', (ctx) =>
+      this.messageHandler.handleDocument(ctx),
+    );
+
     // Text messages (for prompt/text inputs)
     this.bot.on('message:text', (ctx) => this.messageHandler.handleText(ctx));
   }

--- a/apps/server/api/src/services/telegram-bot/telegram-conversation.service.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-conversation.service.ts
@@ -321,15 +321,25 @@ export class TelegramConversationService {
     let summary = `✅ **Ready to run: ${state.workflowName}**\n\n`;
     for (const input of state.requiredInputs) {
       const value = state.collectedInputs.get(input.nodeId);
-      if (input.inputType === 'image') {
-        summary += `📸 ${input.label}: Image received ✓\n`;
-      } else {
-        const displayValue = value
-          ? value.length > 80
-            ? `${value.substring(0, 80)}...`
-            : value
-          : '(empty)';
-        summary += `✏️ ${input.label}: "${displayValue}"\n`;
+      switch (input.inputType) {
+        case 'audio':
+          summary += `🎵 ${input.label}: Audio received ✓\n`;
+          break;
+        case 'image':
+          summary += `📸 ${input.label}: Image received ✓\n`;
+          break;
+        case 'text': {
+          const displayValue = value
+            ? value.length > 80
+              ? `${value.substring(0, 80)}...`
+              : value
+            : '(empty)';
+          summary += `✏️ ${input.label}: "${displayValue}"\n`;
+          break;
+        }
+        case 'video':
+          summary += `🎬 ${input.label}: Video received ✓\n`;
+          break;
       }
     }
 

--- a/apps/server/api/src/services/telegram-bot/telegram-conversation.service.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-conversation.service.ts
@@ -340,6 +340,15 @@ export class TelegramConversationService {
         case 'video':
           summary += `🎬 ${input.label}: Video received ✓\n`;
           break;
+        default: {
+          const displayFallback = value
+            ? value.length > 80
+              ? `${value.substring(0, 80)}...`
+              : value
+            : '(received)';
+          summary += `📎 ${input.label}: ${displayFallback}\n`;
+          break;
+        }
       }
     }
 

--- a/apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts
@@ -1,18 +1,39 @@
 /**
  * Telegram Message Handler Service
  *
- * Handles raw photo and text messages: downloading photos from Telegram,
- * feeding them into the active conversation as collected inputs, capturing a
- * pending generation reference image, and routing free-text prompts to either
- * input collection or a pending-image generate run.
+ * Handles Telegram photo, audio, video, document, and text messages:
+ * downloading media from Telegram, feeding it into the active conversation as
+ * collected inputs, capturing a pending generation reference image, and routing
+ * free-text prompts to either input collection or a pending-image generate run.
  */
 
+import path from 'node:path';
 import type { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import type {
+  ConversationState,
+  WorkflowInput,
+} from '@api/services/telegram-bot/telegram-bot.types';
 import type { TelegramConversationService } from '@api/services/telegram-bot/telegram-conversation.service';
 import type { TelegramRunCommandsService } from '@api/services/telegram-bot/telegram-run-commands.service';
 import { FileInputType } from '@genfeedai/enums';
 import type { LoggerService } from '@libs/logger/logger.service';
 import type { Context } from 'grammy';
+
+type TelegramMediaInputType = Extract<
+  WorkflowInput['inputType'],
+  'audio' | 'video'
+>;
+type TelegramMediaWorkflowInput = WorkflowInput & {
+  inputType: TelegramMediaInputType;
+};
+
+type TelegramMediaPayload = {
+  defaultContentType: string;
+  fallbackExtension: string;
+  fileId: string;
+  fileName?: string;
+  mimeType?: string;
+};
 
 export class TelegramMessageHandlerService {
   private botToken?: string;
@@ -74,9 +95,7 @@ export class TelegramMessageHandlerService {
 
     const currentInput = state.requiredInputs[state.currentInputIndex];
     if (!currentInput || currentInput.inputType !== 'image') {
-      await ctx.reply(
-        "I'm not expecting an image right now. Please send text.",
-      );
+      await ctx.reply(this.getExpectedInputMessage(currentInput?.inputType));
       return;
     }
 
@@ -103,6 +122,65 @@ export class TelegramMessageHandlerService {
       });
       await ctx.reply('❌ Failed to download the photo. Please try again.');
     }
+  }
+
+  /** Handle incoming Telegram audio or voice messages for audio inputs. */
+  async handleAudio(ctx: Context): Promise<void> {
+    const payload = this.getAudioPayload(ctx);
+    if (!payload) {
+      return;
+    }
+
+    await this.handleMedia(ctx, 'audio', payload);
+  }
+
+  /** Handle incoming Telegram video messages for video inputs. */
+  async handleVideo(ctx: Context): Promise<void> {
+    const payload = this.getVideoPayload(ctx);
+    if (!payload) {
+      return;
+    }
+
+    await this.handleMedia(ctx, 'video', payload);
+  }
+
+  /** Handle document uploads when they are used as audio/video workflow input. */
+  async handleDocument(ctx: Context): Promise<void> {
+    const chatId = ctx.chat?.id;
+    const document = ctx.message?.document;
+    if (!chatId || !document) {
+      return;
+    }
+
+    const state = this.conversation.getState(chatId);
+    if (!state || state.step !== 'collecting_inputs') {
+      return;
+    }
+
+    const currentInput = state.requiredInputs[state.currentInputIndex];
+    if (
+      !currentInput ||
+      (currentInput.inputType !== 'audio' && currentInput.inputType !== 'video')
+    ) {
+      await ctx.reply(this.getExpectedInputMessage(currentInput?.inputType));
+      return;
+    }
+
+    const mimeType = document.mime_type;
+    const inferredType = this.inferDocumentMediaType(mimeType);
+    if (inferredType && inferredType !== currentInput.inputType) {
+      await ctx.reply(this.getExpectedInputMessage(currentInput.inputType));
+      return;
+    }
+
+    await this.collectMediaInput(ctx, chatId, state, currentInput, {
+      defaultContentType:
+        currentInput.inputType === 'audio' ? 'audio/mpeg' : 'video/mp4',
+      fallbackExtension: currentInput.inputType === 'audio' ? '.mp3' : '.mp4',
+      fileId: document.file_id,
+      fileName: document.file_name,
+      mimeType,
+    });
   }
 
   /** Handle an incoming text message (prompt input or pending generation). */
@@ -136,7 +214,7 @@ export class TelegramMessageHandlerService {
 
     const currentInput = state.requiredInputs[state.currentInputIndex];
     if (!currentInput || currentInput.inputType !== 'text') {
-      await ctx.reply("I'm expecting an image, not text. Please send a photo.");
+      await ctx.reply(this.getExpectedInputMessage(currentInput?.inputType));
       return;
     }
 
@@ -150,6 +228,136 @@ export class TelegramMessageHandlerService {
     state.currentInputIndex++;
 
     await this.conversation.promptNextInput(ctx, chatId);
+  }
+
+  private getAudioPayload(ctx: Context): TelegramMediaPayload | undefined {
+    const audio = ctx.message?.audio;
+    if (audio) {
+      return {
+        defaultContentType: audio.mime_type || 'audio/mpeg',
+        fallbackExtension: '.mp3',
+        fileId: audio.file_id,
+        fileName: audio.file_name,
+        mimeType: audio.mime_type,
+      };
+    }
+
+    const voice = ctx.message?.voice;
+    if (voice) {
+      return {
+        defaultContentType: voice.mime_type || 'audio/ogg',
+        fallbackExtension: '.ogg',
+        fileId: voice.file_id,
+        mimeType: voice.mime_type,
+      };
+    }
+
+    return undefined;
+  }
+
+  private getVideoPayload(ctx: Context): TelegramMediaPayload | undefined {
+    const video = ctx.message?.video;
+    if (!video) {
+      return undefined;
+    }
+
+    return {
+      defaultContentType: video.mime_type || 'video/mp4',
+      fallbackExtension: '.mp4',
+      fileId: video.file_id,
+      fileName: video.file_name,
+      mimeType: video.mime_type,
+    };
+  }
+
+  private inferDocumentMediaType(
+    mimeType?: string,
+  ): TelegramMediaInputType | undefined {
+    if (mimeType?.startsWith('audio/')) {
+      return 'audio';
+    }
+
+    if (mimeType?.startsWith('video/')) {
+      return 'video';
+    }
+
+    return undefined;
+  }
+
+  private async handleMedia(
+    ctx: Context,
+    mediaType: TelegramMediaInputType,
+    payload: TelegramMediaPayload,
+  ): Promise<void> {
+    const chatId = ctx.chat?.id;
+    if (!chatId) {
+      return;
+    }
+
+    const state = this.conversation.getState(chatId);
+    if (!state || state.step !== 'collecting_inputs') {
+      return;
+    }
+
+    const currentInput = state.requiredInputs[state.currentInputIndex];
+    if (!currentInput || currentInput.inputType !== mediaType) {
+      await ctx.reply(this.getExpectedInputMessage(currentInput?.inputType));
+      return;
+    }
+
+    await this.collectMediaInput(ctx, chatId, state, currentInput, payload);
+  }
+
+  private async collectMediaInput(
+    ctx: Context,
+    chatId: number,
+    state: ConversationState,
+    currentInput: TelegramMediaWorkflowInput,
+    payload: TelegramMediaPayload,
+  ): Promise<void> {
+    try {
+      const mediaUrl = await this.downloadMediaFromTelegram(
+        ctx,
+        payload,
+        chatId,
+        currentInput.nodeId,
+        currentInput.inputType,
+      );
+
+      state.collectedInputs.set(currentInput.nodeId, mediaUrl);
+      state.currentInputIndex++;
+
+      this.loggerService.log(
+        `TelegramBotService: ${currentInput.inputType} saved for node ${currentInput.nodeId}`,
+      );
+
+      await this.conversation.promptNextInput(ctx, chatId);
+    } catch (error) {
+      this.loggerService.error(
+        `TelegramBotService: Failed to download ${currentInput.inputType}`,
+        { error },
+      );
+      await ctx.reply(
+        `❌ Failed to download the ${currentInput.inputType}. Please try again.`,
+      );
+    }
+  }
+
+  private getExpectedInputMessage(
+    expected?: WorkflowInput['inputType'],
+  ): string {
+    switch (expected) {
+      case 'audio':
+        return "I'm expecting audio right now. Please send an audio file.";
+      case 'image':
+        return "I'm expecting an image right now. Please send a photo.";
+      case 'text':
+        return "I'm expecting text right now. Please send a message.";
+      case 'video':
+        return "I'm expecting video right now. Please send a video.";
+      default:
+        return "I'm not expecting a file right now. Send /workflows to start.";
+    }
   }
 
   /**
@@ -178,7 +386,6 @@ export class TelegramMessageHandlerService {
     const buffer = Buffer.from(await response.arrayBuffer());
     const contentType = response.headers.get('content-type') || 'image/jpeg';
 
-    const path = await import('node:path');
     const ext = path.extname(file.file_path || '') || '.jpg';
     const key = `telegram-uploads/${chatId}-${nodeId}-${Date.now()}${ext}`;
 
@@ -194,5 +401,49 @@ export class TelegramMessageHandlerService {
     }
 
     return { imageUrl: metadata.publicUrl };
+  }
+
+  private async downloadMediaFromTelegram(
+    ctx: Context,
+    payload: TelegramMediaPayload,
+    chatId: number,
+    nodeId: string,
+    mediaType: TelegramMediaInputType,
+  ): Promise<string> {
+    if (!this.filesClientService) {
+      throw new Error('File storage service is unavailable');
+    }
+
+    const file = await ctx.api.getFile(payload.fileId);
+    const telegramFileUrl = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+
+    const response = await fetch(telegramFileUrl);
+    if (!response.ok) {
+      throw new Error(`Telegram file download failed: ${response.status}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const contentType =
+      response.headers.get('content-type') ||
+      payload.mimeType ||
+      payload.defaultContentType;
+    const ext =
+      path.extname(file.file_path || '') ||
+      path.extname(payload.fileName || '') ||
+      payload.fallbackExtension;
+    const key = `telegram-uploads/${chatId}-${nodeId}-${Date.now()}${ext}`;
+    const uploadType = mediaType === 'audio' ? 'musics' : 'videos';
+
+    const metadata = await this.filesClientService.uploadToS3(key, uploadType, {
+      contentType,
+      data: buffer,
+      type: FileInputType.BUFFER,
+    });
+
+    if (!metadata.publicUrl) {
+      throw new Error(`Re-hosted ${mediaType} did not return a public URL`);
+    }
+
+    return metadata.publicUrl;
   }
 }

--- a/apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts
@@ -168,8 +168,14 @@ export class TelegramMessageHandlerService {
 
     const mimeType = document.mime_type;
     const inferredType = this.inferDocumentMediaType(mimeType);
-    if (inferredType && inferredType !== currentInput.inputType) {
-      await ctx.reply(this.getExpectedInputMessage(currentInput.inputType));
+    // Reject when the media type cannot be confirmed: an unrecognised MIME
+    // (inferredType === undefined) must not be silently accepted into an
+    // audio/video slot, and a confirmed mismatch is equally invalid.
+    if (!inferredType || inferredType !== currentInput.inputType) {
+      const reason = inferredType
+        ? this.getExpectedInputMessage(currentInput.inputType)
+        : `❌ The file type couldn't be recognized. Please send a valid ${currentInput.inputType} file.`;
+      await ctx.reply(reason);
       return;
     }
 
@@ -415,6 +421,15 @@ export class TelegramMessageHandlerService {
     }
 
     const file = await ctx.api.getFile(payload.fileId);
+
+    // Telegram omits file_path for files larger than the 20 MB Bot API limit.
+    if (!file.file_path) {
+      await ctx.reply(
+        '❌ This file is too large for the Telegram bot to download (limit: 20 MB). Please compress it or use a smaller file.',
+      );
+      throw new Error('Telegram file too large: file_path not returned by API');
+    }
+
     const telegramFileUrl = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
 
     const response = await fetch(telegramFileUrl);


### PR DESCRIPTION
## Summary
- Register Telegram audio, voice, video, and document message handlers for workflow input collection.
- Re-host Telegram audio/video files through FilesClientService before storing workflow input URLs, matching the existing token-free image path.
- Show audio/video inputs as media in confirmation instead of raw text URLs.
- Add regression coverage for media collection and bot event registration.

Closes #862

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bunx biome check --write apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts apps/server/api/src/services/telegram-bot/telegram-bot.service.ts apps/server/api/src/services/telegram-bot/telegram-conversation.service.ts apps/server/api/src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts apps/server/api/src/services/telegram-bot/__tests__/telegram-bot.service.spec.ts`
- `bun run --cwd apps/server/api test:file src/services/telegram-bot/telegram-bot.controller.spec.ts src/services/telegram-bot/telegram-bot.service.spec.ts src/services/telegram-bot/__tests__/telegram-bot.service.spec.ts src/services/telegram-bot/__tests__/telegram-conversation.service.spec.ts src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts src/services/telegram-bot/__tests__/telegram-workflow-executors.spec.ts src/services/telegram-bot/__tests__/telegram-workflow-loader.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bunx turbo run lint --filter=@genfeedai/api`
- `git diff --check origin/master..HEAD`
- `bun scripts/run-secretlint.ts $(git diff --cached --name-only)`
- pre-commit lint-staged hook: Secretlint + Biome passed

## Notes
- A manual standalone `bun scripts/run-secretlint.ts --no-glob` invocation hung silently and was interrupted; the same hook command later completed successfully during `git commit`.
- No live Telegram bot, production service, or external account action was run.