### PR TITLE
fix(infra): set ElastiCache transit_encryption_mode + grant deploy-role SSM write (unblock #931 prod deploy)

### DIFF
--- a/infra/terraform/genfeed-prod/elasticache.tf
+++ b/infra/terraform/genfeed-prod/elasticache.tf
@@ -34,6 +34,12 @@ resource "aws_elasticache_replication_group" "redis" {
   automatic_failover_enabled = false
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
+  # AWS requires a transit_encryption_mode when enabling in-transit encryption on
+  # an existing replication group. "preferred" accepts both encrypted and
+  # unencrypted client connections during the migration, so existing non-TLS
+  # clients keep working while services roll over to TLS+AUTH. Tighten to
+  # "required" in a follow-up once all clients use rediss://.
+  transit_encryption_mode    = "preferred"
   auth_token                 = random_password.redis_auth_token.result
   auth_token_update_strategy = "SET"
   apply_immediately          = true


### PR DESCRIPTION
Forward-fix (NOT a back-out) for the failed fastlane prod deploy (run 28448954233).

**Two blockers, both fixed:**
1. `ssm:PutParameter` AccessDenied for `gha-genfeed-deploy` → granted out-of-band via a scoped inline policy (`gha-genfeed-redis-ssm-write`, scoped to `/genfeed/production/*`). bootstrap is local-state so couldn't be applied here; this matches the grant already in `bootstrap/main.tf`, reconciled on next bootstrap apply.
2. ElastiCache modify needs `transit_encryption_mode` → set to `preferred` (accepts encrypted + unencrypted clients during migration; existing non-TLS clients keep working). Tighten to `required` later.

Keeps #931's Redis TLS+AUTH. Re-deploy after merge.