### PR TITLE
fix(website): gate marketing events on ad consent

### DIFF
--- a/apps/website/packages/marketing/MarketingTrackingProvider.test.tsx
+++ b/apps/website/packages/marketing/MarketingTrackingProvider.test.tsx
@@ -1,0 +1,163 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MARKETING_CONSENT_STORAGE_KEY } from './consent';
+import { WEBSITE_MARKETING_EVENTS } from './events';
+import MarketingTrackingProvider from './MarketingTrackingProvider';
+
+const browserMocks = vi.hoisted(() => ({
+  loadMarketingTags: vi.fn(),
+  setGoogleConsent: vi.fn(),
+  trackWebsiteMarketingEvent: vi.fn(
+    (event: { eventId?: string; name: string }) =>
+      event.eventId ?? `${event.name}:test`,
+  ),
+}));
+
+const navigationMocks = vi.hoisted(() => ({
+  pathname: '/',
+  searchParams: new URLSearchParams(),
+}));
+
+const localStorageStore = new Map<string, string>();
+const localStorageMock = {
+  clear: () => localStorageStore.clear(),
+  getItem: (key: string) => localStorageStore.get(key) ?? null,
+  removeItem: (key: string) => {
+    localStorageStore.delete(key);
+  },
+  setItem: (key: string, value: string) => {
+    localStorageStore.set(key, value);
+  },
+};
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigationMocks.pathname,
+  useSearchParams: () => navigationMocks.searchParams,
+}));
+
+vi.mock('./browser', () => ({
+  loadMarketingTags: browserMocks.loadMarketingTags,
+  setGoogleConsent: browserMocks.setGoogleConsent,
+  trackWebsiteMarketingEvent: browserMocks.trackWebsiteMarketingEvent,
+}));
+
+function renderProvider(
+  children: ReactNode = <button type="button">Child</button>,
+) {
+  return render(
+    <MarketingTrackingProvider
+      config={{
+        gtmContainerId: 'GTM-TEST',
+        metaPixelId: 'meta-test',
+      }}
+      consentDefault="denied"
+    >
+      {children}
+    </MarketingTrackingProvider>,
+  );
+}
+
+function dispatchTrackedButton(action: string): void {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent('genfeed:marketing:button-click', {
+        detail: {
+          trackingData: { action },
+          trackingName: 'test_cta_click',
+        },
+      }),
+    );
+  });
+}
+
+describe('MarketingTrackingProvider', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: localStorageMock,
+    });
+    window.localStorage.clear();
+    navigationMocks.pathname = '/';
+    navigationMocks.searchParams = new URLSearchParams();
+    vi.clearAllMocks();
+  });
+
+  it('fails closed while consent is unavailable or denied', async () => {
+    renderProvider();
+
+    await screen.findByRole('button', { name: /accept/i });
+    dispatchTrackedButton('book_demo');
+
+    expect(browserMocks.loadMarketingTags).not.toHaveBeenCalled();
+    expect(browserMocks.trackWebsiteMarketingEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not load marketing tags when only analytics storage is granted', async () => {
+    window.localStorage.setItem(
+      MARKETING_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        adStorage: 'denied',
+        analyticsStorage: 'granted',
+        updatedAt: '2026-06-30T00:00:00.000Z',
+      }),
+    );
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(browserMocks.setGoogleConsent).toHaveBeenCalledWith({
+        adStorage: 'denied',
+        analyticsStorage: 'granted',
+      }),
+    );
+    dispatchTrackedButton('book_demo');
+
+    expect(browserMocks.loadMarketingTags).not.toHaveBeenCalled();
+    expect(browserMocks.trackWebsiteMarketingEvent).not.toHaveBeenCalled();
+  });
+
+  it('loads tags and routes typed page and CTA events after consent', async () => {
+    navigationMocks.pathname = '/pricing';
+    renderProvider();
+
+    fireEvent.click(await screen.findByRole('button', { name: /accept/i }));
+
+    await waitFor(() =>
+      expect(browserMocks.loadMarketingTags).toHaveBeenCalledWith({
+        gtmContainerId: 'GTM-TEST',
+        metaPixelId: 'meta-test',
+      }),
+    );
+    await waitFor(() =>
+      expect(browserMocks.trackWebsiteMarketingEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: WEBSITE_MARKETING_EVENTS.PAGE_VIEW,
+        }),
+        expect.any(Object),
+      ),
+    );
+
+    browserMocks.trackWebsiteMarketingEvent.mockClear();
+    dispatchTrackedButton('book_demo');
+
+    expect(
+      browserMocks.trackWebsiteMarketingEvent.mock.calls.map(
+        ([event]) => event.name,
+      ),
+    ).toEqual([
+      WEBSITE_MARKETING_EVENTS.CTA_CLICK,
+      WEBSITE_MARKETING_EVENTS.BOOK_CALL,
+    ]);
+  });
+});

--- a/apps/website/packages/marketing/MarketingTrackingProvider.tsx
+++ b/apps/website/packages/marketing/MarketingTrackingProvider.tsx
@@ -13,6 +13,7 @@ import {
 } from './browser';
 import {
   createConsentState,
+  hasMarketingConsent,
   MARKETING_CONSENT_STORAGE_KEY,
   type MarketingConsentState,
   parseMarketingConsent,
@@ -78,10 +79,7 @@ function MarketingPageTracker({
   consentRef.current = consent;
 
   useEffect(() => {
-    if (
-      consent?.adStorage !== 'granted' &&
-      consent?.analyticsStorage !== 'granted'
-    ) {
+    if (!hasMarketingConsent(consent)) {
       return;
     }
 
@@ -112,10 +110,7 @@ function MarketingPageTracker({
   useEffect(() => {
     const handleTrackedButton = (event: Event) => {
       const currentConsent = consentRef.current;
-      if (
-        currentConsent?.adStorage !== 'granted' &&
-        currentConsent?.analyticsStorage !== 'granted'
-      ) {
+      if (!hasMarketingConsent(currentConsent)) {
         return;
       }
 
@@ -186,10 +181,7 @@ export default function MarketingTrackingProvider({
       analyticsStorage: initialConsent.analyticsStorage,
     });
 
-    if (
-      initialConsent.adStorage === 'granted' ||
-      initialConsent.analyticsStorage === 'granted'
-    ) {
+    if (hasMarketingConsent(initialConsent)) {
       loadMarketingTags(config);
     }
   }, [config, consentDefault]);
@@ -206,10 +198,7 @@ export default function MarketingTrackingProvider({
       analyticsStorage: nextConsent.analyticsStorage,
     });
 
-    if (
-      nextConsent.adStorage === 'granted' ||
-      nextConsent.analyticsStorage === 'granted'
-    ) {
+    if (hasMarketingConsent(nextConsent)) {
       loadMarketingTags(config);
     }
   };

--- a/apps/website/packages/marketing/consent.test.ts
+++ b/apps/website/packages/marketing/consent.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createConsentState, parseMarketingConsent } from './consent';
+import {
+  createConsentState,
+  hasMarketingConsent,
+  parseMarketingConsent,
+} from './consent';
 
 describe('marketing consent', () => {
   it('creates explicit granted or denied consent states', () => {
@@ -26,5 +30,18 @@ describe('marketing consent', () => {
 
     expect(parseMarketingConsent('{"adStorage":"maybe"}')).toBeNull();
     expect(parseMarketingConsent('not-json')).toBeNull();
+  });
+
+  it('requires ad storage consent before marketing tags can run', () => {
+    expect(hasMarketingConsent(null)).toBe(false);
+    expect(hasMarketingConsent(createConsentState('denied'))).toBe(false);
+    expect(
+      hasMarketingConsent({
+        adStorage: 'denied',
+        analyticsStorage: 'granted',
+        updatedAt: '2026-05-03T00:00:00.000Z',
+      }),
+    ).toBe(false);
+    expect(hasMarketingConsent(createConsentState('granted'))).toBe(true);
   });
 });

--- a/apps/website/packages/marketing/consent.ts
+++ b/apps/website/packages/marketing/consent.ts
@@ -48,3 +48,9 @@ export function parseMarketingConsent(
 
   return null;
 }
+
+export function hasMarketingConsent(
+  state: MarketingConsentState | null,
+): boolean {
+  return state?.adStorage === 'granted';
+}


### PR DESCRIPTION
## Summary

- Closes #932
- Refs #250
- Requires website marketing tracking to have `adStorage=granted` before loading marketing tags or emitting page/CTA marketing events
- Adds provider-level regression coverage for denied, analytics-only, and granted consent states

## Validation

- `bun run --cwd apps/website test -- packages/marketing/consent.test.ts packages/marketing/events.test.ts packages/marketing/MarketingTrackingProvider.test.tsx packages/components/buttons/request-access/button-request-access/ButtonRequestAccess.test.tsx`
- `bunx biome check apps/website/packages/marketing/consent.ts apps/website/packages/marketing/consent.test.ts apps/website/packages/marketing/MarketingTrackingProvider.tsx apps/website/packages/marketing/MarketingTrackingProvider.test.tsx`
- `bun run --cwd apps/website type-check`
- `git diff --check`
- `git diff --cached --check`
- `bun scripts/run-secretlint.ts apps/website/packages/marketing/consent.ts apps/website/packages/marketing/consent.test.ts apps/website/packages/marketing/MarketingTrackingProvider.tsx apps/website/packages/marketing/MarketingTrackingProvider.test.tsx`
- Pre-commit lint-staged: Secretlint, Biome, raw-HTML guard

## Notes

- No vendor snippets or conversion API secrets were added.
- The parent #250 remains open for GTM/container configuration and broader vendor/server conversion rollout.