### PR TITLE
[codex] Restore admin shell navigation

### DIFF
--- a/apps/app/packages/config/admin-menu-items.config.test.ts
+++ b/apps/app/packages/config/admin-menu-items.config.test.ts
@@ -26,4 +26,10 @@ describe('ADMIN_MENU_ITEMS', () => {
     expect(hrefs).toContain('/admin/administration/subscriptions');
     expect(hrefs).toContain('/admin/overview/analytics/all');
   });
+
+  it('keeps management destinations directly visible in the admin sidebar', () => {
+    expect(ADMIN_MENU_ITEMS).not.toContainEqual(
+      expect.objectContaining({ drillDown: true }),
+    );
+  });
 });

--- a/apps/app/packages/config/admin-menu-items.config.ts
+++ b/apps/app/packages/config/admin-menu-items.config.ts
@@ -45,7 +45,6 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiChatBubbleLeftRight,
   },
   {
-    drillDown: true,
     group: 'Overview',
     href: APP_ROUTES.ADMIN.ROOT,
     label: 'Dashboard',
@@ -70,7 +69,6 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiClipboardDocumentList,
   },
   {
-    drillDown: true,
     group: 'Content',
     href: APP_ROUTES.ADMIN.CONTENT.POSTS,
     label: 'Posts',
@@ -103,7 +101,6 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiPhoto,
   },
   {
-    drillDown: true,
     group: 'AI & Automation',
     href: APP_ROUTES.ADMIN.AUTOMATION.MODELS_ALL,
     label: 'Models',
@@ -144,7 +141,6 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiClipboardDocumentList,
   },
   {
-    drillDown: true,
     group: 'Configuration',
     href: APP_ROUTES.ADMIN.CONFIGURATION.ELEMENTS_BLACKLISTS,
     label: 'Elements',
@@ -177,7 +173,6 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiTag,
   },
   {
-    drillDown: true,
     group: 'Administration',
     href: APP_ROUTES.ADMIN.ORGANIZATION,
     label: 'Organizations',
@@ -226,7 +221,6 @@ export const ADMIN_MENU_ITEMS: MenuItemConfig[] = [
     solid: HiMegaphone,
   },
   {
-    drillDown: true,
     group: 'Fleet',
     hasDividerAbove: true,
     href: APP_ROUTES.ADMIN.FLEET.CHARACTERS,

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockSearchParams = new URLSearchParams();
 const appSwitcherSpy = vi.hoisted(() => vi.fn());
+const mockAccessState = vi.hoisted(() => ({
+  isSuperAdmin: false,
+}));
 const originalLocation = window.location;
 
 vi.mock('@genfeedai/enums', () => ({
@@ -50,6 +53,13 @@ vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
   }),
 }));
 
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => mockAccessState,
+  }),
+);
+
 vi.mock('@ui/primitives/button', () => ({
   Button: ({
     children,
@@ -88,6 +98,7 @@ vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
     brandSlug?: string;
     currentApp?: string;
     orgSlug: string;
+    showAdmin?: boolean;
     variant?: string;
   }) => {
     appSwitcherSpy(props);
@@ -133,6 +144,7 @@ const { default: AppProtectedTopbar } = await import('./AppProtectedTopbar');
 describe('AppProtectedTopbar', () => {
   beforeEach(() => {
     mockSearchParams = new URLSearchParams();
+    mockAccessState.isSuperAdmin = false;
     appSwitcherSpy.mockClear();
     delete process.env.NEXT_PUBLIC_DESKTOP_SHELL;
     delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
@@ -220,6 +232,28 @@ describe('AppProtectedTopbar', () => {
         brandSlug: 'brand',
         currentApp: 'workspace',
         orgSlug: 'acme',
+      }),
+    );
+  });
+
+  it('enables the admin app switcher item for platform admins', () => {
+    mockAccessState.isSuperAdmin = true;
+
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="workspace" />);
+
+    expect(appSwitcherSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showAdmin: true,
+      }),
+    );
+  });
+
+  it('hides the admin app switcher item for non-admin users', () => {
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="workspace" />);
+
+    expect(appSwitcherSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showAdmin: false,
       }),
     );
   });

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { APP_ROUTES } from '@genfeedai/constants';
+import { useAccessState } from '@genfeedai/contexts/providers/access-state/access-state.provider';
 import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
 import {
   getBrandEntityId,
@@ -51,6 +52,7 @@ function AppProtectedTopbarContent({
   const { push } = useRouter();
   const { brandId, brands, selectedBrand, setBrandId, setOrganizationId } =
     useBrand();
+  const { isSuperAdmin } = useAccessState();
   // Route props are authoritative; only fall back to useOrgUrl when the shell is
   // rendered without route context. On org-level `/:org/~/...` pages
   // effectiveBrandSlug stays undefined so the app switcher links into org-scoped
@@ -189,6 +191,7 @@ function AppProtectedTopbarContent({
               currentApp={currentApp ?? 'workspace'}
               orgSlug={effectiveOrgSlug}
               brandSlug={effectiveBrandSlug}
+              showAdmin={isSuperAdmin}
             />
           ) : null}
 

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -156,11 +156,12 @@ const DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND: Record<
   paid_creative_reference: 14,
   public_platform_reference: 7,
 };
-const TREND_SOURCE_INTENDED_USES = new Set<TrendSourceIntendedUse>([
-  'evergreen_prompt_context',
-  'organic_trend_discovery',
-  'paid_creative_analysis',
-]);
+const TREND_SOURCE_INTENDED_USES: ReadonlySet<string> =
+  new Set<TrendSourceIntendedUse>([
+    'evergreen_prompt_context',
+    'organic_trend_discovery',
+    'paid_creative_analysis',
+  ]);
 
 @Injectable()
 export class TrendReferenceCorpusService {
@@ -859,7 +860,7 @@ export class TrendReferenceCorpusService {
     const bySegment = new Map<string, FreshnessSegmentAccumulator>();
 
     for (const doc of referenceDocs) {
-      const data = this.asRecord(doc.data) as ReferenceRecordData;
+      const data = this.asRecord(doc.data) as unknown as ReferenceRecordData;
       const classification = this.resolveSourceClassification(
         data.sourceClassification,
       );

--- a/packages/interfaces/src/ui/menu-config.interface.ts
+++ b/packages/interfaces/src/ui/menu-config.interface.ts
@@ -2,6 +2,7 @@ import type { ComponentType, ReactNode } from 'react';
 import type { ILabeledItem } from '../index';
 
 export type AppContext =
+  | 'admin'
   | 'workspace'
   | 'agent'
   | 'library'

--- a/packages/props/ui/app-switcher.props.ts
+++ b/packages/props/ui/app-switcher.props.ts
@@ -5,6 +5,8 @@ export interface AppSwitcherProps {
   currentApp: AppContext;
   orgSlug: string;
   preservedSearch?: string;
+  /** Include platform-admin navigation for users with platform access. */
+  showAdmin?: boolean;
   /** Trigger style: compact grid icon (sidebar) or labeled section pill (topbar) */
   variant?: 'icon' | 'labeled';
 }

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -122,6 +122,18 @@ describe('AppSwitcher', () => {
     ]) {
       expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
     }
+    expect(
+      screen.queryByRole('link', { name: 'Admin' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the admin section only when enabled', () => {
+    render(<AppSwitcher orgSlug="acme" currentApp="workspace" showAdmin />);
+
+    expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute(
+      'href',
+      '/admin',
+    );
   });
 
   it('marks the active app with aria-current="page"', () => {
@@ -129,6 +141,15 @@ describe('AppSwitcher', () => {
     const activeButton = screen.getByRole('link', { name: 'Automate' });
 
     expect(activeButton).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks admin active when the admin shell renders the switcher', () => {
+    render(<AppSwitcher orgSlug="acme" currentApp="admin" showAdmin />);
+
+    expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
   });
 
   it('does not set aria-current on inactive app buttons', () => {

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -13,6 +13,7 @@ import {
   HiOutlineFolder,
   HiOutlinePaperAirplane,
   HiOutlineRectangleGroup,
+  HiOutlineShieldCheck,
   HiOutlineSparkles,
   HiOutlineSquares2X2,
 } from 'react-icons/hi2';
@@ -81,6 +82,12 @@ const SECTION_APPS: LifecycleAppSwitcherItemConfig[] = [
       brand
         ? `/${org}/${brand}/analytics/overview`
         : `/${org}/~/analytics/overview`,
+  },
+  {
+    icon: HiOutlineShieldCheck,
+    id: 'admin',
+    label: 'Admin',
+    route: () => '/admin',
   },
 ];
 
@@ -162,6 +169,7 @@ export function AppSwitcher({
   currentApp,
   orgSlug,
   preservedSearch,
+  showAdmin = false,
   variant = 'icon',
 }: AppSwitcherProps) {
   const preventTriggerAutoFocusRef = useRef(false);
@@ -174,7 +182,10 @@ export function AppSwitcher({
     preventTriggerAutoFocusRef.current = true;
   };
 
-  const activeApp = SECTION_APPS.find((app) => isActiveApp(app, currentApp));
+  const apps = showAdmin
+    ? SECTION_APPS
+    : SECTION_APPS.filter((app) => app.id !== 'admin');
+  const activeApp = apps.find((app) => isActiveApp(app, currentApp));
   const ActiveIcon = activeApp?.icon ?? HiOutlineSquares2X2;
   const activeLabel = activeApp?.label ?? 'Home';
 
@@ -220,7 +231,7 @@ export function AppSwitcher({
         }}
       >
         <DropdownMenuLabel>Sections</DropdownMenuLabel>
-        {SECTION_APPS.map((app) => (
+        {apps.map((app) => (
           <AppDropdownItem
             key={app.id}
             app={app}

--- a/packages/ui/src/components/shell/topbars/AdminTopbar.test.tsx
+++ b/packages/ui/src/components/shell/topbars/AdminTopbar.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const appSwitcherSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@genfeedai/enums', () => ({
+  ButtonSize: { ICON: 'icon' },
+  ButtonVariant: { GHOST: 'ghost', OUTLINE: 'outline' },
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    ariaLabel,
+    'aria-label': ariaLabelAttribute,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    ariaLabel?: string;
+    'aria-label'?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel ?? ariaLabelAttribute}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
+  AppSwitcher: (props: {
+    brandSlug?: string;
+    currentApp: string;
+    orgSlug: string;
+    showAdmin?: boolean;
+    variant?: string;
+  }) => {
+    appSwitcherSpy(props);
+    return <div data-testid="app-switcher">{props.currentApp}</div>;
+  },
+}));
+
+vi.mock('@ui/topbars/breadcrumbs/TopbarBreadcrumbs', () => ({
+  default: ({ rootLabel }: { rootLabel: string }) => (
+    <nav aria-label="Breadcrumbs">{rootLabel}</nav>
+  ),
+}));
+
+const { default: AdminTopbar } = await import('./AdminTopbar');
+
+describe('AdminTopbar', () => {
+  it('renders the app switcher with the admin section active', () => {
+    render(
+      <AdminTopbar orgSlug="acme" brandSlug="brand" currentApp="workspace" />,
+    );
+
+    expect(screen.getByTestId('app-switcher')).toHaveTextContent('admin');
+    expect(appSwitcherSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandSlug: 'brand',
+        currentApp: 'admin',
+        orgSlug: 'acme',
+        showAdmin: true,
+      }),
+    );
+  });
+
+  it('does not render the switcher until route context is available', () => {
+    render(<AdminTopbar />);
+
+    expect(screen.queryByTestId('app-switcher')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/shell/topbars/AdminTopbar.tsx
+++ b/packages/ui/src/components/shell/topbars/AdminTopbar.tsx
@@ -3,6 +3,7 @@
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { TopbarProps } from '@genfeedai/props/navigation/topbar.props';
 import { Button } from '@ui/primitives/button';
+import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
 import TopbarBreadcrumbs from '@ui/topbars/breadcrumbs/TopbarBreadcrumbs';
 import { HiBars3, HiOutlineSparkles, HiXMark } from 'react-icons/hi2';
 
@@ -11,6 +12,8 @@ export default function AdminTopbar({
   isMenuOpen,
   isAgentCollapsed,
   onAgentToggle,
+  orgSlug,
+  brandSlug,
 }: TopbarProps = {}) {
   const ToggleIcon = isMenuOpen ? HiXMark : HiBars3;
 
@@ -36,7 +39,17 @@ export default function AdminTopbar({
           <TopbarBreadcrumbs rootLabel="Admin" />
         </div>
 
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          {orgSlug ? (
+            <AppSwitcher
+              variant="icon"
+              currentApp="admin"
+              orgSlug={orgSlug}
+              brandSlug={brandSlug}
+              showAdmin
+            />
+          ) : null}
+
           {onAgentToggle ? (
             <Button
               variant={ButtonVariant.OUTLINE}


### PR DESCRIPTION
## Summary

- Restores the admin sidebar as a direct management menu instead of auto-drilling into the Overview group.
- Adds the Admin section to the shared app switcher for platform superadmins.
- Renders the shared app switcher in the admin topbar with Admin marked active.

## Root Cause

`/admin` was using the shared nested sidebar behavior with admin menu groups marked as `drillDown`. Since Dashboard is active inside the `Overview` group, the sidebar auto-entered that group and hid the rest of the admin management sections behind a misleading nested back row.

## Validation

- `bun run --cwd packages/ui test src/components/shell/app-switcher/AppSwitcher.test.tsx src/components/shell/topbars/AdminTopbar.test.tsx`
- `bun run --cwd apps/app test src/components/shell/AppProtectedTopbar.test.tsx packages/config/admin-menu-items.config.test.ts`
- `bun run --cwd apps/app test packages/components/app-protected-layout.test.tsx`
- `bun run --cwd packages/ui build`
- `bun run --cwd apps/app lint`
- `bun run design:lint` (existing warnings only, no errors)
- `git diff --check`
- staged secret scan via pre-commit hooks