### PR TITLE
Resolve clip brand defaults

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
@@ -43,6 +43,7 @@ export default function StudioClipsPage() {
     error,
     handleAnalyze,
     handleGenerate,
+    identityDefaults,
     isSubmitting,
     maxClips,
     minViralityScore,
@@ -175,6 +176,14 @@ export default function StudioClipsPage() {
                   />
                 </div>
               </div>
+
+              <p className="text-xs text-zinc-500">
+                {identityDefaults.isComplete
+                  ? identityDefaults.source === 'brand'
+                    ? 'Using saved brand HeyGen avatar and voice defaults.'
+                    : 'Using saved organization HeyGen voice default.'
+                  : `Missing ${identityDefaults.missing.join(' and ')} defaults. Enter IDs manually or save them in brand defaults.`}
+              </p>
 
               {/* Provider */}
               <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.test.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.test.ts
@@ -1,0 +1,76 @@
+import type { IBrand, IOrganizationSetting } from '@genfeedai/interfaces';
+import { describe, expect, it } from 'vitest';
+
+import { resolveStudioClipIdentityDefaults } from './useStudioClipsPage';
+
+describe('resolveStudioClipIdentityDefaults', () => {
+  it('prefills saved brand HeyGen avatar and voice defaults', () => {
+    const selectedBrand = {
+      agentConfig: {
+        heygenAvatarId: 'brand-avatar-1',
+        heygenVoiceId: 'brand-voice-1',
+      },
+    } satisfies Pick<IBrand, 'agentConfig'>;
+
+    expect(
+      resolveStudioClipIdentityDefaults({ selectedBrand, settings: null }),
+    ).toEqual({
+      avatarId: 'brand-avatar-1',
+      avatarProvider: 'heygen',
+      isComplete: true,
+      missing: [],
+      source: 'brand',
+      voiceId: 'brand-voice-1',
+    });
+  });
+
+  it('combines saved brand avatar with organization HeyGen voice ref', () => {
+    const selectedBrand = {
+      agentConfig: {
+        heygenAvatarId: 'brand-avatar-2',
+      },
+    } satisfies Pick<IBrand, 'agentConfig'>;
+    const settings = {
+      defaultVoiceRef: {
+        externalVoiceId: 'org-voice-2',
+        provider: 'heygen',
+        source: 'catalog',
+      },
+    } satisfies Pick<IOrganizationSetting, 'defaultVoiceRef'>;
+
+    expect(
+      resolveStudioClipIdentityDefaults({ selectedBrand, settings }),
+    ).toEqual({
+      avatarId: 'brand-avatar-2',
+      avatarProvider: 'heygen',
+      isComplete: true,
+      missing: [],
+      source: 'brand',
+      voiceId: 'org-voice-2',
+    });
+  });
+
+  it('ignores non-HeyGen voice refs for direct clip generation', () => {
+    const selectedBrand = {
+      agentConfig: {
+        heygenAvatarId: 'brand-avatar-3',
+        defaultVoiceRef: {
+          externalVoiceId: 'elevenlabs-voice-3',
+          provider: 'elevenlabs',
+          source: 'catalog',
+        },
+      },
+    } satisfies Pick<IBrand, 'agentConfig'>;
+
+    expect(
+      resolveStudioClipIdentityDefaults({ selectedBrand, settings: null }),
+    ).toEqual({
+      avatarId: 'brand-avatar-3',
+      avatarProvider: 'heygen',
+      isComplete: false,
+      missing: ['voice'],
+      source: 'brand',
+      voiceId: undefined,
+    });
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
@@ -1,4 +1,6 @@
+import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
+import type { IBrand, IOrganizationSetting } from '@genfeedai/interfaces';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useDocumentVisibility } from '@hooks/ui/use-document-visibility/use-document-visibility';
 import type {
@@ -13,8 +15,89 @@ import { ClipsApiService } from './services/clips-api.service';
 
 const TERMINAL_PROJECT_STATUSES = new Set(['completed', 'failed']);
 
+type StudioClipIdentityField = 'avatar' | 'voice';
+type StudioClipIdentitySource = 'brand' | 'missing' | 'organization';
+
+interface StudioClipIdentityDefaults {
+  avatarId?: string;
+  avatarProvider: AvatarProvider;
+  isComplete: boolean;
+  missing: StudioClipIdentityField[];
+  source: StudioClipIdentitySource;
+  voiceId?: string;
+}
+
+interface StudioClipIdentityContext {
+  selectedBrand?: Pick<IBrand, 'agentConfig'> | null;
+  settings?: Pick<IOrganizationSetting, 'defaultVoiceRef'> | null;
+}
+
+function isHeygenProvider(provider?: string | null): boolean {
+  return provider?.toLowerCase() === 'heygen';
+}
+
+function readNonEmptyString(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveHeygenVoiceRef(
+  ref:
+    | NonNullable<IBrand['agentConfig']>['defaultVoiceRef']
+    | IOrganizationSetting['defaultVoiceRef']
+    | undefined,
+): string | undefined {
+  if (
+    ref?.source !== 'catalog' ||
+    !isHeygenProvider(ref.provider) ||
+    !ref.externalVoiceId
+  ) {
+    return undefined;
+  }
+
+  return readNonEmptyString(ref.externalVoiceId);
+}
+
+export function resolveStudioClipIdentityDefaults({
+  selectedBrand,
+  settings,
+}: StudioClipIdentityContext): StudioClipIdentityDefaults {
+  const brandConfig = selectedBrand?.agentConfig;
+  const brandAvatarId = readNonEmptyString(brandConfig?.heygenAvatarId);
+  const brandVoiceId =
+    readNonEmptyString(brandConfig?.heygenVoiceId) ??
+    resolveHeygenVoiceRef(brandConfig?.defaultVoiceRef);
+  const organizationVoiceId = resolveHeygenVoiceRef(settings?.defaultVoiceRef);
+  const avatarId = brandAvatarId;
+  const voiceId = brandVoiceId ?? organizationVoiceId;
+  const missing: StudioClipIdentityField[] = [];
+
+  if (!avatarId) {
+    missing.push('avatar');
+  }
+
+  if (!voiceId) {
+    missing.push('voice');
+  }
+
+  return {
+    avatarId,
+    avatarProvider: 'heygen',
+    isComplete: missing.length === 0,
+    missing,
+    source:
+      avatarId || brandVoiceId
+        ? 'brand'
+        : organizationVoiceId
+          ? 'organization'
+          : 'missing',
+    voiceId,
+  };
+}
+
 export function useStudioClipsPage() {
   const { getToken } = useAuthIdentity();
+  const { selectedBrand, settings } = useBrand();
 
   const resolveToken = useCallback(async (): Promise<string> => {
     return (await resolveAuthToken(getToken)) ?? '';
@@ -53,6 +136,27 @@ export function useStudioClipsPage() {
     null,
   );
   const isDocumentVisible = useDocumentVisibility();
+  const identityDefaults = useMemo(
+    () => resolveStudioClipIdentityDefaults({ selectedBrand, settings }),
+    [selectedBrand, settings],
+  );
+
+  useEffect(() => {
+    if (identityDefaults.avatarId && !avatarId) {
+      setAvatarId(identityDefaults.avatarId);
+      setAvatarProvider(identityDefaults.avatarProvider);
+    }
+
+    if (identityDefaults.voiceId && !voiceId) {
+      setVoiceId(identityDefaults.voiceId);
+    }
+  }, [
+    avatarId,
+    identityDefaults.avatarId,
+    identityDefaults.avatarProvider,
+    identityDefaults.voiceId,
+    voiceId,
+  ]);
 
   // ─── Step 1: Analyze ─────────────────────────────────────────
   const handleAnalyze = useCallback(async () => {
@@ -333,6 +437,7 @@ export function useStudioClipsPage() {
     error,
     handleAnalyze,
     handleGenerate,
+    identityDefaults,
     isSubmitting,
     maxClips,
     minViralityScore,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -1799,6 +1799,140 @@ describe('AgentToolExecutorService', () => {
     );
   });
 
+  it('should resolve brand HeyGen defaults for prepare_clip_workflow_run', async () => {
+    const { brandsService, service, workflowsService } = createService();
+
+    brandsService.findOne.mockResolvedValue({
+      _id: '67a1234567890123456789aa',
+      agentConfig: {
+        heygenAvatarId: 'brand-avatar-1',
+        heygenVoiceId: 'brand-voice-1',
+      },
+    });
+    workflowsService.findAll.mockResolvedValue({ docs: [] });
+
+    const result = await service.executeTool(
+      AgentToolName.PREPARE_CLIP_WORKFLOW_RUN,
+      {
+        prompt: 'Generate a defaulted clip',
+      },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    const action = result.nextActions?.[0];
+    expect(action?.clipRun?.identity).toEqual(
+      expect.objectContaining({
+        avatarId: 'brand-avatar-1',
+        isComplete: true,
+        source: 'brand',
+        voiceId: 'brand-voice-1',
+      }),
+    );
+    expect(action?.clipRun?.inputValues).toEqual(
+      expect.objectContaining({
+        avatarId: 'brand-avatar-1',
+        heygenAvatarId: 'brand-avatar-1',
+        heygenVoiceId: 'brand-voice-1',
+        identityStatus: 'ready',
+        voiceId: 'brand-voice-1',
+      }),
+    );
+    expect(action?.clipRunState).toEqual(
+      expect.objectContaining({
+        identity: expect.objectContaining({
+          avatarId: 'brand-avatar-1',
+          voiceId: 'brand-voice-1',
+        }),
+      }),
+    );
+  });
+
+  it('should merge brand avatar with organization HeyGen voice fallback', async () => {
+    const {
+      brandsService,
+      organizationSettingsService,
+      service,
+      workflowsService,
+    } = createService();
+
+    brandsService.findOne.mockResolvedValue({
+      _id: '67a1234567890123456789aa',
+      agentConfig: {
+        heygenAvatarId: 'brand-avatar-2',
+      },
+    });
+    organizationSettingsService.findOne.mockResolvedValue({
+      _id: 'settings-1',
+      defaultVoiceRef: {
+        externalVoiceId: 'org-heygen-voice-2',
+        provider: 'heygen',
+        source: 'catalog',
+      },
+    });
+    workflowsService.findAll.mockResolvedValue({ docs: [] });
+
+    const result = await service.executeTool(
+      AgentToolName.PREPARE_CLIP_WORKFLOW_RUN,
+      {
+        prompt: 'Generate a mixed-default clip',
+      },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    const identity = result.nextActions?.[0].clipRun?.identity;
+    expect(identity).toEqual(
+      expect.objectContaining({
+        avatarId: 'brand-avatar-2',
+        isComplete: true,
+        source: 'brand',
+        voiceId: 'org-heygen-voice-2',
+      }),
+    );
+  });
+
+  it('should surface missing clip identity defaults before generation', async () => {
+    const { brandsService, service, workflowsService } = createService();
+
+    brandsService.findOne.mockResolvedValue(null);
+    workflowsService.findAll.mockResolvedValue({ docs: [] });
+
+    const result = await service.executeTool(
+      AgentToolName.PREPARE_CLIP_WORKFLOW_RUN,
+      {
+        prompt: 'Generate a clip without defaults',
+      },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    const action = result.nextActions?.[0];
+    expect(action?.description).toContain(
+      'Clip identity defaults are incomplete',
+    );
+    expect(action?.clipRun?.identity).toEqual(
+      expect.objectContaining({
+        isComplete: false,
+        missing: ['avatar', 'voice'],
+        source: 'missing',
+      }),
+    );
+    expect(action?.clipRun?.inputValues).toEqual(
+      expect.objectContaining({
+        identityStatus: 'missing_identity',
+        missingIdentity: ['avatar', 'voice'],
+      }),
+    );
+  });
+
   it('should sanitize colon-prefixed batch ids for list_review_queue and return a conversation card', async () => {
     const { batchGenerationService, service } = createService();
     batchGenerationService.getBatch = vi.fn().mockResolvedValue({

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -65,10 +65,14 @@ import {
   PostStatus,
   Status,
   VoiceCloneStatus,
+  VoiceProvider,
   VoteEntityModel,
   WorkflowTrigger,
 } from '@genfeedai/enums';
 import type {
+  AgentClipRunIdentity,
+  AgentClipRunIdentityField,
+  AgentClipRunIdentitySource,
   AgentDashboardOperation,
   AgentIngredientItem,
   AgentToolResult,
@@ -139,6 +143,20 @@ interface ToolRouteSlugs {
 interface DashboardHydrationState {
   status?: 'idle' | 'loading' | 'ready';
   staggerMs?: number;
+}
+
+interface DefaultVoiceRefLike {
+  externalVoiceId?: unknown;
+  provider?: unknown;
+  source?: unknown;
+}
+
+interface ResolvedClipIdentityInput {
+  avatarId?: string;
+  avatarProvider?: string;
+  source: AgentClipRunIdentitySource;
+  voiceId?: string;
+  voiceProvider?: string;
 }
 
 type HydratableDashboardBlock<T extends AgentUIBlock = AgentUIBlock> = T & {
@@ -7895,6 +7913,168 @@ export class AgentToolExecutorService {
     };
   }
 
+  private resolveClipWorkflowIdentity(
+    params: Record<string, unknown>,
+    brand: unknown,
+    organizationSettings: unknown,
+  ): AgentClipRunIdentity {
+    const explicitAvatarId =
+      this.readOptionalString(params.avatarId) ??
+      this.readOptionalString(params.heygenAvatarId);
+    const explicitVoiceId =
+      this.readOptionalString(params.voiceId) ??
+      this.readOptionalString(params.heygenVoiceId);
+    const brandRecord = this.readObjectRecord(brand);
+    const brandAgentConfig = this.readObjectRecord(brandRecord?.agentConfig);
+    const brandAvatarId = this.readOptionalString(
+      brandAgentConfig?.heygenAvatarId,
+    );
+    const brandVoiceId =
+      this.readOptionalString(brandAgentConfig?.heygenVoiceId) ??
+      this.readHeygenVoiceIdFromDefaultRef(brandAgentConfig?.defaultVoiceRef) ??
+      (this.isHeygenProvider(brandAgentConfig?.defaultVoiceProvider)
+        ? this.readOptionalString(brandAgentConfig?.defaultVoiceId)
+        : undefined);
+    const orgSettingsRecord = this.readObjectRecord(organizationSettings);
+    const organizationVoiceId =
+      this.readHeygenVoiceIdFromDefaultRef(
+        orgSettingsRecord?.defaultVoiceRef,
+      ) ??
+      (this.isHeygenProvider(orgSettingsRecord?.defaultVoiceProvider)
+        ? this.readOptionalString(orgSettingsRecord?.defaultVoiceId)
+        : undefined);
+
+    const source: AgentClipRunIdentitySource =
+      explicitAvatarId || explicitVoiceId
+        ? 'explicit'
+        : brandAvatarId || brandVoiceId
+          ? 'brand'
+          : organizationVoiceId
+            ? 'organization'
+            : 'missing';
+    const avatarId = explicitAvatarId ?? brandAvatarId;
+    const voiceId = explicitVoiceId ?? brandVoiceId ?? organizationVoiceId;
+
+    return this.createClipIdentity({
+      avatarId,
+      avatarProvider:
+        this.readOptionalString(params.avatarProvider) ??
+        (avatarId ? VoiceProvider.HEYGEN : undefined),
+      source,
+      voiceId,
+      voiceProvider:
+        this.readOptionalString(params.voiceProvider) ??
+        (voiceId ? VoiceProvider.HEYGEN : undefined),
+    });
+  }
+
+  private createClipIdentity(
+    input: ResolvedClipIdentityInput,
+  ): AgentClipRunIdentity {
+    const missing: AgentClipRunIdentityField[] = [];
+
+    if (!input.avatarId) {
+      missing.push('avatar');
+    }
+
+    if (!input.voiceId) {
+      missing.push('voice');
+    }
+
+    return {
+      avatarId: input.avatarId,
+      avatarProvider: input.avatarProvider,
+      isComplete: missing.length === 0,
+      label: this.getClipIdentityLabel(input.source, missing),
+      missing,
+      source: input.source,
+      useIdentity: true,
+      voiceId: input.voiceId,
+      voiceProvider: input.voiceProvider,
+    };
+  }
+
+  private getClipIdentityLabel(
+    source: AgentClipRunIdentitySource,
+    missing: AgentClipRunIdentityField[],
+  ): string {
+    if (missing.length > 0) {
+      return `Missing ${missing.join(' and ')} defaults`;
+    }
+
+    switch (source) {
+      case 'explicit':
+        return 'Explicit clip identity';
+      case 'brand':
+        return 'Brand clip defaults';
+      case 'organization':
+        return 'Organization clip defaults';
+      default:
+        return 'Clip identity defaults';
+    }
+  }
+
+  private buildClipIdentityInputValues(
+    identity: AgentClipRunIdentity,
+  ): Record<string, unknown> {
+    const values: Record<string, unknown> = {
+      identitySource: identity.source,
+      identityStatus: identity.isComplete ? 'ready' : 'missing_identity',
+      missingIdentity: identity.missing,
+      useIdentity: identity.useIdentity,
+    };
+
+    if (identity.avatarId) {
+      values.avatarId = identity.avatarId;
+      values.avatarProvider = identity.avatarProvider ?? VoiceProvider.HEYGEN;
+
+      if (
+        (identity.avatarProvider ?? VoiceProvider.HEYGEN) ===
+        VoiceProvider.HEYGEN
+      ) {
+        values.heygenAvatarId = identity.avatarId;
+      }
+    }
+
+    if (identity.voiceId) {
+      values.voiceId = identity.voiceId;
+      values.voiceProvider = identity.voiceProvider ?? VoiceProvider.HEYGEN;
+
+      if (
+        (identity.voiceProvider ?? VoiceProvider.HEYGEN) ===
+        VoiceProvider.HEYGEN
+      ) {
+        values.heygenVoiceId = identity.voiceId;
+      }
+    }
+
+    return values;
+  }
+
+  private readObjectRecord(
+    value: unknown,
+  ): Record<string, unknown> | undefined {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : undefined;
+  }
+
+  private readHeygenVoiceIdFromDefaultRef(value: unknown): string | undefined {
+    const ref = this.readObjectRecord(value) as DefaultVoiceRefLike | undefined;
+
+    if (ref?.source !== 'catalog' || !this.isHeygenProvider(ref.provider)) {
+      return undefined;
+    }
+
+    return this.readOptionalString(ref.externalVoiceId);
+  }
+
+  private isHeygenProvider(value: unknown): boolean {
+    return (
+      typeof value === 'string' && value.toLowerCase() === VoiceProvider.HEYGEN
+    );
+  }
+
   private async prepareClipWorkflowRun(
     params: Record<string, unknown>,
     ctx: ToolExecutionContext,
@@ -7911,6 +8091,18 @@ export class AgentToolExecutorService {
     const selectedBrandId = currentBrand
       ? String((currentBrand as Record<string, unknown>)._id)
       : null;
+    const orgSettings = this.organizationSettingsService
+      ? await this.organizationSettingsService.findOne({
+          isDeleted: false,
+          organization: ctx.organizationId,
+        })
+      : null;
+    const identity = this.resolveClipWorkflowIdentity(
+      params,
+      currentBrand,
+      orgSettings,
+    );
+    const identityInputValues = this.buildClipIdentityInputValues(identity);
     const requestedWorkflowId = (
       params.workflowId as string | undefined
     )?.trim();
@@ -7996,6 +8188,7 @@ export class AgentToolExecutorService {
       data: {
         durationSeconds,
         format: 'landscape',
+        identity,
         intent: 'twitter_clip',
         mergeGeneratedVideos,
         prompt,
@@ -8007,10 +8200,12 @@ export class AgentToolExecutorService {
             autonomousMode,
             durationSeconds,
             format: 'landscape',
+            identity,
             inputValues: {
               confirmBeforePublish: true,
               duration: durationSeconds,
               format: 'landscape',
+              ...identityInputValues,
               intent: 'twitter_clip',
               mergeGeneratedVideos,
               prompt,
@@ -8024,6 +8219,7 @@ export class AgentToolExecutorService {
             brandId: selectedBrandId ?? '',
             clipProjectId: selectedWorkflow ?? `clip-${Date.now()}`,
             currentStep: 'generate',
+            identity,
             modes: {
               aspectRatio: '16:9' as const,
               confirmBeforePublish: true,
@@ -8067,8 +8263,9 @@ export class AgentToolExecutorService {
               },
             ],
           },
-          description:
-            'Generate a 30-second landscape clip, optionally merge multiple clips, then reframe to portrait for Instagram.',
+          description: identity.isComplete
+            ? 'Generate a 30-second landscape clip, optionally merge multiple clips, then reframe to portrait for Instagram.'
+            : 'Clip identity defaults are incomplete. Add the missing avatar or voice defaults before generating.',
           id: `clip-workflow-run-${Date.now()}`,
           title: 'Run Clip Workflow (X → IG)',
           type: 'clip_workflow_run_card' as const,

--- a/packages/agent/src/components/ClipRunCard.spec.tsx
+++ b/packages/agent/src/components/ClipRunCard.spec.tsx
@@ -125,6 +125,32 @@ describe('ClipRunCard', () => {
     );
   });
 
+  it('shows resolved clip identity status', () => {
+    render(
+      <ClipRunCard
+        state={makeState({
+          identity: {
+            avatarId: 'avatar-1',
+            avatarProvider: 'heygen',
+            isComplete: true,
+            label: 'Brand clip defaults',
+            missing: [],
+            source: 'brand',
+            useIdentity: true,
+            voiceId: 'voice-1',
+            voiceProvider: 'heygen',
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Clip identity')).toBeDefined();
+    expect(screen.getByText('Brand clip defaults')).toBeDefined();
+    expect(
+      screen.getByText('Avatar avatar-1 and voice voice-1 are ready.'),
+    ).toBeDefined();
+  });
+
   it('shows error state with message', () => {
     const state = makeState({
       status: 'failed',

--- a/packages/agent/src/components/ClipRunCard.tsx
+++ b/packages/agent/src/components/ClipRunCard.tsx
@@ -4,6 +4,7 @@ import type {
   ClipRunStep,
 } from '@genfeedai/agent/models/clip-run-card.model';
 import { ButtonVariant } from '@genfeedai/enums';
+import type { AgentClipRunIdentity } from '@genfeedai/interfaces';
 import { Button } from '@ui/primitives/button';
 import type { ReactElement } from 'react';
 import {
@@ -98,6 +99,12 @@ const PLATFORM_LABELS: Record<string, string> = {
   twitter: 'Twitter / X',
 };
 
+function getIdentitySummary(identity: AgentClipRunIdentity): string {
+  return identity.isComplete
+    ? `Avatar ${identity.avatarId} and voice ${identity.voiceId} are ready.`
+    : `Missing ${identity.missing.join(' and ')}.`;
+}
+
 export function ClipRunCard({
   state,
   onConfirm,
@@ -171,6 +178,24 @@ export function ClipRunCard({
             </span>
           </div>
         </div>
+
+        {state.identity && (
+          <div
+            className={`border px-3 py-2 text-xs ${
+              state.identity.isComplete
+                ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300'
+                : 'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-900 dark:bg-yellow-950 dark:text-yellow-300'
+            }`}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium">Clip identity</span>
+              <span>{state.identity.label}</span>
+            </div>
+            <p className="mt-1 text-muted-foreground">
+              {getIdentitySummary(state.identity)}
+            </p>
+          </div>
+        )}
 
         {/* Error state */}
         {state.status === 'failed' && failedStep && (

--- a/packages/agent/src/components/ClipWorkflowRunCard.spec.tsx
+++ b/packages/agent/src/components/ClipWorkflowRunCard.spec.tsx
@@ -4,6 +4,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Effect } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    href: (path: string) => `/test-org/test-brand${path}`,
+  }),
+}));
+
 describe('ClipWorkflowRunCard', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -96,5 +102,47 @@ describe('ClipWorkflowRunCard', () => {
         '/posts/review?batch=batch-123&item=item-456',
       );
     });
+  });
+
+  it('blocks clip generation when identity defaults are incomplete', async () => {
+    const action: AgentUiAction = {
+      clipRun: {
+        identity: {
+          isComplete: false,
+          label: 'Missing avatar and voice defaults',
+          missing: ['avatar', 'voice'],
+          source: 'missing',
+          useIdentity: true,
+        },
+        mergeGeneratedVideos: false,
+        prompt: 'Turn this launch clip into a polished reel',
+      },
+      id: 'clip-missing-identity-1',
+      title: 'Launch clip',
+      type: 'clip_workflow_run_card',
+    };
+
+    const apiService = {
+      createManualReviewBatchEffect: vi.fn(),
+      createPromptEffect: vi.fn(() => Effect.succeed({ id: 'prompt-123' })),
+      generateIngredientEffect: vi.fn(),
+      mergeVideosEffect: vi.fn(),
+      reframeVideoEffect: vi.fn(),
+      resizeVideoEffect: vi.fn(),
+      triggerWorkflowEffect: vi.fn(),
+    };
+
+    render(
+      <ClipWorkflowRunCard action={action} apiService={apiService as never} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Next Step' }));
+
+    expect(
+      await screen.findByText(
+        'Configure saved avatar and voice defaults or enter explicit IDs before generating clips.',
+      ),
+    ).toBeInTheDocument();
+    expect(apiService.createPromptEffect).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/components/ClipWorkflowRunCard.tsx
+++ b/packages/agent/src/components/ClipWorkflowRunCard.tsx
@@ -1,5 +1,6 @@
 import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
+import type { AgentClipRunIdentity } from '@genfeedai/interfaces';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { ReactElement } from 'react';
 import { HiExclamationCircle, HiOutlineFilm } from 'react-icons/hi2';
@@ -11,6 +12,12 @@ import { useClipWorkflowRunCard } from './useClipWorkflowRunCard';
 interface ClipWorkflowRunCardProps {
   action: AgentUiAction;
   apiService: AgentApiService;
+}
+
+function formatMissingIdentity(identity: AgentClipRunIdentity): string {
+  return identity.missing.length > 0
+    ? `Missing ${identity.missing.join(' and ')}`
+    : 'Ready';
 }
 
 export function ClipWorkflowRunCard({
@@ -35,6 +42,7 @@ export function ClipWorkflowRunCard({
     workflowExecutionId,
     generatedVideoIds,
     finalVideoId,
+    identity,
     canMerge,
     draftReviewUrl,
     error,
@@ -86,6 +94,26 @@ export function ClipWorkflowRunCard({
           onMergeNow={() => runOneStep('merge_clips')}
           onOpenSupervisedReview={() => runOneStep('supervised_review')}
         />
+
+        {identity && (
+          <div
+            className={`border px-3 py-2 text-xs ${
+              identity.isComplete
+                ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300'
+                : 'border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-900 dark:bg-yellow-950 dark:text-yellow-300'
+            }`}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium">Clip identity</span>
+              <span>{identity.label}</span>
+            </div>
+            <p className="mt-1 text-muted-foreground">
+              {identity.isComplete
+                ? `Avatar ${identity.avatarId} and voice ${identity.voiceId} are ready.`
+                : formatMissingIdentity(identity)}
+            </p>
+          </div>
+        )}
 
         <ClipWorkflowStepsList steps={steps} />
 

--- a/packages/agent/src/components/useClipWorkflowRunCard.ts
+++ b/packages/agent/src/components/useClipWorkflowRunCard.ts
@@ -6,6 +6,7 @@ import {
   getPromptCategoryForGenerationType,
 } from '@genfeedai/agent/utils/generation-request';
 import { COMPOSE_ROUTES } from '@genfeedai/constants';
+import type { AgentClipRunIdentity } from '@genfeedai/interfaces';
 import { useCallback, useMemo, useState } from 'react';
 
 export type StepKey =
@@ -35,12 +36,48 @@ interface UseClipWorkflowRunCardParams {
   hrefFn: (path: string) => string;
 }
 
+function buildClipIdentityInputValues(
+  identity?: AgentClipRunIdentity,
+): Record<string, unknown> {
+  if (!identity) {
+    return {};
+  }
+
+  return {
+    avatarId: identity.avatarId,
+    avatarProvider: identity.avatarProvider,
+    heygenAvatarId:
+      (identity.avatarProvider ?? 'heygen') === 'heygen'
+        ? identity.avatarId
+        : undefined,
+    heygenVoiceId:
+      (identity.voiceProvider ?? 'heygen') === 'heygen'
+        ? identity.voiceId
+        : undefined,
+    identitySource: identity.source,
+    missingIdentity: identity.missing,
+    useIdentity: identity.useIdentity,
+    voiceId: identity.voiceId,
+    voiceProvider: identity.voiceProvider,
+  };
+}
+
+function getClipIdentityError(identity: AgentClipRunIdentity): string {
+  if (identity.isComplete) {
+    return '';
+  }
+
+  const missing = identity.missing.join(' and ');
+  return `Configure saved ${missing} defaults or enter explicit IDs before generating clips.`;
+}
+
 export function useClipWorkflowRunCard({
   action,
   apiService,
   hrefFn,
 }: UseClipWorkflowRunCardParams) {
   const clipRun = action.clipRun ?? {};
+  const identity = clipRun.identity;
   const [autonomousMode, setAutonomousMode] = useState(
     clipRun.autonomousMode ?? true,
   );
@@ -101,18 +138,24 @@ export function useClipWorkflowRunCard({
       return;
     }
     setStep('trigger_workflow', 'running');
+    if (identity && !identity.isComplete) {
+      throw new Error(getClipIdentityError(identity));
+    }
+
+    const inputValues = {
+      ...(clipRun.inputValues ?? {
+        confirmBeforePublish: true,
+        duration: durationSeconds,
+        format: 'landscape',
+        intent: 'twitter_clip',
+        mergeGeneratedVideos,
+        prompt,
+      }),
+      ...buildClipIdentityInputValues(identity),
+    };
+
     const execution = await runAgentApiEffect(
-      apiService.triggerWorkflowEffect(
-        workflowId,
-        clipRun.inputValues ?? {
-          confirmBeforePublish: true,
-          duration: durationSeconds,
-          format: 'landscape',
-          intent: 'twitter_clip',
-          mergeGeneratedVideos,
-          prompt,
-        },
-      ),
+      apiService.triggerWorkflowEffect(workflowId, inputValues),
     );
     setWorkflowExecutionId(execution.id);
     setStep('trigger_workflow', 'completed');
@@ -120,6 +163,7 @@ export function useClipWorkflowRunCard({
     apiService,
     clipRun.inputValues,
     durationSeconds,
+    identity,
     mergeGeneratedVideos,
     prompt,
     setStep,
@@ -128,6 +172,10 @@ export function useClipWorkflowRunCard({
 
   const runGenerateClip = useCallback(async () => {
     setStep('generate_clip', 'running');
+    if (identity && !identity.isComplete) {
+      throw new Error(getClipIdentityError(identity));
+    }
+
     const promptDoc = await runAgentApiEffect(
       apiService.createPromptEffect({
         category: getPromptCategoryForGenerationType('video'),
@@ -143,6 +191,7 @@ export function useClipWorkflowRunCard({
         buildAgentGenerationRequestBody({
           aspectRatio: '16:9',
           duration: Math.max(5, Math.min(60, durationSeconds)),
+          identity,
           modelKey: clipRun.model || undefined,
           promptId: promptDoc.id,
           promptText: prompt,
@@ -152,7 +201,7 @@ export function useClipWorkflowRunCard({
     );
     setGeneratedVideoIds((prev) => [...prev, result.id]);
     setStep('generate_clip', 'completed');
-  }, [apiService, clipRun.model, durationSeconds, prompt, setStep]);
+  }, [apiService, clipRun.model, durationSeconds, identity, prompt, setStep]);
 
   const runMerge = useCallback(async () => {
     if (!mergeGeneratedVideos || generatedVideoIds.length < 2) {
@@ -334,6 +383,7 @@ export function useClipWorkflowRunCard({
     workflowExecutionId,
     generatedVideoIds,
     finalVideoId,
+    identity,
     canMerge,
     draftReviewUrl,
     error,

--- a/packages/agent/src/models/agent-chat.model.ts
+++ b/packages/agent/src/models/agent-chat.model.ts
@@ -2,6 +2,7 @@ import type { SuggestedAction } from '@genfeedai/agent/models/agent-suggested-ac
 import type { ClipRunCardState } from '@genfeedai/agent/models/clip-run-card.model';
 import type { AgentThreadStatus } from '@genfeedai/enums';
 import type {
+  AgentClipRunIdentity,
   AgentDashboardOperation,
   AgentUIBlock,
 } from '@genfeedai/interfaces';
@@ -199,6 +200,7 @@ export interface AgentUiAction {
     autonomousMode?: boolean;
     durationSeconds?: number;
     format?: 'landscape' | 'portrait' | 'square';
+    identity?: AgentClipRunIdentity;
     inputValues?: Record<string, unknown>;
     mergeGeneratedVideos?: boolean;
     model?: string;

--- a/packages/agent/src/models/clip-run-card.model.ts
+++ b/packages/agent/src/models/clip-run-card.model.ts
@@ -1,3 +1,5 @@
+import type { AgentClipRunIdentity } from '@genfeedai/interfaces';
+
 /** ClipRunStep — one step in the clip run lifecycle */
 export interface ClipRunStep {
   id: string;
@@ -26,6 +28,7 @@ export interface ClipRunCardState {
   currentStep: string;
   steps: ClipRunStep[];
   modes: ClipRunModes;
+  identity?: AgentClipRunIdentity;
   finalOutputUrl?: string;
   status: 'idle' | 'running' | 'paused' | 'done' | 'failed';
   confirmationPending?: boolean;

--- a/packages/agent/src/utils/generation-request.spec.ts
+++ b/packages/agent/src/utils/generation-request.spec.ts
@@ -68,4 +68,35 @@ describe('generation-request', () => {
       width: 1024,
     });
   });
+
+  it('adds HeyGen identity fields when clip identity is resolved', () => {
+    expect(
+      buildAgentGenerationRequestBody({
+        aspectRatio: '16:9',
+        identity: {
+          avatarId: 'avatar-1',
+          avatarProvider: 'heygen',
+          isComplete: true,
+          label: 'Brand clip defaults',
+          missing: [],
+          source: 'brand',
+          useIdentity: true,
+          voiceId: 'voice-1',
+          voiceProvider: 'heygen',
+        },
+        promptId: 'prompt-3',
+        promptText: 'Video prompt',
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        avatarId: 'avatar-1',
+        avatarProvider: 'heygen',
+        heygenAvatarId: 'avatar-1',
+        heygenVoiceId: 'voice-1',
+        useIdentity: true,
+        voiceId: 'voice-1',
+        voiceProvider: 'heygen',
+      }),
+    );
+  });
 });

--- a/packages/agent/src/utils/generation-request.ts
+++ b/packages/agent/src/utils/generation-request.ts
@@ -1,4 +1,5 @@
 import { RouterPriority } from '@genfeedai/enums';
+import type { AgentClipRunIdentity } from '@genfeedai/interfaces';
 
 export const DEFAULT_AGENT_GENERATION_PRIORITY = RouterPriority.QUALITY;
 
@@ -31,6 +32,7 @@ export function getDimensionsForAspectRatio(ratio: string): {
 export function buildAgentGenerationRequestBody({
   aspectRatio,
   duration,
+  identity,
   modelKey,
   prioritize = DEFAULT_AGENT_GENERATION_PRIORITY,
   promptId,
@@ -39,6 +41,7 @@ export function buildAgentGenerationRequestBody({
 }: {
   aspectRatio: string;
   duration?: number;
+  identity?: AgentClipRunIdentity;
   modelKey?: string;
   prioritize?: RouterPriority;
   promptId: string;
@@ -65,6 +68,26 @@ export function buildAgentGenerationRequestBody({
 
   if (waitForCompletion != null) {
     body.waitForCompletion = waitForCompletion;
+  }
+
+  if (identity?.avatarId) {
+    body.avatarId = identity.avatarId;
+    body.avatarProvider = identity.avatarProvider ?? 'heygen';
+    body.useIdentity = true;
+
+    if ((identity.avatarProvider ?? 'heygen') === 'heygen') {
+      body.heygenAvatarId = identity.avatarId;
+    }
+  }
+
+  if (identity?.voiceId) {
+    body.voiceId = identity.voiceId;
+    body.voiceProvider = identity.voiceProvider ?? 'heygen';
+    body.useIdentity = true;
+
+    if ((identity.voiceProvider ?? 'heygen') === 'heygen') {
+      body.heygenVoiceId = identity.voiceId;
+    }
   }
 
   return body;

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -70,6 +70,14 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../helpers/src/$1'),
       },
       {
+        find: /^@genfeedai\/hooks$/,
+        replacement: path.resolve(__dirname, '../hooks'),
+      },
+      {
+        find: /^@genfeedai\/hooks\/(.*)$/,
+        replacement: path.resolve(__dirname, '../hooks/$1'),
+      },
+      {
         find: /^@genfeedai\/contexts$/,
         replacement: path.resolve(__dirname, '../contexts'),
       },

--- a/packages/interfaces/src/ai/agent-ui-action.interface.ts
+++ b/packages/interfaces/src/ai/agent-ui-action.interface.ts
@@ -60,6 +60,26 @@ export interface AgentIngredientItem {
   title?: string;
 }
 
+export type AgentClipRunIdentityField = 'avatar' | 'voice';
+
+export type AgentClipRunIdentitySource =
+  | 'brand'
+  | 'explicit'
+  | 'missing'
+  | 'organization';
+
+export interface AgentClipRunIdentity {
+  avatarId?: string;
+  avatarProvider?: string;
+  isComplete: boolean;
+  label: string;
+  missing: AgentClipRunIdentityField[];
+  source: AgentClipRunIdentitySource;
+  useIdentity: boolean;
+  voiceId?: string;
+  voiceProvider?: string;
+}
+
 export interface AgentUiAction extends AgentUiActionBase {
   ctas?: AgentUiActionCta[];
   data?: Record<string, unknown>;
@@ -106,6 +126,7 @@ export interface AgentUiAction extends AgentUiActionBase {
     autonomousMode?: boolean;
     durationSeconds?: number;
     format?: 'landscape' | 'portrait' | 'square';
+    identity?: AgentClipRunIdentity;
     inputValues?: Record<string, unknown>;
     mergeGeneratedVideos?: boolean;
     model?: string;


### PR DESCRIPTION
## Summary
- Resolves clip workflow avatar/voice identity defaults from explicit IDs, brand HeyGen defaults, and organization HeyGen voice fallback.
- Carries resolved identity into agent clip workflow cards, workflow input values, and generation requests with HeyGen aliases.
- Prefills Studio Clips Avatar ID / Voice ID from saved defaults and shows missing-default guidance before generation.

Closes #232

## Validation
- `bunx vitest run --config vitest.config.ts src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts -t "prepare_clip_workflow_run|clip identity|HeyGen defaults|organization HeyGen voice fallback"`
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/utils/generation-request.spec.ts packages/agent/src/components/ClipRunCard.spec.tsx packages/agent/src/components/ClipWorkflowRunCard.spec.tsx`
- `bunx vitest run --config vitest.config.mts "app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.test.ts"`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/app --filter=@genfeedai/agent --filter=@genfeedai/interfaces`
- `git diff --check origin/master...HEAD`

## Notes
- The full `agent-tool-executor.service.spec.ts` suite still has unrelated existing failures outside the focused clip workflow tests; the touched clip cases pass.
