### PR TITLE
fix(api): make twitter-api-v2 constructor mocks constructable under vitest 4

### DIFF
--- a/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.spec.ts
@@ -10,10 +10,14 @@ const mockGenerateOAuth2AuthLink = vi.fn();
 const mockLoginWithOAuth2 = vi.fn();
 
 vi.mock('twitter-api-v2', () => ({
-  TwitterApi: vi.fn().mockImplementation(() => ({
-    generateOAuth2AuthLink: mockGenerateOAuth2AuthLink,
-    loginWithOAuth2: mockLoginWithOAuth2,
-  })),
+  // vitest 4 constructs the implementation via `new`, so it must be a
+  // constructable function — an arrow implementation throws TypeError.
+  TwitterApi: vi.fn().mockImplementation(function mockTwitterApi() {
+    return {
+      generateOAuth2AuthLink: mockGenerateOAuth2AuthLink,
+      loginWithOAuth2: mockLoginWithOAuth2,
+    };
+  }),
 }));
 
 import { BrandsService } from '@api/collections/brands/services/brands.service';

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.coverage.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.coverage.spec.ts
@@ -37,17 +37,21 @@ const mockV1TrendsByPlace = vi.fn();
 const mockRefreshOAuth2Token = vi.fn();
 
 vi.mock('twitter-api-v2', () => {
-  const MockTwitterApi = vi.fn(() => ({
-    refreshOAuth2Token: mockRefreshOAuth2Token,
-    v1: { trendsByPlace: mockV1TrendsByPlace },
-    v2: {
-      get: mockV2Get,
-      search: mockV2Search,
-      sendDmInConversation: mockV2SendDmInConversation,
-      tweet: mockV2Tweet,
-      uploadMedia: mockV2UploadMedia,
-    },
-  }));
+  // vitest 4 constructs the implementation via `new`, so it must be a
+  // constructable function — an arrow implementation throws TypeError.
+  const MockTwitterApi = vi.fn(function mockTwitterApi() {
+    return {
+      refreshOAuth2Token: mockRefreshOAuth2Token,
+      v1: { trendsByPlace: mockV1TrendsByPlace },
+      v2: {
+        get: mockV2Get,
+        search: mockV2Search,
+        sendDmInConversation: mockV2SendDmInConversation,
+        tweet: mockV2Tweet,
+        uploadMedia: mockV2UploadMedia,
+      },
+    };
+  });
   return { TwitterApi: MockTwitterApi };
 });
 

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.service.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.service.spec.ts
@@ -1,9 +1,13 @@
 const mockSendDm = vi.fn();
 
 vi.mock('twitter-api-v2', () => {
-  const MockTwitterApi = vi.fn(() => ({
-    v2: { sendDm: mockSendDm, sendDmInConversation: mockSendDm },
-  }));
+  // vitest 4 constructs the implementation via `new`, so it must be a
+  // constructable function — an arrow implementation throws TypeError.
+  const MockTwitterApi = vi.fn(function mockTwitterApi() {
+    return {
+      v2: { sendDm: mockSendDm, sendDmInConversation: mockSendDm },
+    };
+  });
   return { TwitterApi: MockTwitterApi };
 });
 


### PR DESCRIPTION
## Summary
- Master's `Test API (changed)` job is red on `270d996e7` — 54 failures across `twitter.service.spec.ts` (4), `twitter.coverage.spec.ts` (48), and `twitter.controller.spec.ts` (2), all `TypeError: ... is not a constructor`.
- vitest 4 constructs `new TwitterApi()` against the mock **implementation**; arrow-function implementations are not constructable.
- These failures were latent, hidden by changed-only test selection — the audit merge wave touched shared imports and pulled the twitter specs into the changed set (confirmed failing at pre-wave `1af7b2c38` too).
- Fix: named function expressions as mock implementations. No production code changes.

## Verification
- `bun run test:file` on all three twitter specs: **62/62 pass**
- `youtube-upload-completion.service.spec.ts` (seen in the failing log trace): 11/11 pass
- `bunx biome check --write` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)