### PR TITLE
refactor(api): normalize event bus logger context

### DIFF
--- a/apps/server/api/src/shared/services/event-bus/event-bus.service.spec.ts
+++ b/apps/server/api/src/shared/services/event-bus/event-bus.service.spec.ts
@@ -60,6 +60,18 @@ describe('EventBusService', () => {
       });
     });
 
+    it('should log emitted events with service context', () => {
+      service.emit('test.event', { key: 'value' });
+
+      expect(loggerService.debug).toHaveBeenCalledWith(
+        'Emitting event: test.event',
+        {
+          data: { key: 'value' },
+          service: 'EventBusService',
+        },
+      );
+    });
+
     it('should call directly registered handlers', () => {
       const handler = vi.fn();
       service.subscribe('test.event', handler);
@@ -164,6 +176,13 @@ describe('EventBusService', () => {
       const unsubscribe = service.subscribe('test.event', handler);
 
       expect(typeof unsubscribe).toBe('function');
+      expect(loggerService.debug).toHaveBeenCalledWith(
+        'Subscribed to event: test.event',
+        {
+          handlerCount: 1,
+          service: 'EventBusService',
+        },
+      );
     });
 
     it('should remove handler when unsubscribe is called', () => {
@@ -273,6 +292,15 @@ describe('EventBusService', () => {
 
       expect(service.getHandlerCount('event.a')).toBe(0);
       expect(service.getHandlerCount('event.b')).toBe(0);
+    });
+
+    it('should log handler clearing with service context', () => {
+      service.clearHandlers();
+
+      expect(loggerService.debug).toHaveBeenCalledWith(
+        'Cleared all event handlers',
+        { service: 'EventBusService' },
+      );
     });
   });
 

--- a/apps/server/api/src/shared/services/event-bus/event-bus.service.ts
+++ b/apps/server/api/src/shared/services/event-bus/event-bus.service.ts
@@ -42,8 +42,10 @@ export class EventBusService implements OnModuleDestroy {
    * All registered handlers will be called.
    */
   emit<T extends DomainEventType>(type: T, data: EventDataByType<T>): void {
-    // @ts-expect-error TS2554
-    this.logger.debug(`Emitting event: ${type}`, { data }, this.context);
+    this.logger.debug(`Emitting event: ${type}`, {
+      data,
+      service: this.context,
+    });
 
     // Emit via EventEmitter2 for NestJS @OnEvent decorators
     this.eventEmitter.emit(type, data);
@@ -83,8 +85,10 @@ export class EventBusService implements OnModuleDestroy {
     type: T,
     data: EventDataByType<T>,
   ): Promise<void> {
-    // @ts-expect-error TS2554
-    this.logger.debug(`Emitting async event: ${type}`, { data }, this.context);
+    this.logger.debug(`Emitting async event: ${type}`, {
+      data,
+      service: this.context,
+    });
 
     // Emit via EventEmitter2 and wait for all listeners
     await this.eventEmitter.emitAsync(type, data);
@@ -127,22 +131,18 @@ export class EventBusService implements OnModuleDestroy {
 
     handlers.add(handler as EventHandler<DomainEventType>);
 
-    this.logger.debug(
-      `Subscribed to event: ${type}`,
-      { handlerCount: handlers.size },
-      // @ts-expect-error TS2554
-      this.context,
-    );
+    this.logger.debug(`Subscribed to event: ${type}`, {
+      handlerCount: handlers.size,
+      service: this.context,
+    });
 
     // Return unsubscribe function
     return () => {
       handlers?.delete(handler as EventHandler<DomainEventType>);
-      this.logger.debug(
-        `Unsubscribed from event: ${type}`,
-        { handlerCount: handlers?.size ?? 0 },
-        // @ts-expect-error TS2554
-        this.context,
-      );
+      this.logger.debug(`Unsubscribed from event: ${type}`, {
+        handlerCount: handlers?.size ?? 0,
+        service: this.context,
+      });
     };
   }
 
@@ -188,8 +188,7 @@ export class EventBusService implements OnModuleDestroy {
    */
   clearHandlers(): void {
     this.handlers.clear();
-    // @ts-expect-error TS2554
-    this.logger.debug('Cleared all event handlers', undefined, this.context);
+    this.logger.debug('Cleared all event handlers', { service: this.context });
   }
 
   onModuleDestroy(): void {


### PR DESCRIPTION
## Summary

- Remove `@ts-expect-error TS2554` suppressions from `EventBusService` debug logging.
- Use the supported two-argument `LoggerService.debug(message, context)` shape with service metadata preserved.
- Add focused assertions for event emission, subscription, and handler-clearing debug context.

Closes #1102

## Validation

- `bun run test:file src/shared/services/event-bus/event-bus.service.spec.ts` (26 tests)
- `bunx biome check --write apps/server/api/src/shared/services/event-bus/event-bus.service.ts apps/server/api/src/shared/services/event-bus/event-bus.service.spec.ts`
- `bunx turbo run type-check --filter=@genfeedai/api`
- `git diff --check`
- `bunx secretlint apps/server/api/src/shared/services/event-bus/event-bus.service.ts apps/server/api/src/shared/services/event-bus/event-bus.service.spec.ts`
- `bun run lint-staged`

## Structural Review

- No file-size, layer-boundary, package-boundary, cast, or new-abstraction findings.
- Diff removes TypeScript suppressions and keeps behavior limited to event bus debug logging metadata.