### PR TITLE
fix(shell): standardize section sub-topbars on the Studio contract

### DIFF
--- a/packages/pages/trends/list/trends-list.test.tsx
+++ b/packages/pages/trends/list/trends-list.test.tsx
@@ -150,16 +150,16 @@ describe('TrendsList', () => {
   it('renders the overview tab as active with platform tabs', () => {
     render(<TrendsList />);
 
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'href',
       '/research/socials',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'data-state',
       'active',
     );
-    expect(screen.getByRole('tab', { name: 'X' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'LinkedIn' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'X' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toBeInTheDocument();
   });
 
   it('renders actual content cards instead of topic-only trend cards', () => {
@@ -206,14 +206,27 @@ describe('TrendsList', () => {
     expect(screen.getByText('Viral hook')).toBeInTheDocument();
   });
 
+  it('renders the section topbar with the title and tabs inside the bordered bar', () => {
+    render(<TrendsList />);
+
+    const topbar = screen.getByTestId('section-topbar');
+
+    expect(topbar).toContainElement(
+      screen.getByRole('heading', { level: 1, name: 'Trending Content' }),
+    );
+    expect(topbar).toContainElement(
+      screen.getByRole('link', { name: 'Overview' }),
+    );
+  });
+
   it('renders socials platform tab links', () => {
     render(<TrendsList />);
 
-    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute(
       'href',
       '/research/twitter',
     );
-    expect(screen.getByRole('tab', { name: 'LinkedIn' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
       'href',
       '/research/linkedin',
     );

--- a/packages/pages/trends/list/trends-list.tsx
+++ b/packages/pages/trends/list/trends-list.tsx
@@ -13,6 +13,7 @@ import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
 import Badge from '@ui/display/badge/Badge';
 import Alert from '@ui/feedback/alert/Alert';
 import Container from '@ui/layout/container/Container';
+import SectionTopbar from '@ui/layout/section-topbar/SectionTopbar';
 import { Button } from '@ui/primitives/button';
 import FormSearchbar from '@ui/primitives/searchbar';
 import { type ChangeEvent, useMemo, useState } from 'react';
@@ -91,153 +92,156 @@ export default function TrendsList() {
   const currentError = error || videosError;
 
   return (
-    <Container
-      description="Actual posts and videos trending across platforms, ready to remix."
-      icon={HiOutlineArrowTrendingUp}
-      label="Trending Content"
-      right={
-        <ButtonRefresh isRefreshing={isRefreshing} onClick={handleRefresh} />
-      }
-    >
-      <div className="mb-6">
-        <SocialsNavigation active="overview" />
-      </div>
+    <>
+      <SectionTopbar
+        title="Trending Content"
+        subtitle="Actual posts and videos trending across platforms, ready to remix."
+        icon={HiOutlineArrowTrendingUp}
+        actions={
+          <ButtonRefresh isRefreshing={isRefreshing} onClick={handleRefresh} />
+        }
+        tabs={<SocialsNavigation active="overview" />}
+      />
 
-      {!isLoading && !currentError ? (
-        <div className="mb-5 flex flex-wrap items-baseline gap-x-6 gap-y-2">
-          <div className="flex items-baseline gap-2">
-            <span className="text-[11px] uppercase tracking-[0.18em] text-foreground/40">
-              Total Posts
-            </span>
-            <span className="text-lg font-semibold text-foreground">
-              {summary.totalItems ?? items.length}
-            </span>
-          </div>
-          <div className="hidden h-4 w-px bg-white/[0.08] sm:block" />
-          <div className="flex items-baseline gap-2">
-            <span className="text-[11px] uppercase tracking-[0.18em] text-foreground/40">
-              Connected
-            </span>
-            <span className="text-lg font-semibold text-foreground">
-              {summary.connectedPlatforms.length}
-            </span>
-          </div>
-          <div className="hidden h-4 w-px bg-white/[0.08] sm:block" />
-          <div className="flex items-baseline gap-2">
-            <span className="text-[11px] uppercase tracking-[0.18em] text-foreground/40">
-              Trend Topics
-            </span>
-            <span className="text-lg font-semibold text-foreground">
-              {summary.totalTrends}
-            </span>
-          </div>
-        </div>
-      ) : null}
-
-      {currentError && !isLoading ? (
-        <Alert type={AlertCategory.ERROR}>
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-1">
-              <div className="font-medium">Failed to load the content feed</div>
-              <div className="text-xs text-foreground/70">
-                Retry to fetch the latest precomputed trend content.
-              </div>
+      <Container>
+        {!isLoading && !currentError ? (
+          <div className="mb-5 flex flex-wrap items-baseline gap-x-6 gap-y-2">
+            <div className="flex items-baseline gap-2">
+              <span className="text-[11px] uppercase tracking-[0.18em] text-foreground/40">
+                Total Posts
+              </span>
+              <span className="text-lg font-semibold text-foreground">
+                {summary.totalItems ?? items.length}
+              </span>
             </div>
-            <Button
-              label="Retry"
-              onClick={() => {
-                handleRefresh().catch(() => {
-                  /* surfaced via hook */
-                });
-              }}
-              variant={ButtonVariant.OUTLINE}
+            <div className="hidden h-4 w-px bg-white/[0.08] sm:block" />
+            <div className="flex items-baseline gap-2">
+              <span className="text-[11px] uppercase tracking-[0.18em] text-foreground/40">
+                Connected
+              </span>
+              <span className="text-lg font-semibold text-foreground">
+                {summary.connectedPlatforms.length}
+              </span>
+            </div>
+            <div className="hidden h-4 w-px bg-white/[0.08] sm:block" />
+            <div className="flex items-baseline gap-2">
+              <span className="text-[11px] uppercase tracking-[0.18em] text-foreground/40">
+                Trend Topics
+              </span>
+              <span className="text-lg font-semibold text-foreground">
+                {summary.totalTrends}
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        {currentError && !isLoading ? (
+          <Alert type={AlertCategory.ERROR}>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <div className="font-medium">
+                  Failed to load the content feed
+                </div>
+                <div className="text-xs text-foreground/70">
+                  Retry to fetch the latest precomputed trend content.
+                </div>
+              </div>
+              <Button
+                label="Retry"
+                onClick={() => {
+                  handleRefresh().catch(() => {
+                    /* surfaced via hook */
+                  });
+                }}
+                variant={ButtonVariant.OUTLINE}
+              />
+            </div>
+          </Alert>
+        ) : null}
+
+        <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="w-full md:max-w-md">
+            <FormSearchbar
+              value={search}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                setSearch(event.target.value)
+              }
+              onClear={() => setSearch('')}
+              placeholder="Search trending content"
             />
           </div>
-        </Alert>
-      ) : null}
-
-      <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div className="w-full md:max-w-md">
-          <FormSearchbar
-            value={search}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              setSearch(event.target.value)
-            }
-            onClear={() => setSearch('')}
-            placeholder="Search trending content"
-          />
+          <Badge variant="ghost">
+            {isLoading ? 'Loading' : `${filteredItems.length} remixable items`}
+          </Badge>
         </div>
-        <Badge variant="ghost">
-          {isLoading ? 'Loading' : `${filteredItems.length} remixable items`}
-        </Badge>
-      </div>
 
-      {isLoading ? (
-        <div className="py-8 text-sm text-foreground/40">
-          Loading content feed…
-        </div>
-      ) : null}
+        {isLoading ? (
+          <div className="py-8 text-sm text-foreground/40">
+            Loading content feed…
+          </div>
+        ) : null}
 
-      {!isLoading && !currentError ? (
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <div className="flex items-center gap-2">
-              <HiOutlineArrowTrendingUp className="size-5 text-foreground/70" />
-              <h2 className="text-lg font-semibold text-foreground">
-                Trending Content Feed
-              </h2>
-              <Badge variant="ghost">Content-first</Badge>
-            </div>
-
-            {filteredItems.length === 0 ? (
-              <div className="py-8 text-center text-sm text-foreground/40">
-                {search.trim()
-                  ? 'No trending content matches your search.'
-                  : 'No remixable trend content is available right now.'}
+        {!isLoading && !currentError ? (
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <div className="flex items-center gap-2">
+                <HiOutlineArrowTrendingUp className="size-5 text-foreground/70" />
+                <h2 className="text-lg font-semibold text-foreground">
+                  Trending Content Feed
+                </h2>
+                <Badge variant="ghost">Content-first</Badge>
               </div>
-            ) : (
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {filteredItems.map((item) => (
-                  <TrendContentCard key={item.id} item={item} />
-                ))}
-              </div>
-            )}
-          </section>
 
-          <section className="space-y-4">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <HiOutlineFilm className="size-5 text-foreground/70" />
-                  <h2 className="text-lg font-semibold text-foreground">
-                    Viral Videos
-                  </h2>
-                  <Badge variant="ghost">Cross-platform</Badge>
+              {filteredItems.length === 0 ? (
+                <div className="py-8 text-center text-sm text-foreground/40">
+                  {search.trim()
+                    ? 'No trending content matches your search.'
+                    : 'No remixable trend content is available right now.'}
                 </div>
-                <div className="text-sm text-foreground/55">
-                  Breakout video patterns adjacent to the saved trend feed.
+              ) : (
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {filteredItems.map((item) => (
+                    <TrendContentCard key={item.id} item={item} />
+                  ))}
                 </div>
+              )}
+            </section>
+
+            <section className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <HiOutlineFilm className="size-5 text-foreground/70" />
+                    <h2 className="text-lg font-semibold text-foreground">
+                      Viral Videos
+                    </h2>
+                    <Badge variant="ghost">Cross-platform</Badge>
+                  </div>
+                  <div className="text-sm text-foreground/55">
+                    Breakout video patterns adjacent to the saved trend feed.
+                  </div>
+                </div>
+
+                <Badge variant={isLoadingVideos ? 'ghost' : 'info'}>
+                  {isLoadingVideos ? 'Loading' : `${viralVideos.length} videos`}
+                </Badge>
               </div>
 
-              <Badge variant={isLoadingVideos ? 'ghost' : 'info'}>
-                {isLoadingVideos ? 'Loading' : `${viralVideos.length} videos`}
-              </Badge>
-            </div>
-
-            {viralVideos.length === 0 ? (
-              <div className="py-3 text-sm text-foreground/40">
-                No viral videos available right now.
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {viralVideos.map((video: ITrendVideo) => (
-                  <ViralVideoCard key={video.id} video={video} />
-                ))}
-              </div>
-            )}
-          </section>
-        </div>
-      ) : null}
-    </Container>
+              {viralVideos.length === 0 ? (
+                <div className="py-3 text-sm text-foreground/40">
+                  No viral videos available right now.
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {viralVideos.map((video: ITrendVideo) => (
+                    <ViralVideoCard key={video.id} video={video} />
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        ) : null}
+      </Container>
+    </>
   );
 }

--- a/packages/pages/trends/platform-detail/trends-platform-detail.test.tsx
+++ b/packages/pages/trends/platform-detail/trends-platform-detail.test.tsx
@@ -144,15 +144,15 @@ describe('TrendsPlatformDetail', () => {
     render(<TrendsPlatformDetail platform="tiktok" />);
 
     expect(mockUseTrendContent).toHaveBeenCalledWith('tiktok');
-    expect(screen.getByRole('tab', { name: 'TikTok' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'TikTok' })).toHaveAttribute(
       'data-state',
       'active',
     );
-    expect(screen.getByRole('tab', { name: 'TikTok' })).toHaveAttribute(
-      'aria-selected',
-      'true',
+    expect(screen.getByRole('link', { name: 'TikTok' })).toHaveAttribute(
+      'aria-current',
+      'page',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'href',
       '/research/socials',
     );
@@ -256,21 +256,20 @@ describe('TrendsPlatformDetail', () => {
 
     render(<TrendsPlatformDetail platform="linkedin" />);
 
-    expect(screen.getByRole('tab', { name: 'LinkedIn' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
       'data-state',
       'active',
     );
-    expect(screen.getByRole('tab', { name: 'LinkedIn' })).toHaveAttribute(
-      'aria-selected',
-      'true',
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
+      'aria-current',
+      'page',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'data-state',
       'inactive',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
-      'aria-selected',
-      'false',
+    expect(screen.getByRole('link', { name: 'Overview' })).not.toHaveAttribute(
+      'aria-current',
     );
   });
 });

--- a/packages/pages/trends/platform-detail/trends-platform-detail.tsx
+++ b/packages/pages/trends/platform-detail/trends-platform-detail.tsx
@@ -25,6 +25,7 @@ import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
 import Badge from '@ui/display/badge/Badge';
 import Alert from '@ui/feedback/alert/Alert';
 import Container from '@ui/layout/container/Container';
+import SectionTopbar from '@ui/layout/section-topbar/SectionTopbar';
 import { Button } from '@ui/primitives/button';
 import { useMemo } from 'react';
 import { HiOutlineArrowTrendingUp } from 'react-icons/hi2';
@@ -146,106 +147,109 @@ export default function TrendsPlatformDetail({
   };
 
   return (
-    <Container
-      description="Platform-specific trending posts and videos, with related signal sets below."
-      icon={HiOutlineArrowTrendingUp}
-      label={`${label} Trends`}
-      right={
-        <ButtonRefresh isRefreshing={isRefreshing} onClick={handleRefresh} />
-      }
-    >
-      <div className="mb-6">
-        <SocialsNavigation active={platform} basePath={basePath} />
-      </div>
-
-      <TrendsPlatformStatBar
-        feedModeLabel={feedModeLabel}
-        totalItems={summary.totalItems ?? items.length}
-        totalTrends={summary.totalTrends}
+    <>
+      <SectionTopbar
+        title={`${label} Trends`}
+        subtitle="Platform-specific trending posts and videos, with related signal sets below."
+        icon={HiOutlineArrowTrendingUp}
+        actions={
+          <ButtonRefresh isRefreshing={isRefreshing} onClick={handleRefresh} />
+        }
+        tabs={<SocialsNavigation active={platform} basePath={basePath} />}
       />
 
-      {platform === Platform.LINKEDIN ? (
-        <div className="mb-5 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-sm text-foreground/65">
-          LinkedIn topics are curated because LinkedIn does not provide a public
-          trends API.
-        </div>
-      ) : null}
+      <Container>
+        <TrendsPlatformStatBar
+          feedModeLabel={feedModeLabel}
+          totalItems={summary.totalItems ?? items.length}
+          totalTrends={summary.totalTrends}
+        />
 
-      {unsupportedContentFeed && platform !== Platform.LINKEDIN ? (
-        <div className="mb-5 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-sm text-foreground/65">
-          No public source-post feed is available for this platform yet. We only
-          show adjacent trend metadata for now.
-        </div>
-      ) : null}
+        {platform === Platform.LINKEDIN ? (
+          <div className="mb-5 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-sm text-foreground/65">
+            LinkedIn topics are curated because LinkedIn does not provide a
+            public trends API.
+          </div>
+        ) : null}
 
-      {error && !isLoading ? (
-        <Alert type={AlertCategory.ERROR}>
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-1">
-              <div className="font-medium">Failed to load platform content</div>
-              <div className="text-xs text-foreground/70">
-                Retry to fetch the latest saved trend feed.
+        {unsupportedContentFeed && platform !== Platform.LINKEDIN ? (
+          <div className="mb-5 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 text-sm text-foreground/65">
+            No public source-post feed is available for this platform yet. We
+            only show adjacent trend metadata for now.
+          </div>
+        ) : null}
+
+        {error && !isLoading ? (
+          <Alert type={AlertCategory.ERROR}>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <div className="font-medium">
+                  Failed to load platform content
+                </div>
+                <div className="text-xs text-foreground/70">
+                  Retry to fetch the latest saved trend feed.
+                </div>
               </div>
+              <Button
+                label="Retry"
+                onClick={() => {
+                  handleRefresh().catch(() => {
+                    /* surfaced via hook */
+                  });
+                }}
+                variant={ButtonVariant.OUTLINE}
+              />
             </div>
-            <Button
-              label="Retry"
-              onClick={() => {
-                handleRefresh().catch(() => {
-                  /* surfaced via hook */
-                });
-              }}
-              variant={ButtonVariant.OUTLINE}
+          </Alert>
+        ) : null}
+
+        {!error ? (
+          <div className="space-y-6">
+            <section className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <HiOutlineArrowTrendingUp className="size-5 text-foreground/70" />
+                <h2 className="text-lg font-semibold text-foreground">
+                  {label} content feed
+                </h2>
+                <Badge variant="ghost">Remix-ready</Badge>
+              </div>
+
+              {unsupportedContentFeed ? (
+                <div className="py-3 text-sm text-foreground/40">
+                  No public content feed available for this platform right now.
+                </div>
+              ) : isLoading ? (
+                <div className="py-3 text-sm text-foreground/40">
+                  Loading content feed…
+                </div>
+              ) : items.length > 0 ? (
+                <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                  {items.map((item) => (
+                    <TrendContentCard key={item.id} item={item} />
+                  ))}
+                </div>
+              ) : (
+                <div className="py-3 text-sm text-foreground/40">
+                  No remixable source posts are available for this platform
+                  right now.
+                </div>
+              )}
+            </section>
+
+            <TrendsPlatformRelatedSections
+              hashtags={hashtags}
+              isLoadingHashtags={isLoadingHashtags}
+              isLoadingSounds={isLoadingSounds}
+              isLoadingVideos={isLoadingVideos}
+              showHashtags={relatedContent.hashtags}
+              showSounds={relatedContent.sounds}
+              showVideos={relatedContent.videos}
+              sounds={sounds}
+              viralVideos={viralVideos}
             />
           </div>
-        </Alert>
-      ) : null}
-
-      {!error ? (
-        <div className="space-y-6">
-          <section className="space-y-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <HiOutlineArrowTrendingUp className="size-5 text-foreground/70" />
-              <h2 className="text-lg font-semibold text-foreground">
-                {label} content feed
-              </h2>
-              <Badge variant="ghost">Remix-ready</Badge>
-            </div>
-
-            {unsupportedContentFeed ? (
-              <div className="py-3 text-sm text-foreground/40">
-                No public content feed available for this platform right now.
-              </div>
-            ) : isLoading ? (
-              <div className="py-3 text-sm text-foreground/40">
-                Loading content feed…
-              </div>
-            ) : items.length > 0 ? (
-              <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                {items.map((item) => (
-                  <TrendContentCard key={item.id} item={item} />
-                ))}
-              </div>
-            ) : (
-              <div className="py-3 text-sm text-foreground/40">
-                No remixable source posts are available for this platform right
-                now.
-              </div>
-            )}
-          </section>
-
-          <TrendsPlatformRelatedSections
-            hashtags={hashtags}
-            isLoadingHashtags={isLoadingHashtags}
-            isLoadingSounds={isLoadingSounds}
-            isLoadingVideos={isLoadingVideos}
-            showHashtags={relatedContent.hashtags}
-            showSounds={relatedContent.sounds}
-            showVideos={relatedContent.videos}
-            sounds={sounds}
-            viralVideos={viralVideos}
-          />
-        </div>
-      ) : null}
-    </Container>
+        ) : null}
+      </Container>
+    </>
   );
 }

--- a/packages/pages/trends/shared/socials-navigation.test.tsx
+++ b/packages/pages/trends/shared/socials-navigation.test.tsx
@@ -26,6 +26,10 @@ vi.mock('next/link', () => ({
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/research/socials',
+  useRouter: () => ({
+    prefetch: vi.fn(),
+    push: vi.fn(),
+  }),
   useSearchParams: () => ({
     toString: () => '',
   }),
@@ -35,35 +39,35 @@ describe('SocialsNavigation', () => {
   it('renders all expected tab links', () => {
     render(<SocialsNavigation active="overview" />);
 
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'href',
       '/research/socials',
     );
-    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute(
       'href',
       '/research/twitter',
     );
-    expect(screen.getByRole('tab', { name: 'Instagram' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Instagram' })).toHaveAttribute(
       'href',
       '/research/instagram',
     );
-    expect(screen.getByRole('tab', { name: 'YouTube' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'YouTube' })).toHaveAttribute(
       'href',
       '/research/youtube',
     );
-    expect(screen.getByRole('tab', { name: 'TikTok' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'TikTok' })).toHaveAttribute(
       'href',
       '/research/tiktok',
     );
-    expect(screen.getByRole('tab', { name: 'LinkedIn' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
       'href',
       '/research/linkedin',
     );
-    expect(screen.getByRole('tab', { name: 'Reddit' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Reddit' })).toHaveAttribute(
       'href',
       '/research/reddit',
     );
-    expect(screen.getByRole('tab', { name: 'Pinterest' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Pinterest' })).toHaveAttribute(
       'href',
       '/research/pinterest',
     );
@@ -72,42 +76,40 @@ describe('SocialsNavigation', () => {
   it('marks the overview tab as active on the socials landing page', () => {
     render(<SocialsNavigation active="overview" />);
 
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'data-state',
       'active',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
-      'aria-selected',
-      'true',
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'aria-current',
+      'page',
     );
-    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute(
       'data-state',
       'inactive',
     );
-    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute(
-      'aria-selected',
-      'false',
+    expect(screen.getByRole('link', { name: 'X' })).not.toHaveAttribute(
+      'aria-current',
     );
   });
 
   it('marks the matching platform tab as active on platform pages', () => {
     render(<SocialsNavigation active="twitter" />);
 
-    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute(
       'data-state',
       'active',
     );
-    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute(
-      'aria-selected',
-      'true',
+    expect(screen.getByRole('link', { name: 'X' })).toHaveAttribute(
+      'aria-current',
+      'page',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
       'data-state',
       'inactive',
     );
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
-      'aria-selected',
-      'false',
+    expect(screen.getByRole('link', { name: 'Overview' })).not.toHaveAttribute(
+      'aria-current',
     );
   });
 });

--- a/packages/pages/vitest.config.ts
+++ b/packages/pages/vitest.config.ts
@@ -27,6 +27,13 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@testing-library\/jest-dom\/vitest$/,
+        replacement: path.resolve(
+          appRoot,
+          './node_modules/@testing-library/jest-dom/dist/vitest.mjs',
+        ),
+      },
+      {
         find: /^@pages$/,
         replacement: pagesRoot,
       },
@@ -235,6 +242,14 @@ export default defineConfig({
         replacement: path.resolve(packageRoot('services'), '$1'),
       },
       {
+        find: /^@ui\/modals\/compound$/,
+        replacement: path.resolve(packageSrc('ui'), './modals/compound'),
+      },
+      {
+        find: /^@ui\/modals\/compound\/(.*)$/,
+        replacement: path.resolve(packageSrc('ui'), './modals/compound/$1'),
+      },
+      {
         find: /^@ui\/primitives$/,
         replacement: path.resolve(packageSrc('ui'), './primitives'),
       },
@@ -274,6 +289,7 @@ export default defineConfig({
       'studio/generate/utils/**/*.test.ts',
       'studio/fastlane/**/*.test.ts',
       'studio/fastlane/**/*.test.tsx',
+      'trends/**/*.test.tsx',
     ],
     name: '@genfeedai/pages',
     setupFiles: [path.resolve(appRoot, './vitest.setup.ts')],

--- a/packages/props/ui/layout/section-topbar.props.ts
+++ b/packages/props/ui/layout/section-topbar.props.ts
@@ -1,0 +1,23 @@
+import type { ComponentType, ReactNode } from 'react';
+
+/**
+ * Section topbar contract (reference: Studio's AssetControlsHeader).
+ *
+ * A full-bleed section header bar rendered as the first child of a page:
+ * no outer margins or max-width cap, a `border-b border-border` that meets
+ * the shell edges, a dense title row, and optional action/tab slots that
+ * stay inside the bordered bar.
+ */
+export interface SectionTopbarProps {
+  /** Section title, rendered as the page h1 */
+  title: string;
+  /** Optional muted one-line subtitle, hidden on narrow widths */
+  subtitle?: string;
+  /** Optional leading icon next to the title */
+  icon?: ComponentType<{ className?: string }>;
+  /** Right-aligned controls (refresh, filters, view toggles) */
+  actions?: ReactNode;
+  /** Tab strip rendered inside the bordered bar, below the title row */
+  tabs?: ReactNode;
+  className?: string;
+}

--- a/packages/ui/src/components/layout/section-topbar/SectionTopbar.test.tsx
+++ b/packages/ui/src/components/layout/section-topbar/SectionTopbar.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import SectionTopbar from '@ui/layout/section-topbar/SectionTopbar';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+describe('SectionTopbar', () => {
+  it('renders a full-bleed bar whose bottom border meets the shell edges', () => {
+    render(<SectionTopbar title="Trending Content" />);
+
+    const topbar = screen.getByTestId('section-topbar');
+
+    // The section topbar contract (from Studio's AssetControlsHeader):
+    // full width, tokenized bottom border, no outer margins or max-width cap.
+    expect(topbar).toHaveClass('w-full', 'border-b', 'border-border');
+    expect(topbar.className).not.toMatch(/\bm[xytblr]?-/);
+    expect(topbar.className).not.toMatch(/max-w-/);
+  });
+
+  it('renders the title as the page h1', () => {
+    render(<SectionTopbar title="Trending Content" />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Trending Content' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders subtitle and actions inside the title row', () => {
+    render(
+      <SectionTopbar
+        title="Trending Content"
+        subtitle="Actual posts and videos trending across platforms."
+        actions={<button type="button">Refresh</button>}
+      />,
+    );
+
+    expect(
+      screen.getByText('Actual posts and videos trending across platforms.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('section-topbar-actions')).toContainElement(
+      screen.getByRole('button', { name: 'Refresh' }),
+    );
+  });
+
+  it('renders tabs inside the bordered bar rather than as a detached block', () => {
+    render(
+      <SectionTopbar
+        title="Trending Content"
+        tabs={<div data-testid="tabs-strip">tabs</div>}
+      />,
+    );
+
+    const topbar = screen.getByTestId('section-topbar');
+    const tabsSlot = screen.getByTestId('section-topbar-tabs');
+
+    expect(topbar).toContainElement(tabsSlot);
+    expect(tabsSlot).toContainElement(screen.getByTestId('tabs-strip'));
+    expect(tabsSlot.className).not.toMatch(/\bmb-\d/);
+  });
+
+  it('omits the actions and tabs slots when not provided', () => {
+    render(<SectionTopbar title="Trending Content" />);
+
+    expect(
+      screen.queryByTestId('section-topbar-actions'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('section-topbar-tabs')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/layout/section-topbar/SectionTopbar.tsx
+++ b/packages/ui/src/components/layout/section-topbar/SectionTopbar.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
+import type { SectionTopbarProps } from '@genfeedai/props/ui/layout/section-topbar.props';
+
+/**
+ * SectionTopbar — the shared sub-topbar for app section pages.
+ *
+ * Encodes the Studio section header contract (see
+ * packages/pages/studio/generate/components/AssetControlsHeader.tsx) as a
+ * reusable primitive: a full-bleed bar whose bottom border touches the shell
+ * edges, with title, optional subtitle, right-aligned actions, and an
+ * optional tab strip that lives inside the same bordered bar. Render it as
+ * the first child of a section page, above any padded content container.
+ */
+export default function SectionTopbar({
+  title,
+  subtitle,
+  icon: Icon,
+  actions,
+  tabs,
+  className,
+}: SectionTopbarProps) {
+  return (
+    <div
+      data-testid="section-topbar"
+      className={cn('w-full border-b border-border', className)}
+    >
+      <div className="flex w-full items-center justify-between gap-3 px-6 py-2">
+        <div className="flex min-w-0 items-baseline gap-2.5">
+          <div className="flex items-center gap-2">
+            {Icon ? (
+              <Icon className="size-4 flex-shrink-0 text-foreground/60" />
+            ) : null}
+            <h1 className="whitespace-nowrap text-sm font-semibold tracking-tight">
+              {title}
+            </h1>
+          </div>
+          {subtitle ? (
+            <p className="hidden min-w-0 truncate text-xs text-foreground/55 lg:block">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+
+        {actions ? (
+          <div
+            data-testid="section-topbar-actions"
+            className="flex flex-wrap items-center justify-end gap-2"
+          >
+            {actions}
+          </div>
+        ) : null}
+      </div>
+
+      {tabs ? (
+        <div
+          data-testid="section-topbar-tabs"
+          className="overflow-x-auto px-4 pb-1.5 scrollbar-thin"
+        >
+          {tabs}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a shared **`SectionTopbar`** primitive ([SectionTopbar.tsx](https://github.com/genfeedai/genfeed.ai/blob/fix/1117-standardize-section-topbars/packages/ui/src/components/layout/section-topbar/SectionTopbar.tsx)) that promotes Studio's sub-topbar treatment (`AssetControlsHeader`) to the reusable section-header contract: a full-bleed bar (`w-full border-b border-border`, no outer margins/max-width) whose bottom border meets the shell edges, a dense title row with optional subtitle + action slot, and a tabs slot that lives **inside** the bordered bar. Border uses the `border-border` token per DESIGN.md ("use border-border for header bottoms") instead of Studio's hardcoded `border-white/[0.08]`. Studio itself is untouched (per PRD non-goal).
- Adopts it on **Research Trending Content** (`TrendsList`, served at /research/discovery and /research/socials) and **platform detail** pages (`TrendsPlatformDetail`, /research/[platform]) — the pages that share the SocialsNavigation tab strip — replacing the padded `Container` header row + detached `mb-6` tabs block that produced the gaps. Content below keeps the existing `Container` padding/max-width; filters, tabs, refresh, and route state are unchanged.

## Tests
- New `SectionTopbar.test.tsx` pins the contract (full-bleed border, h1 title, actions slot, tabs inside the bar, no margins).
- **Reactivated dormant trends tests**: `trends-list.test.tsx`, `trends-platform-detail.test.tsx`, and `socials-navigation.test.tsx` were outside every vitest `include` glob and never ran. Added `trends/**/*.test.tsx` to the pages vitest project (plus jest-dom + `@ui/modals/compound` alias fixes needed to load them) and updated their drifted assertions to the current nav-tabs contract (`role=link` + `aria-current=page` instead of `role=tab` + `aria-selected`, matching the actual Tabs implementation). Added a topbar-integration test asserting the title and tabs render inside the bordered bar.

## Verification
- Focused runs: 16 trends tests + 5 SectionTopbar tests green; scoped `turbo lint`/`type-check` for ui/pages/props/app green. Full suites run in CI.

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)