### PR TITLE
fix(api): repair Prisma 500s on /v1/avatars and /v1/musics

### DIFF
--- a/apps/server/api/src/collections/avatars/controllers/avatars.controller.spec.ts
+++ b/apps/server/api/src/collections/avatars/controllers/avatars.controller.spec.ts
@@ -4,7 +4,9 @@ import type { AvatarsService } from '@api/collections/avatars/services/avatars.s
 import type { ElevenLabsService } from '@api/services/integrations/elevenlabs/elevenlabs.service';
 import type { HedraService } from '@api/services/integrations/hedra/services/hedra.service';
 import type { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
+import { IngredientCategory } from '@genfeedai/enums';
 import type { LoggerService } from '@libs/logger/logger.service';
+import type { Request } from 'express';
 
 const userId = '507f191e810c19729de860ee'.toString();
 const orgId = '507f191e810c19729de860ee'.toString();
@@ -172,6 +174,37 @@ describe('AvatarsController', () => {
       const controller = buildController();
       vi.mocked(mockHedraService.getAvatars).mockRejectedValue(new Error('x'));
       await expect(controller.getHedraAvatars(makeUser())).rejects.toThrow();
+    });
+  });
+
+  describe('findAll', () => {
+    const makeRequest = () =>
+      ({
+        get: () => 'app.test',
+        originalUrl: '/v1/avatars',
+        protocol: 'https',
+      }) as unknown as Request;
+
+    it('should filter by category instead of the legacy "type" field', async () => {
+      const controller = buildController();
+      vi.mocked(mockAvatarsService.findAll).mockResolvedValue({
+        docs: [],
+      } as never);
+
+      await controller.findAll(makeRequest(), makeUser(), {} as never);
+
+      expect(mockAvatarsService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            category: IngredientCategory.AVATAR,
+          }),
+        }),
+        expect.anything(),
+      );
+      // Ingredient has no "type" column — this field name previously caused
+      // PrismaClientValidationError ("Invalid `prisma.ingredient.findMany()`").
+      const [{ where }] = vi.mocked(mockAvatarsService.findAll).mock.calls[0];
+      expect(where).not.toHaveProperty('type');
     });
   });
 });

--- a/apps/server/api/src/collections/avatars/controllers/avatars.controller.ts
+++ b/apps/server/api/src/collections/avatars/controllers/avatars.controller.ts
@@ -21,7 +21,7 @@ import { ElevenLabsService } from '@api/services/integrations/elevenlabs/elevenl
 import { HedraService } from '@api/services/integrations/hedra/services/hedra.service';
 import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
 import { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
-import { ActivitySource } from '@genfeedai/enums';
+import { ActivitySource, IngredientCategory } from '@genfeedai/enums';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
@@ -259,8 +259,8 @@ export class AvatarsController {
     const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(query.isDeleted);
     const aggregate = {
       where: {
+        category: IngredientCategory.AVATAR,
         isDeleted,
-        type: 'avatar',
         user: publicMetadata.user,
       },
       orderBy: handleQuerySort(query.sort),

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
@@ -112,8 +112,12 @@ describe('MusicsController', () => {
         inputQuery as never,
       );
 
+      // Ingredient.isDefault is a non-nullable Boolean column — { not: null } is
+      // not a valid Prisma filter shape for it and crashes with
+      // PrismaClientValidationError ("Argument `not` is missing"). { equals: true }
+      // is both valid and matches this branch's intent (surface default musics).
       expect(query.where.OR[1]).toMatchObject({
-        isDefault: { not: null },
+        isDefault: { equals: true },
       });
       expect(query.where.OR[1]).not.toHaveProperty('scope');
     });

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.ts
@@ -59,8 +59,13 @@ export class MusicsController extends BaseCRUDController<
       'user',
     );
 
+    // Ingredient.isDefault is a non-nullable Boolean column; { not: null } is not
+    // a valid Prisma filter shape for it (only nullable fields accept `not: null`)
+    // and crashed this endpoint with PrismaClientValidationError. This OR branch
+    // exists specifically to surface the org's default music tracks, so default
+    // to { equals: true } when the caller doesn't filter explicitly.
     const isDefault = CollectionFilterUtil.buildBooleanFilter(query.isDefault, {
-      not: null,
+      equals: true,
     });
 
     const scope = CollectionFilterUtil.buildScopeFilter(query.scope);


### PR DESCRIPTION
Found live, sweeping app.genfeed.ai for dead endpoints (studio/avatar + studio/music pages 500 on load).

**`GET /v1/avatars`** — `AvatarsController.findAll` filtered `type: 'avatar'`. Ingredient model has no `type` field, only `category` enum -> `PrismaClientValidationError`. Fixed to `category: IngredientCategory.AVATAR` (commented-out code nearby already showed this was the intended field).

**`GET /v1/musics`** — default-music OR branch built `isDefault` via `buildBooleanFilter(query.isDefault, { not: null })`. `Ingredient.isDefault` is a non-nullable `Boolean` column; `{ not: null }` isn't valid for it -> `PrismaClientValidationError: Argument \`not\` is missing`. Fixed to `{ equals: true }`, matching the branch's actual intent. Existing spec had asserted the buggy shape — updated it.

Verified: 24/24 tests pass (incl. new avatars findAll coverage), api typecheck clean.