### PR TITLE
[codex] Recover workflow-backed social comment triggers

### DIFF
--- a/apps/server/api/src/collections/workflows/services/adapters/instagram-social.adapter.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/adapters/instagram-social.adapter.spec.ts
@@ -72,48 +72,11 @@ describe('InstagramSocialAdapter', () => {
   });
 
   describe('trigger checkers', () => {
-    it('createFollowerChecker should throw not implemented error', async () => {
-      const checker = adapter.createFollowerChecker();
-      await expect(
-        checker({
-          lastFollowerId: null,
-          organizationId: 'org1',
-          platform: 'instagram',
-        }),
-      ).rejects.toThrow('Instagram follower trigger not yet implemented');
-    });
-
-    it('createMentionChecker should throw not implemented error', async () => {
-      const checker = adapter.createMentionChecker();
-      await expect(
-        checker({
-          lastMentionId: null,
-          organizationId: 'org1',
-          platform: 'instagram',
-        }),
-      ).rejects.toThrow('Instagram mention trigger not yet implemented');
-    });
-
-    it('createLikeChecker should throw not implemented error', async () => {
-      const checker = adapter.createLikeChecker();
-      await expect(
-        checker({
-          lastLikeId: null,
-          organizationId: 'org1',
-          platform: 'instagram',
-        }),
-      ).rejects.toThrow('Instagram like trigger not yet implemented');
-    });
-
-    it('createRepostChecker should throw not implemented error', async () => {
-      const checker = adapter.createRepostChecker();
-      await expect(
-        checker({
-          lastRepostId: null,
-          organizationId: 'org1',
-          platform: 'instagram',
-        }),
-      ).rejects.toThrow('Instagram repost trigger not yet implemented');
+    it('does not expose trigger checkers without real backing APIs', () => {
+      expect(adapter.createFollowerChecker).toBeUndefined();
+      expect(adapter.createMentionChecker).toBeUndefined();
+      expect(adapter.createLikeChecker).toBeUndefined();
+      expect(adapter.createRepostChecker).toBeUndefined();
     });
   });
 

--- a/apps/server/api/src/collections/workflows/services/adapters/instagram-social.adapter.ts
+++ b/apps/server/api/src/collections/workflows/services/adapters/instagram-social.adapter.ts
@@ -1,24 +1,22 @@
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
-import type {
-  DmSender,
-  MentionChecker,
-  NewFollowerChecker,
-  NewLikeChecker,
-  NewRepostChecker,
-  ReplyPublisher,
-} from '@genfeedai/workflow-engine';
+import type { DmSender, ReplyPublisher } from '@genfeedai/workflow-engine';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
 /**
  * Instagram Social Adapter
  *
- * Implements all 6 social workflow resolver interfaces using InstagramService.
+ * Implements only Instagram workflow capabilities backed by real APIs.
  * Each method is a bound function that can be injected directly into executors.
  */
 @Injectable()
 export class InstagramSocialAdapter {
   private readonly logContext = 'InstagramSocialAdapter';
+
+  readonly createFollowerChecker?: undefined;
+  readonly createMentionChecker?: undefined;
+  readonly createLikeChecker?: undefined;
+  readonly createRepostChecker?: undefined;
 
   constructor(
     private readonly instagramService: InstagramService,
@@ -90,73 +88,6 @@ export class InstagramSocialAdapter {
       );
 
       return { messageId: messageId ?? `ig_dm_${Date.now()}` };
-    };
-  }
-
-  /**
-   * Creates a NewFollowerChecker for NewFollowerTriggerExecutor.
-   * NOTE: Instagram Graph API doesn't provide a follower list endpoint
-   * for business accounts in a way that supports polling.
-   */
-  createFollowerChecker(): NewFollowerChecker {
-    return async (params) => {
-      this.loggerService.debug(`${this.logContext} checking new followers`, {
-        organizationId: params.organizationId,
-        platform: params.platform,
-      });
-
-      throw new Error(
-        'Instagram follower trigger not yet implemented — requires Instagram webhooks or periodic follower count diff.',
-      );
-    };
-  }
-
-  /**
-   * Creates a MentionChecker for MentionTriggerExecutor.
-   * NOTE: Instagram Graph API supports mentioned_media endpoint.
-   */
-  createMentionChecker(): MentionChecker {
-    return async (params) => {
-      this.loggerService.debug(`${this.logContext} checking mentions`, {
-        organizationId: params.organizationId,
-        platform: params.platform,
-      });
-
-      throw new Error(
-        'Instagram mention trigger not yet implemented — requires Instagram Graph API GET /{ig-user-id}/tags.',
-      );
-    };
-  }
-
-  /**
-   * Creates a NewLikeChecker for NewLikeTriggerExecutor.
-   */
-  createLikeChecker(): NewLikeChecker {
-    return async (params) => {
-      this.loggerService.debug(`${this.logContext} checking new likes`, {
-        organizationId: params.organizationId,
-        platform: params.platform,
-      });
-
-      throw new Error(
-        'Instagram like trigger not yet implemented — requires Instagram webhooks or media insights polling.',
-      );
-    };
-  }
-
-  /**
-   * Creates a NewRepostChecker for NewRepostTriggerExecutor.
-   */
-  createRepostChecker(): NewRepostChecker {
-    return async (params) => {
-      this.loggerService.debug(`${this.logContext} checking new reposts`, {
-        organizationId: params.organizationId,
-        platform: params.platform,
-      });
-
-      throw new Error(
-        'Instagram repost trigger not yet implemented — Instagram does not natively support repost detection.',
-      );
     };
   }
 }

--- a/apps/server/api/src/collections/workflows/services/adapters/social-adapter.factory.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/adapters/social-adapter.factory.spec.ts
@@ -20,11 +20,7 @@ describe('SocialAdapterFactory', () => {
 
     instagramAdapter = {
       createDmSender: vi.fn(),
-      createFollowerChecker: vi.fn(),
-      createLikeChecker: vi.fn(),
-      createMentionChecker: vi.fn(),
       createReplyPublisher: vi.fn(),
-      createRepostChecker: vi.fn(),
     } as unknown as InstagramSocialAdapter;
 
     factory = new SocialAdapterFactory(twitterAdapter, instagramAdapter);

--- a/apps/server/api/src/collections/workflows/services/adapters/social-adapter.factory.ts
+++ b/apps/server/api/src/collections/workflows/services/adapters/social-adapter.factory.ts
@@ -1,7 +1,9 @@
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
 import type {
+  CommentChecker,
   DmSender,
+  EngagementChecker,
   KeywordChecker,
   MentionChecker,
   NewFollowerChecker,
@@ -19,11 +21,13 @@ export type SocialPlatformKey = 'twitter' | 'instagram';
 export interface SocialAdapterInterface {
   createReplyPublisher(): ReplyPublisher;
   createDmSender(): DmSender;
-  createFollowerChecker(): NewFollowerChecker;
-  createMentionChecker(): MentionChecker;
-  createLikeChecker(): NewLikeChecker;
-  createRepostChecker(): NewRepostChecker;
+  createFollowerChecker?(): NewFollowerChecker;
+  createMentionChecker?(): MentionChecker;
+  createLikeChecker?(): NewLikeChecker;
+  createRepostChecker?(): NewRepostChecker;
+  createCommentChecker?(): CommentChecker;
   createKeywordChecker?(): KeywordChecker;
+  createEngagementChecker?(): EngagementChecker;
 }
 
 /**

--- a/apps/server/api/src/collections/workflows/services/adapters/youtube-social.adapter.ts
+++ b/apps/server/api/src/collections/workflows/services/adapters/youtube-social.adapter.ts
@@ -1,0 +1,132 @@
+import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
+import type {
+  CommentChecker,
+  CommentTriggerOutput,
+  ReplyPublisher,
+} from '@genfeedai/workflow-engine';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class YoutubeSocialAdapter {
+  private readonly logContext = 'YoutubeSocialAdapter';
+
+  constructor(
+    private readonly youtubeService: YoutubeService,
+    private readonly loggerService: LoggerService,
+  ) {}
+
+  createReplyPublisher(): ReplyPublisher {
+    return async (params) => {
+      const { organizationId, brandId, postId, text } = params;
+
+      if (!brandId) {
+        throw new Error('brandId is required for YouTube comment replies');
+      }
+
+      this.loggerService.debug(`${this.logContext} replying to comment`, {
+        brandId,
+        organizationId,
+        parentCommentId: postId,
+      });
+
+      const result = await this.youtubeService.replyToComment(
+        organizationId,
+        brandId,
+        postId,
+        text,
+      );
+
+      return {
+        replyId: result.commentId,
+        replyUrl: `https://www.youtube.com/comment/${result.commentId}`,
+      };
+    };
+  }
+
+  createCommentChecker(): CommentChecker {
+    return async (params) => {
+      const {
+        organizationId,
+        brandId,
+        contentIds,
+        keywords,
+        excludeKeywords,
+        lastCommentId,
+      } = params;
+
+      if (!brandId) {
+        throw new Error('brandId is required for YouTube comment polling');
+      }
+
+      const result = await this.youtubeService.listRecentChannelComments(
+        organizationId,
+        brandId,
+        { maxResults: 50 },
+      );
+
+      for (const comment of result.comments) {
+        if (comment.commentId === lastCommentId) {
+          break;
+        }
+
+        if (contentIds.length > 0 && !contentIds.includes(comment.videoId)) {
+          continue;
+        }
+
+        if (
+          !this.matchesKeywordFilters(comment.text, keywords, excludeKeywords)
+        ) {
+          continue;
+        }
+
+        return this.toCommentTriggerOutput(comment);
+      }
+
+      return null;
+    };
+  }
+
+  private matchesKeywordFilters(
+    text: string,
+    keywords: string[],
+    excludeKeywords: string[],
+  ): boolean {
+    const normalizedText = text.toLowerCase();
+
+    if (
+      excludeKeywords.some((keyword) =>
+        normalizedText.includes(keyword.toLowerCase()),
+      )
+    ) {
+      return false;
+    }
+
+    if (keywords.length === 0) {
+      return true;
+    }
+
+    return keywords.some((keyword) =>
+      normalizedText.includes(keyword.toLowerCase()),
+    );
+  }
+
+  private toCommentTriggerOutput(
+    comment: Awaited<
+      ReturnType<YoutubeService['listRecentChannelComments']>
+    >['comments'][number],
+  ): CommentTriggerOutput {
+    return {
+      authorId: comment.authorChannelId,
+      authorUsername: comment.authorDisplayName,
+      commentId: comment.commentId,
+      commentedAt: comment.publishedAt,
+      contentId: comment.videoId,
+      contentUrl: comment.videoUrl,
+      platform: 'youtube',
+      postId: comment.commentId,
+      text: comment.text,
+      videoId: comment.videoId,
+    };
+  }
+}

--- a/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.spec.ts
@@ -18,11 +18,9 @@ describe('ReplyPollingWorkflowService', () => {
     createMentionChecker: vi.fn(),
     createRepostChecker: vi.fn(),
   };
-  const instagramAdapter = {
-    createFollowerChecker: vi.fn(),
-    createLikeChecker: vi.fn(),
-    createMentionChecker: vi.fn(),
-    createRepostChecker: vi.fn(),
+  const instagramAdapter = {};
+  const youtubeAdapter = {
+    createCommentChecker: vi.fn(),
   };
   const configService = { isDevSchedulersEnabled: true };
   const cacheService = { acquireLock: vi.fn(), releaseLock: vi.fn() };
@@ -48,6 +46,9 @@ describe('ReplyPollingWorkflowService', () => {
     twitterAdapter.createMentionChecker.mockReturnValue(
       vi.fn().mockResolvedValue(null),
     );
+    youtubeAdapter.createCommentChecker.mockReturnValue(
+      vi.fn().mockResolvedValue(null),
+    );
 
     service = new ReplyPollingWorkflowService(
       replyBotConfigsService as never,
@@ -57,6 +58,7 @@ describe('ReplyPollingWorkflowService', () => {
       executionQueue as never,
       twitterAdapter as never,
       instagramAdapter as never,
+      youtubeAdapter as never,
       configService as never,
       cacheService as never,
       logger as never,
@@ -198,6 +200,79 @@ describe('ReplyPollingWorkflowService', () => {
             metadata: expect.objectContaining({
               pollState: expect.objectContaining({
                 'mention-1': 'tweet-1',
+              }),
+            }),
+          }),
+        }),
+        where: { id: 'workflow-1' },
+      }),
+    );
+    expect(result).toMatchObject({
+      action: 'socialTriggerPolling',
+      checked: 1,
+      organizationId: 'org-1',
+      status: 'completed',
+      triggered: 1,
+    });
+  });
+
+  it('queues YouTube comment trigger events from connected brand comments', async () => {
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        config: {},
+        defaultRecurringBrandId: null,
+        id: 'workflow-1',
+        nodes: [
+          {
+            data: {
+              config: {
+                brandId: 'brand-1',
+                contentIds: ['video-1'],
+                platform: 'youtube',
+              },
+            },
+            id: 'comment-1',
+            type: 'commentTrigger',
+          },
+        ],
+        organizationId: 'org-1',
+        userId: 'user-1',
+      },
+    ]);
+    youtubeAdapter.createCommentChecker.mockReturnValue(
+      vi.fn().mockResolvedValue({
+        authorId: 'channel-1',
+        authorUsername: 'Viewer',
+        commentId: 'comment-1',
+        contentId: 'video-1',
+        contentUrl: 'https://www.youtube.com/watch?v=video-1',
+        platform: 'youtube',
+        postId: 'comment-1',
+        text: 'nice',
+        videoId: 'video-1',
+      }),
+    );
+
+    const result = await service.runSocialTriggerPolling('org-1');
+
+    expect(executionQueue.queueTriggerEvent).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        commentId: 'comment-1',
+        platform: 'youtube',
+        videoId: 'video-1',
+      }),
+      organizationId: 'org-1',
+      platform: 'youtube',
+      type: 'commentTrigger',
+      userId: 'user-1',
+    });
+    expect(prisma.workflow.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          config: expect.objectContaining({
+            metadata: expect.objectContaining({
+              pollState: expect.objectContaining({
+                'comment-1': 'comment-1',
               }),
             }),
           }),

--- a/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/reply-polling-workflow.service.ts
@@ -4,6 +4,7 @@ import type { ReplyBotConfigDocument } from '@api/collections/reply-bot-configs/
 import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/services/reply-bot-configs.service';
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
+import { YoutubeSocialAdapter } from '@api/collections/workflows/services/adapters/youtube-social.adapter';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
 import type { TriggerEvent } from '@api/collections/workflows/services/workflow-executor.service';
 import { ConfigService } from '@api/config/config.service';
@@ -14,7 +15,11 @@ import {
 } from '@api/services/reply-bot/reply-bot-orchestrator.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
-import { ReplyBotPlatform, WorkflowStatus } from '@genfeedai/enums';
+import {
+  ReplyBotPlatform,
+  WorkflowLifecycle,
+  WorkflowStatus,
+} from '@genfeedai/enums';
 import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import type { Workflow } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -25,6 +30,7 @@ const SOCIAL_TRIGGER_TYPES = [
   'newLikeTrigger',
   'newFollowerTrigger',
   'newRepostTrigger',
+  'commentTrigger',
   'keywordTrigger',
   'engagementTrigger',
 ] as const;
@@ -78,6 +84,7 @@ export class ReplyPollingWorkflowService {
     private readonly executionQueue: WorkflowExecutionQueueService,
     private readonly twitterAdapter: TwitterSocialAdapter,
     private readonly instagramAdapter: InstagramSocialAdapter,
+    private readonly youtubeAdapter: YoutubeSocialAdapter,
     private readonly configService: ConfigService,
     private readonly cacheService: CacheService,
     private readonly logger: LoggerService,
@@ -276,6 +283,7 @@ export class ReplyPollingWorkflowService {
       take: 200,
       where: {
         isDeleted: false,
+        lifecycle: WorkflowLifecycle.PUBLISHED as never,
         organizationId,
         status: WorkflowStatus.ACTIVE as never,
       },
@@ -375,6 +383,13 @@ export class ReplyPollingWorkflowService {
         return this.checkFollowerTrigger(orgId, platform, config, lastEventId);
       case 'newRepostTrigger':
         return this.checkRepostTrigger(orgId, platform, config, lastEventId);
+      case 'commentTrigger':
+        return this.checkCommentTrigger(
+          workflow,
+          platform,
+          config,
+          lastEventId,
+        );
       case 'keywordTrigger':
         return this.checkKeywordTrigger(orgId, platform, config, lastEventId);
       case 'engagementTrigger':
@@ -402,9 +417,7 @@ export class ReplyPollingWorkflowService {
     const checker =
       platform === 'twitter'
         ? this.twitterAdapter.createMentionChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createMentionChecker()
-          : null;
+        : null;
 
     if (!checker) {
       return null;
@@ -435,11 +448,7 @@ export class ReplyPollingWorkflowService {
     lastEventId: string | null,
   ) {
     const checker =
-      platform === 'twitter'
-        ? this.twitterAdapter.createLikeChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createLikeChecker()
-          : null;
+      platform === 'twitter' ? this.twitterAdapter.createLikeChecker() : null;
 
     if (!checker) {
       return null;
@@ -473,9 +482,7 @@ export class ReplyPollingWorkflowService {
     const checker =
       platform === 'twitter'
         ? this.twitterAdapter.createFollowerChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createFollowerChecker()
-          : null;
+        : null;
 
     if (!checker) {
       return null;
@@ -505,11 +512,7 @@ export class ReplyPollingWorkflowService {
     lastEventId: string | null,
   ) {
     const checker =
-      platform === 'twitter'
-        ? this.twitterAdapter.createRepostChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createRepostChecker()
-          : null;
+      platform === 'twitter' ? this.twitterAdapter.createRepostChecker() : null;
 
     if (!checker) {
       return null;
@@ -566,6 +569,54 @@ export class ReplyPollingWorkflowService {
     return {
       data: result as unknown as Record<string, unknown>,
       lastEventId: result.postId,
+      platform,
+    };
+  }
+
+  private async checkCommentTrigger(
+    workflow: Workflow,
+    platform: string,
+    config: Record<string, unknown>,
+    lastEventId: string | null,
+  ) {
+    if (platform !== 'youtube') {
+      return null;
+    }
+
+    const brandId =
+      this.optionalString(config.brandId) ??
+      this.optionalString(workflow.defaultRecurringBrandId);
+
+    if (!brandId) {
+      this.logger.warn(`${this.logContext} comment trigger missing brand`, {
+        platform,
+        workflowId: workflow.id,
+      });
+      return null;
+    }
+
+    const checker = this.youtubeAdapter.createCommentChecker();
+    const contentIds = this.readStringArray(
+      config.contentIds ?? config.videoIds ?? config.postIds,
+    );
+
+    const result = await checker({
+      brandId,
+      contentIds,
+      excludeKeywords: this.readStringArray(config.excludeKeywords),
+      keywords: this.readStringArray(config.keywords),
+      lastCommentId: lastEventId,
+      organizationId: workflow.organizationId,
+      platform: 'youtube',
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      data: result as unknown as Record<string, unknown>,
+      lastEventId: result.commentId,
       platform,
     };
   }
@@ -650,6 +701,14 @@ export class ReplyPollingWorkflowService {
 
   private optionalString(value: unknown): string | undefined {
     return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+
+  private readStringArray(value: unknown): string[] {
+    return Array.isArray(value)
+      ? value.filter(
+          (item): item is string => typeof item === 'string' && item.length > 0,
+        )
+      : [];
   }
 
   private errorMessage(error: unknown): string {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -1027,6 +1027,11 @@ describe('WorkflowEngineAdapterService', () => {
             id: 'n4',
             type: 'trigger-new-repost',
           },
+          {
+            data: { config: {} },
+            id: 'n5',
+            type: 'trigger-comment',
+          },
         ],
         organization: { toString: () => 'org-1' },
         user: { toString: () => 'user-1' },
@@ -1038,6 +1043,7 @@ describe('WorkflowEngineAdapterService', () => {
       expect(result.nodes[1].type).toBe('newFollowerTrigger');
       expect(result.nodes[2].type).toBe('newLikeTrigger');
       expect(result.nodes[3].type).toBe('newRepostTrigger');
+      expect(result.nodes[4].type).toBe('commentTrigger');
     });
 
     it('should map control nodes', () => {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -30,6 +30,7 @@ import type {
 } from '@api/collections/workflows/schemas/workflow.schema';
 import { AdAutomationWorkflowService } from '@api/collections/workflows/services/ad-automation-workflow.service';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
+import { YoutubeSocialAdapter } from '@api/collections/workflows/services/adapters/youtube-social.adapter';
 import { AgentAutopilotWorkflowService } from '@api/collections/workflows/services/agent-autopilot-workflow.service';
 import { AnalyticsSyncWorkflowService } from '@api/collections/workflows/services/analytics-sync-workflow.service';
 import { CampaignOrchestrationWorkflowService } from '@api/collections/workflows/services/campaign-orchestration-workflow.service';
@@ -84,9 +85,12 @@ import {
   createAnalyticsFeedbackExecutor,
   createBrandAssetExecutor,
   createBrandContextExecutor,
+  createCommentTriggerExecutor,
+  createEngagementTriggerExecutor,
   createHookGeneratorExecutor,
   createImageGenExecutor,
   createIterativeSeoRefineExecutor,
+  createKeywordTriggerExecutor,
   createLipSyncExecutor,
   createMentionTriggerExecutor,
   createNewFollowerTriggerExecutor,
@@ -230,6 +234,7 @@ const NODE_TYPE_TO_EXECUTOR: Record<string, string> = {
   // Social interaction nodes
   'social-post-reply': 'postReply',
   'social-send-dm': 'sendDm',
+  'trigger-comment': 'commentTrigger',
   'trigger-mention': 'mentionTrigger',
   'trigger-new-follower': 'newFollowerTrigger',
   'trigger-new-like': 'newLikeTrigger',
@@ -301,6 +306,7 @@ export class WorkflowEngineAdapterService {
     @Optional() private readonly seoScorerService?: SeoScorerService,
     @Optional()
     private readonly workflowExecutionQueueService?: WorkflowExecutionQueueService,
+    @Optional() private readonly youtubeSocialAdapter?: YoutubeSocialAdapter,
   ) {
     this.engine = new WorkflowEngine({
       maxConcurrency: 3,
@@ -1837,7 +1843,7 @@ export class WorkflowEngineAdapterService {
         throw new Error('LLM executor returned empty content');
       }
 
-      return { content, model: response.model };
+      return { content, model: response.model, text: content };
     });
   }
 
@@ -1859,44 +1865,173 @@ export class WorkflowEngineAdapterService {
     const mentionTriggerExecutor = createMentionTriggerExecutor();
     const likeTriggerExecutor = createNewLikeTriggerExecutor();
     const repostTriggerExecutor = createNewRepostTriggerExecutor();
+    const keywordTriggerExecutor = createKeywordTriggerExecutor();
+    const engagementTriggerExecutor = createEngagementTriggerExecutor();
+    const commentTriggerExecutor = createCommentTriggerExecutor();
 
-    if (this.socialAdapterFactory && platforms.length > 0) {
+    // Wire dispatching publishers/checkers that route to the correct platform adapter.
+    // YouTube is backed by its own adapter because it uses the YouTube Data API,
+    // not the Twitter/Instagram social adapter factory.
+    if (this.socialAdapterFactory || this.youtubeSocialAdapter) {
       const socialAdapterFactory = this.socialAdapterFactory;
+      const youtubeSocialAdapter = this.youtubeSocialAdapter;
 
-      // Wire dispatching publishers/checkers that route to the correct platform adapter
       postReplyExecutor.setPublisher((params) => {
+        if (params.platform === 'youtube') {
+          if (!youtubeSocialAdapter) {
+            throw new Error('YouTube social adapter is not available');
+          }
+          return youtubeSocialAdapter.createReplyPublisher()(params);
+        }
+
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
         const adapter = socialAdapterFactory.getAdapter(params.platform);
         return adapter.createReplyPublisher()(params);
       });
 
       sendDmExecutor.setSender((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
         const adapter = socialAdapterFactory.getAdapter(params.platform);
         return adapter.createDmSender()(params);
       });
 
       followerTriggerExecutor.setChecker((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
         const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createFollowerChecker) {
+          throw new Error(
+            `${params.platform} follower trigger is not supported by the configured social adapter`,
+          );
+        }
         return adapter.createFollowerChecker()(params);
       });
 
       mentionTriggerExecutor.setChecker((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
         const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createMentionChecker) {
+          throw new Error(
+            `${params.platform} mention trigger is not supported by the configured social adapter`,
+          );
+        }
         return adapter.createMentionChecker()(params);
       });
 
       likeTriggerExecutor.setChecker((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
         const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createLikeChecker) {
+          throw new Error(
+            `${params.platform} like trigger is not supported by the configured social adapter`,
+          );
+        }
         return adapter.createLikeChecker()(params);
       });
 
       repostTriggerExecutor.setChecker((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
         const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createRepostChecker) {
+          throw new Error(
+            `${params.platform} repost trigger is not supported by the configured social adapter`,
+          );
+        }
         return adapter.createRepostChecker()(params);
       });
 
-      this.loggerService.log(
-        `${this.logContext} social executors wired for platforms: ${platforms.join(', ')}`,
-      );
+      keywordTriggerExecutor.setChecker((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
+        const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createKeywordChecker) {
+          throw new Error(
+            `${params.platform} keyword trigger is not supported by the configured social adapter`,
+          );
+        }
+        return adapter.createKeywordChecker()(params);
+      });
+
+      engagementTriggerExecutor.setChecker((params) => {
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
+        const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createEngagementChecker) {
+          throw new Error(
+            `${params.platform} engagement trigger is not supported by the configured social adapter`,
+          );
+        }
+        return adapter.createEngagementChecker()(params);
+      });
+
+      commentTriggerExecutor.setChecker((params) => {
+        if (params.platform === 'youtube') {
+          if (!youtubeSocialAdapter) {
+            throw new Error('YouTube social adapter is not available');
+          }
+          return youtubeSocialAdapter.createCommentChecker()(params);
+        }
+
+        if (!socialAdapterFactory) {
+          throw new Error(
+            `${params.platform} social adapter factory is not available`,
+          );
+        }
+
+        const adapter = socialAdapterFactory.getAdapter(params.platform);
+        if (!adapter.createCommentChecker) {
+          throw new Error(
+            `${params.platform} comment trigger is not supported by the configured social adapter`,
+          );
+        }
+        return adapter.createCommentChecker()(params);
+      });
+
+      const wiredPlatforms = youtubeSocialAdapter
+        ? [...new Set([...platforms, 'youtube'])]
+        : platforms;
+      if (wiredPlatforms.length > 0) {
+        this.loggerService.log(
+          `${this.logContext} social executors wired for platforms: ${wiredPlatforms.join(', ')}`,
+        );
+      }
     }
 
     // Wrap class executors as NodeExecutor functions
@@ -1923,6 +2058,18 @@ export class WorkflowEngineAdapterService {
     this.engine.registerExecutor(
       repostTriggerExecutor.nodeType,
       this.wrapEngineExecutor(repostTriggerExecutor),
+    );
+    this.engine.registerExecutor(
+      keywordTriggerExecutor.nodeType,
+      this.wrapEngineExecutor(keywordTriggerExecutor),
+    );
+    this.engine.registerExecutor(
+      engagementTriggerExecutor.nodeType,
+      this.wrapEngineExecutor(engagementTriggerExecutor),
+    );
+    this.engine.registerExecutor(
+      commentTriggerExecutor.nodeType,
+      this.wrapEngineExecutor(commentTriggerExecutor),
     );
   }
 

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
@@ -120,11 +120,14 @@ interface ReviewGateApprovalResult {
 // =============================================================================
 
 /** Trigger node types that start a workflow */
-const TRIGGER_NODE_TYPES = new Set([
+const _TRIGGER_NODE_TYPES = new Set([
   'mentionTrigger',
   'newFollowerTrigger',
   'newLikeTrigger',
   'newRepostTrigger',
+  'commentTrigger',
+  'keywordTrigger',
+  'engagementTrigger',
   'postPublishTrigger',
   'trendTrigger',
 ]);
@@ -142,6 +145,12 @@ const EVENT_TYPE_TO_NODE_TYPE: Record<string, string> = {
   newLikeTrigger: 'newLikeTrigger',
   newRepost: 'newRepostTrigger',
   newRepostTrigger: 'newRepostTrigger',
+  comment: 'commentTrigger',
+  commentTrigger: 'commentTrigger',
+  keyword: 'keywordTrigger',
+  keywordTrigger: 'keywordTrigger',
+  engagement: 'engagementTrigger',
+  engagementTrigger: 'engagementTrigger',
   'post-published': 'postPublishTrigger',
   postPublishTrigger: 'postPublishTrigger',
   trend: 'trendTrigger',
@@ -630,6 +639,9 @@ export class WorkflowExecutorService {
         (workflowDoc as unknown as { id: string }).id,
     );
     const startedAt = new Date();
+    const keepsWorkflowActive =
+      trigger === WorkflowExecutionTrigger.SCHEDULED ||
+      trigger === WorkflowExecutionTrigger.EVENT;
 
     let executableWorkflow =
       this.engineAdapter.convertToExecutableWorkflow(workflowDoc);
@@ -699,10 +711,9 @@ export class WorkflowExecutorService {
             executionCount: { increment: 1 },
           }),
           lastExecutedAt: new Date(),
-          status:
-            trigger === WorkflowExecutionTrigger.SCHEDULED
-              ? WorkflowStatus.ACTIVE
-              : WorkflowStatus.RUNNING,
+          status: keepsWorkflowActive
+            ? WorkflowStatus.ACTIVE
+            : WorkflowStatus.RUNNING,
         },
         where: { id: workflowId },
       });
@@ -767,12 +778,11 @@ export class WorkflowExecutorService {
         await this.prisma.workflow.update({
           data: {
             completedAt: new Date(),
-            status:
-              trigger === WorkflowExecutionTrigger.SCHEDULED
-                ? WorkflowStatus.ACTIVE
-                : finalStatus === WorkflowExecutionStatus.COMPLETED
-                  ? WorkflowStatus.COMPLETED
-                  : WorkflowStatus.FAILED,
+            status: keepsWorkflowActive
+              ? WorkflowStatus.ACTIVE
+              : finalStatus === WorkflowExecutionStatus.COMPLETED
+                ? WorkflowStatus.COMPLETED
+                : WorkflowStatus.FAILED,
           } as never,
           where: { id: workflowId },
         });
@@ -863,10 +873,9 @@ export class WorkflowExecutorService {
         // scheduler retries on the next tick; the failure is recorded on the
         // WorkflowExecution record.
         data: {
-          status:
-            trigger === WorkflowExecutionTrigger.SCHEDULED
-              ? WorkflowStatus.ACTIVE
-              : WorkflowStatus.FAILED,
+          status: keepsWorkflowActive
+            ? WorkflowStatus.ACTIVE
+            : WorkflowStatus.FAILED,
         } as never,
         where: { id: workflowId },
       });
@@ -1255,9 +1264,7 @@ export class WorkflowExecutorService {
     // Inject trigger data for trigger nodes
     const triggerNodeType =
       EVENT_TYPE_TO_NODE_TYPE[triggerEvent.type] ?? triggerEvent.type;
-    const triggerNode = workflow.nodes.find(
-      (n) => n.type === triggerNodeType || TRIGGER_NODE_TYPES.has(n.type),
-    );
+    const triggerNode = workflow.nodes.find((n) => n.type === triggerNodeType);
     if (triggerNode) {
       nodeCache.set(triggerNode.id, triggerEvent.data);
       completedNodes.add(triggerNode.id);
@@ -1781,6 +1788,7 @@ export class WorkflowExecutorService {
         isDeleted: false,
         lifecycle: WorkflowLifecycle.PUBLISHED,
         organizationId: event.organizationId,
+        status: WorkflowStatus.ACTIVE,
       },
     });
     const normalizedWorkflows = workflows.map((workflow) =>
@@ -1817,6 +1825,7 @@ export class WorkflowExecutorService {
    */
   private resolveNodeType(visualNodeType: string): string {
     const NODE_TYPE_MAP: Record<string, string> = {
+      'trigger-comment': 'commentTrigger',
       'trigger-mention': 'mentionTrigger',
       'trigger-new-follower': 'newFollowerTrigger',
       'trigger-new-like': 'newLikeTrigger',
@@ -2201,7 +2210,7 @@ export class WorkflowExecutorService {
     branch: string,
     edges: ExecutableEdge[],
     skippedNodes: Set<string>,
-    executionOrder: string[],
+    _executionOrder: string[],
     completedNodes: Set<string>,
   ): void {
     // Find edges from the condition node that DON'T match the taken branch
@@ -2286,7 +2295,7 @@ export class WorkflowExecutorService {
   private skipDownstreamNodes(
     failedNodeId: string,
     edges: ExecutableEdge[],
-    executionOrder: string[],
+    _executionOrder: string[],
     skippedNodes: Set<string>,
     completedNodes: Set<string>,
   ): void {

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -334,6 +334,7 @@ export class WorkflowsService extends BaseService<
                 isDeleted: false,
                 isScheduleEnabled: true,
                 label: template.name,
+                lifecycle: WorkflowLifecycle.PUBLISHED,
                 metadata: {
                   sourceIssue: 782,
                   sourceTemplateId: template.id,

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -12,6 +12,7 @@ import { MetadataModule } from '@api/collections/metadata/metadata.module';
 import { MusicsModule } from '@api/collections/musics/musics.module';
 import { NewslettersModule } from '@api/collections/newsletters/newsletters.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
+import { ReplyBotConfigsModule } from '@api/collections/reply-bot-configs/reply-bot-configs.module';
 import { TrendsModule } from '@api/collections/trends/trends.module';
 import { VideoGenerationModule } from '@api/collections/videos/video-generation.module';
 import { VideosModule } from '@api/collections/videos/videos.module';
@@ -26,11 +27,13 @@ import { WorkflowWebhookManagementController } from '@api/collections/workflows/
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { SocialAdapterFactory } from '@api/collections/workflows/services/adapters/social-adapter.factory';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
+import { YoutubeSocialAdapter } from '@api/collections/workflows/services/adapters/youtube-social.adapter';
 import { BatchWorkflowService } from '@api/collections/workflows/services/batch-workflow.service';
 import {
   BATCH_WORKFLOW_QUEUE,
   BatchWorkflowQueueService,
 } from '@api/collections/workflows/services/batch-workflow-queue.service';
+import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
 import {
   WORKFLOW_EXECUTION_QUEUE,
@@ -47,6 +50,7 @@ import { HeyGenModule } from '@api/services/integrations/heygen/heygen.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
 import { OpenRouterModule } from '@api/services/integrations/openrouter/openrouter.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
+import { YoutubeModule } from '@api/services/integrations/youtube/youtube.module';
 import { NotificationsModule } from '@api/services/notifications/notifications.module';
 import { NotificationsPublisherModule } from '@api/services/notifications/publisher/notifications-publisher.module';
 import { WhisperModule } from '@api/services/whisper/whisper.module';
@@ -97,9 +101,11 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => NotificationsPublisherModule),
     forwardRef(() => OpenRouterModule),
     forwardRef(() => PostsModule),
+    forwardRef(() => ReplyBotConfigsModule),
     forwardRef(() => SharedModule),
     forwardRef(() => TrendsModule),
     forwardRef(() => TwitterModule),
+    forwardRef(() => YoutubeModule),
     forwardRef(() => VideoGenerationModule),
     forwardRef(() => VideosModule),
     forwardRef(() => WhisperModule),
@@ -129,6 +135,7 @@ import { forwardRef, Module } from '@nestjs/common';
   providers: [
     TwitterSocialAdapter,
     InstagramSocialAdapter,
+    YoutubeSocialAdapter,
     SocialAdapterFactory,
     BatchWorkflowQueueService,
     BatchWorkflowService,
@@ -137,6 +144,7 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowExecutionQueueService,
     WorkflowFormatConverterService,
     WorkflowGenerationService,
+    ReplyPollingWorkflowService,
     WorkflowSchedulerService,
     WorkflowsService,
   ],

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-comments.service.spec.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-comments.service.spec.ts
@@ -5,6 +5,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 describe('YoutubeCommentsService', () => {
   let service: YoutubeCommentsService;
+  let mockAuthService: Record<string, unknown>;
+  let mockYoutubeAPI: Record<string, unknown>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,12 +24,6 @@ describe('YoutubeCommentsService', () => {
     }).compile();
 
     service = module.get<YoutubeCommentsService>(YoutubeCommentsService);
-  });
-
-  let mockAuthService: Record<string, unknown>;
-  let mockYoutubeAPI: Record<string, unknown>;
-
-  beforeEach(() => {
     mockAuthService = (service as unknown).authService;
 
     // Mock the YouTube API on the service instance
@@ -35,8 +31,12 @@ describe('YoutubeCommentsService', () => {
       channels: {
         list: vi.fn(),
       },
+      comments: {
+        insert: vi.fn(),
+      },
       commentThreads: {
         insert: vi.fn(),
+        list: vi.fn(),
       },
     };
     (service as unknown).youtubeAPI = mockYoutubeAPI;
@@ -133,6 +133,141 @@ describe('YoutubeCommentsService', () => {
       await expect(
         service.postComment(orgId, brandId, videoId, commentText),
       ).rejects.toThrow('API quota exceeded');
+    });
+  });
+
+  describe('listRecentChannelComments', () => {
+    const orgId = '507f1f77bcf86cd799439011';
+    const brandId = '507f1f77bcf86cd799439022';
+
+    it('lists normalized comments for the connected channel', async () => {
+      const mockAuth = { credentials: { access_token: 'token' } };
+      mockAuthService.refreshToken = vi.fn().mockResolvedValue(mockAuth);
+
+      (mockYoutubeAPI.channels as Record<string, unknown>).list = vi
+        .fn()
+        .mockResolvedValue({
+          data: { items: [{ id: 'UC123' }] },
+        });
+
+      (mockYoutubeAPI.commentThreads as Record<string, unknown>).list = vi
+        .fn()
+        .mockResolvedValue({
+          data: {
+            items: [
+              {
+                id: 'thread-1',
+                snippet: {
+                  topLevelComment: {
+                    id: 'comment-1',
+                    snippet: {
+                      authorChannelId: { value: 'author-channel-1' },
+                      authorDisplayName: 'Viewer',
+                      authorProfileImageUrl: 'https://example.com/avatar.jpg',
+                      likeCount: 3,
+                      publishedAt: '2026-07-01T10:00:00Z',
+                      textDisplay: 'Nice clip',
+                      textOriginal: 'Nice clip',
+                      updatedAt: '2026-07-01T10:00:00Z',
+                    },
+                  },
+                  videoId: 'video-1',
+                },
+              },
+            ],
+            nextPageToken: 'next-token',
+          },
+        });
+
+      const result = await service.listRecentChannelComments(orgId, brandId, {
+        maxResults: 10,
+      });
+
+      expect(result).toEqual({
+        comments: [
+          {
+            authorChannelId: 'author-channel-1',
+            authorDisplayName: 'Viewer',
+            authorProfileImageUrl: 'https://example.com/avatar.jpg',
+            commentId: 'comment-1',
+            likeCount: 3,
+            publishedAt: '2026-07-01T10:00:00Z',
+            text: 'Nice clip',
+            updatedAt: '2026-07-01T10:00:00Z',
+            videoId: 'video-1',
+            videoUrl: 'https://www.youtube.com/watch?v=video-1',
+          },
+        ],
+        nextPageToken: 'next-token',
+      });
+      expect(
+        (mockYoutubeAPI.commentThreads as Record<string, unknown>).list,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allThreadsRelatedToChannelId: 'UC123',
+          auth: mockAuth,
+          maxResults: 10,
+          order: 'time',
+          part: ['snippet'],
+          textFormat: 'plainText',
+        }),
+      );
+    });
+  });
+
+  describe('replyToComment', () => {
+    const orgId = '507f1f77bcf86cd799439011';
+    const brandId = '507f1f77bcf86cd799439022';
+
+    it('replies to an existing YouTube comment', async () => {
+      const mockAuth = { credentials: { access_token: 'token' } };
+      mockAuthService.refreshToken = vi.fn().mockResolvedValue(mockAuth);
+
+      (mockYoutubeAPI.comments as Record<string, unknown>).insert = vi
+        .fn()
+        .mockResolvedValue({
+          data: { id: 'reply-comment-1' },
+        });
+
+      const result = await service.replyToComment(
+        orgId,
+        brandId,
+        'parent-comment-1',
+        'Thanks for watching',
+      );
+
+      expect(result).toEqual({ commentId: 'reply-comment-1' });
+      expect(
+        (mockYoutubeAPI.comments as Record<string, unknown>).insert,
+      ).toHaveBeenCalledWith({
+        auth: mockAuth,
+        part: ['snippet'],
+        requestBody: {
+          snippet: {
+            parentId: 'parent-comment-1',
+            textOriginal: 'Thanks for watching',
+          },
+        },
+      });
+    });
+
+    it('throws when YouTube does not return a reply comment ID', async () => {
+      mockAuthService.refreshToken = vi.fn().mockResolvedValue({});
+
+      (mockYoutubeAPI.comments as Record<string, unknown>).insert = vi
+        .fn()
+        .mockResolvedValue({
+          data: { id: null },
+        });
+
+      await expect(
+        service.replyToComment(
+          orgId,
+          brandId,
+          'parent-comment-1',
+          'Thanks for watching',
+        ),
+      ).rejects.toThrow('Failed to reply to comment - no comment ID returned');
     });
   });
 });

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-comments.service.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-comments.service.ts
@@ -15,6 +15,105 @@ export class YoutubeCommentsService {
     this.youtubeAPI = google.youtube({ version: 'v3' });
   }
 
+  private async getAuthenticatedChannelContext(
+    organizationId: string,
+    brandId: string,
+  ): Promise<{
+    auth: Awaited<ReturnType<YoutubeAuthService['refreshToken']>>;
+    channelId: string;
+  }> {
+    const auth = await this.authService.refreshToken(organizationId, brandId);
+
+    const channelResponse = await this.youtubeAPI.channels.list({
+      auth,
+      mine: true,
+      part: ['id'],
+    });
+
+    const channelId = channelResponse.data.items?.[0]?.id;
+
+    if (!channelId) {
+      throw new Error('Could not retrieve channel ID for authenticated user');
+    }
+
+    return { auth, channelId };
+  }
+
+  /**
+   * List recent top-level comments across the authenticated channel.
+   */
+  async listRecentChannelComments(
+    organizationId: string,
+    brandId: string,
+    options: {
+      maxResults?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<{
+    comments: YoutubeChannelComment[];
+    nextPageToken?: string;
+  }> {
+    const url = `${this.constructorName} listRecentChannelComments`;
+
+    try {
+      const { auth, channelId } = await this.getAuthenticatedChannelContext(
+        organizationId,
+        brandId,
+      );
+
+      const response = await this.youtubeAPI.commentThreads.list({
+        allThreadsRelatedToChannelId: channelId,
+        auth,
+        maxResults: Math.min(Math.max(options.maxResults ?? 25, 1), 100),
+        order: 'time',
+        pageToken: options.pageToken,
+        part: ['snippet'],
+        textFormat: 'plainText',
+      });
+
+      const comments = (response.data.items ?? []).flatMap((thread) => {
+        const threadSnippet = thread.snippet;
+        const topLevelComment = threadSnippet?.topLevelComment;
+        const commentSnippet = topLevelComment?.snippet;
+        const commentId = topLevelComment?.id;
+        const videoId = threadSnippet?.videoId;
+
+        if (!commentId || !videoId || !commentSnippet?.textDisplay) {
+          return [];
+        }
+
+        return [
+          {
+            authorChannelId: commentSnippet.authorChannelId?.value ?? undefined,
+            authorDisplayName: commentSnippet.authorDisplayName ?? undefined,
+            authorProfileImageUrl:
+              commentSnippet.authorProfileImageUrl ?? undefined,
+            commentId,
+            likeCount: commentSnippet.likeCount ?? 0,
+            publishedAt: commentSnippet.publishedAt ?? undefined,
+            text: commentSnippet.textOriginal ?? commentSnippet.textDisplay,
+            updatedAt: commentSnippet.updatedAt ?? undefined,
+            videoId,
+            videoUrl: `https://www.youtube.com/watch?v=${videoId}`,
+          },
+        ];
+      });
+
+      this.loggerService.log(`${url} completed`, {
+        channelId,
+        count: comments.length,
+      });
+
+      return {
+        comments,
+        nextPageToken: response.data.nextPageToken ?? undefined,
+      };
+    } catch (error: unknown) {
+      this.loggerService.error(`${url} failed`, error);
+      throw error;
+    }
+  }
+
   /**
    * Post a top-level comment on a YouTube video
    * @param organizationId The organization ID
@@ -37,20 +136,10 @@ export class YoutubeCommentsService {
         videoId,
       });
 
-      const auth = await this.authService.refreshToken(organizationId, brandId);
-
-      // Get channel ID for the authenticated user
-      const channelResponse = await this.youtubeAPI.channels.list({
-        auth,
-        mine: true,
-        part: ['id'],
-      });
-
-      const channelId = channelResponse.data.items?.[0]?.id;
-
-      if (!channelId) {
-        throw new Error('Could not retrieve channel ID for authenticated user');
-      }
+      const { auth, channelId } = await this.getAuthenticatedChannelContext(
+        organizationId,
+        brandId,
+      );
 
       // Post the comment using commentThreads.insert
       const response = await this.youtubeAPI.commentThreads.insert({
@@ -83,4 +172,65 @@ export class YoutubeCommentsService {
       throw error;
     }
   }
+
+  /**
+   * Reply to an existing top-level YouTube comment.
+   */
+  async replyToComment(
+    organizationId: string,
+    brandId: string,
+    parentCommentId: string,
+    text: string,
+  ): Promise<{ commentId: string }> {
+    const url = `${this.constructorName} replyToComment`;
+
+    try {
+      this.loggerService.log(`${url} started`, {
+        parentCommentId,
+        textLength: text.length,
+      });
+
+      const auth = await this.authService.refreshToken(organizationId, brandId);
+
+      const response = await this.youtubeAPI.comments.insert({
+        auth,
+        part: ['snippet'],
+        requestBody: {
+          snippet: {
+            parentId: parentCommentId,
+            textOriginal: text,
+          },
+        },
+      });
+
+      const commentId = response.data.id;
+
+      if (!commentId) {
+        throw new Error('Failed to reply to comment - no comment ID returned');
+      }
+
+      this.loggerService.log(`${url} completed`, {
+        commentId,
+        parentCommentId,
+      });
+
+      return { commentId };
+    } catch (error: unknown) {
+      this.loggerService.error(`${url} failed`, error);
+      throw error;
+    }
+  }
+}
+
+export interface YoutubeChannelComment {
+  commentId: string;
+  videoId: string;
+  videoUrl: string;
+  text: string;
+  authorChannelId?: string;
+  authorDisplayName?: string;
+  authorProfileImageUrl?: string;
+  likeCount: number;
+  publishedAt?: string;
+  updatedAt?: string;
 }

--- a/apps/server/api/src/services/integrations/youtube/services/youtube.service.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/youtube.service.ts
@@ -193,4 +193,33 @@ export class YoutubeService {
       text,
     );
   }
+
+  listRecentChannelComments(
+    organizationId: string,
+    brandId: string,
+    options?: {
+      maxResults?: number;
+      pageToken?: string;
+    },
+  ) {
+    return this.commentsService.listRecentChannelComments(
+      organizationId,
+      brandId,
+      options,
+    );
+  }
+
+  replyToComment(
+    organizationId: string,
+    brandId: string,
+    parentCommentId: string,
+    text: string,
+  ) {
+    return this.commentsService.replyToComment(
+      organizationId,
+      brandId,
+      parentCommentId,
+      text,
+    );
+  }
 }

--- a/apps/server/workers/src/crons/social-polling/social-polling.module.ts
+++ b/apps/server/workers/src/crons/social-polling/social-polling.module.ts
@@ -1,6 +1,7 @@
 import { CredentialsModule } from '@api/collections/credentials/credentials.module';
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
+import { YoutubeSocialAdapter } from '@api/collections/workflows/services/adapters/youtube-social.adapter';
 import {
   WORKFLOW_EXECUTION_QUEUE,
   WorkflowExecutionQueueService,
@@ -8,6 +9,7 @@ import {
 import { ConfigModule } from '@api/config/config.module';
 import { InstagramModule } from '@api/services/integrations/instagram/instagram.module';
 import { TwitterModule } from '@api/services/integrations/twitter/twitter.module';
+import { YoutubeModule } from '@api/services/integrations/youtube/youtube.module';
 import { LoggerModule } from '@libs/logger/logger.module';
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
@@ -20,6 +22,7 @@ import { SocialPollingService } from '@workers/crons/social-polling/social-polli
     CredentialsModule,
     InstagramModule,
     TwitterModule,
+    YoutubeModule,
     BullModule.registerQueue({ name: WORKFLOW_EXECUTION_QUEUE }),
   ],
   providers: [
@@ -27,6 +30,7 @@ import { SocialPollingService } from '@workers/crons/social-polling/social-polli
     WorkflowExecutionQueueService,
     TwitterSocialAdapter,
     InstagramSocialAdapter,
+    YoutubeSocialAdapter,
   ],
 })
 export class SocialPollingModule {}

--- a/apps/server/workers/src/crons/social-polling/social-polling.service.spec.ts
+++ b/apps/server/workers/src/crons/social-polling/social-polling.service.spec.ts
@@ -1,8 +1,10 @@
 import { SocialPollingService } from '@workers/crons/social-polling/social-polling.service';
 
-const mockWorkflowModel = {
-  find: vi.fn(),
-  updateOne: vi.fn(),
+const mockPrisma = {
+  workflow: {
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
 };
 
 const mockExecutionQueue = {
@@ -19,6 +21,9 @@ const mockTwitterAdapter = {
 };
 
 const mockInstagramAdapter = {};
+const mockYoutubeAdapter = {
+  createCommentChecker: vi.fn(),
+};
 
 const mockLogger = {
   debug: vi.fn(),
@@ -37,12 +42,13 @@ type SocialPollingConstructorArgs = ConstructorParameters<
 
 function createService() {
   return new SocialPollingService(
-    mockWorkflowModel as unknown as SocialPollingConstructorArgs[0],
+    mockPrisma as unknown as SocialPollingConstructorArgs[0],
     mockExecutionQueue as unknown as SocialPollingConstructorArgs[1],
     mockTwitterAdapter as unknown as SocialPollingConstructorArgs[2],
     mockInstagramAdapter as unknown as SocialPollingConstructorArgs[3],
-    mockConfigService as unknown as SocialPollingConstructorArgs[4],
-    mockLogger as unknown as SocialPollingConstructorArgs[5],
+    mockYoutubeAdapter as unknown as SocialPollingConstructorArgs[4],
+    mockConfigService as unknown as SocialPollingConstructorArgs[5],
+    mockLogger as unknown as SocialPollingConstructorArgs[6],
   );
 }
 
@@ -53,10 +59,8 @@ describe('SocialPollingService', () => {
     vi.clearAllMocks();
     mockConfigService.isDevSchedulersEnabled = true;
     service = createService();
-    mockWorkflowModel.find.mockReturnValue({
-      limit: vi.fn().mockReturnValue({ exec: vi.fn().mockResolvedValue([]) }),
-    });
-    mockWorkflowModel.updateOne.mockResolvedValue({});
+    mockPrisma.workflow.findMany.mockResolvedValue([]);
+    mockPrisma.workflow.update.mockResolvedValue({});
   });
 
   it('should be defined', () => {
@@ -65,15 +69,9 @@ describe('SocialPollingService', () => {
 
   it('should skip if already running', async () => {
     // Start first poll
-    mockWorkflowModel.find.mockReturnValue({
-      limit: vi.fn().mockReturnValue({
-        exec: vi
-          .fn()
-          .mockImplementation(
-            () => new Promise((resolve) => setTimeout(() => resolve([]), 100)),
-          ),
-      }),
-    });
+    mockPrisma.workflow.findMany.mockImplementationOnce(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 100)),
+    );
 
     const poll1 = service.pollSocialTriggers();
     const poll2 = service.pollSocialTriggers();
@@ -87,16 +85,18 @@ describe('SocialPollingService', () => {
   });
 
   it('should find workflows with social trigger nodes', async () => {
-    mockWorkflowModel.find.mockReturnValue({
-      limit: vi.fn().mockReturnValue({ exec: vi.fn().mockResolvedValue([]) }),
-    });
+    mockPrisma.workflow.findMany.mockResolvedValue([]);
 
     await service.pollSocialTriggers();
 
-    expect(mockWorkflowModel.find).toHaveBeenCalledWith(
+    expect(mockPrisma.workflow.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        isDeleted: false,
-        status: 'active',
+        take: 200,
+        where: expect.objectContaining({
+          isDeleted: false,
+          lifecycle: 'published',
+          status: 'active',
+        }),
       }),
     );
   });
@@ -106,7 +106,7 @@ describe('SocialPollingService', () => {
 
     await service.pollSocialTriggers();
 
-    expect(mockWorkflowModel.find).not.toHaveBeenCalled();
+    expect(mockPrisma.workflow.findMany).not.toHaveBeenCalled();
   });
 
   it('should trigger workflow execution when mention found', async () => {
@@ -121,8 +121,8 @@ describe('SocialPollingService', () => {
     };
 
     const mockWorkflow = {
-      _id: 'wf1',
-      metadata: {},
+      config: {},
+      id: 'wf1',
       nodes: [
         {
           data: { config: { platform: 'twitter' } },
@@ -130,15 +130,11 @@ describe('SocialPollingService', () => {
           type: 'mentionTrigger',
         },
       ],
-      organization: { toString: () => 'org1' },
-      user: { toString: () => 'user1' },
+      organizationId: 'org1',
+      userId: 'user1',
     };
 
-    mockWorkflowModel.find.mockReturnValue({
-      limit: vi.fn().mockReturnValue({
-        exec: vi.fn().mockResolvedValue([mockWorkflow]),
-      }),
-    });
+    mockPrisma.workflow.findMany.mockResolvedValue([mockWorkflow]);
 
     mockTwitterAdapter.createMentionChecker.mockReturnValue(
       vi.fn().mockResolvedValue(mockMention),
@@ -156,7 +152,7 @@ describe('SocialPollingService', () => {
     );
 
     // Should update poll state
-    expect(prisma.workflow.update).toHaveBeenCalledWith(
+    expect(mockPrisma.workflow.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           config: expect.objectContaining({
@@ -174,8 +170,8 @@ describe('SocialPollingService', () => {
 
   it('should not trigger when checker returns null', async () => {
     const mockWorkflow = {
-      _id: 'wf2',
-      metadata: {},
+      config: {},
+      id: 'wf2',
       nodes: [
         {
           data: { config: { platform: 'twitter' } },
@@ -183,15 +179,11 @@ describe('SocialPollingService', () => {
           type: 'mentionTrigger',
         },
       ],
-      organization: { toString: () => 'org1' },
-      user: { toString: () => 'user1' },
+      organizationId: 'org1',
+      userId: 'user1',
     };
 
-    mockWorkflowModel.find.mockReturnValue({
-      limit: vi.fn().mockReturnValue({
-        exec: vi.fn().mockResolvedValue([mockWorkflow]),
-      }),
-    });
+    mockPrisma.workflow.findMany.mockResolvedValue([mockWorkflow]);
 
     mockTwitterAdapter.createMentionChecker.mockReturnValue(
       vi.fn().mockResolvedValue(null),
@@ -205,8 +197,8 @@ describe('SocialPollingService', () => {
   it('should handle errors per-workflow without stopping cycle', async () => {
     const workflows = [
       {
-        _id: 'wf-good',
-        metadata: {},
+        config: {},
+        id: 'wf-good',
         nodes: [
           {
             data: { config: { platform: 'twitter' } },
@@ -214,12 +206,12 @@ describe('SocialPollingService', () => {
             type: 'mentionTrigger',
           },
         ],
-        organization: { toString: () => 'org1' },
-        user: { toString: () => 'user1' },
+        organizationId: 'org1',
+        userId: 'user1',
       },
       {
-        _id: 'wf-bad',
-        metadata: {},
+        config: {},
+        id: 'wf-bad',
         nodes: [
           {
             data: { config: { platform: 'twitter' } },
@@ -227,16 +219,12 @@ describe('SocialPollingService', () => {
             type: 'mentionTrigger',
           },
         ],
-        organization: { toString: () => 'org2' },
-        user: { toString: () => 'user2' },
+        organizationId: 'org2',
+        userId: 'user2',
       },
     ];
 
-    mockWorkflowModel.find.mockReturnValue({
-      limit: vi.fn().mockReturnValue({
-        exec: vi.fn().mockResolvedValue(workflows),
-      }),
-    });
+    mockPrisma.workflow.findMany.mockResolvedValue(workflows);
 
     let callCount = 0;
     mockTwitterAdapter.createMentionChecker.mockReturnValue(
@@ -257,6 +245,6 @@ describe('SocialPollingService', () => {
       expect.any(Object),
     );
     // Should still update poll state for second workflow
-    expect(mockWorkflowModel.updateOne).toHaveBeenCalled();
+    expect(mockPrisma.workflow.update).toHaveBeenCalled();
   });
 });

--- a/apps/server/workers/src/crons/social-polling/social-polling.service.ts
+++ b/apps/server/workers/src/crons/social-polling/social-polling.service.ts
@@ -1,10 +1,11 @@
 import { InstagramSocialAdapter } from '@api/collections/workflows/services/adapters/instagram-social.adapter';
 import { TwitterSocialAdapter } from '@api/collections/workflows/services/adapters/twitter-social.adapter';
+import { YoutubeSocialAdapter } from '@api/collections/workflows/services/adapters/youtube-social.adapter';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
 import type { TriggerEvent } from '@api/collections/workflows/services/workflow-executor.service';
 import { ConfigService } from '@api/config/config.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { WorkflowStatus } from '@genfeedai/enums';
+import { WorkflowLifecycle, WorkflowStatus } from '@genfeedai/enums';
 import type { Workflow } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -17,6 +18,7 @@ const SOCIAL_TRIGGER_TYPES = [
   'newLikeTrigger',
   'newFollowerTrigger',
   'newRepostTrigger',
+  'commentTrigger',
   'keywordTrigger',
   'engagementTrigger',
 ] as const;
@@ -63,6 +65,7 @@ export class SocialPollingService {
     private readonly executionQueue: WorkflowExecutionQueueService,
     private readonly twitterAdapter: TwitterSocialAdapter,
     private readonly instagramAdapter: InstagramSocialAdapter,
+    private readonly youtubeAdapter: YoutubeSocialAdapter,
     private readonly configService: ConfigService,
     private readonly logger: LoggerService,
   ) {}
@@ -133,6 +136,7 @@ export class SocialPollingService {
       take: 200,
       where: {
         isDeleted: false,
+        lifecycle: WorkflowLifecycle.PUBLISHED as never,
         status: WorkflowStatus.ACTIVE as never,
       },
     });
@@ -249,6 +253,13 @@ export class SocialPollingService {
         return this.checkFollowerTrigger(orgId, platform, config, lastEventId);
       case 'newRepostTrigger':
         return this.checkRepostTrigger(orgId, platform, config, lastEventId);
+      case 'commentTrigger':
+        return this.checkCommentTrigger(
+          workflow,
+          platform,
+          config,
+          lastEventId,
+        );
       case 'keywordTrigger':
         return this.checkKeywordTrigger(orgId, platform, config, lastEventId);
       case 'engagementTrigger':
@@ -272,9 +283,7 @@ export class SocialPollingService {
     const checker =
       platform === 'twitter'
         ? this.twitterAdapter.createMentionChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createMentionChecker()
-          : null;
+        : null;
 
     if (!checker) {
       return null;
@@ -305,11 +314,7 @@ export class SocialPollingService {
     lastEventId: string | null,
   ) {
     const checker =
-      platform === 'twitter'
-        ? this.twitterAdapter.createLikeChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createLikeChecker()
-          : null;
+      platform === 'twitter' ? this.twitterAdapter.createLikeChecker() : null;
 
     if (!checker) {
       return null;
@@ -343,9 +348,7 @@ export class SocialPollingService {
     const checker =
       platform === 'twitter'
         ? this.twitterAdapter.createFollowerChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createFollowerChecker()
-          : null;
+        : null;
 
     if (!checker) {
       return null;
@@ -375,11 +378,7 @@ export class SocialPollingService {
     lastEventId: string | null,
   ) {
     const checker =
-      platform === 'twitter'
-        ? this.twitterAdapter.createRepostChecker()
-        : platform === 'instagram'
-          ? this.instagramAdapter.createRepostChecker()
-          : null;
+      platform === 'twitter' ? this.twitterAdapter.createRepostChecker() : null;
 
     if (!checker) {
       return null;
@@ -438,6 +437,63 @@ export class SocialPollingService {
       lastEventId: result.postId,
       platform,
     };
+  }
+
+  private async checkCommentTrigger(
+    workflow: Workflow,
+    platform: string,
+    config: Record<string, unknown>,
+    lastEventId: string | null,
+  ) {
+    if (platform !== 'youtube') {
+      return null;
+    }
+
+    const brandId =
+      this.optionalString(config.brandId) ??
+      this.optionalString(workflow.defaultRecurringBrandId);
+
+    if (!brandId) {
+      this.logger.warn(`${this.logContext} comment trigger missing brand`, {
+        platform,
+        workflowId: workflow.id,
+      });
+      return null;
+    }
+
+    const result = await this.youtubeAdapter.createCommentChecker()({
+      brandId,
+      contentIds: this.readStringArray(
+        config.contentIds ?? config.videoIds ?? config.postIds,
+      ),
+      excludeKeywords: this.readStringArray(config.excludeKeywords),
+      keywords: this.readStringArray(config.keywords),
+      lastCommentId: lastEventId,
+      organizationId: workflow.organizationId,
+      platform: 'youtube',
+    });
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      data: result as unknown as Record<string, unknown>,
+      lastEventId: result.commentId,
+      platform,
+    };
+  }
+
+  private optionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+
+  private readStringArray(value: unknown): string[] {
+    return Array.isArray(value)
+      ? value.filter(
+          (item): item is string => typeof item === 'string' && item.length > 0,
+        )
+      : [];
   }
 
   private async checkEngagementTrigger(

--- a/packages/workflow-engine/src/executors/executor-registry.spec.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.spec.ts
@@ -108,6 +108,7 @@ describe('executor-registry', () => {
       expect(registry.getImageGenExecutor()).toBeDefined();
       expect(registry.getKeywordTriggerExecutor()).toBeDefined();
       expect(registry.getEngagementTriggerExecutor()).toBeDefined();
+      expect(registry.getCommentTriggerExecutor()).toBeDefined();
     });
 
     it('allows setting custom executor', () => {

--- a/packages/workflow-engine/src/executors/executor-registry.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.ts
@@ -32,6 +32,10 @@ import {
   createColorGradeExecutor,
 } from '@workflow-engine/executors/saas/color-grade-executor';
 import {
+  CommentTriggerExecutor,
+  createCommentTriggerExecutor,
+} from '@workflow-engine/executors/saas/comment-trigger-executor';
+import {
   ConditionExecutor,
   createConditionExecutor,
 } from '@workflow-engine/executors/saas/condition-executor';
@@ -278,6 +282,13 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     executorClass: ColorGradeExecutor,
     factory: () => createColorGradeExecutor(),
     nodeType: 'colorGrade',
+    requiresResolver: true,
+  },
+  commentTrigger: {
+    description: 'Starts workflow when a social comment is detected',
+    executorClass: CommentTriggerExecutor,
+    factory: () => createCommentTriggerExecutor(),
+    nodeType: 'commentTrigger',
     requiresResolver: true,
   },
   condition: {
@@ -910,6 +921,14 @@ export class ExecutorRegistryInstance {
   getEngagementTriggerExecutor(): EngagementTriggerExecutor | undefined {
     const executor = this.executors.get('engagementTrigger');
     return executor instanceof EngagementTriggerExecutor ? executor : undefined;
+  }
+
+  /**
+   * Get the comment trigger executor for checker injection
+   */
+  getCommentTriggerExecutor(): CommentTriggerExecutor | undefined {
+    const executor = this.executors.get('commentTrigger');
+    return executor instanceof CommentTriggerExecutor ? executor : undefined;
   }
 
   /**

--- a/packages/workflow-engine/src/executors/saas/comment-trigger-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/comment-trigger-executor.spec.ts
@@ -1,0 +1,115 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import type { ExecutorInput } from '@workflow-engine/executors/base-executor';
+import {
+  type CommentChecker,
+  type CommentTriggerExecutor,
+  createCommentTriggerExecutor,
+} from '@workflow-engine/executors/saas/comment-trigger-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeInput(config: Record<string, unknown>): ExecutorInput {
+  const node: ExecutableNode = {
+    config,
+    id: 'comment-trigger-1',
+    inputs: [],
+    label: 'Comment Trigger',
+    type: 'commentTrigger',
+  };
+  const context: ExecutionContext = {
+    organizationId: 'org-1',
+    runId: 'run-1',
+    userId: 'user-1',
+    workflowId: 'wf-1',
+  };
+  return { context, inputs: new Map(), node };
+}
+
+describe('CommentTriggerExecutor', () => {
+  let executor: CommentTriggerExecutor;
+  let checker: CommentChecker;
+
+  beforeEach(() => {
+    executor = createCommentTriggerExecutor();
+    checker = vi.fn().mockResolvedValue({
+      commentId: 'comment-1',
+      contentId: 'video-1',
+      platform: 'youtube',
+      postId: 'comment-1',
+      text: 'nice',
+      videoId: 'video-1',
+    });
+    executor.setChecker(checker);
+  });
+
+  it('creates via factory', () => {
+    expect(executor.nodeType).toBe('commentTrigger');
+  });
+
+  it('throws if checker is not configured', async () => {
+    const fresh = createCommentTriggerExecutor();
+    await expect(
+      fresh.execute(makeInput({ platform: 'youtube' })),
+    ).rejects.toThrow('Comment checker not configured');
+  });
+
+  it('checks for comments with configured filters', async () => {
+    const result = await executor.execute(
+      makeInput({
+        brandId: 'brand-1',
+        contentIds: ['video-1'],
+        excludeKeywords: ['spam'],
+        keywords: ['nice'],
+        lastCommentId: 'comment-0',
+        platform: 'youtube',
+      }),
+    );
+
+    expect(checker).toHaveBeenCalledWith({
+      brandId: 'brand-1',
+      contentIds: ['video-1'],
+      excludeKeywords: ['spam'],
+      keywords: ['nice'],
+      lastCommentId: 'comment-0',
+      organizationId: 'org-1',
+      platform: 'youtube',
+    });
+    expect(result.data).toMatchObject({
+      commentId: 'comment-1',
+      platform: 'youtube',
+      text: 'nice',
+    });
+    expect(result.metadata).toMatchObject({
+      commentId: 'comment-1',
+      matched: true,
+      platform: 'youtube',
+    });
+  });
+
+  it('returns unmatched metadata when no comment is found', async () => {
+    checker = vi.fn().mockResolvedValue(null);
+    executor.setChecker(checker);
+
+    const result = await executor.execute(makeInput({ platform: 'youtube' }));
+
+    expect(result).toEqual({
+      data: null,
+      metadata: { matched: false, platform: 'youtube' },
+    });
+  });
+
+  it('validates platform', () => {
+    const result = executor.validate({
+      config: { platform: 'invalid' },
+      id: 'comment-trigger-1',
+      inputs: [],
+      label: 'Comment Trigger',
+      type: 'commentTrigger',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((error) => error.includes('Invalid platform')),
+    ).toBe(true);
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/comment-trigger-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/comment-trigger-executor.ts
@@ -1,0 +1,143 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+export type CommentTriggerPlatform =
+  | 'youtube'
+  | 'instagram'
+  | 'twitter'
+  | 'tiktok'
+  | 'reddit';
+
+export interface CommentTriggerOutput {
+  commentId: string;
+  text: string;
+  platform: CommentTriggerPlatform;
+  authorId?: string;
+  authorUsername?: string;
+  commentedAt?: string;
+  contentId?: string;
+  contentUrl?: string;
+  parentId?: string;
+  postId?: string;
+  videoId?: string;
+}
+
+export type CommentChecker = (params: {
+  organizationId: string;
+  platform: CommentTriggerPlatform;
+  brandId?: string;
+  contentIds: string[];
+  keywords: string[];
+  excludeKeywords: string[];
+  lastCommentId: string | null;
+}) => Promise<CommentTriggerOutput | null>;
+
+export class CommentTriggerExecutor extends BaseExecutor {
+  readonly nodeType = 'commentTrigger';
+  private checker: CommentChecker | null = null;
+
+  setChecker(checker: CommentChecker): void {
+    this.checker = checker;
+  }
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+
+    const platform = node.config.platform;
+    const validPlatforms: CommentTriggerPlatform[] = [
+      'youtube',
+      'instagram',
+      'twitter',
+      'tiktok',
+      'reddit',
+    ];
+    if (
+      !platform ||
+      !validPlatforms.includes(platform as CommentTriggerPlatform)
+    ) {
+      errors.push(
+        `Invalid platform. Must be one of: ${validPlatforms.join(', ')}`,
+      );
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { node, context } = input;
+
+    if (!this.checker) {
+      throw new Error('Comment checker not configured');
+    }
+
+    const platform = this.getRequiredConfig<CommentTriggerPlatform>(
+      node.config,
+      'platform',
+    );
+    const brandId = this.getOptionalConfig<string | undefined>(
+      node.config,
+      'brandId',
+      undefined,
+    );
+    const contentIds = this.getOptionalConfig<string[]>(
+      node.config,
+      'contentIds',
+      [],
+    );
+    const keywords = this.getOptionalConfig<string[]>(
+      node.config,
+      'keywords',
+      [],
+    );
+    const excludeKeywords = this.getOptionalConfig<string[]>(
+      node.config,
+      'excludeKeywords',
+      [],
+    );
+    const lastCommentId = this.getOptionalConfig<string | null>(
+      node.config,
+      'lastCommentId',
+      null,
+    );
+
+    const result = await this.checker({
+      brandId,
+      contentIds,
+      excludeKeywords,
+      keywords,
+      lastCommentId,
+      organizationId: context.organizationId,
+      platform,
+    });
+
+    if (!result) {
+      return {
+        data: null,
+        metadata: { matched: false, platform },
+      };
+    }
+
+    return {
+      data: result,
+      metadata: {
+        commentId: result.commentId,
+        contentId: result.contentId,
+        matched: true,
+        platform,
+      },
+    };
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 0;
+  }
+}
+
+export function createCommentTriggerExecutor(): CommentTriggerExecutor {
+  return new CommentTriggerExecutor();
+}

--- a/packages/workflow-engine/src/executors/saas/index.ts
+++ b/packages/workflow-engine/src/executors/saas/index.ts
@@ -7,6 +7,7 @@ export * from '@workflow-engine/executors/saas/brand-executor';
 // Cinematic post-production executors
 export * from '@workflow-engine/executors/saas/cinematic-camera-presets';
 export * from '@workflow-engine/executors/saas/cinematic-color-grade-executor';
+export * from '@workflow-engine/executors/saas/comment-trigger-executor';
 export * from '@workflow-engine/executors/saas/condition-executor';
 export * from '@workflow-engine/executors/saas/delay-executor';
 // Social trigger executors

--- a/packages/workflow-engine/src/executors/saas/post-reply-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/post-reply-executor.spec.ts
@@ -94,6 +94,25 @@ describe('PostReplyExecutor', () => {
     expect(result.data).toMatchObject({ success: true });
   });
 
+  it('uses input values when config defaults are empty strings', async () => {
+    const input = makeInput(
+      { platform: 'twitter', postId: '', text: '' },
+      {
+        postId: 'tweet-from-edge',
+        text: 'From edge',
+      },
+    );
+
+    await executor.execute(input);
+
+    expect(mockPublisher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postId: 'tweet-from-edge',
+        text: 'From edge',
+      }),
+    );
+  });
+
   it('throws if postId missing', async () => {
     const input = makeInput({ platform: 'twitter', text: 'hello' });
     await expect(executor.execute(input)).rejects.toThrow(
@@ -125,7 +144,7 @@ describe('PostReplyExecutor', () => {
 
   it('validates valid platform', () => {
     const node: ExecutableNode = {
-      config: { platform: 'twitter' },
+      config: { platform: 'youtube' },
       id: 'r1',
       inputs: [],
       label: 'Reply',

--- a/packages/workflow-engine/src/executors/saas/post-reply-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/post-reply-executor.ts
@@ -9,7 +9,12 @@ import type { ExecutableNode } from '@workflow-engine/types';
 // TYPES
 // =============================================================================
 
-export type ReplyPlatform = 'twitter' | 'instagram' | 'threads' | 'facebook';
+export type ReplyPlatform =
+  | 'twitter'
+  | 'instagram'
+  | 'threads'
+  | 'facebook'
+  | 'youtube';
 
 export interface PostReplyConfig {
   /** Platform to reply on */
@@ -82,6 +87,7 @@ export class PostReplyExecutor extends BaseExecutor {
       'instagram',
       'threads',
       'facebook',
+      'youtube',
     ];
     if (!platform || !validPlatforms.includes(platform as ReplyPlatform)) {
       errors.push(
@@ -105,12 +111,8 @@ export class PostReplyExecutor extends BaseExecutor {
     );
 
     // postId and text can come from config or from connected inputs
-    const postId =
-      (node.config.postId as string) ??
-      (inputs.get('postId') as string | undefined);
-    const text =
-      (node.config.text as string) ??
-      (inputs.get('text') as string | undefined);
+    const postId = this.getConfigOrInputString(node, inputs, 'postId');
+    const text = this.getConfigOrInputString(node, inputs, 'text');
 
     if (!postId) {
       throw new Error('Post ID is required (via config or input)');
@@ -119,9 +121,7 @@ export class PostReplyExecutor extends BaseExecutor {
       throw new Error('Reply text is required (via config or input)');
     }
 
-    const mediaUrl =
-      (node.config.mediaUrl as string) ??
-      (inputs.get('mediaUrl') as string | undefined);
+    const mediaUrl = this.getConfigOrInputString(node, inputs, 'mediaUrl');
 
     const result = await this.publisher({
       brandId: node.config.brandId as string | undefined,
@@ -153,6 +153,22 @@ export class PostReplyExecutor extends BaseExecutor {
 
   estimateCost(_node: ExecutableNode): number {
     return 1;
+  }
+
+  private getConfigOrInputString(
+    node: ExecutableNode,
+    inputs: Map<string, unknown>,
+    key: string,
+  ): string | undefined {
+    const configValue = node.config[key];
+    if (typeof configValue === 'string' && configValue.trim().length > 0) {
+      return configValue;
+    }
+
+    const inputValue = inputs.get(key);
+    return typeof inputValue === 'string' && inputValue.trim().length > 0
+      ? inputValue
+      : undefined;
   }
 }
 

--- a/packages/workflow-engine/src/executors/saas/send-dm-executor.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/send-dm-executor.spec.ts
@@ -94,6 +94,26 @@ describe('SendDmExecutor', () => {
     expect(result.data).toMatchObject({ success: true });
   });
 
+  it('uses input values when config defaults are empty strings', async () => {
+    const input = makeInput(
+      { platform: 'instagram', recipientId: '', text: '' },
+      {
+        recipientId: 'user-from-edge',
+        text: 'From edge',
+      },
+    );
+
+    await executor.execute(input);
+
+    expect(mockSender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: 'instagram',
+        recipientId: 'user-from-edge',
+        text: 'From edge',
+      }),
+    );
+  });
+
   it('throws if recipientId missing', async () => {
     const input = makeInput({ platform: 'twitter', text: 'hello' });
     await expect(executor.execute(input)).rejects.toThrow(

--- a/packages/workflow-engine/src/executors/saas/send-dm-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/send-dm-executor.ts
@@ -97,12 +97,12 @@ export class SendDmExecutor extends BaseExecutor {
       'platform',
     );
 
-    const recipientId =
-      (node.config.recipientId as string) ??
-      (inputs.get('recipientId') as string | undefined);
-    const text =
-      (node.config.text as string) ??
-      (inputs.get('text') as string | undefined);
+    const recipientId = this.getConfigOrInputString(
+      node,
+      inputs,
+      'recipientId',
+    );
+    const text = this.getConfigOrInputString(node, inputs, 'text');
 
     if (!recipientId) {
       throw new Error('Recipient ID is required (via config or input)');
@@ -111,9 +111,7 @@ export class SendDmExecutor extends BaseExecutor {
       throw new Error('DM text is required (via config or input)');
     }
 
-    const mediaUrl =
-      (node.config.mediaUrl as string) ??
-      (inputs.get('mediaUrl') as string | undefined);
+    const mediaUrl = this.getConfigOrInputString(node, inputs, 'mediaUrl');
 
     const result = await this.sender({
       brandId: node.config.brandId as string | undefined,
@@ -144,6 +142,22 @@ export class SendDmExecutor extends BaseExecutor {
 
   estimateCost(_node: ExecutableNode): number {
     return 1;
+  }
+
+  private getConfigOrInputString(
+    node: ExecutableNode,
+    inputs: Map<string, unknown>,
+    key: string,
+  ): string | undefined {
+    const configValue = node.config[key];
+    if (typeof configValue === 'string' && configValue.trim().length > 0) {
+      return configValue;
+    }
+
+    const inputValue = inputs.get(key);
+    return typeof inputValue === 'string' && inputValue.trim().length > 0
+      ? inputValue
+      : undefined;
   }
 }
 

--- a/packages/workflow-engine/src/utils/credit-calculator.ts
+++ b/packages/workflow-engine/src/utils/credit-calculator.ts
@@ -18,6 +18,7 @@ export const DEFAULT_CREDIT_COSTS: CreditCostConfig = {
   brand: 0,
   brandAsset: 0,
   brandContext: 0,
+  commentTrigger: 0,
   engagementTrigger: 0, // trigger nodes are free
   keywordTrigger: 0,
   mentionTrigger: 0,

--- a/packages/workflow-saas/src/nodes/comment-trigger.spec.ts
+++ b/packages/workflow-saas/src/nodes/comment-trigger.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commentTriggerNodeDefinition,
+  DEFAULT_COMMENT_TRIGGER_DATA,
+} from './comment-trigger';
+
+describe('commentTrigger node', () => {
+  describe('DEFAULT_COMMENT_TRIGGER_DATA', () => {
+    it('has expected defaults', () => {
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.label).toBe('Comment Trigger');
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.status).toBe('idle');
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.type).toBe('commentTrigger');
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.platform).toBe('youtube');
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.brandId).toBeNull();
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.contentIds).toEqual([]);
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.keywords).toEqual([]);
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.excludeKeywords).toEqual([]);
+      expect(DEFAULT_COMMENT_TRIGGER_DATA.lastCommentId).toBeNull();
+    });
+  });
+
+  describe('commentTriggerNodeDefinition', () => {
+    it('defines comment trigger handles', () => {
+      expect(commentTriggerNodeDefinition.type).toBe('commentTrigger');
+      expect(commentTriggerNodeDefinition.category).toBe('trigger');
+      expect(commentTriggerNodeDefinition.inputs).toEqual([]);
+      expect(
+        commentTriggerNodeDefinition.outputs.map((output) => output.id),
+      ).toEqual([
+        'commentId',
+        'contentId',
+        'contentUrl',
+        'text',
+        'authorId',
+        'authorUsername',
+        'platform',
+      ]);
+    });
+  });
+});

--- a/packages/workflow-saas/src/nodes/comment-trigger.ts
+++ b/packages/workflow-saas/src/nodes/comment-trigger.ts
@@ -1,0 +1,51 @@
+import type { BaseNodeData } from '@workflow-saas/types';
+
+export type CommentTriggerPlatform =
+  | 'youtube'
+  | 'instagram'
+  | 'twitter'
+  | 'tiktok'
+  | 'reddit';
+
+export interface CommentTriggerNodeData extends BaseNodeData {
+  type: 'commentTrigger';
+  platform: CommentTriggerPlatform;
+  brandId: string | null;
+  contentIds: string[];
+  keywords: string[];
+  excludeKeywords: string[];
+  lastCommentId: string | null;
+  lastTriggeredAt: string | null;
+}
+
+export const DEFAULT_COMMENT_TRIGGER_DATA: Partial<CommentTriggerNodeData> = {
+  brandId: null,
+  contentIds: [],
+  excludeKeywords: [],
+  keywords: [],
+  label: 'Comment Trigger',
+  lastCommentId: null,
+  lastTriggeredAt: null,
+  platform: 'youtube',
+  status: 'idle',
+  type: 'commentTrigger',
+};
+
+export const commentTriggerNodeDefinition = {
+  category: 'trigger' as const,
+  defaultData: DEFAULT_COMMENT_TRIGGER_DATA,
+  description: 'Start workflow when a social comment is detected',
+  icon: 'MessageCircle',
+  inputs: [],
+  label: 'Comment Trigger',
+  outputs: [
+    { id: 'commentId', label: 'Comment ID', type: 'text' },
+    { id: 'contentId', label: 'Content ID', type: 'text' },
+    { id: 'contentUrl', label: 'Content URL', type: 'text' },
+    { id: 'text', label: 'Comment Text', type: 'text' },
+    { id: 'authorId', label: 'Author ID', type: 'text' },
+    { id: 'authorUsername', label: 'Author Username', type: 'text' },
+    { id: 'platform', label: 'Platform', type: 'text' },
+  ],
+  type: 'commentTrigger',
+};

--- a/packages/workflow-saas/src/nodes/index.ts
+++ b/packages/workflow-saas/src/nodes/index.ts
@@ -4,6 +4,7 @@ export * from './beat-sync-editor';
 export * from './brand';
 export * from './brand-asset';
 export * from './brand-context';
+export * from './comment-trigger';
 export * from './condition';
 export * from './delay';
 export * from './engagement-trigger';

--- a/packages/workflow-saas/src/nodes/nodes.spec.ts
+++ b/packages/workflow-saas/src/nodes/nodes.spec.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_BRAND_ASSET_DATA,
   DEFAULT_BRAND_CONTEXT_DATA,
   DEFAULT_BRAND_DATA,
+  DEFAULT_COMMENT_TRIGGER_DATA,
   DEFAULT_ENGAGEMENT_TRIGGER_DATA,
   DEFAULT_HOOK_GENERATOR_DATA,
   DEFAULT_IMAGE_TEXT_OVERLAY_DATA,
@@ -23,12 +24,17 @@ import {
 } from '@workflow-saas/nodes';
 import { describe, expect, it } from 'vitest';
 
-const allDefaults: Record<string, unknown> = {
+type NodeDefaultData = {
+  label?: unknown;
+};
+
+const allDefaults: Record<string, NodeDefaultData> = {
   beatAnalysis: DEFAULT_BEAT_ANALYSIS_DATA,
   beatSyncEditor: DEFAULT_BEAT_SYNC_EDITOR_DATA,
   brand: DEFAULT_BRAND_DATA,
   brandAsset: DEFAULT_BRAND_ASSET_DATA,
   brandContext: DEFAULT_BRAND_CONTEXT_DATA,
+  commentTrigger: DEFAULT_COMMENT_TRIGGER_DATA,
   engagementTrigger: DEFAULT_ENGAGEMENT_TRIGGER_DATA,
   hookGenerator: DEFAULT_HOOK_GENERATOR_DATA,
   imageTextOverlay: DEFAULT_IMAGE_TEXT_OVERLAY_DATA,
@@ -52,7 +58,7 @@ describe('node default data', () => {
     describe(name, () => {
       it('is defined and has label', () => {
         expect(data).toBeDefined();
-        expect((data as any).label).toBeTruthy();
+        expect(data.label).toBeTruthy();
       });
     });
   }

--- a/packages/workflow-saas/src/nodes/post-reply.ts
+++ b/packages/workflow-saas/src/nodes/post-reply.ts
@@ -11,7 +11,8 @@ export type PostReplyPlatform =
   | 'twitter'
   | 'instagram'
   | 'threads'
-  | 'facebook';
+  | 'facebook'
+  | 'youtube';
 
 /**
  * Post Reply Node Data

--- a/packages/workflow-saas/src/registry/saas-definitions.ts
+++ b/packages/workflow-saas/src/registry/saas-definitions.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_BRAND_ASSET_DATA,
   DEFAULT_BRAND_CONTEXT_DATA,
   DEFAULT_BRAND_DATA,
+  DEFAULT_COMMENT_TRIGGER_DATA,
   DEFAULT_CONDITION_DATA,
   DEFAULT_DELAY_DATA,
   DEFAULT_ENGAGEMENT_TRIGGER_DATA,
@@ -50,6 +51,7 @@ export type SaaSNodeType =
   | 'brandAsset'
   | 'brandContext'
   | 'patternContext'
+  | 'commentTrigger'
   // control flow
   | 'condition'
   | 'delay'
@@ -165,6 +167,24 @@ export const SAAS_NODE_DEFINITIONS: Record<SaaSNodeType, SaaSNodeDefinition> = {
       { id: 'models', label: 'Default Models', type: 'text' },
     ],
     type: 'brandContext',
+  },
+  commentTrigger: {
+    category: 'automation',
+    defaultData: DEFAULT_COMMENT_TRIGGER_DATA as Record<string, unknown>,
+    description: 'Start workflow when a social comment is detected',
+    icon: 'MessageCircle',
+    inputs: [],
+    label: 'Comment Trigger',
+    outputs: [
+      { id: 'commentId', label: 'Comment ID', type: 'text' },
+      { id: 'contentId', label: 'Content ID', type: 'text' },
+      { id: 'contentUrl', label: 'Content URL', type: 'text' },
+      { id: 'text', label: 'Comment Text', type: 'text' },
+      { id: 'authorId', label: 'Author ID', type: 'text' },
+      { id: 'authorUsername', label: 'Author Username', type: 'text' },
+      { id: 'platform', label: 'Platform', type: 'text' },
+    ],
+    type: 'commentTrigger',
   },
   condition: {
     category: 'processing',


### PR DESCRIPTION
## Summary

Recovered the b042 / 019f1c5d social-trigger slice from the Codex session patch stream.

- Adds `commentTrigger` support to workflow-engine and workflow-saas.
- Wires YouTube channel comment polling via the YouTube Data API and YouTube comment replies through workflow `postReply`.
- Adds `YoutubeSocialAdapter` and registers it in API/workers workflow modules.
- Queues social trigger workflow events from API and worker polling, including YouTube comment triggers.
- Keeps Instagram adapter surface limited to real implemented reply/DM capabilities instead of callable throw-only trigger stubs.
- Preserves LLM `text` output alias for `llm -> postReply.text` workflow paths.

## Verification

- `bunx vitest run --config vitest.config.ts src/executors/saas/comment-trigger-executor.spec.ts src/executors/saas/post-reply-executor.spec.ts src/executors/saas/send-dm-executor.spec.ts src/executors/executor-registry.spec.ts src/utils/credit-calculator-coverage.spec.ts` in `packages/workflow-engine`: 5 files, 39 tests passed
- `bun run build` in `packages/workflow-engine`: passed
- `bunx vitest run --config vitest.config.ts src/nodes/comment-trigger.spec.ts src/nodes/nodes.spec.ts` in `packages/workflow-saas`: 2 files, 24 tests passed
- `bun run build` in `packages/workflow-saas`: passed
- `bunx vitest run --config vitest.config.ts src/collections/workflows/services/workflow-engine-adapter.service.spec.ts src/collections/workflows/services/reply-polling-workflow.service.spec.ts src/collections/workflows/services/adapters/instagram-social.adapter.spec.ts src/collections/workflows/services/adapters/social-adapter.factory.spec.ts src/services/integrations/youtube/services/modules/youtube-comments.service.spec.ts` in `apps/server/api`: 5 files, 70 tests passed
- `bunx vitest run --config vitest.cron.config.ts src/crons/social-polling/social-polling.service.spec.ts` in `apps/server/workers`: 1 file, 7 tests passed
- `bun run build` in `apps/server/api`: passed
- `bun run build` in `apps/server/workers`: passed
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers --filter=@genfeedai/workflow-engine --filter=@genfeedai/workflow-saas`: passed
- `git diff --check HEAD~1..HEAD`: passed