### PR TITLE
refactor(api): consolidate content-run hydration helpers

### DIFF
--- a/apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.ts
+++ b/apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.ts
@@ -1,3 +1,8 @@
+import {
+  hydrateContentRun,
+  isContentRunRecord,
+  toContentRunJsonValue,
+} from '@api/collections/content-runs/utils/content-run-data.util';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import type {
@@ -5,7 +10,6 @@ import type {
   ContentRunRecommendation,
   ContentRunVariant,
 } from '@genfeedai/interfaces';
-import { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';
 
 type ContentRunRow = {
@@ -65,35 +69,14 @@ type VariantAccumulator = {
 export class ContentRunRecommendationsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-  }
-
-  private toJsonValue(value: unknown): Prisma.InputJsonValue {
-    return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
-  }
-
-  private hydrateRun(run: Record<string, unknown>): Record<string, unknown> {
-    const config = this.isRecord(run.config) ? run.config : {};
-
-    return {
-      ...run,
-      ...config,
-      _id: run.id,
-      brand: run.brandId ?? config.brand,
-      organization: run.organizationId ?? config.organization,
-      status: run.status ?? config.status,
-    };
-  }
-
   private readConfig(run: ContentRunRow): Record<string, unknown> {
-    return this.isRecord(run.config) ? run.config : {};
+    return isContentRunRecord(run.config) ? run.config : {};
   }
 
   private readVariants(config: Record<string, unknown>): ContentRunVariant[] {
     return Array.isArray(config.variants)
       ? config.variants.filter((variant): variant is ContentRunVariant =>
-          this.isRecord(variant),
+          isContentRunRecord(variant),
         )
       : [];
   }
@@ -112,7 +95,7 @@ export class ContentRunRecommendationsService {
     return (
       this.readString(row.variantId) ??
       this.readString(
-        this.isRecord((row as Record<string, unknown>).data)
+        isContentRunRecord((row as Record<string, unknown>).data)
           ? ((row as Record<string, unknown>).data as Record<string, unknown>)
               .variantId
           : undefined,
@@ -257,7 +240,7 @@ export class ContentRunRecommendationsService {
     const lowPerformers = scores.filter(
       (score) => score.rank > 1 && score.score < winner.score * 0.5,
     );
-    const brief = this.isRecord(config.brief) ? config.brief : {};
+    const brief = isContentRunRecord(config.brief) ? config.brief : {};
     const hook =
       this.readString(brief.hypothesis) ??
       this.readString(brief.angle) ??
@@ -352,7 +335,7 @@ export class ContentRunRecommendationsService {
     };
 
     const updatedRun = (await this.prisma.contentRun.update({
-      data: { config: this.toJsonValue(nextConfig) },
+      data: { config: toContentRunJsonValue(nextConfig) },
       where: { id: runId },
     })) as unknown as Record<string, unknown>;
 
@@ -360,7 +343,7 @@ export class ContentRunRecommendationsService {
       analyticsSummary,
       recommendations,
       scores,
-      updatedRun: this.hydrateRun(updatedRun),
+      updatedRun: hydrateContentRun(updatedRun) ?? updatedRun,
     };
   }
 }

--- a/apps/server/api/src/collections/content-runs/services/content-runs.service.ts
+++ b/apps/server/api/src/collections/content-runs/services/content-runs.service.ts
@@ -1,4 +1,10 @@
 import type { CreateContentRunBriefDto } from '@api/collections/content-runs/dto/create-content-run-brief.dto';
+import {
+  hydrateContentRun,
+  hydrateContentRuns,
+  isContentRunRecord,
+  toContentRunJsonValue,
+} from '@api/collections/content-runs/utils/content-run-data.util';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { ContentRunSource, ContentRunStatus } from '@genfeedai/enums';
@@ -9,50 +15,11 @@ import type {
   CreateContentRunInput,
   UpdateContentRunInput,
 } from '@genfeedai/interfaces';
-import { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class ContentRunsService {
   constructor(private readonly prisma: PrismaService) {}
-
-  private isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-  }
-
-  private hydrateRun(
-    run: Record<string, unknown> | null,
-  ): Record<string, unknown> | null {
-    if (!run) {
-      return null;
-    }
-
-    const config = this.isRecord(run.config) ? run.config : {};
-    const brand = run.brandId ?? config.brand;
-    const organization = run.organizationId ?? config.organization;
-
-    return {
-      ...run,
-      ...config,
-      _id: run.id,
-      brand,
-      organization,
-      status: run.status ?? config.status,
-    };
-  }
-
-  private hydrateRuns(
-    runs: Record<string, unknown>[],
-  ): Record<string, unknown>[] {
-    return runs.flatMap((run) => {
-      const hydrated = this.hydrateRun(run);
-      return hydrated ? [hydrated] : [];
-    });
-  }
-
-  private toJsonValue(value: unknown): Prisma.InputJsonValue {
-    return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
-  }
 
   private getString(value: unknown): string | undefined {
     return typeof value === 'string' && value.trim().length > 0
@@ -135,10 +102,10 @@ export class ContentRunsService {
   private buildRemixPackVariants(
     run: Record<string, unknown>,
   ): ContentRunVariant[] {
-    const brief = this.isRecord(run.brief)
+    const brief = isContentRunRecord(run.brief)
       ? (run.brief as unknown as ContentRunBrief)
       : {};
-    const publish = this.isRecord(run.publish)
+    const publish = isContentRunRecord(run.publish)
       ? (run.publish as unknown as ContentRunPublishContext)
       : undefined;
     const platform =
@@ -219,14 +186,14 @@ export class ContentRunsService {
     const run = await this.prisma.contentRun.create({
       data: {
         brandId: brand,
-        config: this.toJsonValue(config),
+        config: toContentRunJsonValue(config),
         isDeleted: false,
         organizationId: organization,
         status,
       },
     });
 
-    return this.hydrateRun(run as unknown as Record<string, unknown>) ?? run;
+    return hydrateContentRun(run as unknown as Record<string, unknown>) ?? run;
   }
 
   async createBriefRun(
@@ -266,7 +233,7 @@ export class ContentRunsService {
     const updated = await this.prisma.contentRun.update({
       data: {
         ...(patch.status ? { status: patch.status } : {}),
-        config: this.toJsonValue({
+        config: toContentRunJsonValue({
           ...(existing.config &&
           typeof existing.config === 'object' &&
           !Array.isArray(existing.config)
@@ -279,7 +246,8 @@ export class ContentRunsService {
     });
 
     return (
-      this.hydrateRun(updated as unknown as Record<string, unknown>) ?? updated
+      hydrateContentRun(updated as unknown as Record<string, unknown>) ??
+      updated
     );
   }
 
@@ -296,9 +264,11 @@ export class ContentRunsService {
     }
 
     const hydrated =
-      this.hydrateRun(existing as unknown as Record<string, unknown>) ??
+      hydrateContentRun(existing as unknown as Record<string, unknown>) ??
       existing;
-    const currentConfig = this.isRecord(existing.config) ? existing.config : {};
+    const currentConfig = isContentRunRecord(existing.config)
+      ? existing.config
+      : {};
     const existingVariants = Array.isArray(
       (hydrated as Record<string, unknown>).variants,
     )
@@ -312,7 +282,7 @@ export class ContentRunsService {
 
     const updated = await this.prisma.contentRun.update({
       data: {
-        config: this.toJsonValue({
+        config: toContentRunJsonValue({
           ...currentConfig,
           variants,
         }),
@@ -321,7 +291,8 @@ export class ContentRunsService {
     });
 
     return (
-      this.hydrateRun(updated as unknown as Record<string, unknown>) ?? updated
+      hydrateContentRun(updated as unknown as Record<string, unknown>) ??
+      updated
     );
   }
 
@@ -341,7 +312,7 @@ export class ContentRunsService {
       },
     });
 
-    const hydratedRuns = this.hydrateRuns(
+    const hydratedRuns = hydrateContentRuns(
       runs as unknown as Record<string, unknown>[],
     );
 
@@ -364,6 +335,6 @@ export class ContentRunsService {
       },
     });
 
-    return this.hydrateRun(run as unknown as Record<string, unknown> | null);
+    return hydrateContentRun(run as unknown as Record<string, unknown> | null);
   }
 }

--- a/apps/server/api/src/collections/content-runs/utils/content-run-data.util.spec.ts
+++ b/apps/server/api/src/collections/content-runs/utils/content-run-data.util.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hydrateContentRun,
+  hydrateContentRuns,
+  isContentRunRecord,
+  toContentRunJsonValue,
+} from './content-run-data.util';
+
+describe('content-run-data.util', () => {
+  it('detects plain content-run records', () => {
+    expect(isContentRunRecord({ id: 'run-1' })).toBe(true);
+    expect(isContentRunRecord(null)).toBe(false);
+    expect(isContentRunRecord(['run-1'])).toBe(false);
+  });
+
+  it('hydrates stored config while preserving row field precedence', () => {
+    expect(
+      hydrateContentRun({
+        brandId: 'brand-row',
+        config: {
+          brand: 'brand-config',
+          organization: 'org-config',
+          source: 'hosted',
+          status: 'config-status',
+        },
+        id: 'run-1',
+        organizationId: 'org-row',
+        status: 'row-status',
+      }),
+    ).toEqual({
+      _id: 'run-1',
+      brand: 'brand-row',
+      brandId: 'brand-row',
+      config: {
+        brand: 'brand-config',
+        organization: 'org-config',
+        source: 'hosted',
+        status: 'config-status',
+      },
+      id: 'run-1',
+      organization: 'org-row',
+      organizationId: 'org-row',
+      source: 'hosted',
+      status: 'row-status',
+    });
+  });
+
+  it('hydrates config fallback fields when row fields are missing', () => {
+    expect(
+      hydrateContentRun({
+        config: {
+          brand: 'brand-config',
+          organization: 'org-config',
+          status: 'config-status',
+        },
+        id: 'run-2',
+      }),
+    ).toMatchObject({
+      _id: 'run-2',
+      brand: 'brand-config',
+      organization: 'org-config',
+      status: 'config-status',
+    });
+  });
+
+  it('keeps null runs out of hydrated run lists', () => {
+    expect(hydrateContentRun(null)).toBeNull();
+    expect(hydrateContentRuns([{ config: {}, id: 'run-1' }])).toHaveLength(1);
+  });
+
+  it('serializes undefined as a Prisma JSON null value', () => {
+    expect(toContentRunJsonValue(undefined)).toBeNull();
+  });
+});

--- a/apps/server/api/src/collections/content-runs/utils/content-run-data.util.ts
+++ b/apps/server/api/src/collections/content-runs/utils/content-run-data.util.ts
@@ -1,0 +1,41 @@
+import { Prisma } from '@genfeedai/prisma';
+
+export type ContentRunRecord = Record<string, unknown>;
+
+export function isContentRunRecord(value: unknown): value is ContentRunRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function toContentRunJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value ?? null)) as Prisma.InputJsonValue;
+}
+
+export function hydrateContentRun(
+  run: ContentRunRecord | null,
+): ContentRunRecord | null {
+  if (!run) {
+    return null;
+  }
+
+  const config = isContentRunRecord(run.config) ? run.config : {};
+  const brand = run.brandId ?? config.brand;
+  const organization = run.organizationId ?? config.organization;
+
+  return {
+    ...run,
+    ...config,
+    _id: run.id,
+    brand,
+    organization,
+    status: run.status ?? config.status,
+  };
+}
+
+export function hydrateContentRuns(
+  runs: ContentRunRecord[],
+): ContentRunRecord[] {
+  return runs.flatMap((run) => {
+    const hydrated = hydrateContentRun(run);
+    return hydrated ? [hydrated] : [];
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a collection-local `content-run-data` utility for content-run record guards, Prisma JSON cloning, and hydration.
- Reuses that utility from `ContentRunsService` and `ContentRunRecommendationsService` to remove duplicated helper implementations.
- Adds focused utility coverage for hydration precedence, config fallback, null handling, and JSON null serialization.

Closes #1069

## Validation

- `bunx biome check --write apps/server/api/src/collections/content-runs/services/content-runs.service.ts apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.ts apps/server/api/src/collections/content-runs/utils/content-run-data.util.ts apps/server/api/src/collections/content-runs/utils/content-run-data.util.spec.ts`
- `bun run test:file src/collections/content-runs/utils/content-run-data.util.spec.ts src/collections/content-runs/services/content-runs.service.spec.ts src/collections/content-runs/services/content-run-recommendations.service.spec.ts src/collections/content-runs/controllers/content-runs.controller.spec.ts` (from `apps/server/api`)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/collections/content-runs/services/content-runs.service.ts apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.ts apps/server/api/src/collections/content-runs/utils/content-run-data.util.ts apps/server/api/src/collections/content-runs/utils/content-run-data.util.spec.ts`
- `bun run lint-staged`
