### PR TITLE
test(workers): stub TOKEN_ENCRYPTION_KEY in vitest setup

### DIFF
--- a/apps/server/workers/test/setup-unit.ts
+++ b/apps/server/workers/test/setup-unit.ts
@@ -1,0 +1,15 @@
+/**
+ * Unit Test Setup - runs before all unit tests
+ *
+ * Stubs the ambient env unit tests must never depend on. Processors that
+ * reach EncryptionUtil (via @api imports) resolve the key through
+ * `resolveTokenEncryptionKey()`, which throws when TOKEN_ENCRYPTION_KEY is
+ * unset — specs pass plaintext fixtures, which the cipher passes through.
+ */
+
+// Set test environment
+process.env.NODE_ENV = 'test';
+
+// Mock encryption key — same value as the api test setup so encrypted
+// fixtures interop across service suites.
+process.env.TOKEN_ENCRYPTION_KEY = 'test-encryption-key-for-testing-only';

--- a/apps/server/workers/vitest.config.ts
+++ b/apps/server/workers/vitest.config.ts
@@ -218,6 +218,7 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.spec.ts'],
     passWithNoTests: true,
+    setupFiles: ['./test/setup-unit.ts'],
     testTimeout: 30000,
   },
 });

--- a/apps/server/workers/vitest.cron.config.ts
+++ b/apps/server/workers/vitest.cron.config.ts
@@ -259,6 +259,7 @@ export default defineConfig({
     globals: true,
     include: ['src/crons/**/*.spec.ts'],
     passWithNoTests: false,
+    setupFiles: ['./test/setup-unit.ts'],
     testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Summary

`bun run test --filter=@genfeedai/workers` fails on clean master with **10 test failures** in `reply-bot-polling.processor.spec.ts` and `analytics-twitter.processor.spec.ts` when `TOKEN_ENCRYPTION_KEY` is not set in the shell.

**Root cause:** the crypto consolidation in #1106 made `resolveTokenEncryptionKey()` (packages/libs/crypto/credential-cipher.ts) throw when the env var is unset. These processors call the static `EncryptionUtil.decrypt()` facade, and `apps/server/workers` was the only server app with no vitest `setupFiles` — so its unit tests silently depended on ambient env.

**Fix:** add `apps/server/workers/test/setup-unit.ts` stubbing `NODE_ENV` + `TOKEN_ENCRYPTION_KEY` (same placeholder value as the api test setup for fixture interop), wired via `setupFiles` in both `vitest.config.ts` and `vitest.cron.config.ts`. This matches how every other server app (api, files, notifications, discord, slack, mcp, telegram) handles env in unit tests. Spec fixtures are plaintext, which the cipher passes through unchanged.

Deliberately omitted the global `afterEach(vi.clearAllMocks)` the sibling setups have: existing workers specs manage their own mock lifecycle, and a global clear could change behavior of currently passing tests.

## Verification

```
env -u TOKEN_ENCRYPTION_KEY bun run test --filter=@genfeedai/workers
→ Test Files  29 passed (29)
→ Tests       246 passed (246)
```

Biome + `turbo lint --filter=@genfeedai/workers` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)