### PR TITLE
fix(shell): move org switcher into sidebar header + drop Messages from workspace menu

### DIFF
--- a/apps/app/packages/config/menu-items.config.test.ts
+++ b/apps/app/packages/config/menu-items.config.test.ts
@@ -24,11 +24,15 @@ describe('APP_MENU_ITEMS', () => {
 
     expect(ungroupedLabels).toEqual([
       'Dashboard',
-      'Messages',
       'Inbox',
       'Tasks',
       'Activity',
     ]);
+  });
+
+  it('keeps Messages out of the workspace menu (app switcher owns it)', () => {
+    expect(APP_MENU_ITEMS.map((item) => item.label)).not.toContain('Messages');
+    expect(APP_MENU_ITEMS.map((item) => item.href)).not.toContain('/messages');
   });
 
   it('does not surface content drilldowns in the shared sidebar', () => {
@@ -56,7 +60,6 @@ describe('APP_MENU_ITEMS', () => {
 
     expect(workspaceLabels).toEqual([
       'Dashboard',
-      'Messages',
       'Inbox',
       'Tasks',
       'Activity',

--- a/apps/app/packages/config/menu-items.config.ts
+++ b/apps/app/packages/config/menu-items.config.ts
@@ -1,11 +1,9 @@
 import { APP_ROUTES } from '@genfeedai/constants';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import {
-  HiChatBubbleLeftRight,
   HiClipboardDocumentList,
   HiClock,
   HiInboxStack,
-  HiOutlineChatBubbleLeftRight,
   HiOutlineClipboardDocumentList,
   HiOutlineClock,
   HiOutlineInboxStack,
@@ -28,14 +26,6 @@ export const APP_MENU_ITEMS: MenuItemConfig[] = [
     matchPaths: [APP_ROUTES.WORKSPACE.ROOT, APP_ROUTES.WORKSPACE.OVERVIEW],
     outline: HiOutlineSquares2X2,
     solid: HiSquares2X2,
-  },
-  {
-    group: AppMenuGroup.Root,
-    href: APP_ROUTES.MESSAGES.ROOT,
-    label: 'Messages',
-    matchPaths: [APP_ROUTES.MESSAGES.ROOT],
-    outline: HiOutlineChatBubbleLeftRight,
-    solid: HiChatBubbleLeftRight,
   },
   {
     group: AppMenuGroup.Root,

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -254,16 +254,21 @@ describe('MenuShared', () => {
     ).toBeTruthy();
   });
 
-  it('keeps organization switching out of the sidebar header shell', () => {
-    render(<MenuShared config={config} />);
+  it('renders the org switcher slot inside the sidebar header shell', () => {
+    render(
+      <MenuShared
+        config={config}
+        orgSwitcherSlot={<div data-testid="organization-switcher">Acme</div>}
+      />,
+    );
 
-    expect(screen.getByTestId('sidebar-header-shell')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('organization-switcher'),
-    ).not.toBeInTheDocument();
+    const headerShell = screen.getByTestId('sidebar-header-shell');
+    const orgSwitcher = screen.getByTestId('organization-switcher');
+
+    expect(headerShell).toContainElement(orgSwitcher);
   });
 
-  it('renders the org switcher slot at the top of the sidebar body, above the top slot and nav', () => {
+  it('renders the org switcher in the header above the top slot and nav', () => {
     render(
       <MenuShared
         config={config}
@@ -277,6 +282,9 @@ describe('MenuShared', () => {
     const firstMenuItem = screen.getByText('Dashboard');
 
     expect(orgSwitcher).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-header-shell')).not.toContainElement(
+      topSlot,
+    );
     expect(
       orgSwitcher.compareDocumentPosition(topSlot) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -200,6 +200,16 @@ export default function MenuShared({
           )}
         >
           {sharedCollapseControl}
+          {orgSwitcherSlot ? (
+            <div
+              className={cn(
+                'min-w-0 flex-1 transition-opacity duration-200',
+                isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
+              )}
+            >
+              {orgSwitcherSlot}
+            </div>
+          ) : null}
         </div>
 
         {/* Body — fades out when collapsed, pointer-events disabled */}
@@ -209,10 +219,6 @@ export default function MenuShared({
             isCollapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
           )}
         >
-          {orgSwitcherSlot ? (
-            <div className="px-3 pt-2">{orgSwitcherSlot}</div>
-          ) : null}
-
           {topSlotContent ? (
             <div className="px-3 pt-2">{topSlotContent}</div>
           ) : null}


### PR DESCRIPTION
## Summary
- Moves the organization switcher out of the sidebar body into the sidebar header shell, next to the collapse control — same shell hierarchy as brand context in the topbar. It fades with the same transition as the body when the sidebar collapses.
- Removes **Messages** from the Workspace sidebar menu (`APP_MENU_ITEMS`). Messages remains an app-level surface reached via the app switcher (already covered by `AppSwitcher` tests).
- New Task / Search triggers stay below the context controls, so the focus order remains context → actions → navigation.

## Tests
- `MenuShared.test.tsx`: org switcher now asserted **inside** `sidebar-header-shell`, above top slot and nav (replaces the two body-placement tests).
- `menu-items.config.test.ts`: workspace menu asserted as Dashboard/Inbox/Tasks/Activity, plus an explicit guard that Messages stays out.

## Verification
- `bunx biome check --write` clean, `bunx turbo lint` + `type-check` (ui + app) green
- Full `@genfeedai/ui` suite: 1876 passed; focused `@genfeedai/app` shell tests green

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)