### PR TITLE
fix(deploy): exit boot smoke immediately after health

### DIFF
--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -152,19 +152,20 @@ resource "aws_ecs_task_definition" "boot_smoke" {
       "bash",
       "-lc",
       <<-EOT
-      set -euo pipefail
+      set -uo pipefail
       bun --filter ${local.services.api.filter} start:prod &
       pid=$!
       cleanup() {
+        # After health succeeds, do not wait on Bun/API shutdown; SIGTERM exit
+        # status would turn a successful smoke into a failed ECS task.
         kill "$pid" 2>/dev/null || true
-        wait "$pid" 2>/dev/null || true
       }
       trap cleanup EXIT
 
       for i in $(seq 1 48); do
         if ! kill -0 "$pid" 2>/dev/null; then
           wait "$pid"
-          exit $?
+          exit "$?"
         fi
         if curl -fsS http://127.0.0.1:${local.services.api.port}/v1/health >/dev/null; then
           echo 'Boot smoke OK - API served /v1/health.'


### PR DESCRIPTION
## Summary
- make the production boot-smoke task exit 0 immediately after /v1/health responds
- stop waiting on Bun/API shutdown after successful health, so SIGTERM or child shutdown status cannot flip a successful smoke to exit 1

## Verification
- tofu fmt -check infra/terraform/genfeed-prod/services.tf
- tofu -chdir=infra/terraform/genfeed-prod validate
- git diff --check
- shell reproduction of success-path cleanup exits 0

No local Gitleaks run.