### PR TITLE
fix(api): brand switch — write canonical cuid to member.lastUsedBrandId, not mongoId

### DIFF
--- a/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
@@ -381,17 +381,23 @@ describe('UsersController', () => {
   });
 
   describe('updateBrandSelection', () => {
-    it('should select brand and persist last-used brand on member', async () => {
-      const selectedBrandId = '507f191e810c19729de860ee';
+    it('should persist last-used brand using the canonical cuid id, not the legacy mongoId _id', async () => {
+      // A normalized brand doc carries BOTH a cuid `id` and a legacy `_id`
+      // (= mongoId ?? id). member.lastUsedBrandId is an FK to Brand.id, so the
+      // handler must write `id` — writing `_id` (the mongoId) triggers a P2003
+      // "Invalid Relationship" and blocks brand switch for migrated brands.
+      const canonicalId = 'clbrandcuid000000000000001';
+      const legacyMongoId = '507f191e810c19729de860ee';
       brandsService.selectBrandForUser.mockResolvedValue({
-        _id: selectedBrandId,
+        _id: legacyMongoId,
+        id: canonicalId,
         label: 'Selected Brand',
       });
 
       const result = await controller.updateBrandSelection(
         mockRequest,
         mockUser,
-        selectedBrandId.toString(),
+        legacyMongoId.toString(),
       );
 
       expect(membersService.setLastUsedBrand).toHaveBeenCalledWith(
@@ -401,7 +407,7 @@ describe('UsersController', () => {
           organization: orgId,
           user: userId,
         },
-        selectedBrandId,
+        canonicalId,
       );
       expect(requestContextCacheService.invalidateForUser).toHaveBeenCalledWith(
         userId,

--- a/apps/server/api/src/collections/users/controllers/users.controller.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.ts
@@ -442,7 +442,11 @@ export class UsersController {
       await this.invalidateUserAccessCaches(publicMetadata.user);
     }
 
-    // Persist last-used brand on the member for org-switch recall
+    // Persist last-used brand on the member for org-switch recall.
+    // Use the canonical cuid `data.id`, NOT `data._id` — normalizeDocument sets
+    // `_id = mongoId ?? id`, so for any brand carrying a legacy mongoId, `_id`
+    // is that mongoId and writing it into member.lastUsedBrandId (an FK to
+    // Brand.id) fails with P2003 "Invalid Relationship" and blocks brand switch.
     await this.membersService.setLastUsedBrand(
       {
         isActive: true,
@@ -450,7 +454,7 @@ export class UsersController {
         organization: publicMetadata.organization,
         user: publicMetadata.user,
       },
-      data._id,
+      data.id,
     );
 
     return serializeSingle(request, BrandSerializer, data);


### PR DESCRIPTION
Fixes the 400 "Invalid Relationship" (Prisma P2003) that blocked brand switching. Handler wrote data._id (= mongoId for migrated brands) into member.lastUsedBrandId (FK to Brand.id cuid). Now writes data.id. Spec updated + green (20 passed). Ties to mongoId epic #1041.