### PR TITLE
refactor(api): consolidate campaign credential mapper

### DIFF
--- a/apps/server/api/src/services/campaign/campaign-executor.service.ts
+++ b/apps/server/api/src/services/campaign/campaign-executor.service.ts
@@ -20,12 +20,12 @@ import {
   SYSTEM_WORKFLOW_ACTION_IDS,
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
+import { toReplyBotCredentialData } from '@api/services/campaign/reply-bot-credential.util';
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import {
   type ReplyGenerationOptions,
   ReplyGenerationService,
 } from '@api/services/reply-bot/reply-generation.service';
-import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import {
   CampaignPlatform,
   CampaignSkipReason,
@@ -139,7 +139,7 @@ export class CampaignExecutorService {
       const replyText = await this.generateReply(campaign, target);
 
       // Post reply
-      const credentialData = this.toReplyBotCredentialData(
+      const credentialData = toReplyBotCredentialData(
         credential as Record<string, unknown>,
       );
 
@@ -524,39 +524,5 @@ export class CampaignExecutorService {
     }
 
     return new Date();
-  }
-
-  private toReplyBotCredentialData(
-    credential: Record<string, unknown>,
-  ): IReplyBotCredentialData | null {
-    if (typeof credential.accessToken !== 'string') {
-      return null;
-    }
-
-    return {
-      accessToken: EncryptionUtil.decrypt(credential.accessToken),
-      accessTokenSecret:
-        typeof credential.accessTokenSecret === 'string'
-          ? EncryptionUtil.decrypt(credential.accessTokenSecret)
-          : undefined,
-      externalId:
-        typeof credential.externalId === 'string'
-          ? credential.externalId
-          : undefined,
-      platform:
-        credential.platform === null || credential.platform === undefined
-          ? undefined
-          : (String(
-              credential.platform,
-            ) as IReplyBotCredentialData['platform']),
-      refreshToken:
-        typeof credential.refreshToken === 'string'
-          ? EncryptionUtil.decrypt(credential.refreshToken)
-          : undefined,
-      username:
-        typeof credential.username === 'string'
-          ? credential.username
-          : undefined,
-    };
   }
 }

--- a/apps/server/api/src/services/campaign/dm-campaign-executor.service.ts
+++ b/apps/server/api/src/services/campaign/dm-campaign-executor.service.ts
@@ -17,16 +17,15 @@ import {
   SYSTEM_WORKFLOW_ACTION_IDS,
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
+import { toReplyBotCredentialData } from '@api/services/campaign/reply-bot-credential.util';
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import { ReplyGenerationService } from '@api/services/reply-bot/reply-generation.service';
-import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import {
   CampaignSkipReason,
   CampaignStatus,
   CampaignTargetStatus,
   WorkflowExecutionTrigger,
 } from '@genfeedai/enums';
-import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
@@ -167,7 +166,7 @@ export class DmCampaignExecutorService {
         return { error: errorMessage, success: false };
       }
 
-      const credentialData = this.toReplyBotCredentialData(
+      const credentialData = toReplyBotCredentialData(
         credential as Record<string, unknown>,
       );
 
@@ -357,40 +356,6 @@ export class DmCampaignExecutorService {
 
   private getTargetId(target: CampaignTargetDocument): string {
     return String(target.id ?? target._id);
-  }
-
-  private toReplyBotCredentialData(
-    credential: Record<string, unknown>,
-  ): IReplyBotCredentialData | null {
-    if (typeof credential.accessToken !== 'string') {
-      return null;
-    }
-
-    return {
-      accessToken: EncryptionUtil.decrypt(credential.accessToken),
-      accessTokenSecret:
-        typeof credential.accessTokenSecret === 'string'
-          ? EncryptionUtil.decrypt(credential.accessTokenSecret)
-          : undefined,
-      externalId:
-        typeof credential.externalId === 'string'
-          ? credential.externalId
-          : undefined,
-      platform:
-        credential.platform === null || credential.platform === undefined
-          ? undefined
-          : (String(
-              credential.platform,
-            ) as IReplyBotCredentialData['platform']),
-      refreshToken:
-        typeof credential.refreshToken === 'string'
-          ? EncryptionUtil.decrypt(credential.refreshToken)
-          : undefined,
-      username:
-        typeof credential.username === 'string'
-          ? credential.username
-          : undefined,
-    };
   }
 
   private delay(ms: number): Promise<void> {

--- a/apps/server/api/src/services/campaign/reply-bot-credential.util.spec.ts
+++ b/apps/server/api/src/services/campaign/reply-bot-credential.util.spec.ts
@@ -1,0 +1,59 @@
+import { toReplyBotCredentialData } from '@api/services/campaign/reply-bot-credential.util';
+import { describe, expect, it } from 'vitest';
+
+describe('toReplyBotCredentialData', () => {
+  it('maps full credential data into reply-bot credential data', () => {
+    const result = toReplyBotCredentialData({
+      accessToken: 'access-token',
+      accessTokenSecret: 'access-token-secret',
+      externalId: 'external-id',
+      platform: 'twitter',
+      refreshToken: 'refresh-token',
+      username: 'bot-user',
+    });
+
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      accessTokenSecret: 'access-token-secret',
+      externalId: 'external-id',
+      platform: 'twitter',
+      refreshToken: 'refresh-token',
+      username: 'bot-user',
+    });
+  });
+
+  it('returns null when accessToken is not a string', () => {
+    expect(toReplyBotCredentialData({})).toBeNull();
+    expect(toReplyBotCredentialData({ accessToken: null })).toBeNull();
+    expect(toReplyBotCredentialData({ accessToken: 123 })).toBeNull();
+  });
+
+  it('preserves optional fields as undefined when they are not strings', () => {
+    expect(
+      toReplyBotCredentialData({
+        accessToken: 'access-token',
+        accessTokenSecret: null,
+        externalId: 123,
+        platform: null,
+        refreshToken: false,
+        username: undefined,
+      }),
+    ).toEqual({
+      accessToken: 'access-token',
+      accessTokenSecret: undefined,
+      externalId: undefined,
+      platform: undefined,
+      refreshToken: undefined,
+      username: undefined,
+    });
+  });
+
+  it('keeps legacy platform string coercion', () => {
+    expect(
+      toReplyBotCredentialData({
+        accessToken: 'access-token',
+        platform: 123,
+      })?.platform,
+    ).toBe('123');
+  });
+});

--- a/apps/server/api/src/services/campaign/reply-bot-credential.util.ts
+++ b/apps/server/api/src/services/campaign/reply-bot-credential.util.ts
@@ -1,0 +1,39 @@
+import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
+import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
+
+type ReplyBotCredentialPlatform = IReplyBotCredentialData['platform'];
+
+const readOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const decryptOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? EncryptionUtil.decrypt(value) : undefined;
+
+const readOptionalPlatform = (
+  value: unknown,
+): ReplyBotCredentialPlatform | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  // Campaign credential rows already store enum-compatible platform strings;
+  // keep the legacy string coercion at this credential boundary.
+  return String(value) as ReplyBotCredentialPlatform;
+};
+
+export function toReplyBotCredentialData(
+  credential: Record<string, unknown>,
+): IReplyBotCredentialData | null {
+  if (typeof credential.accessToken !== 'string') {
+    return null;
+  }
+
+  return {
+    accessToken: EncryptionUtil.decrypt(credential.accessToken),
+    accessTokenSecret: decryptOptionalString(credential.accessTokenSecret),
+    externalId: readOptionalString(credential.externalId),
+    platform: readOptionalPlatform(credential.platform),
+    refreshToken: decryptOptionalString(credential.refreshToken),
+    username: readOptionalString(credential.username),
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1080.

- Extracts the duplicated campaign reply-bot credential mapper into `reply-bot-credential.util.ts`.
- Reuses it from `CampaignExecutorService` and `DmCampaignExecutorService`.
- Adds focused characterization coverage for full mapping, missing access token, optional fields, and legacy platform string coercion.

## Validation

- `bun run test:file src/services/campaign/reply-bot-credential.util.spec.ts src/services/campaign/campaign-executor.service.spec.ts src/services/campaign/dm-campaign-executor.service.spec.ts`
- `bunx biome check apps/server/api/src/services/campaign/campaign-executor.service.ts apps/server/api/src/services/campaign/dm-campaign-executor.service.ts apps/server/api/src/services/campaign/reply-bot-credential.util.ts apps/server/api/src/services/campaign/reply-bot-credential.util.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `git diff --cached --name-only | xargs bunx secretlint`
- `bun run lint-staged`

## Structural Review

- No blocker or request-change findings from the structural-review rubric.
- The abstraction has two real production callers, stays campaign-local, preserves the existing unknown-boundary narrowing and platform coercion behavior, and does not change package boundaries or public behavior.
