### PR TITLE
feat(brand): add brand kit review flow

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/brand-detail.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/brand-detail.test.tsx
@@ -174,6 +174,17 @@ vi.mock('@pages/brands/components/overview/BrandDetailOverview', () => ({
   ),
 }));
 
+vi.mock('@pages/brands/components/brand-kit/BrandKitReviewCard', () => ({
+  default: ({ onRefreshBrand }: { onRefreshBrand: () => Promise<void> }) => (
+    <section>
+      Brand Kit Review
+      <button type="button" onClick={() => void onRefreshBrand()}>
+        Refresh Brand Kit
+      </button>
+    </section>
+  ),
+}));
+
 vi.mock('./BrandDetailLatestArticles', () => ({
   default: ({ articles }: { articles?: Array<unknown> }) => (
     <div>Articles {articles?.length ?? 0}</div>
@@ -379,6 +390,7 @@ describe('BrandDetail', () => {
 
     expect(screen.getByText('Banner')).toBeInTheDocument();
     expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Brand Kit Review')).toBeInTheDocument();
     expect(screen.getByText('Videos 1')).toBeInTheDocument();
     expect(screen.getByText('Images 1')).toBeInTheDocument();
     expect(screen.getByText('Articles 1')).toBeInTheDocument();
@@ -413,6 +425,8 @@ describe('BrandDetail', () => {
     expect(mocks.handleRequestDeleteReference).toHaveBeenCalledWith(
       'reference-1',
     );
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Brand Kit' }));
+    expect(mocks.handleRefreshBrand).toHaveBeenCalledWith(true);
     fireEvent.click(
       screen.getByRole('button', {
         name: 'Generate modal banner brand-1 9',

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/brand-detail.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/brand-detail.tsx
@@ -13,6 +13,7 @@ import { useElements } from '@hooks/data/elements/use-elements/use-elements';
 import { useBrandDetail } from '@hooks/pages/use-brand-detail/use-brand-detail';
 import type { Link } from '@models/social/link.model';
 import BrandDetailBanner from '@pages/brands/components/banner/BrandDetailBanner';
+import BrandKitReviewCard from '@pages/brands/components/brand-kit/BrandKitReviewCard';
 import BrandDetailSidebar from '@pages/brands/components/detail-sidebar/BrandDetailSidebar';
 import BrandDetailOverview from '@pages/brands/components/overview/BrandDetailOverview';
 import BrandDetailLinkEditor, {
@@ -258,6 +259,12 @@ export default function BrandDetail() {
           {brand.text && (
             <BrandDetailSystemPrompt text={brand.text} onCopy={handleCopy} />
           )}
+
+          <BrandKitReviewCard
+            brand={brand}
+            brandId={brandId}
+            onRefreshBrand={() => handleRefreshBrand(true)}
+          />
 
           <BrandDetailLatestVideos videos={videos} />
           <BrandDetailLatestImages images={images} />

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
@@ -95,6 +95,7 @@ describe('BrandsController', () => {
         {
           provide: BrandsService,
           useValue: {
+            applyBrandKitDraft: vi.fn(),
             crawlWebsiteBrandKitDraft: vi.fn(),
             create: vi.fn(),
             findAll: vi.fn(),
@@ -329,6 +330,86 @@ describe('BrandsController', () => {
         }),
       });
       expect(brandsService.crawlWebsiteBrandKitDraft).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyBrandKitDraft', () => {
+    it('verifies brand access and passes organization context to the service', async () => {
+      const brandId = '507f191e810c19729de860ee'.toString();
+      const applyResult = {
+        appliedFields: ['description'],
+        brandId,
+        diagnostics: [],
+        preservedFields: [],
+        status: 'accepted',
+      };
+      brandsService.findOne.mockResolvedValue(
+        mockBrand as unknown as BrandEntity,
+      );
+      brandsService.applyBrandKitDraft.mockResolvedValue(
+        applyResult as Awaited<ReturnType<BrandsService['applyBrandKitDraft']>>,
+      );
+
+      const result = await controller.applyBrandKitDraft(mockUser, brandId, {
+        fields: {
+          description: {
+            action: 'accept',
+            value: 'Updated brand description',
+          },
+        },
+      });
+
+      expect(brandsService.findOne).toHaveBeenCalledWith({
+        OR: [
+          { user: '507f191e810c19729de860ee' },
+          { organization: '507f191e810c19729de860ee' },
+        ],
+        _id: brandId,
+        isDeleted: false,
+      });
+      expect(brandsService.applyBrandKitDraft).toHaveBeenCalledWith(
+        brandId,
+        '507f191e810c19729de860ee',
+        {
+          fields: {
+            description: {
+              action: 'accept',
+              value: 'Updated brand description',
+            },
+          },
+        },
+      );
+      expect(result).toEqual({ data: applyResult });
+    });
+
+    it('rejects apply requests without organization context', async () => {
+      const brandId = '507f191e810c19729de860ee'.toString();
+      const userWithoutOrganization = {
+        ...mockUser,
+        publicMetadata: {
+          ...(mockUser.publicMetadata as IAuthPublicMetadata),
+          organization: undefined,
+        },
+      } as unknown as User;
+      brandsService.findOne.mockResolvedValue(
+        mockBrand as unknown as BrandEntity,
+      );
+
+      await expect(
+        controller.applyBrandKitDraft(userWithoutOrganization, brandId, {
+          fields: {
+            description: {
+              action: 'accept',
+              value: 'Updated brand description',
+            },
+          },
+        }),
+      ).rejects.toMatchObject({
+        response: expect.objectContaining({
+          detail: 'Organization context is required',
+        }),
+      });
+      expect(brandsService.applyBrandKitDraft).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -2,6 +2,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { ArticlesService } from '@api/collections/articles/services/articles.service';
 import { STRATEGY_TEMPLATES } from '@api/collections/brands/constants/strategy-templates.constant';
+import { ApplyBrandKitDto } from '@api/collections/brands/dto/apply-brand-kit.dto';
 import { CrawlBrandKitDto } from '@api/collections/brands/dto/crawl-brand-kit.dto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
 import { GenerateBrandVoiceDto } from '@api/collections/brands/dto/generate-brand-voice.dto';
@@ -389,6 +390,38 @@ export class BrandsController extends BaseCRUDController<
     );
 
     return { data: draft };
+  }
+
+  @Post(':id/brand-kit/apply')
+  @HttpCode(200)
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async applyBrandKitDraft(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: ApplyBrandKitDto,
+  ) {
+    await this.verifyBrandAccess(id, user);
+
+    const publicMetadata = getPublicMetadata(user);
+    const organizationId = publicMetadata.organization?.toString();
+
+    if (!organizationId) {
+      throw new HttpException(
+        {
+          detail: 'Organization context is required',
+          title: 'Forbidden',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    const result = await this.brandsService.applyBrandKitDraft(
+      id,
+      organizationId,
+      dto,
+    );
+
+    return { data: result };
   }
 
   @Post(':id/agent-config/generate-voice')

--- a/apps/server/api/src/collections/brands/dto/apply-brand-kit.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/apply-brand-kit.dto.ts
@@ -1,0 +1,33 @@
+import type { BrandKitFieldKey } from '@genfeedai/interfaces';
+import {
+  IsBoolean,
+  IsIn,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class ApplyBrandKitFieldDecisionDto {
+  @IsIn(['accept', 'reject', 'preserve'])
+  action!: 'accept' | 'reject' | 'preserve';
+
+  @IsOptional()
+  value?: unknown;
+
+  @IsOptional()
+  @IsString()
+  assetCandidateId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  replaceExisting?: boolean;
+}
+
+export class ApplyBrandKitDto {
+  @IsOptional()
+  @IsString()
+  draftId?: string;
+
+  @IsObject()
+  fields!: Partial<Record<BrandKitFieldKey, ApplyBrandKitFieldDecisionDto>>;
+}

--- a/apps/server/api/src/collections/brands/services/brands.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.spec.ts
@@ -69,7 +69,7 @@ describe('BrandsService', () => {
         log: vi.fn(),
         warn: vi.fn(),
       } as unknown as LoggerService,
-      {} as CacheService,
+      { invalidateByTags: vi.fn() } as unknown as CacheService,
       brandScraperService as unknown as BrandScraperService,
       llmDispatcher as unknown as LlmDispatcherService,
       {
@@ -243,6 +243,147 @@ describe('BrandsService', () => {
         ]),
       );
       expect(delegate.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyBrandKitDraft', () => {
+    const organizationId = 'org_1';
+    const brandId = 'brand_1';
+
+    it('applies selected scalar, voice, and strategy fields to the brand', async () => {
+      delegate.findFirst.mockResolvedValue({
+        agentConfig: {
+          strategy: { frequency: 'weekly' },
+          voice: { style: 'direct' },
+        },
+        id: brandId,
+        isDeleted: false,
+        organizationId,
+      });
+      delegate.update.mockResolvedValue({
+        description: 'Imported description',
+        id: brandId,
+        organizationId,
+      });
+
+      const result = await service.applyBrandKitDraft(brandId, organizationId, {
+        fields: {
+          description: {
+            action: 'accept',
+            value: 'Imported description',
+          },
+          strategyPlatforms: {
+            action: 'accept',
+            value: ['linkedin', 'youtube'],
+          },
+          voiceTone: {
+            action: 'accept',
+            value: 'Confident',
+          },
+        },
+      });
+
+      expect(delegate.findFirst).toHaveBeenCalledWith({
+        where: { id: brandId, isDeleted: false, organizationId },
+      });
+      expect(delegate.update).toHaveBeenCalledWith({
+        data: {
+          agentConfig: {
+            strategy: {
+              frequency: 'weekly',
+              platforms: ['linkedin', 'youtube'],
+            },
+            voice: {
+              style: 'direct',
+              tone: 'Confident',
+            },
+          },
+          description: 'Imported description',
+        },
+        where: { id: brandId },
+      });
+      expect(result).toEqual({
+        appliedFields: ['description', 'strategyPlatforms', 'voiceTone'],
+        brandId,
+        diagnostics: [],
+        preservedFields: [],
+        status: 'accepted',
+      });
+    });
+
+    it('preserves links and assets until the safe asset import child ships', async () => {
+      delegate.findFirst.mockResolvedValue({
+        agentConfig: {},
+        id: brandId,
+        isDeleted: false,
+        organizationId,
+      });
+
+      const result = await service.applyBrandKitDraft(brandId, organizationId, {
+        fields: {
+          logo: {
+            action: 'accept',
+            value: {
+              role: 'logo',
+              sourceType: 'website',
+              url: 'https://acme.test/logo.svg',
+            },
+          },
+          socialLinks: {
+            action: 'accept',
+            value: [{ platform: 'linkedin', url: 'https://linkedin.test' }],
+          },
+        },
+      });
+
+      expect(delegate.update).not.toHaveBeenCalled();
+      expect(result.appliedFields).toEqual([]);
+      expect(result.preservedFields).toEqual(['logo', 'socialLinks']);
+      expect(result.status).toBe('partial');
+      expect(result.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'brand_kit_apply_deferred_field',
+            fieldKey: 'logo',
+            severity: 'warning',
+          }),
+          expect.objectContaining({
+            code: 'brand_kit_apply_deferred_field',
+            fieldKey: 'socialLinks',
+            severity: 'warning',
+          }),
+        ]),
+      );
+    });
+
+    it('rejects unsupported font candidates without mutating the brand', async () => {
+      delegate.findFirst.mockResolvedValue({
+        agentConfig: {},
+        id: brandId,
+        isDeleted: false,
+        organizationId,
+      });
+
+      const result = await service.applyBrandKitDraft(brandId, organizationId, {
+        fields: {
+          fontFamily: {
+            action: 'accept',
+            value: 'Inter',
+          },
+        },
+      });
+
+      expect(delegate.update).not.toHaveBeenCalled();
+      expect(result.status).toBe('blocked');
+      expect(result.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'brand_kit_apply_invalid_value',
+            fieldKey: 'fontFamily',
+            severity: 'error',
+          }),
+        ]),
+      );
     });
   });
 

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { ApplyBrandKitDto } from '@api/collections/brands/dto/apply-brand-kit.dto';
 import type { CrawlBrandKitDto } from '@api/collections/brands/dto/crawl-brand-kit.dto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
 import type {
@@ -11,7 +12,11 @@ import {
 } from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
 import { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
 import { UpdateBrandAgentConfigDto } from '@api/collections/brands/dto/update-brand-agent-config.dto';
-import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
+import type {
+  BrandAgentStrategy,
+  BrandAgentVoice,
+  BrandDocument,
+} from '@api/collections/brands/schemas/brand.schema';
 import { buildPromptBrandingFromBrand } from '@api/collections/brands/utils/brand-context.util';
 import {
   CACHE_PATTERNS,
@@ -24,21 +29,76 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import { FontFamily } from '@genfeedai/enums';
 import {
   type BrandKitSourceBrand,
   buildBrandKitDraftFromBrand,
   buildBrandKitDraftFromWebsiteScrape,
 } from '@genfeedai/helpers';
 import type {
+  BrandKitFieldKey,
   FastlaneFormat,
   FastlaneIdea,
+  IBrandKitApplyResult,
+  IBrandKitDiagnostic,
   IBrandKitDraft,
   IExtractedSocialLinks,
   IScrapedBrandData,
 } from '@genfeedai/interfaces';
+import { BRAND_KIT_FIELD_OWNERSHIP } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
+
+const BRAND_KIT_SCALAR_FIELDS: Partial<Record<BrandKitFieldKey, string>> = {
+  backgroundColor: 'backgroundColor',
+  description: 'description',
+  fontFamily: 'fontFamily',
+  label: 'label',
+  primaryColor: 'primaryColor',
+  promptGuidelines: 'text',
+  secondaryColor: 'secondaryColor',
+};
+
+const BRAND_KIT_VOICE_FIELDS: Partial<Record<BrandKitFieldKey, string>> = {
+  voiceAudience: 'audience',
+  voiceDoNotSoundLike: 'doNotSoundLike',
+  voiceMessagingPillars: 'messagingPillars',
+  voiceSampleOutput: 'sampleOutput',
+  voiceStyle: 'style',
+  voiceTone: 'tone',
+  voiceValues: 'values',
+};
+
+const BRAND_KIT_STRATEGY_FIELDS: Partial<Record<BrandKitFieldKey, string>> = {
+  strategyContentTypes: 'contentTypes',
+  strategyFrequency: 'frequency',
+  strategyGoals: 'goals',
+  strategyPlatforms: 'platforms',
+};
+
+const BRAND_KIT_DEFERRED_APPLY_FIELDS = new Set<BrandKitFieldKey>([
+  'banner',
+  'logo',
+  'references',
+  'socialLinks',
+]);
+
+const BRAND_KIT_FIELD_KEYS = new Set<BrandKitFieldKey>(
+  BRAND_KIT_FIELD_OWNERSHIP.map((field) => field.key),
+);
+
+const BRAND_KIT_STRING_LIST_FIELDS = new Set<BrandKitFieldKey>([
+  'strategyContentTypes',
+  'strategyGoals',
+  'strategyPlatforms',
+  'voiceAudience',
+  'voiceDoNotSoundLike',
+  'voiceMessagingPillars',
+  'voiceValues',
+]);
+
+const SUPPORTED_FONT_FAMILIES = new Set<string>(Object.values(FontFamily));
 
 @Injectable()
 export class BrandsService extends BaseService<
@@ -259,6 +319,217 @@ export class BrandsService extends BaseService<
         },
       );
     }
+  }
+
+  async applyBrandKitDraft(
+    brandId: string,
+    organizationId: string,
+    dto: ApplyBrandKitDto,
+  ): Promise<IBrandKitApplyResult> {
+    const brand = await this.delegate.findFirst({
+      where: { id: brandId, isDeleted: false, organizationId },
+    });
+
+    if (!brand) {
+      throw new NotFoundException('Brand', brandId);
+    }
+
+    const diagnostics: IBrandKitDiagnostic[] = [];
+    const appliedFields: BrandKitFieldKey[] = [];
+    const preservedFields: BrandKitFieldKey[] = [];
+    const updateData: Record<string, unknown> = {};
+    const voiceUpdates: Record<string, unknown> = {};
+    const strategyUpdates: Record<string, unknown> = {};
+
+    for (const [rawKey, decision] of Object.entries(dto.fields ?? {})) {
+      if (!this.isBrandKitFieldKey(rawKey)) {
+        diagnostics.push({
+          code: 'brand_kit_apply_unknown_field',
+          message: `${rawKey} is not a supported brand kit field.`,
+          severity: 'warning',
+        });
+        continue;
+      }
+
+      if (decision.action === 'preserve' || decision.action === 'reject') {
+        preservedFields.push(rawKey);
+        continue;
+      }
+
+      if (BRAND_KIT_DEFERRED_APPLY_FIELDS.has(rawKey)) {
+        preservedFields.push(rawKey);
+        diagnostics.push({
+          code: 'brand_kit_apply_deferred_field',
+          fieldKey: rawKey,
+          message:
+            'This field was preserved because safe link and asset import is handled by the dedicated Brand Kit asset child issue.',
+          severity: 'warning',
+        });
+        continue;
+      }
+
+      const value = this.coerceBrandKitApplyValue(rawKey, decision.value);
+
+      if (value === undefined) {
+        diagnostics.push({
+          code: 'brand_kit_apply_invalid_value',
+          fieldKey: rawKey,
+          message: `${rawKey} did not include a supported value.`,
+          severity: 'error',
+        });
+        continue;
+      }
+
+      const scalarField = BRAND_KIT_SCALAR_FIELDS[rawKey];
+      const voiceField = BRAND_KIT_VOICE_FIELDS[rawKey];
+      const strategyField = BRAND_KIT_STRATEGY_FIELDS[rawKey];
+
+      if (scalarField) {
+        updateData[scalarField] = value;
+        appliedFields.push(rawKey);
+        continue;
+      }
+
+      if (voiceField) {
+        voiceUpdates[voiceField] = value;
+        appliedFields.push(rawKey);
+        continue;
+      }
+
+      if (strategyField) {
+        strategyUpdates[strategyField] = value;
+        appliedFields.push(rawKey);
+        continue;
+      }
+
+      preservedFields.push(rawKey);
+      diagnostics.push({
+        code: 'brand_kit_apply_unsupported_field',
+        fieldKey: rawKey,
+        message: `${rawKey} is reviewable but not directly applied yet.`,
+        severity: 'warning',
+      });
+    }
+
+    if (
+      Object.keys(voiceUpdates).length > 0 ||
+      Object.keys(strategyUpdates).length > 0
+    ) {
+      updateData.agentConfig = this.mergeBrandKitAgentConfig(
+        brand.agentConfig,
+        voiceUpdates,
+        strategyUpdates,
+      );
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await this.patch(brandId, updateData as Partial<UpdateBrandDto>);
+    }
+
+    const hasBlockingDiagnostic = diagnostics.some(
+      (diagnostic) => diagnostic.severity === 'error',
+    );
+
+    return {
+      appliedFields,
+      brandId,
+      diagnostics,
+      preservedFields,
+      status:
+        hasBlockingDiagnostic && appliedFields.length === 0
+          ? 'blocked'
+          : diagnostics.length > 0 || preservedFields.length > 0
+            ? 'partial'
+            : 'accepted',
+    };
+  }
+
+  private isBrandKitFieldKey(value: string): value is BrandKitFieldKey {
+    return BRAND_KIT_FIELD_KEYS.has(value as BrandKitFieldKey);
+  }
+
+  private coerceBrandKitApplyValue(
+    key: BrandKitFieldKey,
+    value: unknown,
+  ): string | string[] | undefined {
+    if (key === 'fontFamily') {
+      return this.coerceBrandKitFontFamily(value);
+    }
+
+    if (BRAND_KIT_STRING_LIST_FIELDS.has(key)) {
+      return this.coerceBrandKitStringList(value);
+    }
+
+    return this.coerceBrandKitString(value);
+  }
+
+  private coerceBrandKitString(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private coerceBrandKitFontFamily(value: unknown): string | undefined {
+    const normalized = this.coerceBrandKitString(value)
+      ?.toLowerCase()
+      .replaceAll('_', '-');
+
+    if (!normalized) {
+      return undefined;
+    }
+
+    return SUPPORTED_FONT_FAMILIES.has(normalized) ? normalized : undefined;
+  }
+
+  private coerceBrandKitStringList(value: unknown): string[] | undefined {
+    const values = Array.isArray(value)
+      ? value
+      : typeof value === 'string'
+        ? value.split(/[\n,]+/)
+        : [];
+
+    const normalized = values
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(
+        (item, index, all) => item.length > 0 && all.indexOf(item) === index,
+      );
+
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  private toBrandKitRecord(value: unknown): Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? { ...(value as Record<string, unknown>) }
+      : {};
+  }
+
+  private mergeBrandKitAgentConfig(
+    currentAgentConfig: unknown,
+    voiceUpdates: Record<string, unknown>,
+    strategyUpdates: Record<string, unknown>,
+  ): Prisma.InputJsonValue {
+    const currentConfig = this.toBrandKitRecord(currentAgentConfig);
+    const nextConfig: Record<string, unknown> = { ...currentConfig };
+
+    if (Object.keys(voiceUpdates).length > 0) {
+      nextConfig.voice = {
+        ...this.toBrandKitRecord(currentConfig.voice),
+        ...(voiceUpdates as Partial<BrandAgentVoice>),
+      };
+    }
+
+    if (Object.keys(strategyUpdates).length > 0) {
+      nextConfig.strategy = {
+        ...this.toBrandKitRecord(currentConfig.strategy),
+        ...(strategyUpdates as Partial<BrandAgentStrategy>),
+      };
+    }
+
+    return nextConfig as Prisma.InputJsonValue;
   }
 
   private mergeSocialUrlsIntoScrape(

--- a/packages/pages/brands/components/brand-kit/BrandKitReviewCard.test.tsx
+++ b/packages/pages/brands/components/brand-kit/BrandKitReviewCard.test.tsx
@@ -1,0 +1,317 @@
+import type { IBrand, IBrandKitDraft } from '@genfeedai/interfaces';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BrandKitReviewCard from './BrandKitReviewCard';
+
+const mocks = vi.hoisted(() => ({
+  applyBrandKitDraft: vi.fn(),
+  crawlBrandKitWebsite: vi.fn(),
+  getBrandsService: vi.fn(),
+  loggerError: vi.fn(),
+  onRefreshBrand: vi.fn(),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getBrandsService,
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: {
+    error: mocks.loggerError,
+  },
+}));
+
+vi.mock('@services/social/brands.service', () => ({
+  BrandsService: {
+    getInstance: vi.fn(),
+  },
+}));
+
+vi.mock('@ui/card/Card', () => ({
+  default: ({
+    children,
+    description,
+    label,
+  }: {
+    children: ReactNode;
+    description?: string;
+    label?: string;
+  }) => (
+    <section>
+      {label ? <h2>{label}</h2> : null}
+      {description ? <p>{description}</p> : null}
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    isDisabled,
+    label,
+    onClick,
+  }: {
+    children?: ReactNode;
+    isDisabled?: boolean;
+    label?: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button disabled={isDisabled} type="button" onClick={onClick}>
+      {children ?? label}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: ({
+    label,
+    onChange,
+    placeholder,
+    value,
+  }: {
+    label?: string;
+    onChange?: (event: { target: { value: string } }) => void;
+    placeholder?: string;
+    value?: string;
+  }) => (
+    <label>
+      {label}
+      <input
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange?.(event)}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@ui/primitives/textarea', () => ({
+  Textarea: ({
+    'aria-label': ariaLabel,
+    id,
+    onChange,
+    placeholder,
+    value,
+  }: {
+    'aria-label'?: string;
+    id?: string;
+    onChange?: (event: { target: { value: string } }) => void;
+    placeholder?: string;
+    value?: string;
+  }) => (
+    <textarea
+      aria-label={ariaLabel}
+      id={id}
+      placeholder={placeholder}
+      value={value}
+      onChange={(event) => onChange?.(event)}
+    />
+  ),
+}));
+
+vi.mock('@ui/primitives/checkbox', () => ({
+  Checkbox: ({
+    'aria-label': ariaLabel,
+    isChecked,
+    label,
+    onCheckedChange,
+  }: {
+    'aria-label'?: string;
+    isChecked?: boolean;
+    label?: ReactNode;
+    onCheckedChange?: (checked: boolean) => void;
+  }) => (
+    <label>
+      <input
+        aria-label={ariaLabel}
+        checked={isChecked}
+        type="checkbox"
+        onChange={(event) => onCheckedChange?.(event.target.checked)}
+      />
+      {label}
+    </label>
+  ),
+}));
+
+function createDraft(): IBrandKitDraft {
+  return {
+    assetCandidates: [
+      {
+        candidateId: 'candidate-logo',
+        label: 'Website logo',
+        role: 'logo',
+        sourceType: 'website',
+        sourceUrl: 'https://acme.test/logo.png',
+        url: 'https://acme.test/logo.png',
+        width: 512,
+        height: 512,
+      },
+    ],
+    brandId: 'brand-1',
+    diagnostics: [],
+    evidence: [],
+    fields: {
+      description: {
+        applyActionDefault: 'preserve',
+        currentValue: 'Old description',
+        diagnostics: [],
+        evidence: [],
+        group: 'profile',
+        key: 'description',
+        label: 'Description',
+        ownerPath: 'brand.description',
+        proposedValue: 'New description',
+      },
+      logo: {
+        applyActionDefault: 'preserve',
+        currentValue: undefined,
+        diagnostics: [],
+        evidence: [],
+        group: 'assets',
+        key: 'logo',
+        label: 'Logo',
+        ownerPath: 'brand.logo',
+        proposedValue: {
+          role: 'logo',
+          sourceType: 'website',
+          url: 'https://acme.test/logo.png',
+        },
+      },
+      voiceTone: {
+        applyActionDefault: 'preserve',
+        currentValue: 'plain',
+        diagnostics: [],
+        evidence: [],
+        group: 'voice',
+        key: 'voiceTone',
+        label: 'Voice tone',
+        ownerPath: 'brand.agentConfig.voice.tone',
+        proposedValue: 'sharp',
+      },
+    },
+    readiness: {
+      diagnostics: [],
+      missingFields: ['banner'],
+      requiredFields: ['description', 'logo', 'banner'],
+      score: 67,
+      status: 'partial',
+    },
+    sourceType: 'website',
+    status: 'partial',
+  };
+}
+
+const brandFixture = {
+  id: 'brand-1',
+  label: 'Acme',
+} as IBrand;
+
+describe('BrandKitReviewCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.crawlBrandKitWebsite.mockResolvedValue(createDraft());
+    mocks.applyBrandKitDraft.mockResolvedValue({
+      appliedFields: ['description', 'voiceTone'],
+      brandId: 'brand-1',
+      diagnostics: [
+        {
+          code: 'brand_kit_apply_deferred_field',
+          fieldKey: 'logo',
+          message: 'Logo import is preserved for safe asset handling.',
+          severity: 'warning',
+        },
+      ],
+      preservedFields: ['logo'],
+      status: 'partial',
+    });
+    mocks.getBrandsService.mockResolvedValue({
+      applyBrandKitDraft: mocks.applyBrandKitDraft,
+      crawlBrandKitWebsite: mocks.crawlBrandKitWebsite,
+    });
+    mocks.onRefreshBrand.mockResolvedValue(undefined);
+  });
+
+  it('scans, reviews editable fields, and applies selected fields', async () => {
+    render(
+      <BrandKitReviewCard
+        brand={brandFixture}
+        brandId="brand-1"
+        onRefreshBrand={mocks.onRefreshBrand}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Website URL'), {
+      target: { value: 'https://acme.test' },
+    });
+    fireEvent.change(screen.getByLabelText('Social URLs'), {
+      target: { value: 'https://linkedin.com/company/acme' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Scan Website' }));
+
+    await waitFor(() => {
+      expect(mocks.crawlBrandKitWebsite).toHaveBeenCalledWith('brand-1', {
+        socialUrls: ['https://linkedin.com/company/acme'],
+        url: 'https://acme.test',
+      });
+    });
+
+    expect(screen.getByText('67% readiness')).toBeInTheDocument();
+    expect(screen.getByText('Safe import pending')).toBeInTheDocument();
+    expect(screen.getByText(/candidate-logo/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Description proposed value'), {
+      target: { value: 'Edited description' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Apply Selected Fields' }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.applyBrandKitDraft).toHaveBeenCalledWith('brand-1', {
+        draftId: undefined,
+        fields: {
+          description: {
+            action: 'accept',
+            value: 'Edited description',
+          },
+          voiceTone: {
+            action: 'accept',
+            value: 'sharp',
+          },
+        },
+      });
+      expect(mocks.onRefreshBrand).toHaveBeenCalled();
+    });
+  });
+
+  it('does not apply deferred asset fields by default', async () => {
+    render(
+      <BrandKitReviewCard
+        brand={brandFixture}
+        brandId="brand-1"
+        onRefreshBrand={mocks.onRefreshBrand}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Website URL'), {
+      target: { value: 'https://acme.test' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Scan Website' }));
+
+    await screen.findByText('Logo');
+
+    expect(screen.queryByLabelText('Apply Logo')).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Apply Selected Fields' }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.applyBrandKitDraft).toHaveBeenCalled();
+    });
+
+    const applyPayload = mocks.applyBrandKitDraft.mock.calls[0]?.[1];
+    expect(applyPayload.fields.logo).toBeUndefined();
+  });
+});

--- a/packages/pages/brands/components/brand-kit/BrandKitReviewCard.tsx
+++ b/packages/pages/brands/components/brand-kit/BrandKitReviewCard.tsx
@@ -1,0 +1,591 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import {
+  BRAND_KIT_FIELD_OWNERSHIP,
+  type BrandKitFieldGroup,
+  type BrandKitFieldKey,
+  type IBrandKitApplyResult,
+  type IBrandKitAssetCandidate,
+  type IBrandKitDiagnostic,
+  type IBrandKitDraft,
+  type IBrandKitDraftField,
+} from '@genfeedai/interfaces';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import type { BrandKitReviewCardProps } from '@props/pages/brand-detail.props';
+import { logger } from '@services/core/logger.service';
+import { BrandsService } from '@services/social/brands.service';
+import Card from '@ui/card/Card';
+import { Button } from '@ui/primitives/button';
+import { Checkbox } from '@ui/primitives/checkbox';
+import { Input } from '@ui/primitives/input';
+import { Textarea } from '@ui/primitives/textarea';
+import { useCallback, useMemo, useState } from 'react';
+
+const FIELD_GROUP_LABELS: Record<BrandKitFieldGroup, string> = {
+  assets: 'Assets',
+  links: 'Links',
+  profile: 'Profile',
+  strategy: 'Strategy',
+  visual: 'Visual',
+  voice: 'Voice',
+};
+
+const FIELD_GROUP_ORDER: readonly BrandKitFieldGroup[] = [
+  'profile',
+  'visual',
+  'voice',
+  'strategy',
+  'links',
+  'assets',
+];
+
+const DEFERRED_REVIEW_FIELDS = new Set<BrandKitFieldKey>([
+  'banner',
+  'logo',
+  'references',
+  'socialLinks',
+]);
+
+const STRING_LIST_FIELDS = new Set<BrandKitFieldKey>([
+  'strategyContentTypes',
+  'strategyGoals',
+  'strategyPlatforms',
+  'voiceAudience',
+  'voiceDoNotSoundLike',
+  'voiceMessagingPillars',
+  'voiceValues',
+]);
+
+type BrandKitFieldValues = Partial<Record<BrandKitFieldKey, string>>;
+
+type BrandKitGroupedField = {
+  field: IBrandKitDraftField;
+  key: BrandKitFieldKey;
+};
+
+function hasObjectValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function formatBrandKitObject(value: Record<string, unknown>): string {
+  const label = typeof value.label === 'string' ? value.label : '';
+  const url = typeof value.url === 'string' ? value.url : '';
+  const platform = typeof value.platform === 'string' ? value.platform : '';
+  const role = typeof value.role === 'string' ? value.role : '';
+  const dimensions =
+    typeof value.width === 'number' && typeof value.height === 'number'
+      ? `${value.width}x${value.height}`
+      : '';
+
+  return [label, platform, role, dimensions, url].filter(Boolean).join(' ');
+}
+
+function formatBrandKitValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) =>
+        hasObjectValue(entry) ? formatBrandKitObject(entry) : String(entry),
+      )
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  if (hasObjectValue(value)) {
+    return formatBrandKitObject(value);
+  }
+
+  return String(value);
+}
+
+function parseEditableValue(key: BrandKitFieldKey, value: string) {
+  if (!STRING_LIST_FIELDS.has(key)) {
+    return value.trim();
+  }
+
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseSocialUrls(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function hasProposedValue(field: IBrandKitDraftField): boolean {
+  return field.proposedValue !== undefined && field.proposedValue !== null;
+}
+
+function canApplyField(key: BrandKitFieldKey, field: IBrandKitDraftField) {
+  return hasProposedValue(field) && !DEFERRED_REVIEW_FIELDS.has(key);
+}
+
+function getDiagnostics(
+  draft: IBrandKitDraft | null,
+  applyResult: IBrandKitApplyResult | null,
+): IBrandKitDiagnostic[] {
+  return [
+    ...(draft?.diagnostics ?? []),
+    ...(draft?.readiness.diagnostics ?? []),
+    ...(applyResult?.diagnostics ?? []),
+  ];
+}
+
+function getAssetCandidateSummary(candidate: IBrandKitAssetCandidate): string {
+  return [
+    candidate.candidateId,
+    candidate.role,
+    candidate.label,
+    candidate.width && candidate.height
+      ? `${candidate.width}x${candidate.height}`
+      : '',
+    candidate.sourceUrl ?? candidate.url,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export default function BrandKitReviewCard({
+  brand,
+  brandId,
+  onRefreshBrand,
+}: BrandKitReviewCardProps) {
+  const getBrandsService = useAuthedService((token: string) =>
+    BrandsService.getInstance(token),
+  );
+  const [websiteUrl, setWebsiteUrl] = useState('');
+  const [socialUrls, setSocialUrls] = useState('');
+  const [draft, setDraft] = useState<IBrandKitDraft | null>(null);
+  const [fieldValues, setFieldValues] = useState<BrandKitFieldValues>({});
+  const [selectedFields, setSelectedFields] = useState<Set<BrandKitFieldKey>>(
+    new Set(),
+  );
+  const [applyResult, setApplyResult] = useState<IBrandKitApplyResult | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isScanning, setIsScanning] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+
+  const groupedFields = useMemo(() => {
+    const groups = new Map<BrandKitFieldGroup, BrandKitGroupedField[]>();
+
+    for (const group of FIELD_GROUP_ORDER) {
+      groups.set(group, []);
+    }
+
+    if (!draft) {
+      return groups;
+    }
+
+    for (const owner of BRAND_KIT_FIELD_OWNERSHIP) {
+      const field = draft.fields[owner.key];
+
+      if (field) {
+        groups.get(owner.group)?.push({ field, key: owner.key });
+      }
+    }
+
+    return groups;
+  }, [draft]);
+
+  const diagnostics = useMemo(
+    () => getDiagnostics(draft, applyResult),
+    [applyResult, draft],
+  );
+
+  const selectedApplyCount = useMemo(() => {
+    if (!draft) {
+      return 0;
+    }
+
+    return Array.from(selectedFields).filter((key) => {
+      const field = draft.fields[key];
+      return field ? canApplyField(key, field) : false;
+    }).length;
+  }, [draft, selectedFields]);
+
+  const initializeDraftReview = useCallback((nextDraft: IBrandKitDraft) => {
+    const nextValues: BrandKitFieldValues = {};
+    const nextSelected = new Set<BrandKitFieldKey>();
+
+    for (const owner of BRAND_KIT_FIELD_OWNERSHIP) {
+      const field = nextDraft.fields[owner.key];
+
+      if (!field) {
+        continue;
+      }
+
+      nextValues[owner.key] = formatBrandKitValue(
+        field.proposedValue ?? field.currentValue,
+      );
+
+      if (canApplyField(owner.key, field)) {
+        nextSelected.add(owner.key);
+      }
+    }
+
+    setFieldValues(nextValues);
+    setSelectedFields(nextSelected);
+  }, []);
+
+  const handleScan = useCallback(async () => {
+    const url = websiteUrl.trim();
+
+    if (!url) {
+      setError('Enter a website URL before scanning.');
+      return;
+    }
+
+    setIsScanning(true);
+    setError(null);
+    setApplyResult(null);
+
+    try {
+      const service = await getBrandsService();
+      const nextDraft = await service.crawlBrandKitWebsite(brandId, {
+        socialUrls: parseSocialUrls(socialUrls),
+        url,
+      });
+
+      setDraft(nextDraft);
+      initializeDraftReview(nextDraft);
+    } catch (scanError) {
+      logger.error('Failed to crawl brand kit website', scanError);
+      setError('Failed to scan website for brand kit fields.');
+    } finally {
+      setIsScanning(false);
+    }
+  }, [
+    brandId,
+    getBrandsService,
+    initializeDraftReview,
+    socialUrls,
+    websiteUrl,
+  ]);
+
+  const handleToggleField = useCallback(
+    (key: BrandKitFieldKey, checked: boolean) => {
+      setSelectedFields((current) => {
+        const next = new Set(current);
+
+        if (checked) {
+          next.add(key);
+        } else {
+          next.delete(key);
+        }
+
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleFieldValueChange = useCallback(
+    (key: BrandKitFieldKey, value: string) => {
+      setFieldValues((current) => ({
+        ...current,
+        [key]: value,
+      }));
+    },
+    [],
+  );
+
+  const handleApply = useCallback(async () => {
+    if (!draft || selectedApplyCount === 0) {
+      setError('Select at least one supported field to apply.');
+      return;
+    }
+
+    setIsApplying(true);
+    setError(null);
+
+    try {
+      const fields = Array.from(selectedFields).reduce<
+        NonNullable<
+          Parameters<BrandsService['applyBrandKitDraft']>[1]
+        >['fields']
+      >((acc, key) => {
+        const field = draft.fields[key];
+
+        if (field && canApplyField(key, field)) {
+          acc[key] = {
+            action: 'accept',
+            value: parseEditableValue(key, fieldValues[key] ?? ''),
+          };
+        }
+
+        return acc;
+      }, {});
+
+      const service = await getBrandsService();
+      const result = await service.applyBrandKitDraft(brandId, {
+        draftId: draft.id,
+        fields,
+      });
+
+      setApplyResult(result);
+      await onRefreshBrand();
+    } catch (applyError) {
+      logger.error('Failed to apply brand kit draft', applyError);
+      setError('Failed to apply selected brand kit fields.');
+    } finally {
+      setIsApplying(false);
+    }
+  }, [
+    brandId,
+    draft,
+    fieldValues,
+    getBrandsService,
+    onRefreshBrand,
+    selectedApplyCount,
+    selectedFields,
+  ]);
+
+  return (
+    <Card
+      className="p-6"
+      data-testid="brand-kit-review-card"
+      label="Brand Kit Review"
+      description="Scan the brand website, compare proposed fields, and apply selected profile guidance."
+    >
+      <div className="space-y-5">
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+          <Input
+            label="Website URL"
+            placeholder="https://example.com"
+            value={websiteUrl}
+            onChange={(event) => setWebsiteUrl(event.target.value)}
+          />
+
+          <Button
+            className="w-full md:w-auto"
+            isDisabled={!websiteUrl.trim()}
+            isLoading={isScanning}
+            label={draft ? 'Rescan' : 'Scan Website'}
+            onClick={() => void handleScan()}
+          />
+        </div>
+
+        <div>
+          <label
+            className="mb-1 block text-sm font-medium"
+            htmlFor="brand-kit-social-urls"
+          >
+            Social URLs
+          </label>
+          <Textarea
+            id="brand-kit-social-urls"
+            className="min-h-[72px]"
+            placeholder="https://linkedin.com/company/example"
+            value={socialUrls}
+            onChange={(event) => setSocialUrls(event.target.value)}
+          />
+        </div>
+
+        {error ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        {draft ? (
+          <div className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-medium">
+                {draft.readiness.score}% readiness
+              </span>
+              <span className="rounded-full bg-background px-2 py-0.5 text-xs text-muted-foreground">
+                {draft.readiness.status}
+              </span>
+            </div>
+            {draft.readiness.missingFields.length > 0 ? (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Missing: {draft.readiness.missingFields.join(', ')}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        {draft ? (
+          <div className="space-y-5">
+            {FIELD_GROUP_ORDER.map((group) => {
+              const fields = groupedFields.get(group) ?? [];
+
+              if (fields.length === 0) {
+                return null;
+              }
+
+              return (
+                <section key={group} className="space-y-3">
+                  <h3 className="text-sm font-semibold">
+                    {FIELD_GROUP_LABELS[group]}
+                  </h3>
+
+                  <div className="space-y-3">
+                    {fields.map(({ field, key }) => {
+                      const isDeferred = DEFERRED_REVIEW_FIELDS.has(key);
+                      const isSelectable = canApplyField(key, field);
+                      const proposedValue = formatBrandKitValue(
+                        field.proposedValue,
+                      );
+                      const currentValue = formatBrandKitValue(
+                        field.currentValue,
+                      );
+
+                      return (
+                        <div
+                          key={key}
+                          className="rounded-md border border-border p-3"
+                        >
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                              <div className="font-medium">{field.label}</div>
+                              <div className="mt-1 text-xs text-muted-foreground">
+                                Confidence:{' '}
+                                {field.confidence
+                                  ? `${Math.round(field.confidence * 100)}%`
+                                  : 'not scored'}
+                              </div>
+                            </div>
+
+                            {isSelectable ? (
+                              <Checkbox
+                                aria-label={`Apply ${field.label}`}
+                                isChecked={selectedFields.has(key)}
+                                label="Apply"
+                                onCheckedChange={(checked) =>
+                                  handleToggleField(key, checked === true)
+                                }
+                              />
+                            ) : (
+                              <span className="rounded-full bg-background-secondary px-2 py-1 text-xs text-muted-foreground">
+                                {isDeferred
+                                  ? 'Safe import pending'
+                                  : 'Review only'}
+                              </span>
+                            )}
+                          </div>
+
+                          <div className="mt-3 grid gap-3 md:grid-cols-2">
+                            <div>
+                              <div className="mb-1 text-xs font-medium text-muted-foreground">
+                                Current
+                              </div>
+                              <pre className="min-h-12 whitespace-pre-wrap rounded-md bg-background-secondary p-2 text-xs">
+                                {currentValue || 'Empty'}
+                              </pre>
+                            </div>
+
+                            <div>
+                              <div className="mb-1 text-xs font-medium text-muted-foreground">
+                                Proposed
+                              </div>
+                              {isSelectable && selectedFields.has(key) ? (
+                                <Textarea
+                                  aria-label={`${field.label} proposed value`}
+                                  className="min-h-[72px]"
+                                  value={fieldValues[key] ?? proposedValue}
+                                  onChange={(event) =>
+                                    handleFieldValueChange(
+                                      key,
+                                      event.target.value,
+                                    )
+                                  }
+                                />
+                              ) : (
+                                <pre className="min-h-12 whitespace-pre-wrap rounded-md bg-background-secondary p-2 text-xs">
+                                  {proposedValue || 'No proposal'}
+                                </pre>
+                              )}
+                            </div>
+                          </div>
+
+                          {field.diagnostics.length > 0 ? (
+                            <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+                              {field.diagnostics.map((diagnostic) => (
+                                <li key={`${key}-${diagnostic.code}`}>
+                                  {diagnostic.message}
+                                </li>
+                              ))}
+                            </ul>
+                          ) : null}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              );
+            })}
+
+            {draft.assetCandidates.length > 0 ? (
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">Asset Candidates</h3>
+                <ul className="space-y-1 text-xs text-muted-foreground">
+                  {draft.assetCandidates.map((candidate) => (
+                    <li key={candidate.candidateId}>
+                      {getAssetCandidateSummary(candidate)}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            {diagnostics.length > 0 ? (
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">Diagnostics</h3>
+                <ul className="space-y-1 text-xs text-muted-foreground">
+                  {diagnostics.map((diagnostic) => (
+                    <li key={`${diagnostic.code}-${diagnostic.fieldKey ?? ''}`}>
+                      {diagnostic.message}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            {applyResult ? (
+              <div className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm">
+                Applied {applyResult.appliedFields.length} fields; preserved{' '}
+                {applyResult.preservedFields.length}. Status:{' '}
+                {applyResult.status}.
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+              <p className="text-xs text-muted-foreground">
+                {selectedApplyCount} supported fields selected. Assets and
+                social links are reviewed here and preserved for the safe import
+                flow.
+              </p>
+              <Button
+                isDisabled={selectedApplyCount === 0}
+                isLoading={isApplying}
+                label="Apply Selected Fields"
+                onClick={() => void handleApply()}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+            No brand kit draft loaded for {brand.label}.
+          </div>
+        )}
+
+        <Button
+          label="Refresh Brand"
+          variant={ButtonVariant.SECONDARY}
+          onClick={() => void onRefreshBrand()}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/packages/pages/vitest.config.ts
+++ b/packages/pages/vitest.config.ts
@@ -270,6 +270,7 @@ export default defineConfig({
     globals: true,
     include: [
       'packages/pages/analytics/overview/analytics-overview.test.tsx',
+      'brands/components/**/*.test.tsx',
       'studio/generate/utils/**/*.test.ts',
       'studio/fastlane/**/*.test.ts',
       'studio/fastlane/**/*.test.tsx',

--- a/packages/props/pages/brand-detail.props.ts
+++ b/packages/props/pages/brand-detail.props.ts
@@ -92,6 +92,12 @@ export interface BrandDetailIdentityCardProps {
   onRefreshBrand: () => Promise<void>;
 }
 
+export interface BrandKitReviewCardProps {
+  brand: IBrand;
+  brandId: string;
+  onRefreshBrand: () => Promise<void>;
+}
+
 export interface BrandDetailReferencesCardProps {
   brand: IBrand;
   deletingRefId: string | null;

--- a/packages/services/social/brands.service.test.ts
+++ b/packages/services/social/brands.service.test.ts
@@ -50,7 +50,10 @@ vi.mock('@services/core/base.service', () => {
       return new (MockBaseService as new (token: string) => unknown)(token);
     }
 
-    static getDataServiceInstance(ServiceClass: any, ...args: any[]) {
+    static getDataServiceInstance<T>(
+      ServiceClass: new (...args: unknown[]) => T,
+      ...args: unknown[]
+    ) {
       return new ServiceClass(...args);
     }
   }
@@ -191,6 +194,69 @@ describe('BrandsService', () => {
       await service.findBrandAnalytics(mockBrandId);
 
       expect(mockGet).toHaveBeenCalledWith(`/${mockBrandId}/analytics`);
+    });
+  });
+
+  describe('brand kit review endpoints', () => {
+    it('posts website crawl input and unwraps the draft payload', async () => {
+      const draft = {
+        assetCandidates: [],
+        brandId: mockBrandId,
+        diagnostics: [],
+        evidence: [],
+        fields: {},
+        readiness: {
+          diagnostics: [],
+          missingFields: [],
+          requiredFields: [],
+          score: 80,
+          status: 'partial',
+        },
+        sourceType: 'website',
+        status: 'partial',
+      };
+      mockPost.mockResolvedValue({ data: { data: draft } });
+
+      const result = await service.crawlBrandKitWebsite(mockBrandId, {
+        socialUrls: ['https://linkedin.com/company/acme'],
+        url: 'https://acme.test',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(`/${mockBrandId}/brand-kit/crawl`, {
+        socialUrls: ['https://linkedin.com/company/acme'],
+        url: 'https://acme.test',
+      });
+      expect(result).toEqual(draft);
+    });
+
+    it('posts selected field decisions and unwraps the apply result', async () => {
+      const applyResult = {
+        appliedFields: ['description'],
+        brandId: mockBrandId,
+        diagnostics: [],
+        preservedFields: [],
+        status: 'accepted',
+      };
+      mockPost.mockResolvedValue({ data: { data: applyResult } });
+
+      const result = await service.applyBrandKitDraft(mockBrandId, {
+        fields: {
+          description: {
+            action: 'accept',
+            value: 'Imported description',
+          },
+        },
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(`/${mockBrandId}/brand-kit/apply`, {
+        fields: {
+          description: {
+            action: 'accept',
+            value: 'Imported description',
+          },
+        },
+      });
+      expect(result).toEqual(applyResult);
     });
   });
 

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -6,6 +6,9 @@ import type {
   IActivity,
   IAnalytics,
   IArticle,
+  IBrandKitApplyRequest,
+  IBrandKitApplyResult,
+  IBrandKitDraft,
   IImage,
   IPost,
   IQueryParams,
@@ -253,6 +256,27 @@ export class BrandsService extends BaseService<Brand> {
     },
   ): Promise<void> {
     await this.instance.patch(`/${id}/agent-config`, data);
+  }
+
+  public async crawlBrandKitWebsite(
+    id: string,
+    data: {
+      socialUrls?: string[];
+      url: string;
+    },
+  ): Promise<IBrandKitDraft> {
+    return await this.instance
+      .post<{ data: IBrandKitDraft }>(`/${id}/brand-kit/crawl`, data)
+      .then((res) => res.data.data);
+  }
+
+  public async applyBrandKitDraft(
+    id: string,
+    data: Omit<IBrandKitApplyRequest, 'brandId'>,
+  ): Promise<IBrandKitApplyResult> {
+    return await this.instance
+      .post<{ data: IBrandKitApplyResult }>(`/${id}/brand-kit/apply`, data)
+      .then((res) => res.data.data);
   }
 
   public async findBrandAnalytics(

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../interfaces/src/$1'),
       },
       {
+        find: '@genfeedai/pricing',
+        replacement: path.resolve(__dirname, '../pricing/src/index.ts'),
+      },
+      {
         find: '@genfeedai/models',
         replacement: path.resolve(__dirname, '../models'),
       },


### PR DESCRIPTION
## Summary
- Adds a Brand Kit Review card on brand settings for website/social URL scans, field-by-field review, editable supported values, and apply flow.
- Adds the API apply endpoint for selected scalar, voice, strategy, and prompt-guideline fields.
- Keeps logo, banner, reference assets, and social links visible but preserved with diagnostics until the safe asset/link import slice ships.
- Adds client service methods and focused unit coverage for API, service, page wiring, and review-card behavior.

Closes #774
Refs #770

## Validation
- `bunx vitest run --config vitest.config.ts src/collections/brands/controllers/brands.controller.spec.ts src/collections/brands/services/brands.service.spec.ts`
- `bunx vitest run --config vitest.config.ts social/brands.service.test.ts`
- `bunx vitest run --config vitest.config.ts brands/components/brand-kit/BrandKitReviewCard.test.tsx`
- `bunx vitest run --config ./vitest.config.mts app/(protected)/[orgSlug]/[brandSlug]/settings/brand-detail.test.tsx`
- `bunx turbo run type-check --filter=@genfeedai/services --filter=@genfeedai/props`
- `bunx turbo run type-check --filter=@genfeedai/app`
- `bunx turbo run build --filter=@genfeedai/api`
- `bun run audit:api`
- `bun run design:check`
- `bunx biome check <touched files>`
- `git diff --check`
- `bunx secretlint <changed files>`

## Notes
- Direct `tsc -p packages/pages/tsconfig.json --noEmit` still fails on the package's existing unresolved monorepo alias surface; the app type-check covers the imported review-card path.