### PR TITLE
fix(api): skip BullMQ startup version checks

### DIFF
--- a/packages/libs/redis/redis-connection.utils.spec.ts
+++ b/packages/libs/redis/redis-connection.utils.spec.ts
@@ -1,0 +1,53 @@
+import {
+  buildBullMQConnection,
+  buildNodeRedisSocketOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
+import { describe, expect, it } from 'vitest';
+
+describe('redis connection utilities', () => {
+  it('builds lazy BullMQ options without startup version checks', () => {
+    const config = {
+      host: 'redis.internal',
+      password: 'secret',
+      port: 6380,
+      tls: true,
+      url: 'rediss://:secret@redis.internal:6380',
+    };
+
+    const connection = buildBullMQConnection(config);
+
+    expect(connection).toMatchObject({
+      connectTimeout: 3000,
+      enableOfflineQueue: false,
+      enableReadyCheck: false,
+      host: 'redis.internal',
+      lazyConnect: true,
+      maxRetriesPerRequest: 0,
+      password: 'secret',
+      port: 6380,
+      skipVersionCheck: true,
+      tls: {},
+    });
+    expect(connection.retryStrategy()).toBeNull();
+  });
+
+  it('enables node-redis TLS when the URL uses rediss', () => {
+    const config = parseRedisConnection({
+      get: (key) =>
+        key === 'REDIS_URL' ? 'rediss://:secret@redis.internal:6380' : false,
+    });
+
+    expect(config).toEqual({
+      host: 'redis.internal',
+      password: 'secret',
+      port: 6380,
+      tls: true,
+      url: 'rediss://:secret@redis.internal:6380',
+    });
+    expect(buildNodeRedisSocketOptions(config)).toEqual({
+      connectTimeout: 3000,
+      tls: true,
+    });
+  });
+});

--- a/packages/libs/redis/redis-connection.utils.ts
+++ b/packages/libs/redis/redis-connection.utils.ts
@@ -90,6 +90,7 @@ export function buildBullMQConnection(config: ParsedRedisConfig) {
     lazyConnect: true,
     maxRetriesPerRequest: 0,
     retryStrategy: () => null,
+    skipVersionCheck: true,
     ...(config.tls && { tls: {} }),
   };
 }


### PR DESCRIPTION
## Summary
- skip BullMQ Redis version/maxmemory checks during queue startup
- add regression coverage for shared Redis connection options

## Verification
- bunx biome check --write packages/libs/redis/redis-connection.utils.ts packages/libs/redis/redis-connection.utils.spec.ts
- bunx vitest run packages/libs/redis/redis-connection.utils.spec.ts packages/libs/redis/redis.service.spec.ts --config vitest.config.ts
- bun type-check --filter=@genfeedai/api
- bun --filter @genfeedai/api build

Note: no local gitleaks was run.