### PR TITLE
refactor(api): consolidate task queue enqueue helper

### DIFF
--- a/apps/server/api/src/services/task-queue-client/task-queue-client.service.spec.ts
+++ b/apps/server/api/src/services/task-queue-client/task-queue-client.service.spec.ts
@@ -4,12 +4,15 @@ import {
   TaskQueueClientService,
 } from '@api/services/task-queue-client/task-queue-client.service';
 import { HttpService } from '@nestjs/axios';
+import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { of, throwError } from 'rxjs';
 
 describe('TaskQueueClientService', () => {
   let service: TaskQueueClientService;
   let httpService: vi.Mocked<HttpService>;
+  let loggerErrorSpy: ReturnType<typeof vi.spyOn>;
+  let loggerLogSpy: ReturnType<typeof vi.spyOn>;
 
   const mockFilesServiceUrl = 'http://localhost:3012';
 
@@ -52,8 +55,18 @@ describe('TaskQueueClientService', () => {
 
     service = module.get<TaskQueueClientService>(TaskQueueClientService);
     httpService = module.get(HttpService);
+    loggerErrorSpy = vi
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    loggerLogSpy = vi
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
 
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should be defined', () => {
@@ -77,6 +90,9 @@ describe('TaskQueueClientService', () => {
       expect(httpService.post).toHaveBeenCalledWith(
         `${mockFilesServiceUrl}/tasks/queue/transform`,
         mockTaskJobRequest,
+      );
+      expect(loggerLogSpy).toHaveBeenCalledWith(
+        `Queued transform job for asset ${mockTaskJobRequest.assetId}`,
       );
     });
 
@@ -210,6 +226,10 @@ describe('TaskQueueClientService', () => {
       httpService.post.mockReturnValue(throwError(() => error));
 
       await expect(service.queueClipJob(mockTaskJobRequest)).rejects.toThrow(
+        error,
+      );
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Failed to queue clip job',
         error,
       );
     });

--- a/apps/server/api/src/services/task-queue-client/task-queue-client.service.ts
+++ b/apps/server/api/src/services/task-queue-client/task-queue-client.service.ts
@@ -17,6 +17,8 @@ export interface TaskJobRequest {
   priority?: number;
 }
 
+type TaskQueueJobType = 'caption' | 'clip' | 'resize' | 'transform' | 'upscale';
+
 /**
  * TaskQueueClientService
  *
@@ -39,78 +41,37 @@ export class TaskQueueClientService {
   }
 
   async queueTransformJob(data: TaskJobRequest) {
-    try {
-      const response = await firstValueFrom(
-        this.httpService.post(
-          `${this.filesServiceUrl}/tasks/queue/transform`,
-          data,
-        ),
-      );
-      this.logger.log(`Queued transform job for asset ${data.assetId}`);
-      return response.data;
-    } catch (error: unknown) {
-      this.logger.error('Failed to queue transform job', error);
-      throw error;
-    }
+    return this.queueJob('transform', data);
   }
 
   async queueUpscaleJob(data: TaskJobRequest) {
-    try {
-      const response = await firstValueFrom(
-        this.httpService.post(
-          `${this.filesServiceUrl}/tasks/queue/upscale`,
-          data,
-        ),
-      );
-      this.logger.log(`Queued upscale job for asset ${data.assetId}`);
-      return response.data;
-    } catch (error: unknown) {
-      this.logger.error('Failed to queue upscale job', error);
-      throw error;
-    }
+    return this.queueJob('upscale', data);
   }
 
   async queueCaptionJob(data: TaskJobRequest) {
-    try {
-      const response = await firstValueFrom(
-        this.httpService.post(
-          `${this.filesServiceUrl}/tasks/queue/caption`,
-          data,
-        ),
-      );
-      this.logger.log(`Queued caption job for asset ${data.assetId}`);
-      return response.data;
-    } catch (error: unknown) {
-      this.logger.error('Failed to queue caption job', error);
-      throw error;
-    }
+    return this.queueJob('caption', data);
   }
 
   async queueResizeJob(data: TaskJobRequest) {
-    try {
-      const response = await firstValueFrom(
-        this.httpService.post(
-          `${this.filesServiceUrl}/tasks/queue/resize`,
-          data,
-        ),
-      );
-      this.logger.log(`Queued resize job for asset ${data.assetId}`);
-      return response.data;
-    } catch (error: unknown) {
-      this.logger.error('Failed to queue resize job', error);
-      throw error;
-    }
+    return this.queueJob('resize', data);
   }
 
   async queueClipJob(data: TaskJobRequest) {
+    return this.queueJob('clip', data);
+  }
+
+  private async queueJob(type: TaskQueueJobType, data: TaskJobRequest) {
     try {
       const response = await firstValueFrom(
-        this.httpService.post(`${this.filesServiceUrl}/tasks/queue/clip`, data),
+        this.httpService.post(
+          `${this.filesServiceUrl}/tasks/queue/${type}`,
+          data,
+        ),
       );
-      this.logger.log(`Queued clip job for asset ${data.assetId}`);
+      this.logger.log(`Queued ${type} job for asset ${data.assetId}`);
       return response.data;
     } catch (error: unknown) {
-      this.logger.error('Failed to queue clip job', error);
+      this.logger.error(`Failed to queue ${type} job`, error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- Closes #1075
- Replaces five duplicated `TaskQueueClientService` enqueue POST flows with one private `queueJob` helper.
- Keeps the five public queue methods, endpoint paths, success log messages, failure log messages, return behavior, and rethrow behavior intact.
- Adds focused log-message characterization around the centralized success/error behavior.

## Validation

- `bunx biome check --write apps/server/api/src/services/task-queue-client/task-queue-client.service.ts apps/server/api/src/services/task-queue-client/task-queue-client.service.spec.ts`
- `bun run test:file src/services/task-queue-client/task-queue-client.service.spec.ts` from `apps/server/api` (17 tests)
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/services/task-queue-client/task-queue-client.service.ts apps/server/api/src/services/task-queue-client/task-queue-client.service.spec.ts`
- `bun run lint-staged`

## Notes

A direct `bunx tsc -p apps/server/api/tsconfig.typecheck.json --noEmit` currently fails on trunk before this change because of the TS 6 `baseUrl` deprecation. Re-running with `--ignoreDeprecations 6.0` surfaces unrelated existing API type errors in auth, workflow, warmup, main, and integration files; none are in the touched task queue client files.

Structural-review pass: no blocker/request-change findings. The helper has five real callers, deletes duplicated control flow, adds no public API, casts, package-boundary movement, database writes, or branch-spreading.
