### PR TITLE
[codex] Hide local controls on hosted cloud

### DIFF
--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -54,7 +54,14 @@ const workflowUiAliases = {
   '@genfeedai/workflow-ui/ui': path.join(workflowUiRoot, 'src/ui/index.ts'),
 };
 
-const IS_LOCAL_APP_SHELL = !process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+const NEXT_PUBLIC_GENFEED_CLOUD =
+  process.env.NEXT_PUBLIC_GENFEED_CLOUD?.trim() ||
+  process.env.GENFEED_CLOUD?.trim() ||
+  '';
+const IS_CLOUD_APP_SHELL = ['1', 'true'].includes(
+  NEXT_PUBLIC_GENFEED_CLOUD.toLowerCase(),
+);
+const IS_LOCAL_APP_SHELL = !IS_CLOUD_APP_SHELL;
 const DEFAULT_ORG = 'default';
 const DEFAULT_BRAND = 'default';
 const resolvedApiBaseUrl = (
@@ -147,6 +154,12 @@ const config = createAppNextConfig({
   ],
   sentryProject: 'app-genfeed-ai',
 });
+
+config.env = {
+  ...(config.env ?? {}),
+  NEXT_PUBLIC_GENFEED_CLOUD,
+};
+
 config.experimental = {
   ...(config.experimental ?? {}),
   optimizePackageImports: [

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -4,7 +4,7 @@ import {
 } from '@services/core/agent-overlay-coordination.service';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type ReactNode, useEffect } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AppProtectedLayout from './app-protected-layout';
 
 const {
@@ -49,6 +49,7 @@ const mockRouteParams = vi.hoisted(() => ({
   brandSlug: 'brand-123',
   orgSlug: 'org-123',
 }));
+const originalLocation = window.location;
 
 // Stable router instance (matches Next's real App Router, which returns the
 // same object across renders). A fresh `push` per render would cascade through
@@ -369,6 +370,15 @@ vi.mock('@providers/protected-providers/protected-providers', () => ({
 
 vi.mock('@/lib/config/edition', () => ({
   isEEEnabled: () => true,
+  isHostedCloudApp: () => {
+    const cloudFlag = process.env.NEXT_PUBLIC_GENFEED_CLOUD?.trim();
+
+    return (
+      cloudFlag === '1' ||
+      cloudFlag?.toLowerCase() === 'true' ||
+      window.location.hostname === 'app.genfeed.ai'
+    );
+  },
 }));
 
 vi.mock('@services/core/environment.service', () => ({
@@ -435,6 +445,11 @@ describe('AppProtectedLayout', () => {
     toggleOpenSpy.mockClear();
     delete process.env.NEXT_PUBLIC_DESKTOP_SHELL;
     delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'localhost' },
+      writable: true,
+    });
 
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
@@ -444,6 +459,14 @@ describe('AppProtectedLayout', () => {
         removeItem: vi.fn(),
         setItem: vi.fn(),
       },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
     });
   });
 
@@ -689,6 +712,29 @@ describe('AppProtectedLayout', () => {
 
   it('hides the terminal dock on hosted cloud', () => {
     process.env.NEXT_PUBLIC_GENFEED_CLOUD = 'true';
+    mockPathname.value = '/workspace';
+
+    render(
+      <AppProtectedLayout>
+        <div>Protected content</div>
+      </AppProtectedLayout>,
+    );
+
+    expect(screen.queryByTestId('agent-panel-rail')).not.toBeInTheDocument();
+    expect(appLayoutSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentPanel: undefined,
+        onAgentToggle: undefined,
+      }),
+    );
+  });
+
+  it('hides the terminal dock on the hosted app hostname without the cloud env', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'app.genfeed.ai' },
+      writable: true,
+    });
     mockPathname.value = '/workspace';
 
     render(

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -54,7 +54,7 @@ import {
 } from 'react';
 
 import { useOptionalAuth } from '@/hooks/useOptionalAuth';
-import { isEEEnabled } from '@/lib/config/edition';
+import { isEEEnabled, isHostedCloudApp } from '@/lib/config/edition';
 import {
   normalizeProtectedPathname,
   pickOperatorTaskContextSearchParams,
@@ -89,10 +89,7 @@ export function isProtectedWorkspaceRoute(pathname: string): boolean {
 }
 
 function isTerminalDockAvailable(): boolean {
-  return (
-    process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1' ||
-    process.env.NEXT_PUBLIC_GENFEED_CLOUD !== 'true'
-  );
+  return process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1' || !isHostedCloudApp();
 }
 
 export function useAppProtectedLayout(

--- a/apps/app/src/components/cloud-sync-indicator/CloudSyncIndicator.test.tsx
+++ b/apps/app/src/components/cloud-sync-indicator/CloudSyncIndicator.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CloudSyncIndicator from './CloudSyncIndicator';
+
+const cloudSessionState = vi.hoisted(() => ({
+  isConnected: false,
+}));
+
+vi.mock('@/hooks/useCloudSession', () => ({
+  useCloudSession: () => cloudSessionState,
+}));
+
+vi.mock('@/components/desktop/DesktopLocalProviderSettings', () => ({
+  default: () => <div data-testid="desktop-local-provider-settings" />,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    ariaLabel,
+    children,
+    onClick,
+  }: {
+    ariaLabel?: string;
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" aria-label={ariaLabel} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe('CloudSyncIndicator', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    cloudSessionState.isConnected = false;
+    delete process.env.GENFEED_CLOUD;
+    delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    delete process.env.NEXT_PUBLIC_DESKTOP_SHELL;
+    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'localhost' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('does not render on the hosted app hostname without the cloud env', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'app.genfeed.ai' },
+      writable: true,
+    });
+
+    render(<CloudSyncIndicator />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Cloud disconnected' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render when the cloud env uses the canonical numeric flag', () => {
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD = '1';
+
+    render(<CloudSyncIndicator />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Cloud disconnected' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders for local hybrid mode', () => {
+    render(<CloudSyncIndicator />);
+
+    expect(
+      screen.getByRole('button', { name: 'Cloud disconnected' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockSearchParams = new URLSearchParams();
 const appSwitcherSpy = vi.hoisted(() => vi.fn());
+const originalLocation = window.location;
 
 vi.mock('@genfeedai/enums', () => ({
   ButtonSize: { ICON: 'icon' },
@@ -129,6 +130,21 @@ describe('AppProtectedTopbar', () => {
   beforeEach(() => {
     mockSearchParams = new URLSearchParams();
     appSwitcherSpy.mockClear();
+    delete process.env.NEXT_PUBLIC_DESKTOP_SHELL;
+    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'localhost' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    });
   });
 
   it('renders the brand switcher on the left and app switcher with right-side controls', () => {
@@ -193,6 +209,20 @@ describe('AppProtectedTopbar', () => {
       terminalButton.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it('does not render the terminal dock control on the hosted app hostname', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'app.genfeed.ai' },
+      writable: true,
+    });
+
+    render(<AppProtectedTopbar isAgentCollapsed onAgentToggle={vi.fn()} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Open terminal dock' }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders credit balances before the topbar end slot', () => {

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -21,6 +21,7 @@ import { Suspense, useCallback } from 'react';
 import { HiBars3, HiOutlineCommandLine, HiXMark } from 'react-icons/hi2';
 import { PiSidebarSimple } from 'react-icons/pi';
 import CloudSyncIndicator from '@/components/cloud-sync-indicator/CloudSyncIndicator';
+import { isHostedCloudApp } from '@/lib/config/edition';
 import { appendSearchParamsToHref } from '@/lib/navigation/operator-shell';
 
 function getCurrentBrandScopedPath(pathname: string): string {
@@ -94,6 +95,9 @@ function AppProtectedTopbarContent({
   const taskId = searchParams.get('taskId');
   const taskTitle = searchParams.get('taskTitle');
   const ToggleIcon = isMenuOpen ? HiXMark : HiBars3;
+  const shouldRenderAgentToggle =
+    Boolean(onAgentToggle) &&
+    (process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1' || !isHostedCloudApp());
   const backToTaskHref = taskId
     ? href(
         appendSearchParamsToHref(
@@ -179,7 +183,7 @@ function AppProtectedTopbarContent({
             />
           ) : null}
 
-          {onAgentToggle ? (
+          {shouldRenderAgentToggle ? (
             <Button
               type="button"
               variant={ButtonVariant.GHOST}

--- a/apps/app/src/lib/config/edition.ts
+++ b/apps/app/src/lib/config/edition.ts
@@ -5,6 +5,30 @@
  * Server components can also use process.env directly.
  */
 
+const CLOUD_FLAG_VALUES = new Set(['1', 'true']);
+const HOSTED_APP_HOSTNAMES = new Set(['app.genfeed.ai']);
+
+function isTruthyCloudFlag(value: string | undefined): boolean {
+  return CLOUD_FLAG_VALUES.has(value?.trim().toLowerCase() ?? '');
+}
+
+export function isOfficialHostedAppHost(hostname?: string): boolean {
+  const resolvedHostname =
+    hostname ??
+    (typeof window === 'undefined' ? undefined : window.location.hostname);
+
+  return HOSTED_APP_HOSTNAMES.has(resolvedHostname ?? '');
+}
+
+/** True when running as the hosted Genfeed Cloud web app. */
+export function isHostedCloudApp(): boolean {
+  return (
+    isTruthyCloudFlag(process.env.NEXT_PUBLIC_GENFEED_CLOUD) ||
+    isTruthyCloudFlag(process.env.GENFEED_CLOUD) ||
+    isOfficialHostedAppHost()
+  );
+}
+
 /** True when running as Genfeed Cloud (EE features enabled) */
 export function isEEEnabled(): boolean {
   return !!process.env.NEXT_PUBLIC_GENFEED_LICENSE_KEY;
@@ -17,12 +41,12 @@ function _isCoreMode(): boolean {
 
 /** True when running the local app shell. */
 export function isSelfHosted(): boolean {
-  return !process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+  return !isHostedCloudApp();
 }
 
 /** True when the frontend targets Genfeed Cloud services. */
 export function isCloudConnected(): boolean {
-  return process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true';
+  return isHostedCloudApp();
 }
 
 /**
@@ -34,10 +58,10 @@ export function isBetterAuthEnabled(): boolean {
 
 /** True when local app with optional cloud connection configured. */
 export function isHybridMode(): boolean {
-  return !process.env.NEXT_PUBLIC_GENFEED_CLOUD && isBetterAuthEnabled();
+  return !isHostedCloudApp() && isBetterAuthEnabled();
 }
 
 /** True when fully offline. */
 export function isLocalOnly(): boolean {
-  return !process.env.NEXT_PUBLIC_GENFEED_CLOUD && !isBetterAuthEnabled();
+  return !isHostedCloudApp() && !isBetterAuthEnabled();
 }


### PR DESCRIPTION
## Summary

- Hide the terminal dock toggle and cloud sync indicator when the app is running on hosted Genfeed Cloud.
- Centralize hosted cloud detection for the frontend, including `NEXT_PUBLIC_GENFEED_CLOUD`, `GENFEED_CLOUD`, and the official `app.genfeed.ai` hostname.
- Propagate `GENFEED_CLOUD` into the Next client env as `NEXT_PUBLIC_GENFEED_CLOUD` so hosted builds do not fall through as local/self-hosted.
- Add regression coverage for hosted hostname and numeric cloud flag behavior.

## Root Cause

The hosted app could fall through to local/hybrid UI behavior when `NEXT_PUBLIC_GENFEED_CLOUD` was absent or not exactly `true`, leaving local-only controls visible on `app.genfeed.ai`.

## Validation

- `bunx biome check --write apps/app/src/lib/config/edition.ts apps/app/src/components/shell/AppProtectedTopbar.tsx apps/app/src/components/shell/AppProtectedTopbar.test.tsx apps/app/src/components/cloud-sync-indicator/CloudSyncIndicator.test.tsx apps/app/packages/components/useAppProtectedLayout.ts apps/app/packages/components/app-protected-layout.test.tsx apps/app/next.config.ts`
- `bun run test src/components/cloud-sync-indicator/CloudSyncIndicator.test.tsx src/components/shell/AppProtectedTopbar.test.tsx packages/components/app-protected-layout.test.tsx next.config.test.ts`
- `bun run design:lint` (0 errors; existing warnings only)
- `bun run type-check`
- staged `secretlint` and staged secret-pattern scan before commit

