### PR TITLE
fix(app): resolve workspace infinite spinner + add missing /workspace/activity route

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/activity/loading.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/activity/loading.tsx
@@ -1,0 +1,5 @@
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+
+export default function Loading() {
+  return <LazyLoadingFallback variant="grid" />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/activity/page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/activity/page.spec.tsx
@@ -1,0 +1,4 @@
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import * as PageModule from './page';
+
+runPageModuleTests('app/(protected)/workspace/activity/page', PageModule);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/activity/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/activity/page.tsx
@@ -1,0 +1,13 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import ErrorBoundary from '@ui/display/error-boundary/ErrorBoundary';
+import WorkspacePageContent from '../workspace-page';
+
+export const generateMetadata = createPageMetadata('Workspace Activity');
+
+export default function WorkspaceActivityPage() {
+  return (
+    <ErrorBoundary>
+      <WorkspacePageContent section="activity" />
+    </ErrorBoundary>
+  );
+}

--- a/packages/contexts/user/brand-context/brand-context.helpers.test.ts
+++ b/packages/contexts/user/brand-context/brand-context.helpers.test.ts
@@ -1,0 +1,49 @@
+import type { IBrand } from '@genfeedai/interfaces';
+import { describe, expect, it } from 'vitest';
+import { getBrandOrganizationId } from './brand-context.helpers';
+
+describe('getBrandOrganizationId', () => {
+  it('returns the nested organization id when present', () => {
+    const brand = {
+      organization: { id: 'org_123', slug: 'acme' },
+    } as unknown as IBrand;
+
+    expect(getBrandOrganizationId(brand)).toBe('org_123');
+  });
+
+  it('returns the nested organization _id when present', () => {
+    const brand = {
+      organization: { _id: 'org_456', slug: 'acme' },
+    } as unknown as IBrand;
+
+    expect(getBrandOrganizationId(brand)).toBe('org_456');
+  });
+
+  it('returns the organization when it is a raw id string', () => {
+    const brand = { organization: 'org_789' } as unknown as IBrand;
+
+    expect(getBrandOrganizationId(brand)).toBe('org_789');
+  });
+
+  it('falls back to the top-level organizationId when the bootstrap nests organization as { slug } only', () => {
+    // Mirrors the protected-bootstrap payload shape, where the nested
+    // organization is serialized as `{ slug }` and the id lives top-level.
+    const brand = {
+      organizationId: 'org_top',
+      organization: { slug: 'acme' },
+    } as unknown as IBrand;
+
+    expect(getBrandOrganizationId(brand)).toBe('org_top');
+  });
+
+  it('returns an empty string when no organization id is resolvable', () => {
+    const brand = { organization: { slug: 'acme' } } as unknown as IBrand;
+
+    expect(getBrandOrganizationId(brand)).toBe('');
+  });
+
+  it('returns an empty string for nullish brands', () => {
+    expect(getBrandOrganizationId(null)).toBe('');
+    expect(getBrandOrganizationId(undefined)).toBe('');
+  });
+});

--- a/packages/contexts/user/brand-context/brand-context.helpers.ts
+++ b/packages/contexts/user/brand-context/brand-context.helpers.ts
@@ -44,6 +44,21 @@ export function getBrandOrganizationId(
     return organization._id;
   }
 
+  // The protected bootstrap serializer nests `organization` as `{ slug }` only,
+  // exposing the organization id as the brand's top-level `organizationId`
+  // field. Fall back to it so the org scope resolves — otherwise
+  // `scopedOrganizationId` stays empty, the access-state query never enables,
+  // `accessState` is null, and OnboardingGuard/SubscriptionGuard spin forever.
+  const brandWithOrgId = brand as unknown as {
+    organizationId?: unknown;
+  } | null;
+  if (
+    typeof brandWithOrgId?.organizationId === 'string' &&
+    brandWithOrgId.organizationId.length > 0
+  ) {
+    return brandWithOrgId.organizationId;
+  }
+
   return '';
 }
 


### PR DESCRIPTION
## The bug
The workspace (org + brand routes) stuck on an infinite spinner **even on a clean, fully-authenticated load** (`get-session` 200 → `token` 200 → `bootstrap` 200). Diagnosed live on prod.

## Root cause 1 — org id never resolves → guards spin forever
`getBrandOrganizationId` only read the **nested** `brand.organization` (`.id`/`._id`). But the protected-bootstrap serializer nests `organization` as `{ slug }` only; the org id is the brand's **top-level `organizationId`**. So it returned `''` → `scopedOrganizationId` empty → `AccessStateProvider` query disabled (`enabled: !!organizationId`) → `accessState` null → `OnboardingGuard`/`SubscriptionGuard` render their spinner forever. **Fix:** fall back to top-level `organizationId`. Added `brand-context.helpers.test.ts` (6 cases).

## Root cause 2 — `/workspace/activity` 404
Sidebar 'Activity' → `APP_ROUTES.WORKSPACE.ACTIVITY` (`/workspace/activity`) but no route segment existed (only `overview` + `inbox`) → `_rsc` 404. `activity` is a valid `WorkspaceSection`. **Fix:** add the route (page + loading + spec) rendering `WorkspacePageContent section=\"activity\"`.

Verified: 6/6 helper tests pass, contexts typecheck clean. These are in current master (not version skew) — confirmed no auth/bootstrap code changed between the deployed image and master.