### PR TITLE
Consolidate video output path guard

### DIFF
--- a/apps/server/api/src/collections/videos/controllers/captions/videos-captions.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/captions/videos-captions.controller.ts
@@ -6,6 +6,7 @@ import { MetadataEntity } from '@api/collections/metadata/entities/metadata.enti
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { CreateVideoWithCaptionsDto } from '@api/collections/videos/dto/create-video.dto';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { requireVideoOutputPath } from '@api/collections/videos/utils/video-processing-result.util';
 import { ConfigService } from '@api/config/config.service';
 import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
@@ -82,14 +83,6 @@ export class VideosCaptionsController {
     private readonly videosService: VideosService,
     private readonly websocketService: NotificationsPublisherService,
   ) {}
-
-  private requireOutputPath(value: unknown): string {
-    if (typeof value !== 'string' || value.length === 0) {
-      throw new Error('Video processing result missing outputPath');
-    }
-
-    return value;
-  }
 
   @Get(':videoId/captions')
   @Cache({
@@ -201,7 +194,7 @@ export class VideosCaptionsController {
       })
       .then(async (job) => {
         const result = await this.fileQueueService.waitForJob(job.jobId, 60000);
-        const output = this.requireOutputPath(result.outputPath);
+        const output = requireVideoOutputPath(result.outputPath);
         const ingredientId = String(ingredientData._id);
 
         this.filesClientService

--- a/apps/server/api/src/collections/videos/controllers/relationships/videos-relationships.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/relationships/videos-relationships.controller.ts
@@ -20,6 +20,7 @@ import { CreateMergedVideoDto } from '@api/collections/videos/dto/create-video.d
 import { VideosQueryDto } from '@api/collections/videos/dto/videos-query.dto';
 import type { Video } from '@api/collections/videos/schemas/video.schema';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { requireVideoOutputPath } from '@api/collections/videos/utils/video-processing-result.util';
 import { ConfigService } from '@api/config/config.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
@@ -96,14 +97,6 @@ export class VideosRelationshipsController {
     private readonly websocketService: NotificationsPublisherService,
     private readonly whisperService: WhisperService,
   ) {}
-
-  private requireOutputPath(value: unknown): string {
-    if (typeof value !== 'string' || value.length === 0) {
-      throw new Error('Video processing result missing outputPath');
-    }
-
-    return value;
-  }
 
   @Get(':videoId/children')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
@@ -274,7 +267,7 @@ export class VideosRelationshipsController {
           job.jobId,
           300_000,
         );
-        let output = this.requireOutputPath(result.outputPath);
+        let output = requireVideoOutputPath(result.outputPath);
 
         if (isResizeEnabled) {
           // Queue portrait conversion in files.genfeed service
@@ -296,7 +289,7 @@ export class VideosRelationshipsController {
             portraitJob.jobId,
             180000, // 3 minutes for portrait conversion
           );
-          output = this.requireOutputPath(result.outputPath);
+          output = requireVideoOutputPath(result.outputPath);
         }
 
         // Upload to S3 the first version of the video
@@ -344,7 +337,7 @@ export class VideosRelationshipsController {
               captionsJob.jobId,
               180000, // 3 minutes for adding captions
             );
-            output = this.requireOutputPath(result.outputPath);
+            output = requireVideoOutputPath(result.outputPath);
           } catch (error: unknown) {
             this.loggerService.error(
               `Failed to generate or add captions for merged video ${ingredientId}`,

--- a/apps/server/api/src/collections/videos/controllers/transformations/edits/videos-edits.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/transformations/edits/videos-edits.controller.ts
@@ -3,6 +3,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { requireVideoOutputPath } from '@api/collections/videos/utils/video-processing-result.util';
 import { ConfigService } from '@api/config/config.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
@@ -60,14 +61,6 @@ export class VideosEditsController {
     private readonly videosService: VideosService,
     private readonly websocketService: NotificationsPublisherService,
   ) {}
-
-  private requireOutputPath(value: unknown): string {
-    if (typeof value !== 'string' || value.length === 0) {
-      throw new Error('Video processing result missing outputPath');
-    }
-
-    return value;
-  }
 
   @Post(':videoId/trim')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
@@ -136,7 +129,7 @@ export class VideosEditsController {
             job.jobId,
             60000,
           );
-          const output = this.requireOutputPath(result.outputPath);
+          const output = requireVideoOutputPath(result.outputPath);
           const meta = await this.filesClientService.uploadToS3(
             ingredientData._id,
             `videos`,
@@ -277,7 +270,7 @@ export class VideosEditsController {
             job.jobId,
             60000,
           );
-          const output = this.requireOutputPath(result.outputPath);
+          const output = requireVideoOutputPath(result.outputPath);
           const meta = await this.filesClientService.uploadToS3(
             ingredientData._id,
             `videos`,

--- a/apps/server/api/src/collections/videos/controllers/transformations/resize/videos-resize.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/transformations/resize/videos-resize.controller.ts
@@ -3,6 +3,7 @@ import { IngredientsService } from '@api/collections/ingredients/services/ingred
 import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { requireVideoOutputPath } from '@api/collections/videos/utils/video-processing-result.util';
 import { ConfigService } from '@api/config/config.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
@@ -51,14 +52,6 @@ export class VideosResizeController {
     private readonly videosService: VideosService,
     private readonly websocketService: NotificationsPublisherService,
   ) {}
-
-  private requireOutputPath(value: unknown): string {
-    if (typeof value !== 'string' || value.length === 0) {
-      throw new Error('Video processing result missing outputPath');
-    }
-
-    return value;
-  }
 
   @Post(':videoId/resize')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
@@ -111,7 +104,7 @@ export class VideosResizeController {
       })
       .then(async (job) => {
         const result = await this.fileQueueService.waitForJob(job.jobId, 60000);
-        const output = this.requireOutputPath(result.outputPath);
+        const output = requireVideoOutputPath(result.outputPath);
         const ingredientId = String(ingredientData._id);
 
         return this.filesClientService
@@ -186,7 +179,7 @@ export class VideosResizeController {
       })
       .then(async (job) => {
         const result = await this.fileQueueService.waitForJob(job.jobId, 60000);
-        const output = this.requireOutputPath(result.outputPath);
+        const output = requireVideoOutputPath(result.outputPath);
         const meta = await this.filesClientService.uploadToS3(
           ingredientData._id,
           `videos`,

--- a/apps/server/api/src/collections/videos/utils/video-processing-result.util.spec.ts
+++ b/apps/server/api/src/collections/videos/utils/video-processing-result.util.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { requireVideoOutputPath } from './video-processing-result.util';
+
+describe('requireVideoOutputPath', () => {
+  it('returns a non-empty output path', () => {
+    expect(requireVideoOutputPath('/tmp/video.mp4')).toBe('/tmp/video.mp4');
+  });
+
+  it.each([
+    [''],
+    [null],
+    [undefined],
+    [123],
+    [{}],
+  ])('rejects %p as a missing output path', (value) => {
+    expect(() => requireVideoOutputPath(value)).toThrow(
+      'Video processing result missing outputPath',
+    );
+  });
+});

--- a/apps/server/api/src/collections/videos/utils/video-processing-result.util.ts
+++ b/apps/server/api/src/collections/videos/utils/video-processing-result.util.ts
@@ -1,0 +1,7 @@
+export function requireVideoOutputPath(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error('Video processing result missing outputPath');
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary

Closes #1046.

- Extracts the duplicated non-empty video output path guard into `requireVideoOutputPath`.
- Replaces the four identical private controller helpers in captions, relationships, edits, and resize controllers.
- Leaves the effects controller helper out of scope because it has different empty-string behavior and a different error message.

## Refactor Fit

This is a bounded behavior-preserving DRY cleanup selected from the fallback structural/code-quality scan because the existing `code-quality` issue queue was In Progress, Human Review, or Deferred. The shared helper has four real callers and preserves the existing `Video processing result missing outputPath` error surface.

Skills/rubric used: `ultracode`, `refactor-code`, `structural-review`, `de-slop`, `typescript-refactor`.

## Validation

- `bunx biome check --write apps/server/api/src/collections/videos/controllers/captions/videos-captions.controller.ts apps/server/api/src/collections/videos/controllers/relationships/videos-relationships.controller.ts apps/server/api/src/collections/videos/controllers/transformations/edits/videos-edits.controller.ts apps/server/api/src/collections/videos/controllers/transformations/resize/videos-resize.controller.ts apps/server/api/src/collections/videos/utils/video-processing-result.util.ts apps/server/api/src/collections/videos/utils/video-processing-result.util.spec.ts`
- `bun run test:file -- src/collections/videos/utils/video-processing-result.util.spec.ts src/collections/videos/controllers/transformations/resize/videos-resize.controller.spec.ts src/collections/videos/controllers/transformations/edits/videos-edits.controller.spec.ts src/collections/videos/controllers/captions/videos-captions.controller.spec.ts src/collections/videos/controllers/relationships/videos-relationships.controller.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/collections/videos/controllers/captions/videos-captions.controller.ts apps/server/api/src/collections/videos/controllers/relationships/videos-relationships.controller.ts apps/server/api/src/collections/videos/controllers/transformations/edits/videos-edits.controller.ts apps/server/api/src/collections/videos/controllers/transformations/resize/videos-resize.controller.ts apps/server/api/src/collections/videos/utils/video-processing-result.util.ts apps/server/api/src/collections/videos/utils/video-processing-result.util.spec.ts`
- `bun run lint-staged`

Note: the first API type-check attempt hit a stale local TypeScript project-reference artifact where `packages/enums` had `tsconfig.tsbuildinfo` but no `dist/`. I forced local `enums`/`constants` project-reference builds and reran the same API type-check successfully; no generated dist files are part of this PR.

## Structural Review

No blocker or request-change findings in the changed diff. The new helper earns its keep through four identical call sites, adds one narrow runtime guard around an `unknown` file-queue result boundary, and does not introduce package-boundary movement, public API changes, casts, branching, or broader controller decomposition.