### PR TITLE
Tighten card and list spacing across UI surfaces

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx
@@ -66,7 +66,7 @@ export default function PostsWritePreviewPanel({
         </span>
       </div>
 
-      <div className="mt-5 grid gap-3">
+      <div className="mt-5 divide-y divide-white/10">
         {draftSegments.map((segment, index) => {
           const count = segment.length;
           const isOverLimit = characterLimit !== null && count > characterLimit;
@@ -74,7 +74,7 @@ export default function PostsWritePreviewPanel({
           return (
             <div
               key={`preview-segment-${index.toString()}`}
-              className="rounded-xl border border-white/10 bg-black/20 p-4"
+              className="py-4 first:pt-0 last:pb-0"
             >
               <div className="mb-3 flex items-center justify-between gap-3 text-xs">
                 <span className="font-medium text-foreground/70">
@@ -104,7 +104,7 @@ export default function PostsWritePreviewPanel({
         })}
       </div>
 
-      <div className="mt-5 rounded-xl border border-white/10 bg-black/10 p-4 text-sm text-foreground/60">
+      <div className="mt-5 border-t border-white/10 pt-4 text-sm text-foreground/60">
         <p className="font-medium text-foreground">Agent context</p>
         <p className="mt-1">
           The co-pilot sees the current draft, selected text, format, account,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/ingredients/library-landing-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/ingredients/library-landing-page.test.tsx
@@ -60,6 +60,7 @@ describe('LibraryLandingPage', () => {
     expect(videosTile.tagName).toBe('A');
     expect(imagesTile.tagName).toBe('A');
     expect(voicesTile.tagName).toBe('A');
+    expect(videosTile).toHaveClass('rounded-card');
     expect(screen.getAllByRole('link')).toHaveLength(7);
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/ingredients/library-landing-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/ingredients/library-landing-page.tsx
@@ -117,7 +117,7 @@ function LibraryCategoryTile({
       aria-describedby={descriptionId}
       data-testid={testId}
       className={cn(
-        'group block h-full rounded border border-white/[0.08] bg-card text-card-foreground shadow-[0_24px_60px_-40px_rgba(0,0,0,0.8)] transition-[border-color,background-color,box-shadow,transform] duration-200 ease-out',
+        'group block h-full rounded-card border border-white/[0.08] bg-card text-card-foreground shadow-[0_24px_60px_-40px_rgba(0,0,0,0.8)] transition-[border-color,background-color,box-shadow,transform] duration-200 ease-out',
         'hover:-translate-y-0.5 hover:border-white/[0.16] hover:bg-white/[0.02] hover:shadow-[0_28px_70px_-44px_rgba(0,0,0,0.9)]',
         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
       )}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-outputs-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-outputs-card.tsx
@@ -62,13 +62,16 @@ export function WorkspaceTaskOutputsCard({
       ) : null}
 
       {linkedOutputGroups.length > 0 ? (
-        <div className="space-y-3" data-testid="workspace-task-linked-outputs">
+        <div
+          className="divide-y divide-white/10"
+          data-testid="workspace-task-linked-outputs"
+        >
           {linkedOutputGroups.map((group) => {
             const outputs = [group.root, ...group.children];
             return (
               <article
                 key={group.root.id}
-                className="rounded-xl border border-white/10 bg-white/[0.03] p-3"
+                className="py-3 first:pt-0 last:pb-0"
               >
                 <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                   <p className="font-medium text-foreground">
@@ -79,7 +82,7 @@ export function WorkspaceTaskOutputsCard({
                   </span>
                 </div>
 
-                <div className="space-y-3">
+                <div className="divide-y divide-white/10">
                   {outputs.map((output) => {
                     const description =
                       getWorkspaceLinkedOutputDescription(output);
@@ -88,7 +91,7 @@ export function WorkspaceTaskOutputsCard({
                     return (
                       <div
                         key={output.id}
-                        className="rounded-lg border border-white/10 bg-black/30 p-3"
+                        className="py-3 first:pt-0 last:pb-0"
                       >
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <div className="space-y-1">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-thread-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-thread-card.tsx
@@ -20,7 +20,10 @@ export function WorkspaceTaskThreadCard({
       label="Task thread"
       bodyClassName="space-y-3 border-l border-sky-400/30 p-4 text-sm text-foreground/75"
     >
-      <div className="space-y-3" data-testid="workspace-task-events">
+      <div
+        className="divide-y divide-white/10"
+        data-testid="workspace-task-events"
+      >
         {[...eventStream]
           .slice()
           .sort((left, right) =>
@@ -30,10 +33,7 @@ export function WorkspaceTaskThreadCard({
             const message = getWorkspaceEventMessage(event);
 
             return (
-              <article
-                key={event.id}
-                className="rounded-xl border border-white/10 bg-white/[0.03] p-3"
-              >
+              <article key={event.id} className="py-3 first:pt-0 last:pb-0">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <p className="font-medium text-foreground">
                     {formatWorkspaceEventLabel(event)}

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/help/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/help/content.test.tsx
@@ -1,8 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import Module from './content.tsx';
 
 describe('settings-help-page.tsx', () => {
   it('exports a component', () => {
     expect(Module).toBeDefined();
+  });
+
+  it('uses the shared LinkCard instead of a local rounded link tile', () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        'app/(protected)/[orgSlug]/~/settings/(pages)/help/content.tsx',
+      ),
+      'utf8',
+    );
+
+    expect(source).toContain("from '@/components/ui/link-card'");
+    expect(source).not.toContain("from '@ui/card/Card'");
+    expect(source).not.toContain('<Card');
+    expect(source).not.toContain('rounded-lg border border-border');
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/help/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/help/content.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { EnvironmentService } from '@services/core/environment.service';
-import Card from '@ui/card/Card';
 import type { ComponentType } from 'react';
 import {
   FaDiscord,
@@ -16,6 +15,7 @@ import {
   HiDocumentText,
 } from 'react-icons/hi2';
 import { SiSubstack } from 'react-icons/si';
+import { LinkCard } from '@/components/ui/link-card';
 
 interface LinkItem {
   label: string;
@@ -69,42 +69,40 @@ const COMMUNITY: LinkItem[] = [
   },
 ];
 
-function LinkCard({ item }: { item: LinkItem }) {
-  const Icon = item.icon;
+function HelpLinkCard({ item }: { item: LinkItem }) {
   return (
-    <a
+    <LinkCard
       href={item.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex items-center gap-3 rounded-lg border border-border p-4 no-underline text-foreground transition-colors hover:bg-muted/50"
-    >
-      <Icon className="size-5 shrink-0 text-muted-foreground" />
-      <span className="flex-1 text-sm font-medium">{item.label}</span>
-      <HiArrowTopRightOnSquare className="size-4 shrink-0 text-muted-foreground" />
-    </a>
+      icon={item.icon}
+      title={item.label}
+      className="p-4 no-underline text-sm"
+      trailingIcon={
+        <HiArrowTopRightOnSquare className="size-4 shrink-0 text-muted-foreground" />
+      }
+    />
   );
 }
 
 export default function SettingsHelpPage() {
   return (
     <div className="space-y-6">
-      <Card className="p-6">
-        <h2 className="text-lg font-semibold mb-4">Resources</h2>
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Resources</h2>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {RESOURCES.map((item) => (
-            <LinkCard key={item.label} item={item} />
+            <HelpLinkCard key={item.label} item={item} />
           ))}
         </div>
-      </Card>
+      </section>
 
-      <Card className="p-6">
-        <h2 className="text-lg font-semibold mb-4">Community</h2>
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Community</h2>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {COMMUNITY.map((item) => (
-            <LinkCard key={item.label} item={item} />
+            <HelpLinkCard key={item.label} item={item} />
           ))}
         </div>
-      </Card>
+      </section>
     </div>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx
@@ -544,7 +544,7 @@ export default function SettingsApiKeysPage() {
           </div>
 
           {productPlainKey ? (
-            <div className="mt-4 rounded-md border border-border bg-muted/30 p-3">
+            <div className="mt-4 border-t border-border pt-3">
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-xs font-medium">{productPlainKey.label}</p>

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-rewards-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-rewards-card.tsx
@@ -59,17 +59,14 @@ export default function SettingsProgressRewardsCard({
         )}
       </div>
 
-      <div className="mt-6 space-y-3">
+      <div className="mt-6 divide-y divide-white/10">
         {milestoneStates.map((milestone) => (
           <div
             key={milestone.days}
             className={cn(
-              'rounded-2xl border p-4',
-              milestone.isAchieved
-                ? 'border-emerald-400/20 bg-emerald-400/8'
-                : milestone.isNext
-                  ? 'border-orange-400/20 bg-orange-400/8'
-                  : 'border-white/10 bg-black/10',
+              'py-4 first:pt-0 last:pb-0',
+              milestone.isAchieved && 'text-emerald-100',
+              milestone.isNext && 'text-orange-100',
             )}
           >
             <div className="flex items-start justify-between gap-3">

--- a/apps/app/src/components/ui/link-card.tsx
+++ b/apps/app/src/components/ui/link-card.tsx
@@ -1,21 +1,26 @@
+import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 export interface LinkCardProps {
+  className?: string;
+  description?: string;
   href: string;
   icon: React.ComponentType<{ className?: string }>;
   title: string;
-  description: string;
   /** Large icon style (for prominent cards) */
   prominent?: boolean;
+  trailingIcon?: ReactNode;
 }
 
 /** Clickable external link card */
 export function LinkCard({
+  className,
+  description,
   href,
   icon: Icon,
   title,
-  description,
   prominent,
+  trailingIcon,
 }: LinkCardProps) {
   return (
     <a
@@ -25,6 +30,7 @@ export function LinkCard({
       className={cn(
         'flex items-center gap-3 rounded-card border border-border transition hover:border-primary/50 hover:bg-secondary/30',
         prominent ? 'p-4' : 'p-3',
+        className,
       )}
     >
       {prominent ? (
@@ -32,19 +38,22 @@ export function LinkCard({
           <Icon className="size-5 text-primary" />
         </div>
       ) : (
-        <Icon className="size-5 text-muted-foreground" />
+        <Icon className="size-5 shrink-0 text-muted-foreground" />
       )}
-      <div>
+      <div className="min-w-0 flex-1">
         <div className="font-medium text-foreground">{title}</div>
-        <p
-          className={cn(
-            prominent ? 'text-sm' : 'text-xs',
-            'text-muted-foreground',
-          )}
-        >
-          {description}
-        </p>
+        {description ? (
+          <p
+            className={cn(
+              prominent ? 'text-sm' : 'text-xs',
+              'text-muted-foreground',
+            )}
+          >
+            {description}
+          </p>
+        ) : null}
       </div>
+      {trailingIcon}
     </a>
   );
 }

--- a/apps/app/src/features/workflows/pages/batch/BatchComposer.tsx
+++ b/apps/app/src/features/workflows/pages/batch/BatchComposer.tsx
@@ -276,13 +276,13 @@ export default function BatchComposer({
             No recent batch jobs yet.
           </InsetSurface>
         ) : (
-          <div className="space-y-3">
+          <div className="divide-y divide-white/[0.08]">
             {recentJobs.map((job) => (
               <Button
                 key={job._id}
                 variant={ButtonVariant.UNSTYLED}
                 onClick={() => void onOpenRecentJob(job._id)}
-                className="w-full rounded-xl border border-white/10 bg-background/40 p-4 text-left transition hover:border-white/20 hover:bg-background/60"
+                className="w-full py-4 text-left transition hover:bg-foreground/[0.03]"
               >
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>

--- a/packages/pages/analytics/overview/analytics-overview-hero.tsx
+++ b/packages/pages/analytics/overview/analytics-overview-hero.tsx
@@ -43,7 +43,7 @@ export default function AnalyticsOverviewHero({
   orgHref,
 }: AnalyticsOverviewHeroProps) {
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.7fr)_minmax(280px,0.9fr)]">
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1.7fr)_minmax(280px,0.9fr)]">
       <div className="space-y-5">
         <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-foreground/60">
           {dashboardState === 'active' ? (
@@ -87,7 +87,7 @@ export default function AnalyticsOverviewHero({
         </div>
       </div>
 
-      <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.02] p-4 lg:p-5">
+      <aside className="border-t border-white/[0.08] pt-5 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
         <div className="flex items-center justify-between gap-3">
           <div>
             <div className="text-sm font-medium text-foreground">
@@ -100,22 +100,22 @@ export default function AnalyticsOverviewHero({
           <HiOutlineSquares2X2 className="size-5 text-foreground/45" />
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+        <div className="mt-4 divide-y divide-white/[0.08]">
           {heroContent.progressItems.map((item) => (
             <div
               key={item.label}
-              className="rounded-xl border border-white/[0.08] bg-black/10 p-4"
+              className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-4 py-4 first:pt-0 last:pb-0 lg:block"
             >
-              <div className="text-xs uppercase tracking-[0.22em] text-foreground/40">
+              <div className="text-xs uppercase tracking-[0.22em] text-foreground/40 lg:mb-2">
                 {item.label}
               </div>
-              <div className="mt-2 text-3xl font-serif text-foreground">
+              <div className="text-3xl font-serif text-foreground">
                 {item.value}
               </div>
             </div>
           ))}
         </div>
-      </div>
+      </aside>
     </div>
   );
 }

--- a/packages/pages/analytics/overview/analytics-overview.test.tsx
+++ b/packages/pages/analytics/overview/analytics-overview.test.tsx
@@ -346,6 +346,9 @@ describe('AnalyticsOverview', () => {
     expect(markup).toContain('Warming up');
     expect(markup).toContain('Coverage so far');
     expect(markup).toContain('/posts');
+    expect(markup).toContain('border-y border-white/[0.08]');
+    expect(markup).not.toContain('rounded-2xl border');
+    expect(markup).not.toContain('bg-black/10 p-4');
   });
 
   it('renders the active dashboard when metrics and time series data are available', () => {

--- a/packages/pages/analytics/overview/analytics-overview.tsx
+++ b/packages/pages/analytics/overview/analytics-overview.tsx
@@ -128,16 +128,13 @@ export default function AnalyticsOverview({
       <div
         className={cn('flex flex-col gap-6', showAgentDashboard && 'hidden')}
       >
-        <Card
-          variant={CardVariant.DEFAULT}
-          bodyClassName="overflow-hidden p-6 lg:p-8"
-        >
+        <section className="border-y border-white/[0.08] bg-card/70 px-6 py-8 lg:px-8">
           <AnalyticsOverviewHero
             dashboardState={dashboardState}
             heroContent={heroContent}
             orgHref={orgHref}
           />
-        </Card>
+        </section>
 
         <AnalyticsOverviewAlerts
           cachedLabel={cachedLabel}

--- a/packages/ui/src/components/posts/post-detail-sidebar/PostSidebarReviewCard.tsx
+++ b/packages/ui/src/components/posts/post-detail-sidebar/PostSidebarReviewCard.tsx
@@ -112,11 +112,11 @@ export default function PostSidebarReviewCard({
           )}
 
           {reviewEvents.length > 0 && (
-            <div className="mt-4 space-y-3">
+            <div className="mt-4 divide-y divide-border">
               {reviewEvents.map((event) => (
                 <div
                   key={`${event.reviewedAt}-${event.decision}`}
-                  className="rounded-lg border border-border bg-background/40 p-3 text-sm"
+                  className="py-3 text-sm first:pt-0 last:pb-0"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <span className="font-medium">

--- a/scripts/check-no-nested-cards.ts
+++ b/scripts/check-no-nested-cards.ts
@@ -1,0 +1,332 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { globSync } from 'glob';
+import ts from 'typescript';
+
+const logger = {
+  error: (message: string) => console.error(`[CheckNoNestedCards] ${message}`),
+  log: (message: string) => console.log(`[CheckNoNestedCards] ${message}`),
+};
+
+const INCLUDE_GLOBS = [
+  'apps/app/**/*.{tsx,jsx}',
+  'packages/pages/**/*.{tsx,jsx}',
+  'packages/ui/src/**/*.{tsx,jsx}',
+];
+
+const EXCLUDE_GLOBS = [
+  '**/*.test.*',
+  '**/*.spec.*',
+  '**/*.stories.*',
+  '**/*.md',
+  '**/*.mdx',
+  '**/dist/**',
+  '**/node_modules/**',
+];
+
+const ICON_COMPONENT_PREFIXES = [
+  'Ai',
+  'Bi',
+  'Bs',
+  'Cg',
+  'Ci',
+  'Di',
+  'Fa',
+  'Fc',
+  'Fi',
+  'Gi',
+  'Go',
+  'Gr',
+  'Hi',
+  'Im',
+  'Io',
+  'Lu',
+  'Md',
+  'Pi',
+  'Ri',
+  'Rx',
+  'Si',
+  'Sl',
+  'Tb',
+  'Ti',
+  'Vsc',
+  'Wi',
+];
+
+const CARD_HELPER_COMPONENTS = new Set([
+  'CardContent',
+  'CardEmptyContent',
+  'CardIcon',
+]);
+
+const CARD_SURFACE_COMPONENTS = new Set([
+  'Card',
+  'EmptyStateCard',
+  'FolderCard',
+  'KPICard',
+  'LinkCard',
+  'MetricCard',
+  'OverviewPlaceholderCard',
+  'PricingCard',
+  'SetupCard',
+  'StatCard',
+  'StatsCards',
+]);
+
+const CARD_CHROME_EXEMPT_COMPONENTS = new Set([
+  'Input',
+  'Select',
+  'SelectContent',
+  'SelectItem',
+  'SelectTrigger',
+  'SelectValue',
+  'Textarea',
+]);
+
+type Violation = {
+  detail: string;
+  file: string;
+  kind: 'nested-card-component' | 'nested-card-chrome';
+  line: number;
+};
+
+export function runCheckNoNestedCards(): { violations: Violation[] } {
+  const rootDir = process.cwd();
+  const files = globSync(INCLUDE_GLOBS, {
+    absolute: true,
+    ignore: EXCLUDE_GLOBS,
+    nodir: true,
+  });
+
+  const violations: Violation[] = [];
+
+  for (const filePath of files) {
+    const content = readFileSync(filePath, 'utf8');
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      filePath.endsWith('.tsx') || filePath.endsWith('.jsx')
+        ? ts.ScriptKind.TSX
+        : ts.ScriptKind.TS,
+    );
+    const relativePath = path.relative(rootDir, filePath);
+
+    collectViolations(sourceFile, relativePath, violations);
+  }
+
+  return { violations };
+}
+
+function collectViolations(
+  sourceFile: ts.SourceFile,
+  relativePath: string,
+  violations: Violation[],
+) {
+  function visit(node: ts.Node, cardDepth: number) {
+    if (ts.isJsxElement(node)) {
+      const tagName = getTagName(node.openingElement.tagName);
+      const isCardSurface = isCardSurfaceTag(tagName);
+
+      checkNode({
+        cardDepth,
+        className: getClassName(node.openingElement.attributes),
+        isCardSurface,
+        node,
+        relativePath,
+        sourceFile,
+        tagName,
+        violations,
+      });
+
+      const nextCardDepth = cardDepth + (isCardSurface ? 1 : 0);
+      for (const child of node.children) {
+        visit(child, nextCardDepth);
+      }
+      return;
+    }
+
+    if (ts.isJsxSelfClosingElement(node)) {
+      const tagName = getTagName(node.tagName);
+      const isCardSurface = isCardSurfaceTag(tagName);
+
+      checkNode({
+        cardDepth,
+        className: getClassName(node.attributes),
+        isCardSurface,
+        node,
+        relativePath,
+        sourceFile,
+        tagName,
+        violations,
+      });
+      return;
+    }
+
+    ts.forEachChild(node, (child) => visit(child, cardDepth));
+  }
+
+  visit(sourceFile, 0);
+}
+
+function checkNode({
+  cardDepth,
+  className,
+  isCardSurface,
+  node,
+  relativePath,
+  sourceFile,
+  tagName,
+  violations,
+}: {
+  cardDepth: number;
+  className: string;
+  isCardSurface: boolean;
+  node: ts.Node;
+  relativePath: string;
+  sourceFile: ts.SourceFile;
+  tagName: string;
+  violations: Violation[];
+}) {
+  if (cardDepth === 0) {
+    return;
+  }
+
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line +
+    1;
+
+  if (isCardSurface) {
+    violations.push({
+      detail: tagName,
+      file: relativePath,
+      kind: 'nested-card-component',
+      line,
+    });
+    return;
+  }
+
+  if (
+    !CARD_CHROME_EXEMPT_COMPONENTS.has(tagName) &&
+    hasNestedCardChrome(className)
+  ) {
+    violations.push({
+      detail: className,
+      file: relativePath,
+      kind: 'nested-card-chrome',
+      line,
+    });
+  }
+}
+
+function getTagName(tagName: ts.JsxTagNameExpression): string {
+  if (ts.isIdentifier(tagName)) {
+    return tagName.text;
+  }
+
+  if (ts.isPropertyAccessExpression(tagName)) {
+    return tagName.name.text;
+  }
+
+  return tagName.getText();
+}
+
+function isCardSurfaceTag(tagName: string): boolean {
+  if (CARD_HELPER_COMPONENTS.has(tagName)) {
+    return false;
+  }
+
+  return (
+    CARD_SURFACE_COMPONENTS.has(tagName) &&
+    !ICON_COMPONENT_PREFIXES.some((prefix) => tagName.startsWith(prefix))
+  );
+}
+
+function getClassName(attributes: ts.JsxAttributes): string {
+  const fragments: string[] = [];
+
+  for (const property of attributes.properties) {
+    if (!ts.isJsxAttribute(property)) {
+      continue;
+    }
+
+    if (property.name.text !== 'className' || !property.initializer) {
+      continue;
+    }
+
+    collectStringFragments(property.initializer, fragments);
+  }
+
+  return fragments.join(' ');
+}
+
+function collectStringFragments(node: ts.Node, fragments: string[]) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    fragments.push(node.text);
+    return;
+  }
+
+  if (ts.isJsxExpression(node) && node.expression) {
+    collectStringFragments(node.expression, fragments);
+    return;
+  }
+
+  ts.forEachChild(node, (child) => collectStringFragments(child, fragments));
+}
+
+function hasNestedCardChrome(className: string): boolean {
+  if (!className) {
+    return false;
+  }
+
+  const classTokens = className.split(/\s+/).filter(Boolean);
+  const hasRounded = classTokens.some(
+    (classToken) =>
+      classToken.includes('rounded') && !classToken.includes('rounded-full'),
+  );
+  const hasBorder = classTokens.some(
+    (classToken) =>
+      classToken === 'border' ||
+      classToken.startsWith('border-') ||
+      classToken.includes(':border') ||
+      classToken.includes(':border-'),
+  );
+  const hasBackgroundOrShadow = classTokens.some(
+    (classToken) =>
+      classToken.startsWith('bg-') ||
+      classToken.startsWith('shadow-') ||
+      classToken.includes(':bg-') ||
+      classToken.includes(':shadow-'),
+  );
+  const hasPanelPadding = classTokens.some((classToken) =>
+    /(^|:)p-(3|4|5|6|7|8|9|10|11|12|\[)/.test(classToken),
+  );
+
+  return hasRounded && hasBorder && hasBackgroundOrShadow && hasPanelPadding;
+}
+
+function isMainModule(): boolean {
+  const entryPoint = process.argv[1];
+  return Boolean(entryPoint) && path.resolve(entryPoint) === __filename;
+}
+
+if (isMainModule()) {
+  const { violations } = runCheckNoNestedCards();
+
+  if (violations.length > 0) {
+    logger.error(
+      'Nested card composition found. Use one card surface, then rows, separators, or unframed layout inside it.',
+    );
+
+    for (const violation of violations) {
+      logger.error(
+        `- [${violation.kind}] ${violation.file}:${violation.line} (${violation.detail})`,
+      );
+    }
+
+    process.exit(1);
+  }
+
+  logger.log('No nested card composition found.');
+}

--- a/scripts/ui/check-ui-guards.ts
+++ b/scripts/ui/check-ui-guards.ts
@@ -22,6 +22,11 @@ const checks = [
     required: false,
   },
   {
+    command: ['bun', 'run', 'scripts/check-no-nested-cards.ts'],
+    name: 'Nested card composition',
+    required: true,
+  },
+  {
     command: ['bun', 'run', 'scripts/check-modal-standard-usage.ts'],
     name: 'Modal architecture',
     required: true,


### PR DESCRIPTION
## Summary
- Replace several nested card-like panels with divider-based row layouts to reduce visual heaviness and keep spacing consistent.
- Consolidate help links onto the shared `LinkCard` component and add coverage for the shared variant.
- Add a new guard script to detect nested card composition and wire it into the UI checks.

## Testing
- Updated and added unit tests for the analytics overview, library landing page, and help page composition.
- Validation for the new nested-card guard is covered by the UI check wiring.
- Not run (not requested).