### PR TITLE
Wire hook generator workflow node

### DIFF
--- a/apps/app/src/features/workflows/nodes/merged-node-types.spec.ts
+++ b/apps/app/src/features/workflows/nodes/merged-node-types.spec.ts
@@ -5,6 +5,7 @@ import { cloudNodeTypes } from './merged-node-types';
 const TEMPLATE_NODE_TYPES = [
   'ai-avatar-video',
   'effect-captions',
+  'hookGenerator',
   'imageGen',
   'musicSource',
   'promptConstructor',

--- a/apps/app/src/features/workflows/nodes/saas/HookGeneratorNode.tsx
+++ b/apps/app/src/features/workflows/nodes/saas/HookGeneratorNode.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import type {
+  HookFormula,
+  HookGeneratorNodeData,
+  HookToneStyle,
+} from '@genfeedai/workflow-saas';
+import {
+  selectUpdateNodeData,
+  useWorkflowStore,
+} from '@genfeedai/workflow-ui/stores';
+import type { NodeProps } from '@xyflow/react';
+import { Zap } from 'lucide-react';
+import { memo, useCallback } from 'react';
+import { NodeBadge } from '@/features/workflows/components/ui/badge';
+import { NodeCard, NodeHeader } from '@/features/workflows/components/ui/card';
+import {
+  NodeInput,
+  NodeSelect,
+} from '@/features/workflows/components/ui/inputs';
+import {
+  HelpText,
+  ProcessingMessage,
+} from '@/features/workflows/components/ui/status';
+import { coerceNodeData } from '@/features/workflows/nodes/node-data';
+
+const HOOK_FORMULA_OPTIONS: Array<{ label: string; value: HookFormula }> = [
+  { label: 'Curiosity gap', value: 'curiosity_gap' },
+  {
+    label: 'Conflict resolution',
+    value: 'person_conflict_resolution',
+  },
+  { label: 'List reveal', value: 'list_reveal' },
+  { label: 'Transformation', value: 'transformation' },
+  { label: 'Challenge', value: 'challenge' },
+];
+
+const TONE_STYLE_OPTIONS: Array<{ label: string; value: HookToneStyle }> = [
+  { label: 'Storytelling', value: 'storytelling' },
+  { label: 'Provocative', value: 'provocative' },
+  { label: 'Educational', value: 'educational' },
+  { label: 'Humorous', value: 'humorous' },
+  { label: 'Dramatic', value: 'dramatic' },
+];
+
+function emptyToNull(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function HookGeneratorNodeComponent(props: NodeProps): React.JSX.Element {
+  const { id } = props;
+  const data = coerceNodeData<HookGeneratorNodeData>(
+    props.data,
+    hookGeneratorNodeDefaults,
+  );
+  const updateNodeData = useWorkflowStore(selectUpdateNodeData);
+
+  const handleNicheChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      updateNodeData(id, { niche: emptyToNull(event.target.value) });
+    },
+    [id, updateNodeData],
+  );
+
+  const handleProductChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      updateNodeData(id, { product: emptyToNull(event.target.value) });
+    },
+    [id, updateNodeData],
+  );
+
+  const handleFormulaChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      updateNodeData(id, { hookFormula: event.target.value as HookFormula });
+    },
+    [id, updateNodeData],
+  );
+
+  const handleToneChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      updateNodeData(id, { toneStyle: event.target.value as HookToneStyle });
+    },
+    [id, updateNodeData],
+  );
+
+  const outputHashtags = Array.isArray(data.outputHashtags)
+    ? data.outputHashtags
+    : [];
+  const outputSlidePrompts = Array.isArray(data.outputSlidePrompts)
+    ? data.outputSlidePrompts
+    : [];
+  const hasOutput =
+    Boolean(data.outputHookText) ||
+    Boolean(data.outputCaptionHook) ||
+    outputHashtags.length > 0 ||
+    outputSlidePrompts.length > 0;
+
+  return (
+    <NodeCard>
+      <NodeHeader
+        icon={<Zap className="size-4" />}
+        title="Hook Generator"
+        badge={<NodeBadge variant="purple">SaaS</NodeBadge>}
+      />
+
+      <div className="grid grid-cols-2 gap-2">
+        <NodeInput
+          label="Niche"
+          value={data.niche ?? ''}
+          onChange={handleNicheChange}
+          placeholder="AI creators"
+        />
+        <NodeInput
+          label="Product"
+          value={data.product ?? ''}
+          onChange={handleProductChange}
+          placeholder="Workflow automation"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <NodeSelect
+          label="Formula"
+          value={data.hookFormula}
+          onChange={handleFormulaChange}
+        >
+          {HOOK_FORMULA_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </NodeSelect>
+        <NodeSelect
+          label="Tone"
+          value={data.toneStyle}
+          onChange={handleToneChange}
+        >
+          {TONE_STYLE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </NodeSelect>
+      </div>
+
+      {data.status === 'processing' && (
+        <ProcessingMessage message="Generating hook set..." />
+      )}
+
+      {hasOutput ? (
+        <div className="space-y-2 border border-white/[0.08] bg-muted/30 p-2">
+          {data.outputHookText && (
+            <p className="text-xs font-medium">{data.outputHookText}</p>
+          )}
+          {data.outputCaptionHook && (
+            <p className="line-clamp-2 text-xs text-muted-foreground">
+              {data.outputCaptionHook}
+            </p>
+          )}
+          {outputHashtags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {outputHashtags.map((hashtag) => (
+                <span
+                  key={hashtag}
+                  className="rounded-full border border-border/80 bg-secondary/40 px-2 py-0.5 text-[10px] text-muted-foreground"
+                >
+                  {hashtag}
+                </span>
+              ))}
+            </div>
+          )}
+          {outputSlidePrompts.length > 0 && (
+            <p className="text-[10px] text-muted-foreground">
+              {outputSlidePrompts.length} slide prompts ready
+            </p>
+          )}
+        </div>
+      ) : (
+        <HelpText>
+          Connect trend or brand context to generate hooks at execution time
+        </HelpText>
+      )}
+    </NodeCard>
+  );
+}
+
+export const HookGeneratorNode = memo(HookGeneratorNodeComponent);
+
+const hookGeneratorNodeDefaults: Partial<HookGeneratorNodeData> = {
+  hookFormula: 'curiosity_gap',
+  inputBrandContext: null,
+  inputTrendData: null,
+  label: 'Hook Generator',
+  niche: null,
+  outputCaptionHook: null,
+  outputHashtags: [],
+  outputHookText: null,
+  outputSlidePrompts: [],
+  product: null,
+  status: 'idle',
+  toneStyle: 'storytelling',
+  type: 'hookGenerator',
+};

--- a/apps/app/src/features/workflows/nodes/saas/index.ts
+++ b/apps/app/src/features/workflows/nodes/saas/index.ts
@@ -1,6 +1,7 @@
 import { BrandAssetNode } from '@/features/workflows/nodes/saas/BrandAssetNode';
 import { BrandContextNode } from '@/features/workflows/nodes/saas/BrandContextNode';
 import { BrandNode } from '@/features/workflows/nodes/saas/BrandNode';
+import { HookGeneratorNode } from '@/features/workflows/nodes/saas/HookGeneratorNode';
 import { PersonaContentPlanNode } from '@/features/workflows/nodes/saas/PersonaContentPlanNode';
 import { PersonaPhotoSessionNode } from '@/features/workflows/nodes/saas/PersonaPhotoSessionNode';
 import { PersonaVideoContentNode } from '@/features/workflows/nodes/saas/PersonaVideoContentNode';
@@ -14,6 +15,7 @@ export const saasNodeTypes = {
   brand: BrandNode,
   brandAsset: BrandAssetNode,
   brandContext: BrandContextNode,
+  hookGenerator: HookGeneratorNode,
   personaContentPlan: PersonaContentPlanNode,
   personaPhotoSession: PersonaPhotoSessionNode,
   personaVideoContent: PersonaVideoContentNode,

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -386,6 +386,46 @@ describe('WorkflowEngineAdapterService', () => {
       );
     });
 
+    it('executes hook generator without invoking fallback behavior', async () => {
+      const workflow = service.convertToExecutableWorkflow({
+        _id: { toString: () => 'wf-hook-generator' },
+        nodes: [
+          {
+            data: {
+              config: {
+                hookFormula: 'list_reveal',
+                niche: 'AI founders',
+                product: 'content loops',
+                toneStyle: 'educational',
+              },
+              label: 'Hook Generator',
+            },
+            id: 'hook',
+            type: 'hookGenerator',
+          },
+        ],
+        organization: { toString: () => 'org-1' },
+        user: { toString: () => 'user-1' },
+      });
+
+      const result = await service.executeWorkflow(workflow);
+      const output = result.nodeResults.get('hook')?.output as {
+        captionHook: string;
+        hashtags: string[];
+        hookText: string;
+        slidePrompts: string[];
+      };
+
+      expect(result.status).toBe('completed');
+      expect(output.hookText).toContain('Here is what matters');
+      expect(output.hashtags).toContain('#aifounders');
+      expect(output.slidePrompts).toHaveLength(6);
+      expect(loggerService.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('fallback executor invoked'),
+        expect.objectContaining({ nodeType: 'hookGenerator' }),
+      );
+    });
+
     it('executes trend trigger with analytics keywords when no social trend adapter is available', async () => {
       const workflow = service.convertToExecutableWorkflow({
         _id: { toString: () => 'wf-trend' },

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -84,6 +84,7 @@ import {
   createAnalyticsFeedbackExecutor,
   createBrandAssetExecutor,
   createBrandContextExecutor,
+  createHookGeneratorExecutor,
   createImageGenExecutor,
   createIterativeSeoRefineExecutor,
   createLipSyncExecutor,
@@ -311,6 +312,7 @@ export class WorkflowEngineAdapterService {
     this.registerAvatarVideoExecutor();
     this.registerImageGenExecutor();
     this.registerPromptConstructorExecutor();
+    this.registerHookGeneratorExecutor();
     this.registerPostExecutor();
     this.registerNewsletterExecutor();
     this.registerCaptionsExecutor();
@@ -1786,6 +1788,15 @@ export class WorkflowEngineAdapterService {
     this.engine.registerExecutor(
       'promptConstructor',
       this.wrapEngineExecutor(promptConstructorExecutor),
+    );
+  }
+
+  private registerHookGeneratorExecutor(): void {
+    const hookGeneratorExecutor = createHookGeneratorExecutor();
+
+    this.engine.registerExecutor(
+      'hookGenerator',
+      this.wrapEngineExecutor(hookGeneratorExecutor),
     );
   }
 

--- a/packages/workflow-engine/src/executors/executor-registry.spec.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.spec.ts
@@ -16,6 +16,7 @@ describe('executor-registry', () => {
       expect(types).toContain('publish');
       expect(types).toContain('condition');
       expect(types).toContain('delay');
+      expect(types).toContain('hookGenerator');
       expect(types).toContain('noop');
     });
   });
@@ -55,6 +56,13 @@ describe('executor-registry', () => {
       expect(meta).toBeDefined();
       expect(meta?.nodeType).toBe('brand');
       expect(meta?.requiresResolver).toBe(true);
+    });
+
+    it('returns metadata for hookGenerator without a resolver requirement', () => {
+      const meta = getExecutorMetadata('hookGenerator');
+      expect(meta).toBeDefined();
+      expect(meta?.nodeType).toBe('hookGenerator');
+      expect(meta?.requiresResolver).toBe(false);
     });
 
     it('returns undefined for unknown type', () => {

--- a/packages/workflow-engine/src/executors/executor-registry.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.ts
@@ -48,6 +48,10 @@ import {
   FilmGrainExecutor,
 } from '@workflow-engine/executors/saas/film-grain-executor';
 import {
+  createHookGeneratorExecutor,
+  HookGeneratorExecutor,
+} from '@workflow-engine/executors/saas/hook-generator-executor';
+import {
   createImageGenExecutor,
   ImageGenExecutor,
 } from '@workflow-engine/executors/saas/image-gen-executor';
@@ -198,6 +202,7 @@ import {
  * | cinematicColorGrade | CinematicColorGradeExecutor | ./saas/cinematic-color-grade-executor.ts |
  * | filmGrain       | FilmGrainExecutor        | ./saas/film-grain-executor.ts         |
  * | lensEffects     | LensEffectsExecutor      | ./saas/lens-effects-executor.ts       |
+ * | hookGenerator   | HookGeneratorExecutor    | ./saas/hook-generator-executor.ts     |
  * | promptConstructor | PromptConstructorExecutor | ./saas/prompt-constructor-executor.ts |
  * | voiceChange     | VoiceChangeExecutor      | ./saas/voice-change-executor.ts       |
  * | lipSync         | LipSyncExecutor          | ./saas/lip-sync-executor.ts           |
@@ -306,6 +311,14 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     factory: () => createFilmGrainExecutor(),
     nodeType: 'filmGrain',
     requiresResolver: true,
+  },
+  hookGenerator: {
+    description:
+      'Generates hook text, caption openings, hashtags, and slide prompts from trend and brand context',
+    executorClass: HookGeneratorExecutor,
+    factory: () => createHookGeneratorExecutor(),
+    nodeType: 'hookGenerator',
+    requiresResolver: false,
   },
   imageGen: {
     description:

--- a/packages/workflow-engine/src/executors/saas/hook-generator-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/hook-generator-executor.spec.ts
@@ -1,0 +1,139 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  createHookGeneratorExecutor,
+  type HookGeneratorExecutor,
+  type HookGeneratorOutput,
+} from '@workflow-engine/executors/saas/hook-generator-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+function makeNode(
+  configOverrides: Record<string, unknown> = {},
+): ExecutableNode {
+  return {
+    config: {
+      hookFormula: 'curiosity_gap',
+      niche: 'AI founders',
+      product: 'workflow automation',
+      toneStyle: 'storytelling',
+      ...configOverrides,
+    },
+    id: 'hook-1',
+    inputs: [],
+    label: 'Hook Generator',
+    type: 'hookGenerator',
+  };
+}
+
+function makeContext(): ExecutionContext {
+  return {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+}
+
+function makeInput(
+  configOverrides: Record<string, unknown> = {},
+  inputEntries: [string, unknown][] = [],
+): ExecutorInput {
+  return {
+    context: makeContext(),
+    inputs: new Map<string, unknown>(inputEntries),
+    node: makeNode(configOverrides),
+  };
+}
+
+describe('HookGeneratorExecutor', () => {
+  let executor: HookGeneratorExecutor;
+
+  beforeEach(() => {
+    executor = createHookGeneratorExecutor();
+  });
+
+  describe('validate', () => {
+    it('passes with valid hook settings', () => {
+      const result = executor.validate(makeNode());
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('fails for invalid formula and tone values', () => {
+      const result = executor.validate(
+        makeNode({
+          hookFormula: 'unsupported',
+          toneStyle: 'flat',
+        }),
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'Invalid hookFormula. Must be one of: person_conflict_resolution, curiosity_gap, list_reveal, transformation, challenge',
+      );
+      expect(result.errors).toContain(
+        'Invalid toneStyle. Must be one of: storytelling, provocative, educational, humorous, dramatic',
+      );
+    });
+
+    it('fails when optional text config is blank', () => {
+      const result = executor.validate(makeNode({ niche: ' ' }));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'niche must be a non-empty string when provided',
+      );
+    });
+  });
+
+  describe('estimateCost', () => {
+    it('returns one credit', () => {
+      expect(executor.estimateCost(makeNode())).toBe(1);
+    });
+  });
+
+  describe('execute', () => {
+    it('emits hook text, caption hook, hashtags, and six slide prompts', async () => {
+      const result = await executor.execute(
+        makeInput({ hookFormula: 'challenge', toneStyle: 'dramatic' }, [
+          [
+            'trendData',
+            {
+              hashtags: ['#AIContent', 'founder tips'],
+              topic: 'autonomous content loops',
+            },
+          ],
+          ['brand', { voice: 'direct and practical' }],
+        ]),
+      );
+      const output = result.data as HookGeneratorOutput;
+
+      expect(output.hookText).toContain('The moment everything changed');
+      expect(output.captionHook).toContain('autonomous content loops');
+      expect(output.captionHook).toContain('direct and practical');
+      expect(output.hashtags).toEqual([
+        '#aicontent',
+        '#foundertips',
+        '#aifounders',
+        '#workflowautomation',
+        '#content',
+      ]);
+      expect(output.slidePrompts).toHaveLength(6);
+      expect(output.slidePrompts[0]).toContain('workflow automation');
+      expect(result.metadata?.formula).toBe('challenge');
+      expect(result.metadata?.toneStyle).toBe('dramatic');
+    });
+
+    it('uses defaults when config and inputs are sparse', async () => {
+      const result = await executor.execute(makeInput({}));
+      const output = result.data as HookGeneratorOutput;
+
+      expect(output.hookText).toContain('I tried workflow automation');
+      expect(output.captionHook).toBe(output.hookText);
+      expect(output.hashtags).toContain('#aifounders');
+      expect(output.slidePrompts).toHaveLength(6);
+    });
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/hook-generator-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/hook-generator-executor.ts
@@ -1,0 +1,327 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+export type HookFormula =
+  | 'person_conflict_resolution'
+  | 'curiosity_gap'
+  | 'list_reveal'
+  | 'transformation'
+  | 'challenge';
+
+export type HookToneStyle =
+  | 'storytelling'
+  | 'provocative'
+  | 'educational'
+  | 'humorous'
+  | 'dramatic';
+
+export interface HookGeneratorConfig {
+  niche?: string | null;
+  product?: string | null;
+  hookFormula?: HookFormula;
+  toneStyle?: HookToneStyle;
+  inputTrendData?: string | null;
+  inputBrandContext?: string | null;
+}
+
+export interface HookGeneratorOutput {
+  hookText: string;
+  captionHook: string;
+  hashtags: string[];
+  slidePrompts: string[];
+}
+
+interface HookContext {
+  brandContext: string | null;
+  niche: string;
+  product: string | null;
+  topic: string;
+  trendContext: string | null;
+}
+
+const DEFAULT_HOOK_FORMULA: HookFormula = 'curiosity_gap';
+const DEFAULT_TONE_STYLE: HookToneStyle = 'storytelling';
+const DEFAULT_TOPIC = 'your next content idea';
+const SLIDE_PROMPT_COUNT = 6;
+const MAX_HASHTAG_COUNT = 5;
+
+const VALID_FORMULAS = new Set<HookFormula>([
+  'person_conflict_resolution',
+  'curiosity_gap',
+  'list_reveal',
+  'transformation',
+  'challenge',
+]);
+
+const VALID_TONE_STYLES = new Set<HookToneStyle>([
+  'storytelling',
+  'provocative',
+  'educational',
+  'humorous',
+  'dramatic',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function stringifyContext(value: unknown): string | null {
+  const text = toNonEmptyString(value);
+  if (text) {
+    return text;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const preferredKeys = [
+    'topic',
+    'matchedKeyword',
+    'trend',
+    'summary',
+    'voice',
+    'brandVoice',
+    'label',
+    'name',
+  ];
+
+  for (const key of preferredKeys) {
+    const candidate = toNonEmptyString(value[key]);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function buildHashtag(value: string): string | null {
+  const normalized = value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+  return normalized.length > 0 ? `#${normalized}` : null;
+}
+
+function collectHashtags(
+  trendInput: unknown,
+  niche: string,
+  product: string | null,
+): string[] {
+  const tags: string[] = [];
+
+  if (isRecord(trendInput) && Array.isArray(trendInput.hashtags)) {
+    for (const hashtag of trendInput.hashtags) {
+      const tag = toNonEmptyString(hashtag);
+      if (tag) {
+        tags.push(tag);
+      }
+    }
+  }
+
+  const trendText = stringifyContext(trendInput);
+  if (trendText) {
+    const matches = trendText.match(/#[a-zA-Z0-9_]+/g) ?? [];
+    tags.push(...matches);
+  }
+
+  tags.push(niche);
+  if (product) {
+    tags.push(product);
+  }
+  tags.push('content');
+  tags.push('creator');
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const tag of tags) {
+    const hashtag = buildHashtag(tag);
+    if (!hashtag || seen.has(hashtag)) {
+      continue;
+    }
+
+    seen.add(hashtag);
+    normalized.push(hashtag);
+
+    if (normalized.length >= MAX_HASHTAG_COUNT) {
+      break;
+    }
+  }
+
+  return normalized;
+}
+
+function resolveHookContext(
+  node: ExecutableNode,
+  inputs: Map<string, unknown>,
+): HookContext {
+  const config = node.config as HookGeneratorConfig;
+  const trendInput = inputs.get('trendData') ?? config.inputTrendData;
+  const brandInput = inputs.get('brand') ?? config.inputBrandContext;
+  const trendContext = stringifyContext(trendInput);
+  const brandContext = stringifyContext(brandInput);
+  const product = toNonEmptyString(config.product);
+  const niche = toNonEmptyString(config.niche) ?? trendContext ?? DEFAULT_TOPIC;
+
+  return {
+    brandContext,
+    niche,
+    product,
+    topic: product ?? niche,
+    trendContext,
+  };
+}
+
+function createFormulaHook(formula: HookFormula, context: HookContext): string {
+  const topic = context.topic;
+  const audience = context.niche;
+
+  switch (formula) {
+    case 'person_conflict_resolution':
+      return `${audience} hit a wall with ${topic}, then this fixed it`;
+    case 'curiosity_gap':
+      return `I tried ${topic} and the result was not what anyone expected`;
+    case 'list_reveal':
+      return `5 ${topic} lessons creators keep learning too late`;
+    case 'transformation':
+      return `Before vs after: turning ${topic} into repeatable growth`;
+    case 'challenge':
+      return `Can ${topic} actually perform when the pressure is real?`;
+  }
+}
+
+function applyTone(hook: string, toneStyle: HookToneStyle): string {
+  switch (toneStyle) {
+    case 'storytelling':
+      return hook;
+    case 'provocative':
+      return `Stop ignoring this: ${hook}`;
+    case 'educational':
+      return `Here is what matters: ${hook}`;
+    case 'humorous':
+      return `This sounded ridiculous until it worked: ${hook}`;
+    case 'dramatic':
+      return `The moment everything changed: ${hook}`;
+  }
+}
+
+function createCaptionHook(hookText: string, context: HookContext): string {
+  const details = [context.trendContext, context.brandContext]
+    .flatMap((value) => (value ? [value] : []))
+    .slice(0, 2);
+
+  if (details.length === 0) {
+    return hookText;
+  }
+
+  return `${hookText}. ${details.join(' ')}`;
+}
+
+function createSlidePrompts(context: HookContext): string[] {
+  const brandClause = context.brandContext
+    ? ` with ${context.brandContext} brand cues`
+    : '';
+  const trendClause = context.trendContext
+    ? ` referencing ${context.trendContext}`
+    : '';
+
+  return [
+    `Opening slide visual for ${context.topic}${brandClause}${trendClause}`,
+    `Problem scene showing why ${context.niche} needs a better answer`,
+    `Discovery moment that reveals the key insight behind ${context.topic}`,
+    `Proof slide with a concrete example of ${context.topic} working`,
+    `Outcome slide showing the transformation for ${context.niche}`,
+    `Final call-to-action slide inviting viewers to try ${context.topic}`,
+  ].slice(0, SLIDE_PROMPT_COUNT);
+}
+
+export class HookGeneratorExecutor extends BaseExecutor {
+  readonly nodeType = 'hookGenerator';
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+    const config = node.config as HookGeneratorConfig;
+
+    if (
+      config.hookFormula !== undefined &&
+      !VALID_FORMULAS.has(config.hookFormula)
+    ) {
+      errors.push(
+        'Invalid hookFormula. Must be one of: person_conflict_resolution, curiosity_gap, list_reveal, transformation, challenge',
+      );
+    }
+
+    if (
+      config.toneStyle !== undefined &&
+      !VALID_TONE_STYLES.has(config.toneStyle)
+    ) {
+      errors.push(
+        'Invalid toneStyle. Must be one of: storytelling, provocative, educational, humorous, dramatic',
+      );
+    }
+
+    for (const field of ['niche', 'product'] as const) {
+      const value = config[field];
+      if (
+        value !== undefined &&
+        value !== null &&
+        (typeof value !== 'string' || value.trim().length === 0)
+      ) {
+        errors.push(`${field} must be a non-empty string when provided`);
+      }
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 1;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { inputs, node } = input;
+    const config = node.config as HookGeneratorConfig;
+    const formula = config.hookFormula ?? DEFAULT_HOOK_FORMULA;
+    const toneStyle = config.toneStyle ?? DEFAULT_TONE_STYLE;
+    const context = resolveHookContext(node, inputs);
+
+    const hookText = applyTone(createFormulaHook(formula, context), toneStyle);
+    const output: HookGeneratorOutput = {
+      captionHook: createCaptionHook(hookText, context),
+      hashtags: collectHashtags(
+        inputs.get('trendData') ?? config.inputTrendData,
+        context.niche,
+        context.product,
+      ),
+      hookText,
+      slidePrompts: createSlidePrompts(context),
+    };
+
+    return {
+      data: output,
+      metadata: {
+        formula,
+        hashtagCount: output.hashtags.length,
+        slidePromptCount: output.slidePrompts.length,
+        toneStyle,
+      },
+    };
+  }
+}
+
+export function createHookGeneratorExecutor(): HookGeneratorExecutor {
+  return new HookGeneratorExecutor();
+}

--- a/packages/workflow-engine/src/executors/saas/index.ts
+++ b/packages/workflow-engine/src/executors/saas/index.ts
@@ -13,6 +13,7 @@ export * from '@workflow-engine/executors/saas/delay-executor';
 export * from '@workflow-engine/executors/saas/engagement-trigger-executor';
 export * from '@workflow-engine/executors/saas/film-grain-executor';
 // AI generation executors
+export * from '@workflow-engine/executors/saas/hook-generator-executor';
 export * from '@workflow-engine/executors/saas/image-gen-executor';
 // SEO score -> rewrite -> re-score loop executor
 export * from '@workflow-engine/executors/saas/iterative-seo-refine-executor';

--- a/packages/workflow-engine/src/utils/credit-calculator.ts
+++ b/packages/workflow-engine/src/utils/credit-calculator.ts
@@ -54,6 +54,7 @@ export const DEFAULT_CREDIT_COSTS: CreditCostConfig = {
   // ----- text / content generation -----
   caption: 1, // legacy alias
   generateArticle: 3, // legacy alias
+  hookGenerator: 1, // [ESTIMATED] deterministic content generation; comparable to caption
   iterativeSeoRefine: 15, // [ESTIMATED] default maxIterations(3) x (score 2 + rewrite 3) -> ~15; the engine reads this flat value for budgeting, while executor.estimateCost scales with the configured maxIterations
   postReply: 1, // [ESTIMATED] comparable to caption
   seoRewrite: 3, // [ESTIMATED] LLM rewrite; comparable to generateArticle
@@ -259,6 +260,7 @@ const NODE_CATEGORY_MAP: Record<string, string> = {
   generateImage: 'ai',
   generateMusic: 'ai',
   generateVideo: 'ai',
+  hookGenerator: 'ai',
   imageGen: 'ai',
   iterativeSeoRefine: 'ai',
   lipSync: 'ai',


### PR DESCRIPTION
## Summary
- Add a dedicated `hookGenerator` workflow-engine executor that emits hook text, caption openings, hashtags, and slide prompts.
- Register `hookGenerator` in the executor registry, credit-cost coverage, and API workflow adapter.
- Add a cloud workflow UI node component and node-type map coverage for `hookGenerator`.

## Validation
- `bun test packages/workflow-engine/src/executors/saas/hook-generator-executor.spec.ts packages/workflow-engine/src/executors/executor-registry.spec.ts packages/workflow-engine/src/utils/credit-calculator-coverage.spec.ts`
- `bun --cwd apps/app test src/features/workflows/nodes/merged-node-types.spec.ts`
- `bun --cwd apps/server/api test src/collections/workflows/services/workflow-engine-adapter.service.spec.ts`
- `bunx biome check packages/workflow-engine/src/executors/saas/hook-generator-executor.ts packages/workflow-engine/src/executors/saas/hook-generator-executor.spec.ts packages/workflow-engine/src/executors/saas/index.ts packages/workflow-engine/src/executors/executor-registry.ts packages/workflow-engine/src/executors/executor-registry.spec.ts packages/workflow-engine/src/utils/credit-calculator.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts apps/app/src/features/workflows/nodes/saas/HookGeneratorNode.tsx apps/app/src/features/workflows/nodes/saas/index.ts apps/app/src/features/workflows/nodes/merged-node-types.spec.ts`
- `bun run --cwd packages/workflow-engine build`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/app`
- `bunx turbo run type-check --filter=@genfeedai/app`
- `git diff --check`

Closes #997
Refs #481