### PR TITLE
fix(deploy): preserve successful boot smoke exit

### DIFF
--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -151,7 +151,33 @@ resource "aws_ecs_task_definition" "boot_smoke" {
     command = [
       "bash",
       "-lc",
-      "set -euo pipefail; bun --filter ${local.services.api.filter} start:prod & pid=$!; trap 'kill $pid 2>/dev/null || true' EXIT; for i in $(seq 1 48); do if ! kill -0 $pid 2>/dev/null; then wait $pid; exit $?; fi; if curl -fsS http://127.0.0.1:${local.services.api.port}/v1/health >/dev/null; then echo 'Boot smoke OK — API served /v1/health.'; exit 0; fi; sleep 10; done; echo 'API did not serve /v1/health within boot-smoke window' >&2; exit 1",
+      <<-EOT
+      set -euo pipefail
+      bun --filter ${local.services.api.filter} start:prod &
+      pid=$!
+      cleanup() {
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+      }
+      trap cleanup EXIT
+
+      for i in $(seq 1 48); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+          wait "$pid"
+          exit $?
+        fi
+        if curl -fsS http://127.0.0.1:${local.services.api.port}/v1/health >/dev/null; then
+          echo 'Boot smoke OK - API served /v1/health.'
+          trap - EXIT
+          cleanup
+          exit 0
+        fi
+        sleep 10
+      done
+
+      echo 'API did not serve /v1/health within boot-smoke window' >&2
+      exit 1
+      EOT
     ]
     secrets = local.task_secrets
     environment = concat(local.internal_env, [


### PR DESCRIPTION
## Summary
- make the ECS boot-smoke wrapper explicitly preserve a successful health-check exit
- clean up the background API process after success without leaking its termination status into the task exit code

## Verification
- tofu fmt -check infra/terraform/genfeed-prod/services.tf
- git diff --check
- tofu -chdir=infra/terraform/genfeed-prod init -backend=false
- tofu -chdir=infra/terraform/genfeed-prod validate

No local Gitleaks run.