### PR TITLE
fix(deploy): preserve PATH for Vercel build

### DIFF
--- a/.github/workflows/deploy-vercel-frontends.yml
+++ b/.github/workflows/deploy-vercel-frontends.yml
@@ -53,6 +53,19 @@ jobs:
         working-directory: ${{ matrix.path }}
         run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
 
+      - name: Preserve runner PATH for local Vercel build
+        working-directory: ${{ matrix.path }}
+        run: |
+          env_file=".vercel/.env.production.local"
+          if [ -f "$env_file" ] && grep -q '^PATH=' "$env_file"; then
+            awk '!/^PATH=/' "$env_file" > "${env_file}.tmp"
+            mv "${env_file}.tmp" "$env_file"
+            echo "Removed reserved PATH from ${env_file}"
+          fi
+          command -v sh
+          command -v bun
+          command -v vercel
+
       - name: Build ${{ matrix.label }}
         working-directory: ${{ matrix.path }}
         run: vercel build --prod --token="${VERCEL_TOKEN}"


### PR DESCRIPTION
## Summary
- remove any pulled Vercel production PATH entry before local vercel build
- keep runner shell/bun/vercel PATH available so install/build commands can spawn sh

## Verification
- ruby YAML parse for deploy-vercel-frontends.yml
- git diff --check
- synthetic env-file sanitize check

Note: did not run local gitleaks.