### PR TITLE
fix(app): label studio shell section "Studio"; refresh stale E2E shell contracts

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -116,7 +116,7 @@ export default function AppProtectedLayoutSidebar({
           taskContextSearchParams,
         )}
         currentApp={currentApp}
-        sectionLabel="Library"
+        sectionLabel="Studio"
         shellChromeVariant={shellChromeVariant}
       />
     );

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -823,7 +823,7 @@ describe('AppProtectedLayout', () => {
 
     expect(appSidebarSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        sectionLabel: 'Library',
+        sectionLabel: 'Studio',
         shellChromeVariant: 'default',
       }),
     );

--- a/playwright/e2e/tests/core/content-loop.spec.ts
+++ b/playwright/e2e/tests/core/content-loop.spec.ts
@@ -56,8 +56,10 @@ test.describe('Core Content Loop', () => {
     await overviewPage.goto('/workspace/overview');
 
     await expect(overviewPage.mainContent).toBeVisible();
+    // The page h1 is "Dashboard" (level 1); the "Workspace" qualifier now lives in
+    // the breadcrumb navigation, not the heading.
     await expect(
-      authenticatedPage.getByRole('heading', { name: 'Workspace Dashboard' }),
+      authenticatedPage.getByRole('heading', { level: 1, name: 'Dashboard' }),
     ).toBeVisible();
     await expect(
       authenticatedPage.getByRole('heading', { name: 'Operator tools' }),

--- a/playwright/e2e/tests/core/modal-cleanup.spec.ts
+++ b/playwright/e2e/tests/core/modal-cleanup.spec.ts
@@ -54,8 +54,9 @@ test.describe('Modal cleanup', () => {
     authenticatedPage,
   }) => {
     await authenticatedPage.goto('/workspace/overview');
+    // Page h1 is "Dashboard" (level 1); "Workspace" now lives in the breadcrumb.
     await expect(
-      authenticatedPage.getByRole('heading', { name: 'Workspace Dashboard' }),
+      authenticatedPage.getByRole('heading', { level: 1, name: 'Dashboard' }),
     ).toBeVisible();
 
     await setStaleModalGlobalState(authenticatedPage);

--- a/playwright/e2e/tests/shell/page-context-contract.spec.ts
+++ b/playwright/e2e/tests/shell/page-context-contract.spec.ts
@@ -36,7 +36,10 @@ const CONTRACTS: PageContextContract[] = [
     route: `${BRAND_BASE}/studio/image`,
     currentApp: 'studio',
     sectionLabel: 'Studio',
-    sidebarLabels: ['Library', 'Image', 'Video', 'Batch'],
+    // Studio nav lists generation types (Image/Video/Avatar/Music/Batch). The old
+    // 'Library' entry only matched the section-header text back when the studio
+    // shell mislabeled its section 'Library'; that header is now 'Studio'.
+    sidebarLabels: ['Image', 'Video', 'Batch'],
   },
   {
     route: `${BRAND_BASE}/posts/scheduled`,


### PR DESCRIPTION
## What

The production deploy gate's **full E2E suite** — running to completion for the first time after the earlier gate layers (#1040 Test API, #1042 Test Packages) were fixed — surfaced 3 deterministic `[app-core]` failures (retries=2 exhausted, so real).

### Real bug (source fix)
`AppProtectedLayoutSidebar` rendered the **studio** route's sidebar with `sectionLabel="Library"` — copy-pasted from the library branch — even though it uses `studioMenuItems`. So the studio shell's section header read "Library". Set it to **"Studio"**. The `page-context-contract` E2E encoded the correct intent (studio → "Studio") and caught this; a **unit test had pinned the wrong value** (`'Library'`) — updated to `'Studio'`.

### Stale test expectations (app was correct; specs lagged UI refactors)
Confirmed via the CI failure screenshots + a11y snapshots — the pages render correctly:
- **content-loop / modal-cleanup**: asserted a heading `"Workspace Dashboard"`; the page `h1` is now `"Dashboard"` (the "Workspace" qualifier moved to the breadcrumb). All other assertions (Operator tools, Studio Image, Workflows, Open Inbox) already pass.
- **page-context-contract studio**: `sidebarLabels` listed `"Library"`, which only ever matched the *mislabeled* section header; the real studio nav is Image/Video/Avatar/Music/Batch. Assert Image/Video/Batch.

## Verification (local, single worker)
- All 3 originally-failing tests pass.
- All **5** page-context contracts pass (workspace, library, studio, posts, workflows) — studio fix doesn't regress others.
- `app-protected-layout` unit suite green (24 passed).

Unblocks the v0.4.1 production deploy gate (E2E Suite). Follow-up to #1040, #1042.