### PR TITLE
Expose agent MCP controls

### DIFF
--- a/apps/server/mcp/src/services/client.service.spec.ts
+++ b/apps/server/mcp/src/services/client.service.spec.ts
@@ -577,6 +577,157 @@ describe('ClientService (MCP)', () => {
     });
   });
 
+  // ==================== AGENT RUN TESTS ====================
+
+  describe('listAgentRuns', () => {
+    it('should list active agent runs', async () => {
+      const mockResponse = {
+        data: {
+          data: [
+            {
+              attributes: { label: 'Active run', status: 'RUNNING' },
+              id: 'run-1',
+            },
+          ],
+        },
+      };
+
+      (mockAxiosInstance.get as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.listAgentRuns({ active: true, limit: 5 });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/runs/active', {
+        params: { limit: 5 },
+      });
+      expect(result).toEqual([
+        { id: 'run-1', label: 'Active run', status: 'RUNNING' },
+      ]);
+    });
+
+    it('should filter historical agent runs', async () => {
+      const mockResponse = { data: { data: [] } };
+
+      (mockAxiosInstance.get as Mock).mockResolvedValue(mockResponse);
+
+      await service.listAgentRuns({
+        historyOnly: true,
+        limit: 10,
+        q: 'draft',
+        status: 'FAILED',
+      });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/runs', {
+        params: {
+          'page[limit]': 10,
+          historyOnly: true,
+          q: 'draft',
+          status: 'FAILED',
+        },
+      });
+    });
+  });
+
+  describe('getAgentRun', () => {
+    it('should return a single agent run', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            attributes: { label: 'Run detail', status: 'COMPLETED' },
+            id: 'run-1',
+          },
+        },
+      };
+
+      (mockAxiosInstance.get as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.getAgentRun('run-1');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/runs/run-1');
+      expect(result).toEqual({
+        id: 'run-1',
+        label: 'Run detail',
+        status: 'COMPLETED',
+      });
+    });
+  });
+
+  describe('getAgentRunContent', () => {
+    it('should return content produced by a run', async () => {
+      const mockResponse = {
+        data: { ingredients: [], posts: [{ id: 'post-1' }] },
+      };
+
+      (mockAxiosInstance.get as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.getAgentRunContent('run-1');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/runs/run-1/content');
+      expect(result).toEqual({ ingredients: [], posts: [{ id: 'post-1' }] });
+    });
+  });
+
+  describe('cancelAgentRun', () => {
+    it('should cancel an agent run', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            attributes: { status: 'CANCELLED' },
+            id: 'run-1',
+          },
+        },
+      };
+
+      (mockAxiosInstance.post as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.cancelAgentRun('run-1');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/runs/run-1/cancellations',
+      );
+      expect(result).toEqual({ id: 'run-1', status: 'CANCELLED' });
+    });
+  });
+
+  describe('retryAgentRun', () => {
+    it('retries a run by sending a follow-up message to its thread', async () => {
+      (mockAxiosInstance.get as Mock).mockResolvedValueOnce({
+        data: {
+          data: {
+            attributes: { metadata: { threadId: 'thread-1' } },
+            id: 'run-1',
+          },
+        },
+      });
+      (mockAxiosInstance.post as Mock).mockResolvedValueOnce({
+        data: { data: { id: 'turn-1' } },
+      });
+
+      const result = await service.retryAgentRun('run-1', 'Retry this run');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/runs/run-1');
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/threads/thread-1/messages',
+        { content: 'Retry this run' },
+      );
+      expect(result).toEqual({ id: 'turn-1' });
+    });
+
+    it('rejects retry when the run has no persisted thread', async () => {
+      (mockAxiosInstance.get as Mock).mockResolvedValueOnce({
+        data: {
+          data: {
+            attributes: { status: 'FAILED' },
+            id: 'run-1',
+          },
+        },
+      });
+
+      await expect(service.retryAgentRun('run-1')).rejects.toThrow(
+        'Agent run has no persisted thread to retry',
+      );
+    });
+  });
+
   // ==================== WORKFLOW TESTS ====================
 
   describe('createWorkflow', () => {

--- a/apps/server/mcp/src/services/client.service.ts
+++ b/apps/server/mcp/src/services/client.service.ts
@@ -2,7 +2,11 @@ import type { AgentToolResult } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { ConfigService } from '@mcp/config/config.service';
 import { AdsClient } from '@mcp/services/client/ads.client';
-import { AgentClient } from '@mcp/services/client/agent.client';
+import {
+  AgentClient,
+  type AgentRunListParams,
+  type AgentRunResponse,
+} from '@mcp/services/client/agent.client';
 import { AnalyticsClient } from '@mcp/services/client/analytics.client';
 import { BaseApiClient } from '@mcp/services/client/base-api-client';
 import type {
@@ -160,6 +164,22 @@ export class ClientService {
     return this.agent.attachApprovalResult(approvalId, result);
   }
 
+  listAgentRuns(params: AgentRunListParams = {}): Promise<AgentRunResponse[]> {
+    return this.agent.listAgentRuns(params);
+  }
+
+  getAgentRun(runId: string): Promise<AgentRunResponse> {
+    return this.agent.getAgentRun(runId);
+  }
+
+  getAgentRunContent(runId: string): Promise<Record<string, unknown>> {
+    return this.agent.getAgentRunContent(runId);
+  }
+
+  cancelAgentRun(runId: string): Promise<AgentRunResponse> {
+    return this.agent.cancelAgentRun(runId);
+  }
+
   // ── Media (video / image / avatar / music) ──
 
   createVideo(params: VideoCreationParams): Promise<VideoResponse> {
@@ -286,6 +306,49 @@ export class ClientService {
     message: string,
   ): Promise<Record<string, unknown>> {
     return this.workspace.sendChatMessage(threadId, message);
+  }
+
+  async retryAgentRun(
+    runId: string,
+    message?: string,
+  ): Promise<Record<string, unknown>> {
+    const run = await this.getAgentRun(runId);
+    const threadId = this.resolveAgentRunThreadId(run);
+
+    if (!threadId) {
+      throw new Error('Agent run has no persisted thread to retry');
+    }
+
+    const retryMessage =
+      message ??
+      `Retry agent run ${runId}. Continue from the prior run context and explain what changed before taking action.`;
+
+    return this.sendChatMessage(threadId, retryMessage);
+  }
+
+  private resolveAgentRunThreadId(run: AgentRunResponse): string | null {
+    const thread = run.thread;
+    if (typeof thread === 'string' && thread.length > 0) {
+      return thread;
+    }
+
+    if (thread && typeof thread === 'object') {
+      const threadRecord = thread as Record<string, unknown>;
+      const id = threadRecord.id ?? threadRecord._id;
+      if (typeof id === 'string' && id.length > 0) {
+        return id;
+      }
+    }
+
+    const metadata = run.metadata;
+    if (metadata && typeof metadata === 'object') {
+      const threadId = (metadata as Record<string, unknown>).threadId;
+      if (typeof threadId === 'string' && threadId.length > 0) {
+        return threadId;
+      }
+    }
+
+    return null;
   }
 
   // ── Workflows ──

--- a/apps/server/mcp/src/services/client/agent.client.ts
+++ b/apps/server/mcp/src/services/client/agent.client.ts
@@ -4,6 +4,31 @@ import type {
   McpApprovalResource,
 } from '@mcp/shared/interfaces/approval.interface';
 import type { BaseApiClient } from './base-api-client';
+import type { JsonApiResource } from './client.types';
+
+export interface AgentRunListParams {
+  active?: boolean;
+  cursor?: string;
+  historyOnly?: boolean;
+  limit?: number;
+  q?: string;
+  status?: string;
+}
+
+export type AgentRunResponse = Record<string, unknown>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function mapAgentRunResource(resource: JsonApiResource): AgentRunResponse {
+  return {
+    ...asRecord(resource.attributes),
+    id: resource.id ?? asRecord(resource.attributes).id,
+  };
+}
 
 /**
  * Agent-tool proxying and the human-in-the-loop approval lifecycle for mutating
@@ -29,6 +54,82 @@ export class AgentClient {
         return response.data as AgentToolResult;
       },
       this.base.failWithDetail(`Failed to execute ${name}`),
+    );
+  }
+
+  listAgentRuns(params: AgentRunListParams = {}): Promise<AgentRunResponse[]> {
+    const limit = params.limit ?? 20;
+    const endpoint = params.active ? '/runs/active' : '/runs';
+    const queryParams: Record<string, boolean | number | string> = params.active
+      ? { limit }
+      : { 'page[limit]': limit };
+
+    if (params.cursor) {
+      queryParams.cursor = params.cursor;
+    }
+
+    if (!params.active) {
+      if (params.historyOnly !== undefined) {
+        queryParams.historyOnly = params.historyOnly;
+      }
+      if (params.q) {
+        queryParams.q = params.q;
+      }
+      if (params.status) {
+        queryParams.status = params.status;
+      }
+    }
+
+    return this.base.request(
+      'listing agent runs',
+      async (http) => {
+        const response = await http.get(endpoint, { params: queryParams });
+        return this.base
+          .unwrapList<JsonApiResource>(response)
+          .map(mapAgentRunResource);
+      },
+      this.base.failWithDetail('Failed to list agent runs'),
+    );
+  }
+
+  getAgentRun(runId: string): Promise<AgentRunResponse> {
+    return this.base.request(
+      `fetching agent run ${runId}`,
+      async (http) => {
+        const response = await http.get(`/runs/${encodeURIComponent(runId)}`);
+        return mapAgentRunResource(
+          this.base.unwrapData<JsonApiResource>(response),
+        );
+      },
+      this.base.failWithDetail('Failed to fetch agent run'),
+    );
+  }
+
+  getAgentRunContent(runId: string): Promise<Record<string, unknown>> {
+    return this.base.request(
+      `fetching agent run content ${runId}`,
+      async (http) => {
+        const response = await http.get(
+          `/runs/${encodeURIComponent(runId)}/content`,
+        );
+        return this.base.unwrapObject(response);
+      },
+      this.base.failWithDetail('Failed to fetch agent run content'),
+    );
+  }
+
+  cancelAgentRun(runId: string): Promise<AgentRunResponse> {
+    return this.base.request(
+      `cancelling agent run ${runId}`,
+      async (http) => {
+        const response = await http.post(
+          `/runs/${encodeURIComponent(runId)}/cancellations`,
+        );
+        return mapAgentRunResource(
+          this.base.unwrapData<JsonApiResource>(response),
+        );
+      },
+      this.base.failWithDetail('Failed to cancel agent run'),
     );
   }
 

--- a/apps/server/mcp/src/services/tool-registry.service.spec.ts
+++ b/apps/server/mcp/src/services/tool-registry.service.spec.ts
@@ -7,7 +7,32 @@ import { Test, TestingModule } from '@nestjs/testing';
 const MOCK_TOOLS = [
   { name: 'generate_video', requiredRole: undefined, surfaces: { mcp: true } },
   {
+    name: 'cancel_agent_run',
+    requiredRole: undefined,
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'get_agent_run',
+    requiredRole: undefined,
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'get_agent_run_content',
+    requiredRole: undefined,
+    surfaces: { mcp: true },
+  },
+  {
     name: 'get_video_status',
+    requiredRole: undefined,
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'list_agent_runs',
+    requiredRole: undefined,
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'retry_agent_run',
     requiredRole: undefined,
     surfaces: { mcp: true },
   },
@@ -70,15 +95,20 @@ vi.mock('@mcp/guards/mcp-auth.guard', () => ({
 describe('ToolRegistryService', () => {
   let service: ToolRegistryService;
   let clientService: {
+    cancelAgentRun: ReturnType<typeof vi.fn>;
     executeAgentTool: ReturnType<typeof vi.fn>;
+    getAgentRun: ReturnType<typeof vi.fn>;
+    getAgentRunContent: ReturnType<typeof vi.fn>;
     getVideoStatus: ReturnType<typeof vi.fn>;
     listVideos: ReturnType<typeof vi.fn>;
+    listAgentRuns: ReturnType<typeof vi.fn>;
     getVideoAnalytics: ReturnType<typeof vi.fn>;
     listImages: ReturnType<typeof vi.fn>;
     createArticle: ReturnType<typeof vi.fn>;
     createApproval: ReturnType<typeof vi.fn>;
     getWorkflowStatus: ReturnType<typeof vi.fn>;
     getOrganizationAnalytics: ReturnType<typeof vi.fn>;
+    retryAgentRun: ReturnType<typeof vi.fn>;
     setBearerToken: ReturnType<typeof vi.fn>;
   };
   let logger: {
@@ -93,6 +123,10 @@ describe('ToolRegistryService', () => {
         {
           provide: ClientService,
           useValue: {
+            cancelAgentRun: vi.fn().mockResolvedValue({
+              id: 'run-1',
+              status: 'CANCELLED',
+            }),
             createApproval: vi.fn().mockResolvedValue({
               id: 'apr-art-1',
               status: 'PENDING',
@@ -114,6 +148,14 @@ describe('ToolRegistryService', () => {
             getOrganizationAnalytics: vi
               .fn()
               .mockResolvedValue({ totalViews: 9999 }),
+            getAgentRun: vi.fn().mockResolvedValue({
+              id: 'run-1',
+              label: 'Agent run',
+              status: 'RUNNING',
+            }),
+            getAgentRunContent: vi.fn().mockResolvedValue({
+              posts: [{ id: 'post-1' }],
+            }),
             getVideoAnalytics: vi.fn().mockResolvedValue({ views: 1000 }),
             getVideoStatus: vi
               .fn()
@@ -126,9 +168,16 @@ describe('ToolRegistryService', () => {
               steps: [],
             }),
             listImages: vi.fn().mockResolvedValue([]),
+            listAgentRuns: vi
+              .fn()
+              .mockResolvedValue([{ id: 'run-1', status: 'RUNNING' }]),
             listVideos: vi
               .fn()
               .mockResolvedValue([{ id: 'vid-1', title: 'Test' }]),
+            retryAgentRun: vi.fn().mockResolvedValue({
+              runId: 'run-2',
+              threadId: 'thread-1',
+            }),
             setBearerToken: vi.fn(),
           },
         },
@@ -215,6 +264,76 @@ describe('ToolRegistryService', () => {
     expect(
       (result as { content: { text: string }[] }).content[0].text,
     ).toContain('vid-1');
+  });
+
+  it('handleToolCall list_agent_runs returns bounded agent runs', async () => {
+    const result = await service.handleToolCall({
+      arguments: { active: true, limit: 5 },
+      name: 'list_agent_runs',
+    });
+
+    expect(clientService.listAgentRuns).toHaveBeenCalledWith({
+      active: true,
+      cursor: undefined,
+      historyOnly: undefined,
+      limit: 5,
+      q: undefined,
+      status: undefined,
+    });
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('run-1');
+  });
+
+  it('handleToolCall get_agent_run inspects one run', async () => {
+    const result = await service.handleToolCall({
+      arguments: { runId: 'run-1' },
+      name: 'get_agent_run',
+    });
+
+    expect(clientService.getAgentRun).toHaveBeenCalledWith('run-1');
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('Agent run');
+  });
+
+  it('handleToolCall get_agent_run_content returns produced content', async () => {
+    const result = await service.handleToolCall({
+      arguments: { runId: 'run-1' },
+      name: 'get_agent_run_content',
+    });
+
+    expect(clientService.getAgentRunContent).toHaveBeenCalledWith('run-1');
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('post-1');
+  });
+
+  it('handleToolCall cancel_agent_run cancels through the API client', async () => {
+    const result = await service.handleToolCall({
+      arguments: { runId: 'run-1' },
+      name: 'cancel_agent_run',
+    });
+
+    expect(clientService.cancelAgentRun).toHaveBeenCalledWith('run-1');
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('CANCELLED');
+  });
+
+  it('handleToolCall retry_agent_run continues the persisted thread', async () => {
+    const result = await service.handleToolCall({
+      arguments: { message: 'Try again with less scope', runId: 'run-1' },
+      name: 'retry_agent_run',
+    });
+
+    expect(clientService.retryAgentRun).toHaveBeenCalledWith(
+      'run-1',
+      'Try again with less scope',
+    );
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('run-2');
   });
 
   describe('role gating', () => {

--- a/apps/server/mcp/src/services/tool-registry.service.ts
+++ b/apps/server/mcp/src/services/tool-registry.service.ts
@@ -36,6 +36,16 @@ const AGENT_EXECUTOR_TOOL_NAMES: ReadonlySet<string> = new Set<string>(
   Object.values(AgentToolName),
 );
 
+const AGENT_CHAT_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
+  'cancel_agent_run',
+  'create_chat',
+  'get_agent_run',
+  'get_agent_run_content',
+  'list_agent_runs',
+  'retry_agent_run',
+  'send_chat_message',
+]);
+
 /**
  * Mutating MCP tools that must NOT execute immediately — instead they persist a
  * pending approval (human-in-the-loop) and only run once approved. Names are the
@@ -148,6 +158,10 @@ export class ToolRegistryService {
    * and for executing an approved deferred action.
    */
   private async executeTool(name: string, args: Record<string, unknown>) {
+    if (AGENT_CHAT_TOOL_NAMES.has(name)) {
+      return handleAgentChatTool(this.clientService, name, args);
+    }
+
     if (AGENT_EXECUTOR_TOOL_NAMES.has(name)) {
       const result = await this.clientService.executeAgentTool(name, args);
       return this.toMcpResult(result);
@@ -721,10 +735,6 @@ export class ToolRegistryService {
       name === 'get_darkroom_job_status'
     ) {
       return handleDarkroomGenerationTool(this.clientService, name, args);
-    }
-
-    if (['create_chat', 'send_chat_message'].includes(name)) {
-      return handleAgentChatTool(this.clientService, name, args);
     }
 
     if (

--- a/apps/server/mcp/src/tools/agent-chat.tool.ts
+++ b/apps/server/mcp/src/tools/agent-chat.tool.ts
@@ -1,5 +1,56 @@
 import type { ClientService } from '@mcp/services/client.service';
 
+type AgentChatToolResult = Promise<{
+  content: Array<{ text: string; type: 'text' }>;
+}>;
+
+function requiredStringArg(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${key} required`);
+  }
+  return value;
+}
+
+function optionalStringArg(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = args[key];
+  return typeof value === 'string' && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function optionalNumberArg(
+  args: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = args[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function optionalBooleanArg(
+  args: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = args[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function jsonText(label: string, payload: unknown) {
+  return {
+    content: [
+      {
+        text: `${label}:\n\n${JSON.stringify(payload, null, 2)}`,
+        type: 'text' as const,
+      },
+    ],
+  };
+}
+
 export function handleAgentChatTool(
   client: ClientService,
   name: string,
@@ -7,34 +58,50 @@ export function handleAgentChatTool(
 ) {
   const handlers: Record<
     string,
-    (args: Record<string, unknown>) => Promise<{
-      content: Array<{ text: string; type: 'text' }>;
-    }>
+    (args: Record<string, unknown>) => AgentChatToolResult
   > = {
+    cancel_agent_run: async (a) => {
+      const result = await client.cancelAgentRun(requiredStringArg(a, 'runId'));
+      return jsonText('Agent run cancelled', result);
+    },
     create_chat: async () => {
       const chat = await client.createChat();
-      return {
-        content: [
-          {
-            text: `Chat created:\n\n${JSON.stringify(chat, null, 2)}`,
-            type: 'text' as const,
-          },
-        ],
-      };
+      return jsonText('Chat created', chat);
+    },
+    get_agent_run: async (a) => {
+      const run = await client.getAgentRun(requiredStringArg(a, 'runId'));
+      return jsonText('Agent run', run);
+    },
+    get_agent_run_content: async (a) => {
+      const content = await client.getAgentRunContent(
+        requiredStringArg(a, 'runId'),
+      );
+      return jsonText('Agent run content', content);
+    },
+    list_agent_runs: async (a) => {
+      const runs = await client.listAgentRuns({
+        active: optionalBooleanArg(a, 'active'),
+        cursor: optionalStringArg(a, 'cursor'),
+        historyOnly: optionalBooleanArg(a, 'historyOnly'),
+        limit: optionalNumberArg(a, 'limit'),
+        q: optionalStringArg(a, 'q'),
+        status: optionalStringArg(a, 'status'),
+      });
+      return jsonText('Agent runs', runs);
+    },
+    retry_agent_run: async (a) => {
+      const result = await client.retryAgentRun(
+        requiredStringArg(a, 'runId'),
+        optionalStringArg(a, 'message'),
+      );
+      return jsonText('Agent run retry requested', result);
     },
     send_chat_message: async (a) => {
       const result = await client.sendChatMessage(
-        a.threadId as string,
-        a.message as string,
+        requiredStringArg(a, 'threadId'),
+        requiredStringArg(a, 'message'),
       );
-      return {
-        content: [
-          {
-            text: `Response:\n\n${JSON.stringify(result, null, 2)}`,
-            type: 'text' as const,
-          },
-        ],
-      };
+      return jsonText('Response', result);
     },
   };
 

--- a/packages/tools/src/registry/source/mcp-only/agent-control.tools.ts
+++ b/packages/tools/src/registry/source/mcp-only/agent-control.tools.ts
@@ -3,10 +3,122 @@ import type { SourceTool } from '../../../interfaces/source-tool.interface.js';
 export const MCP_AGENT_CONTROL_TOOLS: SourceTool[] = [
   {
     creditCost: 0,
+    description: 'Cancel a running or pending agent run',
+    name: 'cancel_agent_run',
+    parameters: {
+      properties: {
+        runId: {
+          description: 'The agent run ID to cancel',
+          type: 'string',
+        },
+      },
+      required: ['runId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: false, cliAgentVisible: false, mcp: true },
+  },
+  {
+    creditCost: 0,
     description: 'Start a new agent conversation',
     name: 'create_chat',
     parameters: {
       properties: {},
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: false, cliAgentVisible: false, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description: 'Inspect a single agent run',
+    name: 'get_agent_run',
+    parameters: {
+      properties: {
+        runId: {
+          description: 'The agent run ID to inspect',
+          type: 'string',
+        },
+      },
+      required: ['runId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: false, cliAgentVisible: false, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description: 'Inspect content produced by an agent run',
+    name: 'get_agent_run_content',
+    parameters: {
+      properties: {
+        runId: {
+          description:
+            'The agent run ID whose produced content should be returned',
+          type: 'string',
+        },
+      },
+      required: ['runId'],
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: false, cliAgentVisible: false, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description: 'List recent or active agent runs',
+    name: 'list_agent_runs',
+    parameters: {
+      properties: {
+        active: {
+          description: 'When true, return only pending or running agent runs',
+          type: 'boolean',
+        },
+        cursor: {
+          description: 'Optional pagination cursor from the previous page',
+          type: 'string',
+        },
+        historyOnly: {
+          description: 'When true, exclude pending and running agent runs',
+          type: 'boolean',
+        },
+        limit: {
+          description: 'Maximum number of runs to return',
+          type: 'number',
+        },
+        q: {
+          description: 'Search label, objective, and routing metadata',
+          type: 'string',
+        },
+        status: {
+          description:
+            'Optional status filter such as PENDING, RUNNING, COMPLETED, FAILED, or CANCELLED',
+          type: 'string',
+        },
+      },
+      type: 'object',
+    },
+    requiredRole: 'user',
+    surfaces: { agent: false, cliAgentVisible: false, mcp: true },
+  },
+  {
+    creditCost: 0,
+    description:
+      'Retry an agent run by sending a follow-up message on its persisted thread',
+    name: 'retry_agent_run',
+    parameters: {
+      properties: {
+        message: {
+          description:
+            'Optional retry instruction. Defaults to continuing the prior run context.',
+          type: 'string',
+        },
+        runId: {
+          description: 'The agent run ID to retry from',
+          type: 'string',
+        },
+      },
+      required: ['runId'],
       type: 'object',
     },
     requiredRole: 'user',

--- a/packages/tools/src/registry/source/source-tools.test.ts
+++ b/packages/tools/src/registry/source/source-tools.test.ts
@@ -25,6 +25,7 @@ const EXPECTED_TOOL_NAMES = [
   'analyze_performance',
   'batch_approve_reject',
   'benchmark_ad_performance',
+  'cancel_agent_run',
   'capture_memory',
   'check_goal_progress',
   'check_onboarding_status',
@@ -63,6 +64,8 @@ const EXPECTED_TOOL_NAMES = [
   'generate_voice',
   'get_account_info',
   'get_ad_performance_insights',
+  'get_agent_run',
+  'get_agent_run_content',
   'get_analytics',
   'get_approval_summary',
   'get_article',
@@ -97,6 +100,7 @@ const EXPECTED_TOOL_NAMES = [
   'get_workflow_status',
   'initiate_oauth_connect',
   'install_official_workflow',
+  'list_agent_runs',
   'list_avatars',
   'list_brands',
   'list_google_ads_campaigns',
@@ -129,6 +133,7 @@ const EXPECTED_TOOL_NAMES = [
   'request_asset',
   'resolve_approval',
   'resolve_handle',
+  'retry_agent_run',
   'run_captioning',
   'schedule_post',
   'score_seo',
@@ -192,7 +197,7 @@ describe('SOURCE_TOOLS registry split (#692)', () => {
   it('partitions tools by their declared surface', () => {
     expect(OVERLAP_TOOLS).toHaveLength(11);
     expect(AGENT_ONLY_TOOLS).toHaveLength(55);
-    expect(MCP_ONLY_TOOLS).toHaveLength(55);
+    expect(MCP_ONLY_TOOLS).toHaveLength(60);
     expect(BRAND_INTERVIEW_TOOLS).toHaveLength(4);
     expect(
       OVERLAP_TOOLS.every((tool) => tool.surfaces.agent && tool.surfaces.mcp),


### PR DESCRIPTION
## Summary
- Adds MCP metadata for agent-run list, inspect, content, cancel, and retry controls alongside existing chat trigger tools.
- Wires the MCP client to the existing agent-run API endpoints and retries through the persisted thread when available.
- Adds focused registry and client tests for the new control path and the list_agent_runs routing precedence.

Closes #1017
Refs #1009

## Validation
- bunx vitest run --config vitest.config.ts src/services/client.service.spec.ts src/services/tool-registry.service.spec.ts (apps/server/mcp)
- bunx vitest run --config vitest.config.ts src/registry/source/source-tools.test.ts (packages/tools)
- bunx biome check --write apps/server/mcp/src/services/client.service.spec.ts apps/server/mcp/src/services/client.service.ts apps/server/mcp/src/services/client/agent.client.ts apps/server/mcp/src/services/tool-registry.service.spec.ts apps/server/mcp/src/services/tool-registry.service.ts apps/server/mcp/src/tools/agent-chat.tool.ts packages/tools/src/registry/source/mcp-only/agent-control.tools.ts packages/tools/src/registry/source/source-tools.test.ts
- bun scripts/run-secretlint.ts <touched files>
- bunx turbo run type-check --filter=@genfeedai/tools
- bunx turbo run build --filter=@genfeedai/tools
- bunx turbo run build --filter=@genfeedai/mcp
- bunx turbo run type-check --filter=@genfeedai/mcp
- git diff --check

## Notes
- The selected issue did not carry a queue label; this PR is labeled codex:automation because it was selected by the Codex automation.
- The first MCP build exposed a stale missing @genfeedai/enums dist artifact; forcing the ignored package output with tsc --build --force resolved it, and the rerun passed.