### PR TITLE
fix(ui): green @genfeedai/ui specs blocking the production deploy gate

### DIFF
--- a/packages/ui/src/components/command-palette/command-palette-initializer/CommandPaletteInitializer.test.tsx
+++ b/packages/ui/src/components/command-palette/command-palette-initializer/CommandPaletteInitializer.test.tsx
@@ -1,5 +1,3 @@
-import { useUser } from '@genfeedai/auth-client/react';
-import { getAuthPublicData } from '@genfeedai/helpers/auth/auth.helper';
 import { useAdminCommandRegistration } from '@genfeedai/hooks/commands/use-admin-command-registration/use-admin-command-registration';
 import { useDefaultCommandsRegistration } from '@genfeedai/hooks/commands/use-default-commands-registration/use-default-commands-registration';
 import { useCommandPalette } from '@genfeedai/hooks/ui/use-command-palette/use-command-palette';
@@ -7,13 +5,14 @@ import { render } from '@testing-library/react';
 import { CommandPaletteInitializer } from '@ui/command-palette/command-palette-initializer/CommandPaletteInitializer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useUser: vi.fn(),
-}));
+const useAccessStateMock = vi.fn();
 
-vi.mock('@genfeedai/helpers/auth/auth.helper', () => ({
-  getAuthPublicData: vi.fn(),
-}));
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => useAccessStateMock(),
+  }),
+);
 
 vi.mock('@genfeedai/hooks/ui/use-command-palette/use-command-palette', () => ({
   useCommandPalette: vi.fn(),
@@ -33,8 +32,6 @@ vi.mock(
   }),
 );
 
-const useUserMock = vi.mocked(useUser);
-const getAuthPublicDataMock = vi.mocked(getAuthPublicData);
 const useCommandPaletteMock = vi.mocked(useCommandPalette);
 const useDefaultCommandsRegistrationMock = vi.mocked(
   useDefaultCommandsRegistration,
@@ -43,8 +40,17 @@ const useAdminCommandRegistrationMock = vi.mocked(useAdminCommandRegistration);
 
 describe('CommandPaletteInitializer', () => {
   beforeEach(() => {
-    useUserMock.mockReturnValue({ isLoaded: true, user: { id: 'user' } });
-    getAuthPublicDataMock.mockReturnValue({ isSuperAdmin: true });
+    useAccessStateMock.mockReturnValue({
+      accessState: null,
+      canAccessApp: true,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: true,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    });
     useCommandPaletteMock.mockReturnValue({
       registerCommand: vi.fn(),
       unregisterCommand: vi.fn(),
@@ -64,7 +70,17 @@ describe('CommandPaletteInitializer', () => {
   });
 
   it('handles non super admin users', () => {
-    getAuthPublicDataMock.mockReturnValue({ isSuperAdmin: false });
+    useAccessStateMock.mockReturnValue({
+      accessState: null,
+      canAccessApp: false,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: false,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    });
     render(<CommandPaletteInitializer />);
 
     expect(useAdminCommandRegistrationMock).toHaveBeenCalledWith(

--- a/packages/ui/src/components/guards/onboarding/OnboardingGuard.test.tsx
+++ b/packages/ui/src/components/guards/onboarding/OnboardingGuard.test.tsx
@@ -20,9 +20,9 @@ vi.mock('@genfeedai/contexts/user/user-context/user-context', () => ({
   useCurrentUser: () => useCurrentUserMock(),
 }));
 
-const useAuthMock = vi.fn();
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => useAuthMock(),
+const useAuthIdentityMock = vi.fn();
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => useAuthIdentityMock(),
 }));
 
 const useAccessStateMock = vi.fn();
@@ -43,9 +43,13 @@ describe('OnboardingGuard', () => {
     process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'pk_test_fake';
     delete process.env.NEXT_PUBLIC_GENFEED_LICENSE_KEY;
     pathnameMock.mockReturnValue('/dashboard');
-    useAuthMock.mockReturnValue({
+    useAuthIdentityMock.mockReturnValue({
+      getToken: vi.fn(),
       isLoaded: true,
       isSignedIn: true,
+      orgId: null,
+      sessionId: 'session_1',
+      userId: 'user_1',
     });
   });
 
@@ -176,9 +180,13 @@ describe('OnboardingGuard', () => {
   });
 
   it('should redirect unsigned users to login', async () => {
-    useAuthMock.mockReturnValue({
+    useAuthIdentityMock.mockReturnValue({
+      getToken: vi.fn(),
       isLoaded: true,
       isSignedIn: false,
+      orgId: null,
+      sessionId: null,
+      userId: null,
     });
     useCurrentUserMock.mockReturnValue({
       currentUser: null,

--- a/packages/ui/src/components/layouts/app/AppLayout.test.tsx
+++ b/packages/ui/src/components/layouts/app/AppLayout.test.tsx
@@ -132,7 +132,7 @@ describe('AppLayout', () => {
   });
 
   it('collapses the desktop sidebar to only the Genfeed logo toggle', async () => {
-    window.localStorage.setItem('genfeed:sidebar:collapsed:anon', 'true');
+    window.localStorage.setItem('genfeed:sidebar:collapsed:auth', 'true');
 
     render(
       <AppLayout menuComponent={<MenuComponent />}>

--- a/packages/ui/src/components/menus/switchers/MenuAppSwitcher.test.tsx
+++ b/packages/ui/src/components/menus/switchers/MenuAppSwitcher.test.tsx
@@ -1,6 +1,23 @@
 import { render } from '@testing-library/react';
 import MenuAppSwitcher from '@ui/menus/switchers/MenuAppSwitcher';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => ({
+      accessState: null,
+      canAccessApp: true,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: false,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    }),
+  }),
+);
 
 describe('MenuAppSwitcher', () => {
   it('should render without crashing', () => {

--- a/packages/ui/src/components/modals/elements/blacklist/ModalBlacklist.test.tsx
+++ b/packages/ui/src/components/modals/elements/blacklist/ModalBlacklist.test.tsx
@@ -7,17 +7,21 @@ vi.mock('@ui/modals/modal/Modal', () => ({
   default: ({ children }: any) => <div data-testid="modal">{children}</div>,
 }));
 
-vi.mock('@genfeedai/hooks/ui/use-crud-modal', () => ({
+vi.mock('@genfeedai/hooks/ui/use-crud-modal/use-crud-modal', () => ({
   useCrudModal: () => ({
+    closeModal: vi.fn(),
     form: {
-      formState: { errors: {} },
+      control: {},
+      formState: { errors: {}, isValid: false },
       handleSubmit: vi.fn((fn) => fn),
       register: vi.fn(),
       setValue: vi.fn(),
       watch: vi.fn(() => ''),
     },
+    formRef: { current: null },
     handleDelete: vi.fn(),
     isSubmitting: false,
+    onSubmit: vi.fn(),
   }),
 }));
 
@@ -35,6 +39,59 @@ vi.mock('@genfeedai/auth-client/react', () => ({
       publicMetadata: {},
     },
   }),
+}));
+
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => ({
+      accessState: null,
+      canAccessApp: true,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: false,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    }),
+  }),
+);
+
+vi.mock('@ui/modals/actions/ModalActions', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: (props: { name?: string }) => (
+    <input data-testid={`input-${props.name ?? 'unknown'}`} />
+  ),
+}));
+
+vi.mock('@ui/primitives/select', () => ({
+  SelectField: (props: { name?: string }) => (
+    <select data-testid={`select-${props.name ?? 'unknown'}`} />
+  ),
+}));
+
+vi.mock('@ui/primitives/checkbox', () => ({
+  Checkbox: (props: { name?: string }) => (
+    <input
+      type="checkbox"
+      data-testid={`checkbox-${props.name ?? 'unknown'}`}
+    />
+  ),
+}));
+
+vi.mock('@ui/primitives/field', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({ label, onClick }: { label?: string; onClick?: () => void }) => (
+    <button onClick={onClick}>{label}</button>
+  ),
+  buttonVariants: () => '',
 }));
 
 describe('ModalBlacklist', () => {

--- a/packages/ui/src/components/modals/elements/mood/ModalMood.test.tsx
+++ b/packages/ui/src/components/modals/elements/mood/ModalMood.test.tsx
@@ -39,6 +39,23 @@ vi.mock('@genfeedai/helpers/auth/auth.helper', () => ({
   getAuthPublicData: () => ({ isSuperAdmin: false }),
 }));
 
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => ({
+      accessState: null,
+      canAccessApp: true,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: false,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    }),
+  }),
+);
+
 vi.mock('@ui/modals/actions/ModalActions', () => ({
   default: ({ children }: any) => <div>{children}</div>,
 }));

--- a/packages/ui/src/components/modals/elements/scene/ModalScene.test.tsx
+++ b/packages/ui/src/components/modals/elements/scene/ModalScene.test.tsx
@@ -39,6 +39,23 @@ vi.mock('@genfeedai/helpers/auth/auth.helper', () => ({
   getAuthPublicData: () => ({ isSuperAdmin: false }),
 }));
 
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => ({
+      accessState: null,
+      canAccessApp: true,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: false,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    }),
+  }),
+);
+
 vi.mock('@ui/modals/actions/ModalActions', () => ({
   default: ({ children }: any) => <div>{children}</div>,
 }));

--- a/packages/ui/src/components/modals/elements/sound/ModalSound.test.tsx
+++ b/packages/ui/src/components/modals/elements/sound/ModalSound.test.tsx
@@ -39,6 +39,23 @@ vi.mock('@genfeedai/helpers/auth/auth.helper', () => ({
   getAuthPublicData: () => ({ isSuperAdmin: false }),
 }));
 
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    useAccessState: () => ({
+      accessState: null,
+      canAccessApp: true,
+      hasPaygCredits: false,
+      isByok: false,
+      isLoading: false,
+      isSubscribed: false,
+      isSuperAdmin: false,
+      needsOnboarding: false,
+      refreshAccessState: vi.fn(),
+    }),
+  }),
+);
+
 vi.mock('@ui/modals/actions/ModalActions', () => ({
   default: ({ children }: any) => <div>{children}</div>,
 }));

--- a/packages/ui/src/components/topbars/end/TopbarEnd.test.tsx
+++ b/packages/ui/src/components/topbars/end/TopbarEnd.test.tsx
@@ -18,10 +18,44 @@ vi.mock('@genfeedai/auth-client/react', () => ({
   }),
 }));
 
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({
+    getToken: vi.fn().mockResolvedValue('mock-token'),
+    isLoaded: true,
+    isSignedIn: true,
+    orgId: 'org_test123',
+    sessionId: 'sess_test123',
+    userId: 'user_test',
+  }),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-user/use-auth-user', () => ({
+  useAuthUser: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    user: {
+      firstName: 'Test',
+      fullName: 'Test User',
+      id: 'user_test',
+      imageUrl: null,
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+      publicMetadata: {},
+      reload: vi.fn(),
+      updatedAt: null,
+    },
+  }),
+}));
+
 vi.mock('@ui/menus/user-dropdown/UserDropdown', () => ({
   default: (props: Record<string, unknown>) => {
     userDropdownSpy(props);
-    return <div data-testid="topbar-user-settings" />;
+    return (
+      <>
+        <div data-testid="topbar-user-button" />
+        <div data-testid="topbar-user-settings" />
+      </>
+    );
   },
 }));
 


### PR DESCRIPTION
## What

9 `@genfeedai/ui` component specs (15 tests) fail in the **full** package suite. The production deploy QA gate runs the full suite; normal master-push CI skips Test Packages via changed-scope, so this red was masked — the v0.4.1 deploy (run 28514741393) passed the API/Build/E2E gates but failed here.

**Root cause:** the components consume the `AccessStateProvider` context / migrated Better Auth hooks, but the tests render without the matching mocks (12/15 threw `useAccessState must be used within an AccessStateProvider`; the rest were downstream).

## Fix (one class, per-file)
- Mock `useAccessState` at its real path (`@genfeedai/contexts/providers/access-state/access-state.provider`) returning a complete `AccessStateContextValue`, with per-test values where the component branches on `isSuperAdmin` / `needsOnboarding` / `canAccessApp`: **ModalSound, ModalScene, ModalMood, ModalBlacklist, MenuAppSwitcher, CommandPaletteInitializer**.
- **OnboardingGuard**: mock `useAuthIdentity` at its real path instead of the stale `@genfeedai/auth-client/react` `useAuth` — the 4 tests fell through to real Better Auth state and always redirected to `/login`.
- **TopbarEnd**: mock `useAuthIdentity`/`useAuthUser` so the signed-in guard passes and `UserDropdown` renders.
- **AppLayout**: seed the sidebar-collapsed storage key the component actually reads in jsdom (`:auth` — `getSidebarCollapsedStorageKey()` returns `:auth` whenever `window` is defined; the old `:anon` seed was never read). No source or assertions changed.

## Verification
- All 9 files: **33 passed**.
- Full `@genfeedai/ui` project (gate scope): **1870 passed, 0 failures** (293 files).

Unblocks the v0.4.1 production deploy gate (Test Packages). Follow-up to #1040.