### PR TITLE
feat(brand): crawl website brand kit drafts

### DIFF
--- a/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
@@ -95,6 +95,7 @@ describe('BrandsController', () => {
         {
           provide: BrandsService,
           useValue: {
+            crawlWebsiteBrandKitDraft: vi.fn(),
             create: vi.fn(),
             findAll: vi.fn(),
             findOne: vi.fn(),
@@ -254,6 +255,80 @@ describe('BrandsController', () => {
       );
 
       expect(cacheMetadata).toBeUndefined();
+    });
+  });
+
+  describe('crawlBrandKitWebsite', () => {
+    it('verifies brand access and passes organization context to the service', async () => {
+      const brandId = '507f191e810c19729de860ee'.toString();
+      const draft = {
+        assetCandidates: [],
+        brandId,
+        diagnostics: [],
+        evidence: [],
+        fields: {},
+        readiness: {
+          diagnostics: [],
+          missingFields: [],
+          requiredFields: [],
+          score: 100,
+          status: 'complete',
+        },
+        sourceType: 'website',
+        status: 'ready',
+      };
+      brandsService.findOne.mockResolvedValue(
+        mockBrand as unknown as BrandEntity,
+      );
+      brandsService.crawlWebsiteBrandKitDraft.mockResolvedValue(
+        draft as Awaited<
+          ReturnType<BrandsService['crawlWebsiteBrandKitDraft']>
+        >,
+      );
+
+      const result = await controller.crawlBrandKitWebsite(mockUser, brandId, {
+        url: 'https://acme.com',
+      });
+
+      expect(brandsService.findOne).toHaveBeenCalledWith({
+        OR: [
+          { user: '507f191e810c19729de860ee' },
+          { organization: '507f191e810c19729de860ee' },
+        ],
+        _id: brandId,
+        isDeleted: false,
+      });
+      expect(brandsService.crawlWebsiteBrandKitDraft).toHaveBeenCalledWith(
+        brandId,
+        '507f191e810c19729de860ee',
+        { url: 'https://acme.com' },
+      );
+      expect(result).toEqual({ data: draft });
+    });
+
+    it('rejects crawl requests without organization context', async () => {
+      const brandId = '507f191e810c19729de860ee'.toString();
+      const userWithoutOrganization = {
+        ...mockUser,
+        publicMetadata: {
+          ...(mockUser.publicMetadata as IAuthPublicMetadata),
+          organization: undefined,
+        },
+      } as unknown as User;
+      brandsService.findOne.mockResolvedValue(
+        mockBrand as unknown as BrandEntity,
+      );
+
+      await expect(
+        controller.crawlBrandKitWebsite(userWithoutOrganization, brandId, {
+          url: 'https://acme.com',
+        }),
+      ).rejects.toMatchObject({
+        response: expect.objectContaining({
+          detail: 'Organization context is required',
+        }),
+      });
+      expect(brandsService.crawlWebsiteBrandKitDraft).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -2,6 +2,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { ArticlesService } from '@api/collections/articles/services/articles.service';
 import { STRATEGY_TEMPLATES } from '@api/collections/brands/constants/strategy-templates.constant';
+import { CrawlBrandKitDto } from '@api/collections/brands/dto/crawl-brand-kit.dto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
 import { GenerateBrandVoiceDto } from '@api/collections/brands/dto/generate-brand-voice.dto';
 import { GenerateFastlaneIdeasDto } from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
@@ -53,6 +54,7 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
   HttpException,
   HttpStatus,
   Inject,
@@ -355,6 +357,38 @@ export class BrandsController extends BaseCRUDController<
     }
 
     return serializeSingle(request, BrandSerializer, updatedBrand);
+  }
+
+  @Post(':id/brand-kit/crawl')
+  @HttpCode(200)
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async crawlBrandKitWebsite(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: CrawlBrandKitDto,
+  ) {
+    await this.verifyBrandAccess(id, user);
+
+    const publicMetadata = getPublicMetadata(user);
+    const organizationId = publicMetadata.organization?.toString();
+
+    if (!organizationId) {
+      throw new HttpException(
+        {
+          detail: 'Organization context is required',
+          title: 'Forbidden',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    const draft = await this.brandsService.crawlWebsiteBrandKitDraft(
+      id,
+      organizationId,
+      dto,
+    );
+
+    return { data: draft };
   }
 
   @Post(':id/agent-config/generate-voice')

--- a/apps/server/api/src/collections/brands/dto/crawl-brand-kit.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/crawl-brand-kit.dto.ts
@@ -1,0 +1,19 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+
+export class CrawlBrandKitDto {
+  @IsString()
+  @MinLength(1)
+  url!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(5)
+  @IsString({ each: true })
+  socialUrls?: string[];
+}

--- a/apps/server/api/src/collections/brands/services/brands.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.spec.ts
@@ -34,9 +34,17 @@ import { BadRequestException } from '@nestjs/common';
 describe('BrandsService', () => {
   let service: BrandsService;
   let delegate: Record<string, ReturnType<typeof vi.fn>>;
+  let brandScraperService: {
+    scrapeWebsite: ReturnType<typeof vi.fn>;
+    validateUrl: ReturnType<typeof vi.fn>;
+  };
   let llmDispatcher: { chatCompletion: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    brandScraperService = {
+      scrapeWebsite: vi.fn(),
+      validateUrl: vi.fn(),
+    };
     llmDispatcher = { chatCompletion: vi.fn() };
     delegate = {
       count: vi.fn(),
@@ -62,7 +70,7 @@ describe('BrandsService', () => {
         warn: vi.fn(),
       } as unknown as LoggerService,
       {} as CacheService,
-      {} as BrandScraperService,
+      brandScraperService as unknown as BrandScraperService,
       llmDispatcher as unknown as LlmDispatcherService,
       {
         invalidate: vi.fn(),
@@ -134,6 +142,108 @@ describe('BrandsService', () => {
       ),
     ).rejects.toThrow(NotFoundException);
     expect(delegate.updateMany).not.toHaveBeenCalled();
+  });
+
+  describe('crawlWebsiteBrandKitDraft', () => {
+    const organizationId = 'org_1';
+    const brandId = 'brand_1';
+
+    it('returns a website-sourced draft without mutating the brand', async () => {
+      brandScraperService.validateUrl.mockReturnValue({ isValid: true });
+      brandScraperService.scrapeWebsite.mockResolvedValue({
+        bannerUrl: 'https://acme.com/hero.jpg',
+        companyName: 'Acme Website',
+        description: 'Website description',
+        fontCandidates: ['Inter'],
+        logoUrl: 'https://acme.com/logo.svg',
+        primaryColor: '#3366ff',
+        referenceImageUrls: ['https://acme.com/reference.jpg'],
+        scrapedAt: new Date('2026-06-30T10:00:00Z'),
+        sourceUrl: 'https://acme.com',
+      });
+      delegate.findFirst.mockResolvedValue({
+        id: brandId,
+        isDeleted: false,
+        label: 'Current Acme',
+        organization: { id: organizationId },
+        organizationId,
+      });
+
+      const draft = await service.crawlWebsiteBrandKitDraft(
+        brandId,
+        organizationId,
+        {
+          socialUrls: ['https://linkedin.com/company/acme'],
+          url: 'https://acme.com',
+        },
+      );
+
+      expect(delegate.findFirst).toHaveBeenCalledWith({
+        where: { id: brandId, isDeleted: false, organizationId },
+      });
+      expect(brandScraperService.scrapeWebsite).toHaveBeenCalledWith(
+        'https://acme.com',
+      );
+      expect(delegate.update).not.toHaveBeenCalled();
+      expect(delegate.updateMany).not.toHaveBeenCalled();
+      expect(draft.sourceType).toBe('website');
+      expect(draft.fields.label?.currentValue).toBe('Current Acme');
+      expect(draft.fields.label?.proposedValue).toBe('Acme Website');
+      expect(draft.fields.fontFamily?.proposedValue).toBe('Inter');
+      expect(draft.assetCandidates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ role: 'logo' }),
+          expect.objectContaining({ role: 'banner' }),
+          expect.objectContaining({ role: 'reference' }),
+        ]),
+      );
+    });
+
+    it('rejects invalid website URLs before fetching', async () => {
+      brandScraperService.validateUrl.mockReturnValue({
+        error: 'Local URLs are not allowed',
+        isValid: false,
+      });
+
+      await expect(
+        service.crawlWebsiteBrandKitDraft(brandId, organizationId, {
+          url: 'http://127.0.0.1',
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(brandScraperService.scrapeWebsite).not.toHaveBeenCalled();
+      expect(delegate.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('returns a blocked draft when crawling fails after validation', async () => {
+      brandScraperService.validateUrl.mockReturnValue({ isValid: true });
+      brandScraperService.scrapeWebsite.mockRejectedValue(
+        new Error('Unsupported content type: application/pdf'),
+      );
+      delegate.findFirst.mockResolvedValue({
+        id: brandId,
+        isDeleted: false,
+        label: 'Current Acme',
+        organization: { id: organizationId },
+        organizationId,
+      });
+
+      const draft = await service.crawlWebsiteBrandKitDraft(
+        brandId,
+        organizationId,
+        { url: 'https://acme.com/file.pdf' },
+      );
+
+      expect(draft.status).toBe('blocked');
+      expect(draft.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'brand_kit_website_crawl_failed',
+            severity: 'error',
+          }),
+        ]),
+      );
+      expect(delegate.update).not.toHaveBeenCalled();
+    });
   });
 
   describe('generateFastlaneIdeas', () => {

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -317,23 +317,38 @@ export class BrandsService extends BaseService<
   private detectSocialPlatform(
     url: string,
   ): keyof IExtractedSocialLinks | undefined {
-    const lowerUrl = url.toLowerCase();
-    if (lowerUrl.includes('instagram.com')) {
+    let hostname: string;
+    try {
+      hostname = new URL(url).hostname.toLowerCase();
+    } catch {
+      try {
+        hostname = new URL(`https://${url}`).hostname.toLowerCase();
+      } catch {
+        return undefined;
+      }
+    }
+
+    // Match the registrable host, not a substring, so look-alike domains like
+    // `linkedin.com.evil.test` or `examplex.com` are not misclassified.
+    const isHost = (domain: string): boolean =>
+      hostname === domain || hostname.endsWith(`.${domain}`);
+
+    if (isHost('instagram.com')) {
       return 'instagram';
     }
-    if (lowerUrl.includes('linkedin.com')) {
+    if (isHost('linkedin.com')) {
       return 'linkedin';
     }
-    if (lowerUrl.includes('tiktok.com')) {
+    if (isHost('tiktok.com')) {
       return 'tiktok';
     }
-    if (lowerUrl.includes('twitter.com') || lowerUrl.includes('x.com')) {
+    if (isHost('twitter.com') || isHost('x.com')) {
       return 'twitter';
     }
-    if (lowerUrl.includes('youtube.com') || lowerUrl.includes('youtu.be')) {
+    if (isHost('youtube.com') || isHost('youtu.be')) {
       return 'youtube';
     }
-    if (lowerUrl.includes('facebook.com')) {
+    if (isHost('facebook.com')) {
       return 'facebook';
     }
     return undefined;

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { CrawlBrandKitDto } from '@api/collections/brands/dto/crawl-brand-kit.dto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
 import type {
   GenerateBrandVoiceDto,
@@ -23,7 +24,18 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import type { FastlaneFormat, FastlaneIdea } from '@genfeedai/interfaces';
+import {
+  type BrandKitSourceBrand,
+  buildBrandKitDraftFromBrand,
+  buildBrandKitDraftFromWebsiteScrape,
+} from '@genfeedai/helpers';
+import type {
+  FastlaneFormat,
+  FastlaneIdea,
+  IBrandKitDraft,
+  IExtractedSocialLinks,
+  IScrapedBrandData,
+} from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -180,6 +192,151 @@ export class BrandsService extends BaseService<
         agentConfig: updatedConfig as Record<string, unknown>,
       },
     }) as Promise<BrandDocument>;
+  }
+
+  async crawlWebsiteBrandKitDraft(
+    brandId: string,
+    organizationId: string,
+    dto: CrawlBrandKitDto,
+  ): Promise<IBrandKitDraft> {
+    const validation = this.brandScraperService.validateUrl(dto.url);
+    if (!validation.isValid) {
+      throw new BadRequestException({
+        code: 'brand_kit_invalid_website_url',
+        detail: validation.error ?? 'Invalid website URL',
+        title: 'Bad Request',
+      });
+    }
+
+    const brand = await this.findOne({
+      id: brandId,
+      isDeleted: false,
+      organizationId,
+    });
+
+    if (!brand) {
+      throw new NotFoundException('Brand', brandId);
+    }
+
+    try {
+      const scraped = await this.brandScraperService.scrapeWebsite(dto.url);
+      const diagnostics = this.readSocialUrlDiagnostics(dto.socialUrls);
+      const enrichedScrape = this.mergeSocialUrlsIntoScrape(
+        scraped,
+        dto.socialUrls,
+      );
+
+      return buildBrandKitDraftFromWebsiteScrape(
+        brand as unknown as BrandKitSourceBrand,
+        enrichedScrape,
+        {
+          diagnostics,
+        },
+      );
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Website crawl failed';
+
+      return buildBrandKitDraftFromBrand(
+        brand as unknown as BrandKitSourceBrand,
+        {
+          diagnostics: [
+            {
+              code: 'brand_kit_website_crawl_failed',
+              message: `Website crawl failed: ${message}`,
+              severity: 'error',
+            },
+          ],
+          evidence: [
+            {
+              excerpt: message,
+              label: 'Website crawl failed',
+              sourceType: 'website',
+              url: dto.url,
+            },
+          ],
+          sourceType: 'website',
+        },
+      );
+    }
+  }
+
+  private mergeSocialUrlsIntoScrape(
+    scraped: IScrapedBrandData,
+    socialUrls: string[] | undefined,
+  ): IScrapedBrandData {
+    if (!socialUrls?.length) {
+      return scraped;
+    }
+
+    const socialLinks: IExtractedSocialLinks = {
+      ...(scraped.socialLinks ?? {}),
+    };
+
+    for (const url of socialUrls) {
+      const validation = this.brandScraperService.validateUrl(url);
+      if (!validation.isValid) {
+        continue;
+      }
+
+      const platform = this.detectSocialPlatform(url);
+      if (platform) {
+        socialLinks[platform] = url;
+      }
+    }
+
+    return {
+      ...scraped,
+      socialLinks,
+    };
+  }
+
+  private readSocialUrlDiagnostics(
+    socialUrls: string[] | undefined,
+  ): IBrandKitDraft['diagnostics'] {
+    if (!socialUrls?.length) {
+      return [];
+    }
+
+    return socialUrls.flatMap((url) => {
+      const validation = this.brandScraperService.validateUrl(url);
+      if (!validation.isValid) {
+        return [
+          {
+            code: 'brand_kit_invalid_social_url',
+            message: `${url} was skipped: ${validation.error ?? 'invalid URL'}.`,
+            severity: 'warning' as const,
+          },
+        ];
+      }
+
+      return [];
+    });
+  }
+
+  private detectSocialPlatform(
+    url: string,
+  ): keyof IExtractedSocialLinks | undefined {
+    const lowerUrl = url.toLowerCase();
+    if (lowerUrl.includes('instagram.com')) {
+      return 'instagram';
+    }
+    if (lowerUrl.includes('linkedin.com')) {
+      return 'linkedin';
+    }
+    if (lowerUrl.includes('tiktok.com')) {
+      return 'tiktok';
+    }
+    if (lowerUrl.includes('twitter.com') || lowerUrl.includes('x.com')) {
+      return 'twitter';
+    }
+    if (lowerUrl.includes('youtube.com') || lowerUrl.includes('youtu.be')) {
+      return 'youtube';
+    }
+    if (lowerUrl.includes('facebook.com')) {
+      return 'facebook';
+    }
+    return undefined;
   }
 
   /**

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
@@ -288,6 +288,43 @@ describe('BrandScraperService', () => {
       expect(result.primaryColor).toBeDefined();
     });
 
+    it('extracts font and asset candidates for brand kit drafts', async () => {
+      const head = [
+        '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700" />',
+        '<style>body { font-family: "Satoshi", sans-serif; color: #123456; }</style>',
+      ].join('\n');
+      const body = [
+        '<img class="logo" src="/logo.svg" alt="Acme logo" />',
+        '<img class="hero" src="/hero.jpg" alt="Hero" />',
+        '<img src="/reference.jpg" alt="Reference" />',
+      ].join('\n');
+      fetchMock.mockResolvedValue(
+        makeResponse(
+          makeHtml({
+            body,
+            head,
+            ogImage: 'https://acme.com/social.jpg',
+            title: 'Acme | Home',
+          }),
+        ),
+      );
+
+      const result = await service.scrapeWebsite('https://acme.com');
+
+      expect(result.fontFamily).toBe('Inter');
+      expect(result.fontCandidates).toEqual(
+        expect.arrayContaining(['Inter', 'Satoshi']),
+      );
+      expect(result.logoUrl).toBe('https://acme.com/logo.svg');
+      expect(result.bannerUrl).toBe('https://acme.com/hero.jpg');
+      expect(result.referenceImageUrls).toEqual(
+        expect.arrayContaining([
+          'https://acme.com/social.jpg',
+          'https://acme.com/reference.jpg',
+        ]),
+      );
+    });
+
     it('extracts value propositions from bullet characters', async () => {
       const body = [
         '<p>&#8226; Ship faster than competitors</p>',
@@ -339,6 +376,19 @@ describe('BrandScraperService', () => {
 
       const result = await service.scrapeWebsite('https://acme.com');
       expect(result).toBeDefined();
+    });
+
+    it('rejects non-HTML responses before parsing', async () => {
+      fetchMock.mockResolvedValue(
+        new Response('not html', {
+          headers: { 'content-type': 'application/pdf' },
+          status: 200,
+        }),
+      );
+
+      await expect(service.scrapeWebsite('https://acme.com')).rejects.toThrow(
+        'Unsupported content type',
+      );
     });
   });
 

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
@@ -891,15 +891,21 @@ export class BrandScraperService {
     const images: WebsiteScrapingResult['images'] = [];
     const seen = new Set<string>();
 
-    const addImage = (src: string | undefined, alt?: string): void => {
+    const addImage = (
+      src: string | undefined,
+      alt?: string,
+      isSrcSet = false,
+    ): void => {
       if (!src || src.startsWith('data:')) {
         return;
       }
 
-      const resolved = this.resolveUrl(
-        this.extractSrcFromSrcSet(src),
-        sourceUrl,
-      );
+      // Only treat the value as a srcset (comma-separated candidate list) when
+      // it actually came from a srcset attribute. Plain src/data-src URLs can
+      // legitimately contain commas (e.g. CDN transform params) and must not be
+      // truncated at the first comma.
+      const candidate = isSrcSet ? this.extractSrcFromSrcSet(src) : src;
+      const resolved = this.resolveUrl(candidate, sourceUrl);
       if (!resolved || seen.has(resolved)) {
         return;
       }
@@ -918,10 +924,12 @@ export class BrandScraperService {
     );
 
     $('img[src], img[data-src], img[srcset]').each((_i, el) => {
-      addImage(
-        $(el).attr('src') ?? $(el).attr('data-src') ?? $(el).attr('srcset'),
-        $(el).attr('alt'),
-      );
+      const direct = $(el).attr('src') ?? $(el).attr('data-src');
+      if (direct) {
+        addImage(direct, $(el).attr('alt'));
+      } else {
+        addImage($(el).attr('srcset'), $(el).attr('alt'), true);
+      }
     });
 
     return images.slice(0, MAX_IMAGE_CANDIDATES);

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
@@ -26,6 +26,8 @@ const MAX_RETRY_ATTEMPTS = 3;
 
 /** Base delay in ms for exponential backoff on 429 responses */
 const RETRY_BASE_DELAY_MS = 1_000;
+const MAX_IMAGE_CANDIDATES = 12;
+const MAX_FONT_CANDIDATES = 8;
 
 /**
  * BrandScraperService
@@ -76,8 +78,10 @@ export class BrandScraperService {
 
         return {
           aboutText: undefined,
+          bannerUrl: fallback.ogImage,
           companyName: companyName || fallback.siteName,
           description: fallback.description || fallback.ogDescription,
+          fontCandidates: [],
           fontFamily: undefined,
           heroText: undefined,
           logoUrl: undefined,
@@ -412,6 +416,7 @@ export class BrandScraperService {
       );
     }
 
+    this.assertHtmlResponse(response);
     const html = await response.text();
     const $ = cheerio.load(html);
 
@@ -491,6 +496,7 @@ export class BrandScraperService {
       );
     }
 
+    this.assertHtmlResponse(response);
     const html = await response.text();
     const $ = cheerio.load(html);
 
@@ -543,6 +549,7 @@ export class BrandScraperService {
 
     // Extract colors from theme-color meta, <style> tags, inline styles
     const colors = this.extractColorsFromDom($);
+    const fonts = this.extractFontsFromDom($);
 
     // Extract headings
     const headings = this.extractHeadingsFromDom($);
@@ -556,17 +563,20 @@ export class BrandScraperService {
 
     // Extract logo
     const logoUrl = this.extractLogoFromDom($, sourceUrl);
+    const images = this.extractImagesFromDom($, sourceUrl);
+    const bannerUrl = this.extractBannerFromDom($, sourceUrl, ogImage, images);
 
     return {
       aboutText,
+      bannerUrl,
       canonical,
       colors,
       description,
       favicon,
-      fonts: [],
+      fonts,
       headings,
       heroText: headings[0],
-      images: [],
+      images,
       logoUrl,
       ogDescription,
       ogImage,
@@ -599,14 +609,25 @@ export class BrandScraperService {
 
     return {
       aboutText: scrapedContent.aboutText,
+      bannerUrl: scrapedContent.bannerUrl,
       companyName,
       description: scrapedContent.description || scrapedContent.ogDescription,
+      fontCandidates: scrapedContent.fonts,
       fontFamily: scrapedContent.fonts[0],
       heroText: scrapedContent.heroText,
       logoUrl: scrapedContent.logoUrl,
       metaDescription: scrapedContent.description,
       ogImage: scrapedContent.ogImage,
       primaryColor: scrapedContent.colors.primary,
+      referenceImageUrls: scrapedContent.images
+        .map((image) => image.src)
+        .filter(
+          (src, index, all) =>
+            src !== scrapedContent.logoUrl &&
+            src !== scrapedContent.bannerUrl &&
+            all.indexOf(src) === index,
+        )
+        .slice(0, MAX_IMAGE_CANDIDATES),
       scrapedAt: scrapedContent.scrapedAt,
       secondaryColor: scrapedContent.colors.secondary,
       socialLinks: scrapedContent.socialLinks,
@@ -745,6 +766,74 @@ export class BrandScraperService {
     };
   }
 
+  private extractFontsFromDom($: cheerio.CheerioAPI): string[] {
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+
+    const addFont = (font: string): void => {
+      const normalized = font
+        .split(',')
+        .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+        .find((part) => part.length > 0);
+
+      if (
+        !normalized ||
+        /^(system-ui|sans-serif|serif|monospace|inherit|initial|var\()/i.test(
+          normalized,
+        ) ||
+        seen.has(normalized)
+      ) {
+        return;
+      }
+
+      seen.add(normalized);
+      candidates.push(normalized);
+    };
+
+    $('link[href*="fonts.googleapis.com"]').each((_i, el) => {
+      const href = $(el).attr('href');
+      if (!href) {
+        return;
+      }
+      try {
+        const family = new URL(
+          href,
+          'https://fonts.googleapis.com',
+        ).searchParams
+          .get('family')
+          ?.split(':')[0]
+          ?.replace(/\+/g, ' ');
+        if (family) {
+          addFont(family);
+        }
+      } catch {
+        // Ignore malformed stylesheet URLs; inline declarations still apply.
+      }
+    });
+
+    const cssText: string[] = [];
+    $('style').each((_i, el) => {
+      cssText.push($(el).text());
+    });
+    $('[style]').each((_i, el) => {
+      const style = $(el).attr('style');
+      if (style) {
+        cssText.push(style);
+      }
+    });
+
+    const fontMatches = cssText
+      .join(' ')
+      .matchAll(/font-family\s*:\s*([^;{}]+)/gi);
+    for (const match of fontMatches) {
+      if (match[1]) {
+        addFont(match[1]);
+      }
+    }
+
+    return candidates.slice(0, MAX_FONT_CANDIDATES);
+  }
+
   /**
    * Extract headings from DOM
    */
@@ -795,6 +884,82 @@ export class BrandScraperService {
     return undefined;
   }
 
+  private extractImagesFromDom(
+    $: cheerio.CheerioAPI,
+    sourceUrl: string,
+  ): WebsiteScrapingResult['images'] {
+    const images: WebsiteScrapingResult['images'] = [];
+    const seen = new Set<string>();
+
+    const addImage = (src: string | undefined, alt?: string): void => {
+      if (!src || src.startsWith('data:')) {
+        return;
+      }
+
+      const resolved = this.resolveUrl(
+        this.extractSrcFromSrcSet(src),
+        sourceUrl,
+      );
+      if (!resolved || seen.has(resolved)) {
+        return;
+      }
+
+      seen.add(resolved);
+      images.push({
+        alt: alt?.trim() || undefined,
+        src: resolved,
+      });
+    };
+
+    $('meta[property="og:image"], meta[name="twitter:image"]').each(
+      (_i, el) => {
+        addImage($(el).attr('content'), 'Social preview image');
+      },
+    );
+
+    $('img[src], img[data-src], img[srcset]').each((_i, el) => {
+      addImage(
+        $(el).attr('src') ?? $(el).attr('data-src') ?? $(el).attr('srcset'),
+        $(el).attr('alt'),
+      );
+    });
+
+    return images.slice(0, MAX_IMAGE_CANDIDATES);
+  }
+
+  private extractBannerFromDom(
+    $: cheerio.CheerioAPI,
+    sourceUrl: string,
+    ogImage: string | undefined,
+    images: WebsiteScrapingResult['images'],
+  ): string | undefined {
+    const bannerSelectors = [
+      'img[class*="hero"]',
+      'img[class*="banner"]',
+      'img[id*="hero"]',
+      'img[id*="banner"]',
+      '[class*="hero"] img',
+      '[class*="banner"] img',
+    ];
+
+    for (const selector of bannerSelectors) {
+      const src = $(selector).first().attr('src');
+      if (src) {
+        return this.resolveUrl(src, sourceUrl);
+      }
+    }
+
+    if (ogImage) {
+      return this.resolveUrl(ogImage, sourceUrl);
+    }
+
+    return images[0]?.src;
+  }
+
+  private extractSrcFromSrcSet(value: string): string {
+    return value.split(',')[0]?.trim().split(/\s+/)[0] ?? value;
+  }
+
   /**
    * Resolve a potentially relative URL against a base URL
    */
@@ -803,6 +968,17 @@ export class BrandScraperService {
       return new URL(href, base).href;
     } catch {
       return href;
+    }
+  }
+
+  private assertHtmlResponse(response: Response): void {
+    const contentType = response.headers.get('content-type');
+    if (
+      contentType &&
+      !contentType.includes('text/html') &&
+      !contentType.includes('application/xhtml+xml')
+    ) {
+      throw new Error(`Unsupported content type: ${contentType}`);
     }
   }
 

--- a/packages/helpers/src/brand-kit-contract.helper.test.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.test.ts
@@ -5,6 +5,7 @@ import type {
 import {
   type BrandKitSourceBrand,
   buildBrandKitDraftFromBrand,
+  buildBrandKitDraftFromWebsiteScrape,
   computeBrandKitReadiness,
 } from '@helpers/brand-kit-contract.helper';
 
@@ -234,6 +235,53 @@ describe('brand kit contract helpers', () => {
         expect.objectContaining({
           code: 'brand_kit_private_source_blocked',
           severity: 'error',
+        }),
+      ]),
+    );
+  });
+
+  it('maps a website scrape into proposed brand kit fields and asset candidates', () => {
+    const draft = buildBrandKitDraftFromWebsiteScrape(createCompleteBrand(), {
+      bannerUrl: 'https://acme.example/hero.jpg',
+      companyName: 'Acme Website',
+      description: 'Website-sourced operating system for creators.',
+      fontCandidates: ['Inter', 'Satoshi'],
+      logoUrl: 'https://acme.example/logo.svg',
+      primaryColor: '#3366ff',
+      referenceImageUrls: [
+        'https://acme.example/hero.jpg',
+        'https://acme.example/reference.jpg',
+      ],
+      scrapedAt: new Date('2026-06-30T10:00:00Z'),
+      socialLinks: {
+        linkedin: 'https://linkedin.com/company/acme',
+      },
+      sourceUrl: 'https://acme.example',
+      tagline: 'Create on brand.',
+    });
+
+    expect(draft.sourceType).toBe('website');
+    expect(draft.fields.label?.currentValue).toBe('Acme');
+    expect(draft.fields.label?.proposedValue).toBe('Acme Website');
+    expect(draft.fields.primaryColor?.proposedValue).toBe('#3366ff');
+    expect(draft.fields.fontFamily?.proposedValue).toBe('Inter');
+    expect(draft.fields.promptGuidelines?.proposedValue).toContain(
+      'Create on brand.',
+    );
+    expect(draft.assetCandidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'logo',
+          sourceType: 'website',
+          url: 'https://acme.example/logo.svg',
+        }),
+        expect.objectContaining({
+          role: 'banner',
+          url: 'https://acme.example/hero.jpg',
+        }),
+        expect.objectContaining({
+          role: 'reference',
+          url: 'https://acme.example/reference.jpg',
         }),
       ]),
     );

--- a/packages/helpers/src/brand-kit-contract.helper.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.ts
@@ -3,6 +3,7 @@ import {
   type BrandKitAssetRole,
   type BrandKitFieldKey,
   type BrandKitSourceType,
+  type IBrandKitAssetCandidate,
   type IBrandKitAssetValue,
   type IBrandKitDiagnostic,
   type IBrandKitDraft,
@@ -11,6 +12,7 @@ import {
   type IBrandKitReadiness,
   type IBrandKitSocialLink,
   type IBrandKitSourceEvidence,
+  type IScrapedBrandData,
 } from '@genfeedai/interfaces';
 
 interface BrandKitAssetSource {
@@ -75,6 +77,10 @@ export interface BuildBrandKitDraftOptions {
   sourceType?: BrandKitSourceType;
   evidence?: IBrandKitSourceEvidence[];
   diagnostics?: IBrandKitDiagnostic[];
+  proposedValues?: Partial<Record<BrandKitFieldKey, unknown>>;
+  fieldDiagnostics?: Partial<Record<BrandKitFieldKey, IBrandKitDiagnostic[]>>;
+  fieldConfidence?: Partial<Record<BrandKitFieldKey, number>>;
+  assetCandidates?: IBrandKitAssetCandidate[];
   createdAt?: string;
   updatedAt?: string;
 }
@@ -389,17 +395,34 @@ function buildDraftField(
   brand: BrandKitSourceBrand,
   owner: IBrandKitFieldOwner,
   evidence: IBrandKitSourceEvidence[],
+  options: BuildBrandKitDraftOptions,
 ): IBrandKitDraftField {
-  return {
+  const proposedValue = options.proposedValues?.[owner.key];
+  const currentValue = readCurrentValue(brand, owner.key);
+  const diagnostics = options.fieldDiagnostics?.[owner.key] ?? [];
+  const confidence = options.fieldConfidence?.[owner.key];
+
+  const field: IBrandKitDraftField = {
     applyActionDefault: owner.applyActionDefault,
-    currentValue: readCurrentValue(brand, owner.key),
-    diagnostics: [],
+    diagnostics,
     evidence,
     group: owner.group,
     key: owner.key,
     label: owner.label,
     ownerPath: owner.ownerPath,
   };
+
+  if (currentValue !== undefined) {
+    field.currentValue = currentValue;
+  }
+  if (proposedValue !== undefined) {
+    field.proposedValue = proposedValue;
+  }
+  if (confidence !== undefined) {
+    field.confidence = confidence;
+  }
+
+  return field;
 }
 
 export function buildBrandKitDraftFromBrand(
@@ -420,14 +443,15 @@ export function buildBrandKitDraftFromBrand(
   const fields: Partial<Record<BrandKitFieldKey, IBrandKitDraftField>> = {};
 
   for (const owner of BRAND_KIT_FIELD_OWNERSHIP) {
-    fields[owner.key] = buildDraftField(brand, owner, evidence);
+    fields[owner.key] = buildDraftField(brand, owner, evidence, options);
   }
 
-  const diagnostics = options.diagnostics ?? [];
+  const fieldDiagnostics = Object.values(options.fieldDiagnostics ?? {}).flat();
+  const diagnostics = [...(options.diagnostics ?? []), ...fieldDiagnostics];
   const readiness = buildReadiness(fields, diagnostics);
 
   return {
-    assetCandidates: [],
+    assetCandidates: options.assetCandidates ?? [],
     brandId: brand.id,
     createdAt: options.createdAt,
     diagnostics,
@@ -452,4 +476,246 @@ export function getBrandKitFieldOwner(
   key: BrandKitFieldKey,
 ): IBrandKitFieldOwner {
   return findOwner(key);
+}
+
+function createWebsiteEvidence(
+  scraped: IScrapedBrandData,
+): IBrandKitSourceEvidence[] {
+  const excerpt =
+    scraped.description ??
+    scraped.heroText ??
+    scraped.aboutText ??
+    scraped.valuePropositions?.[0];
+
+  const evidence: IBrandKitSourceEvidence = {
+    label: 'Website crawl',
+    sourceType: 'website',
+    url: scraped.sourceUrl,
+  };
+
+  if (excerpt !== undefined) {
+    evidence.excerpt = excerpt;
+  }
+
+  return [evidence];
+}
+
+function compactTextParts(
+  parts: Array<string | undefined>,
+): string | undefined {
+  const text = parts
+    .filter(hasText)
+    .map((part) => part.trim())
+    .filter((part, index, all) => all.indexOf(part) === index)
+    .join('\n');
+
+  return hasText(text) ? text : undefined;
+}
+
+function buildWebsiteGuidance(scraped: IScrapedBrandData): string | undefined {
+  return compactTextParts([
+    scraped.tagline && `Tagline: ${scraped.tagline}`,
+    scraped.description && `Description: ${scraped.description}`,
+    scraped.heroText && `Hero: ${scraped.heroText}`,
+    scraped.aboutText && `About: ${scraped.aboutText}`,
+    scraped.valuePropositions && scraped.valuePropositions.length > 0
+      ? `Value propositions: ${scraped.valuePropositions.join(' | ')}`
+      : undefined,
+  ]);
+}
+
+function readWebsiteSocialLinks(
+  scraped: IScrapedBrandData,
+): IBrandKitSocialLink[] | undefined {
+  const links: IBrandKitSocialLink[] = [];
+
+  for (const [platform, url] of Object.entries(scraped.socialLinks ?? {})) {
+    if (!hasText(url)) {
+      continue;
+    }
+    links.push({
+      platform,
+      sourceType: 'website',
+      url,
+    });
+  }
+
+  return links.length > 0 ? links : undefined;
+}
+
+function createWebsiteAssetValue(
+  role: BrandKitAssetRole,
+  url: string | undefined,
+  label: string,
+): IBrandKitAssetValue | undefined {
+  if (!hasText(url)) {
+    return undefined;
+  }
+
+  return {
+    label,
+    role,
+    sourceType: 'website',
+    url,
+  };
+}
+
+function uniqueTextValues(values: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (!hasText(value) || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+
+  return result;
+}
+
+function createWebsiteAssetCandidates(
+  scraped: IScrapedBrandData,
+): IBrandKitAssetCandidate[] {
+  const candidates: IBrandKitAssetCandidate[] = [];
+  const sourceUrls = uniqueTextValues([
+    scraped.logoUrl,
+    scraped.bannerUrl,
+    scraped.ogImage,
+    ...(scraped.referenceImageUrls ?? []),
+  ]);
+
+  for (const url of sourceUrls) {
+    const role: BrandKitAssetRole =
+      url === scraped.logoUrl
+        ? 'logo'
+        : url === (scraped.bannerUrl ?? scraped.ogImage)
+          ? 'banner'
+          : 'reference';
+
+    candidates.push({
+      candidateId: `${role}:${candidates.length + 1}:${url}`,
+      label:
+        role === 'logo'
+          ? 'Website logo'
+          : role === 'banner'
+            ? 'Website banner'
+            : 'Website reference image',
+      role,
+      sourceType: 'website',
+      sourceUrl: scraped.sourceUrl,
+      url,
+    });
+  }
+
+  return candidates;
+}
+
+function createMissingWebsiteDiagnostic(
+  fieldKey: BrandKitFieldKey,
+  label: string,
+): IBrandKitDiagnostic {
+  return {
+    code: `brand_kit_website_missing_${fieldKey}`,
+    fieldKey,
+    message: `${label} was not found in the static website crawl.`,
+    severity: 'warning',
+  };
+}
+
+function createWebsiteFieldDiagnostics(
+  scraped: IScrapedBrandData,
+): Partial<Record<BrandKitFieldKey, IBrandKitDiagnostic[]>> {
+  const diagnostics: Partial<Record<BrandKitFieldKey, IBrandKitDiagnostic[]>> =
+    {};
+
+  if (!hasText(scraped.primaryColor)) {
+    diagnostics.primaryColor = [
+      createMissingWebsiteDiagnostic('primaryColor', 'Primary color'),
+    ];
+  }
+
+  if (!hasText(scraped.fontFamily) && !scraped.fontCandidates?.length) {
+    diagnostics.fontFamily = [
+      createMissingWebsiteDiagnostic('fontFamily', 'Font family'),
+    ];
+  }
+
+  if (!hasText(scraped.logoUrl)) {
+    diagnostics.logo = [createMissingWebsiteDiagnostic('logo', 'Logo')];
+  }
+
+  if (!hasText(buildWebsiteGuidance(scraped))) {
+    diagnostics.promptGuidelines = [
+      createMissingWebsiteDiagnostic(
+        'promptGuidelines',
+        'Voice and guidance source text',
+      ),
+    ];
+  }
+
+  return diagnostics;
+}
+
+export function buildBrandKitDraftFromWebsiteScrape(
+  brand: BrandKitSourceBrand,
+  scraped: IScrapedBrandData,
+  options: Omit<
+    BuildBrandKitDraftOptions,
+    'assetCandidates' | 'evidence' | 'fieldDiagnostics' | 'proposedValues'
+  > = {},
+): IBrandKitDraft {
+  const referenceValues = uniqueTextValues(scraped.referenceImageUrls ?? [])
+    .filter(
+      (url) =>
+        url !== scraped.logoUrl &&
+        url !== scraped.bannerUrl &&
+        url !== scraped.ogImage,
+    )
+    .map((url) =>
+      createWebsiteAssetValue('reference', url, 'Website reference image'),
+    )
+    .filter((value): value is IBrandKitAssetValue => Boolean(value));
+
+  const bannerValue = createWebsiteAssetValue(
+    'banner',
+    scraped.bannerUrl ?? scraped.ogImage,
+    'Website banner',
+  );
+
+  const proposedValues: Partial<Record<BrandKitFieldKey, unknown>> = {};
+  const setProposedValue = (key: BrandKitFieldKey, value: unknown): void => {
+    if (value !== undefined) {
+      proposedValues[key] = value;
+    }
+  };
+
+  setProposedValue('banner', bannerValue);
+  setProposedValue('description', scraped.description ?? scraped.aboutText);
+  setProposedValue(
+    'fontFamily',
+    scraped.fontFamily ?? scraped.fontCandidates?.[0],
+  );
+  setProposedValue('label', scraped.companyName);
+  setProposedValue(
+    'logo',
+    createWebsiteAssetValue('logo', scraped.logoUrl, 'Website logo'),
+  );
+  setProposedValue('primaryColor', scraped.primaryColor);
+  setProposedValue('promptGuidelines', buildWebsiteGuidance(scraped));
+  if (referenceValues.length > 0) {
+    setProposedValue('references', referenceValues);
+  }
+  setProposedValue('secondaryColor', scraped.secondaryColor);
+  setProposedValue('socialLinks', readWebsiteSocialLinks(scraped));
+
+  return buildBrandKitDraftFromBrand(brand, {
+    ...options,
+    assetCandidates: createWebsiteAssetCandidates(scraped),
+    evidence: createWebsiteEvidence(scraped),
+    fieldDiagnostics: createWebsiteFieldDiagnostics(scraped),
+    proposedValues,
+    sourceType: 'website',
+  });
 }

--- a/packages/helpers/src/brand-kit-contract.helper.ts
+++ b/packages/helpers/src/brand-kit-contract.helper.ts
@@ -636,6 +636,12 @@ function createWebsiteFieldDiagnostics(
     ];
   }
 
+  if (!hasText(scraped.secondaryColor)) {
+    diagnostics.secondaryColor = [
+      createMissingWebsiteDiagnostic('secondaryColor', 'Secondary color'),
+    ];
+  }
+
   if (!hasText(scraped.fontFamily) && !scraped.fontCandidates?.length) {
     diagnostics.fontFamily = [
       createMissingWebsiteDiagnostic('fontFamily', 'Font family'),

--- a/packages/interfaces/src/onboarding/onboarding.interface.ts
+++ b/packages/interfaces/src/onboarding/onboarding.interface.ts
@@ -39,9 +39,12 @@ export interface IScrapedBrandData {
 
   // Visual
   logoUrl?: string;
+  bannerUrl?: string;
   primaryColor?: string;
   secondaryColor?: string;
   fontFamily?: string;
+  fontCandidates?: string[];
+  referenceImageUrls?: string[];
 
   // Content
   heroText?: string;


### PR DESCRIPTION
## Summary
- add a guarded `POST /brands/:id/brand-kit/crawl` action that validates organization-scoped brand access and returns a website-sourced brand kit draft without mutating the brand
- extend website scraping to collect font candidates, banner/reference images, and reject non-HTML responses before parsing
- map scraped website values into brand kit draft proposed values, diagnostics, evidence, and asset candidates

## Validation
- bun run --cwd packages/helpers test src/brand-kit-contract.helper.test.ts
- bun run --cwd apps/server/api test:file src/services/brand-scraper/brand-scraper.service.spec.ts src/collections/brands/services/brands.service.spec.ts src/collections/brands/controllers/brands.controller.spec.ts
- bunx biome check --write apps/server/api/src/collections/brands/controllers/brands.controller.ts apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts apps/server/api/src/collections/brands/dto/crawl-brand-kit.dto.ts apps/server/api/src/collections/brands/services/brands.service.ts apps/server/api/src/collections/brands/services/brands.service.spec.ts apps/server/api/src/services/brand-scraper/brand-scraper.service.ts apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts packages/helpers/src/brand-kit-contract.helper.ts packages/helpers/src/brand-kit-contract.helper.test.ts packages/interfaces/src/onboarding/onboarding.interface.ts
- bun run --cwd apps/server/api lint
- bun run audit:api
- bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/helpers --filter=@genfeedai/interfaces
- git diff --check
- git diff --cached --check
- bun scripts/run-secretlint.ts <touched files>
- bun run lint-staged

Closes #772
Refs #770