### PR TITLE
refactor(api): consolidate user cache invalidation

### DIFF
--- a/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
@@ -143,6 +143,12 @@ describe('UsersController', () => {
       const result = await controller.findMe(mockRequest, mockUser);
 
       expect(usersService.patch).toHaveBeenCalled();
+      expect(requestContextCacheService.invalidateForUser).toHaveBeenCalledWith(
+        userId,
+      );
+      expect(
+        accessBootstrapCacheService.invalidateForUser,
+      ).toHaveBeenCalledWith(userId);
       expect(result).toBeDefined();
     });
   });
@@ -397,6 +403,12 @@ describe('UsersController', () => {
         },
         selectedBrandId,
       );
+      expect(requestContextCacheService.invalidateForUser).toHaveBeenCalledWith(
+        userId,
+      );
+      expect(
+        accessBootstrapCacheService.invalidateForUser,
+      ).toHaveBeenCalledWith(userId);
       expect(result).toBeDefined();
     });
   });

--- a/apps/server/api/src/collections/users/controllers/users.controller.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.ts
@@ -148,6 +148,13 @@ export class UsersController {
     return getIsSuperAdmin(currentUser) || publicMetadata.user === targetUserId;
   }
 
+  private async invalidateUserAccessCaches(userId: string): Promise<void> {
+    await Promise.all([
+      this.requestContextCacheService.invalidateForUser(userId),
+      this.accessBootstrapCacheService.invalidateForUser(userId),
+    ]);
+  }
+
   @Get()
   @SetMetadata('roles', ['superadmin'])
   @LogMethod({ logEnd: false, logError: true, logStart: true })
@@ -224,10 +231,7 @@ export class UsersController {
 
         const userIdString = data._id?.toString();
         if (userIdString) {
-          await Promise.all([
-            this.requestContextCacheService.invalidateForUser(userIdString),
-            this.accessBootstrapCacheService.invalidateForUser(userIdString),
-          ]);
+          await this.invalidateUserAccessCaches(userIdString);
         }
       }
     }
@@ -409,10 +413,7 @@ export class UsersController {
       await this.usersService.patch(publicMetadata.user, {
         lastUsedOrganizationId: String(data._id),
       });
-      await Promise.all([
-        this.requestContextCacheService.invalidateForUser(publicMetadata.user),
-        this.accessBootstrapCacheService.invalidateForUser(publicMetadata.user),
-      ]);
+      await this.invalidateUserAccessCaches(publicMetadata.user);
     }
 
     return serializeSingle(request, OrganizationSerializer, data);
@@ -438,10 +439,7 @@ export class UsersController {
     // Active brand is persisted to the member's lastUsedBrandId below, which the
     // identity resolvers read (epic #735, Phase C — no legacy auth provider write-back).
     if (publicMetadata.user) {
-      await Promise.all([
-        this.requestContextCacheService.invalidateForUser(publicMetadata.user),
-        this.accessBootstrapCacheService.invalidateForUser(publicMetadata.user),
-      ]);
+      await this.invalidateUserAccessCaches(publicMetadata.user);
     }
 
     // Persist last-used brand on the member for org-switch recall
@@ -481,10 +479,7 @@ export class UsersController {
       null,
     );
 
-    await Promise.all([
-      this.requestContextCacheService.invalidateForUser(user.id),
-      this.accessBootstrapCacheService.invalidateForUser(user.id),
-    ]);
+    await this.invalidateUserAccessCaches(user.id);
   }
 
   @Post('me/avatar')
@@ -614,10 +609,7 @@ export class UsersController {
 
     const existingUserId = existingUser._id?.toString();
     if (existingUserId) {
-      await Promise.all([
-        this.requestContextCacheService.invalidateForUser(existingUserId),
-        this.accessBootstrapCacheService.invalidateForUser(existingUserId),
-      ]);
+      await this.invalidateUserAccessCaches(existingUserId);
     }
 
     return data


### PR DESCRIPTION
## Summary

Closes #988.

- Add one private `UsersController.invalidateUserAccessCaches` helper for the request-context + access-bootstrap cache pair.
- Replace the five duplicated controller-local dual invalidation blocks with that helper.
- Extend focused controller coverage for onboarding auto-complete and brand selection cache invalidation.

## Refactor Lane Fit

Behavior-preserving code-quality cleanup from a bounded structural scan. This consolidates duplicated boilerplate in one controller without changing route contracts, serializers, cache keys, or service ownership.

## Validation

- `bunx biome check apps/server/api/src/collections/users/controllers/users.controller.ts apps/server/api/src/collections/users/controllers/users.controller.spec.ts`
- `bun run --cwd apps/server/api test:file src/collections/users/controllers/users.controller.spec.ts` (20 tests)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bun run lint-staged` / commit hook (`secretlint` + staged Biome)

## Structural Review

No blocker/request-change findings in the changed diff. The extracted helper has five same-controller callers, deletes duplicate cache invalidation structure, and adds no public API, package-boundary, type-cast, or behavior changes.