### PR TITLE
fix(test): repair 7 stale package tests blocking deploy gate

### DIFF
--- a/packages/contexts/onboarding/onboarding-context.test.tsx
+++ b/packages/contexts/onboarding/onboarding-context.test.tsx
@@ -5,15 +5,25 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getTokenMock = vi.fn();
+const getBetterAuthTokenMock = vi.fn();
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
 const refetchUserMock = vi.fn();
 const getInstanceMock = vi.fn();
 const updateOnboardingMock = vi.fn();
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => ({
+vi.mock('@genfeedai/auth-client', () => ({
+  getBetterAuthToken: (...args: unknown[]) => getBetterAuthTokenMock(...args),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({
     getToken: getTokenMock,
+    isLoaded: true,
+    isSignedIn: true,
+    orgId: null,
+    sessionId: null,
+    userId: 'mongo_user_123',
   }),
 }));
 
@@ -64,6 +74,7 @@ import OnboardingProvider, {
 describe('OnboardingProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getBetterAuthTokenMock.mockResolvedValue(null);
     getTokenMock.mockResolvedValue('session-token');
     refetchUserMock.mockResolvedValue(undefined);
     updateOnboardingMock.mockResolvedValue(undefined);

--- a/packages/contexts/providers/elements/elements.provider.test.tsx
+++ b/packages/contexts/providers/elements/elements.provider.test.tsx
@@ -9,8 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const useAuthMock = vi.fn();
 const useAuthedServiceMock = vi.fn();
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => useAuthMock(),
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => useAuthMock(),
 }));
 
 vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({

--- a/packages/contexts/providers/promptbar/promptbar.provider.test.tsx
+++ b/packages/contexts/providers/promptbar/promptbar.provider.test.tsx
@@ -10,8 +10,8 @@ const useAuthMock = vi.fn();
 const useBrandMock = vi.fn();
 const useAuthedServiceMock = vi.fn();
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => useAuthMock(),
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => useAuthMock(),
 }));
 
 vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({

--- a/packages/contexts/providers/protected-providers/protected-providers.test.tsx
+++ b/packages/contexts/providers/protected-providers/protected-providers.test.tsx
@@ -9,9 +9,8 @@ const useAuthMock = vi.fn();
 const getPlaywrightAuthStateMock = vi.fn();
 const hasPlaywrightJwtTokenMock = vi.fn();
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => useAuthMock(),
-  useUser: () => ({ user: null }),
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => useAuthMock(),
 }));
 
 vi.mock('@genfeedai/helpers/auth/auth.helper', () => ({
@@ -20,9 +19,9 @@ vi.mock('@genfeedai/helpers/auth/auth.helper', () => ({
   resolveAuthToken: (getToken: () => Promise<string | null>) => getToken(),
 }));
 
-// Better Auth off (default): the shared identity dispatcher resolves to legacy auth provider.
+// Better Auth on (default): the auth gate must run so tests can exercise it.
 vi.mock('@genfeedai/auth-client', () => ({
-  isBetterAuthEnabled: () => false,
+  isBetterAuthEnabled: () => true,
   useBetterAuthIdentity: vi.fn(),
 }));
 
@@ -79,9 +78,6 @@ vi.mock('@genfeedai/services/core/logger.service', () => ({
 describe('ProtectedProviders', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set a fake legacy auth provider key so the LOCAL mode early-return in ProtectedAuthGate is not triggered,
-    // ensuring the gate logic under test remains reachable.
-    process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'pk_test_fake';
     getPlaywrightAuthStateMock.mockReturnValue(null);
     hasPlaywrightJwtTokenMock.mockReturnValue(false);
     useAuthMock.mockReturnValue({
@@ -92,10 +88,6 @@ describe('ProtectedProviders', () => {
       sessionId: 'session-1',
       userId: 'user-1',
     });
-  });
-
-  afterEach(() => {
-    delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
   });
 
   it('renders children through the provider stack', async () => {

--- a/packages/hooks/automation/use-workflow-builder/use-workflow-builder.test.ts
+++ b/packages/hooks/automation/use-workflow-builder/use-workflow-builder.test.ts
@@ -31,10 +31,16 @@ function createNodeRegistryResponse() {
   };
 }
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => ({
+const mockGetBetterAuthToken = vi.fn();
+
+vi.mock('@hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({
     getToken: mockGetToken,
   }),
+}));
+
+vi.mock('@genfeedai/auth-client', () => ({
+  getBetterAuthToken: () => mockGetBetterAuthToken(),
 }));
 
 vi.mock('@genfeedai/services/core/notifications.service', () => ({
@@ -71,6 +77,7 @@ describe('useWorkflowBuilder', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBetterAuthToken.mockResolvedValue(null);
     mockGetToken.mockResolvedValue('token-123');
     originalFetch = globalThis.fetch;
     globalThis.fetch = mockFetch as unknown as typeof fetch;

--- a/packages/hooks/data/tags/use-tags/use-tags.test.ts
+++ b/packages/hooks/data/tags/use-tags/use-tags.test.ts
@@ -7,8 +7,8 @@ import { createQueryWrapper } from '@hooks/tests/query-wrapper';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: vi.fn(() => ({ isSignedIn: true })),
+vi.mock('@hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: vi.fn(() => ({ isSignedIn: true })),
 }));
 
 vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({

--- a/packages/services/core/commands.registry.test.ts
+++ b/packages/services/core/commands.registry.test.ts
@@ -68,7 +68,7 @@ describe('commands.registry', () => {
     it('should have correct number of navigation commands', () => {
       const navigationCommands = createNavigationCommands(TEST_ORG, TEST_BRAND);
 
-      expect(navigationCommands.length).toBe(7);
+      expect(navigationCommands.length).toBe(8);
     });
 
     it('should have overview command with correct properties', () => {


### PR DESCRIPTION
## Summary

Fixes the 7 failing test files in the deploy gate's "Test Packages" CI job (run 28502262922). All fixes are test-only — no source/non-test files were changed, and no source bugs were found.

**Root cause (6 of 7 files):** the tests mocked the legacy auth module `@genfeedai/auth-client/react`'s `useAuth`, which the source no longer imports. Current source uses `useAuthIdentity` from `@hooks/auth/use-auth-identity/use-auth-identity`, which delegates straight to Better Auth's `useBetterAuthIdentity` (`packages/auth-client/src/session.ts`). With the wrong mock target, the real Better Auth session hook executed unmocked during tests, and in two cases the dynamically-imported `getBetterAuthToken()` inside `resolveAuthToken` (`packages/helpers/src/auth/auth.helper.ts`) also ran for real — producing incorrect auth state and cascading assertion failures.

## Changes

- `packages/contexts/onboarding/onboarding-context.test.tsx` — retarget mock to `useAuthIdentity`; mock `getBetterAuthToken` to resolve `null` so `resolveAuthToken` falls through to the test's own `getToken` mock
- `packages/contexts/providers/elements/elements.provider.test.tsx` — retarget mock to `useAuthIdentity` (return shape already matched `AuthIdentity`)
- `packages/contexts/providers/promptbar/promptbar.provider.test.tsx` — same retarget
- `packages/contexts/providers/protected-providers/protected-providers.test.tsx` — retarget mock to `useAuthIdentity`, **and** fix `isBetterAuthEnabled` mock from `false` to `true`. Better Auth is the actual current default (`packages/auth-client/src/config.ts` + its test suite), so the stale `false` mock was bypassing `ProtectedAuthGate` entirely instead of exercising it. Removed the now-inert `NEXT_PUBLIC_BETTER_AUTH_ENABLED` env var hack and its `afterEach` cleanup.
- `packages/hooks/data/tags/use-tags/use-tags.test.ts` — retarget mock to `useAuthIdentity`
- `packages/hooks/automation/use-workflow-builder/use-workflow-builder.test.ts` — retarget mock to `useAuthIdentity`, add `getBetterAuthToken` mock (same `resolveAuthToken` gap as onboarding)
- `packages/services/core/commands.registry.test.ts` — unrelated to auth. A new `nav-moodboard` navigation command was legitimately added to `createNavigationCommands`, making the hardcoded navigation command count of 7 stale. Updated assertion to 8.

## Test plan

- [x] Read each test + the source it exercises to confirm root cause before editing (no blind edits)
- [x] Verified via static reasoning against `bunx vitest run` static analysis (deps not installable in this environment) that mocked shapes now match actual `AuthIdentity`/`resolveAuthToken` contracts
- [x] Pre-commit hooks passed: secretlint, biome, raw-html lint
- [ ] CI "Test Packages" job green on this PR