### PR TITLE
fix(ci): gate heavy test matrix on explicit run_heavy_tests input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,23 @@ on:
   pull_request:
     branches: [master]
   # Allow this gate to be run as a reusable workflow (e.g. by full-suite.yml,
-  # which chains CI → E2E on demand). No inputs needed; secrets are inherited.
+  # which chains CI → E2E on demand). Secrets are inherited.
   workflow_call:
+    inputs:
+      run_heavy_tests:
+        # Gate for the heavy test matrix (packages, server services,
+        # web/desktop/mobile, extensions, app + api shards). Callers on the
+        # release path (full-suite.yml) pass `true` to run the full suite.
+        #
+        # This is an explicit input — NOT a `github.event_name == 'workflow_call'`
+        # check — because a reusable workflow inherits the CALLER's originating
+        # event (e.g. `workflow_dispatch` from deploy-ecs.yml), so `event_name`
+        # is never `workflow_call` here and the old gate silently skipped every
+        # heavy test job on the release QA path.
+        description: 'Run the full heavy test matrix (release QA path).'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -383,7 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
+    if: needs.trust.outputs.is-trusted == 'true' && inputs.run_heavy_tests
     steps:
       - uses: actions/checkout@v5
         with:
@@ -405,7 +420,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
+    if: needs.trust.outputs.is-trusted == 'true' && inputs.run_heavy_tests
     steps:
       - uses: actions/checkout@v5
         with:
@@ -427,7 +442,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
+    if: needs.trust.outputs.is-trusted == 'true' && inputs.run_heavy_tests
     steps:
       - uses: actions/checkout@v5
         with:
@@ -449,7 +464,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true' && github.event_name == 'workflow_call'
+    if: needs.trust.outputs.is-trusted == 'true' && inputs.run_heavy_tests
     steps:
       - uses: actions/checkout@v5
         with:
@@ -471,7 +486,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && github.event_name == 'workflow_call'
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.app == 'true' && inputs.run_heavy_tests
     strategy:
       fail-fast: false
       matrix:
@@ -535,7 +550,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [trust, test-scope]
-    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && github.event_name == 'workflow_call'
+    if: needs.trust.outputs.is-trusted == 'true' && needs.test-scope.outputs.api == 'true' && inputs.run_heavy_tests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -23,6 +23,11 @@ jobs:
   ci:
     name: CI Gate
     uses: ./.github/workflows/ci.yml
+    # Release/full-suite path runs the full heavy test matrix. A reusable
+    # workflow inherits the caller's originating event, so this must be an
+    # explicit input — `github.event_name` is never `workflow_call` downstream.
+    with:
+      run_heavy_tests: true
     secrets: inherit
 
   build-verify:


### PR DESCRIPTION
## Problem

The 6 heavy test jobs in `ci.yml` — **Test Packages, Test Server Services, Test Web/Desktop/Mobile, Test Extensions, Test App (4 shards), Test API (4 shards)** — gate on `github.event_name == 'workflow_call'`.

A **reusable workflow inherits the caller's originating event**. When the release path runs `deploy-ecs.yml` (workflow_dispatch) → `full-suite.yml` → `ci.yml`, `github.event_name` inside ci.yml is `workflow_dispatch`, **never** `workflow_call`. So the gate never matched and every one of these jobs was silently **skipped**:

- On the release/full-suite path → skipped (wrong event).
- On PR / master-push → skipped (these jobs have no push/PR trigger; only `test-app-changed` runs).

Net result: **unit, service, and API tests ran on no path at all.** Release QA passed with zero of them executing.

### Evidence

Last successful production deploy (run `28412538083`, on `5782da120`) — `QA before deploy / CI Gate`:

```
skipped  Test Packages
skipped  Test Server Services
skipped  Test Web, Desktop, Mobile
skipped  Test Extensions
skipped  Test App (Shard …/4)
skipped  Test API (Shard …/4)
```

## Fix

Replace the unreliable `event_name` gate with an explicit `run_heavy_tests` `workflow_call` input. `full-suite.yml` passes `run_heavy_tests: true` on the release path; PR/push leave it default-`false` (focused `test-app-changed` still covers PRs).

An explicit input is immune to the reusable-workflow event-inheritance trap that broke the original gate.

## Scope

- `ci.yml`: add `run_heavy_tests` input; repoint 6 job gates.
- `full-suite.yml`: pass `run_heavy_tests: true` to the CI gate.
- `react-doctor` left unchanged (it has a real `push` fallback).

## Verification

- `python3 yaml.safe_load` parse OK on both files.
- `actionlint` clean (validates `inputs.run_heavy_tests` context refs).
- After merge, confirm the next full-suite run shows the Test* jobs **running**, not skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)