### PR TITLE
refactor(api): decompose OnboardingService god object into focused collaborators (#708)

### DIFF
--- a/apps/server/api/src/endpoints/onboarding/onboarding.interfaces.ts
+++ b/apps/server/api/src/endpoints/onboarding/onboarding.interfaces.ts
@@ -1,0 +1,61 @@
+import type {
+  IExtractedBrandData,
+  OnboardingAccessMode,
+  OnboardingRuntimeAccessMode,
+} from '@genfeedai/interfaces';
+
+/**
+ * Response from brand setup operation
+ */
+export interface BrandSetupResponse {
+  success: boolean;
+  brandId: string;
+  extractedData: IExtractedBrandData;
+  message?: string;
+}
+
+export interface InstallReadinessResponse {
+  access: {
+    byokConfiguredProviders: string[];
+    byokEnabled: boolean;
+    runtimeMode: OnboardingRuntimeAccessMode;
+    selectedMode: OnboardingAccessMode | null;
+    serverDefaultsReady: boolean;
+  };
+  authMode: 'better_auth' | 'none';
+  billingMode: 'cloud_billing' | 'oss_local';
+  localTools: {
+    anyDetected: boolean;
+    claude: boolean;
+    codex: boolean;
+    detected: string[];
+  };
+  providers: {
+    anyConfigured: boolean;
+    configured: string[];
+    fal: boolean;
+    imageGenerationReady: boolean;
+    openai: boolean;
+    replicate: boolean;
+    textGenerationReady: boolean;
+  };
+  ui: {
+    showBilling: boolean;
+    showCloudUpgradeCta: boolean;
+    showCredits: boolean;
+    showLocalTools: boolean;
+    showPricing: boolean;
+  };
+  workspace: {
+    brandId: string | null;
+    hasBrand: boolean;
+    hasOrganization: boolean;
+    organizationId: string | null;
+  };
+}
+
+export interface OnboardingWorkspaceContext {
+  brandId: string | null;
+  organizationId: string;
+  userId: string;
+}

--- a/apps/server/api/src/endpoints/onboarding/onboarding.module.ts
+++ b/apps/server/api/src/endpoints/onboarding/onboarding.module.ts
@@ -13,6 +13,10 @@ import { CommonModule } from '@api/common/common.module';
 import { OnboardingController } from '@api/endpoints/onboarding/onboarding.controller';
 import { OnboardingService } from '@api/endpoints/onboarding/onboarding.service';
 import { ProactiveOnboardingService } from '@api/endpoints/onboarding/proactive-onboarding.service';
+import { BrandDataMapper } from '@api/endpoints/onboarding/services/brand-data.mapper';
+import { BrandPersistenceService } from '@api/endpoints/onboarding/services/brand-persistence.service';
+import { OnboardingPreviewService } from '@api/endpoints/onboarding/services/onboarding-preview.service';
+import { OnboardingReadinessService } from '@api/endpoints/onboarding/services/onboarding-readiness.service';
 import { BatchGenerationModule } from '@api/services/batch-generation/batch-generation.module';
 import { BrandScraperModule } from '@api/services/brand-scraper/brand-scraper.module';
 import { FilesClientModule } from '@api/services/files-microservice/client/files-client.module';
@@ -47,6 +51,10 @@ import { forwardRef, Module } from '@nestjs/common';
     OnboardingService,
     MasterPromptGeneratorService,
     ProactiveOnboardingService,
+    BrandDataMapper,
+    BrandPersistenceService,
+    OnboardingPreviewService,
+    OnboardingReadinessService,
   ],
 })
 export class OnboardingModule {}

--- a/apps/server/api/src/endpoints/onboarding/onboarding.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/onboarding.service.ts
@@ -1,15 +1,6 @@
-import { spawnSync } from 'node:child_process';
-import process from 'node:process';
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
-import type { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
-import type {
-  BrandAgentConfig,
-  BrandReferenceImage,
-} from '@api/collections/brands/schemas/brand.schema';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
-import { LinksService } from '@api/collections/links/services/links.service';
-import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { UserSetupService } from '@api/collections/users/services/user-setup.service';
@@ -23,28 +14,26 @@ import type {
 } from '@api/endpoints/onboarding/dto/brand-setup.dto';
 import { GeneratePreviewDto } from '@api/endpoints/onboarding/dto/generate-preview.dto';
 import { ReferenceImageDto } from '@api/endpoints/onboarding/dto/reference-images.dto';
+import type {
+  BrandSetupResponse,
+  InstallReadinessResponse,
+  OnboardingWorkspaceContext,
+} from '@api/endpoints/onboarding/onboarding.interfaces';
 import { ProactiveOnboardingService } from '@api/endpoints/onboarding/proactive-onboarding.service';
+import { BrandDataMapper } from '@api/endpoints/onboarding/services/brand-data.mapper';
+import { BrandPersistenceService } from '@api/endpoints/onboarding/services/brand-persistence.service';
+import { withOnboardingErrorHandling } from '@api/endpoints/onboarding/services/onboarding-error.util';
+import { OnboardingPreviewService } from '@api/endpoints/onboarding/services/onboarding-preview.service';
+import { OnboardingReadinessService } from '@api/endpoints/onboarding/services/onboarding-readiness.service';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
-import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
-import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
 import { MasterPromptGeneratorService } from '@api/services/knowledge-base/master-prompt-generator.service';
-import { IS_CLOUD, isEEEnabled } from '@genfeedai/config';
-import { MODEL_KEYS } from '@genfeedai/constants';
-import {
-  FileInputType,
-  LinkCategory,
-  type OrganizationCategory,
-} from '@genfeedai/enums';
+import type { OrganizationCategory } from '@genfeedai/enums';
 import type {
+  IBrandVoiceAnalysis,
   IExtractedBrandData,
-  IOnboardingAccessPreference,
-  IOrganizationSetting,
   IScrapedBrandData,
-  OnboardingAccessMode,
-  OnboardingRuntimeAccessMode,
 } from '@genfeedai/interfaces';
-import { Prisma } from '@genfeedai/prisma';
 import {
   type IOnboardingJourneyMissionState,
   ONBOARDING_JOURNEY_MISSIONS,
@@ -53,74 +42,21 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 
-/** Credits cost for generating an onboarding preview image */
-const ONBOARDING_PREVIEW_CREDIT_COST = 5;
-
-/**
- * Response from brand setup operation
- */
-export interface BrandSetupResponse {
-  success: boolean;
-  brandId: string;
-  extractedData: IExtractedBrandData;
-  message?: string;
-}
-
-export interface InstallReadinessResponse {
-  access: {
-    byokConfiguredProviders: string[];
-    byokEnabled: boolean;
-    runtimeMode: OnboardingRuntimeAccessMode;
-    selectedMode: OnboardingAccessMode | null;
-    serverDefaultsReady: boolean;
-  };
-  authMode: 'better_auth' | 'none';
-  billingMode: 'cloud_billing' | 'oss_local';
-  localTools: {
-    anyDetected: boolean;
-    claude: boolean;
-    codex: boolean;
-    detected: string[];
-  };
-  providers: {
-    anyConfigured: boolean;
-    configured: string[];
-    fal: boolean;
-    imageGenerationReady: boolean;
-    openai: boolean;
-    replicate: boolean;
-    textGenerationReady: boolean;
-  };
-  ui: {
-    showBilling: boolean;
-    showCloudUpgradeCta: boolean;
-    showCredits: boolean;
-    showLocalTools: boolean;
-    showPricing: boolean;
-  };
-  workspace: {
-    brandId: string | null;
-    hasBrand: boolean;
-    hasOrganization: boolean;
-    organizationId: string | null;
-  };
-}
-
-interface OnboardingWorkspaceContext {
-  brandId: string | null;
-  organizationId: string;
-  userId: string;
-}
-
 /**
  * OnboardingService
  *
- * Handles the onboarding flow:
+ * Orchestrates the onboarding flow, delegating to focused collaborators:
+ * - OnboardingReadinessService — env/CLI readiness probing and status reads
+ * - BrandDataMapper — pure scrape-result → brand-data normalization
+ * - BrandPersistenceService — brand/org writes and slug syncing
+ * - OnboardingPreviewService — preview image generation pipeline
+ *
+ * Flow:
  * 1. Accept brand URL from user
  * 2. Scrape website for brand information
  * 3. Analyze with AI to extract brand voice
  * 4. Update Brand structured guidance
- * 6. Mark onboarding as complete
+ * 5. Mark onboarding as complete
  */
 @Injectable()
 export class OnboardingService {
@@ -131,11 +67,7 @@ export class OnboardingService {
     private readonly brandScraperService: BrandScraperService,
     private readonly masterPromptGeneratorService: MasterPromptGeneratorService,
     private readonly brandsService: BrandsService,
-    private readonly comfyUIService: ComfyUIService,
     private readonly creditsUtilsService: CreditsUtilsService,
-    private readonly filesClientService: FilesClientService,
-    private readonly linksService: LinksService,
-    private readonly membersService: MembersService,
     private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly organizationsService: OrganizationsService,
     private readonly usersService: UsersService,
@@ -143,6 +75,10 @@ export class OnboardingService {
     private readonly requestContextCacheService: RequestContextCacheService,
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
     private readonly userSetupService: UserSetupService,
+    private readonly brandDataMapper: BrandDataMapper,
+    private readonly brandPersistenceService: BrandPersistenceService,
+    private readonly onboardingPreviewService: OnboardingPreviewService,
+    private readonly onboardingReadinessService: OnboardingReadinessService,
   ) {}
 
   private getEntityId(record: unknown): string {
@@ -154,10 +90,6 @@ export class OnboardingService {
     const id = entity.id ?? entity._id;
 
     return typeof id === 'string' ? id : '';
-  }
-
-  private isConfigured(value: unknown): boolean {
-    return typeof value === 'string' && value.trim().length > 0;
   }
 
   private async ensureOnboardingWorkspace(
@@ -246,256 +178,103 @@ export class OnboardingService {
     return { brandId, organizationId, userId };
   }
 
-  private getProviderReadiness() {
-    const replicate = this.isConfigured(process.env.REPLICATE_KEY);
-    const fal = this.isConfigured(process.env.FAL_API_KEY);
-    const openai = this.isConfigured(process.env.OPENAI_API_KEY);
-    const configured = [
-      replicate ? 'replicate' : null,
-      fal ? 'fal' : null,
-      openai ? 'openai' : null,
-    ].filter((value): value is string => value !== null);
-
-    return {
-      anyConfigured: configured.length > 0,
-      configured,
-      fal,
-      imageGenerationReady: fal || replicate,
-      openai,
-      replicate,
-      textGenerationReady: openai,
-    };
-  }
-
-  private isCommandAvailable(command: string): boolean {
-    const result = spawnSync(command, ['--version'], {
-      encoding: 'utf8',
-      shell: false,
-      stdio: 'ignore',
-    });
-
-    if (result.error) {
-      return false;
-    }
-
-    return result.status === 0;
-  }
-
-  private getLocalToolReadiness() {
-    if (IS_CLOUD) {
-      return { anyDetected: false, claude: false, codex: false, detected: [] };
-    }
-
-    const claude = this.isCommandAvailable('claude');
-    const codex = this.isCommandAvailable('codex');
-    const detected = [claude ? 'claude' : null, codex ? 'codex' : null].filter(
-      (value): value is string => value !== null,
-    );
-
-    return {
-      anyDetected: detected.length > 0,
-      claude,
-      codex,
-      detected,
-    };
-  }
-
-  private normalizeAccessMode(value: unknown): OnboardingAccessMode | null {
-    if (value === 'server' || value === 'byok' || value === 'cloud') {
-      return value;
-    }
-
-    return null;
-  }
-
-  private getSelectedAccessMode(
-    dashboardPreferences?: unknown,
-  ): OnboardingAccessMode | null {
-    if (!dashboardPreferences || typeof dashboardPreferences !== 'object') {
-      return null;
-    }
-
-    const onboarding = (
-      dashboardPreferences as { onboarding?: IOnboardingAccessPreference }
-    ).onboarding;
-
-    return this.normalizeAccessMode(onboarding?.accessMode);
-  }
-
-  private getConfiguredByokProviders(
-    organizationSettings?: Pick<IOrganizationSetting, 'byokKeys'> | null,
-  ): string[] {
-    const byokKeys = organizationSettings?.byokKeys;
-
-    if (!byokKeys || typeof byokKeys !== 'object') {
-      return [];
-    }
-
-    return Object.entries(byokKeys).flatMap(([providerKey, entry]) => {
-      if (!entry?.isEnabled || !entry.apiKey?.trim()) {
-        return [];
-      }
-
-      const provider =
-        typeof entry.provider === 'string' && entry.provider.trim()
-          ? entry.provider
-          : providerKey;
-
-      return [provider];
-    });
-  }
-
-  private readBrandAgentConfig(value: unknown): BrandAgentConfig {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return {};
-    }
-
-    return value as BrandAgentConfig;
-  }
-
-  private readBrandReferenceImages(value: unknown): BrandReferenceImage[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    return value.flatMap((entry) => {
-      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
-        return [];
-      }
-
-      const record = entry as Record<string, unknown>;
-      const category =
-        typeof record.category === 'string' ? record.category : 'reference';
-      const label = typeof record.label === 'string' ? record.label : undefined;
-      const url = typeof record.url === 'string' ? record.url : undefined;
-      const isDefault =
-        typeof record.isDefault === 'boolean' ? record.isDefault : undefined;
-
-      return [
-        {
-          category,
-          ...(isDefault !== undefined ? { isDefault } : {}),
-          ...(label ? { label } : {}),
-          ...(url ? { url } : {}),
-        } as BrandReferenceImage,
-      ];
-    });
-  }
-
-  private buildFallbackScrapedData(
+  /**
+   * Detect brand sources from the setup DTO and scrape them, falling back
+   * to a minimal brand payload when scraping fails.
+   */
+  private async scrapeBrandData(
     dto: BrandSetupDto,
     existingBrand: { label?: string | null },
-  ): IScrapedBrandData {
-    const fallbackLabel =
-      dto.brandName?.trim() || existingBrand.label?.trim() || 'Brand';
-
-    return {
-      aboutText: undefined,
-      companyName: fallbackLabel,
-      description: undefined,
-      fontFamily: undefined,
-      heroText: undefined,
-      logoUrl: undefined,
-      metaDescription: undefined,
-      ogImage: undefined,
-      primaryColor: undefined,
-      scrapedAt: new Date(),
-      secondaryColor: undefined,
-      socialLinks: {},
-      sourceUrl: dto.brandUrl,
-      tagline: undefined,
-      valuePropositions: [],
+    caller: string,
+  ): Promise<IScrapedBrandData> {
+    const detectedSources = this.brandScraperService.detectUrlType(
+      dto.brandUrl,
+    );
+    const sources = {
+      linkedinUrl: dto.linkedinUrl || detectedSources.linkedinUrl,
+      websiteUrl: detectedSources.websiteUrl,
+      xProfileUrl: dto.xProfileUrl || detectedSources.xProfileUrl,
     };
-  }
 
-  private async resolveOnboardingBrand(
-    organizationId: string,
-    userId: string,
-    brandId?: string | null,
-  ) {
-    if (brandId && /^[0-9a-f]{24}$/i.test(brandId)) {
-      const metadataBrand = await this.brandsService.findOne(
-        {
-          _id: brandId,
-          isDeleted: false,
-          organization: organizationId,
-          user: userId,
-        },
-        'none',
-      );
+    // If the primary URL was detected as social, keep it as websiteUrl too
+    // only when no websiteUrl was resolved
+    if (!sources.websiteUrl && !sources.linkedinUrl && !sources.xProfileUrl) {
+      sources.websiteUrl = dto.brandUrl;
+    }
 
-      if (metadataBrand) {
-        return metadataBrand;
+    const hasMultipleSources =
+      [sources.websiteUrl, sources.linkedinUrl, sources.xProfileUrl].filter(
+        Boolean,
+      ).length > 1;
+
+    this.loggerService.log(`${caller} scraping brand sources`, {
+      detectedType: Object.keys(detectedSources).find(
+        (k) => detectedSources[k as keyof typeof detectedSources],
+      ),
+      hasMultipleSources,
+      url: dto.brandUrl,
+    });
+
+    try {
+      if (hasMultipleSources) {
+        const merged = await this.brandScraperService.scrapeAllSources(sources);
+        return this.brandDataMapper.mapMergedSources(merged, dto.brandUrl);
       }
+
+      if (sources.linkedinUrl) {
+        const linkedinData = await this.brandScraperService.scrapeLinkedIn(
+          sources.linkedinUrl,
+        );
+        return this.brandDataMapper.mapLinkedInData(linkedinData, dto.brandUrl);
+      }
+
+      if (sources.xProfileUrl) {
+        const xData = await this.brandScraperService.scrapeXProfile(
+          sources.xProfileUrl,
+        );
+        return this.brandDataMapper.mapXProfileData(xData, dto.brandUrl);
+      }
+
+      return await this.brandScraperService.scrapeWebsite(dto.brandUrl);
+    } catch (scrapeError: unknown) {
+      this.loggerService.warn(
+        `${caller} scrape failed, continuing with minimal brand setup`,
+        {
+          error:
+            scrapeError instanceof Error
+              ? scrapeError.message
+              : String(scrapeError),
+          url: dto.brandUrl,
+        },
+      );
+      return this.brandDataMapper.buildFallbackScrapedData(dto, existingBrand);
     }
-
-    const selectedBrand = await this.brandsService.findOne(
-      {
-        isDeleted: false,
-        isSelected: true,
-        organization: organizationId,
-        user: userId,
-      },
-      'none',
-    );
-
-    if (selectedBrand) {
-      return selectedBrand;
-    }
-
-    return this.brandsService.findOne(
-      {
-        isDeleted: false,
-        organization: organizationId,
-        user: userId,
-      },
-      'none',
-    );
   }
 
-  private async resolveWritableOnboardingBrand(
-    brand: { _id: string; label?: string | null },
+  /**
+   * Analyze brand voice with AI when the scraped data has analyzable content.
+   */
+  private async analyzeBrandVoice(
+    scrapedData: IScrapedBrandData,
     organizationId: string,
     userId: string,
-    label?: string,
-  ) {
-    const normalizedLabel = label?.trim();
+  ): Promise<IBrandVoiceAnalysis | undefined> {
+    const hasAnalyzableContent = Boolean(
+      scrapedData.description ||
+        scrapedData.aboutText ||
+        scrapedData.heroText ||
+        scrapedData.tagline ||
+        (scrapedData.valuePropositions?.length ?? 0) > 0,
+    );
 
-    if (!normalizedLabel) {
-      return brand;
+    if (!hasAnalyzableContent) {
+      return undefined;
     }
 
-    const matchingBrand = await this.brandsService.findOne(
-      {
-        isDeleted: false,
-        label: normalizedLabel,
-        organization: organizationId,
-      },
-      'none',
-    );
-
-    if (!matchingBrand || String(matchingBrand._id) === String(brand._id)) {
-      return brand;
-    }
-
-    await this.brandsService.selectBrandForUser(
-      String(matchingBrand._id),
-      String(userId),
-      String(organizationId),
-    );
-    // Persist the selected brand on the member so the identity resolvers route
-    // to it (epic #735, Phase C — no legacy auth provider write-back).
-    await this.membersService.setLastUsedBrand(
-      {
-        isActive: true,
-        isDeleted: false,
-        organization: String(organizationId),
-        user: String(userId),
-      },
-      String(matchingBrand._id),
-    );
-
-    return matchingBrand;
+    return this.masterPromptGeneratorService.analyzeBrandVoice(scrapedData, {
+      organizationId: organizationId.toString(),
+      userId: userId.toString(),
+    });
   }
 
   /**
@@ -508,244 +287,118 @@ export class OnboardingService {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${caller} starting`, { brandUrl: dto.brandUrl });
 
-    try {
-      // 1. Validate URL
-      const validation = this.brandScraperService.validateUrl(dto.brandUrl);
-      if (!validation.isValid) {
-        throw new HttpException(
-          { detail: validation.error, title: 'Invalid URL' },
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-
-      const workspace = await this.ensureOnboardingWorkspace(user);
-      const organizationId = workspace.organizationId;
-      const userId = workspace.userId;
-      const metadataBrandId = workspace.brandId;
-
-      // 2. Find existing brand for user (created during signup)
-      const existingBrand = await this.resolveOnboardingBrand(
-        organizationId,
-        userId,
-        metadataBrandId,
-      );
-
-      if (!existingBrand) {
-        throw new HttpException(
-          { detail: 'No brand found for user', title: 'Brand Not Found' },
-          HttpStatus.NOT_FOUND,
-        );
-      }
-
-      // 3. Auto-detect URL type and build sources
-      const detectedSources = this.brandScraperService.detectUrlType(
-        dto.brandUrl,
-      );
-      const sources = {
-        linkedinUrl: dto.linkedinUrl || detectedSources.linkedinUrl,
-        websiteUrl: detectedSources.websiteUrl,
-        xProfileUrl: dto.xProfileUrl || detectedSources.xProfileUrl,
-      };
-
-      // If the primary URL was detected as social, keep it as websiteUrl too
-      // only when no websiteUrl was resolved
-      if (!sources.websiteUrl && !sources.linkedinUrl && !sources.xProfileUrl) {
-        sources.websiteUrl = dto.brandUrl;
-      }
-
-      const hasMultipleSources =
-        [sources.websiteUrl, sources.linkedinUrl, sources.xProfileUrl].filter(
-          Boolean,
-        ).length > 1;
-
-      this.loggerService.log(`${caller} scraping brand sources`, {
-        detectedType: Object.keys(detectedSources).find(
-          (k) => detectedSources[k as keyof typeof detectedSources],
-        ),
-        hasMultipleSources,
-        url: dto.brandUrl,
-      });
-
-      let scrapedData: IScrapedBrandData;
-      try {
-        if (hasMultipleSources) {
-          const merged =
-            await this.brandScraperService.scrapeAllSources(sources);
-          scrapedData = {
-            aboutText: merged.aboutText,
-            companyName: merged.companyName,
-            description: merged.description,
-            fontFamily: merged.fontFamily,
-            heroText: merged.heroText,
-            logoUrl: merged.logoUrl,
-            metaDescription: merged.description,
-            ogImage: undefined,
-            primaryColor: merged.primaryColor,
-            scrapedAt: merged.scrapedAt,
-            secondaryColor: merged.secondaryColor,
-            socialLinks: merged.socialLinks,
-            sourceUrl: dto.brandUrl,
-            tagline: merged.tagline,
-            valuePropositions: merged.valuePropositions,
-          };
-        } else if (sources.linkedinUrl) {
-          const linkedinData = await this.brandScraperService.scrapeLinkedIn(
-            sources.linkedinUrl,
-          );
-          scrapedData = {
-            aboutText: undefined,
-            companyName: linkedinData.companyName,
-            description: linkedinData.description,
-            fontFamily: undefined,
-            heroText: undefined,
-            logoUrl: linkedinData.logoUrl,
-            metaDescription: linkedinData.description,
-            ogImage: linkedinData.coverImageUrl,
-            primaryColor: undefined,
-            scrapedAt: linkedinData.scrapedAt,
-            secondaryColor: undefined,
-            socialLinks: {},
-            sourceUrl: dto.brandUrl,
-            tagline: undefined,
-            valuePropositions: [],
-          };
-        } else if (sources.xProfileUrl) {
-          const xData = await this.brandScraperService.scrapeXProfile(
-            sources.xProfileUrl,
-          );
-          scrapedData = {
-            aboutText: undefined,
-            companyName: xData.displayName,
-            description: xData.bio,
-            fontFamily: undefined,
-            heroText: undefined,
-            logoUrl: xData.profileImageUrl,
-            metaDescription: xData.bio,
-            ogImage: xData.profileImageUrl,
-            primaryColor: undefined,
-            scrapedAt: xData.scrapedAt,
-            secondaryColor: undefined,
-            socialLinks: {},
-            sourceUrl: dto.brandUrl,
-            tagline: undefined,
-            valuePropositions: [],
-          };
-        } else {
-          scrapedData = await this.brandScraperService.scrapeWebsite(
-            dto.brandUrl,
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      {
+        detail: 'Failed to setup brand',
+        hasHttpExceptionPassthrough: true,
+        hasPrismaPassthrough: true,
+        isErrorMessageUsed: true,
+        title: 'Brand Setup Failed',
+      },
+      async () => {
+        // 1. Validate URL
+        const validation = this.brandScraperService.validateUrl(dto.brandUrl);
+        if (!validation.isValid) {
+          throw new HttpException(
+            { detail: validation.error, title: 'Invalid URL' },
+            HttpStatus.BAD_REQUEST,
           );
         }
-      } catch (scrapeError: unknown) {
-        this.loggerService.warn(
-          `${caller} scrape failed, continuing with minimal brand setup`,
-          {
-            error:
-              scrapeError instanceof Error
-                ? scrapeError.message
-                : String(scrapeError),
-            url: dto.brandUrl,
-          },
+
+        const workspace = await this.ensureOnboardingWorkspace(user);
+        const organizationId = workspace.organizationId;
+        const userId = workspace.userId;
+
+        // 2. Find existing brand for user (created during signup)
+        const existingBrand =
+          await this.brandPersistenceService.resolveOnboardingBrand(
+            organizationId,
+            userId,
+            workspace.brandId,
+          );
+
+        if (!existingBrand) {
+          throw new HttpException(
+            { detail: 'No brand found for user', title: 'Brand Not Found' },
+            HttpStatus.NOT_FOUND,
+          );
+        }
+
+        // 3. Scrape brand sources (auto-detected from the URL)
+        const scrapedData = await this.scrapeBrandData(
+          dto,
+          existingBrand,
+          caller,
         );
-        scrapedData = this.buildFallbackScrapedData(dto, existingBrand);
-      }
 
-      // 4. Analyze brand voice with AI
-      this.loggerService.log(`${caller} analyzing brand voice`);
-      const brandVoice =
-        scrapedData.description ||
-        scrapedData.aboutText ||
-        scrapedData.heroText ||
-        scrapedData.tagline ||
-        (scrapedData.valuePropositions?.length ?? 0) > 0
-          ? await this.masterPromptGeneratorService.analyzeBrandVoice(
-              scrapedData,
-              {
-                organizationId: organizationId.toString(),
-                userId: userId.toString(),
-              },
-            )
-          : undefined;
-
-      // 5. Build complete extracted data
-      const extractedData: IExtractedBrandData = {
-        ...scrapedData,
-        brandVoice,
-      };
-
-      // 6. Update brand with extracted data
-      const labelOverride = dto.brandName?.trim() || undefined;
-      const resolvedLabel = labelOverride || scrapedData.companyName;
-      const targetBrand = await this.resolveWritableOnboardingBrand(
-        existingBrand,
-        organizationId,
-        userId,
-        resolvedLabel,
-      );
-
-      await this.updateBrandWithScrapedData(
-        targetBrand._id,
-        scrapedData,
-        dto,
-        labelOverride,
-      );
-      await this.upsertBrandWebsiteLink(targetBrand._id, dto.brandUrl);
-      await this.updateBrandGuidance(targetBrand._id, extractedData);
-
-      // 6b. Sync organization and brand label and slug
-      if (resolvedLabel) {
-        const orgSlug = await this.organizationsService.generateUniqueSlug(
-          resolvedLabel,
-          organizationId.toString(),
+        // 4. Analyze brand voice with AI
+        this.loggerService.log(`${caller} analyzing brand voice`);
+        const brandVoice = await this.analyzeBrandVoice(
+          scrapedData,
+          organizationId,
+          userId,
         );
-        await this.organizationsService.patch(organizationId.toString(), {
-          label: resolvedLabel,
-          slug: orgSlug,
+
+        // 5. Build complete extracted data
+        const extractedData: IExtractedBrandData = {
+          ...scrapedData,
+          brandVoice,
+        };
+
+        // 6. Update brand with extracted data
+        const labelOverride = dto.brandName?.trim() || undefined;
+        const resolvedLabel = labelOverride || scrapedData.companyName;
+        const targetBrand =
+          await this.brandPersistenceService.resolveWritableOnboardingBrand(
+            existingBrand,
+            organizationId,
+            userId,
+            resolvedLabel,
+          );
+
+        await this.brandPersistenceService.updateBrandWithScrapedData(
+          targetBrand._id,
+          scrapedData,
+          dto,
+          labelOverride,
+        );
+        await this.brandPersistenceService.upsertBrandWebsiteLink(
+          targetBrand._id,
+          dto.brandUrl,
+        );
+        await this.brandPersistenceService.updateBrandGuidance(
+          targetBrand._id,
+          extractedData,
+        );
+
+        // 6b. Sync organization and brand label and slug
+        if (resolvedLabel) {
+          await this.brandPersistenceService.syncBrandAndOrgSlug(
+            resolvedLabel,
+            organizationId.toString(),
+            targetBrand._id,
+          );
+        }
+
+        await this.unlockCompanyInfoJourneyReward(organizationId.toString());
+
+        // 7. Mark first login as complete
+        await this.completeOnboarding(organizationId);
+
+        this.loggerService.log(`${caller} completed`, {
+          brandId: targetBrand._id.toString(),
         });
 
-        const brandSlug = await this.brandsService.generateUniqueSlug(
-          resolvedLabel,
-          targetBrand._id,
-        );
-        await this.brandsService.patch(targetBrand._id, { slug: brandSlug });
-      }
-
-      await this.unlockCompanyInfoJourneyReward(organizationId.toString());
-
-      // 7. Mark first login as complete
-      await this.completeOnboarding(organizationId);
-
-      this.loggerService.log(`${caller} completed`, {
-        brandId: targetBrand._id.toString(),
-      });
-
-      return {
-        brandId: targetBrand._id.toString(),
-        extractedData,
-        message: 'Brand setup completed successfully',
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      if (error instanceof HttpException) {
-        throw error;
-      }
-
-      // Let Prisma errors (e.g. P2002 slug collision) bubble to the global
-      // DatabaseExceptionFilter, which maps them to the correct 4xx status
-      // instead of a generic 500.
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
-        throw error;
-      }
-
-      throw new HttpException(
-        {
-          detail: (error as Error)?.message || 'Failed to setup brand',
-          title: 'Brand Setup Failed',
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+        return {
+          brandId: targetBrand._id.toString(),
+          extractedData,
+          message: 'Brand setup completed successfully',
+          success: true,
+        };
+      },
+    );
   }
 
   private async unlockCompanyInfoJourneyReward(
@@ -814,92 +467,81 @@ export class OnboardingService {
     const publicMetadata = getPublicMetadata(user);
     const organizationId = publicMetadata.organization;
 
-    try {
-      // Verify brand belongs to user's organization
-      const brand = await this.brandsService.findOne(
-        {
-          _id: brandId,
-          isDeleted: false,
-          organization: organizationId,
-        },
-        'none',
-      );
-
-      if (!brand) {
-        throw new HttpException(
-          { detail: 'Brand not found', title: 'Not Found' },
-          HttpStatus.NOT_FOUND,
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      {
+        detail: 'Failed to confirm brand data',
+        hasHttpExceptionPassthrough: true,
+        hasPrismaPassthrough: true,
+        title: 'Error',
+      },
+      async () => {
+        // Verify brand belongs to user's organization
+        const brand = await this.brandsService.findOne(
+          {
+            _id: brandId,
+            isDeleted: false,
+            organization: organizationId,
+          },
+          'none',
         );
-      }
 
-      // Update brand with overrides
-      const updateData: Record<string, unknown> = {};
+        if (!brand) {
+          throw new HttpException(
+            { detail: 'Brand not found', title: 'Not Found' },
+            HttpStatus.NOT_FOUND,
+          );
+        }
 
-      if (dto.label) {
-        updateData.label = dto.label;
-      }
-      if (dto.description) {
-        updateData.description = dto.description;
-      }
-      if (dto.primaryColor) {
-        updateData.primaryColor = dto.primaryColor;
-      }
-      if (dto.secondaryColor) {
-        updateData.secondaryColor = dto.secondaryColor;
-      }
-      if (dto.fontFamily) {
-        updateData.fontFamily = dto.fontFamily;
-      }
+        // Update brand with overrides
+        const updateData: Record<string, unknown> = {};
 
-      if (Object.keys(updateData).length > 0) {
-        await this.brandsService.patch(brand._id, updateData);
-      }
+        if (dto.label) {
+          updateData.label = dto.label;
+        }
+        if (dto.description) {
+          updateData.description = dto.description;
+        }
+        if (dto.primaryColor) {
+          updateData.primaryColor = dto.primaryColor;
+        }
+        if (dto.secondaryColor) {
+          updateData.secondaryColor = dto.secondaryColor;
+        }
+        if (dto.fontFamily) {
+          updateData.fontFamily = dto.fontFamily;
+        }
 
-      // Sync organization and brand label and slug when brand label is updated
-      if (dto.label) {
-        const orgSlug = await this.organizationsService.generateUniqueSlug(
-          dto.label,
-          organizationId.toString(),
-        );
-        await this.organizationsService.patch(organizationId.toString(), {
-          label: dto.label,
-          slug: orgSlug,
-        });
+        if (Object.keys(updateData).length > 0) {
+          await this.brandsService.patch(brand._id, updateData);
+        }
 
-        const brandSlug = await this.brandsService.generateUniqueSlug(
-          dto.label,
-          brand._id,
-        );
-        await this.brandsService.patch(brand._id, { slug: brandSlug });
-      }
+        // Sync organization and brand label and slug when brand label is updated
+        if (dto.label) {
+          await this.brandPersistenceService.syncBrandAndOrgSlug(
+            dto.label,
+            organizationId.toString(),
+            brand._id,
+          );
+        }
 
-      // Update canonical brand guidance if voice overrides provided
-      if (dto.tone || dto.voice || dto.audience) {
-        await this.updateBrandGuidanceOverrides(brand._id, dto);
-      }
+        // Update canonical brand guidance if voice overrides provided
+        if (dto.tone || dto.voice || dto.audience) {
+          await this.brandPersistenceService.updateBrandGuidanceOverrides(
+            brand._id,
+            dto,
+          );
+        }
 
-      this.loggerService.log(`${caller} completed`);
+        this.loggerService.log(`${caller} completed`);
 
-      return {
-        message: 'Brand data confirmed successfully',
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      if (error instanceof HttpException) {
-        throw error;
-      }
-
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
-        throw error;
-      }
-
-      throw new HttpException(
-        { detail: 'Failed to confirm brand data', title: 'Error' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+        return {
+          message: 'Brand data confirmed successfully',
+          success: true,
+        };
+      },
+    );
   }
 
   /**
@@ -911,25 +553,23 @@ export class OnboardingService {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${caller} starting`);
 
-    try {
-      const { organizationId } = await this.ensureOnboardingWorkspace(user);
-      // Mark onboarding as skipped
-      await this.completeOnboarding(organizationId);
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      { detail: 'Failed to skip onboarding', title: 'Error' },
+      async () => {
+        const { organizationId } = await this.ensureOnboardingWorkspace(user);
+        // Mark onboarding as skipped
+        await this.completeOnboarding(organizationId);
 
-      this.loggerService.log(`${caller} completed`);
+        this.loggerService.log(`${caller} completed`);
 
-      return {
-        message: 'Onboarding skipped. You can set up your brand later.',
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      throw new HttpException(
-        { detail: 'Failed to skip onboarding', title: 'Error' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+        return {
+          message: 'Onboarding skipped. You can set up your brand later.',
+          success: true,
+        };
+      },
+    );
   }
 
   /**
@@ -940,107 +580,13 @@ export class OnboardingService {
   ): Promise<{ isFirstLogin: boolean; hasCompletedOnboarding: boolean }> {
     const { organizationId } = await this.ensureOnboardingWorkspace(user);
 
-    const settings = await this.organizationSettingsService.findOne({
-      isDeleted: false,
-      organization: organizationId,
-    });
-
-    return {
-      hasCompletedOnboarding: settings?.isFirstLogin === false,
-      isFirstLogin: settings?.isFirstLogin ?? true,
-    };
+    return this.onboardingReadinessService.getOnboardingStatus(organizationId);
   }
 
   async getInstallReadiness(user: User): Promise<InstallReadinessResponse> {
     const workspace = await this.ensureOnboardingWorkspace(user);
-    const organizationId = workspace.organizationId;
-    const brandId = workspace.brandId;
-    const userId = workspace.userId;
-    const providers = this.getProviderReadiness();
-    const showBillingUi = isEEEnabled();
 
-    let hasOrganization = false;
-    let hasBrand = false;
-    let selectedMode: OnboardingAccessMode | null = null;
-    let organizationSettings: Pick<
-      IOrganizationSetting,
-      'byokKeys' | 'isByokEnabled'
-    > | null = null;
-
-    if (userId && /^[0-9a-f]{24}$/i.test(userId)) {
-      const dbUser = await this.usersService.findOne({
-        _id: userId,
-        isDeleted: false,
-      });
-
-      selectedMode = this.getSelectedAccessMode(
-        (dbUser?.settings as { dashboardPreferences?: unknown } | undefined)
-          ?.dashboardPreferences,
-      );
-    }
-
-    if (organizationId && /^[0-9a-f]{24}$/i.test(organizationId)) {
-      const organization = await this.organizationsService.findOne({
-        _id: organizationId,
-        isDeleted: false,
-      });
-
-      hasOrganization = !!organization;
-
-      if (organization) {
-        const [brand, settings] = await Promise.all([
-          this.brandsService.findOne({
-            isDeleted: false,
-            organization: organization._id,
-          }),
-          this.organizationSettingsService.findOne({
-            isDeleted: false,
-            organization: organization._id,
-          }),
-        ]);
-
-        hasBrand = !!brand;
-        organizationSettings = settings as unknown as Pick<
-          IOrganizationSetting,
-          'byokKeys' | 'isByokEnabled'
-        >;
-      }
-    }
-
-    const byokConfiguredProviders =
-      this.getConfiguredByokProviders(organizationSettings);
-    const runtimeMode: OnboardingRuntimeAccessMode =
-      byokConfiguredProviders.length > 0 ? 'byok' : 'server';
-    const byokEnabled =
-      Boolean(organizationSettings?.isByokEnabled) ||
-      byokConfiguredProviders.length > 0;
-
-    return {
-      access: {
-        byokConfiguredProviders,
-        byokEnabled,
-        runtimeMode,
-        selectedMode,
-        serverDefaultsReady: providers.anyConfigured,
-      },
-      authMode: user.id ? 'better_auth' : 'none',
-      billingMode: showBillingUi ? 'cloud_billing' : 'oss_local',
-      localTools: this.getLocalToolReadiness(),
-      providers,
-      ui: {
-        showBilling: showBillingUi,
-        showCloudUpgradeCta: !showBillingUi,
-        showCredits: showBillingUi,
-        showLocalTools: !IS_CLOUD,
-        showPricing: showBillingUi,
-      },
-      workspace: {
-        brandId,
-        hasBrand,
-        hasOrganization,
-        organizationId,
-      },
-    };
+    return this.onboardingReadinessService.getInstallReadiness(user, workspace);
   }
 
   /**
@@ -1053,34 +599,32 @@ export class OnboardingService {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${caller} starting`, { category });
 
-    try {
-      const { organizationId } = await this.ensureOnboardingWorkspace(
-        user,
-        category,
-      );
-      await this.organizationsService.patch(organizationId.toString(), {
-        accountType: category,
-        category,
-      });
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      {
+        detail: 'Failed to set account type',
+        hasHttpExceptionPassthrough: true,
+        title: 'Error',
+      },
+      async () => {
+        const { organizationId } = await this.ensureOnboardingWorkspace(
+          user,
+          category,
+        );
+        await this.organizationsService.patch(organizationId.toString(), {
+          accountType: category,
+          category,
+        });
 
-      this.loggerService.log(`${caller} completed`, { category });
+        this.loggerService.log(`${caller} completed`, { category });
 
-      return {
-        message: `Account type set to ${category}`,
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      if (error instanceof HttpException) {
-        throw error;
-      }
-
-      throw new HttpException(
-        { detail: 'Failed to set account type', title: 'Error' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+        return {
+          message: `Account type set to ${category}`,
+          success: true,
+        };
+      },
+    );
   }
 
   /**
@@ -1092,54 +636,52 @@ export class OnboardingService {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${caller} starting`);
 
-    try {
-      const workspace = await this.ensureOnboardingWorkspace(user);
-      const publicMetadata = getPublicMetadata(user);
-      const proactiveLeadId = publicMetadata.proactiveLeadId?.toString();
-      const organizationId = workspace.organizationId;
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      { detail: 'Failed to complete onboarding funnel', title: 'Error' },
+      async () => {
+        const workspace = await this.ensureOnboardingWorkspace(user);
+        const publicMetadata = getPublicMetadata(user);
+        const proactiveLeadId = publicMetadata.proactiveLeadId?.toString();
+        const organizationId = workspace.organizationId;
 
-      if (proactiveLeadId && organizationId) {
-        await this.proactiveOnboardingService.markPaymentMade(
-          proactiveLeadId,
-          organizationId,
-        );
-      }
+        if (proactiveLeadId && organizationId) {
+          await this.proactiveOnboardingService.markPaymentMade(
+            proactiveLeadId,
+            organizationId,
+          );
+        }
 
-      // Update the DB so OnboardingGuard is satisfied; onboarding completion is
-      // read from the User row, not provider metadata.
-      const dbUser = await this.usersService.findOne({
-        authProviderId: user.id,
-      });
-      if (dbUser && !dbUser.isOnboardingCompleted) {
-        await this.usersService.patch(dbUser._id, {
-          isOnboardingCompleted: true,
-          onboardingCompletedAt: new Date(),
-          onboardingStepsCompleted: ['brand', 'providers'],
+        // Update the DB so OnboardingGuard is satisfied; onboarding completion is
+        // read from the User row, not provider metadata.
+        const dbUser = await this.usersService.findOne({
+          authProviderId: user.id,
         });
-      }
+        if (dbUser && !dbUser.isOnboardingCompleted) {
+          await this.usersService.patch(dbUser._id, {
+            isOnboardingCompleted: true,
+            onboardingCompletedAt: new Date(),
+            onboardingStepsCompleted: ['brand', 'providers'],
+          });
+        }
 
-      const dbUserId = dbUser?._id?.toString();
-      if (dbUserId) {
-        await Promise.all([
-          this.requestContextCacheService.invalidateForUser(dbUserId),
-          this.accessBootstrapCacheService.invalidateForUser(dbUserId),
-        ]);
-      }
+        const dbUserId = dbUser?._id?.toString();
+        if (dbUserId) {
+          await Promise.all([
+            this.requestContextCacheService.invalidateForUser(dbUserId),
+            this.accessBootstrapCacheService.invalidateForUser(dbUserId),
+          ]);
+        }
 
-      this.loggerService.log(`${caller} completed`);
+        this.loggerService.log(`${caller} completed`);
 
-      return {
-        message: 'Onboarding funnel completed',
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      throw new HttpException(
-        { detail: 'Failed to complete onboarding funnel', title: 'Error' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+        return {
+          message: 'Onboarding funnel completed',
+          success: true,
+        };
+      },
+    );
   }
 
   async getProactiveWorkspace(user: User): Promise<{
@@ -1207,157 +749,12 @@ export class OnboardingService {
 
   /**
    * Generate an AI preview image during onboarding
-   * Uses ComfyUI to generate an image based on brand data and content type
    */
   async generateOnboardingPreview(
     dto: GeneratePreviewDto,
     user: User,
   ): Promise<{ imageUrl: string; prompt: string }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(`${caller} starting`, {
-      brandId: dto.brandId,
-      contentType: dto.contentType,
-    });
-
-    const publicMetadata = getPublicMetadata(user);
-    const organizationId = publicMetadata.organization?.toString();
-    const userId = publicMetadata.user?.toString();
-
-    if (!organizationId || !userId) {
-      throw new HttpException(
-        {
-          detail: 'Missing organization or user context',
-          title: 'Bad Request',
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    try {
-      // 1. Fetch brand data
-      const brand = await this.brandsService.findOne(
-        {
-          _id: dto.brandId,
-          isDeleted: false,
-          organization: organizationId,
-        },
-        'none',
-      );
-
-      if (!brand) {
-        throw new HttpException(
-          { detail: 'Brand not found', title: 'Not Found' },
-          HttpStatus.NOT_FOUND,
-        );
-      }
-
-      // 2. Check credits availability
-      const hasCredits =
-        await this.creditsUtilsService.checkOrganizationCreditsAvailable(
-          organizationId,
-          ONBOARDING_PREVIEW_CREDIT_COST,
-        );
-
-      if (!hasCredits) {
-        throw new HttpException(
-          {
-            detail: 'Insufficient credits for preview generation',
-            title: 'Insufficient Credits',
-          },
-          HttpStatus.PAYMENT_REQUIRED,
-        );
-      }
-
-      // 3. Build prompt based on content type
-      const prompt = this.buildPreviewPrompt(
-        dto.contentType,
-        brand.label || '',
-        brand.description || '',
-        brand.primaryColor || '',
-        brand.secondaryColor || '',
-      );
-
-      // 4. Generate image via ComfyUI
-      this.loggerService.log(`${caller} generating image via ComfyUI`, {
-        contentType: dto.contentType,
-      });
-
-      const { imageBuffer } = await this.comfyUIService.generateImage(
-        MODEL_KEYS.GENFEED_AI_Z_IMAGE_TURBO,
-        {
-          height: 1024,
-          prompt,
-          steps: 4,
-          width: 1024,
-        },
-      );
-
-      // 5. Upload to S3
-      const uploadKey = `${organizationId}/onboarding-preview-${Date.now()}`;
-      const { publicUrl } = await this.filesClientService.getPresignedUploadUrl(
-        uploadKey,
-        'onboarding',
-        'image/png',
-      );
-
-      await this.filesClientService.uploadToS3(uploadKey, 'onboarding', {
-        contentType: 'image/png',
-        data: imageBuffer,
-        type: FileInputType.BUFFER,
-      });
-
-      // 6. Deduct credits
-      await this.creditsUtilsService.deductCreditsFromOrganization(
-        organizationId,
-        userId,
-        ONBOARDING_PREVIEW_CREDIT_COST,
-        'Onboarding preview image',
-      );
-
-      // 7. Save preview URL to brand
-      await this.brandsService.patch(brand._id, {
-        // @ts-expect-error onboardingPreviewUrl is valid
-        onboardingPreviewUrl: publicUrl,
-      });
-
-      this.loggerService.log(`${caller} completed`, {
-        brandId: dto.brandId,
-        imageUrl: publicUrl,
-      });
-
-      return { imageUrl: publicUrl, prompt };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      if (error instanceof HttpException) {
-        throw error;
-      }
-
-      throw new HttpException(
-        {
-          detail: (error as Error)?.message || 'Failed to generate preview',
-          title: 'Preview Generation Failed',
-        },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
-  }
-
-  /**
-   * Build a prompt for onboarding preview image generation
-   */
-  private buildPreviewPrompt(
-    contentType: string,
-    brandName: string,
-    brandDescription: string,
-    primaryColor: string,
-    secondaryColor: string,
-  ): string {
-    if (contentType === 'ads') {
-      return `A stunning high-end advertisement for ${brandName}, ${brandDescription}, featuring a professional model presenting the brand, brand colors ${primaryColor} and ${secondaryColor}, commercial product photography, studio lighting, high fashion`;
-    }
-
-    return `A premium social media content post for ${brandName}, ${brandDescription}, featuring an attractive influencer promoting the brand, brand colors ${primaryColor} and ${secondaryColor}, Instagram lifestyle photography, natural lighting, aspirational`;
+    return this.onboardingPreviewService.generateOnboardingPreview(dto, user);
   }
 
   /**
@@ -1368,50 +765,13 @@ export class OnboardingService {
     images: ReferenceImageDto[],
     user: User,
   ): Promise<{ success: boolean; count: number }> {
-    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    this.loggerService.log(`${caller} starting`, { brandId });
-
     const publicMetadata = getPublicMetadata(user);
-    const organizationId = publicMetadata.organization;
 
-    const brand = await this.brandsService.findOne(
-      {
-        _id: brandId,
-        isDeleted: false,
-        organization: organizationId,
-      },
-      'none',
-    );
-
-    if (!brand) {
-      throw new HttpException(
-        { detail: 'Brand not found', title: 'Not Found' },
-        HttpStatus.NOT_FOUND,
-      );
-    }
-
-    const brandId_str = String(
-      (brand as Record<string, unknown>).id ?? brand._id,
-    );
-    const existingImages = this.readBrandReferenceImages(brand.referenceImages);
-    await this.brandsService.patch(brandId_str, {
-      referenceImages: [
-        ...existingImages,
-        ...images.map((image) => ({
-          category: image.category,
-          isDefault: image.isDefault,
-          label: image.label,
-          url: image.url,
-        })),
-      ],
-    });
-
-    this.loggerService.log(`${caller} completed`, {
+    return this.brandPersistenceService.addReferenceImages(
       brandId,
-      count: images.length,
-    });
-
-    return { count: images.length, success: true };
+      images,
+      publicMetadata.organization,
+    );
   }
 
   /**
@@ -1426,256 +786,53 @@ export class OnboardingService {
       brandName: dto.brandName,
     });
 
-    try {
-      const workspace = await this.ensureOnboardingWorkspace(user);
-      const organizationId = workspace.organizationId;
-      const userId = workspace.userId;
-
-      const brand = await this.brandsService.findOne(
-        {
-          isDeleted: false,
-          organization: organizationId,
-          user: userId,
-        },
-        'none',
-      );
-
-      if (!brand) {
-        throw new HttpException(
-          { detail: 'No brand found for user', title: 'Brand Not Found' },
-          HttpStatus.NOT_FOUND,
-        );
-      }
-
-      await this.brandsService.patch(brand._id, {
-        label: dto.brandName,
-      });
-
-      const slug = await this.organizationsService.generateUniqueSlug(
-        dto.brandName,
-        organizationId.toString(),
-      );
-      await this.organizationsService.patch(organizationId.toString(), {
-        label: dto.brandName,
-        slug,
-      });
-
-      this.loggerService.log(`${caller} completed`);
-
-      return {
-        message: 'Brand name updated successfully',
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      if (error instanceof HttpException) {
-        throw error;
-      }
-
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
-        throw error;
-      }
-
-      throw new HttpException(
-        { detail: 'Failed to update brand name', title: 'Error' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
-  }
-
-  /**
-   * Update brand entity with scraped data
-   */
-  private async updateBrandWithScrapedData(
-    brandId: string,
-    scrapedData: IScrapedBrandData,
-    dto: BrandSetupDto,
-    labelOverride?: string,
-  ): Promise<void> {
-    const updateData: Record<string, unknown> = {};
-
-    const label = labelOverride || scrapedData.companyName;
-    if (label) {
-      updateData.label = label;
-    }
-
-    if (scrapedData.description) {
-      updateData.description = scrapedData.description;
-    }
-
-    if (scrapedData.primaryColor) {
-      updateData.primaryColor = scrapedData.primaryColor;
-    }
-
-    if (scrapedData.secondaryColor) {
-      updateData.secondaryColor = scrapedData.secondaryColor;
-    }
-
-    if (scrapedData.fontFamily) {
-      updateData.fontFamily = scrapedData.fontFamily;
-    }
-
-    // Build system prompt from scraped content
-    if (scrapedData.tagline || scrapedData.aboutText) {
-      const systemPromptParts: string[] = [];
-
-      if (scrapedData.companyName) {
-        systemPromptParts.push(
-          `You are creating content for ${scrapedData.companyName}.`,
-        );
-      }
-
-      if (scrapedData.tagline) {
-        systemPromptParts.push(`Brand tagline: "${scrapedData.tagline}"`);
-      }
-
-      if (scrapedData.aboutText) {
-        systemPromptParts.push(`About the brand: ${scrapedData.aboutText}`);
-      }
-
-      if (dto.industry) {
-        systemPromptParts.push(`Industry: ${dto.industry}`);
-      }
-
-      if (dto.targetAudience) {
-        systemPromptParts.push(`Target audience: ${dto.targetAudience}`);
-      }
-
-      updateData.text = systemPromptParts.join('\n\n');
-    }
-
-    if (Object.keys(updateData).length > 0) {
-      await this.brandsService.patch(
-        brandId,
-        updateData as Partial<UpdateBrandDto>,
-      );
-    }
-  }
-
-  private async upsertBrandWebsiteLink(
-    brandId: string,
-    websiteUrl: string,
-  ): Promise<void> {
-    const normalizedUrl = websiteUrl.trim();
-
-    if (!normalizedUrl) {
-      return;
-    }
-
-    const existingWebsiteLink = await this.linksService.findOne({
-      brand: brandId,
-      category: LinkCategory.WEBSITE,
-      isDeleted: false,
-    });
-
-    if (existingWebsiteLink) {
-      await this.linksService.patch(String(existingWebsiteLink.id), {
-        label: 'Website',
-        url: normalizedUrl,
-      });
-      return;
-    }
-
-    await this.linksService.create({
-      brand: brandId,
-      category: LinkCategory.WEBSITE,
-      label: 'Website',
-      url: normalizedUrl,
-    });
-  }
-
-  private async updateBrandGuidance(
-    brandId: string,
-    extractedData: IExtractedBrandData,
-  ): Promise<void> {
-    const brand = await this.brandsService.findOne({
-      _id: brandId,
-      isDeleted: false,
-    });
-
-    if (!brand) {
-      return;
-    }
-
-    const brandAgentConfig = this.readBrandAgentConfig(brand.agentConfig);
-
-    const extractedVoice = extractedData.brandVoice as
-      | {
-          audience?: string;
-          doNotSoundLike?: string[];
-          hashtags?: string[];
-          messagingPillars?: string[];
-          sampleOutput?: string;
-          taglines?: string[];
-          tone?: string;
-          values?: string[];
-          voice?: string;
-        }
-      | undefined;
-
-    const nextVoice = extractedData.brandVoice
-      ? {
-          ...(brandAgentConfig.voice ?? {}),
-          audience: extractedVoice?.audience
-            ? extractedVoice.audience
-                .split(',')
-                .map((value) => value.trim())
-                .filter(Boolean)
-            : (brandAgentConfig.voice?.audience ?? []),
-          doNotSoundLike: extractedVoice?.doNotSoundLike ?? [],
-          hashtags: extractedVoice?.hashtags ?? [],
-          messagingPillars: extractedVoice?.messagingPillars ?? [],
-          sampleOutput: extractedVoice?.sampleOutput,
-          style: extractedVoice?.voice,
-          taglines: extractedVoice?.taglines ?? [],
-          tone: extractedVoice?.tone,
-          values: extractedVoice?.values ?? [],
-        }
-      : brandAgentConfig.voice;
-
-    await this.brandsService.patch(brandId, {
-      agentConfig: {
-        ...brandAgentConfig,
-        ...(nextVoice ? { voice: nextVoice } : {}),
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      {
+        detail: 'Failed to update brand name',
+        hasHttpExceptionPassthrough: true,
+        hasPrismaPassthrough: true,
+        title: 'Error',
       },
-    });
-  }
+      async () => {
+        const workspace = await this.ensureOnboardingWorkspace(user);
+        const organizationId = workspace.organizationId;
+        const userId = workspace.userId;
 
-  private async updateBrandGuidanceOverrides(
-    brandId: string,
-    dto: ConfirmBrandDataDto,
-  ): Promise<void> {
-    const brand = await this.brandsService.findOne({
-      _id: brandId,
-      isDeleted: false,
-    });
+        const brand = await this.brandsService.findOne(
+          {
+            isDeleted: false,
+            organization: organizationId,
+            user: userId,
+          },
+          'none',
+        );
 
-    if (!brand) {
-      return;
-    }
+        if (!brand) {
+          throw new HttpException(
+            { detail: 'No brand found for user', title: 'Brand Not Found' },
+            HttpStatus.NOT_FOUND,
+          );
+        }
 
-    const brandAgentConfig = this.readBrandAgentConfig(brand.agentConfig);
-    const existingVoice = brandAgentConfig.voice ?? {};
+        await this.brandsService.patch(brand._id, {
+          label: dto.brandName,
+        });
 
-    await this.brandsService.patch(brandId, {
-      agentConfig: {
-        ...brandAgentConfig,
-        voice: {
-          ...existingVoice,
-          ...(dto.audience
-            ? {
-                audience: dto.audience
-                  .split(',')
-                  .map((value) => value.trim())
-                  .filter(Boolean),
-              }
-            : {}),
-          ...(dto.tone ? { tone: dto.tone } : {}),
-          ...(dto.voice ? { style: dto.voice } : {}),
-        },
+        await this.brandPersistenceService.syncOrgLabelAndSlug(
+          dto.brandName,
+          organizationId.toString(),
+        );
+
+        this.loggerService.log(`${caller} completed`);
+
+        return {
+          message: 'Brand name updated successfully',
+          success: true,
+        };
       },
-    });
+    );
   }
 
   /**
@@ -1698,68 +855,66 @@ export class OnboardingService {
     const publicMetadata = getPublicMetadata(user);
     const organizationId = publicMetadata.organization;
 
-    try {
-      // Check if org already has a prefix
-      const org = await this.organizationsService.findOne({
-        _id: organizationId,
-        isDeleted: false,
-      });
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      {
+        detail: 'Failed to set organization prefix',
+        hasHttpExceptionPassthrough: true,
+        title: 'Error',
+      },
+      async () => {
+        // Check if org already has a prefix
+        const org = await this.organizationsService.findOne({
+          _id: organizationId,
+          isDeleted: false,
+        });
 
-      if (!org) {
-        throw new HttpException(
-          { detail: 'Organization not found', title: 'Not Found' },
-          HttpStatus.NOT_FOUND,
-        );
-      }
+        if (!org) {
+          throw new HttpException(
+            { detail: 'Organization not found', title: 'Not Found' },
+            HttpStatus.NOT_FOUND,
+          );
+        }
 
-      if (org.prefix) {
-        throw new HttpException(
-          {
-            detail: `Organization already has prefix "${org.prefix}". Prefix is immutable once set.`,
-            title: 'Conflict',
-          },
-          HttpStatus.CONFLICT,
-        );
-      }
+        if (org.prefix) {
+          throw new HttpException(
+            {
+              detail: `Organization already has prefix "${org.prefix}". Prefix is immutable once set.`,
+              title: 'Conflict',
+            },
+            HttpStatus.CONFLICT,
+          );
+        }
 
-      // Check uniqueness
-      const isAvailable =
-        await this.organizationsService.isPrefixAvailable(prefix);
-      if (!isAvailable) {
-        throw new HttpException(
-          {
-            detail: `Prefix "${prefix}" is already taken`,
-            title: 'Conflict',
-          },
-          HttpStatus.CONFLICT,
-        );
-      }
+        // Check uniqueness
+        const isAvailable =
+          await this.organizationsService.isPrefixAvailable(prefix);
+        if (!isAvailable) {
+          throw new HttpException(
+            {
+              detail: `Prefix "${prefix}" is already taken`,
+              title: 'Conflict',
+            },
+            HttpStatus.CONFLICT,
+          );
+        }
 
-      // Set the prefix
-      await this.organizationsService.patch(organizationId.toString(), {
-        // @ts-expect-error prefix is not in UpdateOrganizationDto (immutable), but we set it directly here during onboarding
-        prefix: prefix.toUpperCase(),
-      });
+        // Set the prefix
+        await this.organizationsService.patch(organizationId.toString(), {
+          // @ts-expect-error prefix is not in UpdateOrganizationDto (immutable), but we set it directly here during onboarding
+          prefix: prefix.toUpperCase(),
+        });
 
-      this.loggerService.log(`${caller} completed`, { prefix });
+        this.loggerService.log(`${caller} completed`, { prefix });
 
-      return {
-        message: `Organization prefix set to "${prefix.toUpperCase()}"`,
-        prefix: prefix.toUpperCase(),
-        success: true,
-      };
-    } catch (error: unknown) {
-      this.loggerService.error(`${caller} failed`, error);
-
-      if (error instanceof HttpException) {
-        throw error;
-      }
-
-      throw new HttpException(
-        { detail: 'Failed to set organization prefix', title: 'Error' },
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+        return {
+          message: `Organization prefix set to "${prefix.toUpperCase()}"`,
+          prefix: prefix.toUpperCase(),
+          success: true,
+        };
+      },
+    );
   }
 
   /**

--- a/apps/server/api/src/endpoints/onboarding/services/brand-data.mapper.spec.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/brand-data.mapper.spec.ts
@@ -1,0 +1,331 @@
+import type { BrandSetupDto } from '@api/endpoints/onboarding/dto/brand-setup.dto';
+import type {
+  LinkedInScrapedData,
+  MergedBrandAnalysis,
+  XProfileScrapedData,
+} from '@api/services/brand-scraper/interfaces/brand-scraper.interfaces';
+import type { IExtractedBrandData } from '@genfeedai/interfaces';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BrandDataMapper } from './brand-data.mapper';
+
+describe('BrandDataMapper', () => {
+  let mapper: BrandDataMapper;
+
+  beforeEach(() => {
+    mapper = new BrandDataMapper();
+  });
+
+  describe('buildScrapedBrandData', () => {
+    it('fills the full IScrapedBrandData shape with defaults', () => {
+      const scrapedAt = new Date('2026-01-01');
+
+      const result = mapper.buildScrapedBrandData({
+        scrapedAt,
+        sourceUrl: 'https://example.com',
+      });
+
+      expect(result).toEqual({
+        aboutText: undefined,
+        companyName: undefined,
+        description: undefined,
+        fontFamily: undefined,
+        heroText: undefined,
+        logoUrl: undefined,
+        metaDescription: undefined,
+        ogImage: undefined,
+        primaryColor: undefined,
+        scrapedAt,
+        secondaryColor: undefined,
+        socialLinks: {},
+        sourceUrl: 'https://example.com',
+        tagline: undefined,
+        valuePropositions: [],
+      });
+    });
+
+    it('lets provided fields override the defaults', () => {
+      const result = mapper.buildScrapedBrandData({
+        companyName: 'Acme',
+        scrapedAt: new Date('2026-01-01'),
+        sourceUrl: 'https://acme.com',
+        valuePropositions: ['fast'],
+      });
+
+      expect(result.companyName).toBe('Acme');
+      expect(result.valuePropositions).toEqual(['fast']);
+    });
+  });
+
+  describe('mapMergedSources', () => {
+    it('maps the merged analysis and mirrors description into metaDescription', () => {
+      const scrapedAt = new Date('2026-02-02');
+      const merged = {
+        aboutText: 'About us',
+        companyName: 'Acme',
+        contentSamples: [],
+        description: 'We make anvils',
+        fontFamily: 'Inter',
+        heroText: 'Hero',
+        logoUrl: 'https://acme.com/logo.png',
+        primaryColor: '#111111',
+        scrapedAt,
+        secondaryColor: '#222222',
+        socialLinks: { twitter: 'https://x.com/acme' },
+        sourceUrls: ['https://acme.com'],
+        tagline: 'Anvils for all',
+        valuePropositions: ['durable'],
+      } as MergedBrandAnalysis;
+
+      const result = mapper.mapMergedSources(merged, 'https://acme.com');
+
+      expect(result.metaDescription).toBe('We make anvils');
+      expect(result.ogImage).toBeUndefined();
+      expect(result.socialLinks).toEqual({ twitter: 'https://x.com/acme' });
+      expect(result.sourceUrl).toBe('https://acme.com');
+      expect(result.tagline).toBe('Anvils for all');
+    });
+  });
+
+  describe('mapLinkedInData', () => {
+    it('maps LinkedIn data with cover image as ogImage', () => {
+      const scrapedAt = new Date('2026-02-02');
+      const linkedinData = {
+        companyName: 'Acme',
+        coverImageUrl: 'https://cdn/cover.png',
+        description: 'B2B anvils',
+        logoUrl: 'https://cdn/logo.png',
+        recentPosts: [],
+        scrapedAt,
+        sourceUrl: 'https://linkedin.com/company/acme',
+      } as LinkedInScrapedData;
+
+      const result = mapper.mapLinkedInData(
+        linkedinData,
+        'https://linkedin.com/company/acme',
+      );
+
+      expect(result.companyName).toBe('Acme');
+      expect(result.metaDescription).toBe('B2B anvils');
+      expect(result.ogImage).toBe('https://cdn/cover.png');
+      expect(result.socialLinks).toEqual({});
+      expect(result.valuePropositions).toEqual([]);
+    });
+  });
+
+  describe('mapXProfileData', () => {
+    it('maps X profile data with the profile image as logo and ogImage', () => {
+      const scrapedAt = new Date('2026-02-02');
+      const xData = {
+        bio: 'Anvil maker',
+        contentStyle: {
+          contentTypes: [],
+          usesEmojis: false,
+          usesHashtags: false,
+        },
+        displayName: 'Acme',
+        profileImageUrl: 'https://cdn/avatar.png',
+        recentTweets: [],
+        scrapedAt,
+        sourceUrl: 'https://x.com/acme',
+      } as XProfileScrapedData;
+
+      const result = mapper.mapXProfileData(xData, 'https://x.com/acme');
+
+      expect(result.companyName).toBe('Acme');
+      expect(result.description).toBe('Anvil maker');
+      expect(result.logoUrl).toBe('https://cdn/avatar.png');
+      expect(result.ogImage).toBe('https://cdn/avatar.png');
+    });
+  });
+
+  describe('buildFallbackScrapedData', () => {
+    it('prefers the DTO brand name over the existing brand label', () => {
+      const dto = {
+        brandName: '  Acme  ',
+        brandUrl: 'https://acme.com',
+      } as BrandSetupDto;
+
+      const result = mapper.buildFallbackScrapedData(dto, { label: 'Old' });
+
+      expect(result.companyName).toBe('Acme');
+      expect(result.sourceUrl).toBe('https://acme.com');
+    });
+
+    it('falls back to the existing brand label, then a generic name', () => {
+      const dto = { brandUrl: 'https://acme.com' } as BrandSetupDto;
+
+      expect(
+        mapper.buildFallbackScrapedData(dto, { label: 'Existing' }).companyName,
+      ).toBe('Existing');
+      expect(
+        mapper.buildFallbackScrapedData(dto, { label: null }).companyName,
+      ).toBe('Brand');
+    });
+  });
+
+  describe('readBrandAgentConfig', () => {
+    it('returns an empty config for non-object values', () => {
+      expect(mapper.readBrandAgentConfig(null)).toEqual({});
+      expect(mapper.readBrandAgentConfig('nope')).toEqual({});
+      expect(mapper.readBrandAgentConfig([1, 2])).toEqual({});
+    });
+
+    it('passes through object values', () => {
+      const config = { persona: 'friendly' };
+
+      expect(mapper.readBrandAgentConfig(config)).toBe(config);
+    });
+  });
+
+  describe('readBrandReferenceImages', () => {
+    it('returns an empty array for non-array values', () => {
+      expect(mapper.readBrandReferenceImages(null)).toEqual([]);
+      expect(mapper.readBrandReferenceImages({})).toEqual([]);
+    });
+
+    it('normalizes entries and drops non-object items', () => {
+      const result = mapper.readBrandReferenceImages([
+        { category: 'logo', isDefault: true, label: 'Logo', url: 'https://x' },
+        { label: 42, url: 'https://y' },
+        'garbage',
+        null,
+      ]);
+
+      expect(result).toEqual([
+        { category: 'logo', isDefault: true, label: 'Logo', url: 'https://x' },
+        { category: 'reference', url: 'https://y' },
+      ]);
+    });
+  });
+
+  describe('buildPreviewPrompt', () => {
+    it('builds an advertisement prompt for ads content', () => {
+      const prompt = mapper.buildPreviewPrompt(
+        'ads',
+        'Acme',
+        'anvils',
+        '#111',
+        '#222',
+      );
+
+      expect(prompt).toContain('advertisement for Acme');
+      expect(prompt).toContain('#111 and #222');
+    });
+
+    it('builds a social media prompt for any other content type', () => {
+      const prompt = mapper.buildPreviewPrompt(
+        'social-post',
+        'Acme',
+        'anvils',
+        '#111',
+        '#222',
+      );
+
+      expect(prompt).toContain('social media content post for Acme');
+    });
+  });
+
+  describe('parseAudienceList', () => {
+    it('splits on commas, trims, and drops empties', () => {
+      expect(mapper.parseAudienceList(' founders , , devs,')).toEqual([
+        'founders',
+        'devs',
+      ]);
+    });
+  });
+
+  describe('mergeExtractedVoice', () => {
+    it('returns the config unchanged when no brand voice was extracted', () => {
+      const config = { voice: { tone: 'calm' } };
+
+      const result = mapper.mergeExtractedVoice(config, {
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      } as IExtractedBrandData);
+
+      expect(result).toEqual(config);
+    });
+
+    it('merges the extracted voice over the existing voice', () => {
+      const config = {
+        persona: 'friendly',
+        voice: { audience: ['old'], tone: 'calm' },
+      };
+      const extractedData = {
+        brandVoice: {
+          audience: 'founders, devs',
+          hashtags: ['#acme'],
+          taglines: ['Anvils for all'],
+          tone: 'bold',
+          values: ['quality'],
+          voice: 'confident',
+        },
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      } as IExtractedBrandData;
+
+      const result = mapper.mergeExtractedVoice(config, extractedData);
+
+      expect(result.persona).toBe('friendly');
+      expect(result.voice).toEqual({
+        audience: ['founders', 'devs'],
+        doNotSoundLike: [],
+        hashtags: ['#acme'],
+        messagingPillars: [],
+        sampleOutput: undefined,
+        style: 'confident',
+        taglines: ['Anvils for all'],
+        tone: 'bold',
+        values: ['quality'],
+      });
+    });
+
+    it('keeps the existing audience when the extracted voice has none', () => {
+      const config = { voice: { audience: ['old'] } };
+      const extractedData = {
+        brandVoice: {
+          audience: '',
+          hashtags: [],
+          taglines: [],
+          tone: 'bold',
+          values: [],
+          voice: 'confident',
+        },
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      } as IExtractedBrandData;
+
+      const result = mapper.mergeExtractedVoice(config, extractedData);
+
+      expect(result.voice?.audience).toEqual(['old']);
+    });
+  });
+
+  describe('mergeVoiceOverrides', () => {
+    it('applies only the provided overrides on top of the existing voice', () => {
+      const config = {
+        voice: { style: 'plain', taglines: ['keep'], tone: 'calm' },
+      };
+
+      const result = mapper.mergeVoiceOverrides(config, {
+        audience: 'founders, devs',
+        tone: 'bold',
+      });
+
+      expect(result.voice).toEqual({
+        audience: ['founders', 'devs'],
+        style: 'plain',
+        taglines: ['keep'],
+        tone: 'bold',
+      });
+    });
+
+    it('keeps the existing voice untouched when no overrides are provided', () => {
+      const config = { voice: { tone: 'calm' } };
+
+      const result = mapper.mergeVoiceOverrides(config, {});
+
+      expect(result.voice).toEqual({ tone: 'calm' });
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/onboarding/services/brand-data.mapper.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/brand-data.mapper.ts
@@ -1,0 +1,258 @@
+import type {
+  BrandAgentConfig,
+  BrandAgentVoice,
+  BrandReferenceImage,
+} from '@api/collections/brands/schemas/brand.schema';
+import type {
+  BrandSetupDto,
+  ConfirmBrandDataDto,
+} from '@api/endpoints/onboarding/dto/brand-setup.dto';
+import type {
+  LinkedInScrapedData,
+  MergedBrandAnalysis,
+  XProfileScrapedData,
+} from '@api/services/brand-scraper/interfaces/brand-scraper.interfaces';
+import type {
+  IExtractedBrandData,
+  IScrapedBrandData,
+} from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Shape of the AI brand-voice analysis consumed by the guidance merge.
+ */
+interface ExtractedBrandVoice {
+  audience?: string;
+  doNotSoundLike?: string[];
+  hashtags?: string[];
+  messagingPillars?: string[];
+  sampleOutput?: string;
+  taglines?: string[];
+  tone?: string;
+  values?: string[];
+  voice?: string;
+}
+
+/**
+ * BrandDataMapper
+ *
+ * Pure, dependency-free mapping between scraper outputs, onboarding DTOs,
+ * and the persisted brand shapes. Every scrape source normalizes into
+ * IScrapedBrandData through a single builder so the shape cannot drift
+ * between branches.
+ */
+@Injectable()
+export class BrandDataMapper {
+  /**
+   * Single builder for the IScrapedBrandData shape. All normalizers funnel
+   * through here so defaults (empty socialLinks/valuePropositions) stay
+   * consistent across scrape sources.
+   */
+  buildScrapedBrandData(
+    data: Partial<IScrapedBrandData> &
+      Pick<IScrapedBrandData, 'scrapedAt' | 'sourceUrl'>,
+  ): IScrapedBrandData {
+    return {
+      aboutText: undefined,
+      companyName: undefined,
+      description: undefined,
+      fontFamily: undefined,
+      heroText: undefined,
+      logoUrl: undefined,
+      metaDescription: undefined,
+      ogImage: undefined,
+      primaryColor: undefined,
+      secondaryColor: undefined,
+      socialLinks: {},
+      tagline: undefined,
+      valuePropositions: [],
+      ...data,
+    };
+  }
+
+  mapMergedSources(
+    merged: MergedBrandAnalysis,
+    sourceUrl: string,
+  ): IScrapedBrandData {
+    return this.buildScrapedBrandData({
+      aboutText: merged.aboutText,
+      companyName: merged.companyName,
+      description: merged.description,
+      fontFamily: merged.fontFamily,
+      heroText: merged.heroText,
+      logoUrl: merged.logoUrl,
+      metaDescription: merged.description,
+      primaryColor: merged.primaryColor,
+      scrapedAt: merged.scrapedAt,
+      secondaryColor: merged.secondaryColor,
+      socialLinks: merged.socialLinks,
+      sourceUrl,
+      tagline: merged.tagline,
+      valuePropositions: merged.valuePropositions,
+    });
+  }
+
+  mapLinkedInData(
+    linkedinData: LinkedInScrapedData,
+    sourceUrl: string,
+  ): IScrapedBrandData {
+    return this.buildScrapedBrandData({
+      companyName: linkedinData.companyName,
+      description: linkedinData.description,
+      logoUrl: linkedinData.logoUrl,
+      metaDescription: linkedinData.description,
+      ogImage: linkedinData.coverImageUrl,
+      scrapedAt: linkedinData.scrapedAt,
+      sourceUrl,
+    });
+  }
+
+  mapXProfileData(
+    xData: XProfileScrapedData,
+    sourceUrl: string,
+  ): IScrapedBrandData {
+    return this.buildScrapedBrandData({
+      companyName: xData.displayName,
+      description: xData.bio,
+      logoUrl: xData.profileImageUrl,
+      metaDescription: xData.bio,
+      ogImage: xData.profileImageUrl,
+      scrapedAt: xData.scrapedAt,
+      sourceUrl,
+    });
+  }
+
+  buildFallbackScrapedData(
+    dto: BrandSetupDto,
+    existingBrand: { label?: string | null },
+  ): IScrapedBrandData {
+    const fallbackLabel =
+      dto.brandName?.trim() || existingBrand.label?.trim() || 'Brand';
+
+    return this.buildScrapedBrandData({
+      companyName: fallbackLabel,
+      scrapedAt: new Date(),
+      sourceUrl: dto.brandUrl,
+    });
+  }
+
+  readBrandAgentConfig(value: unknown): BrandAgentConfig {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return {};
+    }
+
+    return value as BrandAgentConfig;
+  }
+
+  readBrandReferenceImages(value: unknown): BrandReferenceImage[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.flatMap((entry) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        return [];
+      }
+
+      const record = entry as Record<string, unknown>;
+      const category =
+        typeof record.category === 'string' ? record.category : 'reference';
+      const label = typeof record.label === 'string' ? record.label : undefined;
+      const url = typeof record.url === 'string' ? record.url : undefined;
+      const isDefault =
+        typeof record.isDefault === 'boolean' ? record.isDefault : undefined;
+
+      return [
+        {
+          category,
+          ...(isDefault !== undefined ? { isDefault } : {}),
+          ...(label ? { label } : {}),
+          ...(url ? { url } : {}),
+        } as BrandReferenceImage,
+      ];
+    });
+  }
+
+  /**
+   * Build a prompt for onboarding preview image generation
+   */
+  buildPreviewPrompt(
+    contentType: string,
+    brandName: string,
+    brandDescription: string,
+    primaryColor: string,
+    secondaryColor: string,
+  ): string {
+    if (contentType === 'ads') {
+      return `A stunning high-end advertisement for ${brandName}, ${brandDescription}, featuring a professional model presenting the brand, brand colors ${primaryColor} and ${secondaryColor}, commercial product photography, studio lighting, high fashion`;
+    }
+
+    return `A premium social media content post for ${brandName}, ${brandDescription}, featuring an attractive influencer promoting the brand, brand colors ${primaryColor} and ${secondaryColor}, Instagram lifestyle photography, natural lighting, aspirational`;
+  }
+
+  parseAudienceList(audience: string): string[] {
+    return audience
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  /**
+   * Merge the AI-extracted brand voice into the existing agent config,
+   * returning the full agentConfig patch payload.
+   */
+  mergeExtractedVoice(
+    brandAgentConfig: BrandAgentConfig,
+    extractedData: IExtractedBrandData,
+  ): BrandAgentConfig {
+    const extractedVoice = extractedData.brandVoice as
+      | ExtractedBrandVoice
+      | undefined;
+
+    const nextVoice: Partial<BrandAgentVoice> | undefined =
+      extractedData.brandVoice
+        ? {
+            ...(brandAgentConfig.voice ?? {}),
+            audience: extractedVoice?.audience
+              ? this.parseAudienceList(extractedVoice.audience)
+              : (brandAgentConfig.voice?.audience ?? []),
+            doNotSoundLike: extractedVoice?.doNotSoundLike ?? [],
+            hashtags: extractedVoice?.hashtags ?? [],
+            messagingPillars: extractedVoice?.messagingPillars ?? [],
+            sampleOutput: extractedVoice?.sampleOutput,
+            style: extractedVoice?.voice,
+            taglines: extractedVoice?.taglines ?? [],
+            tone: extractedVoice?.tone,
+            values: extractedVoice?.values ?? [],
+          }
+        : brandAgentConfig.voice;
+
+    return {
+      ...brandAgentConfig,
+      ...(nextVoice ? { voice: nextVoice } : {}),
+    };
+  }
+
+  /**
+   * Merge user-provided voice overrides into the existing agent config,
+   * returning the full agentConfig patch payload.
+   */
+  mergeVoiceOverrides(
+    brandAgentConfig: BrandAgentConfig,
+    dto: ConfirmBrandDataDto,
+  ): BrandAgentConfig {
+    const existingVoice = brandAgentConfig.voice ?? {};
+
+    return {
+      ...brandAgentConfig,
+      voice: {
+        ...existingVoice,
+        ...(dto.audience
+          ? { audience: this.parseAudienceList(dto.audience) }
+          : {}),
+        ...(dto.tone ? { tone: dto.tone } : {}),
+        ...(dto.voice ? { style: dto.voice } : {}),
+      },
+    };
+  }
+}

--- a/apps/server/api/src/endpoints/onboarding/services/brand-persistence.service.spec.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/brand-persistence.service.spec.ts
@@ -1,0 +1,399 @@
+import type { BrandsService } from '@api/collections/brands/services/brands.service';
+import type { LinksService } from '@api/collections/links/services/links.service';
+import type { MembersService } from '@api/collections/members/services/members.service';
+import type { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import type { BrandSetupDto } from '@api/endpoints/onboarding/dto/brand-setup.dto';
+import type { ReferenceImageDto } from '@api/endpoints/onboarding/dto/reference-images.dto';
+import { LinkCategory } from '@genfeedai/enums';
+import type { IExtractedBrandData } from '@genfeedai/interfaces';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { HttpException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrandDataMapper } from './brand-data.mapper';
+import { BrandPersistenceService } from './brand-persistence.service';
+
+describe('BrandPersistenceService', () => {
+  let service: BrandPersistenceService;
+  let brandsService: {
+    findOne: ReturnType<typeof vi.fn>;
+    generateUniqueSlug: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+    selectBrandForUser: ReturnType<typeof vi.fn>;
+  };
+  let linksService: {
+    create: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+  let membersService: { setLastUsedBrand: ReturnType<typeof vi.fn> };
+  let organizationsService: {
+    generateUniqueSlug: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+  let loggerService: {
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    brandsService = {
+      findOne: vi.fn(),
+      generateUniqueSlug: vi.fn(),
+      patch: vi.fn(),
+      selectBrandForUser: vi.fn(),
+    };
+    linksService = {
+      create: vi.fn(),
+      findOne: vi.fn(),
+      patch: vi.fn(),
+    };
+    membersService = {
+      setLastUsedBrand: vi.fn(),
+    };
+    organizationsService = {
+      generateUniqueSlug: vi.fn(),
+      patch: vi.fn(),
+    };
+    loggerService = {
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    service = new BrandPersistenceService(
+      loggerService as unknown as LoggerService,
+      brandsService as unknown as BrandsService,
+      linksService as unknown as LinksService,
+      membersService as unknown as MembersService,
+      organizationsService as unknown as OrganizationsService,
+      new BrandDataMapper(),
+    );
+  });
+
+  describe('resolveOnboardingBrand', () => {
+    it('prefers the metadata brand when the id is a valid 24-hex id', async () => {
+      const metadataBrand = { _id: 'a'.repeat(24) };
+      brandsService.findOne.mockResolvedValueOnce(metadataBrand);
+
+      const result = await service.resolveOnboardingBrand(
+        'org_1',
+        'user_1',
+        'a'.repeat(24),
+      );
+
+      expect(result).toBe(metadataBrand);
+      expect(brandsService.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the selected brand, then any brand for the user', async () => {
+      const anyBrand = { _id: 'brand_any' };
+      brandsService.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(anyBrand);
+
+      const result = await service.resolveOnboardingBrand(
+        'org_1',
+        'user_1',
+        'not-a-hex-id',
+      );
+
+      expect(result).toBe(anyBrand);
+      expect(brandsService.findOne).toHaveBeenNthCalledWith(
+        1,
+        {
+          isDeleted: false,
+          isSelected: true,
+          organization: 'org_1',
+          user: 'user_1',
+        },
+        'none',
+      );
+    });
+  });
+
+  describe('resolveWritableOnboardingBrand', () => {
+    it('returns the original brand when no label is provided', async () => {
+      const brand = { _id: 'brand_1' };
+
+      const result = await service.resolveWritableOnboardingBrand(
+        brand,
+        'org_1',
+        'user_1',
+        '  ',
+      );
+
+      expect(result).toBe(brand);
+      expect(brandsService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('switches to the label-matching brand and persists the selection', async () => {
+      const brand = { _id: 'brand_1' };
+      const matching = { _id: 'brand_2' };
+      brandsService.findOne.mockResolvedValueOnce(matching);
+
+      const result = await service.resolveWritableOnboardingBrand(
+        brand,
+        'org_1',
+        'user_1',
+        'Acme',
+      );
+
+      expect(result).toBe(matching);
+      expect(brandsService.selectBrandForUser).toHaveBeenCalledWith(
+        'brand_2',
+        'user_1',
+        'org_1',
+      );
+      expect(membersService.setLastUsedBrand).toHaveBeenCalledWith(
+        {
+          isActive: true,
+          isDeleted: false,
+          organization: 'org_1',
+          user: 'user_1',
+        },
+        'brand_2',
+      );
+    });
+
+    it('keeps the original brand when the match is the same brand', async () => {
+      const brand = { _id: 'brand_1' };
+      brandsService.findOne.mockResolvedValueOnce({ _id: 'brand_1' });
+
+      const result = await service.resolveWritableOnboardingBrand(
+        brand,
+        'org_1',
+        'user_1',
+        'Acme',
+      );
+
+      expect(result).toBe(brand);
+      expect(brandsService.selectBrandForUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateBrandWithScrapedData', () => {
+    it('patches scraped fields and builds the system prompt', async () => {
+      const scrapedData = {
+        aboutText: 'About us',
+        companyName: 'Acme',
+        description: 'We make anvils',
+        primaryColor: '#111',
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+        tagline: 'Anvils for all',
+      };
+      const dto = {
+        brandUrl: 'https://acme.com',
+        industry: 'Manufacturing',
+        targetAudience: 'Coyotes',
+      } as BrandSetupDto;
+
+      await service.updateBrandWithScrapedData(
+        'brand_1',
+        scrapedData,
+        dto,
+        'Override',
+      );
+
+      expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
+        description: 'We make anvils',
+        label: 'Override',
+        primaryColor: '#111',
+        text: [
+          'You are creating content for Acme.',
+          'Brand tagline: "Anvils for all"',
+          'About the brand: About us',
+          'Industry: Manufacturing',
+          'Target audience: Coyotes',
+        ].join('\n\n'),
+      });
+    });
+
+    it('skips the patch entirely when there is nothing to update', async () => {
+      await service.updateBrandWithScrapedData(
+        'brand_1',
+        { scrapedAt: new Date(), sourceUrl: 'https://acme.com' },
+        { brandUrl: 'https://acme.com' } as BrandSetupDto,
+      );
+
+      expect(brandsService.patch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('upsertBrandWebsiteLink', () => {
+    it('does nothing for a blank url', async () => {
+      await service.upsertBrandWebsiteLink('brand_1', '   ');
+
+      expect(linksService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('patches the existing website link', async () => {
+      linksService.findOne.mockResolvedValue({ id: 'link_1' });
+
+      await service.upsertBrandWebsiteLink('brand_1', 'https://acme.com');
+
+      expect(linksService.patch).toHaveBeenCalledWith('link_1', {
+        label: 'Website',
+        url: 'https://acme.com',
+      });
+      expect(linksService.create).not.toHaveBeenCalled();
+    });
+
+    it('creates a website link when none exists', async () => {
+      linksService.findOne.mockResolvedValue(null);
+
+      await service.upsertBrandWebsiteLink('brand_1', 'https://acme.com');
+
+      expect(linksService.create).toHaveBeenCalledWith({
+        brand: 'brand_1',
+        category: LinkCategory.WEBSITE,
+        label: 'Website',
+        url: 'https://acme.com',
+      });
+    });
+  });
+
+  describe('updateBrandGuidance', () => {
+    it('returns silently when the brand is missing', async () => {
+      brandsService.findOne.mockResolvedValue(null);
+
+      await service.updateBrandGuidance('brand_1', {
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      } as IExtractedBrandData);
+
+      expect(brandsService.patch).not.toHaveBeenCalled();
+    });
+
+    it('merges the extracted voice into the agent config patch', async () => {
+      brandsService.findOne.mockResolvedValue({
+        _id: 'brand_1',
+        agentConfig: { persona: 'friendly' },
+      });
+
+      await service.updateBrandGuidance('brand_1', {
+        brandVoice: {
+          audience: 'founders',
+          hashtags: [],
+          taglines: [],
+          tone: 'bold',
+          values: [],
+          voice: 'confident',
+        },
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      } as IExtractedBrandData);
+
+      expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
+        agentConfig: expect.objectContaining({
+          persona: 'friendly',
+          voice: expect.objectContaining({
+            audience: ['founders'],
+            style: 'confident',
+            tone: 'bold',
+          }),
+        }),
+      });
+    });
+  });
+
+  describe('updateBrandGuidanceOverrides', () => {
+    it('merges only provided overrides into the existing voice', async () => {
+      brandsService.findOne.mockResolvedValue({
+        _id: 'brand_1',
+        agentConfig: { voice: { style: 'plain', tone: 'calm' } },
+      });
+
+      await service.updateBrandGuidanceOverrides('brand_1', {
+        tone: 'bold',
+      });
+
+      expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
+        agentConfig: {
+          voice: { style: 'plain', tone: 'bold' },
+        },
+      });
+    });
+  });
+
+  describe('syncOrgLabelAndSlug / syncBrandAndOrgSlug', () => {
+    it('syncs the organization label and slug only', async () => {
+      organizationsService.generateUniqueSlug.mockResolvedValue('acme');
+
+      await service.syncOrgLabelAndSlug('Acme', 'org_1');
+
+      expect(organizationsService.generateUniqueSlug).toHaveBeenCalledWith(
+        'Acme',
+        'org_1',
+      );
+      expect(organizationsService.patch).toHaveBeenCalledWith('org_1', {
+        label: 'Acme',
+        slug: 'acme',
+      });
+      expect(brandsService.patch).not.toHaveBeenCalled();
+    });
+
+    it('syncs org label/slug and the brand slug together', async () => {
+      organizationsService.generateUniqueSlug.mockResolvedValue('acme');
+      brandsService.generateUniqueSlug.mockResolvedValue('acme-brand');
+
+      await service.syncBrandAndOrgSlug('Acme', 'org_1', 'brand_1');
+
+      expect(organizationsService.patch).toHaveBeenCalledWith('org_1', {
+        label: 'Acme',
+        slug: 'acme',
+      });
+      expect(brandsService.generateUniqueSlug).toHaveBeenCalledWith(
+        'Acme',
+        'brand_1',
+      );
+      expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
+        slug: 'acme-brand',
+      });
+    });
+  });
+
+  describe('addReferenceImages', () => {
+    it('throws 404 when the brand does not belong to the organization', async () => {
+      brandsService.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.addReferenceImages('brand_1', [], 'org_1'),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('appends new images to the existing reference images', async () => {
+      brandsService.findOne.mockResolvedValue({
+        _id: 'brand_1',
+        referenceImages: [{ category: 'logo', url: 'https://old' }],
+      });
+
+      const result = await service.addReferenceImages(
+        'brand_1',
+        [
+          {
+            category: 'face',
+            isDefault: true,
+            label: 'Face',
+            url: 'https://new',
+          },
+        ] as ReferenceImageDto[],
+        'org_1',
+      );
+
+      expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
+        referenceImages: [
+          { category: 'logo', url: 'https://old' },
+          {
+            category: 'face',
+            isDefault: true,
+            label: 'Face',
+            url: 'https://new',
+          },
+        ],
+      });
+      expect(result).toEqual({ count: 1, success: true });
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/onboarding/services/brand-persistence.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/brand-persistence.service.ts
@@ -1,0 +1,369 @@
+import type { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { LinksService } from '@api/collections/links/services/links.service';
+import { MembersService } from '@api/collections/members/services/members.service';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import type {
+  BrandSetupDto,
+  ConfirmBrandDataDto,
+} from '@api/endpoints/onboarding/dto/brand-setup.dto';
+import type { ReferenceImageDto } from '@api/endpoints/onboarding/dto/reference-images.dto';
+import { BrandDataMapper } from '@api/endpoints/onboarding/services/brand-data.mapper';
+import { LinkCategory } from '@genfeedai/enums';
+import type {
+  IExtractedBrandData,
+  IScrapedBrandData,
+} from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+
+/**
+ * BrandPersistenceService
+ *
+ * Owns every brand/org write performed during onboarding: scraped-data
+ * updates, website-link upserts, canonical guidance merges, reference
+ * images, and the single label→slug sync used by all onboarding flows.
+ */
+@Injectable()
+export class BrandPersistenceService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly loggerService: LoggerService,
+    private readonly brandsService: BrandsService,
+    private readonly linksService: LinksService,
+    private readonly membersService: MembersService,
+    private readonly organizationsService: OrganizationsService,
+    private readonly brandDataMapper: BrandDataMapper,
+  ) {}
+
+  async resolveOnboardingBrand(
+    organizationId: string,
+    userId: string,
+    brandId?: string | null,
+  ) {
+    if (brandId && /^[0-9a-f]{24}$/i.test(brandId)) {
+      const metadataBrand = await this.brandsService.findOne(
+        {
+          _id: brandId,
+          isDeleted: false,
+          organization: organizationId,
+          user: userId,
+        },
+        'none',
+      );
+
+      if (metadataBrand) {
+        return metadataBrand;
+      }
+    }
+
+    const selectedBrand = await this.brandsService.findOne(
+      {
+        isDeleted: false,
+        isSelected: true,
+        organization: organizationId,
+        user: userId,
+      },
+      'none',
+    );
+
+    if (selectedBrand) {
+      return selectedBrand;
+    }
+
+    return this.brandsService.findOne(
+      {
+        isDeleted: false,
+        organization: organizationId,
+        user: userId,
+      },
+      'none',
+    );
+  }
+
+  async resolveWritableOnboardingBrand(
+    brand: { _id: string; label?: string | null },
+    organizationId: string,
+    userId: string,
+    label?: string,
+  ) {
+    const normalizedLabel = label?.trim();
+
+    if (!normalizedLabel) {
+      return brand;
+    }
+
+    const matchingBrand = await this.brandsService.findOne(
+      {
+        isDeleted: false,
+        label: normalizedLabel,
+        organization: organizationId,
+      },
+      'none',
+    );
+
+    if (!matchingBrand || String(matchingBrand._id) === String(brand._id)) {
+      return brand;
+    }
+
+    await this.brandsService.selectBrandForUser(
+      String(matchingBrand._id),
+      String(userId),
+      String(organizationId),
+    );
+    // Persist the selected brand on the member so the identity resolvers route
+    // to it (epic #735, Phase C — no legacy auth provider write-back).
+    await this.membersService.setLastUsedBrand(
+      {
+        isActive: true,
+        isDeleted: false,
+        organization: String(organizationId),
+        user: String(userId),
+      },
+      String(matchingBrand._id),
+    );
+
+    return matchingBrand;
+  }
+
+  /**
+   * Update brand entity with scraped data
+   */
+  async updateBrandWithScrapedData(
+    brandId: string,
+    scrapedData: IScrapedBrandData,
+    dto: BrandSetupDto,
+    labelOverride?: string,
+  ): Promise<void> {
+    const updateData: Record<string, unknown> = {};
+
+    const label = labelOverride || scrapedData.companyName;
+    if (label) {
+      updateData.label = label;
+    }
+
+    if (scrapedData.description) {
+      updateData.description = scrapedData.description;
+    }
+
+    if (scrapedData.primaryColor) {
+      updateData.primaryColor = scrapedData.primaryColor;
+    }
+
+    if (scrapedData.secondaryColor) {
+      updateData.secondaryColor = scrapedData.secondaryColor;
+    }
+
+    if (scrapedData.fontFamily) {
+      updateData.fontFamily = scrapedData.fontFamily;
+    }
+
+    // Build system prompt from scraped content
+    if (scrapedData.tagline || scrapedData.aboutText) {
+      const systemPromptParts: string[] = [];
+
+      if (scrapedData.companyName) {
+        systemPromptParts.push(
+          `You are creating content for ${scrapedData.companyName}.`,
+        );
+      }
+
+      if (scrapedData.tagline) {
+        systemPromptParts.push(`Brand tagline: "${scrapedData.tagline}"`);
+      }
+
+      if (scrapedData.aboutText) {
+        systemPromptParts.push(`About the brand: ${scrapedData.aboutText}`);
+      }
+
+      if (dto.industry) {
+        systemPromptParts.push(`Industry: ${dto.industry}`);
+      }
+
+      if (dto.targetAudience) {
+        systemPromptParts.push(`Target audience: ${dto.targetAudience}`);
+      }
+
+      updateData.text = systemPromptParts.join('\n\n');
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await this.brandsService.patch(
+        brandId,
+        updateData as Partial<UpdateBrandDto>,
+      );
+    }
+  }
+
+  async upsertBrandWebsiteLink(
+    brandId: string,
+    websiteUrl: string,
+  ): Promise<void> {
+    const normalizedUrl = websiteUrl.trim();
+
+    if (!normalizedUrl) {
+      return;
+    }
+
+    const existingWebsiteLink = await this.linksService.findOne({
+      brand: brandId,
+      category: LinkCategory.WEBSITE,
+      isDeleted: false,
+    });
+
+    if (existingWebsiteLink) {
+      await this.linksService.patch(String(existingWebsiteLink.id), {
+        label: 'Website',
+        url: normalizedUrl,
+      });
+      return;
+    }
+
+    await this.linksService.create({
+      brand: brandId,
+      category: LinkCategory.WEBSITE,
+      label: 'Website',
+      url: normalizedUrl,
+    });
+  }
+
+  async updateBrandGuidance(
+    brandId: string,
+    extractedData: IExtractedBrandData,
+  ): Promise<void> {
+    const brand = await this.brandsService.findOne({
+      _id: brandId,
+      isDeleted: false,
+    });
+
+    if (!brand) {
+      return;
+    }
+
+    const brandAgentConfig = this.brandDataMapper.readBrandAgentConfig(
+      brand.agentConfig,
+    );
+
+    await this.brandsService.patch(brandId, {
+      agentConfig: this.brandDataMapper.mergeExtractedVoice(
+        brandAgentConfig,
+        extractedData,
+      ),
+    });
+  }
+
+  async updateBrandGuidanceOverrides(
+    brandId: string,
+    dto: ConfirmBrandDataDto,
+  ): Promise<void> {
+    const brand = await this.brandsService.findOne({
+      _id: brandId,
+      isDeleted: false,
+    });
+
+    if (!brand) {
+      return;
+    }
+
+    const brandAgentConfig = this.brandDataMapper.readBrandAgentConfig(
+      brand.agentConfig,
+    );
+
+    await this.brandsService.patch(brandId, {
+      agentConfig: this.brandDataMapper.mergeVoiceOverrides(
+        brandAgentConfig,
+        dto,
+      ),
+    });
+  }
+
+  /**
+   * Sync the organization label and slug from a brand label.
+   * Single canonical implementation of the previously-triplicated block.
+   */
+  async syncOrgLabelAndSlug(
+    label: string,
+    organizationId: string,
+  ): Promise<void> {
+    const orgSlug = await this.organizationsService.generateUniqueSlug(
+      label,
+      organizationId,
+    );
+    await this.organizationsService.patch(organizationId, {
+      label,
+      slug: orgSlug,
+    });
+  }
+
+  /**
+   * Sync organization label/slug and the brand slug from a brand label.
+   */
+  async syncBrandAndOrgSlug(
+    label: string,
+    organizationId: string,
+    brandId: string,
+  ): Promise<void> {
+    await this.syncOrgLabelAndSlug(label, organizationId);
+
+    const brandSlug = await this.brandsService.generateUniqueSlug(
+      label,
+      brandId,
+    );
+    await this.brandsService.patch(brandId, { slug: brandSlug });
+  }
+
+  /**
+   * Add reference images to a brand
+   */
+  async addReferenceImages(
+    brandId: string,
+    images: ReferenceImageDto[],
+    organizationId: string,
+  ): Promise<{ success: boolean; count: number }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(`${caller} starting`, { brandId });
+
+    const brand = await this.brandsService.findOne(
+      {
+        _id: brandId,
+        isDeleted: false,
+        organization: organizationId,
+      },
+      'none',
+    );
+
+    if (!brand) {
+      throw new HttpException(
+        { detail: 'Brand not found', title: 'Not Found' },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const brandId_str = String(
+      (brand as Record<string, unknown>).id ?? brand._id,
+    );
+    const existingImages = this.brandDataMapper.readBrandReferenceImages(
+      brand.referenceImages,
+    );
+    await this.brandsService.patch(brandId_str, {
+      referenceImages: [
+        ...existingImages,
+        ...images.map((image) => ({
+          category: image.category,
+          isDefault: image.isDefault,
+          label: image.label,
+          url: image.url,
+        })),
+      ],
+    });
+
+    this.loggerService.log(`${caller} completed`, {
+      brandId,
+      count: images.length,
+    });
+
+    return { count: images.length, success: true };
+  }
+}

--- a/apps/server/api/src/endpoints/onboarding/services/onboarding-error.util.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/onboarding-error.util.ts
@@ -1,0 +1,57 @@
+import { Prisma } from '@genfeedai/prisma';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export interface OnboardingErrorOptions {
+  /** Fallback error detail used when the caught error is wrapped. */
+  detail: string;
+  /** Rethrow HttpException as-is instead of wrapping it in a 500. */
+  hasHttpExceptionPassthrough?: boolean;
+  /**
+   * Let known Prisma errors (e.g. P2002 slug collision) bubble to the global
+   * DatabaseExceptionFilter, which maps them to the correct 4xx status
+   * instead of a generic 500.
+   */
+  hasPrismaPassthrough?: boolean;
+  /** Prefer the caught error's message over the fallback detail. */
+  isErrorMessageUsed?: boolean;
+  title: string;
+}
+
+/**
+ * Shared catch prologue for onboarding public methods: logs the failure and
+ * maps unknown errors to a 500 HttpException, optionally passing through
+ * HttpExceptions and known Prisma errors unchanged.
+ */
+export async function withOnboardingErrorHandling<T>(
+  loggerService: LoggerService,
+  caller: string,
+  options: OnboardingErrorOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error: unknown) {
+    loggerService.error(`${caller} failed`, error);
+
+    if (options.hasHttpExceptionPassthrough && error instanceof HttpException) {
+      throw error;
+    }
+
+    if (
+      options.hasPrismaPassthrough &&
+      error instanceof Prisma.PrismaClientKnownRequestError
+    ) {
+      throw error;
+    }
+
+    const detail = options.isErrorMessageUsed
+      ? (error as Error)?.message || options.detail
+      : options.detail;
+
+    throw new HttpException(
+      { detail, title: options.title },
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+}

--- a/apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.ts
@@ -1,0 +1,173 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { GeneratePreviewDto } from '@api/endpoints/onboarding/dto/generate-preview.dto';
+import { BrandDataMapper } from '@api/endpoints/onboarding/services/brand-data.mapper';
+import { withOnboardingErrorHandling } from '@api/endpoints/onboarding/services/onboarding-error.util';
+import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { FileInputType } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+
+/** Credits cost for generating an onboarding preview image */
+const ONBOARDING_PREVIEW_CREDIT_COST = 5;
+
+/**
+ * OnboardingPreviewService
+ *
+ * Owns the onboarding preview-generation pipeline: brand fetch → credit
+ * check → prompt build → ComfyUI generation → S3 upload → credit deduction
+ * → brand patch.
+ */
+@Injectable()
+export class OnboardingPreviewService {
+  private readonly constructorName: string = String(this.constructor.name);
+
+  constructor(
+    private readonly loggerService: LoggerService,
+    private readonly brandsService: BrandsService,
+    private readonly comfyUIService: ComfyUIService,
+    private readonly creditsUtilsService: CreditsUtilsService,
+    private readonly filesClientService: FilesClientService,
+    private readonly brandDataMapper: BrandDataMapper,
+  ) {}
+
+  /**
+   * Generate an AI preview image during onboarding
+   * Uses ComfyUI to generate an image based on brand data and content type
+   */
+  async generateOnboardingPreview(
+    dto: GeneratePreviewDto,
+    user: User,
+  ): Promise<{ imageUrl: string; prompt: string }> {
+    const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    this.loggerService.log(`${caller} starting`, {
+      brandId: dto.brandId,
+      contentType: dto.contentType,
+    });
+
+    const publicMetadata = getPublicMetadata(user);
+    const organizationId = publicMetadata.organization?.toString();
+    const userId = publicMetadata.user?.toString();
+
+    if (!organizationId || !userId) {
+      throw new HttpException(
+        {
+          detail: 'Missing organization or user context',
+          title: 'Bad Request',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return withOnboardingErrorHandling(
+      this.loggerService,
+      caller,
+      {
+        detail: 'Failed to generate preview',
+        hasHttpExceptionPassthrough: true,
+        isErrorMessageUsed: true,
+        title: 'Preview Generation Failed',
+      },
+      async () => {
+        // 1. Fetch brand data
+        const brand = await this.brandsService.findOne(
+          {
+            _id: dto.brandId,
+            isDeleted: false,
+            organization: organizationId,
+          },
+          'none',
+        );
+
+        if (!brand) {
+          throw new HttpException(
+            { detail: 'Brand not found', title: 'Not Found' },
+            HttpStatus.NOT_FOUND,
+          );
+        }
+
+        // 2. Check credits availability
+        const hasCredits =
+          await this.creditsUtilsService.checkOrganizationCreditsAvailable(
+            organizationId,
+            ONBOARDING_PREVIEW_CREDIT_COST,
+          );
+
+        if (!hasCredits) {
+          throw new HttpException(
+            {
+              detail: 'Insufficient credits for preview generation',
+              title: 'Insufficient Credits',
+            },
+            HttpStatus.PAYMENT_REQUIRED,
+          );
+        }
+
+        // 3. Build prompt based on content type
+        const prompt = this.brandDataMapper.buildPreviewPrompt(
+          dto.contentType,
+          brand.label || '',
+          brand.description || '',
+          brand.primaryColor || '',
+          brand.secondaryColor || '',
+        );
+
+        // 4. Generate image via ComfyUI
+        this.loggerService.log(`${caller} generating image via ComfyUI`, {
+          contentType: dto.contentType,
+        });
+
+        const { imageBuffer } = await this.comfyUIService.generateImage(
+          MODEL_KEYS.GENFEED_AI_Z_IMAGE_TURBO,
+          {
+            height: 1024,
+            prompt,
+            steps: 4,
+            width: 1024,
+          },
+        );
+
+        // 5. Upload to S3
+        const uploadKey = `${organizationId}/onboarding-preview-${Date.now()}`;
+        const { publicUrl } =
+          await this.filesClientService.getPresignedUploadUrl(
+            uploadKey,
+            'onboarding',
+            'image/png',
+          );
+
+        await this.filesClientService.uploadToS3(uploadKey, 'onboarding', {
+          contentType: 'image/png',
+          data: imageBuffer,
+          type: FileInputType.BUFFER,
+        });
+
+        // 6. Deduct credits
+        await this.creditsUtilsService.deductCreditsFromOrganization(
+          organizationId,
+          userId,
+          ONBOARDING_PREVIEW_CREDIT_COST,
+          'Onboarding preview image',
+        );
+
+        // 7. Save preview URL to brand
+        await this.brandsService.patch(brand._id, {
+          // @ts-expect-error onboardingPreviewUrl is valid
+          onboardingPreviewUrl: publicUrl,
+        });
+
+        this.loggerService.log(`${caller} completed`, {
+          brandId: dto.brandId,
+          imageUrl: publicUrl,
+        });
+
+        return { imageUrl: publicUrl, prompt };
+      },
+    );
+  }
+}

--- a/apps/server/api/src/endpoints/onboarding/services/onboarding-readiness.service.spec.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/onboarding-readiness.service.spec.ts
@@ -1,19 +1,7 @@
 import type { BrandsService } from '@api/collections/brands/services/brands.service';
-import type { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
-import type { LinksService } from '@api/collections/links/services/links.service';
-import type { MembersService } from '@api/collections/members/services/members.service';
 import type { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import type { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
-import type { UserSetupService } from '@api/collections/users/services/user-setup.service';
 import type { UsersService } from '@api/collections/users/services/users.service';
-import type { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
-import type { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
-import type { ProactiveOnboardingService } from '@api/endpoints/onboarding/proactive-onboarding.service';
-import type { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
-import type { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
-import type { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
-import type { MasterPromptGeneratorService } from '@api/services/knowledge-base/master-prompt-generator.service';
-import type { LoggerService } from '@libs/logger/logger.service';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockedConfig = vi.hoisted(() => ({ IS_CLOUD: false }));
@@ -42,30 +30,20 @@ type LocalToolReadiness = {
   detected: string[];
 };
 
-describe('OnboardingService local tool readiness', () => {
+describe('OnboardingReadinessService local tool readiness', () => {
   const instantiateService = async (isCloud: boolean) => {
     mockedConfig.IS_CLOUD = isCloud;
     vi.resetModules();
 
-    const { OnboardingService } = await import('./onboarding.service');
+    const { OnboardingReadinessService } = await import(
+      './onboarding-readiness.service'
+    );
 
-    return new OnboardingService(
-      {} as unknown as LoggerService,
-      {} as unknown as BrandScraperService,
-      {} as unknown as MasterPromptGeneratorService,
+    return new OnboardingReadinessService(
       {} as unknown as BrandsService,
-      {} as unknown as ComfyUIService,
-      {} as unknown as CreditsUtilsService,
-      {} as unknown as FilesClientService,
-      {} as unknown as LinksService,
-      {} as unknown as MembersService,
       {} as unknown as OrganizationSettingsService,
       {} as unknown as OrganizationsService,
       {} as unknown as UsersService,
-      {} as unknown as ProactiveOnboardingService,
-      {} as unknown as RequestContextCacheService,
-      {} as unknown as AccessBootstrapCacheService,
-      {} as unknown as UserSetupService,
     ) as unknown as {
       getLocalToolReadiness: () => LocalToolReadiness;
     };

--- a/apps/server/api/src/endpoints/onboarding/services/onboarding-readiness.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/onboarding-readiness.service.ts
@@ -1,0 +1,250 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import { UsersService } from '@api/collections/users/services/users.service';
+import type {
+  InstallReadinessResponse,
+  OnboardingWorkspaceContext,
+} from '@api/endpoints/onboarding/onboarding.interfaces';
+import { IS_CLOUD, isEEEnabled } from '@genfeedai/config';
+import type {
+  IOnboardingAccessPreference,
+  IOrganizationSetting,
+  OnboardingAccessMode,
+  OnboardingRuntimeAccessMode,
+} from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * OnboardingReadinessService
+ *
+ * Owns environment/CLI readiness probing and status reads for onboarding:
+ * provider env keys, local CLI detection, BYOK configuration, and the
+ * install-readiness aggregate.
+ */
+@Injectable()
+export class OnboardingReadinessService {
+  constructor(
+    private readonly brandsService: BrandsService,
+    private readonly organizationSettingsService: OrganizationSettingsService,
+    private readonly organizationsService: OrganizationsService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  private isConfigured(value: unknown): boolean {
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  getProviderReadiness() {
+    const replicate = this.isConfigured(process.env.REPLICATE_KEY);
+    const fal = this.isConfigured(process.env.FAL_API_KEY);
+    const openai = this.isConfigured(process.env.OPENAI_API_KEY);
+    const configured = [
+      replicate ? 'replicate' : null,
+      fal ? 'fal' : null,
+      openai ? 'openai' : null,
+    ].filter((value): value is string => value !== null);
+
+    return {
+      anyConfigured: configured.length > 0,
+      configured,
+      fal,
+      imageGenerationReady: fal || replicate,
+      openai,
+      replicate,
+      textGenerationReady: openai,
+    };
+  }
+
+  private isCommandAvailable(command: string): boolean {
+    const result = spawnSync(command, ['--version'], {
+      encoding: 'utf8',
+      shell: false,
+      stdio: 'ignore',
+    });
+
+    if (result.error) {
+      return false;
+    }
+
+    return result.status === 0;
+  }
+
+  getLocalToolReadiness() {
+    if (IS_CLOUD) {
+      return { anyDetected: false, claude: false, codex: false, detected: [] };
+    }
+
+    const claude = this.isCommandAvailable('claude');
+    const codex = this.isCommandAvailable('codex');
+    const detected = [claude ? 'claude' : null, codex ? 'codex' : null].filter(
+      (value): value is string => value !== null,
+    );
+
+    return {
+      anyDetected: detected.length > 0,
+      claude,
+      codex,
+      detected,
+    };
+  }
+
+  private normalizeAccessMode(value: unknown): OnboardingAccessMode | null {
+    if (value === 'server' || value === 'byok' || value === 'cloud') {
+      return value;
+    }
+
+    return null;
+  }
+
+  private getSelectedAccessMode(
+    dashboardPreferences?: unknown,
+  ): OnboardingAccessMode | null {
+    if (!dashboardPreferences || typeof dashboardPreferences !== 'object') {
+      return null;
+    }
+
+    const onboarding = (
+      dashboardPreferences as { onboarding?: IOnboardingAccessPreference }
+    ).onboarding;
+
+    return this.normalizeAccessMode(onboarding?.accessMode);
+  }
+
+  private getConfiguredByokProviders(
+    organizationSettings?: Pick<IOrganizationSetting, 'byokKeys'> | null,
+  ): string[] {
+    const byokKeys = organizationSettings?.byokKeys;
+
+    if (!byokKeys || typeof byokKeys !== 'object') {
+      return [];
+    }
+
+    return Object.entries(byokKeys).flatMap(([providerKey, entry]) => {
+      if (!entry?.isEnabled || !entry.apiKey?.trim()) {
+        return [];
+      }
+
+      const provider =
+        typeof entry.provider === 'string' && entry.provider.trim()
+          ? entry.provider
+          : providerKey;
+
+      return [provider];
+    });
+  }
+
+  /**
+   * Get onboarding status for an organization
+   */
+  async getOnboardingStatus(
+    organizationId: string,
+  ): Promise<{ isFirstLogin: boolean; hasCompletedOnboarding: boolean }> {
+    const settings = await this.organizationSettingsService.findOne({
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    return {
+      hasCompletedOnboarding: settings?.isFirstLogin === false,
+      isFirstLogin: settings?.isFirstLogin ?? true,
+    };
+  }
+
+  async getInstallReadiness(
+    user: User,
+    workspace: OnboardingWorkspaceContext,
+  ): Promise<InstallReadinessResponse> {
+    const organizationId = workspace.organizationId;
+    const brandId = workspace.brandId;
+    const userId = workspace.userId;
+    const providers = this.getProviderReadiness();
+    const showBillingUi = isEEEnabled();
+
+    let hasOrganization = false;
+    let hasBrand = false;
+    let selectedMode: OnboardingAccessMode | null = null;
+    let organizationSettings: Pick<
+      IOrganizationSetting,
+      'byokKeys' | 'isByokEnabled'
+    > | null = null;
+
+    if (userId && /^[0-9a-f]{24}$/i.test(userId)) {
+      const dbUser = await this.usersService.findOne({
+        _id: userId,
+        isDeleted: false,
+      });
+
+      selectedMode = this.getSelectedAccessMode(
+        (dbUser?.settings as { dashboardPreferences?: unknown } | undefined)
+          ?.dashboardPreferences,
+      );
+    }
+
+    if (organizationId && /^[0-9a-f]{24}$/i.test(organizationId)) {
+      const organization = await this.organizationsService.findOne({
+        _id: organizationId,
+        isDeleted: false,
+      });
+
+      hasOrganization = !!organization;
+
+      if (organization) {
+        const [brand, settings] = await Promise.all([
+          this.brandsService.findOne({
+            isDeleted: false,
+            organization: organization._id,
+          }),
+          this.organizationSettingsService.findOne({
+            isDeleted: false,
+            organization: organization._id,
+          }),
+        ]);
+
+        hasBrand = !!brand;
+        organizationSettings = settings as unknown as Pick<
+          IOrganizationSetting,
+          'byokKeys' | 'isByokEnabled'
+        >;
+      }
+    }
+
+    const byokConfiguredProviders =
+      this.getConfiguredByokProviders(organizationSettings);
+    const runtimeMode: OnboardingRuntimeAccessMode =
+      byokConfiguredProviders.length > 0 ? 'byok' : 'server';
+    const byokEnabled =
+      Boolean(organizationSettings?.isByokEnabled) ||
+      byokConfiguredProviders.length > 0;
+
+    return {
+      access: {
+        byokConfiguredProviders,
+        byokEnabled,
+        runtimeMode,
+        selectedMode,
+        serverDefaultsReady: providers.anyConfigured,
+      },
+      authMode: user.id ? 'better_auth' : 'none',
+      billingMode: showBillingUi ? 'cloud_billing' : 'oss_local',
+      localTools: this.getLocalToolReadiness(),
+      providers,
+      ui: {
+        showBilling: showBillingUi,
+        showCloudUpgradeCta: !showBillingUi,
+        showCredits: showBillingUi,
+        showLocalTools: !IS_CLOUD,
+        showPricing: showBillingUi,
+      },
+      workspace: {
+        brandId,
+        hasBrand,
+        hasOrganization,
+        organizationId,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Decomposes the 1,780-line `OnboardingService` (15 constructor deps, 6 bundled concerns) into an orchestrator plus four focused collaborators, exactly following the restructuring plan in #708. Behavior-preserving: all 14 public method signatures and the controller contract are unchanged.

### New collaborators (`endpoints/onboarding/services/`)
- **`OnboardingReadinessService`** — provider env probing, local CLI detection (`spawnSync`), BYOK config reads, the `getInstallReadiness` aggregate, and onboarding-status reads. Removes the env/spawn concern from the orchestrator.
- **`BrandDataMapper`** (pure, zero deps) — the scrape-source → `IScrapedBrandData` normalizers now funnel through **one** `buildScrapedBrandData` builder (collapses the 4 near-identical 15-key literals), plus `readBrandAgentConfig`/`readBrandReferenceImages` guards, preview-prompt builder, voice merge logic, and a shared `parseAudienceList` (removes the duplicated `split(',').map(trim).filter(Boolean)`).
- **`BrandPersistenceService`** — brand/org writes: scraped-data updates, website-link upsert, guidance merges, reference images, brand resolution, and a single canonical `syncOrgLabelAndSlug`/`syncBrandAndOrgSlug` (kills the triplicated slug-sync block; `updateBrandName` keeps its current org-only sync behavior).
- **`OnboardingPreviewService`** — the full preview pipeline (brand fetch → credit check → prompt → ComfyUI → S3 → credit deduction → brand patch).

### Orchestrator
- 1,780 → **938 lines**; no method exceeds 80 lines (`setupBrand` ~232 → ~120 split across `setupBrand` + `scrapeBrandData` + `analyzeBrandVoice`).
- The 7-fold duplicated try/catch prologue is replaced by `withOnboardingErrorHandling`, configured per-method to preserve **exact** existing behavior (HttpException/Prisma passthrough vs wrap, error-message vs fixed detail — including `skipOnboarding`/`completeFunnel`, which wrap everything today).

### Tests
- `onboarding.controller.spec.ts` (508 lines) — **passes unchanged** ✅ (21 tests)
- New `brand-data.mapper.spec.ts` (19 tests) and `brand-persistence.service.spec.ts` (17 tests) — direct unit specs that do **not** pull `@anthropic-ai/sdk`, closing the documented zero-coverage gap
- `onboarding.service.local-tools.spec.ts` → moved to `services/onboarding-readiness.service.spec.ts` with identical cases (5 tests)
- `onboarding.service.spec.ts` regression suite — passes unchanged (6 tests)

## Verification
- `bunx biome check` on the onboarding dir: clean (2 pre-existing warnings in untouched `proactive-onboarding.service.ts`)
- All 5 onboarding spec files run individually: **68/68 passing**
- Scoped `tsc --noEmit` over `apps/server/api` (ad-hoc config; `@genfeedai/enums`+`constants` built first): **zero diagnostics in `endpoints/onboarding`** (remaining diagnostics are pre-existing config noise outside this change)
- Mac Studio was unreachable for the full workspace gate — relying on CI for `bun type-check` / build / full test suite

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)