### PR TITLE
fix(ci): skip gitleaks on release events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: trust
-    if: needs.trust.outputs.is-trusted == 'true'
+    # gitleaks-action does not support the `release` event ("The [release] event is
+    # not yet supported") and hard-fails on it. Release-triggered runs (self-hosted
+    # publish) skip it — the same commit was already secret-scanned on push to master.
+    if: needs.trust.outputs.is-trusted == 'true' && github.event_name != 'release'
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
`gitleaks-action` hard-fails on the `release` event ('The [release] event is not yet supported'), blocking the self-hosted docker-publish **Full Suite pre-publish gate** on every release (v0.4.0/v0.4.1). Not a real leak — an action limitation.

Fix: gate the gitleaks job with `github.event_name != 'release'`. The commit is already secret-scanned on push to master, so release-triggered runs (self-hosted publish) safely skip it. Unblocks self-hosted image publishing.