### PR TITLE
Add LinkedIn server conversion dispatch

### DIFF
--- a/apps/website/docs/marketing-tracking.md
+++ b/apps/website/docs/marketing-tracking.md
@@ -47,10 +47,20 @@ Public browser config:
 
 Server conversion config:
 
+- `LINKEDIN_CONVERSIONS_API_ACCESS_TOKEN`
+- `LINKEDIN_CONVERSIONS_API_VERSION` (defaults to `202606`)
+- `LINKEDIN_CONVERSIONS_API_ENDPOINT` (optional; defaults to LinkedIn's REST conversion events endpoint)
+- `LINKEDIN_CONVERSION_URN_BOOK_CALL`
+- `LINKEDIN_CONVERSION_URN_LEAD_SUBMIT`
+- `LINKEDIN_CONVERSION_URN_SIGNUP_COMPLETE`
 - `META_CONVERSIONS_API_ACCESS_TOKEN`
 - `META_CONVERSIONS_API_GRAPH_VERSION`
 - `X_CONVERSIONS_API_ENDPOINT`
 - `X_CONVERSIONS_API_BEARER_TOKEN`
+
+LinkedIn Conversions API remains opt-in: the server skips dispatch unless the
+access token, event-specific conversion rule URN, and at least one match
+identifier such as email, `liFatId`, or client IPv4 address are present.
 
 ## Verification Checklist
 
@@ -61,4 +71,5 @@ Local or staging:
 - Use LinkedIn Insight Tag verification to confirm the tag loads only after consent and receives mapped conversion events.
 - Use X Pixel Helper to confirm X Pixel is absent before consent and receives mapped events after consent.
 - Trigger a booking, lead, or signup success event and confirm the browser event and `/api/marketing/conversions` request share the same `eventId`.
+- In LinkedIn Campaign Manager diagnostics, confirm configured server events use the same event ID as browser events and skip when conversion rule URNs or identifiers are absent.
 - In Meta Events Manager and X Ads diagnostics, confirm server events dedupe with browser events by the shared event ID.

--- a/apps/website/packages/marketing/server-conversions.test.ts
+++ b/apps/website/packages/marketing/server-conversions.test.ts
@@ -27,7 +27,7 @@ describe('server conversions', () => {
     ).toBeNull();
   });
 
-  it('sends configured Meta and X conversions with the shared event id', async () => {
+  it('sends configured Meta, LinkedIn, and X conversions with the shared event id', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response('{}'));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -35,7 +35,10 @@ describe('server conversions', () => {
       {
         eventId: 'book_call:1',
         name: 'book_call',
-        payload: { email: 'Founder@Example.com' },
+        payload: {
+          email: 'Founder@Example.com',
+          liFatId: 'li-fat-id',
+        },
         url: 'https://genfeed.ai',
       },
       {
@@ -43,6 +46,12 @@ describe('server conversions', () => {
         userAgent: 'vitest',
       },
       {
+        linkedinAccessToken: 'linkedin-token',
+        linkedinApiEndpoint: 'https://api.linkedin.com/rest/conversionEvents',
+        linkedinApiVersion: '202606',
+        linkedinConversionUrns: {
+          book_call: 'urn:lla:llaPartnerConversion:123',
+        },
         metaAccessToken: 'meta-token',
         metaGraphVersion: 'v99.0',
         metaPixelId: 'meta-pixel',
@@ -54,16 +63,63 @@ describe('server conversions', () => {
       },
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[0]?.[0]).toContain(
       'https://graph.facebook.com/v99.0/meta-pixel/events',
     );
     expect(fetchMock.mock.calls[0]?.[1]?.body).toContain('book_call:1');
     expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      'https://api.linkedin.com/rest/conversionEvents',
+    );
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer linkedin-token',
+      'Linkedin-Version': '202606',
+      'X-Restli-Protocol-Version': '2.0.0',
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain('book_call:1');
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain(
+      'urn:lla:llaPartnerConversion:123',
+    );
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain('SHA256_EMAIL');
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain(
+      'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
+    );
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain(
+      'PLAINTEXT_IP_ADDRESS',
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
       'https://ads-api.x.com/12/measurement/conversions/tag',
     );
-    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain('book_call:1');
-    expect(fetchMock.mock.calls[1]?.[1]?.body).toContain('tw-book-call');
+    expect(fetchMock.mock.calls[2]?.[1]?.body).toContain('book_call:1');
+    expect(fetchMock.mock.calls[2]?.[1]?.body).toContain('tw-book-call');
+  });
+
+  it('skips LinkedIn conversions without configured match identifiers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await sendServerConversions(
+      {
+        eventId: 'signup_complete:1',
+        name: 'signup_complete',
+        payload: {},
+        url: 'https://genfeed.ai',
+      },
+      {},
+      {
+        linkedinAccessToken: 'linkedin-token',
+        linkedinConversionUrns: {
+          signup_complete: 'urn:lla:llaPartnerConversion:456',
+        },
+      },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      linkedin: 'skipped',
+      meta: 'skipped',
+      x: 'skipped',
+    });
   });
 
   it('reports configured providers as failed when the conversion request fails', async () => {
@@ -83,6 +139,10 @@ describe('server conversions', () => {
       },
     );
 
-    expect(result).toEqual({ meta: 'failed', x: 'skipped' });
+    expect(result).toEqual({
+      linkedin: 'skipped',
+      meta: 'failed',
+      x: 'skipped',
+    });
   });
 });

--- a/apps/website/packages/marketing/server-conversions.ts
+++ b/apps/website/packages/marketing/server-conversions.ts
@@ -21,6 +21,10 @@ export interface ServerConversionContext {
 }
 
 export interface ServerConversionConfig {
+  linkedinAccessToken?: string;
+  linkedinApiEndpoint?: string;
+  linkedinApiVersion?: string;
+  linkedinConversionUrns?: Partial<Record<WebsiteMarketingEventName, string>>;
   metaAccessToken?: string;
   metaGraphVersion?: string;
   metaPixelId?: string;
@@ -30,6 +34,7 @@ export interface ServerConversionConfig {
 }
 
 export interface ServerConversionResult {
+  linkedin: 'configured' | 'failed' | 'skipped';
   meta: 'configured' | 'failed' | 'skipped';
   x: 'configured' | 'failed' | 'skipped';
 }
@@ -87,6 +92,32 @@ function getUserData(
   return userData;
 }
 
+function getPayloadString(
+  payload: MarketingEventPayload | undefined,
+  key: string,
+): string | null {
+  const value = payload?.[key];
+
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function isIpv4Address(value: string): boolean {
+  const parts = value.split('.');
+
+  return (
+    parts.length === 4 &&
+    parts.every((part) => {
+      if (!/^\d{1,3}$/.test(part)) {
+        return false;
+      }
+
+      const octet = Number(part);
+
+      return octet >= 0 && octet <= 255;
+    })
+  );
+}
+
 function getMetaEndpoint(config: ServerConversionConfig): string | null {
   if (!config.metaPixelId || !config.metaAccessToken) {
     return null;
@@ -97,6 +128,16 @@ function getMetaEndpoint(config: ServerConversionConfig): string | null {
   return `https://graph.facebook.com/${version}/${config.metaPixelId}/events?access_token=${encodeURIComponent(
     config.metaAccessToken,
   )}`;
+}
+
+function getLinkedinConversionUrns(): Partial<
+  Record<WebsiteMarketingEventName, string>
+> {
+  return {
+    book_call: process.env.LINKEDIN_CONVERSION_URN_BOOK_CALL,
+    lead_submit: process.env.LINKEDIN_CONVERSION_URN_LEAD_SUBMIT,
+    signup_complete: process.env.LINKEDIN_CONVERSION_URN_SIGNUP_COMPLETE,
+  };
 }
 
 function getDefaultXEventIds(): Partial<
@@ -127,10 +168,59 @@ function fetchWithTimeout(
   });
 }
 
+function getLinkedinEndpoint(config: ServerConversionConfig): string | null {
+  if (!config.linkedinAccessToken) {
+    return null;
+  }
+
+  return (
+    config.linkedinApiEndpoint ||
+    'https://api.linkedin.com/rest/conversionEvents'
+  );
+}
+
+function getLinkedinUserIds(
+  event: ServerConversionRequest,
+  context: ServerConversionContext,
+): Array<{ idType: string; idValue: string }> {
+  const userIds: Array<{ idType: string; idValue: string }> = [];
+  const email = getPayloadString(event.payload, 'email');
+  const liFatId =
+    getPayloadString(event.payload, 'liFatId') ||
+    getPayloadString(event.payload, 'li_fat_id');
+
+  if (email) {
+    userIds.push({
+      idType: 'SHA256_EMAIL',
+      idValue: sha256(email),
+    });
+  }
+
+  if (liFatId) {
+    userIds.push({
+      idType: 'LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID',
+      idValue: liFatId,
+    });
+  }
+
+  if (context.clientIp && isIpv4Address(context.clientIp)) {
+    userIds.push({
+      idType: 'PLAINTEXT_IP_ADDRESS',
+      idValue: context.clientIp,
+    });
+  }
+
+  return userIds;
+}
+
 export async function sendServerConversions(
   event: ServerConversionRequest,
   context: ServerConversionContext,
   config: ServerConversionConfig = {
+    linkedinAccessToken: process.env.LINKEDIN_CONVERSIONS_API_ACCESS_TOKEN,
+    linkedinApiEndpoint: process.env.LINKEDIN_CONVERSIONS_API_ENDPOINT,
+    linkedinApiVersion: process.env.LINKEDIN_CONVERSIONS_API_VERSION,
+    linkedinConversionUrns: getLinkedinConversionUrns(),
     metaAccessToken: process.env.META_CONVERSIONS_API_ACCESS_TOKEN,
     metaGraphVersion: process.env.META_CONVERSIONS_API_GRAPH_VERSION,
     metaPixelId: process.env.NEXT_PUBLIC_META_PIXEL_ID,
@@ -145,10 +235,12 @@ export async function sendServerConversions(
     request: Promise<Response>;
   }> = [];
   const result: ServerConversionResult = {
+    linkedin: 'skipped',
     meta: 'skipped',
     x: 'skipped',
   };
   const metaEndpoint = getMetaEndpoint(config);
+  const linkedinEndpoint = getLinkedinEndpoint(config);
 
   if (metaEndpoint) {
     result.meta = 'configured';
@@ -171,6 +263,33 @@ export async function sendServerConversions(
         method: 'POST',
       }),
     });
+  }
+
+  if (linkedinEndpoint) {
+    const linkedinConversion = config.linkedinConversionUrns?.[event.name];
+    const userIds = getLinkedinUserIds(event, context);
+
+    if (linkedinConversion && userIds.length > 0) {
+      result.linkedin = 'configured';
+      calls.push({
+        provider: 'linkedin',
+        request: fetchWithTimeout(linkedinEndpoint, {
+          body: JSON.stringify({
+            conversion: linkedinConversion,
+            conversionHappenedAt: Date.now(),
+            eventId: event.eventId,
+            user: { userIds },
+          }),
+          headers: {
+            Authorization: `Bearer ${config.linkedinAccessToken}`,
+            'Content-Type': 'application/json',
+            'Linkedin-Version': config.linkedinApiVersion || '202606',
+            'X-Restli-Protocol-Version': '2.0.0',
+          },
+          method: 'POST',
+        }),
+      });
+    }
   }
 
   if (config.xApiEndpoint && config.xBearerToken) {


### PR DESCRIPTION
## Summary

- Adds opt-in LinkedIn Conversions API dispatch to the website server conversion pipeline.
- Reuses the existing lower-funnel marketing `eventId` for browser/server dedupe.
- Skips LinkedIn dispatch safely when token, conversion rule URN, or usable match identifiers are missing.
- Documents the new LinkedIn server conversion environment variables and QA step.

## Verification

- `bun install --frozen-lockfile`
- `bunx biome check --write apps/website/packages/marketing/server-conversions.ts apps/website/packages/marketing/server-conversions.test.ts apps/website/docs/marketing-tracking.md`
- `bun run --cwd apps/website test packages/marketing/server-conversions.test.ts`
- `bun run --cwd apps/website type-check`
- `bun run --cwd apps/website lint`
- `git diff --check`

## Notes

- LinkedIn conversion rule creation, OAuth/token provisioning, campaign association, and GTM container setup remain outside this child issue.
- Payload shape follows LinkedIn Conversions API docs: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversions-api

Closes #999
Refs #250