### PR TITLE
[codex] Expose content loop in app switcher

### DIFF
--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -113,6 +113,7 @@ export function useAppProtectedLayout(
     APP_ROUTES.CHAT.ONBOARDING,
   );
   const isComposeRoute = pathname.startsWith(COMPOSE_ROUTES.ROOT);
+  const isResearchRoute = pathname.startsWith('/research');
   const isLibraryLandingRoute = pathname === APP_ROUTES.LIBRARY.INGREDIENTS;
   const isLibraryRoute = pathname.startsWith(APP_ROUTE_PREFIXES.LIBRARY);
   const isStudioPromptBarRoute =
@@ -120,6 +121,7 @@ export function useAppProtectedLayout(
     /^\/studio\/(avatar|image|music|video)(?:\/|$)/.test(pathname);
   const isStudioRoute = pathname.startsWith(APP_ROUTE_PREFIXES.STUDIO);
   const isPostsPromptBarRoute = pathname === APP_ROUTES.POSTS.ROOT;
+  const isRemixRoute = pathname.startsWith('/posts/remix');
   const isPostsRoute = pathname.startsWith(APP_ROUTE_PREFIXES.POSTS);
   const isMissionControlPromptBarRoute =
     pathname === APP_ROUTES.WORKFLOWS.EXECUTIONS ||
@@ -151,19 +153,23 @@ export function useAppProtectedLayout(
     ? 'studio'
     : isLibraryRoute
       ? 'library'
-      : isPostsRoute
-        ? 'posts'
-        : isComposeRoute
-          ? 'compose'
-          : isWorkflowsRoute
-            ? 'workflows'
-            : isEditorRoute
-              ? 'editor'
-              : isAnalyticsRoute
-                ? 'analytics'
-                : isChatRoute
-                  ? 'agent'
-                  : 'workspace';
+      : isResearchRoute
+        ? 'research'
+        : isRemixRoute
+          ? 'remix'
+          : isPostsRoute
+            ? 'posts'
+            : isComposeRoute
+              ? 'compose'
+              : isWorkflowsRoute
+                ? 'workflows'
+                : isEditorRoute
+                  ? 'editor'
+                  : isAnalyticsRoute
+                    ? 'analytics'
+                    : isChatRoute
+                      ? 'agent'
+                      : 'workspace';
 
   const shouldMountAgentPanel =
     isTerminalDockAvailable() &&

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -187,6 +187,7 @@ function AppProtectedTopbarContent({
             <AppSwitcher
               variant="icon"
               currentApp={currentApp ?? 'workspace'}
+              currentPath={pathname}
               orgSlug={effectiveOrgSlug}
               brandSlug={effectiveBrandSlug}
             />

--- a/apps/docs/content/core-loop/index.mdx
+++ b/apps/docs/content/core-loop/index.mdx
@@ -2,7 +2,9 @@
 
 The v1 release is organized around one operating loop:
 
-`trends -> remix -> generate -> publish -> analytics -> repeat`
+`trends -> create -> publish -> analytics -> repeat`
+
+In the product navigation, **Create** is the parent phase for Studio, Remix, Library, and Batch. Remix and generation stay visible, but they sit under the same creation phase instead of becoming separate first-level app surfaces.
 
 The repo already contains the live server surfaces for this loop. This section makes the wiring explicit so the OSS v1 story is inspectable instead of implicit.
 
@@ -12,7 +14,7 @@ The repo already contains the live server surfaces for this loop. This section m
 - **Prelaunch Corpus Health**: launch-minimum targets, health metrics, and freshness expectations for the global trend/reference corpus
 - **Prelaunch Corpus Backfill**: the credential-free global seed path for launch cold-start coverage
 - **Agent Orchestration**: how the V1 agent runtime should own turn state while campaigns, skills, and content pipelines stay as adapters or deterministic execution layers
-- **Step 3: Generation Service**: how generation-facing modules route into provider-backed media and text paths
+- **Step 3: Create**: how remix, library, batch, and generation-facing modules route into provider-backed media and text paths
 - **Step 5: Analytics Backbone**: how analytics-facing services aggregate activity into dashboard-visible output
 
 ## Why This Matters For V1
@@ -40,7 +42,7 @@ flowchart LR
   A["External signals\nTwitter / TikTok / Reddit / YouTube / Instagram"] --> B["Trend ingestion\nTrendsModule + TwitterPipelineModule"]
   B --> C["Stored trends\ncollections/trends"]
   C --> D["Agent runtime\norchestrator + threading + tools"]
-  D --> E["Remix / prompt assembly\ncontent engine + skills"]
+  D --> E["Create workspace\nStudio + Remix + Library + Batch"]
   E --> F["Generation service\nBatchGenerationModule + provider services"]
   F --> G["Generated assets / posts / batches"]
   G --> H["Analytics ingestion\nPostsAnalyticsController + PostAnalyticsService"]

--- a/apps/docs/content/features.mdx
+++ b/apps/docs/content/features.mdx
@@ -113,13 +113,15 @@ Track everything:
 
 The v1 OSS release is centered on a visible operating loop instead of disconnected features:
 
-`trends -> remix -> generate -> publish -> analytics -> repeat`
+`trends -> create -> publish -> analytics -> repeat`
+
+The product menu uses those same four phases as headers. **Create** contains Studio, Remix, Library, and Batch so remixing and generation remain available without splitting the loop into too many first-level surfaces.
 
 The code for that loop already exists across the server modules. The docs now expose the current wiring directly:
 
 - [**Core Loop Overview**](/core-loop) — v1 release spine and module map
 - [**Trend Ingestion**](/core-loop/trend-ingestion) — Step 1 write path into `collections/trends`
-- [**Generation Service**](/core-loop/generation-service) — Step 3 provider-backed generation surface
+- [**Generation Service**](/core-loop/generation-service) — Step 3 provider-backed create surface
 - [**Analytics Backbone**](/core-loop/analytics-backbone) — Step 5 analytics aggregation surface
 
 ### Marketplace

--- a/packages/interfaces/src/ui/menu-config.interface.ts
+++ b/packages/interfaces/src/ui/menu-config.interface.ts
@@ -4,6 +4,8 @@ import type { ILabeledItem } from '../index';
 export type AppContext =
   | 'workspace'
   | 'agent'
+  | 'research'
+  | 'remix'
   | 'library'
   | 'posts'
   | 'studio'

--- a/packages/props/ui/app-switcher.props.ts
+++ b/packages/props/ui/app-switcher.props.ts
@@ -3,6 +3,7 @@ import type { AppContext } from '@genfeedai/interfaces';
 export interface AppSwitcherProps {
   brandSlug?: string;
   currentApp: AppContext;
+  currentPath?: string;
   orgSlug: string;
   preservedSearch?: string;
   /** Trigger style: compact grid icon (sidebar) or labeled section pill (topbar) */

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -115,13 +115,21 @@ describe('AppSwitcher', () => {
   it('renders the first-level workspace sections', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
     for (const label of [
+      'Discovery',
+      'Socials',
+      'Ads',
+      'Studio',
+      'Remix',
       'Library',
-      'Home',
-      'Agent',
-      'Create',
-      'Publish',
-      'Automate',
-      'Analytics',
+      'Batch',
+      'Posts',
+      'Review',
+      'Calendar',
+      'Scheduled',
+      'Overview',
+      'Post Analytics',
+      'Trend Analytics',
+      'Repeat',
     ]) {
       expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
     }
@@ -130,28 +138,28 @@ describe('AppSwitcher', () => {
   it('groups the first-level sections by workflow area', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
 
-    for (const label of ['Workspace', 'Content', 'Distribution']) {
+    for (const label of ['Trends', 'Create', 'Publish', 'Analytics']) {
       expect(screen.getByRole('group', { name: label })).toBeInTheDocument();
     }
   });
 
   it('marks the active app with aria-current="page"', () => {
-    render(<AppSwitcher orgSlug="acme" currentApp="workflows" />);
-    const activeButton = screen.getByRole('link', { name: 'Automate' });
+    render(<AppSwitcher orgSlug="acme" currentApp="posts" />);
+    const activeButton = screen.getByRole('link', { name: 'Posts' });
 
     expect(activeButton).toHaveAttribute('aria-current', 'page');
   });
 
   it('does not set aria-current on inactive app buttons', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
-    expect(screen.getByRole('link', { name: 'Analytics' })).not.toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).not.toHaveAttribute(
       'aria-current',
     );
   });
 
   it('active app button carries the shared shell active state', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="compose" />);
-    const btn = screen.getByRole('link', { name: 'Create' });
+    const btn = screen.getByRole('link', { name: 'Studio' });
     expect(btn).toBeDefined();
     expect(btn).toHaveAttribute('aria-current', 'page');
     expect(btn).toHaveClass('bg-foreground/[0.06]');
@@ -159,9 +167,47 @@ describe('AppSwitcher', () => {
 
   it('inactive app button does not have active-state classes', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="compose" />);
-    const btn = screen.getByRole('link', { name: 'Publish' });
+    const btn = screen.getByRole('link', { name: 'Posts' });
     expect(btn).not.toHaveAttribute('aria-current');
     expect(btn).not.toHaveClass('bg-foreground/[0.06]');
+  });
+
+  it('uses the most specific current path for active state', () => {
+    render(
+      <AppSwitcher
+        orgSlug="acme"
+        currentApp="posts"
+        brandSlug="my-brand"
+        currentPath="/acme/my-brand/posts/remix"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Remix' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Posts' })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+
+  it('highlights nested studio routes under their concrete create entry', () => {
+    render(
+      <AppSwitcher
+        orgSlug="acme"
+        currentApp="studio"
+        brandSlug="my-brand"
+        currentPath="/acme/my-brand/studio/batch"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Batch' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Studio' })).not.toHaveAttribute(
+      'aria-current',
+    );
   });
 
   describe('route generation', () => {
@@ -173,15 +219,15 @@ describe('AppSwitcher', () => {
           brandSlug="my-brand"
         />,
       );
-      expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Studio' })).toHaveAttribute(
         'href',
         '/acme/my-brand/studio/image',
       );
     });
 
-    it('links to org-scoped create when brandSlug is absent', () => {
+    it('links to org-scoped create fallbacks when brandSlug is absent', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
-      expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Studio' })).toHaveAttribute(
         'href',
         '/acme/~/studio/image',
       );
@@ -191,10 +237,12 @@ describe('AppSwitcher', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
 
       for (const [label, href] of [
+        ['Posts', '/acme/~/posts'],
+        ['Remix', '/acme/~/posts'],
+        ['Discovery', '/acme/~/overview'],
+        ['Studio', '/acme/~/studio/image'],
         ['Library', '/acme/~/library'],
-        ['Publish', '/acme/~/posts'],
-        ['Create', '/acme/~/studio/image'],
-        ['Automate', '/acme/~/workflows'],
+        ['Overview', '/acme/~/analytics/overview'],
       ] as const) {
         expect(screen.getByRole('link', { name: label })).toHaveAttribute(
           'href',
@@ -205,7 +253,7 @@ describe('AppSwitcher', () => {
 
     it('links to correct route for workspace app', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="studio" />);
-      expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Discovery' })).toHaveAttribute(
         'href',
         '/acme/~/overview',
       );
@@ -215,15 +263,15 @@ describe('AppSwitcher', () => {
       render(
         <AppSwitcher orgSlug="acme" currentApp="studio" brandSlug="my-brand" />,
       );
-      expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Discovery' })).toHaveAttribute(
         'href',
-        '/acme/my-brand/workspace',
+        '/acme/my-brand/research/discovery',
       );
     });
 
     it('links to correct route for analytics app', () => {
       render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
-      expect(screen.getByRole('link', { name: 'Analytics' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
         'href',
         '/acme/~/analytics/overview',
       );
@@ -238,29 +286,17 @@ describe('AppSwitcher', () => {
         />,
       );
 
-      expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Remix' })).toHaveAttribute(
         'href',
-        '/acme/my-brand/studio/image',
+        '/acme/my-brand/posts/remix',
       );
-      expect(screen.getByRole('link', { name: 'Automate' })).toHaveAttribute(
-        'href',
-        '/acme/my-brand/workflows',
-      );
-      expect(screen.getByRole('link', { name: 'Analytics' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
         'href',
         '/acme/my-brand/analytics/overview',
       );
     });
 
-    it('links to the org-scoped agent app route', () => {
-      render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
-      expect(screen.getByRole('link', { name: 'Agent' })).toHaveAttribute(
-        'href',
-        '/acme/~/chat',
-      );
-    });
-
-    it('links to brand-scoped library pages when a brand is selected', () => {
+    it('links brand-scoped loop surfaces to their canonical routes', () => {
       render(
         <AppSwitcher
           orgSlug="acme"
@@ -268,9 +304,49 @@ describe('AppSwitcher', () => {
           brandSlug="my-brand"
         />,
       );
-      expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
+
+      expect(screen.getByRole('link', { name: 'Discovery' })).toHaveAttribute(
         'href',
-        '/acme/my-brand/library/ingredients',
+        '/acme/my-brand/research/discovery',
+      );
+      expect(screen.getByRole('link', { name: 'Socials' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/research/socials',
+      );
+      expect(screen.getByRole('link', { name: 'Ads' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/research/ads',
+      );
+      expect(screen.getByRole('link', { name: 'Remix' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/posts/remix',
+      );
+      expect(screen.getByRole('link', { name: 'Batch' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/studio/batch',
+      );
+      expect(
+        screen.getByRole('link', { name: 'Post Analytics' }),
+      ).toHaveAttribute('href', '/acme/my-brand/analytics/posts');
+      expect(
+        screen.getByRole('link', { name: 'Trend Analytics' }),
+      ).toHaveAttribute('href', '/acme/my-brand/analytics/trends');
+      expect(screen.getByRole('link', { name: 'Repeat' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/workflows',
+      );
+    });
+
+    it('falls brand-only loop surfaces back to org-level defaults', () => {
+      render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
+
+      expect(screen.getByRole('link', { name: 'Discovery' })).toHaveAttribute(
+        'href',
+        '/acme/~/overview',
+      );
+      expect(screen.getByRole('link', { name: 'Remix' })).toHaveAttribute(
+        'href',
+        '/acme/~/posts',
       );
     });
 
@@ -282,9 +358,21 @@ describe('AppSwitcher', () => {
           brandSlug="my-brand"
         />,
       );
-      expect(screen.getByRole('link', { name: 'Publish' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Posts' })).toHaveAttribute(
         'href',
         '/acme/my-brand/posts',
+      );
+      expect(screen.getByRole('link', { name: 'Review' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/posts/review',
+      );
+      expect(screen.getByRole('link', { name: 'Calendar' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/posts/calendar',
+      );
+      expect(screen.getByRole('link', { name: 'Scheduled' })).toHaveAttribute(
+        'href',
+        '/acme/my-brand/posts/scheduled',
       );
     });
 
@@ -297,7 +385,7 @@ describe('AppSwitcher', () => {
         />,
       );
 
-      expect(screen.getByRole('link', { name: 'Analytics' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
         'href',
         '/acme/~/analytics/overview?taskId=123&taskSource=workspace',
       );

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -8,13 +8,15 @@ import Link from 'next/link';
 import { useRef } from 'react';
 import {
   HiChevronDown,
+  HiOutlineArrowPathRoundedSquare,
+  HiOutlineArrowTrendingUp,
   HiOutlineChartBarSquare,
-  HiOutlineChatBubbleLeftRight,
-  HiOutlineFolder,
+  HiOutlineCheckCircle,
+  HiOutlineClock,
   HiOutlinePaperAirplane,
-  HiOutlineRectangleGroup,
-  HiOutlineSparkles,
+  HiOutlineRectangleStack,
   HiOutlineSquares2X2,
+  HiOutlineViewColumns,
 } from 'react-icons/hi2';
 import { TbGridDots } from 'react-icons/tb';
 import { Button } from '../../../primitives/button';
@@ -29,6 +31,7 @@ import {
 type LifecycleAppSwitcherItemConfig = AppSwitcherItemConfig & {
   activeIds?: AppContext[];
   description: string;
+  itemKey: string;
 };
 
 type AppSwitcherSectionConfig = {
@@ -39,78 +42,169 @@ type AppSwitcherSectionConfig = {
 
 const APP_SWITCHER_SECTIONS: AppSwitcherSectionConfig[] = [
   {
-    id: 'workspace',
-    label: 'Workspace',
+    id: 'trends',
+    label: 'Trends',
     apps: [
       {
-        description: 'Dashboard and context.',
-        icon: HiOutlineSquares2X2,
-        id: 'workspace',
-        label: 'Home',
+        description: 'Find winners.',
+        icon: HiOutlineArrowTrendingUp,
+        id: 'research',
+        itemKey: 'trends-discovery',
+        label: 'Discovery',
         route: (org, brand) =>
-          brand ? `/${org}/${brand}/workspace` : `/${org}/~/overview`,
+          brand ? `/${org}/${brand}/research/discovery` : `/${org}/~/overview`,
       },
       {
-        description: 'Chat and delegated work.',
-        icon: HiOutlineChatBubbleLeftRight,
-        id: 'agent',
-        label: 'Agent',
-        route: (org) => `/${org}/~/chat`,
+        description: 'Watch platforms.',
+        icon: HiOutlineSquares2X2,
+        id: 'research',
+        itemKey: 'trends-socials',
+        label: 'Socials',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/research/socials` : `/${org}/~/overview`,
+      },
+      {
+        description: 'Study ads.',
+        icon: HiOutlineViewColumns,
+        id: 'research',
+        itemKey: 'trends-ads',
+        label: 'Ads',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/research/ads` : `/${org}/~/overview`,
       },
     ],
   },
   {
-    id: 'content',
-    label: 'Content',
+    id: 'create',
+    label: 'Create',
     apps: [
       {
         activeIds: ['studio', 'compose', 'editor'],
-        description: 'Generate and refine media.',
-        icon: HiOutlineSparkles,
+        description: 'Generate media.',
+        icon: HiOutlineSquares2X2,
         id: 'studio',
-        label: 'Create',
+        itemKey: 'create-studio',
+        label: 'Studio',
         route: (org, brand) =>
           brand ? `/${org}/${brand}/studio/image` : `/${org}/~/studio/image`,
       },
       {
-        description: 'Assets and source material.',
-        icon: HiOutlineFolder,
+        description: 'Adapt winners.',
+        icon: HiOutlineArrowPathRoundedSquare,
+        id: 'remix',
+        itemKey: 'create-remix',
+        label: 'Remix',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/posts/remix` : `/${org}/~/posts`,
+      },
+      {
+        description: 'Use source assets.',
+        icon: HiOutlineRectangleStack,
         id: 'library',
+        itemKey: 'create-library',
         label: 'Library',
         route: (org, brand) =>
           brand ? `/${org}/${brand}/library/ingredients` : `/${org}/~/library`,
       },
+      {
+        description: 'Scale creation.',
+        icon: HiOutlineRectangleStack,
+        id: 'studio',
+        itemKey: 'create-batch',
+        label: 'Batch',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/studio/batch` : `/${org}/~/studio/batch`,
+      },
     ],
   },
   {
-    id: 'distribution',
-    label: 'Distribution',
+    id: 'publish',
+    label: 'Publish',
     apps: [
       {
-        description: 'Posts and scheduling.',
+        description: 'Drafts and posts.',
         icon: HiOutlinePaperAirplane,
         id: 'posts',
-        label: 'Publish',
+        itemKey: 'publish-posts',
+        label: 'Posts',
         route: (org, brand) =>
           brand ? `/${org}/${brand}/posts` : `/${org}/~/posts`,
       },
       {
-        description: 'Workflows and batches.',
-        icon: HiOutlineRectangleGroup,
-        id: 'workflows',
-        label: 'Automate',
+        description: 'Approve content.',
+        icon: HiOutlineCheckCircle,
+        id: 'posts',
+        itemKey: 'publish-review',
+        label: 'Review',
         route: (org, brand) =>
-          brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
+          brand ? `/${org}/${brand}/posts/review` : `/${org}/~/posts`,
       },
       {
-        description: 'Performance and trends.',
+        description: 'Plan schedule.',
+        icon: HiOutlineViewColumns,
+        id: 'posts',
+        itemKey: 'publish-calendar',
+        label: 'Calendar',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/posts/calendar` : `/${org}/~/posts`,
+      },
+      {
+        description: 'Queued posts.',
+        icon: HiOutlineClock,
+        id: 'posts',
+        itemKey: 'publish-scheduled',
+        label: 'Scheduled',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/posts/scheduled` : `/${org}/~/posts`,
+      },
+    ],
+  },
+  {
+    id: 'analytics',
+    label: 'Analytics',
+    apps: [
+      {
+        description: 'Measure results.',
         icon: HiOutlineChartBarSquare,
         id: 'analytics',
-        label: 'Analytics',
+        itemKey: 'analytics-overview',
+        label: 'Overview',
         route: (org, brand) =>
           brand
             ? `/${org}/${brand}/analytics/overview`
             : `/${org}/~/analytics/overview`,
+      },
+      {
+        description: 'Inspect posts.',
+        icon: HiOutlinePaperAirplane,
+        id: 'analytics',
+        itemKey: 'analytics-posts',
+        label: 'Post Analytics',
+        route: (org, brand) =>
+          brand
+            ? `/${org}/${brand}/analytics/posts`
+            : `/${org}/~/analytics/overview`,
+      },
+      {
+        description: 'Spot patterns.',
+        icon: HiOutlineArrowTrendingUp,
+        id: 'analytics',
+        itemKey: 'analytics-trends',
+        label: 'Trend Analytics',
+        route: (org, brand) =>
+          brand
+            ? `/${org}/${brand}/analytics/trends`
+            : `/${org}/~/analytics/overview`,
+      },
+      {
+        activeIds: ['workflows'],
+        description: 'Systematize wins.',
+        icon: HiOutlineArrowPathRoundedSquare,
+        id: 'workflows',
+        itemKey: 'analytics-repeat',
+        label: 'Repeat',
+        route: (org, brand) =>
+          brand ? `/${org}/${brand}/workflows` : `/${org}/~/workflows`,
       },
     ],
   },
@@ -149,6 +243,73 @@ function isActiveApp(
   currentApp: AppContext,
 ): boolean {
   return app.id === currentApp || app.activeIds?.includes(currentApp) === true;
+}
+
+function normalizePath(path?: string): string | undefined {
+  if (!path) {
+    return undefined;
+  }
+
+  const [pathname] = path.split('?', 1);
+  const normalizedPathname = pathname.replace(/\/+$/, '');
+
+  return normalizedPathname || '/';
+}
+
+function getPathMatchScore(currentPath: string, targetPath: string): number {
+  const normalizedCurrentPath = normalizePath(currentPath);
+  const normalizedTargetPath = normalizePath(targetPath);
+
+  if (!(normalizedCurrentPath && normalizedTargetPath)) {
+    return 0;
+  }
+
+  if (normalizedCurrentPath === normalizedTargetPath) {
+    return normalizedTargetPath.length + 1000;
+  }
+
+  if (normalizedCurrentPath.startsWith(`${normalizedTargetPath}/`)) {
+    return normalizedTargetPath.length;
+  }
+
+  return 0;
+}
+
+function getActiveItemKey({
+  brandSlug,
+  currentApp,
+  currentPath,
+  orgSlug,
+}: {
+  brandSlug?: string;
+  currentApp: AppContext;
+  currentPath?: string;
+  orgSlug: string;
+}): string | undefined {
+  const normalizedCurrentPath = normalizePath(currentPath);
+
+  if (normalizedCurrentPath) {
+    let activeItemKey: string | undefined;
+    let activeScore = 0;
+
+    for (const app of SECTION_APPS) {
+      const score = getPathMatchScore(
+        normalizedCurrentPath,
+        app.route(orgSlug, brandSlug),
+      );
+
+      if (score > activeScore) {
+        activeItemKey = app.itemKey;
+        activeScore = score;
+      }
+    }
+
+    if (activeItemKey) {
+      return activeItemKey;
+    }
+  }
+
+  return SECTION_APPS.find((app) => isActiveApp(app, currentApp))?.itemKey;
 }
 
 function AppDropdownItem({
@@ -208,6 +369,7 @@ function AppDropdownItem({
 export function AppSwitcher({
   brandSlug,
   currentApp,
+  currentPath,
   orgSlug,
   preservedSearch,
   variant = 'icon',
@@ -222,9 +384,17 @@ export function AppSwitcher({
     preventTriggerAutoFocusRef.current = true;
   };
 
-  const activeApp = SECTION_APPS.find((app) => isActiveApp(app, currentApp));
+  const activeItemKey = getActiveItemKey({
+    brandSlug,
+    currentApp,
+    currentPath,
+    orgSlug,
+  });
+  const activeApp =
+    SECTION_APPS.find((app) => app.itemKey === activeItemKey) ??
+    SECTION_APPS.find((app) => isActiveApp(app, currentApp));
   const ActiveIcon = activeApp?.icon ?? HiOutlineSquares2X2;
-  const activeLabel = activeApp?.label ?? 'Home';
+  const activeLabel = activeApp?.label ?? 'Apps';
 
   return (
     <DropdownMenu modal={false}>
@@ -257,7 +427,7 @@ export function AppSwitcher({
       <DropdownMenuContent
         align="end"
         sideOffset={8}
-        className="max-h-[80vh] w-[calc(100vw-2rem)] overflow-y-auto p-2 sm:w-[42rem]"
+        className="max-h-[80vh] w-[calc(100vw-2rem)] overflow-y-auto p-2 sm:w-[44rem]"
         onCloseAutoFocus={(event) => {
           if (!preventTriggerAutoFocusRef.current) {
             return;
@@ -267,7 +437,7 @@ export function AppSwitcher({
           preventTriggerAutoFocusRef.current = false;
         }}
       >
-        <div className="grid gap-2 sm:grid-cols-3">
+        <div className="grid gap-2 sm:grid-cols-4">
           {APP_SWITCHER_SECTIONS.map((section) => (
             <div
               key={section.id}
@@ -284,9 +454,9 @@ export function AppSwitcher({
               <div className="space-y-1">
                 {section.apps.map((app) => (
                   <AppDropdownItem
-                    key={app.id}
+                    key={app.itemKey}
                     app={app}
-                    isActive={isActiveApp(app, currentApp)}
+                    isActive={app.itemKey === activeItemKey}
                     href={getAppHref(app)}
                     onNavigateStart={handleNavigateStart}
                   />


### PR DESCRIPTION
## Summary

- Reworks the app switcher around the documented AI content loop: Trends, Create, Publish, and Analytics.
- Makes Create the parent section for Studio, Remix, Library, and Batch so the menu avoids `Remix > Remix` while keeping more destinations visible.
- Adds path-specific active matching so nested routes like `/posts/remix` and `/studio/batch` highlight the concrete menu item, not the broader app bucket.
- Updates the core-loop docs to document `trends -> create -> publish -> analytics -> repeat`.

## Validation

- `npx biome check --write apps/docs/content/core-loop/index.mdx apps/docs/content/features.mdx packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx packages/props/ui/app-switcher.props.ts apps/app/src/components/shell/AppProtectedTopbar.tsx`
- `bun run --cwd packages/ui test src/components/shell/app-switcher/AppSwitcher.test.tsx`
- `bun run --cwd apps/app test src/components/shell/AppProtectedTopbar.test.tsx packages/components/app-protected-layout.test.tsx`
- `bun run --cwd packages/ui build`
- `bun run --cwd packages/props type-check`
- `bun run --cwd apps/app lint`
- `bun run --cwd apps/app type-check`
- `bun run --cwd apps/docs lint`
- `bun run --cwd apps/docs type-check`
- `bun run design:lint` (warning-only, no errors)
- `git diff --check`
- `bunx secretlint $(git diff --name-only)`

## Screenshot

Captured locally with Playwright against `apps/app` on `127.0.0.1:3006`:

- `/tmp/genfeed-section-switcher-create-menu-real-popover.png`
- `/tmp/genfeed-section-switcher-create-menu-app.png`
