### PR TITLE
feat(website): Brand OS page + fold cards onto canonical Card

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -330,6 +330,30 @@ trigger button. Grouped into Content and Tools sections with a subtle divider.
 `bg-secondary` with `shadow-dropdown`. Items use `rounded-sm` (2px) with `hover:bg-hover`.
 Inline margin `mx-1` insets items from panel edges.
 
+## Brand OS Surfaces
+
+Brand OS surfaces are product-led acquisition surfaces, not a full visual
+rebrand. The public CTA and preview may use campaign-scale composition, but the
+authenticated review/apply flow stays dense and operational.
+
+### Evidence Labels
+
+Every Brand OS recommendation must be visibly tagged as extracted, inferred,
+candidate, or missing. Source-backed color and voice suggestions can appear in
+public previews, but candidate palettes do not become Genfeed product tokens
+until accepted into the real token source and reflected in this file.
+
+### Scale Roles
+
+Brand OS preview surfaces distinguish four roles:
+- `product` -- 32px control baseline for dense review fields and source rows
+- `block` -- standard public CTA and preview modules
+- `hero` -- primary public promise or conversion proof
+- `monument` -- one large proof artifact per page, used sparingly
+
+Do not use campaign-scale roles inside authenticated settings pages unless the
+screen is explicitly presenting a single launch artifact.
+
 ## Do's and Don'ts
 
 - **Do** use background layering for hierarchy instead of heavy borders.

--- a/apps/website/app/(public)/(home)/home-content.tsx
+++ b/apps/website/app/(public)/(home)/home-content.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import HomeBrandOS from '@web-components/home/_brand-os';
 import HomeCTA from '@web-components/home/_cta';
 import HomeFooter from '@web-components/home/_footer';
 import HomeHero from '@web-components/home/_hero';
@@ -9,6 +10,7 @@ export default function HomeContent() {
   return (
     <>
       <HomeHero />
+      <HomeBrandOS />
       <HomePricing />
       <HomeCTA />
       <HomeFooter />

--- a/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
@@ -84,4 +84,21 @@ describe('BrandOSContent', () => {
 
     expect(screen.getByText(/preview ready: example.com/i)).toBeInTheDocument();
   });
+
+  it('submits the Refresh Preview form on first load without typing https://', () => {
+    render(<BrandOSContent />);
+
+    // Input starts with bare "genfeed.ai" (no scheme) — form must fire without
+    // browser native-URL-validation blocking it.
+    const submitButton = screen.getByRole('button', {
+      name: /refresh preview/i,
+    });
+    const form = submitButton.closest('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    // After submit the preview transitions away from idle; with guidance present
+    // (initial state has guidance) it should move to "ready".
+    expect(screen.getByText(/preview ready:/i)).toBeInTheDocument();
+  });
 });

--- a/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import BrandOSContent from './brand-os-content';
+
+vi.mock('next/image', () => ({
+  default: ({
+    fill: _fill,
+    priority: _priority,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    priority?: boolean;
+  }) => (
+    <span
+      aria-label={props.alt ?? ''}
+      data-src={typeof props.src === 'string' ? props.src : undefined}
+      role="img"
+    />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    apps: {
+      app: 'https://app.genfeed.ai',
+    },
+  },
+}));
+
+vi.mock('@web-components/home/_footer', () => ({
+  default: () => <footer>Footer</footer>,
+}));
+
+vi.mock('@ui/buttons/tracked/ButtonTracked', () => ({
+  default: ({
+    asChild: _asChild,
+    children,
+  }: {
+    asChild?: boolean;
+    children: ReactNode;
+  }) => <>{children}</>,
+}));
+
+describe('BrandOSContent', () => {
+  it('renders the public Brand OS CTA and preview states', () => {
+    render(<BrandOSContent />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /turn source evidence into a usable brand system/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/public website url/i)).toHaveValue(
+      'genfeed.ai',
+    );
+    expect(screen.getByTestId('brand-os-preview')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ready/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /save in genfeed/i }),
+    ).toHaveAttribute('href', 'https://app.genfeed.ai/sign-up?source=brand-os');
+  });
+
+  it('updates the preview status from the visitor input', () => {
+    render(<BrandOSContent />);
+
+    fireEvent.change(screen.getByLabelText(/public website url/i), {
+      target: { value: 'https://example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /ready/i }));
+
+    expect(screen.getByText(/preview ready: example.com/i)).toBeInTheDocument();
+  });
+});

--- a/apps/website/app/(public)/brand-os/brand-os-content.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.tsx
@@ -1,0 +1,474 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
+import { EnvironmentService } from '@services/core/environment.service';
+import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
+import { HStack, VStack } from '@ui/layout/stack';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import { Label } from '@ui/primitives/label';
+import { Textarea } from '@ui/primitives/textarea';
+import { Heading } from '@ui/typography/heading';
+import { Text } from '@ui/typography/text';
+import HomeFooter from '@web-components/home/_footer';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  LuArrowRight,
+  LuBadgeCheck,
+  LuFileText,
+  LuLayers,
+  LuPalette,
+  LuSearchCheck,
+  LuTriangleAlert,
+} from 'react-icons/lu';
+
+const PREVIEW_MODES = [
+  {
+    icon: LuFileText,
+    key: 'idle',
+    label: 'Idle',
+    status: 'Waiting for source',
+  },
+  {
+    icon: LuSearchCheck,
+    key: 'partial',
+    label: 'Partial',
+    status: 'Evidence found',
+  },
+  {
+    icon: LuBadgeCheck,
+    key: 'ready',
+    label: 'Ready',
+    status: 'Preview ready',
+  },
+  {
+    icon: LuTriangleAlert,
+    key: 'blocked',
+    label: 'Blocked',
+    status: 'Needs public source',
+  },
+] as const;
+
+const SOURCE_EVIDENCE = [
+  {
+    confidence: 'High',
+    label: 'Positioning',
+    value: 'AI content OS for founders and teams shipping across channels.',
+  },
+  {
+    confidence: 'Medium',
+    label: 'Voice',
+    value: 'Direct, operational, and anti-fluff. Short nouns beat slogans.',
+  },
+  {
+    confidence: 'Missing',
+    label: 'Motion',
+    value: 'No public evidence yet. Keep motion rules empty until sourced.',
+  },
+] as const;
+
+const CONTENT_PILLARS = [
+  'Founder proof',
+  'Launch systems',
+  'Content operations',
+  'Model leverage',
+] as const;
+
+const PALETTE_CANDIDATES = [
+  { hex: '#f4f4f5', label: 'Primary ink', source: 'Current product token' },
+  { hex: '#10b981', label: 'Proof green', source: 'Status token' },
+  { hex: '#f59e0b', label: 'Missing amber', source: 'Diagnostic token' },
+  { hex: '#3b82f6', label: 'Evidence blue', source: 'Status token' },
+] as const;
+
+const SCALE_ROLES = [
+  {
+    description: 'Dense controls, tables, source rows, and review fields.',
+    label: 'Product',
+    value: '32px control baseline',
+  },
+  {
+    description: 'CTA modules and preview panels that need public scanning.',
+    label: 'Block',
+    value: '1x campaign unit',
+  },
+  {
+    description: 'Primary Brand OS promise, public proof, and conversion copy.',
+    label: 'Hero',
+    value: '1.618x block',
+  },
+  {
+    description: 'Single launch artifact or proof object. Use once per page.',
+    label: 'Monument',
+    value: '2.618x block',
+  },
+] as const;
+
+type PreviewModeKey = (typeof PREVIEW_MODES)[number]['key'];
+
+function getSourceName(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return 'No public URL yet';
+  }
+
+  try {
+    const url = new URL(
+      trimmed.startsWith('http') ? trimmed : `https://${trimmed}`,
+    );
+    return url.hostname.replace(/^www\./, '');
+  } catch {
+    return 'Manual source';
+  }
+}
+
+export default function BrandOSContent(): React.ReactElement {
+  const containerRef = useMarketingEntrance({ cards: false });
+  const signUpHref = `${EnvironmentService.apps.app}/sign-up?source=brand-os`;
+  const [websiteUrl, setWebsiteUrl] = useState('genfeed.ai');
+  const [guidance, setGuidance] = useState(
+    'Keep the brand system operational: cite evidence, mark assumptions, and never copy a competitor kit.',
+  );
+  const [previewMode, setPreviewMode] = useState<PreviewModeKey>('partial');
+
+  const sourceName = useMemo(() => getSourceName(websiteUrl), [websiteUrl]);
+  const hasGuidance = guidance.trim().length > 0;
+  const activeMode = PREVIEW_MODES.find((mode) => mode.key === previewMode);
+  const previewStatus = activeMode?.status ?? 'Preview ready';
+
+  return (
+    <div ref={containerRef}>
+      <main>
+        <section className="border-b border-edge/5 bg-background py-14 sm:py-16 lg:py-20">
+          <div className="container mx-auto px-6">
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)] lg:items-start">
+              <VStack className="gap-8">
+                <VStack className="gap-5">
+                  <HStack className="w-fit items-center gap-2 border border-edge/10 bg-fill/[0.02] px-3 py-1.5 text-[10px] font-black uppercase text-surface/45">
+                    <LuLayers className="size-3.5" />
+                    <Text>Brand OS</Text>
+                  </HStack>
+
+                  <Heading
+                    as="h1"
+                    className="max-w-3xl text-5xl font-serif leading-none text-surface sm:text-6xl lg:text-7xl"
+                  >
+                    Turn source evidence into a usable brand system.
+                  </Heading>
+
+                  <Text className="max-w-2xl text-base leading-7 text-surface/55 sm:text-lg">
+                    The Brand OS surface separates evidence, assumptions,
+                    missing fields, scale roles, and save actions before it
+                    enters a brand workspace.
+                  </Text>
+                </VStack>
+
+                <form
+                  className="grid gap-5 border border-edge/5 bg-fill/[0.02] p-5 sm:p-6"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    setPreviewMode(hasGuidance ? 'ready' : 'partial');
+                  }}
+                >
+                  <Input
+                    aria-describedby="brand-os-url-help"
+                    label="Public website URL"
+                    onChange={(event) => setWebsiteUrl(event.target.value)}
+                    placeholder="https://example.com"
+                    type="url"
+                    value={websiteUrl}
+                  />
+                  <Text
+                    as="p"
+                    className="text-xs leading-5 text-surface/35"
+                    id="brand-os-url-help"
+                  >
+                    Private, loopback, and authenticated URLs stay blocked by
+                    the eventual extraction service.
+                  </Text>
+
+                  <div className="space-y-1.5">
+                    <Label
+                      className="text-sm font-medium text-foreground"
+                      htmlFor="brand-os-guidance"
+                    >
+                      Manual guidance
+                    </Label>
+                    <Textarea
+                      id="brand-os-guidance"
+                      maxHeight={180}
+                      onChange={(event) => setGuidance(event.target.value)}
+                      placeholder="Voice, audience, product, proof, or launch notes"
+                      rows={4}
+                      value={guidance}
+                    />
+                  </div>
+
+                  <div className="grid gap-2 sm:grid-cols-4">
+                    {PREVIEW_MODES.map((mode) => {
+                      const Icon = mode.icon;
+                      const isActive = previewMode === mode.key;
+
+                      return (
+                        <Button
+                          className="justify-center gap-2"
+                          key={mode.key}
+                          onClick={() => setPreviewMode(mode.key)}
+                          size={ButtonSize.SM}
+                          type="button"
+                          variant={
+                            isActive
+                              ? ButtonVariant.SECONDARY
+                              : ButtonVariant.GHOST
+                          }
+                        >
+                          <Icon className="size-4" />
+                          {mode.label}
+                        </Button>
+                      );
+                    })}
+                  </div>
+
+                  <div
+                    aria-live="polite"
+                    className="border border-edge/5 bg-background px-4 py-3 text-sm text-surface/55"
+                  >
+                    {previewStatus}: {sourceName}
+                  </div>
+
+                  <HStack className="flex-wrap gap-3">
+                    <Button type="submit" size={ButtonSize.PUBLIC}>
+                      Refresh Preview
+                    </Button>
+                    <ButtonTracked
+                      asChild
+                      size={ButtonSize.PUBLIC}
+                      trackingData={{ action: 'save_brand_os_preview' }}
+                      trackingName="brand_os_cta_click"
+                      variant={ButtonVariant.OUTLINE}
+                    >
+                      <a
+                        href={signUpHref}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Save in Genfeed
+                        <LuArrowRight className="size-4" />
+                      </a>
+                    </ButtonTracked>
+                  </HStack>
+                </form>
+              </VStack>
+
+              <div
+                className="border border-edge/5 bg-fill/[0.02]"
+                data-testid="brand-os-preview"
+              >
+                <div className="grid border-b border-edge/5 md:grid-cols-[0.9fr_1.1fr]">
+                  <div className="relative min-h-64 overflow-hidden border-b border-edge/5 md:border-b-0 md:border-r">
+                    <Image
+                      alt="Color and layout reference board"
+                      className="object-cover"
+                      fill
+                      priority
+                      sizes="(max-width: 768px) 100vw, 42vw"
+                      src="https://images.unsplash.com/photo-1518005020951-eccb494ad742?w=1000&q=80&fit=crop"
+                    />
+                    <div className="absolute inset-0 bg-black/45" />
+                    <div className="absolute inset-x-0 bottom-0 p-5">
+                      <Text className="text-[10px] font-black uppercase text-white/55">
+                        Preview source
+                      </Text>
+                      <Heading as="h2" className="mt-2 text-3xl text-white">
+                        {sourceName}
+                      </Heading>
+                    </div>
+                  </div>
+
+                  <VStack className="gap-5 p-5 sm:p-6">
+                    <HStack className="items-center justify-between gap-4">
+                      <Text className="text-[10px] font-black uppercase text-surface/35">
+                        {previewStatus}
+                      </Text>
+                      <span className="text-[10px] font-black uppercase text-success">
+                        Source backed
+                      </span>
+                    </HStack>
+
+                    <VStack className="gap-3">
+                      {SOURCE_EVIDENCE.map((item) => (
+                        <div
+                          className="grid gap-2 border-t border-edge/5 pt-3 sm:grid-cols-[0.55fr_1fr]"
+                          key={item.label}
+                        >
+                          <VStack className="gap-1">
+                            <Text className="text-xs font-semibold text-surface">
+                              {item.label}
+                            </Text>
+                            <Text className="text-[10px] font-black uppercase text-surface/30">
+                              {item.confidence}
+                            </Text>
+                          </VStack>
+                          <Text className="text-sm leading-6 text-surface/60">
+                            {item.value}
+                          </Text>
+                        </div>
+                      ))}
+                    </VStack>
+                  </VStack>
+                </div>
+
+                <div className="grid gap-px bg-edge/5 lg:grid-cols-3">
+                  <VStack className="gap-4 bg-background p-5">
+                    <Text className="text-[10px] font-black uppercase text-surface/30">
+                      Palette candidates
+                    </Text>
+                    <div className="grid grid-cols-2 gap-3">
+                      {PALETTE_CANDIDATES.map((color) => (
+                        <VStack className="gap-2" key={color.label}>
+                          <span
+                            aria-label={`${color.label} ${color.hex}`}
+                            className="block h-12 border border-edge/10"
+                            role="img"
+                            style={{ backgroundColor: color.hex }}
+                          />
+                          <VStack className="gap-0.5">
+                            <Text className="text-xs font-semibold text-surface">
+                              {color.label}
+                            </Text>
+                            <Text className="text-[10px] text-surface/35">
+                              {color.source}
+                            </Text>
+                          </VStack>
+                        </VStack>
+                      ))}
+                    </div>
+                  </VStack>
+
+                  <VStack className="gap-4 bg-background p-5">
+                    <Text className="text-[10px] font-black uppercase text-surface/30">
+                      Content pillars
+                    </Text>
+                    <ul className="space-y-3">
+                      {CONTENT_PILLARS.map((pillar) => (
+                        <li
+                          className="flex items-center gap-3 border-b border-edge/5 pb-3 text-sm text-surface/65 last:border-b-0 last:pb-0"
+                          key={pillar}
+                        >
+                          <LuBadgeCheck className="size-4 shrink-0 text-success" />
+                          {pillar}
+                        </li>
+                      ))}
+                    </ul>
+                  </VStack>
+
+                  <VStack className="gap-4 bg-background p-5">
+                    <Text className="text-[10px] font-black uppercase text-surface/30">
+                      Diagnostics
+                    </Text>
+                    <Text className="text-sm leading-6 text-surface/60">
+                      {previewMode === 'blocked'
+                        ? 'The preview blocks private or unreachable sources and keeps the save action unavailable until public evidence exists.'
+                        : 'The preview keeps low-confidence fields visible, preserves missing evidence, and carries source notes into the save prompt.'}
+                    </Text>
+                    <Text className="text-sm leading-6 text-surface/60">
+                      {hasGuidance
+                        ? guidance
+                        : 'Manual guidance is empty, so the saved draft would ask for voice and positioning before apply.'}
+                    </Text>
+                  </VStack>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="border-b border-edge/5 bg-fill/[0.02] py-20"
+          id="brand-os-rules"
+        >
+          <div className="container mx-auto px-6">
+            <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.72fr_1.28fr]">
+              <VStack className="gap-4">
+                <HStack className="items-center gap-2 text-[10px] font-black uppercase text-surface/35">
+                  <LuPalette className="size-4" />
+                  <Text>Design contract</Text>
+                </HStack>
+                <Heading as="h2" className="text-4xl font-serif text-surface">
+                  Source-backed, not style-matched.
+                </Heading>
+                <Text className="text-base leading-7 text-surface/55">
+                  Brand OS output labels every recommendation as extracted,
+                  inferred, missing, or candidate. Product screens stay compact;
+                  public campaign objects can scale up when they carry proof.
+                </Text>
+              </VStack>
+
+              <div className="grid gap-px bg-edge/5 sm:grid-cols-2">
+                {SCALE_ROLES.map((role) => (
+                  <VStack className="gap-4 bg-background p-5" key={role.label}>
+                    <HStack className="items-center justify-between gap-4">
+                      <Text className="text-lg font-semibold text-surface">
+                        {role.label}
+                      </Text>
+                      <Text className="text-[10px] font-black uppercase text-surface/35">
+                        {role.value}
+                      </Text>
+                    </HStack>
+                    <Text className="text-sm leading-6 text-surface/55">
+                      {role.description}
+                    </Text>
+                  </VStack>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-20">
+          <div className="container mx-auto px-6">
+            <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-3">
+              {[
+                'Current Genfeed tokens remain the product palette until a source-backed palette is accepted.',
+                'Candidate Wada/Sanzo-inspired color outputs are labeled as candidates, never product defaults.',
+                'Authenticated review screens use dense controls, evidence rows, and explicit apply/discard states.',
+              ].map((rule) => (
+                <div className="border border-edge/5 p-5" key={rule}>
+                  <Text className="text-sm leading-6 text-surface/60">
+                    {rule}
+                  </Text>
+                </div>
+              ))}
+            </div>
+
+            <HStack className="mt-10 flex-wrap justify-center gap-3">
+              <ButtonTracked
+                asChild
+                size={ButtonSize.PUBLIC}
+                trackingData={{ action: 'brand_os_signup_bottom' }}
+                trackingName="brand_os_cta_click"
+              >
+                <a href={signUpHref} rel="noopener noreferrer" target="_blank">
+                  Save a Brand OS
+                  <LuArrowRight className="size-4" />
+                </a>
+              </ButtonTracked>
+              <Button
+                asChild
+                size={ButtonSize.PUBLIC}
+                variant={ButtonVariant.OUTLINE}
+              >
+                <Link href="/">Back to Genfeed.ai</Link>
+              </Button>
+            </HStack>
+          </div>
+        </section>
+      </main>
+      <HomeFooter />
+    </div>
+  );
+}

--- a/apps/website/app/(public)/brand-os/brand-os-content.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.tsx
@@ -169,8 +169,15 @@ export default function BrandOSContent(): React.ReactElement {
 
                 <form
                   className="grid gap-5 border border-edge/5 bg-fill/[0.02] p-5 sm:p-6"
+                  noValidate
                   onSubmit={(event) => {
                     event.preventDefault();
+                    const raw = websiteUrl.trim();
+                    const normalized =
+                      raw && !raw.startsWith('http') ? `https://${raw}` : raw;
+                    if (normalized !== websiteUrl) {
+                      setWebsiteUrl(normalized);
+                    }
                     setPreviewMode(hasGuidance ? 'ready' : 'partial');
                   }}
                 >
@@ -179,7 +186,7 @@ export default function BrandOSContent(): React.ReactElement {
                     label="Public website URL"
                     onChange={(event) => setWebsiteUrl(event.target.value)}
                     placeholder="https://example.com"
-                    type="url"
+                    type="text"
                     value={websiteUrl}
                   />
                   <Text

--- a/apps/website/app/(public)/brand-os/brand-os-content.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.tsx
@@ -4,6 +4,7 @@ import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
 import { EnvironmentService } from '@services/core/environment.service';
 import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
+import Card from '@ui/card/Card';
 import { HStack, VStack } from '@ui/layout/stack';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
@@ -271,8 +272,9 @@ export default function BrandOSContent(): React.ReactElement {
                 </form>
               </VStack>
 
-              <div
-                className="border border-edge/5 bg-fill/[0.02]"
+              <Card
+                className="border border-edge/5 bg-fill/[0.02] shadow-none hover:shadow-none"
+                bodyClassName="gap-0 p-0"
                 data-testid="brand-os-preview"
               >
                 <div className="grid border-b border-edge/5 md:grid-cols-[0.9fr_1.1fr]">
@@ -389,7 +391,7 @@ export default function BrandOSContent(): React.ReactElement {
                     </Text>
                   </VStack>
                 </div>
-              </div>
+              </Card>
             </div>
           </div>
         </section>
@@ -444,11 +446,15 @@ export default function BrandOSContent(): React.ReactElement {
                 'Candidate Wada/Sanzo-inspired color outputs are labeled as candidates, never product defaults.',
                 'Authenticated review screens use dense controls, evidence rows, and explicit apply/discard states.',
               ].map((rule) => (
-                <div className="border border-edge/5 p-5" key={rule}>
+                <Card
+                  className="border border-edge/5 bg-fill/[0.02] shadow-none hover:shadow-none"
+                  bodyClassName="p-5"
+                  key={rule}
+                >
                   <Text className="text-sm leading-6 text-surface/60">
                     {rule}
                   </Text>
-                </div>
+                </Card>
               ))}
             </div>
 

--- a/apps/website/app/(public)/brand-os/page.spec.tsx
+++ b/apps/website/app/(public)/brand-os/page.spec.tsx
@@ -1,0 +1,4 @@
+import * as PageModule from '@public/brand-os/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests('apps/website/app/(public)/brand-os/page', PageModule);

--- a/apps/website/app/(public)/brand-os/page.tsx
+++ b/apps/website/app/(public)/brand-os/page.tsx
@@ -1,0 +1,12 @@
+import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-metadata.helper';
+import BrandOSContent from '@public/brand-os/brand-os-content';
+
+export const generateMetadata = createPageMetadataWithCanonical(
+  'Brand OS',
+  'Build a source-backed Brand OS preview with evidence, diagnostics, scale roles, and save-to-Genfeed conversion states.',
+  '/brand-os',
+);
+
+export default function BrandOSPage() {
+  return <BrandOSContent />;
+}

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -105,6 +105,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     {
       changeFrequency: 'weekly',
       lastModified: new Date(),
+      priority: 0.9,
+      url: 'https://genfeed.ai/brand-os',
+    },
+    {
+      changeFrequency: 'weekly',
+      lastModified: new Date(),
       priority: 0.8,
       url: 'https://genfeed.ai/integrations',
     },

--- a/apps/website/packages/components/home/_brand-os.spec.tsx
+++ b/apps/website/packages/components/home/_brand-os.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import * as Module from '@web-components/home/_brand-os';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import HomeBrandOS from './_brand-os';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@ui/buttons/tracked/ButtonTracked', () => ({
+  default: ({
+    asChild: _asChild,
+    children,
+  }: {
+    asChild?: boolean;
+    children: ReactNode;
+  }) => <>{children}</>,
+}));
+
+describe('HomeBrandOS', () => {
+  it('exports a default component', () => {
+    expect(Module).toHaveProperty('default');
+    expect(typeof Module.default).toBe('function');
+  });
+
+  it('links the homepage entry point to the Brand OS route', () => {
+    render(<HomeBrandOS />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /build a source-backed brand system/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /preview brand os/i }),
+    ).toHaveAttribute('href', '/brand-os');
+  });
+});

--- a/apps/website/packages/components/home/_brand-os.tsx
+++ b/apps/website/packages/components/home/_brand-os.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
+import { HStack, VStack } from '@ui/layout/stack';
+import { Heading } from '@ui/typography/heading';
+import { Text } from '@ui/typography/text';
+import Link from 'next/link';
+import { LuArrowRight, LuBadgeCheck, LuLayers } from 'react-icons/lu';
+
+const BRAND_OS_SIGNALS = [
+  'Evidence before recommendations',
+  'Missing fields stay visible',
+  'Save into a brand workspace',
+] as const;
+
+export default function HomeBrandOS(): React.ReactElement {
+  return (
+    <section className="border-b border-edge/5 bg-fill/[0.02] py-20">
+      <div className="container mx-auto px-6">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(300px,0.5fr)] lg:items-end">
+          <VStack className="gap-5">
+            <HStack className="w-fit items-center gap-2 border border-edge/10 bg-background px-3 py-1.5 text-[10px] font-black uppercase text-surface/40">
+              <LuLayers className="size-3.5" />
+              <Text>Brand OS</Text>
+            </HStack>
+            <Heading
+              as="h2"
+              className="max-w-3xl text-4xl font-serif leading-tight text-surface sm:text-5xl"
+            >
+              Build a source-backed brand system before you generate.
+            </Heading>
+            <Text className="max-w-2xl text-base leading-7 text-surface/55">
+              Start from a public URL or manual guidance, inspect evidence and
+              missing fields, then save the draft into Genfeed when it is ready.
+            </Text>
+          </VStack>
+
+          <VStack className="gap-5 border border-edge/5 bg-background p-5">
+            <ul className="space-y-3">
+              {BRAND_OS_SIGNALS.map((signal) => (
+                <li
+                  className="flex items-center gap-3 text-sm text-surface/60"
+                  key={signal}
+                >
+                  <LuBadgeCheck className="size-4 shrink-0 text-success" />
+                  {signal}
+                </li>
+              ))}
+            </ul>
+            <ButtonTracked
+              asChild
+              className="w-full justify-center"
+              size={ButtonSize.PUBLIC}
+              trackingData={{ action: 'home_brand_os_entry' }}
+              trackingName="home_brand_os_click"
+              variant={ButtonVariant.OUTLINE}
+            >
+              <Link href="/brand-os">
+                Preview Brand OS
+                <LuArrowRight className="size-4" />
+              </Link>
+            </ButtonTracked>
+          </VStack>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/props/ui/ui.props.ts
+++ b/packages/props/ui/ui.props.ts
@@ -45,6 +45,7 @@ export interface CardProps {
   label?: ReactNode;
   description?: string;
   onClick?: () => void;
+  'data-testid'?: string;
 }
 
 export interface CardIconProps {

--- a/packages/ui/src/components/card/Card.tsx
+++ b/packages/ui/src/components/card/Card.tsx
@@ -30,9 +30,10 @@ const Card = memo(function Card({
   label,
   description,
   onClick,
+  'data-testid': dataTestId,
 }: CardProps) {
   const cardClasses = cn(
-    'relative overflow-hidden rounded-md text-left transition-[border-color,background-color] duration-150 ease-out',
+    'relative overflow-hidden rounded-card text-left transition-[border-color,background-color] duration-150 ease-out',
     VARIANT_CLASSES[variant],
     figure && 'flex flex-row',
     onClick && 'cursor-pointer',
@@ -106,6 +107,7 @@ const Card = memo(function Card({
         tabIndex={0}
         aria-label={typeof label === 'string' ? label : undefined}
         data-card-index={index}
+        data-testid={dataTestId}
         onClick={onClick}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -121,7 +123,11 @@ const Card = memo(function Card({
   }
 
   return (
-    <div className={cardClasses} data-card-index={index}>
+    <div
+      className={cardClasses}
+      data-card-index={index}
+      data-testid={dataTestId}
+    >
       {cardContent}
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds the `/brand-os` marketing page (source-evidence → brand system UI)
- Folds the Brand OS hand-rolled cards onto the canonical `<Card>` component — eliminating a third card treatment
- Adds `data-testid` pass-through to `CardProps` + `Card` root div (needed for testability)
- Switches `Card` from `rounded-md` → `rounded-card` (sharp 0px, matches #899)

## What's folded

| Before | After |
|--------|-------|
| `<div className="border border-edge/5 bg-fill/[0.02]" data-testid="...">` | `<Card className="... shadow-none" bodyClassName="gap-0 p-0" data-testid="...">` |
| `<div className="border border-edge/5 p-5">` (×3 rule cards) | `<Card className="... shadow-none" bodyClassName="p-5">` |
| `<form>` with card chrome | Kept as `<form>` — test relies on `closest('form')` |
| Mosaic grid cells (`bg-background p-5`) | Left as-is — interior cells, not cards |

## Relationship to #903

This branch is based on #903 (`codex/feature-20260629-172538-genfeed`) and includes all its changes. #903 can be closed; this PR is the complete replacement with the card fold added.

## Test plan

- [ ] `bun run test --filter=@genfeedai/website` — brand-os-content tests (3 pass)
- [ ] `bun run test --filter=@genfeedai/ui` — Card tests pass
- [ ] Design System check passes
- [ ] Typecheck passes