### PR TITLE
fix(sidebar): move organization switcher into sidebar top, Vercel-style

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -13,12 +13,14 @@ import { APP_ROUTES } from '@genfeedai/constants';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import type { MenuSharedProps } from '@genfeedai/props/navigation/menu.props';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
+import OrganizationSwitcher from '@ui/menus/organization-switcher/OrganizationSwitcher';
 import SidebarActionTrigger from '@ui/menus/sidebar-action-trigger/SidebarActionTrigger';
 import SidebarSearchTrigger from '@ui/menus/sidebar-search-trigger/SidebarSearchTrigger';
 import AdminSidebar from '@ui/shell/menus/AdminSidebar';
 import AppSidebar from '@ui/shell/menus/AppSidebar';
 import type { ReactNode } from 'react';
 import { HiPlus } from 'react-icons/hi2';
+import { isHostedCloudApp } from '@/lib/config/edition';
 import { withTaskContextHref } from '@/lib/navigation/operator-shell';
 import { dispatchOpenTaskComposer } from '@/lib/workspace/task-composer-events';
 import ChatSidebarContent from './AppProtectedLayoutChatSidebar';
@@ -87,6 +89,10 @@ export default function AppProtectedLayoutSidebar({
   onOpenCommandPalette,
 }: Props) {
   const { href: buildHref, orgHref } = useOrgUrl();
+  const shouldRenderOrganizationSwitcher = isHostedCloudApp();
+  const orgSwitcherSlot = shouldRenderOrganizationSwitcher ? (
+    <OrganizationSwitcher />
+  ) : undefined;
 
   if (isFocusedOnboardingRoute) {
     return null;
@@ -103,6 +109,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Library"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -118,6 +125,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Studio"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -142,6 +150,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Compose"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -157,6 +166,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Workflows"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -172,6 +182,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Editor"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -187,6 +198,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Analytics"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -202,6 +214,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Organization"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -217,6 +230,7 @@ export default function AppProtectedLayoutSidebar({
         currentApp={currentApp}
         sectionLabel="Settings"
         shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
       />
     );
   }
@@ -232,6 +246,7 @@ export default function AppProtectedLayoutSidebar({
       sectionLabel={undefined}
       collapsedSidebarWidth={0}
       mobileSidebarWidth={isConversationRoute ? undefined : 304}
+      orgSwitcherSlot={orgSwitcherSlot}
       renderTopSlot={
         isConversationRoute
           ? undefined

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -89,10 +89,6 @@ vi.mock('@ui/menus/switchers/MenuBrandSwitcher', () => ({
   ),
 }));
 
-vi.mock('@ui/menus/organization-switcher/OrganizationSwitcher', () => ({
-  default: () => <div data-testid="organization-switcher" />,
-}));
-
 vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
   AppSwitcher: (props: {
     brandSlug?: string;
@@ -189,41 +185,6 @@ describe('AppProtectedTopbar', () => {
       switcher.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-  });
-
-  it('renders the organization switcher in the topbar for SaaS cloud mode', () => {
-    process.env.NEXT_PUBLIC_GENFEED_CLOUD = 'true';
-
-    render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
-
-    const organizationSwitcher = screen.getByTestId('organization-switcher');
-    const brandSwitcher = screen.getByTestId('brand-switcher');
-
-    expect(organizationSwitcher).toBeInTheDocument();
-    expect(
-      organizationSwitcher.compareDocumentPosition(brandSwitcher) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-  });
-
-  it('hides the organization switcher outside SaaS cloud mode', () => {
-    render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
-
-    expect(
-      screen.queryByTestId('organization-switcher'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows the organization switcher on the official hosted app hostname', () => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { ...originalLocation, hostname: 'app.genfeed.ai' },
-      writable: true,
-    });
-
-    render(<AppProtectedTopbar orgSlug="acme" currentApp="studio" />);
-
-    expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
   });
 
   it('does not inject the context brand into explicit org-scoped routes', () => {

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -11,7 +11,6 @@ import {
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { TopbarProps } from '@props/navigation/topbar.props';
-import OrganizationSwitcher from '@ui/menus/organization-switcher/OrganizationSwitcher';
 import MenuBrandSwitcher from '@ui/menus/switchers/MenuBrandSwitcher';
 import { Button } from '@ui/primitives/button';
 import { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
@@ -110,11 +109,6 @@ function AppProtectedTopbarContent({
   const taskId = searchParams.get('taskId');
   const taskTitle = searchParams.get('taskTitle');
   const ToggleIcon = isMenuOpen ? HiXMark : HiBars3;
-  const isHostedCloudHostname =
-    typeof window !== 'undefined' &&
-    window.location.hostname === 'app.genfeed.ai';
-  const shouldRenderOrganizationSwitcher =
-    process.env.NEXT_PUBLIC_GENFEED_CLOUD === 'true' || isHostedCloudHostname;
   const shouldRenderAgentToggle =
     Boolean(onAgentToggle) &&
     (process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1' || !isHostedCloudApp());
@@ -158,12 +152,6 @@ function AppProtectedTopbarContent({
             >
               <PiSidebarSimple className="size-4" />
             </Button>
-          ) : null}
-
-          {shouldRenderOrganizationSwitcher ? (
-            <div className="hidden min-w-0 w-40 sm:block sm:w-56">
-              <OrganizationSwitcher />
-            </div>
           ) : null}
 
           {brands.length > 0 ? (

--- a/packages/props/navigation/menu.props.ts
+++ b/packages/props/navigation/menu.props.ts
@@ -70,6 +70,8 @@ export interface MenuSharedProps extends BaseMenuProps, SidebarSizingProps {
   renderFooterSlot?: () => ReactNode;
   /** Shows the signed-in user profile footer in the sidebar */
   showUserProfile?: boolean;
+  /** Renders the organization switcher above `renderTopSlot`, at the very top of the sidebar body */
+  orgSwitcherSlot?: ReactNode;
 }
 
 export interface MenuItemProps {

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -263,6 +263,38 @@ describe('MenuShared', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders the org switcher slot at the top of the sidebar body, above the top slot and nav', () => {
+    render(
+      <MenuShared
+        config={config}
+        orgSwitcherSlot={<div data-testid="organization-switcher">Acme</div>}
+        renderTopSlot={() => <div data-testid="sidebar-top-slot">Search</div>}
+      />,
+    );
+
+    const orgSwitcher = screen.getByTestId('organization-switcher');
+    const topSlot = screen.getByTestId('sidebar-top-slot');
+    const firstMenuItem = screen.getByText('Dashboard');
+
+    expect(orgSwitcher).toBeInTheDocument();
+    expect(
+      orgSwitcher.compareDocumentPosition(topSlot) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      topSlot.compareDocumentPosition(firstMenuItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('omits the org switcher slot when not provided', () => {
+    render(<MenuShared config={config} />);
+
+    expect(
+      screen.queryByTestId('organization-switcher'),
+    ).not.toBeInTheDocument();
+  });
+
   it('attaches the actionable inbox count to the workspace inbox row', () => {
     const inboxConfig: MenuShellConfig = {
       items: [

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -39,6 +39,7 @@ export default function MenuShared({
   conversationActions,
   renderFooterSlot,
   showUserProfile = true,
+  orgSwitcherSlot,
 }: MenuSharedProps) {
   const { push } = useRouter();
 
@@ -207,6 +208,10 @@ export default function MenuShared({
             isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
           )}
         >
+          {orgSwitcherSlot ? (
+            <div className="px-3 pt-2">{orgSwitcherSlot}</div>
+          ) : null}
+
           {topSlotContent ? (
             <div className="px-3 pt-2">{topSlotContent}</div>
           ) : null}

--- a/packages/ui/src/components/shell/menus/AppSidebar.tsx
+++ b/packages/ui/src/components/shell/menus/AppSidebar.tsx
@@ -32,6 +32,7 @@ export interface AppSidebarProps extends BaseMenuProps {
   conversationActions?: MenuSharedProps['conversationActions'];
   renderFooterSlot?: MenuSharedProps['renderFooterSlot'];
   showUserProfile?: MenuSharedProps['showUserProfile'];
+  orgSwitcherSlot?: MenuSharedProps['orgSwitcherSlot'];
   items: MenuShellConfig['items'];
   logoHref?: string;
 }
@@ -58,6 +59,7 @@ export default function AppSidebar({
   conversationActions,
   renderFooterSlot,
   showUserProfile = false,
+  orgSwitcherSlot,
   items,
   logoHref = '/',
 }: AppSidebarProps) {
@@ -92,6 +94,7 @@ export default function AppSidebar({
       conversationActions={conversationActions}
       renderFooterSlot={renderFooterSlot}
       showUserProfile={showUserProfile}
+      orgSwitcherSlot={orgSwitcherSlot}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Move the cloud-only `OrganizationSwitcher` out of `AppProtectedTopbar` and into the top of the sidebar (`AppSidebar`/`MenuShared`), stacked above the search/new-task slot and nav items — Vercel-style team/project selector placement.
- Add `orgSwitcherSlot` to `MenuSharedProps`, threaded through `AppSidebar` (passthrough) and rendered at the very top of the sidebar body in `MenuShared`, above `renderTopSlot` content. `AdminSidebar` intentionally excluded.
- `AppProtectedLayoutSidebar` computes the org switcher element once via `isHostedCloudApp()` and passes it to every non-admin `AppSidebar` call site.
- `isHostedCloudApp()` remains the single source of truth for cloud-only gating (topbar's prior ad-hoc duplicate check removed along with the switcher itself).

## Files changed
- `apps/app/src/components/shell/AppProtectedTopbar.tsx` — removed `OrganizationSwitcher` render + gating
- `apps/app/packages/components/AppProtectedLayoutSidebar.tsx` — computes `orgSwitcherSlot`, passes to all non-admin sidebar call sites
- `packages/props/navigation/menu.props.ts` — new `orgSwitcherSlot?: ReactNode` prop
- `packages/ui/src/components/menus/shared/MenuShared.tsx` — renders slot above `renderTopSlot`
- `packages/ui/src/components/shell/menus/AppSidebar.tsx` — passthrough prop
- `apps/app/src/components/shell/AppProtectedTopbar.test.tsx` — removed obsolete org-switcher mock/tests
- `packages/ui/src/components/menus/shared/MenuShared.test.tsx` — added slot render-order + omission tests

## Test plan
- [x] `bunx vitest run src/components/shell/AppProtectedTopbar.test.tsx --config ./vitest.config.mts` (apps/app) — 11/11 passed
- [x] `bunx vitest run src/components/menus/shared/MenuShared.test.tsx --config vitest.config.ts` (packages/ui) — 22/22 passed
- [x] Secret-scanned staged diff before commit; pre-commit hooks (secretlint, biome, lint-no-raw-html) passed clean