### PR TITLE
fix(deploy): skip 10m image wait for non-server commits

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -157,14 +157,23 @@ jobs:
             return 1
           }
 
-          if wait_for_image "$REQUESTED_TAG"; then
-            echo "sha=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
+          # Explicit tag (rollback / pinned deploy): it must already exist.
+          # Wait in case a build is still in flight, then fail closed.
           if [ "$EXPLICIT_TAG" = "true" ]; then
+            if wait_for_image "$REQUESTED_TAG"; then
+              echo "sha=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "::error::Requested server image ${REQUESTED_TAG} was not found in GHCR after waiting. Build it first or choose an existing image tag."
             exit 1
+          fi
+
+          # Deploying current HEAD. Fast path: server:<HEAD> already published —
+          # use it immediately with no wait loop.
+          if image_exists "$REQUESTED_TAG"; then
+            echo "Server image ready: ${REQUESTED_TAG}"
+            echo "sha=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           server_image_paths=(
@@ -178,21 +187,45 @@ jobs:
             ".github/actions/build-unified-image/**"
           )
 
+          # No image for HEAD yet. Find the newest first-parent ancestor that has
+          # an image, then branch on whether server-image inputs changed since it:
+          #   unchanged -> frontend/workflow-only commit. build-server-image is
+          #     paths-gated and NEVER builds a server:<HEAD> for it, so waiting
+          #     would burn ~10m for an image that will never appear. Reuse the
+          #     ancestor's immutable image immediately.
+          #   changed   -> a server:<HEAD> build is expected/in-flight; wait for
+          #     it (up to ~10m), then fail closed if it never lands.
           echo "No image for HEAD (${HEAD_SHA}); checking recent first-parent ancestors..."
+          ANCESTOR=""
           for sha in $(git rev-list --first-parent -n 50 "$HEAD_SHA" | tail -n +2); do
-            if ! image_exists "$sha"; then
-              continue
+            if image_exists "$sha"; then
+              ANCESTOR="$sha"
+              break
             fi
-            if git diff --quiet "${sha}..${HEAD_SHA}" -- "${server_image_paths[@]}"; then
-              echo "::warning::server:${HEAD_SHA} was not built, but server-image inputs are unchanged since ${sha}; deploying ${sha}."
-              echo "sha=$sha" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "::error::server:${HEAD_SHA} was not found, and server-image inputs changed after newest available ancestor ${sha}. Wait for the Build Server Image workflow for ${HEAD_SHA}, then re-dispatch."
-            exit 1
           done
 
-          echo "::error::No server image found for HEAD or its recent first-parent ancestors."
+          if [ -z "$ANCESTOR" ]; then
+            echo "No first-parent ancestor image found; waiting for server:${HEAD_SHA}..."
+            if wait_for_image "$REQUESTED_TAG"; then
+              echo "sha=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::No server image found for HEAD or its recent first-parent ancestors."
+            exit 1
+          fi
+
+          if git diff --quiet "${ANCESTOR}..${HEAD_SHA}" -- "${server_image_paths[@]}"; then
+            echo "::warning::server:${HEAD_SHA} was not built, but server-image inputs are unchanged since ${ANCESTOR}; deploying ${ANCESTOR} (no wait)."
+            echo "sha=$ANCESTOR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Server-image inputs changed since ${ANCESTOR}; waiting for server:${HEAD_SHA} build..."
+          if wait_for_image "$REQUESTED_TAG"; then
+            echo "sha=$REQUESTED_TAG" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::server:${HEAD_SHA} was not found, and server-image inputs changed after newest available ancestor ${ANCESTOR}. Wait for the Build Server Image workflow for ${HEAD_SHA}, then re-dispatch."
           exit 1
 
       - name: Copy server:<sha> GHCR -> ECR (no rebuild)


### PR DESCRIPTION
## Problem

The `Resolve available server image` step in `deploy-ecs.yml` **always** waited up to ~10 minutes for `server:<HEAD>` (20 × 30s polls) *before* falling back to ancestor reuse:

```bash
if wait_for_image "$REQUESTED_TAG"; then ...   # up to 10m
fi
# ... only now check ancestors
```

For a **frontend- or workflow-only commit**, `build-server-image.yml` is paths-gated and never builds a `server:<HEAD>`. So that image will *never* appear — yet every such deploy burned the full ~10m wait before reusing a perfectly valid ancestor image.

## Fix

Reorder resolution so the wait happens only when an image is actually expected:

1. **Explicit tag** (rollback/pinned) → wait, then fail closed. *(unchanged)*
2. **`server:<HEAD>` already present** → use immediately (fast path, no loop).
3. **Otherwise** find the newest first-parent ancestor with an image:
   - **server-image inputs unchanged** since it → reuse it **immediately, no wait** (the HEAD image will never be built for a non-server commit).
   - **inputs changed** → a `server:<HEAD>` build is expected/in-flight → wait up to ~10m, then fail closed.

### Impact

- Frontend / workflow-only deploys: **~10m of dead polling → a single `git diff`**.
- Server-affecting deploys: unchanged (still wait for the HEAD build).
- Fail-closed safety on explicit tags and missing server builds preserved.

## Verification

- `python3 yaml.safe_load` parse OK.
- `actionlint` clean (incl. shellcheck on the run block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)