### PR TITLE
[codex] Remove Messages from Workspace nav

### DIFF
--- a/apps/app/packages/config/menu-items.config.test.ts
+++ b/apps/app/packages/config/menu-items.config.test.ts
@@ -24,7 +24,6 @@ describe('APP_MENU_ITEMS', () => {
 
     expect(ungroupedLabels).toEqual([
       'Dashboard',
-      'Messages',
       'Inbox',
       'Tasks',
       'Activity',
@@ -56,7 +55,6 @@ describe('APP_MENU_ITEMS', () => {
 
     expect(workspaceLabels).toEqual([
       'Dashboard',
-      'Messages',
       'Inbox',
       'Tasks',
       'Activity',

--- a/apps/app/packages/config/menu-items.config.ts
+++ b/apps/app/packages/config/menu-items.config.ts
@@ -1,11 +1,9 @@
 import { APP_ROUTES } from '@genfeedai/constants';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import {
-  HiChatBubbleLeftRight,
   HiClipboardDocumentList,
   HiClock,
   HiInboxStack,
-  HiOutlineChatBubbleLeftRight,
   HiOutlineClipboardDocumentList,
   HiOutlineClock,
   HiOutlineInboxStack,
@@ -28,14 +26,6 @@ export const APP_MENU_ITEMS: MenuItemConfig[] = [
     matchPaths: [APP_ROUTES.WORKSPACE.ROOT, APP_ROUTES.WORKSPACE.OVERVIEW],
     outline: HiOutlineSquares2X2,
     solid: HiSquares2X2,
-  },
-  {
-    group: AppMenuGroup.Root,
-    href: APP_ROUTES.MESSAGES.ROOT,
-    label: 'Messages',
-    matchPaths: [APP_ROUTES.MESSAGES.ROOT],
-    outline: HiOutlineChatBubbleLeftRight,
-    solid: HiChatBubbleLeftRight,
   },
   {
     group: AppMenuGroup.Root,


### PR DESCRIPTION
## Summary
- Remove Messages from the Workspace sidebar menu.
- Keep Workspace navigation scoped to Dashboard, Inbox, Tasks, and Activity.

Addresses #1116.

## Tests
- bunx biome check --write apps/app/packages/config/menu-items.config.ts apps/app/packages/config/menu-items.config.test.ts
- bun run --cwd apps/app test packages/config/menu-items.config.test.ts
- staged secret scan: no matches
- commit hook: secretlint, Biome