### PR TITLE
fix(test): restore getModelMeta in prisma mocks + add ContentGeoOptimizerHandler provider

### DIFF
--- a/apps/server/api/src/collections/articles/services/articles.service.cache.spec.ts
+++ b/apps/server/api/src/collections/articles/services/articles.service.cache.spec.ts
@@ -1,6 +1,61 @@
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('@genfeedai/prisma', () => ({ PrismaClient: class {} }));
+// `@genfeedai/prisma` re-exports the generated PrismaClient (packages/prisma/
+// src/index.ts -> ../generated/prisma/client/client), which only exists after
+// `prisma generate` runs and is heavy to load in a unit test (real driver
+// adapter wiring). We can't use `vi.mock(..., async (importOriginal) => ...)`
+// here because `importOriginal` evaluates that same generated-client
+// re-export, which is unavailable/expensive in this environment. Instead we
+// stub `PrismaClient` and inline the real `Article` entry from
+// packages/prisma/src/enum-field-map.ts (PRISMA_MODEL_METADATA.Article) so
+// BaseService's `getModelMeta('article')` call (base.service.ts) sees genuine
+// field/enum metadata instead of throwing "no getModelMeta export".
+vi.mock('@genfeedai/prisma', () => ({
+  getModelMeta: (modelName: string) => {
+    const pascal = modelName.charAt(0).toUpperCase() + modelName.slice(1);
+    const metadata: Record<
+      string,
+      {
+        allFields: readonly string[];
+        enumFields: Readonly<
+          Record<string, { enumType: string; isRequired: boolean }>
+        >;
+      }
+    > = {
+      Article: {
+        allFields: [
+          'brand',
+          'brandId',
+          'category',
+          'content',
+          'coverImageUrl',
+          'createdAt',
+          'excerpt',
+          'id',
+          'isDeleted',
+          'mongoId',
+          'organization',
+          'organizationId',
+          'publishedAt',
+          'scope',
+          'seoBreakdown',
+          'seoScore',
+          'slug',
+          'status',
+          'title',
+          'updatedAt',
+          'user',
+          'userId',
+        ],
+        enumFields: {
+          status: { enumType: 'ArticleStatus', isRequired: true },
+        },
+      },
+    };
+    return metadata[pascal];
+  },
+  PrismaClient: class {},
+}));
 
 import type { CreateArticleDto } from '@api/collections/articles/dto/create-article.dto';
 import { ArticlesService } from '@api/collections/articles/services/articles.service';

--- a/apps/server/api/src/collections/newsletters/services/newsletters.service.spec.ts
+++ b/apps/server/api/src/collections/newsletters/services/newsletters.service.spec.ts
@@ -1,3 +1,64 @@
+// `@genfeedai/prisma` re-exports the generated PrismaClient (packages/prisma/
+// src/index.ts -> ../generated/prisma/client/client), unavailable until
+// `prisma generate` runs and heavy to load in a unit test regardless. Stub
+// PrismaClient as a no-op and inline the real `Newsletter` entry from
+// packages/prisma/src/enum-field-map.ts (PRISMA_MODEL_METADATA.Newsletter) so
+// BaseService's `getModelMeta('newsletter')` call (base.service.ts) sees
+// genuine field metadata instead of throwing "no getModelMeta export". Status
+// is a plain string column (enumFields: {}), not a true Prisma enum, so this
+// also keeps enum-normalization a no-op pass-through for the lowercase status
+// strings (`approved`/`published`/`archived`) the tests assert on below.
+vi.mock('@genfeedai/prisma', () => ({
+  getModelMeta: (modelName: string) => {
+    const pascal = modelName.charAt(0).toUpperCase() + modelName.slice(1);
+    const metadata: Record<
+      string,
+      {
+        allFields: readonly string[];
+        enumFields: Readonly<
+          Record<string, { enumType: string; isRequired: boolean }>
+        >;
+      }
+    > = {
+      Newsletter: {
+        allFields: [
+          'agentRun',
+          'agentRunId',
+          'angle',
+          'approvedAt',
+          'approvedByUser',
+          'approvedByUserId',
+          'brand',
+          'brandId',
+          'content',
+          'createdAt',
+          'generationPrompt',
+          'id',
+          'isDeleted',
+          'label',
+          'mongoId',
+          'organization',
+          'organizationId',
+          'publishedAt',
+          'publishedByUser',
+          'publishedByUserId',
+          'scheduledFor',
+          'sourceRefs',
+          'status',
+          'summary',
+          'topic',
+          'updatedAt',
+          'user',
+          'userId',
+        ],
+        enumFields: {},
+      },
+    };
+    return metadata[pascal];
+  },
+  PrismaClient: class {},
+}));
+
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import type { CreateNewsletterDto } from '@api/collections/newsletters/dto/create-newsletter.dto';
 import { NewslettersService } from '@api/collections/newsletters/services/newsletters.service';

--- a/apps/server/api/src/services/skill-executor/stable-provider-path.spec.ts
+++ b/apps/server/api/src/services/skill-executor/stable-provider-path.spec.ts
@@ -5,6 +5,7 @@ import { ByokProviderFactoryService } from '@api/services/byok/byok-provider-fac
 import { FalService } from '@api/services/integrations/fal/fal.service';
 import { LeonardoAIService } from '@api/services/integrations/leonardoai/leonardoai.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
+import { ContentGeoOptimizerHandler } from '@api/services/skill-executor/handlers/content-geo-optimizer.handler';
 import { ContentWritingHandler } from '@api/services/skill-executor/handlers/content-writing.handler';
 import { ImageGenerationHandler } from '@api/services/skill-executor/handlers/image-generation.handler';
 import { TrendDiscoveryHandler } from '@api/services/skill-executor/handlers/trend-discovery.handler';
@@ -106,6 +107,10 @@ describe('stable provider path smoke', () => {
         {
           provide: ManagedInferenceClientService,
           useValue: managedInferenceClientService,
+        },
+        {
+          provide: ContentGeoOptimizerHandler,
+          useValue: { execute: vi.fn() },
         },
         {
           provide: ContentWritingHandler,


### PR DESCRIPTION
Fixes 7 pre-existing API unit-test failures blocking the master CI gate (latent since #942 getModelMeta + #872 GEO optimizer; surfaced by release-batch master push).

- articles.service.cache.spec.ts, newsletters.service.spec.ts: `@genfeedai/prisma` mocks now export `getModelMeta` with real model metadata (explicit inline stub — importOriginal would pull the generated client).
- stable-provider-path.spec.ts: add missing `ContentGeoOptimizerHandler` provider to the test module.

Test-only. ~7 sibling specs still lack getModelMeta in their prisma mock → follow-up issue.