### PR TITLE
test(api): make constructor mocks vitest-4 compatible across 9 latent-failing specs

### DIFF
--- a/apps/server/api/src/endpoints/admin/announcements/announcements.controller.spec.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.controller.spec.ts
@@ -8,12 +8,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnnouncementsController } from './announcements.controller';
 import { AdminAnnouncementsService } from './announcements.service';
 
-vi.mock('@api/endpoints/admin/guards/ip-whitelist.guard', () => ({
-  IpWhitelistGuard: vi
-    .fn()
-    .mockImplementation(() => ({ canActivate: vi.fn().mockReturnValue(true) })),
-}));
-
 vi.mock('@api/helpers/decorators/user/current-user.decorator', () => ({
   CurrentUser:
     () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
@@ -89,10 +83,10 @@ describe('AnnouncementsController', () => {
         { provide: LoggerService, useValue: mockLoggerService },
       ],
     })
-      .overrideGuard('IpWhitelistGuard')
-      .useValue({ canActivate: () => true })
+      .overrideGuard(IpWhitelistGuard)
+      .useValue({ canActivate: vi.fn().mockReturnValue(true) })
       .overrideGuard(SuperAdminGuard)
-      .useValue({ canActivate: () => true })
+      .useValue({ canActivate: vi.fn().mockReturnValue(true) })
       .compile();
 
     controller = module.get<AnnouncementsController>(AnnouncementsController);

--- a/apps/server/api/src/endpoints/admin/announcements/announcements.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/announcements/announcements.service.spec.ts
@@ -14,9 +14,9 @@ vi.mock('@api/shared/utils/encryption/encryption.util');
 
 const mockTweetFn = vi.fn().mockResolvedValue({ data: { id: 'tweet-123' } });
 vi.mock('twitter-api-v2', () => ({
-  TwitterApi: vi
-    .fn()
-    .mockImplementation(() => ({ v2: { tweet: mockTweetFn } })),
+  TwitterApi: vi.fn(function TwitterApiMock() {
+    return { v2: { tweet: mockTweetFn } };
+  }),
 }));
 
 describe('AdminAnnouncementsService', () => {

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.controller.spec.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.controller.spec.ts
@@ -9,12 +9,6 @@ import { AdminWarmupAccountsService } from './warmup-accounts.service';
 
 const mockGetPublicMetadata = vi.fn();
 
-vi.mock('@api/endpoints/admin/guards/ip-whitelist.guard', () => ({
-  IpWhitelistGuard: vi
-    .fn()
-    .mockImplementation(() => ({ canActivate: vi.fn().mockReturnValue(true) })),
-}));
-
 vi.mock('@api/helpers/decorators/user/current-user.decorator', () => ({
   CurrentUser:
     () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
@@ -93,10 +87,10 @@ describe('WarmupAccountsController', () => {
         { provide: LoggerService, useValue: loggerService },
       ],
     })
-      .overrideGuard('IpWhitelistGuard')
-      .useValue({ canActivate: () => true })
+      .overrideGuard(IpWhitelistGuard)
+      .useValue({ canActivate: vi.fn().mockReturnValue(true) })
       .overrideGuard(SuperAdminGuard)
-      .useValue({ canActivate: () => true })
+      .useValue({ canActivate: vi.fn().mockReturnValue(true) })
       .compile();
 
     controller = module.get<WarmupAccountsController>(WarmupAccountsController);

--- a/apps/server/api/src/services/integrations/elevenlabs/elevenlabs.service.spec.ts
+++ b/apps/server/api/src/services/integrations/elevenlabs/elevenlabs.service.spec.ts
@@ -54,15 +54,17 @@ describe('ElevenLabsService', () => {
 
     (
       ElevenLabsClient as unknown as ReturnType<typeof vi.fn>
-    ).mockImplementation(() => ({
-      forcedAlignment: { create: forcedAlignmentMock },
-      textToSpeech: { convertWithTimestamps: ttsConvertMock },
-      voices: {
-        delete: voicesDeleteMock,
-        getAll: voicesGetAllMock,
-        ivc: { create: voicesAddMock },
-      },
-    }));
+    ).mockImplementation(function ElevenLabsClientMock() {
+      return {
+        forcedAlignment: { create: forcedAlignmentMock },
+        textToSpeech: { convertWithTimestamps: ttsConvertMock },
+        voices: {
+          delete: voicesDeleteMock,
+          getAll: voicesGetAllMock,
+          ivc: { create: voicesAddMock },
+        },
+      };
+    });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.spec.ts
+++ b/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.spec.ts
@@ -13,7 +13,9 @@ const mockAuthClientInstance = {
 };
 
 vi.mock('linkedin-api-client', () => ({
-  AuthClient: vi.fn().mockImplementation(() => mockAuthClientInstance),
+  AuthClient: vi.fn(function AuthClientMock() {
+    return mockAuthClientInstance;
+  }),
 }));
 
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';

--- a/apps/server/api/src/services/integrations/openai-llm/services/openai-llm.service.spec.ts
+++ b/apps/server/api/src/services/integrations/openai-llm/services/openai-llm.service.spec.ts
@@ -9,13 +9,15 @@ import { Test, type TestingModule } from '@nestjs/testing';
 const mockCreate = vi.fn();
 
 vi.mock('openai', () => {
-  const MockOpenAI = vi.fn().mockImplementation(() => ({
-    chat: {
-      completions: {
-        create: mockCreate,
+  const MockOpenAI = vi.fn(function OpenAIMock() {
+    return {
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
       },
-    },
-  }));
+    };
+  });
   return { default: MockOpenAI };
 });
 

--- a/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.spec.ts
@@ -10,10 +10,12 @@ const mockGenerateOAuth2AuthLink = vi.fn();
 const mockLoginWithOAuth2 = vi.fn();
 
 vi.mock('twitter-api-v2', () => ({
-  TwitterApi: vi.fn().mockImplementation(() => ({
-    generateOAuth2AuthLink: mockGenerateOAuth2AuthLink,
-    loginWithOAuth2: mockLoginWithOAuth2,
-  })),
+  TwitterApi: vi.fn(function TwitterApiMock() {
+    return {
+      generateOAuth2AuthLink: mockGenerateOAuth2AuthLink,
+      loginWithOAuth2: mockLoginWithOAuth2,
+    };
+  }),
 }));
 
 import { BrandsService } from '@api/collections/brands/services/brands.service';

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.coverage.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.coverage.spec.ts
@@ -37,17 +37,19 @@ const mockV1TrendsByPlace = vi.fn();
 const mockRefreshOAuth2Token = vi.fn();
 
 vi.mock('twitter-api-v2', () => {
-  const MockTwitterApi = vi.fn(() => ({
-    refreshOAuth2Token: mockRefreshOAuth2Token,
-    v1: { trendsByPlace: mockV1TrendsByPlace },
-    v2: {
-      get: mockV2Get,
-      search: mockV2Search,
-      sendDmInConversation: mockV2SendDmInConversation,
-      tweet: mockV2Tweet,
-      uploadMedia: mockV2UploadMedia,
-    },
-  }));
+  const MockTwitterApi = vi.fn(function TwitterApiMock() {
+    return {
+      refreshOAuth2Token: mockRefreshOAuth2Token,
+      v1: { trendsByPlace: mockV1TrendsByPlace },
+      v2: {
+        get: mockV2Get,
+        search: mockV2Search,
+        sendDmInConversation: mockV2SendDmInConversation,
+        tweet: mockV2Tweet,
+        uploadMedia: mockV2UploadMedia,
+      },
+    };
+  });
   return { TwitterApi: MockTwitterApi };
 });
 

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.service.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.service.spec.ts
@@ -1,11 +1,17 @@
 const mockSendDm = vi.fn();
 
 vi.mock('twitter-api-v2', () => {
-  const MockTwitterApi = vi.fn(() => ({
-    v2: { sendDm: mockSendDm, sendDmInConversation: mockSendDm },
-  }));
+  const MockTwitterApi = vi.fn(function TwitterApiMock() {
+    return {
+      v2: { sendDm: mockSendDm, sendDmInConversation: mockSendDm },
+    };
+  });
   return { TwitterApi: MockTwitterApi };
 });
+
+vi.mock('@api/shared/utils/encryption/encryption.util', () => ({
+  EncryptionUtil: { decrypt: vi.fn((val: string) => val) },
+}));
 
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
@@ -112,11 +118,6 @@ describe('TwitterService', () => {
       });
 
       mockSendDm.mockResolvedValue({});
-
-      // Mock EncryptionUtil.decrypt for the access token decryption
-      vi.mock('@api/shared/utils/encryption/encryption.util', () => ({
-        EncryptionUtil: { decrypt: vi.fn((val: string) => val) },
-      }));
 
       await service.sendCommentReplyDm('org', 'acc', 'user', 'hello');
 


### PR DESCRIPTION
## Summary

109 tests across 9 api spec files failed on clean `master` (verified at `d697302d6`) when run directly, but CI stayed green because the changed-files test path never selects these specs — the same latent-blind-spot class #1105/#1161 have been closing.

**Root cause:** vitest 4 rejects mock functions used as constructors when the implementation is an arrow function (`TypeError: ()=>({...}) is not a constructor`). Two variants:

1. **SDK client mocks** — `vi.mock` factories for `twitter-api-v2`, `openai`, `@elevenlabs/elevenlabs-js`, and `linkedin-api-client` built constructors with `vi.fn(() => ({...}))` / `vi.fn().mockImplementation(() => ({...}))`. Services doing `new Client(...)` threw. Some assertion failures were downstream: the service caught the throw, so the `tweet`/`sendDm` mocks were never called.
2. **Guard module mocks** — the admin announcements/warmup-accounts controller specs module-mocked `IpWhitelistGuard` as an arrow-factory `vi.fn()`; Nest's injector `new`s guard classes from `@UseGuards` metadata during `compile()`. The existing `.overrideGuard('IpWhitelistGuard')` used a **string token**, so it never matched the class and didn't prevent instantiation.

## Fix (spec-only, follows existing repo patterns)

- Constructor mocks → `vi.fn(function XMock() { return {...}; })` (same shape as `OAuth2Mock` in `bots-livestream-delivery.service.spec.ts`).
- Guard module mocks removed; specs now use `.overrideGuard(IpWhitelistGuard).useValue({ canActivate: vi.fn().mockReturnValue(true) })` with the real class token.
- Drive-by: hoisted a nested `vi.mock('@api/shared/utils/encryption/encryption.util')` in `twitter.service.spec.ts` to top level (vitest deprecation warning; becomes an error in a future vitest).

## Verification

- `cd apps/server/api && bunx vitest run --config vitest.config.ts <the 9 files>` → **9 files, 129/129 pass**, no warnings (was 109 failed / 20 passed).
- `bunx biome check` on changed files → clean (3 pre-existing warnings unchanged vs master).
- `bunx turbo run type-check --filter=@genfeedai/api` → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)