### PR TITLE
test(messages): verify surface end to end

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx
@@ -1,5 +1,240 @@
 import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ChangeEvent, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SocialMessagesPage from './page';
 
 assertSourceHasExport(
   'app/(protected)/[orgSlug]/[brandSlug]/messages/page.tsx',
 );
+
+const mocks = vi.hoisted(() => ({
+  getService: vi.fn(),
+  href: vi.fn((path: string) => `/acme/demo${path}`),
+  list: vi.fn(),
+  listMessages: vi.fn(),
+  postReply: vi.fn(),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getService,
+}));
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    href: mocks.href,
+  }),
+}));
+
+vi.mock('@ui/layout/container/Container', () => ({
+  default: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+}));
+
+vi.mock('@ui/loading/fallback/LazyLoadingFallback', () => ({
+  default: () => <div>Loading messages</div>,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    asChild,
+    children,
+    disabled,
+    isDisabled,
+    onClick,
+    title,
+  }: {
+    asChild?: boolean;
+    children?: ReactNode;
+    disabled?: boolean;
+    isDisabled?: boolean;
+    onClick?: () => void;
+    title?: string;
+  }) =>
+    asChild ? (
+      (children ?? null)
+    ) : (
+      <button
+        disabled={disabled || isDisabled}
+        title={title}
+        type="button"
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    ),
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    value: string;
+  }) => <input placeholder={placeholder} value={value} onChange={onChange} />,
+}));
+
+vi.mock('@ui/primitives/select', () => ({
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+}));
+
+vi.mock('@ui/primitives/textarea', () => ({
+  Textarea: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+    placeholder?: string;
+    value: string;
+  }) => (
+    <textarea placeholder={placeholder} value={value} onChange={onChange} />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const conversation = {
+  automationState: 'manual',
+  availability: {
+    canPostReply: true,
+    canSendDm: false,
+    sendDmReason: 'YouTube Data API does not support channel DMs',
+  },
+  brandId: 'brand-1',
+  conversationType: 'comment',
+  createdAt: '2026-07-02T08:00:00.000Z',
+  credentialId: 'credential-1',
+  externalConversationId: 'thread-1',
+  id: 'conversation-1',
+  latestMessageAt: '2026-07-02T08:00:00.000Z',
+  latestMessageText: 'Need pricing help',
+  needsReview: true,
+  participantHandle: '@taylor',
+  participantName: 'Taylor',
+  platform: 'youtube',
+  priority: 'normal',
+  sourceContentId: 'video-1',
+  sourceContentTitle: 'Launch video',
+  status: 'open',
+  tags: [],
+  unreadCount: 1,
+  updatedAt: '2026-07-02T08:00:00.000Z',
+};
+
+const messages = [
+  {
+    body: 'Need pricing help',
+    conversationId: 'conversation-1',
+    createdAt: '2026-07-02T08:00:00.000Z',
+    direction: 'inbound',
+    id: 'message-1',
+    messageType: 'comment',
+    platform: 'youtube',
+    senderName: 'Taylor',
+    status: 'received',
+    updatedAt: '2026-07-02T08:00:00.000Z',
+  },
+  {
+    body: 'Here is a drafted answer.',
+    conversationId: 'conversation-1',
+    createdAt: '2026-07-02T08:05:00.000Z',
+    direction: 'outbound',
+    id: 'message-2',
+    messageType: 'reply',
+    platform: 'youtube',
+    status: 'draft',
+    updatedAt: '2026-07-02T08:05:00.000Z',
+  },
+];
+
+describe('SocialMessagesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getService.mockResolvedValue({
+      approveDraft: vi.fn(),
+      createDraft: vi.fn(),
+      list: mocks.list,
+      listMessages: mocks.listMessages,
+      postReply: mocks.postReply,
+      rejectDraft: vi.fn(),
+      sendDm: vi.fn(),
+      syncYoutube: vi.fn(),
+      updateStatus: vi.fn(),
+    });
+    mocks.list.mockResolvedValue([conversation]);
+    mocks.listMessages.mockResolvedValue(messages);
+    mocks.postReply.mockResolvedValue({
+      ...messages[1],
+      body: 'Thanks for the detail.',
+      id: 'message-3',
+      status: 'sent',
+    });
+  });
+
+  it('renders the inbox route, workflow automation link, and reply action', async () => {
+    render(<SocialMessagesPage />);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Messages' }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.list).toHaveBeenCalledWith({ limit: 50, status: 'open' }),
+    );
+
+    expect(screen.getAllByText('Taylor')).not.toHaveLength(0);
+    expect(screen.getAllByText('Need pricing help')).not.toHaveLength(0);
+    expect(screen.getByText('Here is a drafted answer.')).toBeInTheDocument();
+
+    const automationLink = screen.getByRole('link', { name: /Automation/i });
+    expect(automationLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('/workflows/new?'),
+    );
+    expect(automationLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('conversationId=conversation-1'),
+    );
+    expect(automationLink).toHaveAttribute(
+      'href',
+      expect.stringContaining('trigger=commentTrigger'),
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Write a reply or DM'), {
+      target: { value: 'Thanks for the detail.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Reply$/ }));
+
+    await waitFor(() =>
+      expect(mocks.postReply).toHaveBeenCalledWith(
+        'conversation-1',
+        expect.objectContaining({
+          idempotencyKey: expect.stringMatching(
+            /^messages:conversation-1:reply:/,
+          ),
+          text: 'Thanks for the detail.',
+        }),
+      ),
+    );
+    expect(await screen.findByText('Reply posted.')).toBeInTheDocument();
+  });
+});

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts
@@ -444,6 +444,119 @@ describe('SocialInboxService', () => {
     });
   });
 
+  it('keeps the messages surface lifecycle connected from ingestion to workflow approval', async () => {
+    const { conversations, messages, queueService, service, youtubeService } =
+      createContext();
+    const scope = {
+      brandId: 'brand-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+    const inboundInput = {
+      body: '<p>Need pricing help</p>',
+      brandId: 'brand-1',
+      conversationType: 'comment',
+      credentialId: 'credential-1',
+      externalConversationId: 'thread-1',
+      externalMessageId: 'comment-1',
+      externalParentId: 'comment-1',
+      organizationId: 'org-1',
+      participantExternalId: 'author-1',
+      participantHandle: '@taylor',
+      participantName: 'Taylor',
+      platform: 'youtube',
+      sourceContentId: 'video-1',
+      sourceContentTitle: 'Launch video',
+      sourceContentUrl: 'https://youtube.com/watch?v=video-1',
+      userId: 'user-1',
+    };
+
+    const inbound = await service.ingestInboundMessage(inboundInput);
+    const duplicate = await service.ingestInboundMessage(inboundInput);
+
+    expect(duplicate.id).toBe(inbound.id);
+    expect(
+      messages.filter((message) => message.direction === 'inbound'),
+    ).toHaveLength(1);
+    expect(queueService.queueTriggerEvent).toHaveBeenCalledTimes(1);
+
+    const inbox = await service.listConversations(scope, {
+      platform: 'youtube',
+      search: 'pricing',
+      unread: true,
+    });
+    expect(inbox.docs).toHaveLength(1);
+    expect(inbox.docs[0]).toMatchObject({
+      availability: expect.objectContaining({
+        canPostReply: true,
+        canSendDm: false,
+      }),
+      id: inbound.conversationId,
+      latestMessageText: 'Need pricing help',
+      unreadCount: 1,
+    });
+
+    const draft = await service.createDraft(scope, inbound.conversationId, {
+      agentRunId: 'agent-run-1',
+      messageType: 'reply',
+      text: '<strong>Try this answer</strong>',
+      workflowRunId: 'workflow-run-1',
+    });
+    expect(draft).toMatchObject({
+      actionProvenance: {
+        action: 'draft',
+        agentRunId: 'agent-run-1',
+        workflowRunId: 'workflow-run-1',
+      },
+      body: 'Try this answer',
+      status: 'draft',
+    });
+
+    const threadBeforeApproval = await service.listMessages(
+      scope,
+      inbound.conversationId,
+      { limit: 10 },
+    );
+    expect(threadBeforeApproval.docs.map((message) => message.status)).toEqual(
+      expect.arrayContaining(['received', 'draft']),
+    );
+
+    const sent = await service.approveDraft(
+      scope,
+      inbound.conversationId,
+      draft.id,
+    );
+
+    expect(youtubeService.postCommentReply).toHaveBeenCalledWith(
+      'org-1',
+      'brand-1',
+      'comment-1',
+      'Try this answer',
+    );
+    expect(sent).toMatchObject({
+      actionProvenance: {
+        action: 'post_reply',
+        agentRunId: 'agent-run-1',
+        workflowRunId: 'workflow-run-1',
+      },
+      status: 'sent',
+      workflowRunId: 'workflow-run-1',
+    });
+    expect(messages.find((message) => message.id === draft.id)).toMatchObject({
+      actionProvenance: expect.objectContaining({
+        approvedBy: 'user-1',
+        approvedMessageId: sent.id,
+      }),
+      status: 'approved',
+    });
+    expect(conversations[0]).toMatchObject({
+      automationState: 'automated',
+      latestMessageText: 'Try this answer',
+      needsReview: false,
+      unreadCount: 0,
+    });
+  });
+
   it('approves a draft by publishing once and marking the draft approved', async () => {
     const { messages, service, youtubeService } = createContext();
     const inbound = await service.ingestInboundMessage({


### PR DESCRIPTION
## Summary
- Add a `/messages` route smoke test that renders the inbox, verifies the workflow automation link, and exercises the reply action through the Messages service.
- Add a SocialInbox lifecycle regression covering YouTube ingestion dedupe, tenant-scoped inbox listing, workflow trigger queueing, draft provenance, approval publishing, and conversation state updates.

Closes #1025
Refs #1010

## Verification
- `bun install --frozen-lockfile`
- `bunx biome check --write "apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx" apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts`
- `bun run --cwd apps/app test "app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx"`
- `bun run --cwd apps/server/api test:file src/collections/social-inbox/services/social-inbox.service.spec.ts`
- `bunx turbo run lint --filter=@genfeedai/app --filter=@genfeedai/api`
- `bunx turbo run type-check --filter=@genfeedai/app --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint "apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx" apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts`
- `bun run lint-staged`

## Manual Smoke Path
1. Open `/[orgSlug]/[brandSlug]/messages` with an authenticated brand context.
2. Confirm conversations render from `GET /messages`, selecting one loads `GET /messages/:conversationId/messages`, and the Automation link points at `/workflows/new?source=messages&trigger=commentTrigger` with conversation context.
3. Use the reply composer on a reply-capable conversation; confirm the message posts, the thread refreshes, and the conversation state clears review/unread flags.

## Notes
- This is verification-only coverage for the existing Messages surface; no runtime behavior changes.
- The selected issue did not have `codex:automation`, so this PR adds that queue label for automation tracking.
