### PR TITLE
test(e2e): cover agent surface routes

### DIFF
--- a/playwright/e2e/tests/agents/agent-surface.spec.ts
+++ b/playwright/e2e/tests/agents/agent-surface.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '../../fixtures/auth.fixture';
+import {
+  assertRouteRenders,
+  expectNoErrorOverlay,
+  tryClick,
+} from '../../utils/route-assertions';
+
+const AGENT_BASE = '/test-org/~/agent';
+
+const AGENT_ROUTES = [
+  AGENT_BASE,
+  `${AGENT_BASE}/new`,
+  `${AGENT_BASE}/thread-1`,
+  `${AGENT_BASE}/onboarding`,
+  `${AGENT_BASE}/onboarding/thread-1`,
+];
+
+test.describe('Agent surface', () => {
+  test.setTimeout(90_000);
+
+  test('org-scoped agent routes render under the authenticated shell', async ({
+    authenticatedPage,
+  }) => {
+    for (const route of AGENT_ROUTES) {
+      await test.step(route, async () => {
+        await assertRouteRenders(authenticatedPage, route);
+        await expect(authenticatedPage).toHaveURL(/\/test-org\/~\/agent/);
+        await expectNoErrorOverlay(authenticatedPage);
+      });
+    }
+  });
+
+  test('new agent route exposes the conversation entry controls', async ({
+    authenticatedPage,
+  }) => {
+    await assertRouteRenders(authenticatedPage, `${AGENT_BASE}/new`);
+
+    await tryClick(authenticatedPage, 'button:has-text("Plan")');
+    await tryClick(authenticatedPage, 'button:has-text("Attach")');
+
+    await expect(authenticatedPage.locator('body')).toBeVisible();
+    await expectNoErrorOverlay(authenticatedPage);
+  });
+});


### PR DESCRIPTION
## Summary
- Add dedicated Playwright coverage for the canonical org-scoped `/agent` surface.
- Smoke the root, new-thread, thread detail, onboarding, and onboarding thread routes under `/test-org/~/agent`.
- Exercise the new-agent route entry controls with the existing authenticated app-core fixture.

## Issue Fit
Selected Project #12 Backlog P0 issue #1018 (`Verify Agent Surface End To End`). Current `origin/master` already contains the agent route/API foundations, so this PR closes the remaining explicit route-smoke verification slice.

Closes #1018
Refs #1009

## Validation
- `bun install --frozen-lockfile`
- `bunx biome check --write playwright/e2e/tests/agents/agent-surface.spec.ts`
- `node scripts/e2e-route-coverage.mjs`
- `bunx playwright test --config=playwright/configs/playwright.config.ts playwright/e2e/tests/agents/agent-surface.spec.ts --project=app-core`
- `bunx turbo run type-check --filter=@genfeedai/app`
- `bun scripts/run-secretlint.ts playwright/e2e/tests/agents/agent-surface.spec.ts`
- `git diff --check`
- staged `git diff --cached --check`, staged Secretlint, and `bun run lint-staged`

## Manual Smoke Path
- `/test-org/~/agent`
- `/test-org/~/agent/new`
- `/test-org/~/agent/thread-1`
- `/test-org/~/agent/onboarding`
- `/test-org/~/agent/onboarding/thread-1`

## Notes
- The selected issue has no queue label. This PR will be labeled `codex:automation` because this Codex automation selected the work.
