### PR TITLE
refactor(api): collapse generation redirect helper

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -999,7 +999,7 @@ export class AgentOrchestratorService {
           let toolName = requestedToolName;
 
           if (!allowedToolNames.has(requestedToolName)) {
-            const recoveredToolName = this.getUnknownToolRecovery(
+            const recoveredToolName = this.getGenerationPreparationRedirect(
               requestedToolName,
               allowedToolNames,
             );
@@ -1075,7 +1075,7 @@ export class AgentOrchestratorService {
 
           const preRemapToolName = toolName;
           const directGenerationOverride =
-            this.getGenerationPreparationOverride(toolName, allowedToolNames);
+            this.getGenerationPreparationRedirect(toolName, allowedToolNames);
           if (directGenerationOverride) {
             const originalToolName = toolName;
             toolName = directGenerationOverride;
@@ -1755,7 +1755,7 @@ export class AgentOrchestratorService {
           let toolName = requestedToolName;
 
           if (!allowedToolNames.has(requestedToolName)) {
-            const recoveredToolName = this.getUnknownToolRecovery(
+            const recoveredToolName = this.getGenerationPreparationRedirect(
               requestedToolName,
               allowedToolNames,
             );
@@ -1784,7 +1784,7 @@ export class AgentOrchestratorService {
 
           const preRemapToolName = toolName;
           const directGenerationOverride =
-            this.getGenerationPreparationOverride(toolName, allowedToolNames);
+            this.getGenerationPreparationRedirect(toolName, allowedToolNames);
           if (directGenerationOverride) {
             const originalToolName = toolName;
             toolName = directGenerationOverride;
@@ -4086,26 +4086,7 @@ export class AgentOrchestratorService {
     return `Unknown tool requested by model: ${toolName}. Available tools: ${preview}${suffix}`;
   }
 
-  private getUnknownToolRecovery(
-    toolName: AgentToolName,
-    allowedTools: Set<AgentToolName>,
-  ): AgentToolName | null {
-    const canPrepareGeneration = allowedTools.has(
-      AgentToolName.PREPARE_GENERATION,
-    );
-    const isRecoverableGenerationTool =
-      toolName === AgentToolName.GENERATE_IMAGE ||
-      toolName === AgentToolName.GENERATE_VIDEO ||
-      toolName === AgentToolName.GENERATE_AS_IDENTITY;
-
-    if (canPrepareGeneration && isRecoverableGenerationTool) {
-      return AgentToolName.PREPARE_GENERATION;
-    }
-
-    return null;
-  }
-
-  private getGenerationPreparationOverride(
+  private getGenerationPreparationRedirect(
     toolName: AgentToolName,
     allowedTools: Set<AgentToolName>,
   ): AgentToolName | null {


### PR DESCRIPTION
## Summary

- Collapses the duplicate generation redirect predicates in `AgentOrchestratorService` into one `getGenerationPreparationRedirect` helper.
- Updates both sync and streaming tool-loop call sites to use the shared helper.
- Keeps redirect behavior unchanged for `generate_image`, `generate_video`, and `generate_as_identity` when `prepare_generation` is allowed.

Closes #968
Refs #520

## Validation

- `rg "getUnknownToolRecovery|getGenerationPreparationOverride" apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts` returned no matches
- `bunx biome check apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts`
- `bun run --cwd apps/server/api test:file src/services/agent-orchestrator/agent-orchestrator.service.spec.ts` (40 tests)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `git diff --cached --check`
- `bun scripts/run-secretlint.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts`
- `bun run lint-staged`

## Notes

- A direct `bun test apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts` failed before loading tests because that invocation does not resolve the repo's `@api/*` aliases. The configured API Vitest command above passed after Turbo materialized the `@genfeedai/tools` dist entry.
- Structural-review pass found no blocker/request-change findings in the final diff: this deletes a duplicate helper, adds no abstraction layer, and preserves the existing service boundary.