### PR TITLE
[codex] Preserve Agent route when switching brands

### DIFF
--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -26,7 +26,7 @@ import CloudSyncIndicator from '@/components/cloud-sync-indicator/CloudSyncIndic
 import { isHostedCloudApp } from '@/lib/config/edition';
 import {
   appendSearchParamsToHref,
-  getCurrentBrandScopedPath,
+  getBrandSwitchHref,
 } from '@/lib/navigation/operator-shell';
 
 const TOPBAR_BREADCRUMB_ROOT_LABELS: Record<
@@ -100,7 +100,11 @@ function AppProtectedTopbarContent({
 
       if (nextOrgSlug && nextBrand?.slug) {
         push(
-          `/${nextOrgSlug}/${nextBrand.slug}${getCurrentBrandScopedPath(pathname)}`,
+          getBrandSwitchHref({
+            nextBrandSlug: nextBrand.slug,
+            nextOrgSlug,
+            pathname,
+          }),
         );
       }
     },

--- a/apps/app/src/lib/navigation/operator-shell.spec.ts
+++ b/apps/app/src/lib/navigation/operator-shell.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   appendSearchParamsToHref,
   buildTaskLaunchHref,
+  getBrandSwitchHref,
   getCurrentBrandScopedPath,
   normalizeProtectedPathname,
   pickOperatorTaskContextSearchParams,
@@ -32,6 +33,34 @@ describe('operator-shell helpers', () => {
     expect(getCurrentBrandScopedPath('/acme/~/overview')).toBe(
       '/workspace/overview',
     );
+  });
+
+  it('keeps org-scoped app surfaces when switching brands', () => {
+    expect(
+      getBrandSwitchHref({
+        nextBrandSlug: 'sunrise',
+        nextOrgSlug: 'acme',
+        pathname: '/acme/~/agent',
+      }),
+    ).toBe('/acme/~/agent');
+
+    expect(
+      getBrandSwitchHref({
+        nextBrandSlug: 'sunrise',
+        nextOrgSlug: 'acme',
+        pathname: '/acme/~/agent/thread-1',
+      }),
+    ).toBe('/acme/~/agent/thread-1');
+  });
+
+  it('keeps brand-scoped app paths when switching brands', () => {
+    expect(
+      getBrandSwitchHref({
+        nextBrandSlug: 'sunrise',
+        nextOrgSlug: 'acme',
+        pathname: '/acme/moonrise/studio/video',
+      }),
+    ).toBe('/acme/sunrise/studio/video');
   });
 
   it('picks and appends only task context params', () => {

--- a/apps/app/src/lib/navigation/operator-shell.ts
+++ b/apps/app/src/lib/navigation/operator-shell.ts
@@ -69,6 +69,24 @@ export function getCurrentBrandScopedPath(pathname: string): string {
   return APP_ROUTES.WORKSPACE.OVERVIEW;
 }
 
+export function getBrandSwitchHref({
+  nextBrandSlug,
+  nextOrgSlug,
+  pathname,
+}: {
+  nextBrandSlug: string;
+  nextOrgSlug: string;
+  pathname: string;
+}): string {
+  const parts = pathname.split('/').filter(Boolean);
+
+  if (parts.length >= 3 && parts[1] === '~') {
+    return `/${nextOrgSlug}/~/${parts.slice(2).join('/')}`;
+  }
+
+  return `/${nextOrgSlug}/${nextBrandSlug}${getCurrentBrandScopedPath(pathname)}`;
+}
+
 export function pickOperatorTaskContextSearchParams(
   searchParams: URLSearchParams,
 ): URLSearchParams {

--- a/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.test.tsx
+++ b/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.test.tsx
@@ -30,10 +30,11 @@ vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
   }),
 }));
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useUser: () => ({
+vi.mock('@genfeedai/hooks/auth/use-auth-user/use-auth-user', () => ({
+  useAuthUser: () => ({
     user: {
       id: 'user_123',
+      reload: vi.fn(),
     },
   }),
 }));

--- a/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.tsx
+++ b/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.tsx
@@ -45,11 +45,16 @@ export default function MenuBrandSwitcher({
         const service = await getUsersService();
         await service.patchMeBrand(id, { isSelected: true });
         logger.info(`${url} success`);
-        await user?.reload();
         onBrandChange?.(id);
-        setIsUpdatingBrand(false);
+        const reloadPromise = user?.reload();
+        if (reloadPromise) {
+          void reloadPromise.catch((reloadError: unknown) => {
+            logger.warn(`${url} reload failed`, reloadError);
+          });
+        }
       } catch (error) {
         logger.error(`${url} failed`, error);
+      } finally {
         setIsUpdatingBrand(false);
       }
     },


### PR DESCRIPTION
## Summary
- preserve org-scoped app surfaces such as `/genfeed/~/agent` when changing brands
- keep existing same-path brand switching behavior for brand-scoped routes
- stop blocking brand navigation on `user.reload()` after the selected brand PATCH succeeds

## Root cause
The topbar brand switch handler always built `/:org/:brand/<current-brand-path>`. For org-scoped paths, `getCurrentBrandScopedPath()` falls back to Workspace, so Agent brand switching redirected to Workspace.

## Validation
- `bunx biome check --write apps/app/src/lib/navigation/operator-shell.ts apps/app/src/components/shell/AppProtectedTopbar.tsx apps/app/src/lib/navigation/operator-shell.spec.ts packages/ui/src/components/menus/switchers/MenuBrandSwitcher.tsx`
- `bun run --cwd apps/app test src/lib/navigation/operator-shell.spec.ts`
- `bun run --cwd packages/ui test src/components/menus/switchers/MenuBrandSwitcher.test.tsx`
- commit hook: staged secretlint, Biome, raw HTML guard

Fixes #1121