### PR TITLE
[codex] Consolidate shell navigation surfaces

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -110,18 +110,13 @@ export default function AppProtectedLayoutSidebar({
   if (isStudioRoute) {
     return (
       <AppSidebar
-        backHref={withTaskContextHref(
-          buildHref(STUDIO_LOGO_HREF),
-          taskContextSearchParams,
-        )}
-        backLabel="Library"
         items={studioMenuItems}
         logoHref={withTaskContextHref(
           buildHref(STUDIO_LOGO_HREF),
           taskContextSearchParams,
         )}
         currentApp={currentApp}
-        sectionLabel="Studio"
+        sectionLabel="Library"
         shellChromeVariant={shellChromeVariant}
       />
     );

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -798,11 +798,13 @@ describe('AppProtectedLayout', () => {
 
     expect(appSidebarSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        backHref: '/org-123/brand-123/library/ingredients',
-        backLabel: 'Library',
-        sectionLabel: 'Studio',
+        sectionLabel: 'Library',
         shellChromeVariant: 'default',
       }),
+    );
+    expect(appSidebarSpy.mock.calls.at(-1)?.[0]).not.toHaveProperty('backHref');
+    expect(appSidebarSpy.mock.calls.at(-1)?.[0]).not.toHaveProperty(
+      'backLabel',
     );
     expect(screen.queryByTestId('agent-thread-list')).not.toBeInTheDocument();
   });

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -79,6 +79,10 @@ vi.mock('@ui/menus/switchers/MenuBrandSwitcher', () => ({
   ),
 }));
 
+vi.mock('@ui/menus/organization-switcher/OrganizationSwitcher', () => ({
+  default: () => <div data-testid="organization-switcher" />,
+}));
+
 vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
   AppSwitcher: (props: {
     brandSlug?: string;
@@ -165,6 +169,29 @@ describe('AppProtectedTopbar', () => {
       switcher.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it('renders the organization switcher in the topbar for SaaS cloud mode', () => {
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD = 'true';
+
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
+
+    const organizationSwitcher = screen.getByTestId('organization-switcher');
+    const brandSwitcher = screen.getByTestId('brand-switcher');
+
+    expect(organizationSwitcher).toBeInTheDocument();
+    expect(
+      organizationSwitcher.compareDocumentPosition(brandSwitcher) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('hides the organization switcher outside SaaS cloud mode', () => {
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
+
+    expect(
+      screen.queryByTestId('organization-switcher'),
+    ).not.toBeInTheDocument();
   });
 
   it('does not inject the context brand into explicit org-scoped routes', () => {

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -10,6 +10,7 @@ import {
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { TopbarProps } from '@props/navigation/topbar.props';
+import OrganizationSwitcher from '@ui/menus/organization-switcher/OrganizationSwitcher';
 import MenuBrandSwitcher from '@ui/menus/switchers/MenuBrandSwitcher';
 import { Button } from '@ui/primitives/button';
 import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
@@ -95,6 +96,8 @@ function AppProtectedTopbarContent({
   const taskId = searchParams.get('taskId');
   const taskTitle = searchParams.get('taskTitle');
   const ToggleIcon = isMenuOpen ? HiXMark : HiBars3;
+  const shouldRenderOrganizationSwitcher =
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true';
   const shouldRenderAgentToggle =
     Boolean(onAgentToggle) &&
     (process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1' || !isHostedCloudApp());
@@ -138,6 +141,12 @@ function AppProtectedTopbarContent({
             >
               <PiSidebarSimple className="size-4" />
             </Button>
+          ) : null}
+
+          {shouldRenderOrganizationSwitcher ? (
+            <div className="hidden min-w-0 w-40 sm:block sm:w-56">
+              <OrganizationSwitcher />
+            </div>
           ) : null}
 
           {brands.length > 0 ? (

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -171,10 +171,6 @@ vi.mock('@ui/buttons/credits/ButtonCredits', () => ({
   default: () => <div data-testid="button-credits" />,
 }));
 
-vi.mock('@ui/menus/organization-switcher/OrganizationSwitcher', () => ({
-  default: () => <div data-testid="organization-switcher" />,
-}));
-
 vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
   AppSwitcher: () => <div data-testid="app-switcher" />,
 }));
@@ -252,16 +248,7 @@ describe('MenuShared', () => {
     ).toBeTruthy();
   });
 
-  it('renders the organization switcher inside the sidebar header shell', () => {
-    render(<MenuShared config={config} />);
-
-    expect(screen.getByTestId('sidebar-header-shell')).toBeInTheDocument();
-    expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
-  });
-
-  it('hides the organization switcher outside SaaS cloud mode', () => {
-    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
-
+  it('keeps organization switching out of the sidebar header shell', () => {
     render(<MenuShared config={config} />);
 
     expect(screen.getByTestId('sidebar-header-shell')).toBeInTheDocument();

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -5,7 +5,6 @@ import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { MenuSharedProps } from '@genfeedai/props/navigation/menu.props';
 import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import MenuItem from '@ui/menus/item/MenuItem';
-import OrganizationSwitcher from '@ui/menus/organization-switcher/OrganizationSwitcher';
 import SidebarNested from '@ui/menus/sidebar-nested/SidebarNested';
 import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { Button } from '@ui/primitives/button';
@@ -56,8 +55,6 @@ export default function MenuShared({
     isActiveItem,
     primaryItems,
     secondaryItems,
-    topLevelGroups,
-    sectionGroups,
     groupedItems,
     handleLinkClick,
     nestedGroup,
@@ -77,9 +74,6 @@ export default function MenuShared({
     ? (prefixHref({ href: backHref }) ?? backHref)
     : undefined;
   const prefetchBackHref = useNavigationPrefetch(resolvedBackHref);
-  const shouldRenderOrganizationSwitcher =
-    process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true';
-
   const secondaryNavigationContent =
     secondaryItems.length > 0 ? (
       <div
@@ -140,24 +134,13 @@ export default function MenuShared({
         </div>
       )}
       {sectionLabel ? (
-        <>
-          <MenuSharedGroupedItems
-            groups={topLevelGroups}
-            {...sharedGroupProps}
-          />
-          {sectionGroups.length > 0 ? (
-            <CollapsibleGroup
-              label={sectionLabel}
-              isDrillDown={false}
-              storageKey={`__${sectionLabel.toLowerCase()}__`}
-            >
-              <MenuSharedGroupedItems
-                groups={sectionGroups}
-                {...sharedGroupProps}
-              />
-            </CollapsibleGroup>
-          ) : null}
-        </>
+        <CollapsibleGroup
+          label={sectionLabel}
+          isDrillDown={false}
+          storageKey={`__${sectionLabel.toLowerCase()}__`}
+        >
+          <MenuSharedGroupedItems groups={groupedItems} {...sharedGroupProps} />
+        </CollapsibleGroup>
       ) : (
         <MenuSharedGroupedItems groups={groupedItems} {...sharedGroupProps} />
       )}
@@ -215,7 +198,6 @@ export default function MenuShared({
           )}
         >
           {sharedCollapseControl}
-          {shouldRenderOrganizationSwitcher ? <OrganizationSwitcher /> : null}
         </div>
 
         {/* Body — fades out when collapsed, pointer-events disabled */}

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -104,22 +104,20 @@ describe('AppSwitcher', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
     expect(
       screen.getByRole('button', {
-        name: 'Switch app',
+        name: 'Switch section',
       }),
     ).toBeInTheDocument();
   });
 
-  it('renders content apps first and platform apps after the divider', () => {
+  it('renders the first-level workspace sections', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
     for (const label of [
       'Library',
-      'Posts',
-      'Workspace',
+      'Home',
       'Agent',
-      'Studio',
-      'Workflows',
-      'Editor',
-      'Write',
+      'Create',
+      'Publish',
+      'Automate',
       'Analytics',
     ]) {
       expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
@@ -128,7 +126,7 @@ describe('AppSwitcher', () => {
 
   it('marks the active app with aria-current="page"', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workflows" />);
-    const activeButton = screen.getByRole('link', { name: 'Workflows' });
+    const activeButton = screen.getByRole('link', { name: 'Automate' });
 
     expect(activeButton).toHaveAttribute('aria-current', 'page');
   });
@@ -142,7 +140,7 @@ describe('AppSwitcher', () => {
 
   it('active app button carries the shared shell active state', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="compose" />);
-    const btn = screen.getByRole('link', { name: 'Write' });
+    const btn = screen.getByRole('link', { name: 'Create' });
     expect(btn).toBeDefined();
     expect(btn).toHaveAttribute('aria-current', 'page');
     expect(btn).toHaveClass('bg-foreground/[0.06]');
@@ -150,7 +148,7 @@ describe('AppSwitcher', () => {
 
   it('inactive app button does not have active-state classes', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="compose" />);
-    const btn = screen.getByRole('link', { name: 'Editor' });
+    const btn = screen.getByRole('link', { name: 'Publish' });
     expect(btn).not.toHaveAttribute('aria-current');
     expect(btn).not.toHaveClass('bg-foreground/[0.06]');
   });
@@ -164,15 +162,15 @@ describe('AppSwitcher', () => {
           brandSlug="my-brand"
         />,
       );
-      expect(screen.getByRole('link', { name: 'Studio' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
         'href',
         '/acme/my-brand/studio/image',
       );
     });
 
-    it('links to org studio when brandSlug is absent', () => {
+    it('links to org-scoped create when brandSlug is absent', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
-      expect(screen.getByRole('link', { name: 'Studio' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
         'href',
         '/acme/~/studio/image',
       );
@@ -183,11 +181,9 @@ describe('AppSwitcher', () => {
 
       for (const [label, href] of [
         ['Library', '/acme/~/library'],
-        ['Posts', '/acme/~/posts'],
-        ['Studio', '/acme/~/studio/image'],
-        ['Workflows', '/acme/~/workflows'],
-        ['Editor', '/acme/~/editor'],
-        ['Write', '/acme/~/posts'],
+        ['Publish', '/acme/~/posts'],
+        ['Create', '/acme/~/studio/image'],
+        ['Automate', '/acme/~/workflows'],
       ] as const) {
         expect(screen.getByRole('link', { name: label })).toHaveAttribute(
           'href',
@@ -198,7 +194,7 @@ describe('AppSwitcher', () => {
 
     it('links to correct route for workspace app', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="studio" />);
-      expect(screen.getByRole('link', { name: 'Workspace' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
         'href',
         '/acme/~/overview',
       );
@@ -208,7 +204,7 @@ describe('AppSwitcher', () => {
       render(
         <AppSwitcher orgSlug="acme" currentApp="studio" brandSlug="my-brand" />,
       );
-      expect(screen.getByRole('link', { name: 'Workspace' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
         'href',
         '/acme/my-brand/workspace',
       );
@@ -231,15 +227,11 @@ describe('AppSwitcher', () => {
         />,
       );
 
-      expect(screen.getByRole('link', { name: 'Write' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
         'href',
-        '/acme/my-brand/compose/post',
+        '/acme/my-brand/studio/image',
       );
-      expect(screen.getByRole('link', { name: 'Editor' })).toHaveAttribute(
-        'href',
-        '/acme/my-brand/editor',
-      );
-      expect(screen.getByRole('link', { name: 'Workflows' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Automate' })).toHaveAttribute(
         'href',
         '/acme/my-brand/workflows',
       );
@@ -279,7 +271,7 @@ describe('AppSwitcher', () => {
           brandSlug="my-brand"
         />,
       );
-      expect(screen.getByRole('link', { name: 'Posts' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Publish' })).toHaveAttribute(
         'href',
         '/acme/my-brand/posts',
       );

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -2,18 +2,16 @@
 
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
-import type { AppSwitcherItemConfig } from '@genfeedai/interfaces';
+import type { AppContext, AppSwitcherItemConfig } from '@genfeedai/interfaces';
 import type { AppSwitcherProps } from '@genfeedai/props/ui/app-switcher.props';
 import Link from 'next/link';
 import { useRef } from 'react';
 import {
   HiChevronDown,
-  HiOutlineChartBar,
   HiOutlineChartBarSquare,
   HiOutlineChatBubbleLeftRight,
-  HiOutlineDocumentText,
   HiOutlineFolder,
-  HiOutlinePencilSquare,
+  HiOutlinePaperAirplane,
   HiOutlineRectangleGroup,
   HiOutlineSparkles,
   HiOutlineSquares2X2,
@@ -25,32 +23,18 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../../../primitives/dropdown-menu';
 
-const CONTENT_APPS: AppSwitcherItemConfig[] = [
-  {
-    icon: HiOutlineFolder,
-    id: 'library',
-    label: 'Library',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/library`,
-  },
-  {
-    icon: HiOutlineDocumentText,
-    id: 'posts',
-    label: 'Posts',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/posts` : `/${org}/~/posts`,
-  },
-];
+type LifecycleAppSwitcherItemConfig = AppSwitcherItemConfig & {
+  activeIds?: AppContext[];
+};
 
-const PLATFORM_APPS: AppSwitcherItemConfig[] = [
+const SECTION_APPS: LifecycleAppSwitcherItemConfig[] = [
   {
     icon: HiOutlineSquares2X2,
     id: 'workspace',
-    label: 'Workspace',
+    label: 'Home',
     route: (org, brand) =>
       brand ? `/${org}/${brand}/workspace` : `/${org}/~/overview`,
   },
@@ -61,32 +45,33 @@ const PLATFORM_APPS: AppSwitcherItemConfig[] = [
     route: (org) => `/${org}/~/chat`,
   },
   {
+    activeIds: ['studio', 'compose', 'editor'],
     icon: HiOutlineSparkles,
     id: 'studio',
-    label: 'Studio',
+    label: 'Create',
     route: (org, brand) =>
       brand ? `/${org}/${brand}/studio/image` : `/${org}/~/studio/image`,
   },
   {
-    icon: HiOutlineChartBar,
-    id: 'workflows',
-    label: 'Workflows',
+    icon: HiOutlineFolder,
+    id: 'library',
+    label: 'Library',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
+      brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/library`,
   },
   {
-    icon: HiOutlinePencilSquare,
-    id: 'editor',
-    label: 'Editor',
+    icon: HiOutlinePaperAirplane,
+    id: 'posts',
+    label: 'Publish',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/editor` : `/${org}/~/editor`,
+      brand ? `/${org}/${brand}/posts` : `/${org}/~/posts`,
   },
   {
     icon: HiOutlineRectangleGroup,
-    id: 'compose',
-    label: 'Write',
+    id: 'workflows',
+    label: 'Automate',
     route: (org, brand) =>
-      brand ? `/${org}/${brand}/compose/post` : `/${org}/~/posts`,
+      brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
   },
   {
     icon: HiOutlineChartBarSquare,
@@ -98,8 +83,6 @@ const PLATFORM_APPS: AppSwitcherItemConfig[] = [
         : `/${org}/~/analytics/overview`,
   },
 ];
-
-const ALL_APPS: AppSwitcherItemConfig[] = [...PLATFORM_APPS, ...CONTENT_APPS];
 
 function withPreservedSearch(path: string, preservedSearch?: string): string {
   if (!preservedSearch) {
@@ -127,13 +110,20 @@ function withPreservedSearch(path: string, preservedSearch?: string): string {
   return nextSearch ? `${pathname}?${nextSearch}` : pathname;
 }
 
+function isActiveApp(
+  app: LifecycleAppSwitcherItemConfig,
+  currentApp: AppContext,
+): boolean {
+  return app.id === currentApp || app.activeIds?.includes(currentApp) === true;
+}
+
 function AppDropdownItem({
   app,
   isActive,
   href,
   onNavigateStart,
 }: {
-  app: AppSwitcherItemConfig;
+  app: LifecycleAppSwitcherItemConfig;
   isActive: boolean;
   href: string;
   onNavigateStart: () => void;
@@ -184,9 +174,9 @@ export function AppSwitcher({
     preventTriggerAutoFocusRef.current = true;
   };
 
-  const activeApp = ALL_APPS.find((app) => app.id === currentApp);
+  const activeApp = SECTION_APPS.find((app) => isActiveApp(app, currentApp));
   const ActiveIcon = activeApp?.icon ?? HiOutlineSquares2X2;
-  const activeLabel = activeApp?.label ?? 'Workspace';
+  const activeLabel = activeApp?.label ?? 'Home';
 
   return (
     <DropdownMenu modal={false}>
@@ -210,7 +200,7 @@ export function AppSwitcher({
             variant={ButtonVariant.GHOST}
             size={ButtonSize.ICON}
             className="size-7 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0"
-            ariaLabel="Switch app"
+            ariaLabel="Switch section"
           >
             <TbGridDots className="size-4" />
           </Button>
@@ -229,25 +219,12 @@ export function AppSwitcher({
           preventTriggerAutoFocusRef.current = false;
         }}
       >
-        <DropdownMenuLabel>Content</DropdownMenuLabel>
-        {CONTENT_APPS.map((app) => (
+        <DropdownMenuLabel>Sections</DropdownMenuLabel>
+        {SECTION_APPS.map((app) => (
           <AppDropdownItem
             key={app.id}
             app={app}
-            isActive={app.id === currentApp}
-            href={getAppHref(app)}
-            onNavigateStart={handleNavigateStart}
-          />
-        ))}
-
-        <DropdownMenuSeparator />
-
-        <DropdownMenuLabel>Tools</DropdownMenuLabel>
-        {PLATFORM_APPS.map((app) => (
-          <AppDropdownItem
-            key={app.id}
-            app={app}
-            isActive={app.id === currentApp}
+            isActive={isActiveApp(app, currentApp)}
             href={getAppHref(app)}
             onNavigateStart={handleNavigateStart}
           />


### PR DESCRIPTION
## Summary

- Consolidates the app switcher into first-level sections: Home, Agent, Create, Library, Publish, Automate, and Analytics.
- Moves organization switching into the protected topbar for SaaS/cloud mode, before the brand switcher.
- Removes the Studio-to-Library back row and lets Library render as the sidebar section header for the relevant content rail.

## Why

The previous switcher mixed content objects, creation tools, automation systems, and measurement surfaces in one list. This makes the shell read as a set of unrelated apps instead of one content operating system. This PR starts the IA cleanup while preserving existing routes.

## Validation

- `bun run --cwd packages/ui test src/components/shell/app-switcher/AppSwitcher.test.tsx src/components/menus/shared/MenuShared.test.tsx`
- `bun run --cwd apps/app test src/components/shell/AppProtectedTopbar.test.tsx packages/components/app-protected-layout.test.tsx`
- `npx biome check --write ...`
- `bun run design:lint` (warning-only, no errors)
- `bun run --cwd packages/ui build`
- `bun run --cwd apps/app lint`
- `git diff --check`
- staged secret scan via `bunx secretlint $(git diff --cached --name-only)` before commit
