### PR TITLE
[codex] Gate Vercel Insights providers

### DIFF
--- a/apps/app/app/layout.test.tsx
+++ b/apps/app/app/layout.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const appProvidersSpy = vi.fn();
 
@@ -60,7 +60,23 @@ vi.mock('@ui/shell/metadata', () => ({
 }));
 
 describe('app root layout', () => {
+  const originalVercelEnv = process.env.VERCEL;
+
+  beforeEach(() => {
+    appProvidersSpy.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalVercelEnv === undefined) {
+      delete process.env.VERCEL;
+      return;
+    }
+
+    process.env.VERCEL = originalVercelEnv;
+  });
+
   it('boots the app with a single root AppProviders wrapper', async () => {
+    process.env.VERCEL = '1';
     const { default: RootLayout } = await import('./layout');
 
     render(
@@ -78,6 +94,24 @@ describe('app root layout', () => {
         includeVercelAnalytics: true,
         initialTheme: 'dark',
         storageKey: 'theme',
+      }),
+    );
+  });
+
+  it('does not inject Vercel providers outside the Vercel runtime', async () => {
+    delete process.env.VERCEL;
+    const { default: RootLayout } = await import('./layout');
+
+    render(
+      await RootLayout({
+        children: <div>App child</div>,
+      } as never),
+    );
+
+    expect(appProvidersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeSpeedInsights: false,
+        includeVercelAnalytics: false,
       }),
     );
   });

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -39,6 +39,7 @@ function createRuntimeConfigScript(): string {
 export default async function RootLayout({ children }: LayoutProps) {
   const initialTheme = await resolveRequestTheme();
   const isDesktopShell = process.env.NEXT_PUBLIC_DESKTOP_SHELL === '1';
+  const isVercelRuntime = process.env.VERCEL === '1';
   const bodyClassName = isDesktopShell
     ? 'gf-app gf-desktop-shell gf-studio-app'
     : 'gf-app gf-studio-app';
@@ -56,8 +57,8 @@ export default async function RootLayout({ children }: LayoutProps) {
         initialTheme={initialTheme}
         storageKey={THEME_STORAGE_KEY}
         googleAnalyticsId={googleAnalyticsId}
-        includeSpeedInsights={!isDesktopShell}
-        includeVercelAnalytics={!isDesktopShell}
+        includeSpeedInsights={!isDesktopShell && isVercelRuntime}
+        includeVercelAnalytics={!isDesktopShell && isVercelRuntime}
       >
         <Script id="genfeed-runtime-config" strategy="beforeInteractive">
           {createRuntimeConfigScript()}


### PR DESCRIPTION
## Summary
- enable Vercel Analytics and Speed Insights only when the app is actually running in Vercel
- keep Google Analytics behavior unchanged
- add coverage for Vercel and non-Vercel root layout provider flags

## Root cause
The app injected Vercel providers for every non-desktop shell, including non-Vercel production. That caused `/_vercel/insights/script.js` to be requested where the platform route does not exist.

## Validation
- `bunx biome check --write apps/app/app/layout.tsx apps/app/app/layout.test.tsx`
- `bun run --cwd apps/app test app/layout.test.tsx`
- commit hook: staged secretlint, Biome, raw HTML guard

Fixes #1122