### PR TITLE
fix(api): pass LegacyWorkflowStepRunner stub in workflow-backfill module

### DIFF
--- a/apps/server/api/src/migrations/workflow-backfill.module.ts
+++ b/apps/server/api/src/migrations/workflow-backfill.module.ts
@@ -2,6 +2,7 @@ import type { AgentRunsService } from '@api/collections/agent-runs/services/agen
 import { DefaultRecurringContentService } from '@api/collections/brands/services/default-recurring-content.service';
 import type { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { CronJobsService } from '@api/collections/cron-jobs/services/cron-jobs.service';
+import type { LegacyWorkflowStepRunner } from '@api/collections/workflows/services/legacy-workflow-step-runner.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { ConfigModule } from '@api/config/config.module';
 import type { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
@@ -32,6 +33,7 @@ import { Module } from '@nestjs/common';
         new CronJobsService(
           prisma,
           workflowsService,
+          {} as LegacyWorkflowStepRunner,
           {} as AgentRunsService,
           {} as AgentRunQueueService,
           {} as OpenRouterService,


### PR DESCRIPTION
Master's api type-check gate (restored by #1148) fails with one error: `workflow-backfill.module.ts(32,9): TS2554 Expected 10 arguments, but got 9`. The #1076 WorkflowsService split added `LegacyWorkflowStepRunner` as CronJobsService's third constructor dependency; the backfill module's manual factory still passed 9. Stub it like the other unused deps in the same factory.

Verified: `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/workers --force` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)