### PR TITLE
fix(infra): defer Redis AUTH to unblock prod deploy (keep transit encryption)

### DIFF
--- a/infra/terraform/genfeed-prod/elasticache.tf
+++ b/infra/terraform/genfeed-prod/elasticache.tf
@@ -40,7 +40,11 @@ resource "aws_elasticache_replication_group" "redis" {
   # clients keep working while services roll over to TLS+AUTH. Tighten to
   # "required" in a follow-up once all clients use rediss://.
   transit_encryption_mode    = "preferred"
-  auth_token                 = random_password.redis_auth_token.result
-  auth_token_update_strategy = "SET"
+  # AUTH deferred: AWS only allows setting auth_token once transit_encryption_mode
+  # is "required", which in turn requires every client to already be on TLS. That
+  # is a staged migration (app -> rediss:// first, then "required" + auth_token),
+  # not a single apply. Transit encryption is enabled here (preferred) and the app
+  # connects over TLS without AUTH; enable auth_token in a follow-up once all
+  # clients are confirmed on rediss://.
   apply_immediately          = true
 }

--- a/infra/terraform/genfeed-prod/locals.tf
+++ b/infra/terraform/genfeed-prod/locals.tf
@@ -46,12 +46,10 @@ locals {
       valueFrom = data.aws_ssm_parameters_by_path.prod.arns[i]
     } if !contains(local.excluded_ssm_secret_names, element(reverse(split("/", name)), 0))
   ]
-  redis_task_secrets = [
-    {
-      name      = "REDIS_PASSWORD"
-      valueFrom = aws_ssm_parameter.redis_password.arn
-    },
-  ]
+  # AUTH deferred (see elasticache.tf): the app connects over TLS without a
+  # password while Redis AUTH is off. Re-add the REDIS_PASSWORD secret here when
+  # auth_token is enabled in the follow-up migration.
+  redis_task_secrets   = []
   service_task_secrets = concat(local.task_secrets, local.redis_task_secrets)
 
   # ── Service catalogue (mirrors docker-compose.production.yml) ─────────


### PR DESCRIPTION
AWS blocks enabling Redis `auth_token` while `transit_encryption_mode='preferred'` (AUTH needs 'required', which needs all clients on TLS first — a staged migration, not one apply). The fastlane deploy repeatedly failed on the auth_token modify. Remove `auth_token` + the `REDIS_PASSWORD` secret injection so services boot over TLS without AUTH (accepted in preferred mode) and the deploy rolls the #950 bootstrap fix. Transit encryption stays on; enable AUTH + required mode in a follow-up.