### PR TITLE
test(workflow-ui): port execution-store tests into the package (#1151)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -43,6 +43,8 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { apiClient } from '@/lib/api/client';
+import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 interface WorkflowDetailPageClientProps {
@@ -136,6 +138,14 @@ export default function WorkflowDetailPageClient({
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      executionHeaders: getExecutionProviderHeaders,
+      executionHttpClient: {
+        post: <T,>(
+          path: string,
+          body?: Record<string, unknown>,
+          options?: { headers?: Record<string, string> },
+        ): Promise<T> => apiClient.post<T>(path, body, options),
+      },
       logger,
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -43,8 +43,10 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { workflowsApi } from '@/lib/api';
 import { apiClient } from '@/lib/api/client';
 import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
+import { applyEditOperations } from '@/lib/chat/editOperations';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 interface WorkflowDetailPageClientProps {
@@ -138,6 +140,7 @@ export default function WorkflowDetailPageClient({
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      applyEditOperations,
       executionHeaders: getExecutionProviderHeaders,
       executionHttpClient: {
         post: <T,>(
@@ -147,6 +150,14 @@ export default function WorkflowDetailPageClient({
         ): Promise<T> => apiClient.post<T>(path, body, options),
       },
       logger,
+      workflowPersistence: {
+        create: workflowsApi.create,
+        delete: workflowsApi.delete,
+        duplicate: workflowsApi.duplicate,
+        getAll: workflowsApi.getAll,
+        getById: workflowsApi.getById,
+        update: workflowsApi.update,
+      },
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {
           const service = await getWorkflowService();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -44,8 +44,10 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { workflowsApi } from '@/lib/api';
 import { apiClient } from '@/lib/api/client';
 import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
+import { applyEditOperations } from '@/lib/chat/editOperations';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 type WorkflowStoreState = ReturnType<typeof useWorkflowStore.getState>;
@@ -191,6 +193,7 @@ export default function WorkflowNewPageClient() {
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      applyEditOperations,
       executionHeaders: getExecutionProviderHeaders,
       executionHttpClient: {
         post: <T,>(
@@ -200,6 +203,14 @@ export default function WorkflowNewPageClient() {
         ): Promise<T> => apiClient.post<T>(path, body, options),
       },
       logger,
+      workflowPersistence: {
+        create: workflowsApi.create,
+        delete: workflowsApi.delete,
+        duplicate: workflowsApi.duplicate,
+        getAll: workflowsApi.getAll,
+        getById: workflowsApi.getById,
+        update: workflowsApi.update,
+      },
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {
           const service = await getWorkflowService();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -44,6 +44,8 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { apiClient } from '@/lib/api/client';
+import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 type WorkflowStoreState = ReturnType<typeof useWorkflowStore.getState>;
@@ -189,6 +191,14 @@ export default function WorkflowNewPageClient() {
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      executionHeaders: getExecutionProviderHeaders,
+      executionHttpClient: {
+        post: <T,>(
+          path: string,
+          body?: Record<string, unknown>,
+          options?: { headers?: Record<string, string> },
+        ): Promise<T> => apiClient.post<T>(path, body, options),
+      },
       logger,
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {

--- a/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
+++ b/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
@@ -90,20 +90,7 @@ export function useCloudWorkflow({
 
   const bindSharedWorkflowApi = useCallback((service: WorkflowApiService) => {
     useWorkflowStore.setState({
-      listWorkflows: async () => {
-        const workflows = await service.list();
-
-        return workflows.map((workflow) => ({
-          _id: workflow._id,
-          createdAt: workflow.createdAt,
-          edgeStyle: 'default',
-          edges: [],
-          groups: [],
-          name: workflow.name,
-          nodes: [],
-          updatedAt: workflow.updatedAt,
-        }));
-      },
+      listWorkflows: async () => service.list(),
       loadWorkflowById: async (id: string) => {
         await useCloudWorkflowStore.getState().loadFromCloud(id, service);
       },

--- a/apps/app/src/lib/api/execution-headers.ts
+++ b/apps/app/src/lib/api/execution-headers.ts
@@ -1,0 +1,20 @@
+import { useSettingsStore } from '@/store/settingsStore';
+
+/**
+ * Resolve the provider auth headers (Replicate / Fal / HuggingFace BYOK keys)
+ * attached to workflow-execute requests, read from the user's local settings.
+ *
+ * Injected into `packages/workflow-ui` via `WorkflowUIConfig.executionHeaders`
+ * so the package's execution store can carry BYOK credentials without depending
+ * on the app's settings store. Returns an empty record when no keys are set
+ * (e.g. cloud runs, where credentials are resolved server-side).
+ */
+export function getExecutionProviderHeaders(): Record<string, string> {
+  const settings = useSettingsStore.getState();
+
+  return {
+    ...settings.getProviderHeader('replicate'),
+    ...settings.getProviderHeader('fal'),
+    ...settings.getProviderHeader('huggingface'),
+  };
+}

--- a/packages/workflow-ui/src/index.ts
+++ b/packages/workflow-ui/src/index.ts
@@ -37,10 +37,16 @@ export { BaseNode, nodeTypes } from './nodes';
 // Panels
 export { DebugPanel, NodePalette, PanelContainer } from './panels';
 export type {
+  ApplyEditOperations,
+  ApplyEditResult,
+  EditOperation,
   ExecutionHeaderProvider,
   ModelBrowserModalProps,
   PromptLibraryService,
   PromptPickerProps,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowSummary,
   WorkflowUIConfig,
   WorkflowUIHttpClient,
   WorkflowUILogger,
@@ -68,7 +74,15 @@ export { useSettingsStore } from './stores/settingsStore';
 // Stores
 export { useUIStore } from './stores/uiStore';
 export { useWorkflowStore } from './stores/workflow';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './stores/workflow/applyEditOperations';
 export type { ImageHistoryItem } from './stores/workflow/types';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './stores/workflow/workflowPersistence';
 export type {
   DropdownItem,
   OverflowMenuProps,

--- a/packages/workflow-ui/src/index.ts
+++ b/packages/workflow-ui/src/index.ts
@@ -37,16 +37,24 @@ export { BaseNode, nodeTypes } from './nodes';
 // Panels
 export { DebugPanel, NodePalette, PanelContainer } from './panels';
 export type {
+  ExecutionHeaderProvider,
   ModelBrowserModalProps,
   PromptLibraryService,
   PromptPickerProps,
   WorkflowUIConfig,
+  WorkflowUIHttpClient,
   WorkflowUILogger,
 } from './provider';
 // Provider
 export { useWorkflowUIConfig, WorkflowUIProvider } from './provider';
 export { useAnnotationStore } from './stores/annotationStore';
 export { useExecutionStore } from './stores/execution';
+export {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './stores/execution/executionApi';
 export {
   configureWorkflowLogger,
   getWorkflowLogger,

--- a/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
+++ b/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { createContext, type ReactNode, use, useEffect } from 'react';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+} from '../stores/execution/executionApi';
 import { configureWorkflowLogger } from '../stores/executionLogger';
 import { configurePromptLibrary } from '../stores/promptLibraryStore';
 import type { WorkflowUIConfig } from './types';
@@ -38,6 +42,16 @@ export function WorkflowUIProvider({
   useEffect(() => {
     configureWorkflowLogger(config.logger);
   }, [config.logger]);
+
+  // Register the execution HTTP client + provider auth headers. Both reset to
+  // the package's bare-fetch / no-header defaults when unset.
+  useEffect(() => {
+    configureExecutionHttpClient(config.executionHttpClient);
+  }, [config.executionHttpClient]);
+
+  useEffect(() => {
+    configureExecutionHeaders(config.executionHeaders);
+  }, [config.executionHeaders]);
 
   return (
     <WorkflowUIContext.Provider value={config}>

--- a/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
+++ b/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
@@ -7,6 +7,8 @@ import {
 } from '../stores/execution/executionApi';
 import { configureWorkflowLogger } from '../stores/executionLogger';
 import { configurePromptLibrary } from '../stores/promptLibraryStore';
+import { configureApplyEditOperations } from '../stores/workflow/applyEditOperations';
+import { configureWorkflowPersistence } from '../stores/workflow/workflowPersistence';
 import type { WorkflowUIConfig } from './types';
 
 const WorkflowUIContext = createContext<WorkflowUIConfig>({});
@@ -52,6 +54,16 @@ export function WorkflowUIProvider({
   useEffect(() => {
     configureExecutionHeaders(config.executionHeaders);
   }, [config.executionHeaders]);
+
+  // Register the workflow persistence backend + graph edit-operation applier.
+  // Both reset to their defaults (throw / no-op) when unset.
+  useEffect(() => {
+    configureWorkflowPersistence(config.workflowPersistence);
+  }, [config.workflowPersistence]);
+
+  useEffect(() => {
+    configureApplyEditOperations(config.applyEditOperations);
+  }, [config.applyEditOperations]);
 
   return (
     <WorkflowUIContext.Provider value={config}>

--- a/packages/workflow-ui/src/provider/index.ts
+++ b/packages/workflow-ui/src/provider/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ExecutionHeaderProvider,
   FileUploadService,
   ModelBrowserModalProps,
   ModelSchemaService,
@@ -6,6 +7,7 @@ export type {
   PromptPickerProps,
   WorkflowsApiService,
   WorkflowUIConfig,
+  WorkflowUIHttpClient,
   WorkflowUILogger,
 } from './types';
 export { useWorkflowUIConfig, WorkflowUIProvider } from './WorkflowUIProvider';

--- a/packages/workflow-ui/src/provider/index.ts
+++ b/packages/workflow-ui/src/provider/index.ts
@@ -1,4 +1,14 @@
 export type {
+  ApplyEditOperations,
+  ApplyEditResult,
+  EditOperation,
+} from '../stores/workflow/slices/types';
+export type {
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowSummary,
+} from '../stores/workflow/types';
+export type {
   ExecutionHeaderProvider,
   FileUploadService,
   ModelBrowserModalProps,

--- a/packages/workflow-ui/src/provider/types.ts
+++ b/packages/workflow-ui/src/provider/types.ts
@@ -92,6 +92,33 @@ export interface WorkflowUILogger {
 }
 
 // =============================================================================
+// Execution HTTP
+// =============================================================================
+
+/**
+ * HTTP client the execution store issues its POST requests through
+ * (workflow execute, execution stop). The consuming app injects a credentialed
+ * client — one that resolves the correct API base URL and carries auth cookies —
+ * so runs are attributed to the signed-in user. When absent the package falls
+ * back to a bare `fetch` against `NEXT_PUBLIC_API_URL` (its standalone default).
+ */
+export interface WorkflowUIHttpClient {
+  post: <T>(
+    path: string,
+    body?: Record<string, unknown>,
+    options?: { headers?: Record<string, string> },
+  ) => Promise<T>;
+}
+
+/**
+ * Supplies the per-request provider auth headers (Replicate / Fal / HuggingFace
+ * BYOK keys) attached to workflow-execute requests. Returns an empty record when
+ * the user has not configured BYOK keys. Defaults to no headers so the package
+ * stays provider-agnostic standalone.
+ */
+export type ExecutionHeaderProvider = () => Record<string, string>;
+
+// =============================================================================
 // Config
 // =============================================================================
 
@@ -106,6 +133,17 @@ export interface WorkflowUIConfig {
   workflowsApi?: WorkflowsApiService;
   /** Execution-store error reporting (SSE failures, failed runs). No-op if omitted. */
   logger?: WorkflowUILogger;
+  /**
+   * HTTP client the execution store posts through (execute / stop). Defaults to a
+   * bare `fetch` against `NEXT_PUBLIC_API_URL` when omitted; the app injects a
+   * credentialed client so runs carry the signed-in user's session.
+   */
+  executionHttpClient?: WorkflowUIHttpClient;
+  /**
+   * Provider auth headers (Replicate / Fal / HuggingFace BYOK keys) attached to
+   * execute requests. Returns no headers when omitted.
+   */
+  executionHeaders?: ExecutionHeaderProvider;
   /** Injected ModelBrowserModal component (complex, app-specific) */
   ModelBrowserModal?: ComponentType<ModelBrowserModalProps> | null;
   /** Injected PromptPicker component (complex, app-specific) */

--- a/packages/workflow-ui/src/provider/types.ts
+++ b/packages/workflow-ui/src/provider/types.ts
@@ -6,6 +6,8 @@ import type {
   ProviderModel,
 } from '@genfeedai/types';
 import type { ComponentType } from 'react';
+import type { ApplyEditOperations } from '../stores/workflow/slices/types';
+import type { WorkflowPersistenceService } from '../stores/workflow/types';
 
 // =============================================================================
 // File Upload
@@ -144,6 +146,17 @@ export interface WorkflowUIConfig {
    * execute requests. Returns no headers when omitted.
    */
   executionHeaders?: ExecutionHeaderProvider;
+  /**
+   * Persistence backend for the workflow store's CRUD actions (save / load /
+   * list / delete / duplicate / create). Throws a clear "not configured" error
+   * when omitted rather than silently dropping saves.
+   */
+  workflowPersistence?: WorkflowPersistenceService;
+  /**
+   * Graph edit-operation applier used by the chat/agent edit pipeline. Defaults
+   * to a no-op (leaves the graph untouched) when omitted.
+   */
+  applyEditOperations?: ApplyEditOperations;
   /** Injected ModelBrowserModal component (complex, app-specific) */
   ModelBrowserModal?: ComponentType<ModelBrowserModalProps> | null;
   /** Injected PromptPicker component (complex, app-specific) */

--- a/packages/workflow-ui/src/stores/execution/executionApi.test.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowUIHttpClient } from '../../provider/types';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './executionApi';
+
+describe('executionApi', () => {
+  afterEach(() => {
+    // Reset both registries to their standalone defaults so tests don't leak.
+    configureExecutionHttpClient(undefined);
+    configureExecutionHeaders(undefined);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('execution headers', () => {
+    it('defaults to no headers', () => {
+      expect(getExecutionHeaders()).toEqual({});
+    });
+
+    it('resolves headers from the configured provider on each call', () => {
+      const provider = vi
+        .fn()
+        .mockReturnValueOnce({ 'X-Replicate-Key': 'a' })
+        .mockReturnValueOnce({ 'X-Replicate-Key': 'b' });
+      configureExecutionHeaders(provider);
+
+      expect(getExecutionHeaders()).toEqual({ 'X-Replicate-Key': 'a' });
+      expect(getExecutionHeaders()).toEqual({ 'X-Replicate-Key': 'b' });
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+
+    it('reverts to no headers when reconfigured with undefined', () => {
+      configureExecutionHeaders(() => ({ 'X-Fal-Key': 'k' }));
+      configureExecutionHeaders(undefined);
+
+      expect(getExecutionHeaders()).toEqual({});
+    });
+  });
+
+  describe('execution HTTP client', () => {
+    it('routes requests through the configured client', async () => {
+      const client: WorkflowUIHttpClient = {
+        post: vi.fn().mockResolvedValue({ _id: 'exec-1' }),
+      };
+      configureExecutionHttpClient(client);
+
+      const result = await getExecutionHttpClient().post('/x', { a: 1 });
+
+      expect(client.post).toHaveBeenCalledWith('/x', { a: 1 });
+      expect(result).toEqual({ _id: 'exec-1' });
+    });
+
+    it('reverts to the bare-fetch default when reconfigured with undefined', async () => {
+      const custom: WorkflowUIHttpClient = { post: vi.fn() };
+      configureExecutionHttpClient(custom);
+      configureExecutionHttpClient(undefined);
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ _id: 'default' }),
+        ok: true,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getExecutionHttpClient().post(
+        '/workflows/1/execute',
+        {
+          debugMode: false,
+        },
+      );
+
+      expect(custom.post).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ _id: 'default' });
+    });
+
+    describe('bare-fetch default', () => {
+      it('POSTs JSON with Content-Type and merges caller headers', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({ ok: true }),
+          ok: true,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await getExecutionHttpClient().post(
+          '/workflows/1/execute',
+          { debugMode: true },
+          { headers: { 'X-Replicate-Key': 'secret' } },
+        );
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain('/workflows/1/execute');
+        expect(init.method).toBe('POST');
+        expect(init.headers).toEqual({
+          'Content-Type': 'application/json',
+          'X-Replicate-Key': 'secret',
+        });
+        expect(init.body).toBe(JSON.stringify({ debugMode: true }));
+      });
+
+      it('omits the body when none is provided', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({}),
+          ok: true,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await getExecutionHttpClient().post('/executions/1/stop');
+
+        const [, init] = fetchMock.mock.calls[0];
+        expect(init.body).toBeUndefined();
+      });
+
+      it('throws the API error message on a non-ok response', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.resolve({ message: 'nope' }),
+          ok: false,
+          status: 422,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+          getExecutionHttpClient().post('/workflows/1/execute', {}),
+        ).rejects.toThrow('nope');
+      });
+
+      it('falls back to a status message when the error body has none', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+          json: () => Promise.reject(new Error('not json')),
+          ok: false,
+          status: 500,
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+          getExecutionHttpClient().post('/workflows/1/execute', {}),
+        ).rejects.toThrow('API error: 500');
+      });
+    });
+  });
+});

--- a/packages/workflow-ui/src/stores/execution/executionApi.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.ts
@@ -1,0 +1,87 @@
+import type {
+  ExecutionHeaderProvider,
+  WorkflowUIHttpClient,
+} from '../../provider/types';
+
+// =============================================================================
+// Module-level execution HTTP configuration
+// =============================================================================
+
+/**
+ * Injected HTTP client + provider-header supplier for the execution store.
+ *
+ * The execution store (`executeWorkflow`, `stopExecution`, …) lives outside the
+ * React tree (plain Zustand) and cannot read the WorkflowUIProvider context
+ * directly, so both are registered at module scope via
+ * {@link configureExecutionHttpClient} / {@link configureExecutionHeaders} —
+ * the same pattern {@link configureWorkflowLogger} uses.
+ *
+ * Both default to the package's standalone behavior (bare `fetch`, no BYOK
+ * headers) so the package stays usable on its own; the consuming app injects a
+ * credentialed client and its provider auth headers through `WorkflowUIConfig`.
+ */
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
+
+/**
+ * Default fetch-based client. Preserves the package's prior inline `apiPost`
+ * behavior exactly: POST to `NEXT_PUBLIC_API_URL`, JSON body, surface the API's
+ * error message on non-2xx.
+ */
+const DEFAULT_HTTP_CLIENT: WorkflowUIHttpClient = {
+  post: async <T>(
+    path: string,
+    body?: Record<string, unknown>,
+    options?: { headers?: Record<string, string> },
+  ): Promise<T> => {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      method: 'POST',
+      ...(body && { body: JSON.stringify(body) }),
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        (errorData as { message?: string }).message ||
+          `API error: ${response.status}`,
+      );
+    }
+    return response.json() as Promise<T>;
+  },
+};
+
+const NOOP_HEADERS: ExecutionHeaderProvider = () => ({});
+
+let _httpClient: WorkflowUIHttpClient = DEFAULT_HTTP_CLIENT;
+let _headers: ExecutionHeaderProvider = NOOP_HEADERS;
+
+/**
+ * Register the HTTP client the execution store posts through.
+ * Called by WorkflowUIProvider; resets to the bare-fetch default when unset.
+ */
+export function configureExecutionHttpClient(
+  client: WorkflowUIHttpClient | undefined,
+): void {
+  _httpClient = client ?? DEFAULT_HTTP_CLIENT;
+}
+
+/** Read the currently-configured HTTP client (bare fetch until configured). */
+export function getExecutionHttpClient(): WorkflowUIHttpClient {
+  return _httpClient;
+}
+
+/**
+ * Register the provider-auth-header supplier for execute requests.
+ * Called by WorkflowUIProvider; resets to "no headers" when unset.
+ */
+export function configureExecutionHeaders(
+  provider: ExecutionHeaderProvider | undefined,
+): void {
+  _headers = provider ?? NOOP_HEADERS;
+}
+
+/** Resolve the provider auth headers for the current request (empty until configured). */
+export function getExecutionHeaders(): Record<string, string> {
+  return _headers();
+}

--- a/packages/workflow-ui/src/stores/execution/helpers/outputHelpers.test.ts
+++ b/packages/workflow-ui/src/stores/execution/helpers/outputHelpers.test.ts
@@ -1,0 +1,129 @@
+import type { WorkflowNode } from '@genfeedai/types';
+import { describe, expect, it } from 'vitest';
+import { getOutputUpdate } from './outputHelpers';
+
+function workflowStoreFor(node?: Partial<WorkflowNode>) {
+  return {
+    getNodeById: () =>
+      node
+        ? ({
+            data: {},
+            id: 'node-1',
+            position: { x: 0, y: 0 },
+            type: 'prompt',
+            ...node,
+          } as WorkflowNode)
+        : undefined,
+  };
+}
+
+describe('getOutputUpdate', () => {
+  it('returns an empty update when the node is missing', () => {
+    expect(
+      getOutputUpdate(
+        'missing',
+        'https://asset.test/x.png',
+        workflowStoreFor(),
+      ),
+    ).toEqual({});
+  });
+
+  it('maps image generation outputs to first image and all image URLs', () => {
+    expect(
+      getOutputUpdate(
+        'node-1',
+        { images: ['https://asset.test/1.png', 'https://asset.test/2.png'] },
+        workflowStoreFor({ type: 'imageGen' }),
+      ),
+    ).toEqual({
+      outputImage: 'https://asset.test/1.png',
+      outputImages: ['https://asset.test/1.png', 'https://asset.test/2.png'],
+    });
+
+    expect(
+      getOutputUpdate(
+        'node-1',
+        { image: 'https://asset.test/single.png' },
+        workflowStoreFor({ type: 'imageGen' }),
+      ),
+    ).toEqual({
+      outputImage: 'https://asset.test/single.png',
+      outputImages: ['https://asset.test/single.png'],
+    });
+  });
+
+  it('routes unified node outputs by input type', () => {
+    expect(
+      getOutputUpdate(
+        'node-1',
+        ['https://asset.test/upscaled.mp4'],
+        workflowStoreFor({
+          data: { inputType: 'video' },
+          type: 'upscale',
+        }),
+      ),
+    ).toEqual({ outputVideo: 'https://asset.test/upscaled.mp4' });
+
+    expect(
+      getOutputUpdate(
+        'node-1',
+        { url: 'https://asset.test/reframed.png' },
+        workflowStoreFor({
+          data: { inputType: 'image' },
+          type: 'reframe',
+        }),
+      ),
+    ).toEqual({ outputImage: 'https://asset.test/reframed.png' });
+  });
+
+  it.each([
+    ['videoGen'],
+    ['animation'],
+    ['videoStitch'],
+    ['lipSync'],
+    ['voiceChange'],
+    ['motionControl'],
+  ])('maps %s outputs to outputVideo', (type) => {
+    expect(
+      getOutputUpdate(
+        'node-1',
+        { video: 'https://asset.test/video.mp4' },
+        workflowStoreFor({ type }),
+      ),
+    ).toEqual({ outputVideo: 'https://asset.test/video.mp4' });
+  });
+
+  it('maps audio, text, resize, and fallback outputs', () => {
+    expect(
+      getOutputUpdate(
+        'node-1',
+        { audio: 'https://asset.test/audio.mp3' },
+        workflowStoreFor({ type: 'textToSpeech' }),
+      ),
+    ).toEqual({ outputAudio: 'https://asset.test/audio.mp3' });
+
+    expect(
+      getOutputUpdate(
+        'node-1',
+        ['hello ', 'world'],
+        workflowStoreFor({ type: 'llm' }),
+      ),
+    ).toEqual({ outputText: 'hello world' });
+
+    expect(
+      getOutputUpdate(
+        'node-1',
+        { url: 'https://asset.test/resized.png' },
+        workflowStoreFor({ type: 'resize' }),
+      ),
+    ).toEqual({ outputMedia: 'https://asset.test/resized.png' });
+
+    expect(
+      getOutputUpdate(
+        'node-1',
+        [{ url: 'https://asset.test/fallback.png' }],
+        workflowStoreFor({ type: 'unknown' }),
+      ),
+    ).toEqual({ output: 'https://asset.test/fallback.png' });
+  });
+});

--- a/packages/workflow-ui/src/stores/execution/helpers/sseSubscription.test.ts
+++ b/packages/workflow-ui/src/stores/execution/helpers/sseSubscription.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  propagateOutputsDownstream: vi.fn(),
+  setShowDebugPanel: vi.fn(),
+  updateNodeData: vi.fn(),
+}));
+
+vi.mock('../../uiStore', () => ({
+  useUIStore: {
+    getState: () => ({
+      setShowDebugPanel: mocks.setShowDebugPanel,
+    }),
+  },
+}));
+
+vi.mock('../../workflow/workflowStore', () => ({
+  useWorkflowStore: {
+    getState: () => workflowStore,
+  },
+}));
+
+import { NodeStatusEnum } from '@genfeedai/types';
+import { configureWorkflowLogger } from '../../executionLogger';
+import type { ExecutionStore } from '../types';
+import {
+  createExecutionSubscription,
+  createNodeExecutionSubscription,
+} from './sseSubscription';
+
+const workflowStore = {
+  getNodeById: vi.fn((nodeId: string) => ({
+    data: { label: `Node ${nodeId}` },
+    id: nodeId,
+    type: 'imageGen',
+  })),
+  propagateOutputsDownstream: mocks.propagateOutputsDownstream,
+  updateNodeData: mocks.updateNodeData,
+};
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  close = vi.fn();
+
+  onerror: ((event: unknown) => void) | null = null;
+
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  constructor(public readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  emitRaw(data: string) {
+    this.onmessage?.({ data });
+  }
+
+  error(event: unknown = new Error('sse failed')) {
+    this.onerror?.(event);
+  }
+}
+
+function createState(overrides: Partial<ExecutionStore> = {}) {
+  let state: Partial<ExecutionStore> = {
+    activeNodeExecutions: new Map(),
+    debugPayloads: [],
+    jobs: new Map(),
+    ...overrides,
+  };
+
+  const set = vi.fn(
+    (
+      update:
+        | Partial<ExecutionStore>
+        | ((state: ExecutionStore) => Partial<ExecutionStore>),
+    ) => {
+      const patch =
+        typeof update === 'function' ? update(state as ExecutionStore) : update;
+      state = { ...state, ...patch };
+    },
+  );
+
+  return {
+    getState: () => state,
+    set,
+  };
+}
+
+async function flushAsyncHandlers() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('sse subscriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The package resolves its execution logger via injection (the app fork
+    // mocked its concrete logger module).
+    configureWorkflowLogger({ error: mocks.loggerError });
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue({
+          nodeResults: [
+            {
+              nodeId: 'node-1',
+              output: { image: 'https://asset.test/final.png' },
+              status: 'succeeded',
+            },
+          ],
+        }),
+        ok: true,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    configureWorkflowLogger(undefined);
+    vi.unstubAllGlobals();
+  });
+
+  it('subscribes to execution streams and stores the EventSource', () => {
+    const { set, getState } = createState();
+
+    const source = createExecutionSubscription('execution-1', set as never);
+
+    expect(source).toBe(MockEventSource.instances[0]);
+    expect(MockEventSource.instances[0].url).toBe(
+      'http://local.genfeed.ai:3010/api/executions/execution-1/stream',
+    );
+    expect(getState().eventSource).toBe(source);
+  });
+
+  it('updates node status, output, jobs, debug payloads, and completion state', async () => {
+    const { set, getState } = createState();
+    createExecutionSubscription('execution-1', set as never);
+
+    MockEventSource.instances[0].emit({
+      debugMode: true,
+      jobs: [
+        {
+          nodeId: 'node-1',
+          output: { image: 'https://asset.test/job.png' },
+          predictionId: 'prediction-1',
+          result: {
+            debugPayload: {
+              input: { prompt: 'launch' },
+              model: 'model-1',
+              timestamp: '2026-01-01T00:00:00.000Z',
+            },
+          },
+          status: 'succeeded',
+        },
+      ],
+      nodeResults: [
+        {
+          nodeId: 'node-1',
+          output: { images: ['https://asset.test/1.png'] },
+          status: 'complete',
+        },
+        {
+          error: 'bad prompt',
+          nodeId: 'node-2',
+          status: 'error',
+        },
+      ],
+      pendingNodes: [
+        { dependsOn: [], nodeData: {}, nodeId: 'node-3', nodeType: 'llm' },
+      ],
+      status: 'running',
+    });
+    await flushAsyncHandlers();
+
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-1', {
+      error: undefined,
+      outputImage: 'https://asset.test/1.png',
+      outputImages: ['https://asset.test/1.png'],
+      status: NodeStatusEnum.COMPLETE,
+    });
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-2', {
+      error: 'bad prompt',
+      status: NodeStatusEnum.ERROR,
+    });
+    expect(mocks.propagateOutputsDownstream).toHaveBeenCalledWith('node-1');
+    expect(mocks.setShowDebugPanel).toHaveBeenCalledWith(true);
+    expect(getState().lastFailedNodeId).toBe('node-2');
+    expect(getState().debugPayloads).toEqual([
+      {
+        input: { prompt: 'launch' },
+        model: 'model-1',
+        nodeId: 'node-1',
+        nodeName: 'Node node-1',
+        nodeType: 'imageGen',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    expect(getState().jobs?.get('prediction-1')).toMatchObject({
+      nodeId: 'node-1',
+      output: { image: 'https://asset.test/job.png' },
+      status: 'succeeded',
+    });
+
+    MockEventSource.instances[0].emit({
+      nodeResults: [],
+      pendingNodes: [],
+      status: 'completed',
+    });
+    await flushAsyncHandlers();
+
+    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
+    expect(getState()).toMatchObject({
+      currentNodeId: null,
+      eventSource: null,
+      isRunning: false,
+      jobs: new Map(),
+    });
+  });
+
+  it('logs parse failures and reconciles on stream errors', async () => {
+    const { getState, set } = createState({ isRunning: true });
+    createExecutionSubscription('execution-1', set as never);
+
+    MockEventSource.instances[0].emitRaw('{bad json');
+    await flushAsyncHandlers();
+    MockEventSource.instances[0].error();
+    await flushAsyncHandlers();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      'Failed to parse SSE message',
+      {
+        context: 'ExecutionStore',
+        error: expect.any(SyntaxError),
+      },
+    );
+    expect(mocks.loggerError).toHaveBeenCalledWith('SSE connection error', {
+      context: 'ExecutionStore',
+      error: expect.any(Error),
+    });
+    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(
+      'http://local.genfeed.ai:3010/api/executions/execution-1',
+    );
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-1', {
+      error: undefined,
+      outputImage: 'https://asset.test/final.png',
+      outputImages: ['https://asset.test/final.png'],
+      status: NodeStatusEnum.COMPLETE,
+    });
+    expect(getState()).toMatchObject({
+      eventSource: null,
+      isRunning: false,
+    });
+  });
+
+  it('handles node-scoped execution streams without mutating global execution state', async () => {
+    const { getState, set } = createState({
+      activeNodeExecutions: new Map([
+        [
+          'node-1',
+          {
+            eventSource: {} as EventSource,
+            executionId: 'execution-1',
+            nodeIds: ['node-1'],
+          },
+        ],
+      ]),
+    });
+
+    createNodeExecutionSubscription(
+      'execution-1',
+      'node-1',
+      set as never,
+      vi.fn() as never,
+    );
+    MockEventSource.instances[0].emit({
+      jobs: [
+        {
+          nodeId: 'node-2',
+          output: null,
+          predictionId: 'ignored',
+          status: 'processing',
+        },
+        {
+          nodeId: 'node-1',
+          output: null,
+          predictionId: 'kept',
+          status: 'processing',
+        },
+      ],
+      nodeResults: [
+        {
+          nodeId: 'node-1',
+          output: { image: 'https://asset.test/node.png' },
+          status: 'succeeded',
+        },
+      ],
+      status: 'completed',
+    });
+    await flushAsyncHandlers();
+
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-1', {
+      error: undefined,
+      outputImage: 'https://asset.test/node.png',
+      outputImages: ['https://asset.test/node.png'],
+      status: NodeStatusEnum.COMPLETE,
+    });
+    expect(getState().jobs?.has('kept')).toBe(true);
+    expect(getState().jobs?.has('ignored')).toBe(false);
+    expect(getState().activeNodeExecutions?.has('node-1')).toBe(false);
+    expect(MockEventSource.instances[0].close).toHaveBeenCalled();
+  });
+
+  it('logs node-scoped parse and connection errors', async () => {
+    const { getState, set } = createState({
+      activeNodeExecutions: new Map([
+        [
+          'node-1',
+          {
+            eventSource: {} as EventSource,
+            executionId: 'execution-1',
+            nodeIds: ['node-1'],
+          },
+        ],
+      ]),
+    });
+    createNodeExecutionSubscription(
+      'execution-1',
+      'node-1',
+      set as never,
+      vi.fn() as never,
+    );
+
+    MockEventSource.instances[0].emitRaw('{bad json');
+    await flushAsyncHandlers();
+    MockEventSource.instances[0].error();
+    await flushAsyncHandlers();
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      'Failed to parse SSE message (node execution)',
+      { context: 'ExecutionStore', error: expect.any(SyntaxError) },
+    );
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      'SSE connection error (node execution)',
+      { context: 'ExecutionStore', error: expect.any(Error) },
+    );
+    expect(getState().activeNodeExecutions?.has('node-1')).toBe(false);
+  });
+});

--- a/packages/workflow-ui/src/stores/execution/slices/executionSlice.test.ts
+++ b/packages/workflow-ui/src/stores/execution/slices/executionSlice.test.ts
@@ -1,0 +1,399 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createExecutionSubscription: vi.fn(),
+  createNodeExecutionSubscription: vi.fn(),
+  httpPost: vi.fn(),
+  loggerError: vi.fn(),
+  saveWorkflow: vi.fn(),
+  setShowDebugPanel: vi.fn(),
+  updateNodeData: vi.fn(),
+  validateWorkflow: vi.fn(),
+}));
+
+vi.mock('../../uiStore', () => ({
+  useUIStore: {
+    getState: () => ({
+      setShowDebugPanel: mocks.setShowDebugPanel,
+    }),
+  },
+}));
+
+vi.mock('../../settingsStore', () => ({
+  useSettingsStore: {
+    getState: () => ({
+      debugMode: currentSettings.debugMode,
+    }),
+  },
+}));
+
+vi.mock('../../workflow/workflowStore', () => ({
+  useWorkflowStore: {
+    getState: () => currentWorkflow,
+  },
+}));
+
+vi.mock('../helpers/sseSubscription', () => ({
+  createExecutionSubscription: mocks.createExecutionSubscription,
+  createNodeExecutionSubscription: mocks.createNodeExecutionSubscription,
+}));
+
+import { NodeStatusEnum } from '@genfeedai/types';
+import { configureWorkflowLogger } from '../../executionLogger';
+import {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+} from '../executionApi';
+import type { ExecutionStore } from '../types';
+import { createExecutionSlice } from './executionSlice';
+
+const PROVIDER_HEADERS = {
+  'x-fal-key': 'fal',
+  'x-huggingface-key': 'huggingface',
+  'x-replicate-key': 'replicate',
+};
+
+const currentSettings = {
+  debugMode: false,
+};
+
+const currentWorkflow = {
+  isDirty: false,
+  nodes: [{ id: 'node-1' }, { id: 'node-2' }],
+  saveWorkflow: mocks.saveWorkflow,
+  selectedNodeIds: ['node-1'],
+  updateNodeData: mocks.updateNodeData,
+  validateWorkflow: mocks.validateWorkflow,
+  workflowId: 'workflow-1',
+};
+
+function createEventSource() {
+  return { close: vi.fn() } as unknown as EventSource;
+}
+
+function createTestStore(overrides: Partial<ExecutionStore> = {}) {
+  let state: ExecutionStore;
+
+  const set = vi.fn(
+    (
+      update:
+        | Partial<ExecutionStore>
+        | ((state: ExecutionStore) => Partial<ExecutionStore>),
+    ) => {
+      const patch = typeof update === 'function' ? update(state) : update;
+      state = { ...state, ...patch };
+    },
+  );
+  const get = vi.fn(() => state);
+
+  state = {
+    activeNodeExecutions: new Map(),
+    actualCost: 0,
+    addDebugPayload: vi.fn(),
+    addJob: vi.fn(),
+    clearDebugPayloads: vi.fn(),
+    currentNodeId: null,
+    debugPayloads: [],
+    estimatedCost: 0,
+    eventSource: null,
+    executingNodeIds: [],
+    executionId: null,
+    getJobByNodeId: vi.fn(),
+    isRunning: false,
+    jobs: new Map(),
+    lastFailedNodeId: null,
+    pausedAtNodeId: null,
+    updateJob: vi.fn(),
+    validationErrors: null,
+    ...(createExecutionSlice(
+      set as never,
+      get as never,
+      undefined as never,
+    ) as unknown as ExecutionStore),
+    ...overrides,
+  };
+
+  return {
+    getState: () => state,
+    set,
+  };
+}
+
+describe('createExecutionSlice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSettings.debugMode = false;
+    Object.assign(currentWorkflow, {
+      isDirty: false,
+      nodes: [{ id: 'node-1' }, { id: 'node-2' }],
+      selectedNodeIds: ['node-1'],
+      workflowId: 'workflow-1',
+    });
+    // Inject the execution HTTP client, provider headers, and logger through the
+    // package's registries (the app fork mocked its concrete apiClient/logger
+    // modules; the package resolves these via injection).
+    configureExecutionHttpClient({ post: mocks.httpPost });
+    configureExecutionHeaders(() => PROVIDER_HEADERS);
+    configureWorkflowLogger({ error: mocks.loggerError });
+    mocks.validateWorkflow.mockReturnValue({
+      errors: [],
+      isValid: true,
+      warnings: [],
+    });
+    mocks.httpPost.mockResolvedValue({
+      _id: 'execution-1',
+      nodeResults: [],
+      status: 'running',
+      workflowId: 'workflow-1',
+    });
+    mocks.createNodeExecutionSubscription.mockReturnValue(createEventSource());
+  });
+
+  afterEach(() => {
+    configureExecutionHttpClient(undefined);
+    configureExecutionHeaders(undefined);
+    configureWorkflowLogger(undefined);
+  });
+
+  it('manages simple execution state helpers', () => {
+    const store = createTestStore({
+      executionId: 'execution-1',
+      isRunning: false,
+      lastFailedNodeId: 'node-1',
+      validationErrors: {
+        errors: [{ message: 'bad', nodeId: '', severity: 'error' }],
+        isValid: false,
+        warnings: [],
+      },
+    });
+
+    expect(store.getState().canResumeFromFailed()).toBe(true);
+    store.getState().clearValidationErrors();
+    store.getState().setEstimatedCost(42);
+
+    expect(store.getState().validationErrors).toBeNull();
+    expect(store.getState().estimatedCost).toBe(42);
+  });
+
+  it('resets execution, closes active event sources, and clears node statuses', () => {
+    const eventSource = createEventSource();
+    const nodeEventSource = createEventSource();
+    const store = createTestStore({
+      activeNodeExecutions: new Map([
+        [
+          'node-1',
+          {
+            eventSource: nodeEventSource,
+            executionId: 'execution-1',
+            nodeIds: ['node-1'],
+          },
+        ],
+      ]),
+      eventSource,
+      isRunning: true,
+      jobs: new Map([['job-1', {} as never]]),
+    });
+
+    store.getState().resetExecution();
+
+    expect(eventSource.close).toHaveBeenCalled();
+    expect(nodeEventSource.close).toHaveBeenCalled();
+    expect(store.getState()).toMatchObject({
+      activeNodeExecutions: new Map(),
+      currentNodeId: null,
+      eventSource: null,
+      executionId: null,
+      isRunning: false,
+      lastFailedNodeId: null,
+    });
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-1', {
+      error: undefined,
+      progress: undefined,
+      status: NodeStatusEnum.IDLE,
+    });
+  });
+
+  it('starts a full workflow execution after validation and opens debug mode', async () => {
+    currentSettings.debugMode = true;
+    const store = createTestStore();
+
+    await store.getState().executeWorkflow();
+
+    expect(mocks.setShowDebugPanel).toHaveBeenCalledWith(true);
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/workflows/workflow-1/execute',
+      { debugMode: true },
+      { headers: PROVIDER_HEADERS },
+    );
+    expect(mocks.createExecutionSubscription).toHaveBeenCalledWith(
+      'execution-1',
+      expect.any(Function),
+    );
+    expect(store.getState().executionId).toBe('execution-1');
+  });
+
+  it('sets validation errors when full workflow validation fails', async () => {
+    mocks.validateWorkflow.mockReturnValueOnce({
+      errors: [{ message: 'Connect nodes', nodeId: '', severity: 'error' }],
+      isValid: false,
+      warnings: [],
+    });
+    const store = createTestStore();
+
+    await store.getState().executeWorkflow();
+
+    expect(mocks.httpPost).not.toHaveBeenCalled();
+    expect(store.getState().validationErrors).toMatchObject({
+      isValid: false,
+    });
+  });
+
+  it('executes selected nodes and rejects empty selections', async () => {
+    const store = createTestStore();
+
+    await store.getState().executeSelectedNodes();
+
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/workflows/workflow-1/execute',
+      {
+        debugMode: false,
+        selectedNodeIds: ['node-1'],
+      },
+      { headers: PROVIDER_HEADERS },
+    );
+    expect(store.getState().executingNodeIds).toEqual(['node-1']);
+    expect(store.getState().executionId).toBe('execution-1');
+
+    currentWorkflow.selectedNodeIds = [];
+    const emptyStore = createTestStore();
+    await emptyStore.getState().executeSelectedNodes();
+
+    expect(emptyStore.getState().validationErrors).toMatchObject({
+      errors: [{ message: 'No nodes selected', nodeId: '', severity: 'error' }],
+      isValid: false,
+    });
+  });
+
+  it('executes one node and tracks independent node subscriptions', async () => {
+    const store = createTestStore();
+
+    await store.getState().executeNode('node-1');
+
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/workflows/workflow-1/execute',
+      {
+        debugMode: false,
+        selectedNodeIds: ['node-1'],
+      },
+      { headers: PROVIDER_HEADERS },
+    );
+    expect(mocks.createNodeExecutionSubscription).toHaveBeenCalledWith(
+      'execution-1',
+      'node-1',
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(store.getState().isNodeExecuting('node-1')).toBe(true);
+  });
+
+  it('resumes failed executions and handles missing workflow ids', async () => {
+    const store = createTestStore({
+      executionId: 'execution-1',
+      lastFailedNodeId: 'node-1',
+    });
+
+    await store.getState().resumeFromFailed();
+
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/workflows/workflow-1/execute',
+      { debugMode: false },
+      { headers: PROVIDER_HEADERS },
+    );
+    expect(store.getState()).toMatchObject({
+      executionId: 'execution-1',
+      lastFailedNodeId: null,
+    });
+
+    currentWorkflow.workflowId = null as never;
+    const missingWorkflowStore = createTestStore({
+      executionId: 'execution-1',
+      lastFailedNodeId: 'node-1',
+    });
+    await missingWorkflowStore.getState().resumeFromFailed();
+
+    expect(missingWorkflowStore.getState().validationErrors).toMatchObject({
+      errors: [
+        {
+          message: 'Workflow must be saved first',
+          nodeId: '',
+          severity: 'error',
+        },
+      ],
+      isValid: false,
+    });
+  });
+
+  it('stops full and node executions', async () => {
+    const eventSource = createEventSource();
+    const nodeEventSource = createEventSource();
+    const store = createTestStore({
+      activeNodeExecutions: new Map([
+        [
+          'node-1',
+          {
+            eventSource: nodeEventSource,
+            executionId: 'node-execution-1',
+            nodeIds: ['node-1'],
+          },
+        ],
+      ]),
+      eventSource,
+      executionId: 'execution-1',
+      isRunning: true,
+    });
+
+    store.getState().stopExecution();
+    store.getState().stopNodeExecution('node-1');
+
+    expect(eventSource.close).toHaveBeenCalled();
+    expect(nodeEventSource.close).toHaveBeenCalled();
+    expect(mocks.httpPost).toHaveBeenCalledWith('/executions/execution-1/stop');
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/executions/node-execution-1/stop',
+    );
+    expect(store.getState().activeNodeExecutions.has('node-1')).toBe(false);
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-1', {
+      error: undefined,
+      status: NodeStatusEnum.IDLE,
+    });
+  });
+
+  it('surfaces save and API failures as validation or node errors', async () => {
+    const saveError = new Error('save failed');
+    currentWorkflow.isDirty = true;
+    mocks.saveWorkflow.mockRejectedValueOnce(saveError);
+    const selectedStore = createTestStore();
+
+    await selectedStore.getState().executeSelectedNodes();
+
+    expect(selectedStore.getState().validationErrors).toMatchObject({
+      errors: [{ message: 'Failed to save workflow' }],
+      isValid: false,
+    });
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      'Failed to save workflow before execution',
+      { context: 'ExecutionStore', error: saveError },
+    );
+
+    currentWorkflow.isDirty = false;
+    mocks.httpPost.mockRejectedValueOnce(new Error('node failed'));
+    const nodeStore = createTestStore();
+
+    await nodeStore.getState().executeNode('node-1');
+
+    expect(mocks.updateNodeData).toHaveBeenCalledWith('node-1', {
+      error: 'node failed',
+      status: NodeStatusEnum.ERROR,
+    });
+  });
+});

--- a/packages/workflow-ui/src/stores/execution/slices/executionSlice.ts
+++ b/packages/workflow-ui/src/stores/execution/slices/executionSlice.ts
@@ -4,36 +4,28 @@ import { getWorkflowLogger } from '../../executionLogger';
 import { useSettingsStore } from '../../settingsStore';
 import { useUIStore } from '../../uiStore';
 import { useWorkflowStore } from '../../workflow/workflowStore';
+import { getExecutionHeaders, getExecutionHttpClient } from '../executionApi';
 import {
   createExecutionSubscription,
   createNodeExecutionSubscription,
 } from '../helpers/sseSubscription';
 import type { ExecutionData, ExecutionStore, NodeExecution } from '../types';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
+const LOG_CONTEXT = 'ExecutionStore';
 
 /**
- * Simple fetch-based API client for execution operations.
- * Consuming apps can override by providing their own execution store.
+ * Start a workflow execution through the injected HTTP client, carrying the
+ * app's provider auth headers (Replicate / Fal / HuggingFace BYOK keys). Both
+ * the client and the headers default to the package's standalone behavior when
+ * the app has not configured them (see `executionApi`).
  */
-async function apiPost<T>(
+function startExecution(
   path: string,
-  body?: Record<string, unknown>,
-): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
-    ...(body && { body: JSON.stringify(body) }),
+  body: Record<string, unknown>,
+): Promise<ExecutionData> {
+  return getExecutionHttpClient().post<ExecutionData>(path, body, {
+    headers: getExecutionHeaders(),
   });
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(
-      (errorData as { message?: string }).message ||
-        `API error: ${response.status}`,
-    );
-  }
-  return response.json() as Promise<T>;
 }
 
 function validationError(message: string) {
@@ -105,7 +97,11 @@ export const createExecutionSlice: StateCreator<
     if (workflowStore.isDirty || !workflowStore.workflowId) {
       try {
         await workflowStore.saveWorkflow();
-      } catch {
+      } catch (error) {
+        getWorkflowLogger().error(
+          'Failed to save workflow before node execution',
+          { context: LOG_CONTEXT, error },
+        );
         workflowStore.updateNodeData(nodeId, {
           error: 'Failed to save workflow',
           status: NodeStatusEnum.ERROR,
@@ -128,7 +124,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -156,6 +152,10 @@ export const createExecutionSlice: StateCreator<
         return { activeNodeExecutions: newMap };
       });
     } catch (error) {
+      getWorkflowLogger().error('Failed to start node execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       workflowStore.updateNodeData(nodeId, {
         error: error instanceof Error ? error.message : 'Node execution failed',
         status: NodeStatusEnum.ERROR,
@@ -211,7 +211,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -224,6 +224,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(executionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to start partial execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -282,7 +286,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -294,6 +298,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(executionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to start workflow execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -391,7 +399,7 @@ export const createExecutionSlice: StateCreator<
     });
 
     try {
-      const execution = await apiPost<ExecutionData>(
+      const execution = await startExecution(
         `/workflows/${workflowId}/execute`,
         {
           debugMode,
@@ -403,6 +411,10 @@ export const createExecutionSlice: StateCreator<
 
       createExecutionSubscription(newExecutionId, set);
     } catch (error) {
+      getWorkflowLogger().error('Failed to resume execution', {
+        context: LOG_CONTEXT,
+        error,
+      });
       set({
         isRunning: false,
         validationErrors: {
@@ -432,9 +444,14 @@ export const createExecutionSlice: StateCreator<
     }
 
     if (executionId) {
-      apiPost(`/executions/${executionId}/stop`).catch(() => {
-        // Failed to stop execution
-      });
+      getExecutionHttpClient()
+        .post(`/executions/${executionId}/stop`)
+        .catch((error) => {
+          getWorkflowLogger().error('Failed to stop execution', {
+            context: LOG_CONTEXT,
+            error,
+          });
+        });
     }
 
     set({
@@ -451,9 +468,14 @@ export const createExecutionSlice: StateCreator<
     if (nodeExecution) {
       nodeExecution.eventSource.close();
 
-      apiPost(`/executions/${nodeExecution.executionId}/stop`).catch(() => {
-        // Failed to stop node execution
-      });
+      getExecutionHttpClient()
+        .post(`/executions/${nodeExecution.executionId}/stop`)
+        .catch((error) => {
+          getWorkflowLogger().error('Failed to stop node execution', {
+            context: LOG_CONTEXT,
+            error,
+          });
+        });
 
       set((state) => {
         const newMap = new Map(state.activeNodeExecutions);

--- a/packages/workflow-ui/src/stores/index.ts
+++ b/packages/workflow-ui/src/stores/index.ts
@@ -54,9 +54,20 @@ export { PROVIDER_INFO, useSettingsStore } from './settingsStore';
 export type { ModalType, NodeDetailTab } from './uiStore';
 export { useUIStore } from './uiStore';
 // Store types
-export type { WorkflowData, WorkflowState, WorkflowStore } from './workflow';
+export type {
+  WorkflowData,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowState,
+  WorkflowStore,
+  WorkflowSummary,
+} from './workflow';
 // Store hooks
 export { useWorkflowStore } from './workflow';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './workflow/applyEditOperations';
 // Workflow selectors
 export {
   createSelectGroupByNodeId,
@@ -93,3 +104,7 @@ export {
   selectWorkflowId,
   selectWorkflowName,
 } from './workflow/selectors';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflow/workflowPersistence';

--- a/packages/workflow-ui/src/stores/index.ts
+++ b/packages/workflow-ui/src/stores/index.ts
@@ -25,6 +25,12 @@ export { useAnnotationStore } from './annotationStore';
 export { type ContextMenuType, useContextMenuStore } from './contextMenuStore';
 export type { DebugPayload, ExecutionStore, Job } from './execution';
 export { useExecutionStore } from './execution';
+export {
+  configureExecutionHeaders,
+  configureExecutionHttpClient,
+  getExecutionHeaders,
+  getExecutionHttpClient,
+} from './execution/executionApi';
 // Embedded stores (moved from core app)
 export {
   configureWorkflowLogger,

--- a/packages/workflow-ui/src/stores/workflow/applyEditOperations.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/applyEditOperations.test.ts
@@ -1,0 +1,51 @@
+import type { WorkflowEdge, WorkflowNode } from '@genfeedai/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './applyEditOperations';
+import type { EditOperation } from './slices/types';
+
+const nodes = [
+  { data: {}, id: 'a', position: { x: 0, y: 0 }, type: 'prompt' },
+] as unknown as WorkflowNode[];
+const edges = [] as WorkflowEdge[];
+
+describe('applyEditOperations', () => {
+  afterEach(() => {
+    // Reset to the no-op default so tests don't leak an implementation.
+    configureApplyEditOperations(undefined);
+  });
+
+  it('defaults to a no-op that leaves the graph untouched', () => {
+    const operations: EditOperation[] = [{ nodeId: 'a', type: 'removeNode' }];
+
+    const result = getApplyEditOperations()(operations, { edges, nodes });
+
+    expect(result).toEqual({ applied: 0, edges, nodes, skipped: [] });
+  });
+
+  it('routes to the configured implementation with operations + state', () => {
+    const apply = vi
+      .fn()
+      .mockReturnValue({ applied: 1, edges, nodes: [], skipped: [] });
+    configureApplyEditOperations(apply);
+
+    const operations: EditOperation[] = [{ nodeId: 'a', type: 'removeNode' }];
+    const result = getApplyEditOperations()(operations, { edges, nodes });
+
+    expect(apply).toHaveBeenCalledWith(operations, { edges, nodes });
+    expect(result.applied).toBe(1);
+  });
+
+  it('reverts to the no-op when reconfigured with undefined', () => {
+    configureApplyEditOperations(
+      vi.fn().mockReturnValue({ applied: 5, edges, nodes: [], skipped: [] }),
+    );
+    configureApplyEditOperations(undefined);
+
+    const result = getApplyEditOperations()([], { edges, nodes });
+
+    expect(result.applied).toBe(0);
+  });
+});

--- a/packages/workflow-ui/src/stores/workflow/applyEditOperations.ts
+++ b/packages/workflow-ui/src/stores/workflow/applyEditOperations.ts
@@ -1,0 +1,42 @@
+import type { ApplyEditOperations } from './slices/types';
+
+// =============================================================================
+// Module-level applyEditOperations configuration
+// =============================================================================
+
+/**
+ * Injected `applyEditOperations` implementation for the snapshot slice (used by
+ * the chat/agent edit pipeline to mutate the graph). Registered at module scope
+ * via {@link configureApplyEditOperations} because the workflow store lives
+ * outside the React tree.
+ *
+ * Defaults to a no-op that leaves the graph untouched (0 applied) so the package
+ * stays functional standalone; the consuming app injects the real graph-diffing
+ * implementation through `WorkflowUIConfig.applyEditOperations`.
+ */
+const NOOP_APPLY_EDIT_OPERATIONS: ApplyEditOperations = (
+  _operations,
+  state,
+) => ({
+  applied: 0,
+  edges: state.edges,
+  nodes: state.nodes,
+  skipped: [],
+});
+
+let _apply: ApplyEditOperations = NOOP_APPLY_EDIT_OPERATIONS;
+
+/**
+ * Register the `applyEditOperations` implementation the snapshot slice uses.
+ * Called by WorkflowUIProvider; resets to the no-op default when unset.
+ */
+export function configureApplyEditOperations(
+  apply: ApplyEditOperations | undefined,
+): void {
+  _apply = apply ?? NOOP_APPLY_EDIT_OPERATIONS;
+}
+
+/** Read the currently-configured applyEditOperations (no-op until configured). */
+export function getApplyEditOperations(): ApplyEditOperations {
+  return _apply;
+}

--- a/packages/workflow-ui/src/stores/workflow/index.ts
+++ b/packages/workflow-ui/src/stores/workflow/index.ts
@@ -5,5 +5,12 @@
  * Internal implementation uses slices for organization.
  */
 
-export type { WorkflowData, WorkflowState, WorkflowStore } from './types';
+export type {
+  WorkflowData,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowState,
+  WorkflowStore,
+  WorkflowSummary,
+} from './types';
 export { useWorkflowStore } from './workflowStore';

--- a/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
@@ -1,4 +1,5 @@
 import type {
+  EdgeStyle,
   NodeType,
   ValidationResult,
   WorkflowEdge,
@@ -9,9 +10,15 @@ import type {
 } from '@genfeedai/types';
 import { NODE_DEFINITIONS } from '@genfeedai/types';
 import type { StateCreator } from 'zustand';
-import { getConnectedInputsForNode, getUpstreamNodeIds } from '../../../lib';
+import {
+  calculateWorkflowCost,
+  getConnectedInputsForNode,
+  getUpstreamNodeIds,
+} from '../../../lib';
+import { useExecutionStore } from '../../execution/executionStore';
 import { propagateExistingOutputs } from '../helpers/propagation';
-import type { WorkflowData, WorkflowStore } from '../types';
+import type { WorkflowData, WorkflowStore, WorkflowSummary } from '../types';
+import { getWorkflowPersistence } from '../workflowPersistence';
 
 /**
  * Normalize edges loaded from storage to use React Flow edge types.
@@ -50,7 +57,7 @@ export interface PersistenceSlice {
   exportWorkflow: () => WorkflowFile;
   saveWorkflow: (signal?: AbortSignal) => Promise<WorkflowData>;
   loadWorkflowById: (id: string, signal?: AbortSignal) => Promise<void>;
-  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowData[]>;
+  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowSummary[]>;
   deleteWorkflow: (id: string, signal?: AbortSignal) => Promise<void>;
   duplicateWorkflowApi: (
     id: string,
@@ -87,23 +94,50 @@ export const createPersistenceSlice: StateCreator<
     });
   },
 
-  createNewWorkflow: async () => {
-    throw new Error(
-      'createNewWorkflow not implemented - consuming app must provide API integration',
+  createNewWorkflow: async (signal) => {
+    const { edgeStyle } = get();
+
+    const workflow = await getWorkflowPersistence().create(
+      {
+        edgeStyle,
+        edges: [],
+        groups: [],
+        name: 'Untitled Workflow',
+        nodes: [],
+      },
+      signal,
     );
+
+    set({
+      edges: [],
+      groups: [],
+      isDirty: false,
+      nodes: [],
+      selectedNodeIds: [],
+      workflowId: workflow._id,
+      workflowName: workflow.name,
+    });
+
+    return workflow._id;
   },
 
-  deleteWorkflow: async () => {
-    throw new Error(
-      'deleteWorkflow not implemented - consuming app must provide API integration',
-    );
+  deleteWorkflow: async (id, signal) => {
+    await getWorkflowPersistence().delete(id, signal);
+
+    const { workflowId } = get();
+    if (workflowId === id) {
+      set({
+        edges: [],
+        isDirty: false,
+        nodes: [],
+        workflowId: null,
+        workflowName: 'Untitled Workflow',
+      });
+    }
   },
 
-  duplicateWorkflowApi: async () => {
-    throw new Error(
-      'duplicateWorkflowApi not implemented - consuming app must provide API integration',
-    );
-  },
+  duplicateWorkflowApi: (id, signal) =>
+    getWorkflowPersistence().duplicate(id, signal),
 
   exportWorkflow: () => {
     const { nodes, edges, edgeStyle, workflowName, groups } = get();
@@ -157,11 +191,7 @@ export const createPersistenceSlice: StateCreator<
     }).length;
   },
 
-  listWorkflows: async () => {
-    throw new Error(
-      'listWorkflows not implemented - consuming app must provide API integration',
-    );
-  },
+  listWorkflows: (signal) => getWorkflowPersistence().getAll(undefined, signal),
   loadWorkflow: (workflow) => {
     const hydratedNodes = hydrateWorkflowNodes(workflow.nodes);
 
@@ -176,6 +206,9 @@ export const createPersistenceSlice: StateCreator<
       workflowName: workflow.name,
     });
 
+    const estimatedCost = calculateWorkflowCost(hydratedNodes);
+    useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
+
     // Propagate existing outputs to downstream nodes after load
     propagateExistingOutputs(hydratedNodes, get().propagateOutputsDownstream);
 
@@ -183,10 +216,36 @@ export const createPersistenceSlice: StateCreator<
     set({ isDirty: false });
   },
 
-  loadWorkflowById: async () => {
-    throw new Error(
-      'loadWorkflowById not implemented - consuming app must provide API integration',
-    );
+  loadWorkflowById: async (id, signal) => {
+    set({ isLoading: true });
+
+    try {
+      const workflow = await getWorkflowPersistence().getById(id, signal);
+      const nodes = hydrateWorkflowNodes(workflow.nodes);
+
+      set({
+        edgeStyle: workflow.edgeStyle as EdgeStyle,
+        edges: normalizeEdgeTypes(workflow.edges),
+        groups: workflow.groups ?? [],
+        isDirty: false,
+        isLoading: false,
+        nodes,
+        workflowId: workflow._id,
+        workflowName: workflow.name,
+      });
+
+      const estimatedCost = calculateWorkflowCost(nodes);
+      useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
+
+      // Propagate existing outputs to downstream nodes after load
+      propagateExistingOutputs(nodes, get().propagateOutputsDownstream);
+
+      // Propagation after load is idempotent; don't trigger save cycle
+      set({ isDirty: false });
+    } catch (error) {
+      set({ isLoading: false });
+      throw error;
+    }
   },
 
   markCommentViewed: (nodeId: string) => {
@@ -197,12 +256,34 @@ export const createPersistenceSlice: StateCreator<
     });
   },
 
-  // API operations - stubs that throw by default.
-  // Consuming apps override these via the store creator or by extending the slice.
-  saveWorkflow: async () => {
-    throw new Error(
-      'saveWorkflow not implemented - consuming app must provide API integration',
-    );
+  saveWorkflow: async (signal) => {
+    const { nodes, edges, edgeStyle, workflowName, workflowId, groups } = get();
+    set({ isSaving: true });
+
+    try {
+      const input = {
+        edgeStyle,
+        edges,
+        groups,
+        name: workflowName,
+        nodes,
+      };
+
+      const workflow = workflowId
+        ? await getWorkflowPersistence().update(workflowId, input, signal)
+        : await getWorkflowPersistence().create(input, signal);
+
+      set({
+        isDirty: false,
+        isSaving: false,
+        workflowId: workflow._id,
+      });
+
+      return workflow;
+    } catch (error) {
+      set({ isSaving: false });
+      throw error;
+    }
   },
 
   setDirty: (dirty) => {

--- a/packages/workflow-ui/src/stores/workflow/slices/snapshotSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/snapshotSlice.ts
@@ -1,24 +1,7 @@
-import type { WorkflowEdge, WorkflowNode } from '@genfeedai/types';
 import type { StateCreator } from 'zustand';
+import { getApplyEditOperations } from '../applyEditOperations';
 import type { WorkflowStore } from '../types';
-import type { EditOperation, SnapshotSlice, WorkflowSnapshot } from './types';
-
-/**
- * EditOperation type inlined from @/lib/chat/editOperations.
- * The consuming app provides the actual applyEditOperations implementation.
- */
-// Stub applyEditOperations - consuming app should override via the store creator.
-function defaultApplyEditOperations(
-  _operations: EditOperation[],
-  state: { nodes: WorkflowNode[]; edges: WorkflowEdge[] },
-): {
-  nodes: WorkflowNode[];
-  edges: WorkflowEdge[];
-  applied: number;
-  skipped: string[];
-} {
-  return { applied: 0, edges: state.edges, nodes: state.nodes, skipped: [] };
-}
+import type { SnapshotSlice, WorkflowSnapshot } from './types';
 
 export const createSnapshotSlice: StateCreator<
   WorkflowStore & SnapshotSlice,
@@ -28,7 +11,7 @@ export const createSnapshotSlice: StateCreator<
 > = (set, get) => ({
   applyEditOperations: (operations) => {
     const state = get();
-    const result = defaultApplyEditOperations(operations, {
+    const result = getApplyEditOperations()(operations, {
       edges: state.edges,
       nodes: state.nodes,
     });

--- a/packages/workflow-ui/src/stores/workflow/slices/types.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/types.ts
@@ -1,14 +1,52 @@
 import type {
   EdgeStyle,
   NodeGroup,
+  NodeType,
   WorkflowEdge,
   WorkflowNode,
 } from '@genfeedai/types';
 
-export interface EditOperation {
-  type: 'add_node' | 'remove_node' | 'update_node' | 'add_edge' | 'remove_edge';
-  [key: string]: unknown;
+/**
+ * A single atomic change to the workflow graph. Canonical shape shared with the
+ * app's chat/agent edit pipeline — the `applyEditOperations` implementation is
+ * injected (see WorkflowUIConfig.applyEditOperations); this package defaults to
+ * a no-op when unconfigured.
+ */
+export type EditOperation =
+  | {
+      type: 'addNode';
+      nodeType: NodeType;
+      position?: { x: number; y: number };
+      data?: Record<string, unknown>;
+    }
+  | { type: 'removeNode'; nodeId: string }
+  | { type: 'updateNode'; nodeId: string; data: Record<string, unknown> }
+  | {
+      type: 'addEdge';
+      source: string;
+      target: string;
+      sourceHandle?: string;
+      targetHandle?: string;
+    }
+  | { type: 'removeEdge'; edgeId: string };
+
+/** Result of applying a batch of {@link EditOperation}s. */
+export interface ApplyEditResult {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  applied: number;
+  skipped: string[];
 }
+
+/**
+ * Applies a batch of edit operations to the current graph and returns the new
+ * nodes/edges plus how many applied / which were skipped. Injected by the app;
+ * defaults to a no-op that leaves the graph untouched.
+ */
+export type ApplyEditOperations = (
+  operations: EditOperation[],
+  state: { nodes: WorkflowNode[]; edges: WorkflowEdge[] },
+) => ApplyEditResult;
 
 export interface ChatMessage {
   id: string;

--- a/packages/workflow-ui/src/stores/workflow/types.ts
+++ b/packages/workflow-ui/src/stores/workflow/types.ts
@@ -44,6 +44,53 @@ export interface WorkflowData {
   updatedAt?: string;
 }
 
+/** Payload sent to the persistence service on create / update. */
+export interface WorkflowSaveInput {
+  name: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  edgeStyle?: string;
+  groups?: NodeGroup[];
+  tags?: string[];
+}
+
+/** Lightweight workflow projection returned by the list endpoint (no graph). */
+export interface WorkflowSummary {
+  _id: string;
+  name: string;
+  description?: string;
+  lifecycle: 'draft' | 'published' | 'archived';
+  thumbnail?: string | null;
+  thumbnailNodeId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Persistence backend the workflow store's CRUD actions delegate to. Injected by
+ * the consuming app (see WorkflowUIConfig.workflowPersistence); when unconfigured
+ * the package throws a clear "not configured" error — its prior standalone
+ * behavior — rather than silently dropping saves.
+ */
+export interface WorkflowPersistenceService {
+  create: (
+    input: WorkflowSaveInput,
+    signal?: AbortSignal,
+  ) => Promise<WorkflowData>;
+  update: (
+    id: string,
+    input: WorkflowSaveInput,
+    signal?: AbortSignal,
+  ) => Promise<WorkflowData>;
+  getById: (id: string, signal?: AbortSignal) => Promise<WorkflowData>;
+  getAll: (
+    params?: { search?: string; tag?: string },
+    signal?: AbortSignal,
+  ) => Promise<WorkflowSummary[]>;
+  delete: (id: string, signal?: AbortSignal) => Promise<void>;
+  duplicate: (id: string, signal?: AbortSignal) => Promise<WorkflowData>;
+}
+
 // =============================================================================
 // STATE TYPES
 // =============================================================================
@@ -137,7 +184,7 @@ export interface LocalWorkflowActions {
 export interface ApiActions {
   saveWorkflow: (signal?: AbortSignal) => Promise<WorkflowData>;
   loadWorkflowById: (id: string, signal?: AbortSignal) => Promise<void>;
-  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowData[]>;
+  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowSummary[]>;
   deleteWorkflow: (id: string, signal?: AbortSignal) => Promise<void>;
   duplicateWorkflowApi: (
     id: string,

--- a/packages/workflow-ui/src/stores/workflow/workflowPersistence.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/workflowPersistence.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowData, WorkflowPersistenceService } from './types';
+import {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflowPersistence';
+
+const workflow: WorkflowData = {
+  _id: 'wf-1',
+  edgeStyle: 'default',
+  edges: [],
+  name: 'Test',
+  nodes: [],
+};
+
+function makeService(): WorkflowPersistenceService {
+  return {
+    create: vi.fn().mockResolvedValue(workflow),
+    delete: vi.fn().mockResolvedValue(undefined),
+    duplicate: vi.fn().mockResolvedValue(workflow),
+    getAll: vi.fn().mockResolvedValue([]),
+    getById: vi.fn().mockResolvedValue(workflow),
+    update: vi.fn().mockResolvedValue(workflow),
+  };
+}
+
+describe('workflowPersistence', () => {
+  afterEach(() => {
+    // Reset to the throwing default so tests don't leak a service into each other.
+    configureWorkflowPersistence(undefined);
+  });
+
+  it('throws a clear "not configured" error for every method by default', async () => {
+    const service = getWorkflowPersistence();
+
+    await expect(
+      service.create({ edges: [], name: 'x', nodes: [] }),
+    ).rejects.toThrow(/not configured/);
+    await expect(service.getById('id')).rejects.toThrow(/not configured/);
+    await expect(service.getAll()).rejects.toThrow(/not configured/);
+    await expect(service.delete('id')).rejects.toThrow(/not configured/);
+    await expect(service.duplicate('id')).rejects.toThrow(/not configured/);
+    await expect(
+      service.update('id', { edges: [], name: 'x', nodes: [] }),
+    ).rejects.toThrow(/not configured/);
+  });
+
+  it('routes calls to the configured service', async () => {
+    const service = makeService();
+    configureWorkflowPersistence(service);
+
+    const result = await getWorkflowPersistence().getById('wf-1');
+
+    expect(service.getById).toHaveBeenCalledWith('wf-1');
+    expect(result).toEqual(workflow);
+  });
+
+  it('reverts to the throwing default when reconfigured with undefined', async () => {
+    configureWorkflowPersistence(makeService());
+    configureWorkflowPersistence(undefined);
+
+    await expect(getWorkflowPersistence().getById('id')).rejects.toThrow(
+      /not configured/,
+    );
+  });
+});

--- a/packages/workflow-ui/src/stores/workflow/workflowPersistence.ts
+++ b/packages/workflow-ui/src/stores/workflow/workflowPersistence.ts
@@ -1,0 +1,50 @@
+import type { WorkflowPersistenceService } from './types';
+
+// =============================================================================
+// Module-level workflow persistence configuration
+// =============================================================================
+
+/**
+ * Injected persistence backend for the workflow store's CRUD actions
+ * (`saveWorkflow`, `loadWorkflowById`, `listWorkflows`, `deleteWorkflow`,
+ * `duplicateWorkflowApi`, `createNewWorkflow`).
+ *
+ * The workflow store is a plain Zustand store outside the React tree, so the
+ * service is registered at module scope via {@link configureWorkflowPersistence}
+ * — the same pattern the execution HTTP client and logger use.
+ *
+ * When unconfigured, every method throws a clear "not configured" error. This
+ * preserves the package's prior standalone behavior (the stubs threw
+ * "not implemented") — a save must never silently no-op and drop the user's work.
+ */
+function notConfigured(method: string): never {
+  throw new Error(
+    `WorkflowPersistenceService.${method} is not configured — the consuming app must inject workflowPersistence via WorkflowUIConfig`,
+  );
+}
+
+const DEFAULT_PERSISTENCE: WorkflowPersistenceService = {
+  create: async () => notConfigured('create'),
+  delete: async () => notConfigured('delete'),
+  duplicate: async () => notConfigured('duplicate'),
+  getAll: async () => notConfigured('getAll'),
+  getById: async () => notConfigured('getById'),
+  update: async () => notConfigured('update'),
+};
+
+let _persistence: WorkflowPersistenceService = DEFAULT_PERSISTENCE;
+
+/**
+ * Register the persistence backend the workflow store delegates to.
+ * Called by WorkflowUIProvider; resets to the throwing default when unset.
+ */
+export function configureWorkflowPersistence(
+  service: WorkflowPersistenceService | undefined,
+): void {
+  _persistence = service ?? DEFAULT_PERSISTENCE;
+}
+
+/** Read the currently-configured persistence backend (throws until configured). */
+export function getWorkflowPersistence(): WorkflowPersistenceService {
+  return _persistence;
+}


### PR DESCRIPTION
## Summary

Fourth increment of the **workflow-ui fork unification** ([issue #1151](https://github.com/genfeedai/genfeed.ai/issues/1151)). The package's `stores/execution/**` had **zero test coverage**; the `apps/app` fork carried ~879 lines of execution tests that would be lost when the fork is deleted (step 5). This ports all three into the package.

> **Stacked on #1155** (persistence injection) → #1152 → #1149. Base is `feat/workflow-ui-persistence-injection`.

### What this ports
- **`outputHelpers.test.ts`** — verbatim; the helper is byte-identical between fork and package.
- **`executionSlice.test.ts`** — adapted to the package's **injection seams**. The app fork mocked its concrete `@/lib/api/client` and `@services/core/logger.service` modules; the package instead drives `configureExecutionHttpClient` / `configureExecutionHeaders` / `configureWorkflowLogger`, asserting the injected provider headers ride execute requests and that stop requests carry none.
- **`sseSubscription.test.ts`** — same logger-seam adaptation. SSE stream + reconcile URLs remain the package's bare-fetch base. Covers node status/output/job/debug-payload updates, completion teardown, parse + connection-error logging, and node-scoped streams that don't mutate global execution state.

## Verification
- Package vitest **376/376** (was 352 → **+24** execution tests across 3 new files)
- biome clean; secretlint pre-commit hook green

Package-only change — no `apps/app` edits.

## Sequence (issue #1151)
1. Error-reporting seam — #1149
2. Execution HTTP + provider-headers — #1152
3. Persistence + applyEditOperations — #1155
4. **Port execution-store tests — this PR**
5. Reconcile divergences (`edgeSlice` position-dirty; Image History vs `workflowTags`)
6. Delete fork + repoint ~16 consumers, behind Playwright coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)