### PR TITLE
[codex] Guard Agent thread ids

### DIFF
--- a/packages/agent/src/components/AgentThreadList.spec.tsx
+++ b/packages/agent/src/components/AgentThreadList.spec.tsx
@@ -314,6 +314,24 @@ describe('AgentThreadList', () => {
     expect(threadLink?.parentElement).toHaveClass('h-9');
   });
 
+  it('does not render malformed threads without usable ids', async () => {
+    const malformedThread = {
+      ...createThread('conv-bad', 'Malformed thread'),
+      id: undefined as unknown as string,
+    };
+    const validThread = createThread('conv-1', 'Valid thread');
+    const apiService = createApiService({
+      getThreads: vi.fn().mockResolvedValue([malformedThread, validThread]),
+      unarchiveThread: vi.fn(),
+    });
+
+    render(<AgentThreadList apiService={apiService as never} />);
+
+    expect(await screen.findByText('Valid thread')).toBeInTheDocument();
+    expect(screen.queryByText('Malformed thread')).toBeNull();
+    expect(document.querySelector('a[href="/agent/undefined"]')).toBeNull();
+  });
+
   it('clears the active thread and navigates away when archived', async () => {
     const thread = createThread('conv-1', 'Current chat');
     storeState.activeThreadId = 'conv-1';

--- a/packages/agent/src/components/agent-thread-list.helpers.ts
+++ b/packages/agent/src/components/agent-thread-list.helpers.ts
@@ -123,6 +123,17 @@ export function sortThreads(threads: AgentThread[]): AgentThread[] {
   });
 }
 
+export function hasRenderableThreadId(thread: AgentThread): boolean {
+  const threadId = thread.id;
+
+  return (
+    typeof threadId === 'string' &&
+    threadId.trim().length > 0 &&
+    threadId !== 'undefined' &&
+    threadId !== 'null'
+  );
+}
+
 export function isAuthError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;

--- a/packages/agent/src/components/useAgentThreadList.ts
+++ b/packages/agent/src/components/useAgentThreadList.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AGENT_REFRESH_CONVERSATIONS_EVENT,
   getErrorMessage,
+  hasRenderableThreadId,
   isAuthError,
   sortThreads,
 } from './agent-thread-list.helpers';
@@ -88,20 +89,22 @@ export function useAgentThreadList({
       );
       setAuthError(null);
       setLoadError(null);
+      const renderableData = data.filter(hasRenderableThreadId);
       const { threads: current, activeThreadId: currentActiveId } =
         useAgentChatStore.getState();
-      const apiIds = new Set(data.map((item) => item.id));
+      const renderableCurrent = current.filter(hasRenderableThreadId);
+      const apiIds = new Set(renderableData.map((item) => item.id));
 
       const activeThread =
         currentActiveId && !apiIds.has(currentActiveId)
-          ? current.find((t) => t.id === currentActiveId)
+          ? renderableCurrent.find((t) => t.id === currentActiveId)
           : null;
 
       const RECENT_THRESHOLD_MS = 15_000;
       const now = Date.now();
       const recentLocalThreads =
         viewStatus === AgentThreadStatus.ACTIVE
-          ? current.filter(
+          ? renderableCurrent.filter(
               (thread) =>
                 !apiIds.has(thread.id) &&
                 thread.id !== currentActiveId &&
@@ -114,7 +117,7 @@ export function useAgentThreadList({
       const preserved = activeThread
         ? [activeThread, ...recentLocalThreads]
         : recentLocalThreads;
-      setThreads(sortThreads([...preserved, ...data]));
+      setThreads(sortThreads([...preserved, ...renderableData]));
       return true;
     } catch (error) {
       if (abortRef.current?.signal.aborted) {
@@ -486,20 +489,27 @@ export function useAgentThreadList({
 
   const isArchivedView = viewStatus === AgentThreadStatus.ARCHIVED;
 
-  const pinnedThreads = useMemo(
-    () => threads.filter((thread) => thread.isPinned),
+  const renderableThreads = useMemo(
+    () => threads.filter(hasRenderableThreadId),
     [threads],
   );
+  const pinnedThreads = useMemo(
+    () => renderableThreads.filter((thread) => thread.isPinned),
+    [renderableThreads],
+  );
   const regularThreads = useMemo(
-    () => threads.filter((thread) => !thread.isPinned),
-    [threads],
+    () => renderableThreads.filter((thread) => !thread.isPinned),
+    [renderableThreads],
   );
 
   const shouldShowEmptyState =
-    !isLoading && !authError && !loadError && threads.length === 0;
+    !isLoading && !authError && !loadError && renderableThreads.length === 0;
 
   const shouldShowLoadFailureState =
-    !isLoading && !authError && Boolean(loadError) && threads.length === 0;
+    !isLoading &&
+    !authError &&
+    Boolean(loadError) &&
+    renderableThreads.length === 0;
 
   const shouldShowHeader =
     !authError && !shouldShowLoadFailureState && !isLoading;
@@ -517,7 +527,7 @@ export function useAgentThreadList({
   }, [loadThreads]);
 
   return {
-    threads,
+    threads: renderableThreads,
     activeThreadId,
     activeRunStatus,
     isStreaming,

--- a/packages/hooks/commands/use-agent-thread-commands/use-agent-thread-commands.test.ts
+++ b/packages/hooks/commands/use-agent-thread-commands/use-agent-thread-commands.test.ts
@@ -37,6 +37,26 @@ describe('useAgentThreadCommands', () => {
     );
   });
 
+  it('does not register commands for malformed thread ids', () => {
+    renderHook(() =>
+      useAgentThreadCommands({
+        onNavigate: vi.fn(),
+        threads: [
+          { id: undefined as unknown as string, title: 'Missing id' },
+          { id: 'undefined', title: 'Undefined id' },
+          { id: 'thread-1', title: 'First thread' },
+        ],
+      }),
+    );
+
+    expect(registerCommand).toHaveBeenCalledTimes(1);
+    expect(registerCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'agent-thread-thread-1',
+      }),
+    );
+  });
+
   it('does not churn commands when the thread ids and labels are unchanged', () => {
     const { rerender } = renderHook(
       ({

--- a/packages/hooks/commands/use-agent-thread-commands/use-agent-thread-commands.ts
+++ b/packages/hooks/commands/use-agent-thread-commands/use-agent-thread-commands.ts
@@ -17,6 +17,15 @@ export interface UseAgentThreadCommandsOptions {
   enabled?: boolean;
 }
 
+function hasCommandThreadId(thread: AgentThreadCommandItem): boolean {
+  return (
+    typeof thread.id === 'string' &&
+    thread.id.trim().length > 0 &&
+    thread.id !== 'undefined' &&
+    thread.id !== 'null'
+  );
+}
+
 export function useAgentThreadCommands({
   threads,
   onNavigate,
@@ -28,7 +37,7 @@ export function useAgentThreadCommands({
 
   const commands = useMemo<ICommand[]>(
     () =>
-      threads.map((thread) => {
+      threads.filter(hasCommandThreadId).map((thread) => {
         const title = thread.title || 'Untitled Thread';
         const titleWords = title.toLowerCase().split(/\s+/);
 


### PR DESCRIPTION
## Summary
- filter malformed Agent threads with missing, empty, `undefined`, or `null` ids before rendering the conversation list
- apply the same guard to command palette thread registration
- add regression coverage so `/agent/undefined` links are not emitted

## Root cause
The Agent thread list assumed every API/store thread had a valid string id. Production contained at least one malformed/legacy item, which rendered a row link to `/agent/undefined` and triggered failed snapshot requests.

## Validation
- `bunx biome check --write packages/agent/src/components/agent-thread-list.helpers.ts packages/agent/src/components/useAgentThreadList.ts packages/agent/src/components/AgentThreadList.spec.tsx packages/hooks/commands/use-agent-thread-commands/use-agent-thread-commands.ts packages/hooks/commands/use-agent-thread-commands/use-agent-thread-commands.test.ts`
- `bun run --cwd packages/agent test src/components/AgentThreadList.spec.tsx`
- `bun run --cwd packages/hooks test commands/use-agent-thread-commands/use-agent-thread-commands.test.ts`
- commit hook: staged secretlint, Biome, raw HTML guard

Addresses #1119