### PR TITLE
fix(agent-threads): stop 401ing authenticated users on GET /v1/threads

### DIFF
--- a/apps/server/api/src/collections/agent-threads/controllers/agent-threads.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-threads/controllers/agent-threads.controller.spec.ts
@@ -101,13 +101,7 @@ describe('AgentThreadsController', () => {
       expect(args[0]).toEqual(expect.any(String));
       expect(args[1]).toEqual(expect.any(String));
       expect(args[2]).toBeUndefined();
-      expect(usersService.findOne).toHaveBeenCalledWith(
-        {
-          _id: expect.any(String),
-          authProviderId: 'authProvider_123',
-        },
-        [],
-      );
+      expect(usersService.findOne).not.toHaveBeenCalled();
     });
 
     it('should pass explicit status when provided', async () => {
@@ -119,18 +113,25 @@ describe('AgentThreadsController', () => {
       expect(args[0]).toEqual(expect.any(String));
       expect(args[1]).toEqual(expect.any(String));
       expect(args[2]).toBe('active');
-      expect(usersService.findOne).toHaveBeenCalledWith(
-        {
-          _id: expect.any(String),
-          authProviderId: 'authProvider_123',
-        },
-        [],
+      expect(usersService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should trust publicMetadata.user directly with no DB re-lookup (no 401 for authenticated user)', async () => {
+      service.getUserThreads.mockResolvedValue([]);
+
+      await controller.listThreads({} as never, mockUser);
+
+      expect(usersService.findOne).not.toHaveBeenCalled();
+      expect(service.getUserThreads).toHaveBeenCalledWith(
+        mockUser.publicMetadata.user,
+        mockUser.publicMetadata.organization,
+        undefined,
       );
     });
 
     it('should resolve user id from users collection when metadata id is missing', async () => {
-      const resolvedMongoUserId = 'user_resolved';
-      usersService.findOne.mockResolvedValueOnce({ _id: resolvedMongoUserId });
+      const resolvedUserId = 'user_resolved';
+      usersService.findOne.mockResolvedValueOnce({ id: resolvedUserId });
       service.getUserThreads.mockResolvedValue([]);
 
       await controller.listThreads(
@@ -149,6 +150,29 @@ describe('AgentThreadsController', () => {
         { authProviderId: 'authProvider_123' },
         [],
       );
+      expect(service.getUserThreads).toHaveBeenCalledWith(
+        resolvedUserId,
+        expect.any(String),
+        undefined,
+      );
+    });
+
+    it('should not throw 401 when metadata user id is missing but a legacy _id is found', async () => {
+      const resolvedMongoUserId = 'legacy_mongo_id';
+      usersService.findOne.mockResolvedValueOnce({ _id: resolvedMongoUserId });
+      service.getUserThreads.mockResolvedValue([]);
+
+      await controller.listThreads(
+        {} as never,
+        {
+          ...mockUser,
+          publicMetadata: {
+            ...mockUser.publicMetadata,
+            user: '',
+          },
+        } as unknown as User,
+      );
+
       expect(service.getUserThreads).toHaveBeenCalledWith(
         resolvedMongoUserId,
         expect.any(String),

--- a/apps/server/api/src/collections/agent-threads/controllers/agent-threads.controller.ts
+++ b/apps/server/api/src/collections/agent-threads/controllers/agent-threads.controller.ts
@@ -236,7 +236,35 @@ export class AgentThreadsController {
     return organization;
   }
 
+  /**
+   * Resolve the internal (cuid) User.id that AgentThread.userId is a foreign
+   * key to. This must trust the already-authenticated identity the same way
+   * every other working endpoint does (see UsersController): read
+   * `getPublicMetadata(user).user` directly, with no DB re-lookup. That value
+   * is populated once per request by AuthIdentityResolverService and is
+   * exactly the id AgentThread.userId expects.
+   *
+   * Previously this re-derived the id via `usersService.findOne({ _id,
+   * authProviderId })` — an AND filter requiring the stored (legacy)
+   * `authProviderId` column to match the current auth-provider subject. For
+   * users where that legacy field doesn't line up (e.g. Better-Auth users,
+   * or any account reconciled by AuthIdentityResolverService's fallback
+   * paths), both that lookup and its `{ authProviderId }` fallback missed,
+   * throwing UnauthorizedException for an already-authenticated user. That
+   * is the exact 401 loop reported on GET /v1/threads while every other
+   * authenticated endpoint (which trusts publicMetadata.user with no
+   * re-lookup) kept returning 200 for the same token.
+   *
+   * The DB lookup below is retained only as a last-resort fallback for the
+   * rare case where publicMetadata carries no user id at all, and it must
+   * never throw for an authenticated user based on a legacy field mismatch.
+   */
   private async resolveMongoUserId(user: User): Promise<string> {
+    const { user: metadataUserId } = getPublicMetadata(user);
+    if (metadataUserId) {
+      return metadataUserId;
+    }
+
     const authProviderId = user.id;
     if (!authProviderId) {
       throw new UnauthorizedException(
@@ -244,27 +272,12 @@ export class AgentThreadsController {
       );
     }
 
-    const { user: metadataUserId } = getPublicMetadata(user);
-    if (metadataUserId) {
-      const metadataUserDoc = await this.usersService.findOne(
-        { _id: metadataUserId, authProviderId },
-        [],
-      );
-      if (metadataUserDoc?._id) {
-        return String(metadataUserDoc._id);
-      }
-    }
-
     const dbUser = await this.usersService.findOne({ authProviderId }, []);
-    if (!dbUser?._id) {
+    const fallbackUserId = dbUser?.id ?? dbUser?._id;
+    if (!fallbackUserId) {
       throw new UnauthorizedException('User account not found');
     }
 
-    const mongoUserId = String(dbUser._id);
-    if (!mongoUserId) {
-      throw new UnauthorizedException('Invalid user account reference');
-    }
-
-    return mongoUserId;
+    return String(fallbackUserId);
   }
 }


### PR DESCRIPTION
## Summary

- `GET /v1/threads` was 401ing for legitimately-authenticated users while every other authenticated endpoint (organizations/mine, auth/bootstrap, subscriptions, runs/active, agent/credits) returned 200 for the same token.
- Root cause: `AgentThreadsController.resolveMongoUserId` re-derived the caller's internal user id via `usersService.findOne({ _id, authProviderId })`, then a `{ authProviderId }` fallback — both filtered on the legacy `authProviderId` column. For accounts where that field no longer matches the current auth-provider subject (e.g. Better-Auth users, or accounts reconciled by `AuthIdentityResolverService`'s fallback paths), both lookups miss and the method throws `UnauthorizedException('User account not found')` even though the request is authenticated.
- Every other working endpoint (see `UsersController`, and this same controller's `resolveOrganizationId`) trusts `getPublicMetadata(user).user` directly with no DB re-lookup — that id is resolved once per request by `AuthIdentityResolverService` and stamped onto the authenticated user, and `AgentThread.userId` (Prisma `String` FK to `User.id`) matches it exactly.
- Fix: `resolveMongoUserId` now reads `publicMetadata.user` first and only falls back to a DB lookup by `authProviderId` when metadata carries no user id at all — a case that must never throw 401 for an authenticated caller. This single shared method fixes all 4 call sites (`listThreads`, `createThread`, `archiveAllThreads`, `addMessage`).

## Test plan

- [x] `bunx vitest run src/collections/agent-threads/controllers/agent-threads.controller.spec.ts` — 10/10 passing, including new coverage:
  - authenticated user with only `publicMetadata.user` set never triggers a DB lookup and never 401s
  - metadata-missing fallback resolves via `{ authProviderId }` and returns either `id` or legacy `_id` without throwing
- [ ] `apps/server/api` has no dedicated `type-check` script and turbo's `type-check` task only runs each package's own script if defined (verified via `turbo.json` + package.json scan) — no signal available for this package via `bun type-check`. Direct `tsc -p tsconfig.typecheck.json` fails with `TS5101` (`baseUrl` deprecated for TS 6.0.2), reproduced identically against unmodified code via `git stash` — pre-existing tooling gap, unrelated to this change.