### PR TITLE
refactor(api): reuse video output path guard

### DIFF
--- a/apps/server/api/src/collections/videos/services/video-music-orchestration.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-music-orchestration.service.spec.ts
@@ -249,6 +249,31 @@ describe('VideoMusicOrchestrationService', () => {
     });
   });
 
+  // ─── mergeVideoWithMusic ──────────────────────────────────────────────────
+
+  describe('mergeVideoWithMusic', () => {
+    it('uploads the completed merge output path', async () => {
+      const result = await service.mergeVideoWithMusic(
+        'video-ingredient-id',
+        'music-ingredient-id',
+        75,
+        true,
+        makeContext(),
+      );
+
+      expect(result).toBe('test-object-id');
+      expect(fileQueueService.waitForJob).toHaveBeenCalledWith('job-1', 300000);
+      expect(filesClientService.uploadToS3).toHaveBeenCalledWith(
+        'test-object-id',
+        'videos',
+        {
+          path: '/tmp/output.mp4',
+          type: 'file',
+        },
+      );
+    });
+  });
+
   // ─── orchestrateVideoWithMusic ────────────────────────────────────────────
 
   describe('orchestrateVideoWithMusic', () => {

--- a/apps/server/api/src/collections/videos/services/video-music-orchestration.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-music-orchestration.service.ts
@@ -19,6 +19,7 @@ import { PromptEntity } from '@api/collections/prompts/entities/prompt.entity';
 import { PromptsService } from '@api/collections/prompts/services/prompts.service';
 import { BackgroundMusicDto } from '@api/collections/videos/dto/create-video.dto';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { requireVideoOutputPath } from '@api/collections/videos/utils/video-processing-result.util';
 import { ConfigService } from '@api/config/config.service';
 import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
 import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
@@ -81,14 +82,6 @@ export class VideoMusicOrchestrationService {
     readonly _videosService: VideosService,
     private readonly websocketService: NotificationsPublisherService,
   ) {}
-
-  private requireOutputPath(value: unknown): string {
-    if (typeof value !== 'string' || value.length === 0) {
-      throw new Error('Video processing result missing outputPath');
-    }
-
-    return value;
-  }
 
   /**
    * Resolves the music ingredient to use for merging.
@@ -361,7 +354,7 @@ export class VideoMusicOrchestrationService {
         mergedIngredientId,
         'videos',
         {
-          path: this.requireOutputPath(result.outputPath),
+          path: requireVideoOutputPath(result.outputPath),
           type: FileInputType.FILE,
         },
       );


### PR DESCRIPTION
## Summary
- Closes #1063.
- Reuses the canonical `requireVideoOutputPath` helper in `VideoMusicOrchestrationService`.
- Deletes the duplicate private `requireOutputPath` guard and adds focused merge upload-path coverage.

## Refactor lane fit
- Behavior-preserving code-quality cleanup.
- Scoped to one duplicated video output-path guard.
- No queue, websocket, metadata, or failure-handling behavior changes.

## Structural review
- Blockers: none.
- Request changes: none.
- Deferred: the remaining video service size/decomposition questions are outside this issue; this PR only removes the duplicated guard selected in #1063.

## Validation
- `bun run test:file src/collections/videos/services/video-music-orchestration.service.spec.ts src/collections/videos/utils/video-processing-result.util.spec.ts` from `apps/server/api` (2 files, 19 tests)
- `bunx biome check --write apps/server/api/src/collections/videos/services/video-music-orchestration.service.ts apps/server/api/src/collections/videos/services/video-music-orchestration.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/collections/videos/services/video-music-orchestration.service.ts apps/server/api/src/collections/videos/services/video-music-orchestration.service.spec.ts`
- commit hook `lint-staged`
