### PR TITLE
[codex] Remove Agent workspace back row

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutAgentSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutAgentSidebar.tsx
@@ -3,7 +3,6 @@
 import { APP_ROUTES } from '@genfeedai/constants';
 import { Kbd } from '@genfeedai/ui';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
-import SidebarBackRow from '@ui/menus/sidebar-back-row/SidebarBackRow';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { HiPlus } from 'react-icons/hi2';
@@ -17,15 +16,10 @@ export default function AgentSidebarContent({
   conversationActions,
   renderConversations,
 }: Props) {
-  const { href, orgHref } = useOrgUrl();
+  const { orgHref } = useOrgUrl();
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <SidebarBackRow
-        label="Workspace"
-        href={href(APP_ROUTES.WORKSPACE.OVERVIEW)}
-      />
-
       <div className="flex min-h-0 flex-1 flex-col px-3 pb-2 pt-2">
         <div className="flex items-center justify-between px-3 pb-2">
           <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-white/35">

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -834,6 +834,36 @@ describe('AppProtectedLayout', () => {
     expect(screen.queryByTestId('agent-thread-list')).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['/studio/image', 'studio', 'Studio'],
+    ['/library/ingredients', 'library', 'Library'],
+    ['/analytics/overview', 'analytics', 'Analytics'],
+    ['/workflows', 'workflows', 'Workflows'],
+  ])('does not render a Workspace back row for the %s app-switcher surface', (pathname, currentApp, sectionLabel) => {
+    mockPathname.value = pathname;
+
+    render(
+      <AppProtectedLayout>
+        <div>Protected content</div>
+      </AppProtectedLayout>,
+    );
+
+    const sidebarProps = appSidebarSpy.mock.calls.at(-1)?.[0];
+
+    expect(sidebarProps).toEqual(
+      expect.objectContaining({
+        currentApp,
+        sectionLabel,
+        shellChromeVariant: 'default',
+      }),
+    );
+    expect(sidebarProps).not.toHaveProperty('backHref');
+    expect(sidebarProps).not.toHaveProperty('backLabel');
+    expect(
+      screen.queryByRole('link', { name: 'Back to Workspace' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('filters disabled studio categories from the dedicated studio sidebar', () => {
     mockPathname.value = '/studio/image';
     enabledCategoriesState.enabledCategories = ['image', 'video', 'avatar'];

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -650,8 +650,8 @@ describe('AppProtectedLayout', () => {
       screen.queryByTestId('sidebar-search-trigger'),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'Back to Workspace' }),
-    ).toHaveAttribute('href', '/org-123/brand-123/workspace/overview');
+      screen.queryByRole('link', { name: 'Back to Workspace' }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText('Conversations')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Workspace' }),


### PR DESCRIPTION
## Summary
- Remove the redundant Back to Workspace row from the focused Agent sidebar.
- Keep the Agent sidebar focused on Conversations and New Thread.
- Add regression coverage that Studio, Library, Analytics, and Workflows app-switcher surfaces do not receive Workspace back-row props.

Addresses #1119.

## Tests
- bunx biome check --write apps/app/packages/components/AppProtectedLayoutAgentSidebar.tsx apps/app/packages/components/app-protected-layout.test.tsx
- bun run --cwd apps/app test packages/components/app-protected-layout.test.tsx
- bun run design:lint (0 errors; existing DESIGN.md warnings only)
- staged secret scan: no matches
- commit hook: secretlint, Biome, raw HTML guard