### PR TITLE
[codex] Group app switcher sections

### DIFF
--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -73,8 +73,11 @@ vi.mock('../../../primitives/dropdown-menu', () => ({
         {children}
       </button>
     ),
-  DropdownMenuLabel: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
+  DropdownMenuLabel: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & { children: ReactNode }) => (
+    <div {...props}>{children}</div>
   ),
   DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
@@ -121,6 +124,14 @@ describe('AppSwitcher', () => {
       'Analytics',
     ]) {
       expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('groups the first-level sections by workflow area', () => {
+    render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
+
+    for (const label of ['Workspace', 'Content', 'Distribution']) {
+      expect(screen.getByRole('group', { name: label })).toBeInTheDocument();
     }
   });
 

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -28,61 +28,95 @@ import {
 
 type LifecycleAppSwitcherItemConfig = AppSwitcherItemConfig & {
   activeIds?: AppContext[];
+  description: string;
 };
 
-const SECTION_APPS: LifecycleAppSwitcherItemConfig[] = [
+type AppSwitcherSectionConfig = {
+  id: string;
+  label: string;
+  apps: LifecycleAppSwitcherItemConfig[];
+};
+
+const APP_SWITCHER_SECTIONS: AppSwitcherSectionConfig[] = [
   {
-    icon: HiOutlineSquares2X2,
     id: 'workspace',
-    label: 'Home',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/workspace` : `/${org}/~/overview`,
+    label: 'Workspace',
+    apps: [
+      {
+        description: 'Dashboard and context.',
+        icon: HiOutlineSquares2X2,
+        id: 'workspace',
+        label: 'Home',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/workspace` : `/${org}/~/overview`,
+      },
+      {
+        description: 'Chat and delegated work.',
+        icon: HiOutlineChatBubbleLeftRight,
+        id: 'agent',
+        label: 'Agent',
+        route: (org) => `/${org}/~/chat`,
+      },
+    ],
   },
   {
-    icon: HiOutlineChatBubbleLeftRight,
-    id: 'agent',
-    label: 'Agent',
-    route: (org) => `/${org}/~/chat`,
+    id: 'content',
+    label: 'Content',
+    apps: [
+      {
+        activeIds: ['studio', 'compose', 'editor'],
+        description: 'Generate and refine media.',
+        icon: HiOutlineSparkles,
+        id: 'studio',
+        label: 'Create',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/studio/image` : `/${org}/~/studio/image`,
+      },
+      {
+        description: 'Assets and source material.',
+        icon: HiOutlineFolder,
+        id: 'library',
+        label: 'Library',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/library`,
+      },
+    ],
   },
   {
-    activeIds: ['studio', 'compose', 'editor'],
-    icon: HiOutlineSparkles,
-    id: 'studio',
-    label: 'Create',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/studio/image` : `/${org}/~/studio/image`,
-  },
-  {
-    icon: HiOutlineFolder,
-    id: 'library',
-    label: 'Library',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/library`,
-  },
-  {
-    icon: HiOutlinePaperAirplane,
-    id: 'posts',
-    label: 'Publish',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/posts` : `/${org}/~/posts`,
-  },
-  {
-    icon: HiOutlineRectangleGroup,
-    id: 'workflows',
-    label: 'Automate',
-    route: (org, brand) =>
-      brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
-  },
-  {
-    icon: HiOutlineChartBarSquare,
-    id: 'analytics',
-    label: 'Analytics',
-    route: (org, brand) =>
-      brand
-        ? `/${org}/${brand}/analytics/overview`
-        : `/${org}/~/analytics/overview`,
+    id: 'distribution',
+    label: 'Distribution',
+    apps: [
+      {
+        description: 'Posts and scheduling.',
+        icon: HiOutlinePaperAirplane,
+        id: 'posts',
+        label: 'Publish',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/posts` : `/${org}/~/posts`,
+      },
+      {
+        description: 'Workflows and batches.',
+        icon: HiOutlineRectangleGroup,
+        id: 'workflows',
+        label: 'Automate',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
+      },
+      {
+        description: 'Performance and trends.',
+        icon: HiOutlineChartBarSquare,
+        id: 'analytics',
+        label: 'Analytics',
+        route: (org, brand) =>
+          brand
+            ? `/${org}/${brand}/analytics/overview`
+            : `/${org}/~/analytics/overview`,
+      },
+    ],
   },
 ];
+
+const SECTION_APPS = APP_SWITCHER_SECTIONS.flatMap((section) => section.apps);
 
 function withPreservedSearch(path: string, preservedSearch?: string): string {
   if (!preservedSearch) {
@@ -137,20 +171,34 @@ function AppDropdownItem({
         aria-current={isActive ? 'page' : undefined}
         onClick={onNavigateStart}
         className={cn(
-          'flex items-center gap-2.5 px-3 py-1.5 text-[13px]',
-          isActive && 'bg-foreground/[0.06] font-medium',
+          'flex min-h-11 items-start gap-2.5 rounded-md border border-transparent p-2 text-left text-[13px] outline-none transition-colors',
+          'hover:bg-foreground/[0.06] focus:bg-foreground/[0.06]',
+          isActive && 'border-foreground/[0.08] bg-foreground/[0.06]',
         )}
       >
         <Icon
           className={cn(
-            'size-4 shrink-0',
+            'mt-0.5 size-4 shrink-0',
             isActive ? 'text-foreground' : 'text-foreground/50',
           )}
         />
-        <span
-          className={cn(isActive ? 'text-foreground' : 'text-foreground/80')}
-        >
-          {app.label}
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span
+            className={cn(
+              'truncate',
+              isActive
+                ? 'font-medium text-foreground'
+                : 'font-medium text-foreground/85',
+            )}
+          >
+            {app.label}
+          </span>
+          <span
+            aria-hidden="true"
+            className="truncate text-[12px] leading-4 text-foreground/45"
+          >
+            {app.description}
+          </span>
         </span>
       </Link>
     </DropdownMenuItem>
@@ -209,7 +257,7 @@ export function AppSwitcher({
       <DropdownMenuContent
         align="end"
         sideOffset={8}
-        className="w-48"
+        className="max-h-[80vh] w-[calc(100vw-2rem)] overflow-y-auto p-2 sm:w-[42rem]"
         onCloseAutoFocus={(event) => {
           if (!preventTriggerAutoFocusRef.current) {
             return;
@@ -219,16 +267,34 @@ export function AppSwitcher({
           preventTriggerAutoFocusRef.current = false;
         }}
       >
-        <DropdownMenuLabel>Sections</DropdownMenuLabel>
-        {SECTION_APPS.map((app) => (
-          <AppDropdownItem
-            key={app.id}
-            app={app}
-            isActive={isActiveApp(app, currentApp)}
-            href={getAppHref(app)}
-            onNavigateStart={handleNavigateStart}
-          />
-        ))}
+        <div className="grid gap-2 sm:grid-cols-3">
+          {APP_SWITCHER_SECTIONS.map((section) => (
+            <div
+              key={section.id}
+              aria-labelledby={`app-switcher-${section.id}`}
+              className="min-w-0"
+              role="group"
+            >
+              <DropdownMenuLabel
+                id={`app-switcher-${section.id}`}
+                className="px-2 pb-1 pt-0"
+              >
+                {section.label}
+              </DropdownMenuLabel>
+              <div className="space-y-1">
+                {section.apps.map((app) => (
+                  <AppDropdownItem
+                    key={app.id}
+                    app={app}
+                    isActive={isActiveApp(app, currentApp)}
+                    href={getAppHref(app)}
+                    onNavigateStart={handleNavigateStart}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Summary

- Converts the app switcher from a single flat list into a three-column section map: Workspace, Content, and Distribution.
- Keeps Home, Agent, Create, Library, Publish, Automate, and Analytics as first-level destinations while making their workflow grouping visible.
- Adds a focused test assertion so the grouped structure does not regress back into one undifferentiated list.

## Validation

- `bun run --cwd packages/ui test src/components/shell/app-switcher/AppSwitcher.test.tsx`
- `bun run --cwd packages/ui build`
- `bun run design:lint` (warning-only, no errors)
- `git diff --check origin/master..HEAD`
- `bunx secretlint $(git diff --name-only origin/master..HEAD)`

## Screenshot

Captured locally with Playwright against `apps/app` on `127.0.0.1:3005`:

- `/tmp/genfeed-shell-section-switcher-grouped.png`
- `/tmp/genfeed-section-switcher-popover.png`