### PR TITLE
fix(infra): add per-AZ NAT routing

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -82,6 +82,8 @@ tofu apply -var="image_tag=<sha>"
 
 - VPC: defaults to `genfeedai-vpc` plus two stack-created private subnets for
   Fargate tasks and ElastiCache.
+- NAT: production pays for one NAT gateway per private subnet AZ so private task
+  egress does not depend on a single public subnet/AZ.
 - DNS: assumes `genfeed.ai` is a Route53 hosted zone.
 - RDS: looks up `genfeed-data` by identifier and opens its SG to the ECS tasks SG.
 - Secrets: every SSM param under `/genfeed/production/*` is injected as a task

--- a/infra/terraform/genfeed-prod/network.tf
+++ b/infra/terraform/genfeed-prod/network.tf
@@ -1,6 +1,6 @@
-# Private subnets (2 AZ) for ECS instances + awsvpc task ENIs + ElastiCache.
-# awsvpc-on-EC2 task ENIs get no public IP, so they egress (ECR pull, ElevenLabs/
-# legacy auth provider/Stripe/etc.) via a NAT gateway. ALB stays in the existing public subnets.
+# Private subnets (2 AZ) for ECS tasks + ElastiCache.
+# Fargate task ENIs get no public IP, so each AZ egresses through a same-AZ NAT
+# gateway. ALB stays in the existing public subnets.
 resource "aws_subnet" "private" {
   for_each          = var.private_subnet_cidrs
   vpc_id            = var.vpc_id
@@ -9,28 +9,46 @@ resource "aws_subnet" "private" {
   tags              = { Name = "${local.name_prefix}-private-${each.key}" }
 }
 
+moved {
+  from = aws_eip.nat
+  to   = aws_eip.nat["us-west-1b"]
+}
+
 resource "aws_eip" "nat" {
-  domain = "vpc"
-  tags   = { Name = "${local.name_prefix}-nat" }
+  for_each = var.private_subnet_cidrs
+  domain   = "vpc"
+  tags     = { Name = "${local.name_prefix}-nat-${each.key}" }
+}
+
+moved {
+  from = aws_nat_gateway.main
+  to   = aws_nat_gateway.main["us-west-1b"]
 }
 
 resource "aws_nat_gateway" "main" {
-  allocation_id = aws_eip.nat.id
-  subnet_id     = var.nat_public_subnet_id
-  tags          = { Name = "${local.name_prefix}-nat" }
+  for_each      = var.private_subnet_cidrs
+  allocation_id = aws_eip.nat[each.key].id
+  subnet_id     = var.nat_public_subnet_ids_by_az[each.key]
+  tags          = { Name = "${local.name_prefix}-nat-${each.key}" }
+}
+
+moved {
+  from = aws_route_table.private
+  to   = aws_route_table.private["us-west-1b"]
 }
 
 resource "aws_route_table" "private" {
-  vpc_id = var.vpc_id
+  for_each = var.private_subnet_cidrs
+  vpc_id   = var.vpc_id
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main.id
+    nat_gateway_id = aws_nat_gateway.main[each.key].id
   }
-  tags = { Name = "${local.name_prefix}-private" }
+  tags = { Name = "${local.name_prefix}-private-${each.key}" }
 }
 
 resource "aws_route_table_association" "private" {
   for_each       = aws_subnet.private
   subnet_id      = each.value.id
-  route_table_id = aws_route_table.private.id
+  route_table_id = aws_route_table.private[each.key].id
 }

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -52,6 +52,11 @@ output "task_subnets" {
   value = local.private_subnet_ids
 }
 
+output "nat_gateway_ids_by_az" {
+  description = "Production private subnet egress NAT gateways keyed by AZ."
+  value       = { for az, gateway in aws_nat_gateway.main : az => gateway.id }
+}
+
 output "task_security_group" {
   value = aws_security_group.ecs.id
 }

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -19,16 +19,24 @@ variable "vpc_id" {
   default = "vpc-0e7522e453a642bd8" # genfeedai-vpc (10.0.8.0/21)
 }
 
-# Existing public subnets (IGW route) — used for the internet-facing ALB + NAT.
+# Existing public subnets (IGW route) — used for the internet-facing ALB.
 variable "public_subnet_ids" {
   type    = list(string)
   default = ["subnet-04dfe8480e85f0a47", "subnet-07aec43af6ded15f0"] # 1b, 1c
 }
 
-# NAT lives in this public subnet (1b).
-variable "nat_public_subnet_id" {
-  type    = string
-  default = "subnet-04dfe8480e85f0a47"
+# Public subnet for each AZ-local NAT gateway.
+variable "nat_public_subnet_ids_by_az" {
+  type = map(string)
+  default = {
+    "us-west-1b" = "subnet-04dfe8480e85f0a47"
+    "us-west-1c" = "subnet-07aec43af6ded15f0"
+  }
+
+  validation {
+    condition     = length(setsubtract(keys(var.private_subnet_cidrs), keys(var.nat_public_subnet_ids_by_az))) == 0
+    error_message = "nat_public_subnet_ids_by_az must define a public subnet for every private_subnet_cidrs AZ."
+  }
 }
 
 # New private subnets created by this stack for ECS tasks/instances + cache


### PR DESCRIPTION
## Summary

- Replace the single production NAT gateway/private route table with per-AZ NAT gateways and private route tables.
- Preserve the existing `us-west-1b` NAT/EIP/route-table Terraform state addresses with `moved` blocks.
- Document the accepted production cost/availability decision and expose NAT gateway IDs by AZ.

Closes #636

## Verification

- `tofu fmt -check -diff .` in `infra/terraform/genfeed-prod`
- `tofu init -backend=false` in `infra/terraform/genfeed-prod`
- `tofu validate` in `infra/terraform/genfeed-prod`
- static Ruby per-AZ NAT contract assertions
- `bunx prettier --check infra/terraform/README.md`
- `bun scripts/run-secretlint.ts infra/terraform/README.md infra/terraform/genfeed-prod/network.tf infra/terraform/genfeed-prod/outputs.tf infra/terraform/genfeed-prod/variables.tf`
- `git diff --check origin/master..HEAD`

## Not run

- `tofu plan` / `tofu apply`: skipped because this automation must not perform live production infrastructure operations or depend on production Terraform state/AWS credentials.
