### PR TITLE
refactor(api): consolidate content performance category mapper

### DIFF
--- a/apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts
+++ b/apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts
@@ -1,8 +1,9 @@
 import type { ContentPerformanceDocument } from '@api/collections/content-performance/schemas/content-performance.schema';
 import { PerformanceSource } from '@api/collections/content-performance/schemas/content-performance.schema';
+import { mapPostCategoryToContentType } from '@api/collections/content-performance/utils/content-performance-category.util';
 import { BrandMemorySyncService } from '@api/services/brand-memory/brand-memory-sync.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { ContentType, PostCategory } from '@genfeedai/enums';
+import { ContentType } from '@genfeedai/enums';
 import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -59,24 +60,6 @@ export class AnalyticsSyncService {
     private readonly brandMemorySyncService: BrandMemorySyncService,
     private readonly logger: LoggerService,
   ) {}
-
-  /**
-   * Map PostCategory to ContentType
-   */
-  private mapCategoryToContentType(category?: string): ContentType {
-    const mapping: Record<string, ContentType> = {
-      [PostCategory.VIDEO]: ContentType.VIDEO,
-      [PostCategory.REEL]: ContentType.VIDEO,
-      [PostCategory.IMAGE]: ContentType.IMAGE,
-      [PostCategory.ARTICLE]: ContentType.ARTICLE,
-      [PostCategory.TEXT]: ContentType.CAPTION,
-      [PostCategory.POST]: ContentType.CAPTION,
-      [PostCategory.STORY]: ContentType.IMAGE,
-    };
-    return category
-      ? (mapping[category] ?? ContentType.CAPTION)
-      : ContentType.CAPTION;
-  }
 
   /**
    * Compute engagement rate from analytics metrics
@@ -154,7 +137,7 @@ export class AnalyticsSyncService {
       clicks: metrics.clicks,
       comments: metrics.comments,
       contentRunId: post?.contentRunId ?? undefined,
-      contentType: this.mapCategoryToContentType(post?.category ?? undefined),
+      contentType: mapPostCategoryToContentType(post?.category),
       creativeVersion: post?.creativeVersion ?? undefined,
       engagementRate: this.computeEngagementRate(metrics),
       externalPostId: post?.externalId ?? undefined,

--- a/apps/server/api/src/collections/content-performance/services/content-performance.service.ts
+++ b/apps/server/api/src/collections/content-performance/services/content-performance.service.ts
@@ -5,9 +5,9 @@ import { ManualInputDto } from '@api/collections/content-performance/dto/manual-
 import { QueryContentPerformanceDto } from '@api/collections/content-performance/dto/query-content-performance.dto';
 import type { ContentPerformanceDocument } from '@api/collections/content-performance/schemas/content-performance.schema';
 import { PerformanceSource } from '@api/collections/content-performance/schemas/content-performance.schema';
+import { mapPostCategoryToContentType } from '@api/collections/content-performance/utils/content-performance-category.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import { ContentType, PostCategory } from '@genfeedai/enums';
 import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -24,24 +24,6 @@ export class ContentPerformanceService extends BaseService<
     public readonly logger: LoggerService,
   ) {
     super(prisma, 'contentPerformance', logger);
-  }
-
-  /**
-   * Map PostCategory to ContentType
-   */
-  private mapCategoryToContentType(category?: string): ContentType {
-    const mapping: Record<string, ContentType> = {
-      [PostCategory.VIDEO]: ContentType.VIDEO,
-      [PostCategory.REEL]: ContentType.VIDEO,
-      [PostCategory.IMAGE]: ContentType.IMAGE,
-      [PostCategory.ARTICLE]: ContentType.ARTICLE,
-      [PostCategory.TEXT]: ContentType.CAPTION,
-      [PostCategory.POST]: ContentType.CAPTION,
-      [PostCategory.STORY]: ContentType.IMAGE,
-    };
-    return category
-      ? (mapping[category] ?? ContentType.CAPTION)
-      : ContentType.CAPTION;
   }
 
   private toCredentialPlatform(platform?: string): string | undefined {
@@ -180,7 +162,7 @@ export class ContentPerformanceService extends BaseService<
         records.push({
           brandId: post?.brandId ?? validatedBrandId ?? undefined,
           comments: entry.comments ?? 0,
-          contentType: this.mapCategoryToContentType(post?.category),
+          contentType: mapPostCategoryToContentType(post?.category),
           engagementRate: this.computeEngagementRate(entry),
           externalPostId: entry.externalPostId,
           generationId: post?.generationId ?? undefined,
@@ -241,7 +223,7 @@ export class ContentPerformanceService extends BaseService<
     const data = {
       brandId: (post?.brandId as string) ?? undefined,
       comments: dto.comments ?? 0,
-      contentType: this.mapCategoryToContentType(
+      contentType: mapPostCategoryToContentType(
         post?.category as string | undefined,
       ),
       engagementRate: this.computeEngagementRate(dto),

--- a/apps/server/api/src/collections/content-performance/utils/content-performance-category.util.spec.ts
+++ b/apps/server/api/src/collections/content-performance/utils/content-performance-category.util.spec.ts
@@ -1,0 +1,27 @@
+import { ContentType, PostCategory } from '@genfeedai/enums';
+import { describe, expect, it } from 'vitest';
+
+import { mapPostCategoryToContentType } from './content-performance-category.util';
+
+describe('mapPostCategoryToContentType', () => {
+  it.each([
+    [PostCategory.VIDEO, ContentType.VIDEO],
+    [PostCategory.REEL, ContentType.VIDEO],
+    [PostCategory.IMAGE, ContentType.IMAGE],
+    [PostCategory.STORY, ContentType.IMAGE],
+    [PostCategory.ARTICLE, ContentType.ARTICLE],
+    [PostCategory.TEXT, ContentType.CAPTION],
+    [PostCategory.POST, ContentType.CAPTION],
+  ])('maps %s to %s', (category, contentType) => {
+    expect(mapPostCategoryToContentType(category)).toBe(contentType);
+  });
+
+  it.each([
+    undefined,
+    null,
+    '',
+    'unknown-category',
+  ])('defaults %p to caption', (category) => {
+    expect(mapPostCategoryToContentType(category)).toBe(ContentType.CAPTION);
+  });
+});

--- a/apps/server/api/src/collections/content-performance/utils/content-performance-category.util.ts
+++ b/apps/server/api/src/collections/content-performance/utils/content-performance-category.util.ts
@@ -1,0 +1,28 @@
+import { ContentType, PostCategory } from '@genfeedai/enums';
+
+const CONTENT_TYPE_BY_POST_CATEGORY = {
+  [PostCategory.ARTICLE]: ContentType.ARTICLE,
+  [PostCategory.IMAGE]: ContentType.IMAGE,
+  [PostCategory.POST]: ContentType.CAPTION,
+  [PostCategory.REEL]: ContentType.VIDEO,
+  [PostCategory.STORY]: ContentType.IMAGE,
+  [PostCategory.TEXT]: ContentType.CAPTION,
+  [PostCategory.VIDEO]: ContentType.VIDEO,
+} satisfies Partial<Record<PostCategory, ContentType>>;
+
+const isMappedPostCategory = (
+  category: string,
+): category is keyof typeof CONTENT_TYPE_BY_POST_CATEGORY =>
+  category in CONTENT_TYPE_BY_POST_CATEGORY;
+
+export function mapPostCategoryToContentType(
+  category?: string | null,
+): ContentType {
+  if (!category) {
+    return ContentType.CAPTION;
+  }
+
+  return isMappedPostCategory(category)
+    ? CONTENT_TYPE_BY_POST_CATEGORY[category]
+    : ContentType.CAPTION;
+}


### PR DESCRIPTION
## Summary

- Adds a content-performance collection-local mapper for `PostCategory` to `ContentType`.
- Replaces the duplicate private mapper in `ContentPerformanceService` and `AnalyticsSyncService`.
- Adds focused utility coverage for every preserved category mapping and fallback behavior.

Closes #1087.

## Issue Fit

Selected/created fallback issue #1087 because Project #12 had no suitable Backlog/P0-P2 `code-quality` issue available; existing code-quality items were In Progress, Human Review, Deferred, or already covered by open PRs. This is behavior-preserving DRY cleanup in one API collection.

## Structural Review

No blocker/request-change findings: the helper has two real callers, deletes duplicate private methods, keeps enum mapping local to the content-performance collection, adds no public API/package-boundary/cast/DB/control-flow behavior change, and touched files remain small.

Deferred: explorer found a separate event-bus logging cleanup candidate, not implemented because this run is limited to one refactor slice.

## Verification

- `bunx biome check --write apps/server/api/src/collections/content-performance/services/content-performance.service.ts apps/server/api/src/collections/content-performance/services/analytics-sync.service.ts apps/server/api/src/collections/content-performance/utils/content-performance-category.util.ts apps/server/api/src/collections/content-performance/utils/content-performance-category.util.spec.ts`
- `cd apps/server/api && bun run test:file src/collections/content-performance/utils/content-performance-category.util.spec.ts src/collections/content-performance/services/analytics-sync.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check` and staged `git diff --cached --check`
- staged secret path/pattern scan, `bunx secretlint`, and `bun run lint-staged`
