### PR TITLE
refactor(api): consolidate workflow brand guard

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -842,6 +842,67 @@ describe('WorkflowEngineAdapterService', () => {
         },
       );
     });
+
+    it('fails image generation workflows when brandId is missing', async () => {
+      const imageWorkflowService = new WorkflowEngineAdapterService(
+        {
+          ingredientsEndpoint: 'https://ingredients.example.com',
+        } as never,
+        loggerService as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {} as never,
+        {} as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { saveDocumentsInternal: vi.fn() } as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { runModel: vi.fn() } as never,
+        {
+          buildPrompt: vi.fn().mockResolvedValue({
+            input: { prompt: 'resolved prompt' },
+          }),
+        } as never,
+        undefined,
+      );
+
+      const workflow = imageWorkflowService.convertToExecutableWorkflow({
+        _id: { toString: () => 'wf-missing-brand' },
+        edges: [],
+        nodes: [
+          {
+            data: {
+              config: {
+                model: 'qwen/qwen-image',
+                prompt: 'make an image',
+              },
+              label: 'Image',
+            },
+            id: 'image',
+            type: 'imageGen',
+          },
+        ],
+        organization: { toString: () => 'org-1' },
+        user: { toString: () => 'user-1' },
+      });
+
+      const result = await imageWorkflowService.executeWorkflow(workflow);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toBe('imageGen requires a brandId in node config');
+      expect(result.nodeResults.get('image')?.error).toBe(
+        'imageGen requires a brandId in node config',
+      );
+    });
   });
 
   describe('node type to executor mapping', () => {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -460,10 +460,7 @@ export class WorkflowEngineAdapterService {
         undefined,
       );
 
-      const brandId = await this.resolveBrandIdFromConfigOrFail(
-        params.brandId,
-        'imageGen',
-      );
+      const brandId = this.requireBrandId(params.brandId, 'imageGen');
       const pendingOutput = await this.createWorkflowOutputIngredient({
         brandId,
         category: IngredientCategory.IMAGE,
@@ -2392,7 +2389,7 @@ export class WorkflowEngineAdapterService {
       const elevenLabsService = this.elevenLabsService;
 
       ttsExecutor.setResolver(async (text, voiceId, context, node) => {
-        const brandId = await this.resolveBrandIdFromConfigOrFail(
+        const brandId = this.requireBrandId(
           this.readConfigString(node.config, 'brandId'),
           'textToSpeech',
         );
@@ -2885,12 +2882,10 @@ export class WorkflowEngineAdapterService {
   }
 
   private getRequiredBrandId(node: ExecutableNode): string {
-    const brandId = this.readConfigString(node.config, 'brandId');
-    if (!brandId) {
-      throw new Error(`${node.type} requires a brandId in node config`);
-    }
-
-    return brandId;
+    return this.requireBrandId(
+      this.readConfigString(node.config, 'brandId'),
+      node.type,
+    );
   }
 
   private getVideoResultInput(
@@ -2975,10 +2970,7 @@ export class WorkflowEngineAdapterService {
     return { ingredientId, metadataId };
   }
 
-  private async resolveBrandIdFromConfigOrFail(
-    configuredBrandId: unknown,
-    nodeType: string,
-  ): Promise<string> {
+  private requireBrandId(configuredBrandId: unknown, nodeType: string): string {
     if (typeof configuredBrandId === 'string' && configuredBrandId.length > 0) {
       return configuredBrandId;
     }


### PR DESCRIPTION
## Summary
- Closes #970
- Consolidates the duplicated workflow-engine adapter config-brand validation into one synchronous `requireBrandId` helper.
- Routes image generation, text-to-speech, and node-based brand config checks through the same guard while keeping source-ingredient fallback separate.
- Adds a focused workflow adapter characterization test for the missing image-generation brandId failure path.

## Why this fits the refactor lane
Parent #521 flags the oversized workflow adapter and duplicated brand-id resolver logic. This PR is a bounded behavior-preserving slice: one duplicate validation path is collapsed without changing executor registration, queue topology, serializers, controllers, or product behavior.

## Skills / rubric used
- `ultracode`: workflow mode with read-only sidecar investigation and parent-thread integration.
- `refactor-code`: lock behavior, study nearby helper/test patterns, collapse duplication only.
- `structural-review`: selected a contained slice from the broad #521 decomposition findings.
- `typescript-refactor`: kept the config guard as explicit `typeof` narrowing with a synchronous `string` return.
- `de-slop`: diff-only cleanup lens; no broad sweep.

## Validation
- `bun run test:file src/collections/workflows/services/workflow-engine-adapter.service.spec.ts` from `apps/server/api` (43 tests passed)
- `bunx biome check --write apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached --name-only | xargs bunx secretlint`
- Commit hook: lint-staged Biome + secretlint

## Notes
- Raw `bun test apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts` was attempted first and failed before test execution because it did not load the repo `@api` path aliases. The configured API Vitest runner above was used instead.
- Structural-review deferred finding: a read-only sidecar found a separate duplicated review-gate input/preview helper slice between `WorkflowExecutorService` and `WorkflowEngineAdapterService`; not included because this PR is intentionally scoped to #970.
