### PR TITLE
Define clip terminal contracts

### DIFF
--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
@@ -1,0 +1,155 @@
+import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
+import type { CreateClipProjectDto } from '@api/collections/clip-projects/dto/create-clip-project.dto';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createLogger(): LoggerService {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    verbose: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggerService;
+}
+
+function createPrisma() {
+  return {
+    _runtimeDataModel: {
+      models: {
+        ClipProject: {
+          fields: [
+            { name: 'id' },
+            { name: 'mongoId' },
+            { name: 'organizationId' },
+            { name: 'brandId' },
+            { name: 'status' },
+            { name: 'progress' },
+            { name: 'error' },
+            { name: 'readyClipCount' },
+            { name: 'failedClipCount' },
+            { name: 'pendingClipCount' },
+            { name: 'readiness' },
+            { name: 'terminalAt' },
+            { name: 'config' },
+            { name: 'isDeleted' },
+          ],
+        },
+      },
+    },
+    clipProject: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+}
+
+describe('ClipProjectsService', () => {
+  let prisma: ReturnType<typeof createPrisma>;
+  let service: ClipProjectsService;
+
+  beforeEach(() => {
+    prisma = createPrisma();
+    service = new ClipProjectsService(
+      prisma as unknown as PrismaService,
+      createLogger(),
+    );
+  });
+
+  it('maps create DTO fields to durable columns and config JSON', async () => {
+    prisma.clipProject.create.mockResolvedValue({
+      _id: 'project-1',
+      config: {},
+      id: 'project-1',
+      organizationId: 'org-1',
+      progress: 0,
+      readiness: {},
+      status: 'pending',
+    });
+
+    await service.create({
+      language: 'en',
+      name: 'Launch clip',
+      organization: 'org-1',
+      settings: { maxClips: 3 },
+      sourceVideoUrl: 'https://example.com/source.mp4',
+      status: 'pending',
+      user: 'user-1',
+    } as CreateClipProjectDto);
+
+    expect(prisma.clipProject.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        config: expect.objectContaining({
+          language: 'en',
+          name: 'Launch clip',
+          settings: { maxClips: 3 },
+          sourceVideoUrl: 'https://example.com/source.mp4',
+          user: 'user-1',
+        }),
+        organizationId: 'org-1',
+        readiness: expect.objectContaining({
+          state: 'pending',
+          terminal: false,
+        }),
+        status: 'pending',
+      }),
+    });
+  });
+
+  it('merges patch config and adds terminal readiness for completed projects', async () => {
+    prisma.clipProject.findFirst.mockResolvedValue({
+      config: {
+        highlights: [{ id: 'h-1' }],
+        name: 'Existing',
+      },
+      id: 'project-1',
+      organizationId: 'org-1',
+      progress: 40,
+      readiness: {},
+      status: 'generating',
+    });
+    prisma.clipProject.update.mockResolvedValue({
+      config: {},
+      id: 'project-1',
+      organizationId: 'org-1',
+      progress: 100,
+      readiness: {},
+      status: 'completed',
+    });
+
+    await service.patch('legacy-project-id', {
+      error: null,
+      progress: 100,
+      readyClipCount: 2,
+      status: 'completed',
+    });
+
+    expect(prisma.clipProject.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [{ id: 'legacy-project-id' }, { mongoId: 'legacy-project-id' }],
+        isDeleted: false,
+      },
+    });
+    expect(prisma.clipProject.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        config: expect.objectContaining({
+          highlights: [{ id: 'h-1' }],
+          name: 'Existing',
+        }),
+        error: null,
+        progress: 100,
+        readiness: expect.objectContaining({
+          readyActions: ['download', 'edit', 'publish'],
+          state: 'ready',
+          terminal: true,
+        }),
+        readyClipCount: 2,
+        status: 'completed',
+        terminalAt: expect.any(Date),
+      }),
+      where: { id: 'project-1' },
+    });
+  });
+});

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
@@ -1,10 +1,42 @@
 import { CreateClipProjectDto } from '@api/collections/clip-projects/dto/create-clip-project.dto';
 import { UpdateClipProjectDto } from '@api/collections/clip-projects/dto/update-clip-project.dto';
 import type { ClipProjectDocument } from '@api/collections/clip-projects/schemas/clip-project.schema';
+import {
+  buildClipProjectReadiness,
+  isTerminalClipStatus,
+} from '@api/collections/clip-shared/clip-terminal-contract.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import type { PopulateOption } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
+
+type PopulateInput = (string | PopulateOption)[] | 'none';
+
+type ClipProjectWriteDto = Partial<
+  CreateClipProjectDto & UpdateClipProjectDto
+> &
+  Record<string, unknown>;
+
+const PROJECT_SCALAR_KEYS = new Set([
+  '_id',
+  'brand',
+  'brandId',
+  'config',
+  'error',
+  'failedClipCount',
+  'id',
+  'isDeleted',
+  'mongoId',
+  'organization',
+  'organizationId',
+  'pendingClipCount',
+  'progress',
+  'readiness',
+  'readyClipCount',
+  'status',
+  'terminalAt',
+]);
 
 @Injectable()
 export class ClipProjectsService extends BaseService<
@@ -17,5 +49,152 @@ export class ClipProjectsService extends BaseService<
     public readonly logger: LoggerService,
   ) {
     super(prisma, 'clipProject', logger);
+  }
+
+  override async create(
+    createDto: CreateClipProjectDto,
+    populate: PopulateInput = [],
+  ): Promise<ClipProjectDocument> {
+    return await super.create(
+      this.toPrismaWriteData(
+        createDto as unknown as ClipProjectWriteDto,
+        'create',
+      ) as unknown as CreateClipProjectDto,
+      populate,
+    );
+  }
+
+  override async patch(
+    id: string,
+    updateDto: Partial<UpdateClipProjectDto> | Record<string, unknown>,
+    populate: PopulateInput = [],
+  ): Promise<ClipProjectDocument> {
+    const existing = await this.findOne({ _id: id, isDeleted: false });
+    const existingConfig = this.readRecord(
+      (existing as Record<string, unknown> | null)?.config,
+    );
+    const canonicalId =
+      typeof existing?.id === 'string' && existing.id.length > 0
+        ? existing.id
+        : id;
+
+    return await super.patch(
+      canonicalId,
+      this.toPrismaWriteData(updateDto, 'update', existingConfig),
+      populate,
+    );
+  }
+
+  private toPrismaWriteData(
+    dto: ClipProjectWriteDto,
+    mode: 'create' | 'update',
+    existingConfig: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    const data: Record<string, unknown> = {};
+    const config: Record<string, unknown> = { ...existingConfig };
+
+    if (typeof dto._id === 'string' && dto._id.length > 0) {
+      data.mongoId = dto._id;
+    }
+
+    if (typeof dto.mongoId === 'string' && dto.mongoId.length > 0) {
+      data.mongoId = dto.mongoId;
+    }
+
+    if (typeof dto.organization === 'string') {
+      data.organizationId = dto.organization;
+    }
+
+    if (typeof dto.organizationId === 'string') {
+      data.organizationId = dto.organizationId;
+    }
+
+    if (Object.hasOwn(dto, 'brand')) {
+      data.brandId = dto.brand ?? null;
+    }
+
+    if (Object.hasOwn(dto, 'brandId')) {
+      data.brandId = dto.brandId ?? null;
+    }
+
+    this.assignIfOwn(data, dto, 'status');
+    this.assignIfOwn(data, dto, 'progress');
+    this.assignIfOwn(data, dto, 'error');
+    this.assignIfOwn(data, dto, 'readyClipCount');
+    this.assignIfOwn(data, dto, 'failedClipCount');
+    this.assignIfOwn(data, dto, 'pendingClipCount');
+    this.assignIfOwn(data, dto, 'readiness');
+    this.assignIfOwn(data, dto, 'terminalAt');
+    this.assignIfOwn(data, dto, 'isDeleted');
+
+    for (const [key, value] of Object.entries(dto)) {
+      if (PROJECT_SCALAR_KEYS.has(key) || value === undefined) {
+        continue;
+      }
+      config[key] = value;
+    }
+
+    const suppliedConfig = this.readRecord(dto.config);
+    data.config = { ...config, ...suppliedConfig };
+
+    this.applyTerminalDefaults(data, mode);
+
+    return data;
+  }
+
+  private applyTerminalDefaults(
+    data: Record<string, unknown>,
+    mode: 'create' | 'update',
+  ): void {
+    if (mode === 'create' && typeof data.status !== 'string') {
+      data.status = 'pending';
+    }
+
+    if (typeof data.status !== 'string') {
+      return;
+    }
+
+    if (
+      isTerminalClipStatus(data.status) &&
+      !Object.hasOwn(data, 'terminalAt')
+    ) {
+      data.terminalAt = new Date();
+    }
+
+    if (!Object.hasOwn(data, 'readiness')) {
+      data.readiness = buildClipProjectReadiness({
+        error: this.readString(data.error),
+        status: data.status,
+        terminalAt: this.readTerminalAt(data.terminalAt),
+      });
+    }
+  }
+
+  private assignIfOwn(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+    key: string,
+  ): void {
+    if (Object.hasOwn(source, key)) {
+      target[key] = source[key];
+    }
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private readString(value: unknown): string | null {
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private readTerminalAt(value: unknown): Date | string | null {
+    if (value instanceof Date || typeof value === 'string' || value === null) {
+      return value;
+    }
+
+    return null;
   }
 }

--- a/apps/server/api/src/collections/clip-projects/dto/create-clip-project.dto.ts
+++ b/apps/server/api/src/collections/clip-projects/dto/create-clip-project.dto.ts
@@ -1,8 +1,10 @@
+import { ClipProjectStatus } from '@api/collections/clip-projects/schemas/clip-project.schema';
 import { OrganizationalCreateDto } from '@api/shared/dto/base/base.dto';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
+  IsIn,
   IsNumber,
   IsOptional,
   IsString,
@@ -110,8 +112,11 @@ export class CreateClipProjectDto extends OrganizationalCreateDto {
 
   @IsOptional()
   @IsString()
+  @IsIn([...ClipProjectStatus])
   @ApiProperty({
     description: 'Project processing status',
+    enum: ClipProjectStatus,
+    enumName: 'ClipProjectStatus',
     required: false,
   })
   readonly status?: string;

--- a/apps/server/api/src/collections/clip-projects/dto/update-clip-project.dto.ts
+++ b/apps/server/api/src/collections/clip-projects/dto/update-clip-project.dto.ts
@@ -5,12 +5,16 @@ import { Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
+  IsDateString,
   IsIn,
+  IsInt,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   Max,
   Min,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 
@@ -119,12 +123,57 @@ export class UpdateClipProjectDto extends PartialType(CreateClipProjectDto) {
   readonly videoMetadata?: VideoMetadataDto;
 
   @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
   @IsString()
   @ApiProperty({
     description: 'Error message if processing failed',
     required: false,
   })
-  readonly error?: string;
+  readonly error?: string | null;
+
+  @IsOptional()
+  @IsObject()
+  @ApiProperty({
+    description: 'Readiness contract for terminal clip handoff',
+    required: false,
+  })
+  readonly readiness?: Record<string, unknown>;
+
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsDateString()
+  @ApiProperty({
+    description: 'Timestamp when the project reached a terminal status',
+    required: false,
+  })
+  readonly terminalAt?: string | null;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @ApiProperty({
+    description: 'Number of ready clips in the project',
+    required: false,
+  })
+  readonly readyClipCount?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @ApiProperty({
+    description: 'Number of failed clips in the project',
+    required: false,
+  })
+  readonly failedClipCount?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @ApiProperty({
+    description: 'Number of non-terminal clips in the project',
+    required: false,
+  })
+  readonly pendingClipCount?: number;
 
   @IsOptional()
   @IsBoolean()

--- a/apps/server/api/src/collections/clip-projects/schemas/clip-project.schema.ts
+++ b/apps/server/api/src/collections/clip-projects/schemas/clip-project.schema.ts
@@ -1,6 +1,11 @@
-import type { ClipProject } from '@genfeedai/prisma';
+import {
+  CLIP_PROJECT_STATUSES,
+  type ClipReadinessContract,
+  type ClipProjectStatus as SharedClipProjectStatus,
+} from '@genfeedai/interfaces';
+import type { ClipProject as PrismaClipProject } from '@genfeedai/prisma';
 
-export type { ClipProject } from '@genfeedai/prisma';
+export type ClipProject = PrismaClipProject;
 
 export interface IHighlight {
   id: string;
@@ -13,16 +18,7 @@ export interface IHighlight {
   clip_type: string;
 }
 
-export const ClipProjectStatus = [
-  'pending',
-  'transcribing',
-  'analyzing',
-  'analyzed',
-  'clipping',
-  'generating',
-  'completed',
-  'failed',
-] as const;
+export const ClipProjectStatus = CLIP_PROJECT_STATUSES;
 
 export type ClipProjectStatusType = (typeof ClipProjectStatus)[number];
 
@@ -40,19 +36,36 @@ export interface ClipProjectSettings {
   [key: string]: unknown;
 }
 
-export interface ClipProjectDocument extends ClipProject {
+type ClipProjectRecord = Omit<
+  PrismaClipProject,
+  | 'error'
+  | 'failedClipCount'
+  | 'pendingClipCount'
+  | 'progress'
+  | 'readiness'
+  | 'readyClipCount'
+  | 'status'
+  | 'terminalAt'
+>;
+
+export interface ClipProjectDocument extends ClipProjectRecord {
   _id: string;
   brand?: string | null;
-  error?: string;
+  error?: string | null;
+  failedClipCount: number;
   highlights?: ClipProjectHighlight[];
   language?: string;
   name?: string;
   organization?: string;
-  progress?: number;
+  pendingClipCount: number;
+  progress: number;
+  readiness: ClipReadinessContract | Record<string, unknown>;
+  readyClipCount: number;
   settings?: ClipProjectSettings;
   sourceVideoS3Key?: string;
   sourceVideoUrl?: string;
-  status?: ClipProjectStatusType | string;
+  status: SharedClipProjectStatus | string;
+  terminalAt?: Date | null;
   transcriptText?: string;
   user?: string;
   [key: string]: unknown;

--- a/apps/server/api/src/collections/clip-results/clip-results.controller.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.controller.ts
@@ -72,8 +72,10 @@ export class ClipResultsController {
     const resolvedProjectId = projectId || filterProjectId;
 
     if (resolvedProjectId) {
-      const data =
-        await this.clipResultsService.findByProject(resolvedProjectId);
+      const data = await this.clipResultsService.findByProject(
+        resolvedProjectId,
+        publicMetadata.organization,
+      );
       return serializeCollection(request, ClipResultSerializer, {
         docs: data,
         hasNextPage: false,

--- a/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
@@ -1,0 +1,191 @@
+import { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
+import type { CreateClipResultDto } from '@api/collections/clip-results/dto/create-clip-result.dto';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createLogger(): LoggerService {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    verbose: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggerService;
+}
+
+function createPrisma() {
+  return {
+    _runtimeDataModel: {
+      models: {
+        ClipResult: {
+          fields: [
+            { name: 'id' },
+            { name: 'mongoId' },
+            { name: 'organizationId' },
+            { name: 'projectId' },
+            { name: 'providerJobId' },
+            { name: 'viralityScore' },
+            { name: 'status' },
+            { name: 'isSelected' },
+            { name: 'readiness' },
+            { name: 'terminalAt' },
+            { name: 'data' },
+            { name: 'isDeleted' },
+          ],
+        },
+      },
+    },
+    clipResult: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+}
+
+describe('ClipResultsService', () => {
+  let prisma: ReturnType<typeof createPrisma>;
+  let service: ClipResultsService;
+
+  beforeEach(() => {
+    prisma = createPrisma();
+    service = new ClipResultsService(
+      prisma as unknown as PrismaService,
+      createLogger(),
+    );
+  });
+
+  it('maps create DTO fields to durable columns and data JSON', async () => {
+    prisma.clipResult.create.mockResolvedValue({
+      data: {},
+      id: 'clip-1',
+      isSelected: false,
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      readiness: {},
+      status: 'pending',
+    });
+
+    await service.create({
+      clipType: 'hook',
+      duration: 30,
+      endTime: 45,
+      index: 0,
+      organization: 'org-1',
+      project: 'project-1',
+      startTime: 15,
+      status: 'pending',
+      summary: 'A compelling moment',
+      tags: ['ai'],
+      title: 'Clip title',
+      user: 'user-1',
+      viralityScore: 88,
+    } as CreateClipResultDto);
+
+    expect(prisma.clipResult.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        data: expect.objectContaining({
+          clipType: 'hook',
+          duration: 30,
+          endTime: 45,
+          index: 0,
+          startTime: 15,
+          summary: 'A compelling moment',
+          tags: ['ai'],
+          title: 'Clip title',
+          user: 'user-1',
+        }),
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        readiness: expect.objectContaining({
+          state: 'pending',
+          terminal: false,
+        }),
+        status: 'pending',
+        viralityScore: 88,
+      }),
+    });
+  });
+
+  it('merges patch data and adds terminal readiness for completed clips', async () => {
+    prisma.clipResult.findFirst.mockResolvedValue({
+      data: {
+        index: 0,
+        title: 'Existing',
+      },
+      id: 'clip-1',
+      isSelected: false,
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      readiness: {},
+      status: 'extracting',
+    });
+    prisma.clipResult.update.mockResolvedValue({
+      data: {},
+      id: 'clip-1',
+      isSelected: false,
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      readiness: {},
+      status: 'completed',
+    });
+
+    await service.patch('legacy-clip-id', {
+      providerJobId: 'provider-job-1',
+      status: 'completed',
+      videoUrl: 'https://cdn.genfeed.ai/clip.mp4',
+    });
+
+    expect(prisma.clipResult.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        data: expect.objectContaining({
+          index: 0,
+          title: 'Existing',
+          videoUrl: 'https://cdn.genfeed.ai/clip.mp4',
+        }),
+        providerJobId: 'provider-job-1',
+        readiness: expect.objectContaining({
+          readyActions: ['download', 'edit', 'publish'],
+          state: 'ready',
+          terminal: true,
+        }),
+        status: 'completed',
+        terminalAt: expect.any(Date),
+      }),
+      where: { id: 'clip-1' },
+    });
+  });
+
+  it('scopes project lookup by organization when provided', async () => {
+    prisma.clipResult.findMany.mockResolvedValue([
+      {
+        data: { title: 'Clip' },
+        id: 'clip-1',
+        isSelected: false,
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        readiness: {},
+        status: 'completed',
+      },
+    ]);
+
+    const result = await service.findByProject('project-1', 'org-1');
+
+    expect(prisma.clipResult.findMany).toHaveBeenCalledWith({
+      orderBy: { viralityScore: 'desc' },
+      where: {
+        isDeleted: false,
+        organizationId: 'org-1',
+        projectId: 'project-1',
+      },
+    });
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        _id: 'clip-1',
+        title: 'Clip',
+      }),
+    );
+  });
+});

--- a/apps/server/api/src/collections/clip-results/clip-results.service.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.ts
@@ -1,11 +1,39 @@
 import { CreateClipResultDto } from '@api/collections/clip-results/dto/create-clip-result.dto';
 import { UpdateClipResultDto } from '@api/collections/clip-results/dto/update-clip-result.dto';
 import type { ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
+import {
+  buildClipResultReadiness,
+  isTerminalClipStatus,
+} from '@api/collections/clip-shared/clip-terminal-contract.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import type { PopulateOption } from '@genfeedai/interfaces';
 import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
+
+type PopulateInput = (string | PopulateOption)[] | 'none';
+
+type ClipResultWriteDto = Partial<CreateClipResultDto & UpdateClipResultDto> &
+  Record<string, unknown>;
+
+const RESULT_SCALAR_KEYS = new Set([
+  '_id',
+  'data',
+  'id',
+  'isDeleted',
+  'isSelected',
+  'mongoId',
+  'organization',
+  'organizationId',
+  'project',
+  'projectId',
+  'providerJobId',
+  'readiness',
+  'status',
+  'terminalAt',
+  'viralityScore',
+]);
 
 @Injectable()
 export class ClipResultsService extends BaseService<
@@ -21,24 +49,172 @@ export class ClipResultsService extends BaseService<
     super(prisma, 'clipResult', logger);
   }
 
-  findByProject(projectId: string): Promise<ClipResultDocument[]> {
-    return this.delegate.findMany({
+  override async create(
+    createDto: CreateClipResultDto,
+    populate: PopulateInput = [],
+  ): Promise<ClipResultDocument> {
+    return await super.create(
+      this.toPrismaWriteData(
+        createDto as unknown as ClipResultWriteDto,
+        'create',
+      ) as unknown as CreateClipResultDto,
+      populate,
+    );
+  }
+
+  override async patch(
+    id: string,
+    updateDto: Partial<UpdateClipResultDto> | Record<string, unknown>,
+    populate: PopulateInput = [],
+  ): Promise<ClipResultDocument> {
+    const existing = await this.findOne({ _id: id, isDeleted: false });
+    const existingData = this.readRecord(
+      (existing as Record<string, unknown> | null)?.data,
+    );
+    const canonicalId =
+      typeof existing?.id === 'string' && existing.id.length > 0
+        ? existing.id
+        : id;
+
+    return await super.patch(
+      canonicalId,
+      this.toPrismaWriteData(updateDto, 'update', existingData),
+      populate,
+    );
+  }
+
+  async findByProject(
+    projectId: string,
+    organizationId?: string,
+  ): Promise<ClipResultDocument[]> {
+    const docs = await this.delegate.findMany({
       where: {
         isDeleted: false,
+        ...(organizationId ? { organizationId } : {}),
         projectId,
       },
       orderBy: { viralityScore: 'desc' },
-    }) as Promise<ClipResultDocument[]>;
+    });
+
+    return this.normalizeDocuments(docs);
   }
 
-  findByProviderJobId(
+  async findByProviderJobId(
     providerJobId: string,
   ): Promise<ClipResultDocument | null> {
-    return this.delegate.findFirst({
+    const result = await this.delegate.findFirst({
       where: {
         isDeleted: false,
         providerJobId,
       },
-    }) as Promise<ClipResultDocument | null>;
+    });
+
+    return result ? this.normalizeDocument(result) : null;
+  }
+
+  private toPrismaWriteData(
+    dto: ClipResultWriteDto,
+    mode: 'create' | 'update',
+    existingData: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    const data: Record<string, unknown> = {};
+    const legacyData: Record<string, unknown> = { ...existingData };
+
+    if (typeof dto._id === 'string' && dto._id.length > 0) {
+      data.mongoId = dto._id;
+    }
+
+    if (typeof dto.mongoId === 'string' && dto.mongoId.length > 0) {
+      data.mongoId = dto.mongoId;
+    }
+
+    if (typeof dto.organization === 'string') {
+      data.organizationId = dto.organization;
+    }
+
+    if (typeof dto.organizationId === 'string') {
+      data.organizationId = dto.organizationId;
+    }
+
+    if (Object.hasOwn(dto, 'project')) {
+      data.projectId = dto.project ?? null;
+    }
+
+    if (Object.hasOwn(dto, 'projectId')) {
+      data.projectId = dto.projectId ?? null;
+    }
+
+    this.assignIfOwn(data, dto, 'providerJobId');
+    this.assignIfOwn(data, dto, 'viralityScore');
+    this.assignIfOwn(data, dto, 'status');
+    this.assignIfOwn(data, dto, 'isSelected');
+    this.assignIfOwn(data, dto, 'readiness');
+    this.assignIfOwn(data, dto, 'terminalAt');
+    this.assignIfOwn(data, dto, 'isDeleted');
+
+    for (const [key, value] of Object.entries(dto)) {
+      if (RESULT_SCALAR_KEYS.has(key) || value === undefined) {
+        continue;
+      }
+      legacyData[key] = value;
+    }
+
+    const suppliedData = this.readRecord(dto.data);
+    data.data = { ...legacyData, ...suppliedData };
+
+    this.applyTerminalDefaults(data, mode);
+
+    return data;
+  }
+
+  private applyTerminalDefaults(
+    data: Record<string, unknown>,
+    mode: 'create' | 'update',
+  ): void {
+    if (mode === 'create' && typeof data.status !== 'string') {
+      data.status = 'pending';
+    }
+
+    if (typeof data.status !== 'string') {
+      return;
+    }
+
+    if (
+      isTerminalClipStatus(data.status) &&
+      !Object.hasOwn(data, 'terminalAt')
+    ) {
+      data.terminalAt = new Date();
+    }
+
+    if (!Object.hasOwn(data, 'readiness')) {
+      data.readiness = buildClipResultReadiness({
+        status: data.status,
+        terminalAt: this.readTerminalAt(data.terminalAt),
+      });
+    }
+  }
+
+  private assignIfOwn(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+    key: string,
+  ): void {
+    if (Object.hasOwn(source, key)) {
+      target[key] = source[key];
+    }
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private readTerminalAt(value: unknown): Date | string | null {
+    if (value instanceof Date || typeof value === 'string' || value === null) {
+      return value;
+    }
+
+    return null;
   }
 }

--- a/apps/server/api/src/collections/clip-results/dto/create-clip-result.dto.ts
+++ b/apps/server/api/src/collections/clip-results/dto/create-clip-result.dto.ts
@@ -1,7 +1,18 @@
+import { ClipResultStatus } from '@api/collections/clip-results/schemas/clip-result.schema';
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { OrganizationalCreateDto } from '@api/shared/dto/base/base.dto';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsIn,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export class CreateClipResultDto extends OrganizationalCreateDto {
   @IsEntityId()
@@ -70,4 +81,37 @@ export class CreateClipResultDto extends OrganizationalCreateDto {
   @IsOptional()
   @ApiProperty({ description: 'Avatar video provider name', required: false })
   readonly providerName?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsIn([...ClipResultStatus])
+  @ApiProperty({
+    description: 'Clip terminal processing status',
+    enum: ClipResultStatus,
+    enumName: 'ClipResultStatus',
+    required: false,
+  })
+  readonly status?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ description: 'Whether the clip is selected', required: false })
+  readonly isSelected?: boolean;
+
+  @IsObject()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Readiness contract for clip handoff actions',
+    required: false,
+  })
+  readonly readiness?: Record<string, unknown>;
+
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsDateString()
+  @ApiProperty({
+    description: 'Timestamp when the clip reached a terminal status',
+    required: false,
+  })
+  readonly terminalAt?: string | null;
 }

--- a/apps/server/api/src/collections/clip-results/dto/update-clip-result.dto.ts
+++ b/apps/server/api/src/collections/clip-results/dto/update-clip-result.dto.ts
@@ -1,10 +1,25 @@
+import { ClipResultStatus } from '@api/collections/clip-results/schemas/clip-result.schema';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsDateString,
+  IsIn,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 
 export class UpdateClipResultDto {
   @IsString()
   @IsOptional()
-  @ApiProperty({ description: 'Clip status', required: false })
+  @IsIn([...ClipResultStatus])
+  @ApiProperty({
+    description: 'Clip status',
+    enum: ClipResultStatus,
+    enumName: 'ClipResultStatus',
+    required: false,
+  })
   readonly status?: string;
 
   @IsString()
@@ -66,4 +81,21 @@ export class UpdateClipResultDto {
   @IsOptional()
   @ApiProperty({ description: 'Avatar video provider name', required: false })
   readonly providerName?: string;
+
+  @IsObject()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Readiness contract for clip handoff actions',
+    required: false,
+  })
+  readonly readiness?: Record<string, unknown>;
+
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsDateString()
+  @ApiProperty({
+    description: 'Timestamp when the clip reached a terminal status',
+    required: false,
+  })
+  readonly terminalAt?: string | null;
 }

--- a/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
+++ b/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
@@ -1,9 +1,26 @@
+import {
+  CLIP_RESULT_STATUSES,
+  type ClipReadinessContract,
+  type ClipResultStatus as SharedClipResultStatus,
+} from '@genfeedai/interfaces';
 import type { ClipResult as PrismaClipResult } from '@genfeedai/prisma';
 
-export interface ClipResultDocument extends PrismaClipResult {
+export const ClipResultStatus = CLIP_RESULT_STATUSES;
+
+export type ClipResultStatusType = (typeof ClipResultStatus)[number];
+
+type ClipResultRecord = Omit<
+  PrismaClipResult,
+  'isSelected' | 'readiness' | 'status' | 'terminalAt'
+>;
+
+export interface ClipResultDocument extends ClipResultRecord {
   _id: string;
+  isSelected: boolean;
   project?: string | null;
-  status?: string | null;
+  readiness: ClipReadinessContract | Record<string, unknown>;
+  status: SharedClipResultStatus | string;
+  terminalAt?: Date | null;
   videoUrl?: string | null;
   [key: string]: unknown;
 }

--- a/apps/server/api/src/collections/clip-shared/clip-terminal-contract.util.ts
+++ b/apps/server/api/src/collections/clip-shared/clip-terminal-contract.util.ts
@@ -1,0 +1,83 @@
+import type { ClipReadinessContract } from '@genfeedai/interfaces';
+import { CLIP_TERMINAL_STATUSES } from '@genfeedai/interfaces';
+
+const terminalStatuses = new Set<string>(CLIP_TERMINAL_STATUSES);
+
+export function isTerminalClipStatus(status: unknown): boolean {
+  return typeof status === 'string' && terminalStatuses.has(status);
+}
+
+export function buildClipProjectReadiness(input: {
+  error?: string | null;
+  status: string;
+  terminalAt?: Date | string | null;
+}): ClipReadinessContract {
+  if (input.status === 'completed') {
+    return {
+      blockingReasons: [],
+      readyActions: ['download', 'edit', 'publish'],
+      state: 'ready',
+      terminal: true,
+      terminalAt: toIsoString(input.terminalAt),
+    };
+  }
+
+  if (input.status === 'failed') {
+    return {
+      blockingReasons: [input.error || 'clip-project-failed'],
+      readyActions: ['retry'],
+      state: 'failed',
+      terminal: true,
+      terminalAt: toIsoString(input.terminalAt),
+    };
+  }
+
+  return {
+    blockingReasons: [],
+    readyActions: [],
+    state: 'pending',
+    terminal: false,
+    terminalAt: null,
+  };
+}
+
+export function buildClipResultReadiness(input: {
+  status: string;
+  terminalAt?: Date | string | null;
+}): ClipReadinessContract {
+  if (input.status === 'completed') {
+    return {
+      blockingReasons: [],
+      readyActions: ['download', 'edit', 'publish'],
+      state: 'ready',
+      terminal: true,
+      terminalAt: toIsoString(input.terminalAt),
+    };
+  }
+
+  if (input.status === 'failed') {
+    return {
+      blockingReasons: ['clip-result-failed'],
+      readyActions: ['retry'],
+      state: 'failed',
+      terminal: true,
+      terminalAt: toIsoString(input.terminalAt),
+    };
+  }
+
+  return {
+    blockingReasons: [],
+    readyActions: [],
+    state: 'pending',
+    terminal: false,
+    terminalAt: null,
+  };
+}
+
+function toIsoString(value: Date | string | null | undefined): string | null {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts
@@ -300,7 +300,10 @@ describe('HeygenWebhookService', () => {
     });
     expect(deps.clipProjectsService.patch).toHaveBeenCalledWith(projectId, {
       error: null,
+      failedClipCount: 1,
+      pendingClipCount: 0,
       progress: 100,
+      readyClipCount: 1,
       status: 'completed',
     });
   });
@@ -335,7 +338,10 @@ describe('HeygenWebhookService', () => {
     });
     expect(deps.clipProjectsService.patch).toHaveBeenCalledWith(projectId, {
       error: 'All clip generations failed.',
+      failedClipCount: 1,
+      pendingClipCount: 0,
       progress: 100,
+      readyClipCount: 0,
       status: 'failed',
     });
   });

--- a/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.ts
@@ -73,7 +73,12 @@ export class HeygenWebhookService {
           return;
         }
 
-        await this.handleClipResultCallback(projectId, callbackId, body);
+        await this.handleClipResultCallback(
+          projectId,
+          callbackId,
+          body,
+          this.readString(clipResult.organizationId),
+        );
         return;
       }
 
@@ -173,6 +178,7 @@ export class HeygenWebhookService {
     projectId: string,
     clipResultId: string,
     body: HeygenWebhookPayload,
+    organizationId?: string,
   ): Promise<void> {
     const videoUrl = this.getSuccessVideoUrl(body);
     const providerJobId = body.event_data?.video_id;
@@ -199,8 +205,10 @@ export class HeygenWebhookService {
       return;
     }
 
-    const projectClipResults =
-      await this.clipResultsService.findByProject(projectId);
+    const projectClipResults = await this.clipResultsService.findByProject(
+      projectId,
+      organizationId,
+    );
     const hasPendingClipResults = projectClipResults.some((clipResult) => {
       const status = this.readString(clipResult.status);
       return status !== 'completed' && status !== 'failed';
@@ -213,11 +221,22 @@ export class HeygenWebhookService {
     const hasCompletedClip = projectClipResults.some(
       (clipResult) => this.readString(clipResult.status) === 'completed',
     );
+    const readyClipCount = projectClipResults.filter(
+      (clipResult) => this.readString(clipResult.status) === 'completed',
+    ).length;
+    const failedClipCount = projectClipResults.filter(
+      (clipResult) => this.readString(clipResult.status) === 'failed',
+    ).length;
+    const pendingClipCount =
+      projectClipResults.length - readyClipCount - failedClipCount;
 
     if (hasCompletedClip) {
       await this.clipProjectsService.patch(projectId, {
         error: null,
+        failedClipCount,
+        pendingClipCount,
         progress: 100,
+        readyClipCount,
         status: 'completed',
       });
       return;
@@ -225,7 +244,10 @@ export class HeygenWebhookService {
 
     await this.clipProjectsService.patch(projectId, {
       error: 'All clip generations failed.',
+      failedClipCount,
+      pendingClipCount,
       progress: 100,
+      readyClipCount,
       status: 'failed',
     });
   }

--- a/packages/interfaces/src/content/clip-terminal-contract.interface.ts
+++ b/packages/interfaces/src/content/clip-terminal-contract.interface.ts
@@ -1,0 +1,71 @@
+export const CLIP_PROJECT_STATUSES = [
+  'pending',
+  'transcribing',
+  'analyzing',
+  'analyzed',
+  'clipping',
+  'captioning',
+  'generating',
+  'completed',
+  'failed',
+] as const;
+
+export type ClipProjectStatus = (typeof CLIP_PROJECT_STATUSES)[number];
+
+export const CLIP_RESULT_STATUSES = [
+  'pending',
+  'extracting',
+  'captioning',
+  'completed',
+  'failed',
+] as const;
+
+export type ClipResultStatus = (typeof CLIP_RESULT_STATUSES)[number];
+
+export const CLIP_TERMINAL_STATUSES = ['completed', 'failed'] as const;
+
+export type ClipTerminalStatus = (typeof CLIP_TERMINAL_STATUSES)[number];
+
+export const CLIP_READINESS_STATES = [
+  'pending',
+  'ready',
+  'blocked',
+  'failed',
+] as const;
+
+export type ClipReadinessState = (typeof CLIP_READINESS_STATES)[number];
+
+export const CLIP_READY_ACTIONS = [
+  'download',
+  'edit',
+  'publish',
+  'retry',
+] as const;
+
+export type ClipReadyAction = (typeof CLIP_READY_ACTIONS)[number];
+
+export interface ClipReadinessContract {
+  state: ClipReadinessState;
+  terminal: boolean;
+  readyActions: ClipReadyAction[];
+  blockingReasons: string[];
+  terminalAt?: string | null;
+}
+
+export interface ClipProjectTerminalContract {
+  status: ClipProjectStatus;
+  progress: number;
+  readiness: ClipReadinessContract;
+  readyClipCount: number;
+  failedClipCount: number;
+  pendingClipCount: number;
+  terminalAt?: Date | string | null;
+  error?: string | null;
+}
+
+export interface ClipResultTerminalContract {
+  status: ClipResultStatus;
+  readiness: ClipReadinessContract;
+  isSelected: boolean;
+  terminalAt?: Date | string | null;
+}

--- a/packages/interfaces/src/content/index.ts
+++ b/packages/interfaces/src/content/index.ts
@@ -1,6 +1,7 @@
 export * from './account-publishing-context.interface';
 export * from './article.interface';
 export * from './article-extended.interface';
+export * from './clip-terminal-contract.interface';
 export * from './composer-content.interface';
 export * from './content-run.interface';
 export * from './content-run-service.contract';

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -78,6 +78,7 @@ export * from './components/virtual-list.interface';
 export * from './content/account-publishing-context.interface';
 export * from './content/article.interface';
 export * from './content/article-extended.interface';
+export * from './content/clip-terminal-contract.interface';
 export * from './content/composer-content.interface';
 export * from './content/content-run.interface';
 export * from './content/content-run-service.contract';

--- a/packages/prisma/prisma/migrations/20260629202813_add_clip_terminal_contracts/migration.sql
+++ b/packages/prisma/prisma/migrations/20260629202813_add_clip_terminal_contracts/migration.sql
@@ -1,0 +1,55 @@
+ALTER TABLE "clip_projects"
+  ADD COLUMN "status" TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN "progress" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "error" TEXT,
+  ADD COLUMN "readyClipCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "failedClipCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "pendingClipCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "readiness" JSONB NOT NULL DEFAULT '{"state":"pending","terminal":false,"readyActions":[],"blockingReasons":[]}',
+  ADD COLUMN "terminalAt" TIMESTAMP(3);
+
+UPDATE "clip_projects"
+SET
+  "status" = COALESCE(NULLIF("config"->>'status', ''), "status"),
+  "progress" = CASE
+    WHEN ("config"->>'progress') ~ '^[0-9]+$' THEN ("config"->>'progress')::INTEGER
+    ELSE "progress"
+  END,
+  "error" = COALESCE("config"->>'error', "error"),
+  "readiness" = CASE
+    WHEN jsonb_typeof("config"->'readiness') = 'object' THEN "config"->'readiness'
+    WHEN COALESCE(NULLIF("config"->>'status', ''), "status") = 'completed' THEN '{"state":"ready","terminal":true,"readyActions":["download","edit","publish"],"blockingReasons":[]}'::JSONB
+    WHEN COALESCE(NULLIF("config"->>'status', ''), "status") = 'failed' THEN '{"state":"failed","terminal":true,"readyActions":["retry"],"blockingReasons":["clip-project-failed"]}'::JSONB
+    ELSE '{"state":"pending","terminal":false,"readyActions":[],"blockingReasons":[]}'::JSONB
+  END,
+  "terminalAt" = CASE
+    WHEN COALESCE(NULLIF("config"->>'status', ''), "status") IN ('completed', 'failed') THEN "updatedAt"
+    ELSE "terminalAt"
+  END;
+
+ALTER TABLE "clip_results"
+  ADD COLUMN "status" TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN "isSelected" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "readiness" JSONB NOT NULL DEFAULT '{"state":"pending","terminal":false,"readyActions":[],"blockingReasons":[]}',
+  ADD COLUMN "terminalAt" TIMESTAMP(3);
+
+UPDATE "clip_results"
+SET
+  "status" = COALESCE(NULLIF("data"->>'status', ''), "status"),
+  "isSelected" = CASE
+    WHEN "data"->>'isSelected' IN ('true', 'false') THEN ("data"->>'isSelected')::BOOLEAN
+    ELSE "isSelected"
+  END,
+  "readiness" = CASE
+    WHEN jsonb_typeof("data"->'readiness') = 'object' THEN "data"->'readiness'
+    WHEN COALESCE(NULLIF("data"->>'status', ''), "status") = 'completed' THEN '{"state":"ready","terminal":true,"readyActions":["download","edit","publish"],"blockingReasons":[]}'::JSONB
+    WHEN COALESCE(NULLIF("data"->>'status', ''), "status") = 'failed' THEN '{"state":"failed","terminal":true,"readyActions":["retry"],"blockingReasons":["clip-result-failed"]}'::JSONB
+    ELSE '{"state":"pending","terminal":false,"readyActions":[],"blockingReasons":[]}'::JSONB
+  END,
+  "terminalAt" = CASE
+    WHEN COALESCE(NULLIF("data"->>'status', ''), "status") IN ('completed', 'failed') THEN "updatedAt"
+    ELSE "terminalAt"
+  END;
+
+CREATE INDEX "clip_projects_organizationId_status_isDeleted_idx" ON "clip_projects"("organizationId", "status", "isDeleted");
+CREATE INDEX "clip_results_organizationId_projectId_status_isDeleted_idx" ON "clip_results"("organizationId", "projectId", "status", "isDeleted");

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -3836,11 +3836,20 @@ model ClipProject {
   organization   Organization @relation(fields: [organizationId], references: [id])
   brandId        String?
   brand          Brand?       @relation(fields: [brandId], references: [id])
+  status         String       @default("pending")
+  progress       Int          @default(0)
+  error          String?
+  readyClipCount Int          @default(0)
+  failedClipCount Int         @default(0)
+  pendingClipCount Int        @default(0)
+  readiness      Json         @default("{\"state\":\"pending\",\"terminal\":false,\"readyActions\":[],\"blockingReasons\":[]}")
+  terminalAt     DateTime?
   config         Json         @default("{}")
   isDeleted      Boolean      @default(false)
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
+  @@index([organizationId, status, isDeleted])
   @@map("clip_projects")
 }
 
@@ -3852,12 +3861,17 @@ model ClipResult {
   projectId      String?
   providerJobId  String?
   viralityScore  Float?
+  status         String       @default("pending")
+  isSelected     Boolean      @default(false)
+  readiness      Json         @default("{\"state\":\"pending\",\"terminal\":false,\"readyActions\":[],\"blockingReasons\":[]}")
+  terminalAt     DateTime?
   data           Json         @default("{}")
   isDeleted      Boolean      @default(false)
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
   @@index([organizationId, projectId])
+  @@index([organizationId, projectId, status, isDeleted])
   @@index([providerJobId])
   @@map("clip_results")
 }

--- a/packages/props/studio/clips.props.ts
+++ b/packages/props/studio/clips.props.ts
@@ -1,13 +1,18 @@
+import type {
+  ClipReadinessContract,
+  ClipReadyAction,
+  ClipResultStatus,
+} from '@genfeedai/interfaces';
+
 // ─── Shared Types ─────────────────────────────────────────────────
 
 export type AvatarProvider = 'heygen' | 'did' | 'tavus' | 'musetalk';
 
-export type ClipStatus =
-  | 'pending'
-  | 'extracting'
-  | 'captioning'
-  | 'completed'
-  | 'failed';
+export type ClipStatus = ClipResultStatus;
+
+export type ClipReadiness = ClipReadinessContract;
+
+export type { ClipReadyAction };
 
 export type ClipsStep = 'input' | 'review' | 'progress';
 
@@ -37,6 +42,9 @@ export interface ClipResult {
   summary: string;
   viralityScore: number;
   status: ClipStatus;
+  readiness?: ClipReadiness;
+  readyActions?: ClipReadyAction[];
+  terminalAt?: string | null;
   videoUrl?: string;
   captionedVideoUrl?: string;
   clipType?: string;

--- a/packages/serializers/src/attributes/content/clip-project.attributes.ts
+++ b/packages/serializers/src/attributes/content/clip-project.attributes.ts
@@ -15,4 +15,9 @@ export const clipProjectAttributes = createEntityAttributes([
   'progress',
   'settings',
   'error',
+  'readiness',
+  'readyClipCount',
+  'failedClipCount',
+  'pendingClipCount',
+  'terminalAt',
 ]);

--- a/packages/serializers/src/attributes/content/clip-result.attributes.ts
+++ b/packages/serializers/src/attributes/content/clip-result.attributes.ts
@@ -21,4 +21,8 @@ export const clipResultAttributes = createEntityAttributes([
   'captionSrt',
   'status',
   'isSelected',
+  'readiness',
+  'terminalAt',
+  'providerJobId',
+  'providerName',
 ]);


### PR DESCRIPTION
## Summary
- Add shared clip terminal/readiness contracts and expose them through DTOs, serializers, and studio props.
- Add Prisma-backed durable status/readiness/terminal fields for clip projects/results with a migration that backfills from legacy JSON payloads.
- Map legacy clip project/result DTO writes into Prisma-safe scalar columns plus existing `config`/`data` JSON, including org-scoped result lookup and terminal aggregate counts.

Closes #330
Refs #236

## Validation
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `bun run --cwd apps/server/api test:file src/collections/clip-projects/clip-projects.service.spec.ts src/collections/clip-results/clip-results.service.spec.ts src/collections/clip-projects/services/clip-generation.service.spec.ts src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts`
- `bunx biome check <touched files>`
- `bunx turbo run type-check --filter=@genfeedai/interfaces --filter=@genfeedai/props --filter=@genfeedai/serializers`
- `git diff --check`
- `bunx secretlint <touched files>`

## Notes
- Direct API type-check was also run with `bunx tsc --noEmit -p apps/server/api/tsconfig.typecheck.json --ignoreDeprecations 6.0`; it still fails on existing unrelated API diagnostics outside this slice, but no clip-contract diagnostics remain.
