### PR TITLE
docs(memory): failed deploys never burn a version number

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -34,7 +34,7 @@
 - [Genfeed project kanban](genfeed_project_kanban.md) — Use project #12 Genfeed.ai as canonical
 - [Positive memory framing](positive_memory_framing.md) — Write memory as target-state guidance with active sources of truth
 - [Epic status on child start](epic_status_on_child_start.md) — Move parent epics to In Progress as soon as a child starts
-- [Release tag after green deploy](release_tag_after_green_deploy.md) — never cut a version tag/release before the deploy gate passes; failed pre-cut tags get deleted and re-cut same-number
+- [Failed deploys never burn a version](release_tag_after_green_deploy.md) — pre-gate release cutting is normal; on deploy failure fix master and re-cut the SAME version (delete unconsumed tag), never bump
 - [Production deploys master-only](production_deploy_master_only.md) — Never deploy any non-master ref to production unless Vincent explicitly overrides; production deploys run from GitHub CI on master
 - [Vercel release gate](feedback_vercel_release_gate.md) — SaaS Vercel frontends deploy only through the API-first production release workflow; Vercel Git auto-deploy stays disabled
 

--- a/.agents/memory/release_tag_after_green_deploy.md
+++ b/.agents/memory/release_tag_after_green_deploy.md
@@ -1,8 +1,8 @@
-# Release tags only after a green deploy
+# Failed deploys never burn a version number
 
-- **Rule:** Never cut a version tag/GitHub release before the production deploy gate has passed on that exact sha. Sequence: dispatch `deploy-ecs` on master → full QA gate green → ECS rollout succeeds → THEN `gh release create vX.Y.Z --target master`.
-- **Why:** A tag cut before the gate can end up labeling nothing (cloud deploy failed, self-hosted publish failed its pre-publish gate) — burning version numbers on failed deploys and making the version history lie. v0.4.3 was cut pre-gate, failed twice, and had to be deleted (nothing had consumed it).
-- **Failed-deploy handling:** if a deploy fails after a tag was mistakenly cut and NOTHING consumed the tag (no self-hosted image published, no ECS rollout), delete the release + tag and re-cut the SAME version from the fixed sha once green. Do not skip to the next patch number.
-- **Self-hosted alignment:** cutting the release after the cloud deploy is green means the release-triggered self-hosted publish runs its gate on the same proven sha — cloud and self-hosted ship identical, tested code.
+- **Cutting the release before the gates is normal.** The release/tag may be created pre-gate (`gh release create vX.Y.Z --target master`); the release event triggers the gated self-hosted publish and the cloud deploy runs its own QA gate.
+- **THE RULE: a failed deploy never spawns a new version.** If the gate/deploy fails, fix on master and re-ship the SAME vX.Y.Z — delete the unshipped release+tag and re-cut it at the fixed sha (safe when nothing consumed it: no self-hosted image published, no ECS rollout). NEVER bump to vX.Y.Z+1 because a deploy failed.
+- **Version numbers mean "this shipped".** v0.4.3 was cut, failed its gates, got deleted, and is re-cut same-number from the fixed sha once green. Skipping to v0.4.4 would leave a phantom version and make the history lie.
+- **Partial-consumption caveat:** if one side already consumed the tag (e.g. self-hosted image published but cloud failed — v0.4.2), do NOT delete that tag; ship the fix by re-cutting the same next version only if IT is unconsumed, and note the mismatch in the release notes.
 
 last_verified: 2026-07-02


### PR DESCRIPTION
Policy correction from Vincent: cutting the release before the gates is normal; the rule is that a FAILED deploy never spawns a new version — fix master and re-cut the same vX.Y.Z. Replaces the over-strict rule added in #1082.