### PR TITLE
refactor(api): reuse generation response envelope helper

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -2831,6 +2831,11 @@ describe('AgentToolExecutorService', () => {
     );
 
     expect(result.success).toBe(true);
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        id: 'img-123',
+      }),
+    );
     expect(callInternalApiSpy).toHaveBeenCalledWith(
       'POST',
       '/v1/images',
@@ -2840,6 +2845,76 @@ describe('AgentToolExecutorService', () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it('should read generate_image id from a root response envelope', async () => {
+    const { service } = createService();
+
+    vi.spyOn(
+      service as unknown as {
+        callInternalApi: (...args: unknown[]) => Promise<unknown>;
+      },
+      'callInternalApi',
+    ).mockResolvedValue({
+      id: 'img-root-123',
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.GENERATE_IMAGE,
+      { prompt: 'product photo' },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        id: 'img-root-123',
+      }),
+    );
+    expect(result.nextActions?.[0]).toMatchObject({
+      ctas: [{ href: '/g/image/img-root-123', label: 'View in gallery' }],
+      id: 'image-gen-img-root-123',
+    });
+  });
+
+  it('should prefer voice audioUrl from the response envelope', async () => {
+    const { service } = createService();
+
+    vi.spyOn(
+      service as unknown as {
+        callInternalApi: (...args: unknown[]) => Promise<unknown>;
+      },
+      'callInternalApi',
+    ).mockResolvedValue({
+      data: {
+        audioUrl: 'https://cdn.example.test/voice-123.mp3',
+        id: 'voice-123',
+      },
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.GENERATE_VOICE,
+      { text: 'Read this in the brand voice', voiceId: 'voice-default' },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        id: 'voice-123',
+        url: 'https://cdn.example.test/voice-123.mp3',
+      }),
+    );
+    expect(result.nextActions?.[0]).toMatchObject({
+      audio: ['https://cdn.example.test/voice-123.mp3'],
+      ctas: [{ href: '/g/voice/voice-123', label: 'View in gallery' }],
+    });
   });
 
   it('should map hashtags ai_action alias to add-hashtags DTO action', async () => {

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -921,6 +921,14 @@ export class AgentToolExecutorService {
     return value ? this.readOptionalString(value[key]) : undefined;
   }
 
+  private readResponseEnvelopeString(
+    response: Record<string, unknown>,
+    key: string,
+  ): string | undefined {
+    const data = this.isPlainRecord(response.data) ? response.data : undefined;
+    return this.readOptionalString(data?.[key] ?? response[key]);
+  }
+
   private async dispatch(
     toolName: AgentToolName,
     params: Record<string, unknown>,
@@ -5762,9 +5770,7 @@ export class AgentToolExecutorService {
       };
     }
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
+    const id = this.readResponseEnvelopeString(response, 'id');
     const cdnUrl = id
       ? `${this.configService.ingredientsEndpoint}/images/${id}`
       : undefined;
@@ -5772,7 +5778,7 @@ export class AgentToolExecutorService {
     // Fire-and-forget quality check — don't block the generation response
     if (id && this.contentQualityScorerService) {
       this.contentQualityScorerService
-        .scoreAndTag(String(id), 'image', {
+        .scoreAndTag(id, 'image', {
           organizationId: ctx.organizationId,
         })
         .catch((err) =>
@@ -5833,9 +5839,7 @@ export class AgentToolExecutorService {
       ctx,
     );
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
+    const id = this.readResponseEnvelopeString(response, 'id');
     const cdnUrl = id
       ? `${this.configService.ingredientsEndpoint}/images/${id}`
       : undefined;
@@ -5881,9 +5885,7 @@ export class AgentToolExecutorService {
       ctx,
     );
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
+    const id = this.readResponseEnvelopeString(response, 'id');
     const cdnUrl = id
       ? `${this.configService.ingredientsEndpoint}/images/${id}`
       : undefined;
@@ -5957,9 +5959,7 @@ export class AgentToolExecutorService {
       ctx,
     );
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
+    const id = this.readResponseEnvelopeString(response, 'id');
     const cdnUrl = id
       ? `${this.configService.ingredientsEndpoint}/videos/${id}`
       : undefined;
@@ -5967,7 +5967,7 @@ export class AgentToolExecutorService {
     // Fire-and-forget quality check — don't block the generation response
     if (id && this.contentQualityScorerService) {
       this.contentQualityScorerService
-        .scoreAndTag(String(id), 'video', {
+        .scoreAndTag(id, 'video', {
           organizationId: ctx.organizationId,
         })
         .catch((err) =>
@@ -6024,9 +6024,7 @@ export class AgentToolExecutorService {
       ctx,
     );
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
+    const id = this.readResponseEnvelopeString(response, 'id');
     const cdnUrl = id
       ? `${this.configService.ingredientsEndpoint}/musics/${id}`
       : undefined;
@@ -6068,14 +6066,10 @@ export class AgentToolExecutorService {
       ctx,
     );
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
-    const audioUrl =
-      (response.data as Record<string, unknown>)?.audioUrl ??
-      (response as Record<string, unknown>).audioUrl;
+    const id = this.readResponseEnvelopeString(response, 'id');
+    const audioUrl = this.readResponseEnvelopeString(response, 'audioUrl');
     const cdnUrl = audioUrl
-      ? String(audioUrl)
+      ? audioUrl
       : id
         ? `${this.configService.ingredientsEndpoint}/voices/${id}`
         : undefined;
@@ -7296,9 +7290,7 @@ export class AgentToolExecutorService {
       ctx,
     );
 
-    const id =
-      (response.data as Record<string, unknown>)?.id ??
-      (response as Record<string, unknown>).id;
+    const id = this.readResponseEnvelopeString(response, 'id');
 
     return {
       creditsUsed: 0,


### PR DESCRIPTION
## Summary

Closes #992
Parent: #519

- Added one local response-envelope string reader for generation endpoint responses.
- Replaced duplicated generated ingredient `id` extraction across image, reframe, upscale, video, music, voice, and identity generation handlers.
- Reused the same helper for voice `audioUrl` while preserving nested `data.*` and root response fallback behavior.

## Refactor lane fit

- Issue #992 is a focused child of broad code-quality parent #519.
- Behavior-preserving DRY cleanup in one API service and its focused spec.
- No preview-card extraction, handler split, package-boundary change, or user-visible feature work included.

## Structural review

- No blocker/request-change findings in the final changed diff.
- The helper has seven ID callers plus the voice audio URL caller, removes repeated cast-heavy boilerplate, and returns a narrowed optional string through the existing `readOptionalString` pattern.
- Deferred: the broader 9k-line `AgentToolExecutorService` split remains tracked by #519.

## Validation

- `bun run --cwd apps/server/api test:file src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bunx biome check --write apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bun run lint-staged`
