### PR TITLE
Fix workspace shell header hierarchy

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -274,7 +274,9 @@ describe('WorkspacePageContent', () => {
       expect(listMock).toHaveBeenCalledWith({});
     });
 
-    expect(screen.getByText('Workspace Dashboard')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Dashboard' }),
+    ).toHaveClass('sr-only');
     expect(screen.getByTestId('dashboard-stats-strip')).toBeInTheDocument();
     expect(screen.queryByTestId('workspace-nav')).not.toBeInTheDocument();
   });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -400,7 +400,12 @@ describe('WorkspacePageContent', () => {
       />,
     );
 
-    expect(await screen.findByText('Workspace Dashboard')).toBeVisible();
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'Dashboard',
+      }),
+    ).toHaveClass('sr-only');
     await waitFor(() =>
       expect(mocks.agentRunsList).toHaveBeenCalledWith({ page: 1 }),
     );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -135,8 +135,8 @@ function WorkspacePageContentContent({
       label={sectionCopy.title}
       description={sectionCopy.description}
       icon={HiOutlineSquares2X2}
-      promoteHeaderToTopbarOnScroll
-      topbarRight={workspaceHeaderActions}
+      fullWidth
+      titleVisibility="sr-only"
       {...(isInboxSection
         ? {
             activeTab: defaultInboxView,
@@ -164,7 +164,7 @@ function WorkspacePageContentContent({
             },
           }
         : {})}
-      right={workspaceHeaderActions}
+      right={isOverviewSection ? undefined : workspaceHeaderActions}
     >
       {workspaceActionError ? (
         <p className="mb-4 rounded-md border border-rose-400/30 bg-rose-400/8 px-3 py-2 text-xs text-rose-200">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task.helpers.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task.helpers.ts
@@ -79,7 +79,7 @@ export const SECTION_COPY: Record<
   overview: {
     description:
       'Tasks, approvals, live work, and operator handoffs in one control surface.',
-    title: 'Workspace Dashboard',
+    title: 'Dashboard',
   },
 };
 

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -177,6 +177,12 @@ vi.mock('@ui/menus/sidebar-action-trigger/SidebarActionTrigger', () => ({
   ),
 }));
 
+vi.mock('@ui/menus/switchers/MenuBrandSwitcher', () => ({
+  default: ({ variant }: { variant?: string }) => (
+    <div data-testid="sidebar-brand-switcher">{variant}</div>
+  ),
+}));
+
 vi.mock('@app-config/menu-items.config', () => ({
   APP_LOGO_HREF: '/workspace/overview',
   APP_MENU_ITEMS: [{ href: '/workspace', label: 'Workspace' }],
@@ -202,6 +208,22 @@ vi.mock('@contexts/features/command-palette.provider', () => ({
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => ({
     brandId: mockBrandState.brandId,
+    brands: [
+      {
+        id: mockBrandState.brandId,
+        label: 'Moonrise Studio',
+        organization: { id: 'org-123', slug: 'org-123' },
+        slug: 'brand-123',
+      },
+    ],
+    selectedBrand: {
+      id: mockBrandState.brandId,
+      label: 'Moonrise Studio',
+      organization: { id: 'org-123', slug: 'org-123' },
+      slug: 'brand-123',
+    },
+    setBrandId: vi.fn(),
+    setOrganizationId: vi.fn(),
   }),
 }));
 
@@ -497,6 +519,9 @@ describe('AppProtectedLayout', () => {
     );
 
     expect(screen.getByText('Protected content')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('sidebar-brand-switcher'),
+    ).not.toBeInTheDocument();
     expect(appLayoutSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         bannerComponent: expect.anything(),

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -147,18 +147,26 @@ describe('AppProtectedTopbar', () => {
     });
   });
 
-  it('renders the brand switcher on the left and app switcher with right-side controls', () => {
+  it('renders brand scope on the left, breadcrumb title in the middle, and controls on the right', () => {
     render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
 
     const brandSwitcher = screen.getByTestId('brand-switcher');
+    const breadcrumbs = screen.getByRole('navigation', {
+      name: 'Breadcrumb',
+    });
     const switcher = screen.getByTestId('app-switcher');
     const cloudSyncIndicator = screen.getByTestId('cloud-sync-indicator');
 
     expect(brandSwitcher).toHaveTextContent('labeled');
+    expect(breadcrumbs).toHaveTextContent('Studio');
     expect(switcher).toHaveTextContent('icon');
     expect(switcher).toBeInTheDocument();
     expect(
-      brandSwitcher.compareDocumentPosition(switcher) &
+      brandSwitcher.compareDocumentPosition(breadcrumbs) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      breadcrumbs.compareDocumentPosition(switcher) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -13,6 +13,7 @@ import type { TopbarProps } from '@props/navigation/topbar.props';
 import MenuBrandSwitcher from '@ui/menus/switchers/MenuBrandSwitcher';
 import { Button } from '@ui/primitives/button';
 import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
+import TopbarBreadcrumbs from '@ui/topbars/breadcrumbs/TopbarBreadcrumbs';
 import TopbarCreditsBar from '@ui/topbars/credits-bar/TopbarCreditsBar';
 import TopbarEnd from '@ui/topbars/end/TopbarEnd';
 import Link from 'next/link';
@@ -22,17 +23,25 @@ import { HiBars3, HiOutlineCommandLine, HiXMark } from 'react-icons/hi2';
 import { PiSidebarSimple } from 'react-icons/pi';
 import CloudSyncIndicator from '@/components/cloud-sync-indicator/CloudSyncIndicator';
 import { isHostedCloudApp } from '@/lib/config/edition';
-import { appendSearchParamsToHref } from '@/lib/navigation/operator-shell';
+import {
+  appendSearchParamsToHref,
+  getCurrentBrandScopedPath,
+} from '@/lib/navigation/operator-shell';
 
-function getCurrentBrandScopedPath(pathname: string): string {
-  const parts = pathname.split('/').filter(Boolean);
-
-  if (parts.length >= 3 && parts[1] !== '~') {
-    return `/${parts.slice(2).join('/')}`;
-  }
-
-  return APP_ROUTES.WORKSPACE.OVERVIEW;
-}
+const TOPBAR_BREADCRUMB_ROOT_LABELS: Record<
+  NonNullable<TopbarProps['currentApp']>,
+  string
+> = {
+  agent: 'Agent',
+  analytics: 'Analytics',
+  compose: 'Compose',
+  editor: 'Editor',
+  library: 'Library',
+  posts: 'Posts',
+  studio: 'Studio',
+  workflows: 'Workflows',
+  workspace: 'Workspace',
+};
 
 function AppProtectedTopbarContent({
   isMenuOpen,
@@ -109,8 +118,8 @@ function AppProtectedTopbarContent({
 
   return (
     <header className="ship-ui h-full w-full bg-transparent">
-      <div className="flex h-full w-full items-center justify-between gap-2.5 pl-3 pr-2 sm:px-4 lg:px-5">
-        <div className="flex min-w-0 items-center gap-2.5">
+      <div className="grid h-full w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2.5 pl-3 pr-2 sm:px-4 lg:px-5">
+        <div className="flex min-w-0 items-center gap-2.5 justify-self-start">
           {onMenuToggle ? (
             <Button
               type="button"
@@ -141,7 +150,7 @@ function AppProtectedTopbarContent({
           ) : null}
 
           {brands.length > 0 ? (
-            <div className="min-w-0 w-40 sm:w-56">
+            <div className="w-40 min-w-0 sm:w-56 md:w-[14.5rem]">
               <MenuBrandSwitcher
                 variant="labeled"
                 brands={brands}
@@ -152,7 +161,15 @@ function AppProtectedTopbarContent({
           ) : null}
         </div>
 
-        <div className="flex min-w-0 items-center gap-1.5">
+        <div className="hidden min-w-0 justify-center md:flex">
+          <TopbarBreadcrumbs
+            fallbackRootLabel={
+              TOPBAR_BREADCRUMB_ROOT_LABELS[currentApp ?? 'workspace']
+            }
+          />
+        </div>
+
+        <div className="flex min-w-0 items-center justify-end gap-1.5">
           {taskId ? (
             <div className="hidden items-center gap-2 rounded border border-border bg-background-secondary px-2 py-1 text-[11px] lg:flex">
               <span className="font-semibold uppercase tracking-[0.14em] text-emerald-200/80">

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -41,6 +41,8 @@ const TOPBAR_BREADCRUMB_ROOT_LABELS: Record<
   editor: 'Editor',
   library: 'Library',
   posts: 'Posts',
+  remix: 'Remix',
+  research: 'Research',
   studio: 'Studio',
   workflows: 'Workflows',
   workspace: 'Workspace',

--- a/apps/app/src/lib/navigation/operator-shell.spec.ts
+++ b/apps/app/src/lib/navigation/operator-shell.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   appendSearchParamsToHref,
   buildTaskLaunchHref,
+  getCurrentBrandScopedPath,
   normalizeProtectedPathname,
   pickOperatorTaskContextSearchParams,
 } from './operator-shell';
@@ -18,6 +19,18 @@ describe('operator-shell helpers', () => {
     );
     expect(normalizeProtectedPathname('/acme/~/chat/thread-1')).toBe(
       '/chat/thread-1',
+    );
+  });
+
+  it('keeps the current brand-scoped path when switching brands', () => {
+    expect(getCurrentBrandScopedPath('/acme/moonrise/workspace/overview')).toBe(
+      '/workspace/overview',
+    );
+    expect(getCurrentBrandScopedPath('/acme/moonrise/studio/video')).toBe(
+      '/studio/video',
+    );
+    expect(getCurrentBrandScopedPath('/acme/~/overview')).toBe(
+      '/workspace/overview',
     );
   });
 

--- a/apps/app/src/lib/navigation/operator-shell.ts
+++ b/apps/app/src/lib/navigation/operator-shell.ts
@@ -58,6 +58,16 @@ export function normalizeProtectedPathname(rawPathname: string): string {
   return rawPathname;
 }
 
+export function getCurrentBrandScopedPath(pathname: string): string {
+  const parts = pathname.split('/').filter(Boolean);
+
+  if (parts.length >= 3 && parts[1] !== '~') {
+    return `/${parts.slice(2).join('/')}`;
+  }
+
+  return APP_ROUTES.WORKSPACE.OVERVIEW;
+}
+
 export function pickOperatorTaskContextSearchParams(
   searchParams: URLSearchParams,
 ): URLSearchParams {

--- a/packages/props/layout/container-title.props.ts
+++ b/packages/props/layout/container-title.props.ts
@@ -4,4 +4,5 @@ export interface ContainerTitleProps {
   title: ReactNode;
   description?: ReactNode;
   icon?: ComponentType<{ className?: string }> | ReactNode;
+  titleVisibility?: 'visible' | 'sr-only';
 }

--- a/packages/props/ui/ui.props.ts
+++ b/packages/props/ui/ui.props.ts
@@ -59,12 +59,14 @@ export interface ContainerProps {
   label?: ReactNode;
   description?: ReactNode;
   icon?: ComponentType<{ className?: string }> | ReactNode;
+  titleVisibility?: 'visible' | 'sr-only';
   tabs?: TabItem[] | NavigationTab[];
   headerTabs?: TabsProps;
   activeTab?: string;
   onTabChange?: (tabId: string) => void;
   children: ReactNode;
   className?: string;
+  fullWidth?: boolean;
   left?: ReactNode;
   right?: ReactNode;
   topbarRight?: ReactNode;

--- a/packages/ui/src/components/layout/container-title/ContainerTitle.test.tsx
+++ b/packages/ui/src/components/layout/container-title/ContainerTitle.test.tsx
@@ -1,8 +1,22 @@
 import { render, screen } from '@testing-library/react';
 import ContainerTitle from '@ui/layout/container-title/ContainerTitle';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSidebarNavigation = vi.hoisted(() => ({
+  activeGroupId: null as string | null,
+  activePageLabel: null as string | null,
+}));
+
+vi.mock('@genfeedai/contexts/ui/sidebar-navigation-context', () => ({
+  useSidebarNavigation: () => mockSidebarNavigation,
+}));
 
 describe('ContainerTitle', () => {
+  beforeEach(() => {
+    mockSidebarNavigation.activeGroupId = null;
+    mockSidebarNavigation.activePageLabel = null;
+  });
+
   it('renders plain text descriptions inside a paragraph', () => {
     render(
       <ContainerTitle title="Images" description="Generated assets library" />,
@@ -29,5 +43,42 @@ describe('ContainerTitle', () => {
 
     expect(richDescription).toBeInTheDocument();
     expect(richDescription.closest('p')).toBeNull();
+  });
+
+  it('suppresses duplicate single-page breadcrumbs', () => {
+    mockSidebarNavigation.activePageLabel = 'Dashboard';
+
+    render(
+      <ContainerTitle
+        title="Dashboard"
+        description="Workspace control plane"
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('keeps contextual breadcrumbs when they add information', () => {
+    mockSidebarNavigation.activeGroupId = 'Settings';
+    mockSidebarNavigation.activePageLabel = 'Billing';
+
+    render(<ContainerTitle title="Billing" />);
+
+    expect(screen.getByRole('navigation')).toHaveTextContent(
+      'Settings›Billing',
+    );
+  });
+
+  it('can keep the page heading accessible without rendering visible title chrome', () => {
+    render(<ContainerTitle title="Dashboard" titleVisibility="sr-only" />);
+
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'Dashboard',
+    });
+
+    expect(heading).toHaveClass('sr-only');
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/layout/container-title/ContainerTitle.tsx
+++ b/packages/ui/src/components/layout/container-title/ContainerTitle.tsx
@@ -8,9 +8,24 @@ export default function ContainerTitle({
   title,
   description,
   icon,
+  titleVisibility = 'visible',
 }: ContainerTitleProps) {
   const { activeGroupId, activePageLabel } = useSidebarNavigation();
-  const hasBreadcrumb = Boolean(activeGroupId || activePageLabel);
+  if (titleVisibility === 'sr-only') {
+    return <h1 className="sr-only">{title}</h1>;
+  }
+
+  const normalizedTitle =
+    typeof title === 'string' ? title.trim().toLowerCase() : null;
+  const normalizedPageLabel = activePageLabel?.trim().toLowerCase() ?? null;
+  const isDuplicatePageLabel =
+    !activeGroupId &&
+    normalizedTitle !== null &&
+    normalizedPageLabel !== null &&
+    normalizedTitle === normalizedPageLabel;
+  const hasBreadcrumb = Boolean(
+    activeGroupId || (activePageLabel && !isDuplicatePageLabel),
+  );
 
   const isTextDescription =
     typeof description === 'number' || typeof description === 'string';

--- a/packages/ui/src/components/layout/container/Container.test.tsx
+++ b/packages/ui/src/components/layout/container/Container.test.tsx
@@ -17,6 +17,49 @@ describe('Container', () => {
     const { container } = render(<Container>content</Container>);
     const rootElement = container.firstChild as HTMLElement;
     expect(rootElement).toBeInTheDocument();
+    expect(rootElement).toHaveClass('mx-auto');
+    expect(rootElement).toHaveClass('max-w-[1280px]');
+  });
+
+  it('supports full-width pages without the default content cap', () => {
+    const { container } = render(<Container fullWidth>content</Container>);
+    const rootElement = container.firstChild as HTMLElement;
+
+    expect(rootElement).toHaveClass('mx-0');
+    expect(rootElement).toHaveClass('max-w-none');
+    expect(rootElement).not.toHaveClass('mx-auto');
+    expect(rootElement).not.toHaveClass('max-w-[1280px]');
+  });
+
+  it('can keep the h1 for assistive tech without rendering the visible header row', () => {
+    const { container } = render(
+      <Container label="Dashboard" titleVisibility="sr-only">
+        content
+      </Container>,
+    );
+    const rootElement = container.firstChild as HTMLElement;
+
+    expect(screen.getByRole('heading', { name: 'Dashboard' })).toHaveClass(
+      'sr-only',
+    );
+    expect(rootElement.childElementCount).toBe(1);
+  });
+
+  it('keeps header controls visible when the title is screen-reader only', () => {
+    render(
+      <Container
+        label="Inbox"
+        titleVisibility="sr-only"
+        right={<button type="button">Refresh</button>}
+      >
+        content
+      </Container>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Inbox' })).toHaveClass(
+      'sr-only',
+    );
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
   });
 
   it('renders header tabs alongside header actions', () => {

--- a/packages/ui/src/components/layout/container/Container.tsx
+++ b/packages/ui/src/components/layout/container/Container.tsx
@@ -10,6 +10,7 @@ export default function Container({
   label,
   description,
   icon,
+  titleVisibility = 'visible',
   tabs,
   headerTabs,
   activeTab: controlledActiveTab,
@@ -17,6 +18,7 @@ export default function Container({
   left,
   right,
   children,
+  fullWidth = false,
   className = '',
 }: ContainerProps) {
   const [internalActiveTab, setInternalActiveTab] = useState<string>('');
@@ -27,19 +29,29 @@ export default function Container({
   const onTabChange = controlledOnTabChange ?? setInternalActiveTab;
 
   const hasHeaderRight = Boolean(right);
+  const hasVisibleTitle = Boolean(label && titleVisibility !== 'sr-only');
+  const hasScreenReaderTitle = Boolean(label && titleVisibility === 'sr-only');
 
   return (
     <div
-      className={`mx-auto w-full max-w-[1280px] px-5 py-4 sm:px-6 lg:px-6 ${className}`}
+      className={cn(
+        'w-full px-5 py-4 sm:px-6 lg:px-6',
+        fullWidth ? 'mx-0 max-w-none' : 'mx-auto max-w-[1280px]',
+        className,
+      )}
     >
-      {(label || hasHeaderRight) && (
+      {hasScreenReaderTitle ? (
+        <ContainerTitle title={label} titleVisibility="sr-only" />
+      ) : null}
+
+      {(hasVisibleTitle || headerTabs || hasHeaderRight) && (
         <div
           className={cn(
             'mb-4 flex items-center gap-4 border-b border-border pb-3',
-            label ? 'justify-between' : 'justify-end',
+            hasVisibleTitle ? 'justify-between' : 'justify-end',
           )}
         >
-          {label && (
+          {hasVisibleTitle && (
             <ContainerTitle
               title={label}
               description={description}

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -21,6 +21,7 @@ const {
   mockPathname: { value: '/settings/personal' },
   mockPush: vi.fn(),
 }));
+const originalLocation = window.location;
 
 // @genfeedai/auth-client/react is already mocked globally in setup.ts
 // Add UserButton that's not in the global mock
@@ -199,6 +200,11 @@ describe('MenuShared', () => {
 
   afterEach(() => {
     delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    });
   });
 
   const config: MenuConfig = {
@@ -268,6 +274,19 @@ describe('MenuShared', () => {
     expect(
       screen.queryByTestId('organization-switcher'),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows the organization switcher on the official hosted app hostname', () => {
+    delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'app.genfeed.ai' },
+      writable: true,
+    });
+
+    render(<MenuShared config={config} />);
+
+    expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
   });
 
   it('attaches the actionable inbox count to the workspace inbox row', () => {

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -77,8 +77,11 @@ export default function MenuShared({
     ? (prefixHref({ href: backHref }) ?? backHref)
     : undefined;
   const prefetchBackHref = useNavigationPrefetch(resolvedBackHref);
+  const isHostedCloudHostname =
+    typeof window !== 'undefined' &&
+    window.location.hostname === 'app.genfeed.ai';
   const shouldRenderOrganizationSwitcher =
-    process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true';
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true' || isHostedCloudHostname;
 
   const secondaryNavigationContent =
     secondaryItems.length > 0 ? (

--- a/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.test.tsx
+++ b/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.test.tsx
@@ -64,6 +64,36 @@ describe('TopbarBreadcrumbs', () => {
     expect(screen.queryByText('Library')).not.toBeInTheDocument();
   });
 
+  it('uses a fallback root label when the active page has no group', () => {
+    mockNavigationState = {
+      activeGroupId: '',
+      activePageLabel: 'Dashboard',
+      exitNestedGroup: mockExitNestedGroup,
+    };
+
+    render(<TopbarBreadcrumbs fallbackRootLabel="Workspace" />);
+
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Workspace' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the current page as a heading', () => {
+    mockNavigationState = {
+      activeGroupId: '',
+      activePageLabel: 'Dashboard',
+      exitNestedGroup: mockExitNestedGroup,
+    };
+
+    render(<TopbarBreadcrumbs fallbackRootLabel="Workspace" />);
+
+    expect(
+      screen.queryByRole('heading', { name: 'Dashboard' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('exits nested mode when the group breadcrumb is clicked', () => {
     mockNavigationState = {
       activeGroupId: 'Library',

--- a/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.tsx
+++ b/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.tsx
@@ -6,6 +6,8 @@ import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import { Button } from '@ui/primitives/button';
 
 interface TopbarBreadcrumbsProps {
+  /** Used when the active sidebar item has no group (e.g. workspace root nav). */
+  fallbackRootLabel?: string;
   /** Override the first segment label (e.g. "Admin" when no BrandProvider) */
   rootLabel?: string;
 }
@@ -16,12 +18,14 @@ interface TopbarBreadcrumbsProps {
  * Format: Group / Page
  */
 export default function TopbarBreadcrumbs({
+  fallbackRootLabel,
   rootLabel,
 }: TopbarBreadcrumbsProps) {
   const { activeGroupId, activePageLabel, exitNestedGroup } =
     useSidebarNavigation();
 
-  const groupLabel = rootLabel || activeGroupId;
+  const groupLabel = rootLabel || activeGroupId || fallbackRootLabel;
+  const canExitNestedGroup = Boolean(activeGroupId && activePageLabel);
 
   if (!groupLabel && !activePageLabel) {
     return null;
@@ -32,7 +36,7 @@ export default function TopbarBreadcrumbs({
       className="flex items-center gap-1.5 text-[13px]"
       aria-label="Breadcrumb"
     >
-      {groupLabel && activePageLabel ? (
+      {groupLabel && activePageLabel && canExitNestedGroup ? (
         <Button
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
@@ -45,7 +49,7 @@ export default function TopbarBreadcrumbs({
           {groupLabel}
         </Button>
       ) : groupLabel ? (
-        <span className="text-foreground font-semibold truncate max-w-truncate-lg">
+        <span className="max-w-truncate-lg truncate font-semibold text-foreground/50">
           {groupLabel}
         </span>
       ) : null}


### PR DESCRIPTION
## Summary
- Move brand scope to the protected topbar on the main-content side of the sidebar border
- Remove the temporary brand dropdown from the workspace sidebar action stack
- Add Vercel-style topbar breadcrumbs with fallback app roots such as Workspace / Dashboard
- Keep workspace index page titles as accessible sr-only h1s instead of duplicate visible body headers
- Preserve full-width workspace layout and hosted org switcher visibility

## Verification
- bunx vitest run packages/ui/src/components/layout/container-title/ContainerTitle.test.tsx packages/ui/src/components/layout/container/Container.test.tsx packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.test.tsx packages/ui/src/components/menus/shared/MenuShared.test.tsx --config vitest.config.ts
- bunx vitest run src/components/shell/AppProtectedTopbar.test.tsx packages/components/app-protected-layout.test.tsx 'app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx' 'app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx' src/lib/navigation/operator-shell.spec.ts --config vitest.config.mts --maxWorkers=2
- bun run design:lint
- bunx turbo run type-check --filter=@genfeedai/props --filter=@genfeedai/ui --filter=@genfeedai/app
- staged secretlint via pre-commit hook

## Notes
- Browser smoke confirmed the topbar breadcrumb placement and sidebar removal; my hand-rolled auth/API mocks were not stable enough to produce a clean populated shell screenshot, so the authoritative coverage here is unit/component + type/design checks.