### PR TITLE
feat(api): version system workflow templates

### DIFF
--- a/apps/server/api/src/collections/workflows/services/system-workflow-provenance.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/system-workflow-provenance.service.spec.ts
@@ -2,7 +2,11 @@ import {
   SYSTEM_WORKFLOW_ACTION_IDS,
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
-import { SYSTEM_WORKFLOW_METADATA_KEY } from '@api/collections/workflows/system-workflow.contract';
+import {
+  SYSTEM_WORKFLOW_METADATA_KEY,
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+} from '@api/collections/workflows/system-workflow.contract';
 import { WorkflowExecutionTrigger } from '@genfeedai/enums';
 import { WorkflowExecutionStatus as PrismaWorkflowExecutionStatus } from '@genfeedai/prisma';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -69,6 +73,7 @@ describe('SystemWorkflowProvenanceService', () => {
       {
         actionType: 'publish-post',
         canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.SCHEDULED_POST_PUBLISHING,
+        changeSummary: 'Initial scheduled publish workflow wrapper.',
         description: 'Publish scheduled posts.',
         label: 'Scheduled Post Publishing',
         organizationId: 'org-1',
@@ -77,6 +82,7 @@ describe('SystemWorkflowProvenanceService', () => {
         source: 'CronPostsService.publishSinglePost',
         trigger: WorkflowExecutionTrigger.SCHEDULED,
         userId: 'user-1',
+        version: 2,
       },
       action,
     );
@@ -92,11 +98,16 @@ describe('SystemWorkflowProvenanceService', () => {
         data: expect.objectContaining({
           isScheduleEnabled: true,
           metadata: expect.objectContaining({
+            sourceTemplateChangeSummary:
+              'Initial scheduled publish workflow wrapper.',
             sourceTemplateId:
               SYSTEM_WORKFLOW_ACTION_IDS.SCHEDULED_POST_PUBLISHING,
+            sourceTemplateVersion: 2,
             [SYSTEM_WORKFLOW_METADATA_KEY]: expect.objectContaining({
               canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.SCHEDULED_POST_PUBLISHING,
+              changeSummary: 'Initial scheduled publish workflow wrapper.',
               immutable: true,
+              version: 2,
             }),
           }),
           schedule: '*/15 * * * *',
@@ -166,6 +177,45 @@ describe('SystemWorkflowProvenanceService', () => {
         data: expect.objectContaining({
           error: 'Rate limited',
           status: PrismaWorkflowExecutionStatus.FAILED,
+        }),
+      }),
+    );
+  });
+
+  it('defaults action workflow metadata to the current template version', async () => {
+    mockPrisma.workflow.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mockPrisma.workflow.create.mockResolvedValue({
+      id: 'workflow-1',
+      label: 'Twitter Publish Action',
+    });
+
+    await service.runAction(
+      {
+        actionType: 'twitter-original',
+        canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.TWITTER_PUBLISH_ACTION,
+        description: 'Publish Twitter actions.',
+        label: 'Twitter Publish Action',
+        organizationId: 'org-1',
+        source: 'TwitterPipelineService.publish',
+        userId: 'user-1',
+      },
+      async () => ({ success: true }),
+    );
+
+    expect(mockPrisma.workflow.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            sourceTemplateChangeSummary:
+              SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+            sourceTemplateVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+            [SYSTEM_WORKFLOW_METADATA_KEY]: expect.objectContaining({
+              changeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+              version: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+            }),
+          }),
         }),
       }),
     );

--- a/apps/server/api/src/collections/workflows/services/system-workflow-provenance.service.ts
+++ b/apps/server/api/src/collections/workflows/services/system-workflow-provenance.service.ts
@@ -1,6 +1,8 @@
 import {
   buildSystemWorkflowMetadata,
   SYSTEM_WORKFLOW_METADATA_KEY,
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
 } from '@api/collections/workflows/system-workflow.contract';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
@@ -25,14 +27,17 @@ export type SystemWorkflowActionId =
 
 export type SystemWorkflowActionDefinition = {
   canonicalId: SystemWorkflowActionId;
+  changeSummary?: string;
   description: string;
   label: string;
   schedule?: string;
+  version?: number;
 };
 
 export const SYSTEM_WORKFLOW_ACTION_DEFINITIONS = [
   {
     canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.SCHEDULED_POST_PUBLISHING,
+    changeSummary: 'Initial scheduled publish system workflow action wrapper.',
     description:
       'Publishes due scheduled posts through the connected brand credential.',
     label: 'Scheduled Post Publishing',
@@ -40,24 +45,30 @@ export const SYSTEM_WORKFLOW_ACTION_DEFINITIONS = [
   },
   {
     canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.REPLY_DM_AUTOMATION,
+    changeSummary: 'Initial reply and DM system workflow action wrapper.',
     description:
       'Generates and sends reply bot replies and optional DMs through connected social credentials.',
     label: 'Reply and DM Automation',
   },
   {
     canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.TWITTER_PUBLISH_ACTION,
+    changeSummary: 'Initial Twitter publish system workflow action wrapper.',
     description:
       'Publishes Twitter original, reply, and quote actions through connected brand credentials.',
     label: 'Twitter Publish Action',
   },
   {
     canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.CAMPAIGN_REPLY_AUTOMATION,
+    changeSummary:
+      'Initial outreach campaign reply system workflow action wrapper.',
     description:
       'Generates and posts outreach campaign replies through connected brand credentials.',
     label: 'Campaign Reply Automation',
   },
   {
     canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.CAMPAIGN_DM_AUTOMATION,
+    changeSummary:
+      'Initial outreach campaign DM system workflow action wrapper.',
     description:
       'Generates and sends outreach campaign DMs through connected brand credentials.',
     label: 'Campaign DM Automation',
@@ -73,6 +84,7 @@ export type SystemWorkflowProvenance = {
 type SystemWorkflowActionInput<T> = {
   actionType: string;
   canonicalId: SystemWorkflowActionId;
+  changeSummary?: string;
   description: string;
   failureMessage?: (result: T) => string | undefined;
   inputValues?: Record<string, unknown>;
@@ -84,6 +96,7 @@ type SystemWorkflowActionInput<T> = {
   source: string;
   trigger?: WorkflowExecutionTrigger;
   userId?: string;
+  version?: number;
 };
 
 type SystemWorkflowActionResult<T> = {
@@ -110,11 +123,13 @@ export class SystemWorkflowProvenanceService {
     const userId = await this.resolveUserId(input.organizationId, input.userId);
     const workflow = await this.ensureSystemWorkflow({
       canonicalId: input.canonicalId,
+      changeSummary: input.changeSummary,
       description: input.description,
       label: input.label,
       organizationId: input.organizationId,
       schedule: input.schedule,
       userId,
+      version: input.version,
     });
 
     const execution = await this.createExecution({
@@ -164,11 +179,13 @@ export class SystemWorkflowProvenanceService {
 
   private async ensureSystemWorkflow(input: {
     canonicalId: SystemWorkflowActionId;
+    changeSummary?: string;
     description: string;
     label: string;
     organizationId: string;
     schedule?: string;
     userId: string;
+    version?: number;
   }): Promise<WorkflowRecord> {
     const where = {
       isDeleted: false,
@@ -209,11 +226,18 @@ export class SystemWorkflowProvenanceService {
               label: input.label,
               metadata: {
                 sourceIssue: 1011,
+                sourceTemplateChangeSummary:
+                  input.changeSummary ??
+                  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
                 sourceTemplateId: input.canonicalId,
+                sourceTemplateVersion:
+                  input.version ?? SYSTEM_WORKFLOW_TEMPLATE_VERSION,
                 sourceType: 'system-action-workflow',
                 [SYSTEM_WORKFLOW_METADATA_KEY]: buildSystemWorkflowMetadata({
                   canonicalId: input.canonicalId,
+                  changeSummary: input.changeSummary,
                   sourceIssue: 1011,
+                  version: input.version,
                 }),
               },
               nodes: [

--- a/apps/server/api/src/collections/workflows/services/workflows.service.seed.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.seed.spec.ts
@@ -3,6 +3,10 @@ import {
   SYSTEM_WORKFLOW_ACTION_IDS,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
+import {
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+} from '@api/collections/workflows/system-workflow.contract';
 import { WorkflowStatus } from '@genfeedai/enums';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -51,10 +55,13 @@ describe('WorkflowsService seeded livestream bot workflows', () => {
         label: 'Livestream Bot Session Processing',
         metadata: expect.objectContaining({
           sourceIssue: 793,
+          sourceTemplateChangeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
           sourceTemplateId: 'livestream-bot-session-processing',
+          sourceTemplateVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
           sourceType: 'seeded-template',
           systemWorkflow: expect.objectContaining({
             canonicalId: 'livestream-bot-session-processing',
+            changeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
             credentialPolicy: 'tenant-connected-account',
             duplicable: true,
             immutable: true,
@@ -62,6 +69,7 @@ describe('WorkflowsService seeded livestream bot workflows', () => {
             owner: 'genfeed',
             productizationIssue: 1011,
             sourceIssue: 793,
+            version: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
             visibility: 'organization',
           }),
         }),
@@ -101,13 +109,19 @@ describe('WorkflowsService seeded livestream bot workflows', () => {
         label: 'Scheduled Post Publishing',
         metadata: expect.objectContaining({
           sourceIssue: 1011,
+          sourceTemplateChangeSummary:
+            'Initial scheduled publish system workflow action wrapper.',
           sourceTemplateId:
             SYSTEM_WORKFLOW_ACTION_IDS.SCHEDULED_POST_PUBLISHING,
+          sourceTemplateVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
           sourceType: 'system-action-workflow',
           systemWorkflow: expect.objectContaining({
             canonicalId: SYSTEM_WORKFLOW_ACTION_IDS.SCHEDULED_POST_PUBLISHING,
+            changeSummary:
+              'Initial scheduled publish system workflow action wrapper.',
             immutable: true,
             kind: 'system-workflow',
+            version: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
           }),
         }),
         organizationId: 'org-1',

--- a/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
@@ -136,7 +136,9 @@ describe('WorkflowsService system workflow guardrails', () => {
       metadata: {
         systemWorkflow: buildSystemWorkflowMetadata({
           canonicalId: 'daily-trends-digest',
+          changeSummary: 'Initial daily digest version.',
           sourceIssue: 1011,
+          version: 2,
         }),
       },
     } as never);
@@ -163,7 +165,9 @@ describe('WorkflowsService system workflow guardrails', () => {
         sourceType: 'seeded-template',
         systemWorkflow: buildSystemWorkflowMetadata({
           canonicalId: 'daily-trends-digest',
+          changeSummary: 'Initial daily digest version.',
           sourceIssue: 1011,
+          version: 2,
         }),
       },
       nodes: [],
@@ -203,8 +207,15 @@ describe('WorkflowsService system workflow guardrails', () => {
     expect(createInput.metadata?.duplicatedFromSystemWorkflow).toEqual(
       expect.objectContaining({
         canonicalId: 'daily-trends-digest',
+        currentSystemWorkflowChangeSummary: 'Initial daily digest version.',
+        currentSystemWorkflowVersion: 2,
         credentialPolicy: 'tenant-connected-account',
+        sourceWorkflowChangeSummary: 'Initial daily digest version.',
         sourceWorkflowId: 'system-workflow-1',
+        sourceWorkflowVersion: 2,
+        upgradeEligible: false,
+        upgradePolicy: 'manual',
+        upgradeStatus: 'current',
       }),
     );
   });

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -22,6 +22,8 @@ import {
   buildSystemWorkflowMetadata,
   isProtectedSystemWorkflowMetadata,
   SYSTEM_WORKFLOW_METADATA_KEY,
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
 } from '@api/collections/workflows/system-workflow.contract';
 import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
 import { AGENT_AUTOPILOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/agent-autopilot-workflows.template';
@@ -100,19 +102,30 @@ export class WorkflowsService extends BaseService<
   }
 
   private buildSeededSystemWorkflowMetadata(input: {
+    changeSummary?: string;
     extra?: Record<string, unknown>;
     sourceIssue: number;
     sourceTemplateId: string;
     sourceType?: string;
+    version?: number;
   }): Record<string, unknown> {
+    const sourceTemplateVersion =
+      input.version ?? SYSTEM_WORKFLOW_TEMPLATE_VERSION;
+    const sourceTemplateChangeSummary =
+      input.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY;
+
     return {
       ...(input.extra ?? {}),
       sourceIssue: input.sourceIssue,
+      sourceTemplateChangeSummary,
       sourceTemplateId: input.sourceTemplateId,
+      sourceTemplateVersion,
       sourceType: input.sourceType ?? 'seeded-template',
       [SYSTEM_WORKFLOW_METADATA_KEY]: buildSystemWorkflowMetadata({
         canonicalId: input.sourceTemplateId,
+        changeSummary: sourceTemplateChangeSummary,
         sourceIssue: input.sourceIssue,
+        version: sourceTemplateVersion,
       }),
     };
   }
@@ -289,8 +302,10 @@ export class WorkflowsService extends BaseService<
               isScheduleEnabled: true,
               label: 'Daily Trends Digest',
               metadata: this.buildSeededSystemWorkflowMetadata({
+                changeSummary: DAILY_TRENDS_DIGEST_TEMPLATE.changeSummary,
                 sourceIssue: 1011,
                 sourceTemplateId: DAILY_TRENDS_DIGEST_TEMPLATE_ID,
+                version: DAILY_TRENDS_DIGEST_TEMPLATE.version,
               }),
               nodes: DAILY_TRENDS_DIGEST_TEMPLATE.nodes as never,
               organizationId,
@@ -1199,9 +1214,11 @@ export class WorkflowsService extends BaseService<
                 isScheduleEnabled: Boolean(definition.schedule),
                 label: definition.label,
                 metadata: this.buildSeededSystemWorkflowMetadata({
+                  changeSummary: definition.changeSummary,
                   sourceIssue: 1011,
                   sourceTemplateId: definition.canonicalId,
                   sourceType: 'system-action-workflow',
+                  version: definition.version,
                 }),
                 nodes: [
                   {

--- a/apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts
+++ b/apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts
@@ -1,0 +1,99 @@
+import {
+  buildSystemWorkflowDuplicateMetadata,
+  buildSystemWorkflowMetadata,
+  buildSystemWorkflowUpgradeMetadata,
+  getSystemWorkflowDuplicateMetadata,
+} from '@api/collections/workflows/system-workflow.contract';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('system workflow contract', () => {
+  it('stores canonical template version and change summary', () => {
+    const metadata = buildSystemWorkflowMetadata({
+      canonicalId: 'scheduled-post-publishing',
+      changeSummary: 'Route scheduled publishing through system workflows.',
+      sourceIssue: 1029,
+      version: 2,
+    });
+
+    expect(metadata).toMatchObject({
+      canonicalId: 'scheduled-post-publishing',
+      changeSummary: 'Route scheduled publishing through system workflows.',
+      sourceIssue: 1029,
+      version: 2,
+    });
+  });
+
+  it('pins duplicate metadata to the source version without auto-upgrading it', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-01T12:00:00.000Z'));
+
+    try {
+      const metadata = buildSystemWorkflowDuplicateMetadata(
+        {
+          systemWorkflow: buildSystemWorkflowMetadata({
+            canonicalId: 'reply-dm-automation',
+            changeSummary: 'Initial reply and DM workflow wrapper.',
+            sourceIssue: 1011,
+            version: 3,
+          }),
+        },
+        'workflow-source-1',
+      );
+
+      expect(metadata.systemWorkflow).toBeUndefined();
+      expect(metadata.duplicatedFromSystemWorkflow).toMatchObject({
+        canonicalId: 'reply-dm-automation',
+        currentSystemWorkflowChangeSummary:
+          'Initial reply and DM workflow wrapper.',
+        currentSystemWorkflowVersion: 3,
+        duplicatedAt: '2026-07-01T12:00:00.000Z',
+        sourceWorkflowChangeSummary: 'Initial reply and DM workflow wrapper.',
+        sourceWorkflowId: 'workflow-source-1',
+        sourceWorkflowVersion: 3,
+        upgradeEligible: false,
+        upgradePolicy: 'manual',
+        upgradeStatus: 'current',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('marks duplicates upgrade eligible when the canonical template advances', () => {
+    const duplicate = getSystemWorkflowDuplicateMetadata({
+      duplicatedFromSystemWorkflow: {
+        canonicalId: 'scheduled-post-publishing',
+        currentSystemWorkflowChangeSummary: 'Initial version.',
+        currentSystemWorkflowVersion: 1,
+        credentialPolicy: 'tenant-connected-account',
+        duplicatedAt: '2026-07-01T12:00:00.000Z',
+        productizationIssue: 1011,
+        sourceWorkflowChangeSummary: 'Initial version.',
+        sourceWorkflowId: 'workflow-source-1',
+        sourceWorkflowVersion: 1,
+        upgradeEligible: false,
+        upgradePolicy: 'manual',
+        upgradeStatus: 'current',
+      },
+    });
+
+    expect(duplicate).not.toBeNull();
+
+    const upgradeMetadata = buildSystemWorkflowUpgradeMetadata(
+      duplicate!,
+      buildSystemWorkflowMetadata({
+        canonicalId: 'scheduled-post-publishing',
+        changeSummary: 'Add retry provenance.',
+        version: 2,
+      }),
+    );
+
+    expect(upgradeMetadata).toMatchObject({
+      currentSystemWorkflowChangeSummary: 'Add retry provenance.',
+      currentSystemWorkflowVersion: 2,
+      sourceWorkflowVersion: 1,
+      upgradeEligible: true,
+      upgradeStatus: 'upgrade_available',
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/system-workflow.contract.ts
+++ b/apps/server/api/src/collections/workflows/system-workflow.contract.ts
@@ -3,13 +3,19 @@ export const SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY =
   'duplicatedFromSystemWorkflow';
 export const SYSTEM_WORKFLOW_OWNER = 'genfeed';
 export const SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE = 1011;
+export const SYSTEM_WORKFLOW_TEMPLATE_VERSION = 1;
+export const SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY =
+  'Initial system workflow template version.';
 
 export type SystemWorkflowCredentialPolicy =
   | 'tenant-connected-account'
   | 'system-policy';
 
+export type SystemWorkflowUpgradeStatus = 'current' | 'upgrade_available';
+
 export type SystemWorkflowMetadata = {
   canonicalId: string;
+  changeSummary: string;
   credentialPolicy: SystemWorkflowCredentialPolicy;
   duplicable: boolean;
   immutable: boolean;
@@ -17,20 +23,43 @@ export type SystemWorkflowMetadata = {
   owner: typeof SYSTEM_WORKFLOW_OWNER;
   productizationIssue: typeof SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
   sourceIssue?: number;
+  version: number;
   visibility: 'organization';
+};
+
+export type SystemWorkflowDuplicateMetadata = {
+  canonicalId: string;
+  currentSystemWorkflowChangeSummary: string;
+  currentSystemWorkflowVersion: number;
+  credentialPolicy: SystemWorkflowCredentialPolicy;
+  duplicatedAt: string;
+  productizationIssue: typeof SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
+  sourceIssue?: number;
+  sourceWorkflowChangeSummary: string;
+  sourceWorkflowId: string;
+  sourceWorkflowVersion: number;
+  upgradeEligible: boolean;
+  upgradePolicy: 'manual';
+  upgradeStatus: SystemWorkflowUpgradeStatus;
 };
 
 export type BuildSystemWorkflowMetadataInput = {
   canonicalId: string;
+  changeSummary?: string;
   credentialPolicy?: SystemWorkflowCredentialPolicy;
   sourceIssue?: number;
+  version?: number;
 };
 
 export function buildSystemWorkflowMetadata(
   input: BuildSystemWorkflowMetadataInput,
 ): SystemWorkflowMetadata {
+  const version = normalizeSystemWorkflowVersion(input.version);
+
   return {
     canonicalId: input.canonicalId,
+    changeSummary:
+      input.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
     credentialPolicy: input.credentialPolicy ?? 'tenant-connected-account',
     duplicable: true,
     immutable: true,
@@ -38,6 +67,7 @@ export function buildSystemWorkflowMetadata(
     owner: SYSTEM_WORKFLOW_OWNER,
     productizationIssue: SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
     sourceIssue: input.sourceIssue,
+    version,
     visibility: 'organization',
   };
 }
@@ -76,6 +106,31 @@ export function getSystemWorkflowMetadata(
   return record as SystemWorkflowMetadata;
 }
 
+export function getSystemWorkflowDuplicateMetadata(
+  metadata: unknown,
+): SystemWorkflowDuplicateMetadata | null {
+  const duplicateMetadata =
+    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY];
+
+  if (
+    !duplicateMetadata ||
+    typeof duplicateMetadata !== 'object' ||
+    Array.isArray(duplicateMetadata)
+  ) {
+    return null;
+  }
+
+  const record = duplicateMetadata as Record<string, unknown>;
+  if (
+    typeof record.canonicalId !== 'string' ||
+    typeof record.sourceWorkflowId !== 'string'
+  ) {
+    return null;
+  }
+
+  return record as SystemWorkflowDuplicateMetadata;
+}
+
 export function isProtectedSystemWorkflowMetadata(metadata: unknown): boolean {
   const systemWorkflow = getSystemWorkflowMetadata(metadata);
   return systemWorkflow?.immutable === true;
@@ -93,15 +148,57 @@ export function buildSystemWorkflowDuplicateMetadata(
     return duplicatedMetadata;
   }
 
+  const sourceWorkflowVersion = normalizeSystemWorkflowVersion(
+    systemWorkflow.version,
+  );
+  const sourceWorkflowChangeSummary =
+    systemWorkflow.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY;
+
   return {
     ...duplicatedMetadata,
     [SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY]: {
       canonicalId: systemWorkflow.canonicalId,
+      currentSystemWorkflowChangeSummary: sourceWorkflowChangeSummary,
+      currentSystemWorkflowVersion: sourceWorkflowVersion,
       credentialPolicy: systemWorkflow.credentialPolicy,
       duplicatedAt: new Date().toISOString(),
       productizationIssue: systemWorkflow.productizationIssue,
       sourceIssue: systemWorkflow.sourceIssue,
+      sourceWorkflowChangeSummary,
       sourceWorkflowId,
+      sourceWorkflowVersion,
+      upgradeEligible: false,
+      upgradePolicy: 'manual',
+      upgradeStatus: 'current',
     },
   };
+}
+
+export function buildSystemWorkflowUpgradeMetadata(
+  duplicateMetadata: SystemWorkflowDuplicateMetadata,
+  currentSystemWorkflow: SystemWorkflowMetadata,
+): SystemWorkflowDuplicateMetadata {
+  const currentSystemWorkflowVersion = normalizeSystemWorkflowVersion(
+    currentSystemWorkflow.version,
+  );
+  const sourceWorkflowVersion = normalizeSystemWorkflowVersion(
+    duplicateMetadata.sourceWorkflowVersion,
+  );
+  const upgradeEligible = currentSystemWorkflowVersion > sourceWorkflowVersion;
+
+  return {
+    ...duplicateMetadata,
+    currentSystemWorkflowChangeSummary:
+      currentSystemWorkflow.changeSummary ??
+      SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+    currentSystemWorkflowVersion,
+    upgradeEligible,
+    upgradeStatus: upgradeEligible ? 'upgrade_available' : 'current',
+  };
+}
+
+function normalizeSystemWorkflowVersion(version: unknown): number {
+  return typeof version === 'number' && Number.isInteger(version) && version > 0
+    ? version
+    : SYSTEM_WORKFLOW_TEMPLATE_VERSION;
 }

--- a/apps/server/api/src/collections/workflows/templates/daily-trends-digest.template.ts
+++ b/apps/server/api/src/collections/workflows/templates/daily-trends-digest.template.ts
@@ -15,6 +15,8 @@ import { TREND_DIGEST_CREDIT_COST } from '@genfeedai/constants';
  */
 export const DAILY_TRENDS_DIGEST_TEMPLATE: WorkflowTemplate = {
   category: 'trends',
+  changeSummary:
+    'Initial daily trend digest system workflow with trend assembly and owner email delivery.',
   description:
     'Scan the latest social trends daily and email a curated digest to the organization owner. Uses credits per delivered email.',
   icon: 'trending-up',
@@ -83,4 +85,5 @@ export const DAILY_TRENDS_DIGEST_TEMPLATE: WorkflowTemplate = {
     },
   ],
   steps: [],
+  version: 1,
 };

--- a/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
+++ b/apps/server/api/src/collections/workflows/templates/workflow-templates.ts
@@ -55,6 +55,7 @@ export interface WorkflowTemplate {
   name: string;
   description: string;
   category: string;
+  changeSummary?: string;
   icon?: string;
   isScheduleEnabled?: boolean;
   inputVariables?: Array<{
@@ -93,6 +94,7 @@ export interface WorkflowTemplate {
     dependsOn?: string[];
   }>;
   timezone?: string;
+  version?: number;
 }
 
 export const WORKFLOW_TEMPLATES: Record<string, WorkflowTemplate> = {


### PR DESCRIPTION
## Summary
- Add canonical system workflow template version and change-summary metadata for seeded and on-demand system workflows.
- Preserve source/current workflow version metadata on user duplicates with manual upgrade eligibility flags.
- Add focused contract and workflow service tests for duplicate pinning and canonical version-change detection.

## Verification
- `bunx biome check --write apps/server/api/src/collections/workflows/system-workflow.contract.ts apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/services/workflows.service.spec.ts apps/server/api/src/collections/workflows/services/workflows.service.seed.spec.ts apps/server/api/src/collections/workflows/services/system-workflow-provenance.service.ts apps/server/api/src/collections/workflows/services/system-workflow-provenance.service.spec.ts apps/server/api/src/collections/workflows/templates/daily-trends-digest.template.ts apps/server/api/src/collections/workflows/templates/workflow-templates.ts`
- `bun run test:file src/collections/workflows/system-workflow.contract.spec.ts src/collections/workflows/services/workflows.service.spec.ts src/collections/workflows/services/workflows.service.seed.spec.ts src/collections/workflows/services/system-workflow-provenance.service.spec.ts`
- `bunx turbo run lint --filter=@genfeedai/api`
- `bunx turbo run type-check --filter=@genfeedai/api` (API has no package type-check script; dependency builds and env check completed)
- `bun run build` from `apps/server/api`
- `bunx secretlint <touched workflow files>`
- `git diff --check`

No schema migration required; this is additive JSON metadata with compatibility defaults.

Closes #1029
Refs #1011