### PR TITLE
test(e2e): bucket /messages in all-app-pages smoke

### DIFF
--- a/playwright/e2e/tests/smoke/all-app-pages.spec.ts
+++ b/playwright/e2e/tests/smoke/all-app-pages.spec.ts
@@ -135,7 +135,7 @@ const protectedRouteBuckets: RouteBucket[] = [
     route.startsWith('/test-org/brand-1/orchestration'),
   ),
   routeBucket('protected content operations', protectedRoutes, (route) =>
-    /^\/test-org\/brand-1\/(overview|posts|research|studio|tasks|workflows|workspace)(\/|$)/.test(
+    /^\/test-org\/brand-1\/(messages|overview|posts|research|studio|tasks|workflows|workspace)(\/|$)/.test(
       route,
     ),
   ),


### PR DESCRIPTION
Deploy-gate E2E round: route-discovery smoke found the new /messages route unbucketed (Frontend E2E shard 11). Adds it to the brand-scoped content-operations bucket.