### PR TITLE
fix(infra): enable Redis TLS auth

### DIFF
--- a/apps/server/api/src/services/cache/services/cache-client.service.ts
+++ b/apps/server/api/src/services/cache/services/cache-client.service.ts
@@ -1,6 +1,9 @@
 import { ConfigService } from '@api/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
+import {
+  buildNodeRedisClientOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import {
   Injectable,
   type OnModuleDestroy,
@@ -24,8 +27,8 @@ export class CacheClientService implements OnModuleInit, OnModuleDestroy {
   ) {
     const config = parseRedisConnection(this.configService);
 
-    this.client = createClient({
-      socket: {
+    this.client = createClient(
+      buildNodeRedisClientOptions(config, {
         connectTimeout: 3_000,
         reconnectStrategy: (retries: number) => {
           if (retries >= CacheClientService.MAX_RECONNECT_RETRIES) {
@@ -43,10 +46,8 @@ export class CacheClientService implements OnModuleInit, OnModuleDestroy {
           );
           return delay;
         },
-        ...(config.tls && { tls: true }),
-      },
-      url: config.url,
-    });
+      }),
+    );
 
     this.client.on('error', (error: Error) => {
       this.logger.error(`${this.constructorName} Redis client error`, error);

--- a/apps/server/api/src/services/microservices/microservices.service.ts
+++ b/apps/server/api/src/services/microservices/microservices.service.ts
@@ -1,7 +1,10 @@
 import process from 'node:process';
 import { ConfigService } from '@api/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
+import {
+  buildNodeRedisClientOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpService } from '@nestjs/axios';
 import {
@@ -105,14 +108,12 @@ export class MicroservicesService implements OnModuleInit {
     );
 
     try {
-      this.redisClient = createClient({
-        socket: {
+      this.redisClient = createClient(
+        buildNodeRedisClientOptions(config, {
           connectTimeout: MicroservicesService.REDIS_CONNECT_TIMEOUT_MS,
           reconnectStrategy: () => false as const,
-          ...(config.tls ? { tls: true as const } : {}),
-        },
-        url: config.url,
-      });
+        }),
+      );
 
       this.redisClient.on('error', (err: Error) => {
         this.loggerService.error('Redis Client Error', err);

--- a/apps/server/api/src/services/notifications/notifications.service.ts
+++ b/apps/server/api/src/services/notifications/notifications.service.ts
@@ -8,7 +8,10 @@ import type {
   ITelegramMessageOptions,
 } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
-import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
+import {
+  buildNodeRedisClientOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import {
   Injectable,
   type OnModuleDestroy,
@@ -30,14 +33,12 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
     private readonly logger: LoggerService,
   ) {
     const config = parseRedisConnection(this.configService);
-    this.publisher = createClient({
-      socket: {
+    this.publisher = createClient(
+      buildNodeRedisClientOptions(config, {
         connectTimeout: NotificationsService.CONNECT_TIMEOUT_MS,
         reconnectStrategy: () => false as const,
-        ...(config.tls ? { tls: true as const } : {}),
-      },
-      url: config.url,
-    });
+      }),
+    );
 
     this.publisher.on('error', (error: Error) => {
       this.logger.error(`${this.constructorName} Redis publisher error`, error);

--- a/apps/server/files/src/services/websocket/websocket.service.ts
+++ b/apps/server/files/src/services/websocket/websocket.service.ts
@@ -1,7 +1,10 @@
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { ConfigService } from '@files/config/config.service';
 import type { JobProgress } from '@files/shared/interfaces/job.interface';
-import { parseRedisConnection } from '@libs/redis/redis-connection.utils';
+import {
+  buildNodeRedisClientOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import { getUserRoomName } from '@libs/websockets/room-name.util';
 import { Injectable, Logger } from '@nestjs/common';
 import { createClient, type RedisClientType } from 'redis';
@@ -21,13 +24,11 @@ export class WebSocketService {
     try {
       const config = parseRedisConnection(this.configService);
 
-      this.redisPublisher = createClient({
-        socket: {
+      this.redisPublisher = createClient(
+        buildNodeRedisClientOptions(config, {
           connectTimeout: 3_000,
-          ...(config.tls ? { tls: true as const } : {}),
-        },
-        url: config.url,
-      });
+        }),
+      );
       this.redisPublisher.on('error', (err) => {
         this.logger.error('Redis Publisher Error', err);
       });

--- a/apps/server/notifications/src/main.ts
+++ b/apps/server/notifications/src/main.ts
@@ -34,6 +34,7 @@ async function main() {
     configService.get('REDIS_URL') || 'redis://localhost:6379',
     logger,
     redisTls,
+    configService.get('REDIS_PASSWORD'),
   );
 
   try {

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -85,8 +85,11 @@ tofu apply -var="image_tag=<sha>"
 - DNS: assumes `genfeed.ai` is a Route53 hosted zone.
 - RDS: looks up `genfeed-data` by identifier and opens its SG to the ECS tasks SG.
 - Secrets: every SSM param under `/genfeed/production/*` is injected as a task
-  secret (env var = last path segment). Ensure `REDIS_URL` points at ElastiCache
-  and provider keys are valid.
+  secret (env var = last path segment), except Terraform-owned runtime values
+  that are injected directly to avoid duplicate ECS env names. Production Redis
+  uses `REDIS_URL=rediss://<elasticache-primary>:6379`,
+  `REDIS_TLS=true`, and Terraform-managed SSM SecureString
+  `/genfeed/production/REDIS_PASSWORD`.
 
 ## Production Deploy Paths
 
@@ -111,6 +114,34 @@ Active services should roll with `min_healthy=100` and `max_percent=200`.
 Workers verify dependent Cloud Map DNS during startup; stop-then-start deploys
 can temporarily remove `files.genfeed.internal` or
 `notifications.genfeed.internal` and make workers exit.
+
+## Redis TLS and Auth
+
+Production ElastiCache is configured with at-rest encryption, in-transit
+encryption, and AUTH. Terraform generates a 64-character auth token with the
+`random` provider, stores it in SSM Parameter Store as
+`/genfeed/production/REDIS_PASSWORD`, and injects that parameter into every ECS
+task definition as a secret. The Redis URL stays a non-secret container
+environment value:
+
+```text
+REDIS_URL=rediss://<elasticache-primary-endpoint>:6379
+REDIS_TLS=true
+REDIS_PASSWORD=<from SSM SecureString>
+```
+
+The app Redis clients accept `REDIS_PASSWORD` separately from `REDIS_URL`, so
+the token does not need to be embedded into a plaintext task-definition
+environment value. The Terraform state is still sensitive infrastructure state:
+the generated token is marked sensitive by the providers, and the S3 state
+bucket must remain private.
+
+Rollout is through the normal `Deploy ECS (production)` workflow from `master`.
+The pre-roll task-definition target references the ElastiCache endpoint and the
+Redis password parameter, so OpenTofu includes those dependencies before the
+boot-smoke task runs. Do not manually set a stale `/genfeed/production/REDIS_URL`
+SSM parameter; Terraform sets `REDIS_URL` and `REDIS_TLS` as task environment
+values.
 
 ## Cutover and Rollback
 

--- a/infra/terraform/genfeed-prod/.terraform.lock.hcl
+++ b/infra/terraform/genfeed-prod/.terraform.lock.hcl
@@ -27,3 +27,40 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "h1:Lw9im2VBBJQ3RyAbHPQ0rcvcmmcZWm3x+kIOpN+Tv9s=",
+    "h1:U8KXqGCoNI9/guYbTvzgdtVk3fRthoG0UXwm1JoEpIs=",
+    "h1:YXaVd4p6qXPPVaxIBaIDNXmBwT02ZqDn0qD+tYpw8sA=",
+    "h1:cOpc03fphEt/G9Rfc4jLL/fW0D7tgvlXqiDKPF4vuww=",
+    "h1:g09RR7T1xWkeGrZwWvWMT9ncJrFGr1k3CBD585UmO7w=",
+    "h1:gGDdPPibmw2EWROx+sh1RGLjR5+nPwZyrf6/N9jXfeM=",
+    "h1:haE7/nXCOhXKP4oXeEnER3t5CaVQWqujz4nBnpeTUv4=",
+    "h1:ieSVpfZS2lKuMr05ph0QsOVpCzg7uk3cgKBaXR+Ikug=",
+    "h1:ig2s1IS9IzehorRjvVAnKIsUUj8fkgyxct1L/kswcc4=",
+    "h1:j3lS+ZEERFnoab8t1ppDrScGVP/cgWbzlCrEYKTCXYw=",
+    "h1:lxezrKmOiQIySHAM+os8qLVq7hqufDr8h3Hpzvsk+78=",
+    "h1:lzRqBJAG+NETxHbEZUJ/YP3RMEjZBinTX7VmgH3lw60=",
+    "h1:tdSNWK5ApqUsgbdYieyeYLTu6nIZUV3hR1oFqUfAuGo=",
+    "h1:xedet8yH/zI2CfdxsGlK0nlFWc/Bp61yrWsEa3fHB8g=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
+  ]
+}

--- a/infra/terraform/genfeed-prod/elasticache.tf
+++ b/infra/terraform/genfeed-prod/elasticache.tf
@@ -1,14 +1,23 @@
 # Managed redis, off the app instances (state must not live on ephemeral tasks).
-# Single t4g.micro node (~$12/mo). SG-restricted to ECS only.
-#
-# NOTE: after apply, set the SSM param /genfeed/production/REDIS_URL to
-#   redis://<primary_endpoint_address>:6379
-# (no AUTH — access is gated by the cache SG). The app reads REDIS_URL from SSM,
-# so no code change is needed; just repoint the param.
+# Single t4g.micro node (~$12/mo). SG-restricted to ECS only. Production tasks
+# connect with TLS and AUTH; the auth token is stored as an SSM SecureString and
+# injected into ECS task definitions as REDIS_PASSWORD.
 
 resource "aws_elasticache_subnet_group" "redis" {
   name       = "${local.name_prefix}-redis"
   subnet_ids = local.private_subnet_ids
+}
+
+resource "random_password" "redis_auth_token" {
+  length  = 64
+  special = false
+}
+
+resource "aws_ssm_parameter" "redis_password" {
+  name        = "${var.ssm_path}/REDIS_PASSWORD"
+  description = "Production ElastiCache Redis AUTH token."
+  type        = "SecureString"
+  value       = random_password.redis_auth_token.result
 }
 
 resource "aws_elasticache_replication_group" "redis" {
@@ -24,5 +33,8 @@ resource "aws_elasticache_replication_group" "redis" {
   security_group_ids         = [aws_security_group.cache.id]
   automatic_failover_enabled = false
   at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  auth_token                 = random_password.redis_auth_token.result
+  auth_token_update_strategy = "SET"
   apply_immediately          = true
 }

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -26,10 +26,10 @@ locals {
   # segment (e.g. /genfeed/production/DATABASE_URL -> DATABASE_URL).
   # ECS forbids a `secrets` entry sharing a name with an `environment` entry, so
   # any SSM param we also set as a container env var (the Cloud Map inter-service
-  # URLs, REDIS_URL, NODE_ENV, VERSION, PORT, SERVICE_NAME) must be filtered out
-  # of the injected secrets — the env value wins. REDIS_PASSWORD is dropped too:
-  # ElastiCache is no-auth (private + SG-locked) and redis-connection.utils.ts
-  # would otherwise send AUTH (which a no-auth server rejects).
+  # URLs, REDIS_URL, REDIS_TLS, NODE_ENV, VERSION, PORT, SERVICE_NAME) must be
+  # filtered out of the injected secrets — the env value wins. REDIS_PASSWORD is
+  # injected below from the Terraform-managed SecureString so stale/manual params
+  # cannot create duplicate ECS secret names.
   reserved_env_names = toset(concat(
     [for e in local.internal_env : e.name],
     ["PORT", "SERVICE_NAME", "REDIS_PASSWORD"],
@@ -46,6 +46,13 @@ locals {
       valueFrom = data.aws_ssm_parameters_by_path.prod.arns[i]
     } if !contains(local.excluded_ssm_secret_names, element(reverse(split("/", name)), 0))
   ]
+  redis_task_secrets = [
+    {
+      name      = "REDIS_PASSWORD"
+      valueFrom = aws_ssm_parameter.redis_password.arn
+    },
+  ]
+  service_task_secrets = concat(local.task_secrets, local.redis_task_secrets)
 
   # ── Service catalogue (mirrors docker-compose.production.yml) ─────────
   # Fargate launch type: cpu/mem MUST be valid Fargate task pairs (256→512-2048,

--- a/infra/terraform/genfeed-prod/outputs.tf
+++ b/infra/terraform/genfeed-prod/outputs.tf
@@ -23,7 +23,7 @@ output "public_backend_urls" {
 }
 
 output "redis_primary_endpoint" {
-  description = "Set SSM /genfeed/production/REDIS_URL to redis://<this>:6379 after apply."
+  description = "Production Redis endpoint. ECS tasks connect with REDIS_URL=rediss://<this>:6379 and REDIS_PASSWORD from SSM."
   value       = aws_elasticache_replication_group.redis.primary_endpoint_address
 }
 

--- a/infra/terraform/genfeed-prod/providers.tf
+++ b/infra/terraform/genfeed-prod/providers.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.60"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
   }
 }
 

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -5,7 +5,8 @@ locals {
     { name = "GENFEEDAI_MICROSERVICES_MCP_URL", value = "http://mcp.genfeed.internal:${local.services.mcp.port}" },
     { name = "GENFEEDAI_MICROSERVICES_NOTIFICATIONS_URL", value = "http://notifications.genfeed.internal:${local.services.notifications.port}" },
     { name = "GENFEEDAI_API_URL", value = "http://api.genfeed.internal:${local.services.api.port}" },
-    { name = "REDIS_URL", value = "redis://${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379" },
+    { name = "REDIS_URL", value = "rediss://${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379" },
+    { name = "REDIS_TLS", value = "true" },
     { name = "NODE_ENV", value = "production" },
     { name = "VERSION", value = "1.0.0" },
   ]
@@ -33,7 +34,7 @@ module "service" {
   security_group_ids = [aws_security_group.ecs.id]
   namespace_id       = aws_service_discovery_private_dns_namespace.internal.id
 
-  secrets = local.task_secrets
+  secrets = local.service_task_secrets
   environment = concat(local.internal_env, [
     { name = "PORT", value = tostring(each.value.port) },
     { name = "SERVICE_NAME", value = each.key },
@@ -77,7 +78,7 @@ resource "aws_ecs_task_definition" "migrate" {
     # the node entrypoint (`Cannot find module .../packages/prisma/bunx`) and the
     # migrate task exited 1. Matches the services' `["bun", ...]` invocation.
     command     = ["bun", "x", "prisma", "migrate", "deploy"]
-    secrets     = local.task_secrets
+    secrets     = local.service_task_secrets
     environment = [{ name = "NODE_ENV", value = "production" }]
     logConfiguration = {
       logDriver = "awslogs"
@@ -110,7 +111,7 @@ resource "aws_ecs_task_definition" "workflow_backfill" {
     image     = local.image
     essential = true
     command   = ["bun", "--filter", local.services.api.filter, "migrate:workflows"]
-    secrets   = local.task_secrets
+    secrets   = local.service_task_secrets
     environment = concat(local.internal_env, [
       { name = "PORT", value = tostring(local.services.api.port) },
       { name = "SERVICE_NAME", value = "api" },
@@ -180,7 +181,7 @@ resource "aws_ecs_task_definition" "boot_smoke" {
       exit 1
       EOT
     ]
-    secrets = local.task_secrets
+    secrets = local.service_task_secrets
     environment = concat(local.internal_env, [
       { name = "PORT", value = tostring(local.services.api.port) },
       { name = "SERVICE_NAME", value = "api" },

--- a/packages/libs/adapters/redis-io.adapter.spec.ts
+++ b/packages/libs/adapters/redis-io.adapter.spec.ts
@@ -15,6 +15,10 @@ import {
   vi,
 } from 'vitest';
 
+vi.mock('@socket.io/redis-adapter', () => ({
+  createAdapter: vi.fn(),
+}));
+
 type RedisClientSubset = Pick<RedisClientType, 'connect' | 'duplicate'>;
 
 describe('RedisIoAdapter', () => {
@@ -60,7 +64,7 @@ describe('RedisIoAdapter', () => {
     vi.spyOn(redis, 'createClient').mockReturnValue(
       pubClient as unknown as RedisClientType,
     );
-    vi.spyOn(redisAdapter, 'createAdapter').mockReturnValue(
+    vi.mocked(redisAdapter.createAdapter).mockReturnValue(
       adapterConstructor as unknown as ReturnType<
         typeof redisAdapter.createAdapter
       >,
@@ -73,6 +77,42 @@ describe('RedisIoAdapter', () => {
     expect(subClient.connect).toHaveBeenCalledOnce();
     expect(loggerService.log).toHaveBeenCalledWith('Redis adapter connected', {
       service: 'RedisIoAdapter',
+    });
+  });
+
+  it('should pass TLS and password options to Redis clients', async () => {
+    const pubClient = buildMockClient();
+    const subClient = buildMockClient();
+    const adapterConstructor = Symbol('adapter-constructor');
+    const createClientSpy = vi
+      .spyOn(redis, 'createClient')
+      .mockReturnValue(pubClient as unknown as RedisClientType);
+
+    pubClient.duplicate.mockReturnValue(
+      subClient as unknown as RedisClientType,
+    );
+    vi.mocked(redisAdapter.createAdapter).mockReturnValue(
+      adapterConstructor as unknown as ReturnType<
+        typeof redisAdapter.createAdapter
+      >,
+    );
+
+    const adapter = new RedisIoAdapter(
+      undefined,
+      'rediss://redis.internal:6379',
+      loggerService,
+      false,
+      'secret-from-ssm',
+    );
+    await adapter.connectToRedis();
+
+    expect(createClientSpy).toHaveBeenCalledWith({
+      password: 'secret-from-ssm',
+      socket: {
+        connectTimeout: 3000,
+        tls: true,
+      },
+      url: 'rediss://redis.internal:6379',
     });
   });
 

--- a/packages/libs/adapters/redis-io.adapter.ts
+++ b/packages/libs/adapters/redis-io.adapter.ts
@@ -1,5 +1,9 @@
 import type { Server as HttpServer } from 'node:http';
 import type { LoggerService } from '@libs/logger/logger.service';
+import {
+  buildNodeRedisClientOptions,
+  parseRedisConnection,
+} from '@libs/redis/redis-connection.utils';
 import type { INestApplicationContext } from '@nestjs/common';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
@@ -16,6 +20,7 @@ export class RedisIoAdapter extends IoAdapter {
     private readonly redisUrl: string,
     private readonly loggerService: LoggerService,
     private readonly redisTls: boolean = false,
+    private readonly redisPassword?: string,
   ) {
     // Don't pass app to parent - we'll handle server creation ourselves
     super();
@@ -23,15 +28,22 @@ export class RedisIoAdapter extends IoAdapter {
   }
 
   async connectToRedis(): Promise<void> {
-    const tlsFromUrl = this.redisUrl.startsWith('rediss://');
-    const useTls = this.redisTls || tlsFromUrl;
-
-    const pubClient = createClient({
-      socket: {
-        ...(useTls && { tls: true }),
+    const config = parseRedisConnection({
+      get: (key) => {
+        if (key === 'REDIS_URL') {
+          return this.redisUrl;
+        }
+        if (key === 'REDIS_TLS') {
+          return this.redisTls;
+        }
+        if (key === 'REDIS_PASSWORD') {
+          return this.redisPassword;
+        }
+        return undefined;
       },
-      url: this.redisUrl,
     });
+
+    const pubClient = createClient(buildNodeRedisClientOptions(config));
     const subClient = pubClient.duplicate();
 
     try {

--- a/packages/libs/redis/redis-connection.utils.spec.ts
+++ b/packages/libs/redis/redis-connection.utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildBullMQConnection,
+  buildNodeRedisClientOptions,
   buildNodeRedisSocketOptions,
   parseRedisConnection,
 } from '@libs/redis/redis-connection.utils';
@@ -48,6 +49,36 @@ describe('redis connection utilities', () => {
     expect(buildNodeRedisSocketOptions(config)).toEqual({
       connectTimeout: 3000,
       tls: true,
+    });
+  });
+
+  it('passes separately injected Redis passwords to node-redis clients', () => {
+    const config = parseRedisConnection({
+      get: (key) => {
+        if (key === 'REDIS_URL') {
+          return 'rediss://redis.internal:6379';
+        }
+        if (key === 'REDIS_PASSWORD') {
+          return 'secret-from-ssm';
+        }
+        return false;
+      },
+    });
+
+    expect(config).toEqual({
+      host: 'redis.internal',
+      password: 'secret-from-ssm',
+      port: 6379,
+      tls: true,
+      url: 'rediss://redis.internal:6379',
+    });
+    expect(buildNodeRedisClientOptions(config)).toEqual({
+      password: 'secret-from-ssm',
+      socket: {
+        connectTimeout: 3000,
+        tls: true,
+      },
+      url: 'rediss://redis.internal:6379',
     });
   });
 });

--- a/packages/libs/redis/redis-connection.utils.ts
+++ b/packages/libs/redis/redis-connection.utils.ts
@@ -15,6 +15,13 @@ export interface ParsedRedisConfig {
   url: string;
 }
 
+export type RedisReconnectStrategy = (retries: number) => number | false;
+
+export interface NodeRedisConnectionOptions {
+  connectTimeout?: number;
+  reconnectStrategy?: RedisReconnectStrategy;
+}
+
 /**
  * Parse Redis connection from config service.
  * TLS is enabled if EITHER:
@@ -73,6 +80,29 @@ export function buildNodeRedisSocketOptions(
     return { connectTimeout, tls: true };
   }
   return { connectTimeout };
+}
+
+/**
+ * Build node-redis v4 createClient options.
+ * Keep REDIS_PASSWORD separate from REDIS_URL so production can inject the
+ * password as an ECS secret without placing it in a plaintext env value.
+ */
+export function buildNodeRedisClientOptions(
+  config: ParsedRedisConfig,
+  options: NodeRedisConnectionOptions = {},
+) {
+  const socket = {
+    ...buildNodeRedisSocketOptions(config, options.connectTimeout ?? 3_000),
+    ...(options.reconnectStrategy && {
+      reconnectStrategy: options.reconnectStrategy,
+    }),
+  };
+
+  return {
+    ...(config.password && { password: config.password }),
+    socket,
+    url: config.url,
+  };
 }
 
 /**

--- a/packages/libs/redis/redis.service.ts
+++ b/packages/libs/redis/redis.service.ts
@@ -8,7 +8,10 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 import { createClient, type RedisClientType } from 'redis';
-import { parseRedisConnection } from './redis-connection.utils';
+import {
+  buildNodeRedisClientOptions,
+  parseRedisConnection,
+} from './redis-connection.utils';
 
 @Injectable()
 export class RedisService
@@ -48,17 +51,13 @@ export class RedisService
     }
 
     const config = parseRedisConnection(this.configService);
-    const socketOptions = {
+    const clientOptions = buildNodeRedisClientOptions(config, {
       connectTimeout: RedisService.CONNECT_TIMEOUT_MS,
       reconnectStrategy: () => false as const, // Don't retry - fail fast
-      ...(config.tls ? { tls: true as const } : {}),
-    };
+    });
 
     try {
-      this.publisher = createClient({
-        socket: socketOptions,
-        url: config.url,
-      });
+      this.publisher = createClient(clientOptions);
       this.publisher.on('error', (err) =>
         this.logger.error('Redis Publisher Error', err, this.context),
       );
@@ -72,10 +71,7 @@ export class RedisService
         ),
       ]);
 
-      this.subscriber = createClient({
-        socket: socketOptions,
-        url: config.url,
-      });
+      this.subscriber = createClient(clientOptions);
       this.subscriber.on('error', (err) =>
         this.logger.error('Redis Subscriber Error', err, this.context),
       );


### PR DESCRIPTION
Closes #635

## Summary
- enable production ElastiCache in-transit encryption and AUTH with a Terraform-generated token stored as `/genfeed/production/REDIS_PASSWORD` SecureString
- switch ECS service Redis env to `rediss://...` + `REDIS_TLS=true` while injecting `REDIS_PASSWORD` as an ECS secret
- update shared node-redis connection helpers and callers so separately injected Redis passwords authenticate without embedding tokens in `REDIS_URL`
- document the production Redis TLS/auth rollout contract in `infra/terraform/README.md`

## Validation
- `tofu -chdir=infra/terraform/genfeed-prod init -backend=false -input=false`
- `tofu -chdir=infra/terraform/genfeed-prod fmt -check -diff`
- `tofu -chdir=infra/terraform/genfeed-prod validate`
- `bun run test:workspace -- packages/libs/redis/redis-connection.utils.spec.ts packages/libs/adapters/redis-io.adapter.spec.ts packages/libs/redis/redis.service.spec.ts`
- `bunx biome check ...touched Redis/API/files/notifications files...`
- `bunx turbo run type-check --filter=@genfeedai/libs --filter=@genfeedai/api --filter=@genfeedai/files --filter=@genfeedai/notifications`
- `bunx turbo run lint --filter=@genfeedai/libs --filter=@genfeedai/api --filter=@genfeedai/files --filter=@genfeedai/notifications`
- `bunx prettier --check infra/terraform/README.md`
- static Redis TLS/auth Terraform contract assertion
- `git diff --check origin/master..HEAD`
- touched-file Secretlint and pre-commit lint-staged Secretlint/Biome

## Notes
- I did not run `tofu plan` or `tofu apply`; this automation must not perform live production infrastructure operations or depend on production AWS state.
- The generated Redis token is not committed. Terraform stores it in SSM as a SecureString and injects it into ECS task definitions as `REDIS_PASSWORD`. The S3 Terraform state remains sensitive infrastructure state.
