### PR TITLE
feat(workflow-ui): inject workflow persistence + applyEditOperations (#1151)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -43,6 +43,8 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { apiClient } from '@/lib/api/client';
+import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 interface WorkflowDetailPageClientProps {
@@ -136,6 +138,14 @@ export default function WorkflowDetailPageClient({
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      executionHeaders: getExecutionProviderHeaders,
+      executionHttpClient: {
+        post: <T,>(
+          path: string,
+          body?: Record<string, unknown>,
+          options?: { headers?: Record<string, string> },
+        ): Promise<T> => apiClient.post<T>(path, body, options),
+      },
       logger,
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -43,8 +43,10 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { workflowsApi } from '@/lib/api';
 import { apiClient } from '@/lib/api/client';
 import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
+import { applyEditOperations } from '@/lib/chat/editOperations';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 interface WorkflowDetailPageClientProps {
@@ -138,6 +140,7 @@ export default function WorkflowDetailPageClient({
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      applyEditOperations,
       executionHeaders: getExecutionProviderHeaders,
       executionHttpClient: {
         post: <T,>(
@@ -147,6 +150,14 @@ export default function WorkflowDetailPageClient({
         ): Promise<T> => apiClient.post<T>(path, body, options),
       },
       logger,
+      workflowPersistence: {
+        create: workflowsApi.create,
+        delete: workflowsApi.delete,
+        duplicate: workflowsApi.duplicate,
+        getAll: workflowsApi.getAll,
+        getById: workflowsApi.getById,
+        update: workflowsApi.update,
+      },
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {
           const service = await getWorkflowService();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -44,8 +44,10 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { workflowsApi } from '@/lib/api';
 import { apiClient } from '@/lib/api/client';
 import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
+import { applyEditOperations } from '@/lib/chat/editOperations';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 type WorkflowStoreState = ReturnType<typeof useWorkflowStore.getState>;
@@ -191,6 +193,7 @@ export default function WorkflowNewPageClient() {
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      applyEditOperations,
       executionHeaders: getExecutionProviderHeaders,
       executionHttpClient: {
         post: <T,>(
@@ -200,6 +203,14 @@ export default function WorkflowNewPageClient() {
         ): Promise<T> => apiClient.post<T>(path, body, options),
       },
       logger,
+      workflowPersistence: {
+        create: workflowsApi.create,
+        delete: workflowsApi.delete,
+        duplicate: workflowsApi.duplicate,
+        getAll: workflowsApi.getAll,
+        getById: workflowsApi.getById,
+        update: workflowsApi.update,
+      },
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {
           const service = await getWorkflowService();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -44,6 +44,8 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { apiClient } from '@/lib/api/client';
+import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 type WorkflowStoreState = ReturnType<typeof useWorkflowStore.getState>;
@@ -189,6 +191,14 @@ export default function WorkflowNewPageClient() {
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      executionHeaders: getExecutionProviderHeaders,
+      executionHttpClient: {
+        post: <T,>(
+          path: string,
+          body?: Record<string, unknown>,
+          options?: { headers?: Record<string, string> },
+        ): Promise<T> => apiClient.post<T>(path, body, options),
+      },
       logger,
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {

--- a/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
+++ b/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
@@ -90,20 +90,7 @@ export function useCloudWorkflow({
 
   const bindSharedWorkflowApi = useCallback((service: WorkflowApiService) => {
     useWorkflowStore.setState({
-      listWorkflows: async () => {
-        const workflows = await service.list();
-
-        return workflows.map((workflow) => ({
-          _id: workflow._id,
-          createdAt: workflow.createdAt,
-          edgeStyle: 'default',
-          edges: [],
-          groups: [],
-          name: workflow.name,
-          nodes: [],
-          updatedAt: workflow.updatedAt,
-        }));
-      },
+      listWorkflows: async () => service.list(),
       loadWorkflowById: async (id: string) => {
         await useCloudWorkflowStore.getState().loadFromCloud(id, service);
       },

--- a/apps/app/src/lib/api/execution-headers.ts
+++ b/apps/app/src/lib/api/execution-headers.ts
@@ -1,0 +1,20 @@
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * Resolve the provider auth headers (Replicate / Fal / HuggingFace BYOK keys)
+ * attached to workflow-execute requests, read from the user's local settings.
+ *
+ * Injected into `packages/workflow-ui` via `WorkflowUIConfig.executionHeaders`
+ * so the package's execution store can carry BYOK credentials without depending
+ * on the app's settings store. Returns an empty record when no keys are set
+ * (e.g. cloud runs, where credentials are resolved server-side).
+ */
+export function getExecutionProviderHeaders(): Record<string, string> {
+  const settings = useSettingsStore.getState();
+
+  return {
+    ...settings.getProviderHeader('replicate'),
+    ...settings.getProviderHeader('fal'),
+    ...settings.getProviderHeader('huggingface'),
+  };
+}

--- a/packages/workflow-ui/src/index.ts
+++ b/packages/workflow-ui/src/index.ts
@@ -37,10 +37,16 @@ export { BaseNode, nodeTypes } from './nodes';
 // Panels
 export { DebugPanel, NodePalette, PanelContainer } from './panels';
 export type {
+  ApplyEditOperations,
+  ApplyEditResult,
+  EditOperation,
   ExecutionHeaderProvider,
   ModelBrowserModalProps,
   PromptLibraryService,
   PromptPickerProps,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowSummary,
   WorkflowUIConfig,
   WorkflowUIHttpClient,
   WorkflowUILogger,
@@ -68,7 +74,15 @@ export { useSettingsStore } from './stores/settingsStore';
 // Stores
 export { useUIStore } from './stores/uiStore';
 export { useWorkflowStore } from './stores/workflow';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './stores/workflow/applyEditOperations';
 export type { ImageHistoryItem } from './stores/workflow/types';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './stores/workflow/workflowPersistence';
 export type {
   DropdownItem,
   OverflowMenuProps,

--- a/packages/workflow-ui/src/index.ts
+++ b/packages/workflow-ui/src/index.ts
@@ -37,16 +37,24 @@ export { BaseNode, nodeTypes } from './nodes';
 // Panels
 export { DebugPanel, NodePalette, PanelContainer } from './panels';
 export type {
+  ExecutionHeaderProvider,
   ModelBrowserModalProps,
   PromptLibraryService,
   PromptPickerProps,
   WorkflowUIConfig,
+  WorkflowUIHttpClient,
   WorkflowUILogger,
 } from './provider';
 // Provider
 export { useWorkflowUIConfig, WorkflowUIProvider } from './provider';
 export { useAnnotationStore } from './stores/annotationStore';
 export { useExecutionStore } from './stores/execution';
+export {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './stores/execution/executionApi';
 export {
   configureWorkflowLogger,
   getWorkflowLogger,

--- a/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
+++ b/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { createContext, type ReactNode, use, useEffect } from 'react';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+} from '../stores/execution/executionApi';
 import { configureWorkflowLogger } from '../stores/executionLogger';
 import { configurePromptLibrary } from '../stores/promptLibraryStore';
 import type { WorkflowUIConfig } from './types';
@@ -38,6 +42,16 @@ export function WorkflowUIProvider({
   useEffect(() => {
     configureWorkflowLogger(config.logger);
   }, [config.logger]);
+
+  // Register the execution HTTP client + provider auth headers. Both reset to
+  // the package's bare-fetch / no-header defaults when unset.
+  useEffect(() => {
+    configureExecutionHttpClient(config.executionHttpClient);
+  }, [config.executionHttpClient]);
+
+  useEffect(() => {
+    configureExecutionHeaders(config.executionHeaders);
+  }, [config.executionHeaders]);
 
   return (
     <WorkflowUIContext.Provider value={config}>

--- a/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
+++ b/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
@@ -7,6 +7,8 @@ import {
 } from '../stores/execution/executionApi';
 import { configureWorkflowLogger } from '../stores/executionLogger';
 import { configurePromptLibrary } from '../stores/promptLibraryStore';
+import { configureApplyEditOperations } from '../stores/workflow/applyEditOperations';
+import { configureWorkflowPersistence } from '../stores/workflow/workflowPersistence';
 import type { WorkflowUIConfig } from './types';
 
 const WorkflowUIContext = createContext<WorkflowUIConfig>({});
@@ -52,6 +54,16 @@ export function WorkflowUIProvider({
   useEffect(() => {
     configureExecutionHeaders(config.executionHeaders);
   }, [config.executionHeaders]);
+
+  // Register the workflow persistence backend + graph edit-operation applier.
+  // Both reset to their defaults (throw / no-op) when unset.
+  useEffect(() => {
+    configureWorkflowPersistence(config.workflowPersistence);
+  }, [config.workflowPersistence]);
+
+  useEffect(() => {
+    configureApplyEditOperations(config.applyEditOperations);
+  }, [config.applyEditOperations]);
 
   return (
     <WorkflowUIContext.Provider value={config}>

--- a/packages/workflow-ui/src/provider/index.ts
+++ b/packages/workflow-ui/src/provider/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ExecutionHeaderProvider,
   FileUploadService,
   ModelBrowserModalProps,
   ModelSchemaService,
@@ -6,6 +7,7 @@ export type {
   PromptPickerProps,
   WorkflowsApiService,
   WorkflowUIConfig,
+  WorkflowUIHttpClient,
   WorkflowUILogger,
 } from './types';
 export { useWorkflowUIConfig, WorkflowUIProvider } from './WorkflowUIProvider';

--- a/packages/workflow-ui/src/provider/index.ts
+++ b/packages/workflow-ui/src/provider/index.ts
@@ -1,4 +1,14 @@
 export type {
+  ApplyEditOperations,
+  ApplyEditResult,
+  EditOperation,
+} from '../stores/workflow/slices/types';
+export type {
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowSummary,
+} from '../stores/workflow/types';
+export type {
   ExecutionHeaderProvider,
   FileUploadService,
   ModelBrowserModalProps,

--- a/packages/workflow-ui/src/provider/types.ts
+++ b/packages/workflow-ui/src/provider/types.ts
@@ -92,6 +92,33 @@ export interface WorkflowUILogger {
 }
 
 // =============================================================================
+// Execution HTTP
+// =============================================================================
+
+/**
+ * HTTP client the execution store issues its POST requests through
+ * (workflow execute, execution stop). The consuming app injects a credentialed
+ * client — one that resolves the correct API base URL and carries auth cookies —
+ * so runs are attributed to the signed-in user. When absent the package falls
+ * back to a bare `fetch` against `NEXT_PUBLIC_API_URL` (its standalone default).
+ */
+export interface WorkflowUIHttpClient {
+  post: <T>(
+    path: string,
+    body?: Record<string, unknown>,
+    options?: { headers?: Record<string, string> },
+  ) => Promise<T>;
+}
+
+/**
+ * Supplies the per-request provider auth headers (Replicate / Fal / HuggingFace
+ * BYOK keys) attached to workflow-execute requests. Returns an empty record when
+ * the user has not configured BYOK keys. Defaults to no headers so the package
+ * stays provider-agnostic standalone.
+ */
+export type ExecutionHeaderProvider = () => Record<string, string>;
+
+// =============================================================================
 // Config
 // =============================================================================
 
@@ -106,6 +133,17 @@ export interface WorkflowUIConfig {
   workflowsApi?: WorkflowsApiService;
   /** Execution-store error reporting (SSE failures, failed runs). No-op if omitted. */
   logger?: WorkflowUILogger;
+  /**
+   * HTTP client the execution store posts through (execute / stop). Defaults to a
+   * bare `fetch` against `NEXT_PUBLIC_API_URL` when omitted; the app injects a
+   * credentialed client so runs carry the signed-in user's session.
+   */
+  executionHttpClient?: WorkflowUIHttpClient;
+  /**
+   * Provider auth headers (Replicate / Fal / HuggingFace BYOK keys) attached to
+   * execute requests. Returns no headers when omitted.
+   */
+  executionHeaders?: ExecutionHeaderProvider;
   /** Injected ModelBrowserModal component (complex, app-specific) */
   ModelBrowserModal?: ComponentType<ModelBrowserModalProps> | null;
   /** Injected PromptPicker component (complex, app-specific) */

--- a/packages/workflow-ui/src/provider/types.ts
+++ b/packages/workflow-ui/src/provider/types.ts
@@ -6,6 +6,8 @@ import type {
   ProviderModel,
 } from '@genfeedai/types';
 import type { ComponentType } from 'react';
+import type { ApplyEditOperations } from '../stores/workflow/slices/types';
+import type { WorkflowPersistenceService } from '../stores/workflow/types';
 
 // =============================================================================
 // File Upload
@@ -144,6 +146,17 @@ export interface WorkflowUIConfig {
    * execute requests. Returns no headers when omitted.
    */
   executionHeaders?: ExecutionHeaderProvider;
+  /**
+   * Persistence backend for the workflow store's CRUD actions (save / load /
+   * list / delete / duplicate / create). Throws a clear "not configured" error
+   * when omitted rather than silently dropping saves.
+   */
+  workflowPersistence?: WorkflowPersistenceService;
+  /**
+   * Graph edit-operation applier used by the chat/agent edit pipeline. Defaults
+   * to a no-op (leaves the graph untouched) when omitted.
+   */
+  applyEditOperations?: ApplyEditOperations;
   /** Injected ModelBrowserModal component (complex, app-specific) */
   ModelBrowserModal?: ComponentType<ModelBrowserModalProps> | null;
   /** Injected PromptPicker component (complex, app-specific) */

--- a/packages/workflow-ui/src/stores/execution/executionApi.test.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowUIHttpClient } from '../../provider/types';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './executionApi';
+
+describe('executionApi', () => {
+  afterEach(() => {
+    // Reset both registries to their standalone defaults so tests don't leak.
+    configureExecutionHttpClient(undefined);
+    configureExecutionHeaders(undefined);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('execution headers', () => {
+    it('defaults to no headers', () => {
+      expect(getExecutionHeaders()).toEqual({});
+    });
+
+    it('resolves headers from the configured provider on each call', () => {
+      const provider = vi
+        .fn()
+        .mockReturnValueOnce({ 'X-Replicate-Key': 'a' })
+        .mockReturnValueOnce({ 'X-Replicate-Key': 'b' });
+      configureExecutionHeaders(provider);
+
+      expect(getExecutionHeaders()).toEqual({ 'X-Replicate-Key': 'a' });
+      expect(getExecutionHeaders()).toEqual({ 'X-Replicate-Key': 'b' });
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+
+    it('reverts to no headers when reconfigured with undefined', () => {
+      configureExecutionHeaders(() => ({ 'X-Fal-Key': 'k' }));
+      configureExecutionHeaders(undefined);
+
+      expect(getExecutionHeaders()).toEqual({});
+    });
+  });
+
+  describe('execution HTTP client', () => {
+    it('routes requests through the configured client', async () => {
+      const client: WorkflowUIHttpClient = {
+        post: vi.fn().mockResolvedValue({ _id: 'exec-1' }),
+      };
+      configureExecutionHttpClient(client);
+
+      const result = await getExecutionHttpClient().post('/x', { a: 1 });
+
+      expect(client.post).toHaveBeenCalledWith('/x', { a: 1 });
+      expect(result).toEqual({ _id: 'exec-1' });
+    });
+
+    it('reverts to the bare-fetch default when reconfigured with undefined', async () => {
+      const custom: WorkflowUIHttpClient = { post: vi.fn() };
+      configureExecutionHttpClient(custom);
+      configureExecutionHttpClient(undefined);
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ _id: 'default' }),
+        ok: true,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getExecutionHttpClient().post(
+        '/workflows/1/execute',
+        {
+          debugMode: false,
+        },
+      );
+
+      expect(custom.post).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ _id: 'default' });
+    });
+
+    describe('bare-fetch default', () => {
+      it('POSTs JSON with Content-Type and merges caller headers', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({ ok: true }),
+          ok: true,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await getExecutionHttpClient().post(
+          '/workflows/1/execute',
+          { debugMode: true },
+          { headers: { 'X-Replicate-Key': 'secret' } },
+        );
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain('/workflows/1/execute');
+        expect(init.method).toBe('POST');
+        expect(init.headers).toEqual({
+          'Content-Type': 'application/json',
+          'X-Replicate-Key': 'secret',
+        });
+        expect(init.body).toBe(JSON.stringify({ debugMode: true }));
+      });
+
+      it('omits the body when none is provided', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({}),
+          ok: true,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await getExecutionHttpClient().post('/executions/1/stop');
+
+        const [, init] = fetchMock.mock.calls[0];
+        expect(init.body).toBeUndefined();
+      });
+
+      it('throws the API error message on a non-ok response', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({ message: 'nope' }),
+          ok: false,
+          status: 422,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+          getExecutionHttpClient().post('/workflows/1/execute', {}),
+        ).rejects.toThrow('nope');
+      });
+
+      it('falls back to a status message when the error body has none', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.reject(new Error('not json')),
+          ok: false,
+          status: 500,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+          getExecutionHttpClient().post('/workflows/1/execute', {}),
+        ).rejects.toThrow('API error: 500');
+      });
+    });
+  });
+});

--- a/packages/workflow-ui/src/stores/execution/executionApi.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.ts
@@ -1,0 +1,87 @@
+import type {
+  ExecutionHeaderProvider,
+  WorkflowUIHttpClient,
+} from '../../provider/types';
+
+// =============================================================================
+// Module-level execution HTTP configuration
+// =============================================================================
+
+/**
+ * Injected HTTP client + provider-header supplier for the execution store.
+ *
+ * The execution store (`executeWorkflow`, `stopExecution`, …) lives outside the
+ * React tree (plain Zustand) and cannot read the WorkflowUIProvider context
+ * directly, so both are registered at module scope via
+ * {@link configureExecutionHttpClient} / {@link configureExecutionHeaders} —
+ * the same pattern {@link configureWorkflowLogger} uses.
+ *
+ * Both default to the package's standalone behavior (bare `fetch`, no BYOK
+ * headers) so the package stays usable on its own; the consuming app injects a
+ * credentialed client and its provider auth headers through `WorkflowUIConfig`.
+ */
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
+
+/**
+ * Default fetch-based client. Preserves the package's prior inline `apiPost`
+ * behavior exactly: POST to `NEXT_PUBLIC_API_URL`, JSON body, surface the API's
+ * error message on non-2xx.
+ */
+const DEFAULT_HTTP_CLIENT: WorkflowUIHttpClient = {
+  post: async <T>(
+    path: string,
+    body?: Record<string, unknown>,
+    options?: { headers?: Record<string, string> },
+  ): Promise<T> => {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      method: 'POST',
+      ...(body && { body: JSON.stringify(body) }),
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        (errorData as { message?: string }).message ||
+          `API error: ${response.status}`,
+      );
+    }
+    return response.json() as Promise<T>;
+  },
+};
+
+const NOOP_HEADERS: ExecutionHeaderProvider = () => ({});
+
+let _httpClient: WorkflowUIHttpClient = DEFAULT_HTTP_CLIENT;
+let _headers: ExecutionHeaderProvider = NOOP_HEADERS;
+
+/**
+ * Register the HTTP client the execution store posts through.
+ * Called by WorkflowUIProvider; resets to the bare-fetch default when unset.
+ */
+export function configureExecutionHttpClient(
+  client: WorkflowUIHttpClient | undefined,
+): void {
+  _httpClient = client ?? DEFAULT_HTTP_CLIENT;
+}
+
+/** Read the currently-configured HTTP client (bare fetch until configured). */
+export function getExecutionHttpClient(): WorkflowUIHttpClient {
+  return _httpClient;
+}
+
+/**
+ * Register the provider-auth-header supplier for execute requests.
+ * Called by WorkflowUIProvider; resets to "no headers" when unset.
+ */
+export function configureExecutionHeaders(
+  provider: ExecutionHeaderProvider | undefined,
+): void {
+  _headers = provider ?? NOOP_HEADERS;
+}
+
+/** Resolve the provider auth headers for the current request (empty until configured). */
+export function getExecutionHeaders(): Record<string, string> {
+  return _headers();
+}

--- a/packages/workflow-ui/src/stores/execution/slices/executionSlice.ts
+++ b/packages/workflow-ui/src/stores/execution/slices/executionSlice.ts
@@ -4,36 +4,28 @@ import { getWorkflowLogger } from '../../executionLogger';
 import { useSettingsStore } from '../../settingsStore';
 import { useUIStore } from '../../uiStore';
 import { useWorkflowStore } from '../../workflow/workflowStore';
+import { getExecutionHeaders, getExecutionHttpClient } from '../executionApi';
 import {
   createExecutionSubscription,
   createNodeExecutionSubscription,
 } from '../helpers/sseSubscription';
 import type { ExecutionData, ExecutionStore, NodeExecution } from '../types';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
+const LOG_CONTEXT = 'ExecutionStore';
 
 /**
- * Simple fetch-based API client for execution operations.
- * Consuming apps can override by providing their own execution store.
+ * Start a workflow execution through the injected HTTP client, carrying the
+ * app's provider auth headers (Replicate / Fal / HuggingFace BYOK keys). Both
+ * the client and the headers default to the package's standalone behavior when
+ * the app has not configured them (see `executionApi`).
  */
-async function apiPost<T>(
+function startExecution(
   path: string,
-  body?: Record<string, unknown>,
-): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
-    ...(body && { body: JSON.stringify(body) }),
+  body: Record<string, unknown>,
+): Promise<ExecutionData> {
+  return getExecutionHttpClient().post<ExecutionData>(path, body, {
+    headers: getExecutionHeaders(),
   });
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(
-      (errorData as { message?: string }).message ||
-        `API error: ${response.status}`,
-    );
-  }
-  return response.json() as Promise<T>;
 }
 
 function validationError(message: string) {
@@ -105,7 +97,11 @@ export const createExecutionSlice: StateCreator<
     if (workflowStore.isDirty || !workflowStore.workflowId) {
       try {
         await workflowStore.saveWorkflow();
-      } catch {
+      } catch (error) {
+        getWorkflowLogger().error(
+          'Failed to save workflow before node execution',
+          { context: LOG_CONTEXT, error },
+        );
         workflowStore.updateNodeData(nodeId, {
           error: 'Failed to save workflow',
           status: NodeStatusEnum.ERROR,
@@ -128,7 +124,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -156,6 +152,10 @@ export const createExecutionSlice: StateCreator<
         return { activeNodeExecutions: newMap };
       });
     } catch (error) {
+      getWorkflowLogger().error('Failed to start node execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       workflowStore.updateNodeData(nodeId, {
         error: error instanceof Error ? error.message : 'Node execution failed',
         status: NodeStatusEnum.ERROR,
@@ -211,7 +211,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -224,6 +224,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(executionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to start partial execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -282,7 +286,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -294,6 +298,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(executionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to start workflow execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -391,7 +399,7 @@ export const createExecutionSlice: StateCreator<
     });
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -403,6 +411,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(newExecutionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to resume execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -432,9 +444,14 @@ export const createExecutionSlice: StateCreator<
     }
 
     if (executionId) {
-      apiPost(`/executions/${executionId}/stop`).catch(() => {
-        // Failed to stop execution
-      });
+      getExecutionHttpClient()
+        .post(`/executions/${executionId}/stop`)
+        .catch((error) => {
+          getWorkflowLogger().error('Failed to stop execution', {
+            context: LOG_CONTEXT,
+            error,
+          });
+        });
     }
 
     set({
@@ -451,9 +468,14 @@ export const createExecutionSlice: StateCreator<
     if (nodeExecution) {
       nodeExecution.eventSource.close();
 
-      apiPost(`/executions/${nodeExecution.executionId}/stop`).catch(() => {
-        // Failed to stop node execution
-      });
+      getExecutionHttpClient()
+        .post(`/executions/${nodeExecution.executionId}/stop`)
+        .catch((error) => {
+          getWorkflowLogger().error('Failed to stop node execution', {
+            context: LOG_CONTEXT,
+            error,
+          });
+        });
 
       set((state) => {
         const newMap = new Map(state.activeNodeExecutions);

--- a/packages/workflow-ui/src/stores/index.ts
+++ b/packages/workflow-ui/src/stores/index.ts
@@ -54,9 +54,20 @@ export { PROVIDER_INFO, useSettingsStore } from './settingsStore';
 export type { ModalType, NodeDetailTab } from './uiStore';
 export { useUIStore } from './uiStore';
 // Store types
-export type { WorkflowData, WorkflowState, WorkflowStore } from './workflow';
+export type {
+  WorkflowData,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowState,
+  WorkflowStore,
+  WorkflowSummary,
+} from './workflow';
 // Store hooks
 export { useWorkflowStore } from './workflow';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './workflow/applyEditOperations';
 // Workflow selectors
 export {
   createSelectGroupByNodeId,
@@ -93,3 +104,7 @@ export {
   selectWorkflowId,
   selectWorkflowName,
 } from './workflow/selectors';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflow/workflowPersistence';

--- a/packages/workflow-ui/src/stores/index.ts
+++ b/packages/workflow-ui/src/stores/index.ts
@@ -25,6 +25,12 @@ export { useAnnotationStore } from './annotationStore';
 export { type ContextMenuType, useContextMenuStore } from './contextMenuStore';
 export type { DebugPayload, ExecutionStore, Job } from './execution';
 export { useExecutionStore } from './execution';
+export {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './execution/executionApi';
 // Embedded stores (moved from core app)
 export {
   configureWorkflowLogger,

--- a/packages/workflow-ui/src/stores/workflow/applyEditOperations.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/applyEditOperations.test.ts
@@ -1,0 +1,51 @@
+import type { WorkflowEdge, WorkflowNode } from '@genfeedai/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './applyEditOperations';
+import type { EditOperation } from './slices/types';
+
+const nodes = [
+  { data: {}, id: 'a', position: { x: 0, y: 0 }, type: 'prompt' },
+] as unknown as WorkflowNode[];
+const edges = [] as WorkflowEdge[];
+
+describe('applyEditOperations', () => {
+  afterEach(() => {
+    // Reset to the no-op default so tests don't leak an implementation.
+    configureApplyEditOperations(undefined);
+  });
+
+  it('defaults to a no-op that leaves the graph untouched', () => {
+    const operations: EditOperation[] = [{ nodeId: 'a', type: 'removeNode' }];
+
+    const result = getApplyEditOperations()(operations, { edges, nodes });
+
+    expect(result).toEqual({ applied: 0, edges, nodes, skipped: [] });
+  });
+
+  it('routes to the configured implementation with operations + state', () => {
+    const apply = vi
+      .fn()
+      .mockReturnValue({ applied: 1, edges, nodes: [], skipped: [] });
+    configureApplyEditOperations(apply);
+
+    const operations: EditOperation[] = [{ nodeId: 'a', type: 'removeNode' }];
+    const result = getApplyEditOperations()(operations, { edges, nodes });
+
+    expect(apply).toHaveBeenCalledWith(operations, { edges, nodes });
+    expect(result.applied).toBe(1);
+  });
+
+  it('reverts to the no-op when reconfigured with undefined', () => {
+    configureApplyEditOperations(
+      vi.fn().mockReturnValue({ applied: 5, edges, nodes: [], skipped: [] }),
+    );
+    configureApplyEditOperations(undefined);
+
+    const result = getApplyEditOperations()([], { edges, nodes });
+
+    expect(result.applied).toBe(0);
+  });
+});

--- a/packages/workflow-ui/src/stores/workflow/applyEditOperations.ts
+++ b/packages/workflow-ui/src/stores/workflow/applyEditOperations.ts
@@ -1,0 +1,42 @@
+import type { ApplyEditOperations } from './slices/types';
+
+// =============================================================================
+// Module-level applyEditOperations configuration
+// =============================================================================
+
+/**
+ * Injected `applyEditOperations` implementation for the snapshot slice (used by
+ * the chat/agent edit pipeline to mutate the graph). Registered at module scope
+ * via {@link configureApplyEditOperations} because the workflow store lives
+ * outside the React tree.
+ *
+ * Defaults to a no-op that leaves the graph untouched (0 applied) so the package
+ * stays functional standalone; the consuming app injects the real graph-diffing
+ * implementation through `WorkflowUIConfig.applyEditOperations`.
+ */
+const NOOP_APPLY_EDIT_OPERATIONS: ApplyEditOperations = (
+  _operations,
+  state,
+) => ({
+  applied: 0,
+  edges: state.edges,
+  nodes: state.nodes,
+  skipped: [],
+});
+
+let _apply: ApplyEditOperations = NOOP_APPLY_EDIT_OPERATIONS;
+
+/**
+ * Register the `applyEditOperations` implementation the snapshot slice uses.
+ * Called by WorkflowUIProvider; resets to the no-op default when unset.
+ */
+export function configureApplyEditOperations(
+  apply: ApplyEditOperations | undefined,
+): void {
+  _apply = apply ?? NOOP_APPLY_EDIT_OPERATIONS;
+}
+
+/** Read the currently-configured applyEditOperations (no-op until configured). */
+export function getApplyEditOperations(): ApplyEditOperations {
+  return _apply;
+}

--- a/packages/workflow-ui/src/stores/workflow/index.ts
+++ b/packages/workflow-ui/src/stores/workflow/index.ts
@@ -5,5 +5,12 @@
  * Internal implementation uses slices for organization.
  */
 
-export type { WorkflowData, WorkflowState, WorkflowStore } from './types';
+export type {
+  WorkflowData,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowState,
+  WorkflowStore,
+  WorkflowSummary,
+} from './types';
 export { useWorkflowStore } from './workflowStore';

--- a/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
@@ -1,4 +1,5 @@
 import type {
+  EdgeStyle,
   NodeType,
   ValidationResult,
   WorkflowEdge,
@@ -9,9 +10,15 @@ import type {
 } from '@genfeedai/types';
 import { NODE_DEFINITIONS } from '@genfeedai/types';
 import type { StateCreator } from 'zustand';
-import { getConnectedInputsForNode, getUpstreamNodeIds } from '../../../lib';
+import {
+  calculateWorkflowCost,
+  getConnectedInputsForNode,
+  getUpstreamNodeIds,
+} from '../../../lib';
+import { useExecutionStore } from '../../execution/executionStore';
 import { propagateExistingOutputs } from '../helpers/propagation';
-import type { WorkflowData, WorkflowStore } from '../types';
+import type { WorkflowData, WorkflowStore, WorkflowSummary } from '../types';
+import { getWorkflowPersistence } from '../workflowPersistence';
 
 /**
  * Normalize edges loaded from storage to use React Flow edge types.
@@ -50,7 +57,7 @@ export interface PersistenceSlice {
   exportWorkflow: () => WorkflowFile;
   saveWorkflow: (signal?: AbortSignal) => Promise<WorkflowData>;
   loadWorkflowById: (id: string, signal?: AbortSignal) => Promise<void>;
-  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowData[]>;
+  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowSummary[]>;
   deleteWorkflow: (id: string, signal?: AbortSignal) => Promise<void>;
   duplicateWorkflowApi: (
     id: string,
@@ -87,23 +94,50 @@ export const createPersistenceSlice: StateCreator<
     });
   },
 
-  createNewWorkflow: async () => {
-    throw new Error(
-      'createNewWorkflow not implemented - consuming app must provide API integration',
+  createNewWorkflow: async (signal) => {
+    const { edgeStyle } = get();
+
+    const workflow = await getWorkflowPersistence().create(
+      {
+        edgeStyle,
+        edges: [],
+        groups: [],
+        name: 'Untitled Workflow',
+        nodes: [],
+      },
+      signal,
     );
+
+    set({
+      edges: [],
+      groups: [],
+      isDirty: false,
+      nodes: [],
+      selectedNodeIds: [],
+      workflowId: workflow._id,
+      workflowName: workflow.name,
+    });
+
+    return workflow._id;
   },
 
-  deleteWorkflow: async () => {
-    throw new Error(
-      'deleteWorkflow not implemented - consuming app must provide API integration',
-    );
+  deleteWorkflow: async (id, signal) => {
+    await getWorkflowPersistence().delete(id, signal);
+
+    const { workflowId } = get();
+    if (workflowId === id) {
+      set({
+        edges: [],
+        isDirty: false,
+        nodes: [],
+        workflowId: null,
+        workflowName: 'Untitled Workflow',
+      });
+    }
   },
 
-  duplicateWorkflowApi: async () => {
-    throw new Error(
-      'duplicateWorkflowApi not implemented - consuming app must provide API integration',
-    );
-  },
+  duplicateWorkflowApi: (id, signal) =>
+    getWorkflowPersistence().duplicate(id, signal),
 
   exportWorkflow: () => {
     const { nodes, edges, edgeStyle, workflowName, groups } = get();
@@ -157,11 +191,7 @@ export const createPersistenceSlice: StateCreator<
     }).length;
   },
 
-  listWorkflows: async () => {
-    throw new Error(
-      'listWorkflows not implemented - consuming app must provide API integration',
-    );
-  },
+  listWorkflows: (signal) => getWorkflowPersistence().getAll(undefined, signal),
   loadWorkflow: (workflow) => {
     const hydratedNodes = hydrateWorkflowNodes(workflow.nodes);
 
@@ -176,6 +206,9 @@ export const createPersistenceSlice: StateCreator<
       workflowName: workflow.name,
     });
 
+    const estimatedCost = calculateWorkflowCost(hydratedNodes);
+    useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
+
     // Propagate existing outputs to downstream nodes after load
     propagateExistingOutputs(hydratedNodes, get().propagateOutputsDownstream);
 
@@ -183,10 +216,36 @@ export const createPersistenceSlice: StateCreator<
     set({ isDirty: false });
   },
 
-  loadWorkflowById: async () => {
-    throw new Error(
-      'loadWorkflowById not implemented - consuming app must provide API integration',
-    );
+  loadWorkflowById: async (id, signal) => {
+    set({ isLoading: true });
+
+    try {
+      const workflow = await getWorkflowPersistence().getById(id, signal);
+      const nodes = hydrateWorkflowNodes(workflow.nodes);
+
+      set({
+        edgeStyle: workflow.edgeStyle as EdgeStyle,
+        edges: normalizeEdgeTypes(workflow.edges),
+        groups: workflow.groups ?? [],
+        isDirty: false,
+        isLoading: false,
+        nodes,
+        workflowId: workflow._id,
+        workflowName: workflow.name,
+      });
+
+      const estimatedCost = calculateWorkflowCost(nodes);
+      useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
+
+      // Propagate existing outputs to downstream nodes after load
+      propagateExistingOutputs(nodes, get().propagateOutputsDownstream);
+
+      // Propagation after load is idempotent; don't trigger save cycle
+      set({ isDirty: false });
+    } catch (error) {
+      set({ isLoading: false });
+      throw error;
+    }
   },
 
   markCommentViewed: (nodeId: string) => {
@@ -197,12 +256,34 @@ export const createPersistenceSlice: StateCreator<
     });
   },
 
-  // API operations - stubs that throw by default.
-  // Consuming apps override these via the store creator or by extending the slice.
-  saveWorkflow: async () => {
-    throw new Error(
-      'saveWorkflow not implemented - consuming app must provide API integration',
-    );
+  saveWorkflow: async (signal) => {
+    const { nodes, edges, edgeStyle, workflowName, workflowId, groups } = get();
+    set({ isSaving: true });
+
+    try {
+      const input = {
+        edgeStyle,
+        edges,
+        groups,
+        name: workflowName,
+        nodes,
+      };
+
+      const workflow = workflowId
+        ? await getWorkflowPersistence().update(workflowId, input, signal)
+        : await getWorkflowPersistence().create(input, signal);
+
+      set({
+        isDirty: false,
+        isSaving: false,
+        workflowId: workflow._id,
+      });
+
+      return workflow;
+    } catch (error) {
+      set({ isSaving: false });
+      throw error;
+    }
   },
 
   setDirty: (dirty) => {

--- a/packages/workflow-ui/src/stores/workflow/slices/snapshotSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/snapshotSlice.ts
@@ -1,24 +1,7 @@
-import type { WorkflowEdge, WorkflowNode } from '@genfeedai/types';
 import type { StateCreator } from 'zustand';
+import { getApplyEditOperations } from '../applyEditOperations';
 import type { WorkflowStore } from '../types';
-import type { EditOperation, SnapshotSlice, WorkflowSnapshot } from './types';
-
-/**
- * EditOperation type inlined from @/lib/chat/editOperations.
- * The consuming app provides the actual applyEditOperations implementation.
- */
-// Stub applyEditOperations - consuming app should override via the store creator.
-function defaultApplyEditOperations(
-  _operations: EditOperation[],
-  state: { nodes: WorkflowNode[]; edges: WorkflowEdge[] },
-): {
-  nodes: WorkflowNode[];
-  edges: WorkflowEdge[];
-  applied: number;
-  skipped: string[];
-} {
-  return { applied: 0, edges: state.edges, nodes: state.nodes, skipped: [] };
-}
+import type { SnapshotSlice, WorkflowSnapshot } from './types';
 
 export const createSnapshotSlice: StateCreator<
   WorkflowStore & SnapshotSlice,
@@ -28,7 +11,7 @@ export const createSnapshotSlice: StateCreator<
 > = (set, get) => ({
   applyEditOperations: (operations) => {
     const state = get();
-    const result = defaultApplyEditOperations(operations, {
+    const result = getApplyEditOperations()(operations, {
       edges: state.edges,
       nodes: state.nodes,
     });

--- a/packages/workflow-ui/src/stores/workflow/slices/types.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/types.ts
@@ -1,14 +1,52 @@
 import type {
   EdgeStyle,
   NodeGroup,
+  NodeType,
   WorkflowEdge,
   WorkflowNode,
 } from '@genfeedai/types';
 
-export interface EditOperation {
-  type: 'add_node' | 'remove_node' | 'update_node' | 'add_edge' | 'remove_edge';
-  [key: string]: unknown;
+/**
+ * A single atomic change to the workflow graph. Canonical shape shared with the
+ * app's chat/agent edit pipeline — the `applyEditOperations` implementation is
+ * injected (see WorkflowUIConfig.applyEditOperations); this package defaults to
+ * a no-op when unconfigured.
+ */
+export type EditOperation =
+  | {
+      type: 'addNode';
+      nodeType: NodeType;
+      position?: { x: number; y: number };
+      data?: Record<string, unknown>;
+    }
+  | { type: 'removeNode'; nodeId: string }
+  | { type: 'updateNode'; nodeId: string; data: Record<string, unknown> }
+  | {
+      type: 'addEdge';
+      source: string;
+      target: string;
+      sourceHandle?: string;
+      targetHandle?: string;
+    }
+  | { type: 'removeEdge'; edgeId: string };
+
+/** Result of applying a batch of {@link EditOperation}s. */
+export interface ApplyEditResult {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  applied: number;
+  skipped: string[];
 }
+
+/**
+ * Applies a batch of edit operations to the current graph and returns the new
+ * nodes/edges plus how many applied / which were skipped. Injected by the app;
+ * defaults to a no-op that leaves the graph untouched.
+ */
+export type ApplyEditOperations = (
+  operations: EditOperation[],
+  state: { nodes: WorkflowNode[]; edges: WorkflowEdge[] },
+) => ApplyEditResult;
 
 export interface ChatMessage {
   id: string;

--- a/packages/workflow-ui/src/stores/workflow/types.ts
+++ b/packages/workflow-ui/src/stores/workflow/types.ts
@@ -44,6 +44,53 @@ export interface WorkflowData {
   updatedAt?: string;
 }
 
+/** Payload sent to the persistence service on create / update. */
+export interface WorkflowSaveInput {
+  name: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  edgeStyle?: string;
+  groups?: NodeGroup[];
+  tags?: string[];
+}
+
+/** Lightweight workflow projection returned by the list endpoint (no graph). */
+export interface WorkflowSummary {
+  _id: string;
+  name: string;
+  description?: string;
+  lifecycle: 'draft' | 'published' | 'archived';
+  thumbnail?: string | null;
+  thumbnailNodeId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Persistence backend the workflow store's CRUD actions delegate to. Injected by
+ * the consuming app (see WorkflowUIConfig.workflowPersistence); when unconfigured
+ * the package throws a clear "not configured" error — its prior standalone
+ * behavior — rather than silently dropping saves.
+ */
+export interface WorkflowPersistenceService {
+  create: (
+    input: WorkflowSaveInput,
+    signal?: AbortSignal,
+  ) => Promise<WorkflowData>;
+  update: (
+    id: string,
+    input: WorkflowSaveInput,
+    signal?: AbortSignal,
+  ) => Promise<WorkflowData>;
+  getById: (id: string, signal?: AbortSignal) => Promise<WorkflowData>;
+  getAll: (
+    params?: { search?: string; tag?: string },
+    signal?: AbortSignal,
+  ) => Promise<WorkflowSummary[]>;
+  delete: (id: string, signal?: AbortSignal) => Promise<void>;
+  duplicate: (id: string, signal?: AbortSignal) => Promise<WorkflowData>;
+}
+
 // =============================================================================
 // STATE TYPES
 // =============================================================================
@@ -137,7 +184,7 @@ export interface LocalWorkflowActions {
 export interface ApiActions {
   saveWorkflow: (signal?: AbortSignal) => Promise<WorkflowData>;
   loadWorkflowById: (id: string, signal?: AbortSignal) => Promise<void>;
-  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowData[]>;
+  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowSummary[]>;
   deleteWorkflow: (id: string, signal?: AbortSignal) => Promise<void>;
   duplicateWorkflowApi: (
     id: string,

--- a/packages/workflow-ui/src/stores/workflow/workflowPersistence.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/workflowPersistence.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowData, WorkflowPersistenceService } from './types';
+import {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflowPersistence';
+
+const workflow: WorkflowData = {
+  _id: 'wf-1',
+  edgeStyle: 'default',
+  edges: [],
+  name: 'Test',
+  nodes: [],
+};
+
+function makeService(): WorkflowPersistenceService {
+  return {
+    create: vi.fn().mockResolvedValue(workflow),
+    delete: vi.fn().mockResolvedValue(undefined),
+    duplicate: vi.fn().mockResolvedValue(workflow),
+    getAll: vi.fn().mockResolvedValue([]),
+    getById: vi.fn().mockResolvedValue(workflow),
+    update: vi.fn().mockResolvedValue(workflow),
+  };
+}
+
+describe('workflowPersistence', () => {
+  afterEach(() => {
+    // Reset to the throwing default so tests don't leak a service into each other.
+    configureWorkflowPersistence(undefined);
+  });
+
+  it('throws a clear "not configured" error for every method by default', async () => {
+    const service = getWorkflowPersistence();
+
+    await expect(
+      service.create({ edges: [], name: 'x', nodes: [] }),
+    ).rejects.toThrow(/not configured/);
+    await expect(service.getById('id')).rejects.toThrow(/not configured/);
+    await expect(service.getAll()).rejects.toThrow(/not configured/);
+    await expect(service.delete('id')).rejects.toThrow(/not configured/);
+    await expect(service.duplicate('id')).rejects.toThrow(/not configured/);
+    await expect(
+      service.update('id', { edges: [], name: 'x', nodes: [] }),
+    ).rejects.toThrow(/not configured/);
+  });
+
+  it('routes calls to the configured service', async () => {
+    const service = makeService();
+    configureWorkflowPersistence(service);
+
+    const result = await getWorkflowPersistence().getById('wf-1');
+
+    expect(service.getById).toHaveBeenCalledWith('wf-1');
+    expect(result).toEqual(workflow);
+  });
+
+  it('reverts to the throwing default when reconfigured with undefined', async () => {
+    configureWorkflowPersistence(makeService());
+    configureWorkflowPersistence(undefined);
+
+    await expect(getWorkflowPersistence().getById('id')).rejects.toThrow(
+      /not configured/,
+    );
+  });
+});

--- a/packages/workflow-ui/src/stores/workflow/workflowPersistence.ts
+++ b/packages/workflow-ui/src/stores/workflow/workflowPersistence.ts
@@ -1,0 +1,50 @@
+import type { WorkflowPersistenceService } from './types';
+
+// =============================================================================
+// Module-level workflow persistence configuration
+// =============================================================================
+
+/**
+ * Injected persistence backend for the workflow store's CRUD actions
+ * (`saveWorkflow`, `loadWorkflowById`, `listWorkflows`, `deleteWorkflow`,
+ * `duplicateWorkflowApi`, `createNewWorkflow`).
+ *
+ * The workflow store is a plain Zustand store outside the React tree, so the
+ * service is registered at module scope via {@link configureWorkflowPersistence}
+ * — the same pattern the execution HTTP client and logger use.
+ *
+ * When unconfigured, every method throws a clear "not configured" error. This
+ * preserves the package's prior standalone behavior (the stubs threw
+ * "not implemented") — a save must never silently no-op and drop the user's work.
+ */
+function notConfigured(method: string): never {
+  throw new Error(
+    `WorkflowPersistenceService.${method} is not configured — the consuming app must inject workflowPersistence via WorkflowUIConfig`,
+  );
+}
+
+const DEFAULT_PERSISTENCE: WorkflowPersistenceService = {
+  create: async () => notConfigured('create'),
+  delete: async () => notConfigured('delete'),
+  duplicate: async () => notConfigured('duplicate'),
+  getAll: async () => notConfigured('getAll'),
+  getById: async () => notConfigured('getById'),
+  update: async () => notConfigured('update'),
+};
+
+let _persistence: WorkflowPersistenceService = DEFAULT_PERSISTENCE;
+
+/**
+ * Register the persistence backend the workflow store delegates to.
+ * Called by WorkflowUIProvider; resets to the throwing default when unset.
+ */
+export function configureWorkflowPersistence(
+  service: WorkflowPersistenceService | undefined,
+): void {
+  _persistence = service ?? DEFAULT_PERSISTENCE;
+}
+
+/** Read the currently-configured persistence backend (throws until configured). */
+export function getWorkflowPersistence(): WorkflowPersistenceService {
+  return _persistence;
+}


### PR DESCRIPTION
## Summary

Third increment of the **workflow-ui fork unification** ([issue #1151](https://github.com/genfeedai/genfeed.ai/issues/1151), cluster C1). Replaces the package's **throwing persistence stubs** and **no-op `applyEditOperations`** with injected services — the last runtime gap before the `apps/app` fork can be deleted (step 5).

> **Stacked on #1152** (execution-HTTP seam), which stacks on #1149. Base is `feat/workflow-ui-execution-http-injection`; merge in order. GitHub retargets automatically as each lands.

### The problem
`packages/workflow-ui`'s `persistenceSlice` had six methods that `throw 'not implemented'` (`saveWorkflow`, `loadWorkflowById`, `listWorkflows`, `deleteWorkflow`, `duplicateWorkflowApi`, `createNewWorkflow`), and `snapshotSlice`'s `applyEditOperations` was a no-op. The real implementations lived only in the fork. A naive fork deletion would make the desktop builder's **save/load throw at runtime** and silently drop chat/agent edits.

### What this does

**Package**
- The six persistence stubs now delegate to an injected `WorkflowPersistenceService`, porting the fork's real orchestration (`isSaving`/`isLoading` state, node hydration, edge normalization, estimated-cost via the package's own `calculateWorkflowCost`, downstream propagation). `loadWorkflow` gains the same estimated-cost line for parity with `loadWorkflowById`.
- New `stores/workflow/workflowPersistence.ts` registry (`configureWorkflowPersistence` / `getWorkflowPersistence`). Default **throws a clear "not configured" error** — preserving prior standalone behavior; a save must never silently no-op and drop the user's work.
- `snapshotSlice`'s inline no-op is replaced by an injected `ApplyEditOperations` (new `stores/workflow/applyEditOperations.ts`, default no-op). The stale snake_case `EditOperation` placeholder is replaced with the app's **canonical camelCase discriminated union** + `ApplyEditResult`, so the injected impl is fully typed.
- `WorkflowUIProvider` registers both. `listWorkflows` return type tightened from `WorkflowData[]` to a new lightweight `WorkflowSummary[]` (the list endpoint's real shape).

**App (`apps/app`)**
- Both cloud workflow provider configs inject `workflowsApi` (create/update/getById/getAll/delete/duplicate) as the persistence backend and the canonical `applyEditOperations` from `@/lib/chat/editOperations`.
- `useCloudWorkflow`'s `listWorkflows` override returns `service.list()` directly (its `WorkflowSummary` is a superset), dropping the fabricated empty-graph objects it built to satisfy the old `WorkflowData[]` type.

### Deferred (by design)
- Package persistence intentionally omits `workflowTags` (an app-only field). That divergence is reconciled in **step 4**, before the fork deletion in **step 5**.

## Verification
- `@genfeedai/workflow-ui` type-check green (fresh, `--force`)
- `@genfeedai/app` type-check green (fresh, `--force`)
- Full package vitest **352/352** incl. new `workflowPersistence.test.ts` + `applyEditOperations.test.ts`
- biome clean; secretlint + no-raw-html pre-commit hooks green

## Sequence (issue #1151)
1. Error-reporting seam — #1149
2. Execution HTTP + provider-headers — #1152
3. **Persistence + applyEditOperations injection — this PR**
4. Reconcile divergences (`edgeSlice` position-dirty; Image History vs `workflowTags`)
5. Delete fork + repoint ~16 consumers, behind Playwright coverage
6. Port execution-store tests into the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)