### PR TITLE
Explain feedback memory during generation

### DIFF
--- a/apps/server/api/src/collections/agent-memories/services/agent-memories.service.spec.ts
+++ b/apps/server/api/src/collections/agent-memories/services/agent-memories.service.spec.ts
@@ -1,0 +1,122 @@
+import type { AgentMemoryDocument } from '@api/collections/agent-memories/schemas/agent-memory.schema';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { LoggerService } from '@libs/logger/logger.service';
+
+import { AgentMemoriesService } from './agent-memories.service';
+
+describe('AgentMemoriesService', () => {
+  let service: AgentMemoriesService;
+  let agentMemoryDelegate: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
+
+  const orgId = 'org-1';
+  const userId = 'user-1';
+  const brandId = 'brand-1';
+
+  beforeEach(() => {
+    agentMemoryDelegate = {
+      findMany: vi.fn(),
+    };
+
+    service = new AgentMemoriesService(
+      { agentMemory: agentMemoryDelegate } as unknown as PrismaService,
+      {
+        error: vi.fn(),
+        log: vi.fn(),
+        warn: vi.fn(),
+      } as unknown as LoggerService,
+    );
+  });
+
+  it('ranks generation feedback by platform, content type, confidence, recency, and performance relevance', async () => {
+    const now = Date.now();
+    agentMemoryDelegate.findMany.mockResolvedValue([
+      buildMemory({
+        brandId,
+        confidence: 0.92,
+        content:
+          'Launch posts win when the first line names the customer pain.',
+        contentType: 'post',
+        createdAt: new Date(now - 2 * 86_400_000),
+        id: 'winner-memory',
+        importance: 0.8,
+        kind: 'winner',
+        performanceSnapshot: { isWinner: true },
+        platform: 'linkedin',
+        summary: 'Lead with customer pain before the product claim.',
+        tags: ['launch', 'hook'],
+      }),
+      buildMemory({
+        confidence: 0.95,
+        content: 'Old generic writing advice.',
+        contentType: 'generic',
+        createdAt: new Date(now - 120 * 86_400_000),
+        id: 'generic-memory',
+        importance: 0.9,
+        kind: 'instruction',
+        platform: 'twitter',
+      }),
+    ]);
+
+    const result = await service.getFeedbackMemoriesForGeneration(
+      userId,
+      orgId,
+      {
+        brandId,
+        contentType: 'post',
+        platform: 'linkedin',
+        query: 'Write a LinkedIn launch post with a sharp hook',
+      },
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('winner-memory');
+    expect(result[0].generationInfluence.score).toBeGreaterThan(
+      result[1].generationInfluence.score,
+    );
+    expect(result[0].generationInfluence.rankingFactors).toMatchObject({
+      contentType: 7,
+      performance: 5,
+      platform: 8,
+    });
+    expect(result[0].generationInfluence.reasons).toEqual(
+      expect.arrayContaining([
+        'Matches the requested platform linkedin',
+        'Matches requested content type post',
+        'Prior winning pattern',
+        'Performance snapshot marks this as a winner',
+      ]),
+    );
+    expect(result[0].generationInfluence.matchedPromptTerms).toEqual(
+      expect.arrayContaining(['linkedin', 'launch', 'post', 'hook']),
+    );
+  });
+
+  it('returns an empty list when no feedback memory exists', async () => {
+    agentMemoryDelegate.findMany.mockResolvedValue([]);
+
+    await expect(
+      service.getFeedbackMemoriesForGeneration(userId, orgId, {
+        query: 'Generate a post from scratch',
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  function buildMemory(
+    overrides: Partial<AgentMemoryDocument>,
+  ): AgentMemoryDocument {
+    return {
+      _id: overrides.id ?? 'memory-1',
+      content: '',
+      createdAt: new Date(),
+      id: overrides.id ?? 'memory-1',
+      organization: orgId,
+      organizationId: orgId,
+      updatedAt: new Date(),
+      user: userId,
+      userId,
+      ...overrides,
+    } as AgentMemoryDocument;
+  }
+});

--- a/apps/server/api/src/collections/agent-memories/services/agent-memories.service.ts
+++ b/apps/server/api/src/collections/agent-memories/services/agent-memories.service.ts
@@ -42,7 +42,19 @@ interface MemoryQueryOptions {
   contentType?: string;
   brandId?: string;
   pinnedMemoryIds?: string[];
+  platform?: string;
   limit?: number;
+}
+
+export interface AgentFeedbackMemoryInfluence {
+  matchedPromptTerms: string[];
+  reasons: string[];
+  rankingFactors: Record<string, number>;
+  score: number;
+}
+
+export interface AgentFeedbackMemoryDocument extends AgentMemoryDocument {
+  generationInfluence: AgentFeedbackMemoryInfluence;
 }
 
 @Injectable()
@@ -153,6 +165,18 @@ export class AgentMemoriesService extends BaseService<
     organizationId: string,
     options: MemoryQueryOptions = {},
   ): Promise<AgentMemoryDocument[]> {
+    return await this.getFeedbackMemoriesForGeneration(
+      userId,
+      organizationId,
+      options,
+    );
+  }
+
+  async getFeedbackMemoriesForGeneration(
+    userId: string,
+    organizationId: string,
+    options: MemoryQueryOptions = {},
+  ): Promise<AgentFeedbackMemoryDocument[]> {
     const [userMemories, campaignMemories] = await Promise.all([
       this.listForUser(userId, organizationId, {
         limit: 200,
@@ -176,34 +200,40 @@ export class AgentMemoriesService extends BaseService<
     );
     const requestedType = this.normalizeContentType(options.contentType);
     const requestedBrandId = options.brandId;
+    const requestedPlatform = this.normalizeText(options.platform);
     const scored = allMemories
-      .map((memory) => ({
-        memory,
-        score: this.scoreMemory(memory, {
+      .map((memory) => {
+        const influence = this.scoreFeedbackMemory(memory, {
           pinnedMemoryIds,
           queryTerms,
           requestedBrandId,
+          requestedPlatform,
           requestedType,
-        }),
-      }))
-      .filter((entry) => entry.score > 0)
+        });
+
+        return {
+          influence,
+          memory,
+        };
+      })
+      .filter((entry) => entry.influence.score > 0)
       .sort((left, right) => {
-        if (right.score !== left.score) {
-          return right.score - left.score;
+        if (right.influence.score !== left.influence.score) {
+          return right.influence.score - left.influence.score;
         }
 
-        const leftTime = new Date(
-          (left.memory as AgentMemoryDocument & { createdAt?: Date })
-            .createdAt ?? 0,
-        ).getTime();
-        const rightTime = new Date(
-          (right.memory as AgentMemoryDocument & { createdAt?: Date })
-            .createdAt ?? 0,
-        ).getTime();
+        const leftTime = this.getMemoryCreatedAtMs(left.memory);
+        const rightTime = this.getMemoryCreatedAtMs(right.memory);
         return rightTime - leftTime;
       })
       .slice(0, options.limit ?? 8)
-      .map((entry) => entry.memory);
+      .map(
+        (entry) =>
+          ({
+            ...entry.memory,
+            generationInfluence: entry.influence,
+          }) as AgentFeedbackMemoryDocument,
+      );
 
     return scored;
   }
@@ -288,20 +318,38 @@ export class AgentMemoriesService extends BaseService<
     return Math.max(0, Math.min(1, value));
   }
 
-  private scoreMemory(
+  private scoreFeedbackMemory(
     memory: AgentMemoryDocument,
     context: {
       pinnedMemoryIds: Set<string>;
       queryTerms: Set<string>;
       requestedType: AgentMemoryContentType;
       requestedBrandId?: string;
+      requestedPlatform?: string;
     },
-  ): number {
+  ): AgentFeedbackMemoryInfluence {
     let score = 0;
-    const memoryId = String(memory.id);
+    const reasons: string[] = [];
+    const matchedPromptTerms: string[] = [];
+    const rankingFactors: Record<string, number> = {};
+    const memoryId = this.resolveMemoryId(memory);
+    const addScore = (factor: string, value: number, reason?: string) => {
+      if (value <= 0) {
+        return;
+      }
+
+      const normalized = this.roundScore(value);
+      score += normalized;
+      rankingFactors[factor] = this.roundScore(
+        (rankingFactors[factor] ?? 0) + normalized,
+      );
+      if (reason) {
+        reasons.push(reason);
+      }
+    };
 
     if (context.pinnedMemoryIds.has(memoryId)) {
-      score += 100;
+      addScore('pinned', 100, 'Pinned to this thread');
     }
 
     if (
@@ -309,26 +357,85 @@ export class AgentMemoriesService extends BaseService<
       memory.brandId &&
       String(memory.brandId) === context.requestedBrandId
     ) {
-      score += 5;
+      addScore('brand', 6, 'Matches the selected brand');
+    }
+
+    const memoryPlatform = this.normalizeText(memory.platform);
+    if (
+      context.requestedPlatform &&
+      memoryPlatform &&
+      memoryPlatform === context.requestedPlatform
+    ) {
+      addScore(
+        'platform',
+        8,
+        `Matches the requested platform ${context.requestedPlatform}`,
+      );
     }
 
     if (
       context.requestedType !== 'generic' &&
       memory.contentType === context.requestedType
     ) {
-      score += 8;
+      addScore(
+        'contentType',
+        7,
+        `Matches requested content type ${context.requestedType}`,
+      );
     } else if (memory.contentType === 'generic') {
-      score += 1;
+      addScore('contentType', 1, 'Generic feedback can apply broadly');
     }
 
-    if (memory.kind === 'winner' || memory.kind === 'pattern') {
-      score += 4;
-    } else if (memory.kind === 'instruction' || memory.kind === 'preference') {
-      score += 3;
+    switch (memory.kind) {
+      case 'winner':
+        addScore('kind', 7, 'Prior winning pattern');
+        break;
+      case 'pattern':
+        addScore('kind', 6, 'Reusable pattern feedback');
+        break;
+      case 'positive_example':
+        addScore('kind', 5, 'Positive example feedback');
+        break;
+      case 'negative_example':
+        addScore('kind', 5, 'Avoidance feedback');
+        break;
+      case 'preference':
+        addScore('kind', 4, 'User preference feedback');
+        break;
+      case 'reference':
+        addScore('kind', 4, 'Reference feedback');
+        break;
+      case 'instruction':
+      default:
+        addScore('kind', 3, 'Saved instruction feedback');
+        break;
     }
 
-    score += (memory.importance ?? 0.5) * 4;
-    score += (memory.confidence ?? 0.5) * 2;
+    const importance = this.normalizeScore(memory.importance ?? undefined, 0.5);
+    addScore('importance', importance * 3);
+
+    const confidence = this.normalizeScore(memory.confidence ?? undefined, 0.5);
+    addScore(
+      'confidence',
+      confidence * 4,
+      confidence >= 0.7
+        ? `High confidence feedback (${confidence.toFixed(2)})`
+        : undefined,
+    );
+
+    const recency = this.scoreRecency(memory);
+    addScore(
+      'recency',
+      recency * 3,
+      recency >= 0.66 ? 'Recent feedback' : undefined,
+    );
+
+    const performance = this.scorePerformanceRelevance(memory);
+    addScore(
+      'performance',
+      performance.score * 5,
+      performance.reason ?? undefined,
+    );
 
     if (context.queryTerms.size > 0) {
       const haystack = [
@@ -345,14 +452,127 @@ export class AgentMemoriesService extends BaseService<
       for (const term of context.queryTerms) {
         if (haystack.includes(term)) {
           matches += 1;
+          matchedPromptTerms.push(term);
         }
       }
 
-      score += matches * 3;
+      addScore(
+        'query',
+        matches * 3,
+        matches > 0
+          ? `Matches prompt terms: ${matchedPromptTerms.join(', ')}`
+          : undefined,
+      );
     } else {
-      score += 1;
+      addScore('query', 1, 'No specific prompt terms were available');
     }
 
-    return score;
+    return {
+      matchedPromptTerms,
+      rankingFactors,
+      reasons,
+      score: this.roundScore(score),
+    };
+  }
+
+  private scoreRecency(memory: AgentMemoryDocument): number {
+    const createdAtMs = this.getMemoryCreatedAtMs(memory);
+    if (!createdAtMs) {
+      return 0.25;
+    }
+
+    const ageDays = Math.max(0, (Date.now() - createdAtMs) / 86_400_000);
+    return this.roundScore(Math.max(0, 1 - ageDays / 90));
+  }
+
+  private scorePerformanceRelevance(memory: AgentMemoryDocument): {
+    reason?: string;
+    score: number;
+  } {
+    const snapshot = this.readPerformanceSnapshot(memory);
+    if (!snapshot) {
+      return { score: 0 };
+    }
+
+    const outcome = this.normalizeText(snapshot.outcome);
+    const status = this.normalizeText(snapshot.status);
+    const isWinner =
+      snapshot.isWinner === true ||
+      snapshot.winner === true ||
+      outcome === 'winner' ||
+      status === 'winner';
+    if (isWinner) {
+      return {
+        reason: 'Performance snapshot marks this as a winner',
+        score: 1,
+      };
+    }
+
+    const candidates = [
+      'engagementScore',
+      'performanceScore',
+      'qualityScore',
+      'score',
+      'engagementRate',
+      'conversionRate',
+      'ctr',
+    ];
+    let best = 0;
+    for (const key of candidates) {
+      const value = snapshot[key];
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        continue;
+      }
+      const normalized = value > 1 ? value / 100 : value;
+      best = Math.max(best, Math.max(0, Math.min(1, normalized)));
+    }
+
+    if (best >= 0.7) {
+      return {
+        reason: `Performance snapshot is strong (${best.toFixed(2)})`,
+        score: this.roundScore(best),
+      };
+    }
+
+    return { score: this.roundScore(best) };
+  }
+
+  private readPerformanceSnapshot(
+    memory: AgentMemoryDocument,
+  ): Record<string, unknown> | null {
+    const snapshot = memory.performanceSnapshot;
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+      return null;
+    }
+
+    return snapshot as Record<string, unknown>;
+  }
+
+  private normalizeText(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    return normalized || undefined;
+  }
+
+  private getMemoryCreatedAtMs(memory: AgentMemoryDocument): number {
+    const createdAt = (memory as AgentMemoryDocument & { createdAt?: Date })
+      .createdAt;
+    if (!createdAt) {
+      return 0;
+    }
+
+    return new Date(createdAt).getTime();
+  }
+
+  private resolveMemoryId(memory: AgentMemoryDocument): string {
+    const id = memory.id ?? memory._id;
+    return typeof id === 'string' ? id : String(id ?? '');
+  }
+
+  private roundScore(value: number): number {
+    return Math.round(value * 1000) / 1000;
   }
 }

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -35,6 +35,7 @@ describe('AgentOrchestratorService', () => {
   let settingsService: vi.Mocked<SettingsService>;
   let agentStrategiesService: vi.Mocked<AgentStrategiesService>;
   let agentRunsService: vi.Mocked<AgentRunsService>;
+  let agentMemoriesService: vi.Mocked<AgentMemoriesService>;
   let creditsUtilsService: vi.Mocked<CreditsUtilsService>;
   let toolExecutorService: vi.Mocked<AgentToolExecutorService>;
   let streamPublisher: vi.Mocked<AgentStreamPublisherService>;
@@ -72,6 +73,7 @@ describe('AgentOrchestratorService', () => {
       getRecentMessages: vi.fn().mockResolvedValue([]),
     };
     const agentMemoriesServiceMock = {
+      getFeedbackMemoriesForGeneration: vi.fn().mockResolvedValue([]),
       getMemoriesForPrompt: vi.fn().mockResolvedValue([]),
       listForUser: vi.fn().mockResolvedValue([]),
     };
@@ -369,6 +371,7 @@ describe('AgentOrchestratorService', () => {
 
     service = module.get(AgentOrchestratorService);
     agentThreadsService = module.get(AgentThreadsService);
+    agentMemoriesService = module.get(AgentMemoriesService);
     llmDispatcher = module.get(LlmDispatcherService);
     creditsUtilsService = module.get(CreditsUtilsService);
     organizationsService = module.get(OrganizationsService);
@@ -621,6 +624,99 @@ describe('AgentOrchestratorService', () => {
         webSearchEnabled: true,
       }),
     );
+  });
+
+  it('injects ranked feedback memory and exposes generation influence metadata', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+    agentMemoriesService.getFeedbackMemoriesForGeneration.mockResolvedValueOnce(
+      [
+        {
+          _id: 'memory-1',
+          confidence: 0.91,
+          content:
+            'Launch posts perform best when the first line names the customer pain.',
+          contentType: 'post',
+          createdAt: new Date('2026-03-01T00:00:00.000Z'),
+          generationInfluence: {
+            matchedPromptTerms: ['launch', 'post'],
+            rankingFactors: {
+              confidence: 3.64,
+              contentType: 7,
+              performance: 5,
+              platform: 8,
+            },
+            reasons: [
+              'Matches the requested platform linkedin',
+              'Prior winning pattern',
+            ],
+            score: 30.5,
+          },
+          id: 'memory-1',
+          importance: 0.8,
+          kind: 'winner',
+          organization: ORG_ID,
+          organizationId: ORG_ID,
+          platform: 'linkedin',
+          scope: 'brand',
+          summary: 'Lead with customer pain before product claims.',
+          tags: ['launch'],
+          updatedAt: new Date('2026-03-02T00:00:00.000Z'),
+          user: USER_ID,
+          userId: USER_ID,
+        },
+      ] as never,
+    );
+
+    const result = await service.chat(
+      { content: 'Write a LinkedIn launch post' },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    expect(
+      agentMemoriesService.getFeedbackMemoriesForGeneration,
+    ).toHaveBeenCalledWith(
+      USER_ID,
+      ORG_ID,
+      expect.objectContaining({
+        contentType: 'post',
+        limit: 8,
+        query: 'Write a LinkedIn launch post',
+      }),
+    );
+    expect(llmDispatcher.chatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('Saved memory to consider'),
+            role: 'system',
+          }),
+          expect.objectContaining({
+            content: expect.stringContaining(
+              'score 30.5; Matches the requested platform linkedin',
+            ),
+            role: 'system',
+          }),
+        ]),
+      }),
+      ORG_ID,
+    );
+    expect(result.message.metadata).toMatchObject({
+      memoryInfluence: {
+        mode: 'prior_winning_patterns',
+        summary: 'Using 1 prior feedback memory before generation.',
+      },
+    });
+    expect(result.message.metadata.memoryEntries).toEqual([
+      expect.objectContaining({
+        generationInfluence: expect.objectContaining({
+          reasons: expect.arrayContaining(['Prior winning pattern']),
+          score: 30.5,
+        }),
+        id: 'memory-1',
+      }),
+    ]);
   });
 
   it('records requested and actual models into agent run metadata when a run id is present', async () => {

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -1,6 +1,10 @@
 import { AgentCampaignsService } from '@api/collections/agent-campaigns/services/agent-campaigns.service';
 import { type AgentMemoryDocument } from '@api/collections/agent-memories/schemas/agent-memory.schema';
-import { AgentMemoriesService } from '@api/collections/agent-memories/services/agent-memories.service';
+import {
+  type AgentFeedbackMemoryDocument,
+  type AgentFeedbackMemoryInfluence,
+  AgentMemoriesService,
+} from '@api/collections/agent-memories/services/agent-memories.service';
 import { type AgentMessageDocument } from '@api/collections/agent-messages/schemas/agent-message.schema';
 import { AgentMessagesService } from '@api/collections/agent-messages/services/agent-messages.service';
 import { CreateAgentRunDto } from '@api/collections/agent-runs/dto/create-agent-run.dto';
@@ -896,6 +900,8 @@ export class AgentOrchestratorService {
             );
           const memoryEntriesForResponse =
             this.buildMemoryEntriesForResponse(resolvedMemories);
+          const memoryInfluence =
+            this.buildMemoryInfluenceMetadata(resolvedMemories);
           const reasoning = assistantMessage.reasoning_content ?? null;
           const enhancedUiActions = this.buildAssistantUiActions({
             reviewRequired,
@@ -910,6 +916,7 @@ export class AgentOrchestratorService {
             }),
             isFallbackContent: normalizedContent.isFallback,
             memoryEntries: memoryEntriesForResponse,
+            memoryInfluence,
             ...this.buildResolvedModelMetadata(model, Array.from(actualModels)),
             reasoning,
             reviewRequired,
@@ -1495,6 +1502,7 @@ export class AgentOrchestratorService {
       const allUiActions: AgentUiAction[] = [];
       const memoryEntriesForResponse =
         this.buildMemoryEntriesForResponse(memoryEntries);
+      const memoryInfluence = this.buildMemoryInfluenceMetadata(memoryEntries);
       let highestRiskLevel: 'low' | 'medium' | 'high' = 'low';
       let reviewRequired = false;
       let latestUiBlocks: {
@@ -1650,6 +1658,7 @@ export class AgentOrchestratorService {
               creditsRemaining,
               isFallbackContent: normalizedContent.isFallback,
               memoryEntries: memoryEntriesForResponse,
+              memoryInfluence,
               ...this.buildResolvedModelMetadata(
                 model,
                 Array.from(actualModels),
@@ -1703,6 +1712,7 @@ export class AgentOrchestratorService {
               completionMetadata: {
                 isFallbackContent: normalizedContent.isFallback,
                 memoryEntries: memoryEntriesForResponse,
+                memoryInfluence,
                 ...this.buildResolvedModelMetadata(
                   model,
                   Array.from(actualModels),
@@ -3615,17 +3625,20 @@ export class AgentOrchestratorService {
       })) as { systemPrompt?: string; memoryEntryIds?: string[] } | null;
     }
 
-    const memories = await this.agentMemoriesService.getMemoriesForPrompt(
-      context.userId,
-      context.organizationId,
-      {
-        campaignId: context.campaignId,
-        contentType: this.inferMemoryContentType(request.content),
-        limit: 8,
-        pinnedMemoryIds: thread?.memoryEntryIds,
-        query: request.content,
-      },
-    );
+    const memories =
+      await this.agentMemoriesService.getFeedbackMemoriesForGeneration(
+        context.userId,
+        context.organizationId,
+        {
+          brandId: policy.brandId,
+          campaignId: context.campaignId,
+          contentType: this.inferMemoryContentType(request.content),
+          limit: 8,
+          pinnedMemoryIds: thread?.memoryEntryIds,
+          platform: policy.platform,
+          query: request.content,
+        },
+      );
 
     const replyStyle = orgSettings?.agentReplyStyle;
     const subscriptionDefaultModel =
@@ -4559,13 +4572,15 @@ export class AgentOrchestratorService {
   private buildMemoryEntriesForResponse(memoryEntries: AgentMemoryDocument[]) {
     return memoryEntries.map((memory) => {
       const timedMemory = memory as AgentMemoryDocument & { createdAt?: Date };
+      const influence = this.readMemoryInfluence(memory);
 
       return {
         confidence: memory.confidence,
         content: memory.content,
         contentType: memory.contentType,
         createdAt: timedMemory.createdAt?.toISOString(),
-        id: memory._id,
+        generationInfluence: influence,
+        id: memory.id ?? memory._id,
         importance: memory.importance,
         kind: memory.kind,
         platform: memory.platform,
@@ -4578,6 +4593,58 @@ export class AgentOrchestratorService {
         tags: memory.tags ?? [],
       };
     });
+  }
+
+  private buildMemoryInfluenceMetadata(memoryEntries: AgentMemoryDocument[]) {
+    const entries = this.buildMemoryEntriesForResponse(memoryEntries)
+      .filter((entry) => entry.generationInfluence)
+      .map((entry) => ({
+        confidence: entry.confidence,
+        contentType: entry.contentType,
+        id: entry.id,
+        kind: entry.kind,
+        platform: entry.platform,
+        reasons: entry.generationInfluence?.reasons ?? [],
+        score: entry.generationInfluence?.score ?? 0,
+        sourceType: entry.sourceType,
+        summary: entry.summary || entry.content?.slice(0, 160),
+      }));
+
+    if (entries.length === 0) {
+      return {
+        entries: [],
+        mode: 'new_exploration',
+        rankingStrategy: [
+          'platform',
+          'contentType',
+          'recency',
+          'confidence',
+          'performanceRelevance',
+        ],
+        summary:
+          'No relevant prior feedback memory matched this generation request.',
+      };
+    }
+
+    const winningCount = entries.filter((entry) =>
+      ['pattern', 'winner', 'positive_example'].includes(String(entry.kind)),
+    ).length;
+
+    return {
+      entries,
+      mode: winningCount > 0 ? 'prior_winning_patterns' : 'prior_feedback',
+      rankingStrategy: [
+        'platform',
+        'contentType',
+        'recency',
+        'confidence',
+        'performanceRelevance',
+        'queryTerms',
+      ],
+      summary: `Using ${entries.length} prior feedback ${
+        entries.length === 1 ? 'memory' : 'memories'
+      } before generation.`,
+    };
   }
 
   private buildMemoryPromptSections(memories: AgentMemoryDocument[]): string {
@@ -4651,7 +4718,18 @@ export class AgentOrchestratorService {
 
     const prefix = qualifiers.length ? `[${qualifiers.join(' / ')}] ` : '';
     const snippet = base.length > 220 ? `${base.slice(0, 217)}...` : base;
-    return `- ${prefix}${snippet}`;
+    const influence = this.readMemoryInfluence(memory);
+    const topReason = influence?.reasons[0];
+    const influenceSuffix = influence
+      ? ` (score ${influence.score.toFixed(1)}${topReason ? `; ${topReason}` : ''})`
+      : '';
+    return `- ${prefix}${snippet}${influenceSuffix}`;
+  }
+
+  private readMemoryInfluence(
+    memory: AgentMemoryDocument,
+  ): AgentFeedbackMemoryInfluence | undefined {
+    return (memory as Partial<AgentFeedbackMemoryDocument>).generationInfluence;
   }
 
   private inferMemoryContentType(content: string): string {


### PR DESCRIPTION
## Summary
- add explicit feedback-memory retrieval for generation with deterministic influence scoring
- rank memories by platform, content type, recency, confidence, performance relevance, brand, pinned state, and prompt terms
- include `memoryInfluence` and per-memory `generationInfluence` metadata on agent responses so operators can see why prior feedback affected generation

Closes #223

## Validation
- `bun install --frozen-lockfile`
- `bunx biome check --write apps/server/api/src/collections/agent-memories/services/agent-memories.service.ts apps/server/api/src/collections/agent-memories/services/agent-memories.service.spec.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts`
- `bun run --cwd apps/server/api test:file src/collections/agent-memories/services/agent-memories.service.spec.ts src/services/agent-orchestrator/agent-orchestrator.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `bunx turbo run lint --filter=@genfeedai/api`
- `bun run audit:api`
- `git diff --check`
- staged `git diff --cached --check`
- `bun scripts/run-secretlint.ts apps/server/api/src/collections/agent-memories/services/agent-memories.service.ts apps/server/api/src/collections/agent-memories/services/agent-memories.service.spec.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts`
