### PR TITLE
chore(deploy): fix false prod human-gate comment + drop dead BOOT_SMOKE path

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,6 +1,6 @@
 # ECS production deploy (replaces the SSH-waves path post-cutover).
-# Dispatch-only. Flow: validate master -> QA before deploy -> production
-# environment approval -> resolve server:<sha> in GHCR -> copy GHCR->ECR ->
+# Dispatch-only. Flow: validate master -> QA before deploy -> resolve
+# server:<sha> in GHCR -> copy GHCR->ECR ->
 # run Prisma migrate task -> run workflow migration/backfill task -> terraform
 # apply rolls services (task defs are TF-managed with image_tag) -> wait
 # services-stable -> deploy Vercel frontends -> live post-deploy smoke.
@@ -63,7 +63,12 @@ jobs:
     needs: qa-before-deploy
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    environment: production # <- requires reviewer approval (the human gate)
+    # `environment: production` scopes prod secrets/vars. NOTE: no required
+    # reviewers are configured, so this is NOT a human approval gate. Deploy
+    # safety comes from the dispatch-only trigger, the ref==master checks, the
+    # migrate + boot-smoke pre-roll gates below, and ECS circuit-breaker
+    # rollback — not manual approval.
+    environment: production
     steps:
       - uses: actions/checkout@v5
         with:

--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -86,8 +86,8 @@ import { BetterAuthMailerService } from './services/better-auth-mailer.service';
 
         const secret = config.get('BETTER_AUTH_SECRET');
         if (!secret) {
-          // Fail fast at boot (surfaced by BOOT_SMOKE) rather than at first
-          // sign-in: a missing secret would silently break auth.
+          // Fail fast at boot (surfaced by the deploy boot-smoke gate) rather
+          // than at first sign-in: a missing secret would silently break auth.
           throw new Error(
             'BETTER_AUTH_SECRET is required when BETTER_AUTH_ENABLED=true',
           );

--- a/apps/server/api/src/main.ts
+++ b/apps/server/api/src/main.ts
@@ -306,17 +306,6 @@ async function main() {
 
     expressApp.use('/admin/queues', bullBoardAuth, serverAdapter.getRouter());
 
-    if (process.env.BOOT_SMOKE === '1') {
-      // Boot smoke (used as a pre-roll gate in deploy-ecs before services roll):
-      // fully initialize the app — which surfaces crash-on-boot bugs like the
-      // circular-dependency TDZ that shipped because CI has no boot test — then
-      // exit cleanly without listening. Any boot failure throws into the catch
-      // below, which exits non-zero so the gate fails.
-      await app.init();
-      console.info('Boot smoke OK — API initialized cleanly.');
-      process.exit(0);
-    }
-
     console.info(`API bootstrap: starting listener on port ${port}`);
     await withStartupTimeout(
       app.listen(port),
@@ -339,8 +328,9 @@ async function main() {
 // has loaded. A circular-import TDZ (e.g. #711's "Cannot access 'X' before
 // initialization") throws during that import and crashes the process before this
 // line, so exit 0 here means the compiled graph loads cleanly. We exit BEFORE
-// NestFactory/config so the check needs no env, DB, or Redis — unlike BOOT_SMOKE
-// (the full deploy-time init). Note: vitest can't reproduce this TDZ (its SWC/ESM
+// NestFactory/config so the check needs no env, DB, or Redis — unlike the
+// deploy-time boot-smoke ECS task, which boots the full listener against the
+// migrated DB. Note: vitest can't reproduce this TDZ (its SWC/ESM
 // resolution differs); only the compiled build does, which is what CI runs here.
 if (process.env.BOOT_CHECK === '1') {
   process.exit(0);


### PR DESCRIPTION
## Why

Two pieces of the production deploy path described safeguards that don't exist.

### 1. False "human gate" comment
`deploy-ecs.yml` claimed:
```yaml
environment: production # <- requires reviewer approval (the human gate)
```
But the `production` environment has **zero protection rules** (`gh api .../environments/production` → `"protection_rules":[]`). No required reviewers → no human gate. The flow header made the same false claim.

Reworded both to describe the **real** safeguards: dispatch-only trigger, `ref==master` checks, the migrate + boot-smoke pre-roll gates, and ECS circuit-breaker rollback. (Matches vitae.ai, which also runs prod with no env reviewers.)

> Not adding required reviewers is intentional — solo-founder deploy cadence. This PR just stops the comment from lying about it.

### 2. Dead `BOOT_SMOKE` path
The ECS boot-smoke gate was switched (#897) to run the **full listener + curl `/v1/health`** in the TF task (`infra/terraform/genfeed-prod/services.tf`). Nothing sets `BOOT_SMOKE` anymore:
```
$ grep -rn BOOT_SMOKE --include=*.ts --include=*.tf --include=*.yml .
# (only the now-removed code + stale comments)
```
So the `if (process.env.BOOT_SMOKE === '1')` init-and-exit branch in `main.ts` was unreachable dead code whose own comment falsely called it "the pre-roll gate in deploy-ecs". Removed it and fixed the two stale comments that referenced it (`main.ts` BOOT_CHECK note + better-auth secret check).

## No behavior change
- `BOOT_SMOKE` was unreachable → removing it changes nothing at runtime.
- `BOOT_CHECK=1` (the real hermetic PR boot check in `build-verify.yml`) — untouched.
- The ECS boot-smoke task (curl gate) — untouched.

## Verification
- `actionlint` clean on `deploy-ecs.yml`.
- `turbo run type-check --filter=@genfeedai/api` → 17/17 successful.
- `grep BOOT_SMOKE` → no residual references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)