### PR TITLE
refactor(infra): dedupe S3 wrappers and document logger runtime boundary

### DIFF
--- a/apps/server/images/vitest.config.ts
+++ b/apps/server/images/vitest.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
         serviceDir,
         '../../../packages/config/src/index.ts',
       ),
+      '@genfeedai/pricing': path.resolve(
+        serviceDir,
+        '../../../packages/pricing/src/index.ts',
+      ),
+      '@genfeedai/storage': path.resolve(
+        serviceDir,
+        '../../../packages/storage/src/index.ts',
+      ),
       '@genfeedai/types': path.resolve(
         serviceDir,
         '../../../packages/types/src/index.ts',

--- a/apps/server/videos/vitest.config.ts
+++ b/apps/server/videos/vitest.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
         serviceDir,
         '../../../packages/config/src/index.ts',
       ),
+      '@genfeedai/pricing': path.resolve(
+        serviceDir,
+        '../../../packages/pricing/src/index.ts',
+      ),
+      '@genfeedai/storage': path.resolve(
+        serviceDir,
+        '../../../packages/storage/src/index.ts',
+      ),
       '@config': path.resolve(serviceDir, './src/config'),
       '@libs': path.resolve(serviceDir, '../../../packages/libs'),
       '@services': path.resolve(serviceDir, './src/services'),

--- a/apps/server/voices/src/services/voice-dataset.service.spec.ts
+++ b/apps/server/voices/src/services/voice-dataset.service.spec.ts
@@ -1,8 +1,8 @@
 import { LoggerService } from '@libs/logger/logger.service';
+import { S3Service } from '@libs/s3/s3.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@voices/config/config.service';
-import { S3Service } from '@voices/services/s3.service';
 import { VoiceDatasetService } from '@voices/services/voice-dataset.service';
 
 // Mock node:fs/promises

--- a/apps/server/voices/vitest.config.ts
+++ b/apps/server/voices/vitest.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
         serviceDir,
         '../../../packages/config/src/index.ts',
       ),
+      '@genfeedai/pricing': path.resolve(
+        serviceDir,
+        '../../../packages/pricing/src/index.ts',
+      ),
+      '@genfeedai/storage': path.resolve(
+        serviceDir,
+        '../../../packages/storage/src/index.ts',
+      ),
       '@config': path.resolve(serviceDir, './src/config'),
       '@libs': path.resolve(serviceDir, '../../../packages/libs'),
       '@services': path.resolve(serviceDir, './src/services'),

--- a/bun.lock
+++ b/bun.lock
@@ -1011,6 +1011,7 @@
       "dependencies": {
         "@genfeedai/enums": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
+        "@genfeedai/storage": "workspace:*",
         "jose": "^6.2.3",
       },
     },

--- a/packages/libs/logger/logger.service.ts
+++ b/packages/libs/logger/logger.service.ts
@@ -1,6 +1,14 @@
 import { ConsoleLogger, Inject, Injectable } from '@nestjs/common';
 import type { Logger as winstonLogger } from 'winston';
 
+/**
+ * Logger runtime boundary (audit risk 9, issue #1097): this winston-backed
+ * LoggerService is THE logger for the NestJS backend runtime (all
+ * `apps/server/*` services, injected via `@libs/logger/logger.module`).
+ * The frontend/Next.js runtime (browser + SSR) uses the pino/Sentry logger
+ * at `packages/services/core/logger.service.ts` instead — winston and Nest
+ * DI are not browser-compatible. One logger per runtime; do not add a third.
+ */
 @Injectable()
 export class LoggerService extends ConsoleLogger {
   public readonly constructorName: string;

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@genfeedai/enums": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",
+    "@genfeedai/storage": "workspace:*",
     "jose": "^6.2.3"
   },
   "description": "Shared backend library modules and infrastructure helpers for Genfeed server applications",

--- a/packages/libs/s3/s3.service.spec.ts
+++ b/packages/libs/s3/s3.service.spec.ts
@@ -2,46 +2,26 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { S3Service } from '@libs/s3/s3.service';
 import { Test, type TestingModule } from '@nestjs/testing';
 
-// Mock @aws-sdk/client-s3
-const mockSend = vi.fn();
-vi.mock('@aws-sdk/client-s3', () => {
-  class MockS3Client {
-    send = mockSend;
-    constructor() {}
-  }
-  return {
-    GetObjectCommand: class {
-      constructor(public params: Record<string, unknown>) {}
-    },
-    ListObjectsV2Command: class {
-      constructor(public params: Record<string, unknown>) {}
-    },
-    PutObjectCommand: class {
-      constructor(public params: Record<string, unknown>) {}
-    },
-    S3Client: MockS3Client,
-  };
-});
+const mockProvider = {
+  delete: vi.fn(),
+  download: vi.fn().mockResolvedValue(undefined),
+  exists: vi.fn(),
+  getUrl: vi.fn(),
+  list: vi.fn(),
+  listObjects: vi.fn().mockResolvedValue([]),
+  upload: vi.fn(),
+  uploadFromFile: vi.fn().mockResolvedValue(''),
+};
 
-// Mock node:fs/promises
+const mockCreateStorageProvider = vi.fn().mockReturnValue(mockProvider);
+
+vi.mock('@genfeedai/storage', () => ({
+  createStorageProvider: (options?: Record<string, unknown>) =>
+    mockCreateStorageProvider(options),
+}));
+
 vi.mock('node:fs/promises', () => ({
-  mkdir: vi.fn().mockResolvedValue(undefined),
-  readFile: vi.fn().mockResolvedValue(Buffer.from('test-data')),
   stat: vi.fn().mockResolvedValue({ size: 9 }),
-}));
-
-// Mock node:fs
-vi.mock('node:fs', () => ({
-  createWriteStream: vi.fn().mockReturnValue({
-    end: vi.fn(),
-    on: vi.fn(),
-    write: vi.fn(),
-  }),
-}));
-
-// Mock node:stream/promises
-vi.mock('node:stream/promises', () => ({
-  pipeline: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@libs/utils/caller/caller.util', () => ({
@@ -54,7 +34,7 @@ const mockConfigService = {
   AWS_SECRET_ACCESS_KEY: 'test-secret',
 };
 
-describe('S3Service (shared @libs/s3)', () => {
+describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', () => {
   let service: S3Service;
   let mockLoggerService: {
     log: ReturnType<typeof vi.fn>;
@@ -64,6 +44,7 @@ describe('S3Service (shared @libs/s3)', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockCreateStorageProvider.mockReturnValue(mockProvider);
 
     mockLoggerService = {
       error: vi.fn(),
@@ -82,38 +63,58 @@ describe('S3Service (shared @libs/s3)', () => {
     service = module.get<S3Service>(S3Service);
   });
 
-  describe('downloadFile', () => {
-    it('should download a file from S3 to local path', async () => {
-      const mockStream = { pipe: vi.fn() };
-      mockSend.mockResolvedValue({ Body: mockStream });
+  describe('provider resolution', () => {
+    it('creates the provider lazily with config credentials and the bucket', async () => {
+      expect(mockCreateStorageProvider).not.toHaveBeenCalled();
 
+      await service.downloadFile('bucket-a', 'k.png', '/tmp/k.png');
+
+      expect(mockCreateStorageProvider).toHaveBeenCalledTimes(1);
+      expect(mockCreateStorageProvider).toHaveBeenCalledWith({
+        accessKeyId: 'test-key',
+        bucket: 'bucket-a',
+        region: 'us-east-1',
+        secretAccessKey: 'test-secret',
+      });
+    });
+
+    it('caches one provider per bucket', async () => {
+      await service.downloadFile('bucket-a', 'k1.png', '/tmp/k1.png');
+      await service.downloadFile('bucket-a', 'k2.png', '/tmp/k2.png');
+      await service.downloadFile('bucket-b', 'k3.png', '/tmp/k3.png');
+
+      expect(mockCreateStorageProvider).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('downloadFile', () => {
+    it('delegates to provider.download', async () => {
       await service.downloadFile(
         'test-bucket',
         'images/photo.jpg',
         '/tmp/photo.jpg',
       );
 
-      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockProvider.download).toHaveBeenCalledWith(
+        'images/photo.jpg',
+        '/tmp/photo.jpg',
+      );
       expect(mockLoggerService.log).toHaveBeenCalledTimes(2);
     });
 
-    it('should throw if response body is empty', async () => {
-      mockSend.mockResolvedValue({ Body: null });
+    it('propagates provider errors', async () => {
+      mockProvider.download.mockRejectedValueOnce(
+        new Error('Empty response body'),
+      );
 
       await expect(
-        service.downloadFile(
-          'test-bucket',
-          'images/photo.jpg',
-          '/tmp/photo.jpg',
-        ),
+        service.downloadFile('test-bucket', 'images/photo.jpg', '/tmp/p.jpg'),
       ).rejects.toThrow('Empty response body');
     });
   });
 
   describe('uploadFile', () => {
-    it('should upload a file to S3 with explicit content type', async () => {
-      mockSend.mockResolvedValue({});
-
+    it('delegates to provider.uploadFromFile with explicit content type', async () => {
       await service.uploadFile(
         'test-bucket',
         'videos/job123/video.mp4',
@@ -121,56 +122,27 @@ describe('S3Service (shared @libs/s3)', () => {
         'video/mp4',
       );
 
-      expect(mockSend).toHaveBeenCalledTimes(1);
-      // The mock PutObjectCommand stores params on .params
-      const [cmdInstance] = mockSend.mock.calls[0] as [
-        { params: Record<string, unknown> },
-      ];
-      expect(cmdInstance.params.ContentType).toBe('video/mp4');
+      expect(mockProvider.uploadFromFile).toHaveBeenCalledWith(
+        'videos/job123/video.mp4',
+        '/tmp/video.mp4',
+        'video/mp4',
+      );
       expect(mockLoggerService.log).toHaveBeenCalledTimes(2);
     });
 
-    it('should infer content type from extension when not provided (jpg → image/jpeg)', async () => {
-      mockSend.mockResolvedValue({});
+    it('passes undefined content type through for provider-side inference', async () => {
+      await service.uploadFile('test-bucket', 'images/photo.jpg', '/tmp/p.jpg');
 
-      await service.uploadFile(
-        'test-bucket',
+      expect(mockProvider.uploadFromFile).toHaveBeenCalledWith(
         'images/photo.jpg',
-        '/tmp/photo.jpg',
+        '/tmp/p.jpg',
+        undefined,
       );
-
-      expect(mockSend).toHaveBeenCalledTimes(1);
-    });
-
-    it('should infer content type from extension when not provided (mp4 → video/mp4)', async () => {
-      mockSend.mockResolvedValue({});
-
-      await service.uploadFile(
-        'test-bucket',
-        'videos/clip.mp4',
-        '/tmp/clip.mp4',
-      );
-
-      expect(mockSend).toHaveBeenCalledTimes(1);
-    });
-
-    it('should use application/octet-stream for unknown extensions', async () => {
-      mockSend.mockResolvedValue({});
-
-      await service.uploadFile(
-        'test-bucket',
-        'data/model.bin',
-        '/tmp/model.bin',
-      );
-
-      expect(mockSend).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('uploadSafetensors', () => {
-    it('should upload with the canonical S3 key path', async () => {
-      mockSend.mockResolvedValue({});
-
+    it('uploads with the canonical S3 key and octet-stream content type', async () => {
       const result = await service.uploadSafetensors(
         'test-bucket',
         'my-lora',
@@ -181,83 +153,58 @@ describe('S3Service (shared @libs/s3)', () => {
         'ingredients/trainings/loras/my-lora.safetensors',
       );
       expect(result.sizeBytes).toBe(9);
-      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockProvider.uploadFromFile).toHaveBeenCalledWith(
+        'ingredients/trainings/loras/my-lora.safetensors',
+        '/tmp/my-lora.safetensors',
+        'application/octet-stream',
+      );
       expect(mockLoggerService.log).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('listObjects', () => {
-    it('should list objects with the given prefix', async () => {
-      mockSend.mockResolvedValue({
-        Contents: [
-          {
-            Key: 'ingredients/trainings/loras/model-a.safetensors',
-            LastModified: new Date('2024-01-01'),
-            Size: 1024,
-          },
-          {
-            Key: 'ingredients/trainings/loras/model-b.safetensors',
-            LastModified: new Date('2024-01-02'),
-            Size: 2048,
-          },
-        ],
-        NextContinuationToken: undefined,
-      });
+    it('maps StorageObject entries to S3Object with ISO lastModified', async () => {
+      mockProvider.listObjects.mockResolvedValueOnce([
+        {
+          key: 'ingredients/trainings/loras/model-a.safetensors',
+          lastModified: new Date('2024-01-01T00:00:00.000Z'),
+          size: 1024,
+        },
+        {
+          key: 'ingredients/trainings/loras/model-b.safetensors',
+          lastModified: new Date('2024-01-02T00:00:00.000Z'),
+          size: 2048,
+        },
+      ]);
 
       const result = await service.listObjects(
         'test-bucket',
         'ingredients/trainings/loras/',
       );
 
-      expect(result).toHaveLength(2);
-      expect(result[0].key).toBe(
-        'ingredients/trainings/loras/model-a.safetensors',
+      expect(mockProvider.listObjects).toHaveBeenCalledWith(
+        'ingredients/trainings/loras/',
       );
-      expect(result[0].size).toBe(1024);
+      expect(result).toEqual([
+        {
+          key: 'ingredients/trainings/loras/model-a.safetensors',
+          lastModified: '2024-01-01T00:00:00.000Z',
+          size: 1024,
+        },
+        {
+          key: 'ingredients/trainings/loras/model-b.safetensors',
+          lastModified: '2024-01-02T00:00:00.000Z',
+          size: 2048,
+        },
+      ]);
     });
 
-    it('should handle pagination', async () => {
-      mockSend
-        .mockResolvedValueOnce({
-          Contents: [{ Key: 'file1.jpg', LastModified: new Date(), Size: 100 }],
-          NextContinuationToken: 'token-123',
-        })
-        .mockResolvedValueOnce({
-          Contents: [{ Key: 'file2.mp4', LastModified: new Date(), Size: 200 }],
-          NextContinuationToken: undefined,
-        });
-
-      const result = await service.listObjects('test-bucket', 'prefix/');
-
-      expect(result).toHaveLength(2);
-      expect(mockSend).toHaveBeenCalledTimes(2);
-    });
-
-    it('should return empty array when no contents', async () => {
-      mockSend.mockResolvedValue({
-        Contents: undefined,
-        NextContinuationToken: undefined,
-      });
+    it('returns empty array when provider has no objects', async () => {
+      mockProvider.listObjects.mockResolvedValueOnce([]);
 
       const result = await service.listObjects('test-bucket', 'empty/');
 
       expect(result).toHaveLength(0);
-    });
-
-    it('should skip items without Key or Size', async () => {
-      mockSend.mockResolvedValue({
-        Contents: [
-          { Key: 'valid.mp4', LastModified: new Date(), Size: 500 },
-          { Key: undefined, LastModified: new Date(), Size: 100 },
-          { Key: 'no-size.mp4', LastModified: new Date(), Size: undefined },
-        ],
-        NextContinuationToken: undefined,
-      });
-
-      const result = await service.listObjects('test-bucket', 'prefix/');
-
-      expect(result).toHaveLength(1);
-      expect(result[0].key).toBe('valid.mp4');
     });
   });
 });

--- a/packages/libs/s3/s3.service.ts
+++ b/packages/libs/s3/s3.service.ts
@@ -1,14 +1,8 @@
-import { createWriteStream } from 'node:fs';
-import { mkdir, readFile, stat } from 'node:fs/promises';
-import { dirname, extname } from 'node:path';
-import type { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
+import { stat } from 'node:fs/promises';
 import {
-  GetObjectCommand,
-  ListObjectsV2Command,
-  PutObjectCommand,
-  S3Client,
-} from '@aws-sdk/client-s3';
+  createStorageProvider,
+  type StorageProvider,
+} from '@genfeedai/storage';
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
@@ -27,50 +21,35 @@ export interface S3ConfigService {
   AWS_REGION: string;
 }
 
-/** MIME fallback table keyed by lowercase file extension (without the dot). */
-const MIME_BY_EXT: Readonly<Record<string, string>> = {
-  aac: 'audio/aac',
-  avi: 'video/x-msvideo',
-  flac: 'audio/flac',
-  gif: 'image/gif',
-  jpeg: 'image/jpeg',
-  jpg: 'image/jpeg',
-  m4a: 'audio/mp4',
-  mp3: 'audio/mpeg',
-  mp4: 'video/mp4',
-  mov: 'video/quicktime',
-  ogg: 'audio/ogg',
-  png: 'image/png',
-  pth: 'application/octet-stream',
-  safetensors: 'application/octet-stream',
-  wav: 'audio/wav',
-  webm: 'video/webm',
-  webp: 'image/webp',
-};
-
-/** Derive a MIME type from a file path extension, defaulting to application/octet-stream. */
-function mimeFromPath(filePath: string): string {
-  const ext = extname(filePath).replace('.', '').toLowerCase();
-  return MIME_BY_EXT[ext] ?? 'application/octet-stream';
-}
-
+/**
+ * Thin NestJS wrapper over `@genfeedai/storage` — the single S3/local-FS
+ * implementation. Keeps the DI ergonomics and per-call bucket API used by
+ * the images/videos/voices services while `createStorageProvider()` decides
+ * between S3 (cloud) and the local filesystem (self-hosted).
+ */
 @Injectable()
 export class S3Service {
   private readonly constructorName: string = String(this.constructor.name);
-  private readonly client: S3Client;
+  private readonly providers = new Map<string, StorageProvider>();
 
   constructor(
     @Inject('ConfigService')
     private readonly configService: S3ConfigService,
     private readonly loggerService: LoggerService,
-  ) {
-    this.client = new S3Client({
-      credentials: {
+  ) {}
+
+  private providerFor(bucket: string): StorageProvider {
+    let provider = this.providers.get(bucket);
+    if (!provider) {
+      provider = createStorageProvider({
         accessKeyId: this.configService.AWS_ACCESS_KEY_ID,
+        bucket,
+        region: this.configService.AWS_REGION,
         secretAccessKey: this.configService.AWS_SECRET_ACCESS_KEY,
-      },
-      region: this.configService.AWS_REGION,
-    });
+      });
+      this.providers.set(bucket, provider);
+    }
+    return provider;
   }
 
   async downloadFile(
@@ -84,21 +63,10 @@ export class S3Service {
       bucket,
       key,
       localPath,
-      message: 'Downloading file from S3',
+      message: 'Downloading file from storage',
     });
 
-    const command = new GetObjectCommand({ Bucket: bucket, Key: key });
-    const response = await this.client.send(command);
-
-    if (!response.Body) {
-      throw new Error(`Empty response body for s3://${bucket}/${key}`);
-    }
-
-    await mkdir(dirname(localPath), { recursive: true });
-
-    const body = response.Body as Readable;
-    const writeStream = createWriteStream(localPath);
-    await pipeline(body, writeStream);
+    await this.providerFor(bucket).download(key, localPath);
 
     this.loggerService.log(caller, {
       bucket,
@@ -109,11 +77,11 @@ export class S3Service {
   }
 
   /**
-   * Upload a local file to S3.
+   * Upload a local file to storage.
    *
-   * @param contentType - Optional explicit MIME type. When omitted the type is
-   *   inferred from the file extension (with application/octet-stream as the
-   *   final fallback).
+   * @param contentType - Optional explicit MIME type. When omitted the
+   *   provider infers it from the file extension (with
+   *   application/octet-stream as the final fallback).
    */
   async uploadFile(
     bucket: string,
@@ -127,22 +95,11 @@ export class S3Service {
       bucket,
       key,
       localPath,
-      message: 'Uploading file to S3',
+      message: 'Uploading file to storage',
     });
 
-    const fileBuffer = await readFile(localPath);
+    await this.providerFor(bucket).uploadFromFile(key, localPath, contentType);
     const fileStats = await stat(localPath);
-    const resolvedContentType = contentType ?? mimeFromPath(localPath);
-
-    const command = new PutObjectCommand({
-      Body: fileBuffer,
-      Bucket: bucket,
-      ContentLength: fileStats.size,
-      ContentType: resolvedContentType,
-      Key: key,
-    });
-
-    await this.client.send(command);
 
     this.loggerService.log(caller, {
       bucket,
@@ -153,7 +110,7 @@ export class S3Service {
   }
 
   /**
-   * Upload a safetensors LoRA file to the canonical S3 path.
+   * Upload a safetensors LoRA file to the canonical storage path.
    * Always uses application/octet-stream content type.
    */
   async uploadSafetensors(
@@ -168,22 +125,16 @@ export class S3Service {
       bucket,
       localPath,
       loraName,
-      message: 'Uploading safetensors to S3',
+      message: 'Uploading safetensors to storage',
       s3Key,
     });
 
-    const fileBuffer = await readFile(localPath);
+    await this.providerFor(bucket).uploadFromFile(
+      s3Key,
+      localPath,
+      'application/octet-stream',
+    );
     const fileStats = await stat(localPath);
-
-    const command = new PutObjectCommand({
-      Body: fileBuffer,
-      Bucket: bucket,
-      ContentLength: fileStats.size,
-      ContentType: 'application/octet-stream',
-      Key: s3Key,
-    });
-
-    await this.client.send(command);
 
     this.loggerService.log(caller, {
       bucket,
@@ -201,44 +152,24 @@ export class S3Service {
 
     this.loggerService.log(caller, {
       bucket,
-      message: 'Listing S3 objects',
+      message: 'Listing storage objects',
       prefix,
     });
 
-    const objects: S3Object[] = [];
-    let continuationToken: string | undefined;
-
-    do {
-      const command = new ListObjectsV2Command({
-        Bucket: bucket,
-        ContinuationToken: continuationToken,
-        Prefix: prefix,
-      });
-
-      const response = await this.client.send(command);
-
-      if (response.Contents) {
-        for (const item of response.Contents) {
-          if (item.Key && item.Size !== undefined) {
-            objects.push({
-              key: item.Key,
-              lastModified: item.LastModified?.toISOString() ?? '',
-              size: item.Size,
-            });
-          }
-        }
-      }
-
-      continuationToken = response.NextContinuationToken;
-    } while (continuationToken);
+    const objects = await this.providerFor(bucket).listObjects(prefix);
+    const mapped: S3Object[] = objects.map((object) => ({
+      key: object.key,
+      lastModified: object.lastModified.toISOString(),
+      size: object.size,
+    }));
 
     this.loggerService.log(caller, {
       bucket,
-      count: objects.length,
-      message: 'Listed S3 objects',
+      count: mapped.length,
+      message: 'Listed storage objects',
       prefix,
     });
 
-    return objects;
+    return mapped;
   }
 }

--- a/packages/libs/vitest.config.ts
+++ b/packages/libs/vitest.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      '@genfeedai/config': path.resolve(pkgDir, '../config/src/index.ts'),
+      '@genfeedai/storage': path.resolve(pkgDir, '../storage/src/index.ts'),
       '@libs': path.resolve(pkgDir, '.'),
     },
   },

--- a/packages/services/core/logger.service.ts
+++ b/packages/services/core/logger.service.ts
@@ -1,3 +1,11 @@
+/**
+ * Logger runtime boundary (audit risk 9, issue #1097): this pino + Sentry
+ * logger is THE logger for the frontend services runtime — browser and
+ * Next.js SSR, where the NestJS winston LoggerService
+ * (`packages/libs/logger/logger.service.ts`) cannot run (Nest DI, Node-only
+ * transports). Backend services must NOT import this file; they inject the
+ * winston LoggerService. One logger per runtime; do not add a third.
+ */
 import * as Sentry from '@sentry/nextjs';
 import pino, { type Logger as PinoLogger } from 'pino';
 

--- a/packages/storage/__tests__/local-storage.provider.test.ts
+++ b/packages/storage/__tests__/local-storage.provider.test.ts
@@ -1,0 +1,125 @@
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { LocalStorageProvider } from '../src/local-storage.provider';
+
+describe('LocalStorageProvider', () => {
+  let baseDir: string;
+  let scratchDir: string;
+  let provider: LocalStorageProvider;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(tmpdir(), 'genfeed-storage-base-'));
+    scratchDir = await fs.mkdtemp(
+      path.join(tmpdir(), 'genfeed-storage-scratch-'),
+    );
+    provider = new LocalStorageProvider(baseDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { force: true, recursive: true });
+    await fs.rm(scratchDir, { force: true, recursive: true });
+  });
+
+  describe('upload', () => {
+    it('writes buffer under base dir and returns the path', async () => {
+      const result = await provider.upload(
+        Buffer.from('hello'),
+        'images/a/photo.png',
+      );
+
+      expect(result).toBe('images/a/photo.png');
+      const written = await fs.readFile(
+        path.join(baseDir, 'images/a/photo.png'),
+        'utf8',
+      );
+      expect(written).toBe('hello');
+    });
+  });
+
+  describe('uploadFromFile', () => {
+    it('copies a local file into storage', async () => {
+      const source = path.join(scratchDir, 'video.mp4');
+      await fs.writeFile(source, 'video-bytes');
+
+      const result = await provider.uploadFromFile('videos/clip.mp4', source);
+
+      expect(result).toBe('videos/clip.mp4');
+      const written = await fs.readFile(
+        path.join(baseDir, 'videos/clip.mp4'),
+        'utf8',
+      );
+      expect(written).toBe('video-bytes');
+    });
+
+    it('throws when the source file does not exist', async () => {
+      await expect(
+        provider.uploadFromFile(
+          'videos/clip.mp4',
+          path.join(scratchDir, 'missing.mp4'),
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('download', () => {
+    it('copies a stored file to a local path, creating directories', async () => {
+      await provider.upload(Buffer.from('stored'), 'datasets/d1/img.png');
+      const target = path.join(scratchDir, 'nested/dir/img.png');
+
+      await provider.download('datasets/d1/img.png', target);
+
+      expect(await fs.readFile(target, 'utf8')).toBe('stored');
+    });
+
+    it('throws when the stored file does not exist', async () => {
+      await expect(
+        provider.download('missing/file.png', path.join(scratchDir, 'x.png')),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('listObjects', () => {
+    it('recursively lists all files under a prefix with size and mtime', async () => {
+      await provider.upload(Buffer.from('a'), 'loras/model-a.safetensors');
+      await provider.upload(Buffer.from('bb'), 'loras/sub/model-b.safetensors');
+      await provider.upload(Buffer.from('ccc'), 'other/file.txt');
+
+      const objects = await provider.listObjects('loras');
+
+      expect(objects).toHaveLength(2);
+      const keys = objects.map((obj) => obj.key).sort();
+      expect(keys).toEqual([
+        'loras/model-a.safetensors',
+        'loras/sub/model-b.safetensors',
+      ]);
+      const modelA = objects.find(
+        (obj) => obj.key === 'loras/model-a.safetensors',
+      );
+      expect(modelA?.size).toBe(1);
+      expect(modelA?.lastModified).toBeInstanceOf(Date);
+    });
+
+    it('returns empty array for unknown prefix', async () => {
+      expect(await provider.listObjects('nope')).toEqual([]);
+    });
+  });
+
+  describe('existing surface', () => {
+    it('exists / delete / list still behave', async () => {
+      await provider.upload(Buffer.from('x'), 'media/a.png');
+
+      expect(await provider.exists('media/a.png')).toBe(true);
+      const entries = await provider.list('media');
+      expect(entries).toHaveLength(1);
+      expect(entries[0].type).toBe('image');
+
+      await provider.delete('media/a.png');
+      expect(await provider.exists('media/a.png')).toBe(false);
+      expect(existsSync(path.join(baseDir, 'media/a.png'))).toBe(false);
+    });
+  });
+});

--- a/packages/storage/__tests__/s3-storage.provider.test.ts
+++ b/packages/storage/__tests__/s3-storage.provider.test.ts
@@ -1,0 +1,179 @@
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSend = vi.fn();
+const clientConfigs: Array<Record<string, unknown>> = [];
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class MockS3Client {
+    send = mockSend;
+    constructor(config: Record<string, unknown>) {
+      clientConfigs.push(config);
+    }
+  }
+  class MockCommand {
+    constructor(public params: Record<string, unknown>) {}
+  }
+  return {
+    DeleteObjectCommand: class extends MockCommand {},
+    GetObjectCommand: class extends MockCommand {},
+    HeadObjectCommand: class extends MockCommand {},
+    ListObjectsV2Command: class extends MockCommand {},
+    PutObjectCommand: class extends MockCommand {},
+    S3Client: MockS3Client,
+  };
+});
+
+import { S3StorageProvider } from '../src/s3-storage.provider';
+
+describe('S3StorageProvider', () => {
+  let scratchDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    clientConfigs.length = 0;
+    scratchDir = await fs.mkdtemp(path.join(tmpdir(), 'genfeed-s3-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(scratchDir, { force: true, recursive: true });
+  });
+
+  describe('constructor options', () => {
+    it('uses explicit options over environment', () => {
+      const provider = new S3StorageProvider({
+        accessKeyId: 'ak',
+        bucket: 'opt-bucket',
+        region: 'eu-west-3',
+        secretAccessKey: 'sk',
+      });
+
+      expect(provider.getUrl('a.png')).toBe(
+        'https://opt-bucket.s3.eu-west-3.amazonaws.com/a.png',
+      );
+      expect(clientConfigs[0]).toMatchObject({
+        credentials: { accessKeyId: 'ak', secretAccessKey: 'sk' },
+        region: 'eu-west-3',
+      });
+    });
+  });
+
+  describe('uploadFromFile', () => {
+    it('reads the local file and puts it with inferred content type', async () => {
+      mockSend.mockResolvedValue({});
+      const source = path.join(scratchDir, 'clip.mp4');
+      await fs.writeFile(source, 'video-bytes');
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      const result = await provider.uploadFromFile('videos/clip.mp4', source);
+
+      expect(result).toBe('videos/clip.mp4');
+      const [command] = mockSend.mock.calls[0] as [
+        { params: Record<string, unknown> },
+      ];
+      expect(command.params.Bucket).toBe('b');
+      expect(command.params.Key).toBe('videos/clip.mp4');
+      expect(command.params.ContentType).toBe('video/mp4');
+      expect(command.params.ContentLength).toBe(11);
+    });
+
+    it('respects an explicit content type and maps safetensors/pth to octet-stream', async () => {
+      mockSend.mockResolvedValue({});
+      const source = path.join(scratchDir, 'model.safetensors');
+      await fs.writeFile(source, 'weights');
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      await provider.uploadFromFile('loras/model.safetensors', source);
+      await provider.uploadFromFile('loras/model.safetensors', source, 'x/y');
+
+      const [first] = mockSend.mock.calls[0] as [
+        { params: Record<string, unknown> },
+      ];
+      const [second] = mockSend.mock.calls[1] as [
+        { params: Record<string, unknown> },
+      ];
+      expect(first.params.ContentType).toBe('application/octet-stream');
+      expect(second.params.ContentType).toBe('x/y');
+    });
+  });
+
+  describe('download', () => {
+    it('streams the object body to a local path, creating directories', async () => {
+      mockSend.mockResolvedValue({
+        Body: Readable.from(Buffer.from('object-bytes')),
+      });
+      const provider = new S3StorageProvider({ bucket: 'b' });
+      const target = path.join(scratchDir, 'nested/dir/out.png');
+
+      await provider.download('images/out.png', target);
+
+      const [command] = mockSend.mock.calls[0] as [
+        { params: Record<string, unknown> },
+      ];
+      expect(command.params).toMatchObject({
+        Bucket: 'b',
+        Key: 'images/out.png',
+      });
+      expect(await fs.readFile(target, 'utf8')).toBe('object-bytes');
+    });
+
+    it('throws on empty response body', async () => {
+      mockSend.mockResolvedValue({ Body: undefined });
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      await expect(
+        provider.download('images/out.png', path.join(scratchDir, 'x.png')),
+      ).rejects.toThrow('Empty response body');
+    });
+  });
+
+  describe('listObjects', () => {
+    it('paginates through continuation tokens and maps object metadata', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Contents: [
+            { Key: 'p/a.png', LastModified: new Date('2024-01-01'), Size: 1 },
+          ],
+          NextContinuationToken: 'token',
+        })
+        .mockResolvedValueOnce({
+          Contents: [
+            { Key: 'p/b.png', LastModified: new Date('2024-01-02'), Size: 2 },
+          ],
+          NextContinuationToken: undefined,
+        });
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      const objects = await provider.listObjects('p/');
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(objects).toEqual([
+        { key: 'p/a.png', lastModified: new Date('2024-01-01'), size: 1 },
+        { key: 'p/b.png', lastModified: new Date('2024-01-02'), size: 2 },
+      ]);
+      const [secondCall] = mockSend.mock.calls[1] as [
+        { params: Record<string, unknown> },
+      ];
+      expect(secondCall.params.ContinuationToken).toBe('token');
+    });
+
+    it('skips entries missing Key or Size and handles empty listings', async () => {
+      mockSend.mockResolvedValue({
+        Contents: [
+          { Key: 'p/ok.png', LastModified: new Date(), Size: 5 },
+          { Key: undefined, LastModified: new Date(), Size: 1 },
+          { Key: 'p/no-size.png', LastModified: new Date(), Size: undefined },
+        ],
+      });
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      const objects = await provider.listObjects('p/');
+
+      expect(objects).toHaveLength(1);
+      expect(objects[0].key).toBe('p/ok.png');
+    });
+  });
+});

--- a/packages/storage/__tests__/storage-provider.factory.test.ts
+++ b/packages/storage/__tests__/storage-provider.factory.test.ts
@@ -1,0 +1,57 @@
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  DeleteObjectCommand: class {},
+  GetObjectCommand: class {},
+  HeadObjectCommand: class {},
+  ListObjectsV2Command: class {},
+  PutObjectCommand: class {},
+  S3Client: class {},
+}));
+
+describe('createStorageProvider', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@genfeedai/config');
+  });
+
+  it('returns LocalStorageProvider when self-hosted', async () => {
+    vi.doMock('@genfeedai/config', () => ({ IS_SELF_HOSTED: true }));
+    const { createStorageProvider } = await import(
+      '../src/storage-provider.factory'
+    );
+    const { LocalStorageProvider } = await import(
+      '../src/local-storage.provider'
+    );
+    const baseDir = await fs.mkdtemp(path.join(tmpdir(), 'genfeed-factory-'));
+
+    try {
+      expect(createStorageProvider({ baseDir })).toBeInstanceOf(
+        LocalStorageProvider,
+      );
+    } finally {
+      await fs.rm(baseDir, { force: true, recursive: true });
+    }
+  });
+
+  it('returns S3StorageProvider with options when cloud', async () => {
+    vi.doMock('@genfeedai/config', () => ({ IS_SELF_HOSTED: false }));
+    const { createStorageProvider } = await import(
+      '../src/storage-provider.factory'
+    );
+    const { S3StorageProvider } = await import('../src/s3-storage.provider');
+
+    const provider = createStorageProvider({
+      bucket: 'my-bucket',
+      region: 'eu-central-1',
+    });
+
+    expect(provider).toBeInstanceOf(S3StorageProvider);
+    expect(provider.getUrl('k.png')).toBe(
+      'https://my-bucket.s3.eu-central-1.amazonaws.com/k.png',
+    );
+  });
+});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1075.0",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -3,6 +3,8 @@ export { S3StorageProvider } from './s3-storage.provider';
 export type {
   FileEntry,
   ListOptions,
+  StorageObject,
   StorageProvider,
+  StorageProviderOptions,
 } from './storage.provider';
 export { createStorageProvider } from './storage-provider.factory';

--- a/packages/storage/src/local-storage.provider.ts
+++ b/packages/storage/src/local-storage.provider.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type {
   FileEntry,
   ListOptions,
+  StorageObject,
   StorageProvider,
 } from './storage.provider';
 
@@ -58,6 +59,23 @@ export class LocalStorageProvider implements StorageProvider {
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(fullPath, file);
     return filePath;
+  }
+
+  async uploadFromFile(
+    filePath: string,
+    localPath: string,
+    _contentType?: string,
+  ): Promise<string> {
+    const fullPath = path.join(this.baseDir, filePath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.copyFile(localPath, fullPath);
+    return filePath;
+  }
+
+  async download(filePath: string, localPath: string): Promise<void> {
+    const fullPath = path.join(this.baseDir, filePath);
+    await fs.mkdir(path.dirname(localPath), { recursive: true });
+    await fs.copyFile(fullPath, localPath);
   }
 
   getUrl(filePath: string): string {
@@ -115,6 +133,35 @@ export class LocalStorageProvider implements StorageProvider {
     const offset = options?.offset ?? 0;
     const limit = options?.limit ?? fileEntries.length;
     return fileEntries.slice(offset, offset + limit);
+  }
+
+  async listObjects(prefix: string): Promise<StorageObject[]> {
+    const dirPath = path.join(this.baseDir, prefix);
+    if (!existsSync(dirPath)) {
+      return [];
+    }
+
+    const entries = await fs.readdir(dirPath, {
+      recursive: true,
+      withFileTypes: true,
+    });
+    const objects: StorageObject[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const fullPath = path.join(entry.parentPath, entry.name);
+      const stat = await fs.stat(fullPath);
+      objects.push({
+        key: path.relative(this.baseDir, fullPath),
+        lastModified: stat.mtime,
+        size: stat.size,
+      });
+    }
+
+    return objects;
   }
 
   async exists(filePath: string): Promise<boolean> {

--- a/packages/storage/src/s3-storage.provider.ts
+++ b/packages/storage/src/s3-storage.provider.ts
@@ -1,6 +1,11 @@
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import type { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import {
   DeleteObjectCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
@@ -10,19 +15,25 @@ import {
 import type {
   FileEntry,
   ListOptions,
+  StorageObject,
   StorageProvider,
+  StorageProviderOptions,
 } from './storage.provider';
 
 const MIME_BY_EXT: Record<string, string> = {
   '.aac': 'audio/aac',
+  '.avi': 'video/x-msvideo',
   '.flac': 'audio/flac',
   '.gif': 'image/gif',
   '.jpeg': 'image/jpeg',
   '.jpg': 'image/jpeg',
+  '.m4a': 'audio/mp4',
+  '.mov': 'video/quicktime',
   '.mp3': 'audio/mpeg',
   '.mp4': 'video/mp4',
   '.ogg': 'audio/ogg',
   '.png': 'image/png',
+  '.pth': 'application/octet-stream',
   '.safetensors': 'application/octet-stream',
   '.svg': 'image/svg+xml',
   '.wav': 'audio/wav',
@@ -52,14 +63,15 @@ export class S3StorageProvider implements StorageProvider {
   private readonly bucket: string;
   private readonly region: string;
 
-  constructor() {
-    this.bucket = process.env.AWS_S3_BUCKET ?? '';
-    this.region = process.env.AWS_REGION ?? 'us-east-1';
+  constructor(options: StorageProviderOptions = {}) {
+    this.bucket = options.bucket ?? process.env.AWS_S3_BUCKET ?? '';
+    this.region = options.region ?? process.env.AWS_REGION ?? 'us-east-1';
     this.client = new S3Client({
       region: this.region,
       credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+        accessKeyId: options.accessKeyId ?? process.env.AWS_ACCESS_KEY_ID ?? '',
+        secretAccessKey:
+          options.secretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY ?? '',
       },
     });
   }
@@ -78,6 +90,43 @@ export class S3StorageProvider implements StorageProvider {
     });
     await this.client.send(command);
     return filePath;
+  }
+
+  async uploadFromFile(
+    filePath: string,
+    localPath: string,
+    contentType?: string,
+  ): Promise<string> {
+    const fileBuffer = await readFile(localPath);
+    const fileStats = await stat(localPath);
+    const resolvedContentType = contentType ?? mimeFromPath(localPath);
+
+    const command = new PutObjectCommand({
+      Body: fileBuffer,
+      Bucket: this.bucket,
+      ContentLength: fileStats.size,
+      ContentType: resolvedContentType,
+      Key: filePath,
+    });
+    await this.client.send(command);
+    return filePath;
+  }
+
+  async download(filePath: string, localPath: string): Promise<void> {
+    const command = new GetObjectCommand({
+      Bucket: this.bucket,
+      Key: filePath,
+    });
+    const response = await this.client.send(command);
+
+    if (!response.Body) {
+      throw new Error(
+        `Empty response body for s3://${this.bucket}/${filePath}`,
+      );
+    }
+
+    await mkdir(path.dirname(localPath), { recursive: true });
+    await pipeline(response.Body as Readable, createWriteStream(localPath));
   }
 
   getUrl(filePath: string): string {
@@ -121,6 +170,34 @@ export class S3StorageProvider implements StorageProvider {
     const offset = options?.offset ?? 0;
     const limit = options?.limit ?? entries.length;
     return entries.slice(offset, offset + limit);
+  }
+
+  async listObjects(prefix: string): Promise<StorageObject[]> {
+    const objects: StorageObject[] = [];
+    let continuationToken: string | undefined;
+
+    do {
+      const command = new ListObjectsV2Command({
+        Bucket: this.bucket,
+        ContinuationToken: continuationToken,
+        Prefix: prefix,
+      });
+      const response = await this.client.send(command);
+
+      for (const item of response.Contents ?? []) {
+        if (item.Key && item.Size !== undefined) {
+          objects.push({
+            key: item.Key,
+            lastModified: item.LastModified ?? new Date(0),
+            size: item.Size,
+          });
+        }
+      }
+
+      continuationToken = response.NextContinuationToken;
+    } while (continuationToken);
+
+    return objects;
   }
 
   async exists(filePath: string): Promise<boolean> {

--- a/packages/storage/src/storage-provider.factory.ts
+++ b/packages/storage/src/storage-provider.factory.ts
@@ -2,11 +2,16 @@ import { IS_SELF_HOSTED } from '@genfeedai/config';
 
 import { LocalStorageProvider } from './local-storage.provider';
 import { S3StorageProvider } from './s3-storage.provider';
-import type { StorageProvider } from './storage.provider';
+import type {
+  StorageProvider,
+  StorageProviderOptions,
+} from './storage.provider';
 
-export function createStorageProvider(): StorageProvider {
+export function createStorageProvider(
+  options: StorageProviderOptions = {},
+): StorageProvider {
   if (IS_SELF_HOSTED) {
-    return new LocalStorageProvider();
+    return new LocalStorageProvider(options.baseDir);
   }
-  return new S3StorageProvider();
+  return new S3StorageProvider(options);
 }

--- a/packages/storage/src/storage.provider.ts
+++ b/packages/storage/src/storage.provider.ts
@@ -13,10 +13,47 @@ export interface FileEntry {
   modifiedAt: Date;
 }
 
+/** Raw object listing entry (S3 object metadata shape). */
+export interface StorageObject {
+  key: string;
+  size: number;
+  lastModified: Date;
+}
+
+/**
+ * Construction options for storage providers.
+ *
+ * Every field falls back to environment variables (S3) or the default
+ * base directory (local), so `createStorageProvider()` with no arguments
+ * keeps working for existing consumers.
+ */
+export interface StorageProviderOptions {
+  /** S3 bucket. Defaults to AWS_S3_BUCKET. */
+  bucket?: string;
+  /** AWS region. Defaults to AWS_REGION. */
+  region?: string;
+  /** Defaults to AWS_ACCESS_KEY_ID. */
+  accessKeyId?: string;
+  /** Defaults to AWS_SECRET_ACCESS_KEY. */
+  secretAccessKey?: string;
+  /** Local provider base directory. Defaults to GENFEED_STORAGE_PATH. */
+  baseDir?: string;
+}
+
 export interface StorageProvider {
   upload(file: Buffer, path: string, contentType?: string): Promise<string>;
+  /** Upload from a file on the local filesystem. */
+  uploadFromFile(
+    path: string,
+    localPath: string,
+    contentType?: string,
+  ): Promise<string>;
+  /** Download a stored object to a local filesystem path. */
+  download(path: string, localPath: string): Promise<void>;
   getUrl(path: string): string;
   delete(path: string): Promise<void>;
   list(prefix: string, options?: ListOptions): Promise<FileEntry[]>;
+  /** Exhaustive raw listing under a prefix (fully paginated). */
+  listObjects(prefix: string): Promise<StorageObject[]>;
   exists(path: string): Promise<boolean>;
 }

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -18,7 +18,7 @@
     "target": "es2022",
     "types": ["node"]
   },
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["dist", "node_modules", "**/*.spec.ts", "**/*.test.ts"],
   "include": ["src"],
   "references": [
     {

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@genfeedai/config': path.resolve(__dirname, '../config/src/index.ts'),
+    },
+  },
+  test: {
+    coverage: {
+      include: ['src/**/*.ts'],
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+    },
+    environment: 'node',
+    globals: true,
+    include: [
+      'src/**/*.spec.ts',
+      'src/**/*.test.ts',
+      '__tests__/**/*.spec.ts',
+      '__tests__/**/*.test.ts',
+    ],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
Closes #1097 (repo-map audit §6 risk 9, PR #1083).

## S3 — `packages/storage` is now the single implementation

- **`StorageProvider` interface extended** with `download`, `uploadFromFile`, and fully paginated `listObjects`, plus `StorageObject` and `StorageProviderOptions` types.
- **`S3StorageProvider`** now accepts options (bucket/region/credentials) with env-var fallback, so DI consumers can pass ConfigService values while `createStorageProvider()` with no args keeps working. MIME table is the union of the two previous tables.
- **`LocalStorageProvider`** implements the new operations (copy-based download/upload, recursive listing) — self-hosted deployments get local-FS behavior for every operation the wrapper needs.
- **`packages/libs/s3` `S3Service` is now a thin NestJS wrapper**: identical public API (`downloadFile`/`uploadFile`/`uploadSafetensors`/`listObjects` with per-call bucket — zero call-site churn in images/videos/voices), delegating to `createStorageProvider()` with a lazy per-bucket provider cache. No direct `@aws-sdk/client-s3` imports remain in the package, and self-hosted mode now routes these services to the local filesystem instead of constructing an S3 client.

## Logging — one logger per runtime, boundary documented in code

- winston `LoggerService` (`packages/libs/logger`) = NestJS backend runtime (all 12 services).
- pino + `@sentry/nextjs` logger (`packages/services/core/logger.service.ts`) = browser/Next SSR frontend services runtime (196 consumer files; winston/Nest DI cannot run there).
- Verified there is no cross-runtime import in either direction; boundary comments added to both files per the issue's direction ("if the frontend services layer genuinely needs its own, document the boundary").

## Also

- Fixed pre-existing broken import in `voice-dataset.service.spec.ts` (`@voices/services/s3.service` → `@libs/s3/s3.service`) — that spec could not load on master.
- Added `@genfeedai/storage` + `@genfeedai/pricing` src aliases to images/videos/voices vitest configs (matching the existing files-service pattern).
- New test suite for `@genfeedai/storage` (previously untested): vitest config, `test` script, 17 tests.

## Out of scope (noted for follow-up)

- `apps/server/files/src/services/s3/s3.service.ts` — a third, files-local S3 wrapper with a richer surface (presigned URLs, copy, streams, multipart). Not named by the issue/audit risk; folding it into `@genfeedai/storage` is a follow-up.
- #1095 lint ratchet is intentionally sequenced after this merges.

## Verification

- `@genfeedai/storage`: 17/17 tests, `tsc --noEmit` clean
- `packages/libs` s3 spec: 9/9 (two unrelated libs spec failures also fail on master)
- images 149/149, videos 81/81, voices 137/137, files 215/215, services logger 30/30
- `turbo build --filter=@genfeedai/images --filter=@genfeedai/files --filter=@genfeedai/storage` green
- Biome on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)