### PR TITLE
Wire clip result handoffs

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import type { ClipResult } from '@props/studio/clips.props';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import ClipResultCard, { type ClipResult } from './ClipResultCard';
+import ClipResultCard from './ClipResultCard';
 import '@testing-library/jest-dom/vitest';
 
 const pushSpy = vi.fn();
@@ -8,6 +9,12 @@ const pushSpy = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: pushSpy,
+  }),
+}));
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    href: (path: string) => `/acme/brand${path}`,
   }),
 }));
 
@@ -30,8 +37,29 @@ function makeClip(overrides?: Partial<ClipResult>): ClipResult {
 }
 
 describe('ClipResultCard', () => {
-  const mockGetToken = vi.fn().mockResolvedValue('test-token');
-  const apiEndpoint = 'https://api.example.com';
+  const clipsService = {
+    createEditorHandoff: vi.fn().mockResolvedValue({
+      editorPath: '/editor/editor-1',
+      editorProjectId: 'editor-1',
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    }),
+    createPublishHandoff: vi.fn().mockResolvedValue({
+      payload: {
+        assets: [
+          {
+            assetId: 'clip-1',
+            mediaUrl: 'https://cdn.example.com/video.mp4',
+            mimeType: 'video/mp4',
+          },
+        ],
+        metadata: {
+          clipResultId: 'clip-1',
+          summary: 'Clip summary for publish handoff',
+          title: 'My Great Clip',
+        },
+      },
+    }),
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,8 +69,8 @@ describe('ClipResultCard', () => {
     render(
       <ClipResultCard
         clip={makeClip()}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
@@ -54,8 +82,8 @@ describe('ClipResultCard', () => {
     render(
       <ClipResultCard
         clip={makeClip({ status: 'extracting' })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
@@ -66,8 +94,8 @@ describe('ClipResultCard', () => {
     const { rerender } = render(
       <ClipResultCard
         clip={makeClip({ status: 'pending' })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
@@ -77,11 +105,18 @@ describe('ClipResultCard', () => {
     rerender(
       <ClipResultCard
         clip={makeClip({
+          readiness: {
+            blockingReasons: [],
+            readyActions: ['download', 'edit', 'publish'],
+            state: 'ready',
+            terminal: true,
+            terminalAt: '2026-06-30T00:00:00Z',
+          },
           status: 'completed',
           videoUrl: 'https://cdn.example.com/video.mp4',
         })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
@@ -89,39 +124,100 @@ describe('ClipResultCard', () => {
     expect(screen.getByText('Publish')).toBeInTheDocument();
   });
 
-  it('should navigate to publish page with correct params when Publish is clicked', () => {
+  it('should create publish handoff before navigating to compose', async () => {
     render(
       <ClipResultCard
         clip={makeClip({
+          readiness: {
+            blockingReasons: [],
+            readyActions: ['download', 'edit', 'publish'],
+            state: 'ready',
+            terminal: true,
+            terminalAt: '2026-06-30T00:00:00Z',
+          },
           status: 'completed',
           summary: 'Clip summary for publish handoff',
           title: 'My Great Clip',
           videoUrl: 'https://cdn.example.com/video.mp4',
         })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
     fireEvent.click(screen.getByText('Publish'));
 
-    expect(pushSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/compose/post?'),
+    await waitFor(() =>
+      expect(clipsService.createPublishHandoff).toHaveBeenCalledWith(
+        'project-1',
+        'clip-1',
+      ),
     );
     expect(pushSpy).toHaveBeenCalledWith(
-      expect.stringContaining('title=My+Great+Clip'),
+      expect.stringContaining('/acme/brand/compose/post?'),
     );
-    expect(pushSpy).toHaveBeenCalledWith(
-      expect.stringContaining('description=Clip+summary+for+publish+handoff'),
+  });
+
+  it('should create editor handoff before navigating to the editor project', async () => {
+    render(
+      <ClipResultCard
+        clip={makeClip({
+          readiness: {
+            blockingReasons: [],
+            readyActions: ['download', 'edit', 'publish'],
+            state: 'ready',
+            terminal: true,
+            terminalAt: '2026-06-30T00:00:00Z',
+          },
+          status: 'completed',
+          videoUrl: 'https://cdn.example.com/video.mp4',
+        })}
+        clipsService={clipsService as never}
+        projectId="project-1"
+      />,
     );
+
+    fireEvent.click(screen.getByText('Edit'));
+
+    await waitFor(() =>
+      expect(clipsService.createEditorHandoff).toHaveBeenCalledWith(
+        'project-1',
+        'clip-1',
+      ),
+    );
+    expect(pushSpy).toHaveBeenCalledWith('/acme/brand/editor/editor-1');
+  });
+
+  it('should respect ready actions when readiness metadata is present', () => {
+    render(
+      <ClipResultCard
+        clip={makeClip({
+          readiness: {
+            blockingReasons: [],
+            readyActions: ['download'],
+            state: 'ready',
+            terminal: true,
+            terminalAt: '2026-06-30T00:00:00Z',
+          },
+          status: 'completed',
+          videoUrl: 'https://cdn.example.com/video.mp4',
+        })}
+        clipsService={clipsService as never}
+        projectId="project-1"
+      />,
+    );
+
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Publish')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Download video')).toBeInTheDocument();
   });
 
   it('should display virality score', () => {
     render(
       <ClipResultCard
         clip={makeClip({ viralityScore: 92 })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
@@ -132,8 +228,8 @@ describe('ClipResultCard', () => {
     render(
       <ClipResultCard
         clip={makeClip({ tags: ['ai', 'tech', 'startup', 'viral', 'growth'] })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 
@@ -148,8 +244,8 @@ describe('ClipResultCard', () => {
     render(
       <ClipResultCard
         clip={makeClip({ status: 'failed' })}
-        apiEndpoint={apiEndpoint}
-        getToken={mockGetToken}
+        clipsService={clipsService as never}
+        projectId="project-1"
       />,
     );
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
@@ -2,7 +2,9 @@
 
 import { COMPOSE_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant, ComponentSize } from '@genfeedai/enums';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type {
+  ClipReadyAction,
   ClipResult,
   ClipStatus,
   ViralityBadgeProps,
@@ -22,6 +24,7 @@ import type { ClipsApiService } from '../services/clips-api.service';
 interface ClipResultCardProps {
   clip: ClipResult;
   clipsService: ClipsApiService;
+  projectId: string;
 }
 
 const STATUS_CONFIG: Record<ClipStatus, { label: string; color: string }> = {
@@ -69,34 +72,71 @@ function formatDuration(seconds: number): string {
 export default function ClipResultCard({
   clip,
   clipsService,
+  projectId,
 }: ClipResultCardProps) {
   const { push } = useRouter();
+  const { href } = useOrgUrl();
   const statusConfig = STATUS_CONFIG[clip.status] || STATUS_CONFIG.pending;
-  const isReady = clip.status === 'completed';
   const videoUrl = clip.captionedVideoUrl || clip.videoUrl;
+  const canUseAction = useCallback(
+    (action: ClipReadyAction) => {
+      const readyActions = clip.readiness?.readyActions;
+
+      if (readyActions && readyActions.length > 0) {
+        return readyActions.includes(action);
+      }
+
+      return clip.status === 'completed';
+    },
+    [clip.readiness?.readyActions, clip.status],
+  );
+  const canEdit = Boolean(videoUrl && canUseAction('edit'));
+  const canPublish = Boolean(videoUrl && canUseAction('publish'));
+  const canDownload = Boolean(videoUrl && canUseAction('download'));
+  const hasReadyAction = canEdit || canPublish || canDownload;
 
   const handleEdit = useCallback(async () => {
     if (!videoUrl) return;
 
     try {
-      const editorProjectId = await clipsService.createEditorProject(videoUrl);
+      const handoff = await clipsService.createEditorHandoff(
+        projectId,
+        clip._id,
+      );
 
-      if (editorProjectId) {
-        push(`/editor/${editorProjectId}`);
-      }
+      push(href(handoff.editorPath));
     } catch {
-      // Fallback: navigate without creating editor project
-      push(`/editor/new?videoUrl=${encodeURIComponent(videoUrl)}`);
+      push(href('/editor'));
     }
-  }, [videoUrl, clipsService, push]);
+  }, [clip._id, projectId, videoUrl, clipsService, href, push]);
 
-  const handlePublish = useCallback(() => {
+  const handlePublish = useCallback(async () => {
+    const handoff = await clipsService.createPublishHandoff(
+      projectId,
+      clip._id,
+    );
+    const asset = handoff.payload.assets[0];
+    const title = handoff.payload.metadata?.title ?? clip.title;
+    const description =
+      handoff.payload.metadata?.summary ?? asset?.caption ?? clip.summary;
     const params = new URLSearchParams({
-      description: clip.summary,
-      title: clip.title,
+      clipProjectId: projectId,
+      clipResultId: handoff.payload.metadata?.clipResultId ?? clip._id,
+      description,
+      mediaUrl: asset?.mediaUrl ?? videoUrl ?? '',
+      title,
     });
-    push(`${COMPOSE_ROUTES.POST}?${params.toString()}`);
-  }, [clip.summary, clip.title, push]);
+    push(`${href(COMPOSE_ROUTES.POST)}?${params.toString()}`);
+  }, [
+    clip._id,
+    clip.summary,
+    clip.title,
+    projectId,
+    videoUrl,
+    clipsService,
+    href,
+    push,
+  ]);
 
   const handleDownload = useCallback(() => {
     if (!videoUrl) return;
@@ -165,40 +205,46 @@ export default function ClipResultCard({
       )}
 
       {/* Actions -- visible when ready */}
-      {isReady && videoUrl && (
+      {hasReadyAction && videoUrl && (
         <div className="mt-auto flex gap-2 pt-2">
-          <Button
-            variant={ButtonVariant.UNSTYLED}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-300 hover:bg-zinc-700"
-            onClick={handleEdit}
-            title="Edit in video editor"
-          >
-            <HiOutlinePencilSquare className="size-3.5" />
-            <span>Edit</span>
-          </Button>
-          <Button
-            variant={ButtonVariant.UNSTYLED}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-white hover:bg-primary"
-            onClick={handlePublish}
-            title="Publish to social platforms"
-          >
-            <HiOutlineRocketLaunch className="size-3.5" />
-            <span>Publish</span>
-          </Button>
-          <Button
-            variant={ButtonVariant.UNSTYLED}
-            className="flex items-center justify-center rounded-lg bg-zinc-800 px-2.5 py-2 text-zinc-300 hover:bg-zinc-700"
-            onClick={handleDownload}
-            aria-label="Download video"
-            title="Download video"
-          >
-            <HiOutlineArrowDownTray className="size-3.5" />
-          </Button>
+          {canEdit && (
+            <Button
+              variant={ButtonVariant.UNSTYLED}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-300 hover:bg-zinc-700"
+              onClick={handleEdit}
+              title="Edit in video editor"
+            >
+              <HiOutlinePencilSquare className="size-3.5" />
+              <span>Edit</span>
+            </Button>
+          )}
+          {canPublish && (
+            <Button
+              variant={ButtonVariant.UNSTYLED}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-white hover:bg-primary"
+              onClick={handlePublish}
+              title="Publish to social platforms"
+            >
+              <HiOutlineRocketLaunch className="size-3.5" />
+              <span>Publish</span>
+            </Button>
+          )}
+          {canDownload && (
+            <Button
+              variant={ButtonVariant.UNSTYLED}
+              className="flex items-center justify-center rounded-lg bg-zinc-800 px-2.5 py-2 text-zinc-300 hover:bg-zinc-700"
+              onClick={handleDownload}
+              aria-label="Download video"
+              title="Download video"
+            >
+              <HiOutlineArrowDownTray className="size-3.5" />
+            </Button>
+          )}
         </div>
       )}
 
       {/* Processing indicator */}
-      {!isReady && clip.status !== 'failed' && (
+      {!hasReadyAction && clip.status !== 'failed' && (
         <div className="mt-auto flex items-center justify-center pt-3">
           <Spinner size={ComponentSize.SM} className="text-primary/50" />
         </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
@@ -57,6 +57,7 @@ export default function ClipsProgressView({
               key={clip._id}
               clip={clip}
               clipsService={clipsService}
+              projectId={project.projectId}
             />
           ))}
         </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts
@@ -35,6 +35,28 @@ interface ProjectResponse {
   status?: string;
 }
 
+interface EditorHandoffResponse {
+  editorPath: string;
+  editorProjectId: string;
+  videoUrl: string;
+}
+
+interface PublishHandoffResponse {
+  payload: {
+    assets: Array<{
+      assetId: string;
+      caption?: string;
+      mediaUrl: string;
+      mimeType: string;
+    }>;
+    metadata?: {
+      clipResultId?: string;
+      summary?: string | null;
+      title?: string | null;
+    };
+  };
+}
+
 interface RewriteHighlightPayload {
   platform: string;
   tone: string;
@@ -233,5 +255,25 @@ export class ClipsApiService {
       },
     );
     return data?.data?.id ?? data?.data?._id;
+  }
+
+  async createEditorHandoff(
+    projectId: string,
+    clipResultId: string,
+  ): Promise<EditorHandoffResponse> {
+    return this.fetchJson<EditorHandoffResponse>(
+      `${this.apiEndpoint}/clip-projects/${projectId}/results/${clipResultId}/editor-handoff`,
+      { method: 'POST' },
+    );
+  }
+
+  async createPublishHandoff(
+    projectId: string,
+    clipResultId: string,
+  ): Promise<PublishHandoffResponse> {
+    return this.fetchJson<PublishHandoffResponse>(
+      `${this.apiEndpoint}/clip-projects/${projectId}/results/${clipResultId}/publish-handoff`,
+      { method: 'POST' },
+    );
   }
 }

--- a/apps/server/api/src/collections/clip-projects/clip-projects.controller.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.controller.spec.ts
@@ -5,10 +5,13 @@ import type { GenerateClipsDto } from '@api/collections/clip-projects/dto/genera
 import type { ClipProjectDocument } from '@api/collections/clip-projects/schemas/clip-project.schema';
 import type { ClipGenerationService } from '@api/collections/clip-projects/services/clip-generation.service';
 import type { HighlightRewriteService } from '@api/collections/clip-projects/services/highlight-rewrite.service';
+import type { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import type { EditorProjectsService } from '@api/collections/editor-projects/editor-projects.service';
 import { InsufficientCreditsException } from '@api/helpers/exceptions/business/business-logic.exception';
 import type { ClipAnalyzeQueueService } from '@api/queues/clip-analyze/clip-analyze.queue.service';
 import type { ClipFactoryQueueService } from '@api/queues/clip-factory/clip-factory-queue.service';
+import type { PublishHandoffService } from '@api/services/clip-orchestrator/publish-handoff.service';
 import type { LoggerService } from '@libs/logger/logger.service';
 import { plainToInstance } from 'class-transformer';
 import { validateSync } from 'class-validator';
@@ -25,12 +28,13 @@ function createMockLogger(): LoggerService {
 
 function createMockClipProjectsService(): Pick<
   ClipProjectsService,
-  'create' | 'findOne' | 'patch'
+  'create' | 'findOne' | 'patch' | 'reconcileTerminalState'
 > {
   return {
     create: vi.fn(),
     findOne: vi.fn(),
     patch: vi.fn(),
+    reconcileTerminalState: vi.fn(),
   };
 }
 
@@ -83,9 +87,16 @@ describe('ClipProjectsController', () => {
   let clipProjectsService: ReturnType<typeof createMockClipProjectsService>;
   let clipGenerationService: ReturnType<typeof createMockClipGenerationService>;
   let clipFactoryQueueService: { enqueue: ReturnType<typeof vi.fn> };
+  let clipResultsService: {
+    findProjectResultForHandoff: ReturnType<typeof vi.fn>;
+  };
   let creditsUtilsService: {
     checkOrganizationCreditsAvailable: ReturnType<typeof vi.fn>;
     getOrganizationCreditsBalance: ReturnType<typeof vi.fn>;
+  };
+  let editorProjectsService: { create: ReturnType<typeof vi.fn> };
+  let publishHandoffService: {
+    preparePublishHandoff: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -94,9 +105,18 @@ describe('ClipProjectsController', () => {
     clipFactoryQueueService = {
       enqueue: vi.fn(),
     };
+    clipResultsService = {
+      findProjectResultForHandoff: vi.fn(),
+    };
     creditsUtilsService = {
       checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
       getOrganizationCreditsBalance: vi.fn().mockResolvedValue(100),
+    };
+    editorProjectsService = {
+      create: vi.fn(),
+    };
+    publishHandoffService = {
+      preparePublishHandoff: vi.fn(),
     };
 
     controller = new ClipProjectsController(
@@ -107,6 +127,9 @@ describe('ClipProjectsController', () => {
       clipGenerationService as ClipGenerationService,
       { rewrite: vi.fn() } as unknown as HighlightRewriteService,
       creditsUtilsService as unknown as CreditsUtilsService,
+      clipResultsService as unknown as ClipResultsService,
+      editorProjectsService as unknown as EditorProjectsService,
+      publishHandoffService as unknown as PublishHandoffService,
     );
   });
 
@@ -300,5 +323,152 @@ describe('ClipProjectsController', () => {
       }),
     );
     expect(result.status).toBe('failed');
+  });
+
+  it('creates an editor handoff for a ready clip result', async () => {
+    const project = createProject(projectId, organizationId);
+    vi.mocked(clipProjectsService.findOne).mockResolvedValue(project);
+    vi.mocked(clipProjectsService.reconcileTerminalState).mockResolvedValue(
+      project,
+    );
+    clipResultsService.findProjectResultForHandoff.mockResolvedValue({
+      _id: 'clip-result-1',
+      duration: 12,
+      readiness: {
+        blockingReasons: [],
+        readyActions: ['download', 'edit', 'publish'],
+        state: 'ready',
+        terminal: true,
+      },
+      status: 'completed',
+      title: 'Launch clip',
+      videoUrl: 'https://cdn.genfeed.ai/clip.mp4',
+    });
+    editorProjectsService.create.mockResolvedValue({
+      _id: 'editor-project-1',
+      id: 'editor-project-1',
+    });
+
+    const result = await controller.createEditorHandoff(
+      currentUser as never,
+      projectId,
+      'clip-result-1',
+    );
+
+    expect(clipResultsService.findProjectResultForHandoff).toHaveBeenCalledWith(
+      {
+        clipResultId: 'clip-result-1',
+        organizationId,
+        projectId,
+      },
+    );
+    expect(editorProjectsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId,
+        tracks: [
+          expect.objectContaining({
+            clips: [
+              expect.objectContaining({
+                ingredientUrl: 'https://cdn.genfeed.ai/clip.mp4',
+              }),
+            ],
+          }),
+        ],
+        userId,
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        editorPath: '/editor/editor-project-1',
+        editorProjectId: 'editor-project-1',
+      }),
+    );
+  });
+
+  it('prepares publish handoff for a ready clip result', async () => {
+    const project = createProject(projectId, organizationId);
+    vi.mocked(clipProjectsService.findOne).mockResolvedValue(project);
+    vi.mocked(clipProjectsService.reconcileTerminalState).mockResolvedValue(
+      project,
+    );
+    clipResultsService.findProjectResultForHandoff.mockResolvedValue({
+      _id: 'clip-result-1',
+      readiness: {
+        blockingReasons: [],
+        readyActions: ['download', 'edit', 'publish'],
+        state: 'ready',
+        terminal: true,
+      },
+      status: 'completed',
+      summary: 'Clip summary',
+      title: 'Launch clip',
+      videoUrl: 'https://cdn.genfeed.ai/clip.mp4',
+    });
+    publishHandoffService.preparePublishHandoff.mockResolvedValue({
+      assets: [
+        {
+          assetId: 'clip-result-1',
+          mediaUrl: 'https://cdn.genfeed.ai/clip.mp4',
+          mimeType: 'video/mp4',
+        },
+      ],
+      clipProjectId: projectId,
+      confirmBeforePublish: true,
+      platforms: ['instagram'],
+      preparedAt: '2026-06-30T00:00:00.000Z',
+      schedule: 'immediate',
+    });
+
+    const result = await controller.createPublishHandoff(
+      currentUser as never,
+      projectId,
+      'clip-result-1',
+    );
+
+    expect(publishHandoffService.preparePublishHandoff).toHaveBeenCalledWith(
+      projectId,
+      ['clip-result-1'],
+      expect.objectContaining({
+        assets: {
+          'clip-result-1': expect.objectContaining({
+            caption: 'Clip summary',
+            mediaUrl: 'https://cdn.genfeed.ai/clip.mp4',
+          }),
+        },
+      }),
+    );
+    expect(result.payload).toEqual(
+      expect.objectContaining({
+        confirmBeforePublish: true,
+      }),
+    );
+  });
+
+  it('rejects handoff when readiness metadata does not allow the action', async () => {
+    const project = createProject(projectId, organizationId);
+    vi.mocked(clipProjectsService.findOne).mockResolvedValue(project);
+    vi.mocked(clipProjectsService.reconcileTerminalState).mockResolvedValue(
+      project,
+    );
+    clipResultsService.findProjectResultForHandoff.mockResolvedValue({
+      _id: 'clip-result-1',
+      readiness: {
+        blockingReasons: [],
+        readyActions: ['download'],
+        state: 'ready',
+        terminal: true,
+      },
+      status: 'completed',
+      videoUrl: 'https://cdn.genfeed.ai/clip.mp4',
+    });
+
+    await expect(
+      controller.createPublishHandoff(
+        currentUser as never,
+        projectId,
+        'clip-result-1',
+      ),
+    ).rejects.toThrow('not ready for publish handoff');
+    expect(publishHandoffService.preparePublishHandoff).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/collections/clip-projects/clip-projects.controller.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.controller.ts
@@ -12,7 +12,10 @@ import { UpdateClipProjectDto } from '@api/collections/clip-projects/dto/update-
 import { type ClipProjectDocument } from '@api/collections/clip-projects/schemas/clip-project.schema';
 import { ClipGenerationService } from '@api/collections/clip-projects/services/clip-generation.service';
 import { HighlightRewriteService } from '@api/collections/clip-projects/services/highlight-rewrite.service';
+import { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
+import type { ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { EditorProjectsService } from '@api/collections/editor-projects/editor-projects.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -30,8 +33,11 @@ import {
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { ClipAnalyzeQueueService } from '@api/queues/clip-analyze/clip-analyze.queue.service';
 import { ClipFactoryQueueService } from '@api/queues/clip-factory/clip-factory-queue.service';
+import { PublishHandoffService } from '@api/services/clip-orchestrator/publish-handoff.service';
 import { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
+import { EditorTrackType, IngredientFormat } from '@genfeedai/enums';
 import type {
+  ClipReadyAction,
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
   SortObject,
@@ -55,6 +61,21 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { Request } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+interface ClipEditorHandoffResponse {
+  clipProjectId: string;
+  clipResultId: string;
+  editorPath: string;
+  editorProjectId: string;
+  videoUrl: string;
+}
+
+interface ClipPublishHandoffResponse {
+  clipProjectId: string;
+  clipResultId: string;
+  payload: Awaited<ReturnType<PublishHandoffService['preparePublishHandoff']>>;
+}
 
 @AutoSwagger()
 @ApiTags('clip-projects')
@@ -72,6 +93,9 @@ export class ClipProjectsController {
     private readonly clipGenerationService: ClipGenerationService,
     private readonly highlightRewriteService: HighlightRewriteService,
     private readonly creditsUtilsService: CreditsUtilsService,
+    private readonly clipResultsService: ClipResultsService,
+    private readonly editorProjectsService: EditorProjectsService,
+    private readonly publishHandoffService: PublishHandoffService,
   ) {}
 
   @Post('from-youtube')
@@ -413,17 +437,248 @@ export class ClipProjectsController {
   ): Promise<JsonApiSingleResponse> {
     const publicMetadata = getPublicMetadata(user);
 
-    const data = await this.clipProjectsService.findOne({
-      _id: id,
-      isDeleted: false,
-      organization: publicMetadata.organization,
-    });
+    const data = await this.clipProjectsService.reconcileTerminalState(
+      id,
+      publicMetadata.organization,
+    );
 
     if (!data) {
       return returnNotFound(this.constructorName, id);
     }
 
     return serializeSingle(request, ClipProjectSerializer, data);
+  }
+
+  @Post(':projectId/results/:clipResultId/editor-handoff')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    description:
+      'Validate a ready clip result and create an editor project handoff from its terminal media URL.',
+    summary: 'Create editor handoff for a ready clip result',
+  })
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async createEditorHandoff(
+    @CurrentUser() user: User,
+    @Param('projectId') projectId: string,
+    @Param('clipResultId') clipResultId: string,
+  ): Promise<ClipEditorHandoffResponse> {
+    const publicMetadata = getPublicMetadata(user);
+    await this.resolveOwnedProject(projectId, publicMetadata.organization);
+    await this.clipProjectsService.reconcileTerminalState(
+      projectId,
+      publicMetadata.organization,
+    );
+
+    const clipResult = await this.resolveReadyClipResult({
+      action: 'edit',
+      clipResultId,
+      organizationId: publicMetadata.organization,
+      projectId,
+    });
+    const videoUrl = this.resolveClipVideoUrl(clipResult);
+    const durationFrames = this.resolveClipDurationFrames(clipResult);
+    const editorProject = await this.editorProjectsService.create({
+      ...(publicMetadata.brand ? { brandId: publicMetadata.brand } : {}),
+      config: {
+        clipHandoff: {
+          clipProjectId: projectId,
+          clipResultId: String(clipResult._id ?? clipResult.id),
+          source: 'clip-result',
+        },
+        name: `${this.readString(clipResult.title) ?? 'Clip'} edit`,
+        settings: {
+          backgroundColor: '#000000',
+          format: IngredientFormat.PORTRAIT,
+          fps: 30,
+          height: 1920,
+          width: 1080,
+        },
+        status: 'draft',
+        totalDurationFrames: durationFrames,
+      },
+      organizationId: publicMetadata.organization,
+      tracks: [
+        {
+          clips: [
+            {
+              durationFrames,
+              effects: [],
+              id: uuidv4(),
+              ingredientId: String(clipResult._id ?? clipResult.id),
+              ingredientUrl: videoUrl,
+              sourceEndFrame: durationFrames,
+              sourceStartFrame: 0,
+              startFrame: 0,
+              thumbnailUrl: this.readString(clipResult.thumbnailUrl),
+              volume: 100,
+            },
+          ],
+          id: uuidv4(),
+          isLocked: false,
+          isMuted: false,
+          name: 'Clip 1',
+          type: EditorTrackType.VIDEO,
+          volume: 100,
+        },
+      ],
+      userId: publicMetadata.user,
+    } as never);
+    const editorProjectId = String(editorProject._id ?? editorProject.id);
+
+    return {
+      clipProjectId: projectId,
+      clipResultId: String(clipResult._id ?? clipResult.id),
+      editorPath: `/editor/${editorProjectId}`,
+      editorProjectId,
+      videoUrl,
+    };
+  }
+
+  @Post(':projectId/results/:clipResultId/publish-handoff')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    description:
+      'Validate a ready clip result and prepare a user-confirmed publish handoff payload.',
+    summary: 'Prepare publish handoff for a ready clip result',
+  })
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async createPublishHandoff(
+    @CurrentUser() user: User,
+    @Param('projectId') projectId: string,
+    @Param('clipResultId') clipResultId: string,
+  ): Promise<ClipPublishHandoffResponse> {
+    const publicMetadata = getPublicMetadata(user);
+    await this.resolveOwnedProject(projectId, publicMetadata.organization);
+    await this.clipProjectsService.reconcileTerminalState(
+      projectId,
+      publicMetadata.organization,
+    );
+
+    const clipResult = await this.resolveReadyClipResult({
+      action: 'publish',
+      clipResultId,
+      organizationId: publicMetadata.organization,
+      projectId,
+    });
+    const resolvedClipResultId = String(clipResult._id ?? clipResult.id);
+    const videoUrl = this.resolveClipVideoUrl(clipResult);
+    const payload = await this.publishHandoffService.preparePublishHandoff(
+      projectId,
+      [resolvedClipResultId],
+      {
+        assets: {
+          [resolvedClipResultId]: {
+            caption: this.readString(clipResult.summary) ?? undefined,
+            mediaUrl: videoUrl,
+            mimeType: 'video/mp4',
+          },
+        },
+        metadata: {
+          clipResultId: resolvedClipResultId,
+          summary: this.readString(clipResult.summary),
+          title: this.readString(clipResult.title),
+        },
+      },
+    );
+
+    return {
+      clipProjectId: projectId,
+      clipResultId: resolvedClipResultId,
+      payload,
+    };
+  }
+
+  private async resolveOwnedProject(
+    projectId: string,
+    organizationId: string,
+  ): Promise<ClipProjectDocument> {
+    const project = await this.clipProjectsService.findOne({
+      _id: projectId,
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!project) {
+      throw new NotFoundException(`ClipProject ${projectId} not found`);
+    }
+
+    return project;
+  }
+
+  private async resolveReadyClipResult(input: {
+    action: ClipReadyAction;
+    clipResultId: string;
+    organizationId: string;
+    projectId: string;
+  }): Promise<ClipResultDocument> {
+    const clipResult =
+      await this.clipResultsService.findProjectResultForHandoff({
+        clipResultId: input.clipResultId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+
+    if (!clipResult) {
+      throw new NotFoundException(`ClipResult ${input.clipResultId} not found`);
+    }
+
+    if (!this.isClipReadyForAction(clipResult, input.action)) {
+      throw new BadRequestException(
+        `ClipResult ${input.clipResultId} is not ready for ${input.action} handoff.`,
+      );
+    }
+
+    this.resolveClipVideoUrl(clipResult);
+
+    return clipResult;
+  }
+
+  private isClipReadyForAction(
+    clipResult: ClipResultDocument,
+    action: ClipReadyAction,
+  ): boolean {
+    const readiness = this.readRecord(clipResult.readiness);
+    const readyActions = Array.isArray(readiness.readyActions)
+      ? readiness.readyActions
+      : [];
+
+    if (readyActions.length > 0) {
+      return readyActions.includes(action);
+    }
+
+    return this.readString(clipResult.status) === 'completed';
+  }
+
+  private resolveClipVideoUrl(clipResult: ClipResultDocument): string {
+    const videoUrl =
+      this.readString(clipResult.captionedVideoUrl) ??
+      this.readString(clipResult.videoUrl);
+
+    if (!videoUrl) {
+      throw new BadRequestException('Clip result has no terminal video URL.');
+    }
+
+    return videoUrl;
+  }
+
+  private resolveClipDurationFrames(clipResult: ClipResultDocument): number {
+    const duration =
+      typeof clipResult.duration === 'number' &&
+      Number.isFinite(clipResult.duration)
+        ? clipResult.duration
+        : 10;
+
+    return Math.max(1, Math.round(duration * 30));
+  }
+
+  private readRecord(value: unknown): Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private readString(value: unknown): string | null {
+    return typeof value === 'string' && value.length > 0 ? value : null;
   }
 
   @Patch(':id')

--- a/apps/server/api/src/collections/clip-projects/clip-projects.module.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.module.ts
@@ -1,8 +1,11 @@
 import { ClipProjectsController } from '@api/collections/clip-projects/clip-projects.controller';
 import { ClipProjectsCoreModule } from '@api/collections/clip-projects/clip-projects-core.module';
+import { ClipResultsModule } from '@api/collections/clip-results/clip-results.module';
 import { CreditsModule } from '@api/collections/credits/credits.module';
+import { EditorProjectsModule } from '@api/collections/editor-projects/editor-projects.module';
 import { ClipAnalyzeModule } from '@api/queues/clip-analyze/clip-analyze.module';
 import { ClipFactoryModule } from '@api/queues/clip-factory/clip-factory.module';
+import { ClipOrchestratorModule } from '@api/services/clip-orchestrator/clip-orchestrator.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
@@ -10,9 +13,12 @@ import { forwardRef, Module } from '@nestjs/common';
   exports: [ClipProjectsCoreModule],
   imports: [
     forwardRef(() => ClipProjectsCoreModule),
+    forwardRef(() => ClipResultsModule),
     forwardRef(() => CreditsModule),
+    forwardRef(() => EditorProjectsModule),
     forwardRef(() => ClipAnalyzeModule),
     forwardRef(() => ClipFactoryModule),
+    forwardRef(() => ClipOrchestratorModule),
   ],
 })
 export class ClipProjectsModule {}

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
@@ -1,5 +1,29 @@
+vi.mock('@genfeedai/prisma', () => ({
+  PrismaClient: class {},
+  getModelMeta: () => ({
+    allFields: [
+      'id',
+      'mongoId',
+      'organizationId',
+      'brandId',
+      'status',
+      'progress',
+      'error',
+      'readyClipCount',
+      'failedClipCount',
+      'pendingClipCount',
+      'readiness',
+      'terminalAt',
+      'config',
+      'isDeleted',
+    ],
+    enumFields: {},
+  }),
+}));
+
 import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
 import type { CreateClipProjectDto } from '@api/collections/clip-projects/dto/create-clip-project.dto';
+import type { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import type { LoggerService } from '@libs/logger/logger.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -49,12 +73,17 @@ function createPrisma() {
 describe('ClipProjectsService', () => {
   let prisma: ReturnType<typeof createPrisma>;
   let service: ClipProjectsService;
+  let clipResultsService: { findByProject: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     prisma = createPrisma();
+    clipResultsService = {
+      findByProject: vi.fn(),
+    };
     service = new ClipProjectsService(
       prisma as unknown as PrismaService,
       createLogger(),
+      clipResultsService as unknown as ClipResultsService,
     );
   });
 
@@ -148,6 +177,86 @@ describe('ClipProjectsService', () => {
         readyClipCount: 2,
         status: 'completed',
         terminalAt: expect.any(Date),
+      }),
+      where: { id: 'project-1' },
+    });
+  });
+
+  it('reconciles project terminal state from completed and failed clip results', async () => {
+    prisma.clipProject.findFirst.mockResolvedValue({
+      config: {},
+      failedClipCount: 0,
+      id: 'project-1',
+      organizationId: 'org-1',
+      pendingClipCount: 2,
+      progress: 50,
+      readyClipCount: 0,
+      readiness: {},
+      status: 'generating',
+    });
+    prisma.clipProject.update.mockResolvedValue({
+      config: {},
+      failedClipCount: 1,
+      id: 'project-1',
+      organizationId: 'org-1',
+      pendingClipCount: 0,
+      progress: 100,
+      readyClipCount: 1,
+      readiness: {},
+      status: 'completed',
+    });
+    clipResultsService.findByProject.mockResolvedValue([
+      { status: 'completed' },
+      { status: 'failed' },
+    ]);
+
+    await service.reconcileTerminalState('project-1', 'org-1');
+
+    expect(clipResultsService.findByProject).toHaveBeenCalledWith(
+      'project-1',
+      'org-1',
+    );
+    expect(prisma.clipProject.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        error: null,
+        failedClipCount: 1,
+        pendingClipCount: 0,
+        progress: 100,
+        readyClipCount: 1,
+        readiness: expect.objectContaining({
+          readyActions: ['download', 'edit', 'publish'],
+          state: 'ready',
+        }),
+        status: 'completed',
+      }),
+      where: { id: 'project-1' },
+    });
+  });
+
+  it('keeps project non-terminal while child clips are still pending', async () => {
+    prisma.clipProject.findFirst.mockResolvedValue({
+      config: {},
+      failedClipCount: 0,
+      id: 'project-1',
+      organizationId: 'org-1',
+      pendingClipCount: 2,
+      progress: 25,
+      readyClipCount: 0,
+      readiness: {},
+      status: 'generating',
+    });
+    clipResultsService.findByProject.mockResolvedValue([
+      { status: 'completed' },
+      { status: 'extracting' },
+    ]);
+
+    await service.reconcileTerminalState('project-1', 'org-1');
+
+    expect(prisma.clipProject.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        failedClipCount: 0,
+        pendingClipCount: 1,
+        readyClipCount: 1,
       }),
       where: { id: 'project-1' },
     });

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
@@ -1,6 +1,7 @@
 import { CreateClipProjectDto } from '@api/collections/clip-projects/dto/create-clip-project.dto';
 import { UpdateClipProjectDto } from '@api/collections/clip-projects/dto/update-clip-project.dto';
 import type { ClipProjectDocument } from '@api/collections/clip-projects/schemas/clip-project.schema';
+import { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
 import {
   buildClipProjectReadiness,
   isTerminalClipStatus,
@@ -47,6 +48,7 @@ export class ClipProjectsService extends BaseService<
   constructor(
     public readonly prisma: PrismaService,
     public readonly logger: LoggerService,
+    private readonly clipResultsService: ClipResultsService,
   ) {
     super(prisma, 'clipProject', logger);
   }
@@ -83,6 +85,64 @@ export class ClipProjectsService extends BaseService<
       this.toPrismaWriteData(updateDto, 'update', existingConfig),
       populate,
     );
+  }
+
+  async reconcileTerminalState(
+    projectId: string,
+    organizationId?: string,
+  ): Promise<ClipProjectDocument | null> {
+    const project = await this.findOne({
+      _id: projectId,
+      isDeleted: false,
+      ...(organizationId ? { organization: organizationId } : {}),
+    });
+
+    if (!project) {
+      return null;
+    }
+
+    const canonicalProjectId =
+      this.readString(project._id) ?? this.readString(project.id) ?? projectId;
+    const results = await this.clipResultsService.findByProject(
+      canonicalProjectId,
+      organizationId,
+    );
+
+    if (results.length === 0) {
+      return project;
+    }
+
+    const readyClipCount = results.filter(
+      (result) => this.readString(result.status) === 'completed',
+    ).length;
+    const failedClipCount = results.filter(
+      (result) => this.readString(result.status) === 'failed',
+    ).length;
+    const pendingClipCount = results.length - readyClipCount - failedClipCount;
+
+    const update: Record<string, unknown> = {
+      failedClipCount,
+      pendingClipCount,
+      readyClipCount,
+    };
+
+    if (pendingClipCount === 0) {
+      update.progress = 100;
+
+      if (readyClipCount > 0) {
+        update.error = null;
+        update.status = 'completed';
+      } else {
+        update.error = 'All clip generations failed.';
+        update.status = 'failed';
+      }
+    }
+
+    if (!this.hasReconciliationChange(project, update)) {
+      return project;
+    }
+
+    return this.patch(canonicalProjectId, update);
   }
 
   private toPrismaWriteData(
@@ -188,6 +248,15 @@ export class ClipProjectsService extends BaseService<
 
   private readString(value: unknown): string | null {
     return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private hasReconciliationChange(
+    project: ClipProjectDocument,
+    update: Record<string, unknown>,
+  ): boolean {
+    return Object.entries(update).some(
+      ([key, value]) => project[key] !== value,
+    );
   }
 
   private readTerminalAt(value: unknown): Date | string | null {

--- a/apps/server/api/src/collections/clip-results/clip-results.controller.spec.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.controller.spec.ts
@@ -93,7 +93,10 @@ describe('ClipResultsController', () => {
 
       await controller.findAll(mockReq, 'project-1', '', mockUser);
 
-      expect(service.findByProject).toHaveBeenCalledWith('project-1');
+      expect(service.findByProject).toHaveBeenCalledWith(
+        'project-1',
+        organizationId,
+      );
       expect(service.findAllByOrganization).not.toHaveBeenCalled();
     });
 
@@ -103,7 +106,10 @@ describe('ClipResultsController', () => {
 
       await controller.findAll(mockReq, '', 'project-2', mockUser);
 
-      expect(service.findByProject).toHaveBeenCalledWith('project-2');
+      expect(service.findByProject).toHaveBeenCalledWith(
+        'project-2',
+        organizationId,
+      );
     });
 
     it('should find all by organization when no project filter is given', async () => {

--- a/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
@@ -1,3 +1,24 @@
+vi.mock('@genfeedai/prisma', () => ({
+  PrismaClient: class {},
+  getModelMeta: () => ({
+    allFields: [
+      'id',
+      'mongoId',
+      'organizationId',
+      'projectId',
+      'providerJobId',
+      'viralityScore',
+      'status',
+      'isSelected',
+      'readiness',
+      'terminalAt',
+      'data',
+      'isDeleted',
+    ],
+    enumFields: {},
+  }),
+}));
+
 import { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
 import type { CreateClipResultDto } from '@api/collections/clip-results/dto/create-clip-result.dto';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -182,6 +203,46 @@ describe('ClipResultsService', () => {
       },
     });
     expect(result[0]).toEqual(
+      expect.objectContaining({
+        _id: 'clip-1',
+        title: 'Clip',
+      }),
+    );
+  });
+
+  it('resolves a project clip result by id, mongo id, or provider job id for handoff', async () => {
+    prisma.clipResult.findFirst.mockResolvedValue({
+      data: { title: 'Clip' },
+      id: 'clip-1',
+      isSelected: false,
+      organizationId: 'org-1',
+      projectId: 'project-1',
+      readiness: {
+        readyActions: ['download', 'edit', 'publish'],
+        state: 'ready',
+      },
+      status: 'completed',
+    });
+
+    const result = await service.findProjectResultForHandoff({
+      clipResultId: 'provider-job-1',
+      organizationId: 'org-1',
+      projectId: 'project-1',
+    });
+
+    expect(prisma.clipResult.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { id: 'provider-job-1' },
+          { mongoId: 'provider-job-1' },
+          { providerJobId: 'provider-job-1' },
+        ],
+        isDeleted: false,
+        organizationId: 'org-1',
+        projectId: 'project-1',
+      },
+    });
+    expect(result).toEqual(
       expect.objectContaining({
         _id: 'clip-1',
         title: 'Clip',

--- a/apps/server/api/src/collections/clip-results/clip-results.service.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.ts
@@ -112,6 +112,27 @@ export class ClipResultsService extends BaseService<
     return result ? this.normalizeDocument(result) : null;
   }
 
+  async findProjectResultForHandoff(input: {
+    clipResultId: string;
+    organizationId: string;
+    projectId: string;
+  }): Promise<ClipResultDocument | null> {
+    const result = await this.delegate.findFirst({
+      where: {
+        OR: [
+          { id: input.clipResultId },
+          { mongoId: input.clipResultId },
+          { providerJobId: input.clipResultId },
+        ],
+        isDeleted: false,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      },
+    });
+
+    return result ? this.normalizeDocument(result) : null;
+  }
+
   private toPrismaWriteData(
     dto: ClipResultWriteDto,
     mode: 'create' | 'update',

--- a/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts
@@ -29,6 +29,7 @@ function createMockDeps() {
 
   const clipProjectsService = {
     patch: vi.fn(),
+    reconcileTerminalState: vi.fn(),
   };
 
   const clipResultsService = {
@@ -289,7 +290,7 @@ describe('HeygenWebhookService', () => {
       { status: 'failed' },
     ]);
     deps.clipResultsService.patch.mockResolvedValue({});
-    deps.clipProjectsService.patch.mockResolvedValue({});
+    deps.clipProjectsService.reconcileTerminalState.mockResolvedValue({});
 
     await service.handleCallback(body);
 
@@ -298,14 +299,9 @@ describe('HeygenWebhookService', () => {
       status: 'completed',
       videoUrl: 'https://cdn.heygen.com/clip.mp4',
     });
-    expect(deps.clipProjectsService.patch).toHaveBeenCalledWith(projectId, {
-      error: null,
-      failedClipCount: 1,
-      pendingClipCount: 0,
-      progress: 100,
-      readyClipCount: 1,
-      status: 'completed',
-    });
+    expect(
+      deps.clipProjectsService.reconcileTerminalState,
+    ).toHaveBeenCalledWith(projectId, undefined);
   });
 
   it('should fail the parent project when the final clip fails', async () => {
@@ -328,7 +324,7 @@ describe('HeygenWebhookService', () => {
       { status: 'failed' },
     ]);
     deps.clipResultsService.patch.mockResolvedValue({});
-    deps.clipProjectsService.patch.mockResolvedValue({});
+    deps.clipProjectsService.reconcileTerminalState.mockResolvedValue({});
 
     await service.handleCallback(body);
 
@@ -336,14 +332,9 @@ describe('HeygenWebhookService', () => {
       providerJobId: 'provider-job-1',
       status: 'failed',
     });
-    expect(deps.clipProjectsService.patch).toHaveBeenCalledWith(projectId, {
-      error: 'All clip generations failed.',
-      failedClipCount: 1,
-      pendingClipCount: 0,
-      progress: 100,
-      readyClipCount: 0,
-      status: 'failed',
-    });
+    expect(
+      deps.clipProjectsService.reconcileTerminalState,
+    ).toHaveBeenCalledWith(projectId, undefined);
   });
 
   it('should continue to process legacy metadata-backed avatar success callbacks', async () => {

--- a/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.ts
@@ -205,50 +205,9 @@ export class HeygenWebhookService {
       return;
     }
 
-    const projectClipResults = await this.clipResultsService.findByProject(
+    await this.clipProjectsService.reconcileTerminalState(
       projectId,
       organizationId,
     );
-    const hasPendingClipResults = projectClipResults.some((clipResult) => {
-      const status = this.readString(clipResult.status);
-      return status !== 'completed' && status !== 'failed';
-    });
-
-    if (hasPendingClipResults) {
-      return;
-    }
-
-    const hasCompletedClip = projectClipResults.some(
-      (clipResult) => this.readString(clipResult.status) === 'completed',
-    );
-    const readyClipCount = projectClipResults.filter(
-      (clipResult) => this.readString(clipResult.status) === 'completed',
-    ).length;
-    const failedClipCount = projectClipResults.filter(
-      (clipResult) => this.readString(clipResult.status) === 'failed',
-    ).length;
-    const pendingClipCount =
-      projectClipResults.length - readyClipCount - failedClipCount;
-
-    if (hasCompletedClip) {
-      await this.clipProjectsService.patch(projectId, {
-        error: null,
-        failedClipCount,
-        pendingClipCount,
-        progress: 100,
-        readyClipCount,
-        status: 'completed',
-      });
-      return;
-    }
-
-    await this.clipProjectsService.patch(projectId, {
-      error: 'All clip generations failed.',
-      failedClipCount,
-      pendingClipCount,
-      progress: 100,
-      readyClipCount,
-      status: 'failed',
-    });
   }
 }


### PR DESCRIPTION
## Summary
- Reconcile clip project terminal state from child clip results and reuse that reconciliation from HeyGen callbacks.
- Add ready-result editor and publish handoff endpoints scoped by organization, project, clip result, and readiness action metadata.
- Wire the Clips UI actions through the handoff endpoints before routing users to editor or compose.

## Verification
- `bun run --cwd apps/server/api test:file src/collections/clip-projects/clip-projects.service.spec.ts src/collections/clip-projects/clip-projects.controller.spec.ts src/collections/clip-results/clip-results.service.spec.ts src/collections/clip-results/clip-results.controller.spec.ts src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts`
- `bun run --cwd apps/app test app/'(protected)'/'[orgSlug]'/'[brandSlug]'/studio/clips/components/ClipResultCard.test.tsx`
- `bunx biome check --write apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/studio/clips/components/ClipResultCard.test.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/studio/clips/components/ClipResultCard.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/studio/clips/components/ClipsProgressView.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/studio/clips/services/clips-api.service.ts apps/server/api/src/collections/clip-projects/clip-projects.controller.spec.ts apps/server/api/src/collections/clip-projects/clip-projects.controller.ts apps/server/api/src/collections/clip-projects/clip-projects.module.ts apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts apps/server/api/src/collections/clip-projects/clip-projects.service.ts apps/server/api/src/collections/clip-results/clip-results.controller.spec.ts apps/server/api/src/collections/clip-results/clip-results.service.spec.ts apps/server/api/src/collections/clip-results/clip-results.service.ts apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.spec.ts apps/server/api/src/endpoints/webhooks/heygen/webhooks.heygen.service.ts`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/app`
- `bunx turbo run lint --filter=@genfeedai/api --filter=@genfeedai/app`
- `bun run audit:api`
- `git diff --check`

Closes #331
