### PR TITLE
test(mcp): cover social message controls

### DIFF
--- a/apps/server/mcp/src/services/client.service.spec.ts
+++ b/apps/server/mcp/src/services/client.service.spec.ts
@@ -18,6 +18,7 @@ describe('ClientService (MCP)', () => {
     } as any,
     delete: vi.fn(),
     get: vi.fn(),
+    patch: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
   };
@@ -1079,6 +1080,212 @@ describe('ClientService (MCP)', () => {
       );
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe('daily-image-generation');
+    });
+  });
+
+  // ==================== SOCIAL MESSAGES TESTS ====================
+
+  describe('listSocialConversations', () => {
+    it('should list conversations with review filters', async () => {
+      const mockResponse = {
+        data: {
+          data: [
+            {
+              attributes: {
+                latestMessageText: 'Can I get the template?',
+                platform: 'youtube',
+                status: 'open',
+              },
+              id: 'conv-1',
+            },
+          ],
+          meta: { page: 1, totalPages: 1 },
+        },
+      };
+
+      (mockAxiosInstance.get as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.listSocialConversations({
+        limit: 5,
+        needsReview: true,
+        platform: 'youtube',
+        status: 'open',
+      });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/messages', {
+        params: {
+          limit: 5,
+          needsReview: true,
+          platform: 'youtube',
+          status: 'open',
+        },
+      });
+      expect(result).toEqual({
+        conversations: [
+          {
+            id: 'conv-1',
+            latestMessageText: 'Can I get the template?',
+            platform: 'youtube',
+            status: 'open',
+          },
+        ],
+        meta: { page: 1, totalPages: 1 },
+      });
+    });
+  });
+
+  describe('getSocialConversation', () => {
+    it('should inspect a conversation and include bounded recent messages', async () => {
+      (mockAxiosInstance.get as Mock)
+        .mockResolvedValueOnce({
+          data: {
+            data: {
+              attributes: { platform: 'instagram', status: 'needs_review' },
+              id: 'conv-1',
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            data: [
+              {
+                attributes: { body: 'Interested', status: 'received' },
+                id: 'msg-1',
+              },
+            ],
+          },
+        });
+
+      const result = await service.getSocialConversation('conv-1', {
+        limit: 10,
+      });
+
+      expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+        1,
+        '/messages/conv-1',
+      );
+      expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+        2,
+        '/messages/conv-1/messages',
+        { params: { limit: 10 } },
+      );
+      expect(result).toEqual({
+        conversation: {
+          id: 'conv-1',
+          platform: 'instagram',
+          status: 'needs_review',
+        },
+        messages: [{ body: 'Interested', id: 'msg-1', status: 'received' }],
+      });
+    });
+  });
+
+  describe('social message actions', () => {
+    it('should create a provenance-backed reply draft without publishing', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            attributes: {
+              actionProvenance: { actorType: 'agent' },
+              body: 'Thanks for asking',
+              status: 'draft',
+            },
+            id: 'msg-draft',
+          },
+        },
+      };
+
+      (mockAxiosInstance.post as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.createSocialReplyDraft('conv-1', {
+        agentRunId: 'agent-run-1',
+        text: 'Thanks for asking',
+        workflowRunId: 'workflow-run-1',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/messages/conv-1/drafts',
+        {
+          agentRunId: 'agent-run-1',
+          text: 'Thanks for asking',
+          workflowRunId: 'workflow-run-1',
+        },
+      );
+      expect(result).toEqual({
+        actionProvenance: { actorType: 'agent' },
+        body: 'Thanks for asking',
+        id: 'msg-draft',
+        status: 'draft',
+      });
+    });
+
+    it('should post replies through the social inbox action route', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            attributes: { body: 'Public reply', status: 'sent' },
+            id: 'msg-reply',
+          },
+        },
+      };
+
+      (mockAxiosInstance.post as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.postSocialReply('conv-1', {
+        idempotencyKey: 'reply-1',
+        text: 'Public reply',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/messages/conv-1/replies',
+        { idempotencyKey: 'reply-1', text: 'Public reply' },
+      );
+      expect(result).toMatchObject({ id: 'msg-reply', status: 'sent' });
+    });
+
+    it('should send DMs through the social inbox action route', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            attributes: { body: 'Private follow-up', status: 'sent' },
+            id: 'msg-dm',
+          },
+        },
+      };
+
+      (mockAxiosInstance.post as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.sendSocialDm('conv-1', {
+        recipientId: 'viewer-1',
+        text: 'Private follow-up',
+      });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/messages/conv-1/dms',
+        { recipientId: 'viewer-1', text: 'Private follow-up' },
+      );
+      expect(result).toMatchObject({ id: 'msg-dm', status: 'sent' });
+    });
+
+    it('should update social conversation metadata through patch routes', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            attributes: { assignedOwnerId: 'user-2', tags: ['lead'] },
+            id: 'conv-1',
+          },
+        },
+      };
+
+      (mockAxiosInstance.patch as Mock).mockResolvedValue(mockResponse);
+
+      const result = await service.updateSocialTags('conv-1', ['lead']);
+
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
+        '/messages/conv-1/tags',
+        { tags: ['lead'] },
+      );
+      expect(result).toMatchObject({ id: 'conv-1', tags: ['lead'] });
     });
   });
 

--- a/apps/server/mcp/src/services/tool-registry.service.spec.ts
+++ b/apps/server/mcp/src/services/tool-registry.service.spec.ts
@@ -101,6 +101,56 @@ const MOCK_TOOLS = [
     requiredRole: 'admin',
     surfaces: { mcp: true },
   },
+  {
+    name: 'list_social_conversations',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'get_social_conversation',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'create_social_reply_draft',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'approve_social_draft',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'reject_social_draft',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'post_social_reply',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'send_social_dm',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'tag_social_conversation',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'assign_social_conversation',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
+  {
+    name: 'mark_social_conversation_resolved',
+    requiredRole: 'user',
+    surfaces: { mcp: true },
+  },
 ];
 
 const TOOLS_BY_NAME = new Map(MOCK_TOOLS.map((t) => [t.name, t]));
@@ -131,15 +181,25 @@ describe('ToolRegistryService', () => {
     listImages: ReturnType<typeof vi.fn>;
     createArticle: ReturnType<typeof vi.fn>;
     createApproval: ReturnType<typeof vi.fn>;
+    approveSocialDraft: ReturnType<typeof vi.fn>;
+    assignSocialConversation: ReturnType<typeof vi.fn>;
+    createSocialReplyDraft: ReturnType<typeof vi.fn>;
     getWorkflowStatus: ReturnType<typeof vi.fn>;
+    getSocialConversation: ReturnType<typeof vi.fn>;
     inspectWorkflow: ReturnType<typeof vi.fn>;
     duplicateWorkflow: ReturnType<typeof vi.fn>;
     setWorkflowSchedule: ReturnType<typeof vi.fn>;
     listWorkflowRuns: ReturnType<typeof vi.fn>;
     getWorkflowRun: ReturnType<typeof vi.fn>;
     getOrganizationAnalytics: ReturnType<typeof vi.fn>;
+    listSocialConversations: ReturnType<typeof vi.fn>;
+    markSocialConversationResolved: ReturnType<typeof vi.fn>;
+    postSocialReply: ReturnType<typeof vi.fn>;
+    rejectSocialDraft: ReturnType<typeof vi.fn>;
     retryAgentRun: ReturnType<typeof vi.fn>;
+    sendSocialDm: ReturnType<typeof vi.fn>;
     setBearerToken: ReturnType<typeof vi.fn>;
+    updateSocialTags: ReturnType<typeof vi.fn>;
   };
   let logger: {
     debug: ReturnType<typeof vi.fn>;
@@ -157,17 +217,28 @@ describe('ToolRegistryService', () => {
               id: 'run-1',
               status: 'CANCELLED',
             }),
-            createApproval: vi.fn().mockResolvedValue({
-              id: 'apr-art-1',
-              status: 'PENDING',
-              toolName: 'create_article',
-            }),
+            approveSocialDraft: vi
+              .fn()
+              .mockResolvedValue({ id: 'msg-approved', status: 'sent' }),
+            assignSocialConversation: vi
+              .fn()
+              .mockResolvedValue({ assignedOwnerId: 'user-2', id: 'conv-1' }),
+            createApproval: vi.fn().mockImplementation((toolName: string) =>
+              Promise.resolve({
+                id: 'apr-1',
+                status: 'PENDING',
+                toolName,
+              }),
+            ),
             createArticle: vi.fn().mockResolvedValue({
               id: 'art-1',
               status: 'draft',
               title: 'AI News',
               wordCount: 500,
             }),
+            createSocialReplyDraft: vi
+              .fn()
+              .mockResolvedValue({ id: 'msg-draft', status: 'draft' }),
             executeAgentTool: vi.fn().mockImplementation((name: string) =>
               Promise.resolve({
                 creditsUsed: 1,
@@ -178,6 +249,10 @@ describe('ToolRegistryService', () => {
             getOrganizationAnalytics: vi
               .fn()
               .mockResolvedValue({ totalViews: 9999 }),
+            getSocialConversation: vi.fn().mockResolvedValue({
+              conversation: { id: 'conv-1', status: 'open' },
+              messages: [{ id: 'msg-1', status: 'received' }],
+            }),
             getAgentRun: vi.fn().mockResolvedValue({
               id: 'run-1',
               label: 'Agent run',
@@ -226,14 +301,33 @@ describe('ToolRegistryService', () => {
             listAgentRuns: vi
               .fn()
               .mockResolvedValue([{ id: 'run-1', status: 'RUNNING' }]),
+            listSocialConversations: vi.fn().mockResolvedValue({
+              conversations: [{ id: 'conv-1', status: 'open' }],
+              meta: { page: 1 },
+            }),
             listVideos: vi
               .fn()
               .mockResolvedValue([{ id: 'vid-1', title: 'Test' }]),
+            markSocialConversationResolved: vi
+              .fn()
+              .mockResolvedValue({ id: 'conv-1', status: 'resolved' }),
+            postSocialReply: vi
+              .fn()
+              .mockResolvedValue({ id: 'msg-reply', status: 'sent' }),
+            rejectSocialDraft: vi
+              .fn()
+              .mockResolvedValue({ id: 'msg-draft', status: 'rejected' }),
             retryAgentRun: vi.fn().mockResolvedValue({
               runId: 'run-2',
               threadId: 'thread-1',
             }),
+            sendSocialDm: vi
+              .fn()
+              .mockResolvedValue({ id: 'msg-dm', status: 'sent' }),
             setBearerToken: vi.fn(),
+            updateSocialTags: vi
+              .fn()
+              .mockResolvedValue({ id: 'conv-1', tags: ['lead'] }),
           },
         },
         {
@@ -467,6 +561,139 @@ describe('ToolRegistryService', () => {
     expect(
       (result as { content: { text: string }[] }).content[0].text,
     ).toContain('completed');
+  });
+
+  it('handleToolCall list_social_conversations forwards bounded filters', async () => {
+    const result = await service.handleToolCall({
+      arguments: {
+        limit: 5,
+        needsReview: true,
+        platform: 'youtube',
+        status: 'open',
+      },
+      name: 'list_social_conversations',
+    });
+
+    expect(clientService.listSocialConversations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 5,
+        needsReview: true,
+        platform: 'youtube',
+        status: 'open',
+      }),
+    );
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('conv-1');
+  });
+
+  it('handleToolCall get_social_conversation includes recent messages by default', async () => {
+    const result = await service.handleToolCall({
+      arguments: { conversationId: 'conv-1', limit: 10 },
+      name: 'get_social_conversation',
+    });
+
+    expect(clientService.getSocialConversation).toHaveBeenCalledWith('conv-1', {
+      includeMessages: true,
+      limit: 10,
+    });
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('msg-1');
+  });
+
+  it('handleToolCall create_social_reply_draft records provenance without external send approval', async () => {
+    const result = await service.handleToolCall({
+      arguments: {
+        agentRunId: 'agent-run-1',
+        conversationId: 'conv-1',
+        text: 'Thanks for the comment',
+        workflowRunId: 'workflow-run-1',
+      },
+      name: 'create_social_reply_draft',
+    });
+
+    expect(clientService.createSocialReplyDraft).toHaveBeenCalledWith(
+      'conv-1',
+      {
+        agentRunId: 'agent-run-1',
+        idempotencyKey: undefined,
+        messageType: undefined,
+        recipientId: undefined,
+        text: 'Thanks for the comment',
+        workflowRunId: 'workflow-run-1',
+      },
+    );
+    expect(clientService.createApproval).not.toHaveBeenCalled();
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('msg-draft');
+  });
+
+  it('handleToolCall reject_social_draft updates review state without external send approval', async () => {
+    const result = await service.handleToolCall({
+      arguments: {
+        conversationId: 'conv-1',
+        messageId: 'msg-draft',
+        reason: 'Needs a softer tone',
+      },
+      name: 'reject_social_draft',
+    });
+
+    expect(clientService.rejectSocialDraft).toHaveBeenCalledWith(
+      'conv-1',
+      'msg-draft',
+      'Needs a softer tone',
+    );
+    expect(clientService.createApproval).not.toHaveBeenCalled();
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('rejected');
+  });
+
+  it('handleToolCall post_social_reply queues approval before external publishing', async () => {
+    const result = await service.handleToolCall({
+      arguments: {
+        conversationId: 'conv-1',
+        text: 'Posting publicly',
+        workflowRunId: 'workflow-run-1',
+      },
+      name: 'post_social_reply',
+    });
+
+    expect(clientService.createApproval).toHaveBeenCalledWith(
+      'post_social_reply',
+      {
+        conversationId: 'conv-1',
+        text: 'Posting publicly',
+        workflowRunId: 'workflow-run-1',
+      },
+    );
+    expect(clientService.postSocialReply).not.toHaveBeenCalled();
+    expect(
+      (result as { content: { text: string }[] }).content[0].text,
+    ).toContain('requires approval');
+  });
+
+  it('handleToolCall send_social_dm queues approval before external messaging', async () => {
+    await service.handleToolCall({
+      arguments: {
+        conversationId: 'conv-1',
+        recipientId: 'viewer-1',
+        text: 'Private follow-up',
+      },
+      name: 'send_social_dm',
+    });
+
+    expect(clientService.createApproval).toHaveBeenCalledWith(
+      'send_social_dm',
+      {
+        conversationId: 'conv-1',
+        recipientId: 'viewer-1',
+        text: 'Private follow-up',
+      },
+    );
+    expect(clientService.sendSocialDm).not.toHaveBeenCalled();
   });
 
   describe('role gating', () => {


### PR DESCRIPTION
## Summary
- add focused MCP registry coverage for social message list/inspect/draft/reject controls
- assert external social reply and DM tools create approval records before publishing
- add MCP client coverage for social inbox list/detail/action routes and JSON:API flattening

## Validation
- bun install --frozen-lockfile
- bunx biome check --write apps/server/mcp/src/services/tool-registry.service.spec.ts apps/server/mcp/src/services/client.service.spec.ts
- bun run --cwd apps/server/mcp test src/services/tool-registry.service.spec.ts src/services/client.service.spec.ts
- bunx turbo run lint --filter=@genfeedai/mcp
- bunx turbo run type-check --filter=@genfeedai/mcp
- bunx turbo run build --filter=@genfeedai/mcp
- git diff --check
- bun scripts/run-secretlint.ts apps/server/mcp/src/services/tool-registry.service.spec.ts apps/server/mcp/src/services/client.service.spec.ts

Closes #1024
Refs #1010