### PR TITLE
feat(prisma): enforce natural-key uniqueness + consolidate Asset soft-delete (#1185)

### DIFF
--- a/apps/server/api/src/collections/assets/entities/asset.entity.ts
+++ b/apps/server/api/src/collections/assets/entities/asset.entity.ts
@@ -28,5 +28,4 @@ export class AssetEntity extends BaseEntity implements Asset {
   declare readonly uploadPolicy: string | null;
   declare readonly originalFileName: string | null;
   declare readonly displayName: string | null;
-  declare readonly deletedAt: Date | null;
 }

--- a/apps/server/api/src/collections/posts/services/post-analytics.service.ts
+++ b/apps/server/api/src/collections/posts/services/post-analytics.service.ts
@@ -164,7 +164,7 @@ export class PostAnalyticsService extends BaseService<
       } as never,
       where: {
         postId_platform_date: { date: today, platform, postId },
-      } as never,
+      },
     });
 
     return result ? new PostAnalyticsEntity(result as never) : null;

--- a/apps/server/api/src/services/sync/desktop-sync.service.ts
+++ b/apps/server/api/src/services/sync/desktop-sync.service.ts
@@ -417,7 +417,6 @@ export class DesktopSyncService {
         select: {
           cloudObjectKey: true,
           createdAt: true,
-          deletedAt: true,
           displayName: true,
           id: true,
           isDeleted: true,
@@ -503,12 +502,15 @@ export class DesktopSyncService {
           },
         });
 
-        if (existing?.deletedAt || existing?.isDeleted) {
+        if (existing?.isDeleted) {
           rejected++;
           assets.push({
             cloudAssetId: existing.id,
             cloudObjectKey: existing.cloudObjectKey,
-            deletedAt: existing.deletedAt,
+            // Soft-delete timestamp is no longer stored on Asset (isDeleted is the
+            // sole soft-delete signal); surface updatedAt as the deletion instant
+            // so the desktop client's tombstone timeline stays populated.
+            deletedAt: existing.updatedAt,
             localAssetId: asset.id,
             reason: 'cloud-deleted',
             residency: existing.residency,
@@ -811,7 +813,7 @@ export class DesktopSyncService {
       try {
         if (op.entityType === 'asset' && op.operation === 'delete') {
           await this.prisma.asset.updateMany({
-            data: { deletedAt: new Date(), isDeleted: true },
+            data: { isDeleted: true },
             where: {
               localAssetId: op.entityId,
               parentOrgId: organizationId,

--- a/packages/prisma/prisma/migrations/20260703120000_consolidate_asset_soft_delete/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120000_consolidate_asset_soft_delete/migration.sql
@@ -1,0 +1,29 @@
+-- Consolidate Asset soft-delete onto the single repo-wide convention `isDeleted`
+-- (#1185, epic #1176). The `assets` table was the ONLY model carrying both
+-- `deletedAt DateTime?` and `isDeleted Boolean` — the one place two competing
+-- soft-delete conventions coexisted, exactly the inconsistency that leads a
+-- future contributor to copy the wrong pattern.
+--
+-- Data-conflict resolution (documented decision, per PRD NFR)
+-- ----------------------------------------------------------
+-- Business rule: a row with `deletedAt` set counts as deleted. This is not a
+-- new decision — the desktop-sync read path already unioned the two signals
+-- (`existing.deletedAt || existing.isDeleted`) and the delete writer set BOTH
+-- fields together, so at runtime a non-null `deletedAt` was already treated as
+-- deleted. We therefore backfill `isDeleted = true` wherever `deletedAt` is set
+-- but `isDeleted` is still false BEFORE dropping the column, so no delete state
+-- is lost. The reverse case (`isDeleted = true`, `deletedAt` null) is already
+-- fully represented by `isDeleted` and needs no action.
+--
+-- `updatedAt` is intentionally NOT bumped: these rows were already effectively
+-- deleted and already tombstoned on desktop clients, so re-stamping them would
+-- trigger a needless re-sync without changing any observable state.
+
+-- Step 1: Preserve delete state from the column being removed.
+UPDATE "assets"
+SET    "isDeleted" = true
+WHERE  "deletedAt" IS NOT NULL
+  AND  "isDeleted" = false;
+
+-- Step 2: Drop the redundant soft-delete column. Idempotent for re-run safety.
+ALTER TABLE "assets" DROP COLUMN IF EXISTS "deletedAt";

--- a/packages/prisma/prisma/migrations/20260703120100_add_post_analytics_daily_unique/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120100_add_post_analytics_daily_unique/migration.sql
@@ -1,0 +1,45 @@
+-- Enforce one analytics snapshot per (post, platform, day) on `post_analytics`
+-- (#1185, epic #1176).
+--
+-- Why this is a natural key
+-- -------------------------
+-- `PostAnalyticsService.upsertTodaysAnalytics` / `updateFromMetrics` already
+-- upsert on `where: { postId_platform_date: { postId, platform, date } }` and
+-- catch a P2002 to serialize concurrent writers — but the constraint was only
+-- ever expressed in application code (with an `as never` cast) and never existed
+-- in the schema or a migration: classic drift. Without the DB constraint the
+-- upsert's `where` is not a valid unique locator and the P2002 catch can never
+-- fire. This aligns the DB with the code's assumption and mirrors the existing
+-- `ArticleAnalytics @@unique([articleId, date])`. `date` is always normalized to
+-- UTC midnight by the writer, so the tuple is a true per-day natural key.
+--
+-- Safety against existing duplicates
+-- ----------------------------------
+-- `post_analytics` has NO soft-delete column, so duplicates cannot be collapsed
+-- by soft-deleting losers, and silently hard-deleting analytics rows would be
+-- data loss. Instead we abort loudly if any duplicate group exists: the whole
+-- migration is transactional, so RAISE rolls it back cleanly and leaves the data
+-- untouched for a reviewed manual dedupe before re-apply. On production the
+-- unique index is expected to already exist (the app has been running against
+-- it), so `IF NOT EXISTS` makes this a no-op there and a real create only on
+-- databases that lack it.
+DO $$
+DECLARE
+  dup_count integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT 1
+    FROM "post_analytics"
+    GROUP BY "postId", "platform", "date"
+    HAVING COUNT(*) > 1
+  ) AS dupes;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Migration aborted (#1185): % duplicate (postId, platform, date) group(s) in post_analytics. Dedupe these before applying the unique constraint.', dup_count;
+  END IF;
+END$$;
+
+-- Name MUST match Prisma's default for `@@unique([postId, platform, date])` on
+-- `@@map("post_analytics")` so the schema and database stay drift-free.
+CREATE UNIQUE INDEX IF NOT EXISTS "post_analytics_postId_platform_date_key"
+  ON "post_analytics" ("postId", "platform", "date");

--- a/packages/prisma/prisma/migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql
@@ -1,0 +1,73 @@
+-- Enforce one LIVE local record per Stripe identity (#1185, epic #1176).
+--
+-- Why these are natural keys
+-- --------------------------
+-- Stripe customer ids (`cus_…`) and subscription ids (`sub_…`) are globally
+-- unique and never reused by Stripe. The billing webhook resolves a SINGLE local
+-- row by them — `CustomersService.findByStripeCustomerId` (findFirst) and
+-- `subscriptionsService.findOne({ stripeSubscriptionId })` — so two live rows
+-- sharing one Stripe id is a latent data-integrity bug (double-processed
+-- webhook, re-link race). The app already assumes at-most-one; this makes the
+-- database guarantee it.
+--
+-- Scope: live rows only
+-- ---------------------
+-- Uniqueness is scoped to `isDeleted = false` and non-null ids. Soft-deleted
+-- history and not-yet-provisioned rows (null id) are intentionally excluded so a
+-- legitimate resubscribe/relink after a soft delete cannot be blocked. Because
+-- the predicate carries a WHERE clause, these are PARTIAL unique indexes, which
+-- Prisma cannot represent as `@@unique` and ignores during introspection — so
+-- they live in raw SQL only, exactly like the #892 default-recurring-workflow
+-- partial unique index. There is deliberately no schema.prisma counterpart.
+--
+-- Safety against existing duplicates
+-- ----------------------------------
+-- Each index is preceded by a preflight that aborts the (transactional)
+-- migration if a live duplicate already exists, surfacing the pre-existing bug
+-- for a reviewed manual merge rather than failing mid-build or corrupting data.
+
+-- ── customers.stripeCustomerId ──────────────────────────────────────────────
+DO $$
+DECLARE
+  dup_count integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT 1
+    FROM "customers"
+    WHERE "stripeCustomerId" IS NOT NULL
+      AND "isDeleted" = false
+    GROUP BY "stripeCustomerId"
+    HAVING COUNT(*) > 1
+  ) AS dupes;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Migration aborted (#1185): % live duplicate stripeCustomerId group(s) in customers. Merge them before applying the unique index.', dup_count;
+  END IF;
+END$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "customers_stripeCustomerId_live_key"
+  ON "customers" ("stripeCustomerId")
+  WHERE "stripeCustomerId" IS NOT NULL AND "isDeleted" = false;
+
+-- ── subscriptions.stripeSubscriptionId ──────────────────────────────────────
+DO $$
+DECLARE
+  dup_count integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT 1
+    FROM "subscriptions"
+    WHERE "stripeSubscriptionId" IS NOT NULL
+      AND "isDeleted" = false
+    GROUP BY "stripeSubscriptionId"
+    HAVING COUNT(*) > 1
+  ) AS dupes;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Migration aborted (#1185): % live duplicate stripeSubscriptionId group(s) in subscriptions. Merge them before applying the unique index.', dup_count;
+  END IF;
+END$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "subscriptions_stripeSubscriptionId_live_key"
+  ON "subscriptions" ("stripeSubscriptionId")
+  WHERE "stripeSubscriptionId" IS NOT NULL AND "isDeleted" = false;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1719,7 +1719,6 @@ model Asset {
   uploadPolicy       String?
   originalFileName   String?
   displayName        String?
-  deletedAt          DateTime?
   isDeleted          Boolean       @default(false)
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @updatedAt
@@ -1953,6 +1952,12 @@ model PostAnalytics {
 
   ingredients Ingredient[] @relation("post_analytics_ingredients")
 
+  // One analytics snapshot per post, per platform, per day. The ingestion
+  // service (`upsertTodaysAnalytics`) upserts on this exact tuple and relies on
+  // a P2002 to serialize concurrent writers — mirrors ArticleAnalytics'
+  // `@@unique([articleId, date])`. `date` is always normalized to UTC midnight
+  // by the writer, so the tuple is a true daily natural key.
+  @@unique([postId, platform, date])
   @@index([date(sort: Desc)])
   @@index([organizationId, date(sort: Desc)])
   @@index([brandId, date(sort: Desc)])

--- a/packages/prisma/src/enum-field-map.ts
+++ b/packages/prisma/src/enum-field-map.ts
@@ -538,7 +538,6 @@ export const PRISMA_MODEL_METADATA: Readonly<Record<string, ModelFieldMeta>> = {
       'category',
       'cloudObjectKey',
       'createdAt',
-      'deletedAt',
       'displayName',
       'externalId',
       'id',


### PR DESCRIPTION
Closes #1185. Part of epic #1176.

## Summary

Audits schema uniqueness and soft-delete conventions across the 152-model Prisma schema. The schema leaned almost entirely on application code to prevent duplicate natural keys, and one model (`Asset`) carried **both** soft-delete conventions. This PR:

1. Adds **3 database-level uniqueness constraints** — only for natural keys the application *already assumes* are unique (so production is clean by construction), each behind a preflight abort guard.
2. Consolidates `Asset` soft-delete onto the repo convention `isDeleted` (removes the schema's last `deletedAt`).
3. Delivers a **reviewable audit** of the remaining natural-key candidates, deliberately **not** force-constraining ambiguous ones.

Conservative by design: I can't validate against production data locally, so every new constraint's migration **aborts loudly (transactional `RAISE`) if a pre-existing duplicate is found** rather than silently deleting data or failing mid-build. Anything I could not justify from the data model is flagged below, not added.

## Constraints added (safe-to-constrain)

| Model | Constraint | Why safe |
|---|---|---|
| `PostAnalytics` | `@@unique([postId, platform, date])` | The ingestion service **already** upserts on `postId_platform_date` and catches `P2002`, but the constraint lived only in code (`as never` cast) and never in the schema/DB — **schema drift**. Mirrors the existing `ArticleAnalytics @@unique([articleId, date])`. `date` is normalized to UTC midnight by the writer. Fixes a latent bug (the upsert `where` was not a valid unique locator, so `P2002` could never fire). Removed the `as never` casts now that the compound input is real. |
| `customers.stripeCustomerId` | partial unique `WHERE isDeleted=false AND id IS NOT NULL` | Stripe customer ids are globally unique and never reused; `findByStripeCustomerId` resolves a single row. |
| `subscriptions.stripeSubscriptionId` | partial unique `WHERE isDeleted=false AND id IS NOT NULL` | Same: `findOne({ stripeSubscriptionId })` resolves a single row; Stripe ids are globally unique. |

The two billing constraints are **partial** indexes (scoped to live rows so a legitimate resubscribe/relink after a soft delete is never blocked). Prisma can't represent partial predicates as `@@unique`, so they are raw-SQL indexes only — the same approach as the #892 default-recurring-workflow partial unique. `schema.prisma` now has **11** `@@unique` directives (was 10).

## Soft-delete consolidation

`Asset` was the **only** model with both `deletedAt` and `isDeleted`.

- Migration backfills `isDeleted = true` where `deletedAt` was set, **before** dropping the column — **zero delete state lost**. Documented decision: a set `deletedAt` counts as deleted, matching the desktop-sync read path that already unioned both signals (`existing.deletedAt || existing.isDeleted`).
- Updated the server desktop-sync read/write paths and `AssetEntity` to `isDeleted`. The desktop tombstone timestamp on the wire payload is now derived from `updatedAt`, which the desktop client already falls back to.
- `schema.prisma` now has **zero** `deletedAt` occurrences.

## Migrations

All three are idempotent (`IF NOT EXISTS`) and guarded:

- `20260703120000_consolidate_asset_soft_delete` — backfill + drop `assets.deletedAt`.
- `20260703120100_add_post_analytics_daily_unique` — preflight abort-if-dup + unique index (name matches Prisma's default, drift-free).
- `20260703120200_add_billing_stripe_live_uniques` — preflight abort-if-dup + two partial unique indexes.

> Note: migrations are generated and validated, **not** applied to any real DB locally. `post_analytics`'s index is expected to already exist on production (the app runs against it), so `IF NOT EXISTS` makes it a no-op there.

## Audit of remaining natural-key candidates (NOT constrained)

Reviewed all 152 models. Beyond the 3 above, candidates were classified but deliberately deferred — each needs product/architecture sign-off or a dedupe pass first, per the PRD's Phase-1 gate.

**Needs-dedupe-first / ambiguous scope (flagged, not added):**
- `Article.slug`, `Persona.slug`/`handle` — public routes resolve globally but rows are org-scoped; global-vs-org scope undecided and cross-org dupes are plausible in prod.
- `Credential.externalId` (per platform + owner) — the PRD's "credential identity tuple"; owner scope (org vs brand vs user) genuinely ambiguous, auth-adjacent.
- `Account (user_credentials) [providerId, accountId]`, `Verification` identifier/value — **Better Auth-managed** tables; adding a unique risks login breakage — verify Better Auth's own expectations first.
- `Element*.key` (8 dictionary models), `Template.key`, `FontFamilyRecord.key` — nullable dictionary keys, no app-level enforcement evidence; likely seed dupes.
- `TrackedLink.customSlug`, `Watchlist.handle`, `Metadata.externalId`, `CampaignTarget.externalId`, `Post.externalId`, extra `SocialConversation`/`SocialMessage` external ids — plausible scoped keys with no enforcement evidence; high-volume, need a dedupe pass.
- `Invitation [organizationId, email]` (pending only), `Run.idempotencyKey` — status/action-scoped; need flow review.

**Intentionally non-unique (documented reason):**
- All `label`/`name`/`title` display fields (`Newsletter`, `Agent*`, `Workflow`, `CronJob`, `Bot`, `ContentPlan`, `Skill`, `Project`, `Model.label`, `Template.label`, …) — user-facing names, legitimately repeatable.
- `Subscription.stripePriceId`, `.plan` — a price/plan is shared across many subscriptions by design.

**Deferred to epic #1041 (out of scope here):** all `mongoId` natural keys (already `@unique`; not touched).

## Verification

- `prisma validate` — valid ✓
- `prisma generate` + model-metadata regen — clean; tracked `enum-field-map.ts` drops `Asset.deletedAt` ✓
- `biome check` — clean ✓
- `@genfeedai/api` type-check — 19/19 tasks green ✓
- `@genfeedai/prisma` tests — 20/20 passed ✓
- Migrations reviewed for idempotency + abort-on-duplicate safety; **not** applied to a real DB locally (per repo policy — CI / staging will apply).
