### PR TITLE
fix(app): harmonize workspace dashboard cards onto the canonical Card surface (#1115)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
@@ -312,11 +312,7 @@ export function DashboardStatsStrip({
     <section data-testid="dashboard-stats-strip">
       <DashboardGrid>
         {items.map((item) => (
-          <Card
-            key={item.label}
-            className="rounded-md border-border bg-background-secondary shadow-none"
-            bodyClassName="p-4"
-          >
+          <Card key={item.label} bodyClassName="p-4">
             {item.isLoading ? (
               <Skeleton variant="text" height={32} className="w-16" />
             ) : (
@@ -361,10 +357,7 @@ interface MiniChartCardProps {
 
 function MiniChartCard({ children, subtitle, title }: MiniChartCardProps) {
   return (
-    <Card
-      className="rounded-md border-border bg-background-secondary shadow-none"
-      bodyClassName="p-4"
-    >
+    <Card bodyClassName="p-4">
       <div className="mb-2 space-y-0.5">
         <h3 className="text-xs font-semibold text-foreground">{title}</h3>
         <p className="text-[10px] uppercase tracking-wider text-foreground/40">
@@ -675,10 +668,7 @@ export function DashboardRecentActivity({
           <Link href="/workspace/inbox/unread">View All &rarr;</Link>
         </Button>
       </div>
-      <Card
-        className="rounded-md border-border bg-background-secondary shadow-none"
-        bodyClassName="p-0"
-      >
+      <Card bodyClassName="p-0">
         {isLoading && sortedTasks.length === 0 ? (
           <div className="px-4 py-2">
             <WorkspaceTaskRowsSkeleton rows={4} />
@@ -782,10 +772,7 @@ export function DashboardRecentTasks({
           <Link href="/workspace/inbox/unread">View All &rarr;</Link>
         </Button>
       </div>
-      <Card
-        className="rounded-md border-border bg-background-secondary shadow-none"
-        bodyClassName="p-0"
-      >
+      <Card bodyClassName="p-0">
         {isLoading && sortedTasks.length === 0 ? (
           <div className="px-4 py-2">
             <WorkspaceTaskRowsSkeleton rows={4} />


### PR DESCRIPTION
Closes #1115. Scoped, zero-shared-primitive-risk pass. Remaining modules split into a dedicated follow-up: #1158.

## Problem (verified on prod `app.genfeed.ai/genfeed/6677/workspace/overview`)
The workspace overview rendered **three** card treatments where the design system defines one:
1. **Off-contract override** (stat strip, mini charts, Recent Activity, Recent Tasks): `rounded-md border-border bg-background-secondary shadow-none` → borderless, wrong radius, wrong background.
2. **Canonical Card** (Task queue, sidebar modules): `bg-card` + inset `shadow-border` + `rounded-card` — the `DESIGN.md` contract.
3. **Shell-panel** (Research Trends via `WorkspaceSurface`): drop-shadow + `.gen-shell-panel`.

`DESIGN.md` is explicit: cards use `bg-card` + inset `shadow-border` (**not** CSS `border`), and "Don't use CSS border for card containment" / "Don't nest cards in cards."

## Change
Delete the four off-contract `className` overrides in `workspace-dashboard.tsx` so the stat strip, mini charts, Recent Activity, and Recent Tasks fall back to `Card`'s canonical default surface — matching Task queue and the sidebar cards. **Chrome only, no behavior change** (`bodyClassName` padding preserved).

`-17 / +4` lines, one file.

## Verification
- Focused: `workspace-dashboard.test.tsx` — **7/7 pass**; biome clean; secretlint + no-raw-html pre-commit hooks pass.
- Type-safe by construction (only optional `Card` props removed; the test renders the component).
- Visual direction validated live: applying `Card`'s exact computed surface (`bg-card` rgb(18,20,23), inset 1px border, square `rounded-card`) to the outliers on the live prod page produced one coherent card system — the "slight-gray, one style" target. Pixel QA of the built change is pending a preview deploy (route is auth-gated; not reproducible headlessly).

## Deferred → tracked in #1158 (need shared-primitive decisions + visual QA — intentionally out of this PR)
- **Research Trends** renders via `WorkspaceSurface`, a shell-panel primitive shared by **~24** admin/overview surfaces. Harmonizing it safely = add an **additive** `card` tone to `WorkspaceSurface` (leaves the 24 consumers untouched) and forward it through `OverviewTrendsPanel` (also used on the brand overview). Left out here to keep this PR contained and low-risk.
- **Inbox preview** is a raw `<section>` around `AppTable` with no card chrome.

Note: `/v1/credits/topbar-balances` returns HTTP 200 with a real zero balance for this empty test org — the "Credits 0" topbar is correct, not a bug (checked separately during the audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)