### PR TITLE
chore(docs): fix AGENTS.md pre-push baseline to bunx + refresh last-verified

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Last Verified
 
-- **Date:** 2026-06-09
-- **Sources:** local monorepo structure + GitHub issues
+- **Date:** 2026-07-02
+- **Sources:** local monorepo structure (memory/skills symlinks, trunk rules, pre-push commands)
 
 ## Project Memory — READ AT SESSION START
 
@@ -72,7 +72,7 @@ Detailed docs: `.agents/README.md`
 ## Pre-Push Baseline
 
 ```bash
-npx biome check --write .
+bunx biome check --write .
 bunx turbo lint
 bun type-check
 bun run test --filter=@genfeedai/[changed-package]


### PR DESCRIPTION
## What

- `AGENTS.md` pre-push baseline said `npx biome check --write .` — corrected to `bunx` (Bun-only workspace; matches `CLAUDE.md`'s pre-push checklist).
- Bumped **Last Verified** to 2026-07-02 after re-checking the file's claims against the working tree: `.claude/memory` / `.codex/memory` / `.codex/skills` symlinks exist, trunk rules match, pre-push commands match.

## Why

Part of a staleness audit across all CLAUDE.md/AGENTS.md layers (global + workspace + repo). This was the only git-tracked fix; workspace- and user-level files were updated outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)