### PR TITLE
[codex] Fix Research sidebar navigation

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -6,6 +6,7 @@ import { COMPOSE_LOGO_HREF } from '@app-config/compose-menu-items.config';
 import { LIBRARY_LOGO_HREF } from '@app-config/library-menu-items.config';
 import { APP_LOGO_HREF } from '@app-config/menu-items.config';
 import { ORG_LOGO_HREF } from '@app-config/org-menu-items.config';
+import { RESEARCH_LOGO_HREF } from '@app-config/research-menu-items.config';
 import { SETTINGS_LOGO_HREF } from '@app-config/settings-menu-items.config';
 import { STUDIO_LOGO_HREF } from '@app-config/studio-menu-items.config';
 import { WORKFLOWS_LOGO_HREF } from '@app-config/workflows-menu-items.config';
@@ -41,6 +42,7 @@ type Props = {
   isFocusedOnboardingRoute: boolean;
   isLibraryRoute: boolean;
   isOrgRoute: boolean;
+  isResearchRoute: boolean;
   isSettingsRoute: boolean;
   isStudioRoute: boolean;
   isWorkflowsRoute: boolean;
@@ -50,6 +52,7 @@ type Props = {
   libraryMenuItems: MenuItemConfig[];
   menuItems: MenuItemConfig[];
   orgMenuItems: MenuItemConfig[];
+  researchMenuItems: MenuItemConfig[];
   secondaryMenuItems: MenuItemConfig[];
   settingsMenuItems: MenuItemConfig[];
   studioMenuItems: MenuItemConfig[];
@@ -71,6 +74,7 @@ export default function AppProtectedLayoutSidebar({
   isFocusedOnboardingRoute,
   isLibraryRoute,
   isOrgRoute,
+  isResearchRoute,
   isSettingsRoute,
   isStudioRoute,
   isWorkflowsRoute,
@@ -80,6 +84,7 @@ export default function AppProtectedLayoutSidebar({
   libraryMenuItems,
   menuItems,
   orgMenuItems,
+  researchMenuItems,
   secondaryMenuItems,
   settingsMenuItems,
   studioMenuItems,
@@ -197,6 +202,22 @@ export default function AppProtectedLayoutSidebar({
         )}
         currentApp={currentApp}
         sectionLabel="Analytics"
+        shellChromeVariant={shellChromeVariant}
+        orgSwitcherSlot={orgSwitcherSlot}
+      />
+    );
+  }
+
+  if (isResearchRoute) {
+    return (
+      <AppSidebar
+        items={researchMenuItems}
+        logoHref={withTaskContextHref(
+          buildHref(RESEARCH_LOGO_HREF),
+          taskContextSearchParams,
+        )}
+        currentApp={currentApp}
+        sectionLabel="Research"
         shellChromeVariant={shellChromeVariant}
         orgSwitcherSlot={orgSwitcherSlot}
       />

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -199,6 +199,15 @@ vi.mock('@app-config/menu-items.config', () => ({
   POSTS_INSERT_AFTER_LABEL: 'Posts',
 }));
 
+vi.mock('@app-config/research-menu-items.config', () => ({
+  RESEARCH_LOGO_HREF: '/research/discovery',
+  RESEARCH_MENU_ITEMS: [
+    { href: '/research/discovery', label: 'Discovery' },
+    { href: '/research/socials', label: 'Socials' },
+    { href: '/research/ads', label: 'Ads' },
+  ],
+}));
+
 vi.mock('@contexts/features/command-palette.provider', () => ({
   CommandPaletteProvider: ({ children }: { children: ReactNode }) => (
     <>{children}</>
@@ -850,6 +859,39 @@ describe('AppProtectedLayout', () => {
           expect.objectContaining({
             href: '/studio/music',
             label: 'Music',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('renders a dedicated research sidebar on research routes', () => {
+    mockPathname.value = '/research/discovery';
+
+    render(
+      <AppProtectedLayout>
+        <div>Protected content</div>
+      </AppProtectedLayout>,
+    );
+
+    expect(appSidebarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentApp: 'research',
+        items: [
+          { href: '/research/discovery', label: 'Discovery' },
+          { href: '/research/socials', label: 'Socials' },
+          { href: '/research/ads', label: 'Ads' },
+        ],
+        sectionLabel: 'Research',
+        shellChromeVariant: 'default',
+      }),
+    );
+    expect(appSidebarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: expect.not.arrayContaining([
+          expect.objectContaining({
+            href: '/workspace',
+            label: 'Workspace',
           }),
         ]),
       }),

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -114,6 +114,7 @@ function AppLayoutWithDynamicMenu({
     isMoodboardRoute,
     isOrgRoute,
     isPromptBarRoute,
+    isResearchRoute,
     isSettingsRoute,
     isStudioRoute,
     isWorkflowsRoute,
@@ -132,6 +133,7 @@ function AppLayoutWithDynamicMenu({
     libraryMenuItems,
     menuItems,
     orgMenuItems,
+    researchMenuItems,
     secondaryMenuItems,
     settingsMenuItems,
     studioMenuItems,
@@ -176,6 +178,7 @@ function AppLayoutWithDynamicMenu({
         isFocusedOnboardingRoute={isFocusedOnboardingRoute}
         isLibraryRoute={isLibraryRoute}
         isOrgRoute={isOrgRoute}
+        isResearchRoute={isResearchRoute}
         isSettingsRoute={isSettingsRoute}
         isStudioRoute={isStudioRoute}
         isWorkflowsRoute={isWorkflowsRoute}
@@ -185,6 +188,7 @@ function AppLayoutWithDynamicMenu({
         libraryMenuItems={libraryMenuItems}
         menuItems={menuItems}
         orgMenuItems={orgMenuItems}
+        researchMenuItems={researchMenuItems}
         secondaryMenuItems={secondaryMenuItems}
         settingsMenuItems={settingsMenuItems}
         studioMenuItems={studioMenuItems}
@@ -211,12 +215,14 @@ function AppLayoutWithDynamicMenu({
     isLibraryRoute,
     isMoodboardRoute,
     isOrgRoute,
+    isResearchRoute,
     isSettingsRoute,
     isStudioRoute,
     isWorkflowsRoute,
     libraryMenuItems,
     menuItems,
     orgMenuItems,
+    researchMenuItems,
     renderConversations,
     secondaryMenuItems,
     settingsMenuItems,

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -8,6 +8,7 @@ import {
   POSTS_INSERT_AFTER_LABEL,
 } from '@app-config/menu-items.config';
 import { ORG_MENU_ITEMS } from '@app-config/org-menu-items.config';
+import { RESEARCH_MENU_ITEMS } from '@app-config/research-menu-items.config';
 import { SETTINGS_MENU_ITEMS } from '@app-config/settings-menu-items.config';
 import { STUDIO_MENU_ITEMS } from '@app-config/studio-menu-items.config';
 import { WORKFLOWS_MENU_ITEMS } from '@app-config/workflows-menu-items.config';
@@ -113,7 +114,9 @@ export function useAppProtectedLayout(
     APP_ROUTES.AGENT.ONBOARDING,
   );
   const isComposeRoute = pathname.startsWith(COMPOSE_ROUTES.ROOT);
-  const isResearchRoute = pathname.startsWith('/research');
+  const isResearchRoute =
+    pathname === APP_ROUTES.RESEARCH.ROOT ||
+    pathname.startsWith(`${APP_ROUTES.RESEARCH.ROOT}/`);
   const isLibraryLandingRoute = pathname === APP_ROUTES.LIBRARY.INGREDIENTS;
   const isLibraryRoute = pathname.startsWith(APP_ROUTE_PREFIXES.LIBRARY);
   const isMessagesRoute = pathname.startsWith(APP_ROUTE_PREFIXES.MESSAGES);
@@ -469,6 +472,17 @@ export function useAppProtectedLayout(
     [taskContextSearchParams],
   );
 
+  const researchMenuItems = useMemo(
+    () =>
+      RESEARCH_MENU_ITEMS.map(
+        (item): MenuItemConfig => ({
+          ...item,
+          href: withTaskContextHref(item.href, taskContextSearchParams),
+        }),
+      ),
+    [taskContextSearchParams],
+  );
+
   const orgMenuItems = useMemo(
     () =>
       ORG_MENU_ITEMS.map(
@@ -521,6 +535,7 @@ export function useAppProtectedLayout(
     isMoodboardRoute,
     isOrgRoute,
     isPromptBarRoute,
+    isResearchRoute,
     isSettingsRoute,
     isStudioRoute,
     isWorkflowsRoute,
@@ -543,6 +558,7 @@ export function useAppProtectedLayout(
     libraryMenuItems,
     menuItems,
     orgMenuItems,
+    researchMenuItems,
     secondaryMenuItems,
     settingsMenuItems,
     studioMenuItems,

--- a/apps/app/packages/config/research-menu-items.config.test.ts
+++ b/apps/app/packages/config/research-menu-items.config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RESEARCH_LOGO_HREF,
+  RESEARCH_MENU_ITEMS,
+} from './research-menu-items.config';
+
+describe('RESEARCH_MENU_ITEMS', () => {
+  it('points the logo at Research Discovery', () => {
+    expect(RESEARCH_LOGO_HREF).toBe('/research/discovery');
+  });
+
+  it('renders the Research entrypoints only', () => {
+    expect(RESEARCH_MENU_ITEMS.map((item) => item.label)).toEqual([
+      'Discovery',
+      'Socials',
+      'Ads',
+    ]);
+  });
+
+  it('keeps Workspace and Messages routes out of the Research sidebar', () => {
+    const hrefs = RESEARCH_MENU_ITEMS.map((item) => item.href);
+
+    expect(hrefs).not.toContain('/workspace/overview');
+    expect(hrefs).not.toContain('/messages');
+  });
+
+  it('has no duplicate hrefs', () => {
+    const hrefs = RESEARCH_MENU_ITEMS.flatMap((item) =>
+      item.href ? [item.href] : [],
+    );
+    const unique = new Set(hrefs);
+
+    expect(hrefs.length).toBe(unique.size);
+  });
+});

--- a/apps/app/packages/config/research-menu-items.config.ts
+++ b/apps/app/packages/config/research-menu-items.config.ts
@@ -1,0 +1,43 @@
+import { APP_ROUTES } from '@genfeedai/constants';
+import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
+import {
+  HiArrowTrendingUp,
+  HiMegaphone,
+  HiOutlineArrowTrendingUp,
+  HiOutlineMegaphone,
+  HiOutlineSquares2X2,
+  HiSquares2X2,
+} from 'react-icons/hi2';
+
+export const RESEARCH_MENU_ITEMS: MenuItemConfig[] = [
+  {
+    group: '',
+    href: APP_ROUTES.RESEARCH.DISCOVERY,
+    label: 'Discovery',
+    matchPaths: [APP_ROUTES.RESEARCH.ROOT, APP_ROUTES.RESEARCH.DISCOVERY],
+    outline: HiOutlineArrowTrendingUp,
+    solid: HiArrowTrendingUp,
+  },
+  {
+    group: '',
+    href: APP_ROUTES.RESEARCH.SOCIALS,
+    label: 'Socials',
+    matchPaths: [APP_ROUTES.RESEARCH.SOCIALS],
+    outline: HiOutlineSquares2X2,
+    solid: HiSquares2X2,
+  },
+  {
+    group: '',
+    href: APP_ROUTES.RESEARCH.ADS,
+    label: 'Ads',
+    matchPaths: [
+      APP_ROUTES.RESEARCH.ADS,
+      APP_ROUTES.RESEARCH.ADS_GOOGLE,
+      APP_ROUTES.RESEARCH.ADS_META,
+    ],
+    outline: HiOutlineMegaphone,
+    solid: HiMegaphone,
+  },
+];
+
+export const RESEARCH_LOGO_HREF = APP_ROUTES.RESEARCH.DISCOVERY;


### PR DESCRIPTION
## Summary
- Add dedicated Research sidebar menu items for Discovery, Socials, and Ads.
- Wire Research routes into the protected shell so they no longer fall back to Workspace navigation.
- Add coverage for the Research menu config and protected layout route branch.

Addresses #1118.

## Tests
- bunx biome check --write apps/app/packages/config/research-menu-items.config.ts apps/app/packages/config/research-menu-items.config.test.ts apps/app/packages/components/useAppProtectedLayout.ts apps/app/packages/components/AppProtectedLayoutSidebar.tsx apps/app/packages/components/app-protected-layout.tsx apps/app/packages/components/app-protected-layout.test.tsx
- bun run --cwd apps/app test packages/config/research-menu-items.config.test.ts packages/components/app-protected-layout.test.tsx
- staged secret scan: no matches
- commit hook: secretlint, Biome, raw HTML guard