### PR TITLE
[codex] Clarify sidebar section header behavior

### DIFF
--- a/packages/interfaces/src/ui/menu-config.interface.ts
+++ b/packages/interfaces/src/ui/menu-config.interface.ts
@@ -33,6 +33,8 @@ export interface MenuItemConfig {
   isComingSoon?: boolean;
   /** When true on the first item of a group, renders a visual divider above the group */
   hasDividerAbove?: boolean;
+  /** When true on the first item of a named group, the group header can collapse its items */
+  isCollapsible?: boolean;
   /** When true, renders as a visually prominent CTA button */
   isPrimary?: boolean;
   /** Marks runtime-generated items (e.g. connected credentials) */

--- a/packages/ui/src/components/menus/shared/CollapsibleGroup.tsx
+++ b/packages/ui/src/components/menus/shared/CollapsibleGroup.tsx
@@ -56,10 +56,10 @@ function subscribeCollapsedGroups(onStoreChange: () => void): () => void {
   };
 }
 
-/** Collapsible group with label header and toggle */
 export default function CollapsibleGroup({
   label,
   isDrillDown,
+  isCollapsible = false,
   children,
   storageKey,
   actions,
@@ -70,6 +70,7 @@ export default function CollapsibleGroup({
 }: {
   label: string;
   isDrillDown: boolean;
+  isCollapsible?: boolean;
   children: React.ReactNode;
   storageKey?: string;
   actions?: React.ReactNode;
@@ -105,6 +106,25 @@ export default function CollapsibleGroup({
   // Ungrouped items (empty label) render flat without a collapsible header
   if (!label) {
     return <div className={cn('mt-1', className)}>{children}</div>;
+  }
+
+  if (!isCollapsible) {
+    return (
+      <div className={cn('mt-2', className)}>
+        <div
+          className={cn(
+            'flex w-full items-center p-1 text-foreground/30',
+            headerClassName,
+          )}
+        >
+          <span className="text-[10px] font-bold uppercase tracking-[0.15em]">
+            {label}
+          </span>
+          {actions && <div className="ml-auto">{actions}</div>}
+        </div>
+        <div className={contentClassName}>{children}</div>
+      </div>
+    );
   }
 
   return (

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -192,6 +192,18 @@ describe('MenuShared', () => {
     mockLogoUrl.value = '';
     mockPathname.value = '/settings/personal';
     process.env.NEXT_PUBLIC_GENFEED_CLOUD = 'true';
+    const storage = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        clear: vi.fn(() => storage.clear()),
+        getItem: vi.fn((key: string) => storage.get(key) ?? null),
+        removeItem: vi.fn((key: string) => storage.delete(key)),
+        setItem: vi.fn((key: string, value: string) => {
+          storage.set(key, value);
+        }),
+      },
+    });
   });
 
   afterEach(() => {
@@ -376,13 +388,67 @@ describe('MenuShared', () => {
 
     render(<MenuShared config={workspaceConfig} sectionLabel="Workspace" />);
 
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Workspace' }),
-    ).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Workspace' }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Tasks')).toBeInTheDocument();
     expect(screen.getByText(/Inbox/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Library' })).toBeInTheDocument();
+  });
+
+  it('renders named menu groups as static section headers by default', () => {
+    const groupedConfig: MenuConfig = {
+      items: [
+        {
+          group: 'ATS',
+          href: '/candidates',
+          label: 'Candidates',
+        },
+        {
+          group: 'ATS',
+          href: '/jobs',
+          label: 'Jobs',
+        },
+      ],
+      logoHref: '/',
+    };
+
+    render(<MenuShared config={groupedConfig} />);
+
+    expect(screen.getByText('ATS')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'ATS' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Candidates')).toBeInTheDocument();
+    expect(screen.getByText('Jobs')).toBeInTheDocument();
+  });
+
+  it('collapses named menu groups only when the first item opts in', () => {
+    const groupedConfig: MenuConfig = {
+      items: [
+        {
+          group: 'Operations',
+          href: '/runs',
+          isCollapsible: true,
+          label: 'Runs',
+        },
+        {
+          group: 'Operations',
+          href: '/workflows',
+          label: 'Workflows',
+        },
+      ],
+      logoHref: '/',
+    };
+
+    render(<MenuShared config={groupedConfig} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Operations' }));
+
+    expect(screen.queryByText('Runs')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workflows')).not.toBeInTheDocument();
   });
 
   it('renders secondary destinations outside the primary navigation groups', () => {

--- a/packages/ui/src/components/menus/shared/MenuSharedConversations.tsx
+++ b/packages/ui/src/components/menus/shared/MenuSharedConversations.tsx
@@ -36,6 +36,7 @@ export default function MenuSharedConversations({
       <CollapsibleGroup
         label="Conversations"
         isDrillDown={false}
+        isCollapsible
         storageKey="__conversations__"
         actions={conversationActions}
         className={cn(

--- a/packages/ui/src/components/menus/shared/MenuSharedGroupedItems.tsx
+++ b/packages/ui/src/components/menus/shared/MenuSharedGroupedItems.tsx
@@ -35,6 +35,7 @@ export default function MenuSharedGroupedItems({
           <CollapsibleGroup
             label={group.group}
             isDrillDown={group.items[0]?.drillDown === true}
+            isCollapsible={group.items[0]?.isCollapsible === true}
           >
             {group.items[0]?.drillDown ? (
               <DrillDownGroupRow


### PR DESCRIPTION
## Summary
- Make shared sidebar section headers static by default, matching the block-header model used for local navigation groups.
- Add explicit `isCollapsible` support on grouped menu items for the cases that should collapse.
- Keep Conversations collapsible by opting that shared group in explicitly.
- Add regression coverage for static app/sidebar section labels, static named groups, and explicit collapsible groups.

## Menu model
- App switcher groups are cross-app blocks.
- Sidebar `sectionLabel` is the current app/surface header.
- Sidebar `group` values split local navigation into static blocks.
- Collapsing is opt-in via `isCollapsible` on the first item of a named group.
- Drilldown groups remain drilldown rows, not section headers.

## Tests
- bunx biome check --write packages/interfaces/src/ui/menu-config.interface.ts packages/ui/src/components/menus/shared/CollapsibleGroup.tsx packages/ui/src/components/menus/shared/MenuSharedGroupedItems.tsx packages/ui/src/components/menus/shared/MenuSharedConversations.tsx packages/ui/src/components/menus/shared/MenuShared.test.tsx
- bun run --cwd packages/ui test src/components/menus/shared/MenuShared.test.tsx
- bun run design:lint (0 errors; existing DESIGN.md warnings only)
- bun run --cwd packages/ui build
- bun run --cwd packages/enums build, then bun run --cwd packages/interfaces type-check
- staged secret scan: no matches
- commit hook: secretlint, Biome, raw HTML guard