### PR TITLE
refactor(api): remove dead orchestrator memory flush path

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -4895,48 +4895,6 @@ export class AgentOrchestratorService {
     return runEffectPromise(this.runInThreadLaneEffect(threadId, run));
   }
 
-  private async flushThreadMemory(
-    threadId: string,
-    context: AgentChatContext,
-    reason: 'archive' | 'branch',
-  ): Promise<void> {
-    if (!this.agentThreadEngineService) {
-      return;
-    }
-
-    const recentMessages = await this.agentMessagesService.getMessagesByRoom(
-      threadId,
-      context.organizationId,
-      { limit: 12, page: 1 },
-    );
-    const summary = recentMessages
-      .slice()
-      .reverse()
-      .filter(
-        (message) =>
-          message.role === AgentMessageRole.USER ||
-          message.role === AgentMessageRole.ASSISTANT,
-      )
-      .map((message) => `${message.role}: ${message.content ?? ''}`.trim())
-      .filter((entry) => entry.length > 0)
-      .join('\n')
-      .slice(0, 4000);
-
-    if (!summary) {
-      return;
-    }
-
-    await runEffectPromise(
-      this.recordThreadMemoryFlushEffect(
-        threadId,
-        context.organizationId,
-        context.userId,
-        summary,
-        ['agent-thread', reason],
-      ),
-    );
-  }
-
   private async recordThreadTurnStarted(params: {
     context: AgentChatContext;
     threadId: string;
@@ -5632,26 +5590,6 @@ export class AgentOrchestratorService {
     return this.agentThreadEngineService
       .recordProfileSnapshotEffect(threadId, organizationId, userId, profile)
       .pipe(Effect.asVoid);
-  }
-
-  private recordThreadMemoryFlushEffect(
-    threadId: string,
-    organizationId: string,
-    userId: string,
-    content: string,
-    tags: string[],
-  ): Effect.Effect<string | null, unknown> {
-    if (!this.agentThreadEngineService) {
-      return Effect.succeed(null);
-    }
-
-    return this.agentThreadEngineService.recordMemoryFlushEffect(
-      threadId,
-      organizationId,
-      userId,
-      content,
-      tags,
-    );
   }
 
   private runInThreadLaneEffect<T>(


### PR DESCRIPTION
## Summary

Closes #1001
Parent context: #520

- Removed the private zero-caller `flushThreadMemory` path from `AgentOrchestratorService`.
- Removed the now-unreachable `recordThreadMemoryFlushEffect` helper.
- Left the live thread memory flush implementation in `agent-threads.controller.ts` unchanged.

## Refactor lane fit

- Issue #1001 is a focused code-quality/dead-code cleanup created from the fallback structural scan.
- Behavior-preserving deletion in one API service; no broader orchestrator decomposition, feature work, package-boundary change, or public API change.

## Structural review

- No blocker/request-change findings in the final changed diff.
- Diff deletes private dead code, adds no new abstraction layer, no casts, no branching, and no new dependencies.
- Deferred: the broader 6k-line `AgentOrchestratorService` split remains tracked by #520.

## Validation

- `rg "flushThreadMemory|recordThreadMemoryFlushEffect" apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts` returned no matches.
- `bunx turbo run build --filter=@genfeedai/tools` (materialized local package entrypoint required by the focused API spec)
- `bun run --cwd apps/server/api test:file src/services/agent-orchestrator/agent-orchestrator.service.spec.ts`
- `bunx biome check --write apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts`
- `bun run lint-staged`

## Note

The first focused spec attempt failed before loading tests because `@genfeedai/tools` did not have `dist/` in this fresh worktree. Building `@genfeedai/tools` fixed local package resolution; the same focused spec then passed (40 tests).
