### PR TITLE
fix(deploy): run Vercel build from repo root

### DIFF
--- a/.github/workflows/deploy-vercel-frontends.yml
+++ b/.github/workflows/deploy-vercel-frontends.yml
@@ -27,13 +27,10 @@ jobs:
       matrix:
         include:
           - label: app.genfeed.ai
-            path: apps/app
             project_id: prj_1iMHTqANXgCLd3wALOFcWNtgrdAc
           - label: genfeed.ai
-            path: apps/website
             project_id: prj_77xnWYm4Fp3ngF1SpeuF5lwhOG7I
           - label: docs.genfeed.ai
-            path: apps/docs
             project_id: prj_SdDiBAjBgxhqmsbDBZ6mmIOAnqUL
     env:
       VERCEL_ORG_ID: team_hFVCbNU4RnfEpQOeSWRxmhEJ
@@ -50,11 +47,9 @@ jobs:
         run: bun add --global vercel@54.4.1
 
       - name: Pull Vercel production environment
-        working-directory: ${{ matrix.path }}
         run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
 
       - name: Preserve runner PATH for local Vercel build
-        working-directory: ${{ matrix.path }}
         run: |
           env_file=".vercel/.env.production.local"
           if [ -f "$env_file" ] && grep -q '^PATH=' "$env_file"; then
@@ -67,12 +62,10 @@ jobs:
           command -v vercel
 
       - name: Build ${{ matrix.label }}
-        working-directory: ${{ matrix.path }}
         run: vercel build --prod --token="${VERCEL_TOKEN}"
 
       - name: Deploy ${{ matrix.label }}
         id: deploy
-        working-directory: ${{ matrix.path }}
         run: |
           url="$(vercel deploy --prebuilt --prod --token="${VERCEL_TOKEN}")"
           echo "${url}"


### PR DESCRIPTION
## Summary
- run Vercel pull/build/deploy from repository root
- let each Vercel project apply its configured rootDirectory exactly once
- removes the duplicated apps/app/apps/app package.json resolution failure

## Verification
- ruby YAML parse for deploy-vercel-frontends.yml
- git diff --check
- confirmed no remaining matrix.path workflow references

Note: did not run local gitleaks.