### PR TITLE
fix(app): harmonize Research Trends + Inbox preview onto the canonical card surface

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom/vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import WorkspacePageContent from './workspace-page';
 
@@ -419,5 +425,16 @@ describe('WorkspacePageContent', () => {
     expect(screen.getByText('Operator tools')).toBeVisible();
     expect(screen.getByLabelText('Studio Image')).toBeVisible();
     expect(screen.getByLabelText('Studio Video')).toBeVisible();
+  });
+
+  it('wraps the overview inbox preview in the canonical dashboard card', async () => {
+    render(<WorkspacePageContent section="overview" />);
+
+    const inbox = await screen.findByTestId('workspace-inbox');
+
+    expect(within(inbox).getByText('Inbox')).toBeInTheDocument();
+    expect(
+      within(inbox).getByText('Latest items waiting on your review.'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -8,6 +8,7 @@ import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props';
 import type { Task } from '@services/management/tasks.service';
 import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
+import Card from '@ui/card/Card';
 import { Skeleton } from '@ui/display/skeleton/skeleton';
 import AppTable from '@ui/display/table/Table';
 import Container from '@ui/layout/container/Container';
@@ -133,6 +134,27 @@ function WorkspacePageContentContent({
     ],
   );
 
+  const inboxTable = (
+    <AppTable<Task>
+      items={
+        section === 'inbox' ? visibleInboxTasks : reviewInboxTasks.slice(0, 5)
+      }
+      isLoading={isWorkspaceTasksLoading}
+      emptyLabel={
+        section === 'inbox' && defaultInboxView === 'unread'
+          ? 'No unread inbox items right now.'
+          : 'No inbox items yet.'
+      }
+      getRowKey={(task) => task.id}
+      getItemId={(task) => task.id}
+      onRowClick={(task) => {
+        setSelectedTaskId(task.id);
+        replaceTaskSearchParam(task.id);
+      }}
+      columns={workspaceInboxTableColumns}
+    />
+  );
+
   return (
     <Container
       label={sectionCopy.title}
@@ -234,29 +256,22 @@ function WorkspacePageContentContent({
               data-testid="workspace-inbox"
               className="space-y-3"
             >
-              <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-foreground/35">
-                {section === 'inbox' ? defaultInboxView : 'Inbox'}
-              </h2>
-              <AppTable<Task>
-                items={
-                  section === 'inbox'
-                    ? visibleInboxTasks
-                    : reviewInboxTasks.slice(0, 5)
-                }
-                isLoading={isWorkspaceTasksLoading}
-                emptyLabel={
-                  section === 'inbox' && defaultInboxView === 'unread'
-                    ? 'No unread inbox items right now.'
-                    : 'No inbox items yet.'
-                }
-                getRowKey={(task) => task.id}
-                getItemId={(task) => task.id}
-                onRowClick={(task) => {
-                  setSelectedTaskId(task.id);
-                  replaceTaskSearchParam(task.id);
-                }}
-                columns={workspaceInboxTableColumns}
-              />
+              {section === 'inbox' ? (
+                <>
+                  <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-foreground/35">
+                    {defaultInboxView}
+                  </h2>
+                  {inboxTable}
+                </>
+              ) : (
+                <Card
+                  label="Inbox"
+                  description="Latest items waiting on your review."
+                  bodyClassName="space-y-3 p-4"
+                >
+                  {inboxTable}
+                </Card>
+              )}
             </section>
           ) : null}
 

--- a/packages/ui/src/components/overview/OverviewTrendsPanel.test.tsx
+++ b/packages/ui/src/components/overview/OverviewTrendsPanel.test.tsx
@@ -33,13 +33,15 @@ vi.mock('@ui/overview/WorkspaceSurface', () => ({
     children,
     eyebrow,
     title,
+    tone,
   }: {
     actions?: ReactNode;
     children: ReactNode;
     eyebrow?: ReactNode;
     title?: ReactNode;
+    tone?: string;
   }) => (
-    <section>
+    <section data-testid="workspace-surface" data-tone={tone}>
       {eyebrow ? <p>{eyebrow}</p> : null}
       {title ? <h2>{title}</h2> : null}
       {actions ? <div>{actions}</div> : null}
@@ -115,6 +117,37 @@ describe('OverviewTrendsPanel', () => {
 
     expect(screen.getByText('Social Trends')).toBeInTheDocument();
     expect(screen.getByText('Research Trends')).toBeInTheDocument();
+  });
+
+  it('defaults to the canonical dashboard card tone', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        trends={TRENDS}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByTestId('workspace-surface')).toHaveAttribute(
+      'data-tone',
+      'card',
+    );
+  });
+
+  it('forwards an explicit tone override to WorkspaceSurface', () => {
+    render(
+      <OverviewTrendsPanel
+        isLoading={false}
+        tone="default"
+        trends={TRENDS}
+        viewAllHref="/research/discovery"
+      />,
+    );
+
+    expect(screen.getByTestId('workspace-surface')).toHaveAttribute(
+      'data-tone',
+      'default',
+    );
   });
 
   it('renders the "View All" link with the correct href', () => {

--- a/packages/ui/src/components/overview/OverviewTrendsPanel.tsx
+++ b/packages/ui/src/components/overview/OverviewTrendsPanel.tsx
@@ -5,7 +5,10 @@ import { Button } from '@ui/primitives/button';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { HiOutlineArrowRight } from 'react-icons/hi2';
-import { WorkspaceSurface } from './WorkspaceSurface';
+import {
+  WorkspaceSurface,
+  type WorkspaceSurfaceTone,
+} from './WorkspaceSurface';
 
 const PLATFORM_BADGE_CLASSES: Record<string, string> = {
   instagram: 'bg-fuchsia-500/12 text-fuchsia-300 border-fuchsia-500/20',
@@ -35,12 +38,15 @@ export interface OverviewTrendsPanelProps {
   isLoading: boolean;
   trends: TrendItem[];
   viewAllHref: string;
+  /** Surface tone; defaults to the canonical dashboard card surface */
+  tone?: WorkspaceSurfaceTone;
 }
 
 export function OverviewTrendsPanel({
   isLoading,
   trends,
   viewAllHref,
+  tone = 'card',
 }: OverviewTrendsPanelProps) {
   const topTrends = useMemo(
     () =>
@@ -52,7 +58,7 @@ export function OverviewTrendsPanel({
     <WorkspaceSurface
       eyebrow="Social Trends"
       title="Research Trends"
-      tone="default"
+      tone={tone}
       className="flex h-full flex-col gap-4"
       data-testid="overview-trends-panel"
       actions={

--- a/packages/ui/src/components/overview/WorkspaceSurface.test.tsx
+++ b/packages/ui/src/components/overview/WorkspaceSurface.test.tsx
@@ -43,6 +43,31 @@ describe('WorkspaceSurface', () => {
     expect(container.querySelector('.px-4')).toBeInTheDocument();
   });
 
+  it('renders the canonical dashboard card surface for the card tone', () => {
+    const { container } = render(
+      <WorkspaceSurface tone="card">Body</WorkspaceSurface>,
+    );
+
+    const section = container.querySelector('section');
+    expect(section).toHaveClass('bg-card');
+    expect(section).toHaveClass('shadow-border');
+    expect(section).toHaveClass('rounded-card');
+    expect(section).not.toHaveClass('gen-shell-panel');
+  });
+
+  it('does not change the shell-panel treatment of existing tones', () => {
+    for (const tone of ['default', 'muted', 'elevated'] as const) {
+      const { container, unmount } = render(
+        <WorkspaceSurface tone={tone}>Body</WorkspaceSurface>,
+      );
+
+      const section = container.querySelector('section');
+      expect(section).toHaveClass('gen-shell-panel');
+      expect(section).not.toHaveClass('bg-card');
+      unmount();
+    }
+  });
+
   it('can render without a frame', () => {
     const { container } = render(
       <WorkspaceSurface framed={false}>Body</WorkspaceSurface>,

--- a/packages/ui/src/components/overview/WorkspaceSurface.tsx
+++ b/packages/ui/src/components/overview/WorkspaceSurface.tsx
@@ -2,9 +2,12 @@ import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 type WorkspaceSurfaceDensity = 'compact' | 'comfortable';
-type WorkspaceSurfaceTone = 'default' | 'muted' | 'elevated';
+export type WorkspaceSurfaceTone = 'default' | 'muted' | 'elevated' | 'card';
 
 const FRAME_TONE_CLASSES: Record<WorkspaceSurfaceTone, string> = {
+  // Canonical dashboard card surface (DESIGN.md §Card): bg-card + inset
+  // shadow-border instead of the shell-panel drop shadow.
+  card: 'ship-ui rounded-card bg-card text-card-foreground shadow-border',
   default:
     'ship-ui gen-shell-panel rounded-md border-white/[0.06] bg-background/88 shadow-[0_28px_72px_-48px_rgba(0,0,0,0.92)]',
   elevated:
@@ -53,7 +56,10 @@ export function WorkspaceSurface({
       {...props}
       className={cn(
         framed
-          ? cn('rounded', FRAME_TONE_CLASSES[tone])
+          ? cn(
+              tone === 'card' ? 'rounded-card' : 'rounded',
+              FRAME_TONE_CLASSES[tone],
+            )
           : 'ship-ui border-0 bg-transparent shadow-none',
         className,
       )}


### PR DESCRIPTION
Follow-up to #1115 / builds on the direction from #1154.

## Summary
- **WorkspaceSurface**: adds an additive `card` tone — `bg-card` + inset `shadow-border` + `rounded-card` per DESIGN.md §Card. The existing `default`/`muted`/`elevated` tones (used by the ~24 admin/fleet/overview consumers) are untouched, and the `framed` branch's `rounded` vs `rounded-card` radius conflict is resolved explicitly (card tone → `rounded-card`, others keep `rounded`).
- **OverviewTrendsPanel**: forwards a `tone` prop to WorkspaceSurface, defaulting to `card`. Decision on the open question in #1158: the brand-overview usage **harmonizes too** — the panel now renders the canonical dashboard card surface on both the workspace overview and the brand overview, with an override available if a consumer ever needs the shell-panel look.
- **Inbox preview**: the workspace-overview inbox module was a raw `<section>` + eyebrow `<h2>` around `AppTable` with no card chrome. It now wraps the table in the canonical `Card` (`label="Inbox"`, matching the Task queue module's pattern). The full `/workspace/inbox` section page keeps its existing plain table layout under the section header/tabs.

## Tests
- `WorkspaceSurface.test.tsx`: card tone renders `bg-card shadow-border rounded-card` without `gen-shell-panel`; existing tones keep the shell-panel treatment.
- `OverviewTrendsPanel.test.tsx`: default tone is `card`; explicit override forwards.
- `workspace-page.test.tsx`: overview inbox preview renders inside the canonical card.

## Verification
- Focused runs green: WorkspaceSurface + OverviewTrendsPanel (14), workspace-page (4), overview-dashboard-sections + workspace-dashboard (14). Scoped `turbo lint`/`type-check` green. Full suites in CI.
- Pixel QA on a preview deploy still recommended per the issue (route is auth-gated).

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)