### PR TITLE
fix(auth): Library page shows 0 ingredients — org resolution silently returns undefined

### DIFF
--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts
@@ -144,4 +144,43 @@ describe('BetterAuthIdentityResolverService', () => {
     expect(identity.organizationId).toBe('org_pref');
     expect(identity.brandId).toBe('brand_pref');
   });
+
+  // Library-loading bug (images/videos/gifs/agent-* list endpoints): an
+  // active membership row whose organization can no longer be resolved (e.g.
+  // soft-deleted org, orphaned member row) must not silently resolve to
+  // `organizationId: undefined`. Downstream, every
+  // `{ organization: publicMetadata.organization } OR { userId: currentUser }`
+  // list filter treats an `undefined` organization branch as a no-op entry
+  // that BaseService.normalizeWhere drops from the OR array — collapsing the
+  // query to "created by me only" and returning 200 OK with 0 results for
+  // teammate-created content, with no visible error anywhere. Fail loudly
+  // instead so the real data problem (an inaccessible org for a live member
+  // row) surfaces immediately rather than presenting as a silent empty list.
+  it('throws Unauthorized instead of silently returning an undefined organizationId when every membership organization fails to resolve', async () => {
+    usersService.findOne.mockResolvedValue({ id: 'user_orphaned' });
+    membersService.find.mockResolvedValue([
+      { organizationId: 'org_soft_deleted' },
+    ]);
+    // Owner lookup → null; membership lookup for the only membership → null
+    // (organization soft-deleted or otherwise inaccessible).
+    organizationsService.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    await expect(resolver.resolve('user_orphaned')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    expect(brandsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when a user genuinely has no memberships at all (new/unassigned account)', async () => {
+    usersService.findOne.mockResolvedValue({ id: 'user_no_memberships' });
+    membersService.find.mockResolvedValue([]);
+    organizationsService.findOne.mockResolvedValue(null);
+
+    const identity = await resolver.resolve('user_no_memberships');
+
+    expect(identity.organizationId).toBeUndefined();
+    expect(identity.brandId).toBeUndefined();
+  });
 });

--- a/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.ts
@@ -77,6 +77,21 @@ export class BetterAuthIdentityResolverService {
       members,
       lastUsedOrganizationId,
     );
+
+    // A user with active membership rows must resolve to SOME organization.
+    // Silently returning `organizationId: undefined` here let every
+    // downstream `{ organization: publicMetadata.organization }` OR-branch
+    // (images/videos/gifs/agent-* controllers) collapse to `{}` and get
+    // dropped by BaseService.normalizeWhere's empty-entry filter — silently
+    // narrowing list queries to self-created records only (200 OK, 0 results)
+    // instead of surfacing the real problem: an orphaned/inaccessible
+    // organization for a live membership row.
+    if (!organizationId && members.length > 0) {
+      throw new UnauthorizedException(
+        'Unable to resolve an accessible organization for this account',
+      );
+    }
+
     const brandId = organizationId
       ? await this.resolveBrandId(organizationId, members)
       : undefined;


### PR DESCRIPTION
## Root cause

Backend, not frontend. Not the originally-suspected enum-casing or mongoId/cuid `lastUsedBrandId` theories (both ruled out — see below).

`BetterAuthIdentityResolverService.resolveOrganizationId()` can legitimately return `undefined` for an authenticated user who has active `Member` rows, if every candidate organization lookup fails (owner-org lookup null, and every membership's `organizationsService.findOne` lookup null). Since `Member.organizationId` is a non-nullable FK to `Organization.id`, this can only happen for a live membership row whose referenced organization is soft-deleted (or otherwise inaccessible) — an orphaned member row, not a data-format/casing issue.

Call chain to the reported symptom (`GET /v1/images?...&brand=<cuid>` → 200 OK, 0 images):

1. `resolveOrganizationId()` returns `undefined` (all fallbacks exhausted).
2. `BetterAuthStrategy.validate()` passes this straight into `publicMetadata.organization` with no guard.
3. `getPublicMetadata()`'s spread (`{...EMPTY_PUBLIC_METADATA, ...(user.publicMetadata ?? {})}`) preserves the `undefined` value as an own enumerable property (verified directly — spreading `{ organization: undefined }` over a default does overwrite the key, even though `JSON.stringify` later omits it from output).
4. `images.controller.ts` builds `{ organization: publicMetadata.organization } OR { userId: currentUser }`.
5. `BaseService.normalizeWhere()`'s `.filter((entry) => Object.keys(entry).length > 0)` (a deliberate anti-tenancy-leak safeguard) drops the now-empty organization branch.
6. Only `{ userId: currentUser }` survives — any ingredient not created by the exact viewing user becomes invisible to them, reproducing "200 OK, 0 images" for teammate-created content.

## Theories investigated and ruled out

- Status/category enum casing (`@genfeedai/enums` vs Prisma) — refuted, no casing mismatch found in either enum.
- Folder/training implicit-null-filter — refuted.
- Brand relation-shape for a valid cuid — moot; `buildBrandFilter` short-circuits via `isEntityId(query.brand)` before touching `lastUsedBrandId`/`publicMetadata.brand`.
- `publicMetadata` empty-string-default degenerate OR — refined but not the mechanism (actual value is `undefined`, not `''`).
- mongoId-vs-cuid `lastUsedBrandId` corruption (#1052, already shipped) — real fix, but for the brand-**switch write** path. Doesn't apply here because the reported request supplies `brand=<cuid>` directly as a query param, which bypasses `lastUsedBrandId` entirely.
- Org/brand independent-resolution divergence — real structural gap, refined into the confirmed root cause above (the specific undocumented failure mode that makes divergence happen: soft-deleted org + orphaned member row).

## Fix

`BetterAuthIdentityResolverService.resolve()` now throws `UnauthorizedException` when a user has at least one active `Member` row but `resolveOrganizationId()` cannot resolve any of them to an accessible organization. This converts a silent, undiagnosable "200 OK, 0 results" into an immediate, debuggable 401 at the identity-resolution layer — the correct layer, since the underlying problem is an inaccessible organization for a live membership, not anything wrong with the images list query itself.

Deliberately did **not**:
- Loosen `BaseService.normalizeWhere()`'s empty-entry filtering — that's an intentional anti-tenancy-leak safeguard.
- Patch around it in `images.controller.ts` — the bug isn't there, it's upstream in identity resolution.
- Relax any existing test.

## Uncertainty

The exact production trigger (a soft-deleted org with an orphaned active member row) has not been directly confirmed against prod data — I don't have prod DB access from this environment. This fix converts the failure mode from silent data loss to a loud, immediate error, which is the correct defensive posture regardless of how common the trigger is in practice. It does not itself repair any already-orphaned member rows in production; that would be a separate, out-of-scope data-cleanup task if the underlying orphaned rows are confirmed to exist.

## Verification

- Typecheck: `bunx tsc --noEmit -p apps/server/api/tsconfig.json` — no errors in touched files.
- `bunx vitest run apps/server/api/src/auth/better-auth/services/better-auth-identity-resolver.service.spec.ts` — 8 passed (6 existing untouched + 2 new: throws when every membership org fails to resolve; does not throw when user has zero memberships).
- `bunx vitest run apps/server/api/src/auth/better-auth/passport/better-auth.strategy.spec.ts` — 4 passed, confirming the strategy (which mocks the resolver directly) is unaffected by the new throw.