### PR TITLE
fix(api): keep workflow automations out of boot graph

### DIFF
--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -3,24 +3,15 @@
  * Automation templates: reusable multi-step workflows, triggers (manual/auto),
 dependency management, and workflow execution tracking.
  */
-import { AdOptimizationConfigsModule } from '@api/collections/ad-optimization-configs/ad-optimization-configs.module';
-import { AdPerformanceModule } from '@api/collections/ad-performance/ad-performance.module';
-import { AgentGoalsModule } from '@api/collections/agent-goals/agent-goals.module';
-import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
-import { BotsModule } from '@api/collections/bots/bots.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CaptionsModule } from '@api/collections/captions/captions.module';
-import { ContentSchedulesModule } from '@api/collections/content-schedules/content-schedules.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
 import { CreditsModule } from '@api/collections/credits/credits.module';
-import { CronJobsModule } from '@api/collections/cron-jobs/cron-jobs.module';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
 import { MusicsModule } from '@api/collections/musics/musics.module';
 import { NewslettersModule } from '@api/collections/newsletters/newsletters.module';
-import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
-import { ReplyBotConfigsModule } from '@api/collections/reply-bot-configs/reply-bot-configs.module';
 import { TrendsModule } from '@api/collections/trends/trends.module';
 import { VideoGenerationModule } from '@api/collections/videos/video-generation.module';
 import { VideosModule } from '@api/collections/videos/videos.module';
@@ -32,22 +23,14 @@ import { WorkflowCrudController } from '@api/collections/workflows/controllers/w
 import { WorkflowExecutionController } from '@api/collections/workflows/controllers/workflow-execution.controller';
 import { WorkflowMarketplaceController } from '@api/collections/workflows/controllers/workflow-marketplace.controller';
 import { WorkflowWebhookManagementController } from '@api/collections/workflows/controllers/workflow-webhook-management.controller';
-import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
-import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
-import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { BatchWorkflowService } from '@api/collections/workflows/services/batch-workflow.service';
 import {
   BATCH_WORKFLOW_QUEUE,
   BatchWorkflowQueueService,
 } from '@api/collections/workflows/services/batch-workflow-queue.service';
-import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
-import { ContentProductionWorkflowService } from '@api/collections/workflows/services/content-production-workflow.service';
-import { LivestreamBotWorkflowService } from '@api/collections/workflows/services/livestream-bot-workflow.service';
-import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
-import { TrendNotificationWorkflowService } from '@api/collections/workflows/services/trend-notification-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import {
   WORKFLOW_EXECUTION_QUEUE,
@@ -59,24 +42,13 @@ import { WorkflowGenerationService } from '@api/collections/workflows/services/w
 import { WorkflowSchedulerService } from '@api/collections/workflows/services/workflow-scheduler.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { MarketplaceIntegrationModule } from '@api/marketplace-integration/marketplace-integration.module';
-import { QueuesModule } from '@api/queues/core/queues.module';
-import { AgentCampaignOrchestratorModule } from '@api/services/agent-campaign/agent-campaign-orchestrator.module';
-import { AiInfluencerModule } from '@api/services/ai-influencer/ai-influencer.module';
-import { ContentEngineModule } from '@api/services/content-engine/content-engine.module';
-import { ContentGatewayModule } from '@api/services/content-gateway/content-gateway.module';
-import { ContentOrchestrationModule } from '@api/services/content-orchestration/content-orchestration.module';
 import { ElevenLabsModule } from '@api/services/integrations/elevenlabs/elevenlabs.module';
-import { GoogleAdsModule } from '@api/services/integrations/google-ads/google-ads.module';
 import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
-import { MetaAdsModule } from '@api/services/integrations/meta-ads/meta-ads.module';
 import { OpenRouterModule } from '@api/services/integrations/openrouter/openrouter.module';
-import { TikTokAdsModule } from '@api/services/integrations/tiktok-ads/tiktok-ads.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
-import { ReplyBotModule } from '@api/services/reply-bot/reply-bot.module';
-import { SeoModule } from '@api/services/seo/seo.module';
 import { WhisperModule } from '@api/services/whisper/whisper.module';
 import { WorkflowExecutorModule } from '@api/services/workflow-executor/workflow-executor.module';
 import { SharedModule } from '@api/shared/shared.module';
@@ -107,53 +79,25 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowExecutionQueueService,
     WorkflowFormatConverterService,
     WorkflowGenerationService,
-    AdAutomationWorkflowService,
-    AgentAutopilotWorkflowService,
-    AnalyticsSyncWorkflowService,
-    CampaignOrchestrationWorkflowService,
-    ContentProductionWorkflowService,
-    LivestreamBotWorkflowService,
-    ReplyPollingWorkflowService,
-    TrendNotificationWorkflowService,
   ],
   imports: [
-    forwardRef(() => AdOptimizationConfigsModule),
-    forwardRef(() => AdPerformanceModule),
-    forwardRef(() => AgentCampaignOrchestratorModule),
-    forwardRef(() => AgentGoalsModule),
-    forwardRef(() => AgentRunsModule),
-    forwardRef(() => AiInfluencerModule),
-    forwardRef(() => BotsModule),
     forwardRef(() => BrandsModule),
     forwardRef(() => CaptionsModule),
-    forwardRef(() => ContentEngineModule),
-    forwardRef(() => ContentGatewayModule),
-    forwardRef(() => ContentOrchestrationModule),
-    forwardRef(() => ContentSchedulesModule),
     forwardRef(() => CredentialsCoreModule),
-    forwardRef(() => CronJobsModule),
     forwardRef(() => CreditsModule),
     forwardRef(() => ElevenLabsModule),
-    forwardRef(() => GoogleAdsModule),
     forwardRef(() => HeyGenModule),
     forwardRef(() => IngredientsModule),
     forwardRef(() => InstagramModule),
     forwardRef(() => MarketplaceIntegrationModule),
     forwardRef(() => MetadataModule),
-    forwardRef(() => MetaAdsModule),
     forwardRef(() => MusicsModule),
     forwardRef(() => NewslettersModule),
     forwardRef(() => NotificationsModule),
     forwardRef(() => NotificationsPublisherModule),
-    forwardRef(() => OrganizationSettingsModule),
     forwardRef(() => OpenRouterModule),
     forwardRef(() => PostsModule),
-    forwardRef(() => QueuesModule),
-    forwardRef(() => ReplyBotConfigsModule),
-    forwardRef(() => ReplyBotModule),
-    forwardRef(() => SeoModule),
     forwardRef(() => SharedModule),
-    forwardRef(() => TikTokAdsModule),
     forwardRef(() => TrendsModule),
     forwardRef(() => TwitterModule),
     forwardRef(() => VideoGenerationModule),
@@ -186,16 +130,8 @@ import { forwardRef, Module } from '@nestjs/common';
     TwitterSocialAdapter,
     InstagramSocialAdapter,
     SocialAdapterFactory,
-    AdAutomationWorkflowService,
-    AgentAutopilotWorkflowService,
-    AnalyticsSyncWorkflowService,
     BatchWorkflowQueueService,
     BatchWorkflowService,
-    CampaignOrchestrationWorkflowService,
-    ContentProductionWorkflowService,
-    LivestreamBotWorkflowService,
-    ReplyPollingWorkflowService,
-    TrendNotificationWorkflowService,
     WorkflowEngineAdapterService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,


### PR DESCRIPTION
## Summary
- remove newly eager workflow automation providers from `WorkflowsModule`
- remove broad ads/reply/content/queue imports that expanded the Nest boot graph
- keep `WorkflowEngineAdapterService` optional handler paths intact so missing automation handlers are skipped instead of forcing startup resolution

## Why
The production deploy for master `a96ec8b3` passed image build but failed before ECS rollout in the boot-smoke gate. The new image reached `API bootstrap: creating Nest application` and then stayed inside Nest dependency resolution until the smoke window expired. Verbose one-off Fargate probing showed the boot graph recursing through the newly imported workflow automation module surface, not failing on Redis or Better Auth.

## Verification
- `bunx biome check --write apps/server/api/src/collections/workflows/workflows.module.ts`
- `bun type-check --filter=@genfeedai/api`
- `bun --filter @genfeedai/api build`
- `git diff --check`

No local gitleaks run.