### PR TITLE
test(workflow-ui): reconcile fork divergences — position-dirty + image history (#1151)

### DIFF
--- a/packages/workflow-ui/src/stores/workflow/slices/edgeSlice.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/edgeSlice.test.ts
@@ -1,36 +1,107 @@
-import type { NodeChange } from '@xyflow/react';
+import type { EdgeChange, NodeChange } from '@xyflow/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { useWorkflowStore } from '../workflowStore';
 
-describe('edgeSlice onNodesChange', () => {
+/**
+ * Canonical dirty semantics for the workflow graph (issue #1151, step 4).
+ *
+ * The app fork's `onNodesChange` did NOT treat `position` changes as
+ * dirty-relevant, so dragging a node never triggered the debounced auto-save and
+ * node layout was silently lost on reload (`handleNodeDragStop` only resets a UI
+ * flag; there is no other persistence path). The package treats `position` as
+ * dirty — the correct behavior — so these tests lock it in before the fork is
+ * deleted and its consumers adopt this slice (step 5).
+ */
+describe('edgeSlice onNodesChange dirty semantics', () => {
   beforeEach(() => {
     useWorkflowStore.getState().clearWorkflow();
   });
 
-  it('marks the workflow dirty when a node position changes', () => {
-    const store = useWorkflowStore.getState();
-    const nodeId = store.addNode('prompt', { x: 0, y: 0 });
-
+  function addNodeAndClean(): string {
+    const nodeId = useWorkflowStore
+      .getState()
+      .addNode('prompt', { x: 0, y: 0 });
     useWorkflowStore.getState().setDirty(false);
+    return nodeId;
+  }
 
-    const changes: NodeChange[] = [
+  it('marks dirty and moves the node on a position change', () => {
+    const nodeId = addNodeAndClean();
+
+    useWorkflowStore.getState().onNodesChange([
       {
         dragging: false,
         id: nodeId,
         position: { x: 120, y: 180 },
         positionAbsolute: { x: 120, y: 180 },
         type: 'position',
-      },
-    ];
-
-    useWorkflowStore.getState().onNodesChange(changes);
+      } as NodeChange,
+    ]);
 
     const nextState = useWorkflowStore.getState();
-
     expect(nextState.isDirty).toBe(true);
     expect(
       nextState.nodes.find((node) => node.id === nodeId)?.position,
     ).toEqual({ x: 120, y: 180 });
+  });
+
+  it('marks dirty on structural changes (remove, replace)', () => {
+    const nodeId = addNodeAndClean();
+    const node = useWorkflowStore
+      .getState()
+      .nodes.find((n) => n.id === nodeId) as NonNullable<
+      ReturnType<typeof useWorkflowStore.getState>['nodes'][number]
+    >;
+
+    useWorkflowStore.getState().onNodesChange([{ id: nodeId, type: 'remove' }]);
+    expect(useWorkflowStore.getState().isDirty).toBe(true);
+
+    useWorkflowStore.getState().clearWorkflow();
+    useWorkflowStore.getState().setDirty(false);
+    useWorkflowStore
+      .getState()
+      .onNodesChange([{ item: node, type: 'add' } as NodeChange]);
+    expect(useWorkflowStore.getState().isDirty).toBe(true);
+  });
+
+  it('does NOT mark dirty on cosmetic changes (select, dimensions)', () => {
+    const nodeId = addNodeAndClean();
+
+    useWorkflowStore
+      .getState()
+      .onNodesChange([{ id: nodeId, selected: true, type: 'select' }]);
+    expect(useWorkflowStore.getState().isDirty).toBe(false);
+
+    useWorkflowStore.getState().onNodesChange([
+      {
+        dimensions: { height: 42, width: 42 },
+        id: nodeId,
+        type: 'dimensions',
+      } as NodeChange,
+    ]);
+    expect(useWorkflowStore.getState().isDirty).toBe(false);
+  });
+});
+
+describe('edgeSlice onEdgesChange dirty semantics', () => {
+  beforeEach(() => {
+    useWorkflowStore.getState().clearWorkflow();
+  });
+
+  it('marks dirty on structural edge changes but not on selection', () => {
+    useWorkflowStore.getState().setDirty(false);
+    useWorkflowStore
+      .getState()
+      .onEdgesChange([{ id: 'edge-1', type: 'remove' }]);
+    expect(useWorkflowStore.getState().isDirty).toBe(true);
+
+    useWorkflowStore.getState().setDirty(false);
+    useWorkflowStore
+      .getState()
+      .onEdgesChange([
+        { id: 'edge-1', selected: true, type: 'select' } as EdgeChange,
+      ]);
+    expect(useWorkflowStore.getState().isDirty).toBe(false);
   });
 });

--- a/packages/workflow-ui/src/stores/workflow/slices/nodeSlice.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/nodeSlice.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useWorkflowStore } from '../workflowStore';
+
+/**
+ * Global Image History is a package-only feature (issue #1151, step 4): the app
+ * fork never had it. Reconciliation keeps it as canonical (its own
+ * `GlobalImageHistory` panel consumes it), while the fork's dead `workflowTags`
+ * plumbing — `setWorkflowTags` had zero callers — is dropped rather than ported.
+ * These tests lock the kept feature so the fork deletion (step 5) can't regress it.
+ */
+describe('nodeSlice global image history', () => {
+  beforeEach(() => {
+    useWorkflowStore.getState().clearGlobalHistory();
+  });
+
+  it('prepends new items with a generated id', () => {
+    useWorkflowStore
+      .getState()
+      .addToGlobalHistory({ image: 'https://asset.test/a.png', prompt: 'a' });
+    useWorkflowStore
+      .getState()
+      .addToGlobalHistory({ image: 'https://asset.test/b.png', prompt: 'b' });
+
+    const history = useWorkflowStore.getState().globalImageHistory;
+    expect(history).toHaveLength(2);
+    // Most recent first.
+    expect(history[0].image).toBe('https://asset.test/b.png');
+    expect(history[1].image).toBe('https://asset.test/a.png');
+    expect(history[0].id).toBeTruthy();
+    expect(history[0].id).not.toBe(history[1].id);
+  });
+
+  it('caps history at 100 items', () => {
+    for (let i = 0; i < 105; i++) {
+      useWorkflowStore
+        .getState()
+        .addToGlobalHistory({ image: `https://asset.test/${i}.png` });
+    }
+
+    const history = useWorkflowStore.getState().globalImageHistory;
+    expect(history).toHaveLength(100);
+    // The newest (index 104) is retained at the front; the oldest are dropped.
+    expect(history[0].image).toBe('https://asset.test/104.png');
+    expect(history[99].image).toBe('https://asset.test/5.png');
+  });
+
+  it('clears history', () => {
+    useWorkflowStore
+      .getState()
+      .addToGlobalHistory({ image: 'https://asset.test/a.png' });
+    useWorkflowStore.getState().clearGlobalHistory();
+
+    expect(useWorkflowStore.getState().globalImageHistory).toEqual([]);
+  });
+});


### PR DESCRIPTION
Rebase of #1157 onto master. The workflow-ui unification stack it sat on (#1149–#1160) has fully merged, so this carries only the PR's unique commit: canonical position-dirty semantics + image history reconciliation tests locking the #1151 divergences.

Verified: `bun run test --filter=@genfeedai/workflow-ui` — 26 files, 352 tests green on top of current master.

Supersedes #1157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)