### PR TITLE
ci: gate self-hosted release publish on full-suite + build-verify-selfhosted

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,9 +44,42 @@ jobs:
         env:
           RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish || '' }}
 
+  # Full-suite gate — the community image users `docker run` must not publish
+  # until the ENTIRE suite is green: the ci.yml unit matrix (sharded app + api +
+  # packages + server services + web/desktop/mobile + extensions), the prod-image
+  # build-verify boot check, and the e2e suite. full-suite chains all three via
+  # workflow_call. Mirrors the qa-before-deploy gate in deploy-ecs.yml so a
+  # release publishes the same verification bar a production deploy clears.
+  verify-suite:
+    name: Full Suite (pre-publish gate)
+    needs: validate-master-ref
+    # Mirror deploy-ecs.yml's qa-before-deploy grant: ci.yml requests
+    # pull-requests/statuses write, build-verify needs packages:write (GHCR
+    # cache login). A reusable workflow is capped by the caller's job-level
+    # permissions, so they must be declared here, not just at workflow top-level.
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+      statuses: write
+    uses: ./.github/workflows/full-suite.yml
+    secrets: inherit
+
+  # Community-image boot gate — full-suite's build-verify covers the MICROSERVICE
+  # (prod) image, not docker/Dockerfile.selfhosted. This is the all-in-one
+  # community image this workflow is about to push, so its dedicated build/boot
+  # guard (previously wired into nothing automated) must gate the publish too.
+  verify-selfhosted:
+    name: Self-Hosted Build Verify (pre-publish gate)
+    needs: validate-master-ref
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-verify-selfhosted.yml
+
   build-and-push:
     name: Build & Push Self-Hosted Image
-    needs: validate-master-ref
+    needs: [validate-master-ref, verify-suite, verify-selfhosted]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

Closes the **"all tests on release"** gap. Today the community image users `docker run` is published on `release: published` with **zero** test gate — only `validate-master-ref`. The full unit matrix + e2e only ran at production **deploy** (`deploy-ecs` → `qa-before-deploy` → `full-suite`), never at the release cut. So a release could ship a broken self-hosted image.

## Change

`docker-publish.yml` `build-and-push` now `needs: [validate-master-ref, verify-suite, verify-selfhosted]`:

- **`verify-suite`** → `full-suite.yml` (ci unit matrix: sharded app + api + packages + server-services + web/desktop/mobile + extensions, **plus** `build-verify` prod-image boot **plus** `e2e`). Permissions mirror `deploy-ecs.yml`'s `qa-before-deploy` grant (a reusable workflow is capped by the caller's job-level permissions).
- **`verify-selfhosted`** → `build-verify-selfhosted.yml`, the all-in-one community-image build/boot guard that was previously wired into **no** automated path. full-suite's `build-verify` only covers the microservice/prod image; this covers `docker/Dockerfile.selfhosted`.

A verify failure leaves the GitHub release present but **blocks the image push** — the artifact users run is what's protected.

## Tradeoff

Adds ~20–30 min to a release publish. Intentional: a release now clears the same bar a production deploy does (defense-in-depth: community image vs. prod deploy).

## Validation

- `actionlint` clean on `docker-publish.yml`, `full-suite.yml`, `build-verify-selfhosted.yml`.
- To verify behavior: dispatch *Docker Publish (Self-Hosted)* (`workflow_dispatch`, `tag: staging`) from master → confirm both verify jobs run and `build-and-push` is blocked until both are green.

Part of a CI consolidation initiative prompted by #895 (more PRs follow: per-PR API tests + guard consolidation, dead-workflow cleanup, version-drift fixes).