### PR TITLE
Add productized daily routine templates

### DIFF
--- a/apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx
+++ b/apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx
@@ -22,6 +22,7 @@ const TEMPLATE_CATEGORIES = [
   { id: 'integration', label: 'Integration' },
   { id: 'generation', label: 'Generation' },
   { id: 'real-estate', label: 'Real Estate' },
+  { id: 'routines', label: 'Routines' },
 ];
 
 type PageState = {

--- a/apps/app/src/features/workflows/services/workflow-api.test.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.test.ts
@@ -317,7 +317,19 @@ describe('WorkflowApiService', () => {
           },
         },
       })
-      .mockResolvedValueOnce({ data: { data: [{ id: 'template-1' }] } })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              id: 'template-1',
+              routine: {
+                kind: 'productized-daily-routine',
+                trackingTasks: [{ key: 'review-trend-brief' }],
+              },
+            },
+          ],
+        },
+      })
       .mockResolvedValueOnce({ data: { data: { _id: 'batch-1', items: [] } } })
       .mockResolvedValueOnce({ data: { data: [{ _id: 'batch-1' }] } });
     mocks.delete.mockResolvedValueOnce({ data: undefined });
@@ -340,7 +352,13 @@ describe('WorkflowApiService', () => {
       service().submitApproval('workflow-1', 'execution-1', 'review-1', true),
     ).resolves.toMatchObject({ status: 'approved' });
     await expect(service().listTemplates()).resolves.toEqual([
-      { id: 'template-1' },
+      {
+        id: 'template-1',
+        routine: {
+          kind: 'productized-daily-routine',
+          trackingTasks: [{ key: 'review-trend-brief' }],
+        },
+      },
     ]);
     await expect(service().listBrands()).resolves.toEqual([
       {

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -211,6 +211,7 @@ export interface WorkflowTemplate {
   description: string;
   category: string;
   icon?: string;
+  isScheduleEnabled?: boolean;
   inputVariables?: Array<{
     key: string;
     type: string;
@@ -220,6 +221,46 @@ export interface WorkflowTemplate {
     required?: boolean;
     validation?: Record<string, unknown>;
   }>;
+  routine?: {
+    cadence: 'daily';
+    inputContract: Array<{
+      defaultValue?: unknown;
+      description?: string;
+      key: string;
+      label: string;
+      required: boolean;
+      type: 'boolean' | 'number' | 'select' | 'text';
+    }>;
+    kind: 'productized-daily-routine';
+    outputDestinations: Array<{
+      key: string;
+      label: string;
+      required: boolean;
+      type: 'email' | 'social_publish' | 'task' | 'workflow_output';
+    }>;
+    parentIssue: number;
+    recommendedSkills: string[];
+    requiredSkills: string[];
+    reviewDefaults: {
+      autoApproveIfNoResponse: boolean;
+      notifyChannels: string[];
+      requireApproval: boolean;
+      reviewState: 'pending_approval';
+      timeoutHours: number;
+    };
+    sourceIssue: number;
+    trackingTasks: Array<{
+      description: string;
+      key: string;
+      outputType: 'newsletter' | 'post';
+      priority: 'critical' | 'high' | 'low' | 'medium';
+      reviewState: 'pending_approval';
+      status: 'in_review' | 'todo';
+      title: string;
+    }>;
+    version: number;
+  };
+  schedule?: string;
   nodes?: Node[];
   edges?: Edge[];
   steps: Array<{
@@ -229,6 +270,7 @@ export interface WorkflowTemplate {
     config: Record<string, unknown>;
     dependsOn?: string[];
   }>;
+  timezone?: string;
 }
 
 /** Webhook info returned from the API */

--- a/apps/server/api/src/collections/workflows/controllers/workflow-marketplace.controller.spec.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-marketplace.controller.spec.ts
@@ -50,7 +50,14 @@ describe('WorkflowMarketplaceController', () => {
     it('should return workflow templates', async () => {
       const templates = [
         { name: 'Social Media Automation', steps: [] },
-        { name: 'Content Publishing', steps: [] },
+        {
+          name: 'Daily Trend Loop',
+          routine: {
+            kind: 'productized-daily-routine',
+            trackingTasks: [{ key: 'review-trend-brief' }],
+          },
+          steps: [],
+        },
       ];
 
       mockWorkflowsService.getWorkflowTemplates.mockResolvedValue(templates);
@@ -59,6 +66,13 @@ describe('WorkflowMarketplaceController', () => {
 
       expect(service.getWorkflowTemplates).toHaveBeenCalled();
       expect(result.data).toEqual(templates);
+      expect(result.data[1]).toMatchObject({
+        name: 'Daily Trend Loop',
+        routine: {
+          kind: 'productized-daily-routine',
+          trackingTasks: [{ key: 'review-trend-brief' }],
+        },
+      });
     });
   });
 });

--- a/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
@@ -1,0 +1,116 @@
+import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import { WorkflowStatus, WorkflowStepStatus } from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('WorkflowsService template creation', () => {
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  let service: WorkflowsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new WorkflowsService({} as never, logger as never);
+    vi.spyOn(service, 'create').mockResolvedValue({
+      _id: { toString: () => 'workflow-1' },
+      id: 'workflow-1',
+      label: 'Workflow: release-loop',
+      metadata: {},
+      nodes: [],
+      steps: [],
+    } as never);
+    vi.spyOn(service, 'executeWorkflowCompat').mockResolvedValue({
+      mode: 'node',
+    });
+  });
+
+  it('copies productized routine metadata and schedule defaults from the selected template', async () => {
+    await service.createWorkflow('user-1', 'org-1', {
+      edges: [],
+      metadata: {
+        createdFrom: 'templates',
+      },
+      nodes: [],
+      templateId: 'release-loop',
+    } as never);
+
+    const createInput = vi.mocked(service.create).mock.calls[0]?.[0] as {
+      isScheduleEnabled?: boolean;
+      metadata?: Record<string, unknown>;
+      nodes?: Array<{ id: string; type: string }>;
+      schedule?: string;
+      status?: WorkflowStatus;
+      steps?: Array<{ id: string; status: WorkflowStepStatus }>;
+      timezone?: string;
+    };
+
+    expect(createInput).toMatchObject({
+      isScheduleEnabled: true,
+      metadata: {
+        createdFrom: 'templates',
+        productizedRoutine: {
+          kind: 'productized-daily-routine',
+          outputDestinations: expect.arrayContaining([
+            expect.objectContaining({ key: 'releaseAssets' }),
+          ]),
+          parentIssue: 224,
+          reviewDefaults: expect.objectContaining({
+            requireApproval: true,
+            reviewState: 'pending_approval',
+          }),
+          sourceIssue: 976,
+          trackingTasks: expect.arrayContaining([
+            expect.objectContaining({ key: 'review-release-assets' }),
+          ]),
+        },
+        sourceTemplateId: 'release-loop',
+        sourceType: 'seeded-template',
+      },
+      schedule: '0 9 * * *',
+      status: WorkflowStatus.ACTIVE,
+      timezone: 'UTC',
+    });
+    expect(createInput.nodes?.map((node) => node.type)).toEqual(
+      expect.arrayContaining(['llm', 'reviewGate', 'workflow-output']),
+    );
+    expect(createInput.steps?.map((step) => step.status)).toEqual([
+      WorkflowStepStatus.PENDING,
+      WorkflowStepStatus.PENDING,
+    ]);
+  });
+
+  it('keeps caller schedule overrides while preserving routine metadata', async () => {
+    await service.createWorkflow('user-1', 'org-1', {
+      edges: [],
+      isScheduleEnabled: false,
+      nodes: [],
+      schedule: '30 10 * * *',
+      templateId: 'daily-trend-loop',
+      timezone: 'Europe/Malta',
+    } as never);
+
+    const createInput = vi.mocked(service.create).mock.calls[0]?.[0] as {
+      isScheduleEnabled?: boolean;
+      metadata?: Record<string, unknown>;
+      schedule?: string;
+      timezone?: string;
+    };
+
+    expect(createInput).toMatchObject({
+      isScheduleEnabled: false,
+      metadata: {
+        productizedRoutine: expect.objectContaining({
+          kind: 'productized-daily-routine',
+          sourceIssue: 976,
+        }),
+        sourceTemplateId: 'daily-trend-loop',
+      },
+      schedule: '30 10 * * *',
+      timezone: 'Europe/Malta',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -111,6 +111,9 @@ export class WorkflowsService extends BaseService<
       WORKFLOW_TEMPLATES[workflowData.templateId]
     ) {
       const template = WORKFLOW_TEMPLATES[workflowData.templateId];
+      const routineMetadata = template.routine
+        ? { productizedRoutine: template.routine }
+        : {};
       const shouldUseTemplateEdges =
         !workflowData.edges || workflowData.edges.length === 0;
       const shouldUseTemplateInputVariables =
@@ -125,11 +128,16 @@ export class WorkflowsService extends BaseService<
         inputVariables: shouldUseTemplateInputVariables
           ? template.inputVariables
           : workflowData.inputVariables,
+        isScheduleEnabled:
+          workflowData.isScheduleEnabled ?? template.isScheduleEnabled,
         metadata: {
           ...templateMetadata,
+          ...routineMetadata,
           ...(workflowData.metadata ?? {}),
         },
         nodes: shouldUseTemplateNodes ? template.nodes : workflowData.nodes,
+        schedule: workflowData.schedule ?? template.schedule,
+        timezone: workflowData.timezone ?? template.timezone,
       };
       steps = template.steps.map((step) => ({
         ...step,

--- a/apps/server/api/src/collections/workflows/templates/productized-routines.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/productized-routines.template.ts
@@ -1,0 +1,477 @@
+import type {
+  ProductizedRoutineMetadata,
+  WorkflowTemplate,
+} from '@api/collections/workflows/templates/workflow-templates';
+import { WorkflowStepCategory } from '@genfeedai/enums';
+
+export type ProductizedRoutineWorkflowTemplate = WorkflowTemplate & {
+  isScheduleEnabled: true;
+  routine: ProductizedRoutineMetadata;
+  schedule: string;
+  timezone: string;
+};
+
+const DAILY_REVIEW_DEFAULTS = {
+  autoApproveIfNoResponse: false,
+  notifyChannels: ['task-inbox'],
+  requireApproval: true,
+  reviewState: 'pending_approval',
+  timeoutHours: 24,
+} satisfies ProductizedRoutineMetadata['reviewDefaults'];
+
+const dailyTrendInputContract = [
+  {
+    defaultValue: ['tiktok', 'instagram', 'youtube', 'twitter'],
+    description: 'Social platforms to scan for trend candidates.',
+    key: 'platforms',
+    label: 'Platforms',
+    required: true,
+    type: 'select',
+  },
+  {
+    defaultValue: 70,
+    description: 'Minimum viral score for trends included in the daily brief.',
+    key: 'minViralScore',
+    label: 'Minimum Viral Score',
+    required: false,
+    type: 'number',
+  },
+  {
+    defaultValue: 5,
+    description: 'Maximum number of trend candidates included in the brief.',
+    key: 'topN',
+    label: 'Trend Count',
+    required: false,
+    type: 'number',
+  },
+] satisfies ProductizedRoutineMetadata['inputContract'];
+
+const releaseLoopInputContract = [
+  {
+    defaultValue: '',
+    description: 'Name of the product, feature, campaign, or release.',
+    key: 'releaseName',
+    label: 'Release Name',
+    required: true,
+    type: 'text',
+  },
+  {
+    defaultValue: 'Product marketers and existing users',
+    description: 'Primary audience for launch copy and review.',
+    key: 'audience',
+    label: 'Audience',
+    required: true,
+    type: 'text',
+  },
+  {
+    defaultValue: 'social',
+    description: 'Primary distribution lane for the release loop output.',
+    key: 'primaryChannel',
+    label: 'Primary Channel',
+    required: true,
+    type: 'select',
+  },
+  {
+    defaultValue: '',
+    description: 'Launch notes, changelog URL, or internal release brief.',
+    key: 'releaseNotes',
+    label: 'Release Notes',
+    required: false,
+    type: 'text',
+  },
+] satisfies ProductizedRoutineMetadata['inputContract'];
+
+export const PRODUCTIZED_DAILY_ROUTINE_TEMPLATES = [
+  {
+    category: 'routines',
+    description:
+      'Daily trend brief, review gate, and digest handoff for choosing what to create next.',
+    icon: 'repeat',
+    id: 'daily-trend-loop',
+    inputVariables: dailyTrendInputContract,
+    isScheduleEnabled: true,
+    name: 'Daily Trend Loop',
+    nodes: [
+      {
+        data: {
+          config: {
+            minViralScore: 70,
+            platforms: ['tiktok', 'instagram', 'youtube', 'twitter'],
+            topN: 5,
+          },
+          label: 'Assemble Daily Trend Brief',
+        },
+        id: 'trend-digest',
+        position: { x: 0, y: 120 },
+        type: 'trendDigest',
+      },
+      {
+        data: {
+          config: DAILY_REVIEW_DEFAULTS,
+          label: 'Review Trend Brief',
+        },
+        id: 'review-trend-brief',
+        position: { x: 360, y: 120 },
+        type: 'reviewGate',
+      },
+      {
+        data: {
+          config: {},
+          label: 'Email Approved Digest',
+        },
+        id: 'send-approved-digest',
+        position: { x: 720, y: 120 },
+        type: 'sendEmail',
+      },
+      {
+        data: {
+          config: {
+            outputName: 'trendBrief',
+          },
+          label: 'Trend Brief Output',
+        },
+        id: 'workflow-output-trend-brief',
+        position: { x: 1080, y: 120 },
+        type: 'workflow-output',
+      },
+    ],
+    edges: [
+      {
+        id: 'edge-trend-html-to-review',
+        source: 'trend-digest',
+        sourceHandle: 'html',
+        target: 'review-trend-brief',
+        targetHandle: 'caption',
+      },
+      {
+        id: 'edge-digest-to',
+        source: 'trend-digest',
+        sourceHandle: 'to',
+        target: 'send-approved-digest',
+        targetHandle: 'to',
+      },
+      {
+        id: 'edge-digest-subject',
+        source: 'trend-digest',
+        sourceHandle: 'subject',
+        target: 'send-approved-digest',
+        targetHandle: 'subject',
+      },
+      {
+        id: 'edge-review-html-to-email',
+        source: 'review-trend-brief',
+        sourceHandle: 'caption',
+        target: 'send-approved-digest',
+        targetHandle: 'html',
+      },
+      {
+        id: 'edge-review-output',
+        source: 'review-trend-brief',
+        sourceHandle: 'caption',
+        target: 'workflow-output-trend-brief',
+        targetHandle: 'value',
+      },
+    ],
+    routine: {
+      cadence: 'daily',
+      inputContract: dailyTrendInputContract,
+      kind: 'productized-daily-routine',
+      outputDestinations: [
+        {
+          key: 'trendBrief',
+          label: 'Approved trend brief',
+          required: true,
+          type: 'workflow_output',
+        },
+        {
+          key: 'emailDigest',
+          label: 'Email digest to owner',
+          required: true,
+          type: 'email',
+        },
+        {
+          key: 'reviewTask',
+          label: 'Trend brief review task',
+          required: true,
+          type: 'task',
+        },
+      ],
+      parentIssue: 224,
+      recommendedSkills: [
+        'content-strategist',
+        'content-atomizer',
+        'content-reviewer',
+      ],
+      requiredSkills: ['content-strategist', 'content-reviewer'],
+      reviewDefaults: DAILY_REVIEW_DEFAULTS,
+      sourceIssue: 976,
+      trackingTasks: [
+        {
+          description:
+            'Review the generated trend brief and choose the trend to turn into content.',
+          key: 'review-trend-brief',
+          outputType: 'post',
+          priority: 'medium',
+          reviewState: 'pending_approval',
+          status: 'in_review',
+          title: 'Review daily trend brief',
+        },
+        {
+          description:
+            'Create a content task from the selected trend and preferred platform.',
+          key: 'create-from-trend',
+          outputType: 'post',
+          priority: 'medium',
+          reviewState: 'pending_approval',
+          status: 'todo',
+          title: 'Create from selected trend',
+        },
+      ],
+      version: 1,
+    },
+    schedule: '0 8 * * *',
+    steps: [
+      {
+        category: WorkflowStepCategory.PERFORMANCE_TRACK,
+        config: {
+          minViralScore: 70,
+          platforms: ['tiktok', 'instagram', 'youtube', 'twitter'],
+          topN: 5,
+        },
+        id: 'assemble-trend-brief',
+        name: 'Assemble Trend Brief',
+      },
+      {
+        category: WorkflowStepCategory.WEBHOOK,
+        config: DAILY_REVIEW_DEFAULTS,
+        dependsOn: ['assemble-trend-brief'],
+        id: 'review-trend-brief',
+        name: 'Review Trend Brief',
+      },
+    ],
+    timezone: 'UTC',
+  },
+  {
+    category: 'routines',
+    description:
+      'Daily launch copy and review loop for turning release notes into approved distribution assets.',
+    icon: 'rocket',
+    id: 'release-loop',
+    inputVariables: releaseLoopInputContract,
+    isScheduleEnabled: true,
+    name: 'Release Loop',
+    nodes: [
+      {
+        data: {
+          config: {
+            inputName: 'releaseName',
+            inputType: 'text',
+            required: true,
+          },
+          label: 'Release Name',
+        },
+        id: 'workflow-input-release-name',
+        position: { x: 0, y: 40 },
+        type: 'workflow-input',
+      },
+      {
+        data: {
+          config: {
+            inputName: 'audience',
+            inputType: 'text',
+            required: true,
+          },
+          label: 'Audience',
+        },
+        id: 'workflow-input-audience',
+        position: { x: 0, y: 180 },
+        type: 'workflow-input',
+      },
+      {
+        data: {
+          config: {
+            inputName: 'releaseNotes',
+            inputType: 'text',
+            required: false,
+          },
+          label: 'Release Notes',
+        },
+        id: 'workflow-input-release-notes',
+        position: { x: 0, y: 320 },
+        type: 'workflow-input',
+      },
+      {
+        data: {
+          config: {
+            template:
+              'Create a daily release loop brief for {{releaseName}}. Audience: {{audience}}. Notes: {{releaseNotes}}. Return: launch angle, social draft, newsletter blurb, review checklist, and next tracking task.',
+            variables: {},
+          },
+          label: 'Build Release Prompt',
+        },
+        id: 'prompt-constructor-release-loop',
+        position: { x: 360, y: 180 },
+        type: 'ai-prompt-constructor',
+      },
+      {
+        data: {
+          config: {
+            maxTokens: 1400,
+            model: 'openai/gpt-4o-mini',
+            temperature: 0.7,
+          },
+          label: 'Draft Release Assets',
+        },
+        id: 'llm-release-assets',
+        position: { x: 720, y: 180 },
+        type: 'llm',
+      },
+      {
+        data: {
+          config: DAILY_REVIEW_DEFAULTS,
+          label: 'Review Release Assets',
+        },
+        id: 'review-release-assets',
+        position: { x: 1080, y: 180 },
+        type: 'reviewGate',
+      },
+      {
+        data: {
+          config: {
+            outputName: 'releaseAssets',
+          },
+          label: 'Release Assets Output',
+        },
+        id: 'workflow-output-release-assets',
+        position: { x: 1440, y: 180 },
+        type: 'workflow-output',
+      },
+    ],
+    edges: [
+      {
+        id: 'edge-release-name-to-prompt',
+        source: 'workflow-input-release-name',
+        sourceHandle: 'value',
+        target: 'prompt-constructor-release-loop',
+        targetHandle: 'releaseName',
+      },
+      {
+        id: 'edge-audience-to-prompt',
+        source: 'workflow-input-audience',
+        sourceHandle: 'value',
+        target: 'prompt-constructor-release-loop',
+        targetHandle: 'audience',
+      },
+      {
+        id: 'edge-notes-to-prompt',
+        source: 'workflow-input-release-notes',
+        sourceHandle: 'value',
+        target: 'prompt-constructor-release-loop',
+        targetHandle: 'releaseNotes',
+      },
+      {
+        id: 'edge-prompt-to-llm',
+        source: 'prompt-constructor-release-loop',
+        sourceHandle: 'prompt',
+        target: 'llm-release-assets',
+        targetHandle: 'prompt',
+      },
+      {
+        id: 'edge-llm-to-review',
+        source: 'llm-release-assets',
+        sourceHandle: 'text',
+        target: 'review-release-assets',
+        targetHandle: 'caption',
+      },
+      {
+        id: 'edge-review-to-output',
+        source: 'review-release-assets',
+        sourceHandle: 'caption',
+        target: 'workflow-output-release-assets',
+        targetHandle: 'value',
+      },
+    ],
+    routine: {
+      cadence: 'daily',
+      inputContract: releaseLoopInputContract,
+      kind: 'productized-daily-routine',
+      outputDestinations: [
+        {
+          key: 'releaseAssets',
+          label: 'Approved release asset pack',
+          required: true,
+          type: 'workflow_output',
+        },
+        {
+          key: 'reviewTask',
+          label: 'Release asset review task',
+          required: true,
+          type: 'task',
+        },
+        {
+          key: 'socialPublish',
+          label: 'Approved social publishing destination',
+          required: false,
+          type: 'social_publish',
+        },
+      ],
+      parentIssue: 224,
+      recommendedSkills: [
+        'newsletter-creator',
+        'x-content-creator',
+        'linkedin-content-creator',
+        'content-seo-optimizer',
+      ],
+      requiredSkills: [
+        'content-strategist',
+        'content-reviewer',
+        'ad-copy-creator',
+      ],
+      reviewDefaults: DAILY_REVIEW_DEFAULTS,
+      sourceIssue: 976,
+      trackingTasks: [
+        {
+          description:
+            'Review the daily release asset pack before it is distributed.',
+          key: 'review-release-assets',
+          outputType: 'post',
+          priority: 'medium',
+          reviewState: 'pending_approval',
+          status: 'in_review',
+          title: 'Review release assets',
+        },
+        {
+          description:
+            'Publish or schedule the approved release copy on the selected channel.',
+          key: 'publish-approved-release',
+          outputType: 'post',
+          priority: 'medium',
+          reviewState: 'pending_approval',
+          status: 'todo',
+          title: 'Publish approved release copy',
+        },
+      ],
+      version: 1,
+    },
+    schedule: '0 9 * * *',
+    steps: [
+      {
+        category: WorkflowStepCategory.GENERATE_ARTICLE,
+        config: {
+          model: 'openai/gpt-4o-mini',
+          temperature: 0.7,
+        },
+        id: 'draft-release-assets',
+        name: 'Draft Release Assets',
+      },
+      {
+        category: WorkflowStepCategory.WEBHOOK,
+        config: DAILY_REVIEW_DEFAULTS,
+        dependsOn: ['draft-release-assets'],
+        id: 'review-release-assets',
+        name: 'Review Release Assets',
+      },
+    ],
+    timezone: 'UTC',
+  },
+] satisfies ProductizedRoutineWorkflowTemplate[];

--- a/apps/server/api/src/collections/workflows/templates/workflow-templates.spec.ts
+++ b/apps/server/api/src/collections/workflows/templates/workflow-templates.spec.ts
@@ -10,4 +10,37 @@ describe('WorkflowTemplates', () => {
     expect(WORKFLOW_TEMPLATES).toHaveProperty('virtual-staging-rescue');
     expect(WORKFLOW_TEMPLATES).toHaveProperty('floor-plan-interior-preview');
   });
+
+  it('includes productized daily routine templates with review and tracking metadata', () => {
+    const dailyTrendLoop = WORKFLOW_TEMPLATES['daily-trend-loop'];
+    const releaseLoop = WORKFLOW_TEMPLATES['release-loop'];
+
+    expect(dailyTrendLoop?.name).toBe('Daily Trend Loop');
+    expect(releaseLoop?.name).toBe('Release Loop');
+
+    for (const template of [dailyTrendLoop, releaseLoop]) {
+      expect(template).toMatchObject({
+        category: 'routines',
+        isScheduleEnabled: true,
+        routine: {
+          cadence: 'daily',
+          kind: 'productized-daily-routine',
+          parentIssue: 224,
+          reviewDefaults: {
+            requireApproval: true,
+            reviewState: 'pending_approval',
+          },
+          sourceIssue: 976,
+          version: 1,
+        },
+        timezone: 'UTC',
+      });
+      expect(template?.inputVariables?.length).toBeGreaterThan(0);
+      expect(template?.routine?.requiredSkills.length).toBeGreaterThan(0);
+      expect(template?.routine?.recommendedSkills.length).toBeGreaterThan(0);
+      expect(template?.routine?.trackingTasks.length).toBeGreaterThan(0);
+      expect(template?.routine?.outputDestinations.length).toBeGreaterThan(0);
+      expect(template?.schedule).toMatch(/\* \* \*/);
+    }
+  });
 });

--- a/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
+++ b/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
@@ -1,7 +1,54 @@
 import { CONTENT_LOOP_TEMPLATE } from '@api/collections/workflows/templates/content-loop.template';
 import { DAILY_TRENDS_DIGEST_TEMPLATE } from '@api/collections/workflows/templates/daily-trends-digest.template';
 import { GENERATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/generation-templates';
+import { PRODUCTIZED_DAILY_ROUTINE_TEMPLATES } from '@api/collections/workflows/templates/productized-routines.template';
 import { WorkflowStepCategory } from '@genfeedai/enums';
+
+export type RoutineReviewDefaults = {
+  autoApproveIfNoResponse: boolean;
+  notifyChannels: string[];
+  requireApproval: boolean;
+  reviewState: 'pending_approval';
+  timeoutHours: number;
+};
+
+export type RoutineTrackingTask = {
+  description: string;
+  key: string;
+  outputType: 'newsletter' | 'post';
+  priority: 'critical' | 'high' | 'low' | 'medium';
+  reviewState: 'pending_approval';
+  status: 'in_review' | 'todo';
+  title: string;
+};
+
+export type RoutineOutputDestination = {
+  key: string;
+  label: string;
+  required: boolean;
+  type: 'email' | 'social_publish' | 'task' | 'workflow_output';
+};
+
+export type ProductizedRoutineMetadata = {
+  cadence: 'daily';
+  inputContract: Array<{
+    defaultValue?: unknown;
+    description?: string;
+    key: string;
+    label: string;
+    required: boolean;
+    type: 'boolean' | 'number' | 'select' | 'text';
+  }>;
+  kind: 'productized-daily-routine';
+  outputDestinations: RoutineOutputDestination[];
+  parentIssue: number;
+  recommendedSkills: string[];
+  requiredSkills: string[];
+  reviewDefaults: RoutineReviewDefaults;
+  sourceIssue: number;
+  trackingTasks: RoutineTrackingTask[];
+  version: number;
+};
 
 export interface WorkflowTemplate {
   id: string;
@@ -9,6 +56,7 @@ export interface WorkflowTemplate {
   description: string;
   category: string;
   icon?: string;
+  isScheduleEnabled?: boolean;
   inputVariables?: Array<{
     key: string;
     type: string;
@@ -18,6 +66,8 @@ export interface WorkflowTemplate {
     required?: boolean;
     validation?: Record<string, unknown>;
   }>;
+  routine?: ProductizedRoutineMetadata;
+  schedule?: string;
   nodes?: Array<{
     id: string;
     type: string;
@@ -42,10 +92,17 @@ export interface WorkflowTemplate {
     config: Record<string, unknown>;
     dependsOn?: string[];
   }>;
+  timezone?: string;
 }
 
 export const WORKFLOW_TEMPLATES: Record<string, WorkflowTemplate> = {
   ...GENERATION_WORKFLOW_TEMPLATES,
+  ...Object.fromEntries(
+    PRODUCTIZED_DAILY_ROUTINE_TEMPLATES.map((template) => [
+      template.id,
+      template,
+    ]),
+  ),
   'content-loop': CONTENT_LOOP_TEMPLATE,
   'daily-trends-digest': DAILY_TRENDS_DIGEST_TEMPLATE,
   'ad-remix-review': {


### PR DESCRIPTION
## Summary
- Adds Daily Trend Loop and Release Loop productized daily routine templates to the workflow marketplace.
- Persists routine metadata, default schedules, review defaults, tracking tasks, and output destinations when installing from a template.
- Exposes routine metadata in the app workflow API type and adds the Routines template category.

Closes #976
Refs #224

## Validation
- `bun run --cwd apps/server/api test:file src/collections/workflows/templates/workflow-templates.spec.ts src/collections/workflows/controllers/workflow-marketplace.controller.spec.ts src/collections/workflows/services/workflows.service.spec.ts`
- `bun run --cwd apps/app test src/features/workflows/services/workflow-api.test.ts`
- `bunx biome check --write apps/server/api/src/collections/workflows/templates/productized-routines.template.ts apps/server/api/src/collections/workflows/templates/workflow-templates.ts apps/server/api/src/collections/workflows/templates/workflow-templates.spec.ts apps/server/api/src/collections/workflows/controllers/workflow-marketplace.controller.spec.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/services/workflows.service.spec.ts apps/app/src/features/workflows/services/workflow-api.ts apps/app/src/features/workflows/services/workflow-api.test.ts apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx`
- `bun run check:design-system`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/app`
- `git diff --cached --check`
