### PR TITLE
fix(infra): import pre-existing REDIS_PASSWORD SSM param (unblock #931 deploy)

### DIFF
--- a/infra/terraform/genfeed-prod/imports.tf
+++ b/infra/terraform/genfeed-prod/imports.tf
@@ -1,0 +1,9 @@
+# One-time, non-destructive import of the pre-existing REDIS_PASSWORD SSM
+# parameter (created 2026-06-09, before #931 added it to terraform) into state,
+# so the managed aws_ssm_parameter.redis_password reconciles it (UPDATE) instead
+# of failing on apply with ParameterAlreadyExists. Idempotent — a no-op once the
+# resource is already tracked in state. Safe to remove in a later cleanup.
+import {
+  to = aws_ssm_parameter.redis_password
+  id = "/genfeed/production/REDIS_PASSWORD"
+}


### PR DESCRIPTION
Final terraform blocker for the prod restore. The fastlane deploy got transit encryption enabled (done, online migration) but then failed on `aws_ssm_parameter.redis_password`: **ParameterAlreadyExists** — the param was created 2026-06-09 (pre-#931) and isn't in terraform state. Add a non-destructive `import` block so `tofu apply` adopts it and reconciles the value to the ElastiCache `auth_token`, instead of creating. The AUTH modify (which failed earlier 'only supported when encryption-in-transit is enabled') will now succeed since transit is already live. Idempotent.