### PR TITLE
fix(api): accept repeated status query keys on ingredients endpoint

### DIFF
--- a/apps/server/api/src/collections/ingredients/dto/ingredients-query.dto.spec.ts
+++ b/apps/server/api/src/collections/ingredients/dto/ingredients-query.dto.spec.ts
@@ -1,4 +1,6 @@
 import { IngredientsQueryDto } from '@api/collections/ingredients/dto/ingredients-query.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
 
 describe('IngredientsQueryDto', () => {
   it('should be defined', () => {
@@ -11,11 +13,31 @@ describe('IngredientsQueryDto', () => {
       expect(dto).toBeInstanceOf(IngredientsQueryDto);
     });
 
-    // it('should validate successfully with valid data', async () => {
-    //   const dto = new IngredientsQueryDto();
-    //   // Add test data
-    //   const errors = await validate(dto);
-    //   expect(errors.length).toBe(0);
-    // });
+    it('should accept repeated status query keys as an array', async () => {
+      // Express parses ?status=a&status=b as an array on req.query.
+      const dto = plainToInstance(IngredientsQueryDto, {
+        status: ['generated', 'processing', 'validated'],
+      });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.status).toEqual(['generated', 'processing', 'validated']);
+    });
+
+    it('should normalize a single status value into an array', async () => {
+      const dto = plainToInstance(IngredientsQueryDto, { status: 'generated' });
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.status).toEqual(['generated']);
+    });
+
+    it('should validate successfully with no status filter', async () => {
+      const dto = plainToInstance(IngredientsQueryDto, {});
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.status).toBeUndefined();
+    });
   });
 });

--- a/apps/server/api/src/collections/ingredients/dto/ingredients-query.dto.ts
+++ b/apps/server/api/src/collections/ingredients/dto/ingredients-query.dto.ts
@@ -2,7 +2,8 @@ import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { IngredientCategory } from '@genfeedai/enums';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
 
 export class IngredientsQueryDto extends BaseQueryDto {
   @ApiProperty({
@@ -22,12 +23,25 @@ export class IngredientsQueryDto extends BaseQueryDto {
   parent?: string;
 
   @ApiProperty({
-    description: 'Filter ingredients by status',
+    description:
+      'Filter by status using repeated query keys (e.g., ?status=generated&status=validated).',
+    example: ['generated', 'validated'],
     required: false,
+    type: [String],
+  })
+  @Transform(({ value }) => {
+    if (!value) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      return value;
+    }
+    return [value];
   })
   @IsOptional()
-  @IsString()
-  status?: string;
+  @IsArray()
+  @IsString({ each: true })
+  status?: string[];
 
   @ApiProperty({
     description: 'Filter ingredients by category',


### PR DESCRIPTION
Found live on prod: studio/image page 400s on `GET /v1/organizations/:id/ingredients?status=generated&status=processing&status=validated`.

`IngredientsQueryDto.status` was typed single `string` + `@IsString()`. Express parses repeated query keys as an array; class-validator rejects array against `@IsString()` -> 400 'Validation failed'. images/videos/gifs/assets DTOs already use the correct array+`@Transform` pattern; ingredients drifted. Service layer (`CollectionFilterUtil.buildStatusFilter`) already handles `string|string[]`, no change needed there.

Verified: 5/5 new DTO tests pass, 4/4 existing controller tests pass, api typecheck clean.