### PR TITLE
Capture task feedback memory

### DIFF
--- a/apps/server/api/src/collections/agent-memories/agent-memories.module.ts
+++ b/apps/server/api/src/collections/agent-memories/agent-memories.module.ts
@@ -1,17 +1,26 @@
 import { AgentMemoriesController } from '@api/collections/agent-memories/controllers/agent-memories.controller';
 import { AgentMemoriesService } from '@api/collections/agent-memories/services/agent-memories.service';
 import { AgentMemoryCaptureService } from '@api/collections/agent-memories/services/agent-memory-capture.service';
+import { TaskFeedbackMemoryAdapterService } from '@api/collections/agent-memories/services/task-feedback-memory-adapter.service';
 import { BrandMemoryModule } from '@api/collections/brand-memory/brand-memory.module';
 import { ContextsModule } from '@api/collections/contexts/contexts.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [AgentMemoriesController],
-  exports: [AgentMemoriesService, AgentMemoryCaptureService],
+  exports: [
+    AgentMemoriesService,
+    AgentMemoryCaptureService,
+    TaskFeedbackMemoryAdapterService,
+  ],
   imports: [
     forwardRef(() => BrandMemoryModule),
     forwardRef(() => ContextsModule),
   ],
-  providers: [AgentMemoriesService, AgentMemoryCaptureService],
+  providers: [
+    AgentMemoriesService,
+    AgentMemoryCaptureService,
+    TaskFeedbackMemoryAdapterService,
+  ],
 })
 export class AgentMemoriesModule {}

--- a/apps/server/api/src/collections/agent-memories/services/task-feedback-memory-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/agent-memories/services/task-feedback-memory-adapter.service.spec.ts
@@ -1,0 +1,180 @@
+import type { TaskDocument } from '@api/collections/tasks/schemas/task.schema';
+import { LoggerService } from '@libs/logger/logger.service';
+
+import { AgentMemoryCaptureService } from './agent-memory-capture.service';
+import { TaskFeedbackMemoryAdapterService } from './task-feedback-memory-adapter.service';
+
+describe('TaskFeedbackMemoryAdapterService', () => {
+  const organizationId = 'org-1';
+  const userId = 'user-1';
+
+  const task = {
+    _id: 'task-1',
+    approvedOutputIds: ['output-existing'],
+    brand: 'brand-1',
+    eventStream: [],
+    identifier: 'GENA-7',
+    linkedApprovalIds: [],
+    linkedOutputIds: ['output-1'],
+    linkedRunIds: [],
+    organization: organizationId,
+    outputType: 'post',
+    platforms: ['X', 'LinkedIn'],
+    priority: 'medium',
+    qualityAssessment: { score: 0.82, summary: 'Strong hook' },
+    request: 'Write a launch post with a concise hook.',
+    resultPreview: 'Launch week starts with a sharp positioning post.',
+    reviewState: 'pending_approval',
+    reviewTriggered: true,
+    skillVariantIds: [],
+    skillsUsed: [],
+    status: 'in_review',
+    title: 'Draft launch post',
+  } as TaskDocument;
+
+  let captureService: { capture: ReturnType<typeof vi.fn> };
+  let logger: { warn: ReturnType<typeof vi.fn> };
+  let service: TaskFeedbackMemoryAdapterService;
+
+  beforeEach(() => {
+    captureService = {
+      capture: vi.fn().mockResolvedValue({ memory: { id: 'memory-1' } }),
+    };
+    logger = {
+      warn: vi.fn(),
+    };
+    service = new TaskFeedbackMemoryAdapterService(
+      captureService as unknown as AgentMemoryCaptureService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('captures approved task feedback as brand-scoped positive memory', async () => {
+    const result = await service.captureFromTaskReview({
+      decision: 'approved',
+      organizationId,
+      task,
+      userId,
+    });
+
+    expect(result).toBe(true);
+    expect(captureService.capture).toHaveBeenCalledWith(
+      userId,
+      organizationId,
+      expect.objectContaining({
+        brandId: 'brand-1',
+        contentType: 'post',
+        kind: 'positive_example',
+        platform: 'x',
+        scope: 'brand',
+        sourceContentId: 'task-1',
+        sourceMessageId: 'approved',
+        sourceType: 'task_review',
+        summary: 'Approved for GENA-7 Draft launch post',
+        tags: expect.arrayContaining([
+          'task-feedback',
+          'task-review',
+          'approved',
+          'post',
+          'x',
+          'linkedin',
+        ]),
+      }),
+    );
+  });
+
+  it('normalizes requested-change notes into negative-example memory', async () => {
+    await service.captureFromTaskReview({
+      decision: 'changes_requested',
+      note: '  Hook is too soft.   Tighten the CTA. ',
+      organizationId,
+      task,
+      userId,
+    });
+
+    expect(captureService.capture).toHaveBeenCalledWith(
+      userId,
+      organizationId,
+      expect.objectContaining({
+        confidence: 0.8,
+        content: expect.stringContaining(
+          'Reviewer note: Hook is too soft. Tighten the CTA.',
+        ),
+        kind: 'negative_example',
+        performanceSnapshot: expect.objectContaining({
+          decision: 'changes_requested',
+          identifier: 'GENA-7',
+          outputType: 'post',
+          qualityAssessment: { score: 0.82, summary: 'Strong hook' },
+          source: 'task-feedback-memory-adapter',
+          taskId: 'task-1',
+        }),
+        summary:
+          'Changes requested for GENA-7 Draft launch post: Hook is too soft. Tighten the CTA.',
+      }),
+    );
+  });
+
+  it('captures kept outputs with output audit metadata', async () => {
+    await service.captureFromTaskReview({
+      decision: 'output_kept',
+      organizationId,
+      outputId: 'output-1',
+      task,
+      userId,
+    });
+
+    expect(captureService.capture).toHaveBeenCalledWith(
+      userId,
+      organizationId,
+      expect.objectContaining({
+        importance: 0.9,
+        kind: 'positive_example',
+        sourceMessageId: 'output_kept:output-1',
+        performanceSnapshot: expect.objectContaining({
+          decision: 'output_kept',
+          outputId: 'output-1',
+        }),
+      }),
+    );
+  });
+
+  it('skips safely when no reviewer user id is available', async () => {
+    const result = await service.captureFromTaskReview({
+      decision: 'approved',
+      organizationId,
+      task,
+    });
+
+    expect(result).toBe(false);
+    expect(captureService.capture).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Skipping task feedback memory without a user id',
+      expect.objectContaining({ taskId: 'task-1' }),
+    );
+  });
+
+  it('does not fail the review action when memory capture throws', async () => {
+    captureService.capture.mockRejectedValueOnce(new Error('write failed'));
+
+    const result = await service.captureFromTaskReview({
+      decision: 'approved',
+      organizationId,
+      task,
+      userId,
+    });
+
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to capture task feedback memory',
+      expect.objectContaining({
+        error: 'write failed',
+        taskId: 'task-1',
+      }),
+    );
+  });
+});

--- a/apps/server/api/src/collections/agent-memories/services/task-feedback-memory-adapter.service.ts
+++ b/apps/server/api/src/collections/agent-memories/services/task-feedback-memory-adapter.service.ts
@@ -1,0 +1,268 @@
+import type {
+  AgentMemoryContentType,
+  AgentMemoryKind,
+} from '@api/collections/agent-memories/schemas/agent-memory.schema';
+import { AgentMemoryCaptureService } from '@api/collections/agent-memories/services/agent-memory-capture.service';
+import type { TaskDocument } from '@api/collections/tasks/schemas/task.schema';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+export type TaskFeedbackMemoryDecision =
+  | 'approved'
+  | 'changes_requested'
+  | 'dismissed'
+  | 'output_kept'
+  | 'output_trashed';
+
+export interface CaptureTaskFeedbackMemoryInput {
+  decision: TaskFeedbackMemoryDecision;
+  note?: string;
+  organizationId: string;
+  outputId?: string;
+  task: TaskDocument;
+  userId?: string;
+}
+
+@Injectable()
+export class TaskFeedbackMemoryAdapterService {
+  constructor(
+    private readonly agentMemoryCaptureService: AgentMemoryCaptureService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async captureFromTaskReview(
+    input: CaptureTaskFeedbackMemoryInput,
+  ): Promise<boolean> {
+    const taskId = this.extractId(input.task);
+    const userId = input.userId?.trim();
+
+    if (!userId) {
+      this.logger.warn('Skipping task feedback memory without a user id', {
+        decision: input.decision,
+        organizationId: input.organizationId,
+        taskId,
+      });
+      return false;
+    }
+
+    const brandId = this.extractBrandId(input.task);
+    const contentType = this.resolveContentType(input.task.outputType);
+    const platform = this.resolvePlatform(input.task.platforms);
+    const note = this.normalizeNote(input.note);
+    const kind = this.resolveKind(input.decision);
+    const summary = this.buildSummary(input.task, input.decision, note);
+    const content = this.buildContent(
+      input.task,
+      input.decision,
+      note,
+      input.outputId,
+    );
+    const scores = this.resolveScores(input.decision);
+
+    try {
+      await this.agentMemoryCaptureService.capture(
+        userId,
+        input.organizationId,
+        {
+          brandId,
+          confidence: scores.confidence,
+          content,
+          contentType,
+          importance: scores.importance,
+          kind,
+          performanceSnapshot: {
+            approvedOutputIds: input.task.approvedOutputIds ?? [],
+            decision: input.decision,
+            identifier: input.task.identifier,
+            outputId: input.outputId,
+            outputType: input.task.outputType,
+            platforms: input.task.platforms ?? [],
+            qualityAssessment: input.task.qualityAssessment,
+            reviewState: input.task.reviewState,
+            source: 'task-feedback-memory-adapter',
+            status: input.task.status,
+            taskId,
+            title: input.task.title,
+          },
+          platform,
+          saveToContextMemory: Boolean(brandId),
+          scope: brandId ? 'brand' : 'user',
+          sourceContentId: taskId,
+          sourceMessageId: this.buildSourceMessageId(
+            input.decision,
+            input.outputId,
+          ),
+          sourceType: 'task_review',
+          summary,
+          tags: this.buildTags(input.task, input.decision),
+        },
+      );
+      return true;
+    } catch (error) {
+      this.logger.warn('Failed to capture task feedback memory', {
+        decision: input.decision,
+        error: error instanceof Error ? error.message : String(error),
+        organizationId: input.organizationId,
+        taskId,
+      });
+      return false;
+    }
+  }
+
+  private buildContent(
+    task: TaskDocument,
+    decision: TaskFeedbackMemoryDecision,
+    note: string | undefined,
+    outputId: string | undefined,
+  ): string {
+    return [
+      `Task: ${task.identifier ?? this.extractId(task)} - ${task.title}`,
+      `Decision: ${this.humanizeDecision(decision)}`,
+      task.request ? `Request: ${this.compact(task.request)}` : undefined,
+      task.resultPreview
+        ? `Result preview: ${this.compact(task.resultPreview)}`
+        : undefined,
+      note ? `Reviewer note: ${note}` : undefined,
+      outputId ? `Output id: ${outputId}` : undefined,
+      task.qualityAssessment
+        ? `Quality assessment: ${this.compactJson(task.qualityAssessment)}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private buildSourceMessageId(
+    decision: TaskFeedbackMemoryDecision,
+    outputId: string | undefined,
+  ): string {
+    return outputId ? `${decision}:${outputId}` : decision;
+  }
+
+  private buildSummary(
+    task: TaskDocument,
+    decision: TaskFeedbackMemoryDecision,
+    note: string | undefined,
+  ): string {
+    const subject = task.identifier
+      ? `${task.identifier} ${task.title}`
+      : task.title;
+    const base = `${this.humanizeDecision(decision)} for ${subject}`;
+    return note ? `${base}: ${note}` : base;
+  }
+
+  private buildTags(
+    task: TaskDocument,
+    decision: TaskFeedbackMemoryDecision,
+  ): string[] {
+    return Array.from(
+      new Set(
+        [
+          'task-feedback',
+          'task-review',
+          decision,
+          task.outputType,
+          ...(task.platforms ?? []),
+        ]
+          .map((tag) => tag?.toString().trim().toLowerCase())
+          .filter((tag): tag is string => Boolean(tag)),
+      ),
+    );
+  }
+
+  private compact(value: string): string {
+    return value.trim().replace(/\s+/g, ' ');
+  }
+
+  private compactJson(value: Record<string, unknown>): string {
+    return this.compact(JSON.stringify(value)).slice(0, 500);
+  }
+
+  private extractBrandId(task: TaskDocument): string | undefined {
+    return this.normalizeId(
+      (task as Record<string, unknown>).brandId ?? task.brand,
+    );
+  }
+
+  private extractId(task: TaskDocument): string {
+    return this.normalizeId((task as Record<string, unknown>).id) ?? task._id;
+  }
+
+  private humanizeDecision(decision: TaskFeedbackMemoryDecision): string {
+    switch (decision) {
+      case 'approved':
+        return 'Approved';
+      case 'changes_requested':
+        return 'Changes requested';
+      case 'dismissed':
+        return 'Dismissed';
+      case 'output_kept':
+        return 'Output kept';
+      case 'output_trashed':
+        return 'Output trashed';
+    }
+  }
+
+  private normalizeId(value: unknown): string | undefined {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      return this.normalizeId(record.id ?? record._id);
+    }
+
+    return undefined;
+  }
+
+  private normalizeNote(note: string | undefined): string | undefined {
+    const normalized = note?.trim().replace(/\s+/g, ' ');
+    return normalized || undefined;
+  }
+
+  private resolveContentType(outputType: string): AgentMemoryContentType {
+    switch (outputType) {
+      case 'newsletter':
+        return 'newsletter';
+      case 'caption':
+      case 'post':
+        return 'post';
+      default:
+        return 'generic';
+    }
+  }
+
+  private resolveKind(decision: TaskFeedbackMemoryDecision): AgentMemoryKind {
+    switch (decision) {
+      case 'approved':
+      case 'output_kept':
+        return 'positive_example';
+      case 'changes_requested':
+      case 'dismissed':
+      case 'output_trashed':
+        return 'negative_example';
+    }
+  }
+
+  private resolvePlatform(platforms: string[] | undefined): string | undefined {
+    return platforms?.find((platform) => platform.trim())?.toLowerCase();
+  }
+
+  private resolveScores(decision: TaskFeedbackMemoryDecision): {
+    confidence: number;
+    importance: number;
+  } {
+    switch (decision) {
+      case 'output_kept':
+        return { confidence: 0.85, importance: 0.9 };
+      case 'approved':
+        return { confidence: 0.75, importance: 0.8 };
+      case 'changes_requested':
+        return { confidence: 0.8, importance: 0.75 };
+      case 'dismissed':
+      case 'output_trashed':
+        return { confidence: 0.7, importance: 0.65 };
+    }
+  }
+}

--- a/apps/server/api/src/collections/tasks/controllers/tasks.controller.spec.ts
+++ b/apps/server/api/src/collections/tasks/controllers/tasks.controller.spec.ts
@@ -14,12 +14,15 @@ import type { Request } from 'express';
 describe('TasksController', () => {
   let controller: TasksController;
   let tasksService: {
+    approve: ReturnType<typeof vi.fn>;
     areAllChildrenDone: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     findByIdentifier: ReturnType<typeof vi.fn>;
     findChildren: ReturnType<typeof vi.fn>;
     findOne: ReturnType<typeof vi.fn>;
+    keepOutput: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
+    trashOutput: ReturnType<typeof vi.fn>;
   };
   let taskCountersService: { getNextNumber: ReturnType<typeof vi.fn> };
   let organizationsService: { findOne: ReturnType<typeof vi.fn> };
@@ -50,12 +53,15 @@ describe('TasksController', () => {
 
   beforeEach(() => {
     tasksService = {
+      approve: vi.fn(),
       areAllChildrenDone: vi.fn(),
       create: vi.fn(),
       findByIdentifier: vi.fn(),
       findChildren: vi.fn().mockResolvedValue([]),
       findOne: vi.fn(),
+      keepOutput: vi.fn(),
       patch: vi.fn(),
+      trashOutput: vi.fn(),
     };
     taskCountersService = {
       getNextNumber: vi.fn(),
@@ -267,6 +273,66 @@ describe('TasksController', () => {
         organizationId,
       );
       expect('data' in result ? result.data : result).toEqual(children);
+    });
+  });
+
+  describe('review actions', () => {
+    const taskId = '507f191e810c19729de860ee'.toString();
+    const outputId = '607f191e810c19729de860ff'.toString();
+    const task = {
+      _id: taskId,
+      title: 'Review task',
+    } as TaskDocument;
+
+    it('passes the reviewer user id when approving a task', async () => {
+      tasksService.approve.mockResolvedValue(task);
+
+      const result = await controller.approve(mockRequest, mockUser, taskId);
+
+      expect(tasksService.approve).toHaveBeenCalledWith(
+        taskId,
+        organizationId,
+        userId,
+      );
+      expect('data' in result ? result.data : result).toEqual(task);
+    });
+
+    it('passes the reviewer user id when keeping an output', async () => {
+      tasksService.keepOutput.mockResolvedValue(task);
+
+      const result = await controller.keepOutput(
+        mockRequest,
+        mockUser,
+        taskId,
+        outputId,
+      );
+
+      expect(tasksService.keepOutput).toHaveBeenCalledWith(
+        taskId,
+        outputId,
+        organizationId,
+        userId,
+      );
+      expect('data' in result ? result.data : result).toEqual(task);
+    });
+
+    it('passes the reviewer user id when trashing an output', async () => {
+      tasksService.trashOutput.mockResolvedValue(task);
+
+      const result = await controller.trashOutput(
+        mockRequest,
+        mockUser,
+        taskId,
+        outputId,
+      );
+
+      expect(tasksService.trashOutput).toHaveBeenCalledWith(
+        taskId,
+        outputId,
+        organizationId,
+        userId,
+      );
+      expect('data' in result ? result.data : result).toEqual(task);
     });
   });
 });

--- a/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
+++ b/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
@@ -342,8 +342,8 @@ export class TasksController extends BaseCRUDController<
     @CurrentUser() user: User,
     @Param('id') id: string,
   ) {
-    const { organization } = getPublicMetadata(user);
-    const doc = await this.tasksService.approve(id, organization);
+    const { organization, user: userId } = getPublicMetadata(user);
+    const doc = await this.tasksService.approve(id, organization, userId);
     return serializeSingle(request, TaskSerializer, doc);
   }
 
@@ -388,8 +388,13 @@ export class TasksController extends BaseCRUDController<
     @Param('id') id: string,
     @Param('outputId') outputId: string,
   ) {
-    const { organization } = getPublicMetadata(user);
-    const doc = await this.tasksService.keepOutput(id, outputId, organization);
+    const { organization, user: userId } = getPublicMetadata(user);
+    const doc = await this.tasksService.keepOutput(
+      id,
+      outputId,
+      organization,
+      userId,
+    );
     return serializeSingle(request, TaskSerializer, doc);
   }
 
@@ -416,8 +421,13 @@ export class TasksController extends BaseCRUDController<
     @Param('id') id: string,
     @Param('outputId') outputId: string,
   ) {
-    const { organization } = getPublicMetadata(user);
-    const doc = await this.tasksService.trashOutput(id, outputId, organization);
+    const { organization, user: userId } = getPublicMetadata(user);
+    const doc = await this.tasksService.trashOutput(
+      id,
+      outputId,
+      organization,
+      userId,
+    );
     return serializeSingle(request, TaskSerializer, doc);
   }
 

--- a/apps/server/api/src/collections/tasks/services/task-actions.service.spec.ts
+++ b/apps/server/api/src/collections/tasks/services/task-actions.service.spec.ts
@@ -1,0 +1,173 @@
+import { TaskFeedbackMemoryAdapterService } from '@api/collections/agent-memories/services/task-feedback-memory-adapter.service';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import type { TaskDocument } from '@api/collections/tasks/schemas/task.schema';
+import type { TasksService } from '@api/collections/tasks/services/tasks.service';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+
+import { TaskActionsService } from './task-actions.service';
+
+describe('TaskActionsService', () => {
+  const organizationId = 'org-1';
+  const taskId = 'task-1';
+  const reviewerUserId = 'reviewer-1';
+  const assigneeUserId = 'assignee-1';
+  const outputId = 'output-1';
+
+  const baseTask = {
+    _id: taskId,
+    approvedOutputIds: [],
+    assigneeUserId,
+    brand: 'brand-1',
+    eventStream: [],
+    identifier: 'GENA-12',
+    linkedApprovalIds: [],
+    linkedOutputIds: [outputId],
+    linkedRunIds: [],
+    organization: organizationId,
+    outputType: 'post',
+    platforms: ['x'],
+    priority: 'medium',
+    request: 'Draft the launch update.',
+    reviewState: 'pending_approval',
+    reviewTriggered: true,
+    skillVariantIds: [],
+    skillsUsed: [],
+    status: 'in_review',
+    title: 'Launch update',
+  } as TaskDocument;
+
+  let currentTask: TaskDocument;
+  let tasksService: { requireTask: ReturnType<typeof vi.fn> };
+  let prisma: {
+    task: {
+      findFirst: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+  let ingredientsService: {
+    findOne: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+  let notificationsPublisher: { emit: ReturnType<typeof vi.fn> };
+  let taskFeedbackMemoryAdapter: {
+    captureFromTaskReview: ReturnType<typeof vi.fn>;
+  };
+  let service: TaskActionsService;
+
+  beforeEach(() => {
+    currentTask = { ...baseTask, eventStream: [] };
+    tasksService = {
+      requireTask: vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(currentTask)),
+    };
+    prisma = {
+      task: {
+        findFirst: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(currentTask)),
+        update: vi.fn().mockImplementation(({ data }) => {
+          currentTask = { ...currentTask, ...data };
+          return Promise.resolve(currentTask);
+        }),
+      },
+    };
+    ingredientsService = {
+      findOne: vi.fn().mockResolvedValue({ id: outputId }),
+      patch: vi.fn().mockResolvedValue(undefined),
+    };
+    notificationsPublisher = {
+      emit: vi.fn().mockResolvedValue(undefined),
+    };
+    taskFeedbackMemoryAdapter = {
+      captureFromTaskReview: vi.fn().mockResolvedValue(true),
+    };
+
+    service = new TaskActionsService(
+      tasksService as unknown as TasksService,
+      prisma as unknown as PrismaService,
+      ingredientsService as unknown as IngredientsService,
+      notificationsPublisher as unknown as NotificationsPublisherService,
+      taskFeedbackMemoryAdapter as unknown as TaskFeedbackMemoryAdapterService,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('captures approval feedback memory with the reviewer user id', async () => {
+    await service.approve(taskId, organizationId, reviewerUserId);
+
+    expect(
+      taskFeedbackMemoryAdapter.captureFromTaskReview,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'approved',
+        organizationId,
+        task: expect.objectContaining({
+          completedAt: expect.any(Date),
+          reviewState: 'approved',
+          status: 'done',
+        }),
+        userId: reviewerUserId,
+      }),
+    );
+  });
+
+  it('captures requested-change feedback memory with the reviewer note', async () => {
+    await service.requestChanges(
+      taskId,
+      organizationId,
+      reviewerUserId,
+      'Tighten the hook.',
+    );
+
+    expect(
+      taskFeedbackMemoryAdapter.captureFromTaskReview,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'changes_requested',
+        note: 'Tighten the hook.',
+        organizationId,
+        task: expect.objectContaining({
+          requestedChangesReason: 'Tighten the hook.',
+          reviewState: 'changes_requested',
+        }),
+        userId: reviewerUserId,
+      }),
+    );
+  });
+
+  it('captures kept output feedback memory with the output id', async () => {
+    await service.keepOutput(taskId, outputId, organizationId, reviewerUserId);
+
+    expect(
+      taskFeedbackMemoryAdapter.captureFromTaskReview,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'output_kept',
+        organizationId,
+        outputId,
+        task: expect.objectContaining({
+          approvedOutputIds: [outputId],
+        }),
+        userId: reviewerUserId,
+      }),
+    );
+  });
+
+  it('falls back to the task assignee when approval actor is omitted', async () => {
+    await service.approve(taskId, organizationId);
+
+    expect(
+      taskFeedbackMemoryAdapter.captureFromTaskReview,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'approved',
+        userId: assigneeUserId,
+      }),
+    );
+  });
+});

--- a/apps/server/api/src/collections/tasks/services/task-actions.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-actions.service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { TaskFeedbackMemoryAdapterService } from '@api/collections/agent-memories/services/task-feedback-memory-adapter.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { type TaskDocument } from '@api/collections/tasks/schemas/task.schema';
 import type { TasksService } from '@api/collections/tasks/services/tasks.service';
@@ -59,13 +60,18 @@ export class TaskActionsService {
     private readonly prisma: PrismaService,
     private readonly ingredientsService: IngredientsService,
     private readonly notificationsPublisher: NotificationsPublisherService,
+    private readonly taskFeedbackMemoryAdapter: TaskFeedbackMemoryAdapterService,
   ) {}
 
   private get delegate(): TaskDelegate {
     return (this.prisma as unknown as Record<string, TaskDelegate>).task;
   }
 
-  async approve(id: string, organizationId: string): Promise<TaskDocument> {
+  async approve(
+    id: string,
+    organizationId: string,
+    userId?: string,
+  ): Promise<TaskDocument> {
     const task = await this.tasksService.requireTask(id, organizationId);
     const updated = await this.applyReviewTransition(id, {
       completedAt: new Date(),
@@ -75,9 +81,15 @@ export class TaskActionsService {
       failureReason: null,
       requestedChangesReason: null,
     });
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+    const actorUserId = userId ?? task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, actorUserId, {
       type: 'task_approved',
+    });
+    await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
+      decision: 'approved',
+      organizationId,
+      task: updated,
+      userId: actorUserId,
     });
     return updated;
   }
@@ -98,6 +110,13 @@ export class TaskActionsService {
     await this.appendEventAndBroadcast(updated, organizationId, userId, {
       payload: { reason },
       type: 'task_changes_requested',
+    });
+    await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
+      decision: 'changes_requested',
+      note: reason,
+      organizationId,
+      task: updated,
+      userId,
     });
     return updated;
   }
@@ -121,6 +140,13 @@ export class TaskActionsService {
       payload: reason ? { reason } : undefined,
       type: 'task_dismissed',
     });
+    await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
+      decision: 'dismissed',
+      note: reason,
+      organizationId,
+      task: updated,
+      userId,
+    });
     return updated;
   }
 
@@ -128,6 +154,7 @@ export class TaskActionsService {
     id: string,
     outputId: string,
     organizationId: string,
+    userId?: string,
   ): Promise<TaskDocument> {
     const task = await this.requireLinkedOutputTask(
       id,
@@ -141,10 +168,17 @@ export class TaskActionsService {
       'add',
       outputId,
     );
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+    const actorUserId = userId ?? task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, actorUserId, {
       payload: { outputId },
       type: 'output_kept',
+    });
+    await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
+      decision: 'output_kept',
+      organizationId,
+      outputId,
+      task: updated,
+      userId: actorUserId,
     });
     return updated;
   }
@@ -178,6 +212,7 @@ export class TaskActionsService {
     id: string,
     outputId: string,
     organizationId: string,
+    userId?: string,
   ): Promise<TaskDocument> {
     const task = await this.requireLinkedOutputTask(
       id,
@@ -198,10 +233,17 @@ export class TaskActionsService {
       'remove',
       outputId,
     );
-    const userId = task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, userId, {
+    const actorUserId = userId ?? task.assigneeUserId ?? '';
+    await this.appendEventAndBroadcast(updated, organizationId, actorUserId, {
       payload: { outputId },
       type: 'output_trashed',
+    });
+    await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
+      decision: 'output_trashed',
+      organizationId,
+      outputId,
+      task: updated,
+      userId: actorUserId,
     });
     return updated;
   }

--- a/apps/server/api/src/collections/tasks/services/tasks.service.ts
+++ b/apps/server/api/src/collections/tasks/services/tasks.service.ts
@@ -255,8 +255,12 @@ export class TasksService extends BaseService<
   // Review / output actions — thin delegators to TaskActionsService.
   // ===========================================================================
 
-  async approve(id: string, organizationId: string): Promise<TaskDocument> {
-    return this.taskActionsService.approve(id, organizationId);
+  async approve(
+    id: string,
+    organizationId: string,
+    userId?: string,
+  ): Promise<TaskDocument> {
+    return this.taskActionsService.approve(id, organizationId, userId);
   }
 
   async requestChanges(
@@ -286,8 +290,14 @@ export class TasksService extends BaseService<
     id: string,
     outputId: string,
     organizationId: string,
+    userId?: string,
   ): Promise<TaskDocument> {
-    return this.taskActionsService.keepOutput(id, outputId, organizationId);
+    return this.taskActionsService.keepOutput(
+      id,
+      outputId,
+      organizationId,
+      userId,
+    );
   }
 
   async unkeepOutput(
@@ -302,8 +312,14 @@ export class TasksService extends BaseService<
     id: string,
     outputId: string,
     organizationId: string,
+    userId?: string,
   ): Promise<TaskDocument> {
-    return this.taskActionsService.trashOutput(id, outputId, organizationId);
+    return this.taskActionsService.trashOutput(
+      id,
+      outputId,
+      organizationId,
+      userId,
+    );
   }
 
   async attachOutput(

--- a/apps/server/api/src/collections/tasks/tasks.module.ts
+++ b/apps/server/api/src/collections/tasks/tasks.module.ts
@@ -1,3 +1,4 @@
+import { AgentMemoriesModule } from '@api/collections/agent-memories/agent-memories.module';
 import { AgentMessagesModule } from '@api/collections/agent-messages/agent-messages.module';
 import { AgentRunsModule } from '@api/collections/agent-runs/agent-runs.module';
 import { AgentThreadsModule } from '@api/collections/agent-threads/agent-threads.module';
@@ -23,6 +24,7 @@ import { forwardRef, Module } from '@nestjs/common';
   exports: [TasksService],
   imports: [
     forwardRef(() => AgentMessagesModule),
+    forwardRef(() => AgentMemoriesModule),
     forwardRef(() => AgentOrchestratorModule),
     forwardRef(() => AgentRunsModule),
     forwardRef(() => AgentThreadsModule),


### PR DESCRIPTION
## Summary
- Add a task feedback memory adapter that turns approvals, requested changes, dismissals, kept outputs, and trashed outputs into structured `AgentMemory` captures.
- Hook task review/output actions into the adapter while preserving the current reviewer user id from the controller.
- Cover adapter normalization/safe failure, task action hooks, and controller reviewer-id handoff.

Closes #222

## Validation
- `bun install --frozen-lockfile`
- `bunx biome check --write` on touched files
- `bun run --cwd apps/server/api test:file src/collections/agent-memories/services/task-feedback-memory-adapter.service.spec.ts src/collections/tasks/services/task-actions.service.spec.ts src/collections/tasks/controllers/tasks.controller.spec.ts` (3 files, 22 tests)
- `bunx turbo run lint --filter=@genfeedai/api`
- `bun run audit:api` (exits 0; existing medium/low backlog findings remain)
- `bun scripts/run-secretlint.ts` on touched files
- `git diff --check`
- pre-commit lint-staged Biome + Secretlint

## Type-check note
- `bunx turbo run type-check --filter=@genfeedai/api` succeeds for the dependency graph, but `@genfeedai/api` has no package-level `type-check` script.
- Direct `bunx tsc --noEmit -p apps/server/api/tsconfig.typecheck.json --ignoreDeprecations 6.0` still fails on existing unrelated API diagnostics in auth, MCP approval DTOs, entity drift, warmup accounts, integrations, and runtime module settings. No reported diagnostics were in the touched task or agent-memory files.