### PR TITLE
[codex] simplify login chooser labels

### DIFF
--- a/apps/app/app/(public)/login/content.test.tsx
+++ b/apps/app/app/(public)/login/content.test.tsx
@@ -62,15 +62,14 @@ describe('LoginPage', () => {
       screen.getByRole('heading', { name: 'Welcome Back' }),
     ).toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: /^Email/ })).toBeNull();
-    expect(
-      screen.getByRole('button', { name: 'Sign in with Google' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'Sign in with a magic link' }),
-    ).toHaveAttribute('href', '/login/magic-link');
+    expect(screen.getByRole('button', { name: 'Google' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Magic Link' })).toHaveAttribute(
+      'href',
+      '/login/magic-link',
+    );
     expect(
       screen.getByRole('link', {
-        name: 'Sign in with email and password',
+        name: 'Email / Password',
       }),
     ).toHaveAttribute('href', '/login/password');
   });
@@ -84,15 +83,13 @@ describe('LoginPage', () => {
 
     render(<LoginPage />);
 
-    expect(
-      screen.getByRole('link', { name: 'Sign in with a magic link' }),
-    ).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Magic Link' })).toHaveAttribute(
       'href',
       '/login/magic-link?callbackUrl=%2Foauth%2Fcli%3Fport%3D4321',
     );
     expect(
       screen.getByRole('link', {
-        name: 'Sign in with email and password',
+        name: 'Email / Password',
       }),
     ).toHaveAttribute(
       'href',
@@ -103,9 +100,7 @@ describe('LoginPage', () => {
   it('starts Google sign-in with the default callback URL', async () => {
     render(<LoginPage />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Sign in with Google' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
@@ -120,9 +115,7 @@ describe('LoginPage', () => {
 
     render(<LoginPage />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Sign in with Google' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({

--- a/apps/app/app/(public)/login/login-better-auth.tsx
+++ b/apps/app/app/(public)/login/login-better-auth.tsx
@@ -311,7 +311,7 @@ export default function LoginBetterAuth({
             className={AUTH_BUTTON_CLASS_NAME}
             withWrapper={false}
           >
-            Sign in with Google
+            Google
           </Button>
 
           <Button
@@ -322,7 +322,7 @@ export default function LoginBetterAuth({
           >
             <Link href={magicLinkHref}>
               <Sparkles className="size-4" aria-hidden="true" />
-              <span>Sign in with a magic link</span>
+              <span>Magic Link</span>
             </Link>
           </Button>
 
@@ -334,7 +334,7 @@ export default function LoginBetterAuth({
           >
             <Link href={passwordHref}>
               <KeyRound className="size-4" aria-hidden="true" />
-              <span>Sign in with email and password</span>
+              <span>Email / Password</span>
             </Link>
           </Button>
         </div>


### PR DESCRIPTION
## Summary

- Shorten the login chooser labels to `Google`, `Magic Link`, and `Email / Password`.
- Update the focused login tests to assert the new accessible names.

## Validation

- `bun run design:lint`
- `bun run --cwd apps/app test -- 'app/(public)/login/content.test.tsx'`
- `bunx biome check 'apps/app/app/(public)/login/login-better-auth.tsx' 'apps/app/app/(public)/login/content.test.tsx'`
- Pre-commit: secretlint, staged Biome check, raw HTML lint