### PR TITLE
test(architecture): guard social inbox workflow actions

### DIFF
--- a/scripts/architecture/check-product-workflow-boundary.test.ts
+++ b/scripts/architecture/check-product-workflow-boundary.test.ts
@@ -74,6 +74,75 @@ describe('check-product-workflow-boundary', () => {
     expect(result.documentedDetections).toHaveLength(1);
   });
 
+  it('flags undocumented social inbox platform reply and DM actions', () => {
+    writeFixture(
+      'apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts',
+      `
+        export class SocialInboxService {
+          async postReply(): Promise<void> {
+            await this.youtubeService.postCommentReply('org-1', 'brand-1', 'comment-1', 'hello');
+          }
+
+          async sendDm(): Promise<void> {
+            await this.instagramService.sendCommentReplyDm('org-1', 'brand-1', 'user-1', 'hello');
+          }
+        }
+      `,
+    );
+
+    const result = runCheckProductWorkflowBoundary({ exceptions: [] });
+
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'undocumented-product-workflow-boundary',
+        }),
+      ]),
+    );
+    expect(result.detections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'social-inbox-direct-platform-action',
+        }),
+      ]),
+    );
+  });
+
+  it('allows documented social inbox action migration exceptions', () => {
+    writeFixture(
+      'apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts',
+      `
+        export class SocialInboxService {
+          async postReply(): Promise<void> {
+            await this.instagramService.replyToComment('org-1', 'brand-1', 'comment-1', 'hello');
+          }
+        }
+      `,
+    );
+
+    const exceptions: ProductWorkflowBoundaryException[] = [
+      {
+        classification: 'pending-system-workflow-migration',
+        file: 'apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts',
+        id: 'social-inbox-actions',
+        issue: 1032,
+        reason: 'Fixture social inbox action migration.',
+        systemWorkflowIds: ['reply-dm-automation'],
+      },
+    ];
+
+    const result = runCheckProductWorkflowBoundary({ exceptions });
+
+    expect(result.violations).toHaveLength(0);
+    expect(result.documentedDetections).toEqual([
+      expect.objectContaining({
+        detection: expect.objectContaining({
+          ruleId: 'social-inbox-direct-platform-action',
+        }),
+      }),
+    ]);
+  });
+
   it('rejects pending migration exceptions without a replacement workflow id', () => {
     writeFixture(
       'apps/server/api/src/services/reply-bot/orchestrator.service.ts',

--- a/scripts/architecture/check-product-workflow-boundary.ts
+++ b/scripts/architecture/check-product-workflow-boundary.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { globSync } from 'glob';
 
 const DEFAULT_INCLUDE_GLOBS = [
+  'apps/server/api/src/collections/social-inbox/**/*.ts',
   'apps/server/api/src/services/campaign/**/*.ts',
   'apps/server/api/src/services/reply-bot/**/*.ts',
   'apps/server/api/src/services/twitter-pipeline/**/*.ts',
@@ -139,6 +140,15 @@ export const PRODUCT_WORKFLOW_BOUNDARY_EXCEPTIONS: ProductWorkflowBoundaryExcept
     },
     {
       classification: 'pending-system-workflow-migration',
+      file: 'apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts',
+      id: 'social-inbox-manual-actions',
+      issue: 1032,
+      reason:
+        'Manual social inbox reply/DM endpoints still dispatch directly while reply and DM actions move behind workflow execution.',
+      systemWorkflowIds: ['reply-dm-automation'],
+    },
+    {
+      classification: 'pending-system-workflow-migration',
       file: 'apps/server/workers/src/crons/dynamic-jobs/cron.dynamic-jobs.service.ts',
       id: 'legacy-dynamic-jobs-dispatcher',
       issue: 1011,
@@ -236,6 +246,17 @@ const PRODUCT_WORKFLOW_BOUNDARY_RULES: ProductWorkflowBoundaryRule[] = [
       /\b(?:sendInstagramDm|postInstagramComment)\s*\(/.test(source),
     message:
       'Direct social API actions must be isolated behind workflow nodes or documented as pending migration.',
+  },
+  {
+    id: 'social-inbox-direct-platform-action',
+    matches: (file, source) =>
+      file.startsWith('apps/server/api/src/collections/social-inbox/') &&
+      (/\byoutubeService\s*\.\s*postCommentReply\s*\(/.test(source) ||
+        /\binstagramService\s*\.\s*(?:replyToComment|sendCommentReplyDm)\s*\(/.test(
+          source,
+        )),
+    message:
+      'Social inbox reply/DM platform actions must run through workflow execution or be documented as a bounded migration exception.',
   },
   {
     id: 'product-cron-service',


### PR DESCRIPTION
## Summary
- Extend the product workflow boundary guard to scan the social-inbox collection.
- Detect direct YouTube/Instagram social reply and DM platform actions unless they are documented as workflow-backed or pending migration.
- Document the current social inbox manual action path as a bounded pending migration tied to #1032 and `reply-dm-automation`.

## Validation
- `bunx vitest run --config scripts/architecture/vitest.config.ts check-product-workflow-boundary.test.ts`
- `bun run check:architecture`
- `bunx biome check scripts/architecture/check-product-workflow-boundary.ts scripts/architecture/check-product-workflow-boundary.test.ts`
- `bunx secretlint scripts/architecture/check-product-workflow-boundary.ts scripts/architecture/check-product-workflow-boundary.test.ts`
- `git diff --check`
- `git diff --cached --check`
- `bun run lint-staged`

Closes #1034
Refs #1011
Refs #1032