### PR TITLE
feat(trends): classify public reference corpus

### DIFF
--- a/apps/docs/content/core-loop/corpus-health.mdx
+++ b/apps/docs/content/core-loop/corpus-health.mdx
@@ -117,7 +117,7 @@ If the corpus is not launch-ready, downstream readers should still use the exist
 Follow-up implementation should treat this page as the product contract:
 
 - `#211` backfills the first credential-free global source set through `seed:prelaunch-corpus`; it clears the runtime cold-start baseline and starts toward the launch-minimum rows without claiming full launch readiness.
-- `#213` should replace curated topics with public reference ingestion while preserving the platform/content-type targets.
+- `#213` replaces curated topics with public reference ingestion while preserving the platform/content-type targets. The first implementation slice classifies reference records with `sourceKind`, `intendedUse`, `confidence`, `sourceLabel`, `sourceTopic`, `capturedAt`, and `freshnessWindowDays`; LinkedIn fallback topics come from configured public source URLs instead of a hardcoded curated topic list.
 - `#214` should make paid/creative references classifiable so they do not pollute organic trend slices.
 - `#215` should derive prompt-ready packs only from references that satisfy prompt-ready metadata.
 - `#216` should automate the health metrics and freshness checks defined here.

--- a/apps/docs/content/core-loop/prelaunch-corpus-backfill.mdx
+++ b/apps/docs/content/core-loop/prelaunch-corpus-backfill.mdx
@@ -12,6 +12,7 @@ The backfill writes global rows only:
 - `brandId = null`
 - `requiresAuth = false`
 - `metadata.prelaunchCorpus = true`
+- `metadata.source = "public-reference"`
 - `metadata.sourceSetVersion = "2026-06-09"`
 
 It is a launch operations path, not a replacement for provider ingestion or the full health automation tracked by `#216`.
@@ -52,7 +53,9 @@ Themes covered:
 - paid creative breakdowns
 - community research
 
-Every source item includes platform, content type, canonical URL, title or text, author handle, published timestamp, and engagement metrics so prompt assembly can use the reference corpus without fetching live provider APIs.
+Every source item includes platform, content type, canonical URL, title or text, author handle, published timestamp, engagement metrics, and a normalized `sourceClassification` payload so prompt assembly can use the reference corpus without fetching live provider APIs.
+
+The `sourceClassification` payload marks the seed as `sourceKind = "public_platform_reference"` and `intendedUse = "organic_trend_discovery"`. LinkedIn uses the same public-reference contract as the other platforms; it is not a separate curated topic list.
 
 ## Write Contract
 
@@ -109,4 +112,4 @@ Local validation for automation PRs may be skipped when the active policy requir
 
 ## Boundary
 
-This backfill clears the existing cold-start baseline and starts the corpus toward the launch-minimum targets in the health contract. It does not claim the full `480` trend and `1,440` reference launch floor, and it does not replace provider-specific ingestion work in `#213` through `#216`.
+This backfill clears the existing cold-start baseline and starts the corpus toward the launch-minimum targets in the health contract. It does not claim the full `480` trend and `1,440` reference launch floor. The first `#213` slice now replaces the LinkedIn curated-topic fallback with configured public reference topics and preserves `sourceClassification` through the reference-corpus read path; provider-specific ingestion depth remains tracked by the follow-up corpus issues.

--- a/apps/server/api/src/collections/trends/controllers/trends.controller.spec.ts
+++ b/apps/server/api/src/collections/trends/controllers/trends.controller.spec.ts
@@ -296,6 +296,15 @@ describe('TrendsController', () => {
             matchedTrendTopics: ['#AIAgents'],
             platform: 'twitter',
             remixCount: 2,
+            sourceClassification: {
+              capturedAt: '2026-03-25T00:00:00.000Z',
+              confidence: 'medium',
+              freshnessWindowDays: 2,
+              intendedUse: 'organic_trend_discovery',
+              sourceKind: 'public_platform_reference',
+              sourceLabel: 'X / Twitter',
+              sourceTopic: '#AIAgents',
+            },
             sourcePreviewState: 'live',
           },
         ],
@@ -324,6 +333,9 @@ describe('TrendsController', () => {
         items: [
           expect.objectContaining({
             id: 'ref-1',
+            sourceClassification: expect.objectContaining({
+              sourceKind: 'public_platform_reference',
+            }),
           }),
         ],
         summary: {

--- a/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts
+++ b/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts
@@ -1,0 +1,52 @@
+import { buildPrelaunchReferenceCorpusSeeds } from '@api/collections/trends/data/prelaunch-reference-corpus.seed';
+
+describe('prelaunch reference corpus seed', () => {
+  it('classifies every source preview as a public platform reference', () => {
+    const seeds = buildPrelaunchReferenceCorpusSeeds(
+      new Date('2026-06-09T00:00:00.000Z'),
+    );
+
+    expect(seeds).toHaveLength(70);
+    expect(
+      seeds.every(
+        (seed) =>
+          seed.metadata.sourceClassification.sourceKind ===
+            'public_platform_reference' &&
+          seed.metadata.sourceClassification.intendedUse ===
+            'organic_trend_discovery',
+      ),
+    ).toBe(true);
+
+    const sourceItems = seeds.flatMap((seed) => seed.sourcePreview);
+    expect(sourceItems).toHaveLength(140);
+    expect(
+      sourceItems.every(
+        (item) =>
+          item.sourceClassification?.sourceKind ===
+            'public_platform_reference' &&
+          item.sourceClassification.intendedUse === 'organic_trend_discovery' &&
+          typeof item.sourceClassification.sourceLabel === 'string' &&
+          typeof item.sourceClassification.sourceTopic === 'string',
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps LinkedIn in the same public-reference path as other platforms', () => {
+    const seeds = buildPrelaunchReferenceCorpusSeeds(
+      new Date('2026-06-09T00:00:00.000Z'),
+    );
+    const linkedInSeeds = seeds.filter((seed) => seed.platform === 'linkedin');
+
+    expect(linkedInSeeds).toHaveLength(10);
+    expect(
+      linkedInSeeds.every((seed) =>
+        seed.sourcePreview.every(
+          (item) =>
+            item.platform === 'linkedin' &&
+            item.sourceClassification?.sourceLabel === 'LinkedIn' &&
+            item.sourceClassification.confidence !== undefined,
+        ),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts
+++ b/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts
@@ -1,4 +1,7 @@
-import type { TrendSourceItem } from '@api/collections/trends/interfaces/trend.interfaces';
+import type {
+  TrendSourceClassification,
+  TrendSourceItem,
+} from '@api/collections/trends/interfaces/trend.interfaces';
 
 export interface PrelaunchReferenceCorpusSeed {
   growthRate: number;
@@ -8,6 +11,7 @@ export interface PrelaunchReferenceCorpusSeed {
     angle: string;
     hashtags: string[];
     launchCorpusSlice: string;
+    sourceClassification: TrendSourceClassification;
   };
   platform: string;
   sourcePreview: TrendSourceItem[];
@@ -26,6 +30,7 @@ interface CorpusTheme {
 interface CorpusPlatform {
   accountPrefix: string;
   contentType: TrendSourceItem['contentType'];
+  freshnessWindowDays: number;
   key: string;
   label: string;
   sourcePath: (theme: CorpusTheme) => string;
@@ -116,6 +121,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'tiktok',
     contentType: 'video',
+    freshnessWindowDays: 2,
     key: 'tiktok',
     label: 'TikTok',
     sourcePath: (theme) => `https://www.tiktok.com/tag/${theme.hashtag}`,
@@ -124,6 +130,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'instagram',
     contentType: 'video',
+    freshnessWindowDays: 2,
     key: 'instagram',
     label: 'Instagram',
     sourcePath: (theme) =>
@@ -134,6 +141,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'x',
     contentType: 'tweet',
+    freshnessWindowDays: 2,
     key: 'twitter',
     label: 'X / Twitter',
     sourcePath: (theme) => `https://x.com/hashtag/${theme.hashtag}`,
@@ -142,6 +150,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'youtube',
     contentType: 'video',
+    freshnessWindowDays: 7,
     key: 'youtube',
     label: 'YouTube',
     sourcePath: (theme) => `https://www.youtube.com/hashtag/${theme.hashtag}`,
@@ -150,6 +159,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'reddit',
     contentType: 'post',
+    freshnessWindowDays: 7,
     key: 'reddit',
     label: 'Reddit',
     sourcePath: (theme) => `https://www.reddit.com/r/${theme.hashtag}/`,
@@ -158,6 +168,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'pinterest',
     contentType: 'image',
+    freshnessWindowDays: 30,
     key: 'pinterest',
     label: 'Pinterest',
     sourcePath: (theme) =>
@@ -168,6 +179,7 @@ const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'linkedin',
     contentType: 'post',
+    freshnessWindowDays: 7,
     key: 'linkedin',
     label: 'LinkedIn',
     sourcePath: (theme) =>
@@ -186,6 +198,13 @@ export function buildPrelaunchReferenceCorpusSeeds(
       const publishedAt = new Date(
         capturedAt.getTime() - (themeIndex + platformIndex + 1) * 86_400_000,
       ).toISOString();
+      const sourceClassification = buildPublicReferenceClassification({
+        capturedAt,
+        confidence: themeIndex < 4 ? 'medium' : 'low',
+        freshnessWindowDays: platform.freshnessWindowDays,
+        sourceLabel: platform.label,
+        sourceTopic: theme.title,
+      });
 
       return {
         growthRate: 35 + themeIndex * 3 + platformIndex,
@@ -195,13 +214,14 @@ export function buildPrelaunchReferenceCorpusSeeds(
           angle: theme.angle,
           hashtags: [`#${theme.hashtag}`, `#${theme.key.replace(/-/g, '')}`],
           launchCorpusSlice: 'organic-reference',
+          sourceClassification,
         },
         platform: platform.key,
         sourcePreview: [
           {
             authorHandle: `${platform.accountPrefix}-${theme.key}`,
             contentType: platform.contentType,
-            id: `${trendKey}:primary`,
+            id: `${trendKey}-fallback-primary`,
             metrics: {
               comments: 80 + themeIndex * 12,
               likes: 1_200 + platformIndex * 140 + themeIndex * 90,
@@ -210,6 +230,7 @@ export function buildPrelaunchReferenceCorpusSeeds(
             },
             platform: platform.key,
             publishedAt,
+            sourceClassification,
             sourceUrl: platform.sourcePath(theme),
             text: theme.angle,
             title: `${theme.shortTitle} on ${platform.label}`,
@@ -217,7 +238,7 @@ export function buildPrelaunchReferenceCorpusSeeds(
           {
             authorHandle: `${platform.accountPrefix}-reference-${themeIndex + 1}`,
             contentType: platform.contentType,
-            id: `${trendKey}:secondary`,
+            id: `${trendKey}-fallback-secondary`,
             metrics: {
               comments: 45 + platformIndex * 8,
               likes: 760 + themeIndex * 75,
@@ -226,6 +247,7 @@ export function buildPrelaunchReferenceCorpusSeeds(
             },
             platform: platform.key,
             publishedAt,
+            sourceClassification,
             sourceUrl: platform.sourcePathAlt(theme),
             text: `Reference example for ${theme.title.toLowerCase()} in the ${platform.label} launch corpus.`,
             title: `${theme.title}: ${platform.label} reference`,
@@ -236,4 +258,22 @@ export function buildPrelaunchReferenceCorpusSeeds(
       };
     }),
   );
+}
+
+function buildPublicReferenceClassification(input: {
+  capturedAt: Date;
+  confidence: TrendSourceClassification['confidence'];
+  freshnessWindowDays: number;
+  sourceLabel: string;
+  sourceTopic: string;
+}): TrendSourceClassification {
+  return {
+    capturedAt: input.capturedAt.toISOString(),
+    confidence: input.confidence,
+    freshnessWindowDays: input.freshnessWindowDays,
+    intendedUse: 'organic_trend_discovery',
+    sourceKind: 'public_platform_reference',
+    sourceLabel: input.sourceLabel,
+    sourceTopic: input.sourceTopic,
+  };
 }

--- a/apps/server/api/src/collections/trends/interfaces/trend.interfaces.ts
+++ b/apps/server/api/src/collections/trends/interfaces/trend.interfaces.ts
@@ -43,6 +43,29 @@ export interface TrendPreferencesFilter {
   platforms?: string[];
 }
 
+export type TrendSourceConfidence = 'high' | 'low' | 'medium';
+
+export type TrendSourceIntendedUse =
+  | 'evergreen_prompt_context'
+  | 'organic_trend_discovery'
+  | 'paid_creative_analysis';
+
+export type TrendSourceKind =
+  | 'manual_curated_reference'
+  | 'owned_brand_reference'
+  | 'paid_creative_reference'
+  | 'public_platform_reference';
+
+export interface TrendSourceClassification {
+  capturedAt: string;
+  confidence: TrendSourceConfidence;
+  freshnessWindowDays: number;
+  intendedUse: TrendSourceIntendedUse;
+  sourceKind: TrendSourceKind;
+  sourceLabel?: string;
+  sourceTopic?: string;
+}
+
 export interface TrendSourceItem {
   id: string;
   sourceReferenceId?: string;
@@ -55,6 +78,7 @@ export interface TrendSourceItem {
   thumbnailUrl?: string;
   mediaUrl?: string;
   publishedAt?: string;
+  sourceClassification?: TrendSourceClassification;
   metrics?: {
     comments?: number;
     likes?: number;
@@ -116,6 +140,7 @@ export interface TrendSourceReferenceRecord {
   currentMetrics?: TrendSourceItem['metrics'];
   matchedTrendTopics: string[];
   sourcePreviewState: 'live' | 'fallback' | 'empty';
+  sourceClassification?: TrendSourceClassification;
   remixCount: number;
 }
 

--- a/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-prelaunch-corpus.service.ts
@@ -215,7 +215,7 @@ export class TrendPrelaunchCorpusService {
       ...seed.metadata,
       prelaunchCorpus: true,
       prelaunchCorpusKey: seed.key,
-      source: 'curated',
+      source: 'public-reference',
       sourcePreviewCache: seed.sourcePreview,
       sourcePreviewCachedAt: now.toISOString(),
       sourcePreviewState: 'fallback',

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.spec.ts
@@ -222,6 +222,15 @@ describe('TrendSourceItemsService', () => {
       const trend = makeTrend({
         metadata: {
           sampleContent: 'sample',
+          sourceClassification: {
+            capturedAt: '2026-06-09T00:00:00.000Z',
+            confidence: 'low',
+            freshnessWindowDays: 7,
+            intendedUse: 'organic_trend_discovery',
+            sourceKind: 'public_platform_reference',
+            sourceLabel: 'YouTube',
+            sourceTopic: '#ai',
+          },
           urls: ['https://a.com', 'https://b.com'],
         },
         platform: 'youtube',
@@ -233,6 +242,9 @@ describe('TrendSourceItemsService', () => {
       expect(items[0]).toMatchObject({
         contentType: 'post',
         id: 'trend-1-fallback-1',
+        sourceClassification: expect.objectContaining({
+          sourceKind: 'public_platform_reference',
+        }),
         sourceUrl: 'https://a.com',
         text: 'sample',
       });

--- a/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-source-items.service.ts
@@ -1,5 +1,8 @@
 import { TrendEntity } from '@api/collections/trends/entities/trend.entity';
-import type { TrendSourceItem } from '@api/collections/trends/interfaces/trend.interfaces';
+import type {
+  TrendSourceClassification,
+  TrendSourceItem,
+} from '@api/collections/trends/interfaces/trend.interfaces';
 import { TREND_SOURCE_PREVIEW_LIMIT } from '@api/collections/trends/services/modules/trend-source.constants';
 import type {
   ApifyInstagramPost,
@@ -135,6 +138,9 @@ export class TrendSourceItemsService {
       : [];
     const resolvedSourceUrls =
       sourceUrls.length > 0 ? sourceUrls : mediaUrl ? [mediaUrl] : [];
+    const sourceClassification = this.getTrendSourceClassification(
+      trend.metadata?.sourceClassification,
+    );
 
     return resolvedSourceUrls.map((sourceUrl, index) => ({
       authorHandle:
@@ -152,6 +158,7 @@ export class TrendSourceItemsService {
       platform: trend.platform,
       publishedAt: trend.createdAt?.toISOString(),
       sourceUrl,
+      sourceClassification,
       text:
         typeof trend.metadata?.sampleContent === 'string'
           ? trend.metadata.sampleContent
@@ -392,6 +399,27 @@ export class TrendSourceItemsService {
       typeof item.sourceUrl === 'string' &&
       typeof item.contentType === 'string'
     );
+  }
+
+  private getTrendSourceClassification(
+    value: unknown,
+  ): TrendSourceClassification | undefined {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    const classification = value as Record<string, unknown>;
+    if (
+      typeof classification.capturedAt !== 'string' ||
+      typeof classification.confidence !== 'string' ||
+      typeof classification.freshnessWindowDays !== 'number' ||
+      typeof classification.intendedUse !== 'string' ||
+      typeof classification.sourceKind !== 'string'
+    ) {
+      return undefined;
+    }
+
+    return classification as unknown as TrendSourceClassification;
   }
 
   private truncateText(

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
@@ -39,6 +39,15 @@ describe('TrendReferenceCorpusService', () => {
         latestTrendViralityScore: 91,
         matchedTrendTopics: ['ai tools'],
         platform: 'tiktok',
+        sourceClassification: {
+          capturedAt: '2026-06-01T00:00:00.000Z',
+          confidence: 'medium',
+          freshnessWindowDays: 2,
+          intendedUse: 'organic_trend_discovery',
+          sourceKind: 'public_platform_reference',
+          sourceLabel: 'TikTok',
+          sourceTopic: 'ai tools',
+        },
         sourcePreviewState: 'live',
         title: 'AI tools clip',
       },
@@ -279,6 +288,10 @@ describe('TrendReferenceCorpusService', () => {
     expect(result.items[0]).toMatchObject({
       id: 'ref_tiktok',
       platform: 'tiktok',
+      sourceClassification: expect.objectContaining({
+        intendedUse: 'organic_trend_discovery',
+        sourceKind: 'public_platform_reference',
+      }),
       remixCount: 2,
     });
     expect(prisma.trendSourceReferenceLink.findMany).toHaveBeenCalledWith(
@@ -319,6 +332,57 @@ describe('TrendReferenceCorpusService', () => {
           canonicalUrl: { in: ['https://example.com/a'] },
           isDeleted: false,
         },
+      }),
+    );
+  });
+
+  it('persists source classification when syncing public reference items', async () => {
+    prisma.trendSourceReference.findFirst.mockResolvedValueOnce(null);
+    prisma.trendSourceReference.create.mockResolvedValueOnce({
+      id: 'ref_public',
+    });
+
+    await service.syncTrendReferences([
+      {
+        id: 'trend_public',
+        mentions: 2400,
+        platform: 'linkedin',
+        sourcePreview: [
+          {
+            authorHandle: 'openai',
+            contentType: 'post',
+            id: 'linkedin:openai:primary',
+            platform: 'linkedin',
+            sourceClassification: {
+              capturedAt: '2026-06-09T00:00:00.000Z',
+              confidence: 'low',
+              freshnessWindowDays: 7,
+              intendedUse: 'organic_trend_discovery',
+              sourceKind: 'public_platform_reference',
+              sourceLabel: 'OpenAI',
+              sourceTopic: '#openai',
+            },
+            sourceUrl: 'https://www.linkedin.com/company/openai/',
+            title: 'OpenAI public reference',
+          },
+        ],
+        sourcePreviewState: 'fallback',
+        topic: '#openai',
+        viralityScore: 42,
+      },
+    ]);
+
+    expect(prisma.trendSourceReference.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          data: expect.objectContaining({
+            sourceClassification: expect.objectContaining({
+              intendedUse: 'organic_trend_discovery',
+              sourceKind: 'public_platform_reference',
+              sourceLabel: 'OpenAI',
+            }),
+          }),
+        }),
       }),
     );
   });

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -1,6 +1,7 @@
 import type {
   TrendSourceAccountResult,
   TrendSourceAccountSummary,
+  TrendSourceClassification,
   TrendSourceItem,
   TrendSourceReferenceRecord,
   TrendSourceReferenceResult,
@@ -54,6 +55,7 @@ interface ReferenceRecordData {
   platform: string;
   publishedAt?: string;
   sourcePreviewState: 'live' | 'fallback' | 'empty';
+  sourceClassification?: TrendSourceClassification;
   text?: string;
   thumbnailUrl?: string;
   title?: string;
@@ -129,6 +131,9 @@ export class TrendReferenceCorpusService {
                 publishedAt: sourceItem.publishedAt
                   ? new Date(sourceItem.publishedAt).toISOString()
                   : undefined,
+                sourceClassification:
+                  sourceItem.sourceClassification ??
+                  existingData.sourceClassification,
                 sourcePreviewState: trend.sourcePreviewState,
                 text: sourceItem.text,
                 thumbnailUrl: sourceItem.thumbnailUrl,
@@ -164,6 +169,7 @@ export class TrendReferenceCorpusService {
                 publishedAt: sourceItem.publishedAt
                   ? new Date(sourceItem.publishedAt).toISOString()
                   : undefined,
+                sourceClassification: sourceItem.sourceClassification,
                 sourcePreviewState: trend.sourcePreviewState,
                 text: sourceItem.text,
                 thumbnailUrl: sourceItem.thumbnailUrl,
@@ -760,6 +766,7 @@ export class TrendReferenceCorpusService {
       publishedAt: data.publishedAt,
       remixCount: remixCounts.get(id) || 0,
       sourcePreviewState: data.sourcePreviewState,
+      sourceClassification: data.sourceClassification,
       text: data.text,
       thumbnailUrl: data.thumbnailUrl,
       title: data.title,

--- a/apps/server/api/src/collections/trends/services/trends.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trends.service.spec.ts
@@ -605,7 +605,7 @@ describe('TrendsService', () => {
       expect(result.lockedPlatforms).toEqual(['instagram']);
     });
 
-    it('excludes linkedin from the public content feed', async () => {
+    it('does not synthesize LinkedIn content from a stale curated row without references', async () => {
       vi.spyOn(service, 'getTrendsWithAccessControl').mockResolvedValue({
         connectedPlatforms: [],
         lockedPlatforms: ['linkedin'],
@@ -625,6 +625,66 @@ describe('TrendsService', () => {
       const result = await service.getTrendContent('org-1', 'brand-1');
 
       expect(result.items).toEqual([]);
+    });
+
+    it('returns LinkedIn content when public reference previews are stored', async () => {
+      vi.spyOn(service, 'getTrendsWithAccessControl').mockResolvedValue({
+        connectedPlatforms: [],
+        lockedPlatforms: ['linkedin'],
+        trends: [
+          new TrendEntity({
+            ...mockTrend,
+            id: '507f1f77bcf86cd799439024',
+            metadata: {
+              source: 'public-reference',
+              sourceClassification: {
+                capturedAt: '2026-06-09T00:00:00.000Z',
+                confidence: 'low',
+                freshnessWindowDays: 7,
+                intendedUse: 'organic_trend_discovery',
+                sourceKind: 'public_platform_reference',
+                sourceLabel: 'LinkedIn',
+                sourceTopic: '#openai',
+              },
+              sourcePreviewCache: [
+                {
+                  contentType: 'post',
+                  id: 'linkedin:openai-fallback-primary',
+                  platform: 'linkedin',
+                  sourceClassification: {
+                    capturedAt: '2026-06-09T00:00:00.000Z',
+                    confidence: 'low',
+                    freshnessWindowDays: 7,
+                    intendedUse: 'organic_trend_discovery',
+                    sourceKind: 'public_platform_reference',
+                    sourceLabel: 'LinkedIn',
+                    sourceTopic: '#openai',
+                  },
+                  sourceUrl: 'https://www.linkedin.com/company/openai/',
+                  title: 'OpenAI public reference',
+                },
+              ],
+              sourcePreviewState: 'fallback',
+            },
+            platform: 'linkedin',
+            topic: '#openai',
+            viralityScore: 42,
+          } as never),
+        ],
+      });
+
+      const result = await service.getTrendContent('org-1', 'brand-1');
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        platform: 'linkedin',
+        sourceClassification: expect.objectContaining({
+          sourceKind: 'public_platform_reference',
+        }),
+        sourcePreviewState: 'fallback',
+        sourceUrl: 'https://www.linkedin.com/company/openai/',
+        trendTopic: '#openai',
+      });
     });
 
     it('returns bootstrap content when the trend corpus is empty', async () => {

--- a/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.spec.ts
+++ b/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.spec.ts
@@ -346,10 +346,15 @@ describe('LinkedInService', () => {
       expect(trends.length).toBeGreaterThan(0);
       expect(trends[0]?.topic).toBe('#ai');
       expect(trends[0]?.metadata.source).toBe('public-scrape');
+      expect(trends[0]?.metadata.sourceClassification).toMatchObject({
+        confidence: 'medium',
+        intendedUse: 'organic_trend_discovery',
+        sourceKind: 'public_platform_reference',
+      });
       expect(trends[0]?.mentions).toBeGreaterThan(1);
     });
 
-    it('should fall back to curated topics when scraping yields no signal', async () => {
+    it('should fall back to configured public reference topics when scraping yields no signal', async () => {
       mockBrandScraperService.scrapeLinkedIn.mockResolvedValue({
         companyName: 'Empty',
         recentPosts: [],
@@ -359,11 +364,17 @@ describe('LinkedInService', () => {
 
       const trends = await service.getTrends('org-123', 'brand-456');
 
-      expect(trends.length).toBe(10);
+      expect(trends.length).toBeGreaterThan(0);
       expect(trends[0]).toEqual(
         expect.objectContaining({
-          metadata: expect.objectContaining({ source: 'curated' }),
-          topic: '#ai',
+          metadata: expect.objectContaining({
+            source: 'public-reference',
+            sourceClassification: expect.objectContaining({
+              intendedUse: 'organic_trend_discovery',
+              sourceKind: 'public_platform_reference',
+            }),
+          }),
+          topic: '#openai',
         }),
       );
       expect(mockLoggerService.warn).toHaveBeenCalled();

--- a/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.ts
+++ b/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.ts
@@ -1,4 +1,5 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import type { TrendSourceClassification } from '@api/collections/trends/interfaces/trend.interfaces';
 import { ConfigService } from '@api/config/config.service';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
@@ -19,7 +20,8 @@ interface LinkedInTrendTopic {
   mentions: number;
   metadata: {
     sampleContent?: string;
-    source: 'curated' | 'public-scrape';
+    source: 'public-reference' | 'public-scrape';
+    sourceClassification?: TrendSourceClassification;
     thumbnailUrl?: string;
     trendType: 'hashtag' | 'topic';
     urls?: string[];
@@ -583,7 +585,7 @@ export class LinkedInService {
    *
    * The official LinkedIn integration does not expose a public trending-topics
    * endpoint, so we derive live-ish signals from recent public posts on known
-   * public pages and fall back to curated evergreen topics only when public
+   * public pages and fall back to the configured public reference sources when
    * scraping does not yield enough signal.
    */
   public async getTrends(
@@ -622,16 +624,16 @@ export class LinkedInService {
       }
 
       this.loggerService.warn(
-        `${url} - public LinkedIn scrape returned no usable topics, falling back to curated topics`,
+        `${url} - public LinkedIn scrape returned no usable topics, falling back to public reference topics`,
       );
     } catch (error: unknown) {
       this.loggerService.warn(
-        `${url} - public LinkedIn scrape failed, falling back to curated topics`,
+        `${url} - public LinkedIn scrape failed, falling back to public reference topics`,
         { error: error instanceof Error ? error.message : String(error) },
       );
     }
 
-    return this.getCuratedTopics();
+    return this.getPublicReferenceTopics(sourceUrls);
   }
 
   private getTrendSourceUrls(): string[] {
@@ -720,6 +722,12 @@ export class LinkedInService {
         metadata: {
           sampleContent: candidate.sampleContent,
           source: 'public-scrape',
+          sourceClassification: this.buildSourceClassification({
+            capturedAt: new Date(),
+            confidence: 'medium',
+            sourceLabel: 'LinkedIn public posts',
+            sourceTopic: topic,
+          }),
           thumbnailUrl: candidate.thumbnailUrl,
           trendType: topic.startsWith('#') ? 'hashtag' : 'topic',
           urls: Array.from(candidate.sourceUrls),
@@ -764,27 +772,74 @@ export class LinkedInService {
     return Math.round(sourceCoverage * 60 + signalStrength * 40);
   }
 
-  private getCuratedTopics(): LinkedInTrendTopic[] {
-    return [
-      '#ai',
-      '#leadership',
-      '#innovation',
-      '#technology',
-      '#digitaltransformation',
-      '#marketing',
-      '#sustainability',
-      '#entrepreneurship',
-      '#careerdevelopment',
-      '#remotework',
-    ].map((topic) => ({
-      growthRate: 35,
-      mentions: 1,
-      metadata: {
-        source: 'curated',
-        trendType: 'hashtag',
-      },
-      topic,
-    }));
+  private getPublicReferenceTopics(sourceUrls: string[]): LinkedInTrendTopic[] {
+    const capturedAt = new Date();
+    const seenTopics = new Set<string>();
+
+    return sourceUrls.flatMap((sourceUrl, index) => {
+      const sourceLabel = this.getPublicReferenceLabel(sourceUrl);
+      const topic = this.toReferenceTopic(sourceLabel, index);
+      if (seenTopics.has(topic)) {
+        return [];
+      }
+      seenTopics.add(topic);
+
+      return [
+        {
+          growthRate: 20,
+          mentions: 1,
+          metadata: {
+            sampleContent: `Public LinkedIn reference source for ${sourceLabel}.`,
+            source: 'public-reference',
+            sourceClassification: this.buildSourceClassification({
+              capturedAt,
+              confidence: 'low',
+              sourceLabel,
+              sourceTopic: topic,
+            }),
+            trendType: 'topic',
+            urls: [sourceUrl],
+          },
+          topic,
+        },
+      ];
+    });
+  }
+
+  private buildSourceClassification(input: {
+    capturedAt: Date;
+    confidence: TrendSourceClassification['confidence'];
+    sourceLabel: string;
+    sourceTopic: string;
+  }): TrendSourceClassification {
+    return {
+      capturedAt: input.capturedAt.toISOString(),
+      confidence: input.confidence,
+      freshnessWindowDays: 7,
+      intendedUse: 'organic_trend_discovery',
+      sourceKind: 'public_platform_reference',
+      sourceLabel: input.sourceLabel,
+      sourceTopic: input.sourceTopic,
+    };
+  }
+
+  private getPublicReferenceLabel(sourceUrl: string): string {
+    try {
+      const parsed = new URL(sourceUrl);
+      const pathParts = parsed.pathname.split('/').filter(Boolean);
+      const slug = pathParts[pathParts.length - 1] || parsed.hostname;
+      return slug
+        .replace(/[-_]+/g, ' ')
+        .replace(/\b[a-z]/g, (letter) => letter.toUpperCase())
+        .trim();
+    } catch {
+      return sourceUrl.replace(/^https?:\/\//, '').replace(/\/$/, '');
+    }
+  }
+
+  private toReferenceTopic(sourceLabel: string, index: number): string {
+    const token = sourceLabel.toLowerCase().replace(/[^a-z0-9]+/g, '');
+    return token ? `#${token}` : `#linkedinreference${index + 1}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- replaces the LinkedIn curated-topic fallback with configured public reference topics derived from public source URLs
- adds normalized `sourceClassification` metadata for trend source items and reference-corpus records
- marks the prelaunch corpus as `public-reference`, preserves classification through fallback/source sync/read paths, and documents the contract

Closes #213

## Validation
- `bun run --cwd apps/server/api test:file -- src/services/integrations/linkedin/services/linkedin.service.spec.ts src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts src/collections/trends/services/trend-reference-corpus.service.spec.ts src/collections/trends/services/modules/trend-source-items.service.spec.ts src/collections/trends/services/trends.service.spec.ts src/collections/trends/controllers/trends.controller.spec.ts` (94 tests)
- `bunx biome check --write` on touched TypeScript files
- `bunx prettier --check apps/docs/content/core-loop/prelaunch-corpus-backfill.mdx apps/docs/content/core-loop/corpus-health.mdx`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bun run --cwd apps/server/api lint`
- `bun run audit:api` (passed; existing medium/low SQL audit backlog remains)
- `git diff --check` / `git diff --cached --check`
- `bun scripts/run-secretlint.ts` on touched and staged files
- `bun run lint-staged`