### PR TITLE
[codex] Fix admin global navigation links

### DIFF
--- a/apps/app/app/(protected)/admin/configuration/elements/layout.tsx
+++ b/apps/app/app/(protected)/admin/configuration/elements/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import ButtonRefresh from '@components/buttons/refresh/button-refresh/ButtonRefresh';
+import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant, IngredientCategory, ModalEnum } from '@genfeedai/enums';
 import type { IFiltersState } from '@genfeedai/interfaces/utils/filters.interface';
 import { openModal } from '@helpers/ui/modal/modal.helper';
@@ -142,7 +143,7 @@ export default function ElementsLayout({ children }: LayoutProps) {
         >((tabs, type) => {
           if (type !== 'font-families') {
             tabs.push({
-              href: `/configuration/elements/${type}`,
+              href: `${APP_ROUTES.ADMIN.CONFIGURATION.ELEMENTS}/${type}`,
               label: ELEMENT_LABELS[type].label,
             });
           }

--- a/apps/app/app/(protected)/admin/overview/dashboard/overview-page.tsx
+++ b/apps/app/app/(protected)/admin/overview/dashboard/overview-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant } from '@genfeedai/enums';
 import type { OverviewCard } from '@genfeedai/interfaces/ui/overview-card.interface';
 import { cn } from '@helpers/formatting/cn/cn.util';
@@ -46,7 +47,7 @@ const quickActionCards: OverviewCard[] = [
     color: 'bg-white/5 text-foreground',
     cta: 'Manage Users',
     description: 'Accounts, roles, and permissions',
-    href: '/administration/users',
+    href: APP_ROUTES.ADMIN.ADMINISTRATION.USERS,
     icon: HiOutlineUserGroup,
     id: 'users',
     label: 'Users',
@@ -55,7 +56,7 @@ const quickActionCards: OverviewCard[] = [
     color: 'bg-white/5 text-foreground',
     cta: 'View Elements',
     description: 'Presets, blacklists, and settings',
-    href: '/configuration/elements/blacklists',
+    href: APP_ROUTES.ADMIN.CONFIGURATION.ELEMENTS_BLACKLISTS,
     icon: HiOutlineTag,
     id: 'elements',
     label: 'Elements',
@@ -64,7 +65,7 @@ const quickActionCards: OverviewCard[] = [
     color: 'bg-white/5 text-foreground',
     cta: 'View Posts',
     description: 'Posts, performance, and metrics',
-    href: '/content/posts',
+    href: APP_ROUTES.ADMIN.CONTENT.POSTS,
     icon: HiOutlineNewspaper,
     id: 'posts',
     label: 'Posts',

--- a/packages/interfaces/src/ui/menu-config.interface.ts
+++ b/packages/interfaces/src/ui/menu-config.interface.ts
@@ -18,7 +18,7 @@ export type AppContext =
 
 export interface MenuItemConfig {
   href?: string;
-  hrefScope?: 'brand' | 'organization' | 'personal';
+  hrefScope?: 'brand' | 'global' | 'organization' | 'personal';
   label: string;
   icon?: ReactNode;
   outline?: ComponentType<{ className?: string }>;

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -156,8 +156,16 @@ vi.mock('@genfeedai/hooks/data/overview/use-overview-bootstrap', () => ({
 }));
 
 vi.mock('@ui/menus/item/MenuItem', () => ({
-  default: ({ badgeCount, label }: { badgeCount?: number; label: string }) => (
-    <div data-testid="menu-item">
+  default: ({
+    badgeCount,
+    href,
+    label,
+  }: {
+    badgeCount?: number;
+    href?: string;
+    label: string;
+  }) => (
+    <div data-href={href} data-testid="menu-item">
       {label}
       {badgeCount ? ` (${badgeCount})` : ''}
     </div>
@@ -408,6 +416,26 @@ describe('MenuShared', () => {
 
     expect(screen.getByTestId('sidebar-secondary-items')).toBeInTheDocument();
     expect(screen.getByText('Activity')).toBeInTheDocument();
+  });
+
+  it('keeps globally scoped menu hrefs unprefixed', () => {
+    const globalConfig: MenuConfig = {
+      items: [
+        {
+          href: '/admin/agent',
+          hrefScope: 'global',
+          label: 'Agent',
+        },
+      ],
+      logoHref: '/',
+    };
+
+    render(<MenuShared config={globalConfig} />);
+
+    expect(screen.getByText('Agent')).toHaveAttribute(
+      'data-href',
+      '/admin/agent',
+    );
   });
 
   it('does not reuse raw href keys for settings items with different scopes', () => {

--- a/packages/ui/src/components/menus/shared/useMenuShared.ts
+++ b/packages/ui/src/components/menus/shared/useMenuShared.ts
@@ -113,6 +113,10 @@ export function useMenuShared({
         return path;
       }
 
+      if (item.hrefScope === 'global') {
+        return path;
+      }
+
       if (item.hrefScope === 'personal') {
         return path;
       }
@@ -179,7 +183,11 @@ export function useMenuShared({
         return false;
       }
 
-      if (item.hrefScope && item.hrefScope !== routeScope) {
+      if (
+        item.hrefScope &&
+        item.hrefScope !== 'global' &&
+        item.hrefScope !== routeScope
+      ) {
         return false;
       }
 

--- a/packages/ui/src/components/shell/menus/AdminSidebar.tsx
+++ b/packages/ui/src/components/shell/menus/AdminSidebar.tsx
@@ -3,6 +3,7 @@
 import type { MenuConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import type { MenuSharedProps } from '@genfeedai/props/navigation/menu.props';
 import MenuShared from '@ui/menus/shared/MenuShared';
+import { useMemo } from 'react';
 
 export interface AdminSidebarProps extends Partial<MenuSharedProps> {
   items: MenuConfig['items'];
@@ -16,10 +17,16 @@ export default function AdminSidebar({
   items,
   logoHref = '/',
 }: AdminSidebarProps) {
-  const config: MenuConfig = {
-    items,
-    logoHref,
-  };
+  const config = useMemo<MenuConfig>(
+    () => ({
+      items: items.map((item) => ({
+        ...item,
+        hrefScope: 'global',
+      })),
+      logoHref,
+    }),
+    [items, logoHref],
+  );
 
   return (
     <MenuShared


### PR DESCRIPTION
## Summary
- add a `global` menu href scope so admin navigation is not rewritten through org/brand route helpers
- apply global scope inside `AdminSidebar`
- fix admin elements tabs and dashboard quick actions that were missing the `/admin` prefix

## Root cause
The shared sidebar treated admin menu paths like brand-scoped app paths, so `/admin/...` destinations were rewritten under `/genfeed/<brand>/admin/...` and produced 404s.

## Validation
- `bunx biome check --write packages/interfaces/src/ui/menu-config.interface.ts packages/ui/src/components/menus/shared/useMenuShared.ts packages/ui/src/components/shell/menus/AdminSidebar.tsx 'apps/app/app/(protected)/admin/configuration/elements/layout.tsx' 'apps/app/app/(protected)/admin/overview/dashboard/overview-page.tsx' packages/ui/src/components/menus/shared/MenuShared.test.tsx`
- `bun run --cwd packages/ui test src/components/menus/shared/MenuShared.test.tsx`
- commit hook: staged secretlint, Biome, raw HTML guard

Fixes #1120