### PR TITLE
test(generation): add generation-path contract tests (#1184)

### DIFF
--- a/apps/server/api/src/collections/models/utils/model-key.util.spec.ts
+++ b/apps/server/api/src/collections/models/utils/model-key.util.spec.ts
@@ -1,63 +1,301 @@
 import {
+  baseModelKey,
+  isFalDestination,
   isGenfeedAiDestination,
   isReplicateDestination,
+  isReplicateVersionId,
+  isTrainerKey,
   isTrainingKey,
 } from '@api/collections/models/utils/model-key.util';
+import { MODEL_KEYS } from '@genfeedai/constants';
+
+// Contract tests for the model-routing heuristics that decide which provider a
+// given model key resolves to. These are string-prefix/regex heuristics on the
+// revenue path — a misclassification silently routes a paying customer's
+// generation to the wrong provider API. The suites below pin the real-world
+// input space (representative provider keys) plus the ambiguous/malformed edges
+// where the heuristics are most likely to drift. Part of #1184.
 
 describe('model-key.util', () => {
-  it('detects genfeed-ai self-hosted destinations', () => {
-    expect(isGenfeedAiDestination('genfeed-ai/z-image-turbo')).toBe(true);
+  describe('baseModelKey', () => {
+    it('strips the :version suffix', () => {
+      expect(baseModelKey('owner/model:abc123')).toBe('owner/model');
+    });
+
+    it('returns the key unchanged when there is no version suffix', () => {
+      expect(baseModelKey('owner/model')).toBe('owner/model');
+    });
+
+    it('keeps only the segment before the first colon', () => {
+      expect(baseModelKey('owner/model:1.2.3')).toBe('owner/model');
+    });
+
+    it('passes through undefined', () => {
+      expect(baseModelKey(undefined)).toBeUndefined();
+    });
+
+    it('passes through empty string', () => {
+      expect(baseModelKey('')).toBe('');
+    });
   });
 
-  it('does not treat genfeed-ai self-hosted destinations as Replicate', () => {
-    expect(isReplicateDestination('genfeed-ai/z-image-turbo')).toBe(false);
+  describe('isFalDestination', () => {
+    it('detects fal-ai/ prefixed keys', () => {
+      expect(isFalDestination('fal-ai/flux/dev')).toBe(true);
+      expect(isFalDestination('fal-ai/kling-video')).toBe(true);
+    });
+
+    it('is case-insensitive on the prefix', () => {
+      expect(isFalDestination('FAL-AI/Flux')).toBe(true);
+    });
+
+    it('rejects lookalike prefixes that are not fal-ai/', () => {
+      expect(isFalDestination('fal/flux')).toBe(false);
+      expect(isFalDestination('fal-ai-studio/flux')).toBe(false);
+      expect(isFalDestination('myfal-ai/flux')).toBe(false);
+    });
+
+    it('rejects non-string and empty inputs', () => {
+      expect(isFalDestination(undefined)).toBe(false);
+      expect(isFalDestination('')).toBe(false);
+      expect(isFalDestination(null as unknown as string)).toBe(false);
+    });
   });
 
-  it('still treats owner/model destinations as Replicate when not self-hosted', () => {
-    expect(isReplicateDestination('google/imagen-4')).toBe(true);
+  describe('isGenfeedAiDestination', () => {
+    it('detects genfeed-ai/ self-hosted destinations', () => {
+      expect(isGenfeedAiDestination('genfeed-ai/z-image-turbo')).toBe(true);
+    });
+
+    it('is case-insensitive on the prefix', () => {
+      expect(isGenfeedAiDestination('GENFEED-AI/z-image-turbo')).toBe(true);
+    });
+
+    it('does NOT treat the hyphenless genfeedai/ prefix as a genfeed-ai destination', () => {
+      // 'genfeedai/' (training namespace) is distinct from 'genfeed-ai/'
+      // (self-hosted destination); the hyphen is load-bearing.
+      expect(isGenfeedAiDestination('genfeedai/owner/model')).toBe(false);
+    });
+
+    it('rejects non-string and empty inputs', () => {
+      expect(isGenfeedAiDestination(undefined)).toBe(false);
+      expect(isGenfeedAiDestination('')).toBe(false);
+    });
   });
 
-  it('treats dot-versioned Replicate model keys as Replicate', () => {
-    expect(isReplicateDestination('bytedance/seedream-4.5')).toBe(true);
+  describe('isReplicateDestination', () => {
+    it('treats owner/model keys as Replicate', () => {
+      expect(isReplicateDestination('google/imagen-4')).toBe(true);
+      expect(isReplicateDestination('black-forest-labs/flux-schnell')).toBe(
+        true,
+      );
+    });
+
+    it('treats dot-versioned owner/model keys as Replicate', () => {
+      expect(isReplicateDestination('bytedance/seedream-4.5')).toBe(true);
+      expect(isReplicateDestination('bytedance/seedance-2.0')).toBe(true);
+    });
+
+    it('treats owner/model:version keys as Replicate', () => {
+      expect(isReplicateDestination('owner/model:1.2.3')).toBe(true);
+      expect(
+        isReplicateDestination(
+          'stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b',
+        ),
+      ).toBe(true);
+    });
+
+    it('preserves uppercase owner/model keys as Replicate', () => {
+      expect(isReplicateDestination('Google/Imagen-4')).toBe(true);
+    });
+
+    it('excludes fal-ai destinations even when dot-versioned', () => {
+      expect(isReplicateDestination('fal-ai/veo3.1')).toBe(false);
+      expect(isReplicateDestination('fal-ai/seedance-2.0')).toBe(false);
+    });
+
+    it('excludes genfeed-ai self-hosted destinations (any case)', () => {
+      expect(isReplicateDestination('genfeed-ai/z-image-turbo')).toBe(false);
+      expect(isReplicateDestination('GENFEED-AI/z-image-turbo')).toBe(false);
+    });
+
+    it('rejects three-segment training keys (extra slash breaks owner/model)', () => {
+      expect(isReplicateDestination('genfeedai/663a1b/6721cf')).toBe(false);
+      expect(isReplicateDestination('owner/model/extra')).toBe(false);
+    });
+
+    it('rejects dotted owner segments (owner stays dot-free by design)', () => {
+      expect(isReplicateDestination('my.org/model')).toBe(false);
+    });
+
+    it('rejects malformed keys missing an owner or model segment', () => {
+      expect(isReplicateDestination('/model')).toBe(false);
+      expect(isReplicateDestination('owner/')).toBe(false);
+      expect(isReplicateDestination('owner')).toBe(false);
+      expect(isReplicateDestination('')).toBe(false);
+    });
+
+    it('rejects a bare hex version id (no owner/model shape)', () => {
+      expect(
+        isReplicateDestination(
+          'f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db',
+        ),
+      ).toBe(false);
+    });
+
+    it('rejects non-string inputs', () => {
+      expect(isReplicateDestination(undefined)).toBe(false);
+      expect(isReplicateDestination(null as unknown as string)).toBe(false);
+    });
   });
 
-  it('treats dot-versioned owner/model:version Replicate keys as Replicate', () => {
-    expect(isReplicateDestination('bytedance/seedance-2.0')).toBe(true);
-    expect(isReplicateDestination('owner/model:1.2.3')).toBe(true);
-  });
+  describe('isReplicateVersionId', () => {
+    it('detects a full 64-char hex version id', () => {
+      expect(
+        isReplicateVersionId(
+          'f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db',
+        ),
+      ).toBe(true);
+    });
 
-  it('still excludes fal-ai destinations even when dot-versioned', () => {
-    expect(isReplicateDestination('fal-ai/veo3.1')).toBe(false);
-    expect(isReplicateDestination('fal-ai/seedance-2.0')).toBe(false);
+    it('is case-insensitive on hex digits', () => {
+      expect(isReplicateVersionId('A'.repeat(40))).toBe(true);
+    });
+
+    it('accepts exactly 25 hex chars (lower boundary)', () => {
+      expect(isReplicateVersionId('a'.repeat(25))).toBe(true);
+    });
+
+    it('rejects 24 hex chars (just below boundary)', () => {
+      expect(isReplicateVersionId('a'.repeat(24))).toBe(false);
+    });
+
+    it('rejects long strings containing non-hex characters', () => {
+      expect(isReplicateVersionId('g'.repeat(30))).toBe(false);
+      expect(isReplicateVersionId(`${'a'.repeat(30)}-z`)).toBe(false);
+    });
+
+    it('rejects owner/model keys that merely look long', () => {
+      expect(isReplicateVersionId('black-forest-labs/flux-schnell')).toBe(
+        false,
+      );
+    });
+
+    it('rejects non-string and empty inputs', () => {
+      expect(isReplicateVersionId(undefined)).toBe(false);
+      expect(isReplicateVersionId('')).toBe(false);
+    });
   });
 
   describe('isTrainingKey', () => {
-    it('returns true for new genfeed-ai/owner/model format', () => {
+    it('returns true for the new genfeed-ai/owner/model format', () => {
       expect(isTrainingKey('genfeed-ai/663a1b/6721cf')).toBe(true);
     });
 
-    it('returns true for legacy genfeedai/owner/model format', () => {
+    it('returns true for the legacy genfeedai/owner/model format', () => {
       expect(isTrainingKey('genfeedai/663a1b/6721cf')).toBe(true);
     });
 
-    it('returns false for base genfeed-ai model with 2 segments', () => {
+    it('is case-insensitive on the namespace prefix', () => {
+      expect(isTrainingKey('GENFEED-AI/663a1b/6721cf')).toBe(true);
+      expect(isTrainingKey('GenfeedAI/663a1b/6721cf')).toBe(true);
+    });
+
+    it('returns false for a base genfeed-ai model with only 2 segments', () => {
       expect(isTrainingKey('genfeed-ai/flux-dev')).toBe(false);
+    });
+
+    it('returns false when there are more than 3 segments', () => {
+      expect(isTrainingKey('genfeed-ai/663a1b/6721cf/extra')).toBe(false);
     });
 
     it('returns false for non-genfeed model keys', () => {
       expect(isTrainingKey('google/imagen-4')).toBe(false);
+      expect(isTrainingKey('fal-ai/flux/dev')).toBe(false);
     });
 
-    it('returns false for null', () => {
+    it('returns false for null, undefined, and empty string', () => {
       expect(isTrainingKey(null)).toBe(false);
-    });
-
-    it('returns false for undefined', () => {
       expect(isTrainingKey(undefined)).toBe(false);
-    });
-
-    it('returns false for empty string', () => {
       expect(isTrainingKey('')).toBe(false);
     });
+
+    it('returns false for non-string inputs', () => {
+      expect(isTrainingKey(42)).toBe(false);
+      expect(isTrainingKey({})).toBe(false);
+    });
+  });
+
+  describe('isTrainerKey', () => {
+    it('matches the configured fast-flux trainer base key', () => {
+      expect(isTrainerKey(MODEL_KEYS.REPLICATE_FAST_FLUX_TRAINER)).toBe(true);
+      expect(isTrainerKey('replicate/fast-flux-trainer')).toBe(true);
+    });
+
+    it('matches the trainer key even with a :version suffix', () => {
+      expect(
+        isTrainerKey(
+          'replicate/fast-flux-trainer:f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db',
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects other replicate models', () => {
+      expect(isTrainerKey('replicate/other-model')).toBe(false);
+      expect(isTrainerKey('google/imagen-4')).toBe(false);
+    });
+
+    it('rejects undefined and empty string', () => {
+      expect(isTrainerKey(undefined)).toBe(false);
+      expect(isTrainerKey('')).toBe(false);
+    });
+  });
+
+  // Regression guard: a model key must resolve to exactly one provider
+  // destination. If a heuristic starts over-matching (e.g. a fal key leaks
+  // into the Replicate branch), one of these assertions fails before the
+  // misroute can reach production.
+  describe('routing is mutually exclusive', () => {
+    const cases: Array<{
+      key: string;
+      fal: boolean;
+      genfeedAi: boolean;
+      replicate: boolean;
+    }> = [
+      { fal: true, genfeedAi: false, key: 'fal-ai/flux/dev', replicate: false },
+      {
+        fal: false,
+        genfeedAi: true,
+        key: 'genfeed-ai/z-image-turbo',
+        replicate: false,
+      },
+      {
+        fal: false,
+        genfeedAi: false,
+        key: 'google/imagen-4',
+        replicate: true,
+      },
+      {
+        fal: false,
+        genfeedAi: false,
+        key: 'bytedance/seedream-4.5',
+        replicate: true,
+      },
+    ];
+
+    for (const { key, fal, genfeedAi, replicate } of cases) {
+      it(`routes ${key} to exactly one destination`, () => {
+        expect(isFalDestination(key)).toBe(fal);
+        expect(isGenfeedAiDestination(key)).toBe(genfeedAi);
+        expect(isReplicateDestination(key)).toBe(replicate);
+
+        const destinations = [
+          isFalDestination(key),
+          isGenfeedAiDestination(key),
+          isReplicateDestination(key),
+        ].filter(Boolean);
+        expect(destinations).toHaveLength(1);
+      });
+    }
   });
 });

--- a/apps/server/api/src/services/integrations/fal/fal.contract.spec.ts
+++ b/apps/server/api/src/services/integrations/fal/fal.contract.spec.ts
@@ -1,0 +1,209 @@
+vi.mock('@fal-ai/client', () => ({
+  fal: {
+    config: vi.fn(),
+    subscribe: vi.fn(),
+  },
+}));
+
+import { ConfigService } from '@api/config/config.service';
+import { FalService } from '@api/services/integrations/fal/fal.service';
+import { fal } from '@fal-ai/client';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpService } from '@nestjs/axios';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { of } from 'rxjs';
+
+/**
+ * Contract tests for the fal.ai integration (revenue path).
+ *
+ * Two transports are pinned:
+ *  - the SDK path (`fal.subscribe`) used when the platform key is configured;
+ *  - the hand-rolled REST queue path (`https://queue.fal.run/...`) used when a
+ *    per-request BYOK api key override is supplied.
+ *
+ * All provider interaction is mocked/fixture-based; no network calls are made.
+ * Fixtures cover success responses (images/video) and provider failure shapes
+ * (queue FAILED status, empty payloads).
+ *
+ * To update when fal changes its API: adjust the subscribe input assertion, the
+ * queue submit/status/result URL + header assertions, and the response fixtures.
+ */
+const mockFal = fal as unknown as {
+  config: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+};
+
+describe('FalService (contract)', () => {
+  let service: FalService;
+  let httpService: {
+    post: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+  };
+
+  const buildModule = async (apiKey: string | undefined) => {
+    const configService = { get: vi.fn().mockReturnValue(apiKey) };
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
+    httpService = { get: vi.fn(), post: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FalService,
+        { provide: ConfigService, useValue: configService },
+        { provide: LoggerService, useValue: logger },
+        { provide: HttpService, useValue: httpService },
+      ],
+    }).compile();
+
+    service = module.get<FalService>(FalService);
+  };
+
+  afterEach(() => vi.clearAllMocks());
+
+  describe('SDK path — fal.subscribe request/response contract', () => {
+    beforeEach(async () => {
+      await buildModule('platform-key');
+    });
+
+    it('calls fal.subscribe with { input, logs: false } and parses data.images[0]', async () => {
+      // Success fixture: fal returns generated assets under `images`.
+      mockFal.subscribe.mockResolvedValue({
+        data: {
+          images: [
+            {
+              content_type: 'image/png',
+              height: 1024,
+              url: 'https://fal.media/files/out.png',
+              width: 1024,
+            },
+          ],
+        },
+      });
+
+      const input = { image_size: 'square_hd', prompt: 'a red fox' };
+      const result = await service.generateImage('fal-ai/flux/dev', input);
+
+      expect(mockFal.subscribe).toHaveBeenCalledWith('fal-ai/flux/dev', {
+        input,
+        logs: false,
+      });
+      expect(result).toEqual({
+        content_type: 'image/png',
+        height: 1024,
+        url: 'https://fal.media/files/out.png',
+        width: 1024,
+      });
+    });
+
+    it('parses video results from data.video', async () => {
+      // Success fixture: fal video model returns a single `video` asset.
+      mockFal.subscribe.mockResolvedValue({
+        data: {
+          video: {
+            content_type: 'video/mp4',
+            url: 'https://fal.media/files/out.mp4',
+          },
+        },
+      });
+
+      const result = await service.generateVideo('fal-ai/kling-video', {
+        prompt: 'a drone shot',
+      });
+
+      expect(result).toEqual({
+        content_type: 'video/mp4',
+        url: 'https://fal.media/files/out.mp4',
+      });
+    });
+
+    it('throws when the success payload carries no image asset', async () => {
+      // Failure fixture: model completed but returned an empty payload.
+      mockFal.subscribe.mockResolvedValue({ data: {} });
+
+      await expect(
+        service.generateImage('fal-ai/flux/dev', { prompt: 'x' }),
+      ).rejects.toThrow(/no image/i);
+    });
+  });
+
+  describe('REST queue path — BYOK override request/response contract', () => {
+    beforeEach(async () => {
+      // No platform key: the api-key override forces the REST queue transport.
+      await buildModule(undefined);
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('submits to queue.fal.run with a Key auth header, polls status, then fetches the result', async () => {
+      httpService.post.mockReturnValue(of({ data: { request_id: 'req-789' } }));
+      httpService.get
+        // First poll: still processing.
+        .mockReturnValueOnce(of({ data: { status: 'IN_PROGRESS' } }))
+        // Second poll: completed.
+        .mockReturnValueOnce(of({ data: { status: 'COMPLETED' } }))
+        // Result fetch.
+        .mockReturnValueOnce(
+          of({ data: { images: [{ url: 'https://fal.media/byok.png' }] } }),
+        );
+
+      const input = { prompt: 'byok cat' };
+      const promise = service.generateImage(
+        'fal-ai/flux/dev',
+        input,
+        'byok-secret',
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.url).toBe('https://fal.media/byok.png');
+
+      // Submit request contract.
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://queue.fal.run/fal-ai/flux/dev',
+        { ...input },
+        {
+          headers: {
+            Authorization: 'Key byok-secret',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      // Status + result URL contract.
+      expect(httpService.get).toHaveBeenNthCalledWith(
+        1,
+        'https://queue.fal.run/fal-ai/flux/dev/requests/req-789/status',
+        { headers: { Authorization: 'Key byok-secret' } },
+      );
+      expect(httpService.get).toHaveBeenNthCalledWith(
+        3,
+        'https://queue.fal.run/fal-ai/flux/dev/requests/req-789',
+        { headers: { Authorization: 'Key byok-secret' } },
+      );
+    });
+
+    it('throws when the queue reports a FAILED status', async () => {
+      httpService.post.mockReturnValue(of({ data: { request_id: 'req-err' } }));
+      // Failure fixture: fal queue reports terminal FAILED with an error string.
+      httpService.get.mockReturnValueOnce(
+        of({ data: { error: 'ValidationError', status: 'FAILED' } }),
+      );
+
+      const promise = service.generateImage(
+        'fal-ai/flux/dev',
+        { prompt: 'x' },
+        'byok-secret',
+      );
+      const assertion = expect(promise).rejects.toThrow(/request failed/i);
+      await vi.runAllTimersAsync();
+      await assertion;
+    });
+  });
+});

--- a/apps/server/api/src/services/integrations/heygen/services/heygen.contract.spec.ts
+++ b/apps/server/api/src/services/integrations/heygen/services/heygen.contract.spec.ts
@@ -1,0 +1,198 @@
+import { ConfigService } from '@api/config/config.service';
+import { ApiKeyHelperService } from '@api/services/api-key/api-key-helper.service';
+import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpService } from '@nestjs/axios';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { of, throwError } from 'rxjs';
+
+/**
+ * Contract tests for the HeyGen integration (avatar-video revenue path).
+ *
+ * These pin the outgoing request payload shape sent to the HeyGen v2 REST API
+ * and the response shape the service parses back (`data.data.video_id`). The
+ * `HttpService` is mocked; no network calls are made. Fixtures cover a success
+ * response and provider failure shapes (non-200 status, network error).
+ *
+ * To update when HeyGen changes its API: adjust the `/video/generate` and
+ * `/avatar/create` body assertions and the response fixtures below.
+ */
+describe('HeyGenService (contract)', () => {
+  let service: HeyGenService;
+  let httpService: {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+  };
+  let logger: {
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+  };
+
+  const CALLBACK_URL = 'https://webhook.test/v1/webhooks/heygen/callback';
+
+  beforeEach(async () => {
+    httpService = { get: vi.fn(), post: vi.fn() };
+    logger = { error: vi.fn(), log: vi.fn() };
+
+    const configMock = {
+      get: vi.fn((key?: string) => {
+        if (key === 'GENFEEDAI_WEBHOOKS_URL') return 'https://webhook.test';
+        // HEYGEN_WEBHOOK_SECRET intentionally unset → callback carries no token.
+        return undefined;
+      }),
+    };
+    const apiKeyHelperMock = {
+      getApiKey: vi.fn().mockReturnValue('heygen-key'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HeyGenService,
+        { provide: ConfigService, useValue: configMock },
+        { provide: LoggerService, useValue: logger },
+        { provide: ApiKeyHelperService, useValue: apiKeyHelperMock },
+        { provide: HttpService, useValue: httpService },
+      ],
+    }).compile();
+
+    service = module.get<HeyGenService>(HeyGenService);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  describe('generateAvatarVideo — /video/generate request/response contract', () => {
+    it('POSTs the avatar video payload with X-Api-Key and returns data.video_id', async () => {
+      // Success fixture: HeyGen returns the queued video id under data.data.
+      httpService.post.mockReturnValue(
+        of({ data: { data: { video_id: 'vid_abc' } }, status: 200 }),
+      );
+
+      const id = await service.generateAvatarVideo(
+        'meta_1',
+        'avatar_1',
+        'voice_1',
+        'Hello world',
+      );
+
+      expect(id).toBe('vid_abc');
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://api.heygen.com/v2/video/generate',
+        expect.objectContaining({
+          callback_id: 'meta_1',
+          callback_url: CALLBACK_URL,
+          caption: false,
+          dimension: { height: 720, width: 1280 },
+          video_inputs: [
+            expect.objectContaining({
+              character: expect.objectContaining({
+                avatar_id: 'avatar_1',
+                type: 'avatar',
+              }),
+              voice: expect.objectContaining({
+                input_text: 'Hello world',
+                type: 'text',
+                voice_id: 'voice_1',
+              }),
+            }),
+          ],
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Api-Key': 'heygen-key',
+          },
+        },
+      );
+    });
+
+    it('falls back to data.task_id when video_id is absent', async () => {
+      httpService.post.mockReturnValue(
+        of({ data: { data: { task_id: 'task_xyz' } }, status: 200 }),
+      );
+
+      const id = await service.generateAvatarVideo('m', 'a', 'v', 'text');
+      expect(id).toBe('task_xyz');
+    });
+
+    it('throws on a non-200 provider response', async () => {
+      // Failure fixture: HeyGen 400 with an error body.
+      httpService.post.mockReturnValue(
+        of({ data: { error: 'invalid avatar' }, status: 400 }),
+      );
+
+      await expect(
+        service.generateAvatarVideo('m', 'a', 'v', 'text'),
+      ).rejects.toThrow('HeyGen API returned non-200 status');
+    });
+
+    it('rethrows and logs on a network/transport error', async () => {
+      // Failure fixture: transport-level failure (e.g. 500 → axios throws).
+      httpService.post.mockReturnValue(
+        throwError(() => ({ response: { data: {}, status: 500 } })),
+      );
+
+      await expect(
+        service.generateAvatarVideo('m', 'a', 'v', 'text'),
+      ).rejects.toBeDefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('generatePhotoAvatarVideo — voice payload contract', () => {
+    it('uses an audio voice payload when an audio url is supplied', async () => {
+      httpService.post.mockReturnValue(
+        of({ data: { data: { video_id: 'vid_photo' } }, status: 200 }),
+      );
+
+      const id = await service.generatePhotoAvatarVideo(
+        'meta_2',
+        'https://p/photo.png',
+        {
+          audioUrl: 'https://a/audio.mp3',
+        },
+      );
+
+      expect(id).toBe('vid_photo');
+      const [, body] = httpService.post.mock.calls[0];
+      expect(body.video_inputs[0].character).toEqual({
+        photo_url: 'https://p/photo.png',
+        type: 'photo_avatar',
+      });
+      expect(body.video_inputs[0].voice).toEqual({
+        audio_url: 'https://a/audio.mp3',
+        type: 'audio',
+      });
+    });
+
+    it('rejects when neither audio url nor voice id is supplied', async () => {
+      await expect(
+        service.generatePhotoAvatarVideo('meta_3', 'https://p/photo.png', {}),
+      ).rejects.toThrow(/audioUrl or voiceId is required/i);
+    });
+  });
+
+  describe('createAvatar — /avatar/create request/response contract', () => {
+    it('POSTs avatar_name + video_url and returns data.avatar_id', async () => {
+      httpService.post.mockReturnValue(
+        of({ data: { data: { avatar_id: 'av_new' } }, status: 200 }),
+      );
+
+      const id = await service.createAvatar('My Avatar', 'https://v/clip.mp4');
+
+      expect(id).toBe('av_new');
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://api.heygen.com/v2/avatar/create',
+        expect.objectContaining({
+          avatar_name: 'My Avatar',
+          video_url: 'https://v/clip.mp4',
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Api-Key': 'heygen-key',
+          },
+        },
+      );
+    });
+  });
+});

--- a/apps/server/api/src/services/integrations/klingai/klingai.contract.spec.ts
+++ b/apps/server/api/src/services/integrations/klingai/klingai.contract.spec.ts
@@ -1,0 +1,198 @@
+vi.mock('@api/helpers/utils/jwt/jwt.util', () => ({
+  encodeJwtToken: vi.fn(() => 'jwt-token'),
+}));
+
+import { ConfigService } from '@api/config/config.service';
+import { KlingAIService } from '@api/services/integrations/klingai/klingai.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpService } from '@nestjs/axios';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { of, throwError } from 'rxjs';
+
+/**
+ * Contract tests for the KlingAI integration (image + video revenue path).
+ *
+ * These pin the outgoing request payloads for the three KlingAI v1 endpoints
+ * and the `request_id` response parsing. `HttpService` is mocked; no network
+ * calls are made. Fixtures cover success responses and provider failure shapes
+ * (401 auth failure, non-200 status).
+ *
+ * To update when KlingAI changes its API: adjust the endpoint URLs, request
+ * body assertions, and response fixtures below.
+ */
+describe('KlingAIService (contract)', () => {
+  let service: KlingAIService;
+  let httpService: { post: ReturnType<typeof vi.fn> };
+  let logger: {
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+  };
+
+  const CALLBACK_URL = 'https://webhook.test/v1/webhooks/klingai/callback';
+  const INGREDIENTS = 'https://ingredients.test';
+
+  const configMock = {
+    get: vi.fn((key?: string) => {
+      switch (key) {
+        case 'GENFEEDAI_WEBHOOKS_URL':
+          return 'https://webhook.test';
+        case 'KLINGAI_KEY':
+          return 'kling-key';
+        case 'KLINGAI_SECRET':
+          return 'kling-secret';
+        case 'KLINGAI_MODEL':
+          return 'kling-v2';
+        // KLINGAI_WEBHOOK_SECRET intentionally unset → callback carries no token.
+        default:
+          return undefined;
+      }
+    }),
+    ingredientsEndpoint: INGREDIENTS,
+  } as unknown as ConfigService;
+
+  beforeEach(async () => {
+    httpService = {
+      post: vi
+        .fn()
+        .mockReturnValue(
+          of({ data: { request_id: 'kling-req-1' }, status: 200 }),
+        ),
+    };
+    logger = { error: vi.fn(), log: vi.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KlingAIService,
+        { provide: ConfigService, useValue: configMock },
+        { provide: LoggerService, useValue: logger },
+        { provide: HttpService, useValue: httpService },
+      ],
+    }).compile();
+
+    service = module.get<KlingAIService>(KlingAIService);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  describe('generateImage — /images/generations contract', () => {
+    it('POSTs the image payload with a Bearer JWT and returns request_id', async () => {
+      const id = await service.generateImage('a neon skyline', {
+        height: 1024,
+        model: 'kling-v2',
+        reference: 'https://ref/image.png',
+        style: 'cinematic',
+        width: 1024,
+      });
+
+      expect(id).toBe('kling-req-1');
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://api.klingai.com/v1/images/generations',
+        {
+          aspect_ratio: '1:1',
+          callback_url: CALLBACK_URL,
+          image: 'https://ref/image.png',
+          model: 'kling-v2',
+          n: 1,
+          prompt: 'a neon skyline',
+        },
+        {
+          headers: {
+            Authorization: 'Bearer jwt-token',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+  });
+
+  describe('generateTextToVideo — /videos/text2video contract', () => {
+    it('POSTs the text2video payload with duration and aspect ratio', async () => {
+      const id = await service.generateTextToVideo('a rolling wave', {
+        height: 1920,
+        model: 'kling-v2',
+        width: 1080,
+      });
+
+      expect(id).toBe('kling-req-1');
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://api.klingai.com/v1/videos/text2video',
+        {
+          aspect_ratio: '9:16',
+          callback_url: CALLBACK_URL,
+          duration: 5,
+          model: 'kling-v2',
+          prompt: 'a rolling wave',
+        },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer jwt-token',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('generateImageToVideo — /videos/image2video contract', () => {
+    it('POSTs the image2video payload referencing the ingredients image url', async () => {
+      const id = await service.generateImageToVideo(
+        'animate this',
+        'parent-99',
+      );
+
+      expect(id).toBe('kling-req-1');
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://api.klingai.com/v1/videos/image2video',
+        {
+          callback_url: CALLBACK_URL,
+          duration: 5,
+          image: `${INGREDIENTS}/images/parent-99`,
+          model: 'kling-v2',
+          prompt: 'animate this',
+        },
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer jwt-token',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('failure modes', () => {
+    it('throws "KlingAI authorization failed" on a 401 response', async () => {
+      // Failure fixture: KlingAI 401 unauthorized.
+      httpService.post.mockReturnValueOnce(
+        throwError(() => ({ response: { data: {}, status: 401 } })),
+      );
+
+      await expect(service.generateImage('prompt')).rejects.toThrow(
+        'KlingAI authorization failed',
+      );
+    });
+
+    it('throws "KlingAI authorization failed" on a 403 response', async () => {
+      httpService.post.mockReturnValueOnce(
+        throwError(() => ({ response: { data: {}, status: 403 } })),
+      );
+
+      await expect(service.generateTextToVideo('prompt')).rejects.toThrow(
+        'KlingAI authorization failed',
+      );
+    });
+
+    it('swallows a non-200 status (current contract): resolves undefined and logs', async () => {
+      // NOTE: this pins the CURRENT behavior. A generic non-200 (not 401/403)
+      // is caught, logged, and the method resolves `undefined` rather than
+      // rejecting — an upstream caller sees a missing request_id. Documented
+      // here so a future change to reject-on-non-200 updates this assertion
+      // deliberately rather than by accident.
+      httpService.post.mockReturnValueOnce(
+        of({ data: { error: 'server error' }, status: 500 }),
+      );
+
+      const id = await service.generateImage('prompt');
+      expect(id).toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/api/src/services/integrations/replicate/replicate.contract.spec.ts
+++ b/apps/server/api/src/services/integrations/replicate/replicate.contract.spec.ts
@@ -1,0 +1,244 @@
+// Pin IS_CLOUD=true so the cloud request contract (webhook + events filter)
+// is exercised deterministically regardless of the test host's env.
+vi.mock('@genfeedai/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@genfeedai/config')>();
+
+  return {
+    ...actual,
+    IS_CLOUD: true,
+  };
+});
+
+import { ConfigService } from '@api/config/config.service';
+import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, type TestingModule } from '@nestjs/testing';
+
+/**
+ * Contract tests for the Replicate integration (revenue path).
+ *
+ * These pin the request shape sent to the Replicate SDK and the response shape
+ * the service expects back — the seam where a provider API change silently
+ * breaks production generation. The `replicate` client is fully mocked; no
+ * network calls are made. Fixtures cover success responses and representative
+ * provider-error responses.
+ *
+ * To update when Replicate changes its API: adjust the `predictions.create` /
+ * `trainings.create` argument assertions and the response fixtures below.
+ */
+describe('ReplicateService (contract)', () => {
+  let service: ReplicateService;
+
+  const buildService = async () => {
+    const configMock = {
+      get: vi.fn((key?: string) => {
+        switch (key) {
+          case 'REPLICATE_KEY':
+            return 'mock-api-key';
+          case 'GENFEEDAI_WEBHOOKS_URL':
+            return 'https://webhook.test';
+          case 'REPLICATE_MODELS_TRAINER':
+            return 'replicate/fast-flux-trainer:f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db';
+          case 'REPLICATE_MODEL_VISIBILITY':
+            return 'private';
+          case 'REPLICATE_MODEL_HARDWARE':
+            return 'gpu-t4';
+          default:
+            return '';
+        }
+      }),
+    };
+
+    const loggerMock = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      verbose: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReplicateService,
+        { provide: ConfigService, useValue: configMock },
+        { provide: LoggerService, useValue: loggerMock },
+      ],
+    }).compile();
+
+    return {
+      logger: loggerMock,
+      service: module.get<ReplicateService>(ReplicateService),
+    };
+  };
+
+  afterEach(() => vi.clearAllMocks());
+
+  describe('runModel — prediction request/response contract', () => {
+    it('sends { input, version, webhook, webhook_events_filter } and returns the prediction id', async () => {
+      const built = await buildService();
+      service = built.service;
+
+      const predictionsCreate = vi
+        .fn()
+        // Success fixture: Replicate returns a prediction object with an id.
+        .mockResolvedValue({ id: 'pred_abc123', status: 'starting' });
+      service.client = {
+        predictions: { create: predictionsCreate },
+      } as unknown as typeof service.client;
+
+      const input = { num_outputs: 1, prompt: 'a neon city' };
+      const id = await service.runModel('owner/model:v1', input);
+
+      expect(id).toBe('pred_abc123');
+      expect(predictionsCreate).toHaveBeenCalledTimes(1);
+      expect(predictionsCreate).toHaveBeenCalledWith({
+        input,
+        version: 'owner/model:v1',
+        webhook: 'https://webhook.test/v1/webhooks/replicate/callback',
+        webhook_events_filter: ['completed'],
+      });
+    });
+
+    it('rethrows and logs when Replicate rejects (e.g. 422 invalid version)', async () => {
+      const built = await buildService();
+      service = built.service;
+
+      // Failure fixture: Replicate 422 for an invalid model version.
+      const providerError = Object.assign(new Error('Invalid version'), {
+        status: 422,
+        detail: 'The specified version does not exist',
+      });
+      service.client = {
+        predictions: { create: vi.fn().mockRejectedValue(providerError) },
+      } as unknown as typeof service.client;
+
+      await expect(
+        service.runModel('owner/model:bad', { prompt: 'x' }),
+      ).rejects.toThrow('Invalid version');
+      expect(built.logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPrediction — poll response contract', () => {
+    it('returns the raw prediction object from predictions.get', async () => {
+      const built = await buildService();
+      service = built.service;
+
+      // Success fixture: a completed prediction with an output url array.
+      const prediction = {
+        id: 'pred_abc123',
+        output: ['https://replicate.delivery/out/0.png'],
+        status: 'succeeded',
+      };
+      const predictionsGet = vi.fn().mockResolvedValue(prediction);
+      service.client = {
+        predictions: { get: predictionsGet },
+      } as unknown as typeof service.client;
+
+      const result = await service.getPrediction('pred_abc123');
+
+      expect(predictionsGet).toHaveBeenCalledWith('pred_abc123');
+      expect(result).toEqual(prediction);
+    });
+  });
+
+  describe('runTraining — training request/response contract', () => {
+    it('splits owner/model/version and returns the training id on success', async () => {
+      const built = await buildService();
+      service = built.service;
+
+      const trainingsCreate = vi
+        .fn()
+        .mockResolvedValue({ id: 'train_123', status: 'starting' });
+      service.client = {
+        trainings: { create: trainingsCreate },
+      } as unknown as typeof service.client;
+
+      const destination = 'genfeedai/model-name' as `${string}/${string}`;
+      const input = {
+        input_images: 'https://example.com/training.zip',
+        training_steps: 1000,
+        trigger_word: 'TOK',
+      };
+
+      const id = await service.runTraining(destination, input);
+
+      expect(id).toBe('train_123');
+      expect(trainingsCreate).toHaveBeenCalledWith(
+        'replicate',
+        'fast-flux-trainer',
+        'f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db',
+        expect.objectContaining({
+          destination,
+          input,
+          webhook: 'https://webhook.test/v1/webhooks/replicate/callback',
+          webhook_events_filter: ['completed'],
+        }),
+      );
+    });
+
+    it('creates the destination model then retries on a 404 destination-missing error', async () => {
+      const built = await buildService();
+      service = built.service;
+
+      // Failure fixture: Replicate 404 because the destination model is absent.
+      const missing = Object.assign(
+        new Error('The specified training destination does not exist'),
+        { status: 404 },
+      );
+      const trainingsCreate = vi
+        .fn()
+        .mockRejectedValueOnce(missing)
+        .mockResolvedValueOnce({ id: 'train_456' });
+      const modelsCreate = vi.fn().mockResolvedValue({});
+      service.client = {
+        models: { create: modelsCreate },
+        trainings: { create: trainingsCreate },
+      } as unknown as typeof service.client;
+
+      const id = await service.runTraining(
+        'genfeedai/model-name' as `${string}/${string}`,
+        {
+          input_images: 'https://example.com/training.zip',
+          training_steps: 1000,
+          trigger_word: 'TOK',
+        },
+      );
+
+      expect(modelsCreate).toHaveBeenCalledWith(
+        'genfeedai',
+        'model-name',
+        expect.objectContaining({ hardware: 'gpu-t4', visibility: 'private' }),
+      );
+      expect(trainingsCreate).toHaveBeenCalledTimes(2);
+      expect(id).toBe('train_456');
+    });
+
+    it('rethrows non-destination provider errors (e.g. 429 rate limit) without retrying', async () => {
+      const built = await buildService();
+      service = built.service;
+
+      // Failure fixture: Replicate 429 rate limit — not recoverable by
+      // creating a model, so the service must surface it, not silently retry.
+      const rateLimited = Object.assign(new Error('Too many requests'), {
+        status: 429,
+      });
+      const trainingsCreate = vi.fn().mockRejectedValue(rateLimited);
+      const modelsCreate = vi.fn();
+      service.client = {
+        models: { create: modelsCreate },
+        trainings: { create: trainingsCreate },
+      } as unknown as typeof service.client;
+
+      await expect(
+        service.runTraining('genfeedai/model-name' as `${string}/${string}`, {
+          input_images: 'https://example.com/training.zip',
+          training_steps: 1000,
+          trigger_word: 'TOK',
+        }),
+      ).rejects.toThrow('Too many requests');
+      expect(modelsCreate).not.toHaveBeenCalled();
+      expect(trainingsCreate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/server/images/package.json
+++ b/apps/server/images/package.json
@@ -21,8 +21,8 @@
     "start:debug": "cd .. && nest start images --debug --watch",
     "start:dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start images --watch",
     "start:prod": "node -r tsconfig-paths/register --max-old-space-size=8192 --expose-gc ../dist/apps/images/main",
-    "test": "echo 'No tests yet'",
-    "test:cov": "echo 'No tests yet'",
+    "test": "vitest run --config vitest.config.ts",
+    "test:cov": "vitest run --coverage --config vitest.config.ts",
     "type-check": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "version": "1.0.0",

--- a/apps/server/images/src/services/dataset.service.spec.ts
+++ b/apps/server/images/src/services/dataset.service.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from '@images/config/config.service';
 import { DatasetService } from '@images/services/dataset.service';
-import { S3Service } from '@images/services/s3.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { S3Service } from '@libs/s3/s3.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 

--- a/apps/server/videos/package.json
+++ b/apps/server/videos/package.json
@@ -20,8 +20,8 @@
     "start:debug": "cd .. && nest start videos --debug --watch",
     "start:dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start videos --watch",
     "start:prod": "node -r tsconfig-paths/register --max-old-space-size=8192 --expose-gc ../dist/apps/videos/main",
-    "test": "echo 'No tests yet'",
-    "test:cov": "echo 'No tests yet'",
+    "test": "vitest run --config vitest.config.ts",
+    "test:cov": "vitest run --coverage --config vitest.config.ts",
     "type-check": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "version": "1.0.0",

--- a/apps/server/voices/package.json
+++ b/apps/server/voices/package.json
@@ -20,8 +20,8 @@
     "start:debug": "cd .. && nest start voices --debug --watch",
     "start:dev": "cd .. && NODE_OPTIONS=\"--max-old-space-size=2048 --expose-gc\" nest start voices --watch",
     "start:prod": "node -r tsconfig-paths/register --max-old-space-size=8192 --expose-gc ../dist/apps/voices/main",
-    "test": "echo 'No tests yet'",
-    "test:cov": "echo 'No tests yet'",
+    "test": "vitest run --config vitest.config.ts",
+    "test:cov": "vitest run --coverage --config vitest.config.ts",
     "type-check": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "version": "1.0.0",


### PR DESCRIPTION
Closes #1184. Part of Epic #1176.

## What

Adds contract test coverage for the generation revenue path — the provider-routing heuristics and the four hand-rolled provider REST integrations — and turns on the dormant test suites in the standalone GPU services.

### Foundation (Phase 1)
- **Wire real test scripts** in `apps/server/{images,videos,voices}`. All three already had full `vitest.config.ts` files and spec files (15/7/11 files, 163/81/137 tests) but shipped `"test": "echo 'No tests yet'"`, so nothing ran. They now run vitest and are picked up by the existing CI `test-server-services` job (`turbo run test --filter='./apps/server/*'`) — no CI YAML change needed.
- **Fix a stale import** the placeholder was masking: `images/src/services/dataset.service.spec.ts` imported `S3Service` from `@images/services/s3.service` (deleted); source uses `@libs/s3/s3.service`. Images suite is now fully green.
- **Expand `model-key.util.spec.ts`** from 3 covered functions to all 6 routing heuristics (`isFalDestination`, `isGenfeedAiDestination`, `isReplicateDestination`, `isReplicateVersionId`, `isTrainingKey`, `isTrainerKey`) plus `baseModelKey` — real-world provider keys, malformed/ambiguous inputs, version-id lookalikes, boundary lengths, and a **mutual-exclusivity guard** so a misroute (e.g. a fal key leaking into the Replicate branch) fails a test before it reaches production.

### Provider contract tests (Phase 2)
One `*.contract.spec.ts` per provider, each pinning **outgoing request shape + response parsing + ≥1 failure-mode fixture**, fully mocked (no live provider calls):

| Provider | Request contract | Failure fixtures |
|---|---|---|
| **Replicate** | `predictions.create` / `trainings.create` args incl. webhook filter | 422 invalid version, 404 destination-missing→retry, 429 rate-limit (no retry) |
| **fal** | `fal.subscribe` SDK path + `queue.fal.run` BYOK REST submit/poll/result URLs + `Key` auth | queue `FAILED`, empty payload |
| **HeyGen** | `/video/generate` + `/avatar/create` body + `X-Api-Key` | non-200, transport error |
| **Kling** | `/images/generations` + `/videos/text2video` + `/videos/image2video` body + `Bearer` JWT | 401/403 auth, non-200 |

## Verification
- `apps/server/api` — model-key + 4 contract specs: **71 passed**.
- `images` **163** / `videos` **81** / `voices` **137** passed (direct vitest).
- `biome check` clean; pre-commit secretlint clean; no source `.ts` changed (specs are excluded from `tsconfig.typecheck.json`, so type-check is unaffected).

## Note for reviewers
`klingai.contract.spec.ts` deliberately **pins the current behavior** where a generic non-200 (not 401/403) is caught, logged, and resolved to `undefined` rather than thrown — an upstream caller sees a missing `request_id`. This is flagged in an in-test comment as a candidate for a deliberate follow-up (reject-on-non-200) rather than an incidental behavior change on the revenue path in a test-only PR.

## Out of scope (per PRD)
Live provider smoke tests, routing-heuristic redesign, generation-service restructuring, load testing.