### PR TITLE
fix(deploy): cap ECS health check start period

### DIFF
--- a/infra/terraform/modules/service/main.tf
+++ b/infra/terraform/modules/service/main.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_task_definition" "this" {
       interval    = 30
       timeout     = 10
       retries     = 5
-      startPeriod = var.health_grace > 0 ? var.health_grace : 40
+      startPeriod = min(var.health_grace > 0 ? var.health_grace : 40, 300)
     }
   }])
 }


### PR DESCRIPTION
## Summary
- cap ECS container healthCheck.startPeriod at AWS maximum 300 seconds
- preserve service-level health_check_grace_period_seconds for slow-start services

## Verification
- tofu fmt -check infra/terraform/modules/service/main.tf infra/terraform/genfeed-prod/services.tf infra/terraform/genfeed-prod/locals.tf
- tofu -chdir=infra/terraform/genfeed-prod validate
- git diff --check

## Deploy failure addressed
Deploy run 28406744146 failed in Tofu apply because AWS rejected api/workers task definitions with health check startPeriod > 300. Boot smoke passed before this failure.