### PR TITLE
feat(workflow-ui): inject execution HTTP client + provider auth headers (#1151)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -43,6 +43,8 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { apiClient } from '@/lib/api/client';
+import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 interface WorkflowDetailPageClientProps {
@@ -136,6 +138,14 @@ export default function WorkflowDetailPageClient({
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      executionHeaders: getExecutionProviderHeaders,
+      executionHttpClient: {
+        post: <T,>(
+          path: string,
+          body?: Record<string, unknown>,
+          options?: { headers?: Record<string, string> },
+        ): Promise<T> => apiClient.post<T>(path, body, options),
+      },
       logger,
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -44,6 +44,8 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { apiClient } from '@/lib/api/client';
+import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 type WorkflowStoreState = ReturnType<typeof useWorkflowStore.getState>;
@@ -189,6 +191,14 @@ export default function WorkflowNewPageClient() {
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      executionHeaders: getExecutionProviderHeaders,
+      executionHttpClient: {
+        post: <T,>(
+          path: string,
+          body?: Record<string, unknown>,
+          options?: { headers?: Record<string, string> },
+        ): Promise<T> => apiClient.post<T>(path, body, options),
+      },
       logger,
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {

--- a/apps/app/src/lib/api/execution-headers.ts
+++ b/apps/app/src/lib/api/execution-headers.ts
@@ -1,0 +1,20 @@
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * Resolve the provider auth headers (Replicate / Fal / HuggingFace BYOK keys)
+ * attached to workflow-execute requests, read from the user's local settings.
+ *
+ * Injected into `packages/workflow-ui` via `WorkflowUIConfig.executionHeaders`
+ * so the package's execution store can carry BYOK credentials without depending
+ * on the app's settings store. Returns an empty record when no keys are set
+ * (e.g. cloud runs, where credentials are resolved server-side).
+ */
+export function getExecutionProviderHeaders(): Record<string, string> {
+  const settings = useSettingsStore.getState();
+
+  return {
+    ...settings.getProviderHeader('replicate'),
+    ...settings.getProviderHeader('fal'),
+    ...settings.getProviderHeader('huggingface'),
+  };
+}

--- a/packages/workflow-ui/src/index.ts
+++ b/packages/workflow-ui/src/index.ts
@@ -37,16 +37,24 @@ export { BaseNode, nodeTypes } from './nodes';
 // Panels
 export { DebugPanel, NodePalette, PanelContainer } from './panels';
 export type {
+  ExecutionHeaderProvider,
   ModelBrowserModalProps,
   PromptLibraryService,
   PromptPickerProps,
   WorkflowUIConfig,
+  WorkflowUIHttpClient,
   WorkflowUILogger,
 } from './provider';
 // Provider
 export { useWorkflowUIConfig, WorkflowUIProvider } from './provider';
 export { useAnnotationStore } from './stores/annotationStore';
 export { useExecutionStore } from './stores/execution';
+export {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './stores/execution/executionApi';
 export {
   configureWorkflowLogger,
   getWorkflowLogger,

--- a/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
+++ b/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { createContext, type ReactNode, use, useEffect } from 'react';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+} from '../stores/execution/executionApi';
 import { configureWorkflowLogger } from '../stores/executionLogger';
 import { configurePromptLibrary } from '../stores/promptLibraryStore';
 import type { WorkflowUIConfig } from './types';
@@ -38,6 +42,16 @@ export function WorkflowUIProvider({
   useEffect(() => {
     configureWorkflowLogger(config.logger);
   }, [config.logger]);
+
+  // Register the execution HTTP client + provider auth headers. Both reset to
+  // the package's bare-fetch / no-header defaults when unset.
+  useEffect(() => {
+    configureExecutionHttpClient(config.executionHttpClient);
+  }, [config.executionHttpClient]);
+
+  useEffect(() => {
+    configureExecutionHeaders(config.executionHeaders);
+  }, [config.executionHeaders]);
 
   return (
     <WorkflowUIContext.Provider value={config}>

--- a/packages/workflow-ui/src/provider/index.ts
+++ b/packages/workflow-ui/src/provider/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ExecutionHeaderProvider,
   FileUploadService,
   ModelBrowserModalProps,
   ModelSchemaService,
@@ -6,6 +7,7 @@ export type {
   PromptPickerProps,
   WorkflowsApiService,
   WorkflowUIConfig,
+  WorkflowUIHttpClient,
   WorkflowUILogger,
 } from './types';
 export { useWorkflowUIConfig, WorkflowUIProvider } from './WorkflowUIProvider';

--- a/packages/workflow-ui/src/provider/types.ts
+++ b/packages/workflow-ui/src/provider/types.ts
@@ -92,6 +92,33 @@ export interface WorkflowUILogger {
 }
 
 // =============================================================================
+// Execution HTTP
+// =============================================================================
+
+/**
+ * HTTP client the execution store issues its POST requests through
+ * (workflow execute, execution stop). The consuming app injects a credentialed
+ * client — one that resolves the correct API base URL and carries auth cookies —
+ * so runs are attributed to the signed-in user. When absent the package falls
+ * back to a bare `fetch` against `NEXT_PUBLIC_API_URL` (its standalone default).
+ */
+export interface WorkflowUIHttpClient {
+  post: <T>(
+    path: string,
+    body?: Record<string, unknown>,
+    options?: { headers?: Record<string, string> },
+  ) => Promise<T>;
+}
+
+/**
+ * Supplies the per-request provider auth headers (Replicate / Fal / HuggingFace
+ * BYOK keys) attached to workflow-execute requests. Returns an empty record when
+ * the user has not configured BYOK keys. Defaults to no headers so the package
+ * stays provider-agnostic standalone.
+ */
+export type ExecutionHeaderProvider = () => Record<string, string>;
+
+// =============================================================================
 // Config
 // =============================================================================
 
@@ -106,6 +133,17 @@ export interface WorkflowUIConfig {
   workflowsApi?: WorkflowsApiService;
   /** Execution-store error reporting (SSE failures, failed runs). No-op if omitted. */
   logger?: WorkflowUILogger;
+  /**
+   * HTTP client the execution store posts through (execute / stop). Defaults to a
+   * bare `fetch` against `NEXT_PUBLIC_API_URL` when omitted; the app injects a
+   * credentialed client so runs carry the signed-in user's session.
+   */
+  executionHttpClient?: WorkflowUIHttpClient;
+  /**
+   * Provider auth headers (Replicate / Fal / HuggingFace BYOK keys) attached to
+   * execute requests. Returns no headers when omitted.
+   */
+  executionHeaders?: ExecutionHeaderProvider;
   /** Injected ModelBrowserModal component (complex, app-specific) */
   ModelBrowserModal?: ComponentType<ModelBrowserModalProps> | null;
   /** Injected PromptPicker component (complex, app-specific) */

--- a/packages/workflow-ui/src/stores/execution/executionApi.test.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowUIHttpClient } from '../../provider/types';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './executionApi';
+
+describe('executionApi', () => {
+  afterEach(() => {
+    // Reset both registries to their standalone defaults so tests don't leak.
+    configureExecutionHttpClient(undefined);
+    configureExecutionHeaders(undefined);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('execution headers', () => {
+    it('defaults to no headers', () => {
+      expect(getExecutionHeaders()).toEqual({});
+    });
+
+    it('resolves headers from the configured provider on each call', () => {
+      const provider = vi
+        .fn()
+        .mockReturnValueOnce({ 'X-Replicate-Key': 'a' })
+        .mockReturnValueOnce({ 'X-Replicate-Key': 'b' });
+      configureExecutionHeaders(provider);
+
+      expect(getExecutionHeaders()).toEqual({ 'X-Replicate-Key': 'a' });
+      expect(getExecutionHeaders()).toEqual({ 'X-Replicate-Key': 'b' });
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+
+    it('reverts to no headers when reconfigured with undefined', () => {
+      configureExecutionHeaders(() => ({ 'X-Fal-Key': 'k' }));
+      configureExecutionHeaders(undefined);
+
+      expect(getExecutionHeaders()).toEqual({});
+    });
+  });
+
+  describe('execution HTTP client', () => {
+    it('routes requests through the configured client', async () => {
+      const client: WorkflowUIHttpClient = {
+        post: vi.fn().mockResolvedValue({ _id: 'exec-1' }),
+      };
+      configureExecutionHttpClient(client);
+
+      const result = await getExecutionHttpClient().post('/x', { a: 1 });
+
+      expect(client.post).toHaveBeenCalledWith('/x', { a: 1 });
+      expect(result).toEqual({ _id: 'exec-1' });
+    });
+
+    it('reverts to the bare-fetch default when reconfigured with undefined', async () => {
+      const custom: WorkflowUIHttpClient = { post: vi.fn() };
+      configureExecutionHttpClient(custom);
+      configureExecutionHttpClient(undefined);
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ _id: 'default' }),
+        ok: true,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getExecutionHttpClient().post(
+        '/workflows/1/execute',
+        {
+          debugMode: false,
+        },
+      );
+
+      expect(custom.post).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ _id: 'default' });
+    });
+
+    describe('bare-fetch default', () => {
+      it('POSTs JSON with Content-Type and merges caller headers', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({ ok: true }),
+          ok: true,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await getExecutionHttpClient().post(
+          '/workflows/1/execute',
+          { debugMode: true },
+          { headers: { 'X-Replicate-Key': 'secret' } },
+        );
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain('/workflows/1/execute');
+        expect(init.method).toBe('POST');
+        expect(init.headers).toEqual({
+          'Content-Type': 'application/json',
+          'X-Replicate-Key': 'secret',
+        });
+        expect(init.body).toBe(JSON.stringify({ debugMode: true }));
+      });
+
+      it('omits the body when none is provided', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({}),
+          ok: true,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await getExecutionHttpClient().post('/executions/1/stop');
+
+        const [, init] = fetchMock.mock.calls[0];
+        expect(init.body).toBeUndefined();
+      });
+
+      it('throws the API error message on a non-ok response', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({ message: 'nope' }),
+          ok: false,
+          status: 422,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+          getExecutionHttpClient().post('/workflows/1/execute', {}),
+        ).rejects.toThrow('nope');
+      });
+
+      it('falls back to a status message when the error body has none', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.reject(new Error('not json')),
+          ok: false,
+          status: 500,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+          getExecutionHttpClient().post('/workflows/1/execute', {}),
+        ).rejects.toThrow('API error: 500');
+      });
+    });
+  });
+});

--- a/packages/workflow-ui/src/stores/execution/executionApi.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.ts
@@ -1,0 +1,87 @@
+import type {
+  ExecutionHeaderProvider,
+  WorkflowUIHttpClient,
+} from '../../provider/types';
+
+// =============================================================================
+// Module-level execution HTTP configuration
+// =============================================================================
+
+/**
+ * Injected HTTP client + provider-header supplier for the execution store.
+ *
+ * The execution store (`executeWorkflow`, `stopExecution`, …) lives outside the
+ * React tree (plain Zustand) and cannot read the WorkflowUIProvider context
+ * directly, so both are registered at module scope via
+ * {@link configureExecutionHttpClient} / {@link configureExecutionHeaders} —
+ * the same pattern {@link configureWorkflowLogger} uses.
+ *
+ * Both default to the package's standalone behavior (bare `fetch`, no BYOK
+ * headers) so the package stays usable on its own; the consuming app injects a
+ * credentialed client and its provider auth headers through `WorkflowUIConfig`.
+ */
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
+
+/**
+ * Default fetch-based client. Preserves the package's prior inline `apiPost`
+ * behavior exactly: POST to `NEXT_PUBLIC_API_URL`, JSON body, surface the API's
+ * error message on non-2xx.
+ */
+const DEFAULT_HTTP_CLIENT: WorkflowUIHttpClient = {
+  post: async <T>(
+    path: string,
+    body?: Record<string, unknown>,
+    options?: { headers?: Record<string, string> },
+  ): Promise<T> => {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      method: 'POST',
+      ...(body && { body: JSON.stringify(body) }),
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        (errorData as { message?: string }).message ||
+          `API error: ${response.status}`,
+      );
+    }
+    return response.json() as Promise<T>;
+  },
+};
+
+const NOOP_HEADERS: ExecutionHeaderProvider = () => ({});
+
+let _httpClient: WorkflowUIHttpClient = DEFAULT_HTTP_CLIENT;
+let _headers: ExecutionHeaderProvider = NOOP_HEADERS;
+
+/**
+ * Register the HTTP client the execution store posts through.
+ * Called by WorkflowUIProvider; resets to the bare-fetch default when unset.
+ */
+export function configureExecutionHttpClient(
+  client: WorkflowUIHttpClient | undefined,
+): void {
+  _httpClient = client ?? DEFAULT_HTTP_CLIENT;
+}
+
+/** Read the currently-configured HTTP client (bare fetch until configured). */
+export function getExecutionHttpClient(): WorkflowUIHttpClient {
+  return _httpClient;
+}
+
+/**
+ * Register the provider-auth-header supplier for execute requests.
+ * Called by WorkflowUIProvider; resets to "no headers" when unset.
+ */
+export function configureExecutionHeaders(
+  provider: ExecutionHeaderProvider | undefined,
+): void {
+  _headers = provider ?? NOOP_HEADERS;
+}
+
+/** Resolve the provider auth headers for the current request (empty until configured). */
+export function getExecutionHeaders(): Record<string, string> {
+  return _headers();
+}

--- a/packages/workflow-ui/src/stores/execution/slices/executionSlice.ts
+++ b/packages/workflow-ui/src/stores/execution/slices/executionSlice.ts
@@ -4,36 +4,28 @@ import { getWorkflowLogger } from '../../executionLogger';
 import { useSettingsStore } from '../../settingsStore';
 import { useUIStore } from '../../uiStore';
 import { useWorkflowStore } from '../../workflow/workflowStore';
+import { getExecutionHeaders, getExecutionHttpClient } from '../executionApi';
 import {
   createExecutionSubscription,
   createNodeExecutionSubscription,
 } from '../helpers/sseSubscription';
 import type { ExecutionData, ExecutionStore, NodeExecution } from '../types';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
+const LOG_CONTEXT = 'ExecutionStore';
 
 /**
- * Simple fetch-based API client for execution operations.
- * Consuming apps can override by providing their own execution store.
+ * Start a workflow execution through the injected HTTP client, carrying the
+ * app's provider auth headers (Replicate / Fal / HuggingFace BYOK keys). Both
+ * the client and the headers default to the package's standalone behavior when
+ * the app has not configured them (see `executionApi`).
  */
-async function apiPost<T>(
+function startExecution(
   path: string,
-  body?: Record<string, unknown>,
-): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
-    ...(body && { body: JSON.stringify(body) }),
+  body: Record<string, unknown>,
+): Promise<ExecutionData> {
+  return getExecutionHttpClient().post<ExecutionData>(path, body, {
+    headers: getExecutionHeaders(),
   });
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(
-      (errorData as { message?: string }).message ||
-        `API error: ${response.status}`,
-    );
-  }
-  return response.json() as Promise<T>;
 }
 
 function validationError(message: string) {
@@ -105,7 +97,11 @@ export const createExecutionSlice: StateCreator<
     if (workflowStore.isDirty || !workflowStore.workflowId) {
       try {
         await workflowStore.saveWorkflow();
-      } catch {
+      } catch (error) {
+        getWorkflowLogger().error(
+          'Failed to save workflow before node execution',
+          { context: LOG_CONTEXT, error },
+        );
         workflowStore.updateNodeData(nodeId, {
           error: 'Failed to save workflow',
           status: NodeStatusEnum.ERROR,
@@ -128,7 +124,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -156,6 +152,10 @@ export const createExecutionSlice: StateCreator<
         return { activeNodeExecutions: newMap };
       });
     } catch (error) {
+      getWorkflowLogger().error('Failed to start node execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       workflowStore.updateNodeData(nodeId, {
         error: error instanceof Error ? error.message : 'Node execution failed',
         status: NodeStatusEnum.ERROR,
@@ -211,7 +211,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -224,6 +224,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(executionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to start partial execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -282,7 +286,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -294,6 +298,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(executionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to start workflow execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -391,7 +399,7 @@ export const createExecutionSlice: StateCreator<
     });
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -403,6 +411,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(newExecutionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to resume execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -432,9 +444,14 @@ export const createExecutionSlice: StateCreator<
     }
 
     if (executionId) {
-      apiPost(`/executions/${executionId}/stop`).catch(() => {
-        // Failed to stop execution
-      });
+      getExecutionHttpClient()
+        .post(`/executions/${executionId}/stop`)
+        .catch((error) => {
+          getWorkflowLogger().error('Failed to stop execution', {
+            context: LOG_CONTEXT,
+            error,
+          });
+        });
     }
 
     set({
@@ -451,9 +468,14 @@ export const createExecutionSlice: StateCreator<
     if (nodeExecution) {
       nodeExecution.eventSource.close();
 
-      apiPost(`/executions/${nodeExecution.executionId}/stop`).catch(() => {
-        // Failed to stop node execution
-      });
+      getExecutionHttpClient()
+        .post(`/executions/${nodeExecution.executionId}/stop`)
+        .catch((error) => {
+          getWorkflowLogger().error('Failed to stop node execution', {
+            context: LOG_CONTEXT,
+            error,
+          });
+        });
 
       set((state) => {
         const newMap = new Map(state.activeNodeExecutions);

--- a/packages/workflow-ui/src/stores/index.ts
+++ b/packages/workflow-ui/src/stores/index.ts
@@ -25,6 +25,12 @@ export { useAnnotationStore } from './annotationStore';
 export { type ContextMenuType, useContextMenuStore } from './contextMenuStore';
 export type { DebugPayload, ExecutionStore, Job } from './execution';
 export { useExecutionStore } from './execution';
+export {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './execution/executionApi';
 // Embedded stores (moved from core app)
 export {
   configureWorkflowLogger,


### PR DESCRIPTION
## Summary

Second increment of the **workflow-ui fork unification** ([issue #1151](https://github.com/genfeedai/genfeed.ai/issues/1151), cluster C1 of the DRY/slop audit). Delivers the **Execution HTTP + provider-headers injection** seam.

> **Stacked on #1149** (the error-reporting seam). Base is `refactor/workflow-ui-unification`; merge after #1149. GitHub will retarget to `master` once #1149 lands.

### The problem

`packages/workflow-ui`'s execution store issued its `execute` / `stop` requests through a bare `fetch` hardcoded to `NEXT_PUBLIC_API_URL`, JSON-only, **with no credentials and no BYOK provider headers**. The real implementation — credentialed `apiClient` + Replicate/Fal/HuggingFace auth headers — lived only in the `apps/app` fork. This is a prerequisite for deleting that fork (step 5): the package must be able to carry the app's auth before it can replace the fork.

### What this does

**Package**
- `WorkflowUIConfig` gains `executionHttpClient` (`WorkflowUIHttpClient`) and `executionHeaders` (`ExecutionHeaderProvider`).
- New `stores/execution/executionApi.ts` module registry — `configureExecutionHttpClient` / `configureExecutionHeaders` + `get*` accessors — mirroring the `configureWorkflowLogger` pattern from #1149 (the Zustand execution store lives outside the React tree and can't read provider context).
- `WorkflowUIProvider` registers both from config, resetting to defaults when unset.
- **Both default to the package's prior standalone behavior** (bare fetch against `NEXT_PUBLIC_API_URL`, no BYOK headers) — an unconfigured package is unchanged.
- `executionSlice` now posts execute requests through the injected client carrying `getExecutionHeaders()`; `stop` requests go through the client **without** provider headers (matching the app fork). Also restores the execution-path error logging the app fork had (start / resume / stop / save-before-node-execute) through the injected logger — completing B4 parity so the package is a faithful drop-in for step 5.

**App (`apps/app`)**
- Both cloud workflow provider configs inject `apiClient` as the HTTP client and `getExecutionProviderHeaders` as the header supplier.
- Extracts `getExecutionProviderHeaders` into `lib/api/execution-headers.ts` — a stable home that survives the fork deletion in step 5.

## Verification
- `@genfeedai/workflow-ui` type-check green (fresh, `--force`)
- `@genfeedai/app` type-check green (fresh, `--force`)
- Package vitest: new `executionApi.test.ts` (default bare-fetch behavior, header resolution, reset-to-default) + `executionLogger.test.ts` — 12 execution tests green
- biome clean; secretlint + no-raw-html pre-commit hooks green

## Sequence (issue #1151)
1. Error-reporting seam — **#1149**
2. **Execution HTTP + provider-headers injection — this PR**
3. Persistence + `applyEditOperations` injection
4. Port execution-store tests into the package
5. Reconcile divergences (`edgeSlice` position-dirty; Image History vs `workflowTags`)
6. Delete fork + repoint ~16 consumers, behind Playwright coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)