### PR TITLE
refactor(api): inline analytics date-range helpers

### DIFF
--- a/apps/server/api/src/collections/content-performance/services/performance-summary.service.ts
+++ b/apps/server/api/src/collections/content-performance/services/performance-summary.service.ts
@@ -91,10 +91,6 @@ type PostingTimeAnalysisRow = {
 export class PerformanceSummaryService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private parseDateRange(startDate?: Date | string, endDate?: Date | string) {
-    return DateRangeUtil.parseDateRange(startDate, endDate);
-  }
-
   private buildMatchFilter(
     organizationId: string,
     brandId: string,
@@ -133,7 +129,7 @@ export class PerformanceSummaryService {
     const { topN = 5, worstN = 5 } = options;
 
     const { startDate, endDate, previousStartDate, previousEndDate } =
-      this.parseDateRange(options.startDate, options.endDate);
+      DateRangeUtil.parseDateRange(options.startDate, options.endDate);
 
     const matchFilter = this.buildMatchFilter(
       organizationId,
@@ -183,7 +179,7 @@ export class PerformanceSummaryService {
     limit: number = 10,
     dateRange?: { startDate?: Date | string; endDate?: Date | string },
   ): Promise<PerformanceContentItem[]> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       dateRange?.startDate,
       dateRange?.endDate,
     );
@@ -207,10 +203,8 @@ export class PerformanceSummaryService {
     startDate?: Date | string,
     endDate?: Date | string,
   ): Promise<PromptPerformanceItem[]> {
-    const { startDate: parsedStart, endDate: parsedEnd } = this.parseDateRange(
-      startDate,
-      endDate,
-    );
+    const { startDate: parsedStart, endDate: parsedEnd } =
+      DateRangeUtil.parseDateRange(startDate, endDate);
 
     const matchFilter = this.buildMatchFilter(
       organizationId,
@@ -285,7 +279,7 @@ export class PerformanceSummaryService {
     brandId: string,
   ): Promise<string> {
     const { startDate, endDate, previousStartDate, previousEndDate } =
-      this.parseDateRange();
+      DateRangeUtil.parseDateRange();
 
     const matchFilter = this.buildMatchFilter(
       organizationId,

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
@@ -11,13 +11,6 @@ import type { IViralHookPlatformAggResult } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';
 
-export interface Timeframe {
-  startDate: Date;
-  endDate: Date;
-  previousStartDate: Date;
-  previousEndDate: Date;
-}
-
 export interface OverviewMetrics {
   totalPosts: number;
   totalViews: number;
@@ -154,16 +147,6 @@ export class AnalyticsAggregationService {
     private readonly postsService: PostsService,
   ) {}
 
-  /**
-   * Parse date range with validation
-   */
-  private parseDateRange(
-    startDateInput?: Date | string,
-    endDateInput?: Date | string,
-  ): Timeframe {
-    return DateRangeUtil.parseDateRange(startDateInput, endDateInput);
-  }
-
   private readNumber(value: unknown): number {
     return Number(value ?? 0);
   }
@@ -217,7 +200,7 @@ export class AnalyticsAggregationService {
       endDate: parsedEndDate,
       previousStartDate,
       previousEndDate,
-    } = this.parseDateRange(startDate, endDate);
+    } = DateRangeUtil.parseDateRange(startDate, endDate);
 
     const where: Record<string, unknown> = {
       date: { gte: parsedStartDate, lte: parsedEndDate },
@@ -485,7 +468,7 @@ export class AnalyticsAggregationService {
     endDateInput?: Date | string,
     groupBy: 'day' | 'week' = 'day',
   ): Promise<TimeSeriesDataPointWithPlatforms[]> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateInput,
       endDateInput,
     );
@@ -583,7 +566,7 @@ export class AnalyticsAggregationService {
     startDateInput?: Date | string,
     endDateInput?: Date | string,
   ): Promise<PlatformComparison[]> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateInput,
       endDateInput,
     );
@@ -650,7 +633,7 @@ export class AnalyticsAggregationService {
     startDateInput?: Date | string,
     endDateInput?: Date | string,
   ): Promise<TopContent[]> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateInput,
       endDateInput,
     );
@@ -775,7 +758,7 @@ export class AnalyticsAggregationService {
     endDateInput?: Date | string,
   ): Promise<GrowthTrends> {
     const { startDate, endDate, previousStartDate, previousEndDate } =
-      this.parseDateRange(startDateInput, endDateInput);
+      DateRangeUtil.parseDateRange(startDateInput, endDateInput);
 
     const where: Record<string, unknown> = {
       date: { gte: startDate, lte: endDate },
@@ -879,7 +862,7 @@ export class AnalyticsAggregationService {
     startDateInput?: Date | string,
     endDateInput?: Date | string,
   ): Promise<EngagementBreakdown> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateInput,
       endDateInput,
     );
@@ -928,7 +911,7 @@ export class AnalyticsAggregationService {
     startDateInput?: Date | string,
     endDateInput?: Date | string,
   ): Promise<ViralHookSummaryEntity> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateInput,
       endDateInput,
     );
@@ -1169,7 +1152,7 @@ export class AnalyticsAggregationService {
       endDate: parsedEndDate,
       previousStartDate,
       previousEndDate,
-    } = this.parseDateRange(startDate, endDate);
+    } = DateRangeUtil.parseDateRange(startDate, endDate);
 
     const where: Record<string, unknown> = {
       date: { gte: parsedStartDate, lte: parsedEndDate },

--- a/apps/server/api/src/endpoints/analytics/analytics.service.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.service.ts
@@ -7,7 +7,6 @@ import { AnalyticsMetric, CredentialPlatform } from '@genfeedai/enums';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import type { DateRange } from './analytics.types';
 
 type PrismaSql = ReturnType<typeof Prisma.sql>;
 type PostAnalyticsTextColumn = 'brandId' | 'organizationId';
@@ -74,17 +73,6 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     logger: LoggerService,
   ) {
     super(prisma, 'analytic', logger, configService);
-  }
-
-  /**
-   * Parse date range from optional startDate/endDate strings
-   * Uses DateRangeUtil helper with default D-7 to D-1
-   */
-  private parseDateRange(
-    startDateStr?: string,
-    endDateStr?: string,
-  ): DateRange {
-    return DateRangeUtil.parseDateRange(startDateStr, endDateStr);
   }
 
   private postAnalyticsTextColumn(
@@ -269,7 +257,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     organizationId?: string,
   ): Promise<unknown> {
     const { startDate, endDate, previousStartDate, previousEndDate } =
-      this.parseDateRange(startDateStr, endDateStr);
+      DateRangeUtil.parseDateRange(startDateStr, endDateStr);
 
     // Build conditional WHERE fragments
     const brandFilter = this.postAnalyticsOptionalTextFilter(
@@ -438,7 +426,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     brandId?: string,
     organizationId?: string,
   ): Promise<AnalyticsBestPostingTime[]> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateStr,
       endDateStr,
     );
@@ -510,7 +498,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
   ): Promise<unknown[]> {
     // Enforce maximum limit to prevent excessive data fetching
     const safeLimit = Math.min(Math.max(1, limit), 100);
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateStr,
       endDateStr,
     );
@@ -614,7 +602,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     endDateStr?: string,
     brandId?: string,
   ): Promise<unknown> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateStr,
       endDateStr,
     );
@@ -691,7 +679,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     brandId?: string,
   ): Promise<unknown> {
     const { startDate, endDate, previousStartDate, previousEndDate } =
-      this.parseDateRange(startDateStr, endDateStr);
+      DateRangeUtil.parseDateRange(startDateStr, endDateStr);
 
     const brandFilter = this.postAnalyticsOptionalTextFilter(
       'brandId',
@@ -833,7 +821,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     brandId?: string,
     platform?: CredentialPlatform,
   ): Promise<unknown> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateStr,
       endDateStr,
     );
@@ -897,7 +885,7 @@ export class AnalyticsService extends BaseService<Record<string, unknown>> {
     brandId?: string,
     organizationId?: string,
   ): Promise<ViralHooksResult> {
-    const { startDate, endDate } = this.parseDateRange(
+    const { startDate, endDate } = DateRangeUtil.parseDateRange(
       startDateStr,
       endDateStr,
     );

--- a/apps/server/api/src/endpoints/analytics/entity-leaderboard.service.ts
+++ b/apps/server/api/src/endpoints/analytics/entity-leaderboard.service.ts
@@ -68,17 +68,6 @@ export class EntityLeaderboardService {
     private readonly loggerService: LoggerService,
   ) {}
 
-  /**
-   * Parse date range from optional startDate/endDate strings
-   * Uses DateRangeUtil helper with default D-7 to D-1
-   */
-  private parseDateRange(
-    startDateStr?: string,
-    endDateStr?: string,
-  ): DateRange {
-    return DateRangeUtil.parseDateRange(startDateStr, endDateStr);
-  }
-
   private entityColumn(field: EntityField): PrismaSql {
     return Prisma.raw(`"${field}"`);
   }
@@ -310,7 +299,7 @@ export class EntityLeaderboardService {
     sort: LeaderboardSort = LeaderboardSort.ENGAGEMENT,
     limit: number = 10,
   ): Promise<OrgLeaderboardItemEntity[]> {
-    const range = this.parseDateRange(startDateStr, endDateStr);
+    const range = DateRangeUtil.parseDateRange(startDateStr, endDateStr);
     const rows = await this.loadEntitiesWithStats<OrganizationDoc>(
       'organization',
       range,
@@ -361,7 +350,7 @@ export class EntityLeaderboardService {
     limit: number = 10,
     organizationId?: string,
   ): Promise<BrandWithStatsEntity[]> {
-    const range = this.parseDateRange(startDateStr, endDateStr);
+    const range = DateRangeUtil.parseDateRange(startDateStr, endDateStr);
     const rows = await this.loadEntitiesWithStats<BrandDoc>('brand', range, {
       includePlatforms: true,
       organizationId,
@@ -385,7 +374,7 @@ export class EntityLeaderboardService {
     limit: number = 20,
     sort: LeaderboardSort = LeaderboardSort.ENGAGEMENT,
   ): Promise<PaginatedOrgsResponse> {
-    const range = this.parseDateRange(startDateStr, endDateStr);
+    const range = DateRangeUtil.parseDateRange(startDateStr, endDateStr);
     const rows = await this.loadEntitiesWithStats<OrganizationDoc>(
       'organization',
       range,
@@ -427,7 +416,7 @@ export class EntityLeaderboardService {
     sort: LeaderboardSort = LeaderboardSort.ENGAGEMENT,
     organizationId?: string,
   ): Promise<PaginatedBrandsResponse> {
-    const range = this.parseDateRange(startDateStr, endDateStr);
+    const range = DateRangeUtil.parseDateRange(startDateStr, endDateStr);
     const rows = await this.loadEntitiesWithStats<BrandDoc>('brand', range, {
       includePlatforms: true,
       organizationId,


### PR DESCRIPTION
## Summary
- Delete four no-op private analytics `parseDateRange` wrappers that only forwarded to `DateRangeUtil.parseDateRange(...)`.
- Replace internal call sites with direct canonical `DateRangeUtil` calls.
- Remove the now-dead local `Timeframe` return interface from post analytics aggregation.

Closes #1072

## Validation
- `bunx biome check --write apps/server/api/src/endpoints/analytics/analytics.service.ts apps/server/api/src/endpoints/analytics/entity-leaderboard.service.ts apps/server/api/src/collections/content-performance/services/performance-summary.service.ts apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts`
- `bun run test:file src/helpers/utils/date-range/date-range.util.spec.ts src/endpoints/analytics/analytics.service.spec.ts src/endpoints/analytics/entity-leaderboard.service.spec.ts src/collections/posts/services/analytics-aggregation.service.spec.ts src/collections/content-performance/services/analytics-ingestion-dashboard-smoke.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `git diff --cached --check`
- `bunx secretlint apps/server/api/src/endpoints/analytics/analytics.service.ts apps/server/api/src/endpoints/analytics/entity-leaderboard.service.ts apps/server/api/src/collections/content-performance/services/performance-summary.service.ts apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts`
- `bun run lint-staged`

## Structural Review
- Handled: removed thin pass-through abstractions; no new wrappers, casts, branching, query behavior, or package-boundary movement.
- Deferred: `analytics.service.ts` and `analytics-aggregation.service.ts` remain over 1,000 lines from pre-existing analytics debt; this PR reduces those files and keeps decomposition out of scope.