### PR TITLE
refactor(api): reuse workflow string reader

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -2306,8 +2306,8 @@ describe('AgentToolExecutorService', () => {
             type: 'ai-generate-post',
           },
         ],
-        schedule: '0 9 * * 1',
-        timezone: 'Europe/Malta',
+        schedule: ' 0 9 * * 1 ',
+        timezone: ' Europe/Malta ',
       },
       {
         organizationId: '67a123456789012345678901',

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -689,14 +689,8 @@ export class AgentToolExecutorService {
     }
 
     const brand = await this.resolveWorkflowBrand(params, ctx);
-    const schedule =
-      typeof params.schedule === 'string' && params.schedule.trim()
-        ? params.schedule.trim()
-        : undefined;
-    const timezone =
-      typeof params.timezone === 'string' && params.timezone.trim()
-        ? params.timezone.trim()
-        : 'UTC';
+    const schedule = this.readOptionalString(params.schedule);
+    const timezone = this.readOptionalString(params.timezone) ?? 'UTC';
 
     await this.workflowsService.patch(workflowId, {
       brands: brand && brand._id ? [String(brand._id)] : workflow.brands,
@@ -4289,10 +4283,7 @@ export class AgentToolExecutorService {
       requestedContentType === 'newsletter'
         ? requestedContentType
         : 'image';
-    const timezone =
-      typeof params.timezone === 'string' && params.timezone.trim()
-        ? params.timezone.trim()
-        : 'UTC';
+    const timezone = this.readOptionalString(params.timezone) ?? 'UTC';
     const requestedCount =
       typeof params.count === 'number'
         ? params.count
@@ -4515,14 +4506,8 @@ export class AgentToolExecutorService {
     ctx: ToolExecutionContext,
   ): Promise<AgentToolResult> {
     const confirmed = params.confirmed === true;
-    const schedule =
-      typeof params.schedule === 'string' && params.schedule.trim()
-        ? params.schedule.trim()
-        : undefined;
-    const timezone =
-      typeof params.timezone === 'string' && params.timezone.trim()
-        ? params.timezone.trim()
-        : 'UTC';
+    const schedule = this.readOptionalString(params.schedule);
+    const timezone = this.readOptionalString(params.timezone) ?? 'UTC';
 
     let source: OfficialWorkflowSource | null =
       typeof params.sourceId === 'string' &&
@@ -5290,18 +5275,12 @@ export class AgentToolExecutorService {
       !hasGraphPayload &&
       typeof params.description === 'string' &&
       params.description.trim().length > 0;
-    const timezone =
-      typeof params.timezone === 'string' && params.timezone.trim()
-        ? params.timezone.trim()
-        : 'UTC';
+    const timezone = this.readOptionalString(params.timezone) ?? 'UTC';
     const trigger =
       typeof params.trigger === 'string' && params.trigger.trim()
         ? params.trigger
         : WorkflowTrigger.MANUAL;
-    const schedule =
-      typeof params.schedule === 'string' && params.schedule.trim()
-        ? params.schedule.trim()
-        : undefined;
+    const schedule = this.readOptionalString(params.schedule);
     const isScheduleEnabled =
       typeof params.isScheduleEnabled === 'boolean'
         ? params.isScheduleEnabled


### PR DESCRIPTION
## Summary

Closes #979
Parent: #519

- Reuses the existing `readOptionalString` helper for workflow schedule/timezone params in `AgentToolExecutorService`.
- Keeps the legacy `String(params.schedule || '').trim()` scaffold path unchanged because changing that coercion would not be behavior-preserving.
- Adds a focused characterization by passing whitespace-padded schedule/timezone values through the existing `create_workflow` spec and asserting trimmed output.

## Structural review

- Selected from #519's verified DRY findings.
- No new abstraction layer, casts, package boundary changes, or public behavior changes.
- Deferred: the pre-existing 9k-line `AgentToolExecutorService` file-size blocker remains tracked by parent #519 and is intentionally out of scope for this child slice.

## Validation

- `bunx biome check --write apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bun run --cwd apps/server/api test:file src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts` (74 tests)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bun run lint-staged`
