### PR TITLE
fix(studio): align content header gutter to full-width padding

### DIFF
--- a/packages/pages/studio/generate/components/AssetControlsHeader.tsx
+++ b/packages/pages/studio/generate/components/AssetControlsHeader.tsx
@@ -46,7 +46,7 @@ export function AssetControlsHeader({
     'flex items-center rounded-xl border border-white/10 bg-white/[0.03] p-1';
 
   return (
-    <div className="border-b border-white/[0.08] px-4 py-2">
+    <div className="w-full border-b border-white/[0.08] px-6 py-2">
       <div className="flex w-full items-center justify-between gap-3">
         <h1 className="text-sm font-semibold tracking-tight">
           {categoryLabel}


### PR DESCRIPTION
## Summary
- Studio's `AssetControlsHeader` (the category title + filters/view-toggle/refresh toolbar rendered above the studio asset grid) used `px-4` (16px) horizontal padding, while `GenerateContentArea` — the content grid directly below it — uses `px-6` (24px), matching the codebase-wide full-width gutter rhythm.
- This mismatch made the studio header appear narrower / misaligned relative to the content grid beneath it, unlike other content pages (e.g. workspace overview) where header and body share the same gutter.
- No max-width/`mx-auto` constraint exists anywhere in the Studio component chain (`StudioPageContent` -> `GenerationFeatureGuard` -> `StudioGenerateLayout`) or the shared `AppLayout` shell — root cause was purely the `px-4` vs `px-6` gutter mismatch, not a width clip.

## Change
`packages/pages/studio/generate/components/AssetControlsHeader.tsx` root wrapper div:
- Before: `className="border-b border-white/[0.08] px-4 py-2"`
- After: `className="w-full border-b border-white/[0.08] px-6 py-2"`

Scoped to this one component; no other pages touched.

## Verification
- `bunx vitest run --project=@genfeedai/pages studio/generate/components/AssetControlsHeader.test.tsx`: 2 passed / 1 failed. The 1 failure (`asset-controls-separator` testid, expected length 2) is a pre-existing mismatch between this test file and the component — no such testid exists anywhere in the component in either the pre-fix or post-fix state. Confirmed unrelated to this change; the "divider token" assertion (`border-b`, `border-white/[0.08]` on the header shell) in the same file passes, confirming no regression.
- Typecheck: `bunx tsc --noEmit -p packages/pages` on `master` baseline already reports 2848 pre-existing errors (unrelated `@genfeedai/*` path-alias resolution gaps in this package's `tsconfig`, not covered by the vitest alias map). Confirmed via stash/restore that error count is identical with and without this change — this diff introduces zero new type errors.
- Note: `packages/pages/vitest.config.ts` currently has a hand-curated `include` allowlist that does not cover several existing studio test files (including this one, plus `AssetDisplayGrid.test.tsx`, `StudioComposer.test.tsx`, `StudioGenerateLayout.test.tsx`, and the `studio/generate/hooks/*.test.ts(x)` suite) — a pre-existing gap, left out of scope here since widening it isn't necessary for this fix and would pull in unrelated, currently-silent test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)