### PR TITLE
fix(app): redirect bare /workspace/inbox to /unread

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/inbox/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation';
+
+// Bare `/workspace/inbox` has no view segment and would 404. The inbox surface
+// lives under `[view]` (all | recent | unread); default to the unread view so
+// the route (and any stale/bookmarked link to the index) lands on a real page.
+export default async function WorkspaceInboxIndexPage({
+  params,
+}: {
+  params: Promise<{ orgSlug: string; brandSlug: string }>;
+}) {
+  const { orgSlug, brandSlug } = await params;
+
+  redirect(`/${orgSlug}/${brandSlug}/workspace/inbox/unread`);
+}


### PR DESCRIPTION
Bare /workspace/inbox 404'd (only [view] route existed). Adds an index page redirecting to /workspace/inbox/unread. Found during live browser sweep.