### PR TITLE
fix(api): address Sentry analytics and ad insights errors

### DIFF
--- a/apps/server/api/src/endpoints/analytics/analytics.controller.spec.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.controller.spec.ts
@@ -30,7 +30,7 @@ import { InstagramService } from '@api/services/integrations/instagram/services/
 import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok.service';
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
-import { IngredientCategory } from '@genfeedai/enums';
+import { BotStatus, IngredientCategory } from '@genfeedai/enums';
 import {
   type ISubscriptionsService,
   SUBSCRIPTIONS_SERVICE,
@@ -58,6 +58,7 @@ describe('AnalyticsController', () => {
   let analyticsExportService: vi.Mocked<AnalyticsExportService>;
   let entityLeaderboardService: vi.Mocked<EntityLeaderboardService>;
   let businessAnalyticsService: vi.Mocked<BusinessAnalyticsService>;
+  let botsService: vi.Mocked<BotsService>;
   let brandsService: vi.Mocked<BrandsService>;
   let ingredientsService: vi.Mocked<IngredientsService>;
   let postsService: vi.Mocked<PostsService>;
@@ -116,6 +117,11 @@ describe('AnalyticsController', () => {
     brandsService = {
       findAll: vi.fn(),
     } as unknown as vi.Mocked<BrandsService>;
+    botsService = {
+      find: vi.fn().mockResolvedValue([]),
+      findAll: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+      findOne: vi.fn(),
+    } as unknown as vi.Mocked<BotsService>;
     postsService = {
       findAll: vi.fn(),
     } as unknown as vi.Mocked<PostsService>;
@@ -160,11 +166,7 @@ describe('AnalyticsController', () => {
         },
         {
           provide: BotsService,
-          useValue: {
-            find: vi.fn().mockResolvedValue([]),
-            findAll: vi.fn().mockResolvedValue({ data: [], total: 0 }),
-            findOne: vi.fn(),
-          },
+          useValue: botsService,
         },
         {
           provide: CreditTransactionsService,
@@ -262,6 +264,25 @@ describe('AnalyticsController', () => {
         where: { category: 'IMAGE' },
       });
       expect(result).toBeDefined();
+    });
+
+    it('counts active bots with the Bot.status column, not the removed enabled field', async () => {
+      const query = {} as unknown as BaseQueryDto;
+
+      await controller.findAll(mockRequest, query);
+
+      expect(botsService.findAll).toHaveBeenCalledWith(
+        {
+          where: {
+            isDeleted: false,
+            status: BotStatus.ACTIVE,
+          },
+        },
+        expect.any(Object),
+      );
+      expect(botsService.findAll.mock.calls[0][0].where).not.toHaveProperty(
+        'enabled',
+      );
     });
   });
 

--- a/apps/server/api/src/endpoints/analytics/analytics.controller.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.controller.ts
@@ -48,6 +48,7 @@ import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
 import {
+  BotStatus,
   CredentialPlatform,
   IngredientCategory,
   PostStatus,
@@ -220,7 +221,7 @@ export class AnalyticsController {
         options,
       ),
       this.botsService.findAll(
-        { where: { enabled: true, isDeleted: false } },
+        { where: { isDeleted: false, status: BotStatus.ACTIVE } },
         options,
       ),
       this.modelsService.findAll({ where: { isDeleted: false } }, options),

--- a/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts
@@ -124,18 +124,18 @@ describe('AdInsightsAggregationProcessor', () => {
     );
   });
 
-  it('rejects missing aggregation scope', async () => {
+  it('processes legacy jobs with missing aggregation scope as platform scope', async () => {
     const job = makeJob({
       insightTypes: ['ctr'],
     } as AdInsightsAggregationJobData);
 
-    await expect(processor.process(job)).rejects.toThrow(
-      'Unsupported ad insights aggregation scope: undefined',
+    await expect(processor.process(job)).resolves.toBeUndefined();
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'platform ad insights aggregation for window legacy',
+      ),
     );
-    expect(loggerService.error).toHaveBeenCalledWith(
-      'Ad insights aggregation failed',
-      'Unsupported ad insights aggregation scope: undefined',
-    );
+    expect(job.updateProgress).toHaveBeenCalledWith(100);
   });
 
   it('should log error and re-throw if a top-level exception occurs', async () => {

--- a/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts
@@ -17,7 +17,11 @@ export class AdInsightsAggregationProcessor extends WorkerHost {
   }
 
   async process(job: Job<AdInsightsAggregationJobData>): Promise<void> {
-    const { aggregationWindow = 'legacy', insightTypes, scope } = job.data;
+    const {
+      aggregationWindow = 'legacy',
+      insightTypes,
+      scope = AD_INSIGHTS_PLATFORM_SCOPE,
+    } = job.data;
 
     try {
       if (scope !== AD_INSIGHTS_PLATFORM_SCOPE) {


### PR DESCRIPTION
## Summary
- Fixes `API-GENFEED-AI-6D` on `GET /v1/analytics` by counting active bots with the Prisma `Bot.status` column instead of the removed `enabled` field.
- Fixes `API-GENFEED-AI-69` in `AdInsightsAggregationProcessor.process(main)` by treating missing legacy ad-insights job scope as platform scope while still rejecting explicit unsupported scopes.

## Sentry Evidence
- `API-GENFEED-AI-6D`: `PrismaClientValidationError`, release `1.0.0`, environment `production`, route `GET /v1/analytics`, latest event queried `prisma.bot.findMany({ where: { enabled: true } })`; `Bot.enabled` is not in the current Prisma schema.
- `API-GENFEED-AI-69`: `BadRequestException: Unsupported ad insights aggregation scope: undefined`, release `1.0.0`, environment `production`, stack in `apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts`.

## Already Fixed On master, Resolved Separately
- `API-GENFEED-AI-6B`: `/v1/avatars` latest event used removed `Ingredient.type`; fixed by `6d20e70c9` / PR #981 using `category: IngredientCategory.AVATAR`.
- `API-GENFEED-AI-5X`: `/v1/musics` latest event used invalid `isDefault: { not: null }`; fixed by `6d20e70c9` / PR #981 using `{ equals: true }`.
- `API-GENFEED-AI-65`: `/v1/public/articles/slug/:slug` latest event queried removed `users.isSuperAdmin`; fixed by `66d7a8125` / PR #950 using explicit `platformRole` projection.
- `API-GENFEED-AI-6C`: `/v1/onboarding/brand-setup` latest event predated `b007fc8bd` / PR #986, which lets Prisma slug-collision errors reach the DB exception filter instead of a generic 500.

## Validation
- `bun run --cwd apps/server/api test:file src/endpoints/analytics/analytics.controller.spec.ts`
- `bun run --cwd apps/server/workers test src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts`
- `bunx biome check --write apps/server/api/src/endpoints/analytics/analytics.controller.ts apps/server/api/src/endpoints/analytics/analytics.controller.spec.ts apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.ts apps/server/workers/src/processors/api/queues/ad-insights-aggregation/ad-insights-aggregation.processor.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers`
- `git diff --check`
- staged secret-pattern scan; commit hook also ran Biome and secretlint

## Not Covered
- `API-GENFEED-AI-6A`, `API-GENFEED-AI-6F`, `API-GENFEED-AI-6E`, `API-GENFEED-AI-68`, and `API-GENFEED-AI-67` are Sentry performance transactions for slow Prisma workflow/workflow_execution primary-key reads. They have no thrown error, request route, or actionable app stack in the latest events, so this PR does not resolve them.
