### PR TITLE
refactor(props): remove dead ContainerProps declarations

### DIFF
--- a/packages/props/ui/ui.props.ts
+++ b/packages/props/ui/ui.props.ts
@@ -69,8 +69,6 @@ export interface ContainerProps {
   fullWidth?: boolean;
   left?: ReactNode;
   right?: ReactNode;
-  topbarRight?: ReactNode;
-  promoteHeaderToTopbarOnScroll?: boolean;
 }
 
 export interface LinkProps {


### PR DESCRIPTION
## Summary
- Remove `promoteHeaderToTopbarOnScroll` and `topbarRight` from `ContainerProps` in `packages/props/ui/ui.props.ts`.
- A monorepo-wide grep shows both props appear **only** in the interface declaration — `Container.tsx` never reads them and no caller (apps/app, packages/pages, or anywhere else) passes them. Dead API surface with zero behavior behind it.
- Chose deletion over implementing sticky-header/topbar promotion: nothing depends on the behavior, so implementing it would be speculative (green-field philosophy — prefer deletion).

## Verification
- `bunx turbo run type-check --filter=@genfeedai/props --filter=@genfeedai/ui` — green
- `bunx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)