### PR TITLE
feat(api): requeue winning content-run signals into trend ingestion (#166)

### DIFF
--- a/apps/server/api/src/collections/content-runs/content-runs.module.ts
+++ b/apps/server/api/src/collections/content-runs/content-runs.module.ts
@@ -1,12 +1,13 @@
 import { ContentRunsController } from '@api/collections/content-runs/controllers/content-runs.controller';
 import { ContentRunRecommendationsService } from '@api/collections/content-runs/services/content-run-recommendations.service';
 import { ContentRunsService } from '@api/collections/content-runs/services/content-runs.service';
-import { Module } from '@nestjs/common';
+import { ContentOptimizationModule } from '@api/services/content-optimization/content-optimization.module';
+import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [ContentRunsController],
   exports: [ContentRunsService, ContentRunRecommendationsService],
-  imports: [],
+  imports: [forwardRef(() => ContentOptimizationModule)],
   providers: [ContentRunsService, ContentRunRecommendationsService],
 })
 export class ContentRunsModule {}

--- a/apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.spec.ts
+++ b/apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.spec.ts
@@ -1,7 +1,9 @@
 import { ContentRunRecommendationsService } from '@api/collections/content-runs/services/content-run-recommendations.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import type { ContentOptimizationService } from '@api/services/content-optimization/content-optimization.service';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { ContentRunStatus } from '@genfeedai/enums';
+import type { LoggerService } from '@libs/logger/logger.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createdAt = new Date('2026-05-03T10:00:00.000Z');
@@ -40,14 +42,27 @@ describe('ContentRunRecommendationsService', () => {
   const contentPerformance = {
     findMany: vi.fn(),
   };
+  const contentOptimization = {
+    requeueWinnerIntoTrends: vi.fn().mockResolvedValue({ requeued: false }),
+  };
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
   let service: ContentRunRecommendationsService;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new ContentRunRecommendationsService({
-      contentPerformance,
-      contentRun,
-    } as unknown as PrismaService);
+    service = new ContentRunRecommendationsService(
+      {
+        contentPerformance,
+        contentRun,
+      } as unknown as PrismaService,
+      contentOptimization as unknown as ContentOptimizationService,
+      logger as unknown as LoggerService,
+    );
   });
 
   it('scores run variants, persists a winner summary, and creates next actions', async () => {
@@ -142,6 +157,66 @@ describe('ContentRunRecommendationsService', () => {
       }),
       recommendations: expect.any(Array),
     });
+
+    // Winner is fed back into trend ingestion (issue #166).
+    expect(contentOptimization.requeueWinnerIntoTrends).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(contentOptimization.requeueWinnerIntoTrends).toHaveBeenCalledWith(
+      'org-1',
+      'brand-1',
+      expect.objectContaining({
+        contentRunId: 'run-1',
+        format: 'post-thread',
+        hook: 'Proof-led hooks beat generic AI claims',
+        platform: 'twitter',
+        variantId: 'variant-a',
+      }),
+    );
+  });
+
+  it('does not fail run analysis when the winner->trend requeue throws', async () => {
+    contentRun.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      config: runConfig,
+      createdAt,
+      id: 'run-1',
+      organizationId: 'org-1',
+      status: ContentRunStatus.COMPLETED,
+    });
+    contentPerformance.findMany.mockResolvedValue([
+      {
+        clicks: 12,
+        comments: 30,
+        contentRunId: 'run-1',
+        engagementRate: 8.4,
+        likes: 220,
+        performanceScore: 88,
+        platform: 'twitter',
+        saves: 14,
+        shares: 40,
+        variantId: 'variant-a',
+        views: 10_000,
+      },
+    ]);
+    contentRun.update.mockImplementation(({ data }) =>
+      Promise.resolve({
+        brandId: 'brand-1',
+        config: data.config,
+        createdAt,
+        id: 'run-1',
+        organizationId: 'org-1',
+        status: ContentRunStatus.COMPLETED,
+      }),
+    );
+    contentOptimization.requeueWinnerIntoTrends.mockRejectedValue(
+      new Error('trends unavailable'),
+    );
+
+    const result = await service.analyzeRun('org-1', 'run-1');
+
+    expect(result.analyticsSummary.winningVariantId).toBe('variant-a');
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   it('persists a structured analytics collection recommendation when no rows exist', async () => {
@@ -176,6 +251,8 @@ describe('ContentRunRecommendationsService', () => {
         type: 'collect_run_analytics',
       }),
     ]);
+    // No winner exists without performance rows, so nothing is fed to trends.
+    expect(contentOptimization.requeueWinnerIntoTrends).not.toHaveBeenCalled();
   });
 
   it('throws when the run is not scoped to the organization', async () => {

--- a/apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.ts
+++ b/apps/server/api/src/collections/content-runs/services/content-run-recommendations.service.ts
@@ -4,15 +4,21 @@ import {
   toContentRunJsonValue,
 } from '@api/collections/content-runs/utils/content-run-data.util';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import {
+  ContentOptimizationService,
+  type WinnerContentSignal,
+} from '@api/services/content-optimization/content-optimization.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import type {
   ContentRunAnalyticsSummary,
   ContentRunRecommendation,
   ContentRunVariant,
 } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
 type ContentRunRow = {
+  brandId?: string | null;
   config: unknown;
   id: string;
   status: string;
@@ -67,7 +73,11 @@ type VariantAccumulator = {
 
 @Injectable()
 export class ContentRunRecommendationsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly contentOptimizationService: ContentOptimizationService,
+    private readonly logger: LoggerService,
+  ) {}
 
   private readConfig(run: ContentRunRow): Record<string, unknown> {
     return isContentRunRecord(run.config) ? run.config : {};
@@ -339,11 +349,56 @@ export class ContentRunRecommendationsService {
       where: { id: runId },
     })) as unknown as Record<string, unknown>;
 
+    const winner = scores[0];
+    if (winner) {
+      await this.requeueWinnerIntoTrends(organizationId, run, config, winner);
+    }
+
     return {
       analyticsSummary,
       recommendations,
       scores,
       updatedRun: hydrateContentRun(updatedRun) ?? updatedRun,
     };
+  }
+
+  /**
+   * Feed the run's winning variant back into trend ingestion (issue #166).
+   * Best-effort: a trend-enrichment failure must never break run analysis, and
+   * the enrichment itself is gated per-org/brand by the trend opt-in flag.
+   */
+  private async requeueWinnerIntoTrends(
+    organizationId: string,
+    run: ContentRunRow,
+    config: Record<string, unknown>,
+    winner: RunVariantScore,
+  ): Promise<void> {
+    try {
+      const brief = isContentRunRecord(config.brief) ? config.brief : {};
+      const hook =
+        this.readString(brief.hypothesis) ??
+        this.readString(brief.angle) ??
+        winner.variantId;
+
+      const signal: WinnerContentSignal = {
+        avgEngagementRate: winner.avgEngagementRate,
+        contentRunId: run.id,
+        format: winner.format,
+        hook,
+        platform: winner.platform,
+        variantId: winner.variantId,
+      };
+
+      await this.contentOptimizationService.requeueWinnerIntoTrends(
+        organizationId,
+        this.readString(run.brandId),
+        signal,
+      );
+    } catch (error) {
+      this.logger.warn(
+        'Failed to requeue winner into trends; continuing run analysis',
+        { error, runId: run.id },
+      );
+    }
   }
 }

--- a/apps/server/api/src/collections/trends/controllers/trends.controller.ts
+++ b/apps/server/api/src/collections/trends/controllers/trends.controller.ts
@@ -591,6 +591,7 @@ export class TrendsController {
     const preferences = await this.trendPreferencesService.savePreferences(
       organizationId,
       {
+        autoRequeueWinners: dto.autoRequeueWinners,
         brandId: dto.brandId || publicMetadata?.brand,
         categories: dto.categories,
         hashtags: dto.hashtags,
@@ -602,6 +603,7 @@ export class TrendsController {
     return {
       message: 'Trend preferences saved successfully',
       preferences: {
+        autoRequeueWinners: preferences.autoRequeueWinners ?? false,
         categories: preferences.categories || [],
         hashtags: preferences.hashtags || [],
         keywords: preferences.keywords || [],

--- a/apps/server/api/src/collections/trends/dto/trend-preferences.dto.ts
+++ b/apps/server/api/src/collections/trends/dto/trend-preferences.dto.ts
@@ -1,7 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class SaveTrendPreferencesDto {
+  @ApiProperty({
+    description:
+      'Automatically feed winning content-run signals back into trend ingestion (opt-in)',
+    example: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  autoRequeueWinners?: boolean;
+
   @ApiProperty({
     description: 'Brand ID (optional, for brand-specific preferences)',
     required: false,

--- a/apps/server/api/src/collections/trends/schemas/trend-preferences.schema.ts
+++ b/apps/server/api/src/collections/trends/schemas/trend-preferences.schema.ts
@@ -5,5 +5,10 @@ export interface TrendPreferencesDocument extends PrismaTrendPreferences {
   hashtags?: string[];
   keywords?: string[];
   platforms?: string[];
+  /**
+   * When true, winning content-run signals are automatically fed back into this
+   * org/brand's trend ingestion (issue #166). Opt-in: defaults to false.
+   */
+  autoRequeueWinners?: boolean;
   [key: string]: unknown;
 }

--- a/apps/server/api/src/collections/trends/services/trend-preferences.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-preferences.service.spec.ts
@@ -53,6 +53,7 @@ describe('TrendPreferencesService', () => {
       const result = await service.getPreferences(organizationId);
 
       expect(result).toEqual({
+        autoRequeueWinners: false,
         categories: ['tech'],
         hashtags: [],
         keywords: ['ai'],
@@ -75,6 +76,7 @@ describe('TrendPreferencesService', () => {
       const result = await service.getPreferences(organizationId, brandId);
 
       expect(result).toEqual({
+        autoRequeueWinners: false,
         brandId: 'brand1',
         categories: ['fashion'],
         hashtags: [],
@@ -100,6 +102,7 @@ describe('TrendPreferencesService', () => {
       const result = await service.getPreferences(organizationId, brandId);
 
       expect(result).toEqual({
+        autoRequeueWinners: false,
         categories: ['general'],
         hashtags: [],
         keywords: [],
@@ -134,6 +137,17 @@ describe('TrendPreferencesService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should normalize the autoRequeueWinners flag from config', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue({
+        config: { autoRequeueWinners: true, keywords: ['ai'] },
+      });
+
+      const result = await service.getPreferences(organizationId);
+
+      expect(result?.autoRequeueWinners).toBe(true);
+      expect(result?.keywords).toEqual(['ai']);
+    });
   });
 
   describe('savePreferences', () => {
@@ -162,6 +176,7 @@ describe('TrendPreferencesService', () => {
         }),
       );
       expect(result).toEqual({
+        autoRequeueWinners: false,
         categories: ['tech'],
         hashtags: [],
         keywords: ['ai'],
@@ -194,6 +209,7 @@ describe('TrendPreferencesService', () => {
         }),
       );
       expect(result).toEqual({
+        autoRequeueWinners: false,
         categories: ['tech'],
         hashtags: [],
         keywords: ['ai'],
@@ -236,6 +252,87 @@ describe('TrendPreferencesService', () => {
           categories: ['tech'],
         }),
       ).rejects.toThrow('save failed');
+    });
+
+    it('should persist autoRequeueWinners into config when provided', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue(null);
+      prisma.trendPreferences.create.mockResolvedValue({});
+
+      await service.savePreferences(organizationId, {
+        autoRequeueWinners: true,
+        keywords: ['ai'],
+      });
+
+      expect(prisma.trendPreferences.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            config: {
+              autoRequeueWinners: true,
+              categories: [],
+              hashtags: [],
+              keywords: ['ai'],
+              platforms: [],
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should omit autoRequeueWinners from config when not provided', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue(null);
+      prisma.trendPreferences.create.mockResolvedValue({});
+
+      await service.savePreferences(organizationId, { keywords: ['ai'] });
+
+      const createArg = prisma.trendPreferences.create.mock.calls[0][0];
+      expect(createArg.data.config).not.toHaveProperty('autoRequeueWinners');
+    });
+  });
+
+  describe('mergeWinnerSignals', () => {
+    it('should union winner signals into existing preferences and preserve the opt-in flag', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue({
+        config: {
+          autoRequeueWinners: true,
+          keywords: ['ai'],
+          platforms: ['twitter'],
+        },
+        id: 'pref-1',
+      });
+      prisma.trendPreferences.update.mockResolvedValue({});
+
+      await service.mergeWinnerSignals(organizationId, brandId, {
+        keywords: ['ai', 'proof', 'thread'],
+        platforms: ['instagram'],
+      });
+
+      const updateArg = prisma.trendPreferences.update.mock.calls[0][0];
+      expect(updateArg.data.config.autoRequeueWinners).toBe(true);
+      expect(updateArg.data.config.keywords).toEqual(['ai', 'proof', 'thread']);
+      expect(updateArg.data.config.platforms).toEqual(['twitter', 'instagram']);
+    });
+
+    it('should create preferences from signals when none exist', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue(null);
+      prisma.trendPreferences.create.mockResolvedValue({});
+
+      await service.mergeWinnerSignals(organizationId, undefined, {
+        keywords: ['founder', 'proof'],
+        platforms: ['linkedin'],
+      });
+
+      expect(prisma.trendPreferences.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            brandId: null,
+            config: expect.objectContaining({
+              keywords: ['founder', 'proof'],
+              platforms: ['linkedin'],
+            }),
+            organizationId,
+          }),
+        }),
+      );
     });
   });
 });

--- a/apps/server/api/src/collections/trends/services/trend-preferences.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-preferences.service.ts
@@ -44,16 +44,23 @@ export class TrendPreferencesService {
       keywords?: string[];
       platforms?: string[];
       hashtags?: string[];
+      autoRequeueWinners?: boolean;
     },
   ): Promise<TrendPreferencesDocument> {
     try {
       const brandId = preferences.brandId ?? null;
-      const normalizedPreferences = {
+      const normalizedPreferences: Record<string, unknown> = {
         categories: preferences.categories ?? [],
         hashtags: preferences.hashtags ?? [],
         keywords: preferences.keywords ?? [],
         platforms: preferences.platforms ?? [],
       };
+      // Only persist the opt-in flag when the caller supplied it, so callers that
+      // never touch it (the common case) leave the stored config shape untouched.
+      if (preferences.autoRequeueWinners !== undefined) {
+        normalizedPreferences.autoRequeueWinners =
+          preferences.autoRequeueWinners;
+      }
       const updateData = {
         config: normalizedPreferences,
         updatedAt: new Date(),
@@ -100,6 +107,10 @@ export class TrendPreferencesService {
 
     return {
       ...(doc as TrendPreferencesDocument),
+      autoRequeueWinners: this.readBoolean(
+        docRecord.autoRequeueWinners ?? config?.autoRequeueWinners,
+        false,
+      ),
       categories: this.readStringArray(
         docRecord.categories ?? config?.categories,
       ),
@@ -107,6 +118,65 @@ export class TrendPreferencesService {
       keywords: this.readStringArray(docRecord.keywords ?? config?.keywords),
       platforms: this.readStringArray(docRecord.platforms ?? config?.platforms),
     };
+  }
+
+  /**
+   * Merge winning content-run signals into an org/brand's trend preferences so
+   * future trend ingestion is biased toward what already performed (issue #166).
+   * Signals are unioned into the existing arrays; the opt-in flag is preserved.
+   */
+  async mergeWinnerSignals(
+    organizationId: string,
+    brandId: string | undefined,
+    signals: {
+      categories?: string[];
+      hashtags?: string[];
+      keywords?: string[];
+      platforms?: string[];
+    },
+  ): Promise<TrendPreferencesDocument> {
+    const existing = await this.getPreferences(organizationId, brandId);
+
+    return this.savePreferences(organizationId, {
+      autoRequeueWinners: existing?.autoRequeueWinners,
+      brandId,
+      categories: this.unionSignals(existing?.categories, signals.categories),
+      hashtags: this.unionSignals(existing?.hashtags, signals.hashtags),
+      keywords: this.unionSignals(existing?.keywords, signals.keywords),
+      platforms: this.unionSignals(existing?.platforms, signals.platforms),
+    });
+  }
+
+  private unionSignals(
+    existing: string[] | undefined,
+    additions: string[] | undefined,
+  ): string[] {
+    return [
+      ...new Set(
+        [...(existing ?? []), ...(additions ?? [])].filter(
+          (entry): entry is string =>
+            typeof entry === 'string' && entry.length > 0,
+        ),
+      ),
+    ];
+  }
+
+  private readBoolean(value: unknown, fallback: boolean): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'true') {
+        return true;
+      }
+      if (normalized === 'false') {
+        return false;
+      }
+    }
+
+    return fallback;
   }
 
   private readObjectRecord(value: unknown): Record<string, unknown> | null {

--- a/apps/server/api/src/services/content-optimization/content-optimization.module.ts
+++ b/apps/server/api/src/services/content-optimization/content-optimization.module.ts
@@ -1,5 +1,6 @@
 import { BrandMemoryModule } from '@api/collections/brand-memory/brand-memory.module';
 import { ContentPerformanceModule } from '@api/collections/content-performance/content-performance.module';
+import { TrendsModule } from '@api/collections/trends/trends.module';
 import { ConfigModule } from '@api/config/config.module';
 import { ContentOptimizationController } from '@api/services/content-optimization/content-optimization.controller';
 import { ContentOptimizationService } from '@api/services/content-optimization/content-optimization.service';
@@ -18,6 +19,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => BrandMemoryModule),
     forwardRef(() => ContentPerformanceModule),
     forwardRef(() => OpenAiLlmModule),
+    forwardRef(() => TrendsModule),
     BullModule.registerQueue({
       defaultJobOptions: {
         attempts: 3,

--- a/apps/server/api/src/services/content-optimization/content-optimization.service.spec.ts
+++ b/apps/server/api/src/services/content-optimization/content-optimization.service.spec.ts
@@ -20,6 +20,11 @@ describe('ContentOptimizationService', () => {
     logEntry: ReturnType<typeof vi.fn>;
     addInsight: ReturnType<typeof vi.fn>;
   };
+  let mockTrendPreferences: {
+    getPreferences: ReturnType<typeof vi.fn>;
+    mergeWinnerSignals: ReturnType<typeof vi.fn>;
+    savePreferences: ReturnType<typeof vi.fn>;
+  };
 
   const orgId = 'org-123';
   const brandId = 'brand-456';
@@ -168,12 +173,19 @@ describe('ContentOptimizationService', () => {
       logEntry: vi.fn().mockResolvedValue(undefined),
     };
 
+    mockTrendPreferences = {
+      getPreferences: vi.fn().mockResolvedValue(null),
+      mergeWinnerSignals: vi.fn().mockResolvedValue({ id: 'pref-1' }),
+      savePreferences: vi.fn().mockResolvedValue({ id: 'pref-1' }),
+    };
+
     service = new ContentOptimizationService(
       mockLogger,
       mockPerformanceSummary,
       mockOptimizationCycle,
       mockOpenAiLlm,
       mockBrandMemory,
+      mockTrendPreferences,
     );
   });
 
@@ -383,6 +395,70 @@ describe('ContentOptimizationService', () => {
         }),
       );
       expect(mockBrandMemory.addInsight).toHaveBeenCalled();
+    });
+  });
+
+  describe('requeueWinnerIntoTrends', () => {
+    const winner = {
+      avgEngagementRate: 8.2,
+      contentRunId: 'run-1',
+      format: 'post-thread',
+      hook: 'Proof-led hooks beat generic AI claims',
+      platform: 'twitter',
+      variantId: 'variant-a',
+    };
+
+    it('merges winner signals into trend preferences when opt-in is enabled', async () => {
+      mockTrendPreferences.getPreferences.mockResolvedValue({
+        autoRequeueWinners: true,
+      });
+
+      const result = await service.requeueWinnerIntoTrends(
+        orgId,
+        brandId,
+        winner,
+      );
+
+      expect(result.requeued).toBe(true);
+      expect(mockTrendPreferences.mergeWinnerSignals).toHaveBeenCalledTimes(1);
+      const [calledOrg, calledBrand, signals] =
+        mockTrendPreferences.mergeWinnerSignals.mock.calls[0];
+      expect(calledOrg).toBe(orgId);
+      expect(calledBrand).toBe(brandId);
+      expect(signals.platforms).toEqual(['twitter']);
+      // hook tokens (stop-words dropped) + the format keyword, capped
+      expect(signals.keywords).toContain('proof');
+      expect(signals.keywords).toContain('hooks');
+      expect(signals.keywords).toContain('post-thread');
+      expect(signals.keywords).not.toContain('the');
+    });
+
+    it('skips and does not update trends when opt-in is disabled or missing', async () => {
+      mockTrendPreferences.getPreferences.mockResolvedValue(null);
+
+      const result = await service.requeueWinnerIntoTrends(
+        orgId,
+        brandId,
+        winner,
+      );
+
+      expect(result.requeued).toBe(false);
+      expect(result.reason).toBe('winner_trend_enrichment_disabled_or_missing');
+      expect(mockTrendPreferences.mergeWinnerSignals).not.toHaveBeenCalled();
+    });
+
+    it('skips when the winner carries no usable trend signal', async () => {
+      mockTrendPreferences.getPreferences.mockResolvedValue({
+        autoRequeueWinners: true,
+      });
+
+      const result = await service.requeueWinnerIntoTrends(orgId, brandId, {
+        variantId: 'variant-a',
+      });
+
+      expect(result.requeued).toBe(false);
+      expect(result.reason).toBe('no_signal');
+      expect(mockTrendPreferences.mergeWinnerSignals).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/services/content-optimization/content-optimization.service.ts
+++ b/apps/server/api/src/services/content-optimization/content-optimization.service.ts
@@ -8,6 +8,7 @@ import {
   PerformanceSummaryService,
   type WeeklySummary,
 } from '@api/collections/content-performance/services/performance-summary.service';
+import { TrendPreferencesService } from '@api/collections/trends/services/trend-preferences.service';
 import { OpenAiLlmService } from '@api/services/integrations/openai-llm/services/openai-llm.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -78,6 +79,67 @@ export interface AutoApplyResult {
   reason?: string;
 }
 
+/**
+ * A winning content-run signal, extracted at the point a run's winning variant
+ * is identified (issue #166). Used to feed insights back into trend ingestion.
+ */
+export interface WinnerContentSignal {
+  variantId: string;
+  contentRunId?: string;
+  hook?: string;
+  format?: string;
+  platform?: string;
+  avgEngagementRate?: number;
+  keywords?: string[];
+  hashtags?: string[];
+}
+
+export interface RequeueWinnerResult {
+  requeued: boolean;
+  reason?: string;
+  trendPreferencesId?: string;
+  addedKeywords?: string[];
+  addedPlatforms?: string[];
+}
+
+// Common English tokens with no signal value as trend keywords.
+const HOOK_STOP_WORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'and',
+  'are',
+  'but',
+  'for',
+  'from',
+  'has',
+  'have',
+  'how',
+  'into',
+  'its',
+  'new',
+  'not',
+  'our',
+  'out',
+  'that',
+  'the',
+  'their',
+  'them',
+  'they',
+  'this',
+  'was',
+  'were',
+  'what',
+  'when',
+  'why',
+  'will',
+  'with',
+  'you',
+  'your',
+]);
+
+const MAX_WINNER_KEYWORDS = 8;
+
 // ─── Service ─────────────────────────────────────────────────────────
 
 @Injectable()
@@ -90,6 +152,7 @@ export class ContentOptimizationService {
     private readonly optimizationCycleService: OptimizationCycleService,
     private readonly openAiLlmService: OpenAiLlmService,
     private readonly brandMemoryService: BrandMemoryService,
+    private readonly trendPreferencesService: TrendPreferencesService,
   ) {}
 
   // ─── 1. Content Performance Analysis ─────────────────────────────
@@ -365,6 +428,126 @@ export class ContentOptimizationService {
     });
 
     return { applied: true, suggestionId };
+  }
+
+  // ─── 4. Winner → Trend Feedback (issue #166) ─────────────────────
+
+  /**
+   * Close the core loop: when a content run's winning variant is identified,
+   * feed its signals (platform, hook keywords, format) back into the org/brand's
+   * trend preferences so future trend ingestion is biased toward what worked.
+   *
+   * Gated per-org/brand by the `autoRequeueWinners` trend preference (opt-in).
+   */
+  async requeueWinnerIntoTrends(
+    organizationId: string,
+    brandId: string | undefined,
+    winner: WinnerContentSignal,
+  ): Promise<RequeueWinnerResult> {
+    const caller = `${this.logContext}.requeueWinnerIntoTrends`;
+
+    const preferences = await this.trendPreferencesService.getPreferences(
+      organizationId,
+      brandId,
+    );
+
+    if (!preferences?.autoRequeueWinners) {
+      this.logger.log(`${caller} skipped — opt-in disabled or unset`, {
+        brandId,
+        contentRunId: winner.contentRunId,
+      });
+      return {
+        reason: 'winner_trend_enrichment_disabled_or_missing',
+        requeued: false,
+      };
+    }
+
+    const signals = this.deriveWinnerTrendSignals(winner);
+
+    if (signals.keywords.length === 0 && signals.platforms.length === 0) {
+      this.logger.log(`${caller} skipped — no usable trend signal`, {
+        brandId,
+        contentRunId: winner.contentRunId,
+      });
+      return { reason: 'no_signal', requeued: false };
+    }
+
+    const updated = await this.trendPreferencesService.mergeWinnerSignals(
+      organizationId,
+      brandId,
+      signals,
+    );
+
+    this.logger.log(caller, {
+      addedKeywords: signals.keywords,
+      addedPlatforms: signals.platforms,
+      brandId,
+      contentRunId: winner.contentRunId,
+    });
+
+    return {
+      addedKeywords: signals.keywords,
+      addedPlatforms: signals.platforms,
+      requeued: true,
+      trendPreferencesId: updated.id,
+    };
+  }
+
+  private deriveWinnerTrendSignals(winner: WinnerContentSignal): {
+    keywords: string[];
+    hashtags: string[];
+    platforms: string[];
+    categories: string[];
+  } {
+    const platform = this.normalizeToken(winner.platform);
+    const format = this.normalizeToken(winner.format);
+
+    const keywords = [
+      ...new Set(
+        [
+          ...this.tokenizeHook(winner.hook),
+          ...(format ? [format] : []),
+          ...(winner.keywords ?? []).map((keyword) =>
+            this.normalizeToken(keyword),
+          ),
+        ].filter((token): token is string => token.length > 0),
+      ),
+    ].slice(0, MAX_WINNER_KEYWORDS);
+
+    const hashtags = [
+      ...new Set(
+        (winner.hashtags ?? [])
+          .map((tag) => tag.trim())
+          .filter((tag) => tag.length > 0),
+      ),
+    ];
+
+    return {
+      categories: [],
+      hashtags,
+      keywords,
+      platforms: platform ? [platform] : [],
+    };
+  }
+
+  private tokenizeHook(hook: string | undefined): string[] {
+    if (!hook) {
+      return [];
+    }
+
+    return hook
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(
+        (token) =>
+          token.length >= 3 &&
+          !HOOK_STOP_WORDS.has(token) &&
+          !/^\d+$/.test(token),
+      );
+  }
+
+  private normalizeToken(value: string | undefined): string {
+    return typeof value === 'string' ? value.trim().toLowerCase() : '';
   }
 
   // ─── Private Helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the final gap in the 6-step core loop (`trends → remix → generate → publish → analytics → loop`): when a content run's **winning variant** is identified, its signals are now fed back into **trend ingestion** so future runs benefit from what already worked.

Today `ContentRunRecommendationsService.analyzeRun()` already detects a winner and emits a `clone_hook_into_trend` recommendation — but that recommendation was pure descriptive JSON that never touched the trends subsystem. This PR wires that seam through.

## What changed

- **`ContentOptimizationService.requeueWinnerIntoTrends()`** (new) — derives trend signals from a winning variant (platform, hook keywords, format), and merges them into the org/brand's `TrendPreferences`, biasing future trend ingestion/ranking toward proven content. Gated per-org/brand by a new opt-in flag.
- **`content-optimization.module.ts` now imports `TrendsModule`** (AC1).
- **Trigger** — `ContentRunRecommendationsService.analyzeRun()` calls the requeue for the detected winner, **best-effort**: a trend-enrichment failure is caught and logged and never breaks run analysis.
- **Feature flag** — `TrendPreferences.config.autoRequeueWinners` (per-org+brand, **default off = opt-in**), following the existing `AdOptimizationConfig` persisted-config precedent rather than the global env `FeatureFlagService` (which fails open and has no per-org storage). Exposed via `SaveTrendPreferencesDto` so orgs can opt in through `POST /trends/preferences`.
- **`TrendPreferencesService`** gains `mergeWinnerSignals()` (unions signals into existing prefs, preserves the flag) + flag normalization/persistence. No Prisma migration — reuses the existing `config` JSON column.

## Design notes

- The winner is a *computed* top-ranked variant (`scores[0]`), not a persisted status — so the hook lives at the single point winners are actually determined (`analyzeRun`), passing the signal into `ContentOptimizationService` per the issue's acceptance criteria.
- Enrichment biases **trend preferences** (the org's ingestion/ranking inputs) rather than fabricating synthetic `Trend` rows, which keeps the change migration-free and side-effect-safe.
- Module imports use `forwardRef` (repo convention); no new circular dependencies.

## Acceptance criteria

- [x] `content-optimization.module.ts` imports `TrendsModule`
- [x] `ContentOptimizationService` has a wired path from winner → trend enrichment
- [x] Integration test: flagging a run as winner triggers a trend update
- [x] Feature flag respected (opt-in vs opt-out per org)

## Verification

- ✅ `vitest run` on the 3 affected spec files — **36/36 pass** (new: winner→trend trigger, flag gating on/off/no-signal, signal merge + flag persistence, best-effort non-fatal)
- ✅ Biome check (format + lint + import-organize) clean on all 11 files
- ✅ Scoped `tsc --noEmit` (api `tsconfig.typecheck.json`) — no type errors in touched files (only a pre-existing `baseUrl` TS7 deprecation warning in the config, unrelated)
- ⚠️ Full workspace typecheck/build + e2e left to CI (Mac Studio was unreachable this session)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)