### PR TITLE
feat(app): add gated PostHog product analytics (cloud-only)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/usePostsWritePage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/usePostsWritePage.ts
@@ -4,7 +4,7 @@ import {
   useAgentDraftContext,
 } from '@genfeedai/agent';
 import type { DesktopContentPlatform } from '@genfeedai/desktop-contracts';
-import { PostStatus } from '@genfeedai/enums';
+import { GenerationType, PostStatus } from '@genfeedai/enums';
 import type { ICredential } from '@genfeedai/interfaces';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
@@ -13,6 +13,7 @@ import { ClipboardService } from '@services/core/clipboard.service';
 import { track } from '@vercel/analytics';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
 import { getDesktopBridge, isDesktopShell } from '@/lib/desktop/runtime';
 import {
   applyDraftSuggestionToText,
@@ -29,6 +30,13 @@ import {
   type Tone,
   toDesktopPlatform,
 } from './posts-write-page.helpers';
+
+/** Maps the compose-surface format to the canonical analytics generation type. */
+const GENERATION_TYPE_BY_FORMAT: Record<GenerationFormat, GenerationType> = {
+  post: GenerationType.POST,
+  thread: GenerationType.THREAD,
+  'x-article': GenerationType.BLOG,
+};
 
 export function usePostsWritePage() {
   const { push } = useRouter();
@@ -178,6 +186,11 @@ export function usePostsWritePage() {
     setError(null);
     setIsSubmitting(true);
 
+    const generationType = GENERATION_TYPE_BY_FORMAT[mode];
+    captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_STARTED, {
+      generationType,
+    });
+
     try {
       if (mode === 'x-article') {
         if (!selectedCredential) {
@@ -286,8 +299,16 @@ export function usePostsWritePage() {
         platform: selectedCredential.platform,
         tone,
       });
+      captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+        generationType,
+        outcome: 'success',
+      });
       push(href(`/posts/${rootPost.id}`));
     } catch {
+      captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+        generationType,
+        outcome: 'failure',
+      });
       setError('Failed to generate content. Please try again.');
     } finally {
       setIsSubmitting(false);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/useNewslettersPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/useNewslettersPage.ts
@@ -1,4 +1,5 @@
 import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { GenerationType } from '@genfeedai/enums';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { Newsletter } from '@models/content/newsletter.model';
@@ -8,6 +9,10 @@ import { NotificationsService } from '@services/core/notifications.service';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
+
+/** Newsletters publish to the email/newsletter channel rather than a social platform. */
+const NEWSLETTER_PUBLISH_PLATFORM = 'newsletter';
 
 type TopicProposal = {
   angle: string;
@@ -238,6 +243,9 @@ export function useNewslettersPage() {
     }
 
     setIsGeneratingDraft(true);
+    captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_STARTED, {
+      generationType: GenerationType.NEWSLETTER,
+    });
 
     try {
       const service = await getService();
@@ -252,8 +260,16 @@ export function useNewslettersPage() {
       await refresh();
       setSelectedNewsletterId(draft.id);
       await loadContext(draft.id);
+      captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+        generationType: GenerationType.NEWSLETTER,
+        outcome: 'success',
+      });
       notificationsService.success('Newsletter draft ready for review');
     } catch (error) {
+      captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+        generationType: GenerationType.NEWSLETTER,
+        outcome: 'failure',
+      });
       logger.error('Failed to generate newsletter draft', error);
       notificationsService.error('Failed to generate draft');
     } finally {
@@ -347,6 +363,9 @@ export function useNewslettersPage() {
     try {
       const service = await getService();
       await service.publish(id);
+      captureAnalyticsEvent(ANALYTICS_EVENTS.POST_PUBLISHED, {
+        platform: NEWSLETTER_PUBLISH_PLATFORM,
+      });
       await refresh();
       await loadContext(id);
       notificationsService.success('Newsletter published');

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
@@ -1,4 +1,5 @@
 import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { GenerationType } from '@genfeedai/enums';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import type { IBrand, IOrganizationSetting } from '@genfeedai/interfaces';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
@@ -11,6 +12,7 @@ import type {
 } from '@props/studio/clips.props';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
 import { ClipsApiService } from './services/clips-api.service';
 
 const TERMINAL_PROJECT_STATUSES = new Set(['completed', 'failed']);
@@ -135,6 +137,9 @@ export function useStudioClipsPage() {
   const clipsPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  // Guards against re-emitting a completion event when the poll effect re-runs
+  // (e.g. tab visibility toggles) after a project already reached a terminal state.
+  const clipCompletionReportedRef = useRef<string | null>(null);
   const isDocumentVisible = useDocumentVisibility();
   const identityDefaults = useMemo(
     () => resolveStudioClipIdentityDefaults({ selectedBrand, settings }),
@@ -291,6 +296,10 @@ export function useStudioClipsPage() {
 
     setIsSubmitting(true);
     setError(null);
+    clipCompletionReportedRef.current = null;
+    captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_STARTED, {
+      generationType: GenerationType.CLIP,
+    });
 
     try {
       await clipsService.generateClips(project.projectId, {
@@ -308,6 +317,11 @@ export function useStudioClipsPage() {
       setProject((prev) => (prev ? { ...prev, status: 'generating' } : prev));
       setStep('progress');
     } catch (err: unknown) {
+      clipCompletionReportedRef.current = project.projectId;
+      captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+        generationType: GenerationType.CLIP,
+        outcome: 'failure',
+      });
       setError(err instanceof Error ? err.message : 'Something went wrong');
     } finally {
       setIsSubmitting(false);
@@ -370,6 +384,13 @@ export function useStudioClipsPage() {
 
         if (TERMINAL_PROJECT_STATUSES.has(projectStatus)) {
           clearPendingPoll();
+          if (clipCompletionReportedRef.current !== project.projectId) {
+            clipCompletionReportedRef.current = project.projectId;
+            captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+              generationType: GenerationType.CLIP,
+              outcome: projectStatus === 'failed' ? 'failure' : 'success',
+            });
+          }
         } else {
           scheduleNextPoll();
         }

--- a/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.tsx
@@ -30,6 +30,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
 import { normalizeProtectedPathname } from '@/lib/navigation/operator-shell';
 import { AgentWorkspaceContext } from './agent-workspace-context';
 
@@ -197,6 +198,9 @@ function AgentWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
         : orgHref(`${APP_ROUTES.AGENT.ROOT}/${activeThreadId}`);
       newRouteBaselineThreadRef.current = activeThreadId;
       pendingNavigationThreadRef.current = activeThreadId;
+      captureAnalyticsEvent(ANALYTICS_EVENTS.AGENT_THREAD_CREATED, {
+        agentType: isOnboarding ? 'onboarding' : 'standard',
+      });
       replace(nextRoute);
     }
   }, [

--- a/apps/app/instrumentation-client.ts
+++ b/apps/app/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { initAnalytics } from '@/lib/analytics';
 
 Sentry.init({
   debug: false,
@@ -24,5 +25,9 @@ Sentry.init({
 
   tracesSampleRate: 0.2,
 });
+
+// Product analytics (Genfeed Cloud only). No-ops — and never loads posthog-js —
+// in self-hosted or desktop builds. See src/lib/analytics/posthog-client.ts.
+initAnalytics();
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -29,6 +29,7 @@
     "@xyflow/react": "12.11.1",
     "clsx": "2.1.1",
     "next": "16.2.9",
+    "posthog-js": "1.396.4",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "remotion": "4.0.483",

--- a/apps/app/src/lib/analytics/analytics-events.ts
+++ b/apps/app/src/lib/analytics/analytics-events.ts
@@ -1,0 +1,60 @@
+import type { GenerationType } from '@genfeedai/enums';
+
+/**
+ * PostHog product-analytics event taxonomy for the studio app.
+ *
+ * This is the single source of truth for every event Genfeed Cloud emits. Adding
+ * a new event means adding a key here plus its property shape in
+ * {@link AnalyticsEventProperties}; nothing else in the app may capture an event
+ * name that is not declared in this file.
+ *
+ * Privacy contract: property values are restricted to enum-like identifiers,
+ * outcomes, and platform/type slugs. No generated content, prompts, titles, or
+ * other free-text user input is ever permitted as a property value (issue #1178,
+ * FR8). The types below intentionally do not allow arbitrary string bags so the
+ * type-checker enforces that contract at every call site.
+ */
+export const ANALYTICS_EVENTS = {
+  AGENT_THREAD_CREATED: 'agent_thread_created',
+  GENERATION_COMPLETED: 'generation_completed',
+  GENERATION_STARTED: 'generation_started',
+  POST_PUBLISHED: 'post_published',
+  WORKFLOW_RUN_COMPLETED: 'workflow_run_completed',
+  WORKFLOW_RUN_STARTED: 'workflow_run_started',
+} as const;
+
+export type AnalyticsEvent =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+/** Terminal outcome of a tracked action. */
+export type AnalyticsOutcome = 'failure' | 'success';
+
+/**
+ * Property shape for each event. Keys map 1:1 to {@link ANALYTICS_EVENTS} values.
+ * Every property is a bounded identifier — never free-text.
+ */
+export interface AnalyticsEventProperties {
+  [ANALYTICS_EVENTS.AGENT_THREAD_CREATED]: {
+    /** Optional agent-type slug (e.g. the configured agent kind), never a title. */
+    readonly agentType?: string;
+  };
+  [ANALYTICS_EVENTS.GENERATION_STARTED]: {
+    readonly generationType: GenerationType;
+  };
+  [ANALYTICS_EVENTS.GENERATION_COMPLETED]: {
+    readonly generationType: GenerationType;
+    readonly outcome: AnalyticsOutcome;
+  };
+  [ANALYTICS_EVENTS.POST_PUBLISHED]: {
+    /** Connected-platform slug (e.g. "x", "linkedin"), never post content. */
+    readonly platform: string;
+  };
+  [ANALYTICS_EVENTS.WORKFLOW_RUN_STARTED]: {
+    /** Workflow-type slug where known, never a workflow name/description. */
+    readonly workflowType?: string;
+  };
+  [ANALYTICS_EVENTS.WORKFLOW_RUN_COMPLETED]: {
+    readonly workflowType?: string;
+    readonly outcome: AnalyticsOutcome;
+  };
+}

--- a/apps/app/src/lib/analytics/index.ts
+++ b/apps/app/src/lib/analytics/index.ts
@@ -1,0 +1,13 @@
+export {
+  ANALYTICS_EVENTS,
+  type AnalyticsEvent,
+  type AnalyticsEventProperties,
+  type AnalyticsOutcome,
+} from './analytics-events';
+export {
+  captureAnalyticsEvent,
+  identifyAnalyticsOrganization,
+  initAnalytics,
+  isAnalyticsEnabled,
+  resetAnalytics,
+} from './posthog-client';

--- a/apps/app/src/lib/analytics/posthog-client.test.ts
+++ b/apps/app/src/lib/analytics/posthog-client.test.ts
@@ -1,0 +1,172 @@
+import { GenerationType } from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ANALYTICS_EVENTS } from './analytics-events';
+
+const mocks = vi.hoisted(() => ({
+  isCloudConnected: vi.fn(),
+  isDesktopShell: vi.fn(),
+  posthogCapture: vi.fn(),
+  posthogGroup: vi.fn(),
+  posthogInit: vi.fn(),
+  posthogReset: vi.fn(),
+}));
+
+vi.mock('@/lib/config/edition', () => ({
+  isCloudConnected: mocks.isCloudConnected,
+}));
+
+vi.mock('@/lib/desktop/runtime', () => ({
+  isDesktopShell: mocks.isDesktopShell,
+}));
+
+vi.mock('posthog-js', () => ({
+  default: {
+    capture: mocks.posthogCapture,
+    group: mocks.posthogGroup,
+    init: mocks.posthogInit,
+    reset: mocks.posthogReset,
+  },
+}));
+
+type PosthogClientModule = typeof import('./posthog-client');
+
+/**
+ * The module captures NEXT_PUBLIC_POSTHOG_KEY at import time, so every case
+ * re-imports after stubbing env to exercise the intended enabled/disabled state.
+ */
+async function loadClient(): Promise<PosthogClientModule> {
+  vi.resetModules();
+  return import('./posthog-client');
+}
+
+/** Flush the dynamic import()/microtask queue used by initAnalytics. */
+async function flushInit(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  mocks.isCloudConnected.mockReturnValue(true);
+  mocks.isDesktopShell.mockReturnValue(false);
+  vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+});
+
+describe('isAnalyticsEnabled', () => {
+  it('is enabled in cloud, non-desktop builds with a key present', async () => {
+    const client = await loadClient();
+    expect(client.isAnalyticsEnabled()).toBe(true);
+  });
+
+  it('is disabled in self-hosted (non-cloud) builds', async () => {
+    mocks.isCloudConnected.mockReturnValue(false);
+    const client = await loadClient();
+    expect(client.isAnalyticsEnabled()).toBe(false);
+  });
+
+  it('is disabled in desktop builds even when cloud-connected', async () => {
+    mocks.isDesktopShell.mockReturnValue(true);
+    const client = await loadClient();
+    expect(client.isAnalyticsEnabled()).toBe(false);
+  });
+
+  it('is disabled when no PostHog key is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', '');
+    const client = await loadClient();
+    expect(client.isAnalyticsEnabled()).toBe(false);
+  });
+});
+
+describe('initAnalytics', () => {
+  it('constructs the PostHog client in cloud mode', async () => {
+    const client = await loadClient();
+    client.initAnalytics();
+    await flushInit();
+    expect(mocks.posthogInit).toHaveBeenCalledTimes(1);
+    expect(mocks.posthogInit).toHaveBeenCalledWith(
+      'phc_test_key',
+      expect.objectContaining({ autocapture: false }),
+    );
+  });
+
+  it('never constructs the client in self-hosted mode', async () => {
+    mocks.isCloudConnected.mockReturnValue(false);
+    const client = await loadClient();
+    client.initAnalytics();
+    await flushInit();
+    expect(mocks.posthogInit).not.toHaveBeenCalled();
+  });
+
+  it('never constructs the client in desktop mode', async () => {
+    mocks.isDesktopShell.mockReturnValue(true);
+    const client = await loadClient();
+    client.initAnalytics();
+    await flushInit();
+    expect(mocks.posthogInit).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent across repeated calls', async () => {
+    const client = await loadClient();
+    client.initAnalytics();
+    client.initAnalytics();
+    await flushInit();
+    expect(mocks.posthogInit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('captureAnalyticsEvent', () => {
+  it('no-ops (without throwing) before the client is initialised', async () => {
+    const client = await loadClient();
+    expect(() =>
+      client.captureAnalyticsEvent(ANALYTICS_EVENTS.WORKFLOW_RUN_STARTED, {}),
+    ).not.toThrow();
+    expect(mocks.posthogCapture).not.toHaveBeenCalled();
+  });
+
+  it('forwards the event and its bounded properties once initialised', async () => {
+    const client = await loadClient();
+    client.initAnalytics();
+    await flushInit();
+
+    client.captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+      generationType: GenerationType.IMAGE,
+      outcome: 'success',
+    });
+
+    expect(mocks.posthogCapture).toHaveBeenCalledWith('generation_completed', {
+      generationType: 'image',
+      outcome: 'success',
+    });
+  });
+
+  it('swallows capture errors so a tracked action is never blocked', async () => {
+    mocks.posthogCapture.mockImplementation(() => {
+      throw new Error('network down');
+    });
+    const client = await loadClient();
+    client.initAnalytics();
+    await flushInit();
+
+    expect(() =>
+      client.captureAnalyticsEvent(ANALYTICS_EVENTS.AGENT_THREAD_CREATED, {}),
+    ).not.toThrow();
+  });
+});
+
+describe('event taxonomy', () => {
+  it('exposes exactly the six required events as snake_case slugs', () => {
+    const values = Object.values(ANALYTICS_EVENTS);
+    expect(new Set(values).size).toBe(values.length);
+    for (const name of values) {
+      expect(name).toMatch(/^[a-z][a-z_]*[a-z]$/);
+    }
+    expect(values).toEqual(
+      expect.arrayContaining([
+        'agent_thread_created',
+        'generation_completed',
+        'generation_started',
+        'post_published',
+        'workflow_run_completed',
+        'workflow_run_started',
+      ]),
+    );
+  });
+});

--- a/apps/app/src/lib/analytics/posthog-client.ts
+++ b/apps/app/src/lib/analytics/posthog-client.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import type { PostHog } from 'posthog-js';
+import { isCloudConnected } from '@/lib/config/edition';
+import { isDesktopShell } from '@/lib/desktop/runtime';
+import type {
+  AnalyticsEvent,
+  AnalyticsEventProperties,
+} from './analytics-events';
+
+/**
+ * Gated PostHog client for Genfeed Cloud product analytics (issue #1178).
+ *
+ * Hard privacy boundary: analytics only ever activates inside the cloud
+ * deployment boundary. In self-hosted (Community) and desktop builds the client
+ * is never constructed, no script is loaded, and no network request is made —
+ * this is a privacy commitment, not an operator-managed toggle. `posthog-js` is
+ * pulled in via a dynamic `import()` so its bytes never execute (and are
+ * code-split out of the critical path) unless the gate resolves to enabled.
+ *
+ * All capture calls are fire-and-forget and defensively wrapped: a failed load,
+ * unreachable ingestion endpoint, or SDK error must never block, delay, or throw
+ * into the user-facing action being tracked, and must never reach Sentry.
+ */
+
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const POSTHOG_HOST =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+
+let client: PostHog | null = null;
+let hasInitStarted = false;
+
+/**
+ * True only when the app is a cloud-connected, non-desktop build with a
+ * PostHog key present. Resolved fresh so tests can flip env/mode between cases;
+ * in production the inputs are fixed for the lifetime of the session.
+ */
+export function isAnalyticsEnabled(): boolean {
+  return Boolean(POSTHOG_KEY) && isCloudConnected() && !isDesktopShell();
+}
+
+/**
+ * Initialise the PostHog client once, only when analytics is enabled. Safe to
+ * call on every app boot: it no-ops on the server, when disabled, or when
+ * already initialised. Never awaited by callers — initialisation is best-effort.
+ */
+export function initAnalytics(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (hasInitStarted || !isAnalyticsEnabled()) {
+    return;
+  }
+  hasInitStarted = true;
+
+  void import('posthog-js')
+    .then(({ default: posthog }) => {
+      posthog.init(POSTHOG_KEY as string, {
+        api_host: POSTHOG_HOST,
+        // Explicit, custom-event product analytics only. Autocapture is off so
+        // no clicked element text (post titles, generated copy) can ever leak
+        // into events, and session recording is off (a non-goal of #1178).
+        autocapture: false,
+        capture_pageview: true,
+        disable_session_recording: true,
+        // Only build person profiles once a user is identified — keeps
+        // anonymous, self-serve traffic out of person-based billing/analytics.
+        person_profiles: 'identified_only',
+      });
+      client = posthog;
+    })
+    .catch(() => {
+      // Best-effort: swallow load/init failures so analytics can never surface
+      // as an application error.
+    });
+}
+
+/**
+ * Capture a typed product-analytics event. No-ops entirely when the client is
+ * not initialised (i.e. every non-cloud build). Property shapes are enforced by
+ * {@link AnalyticsEventProperties}; free-text values are structurally excluded.
+ */
+export function captureAnalyticsEvent<E extends AnalyticsEvent>(
+  event: E,
+  properties: AnalyticsEventProperties[E],
+): void {
+  if (!client) {
+    return;
+  }
+  try {
+    client.capture(event, properties);
+  } catch {
+    // Fire-and-forget: a capture failure must never block the tracked action.
+  }
+}
+
+/**
+ * Associate subsequent events with an organization group. Called from the
+ * authenticated shell once an org id is known. No PII — the id is an opaque
+ * identifier the client already holds.
+ */
+export function identifyAnalyticsOrganization(organizationId: string): void {
+  if (!client || !organizationId) {
+    return;
+  }
+  try {
+    client.group('organization', organizationId);
+  } catch {
+    // Best-effort grouping.
+  }
+}
+
+/** Clear the current user/group association (e.g. on sign-out). */
+export function resetAnalytics(): void {
+  if (!client) {
+    return;
+  }
+  try {
+    client.reset();
+  } catch {
+    // Best-effort reset.
+  }
+}
+
+/** Test-only hook to reset module singleton state between cases. */
+export function __resetAnalyticsForTests(): void {
+  client = null;
+  hasInitStarted = false;
+}

--- a/apps/app/src/store/execution/helpers/sseSubscription.ts
+++ b/apps/app/src/store/execution/helpers/sseSubscription.ts
@@ -3,6 +3,7 @@ import { NodeStatusEnum } from '@genfeedai/types';
 import { useUIStore } from '@genfeedai/workflow-ui/stores';
 import { logger } from '@services/core/logger.service';
 import type { StoreApi } from 'zustand';
+import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
 import { useWorkflowStore } from '@/store/workflowStore';
 import type {
   DebugPayload,
@@ -242,6 +243,13 @@ export function createExecutionSubscription(
             eventSource: null,
             isRunning: false,
             jobs: new Map(),
+          });
+
+          captureAnalyticsEvent(ANALYTICS_EVENTS.WORKFLOW_RUN_COMPLETED, {
+            outcome:
+              data.status === 'completed' && !hasFailedNode
+                ? 'success'
+                : 'failure',
           });
 
           if (data.status === 'failed' || hasFailedNode) {

--- a/apps/app/src/store/execution/slices/executionSlice.ts
+++ b/apps/app/src/store/execution/slices/executionSlice.ts
@@ -2,6 +2,7 @@ import { NodeStatusEnum } from '@genfeedai/types';
 import { useUIStore } from '@genfeedai/workflow-ui/stores';
 import { logger } from '@services/core/logger.service';
 import type { StateCreator } from 'zustand';
+import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
 import { apiClient } from '@/lib/api/client';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useWorkflowStore } from '@/store/workflowStore';
@@ -315,6 +316,7 @@ export const createExecutionSlice: StateCreator<
     }
 
     set({ isRunning: true });
+    captureAnalyticsEvent(ANALYTICS_EVENTS.WORKFLOW_RUN_STARTED, {});
 
     for (const node of workflowStore.nodes) {
       workflowStore.updateNodeData(node.id, {

--- a/bun.lock
+++ b/bun.lock
@@ -206,6 +206,7 @@
         "@xyflow/react": "12.11.1",
         "clsx": "2.1.1",
         "next": "16.2.9",
+        "posthog-js": "1.396.4",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "remotion": "4.0.483",
@@ -2643,6 +2644,10 @@
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
+    "@posthog/core": ["@posthog/core@1.39.6", "", { "dependencies": { "@posthog/types": "^1.392.0" } }, "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw=="],
+
+    "@posthog/types": ["@posthog/types@1.392.0", "", {}, "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw=="],
+
     "@prisma/adapter-pg": ["@prisma/adapter-pg@7.8.0", "", { "dependencies": { "@prisma/driver-adapter-utils": "7.8.0", "@types/pg": "^8.16.0", "pg": "^8.16.3", "postgres-array": "3.0.4" } }, "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg=="],
 
     "@prisma/client": ["@prisma/client@7.8.0", "", { "dependencies": { "@prisma/client-runtime-utils": "7.8.0" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw=="],
@@ -4951,7 +4956,7 @@
 
     "fetch-nodeshim": ["fetch-nodeshim@0.4.10", "", {}, "sha512-m6I8ALe4L4XpdETy7MJZWs6L1IVMbjs99bwbpIKphxX+0CTns4IKDWJY0LWfr4YsFjfg+z1TjzTMU8lKl8rG0w=="],
 
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "ffmpeg-static": ["ffmpeg-static@5.3.0", "", { "dependencies": { "@derhuerst/http-basic": "^8.2.0", "env-paths": "^2.2.0", "https-proxy-agent": "^5.0.0", "progress": "^2.0.3" } }, "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg=="],
 
@@ -6341,6 +6346,8 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "posthog-js": ["posthog-js@1.396.4", "", { "dependencies": { "@posthog/core": "^1.39.3", "@posthog/types": "^1.392.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-PycBmwKQD1T7YFYrGRb8rjQET/UVnexgUy8gVe6UBEhwHXEIhZF4na5VakJbn4zu1wg4tzjt8r7PA4VLu6bDjg=="],
+
     "posthtml": ["posthtml@0.16.7", "", { "dependencies": { "posthtml-parser": "^0.11.0", "posthtml-render": "^3.0.0" } }, "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw=="],
 
     "posthtml-parser": ["posthtml-parser@0.10.2", "", { "dependencies": { "htmlparser2": "^7.1.1" } }, "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg=="],
@@ -6438,6 +6445,8 @@
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "query-string": ["query-string@7.1.3", "", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
 
@@ -7450,6 +7459,8 @@
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "web-tree-sitter": ["web-tree-sitter@0.24.5", "", {}, "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
@@ -9053,6 +9064,8 @@
 
     "plasmo/dotenv-expand": ["dotenv-expand@12.0.1", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ=="],
 
+    "plasmo/fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
     "plasmo/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "plasmo/sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
@@ -9062,6 +9075,10 @@
     "plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "posthog-js/core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
+    "posthog-js/preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
     "posthtml/posthtml-parser": ["posthtml-parser@0.11.0", "", { "dependencies": { "htmlparser2": "^7.1.1" } }, "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw=="],
 


### PR DESCRIPTION
Closes #1178 (part of Epic #1176 — stack audit remediation).

## Summary

Genfeed shipped 6 app surfaces + 12 backend services with **zero product analytics** (only `@vercel/analytics` on the marketing site). This wires PostHog event tracking into the studio app (`apps/app`), **hard-gated to cloud/SaaS deployments** — it never initializes, and `posthog-js` is never loaded, in self-hosted (Community) or desktop builds.

## Foundation — `apps/app/src/lib/analytics/`

- **`analytics-events.ts`** — typed event taxonomy. Property shapes are structurally bounded (enum/outcome/slug only), so free-text prompts or generated content **cannot** be passed as a property value (FR8). Single source of truth for the taxonomy.
- **`posthog-client.ts`** — gated singleton. Enabled only when `isCloudConnected() && !isDesktopShell() && a key is present`. `posthog-js` is pulled via a **dynamic `import()`** so zero PostHog bytes execute (and it's code-split out) in non-cloud builds. Every capture is fire-and-forget and defensively wrapped — a failed load / unreachable endpoint / SDK error never blocks the tracked action and never reaches Sentry. Autocapture and session recording are off (no clicked-element text can leak; replay is a non-goal).
- Init wired in `instrumentation-client.ts` alongside the existing Sentry init.

## Events instrumented (at real `apps/app` client trigger points)

| Event | Where |
|---|---|
| `generation_started` / `generation_completed` | compose/post (post·thread·x-article), studio/clips, newsletters draft |
| `workflow_run_started` | execution store (`executeWorkflow`) |
| `workflow_run_completed` | SSE subscription terminal branch (outcome from status) |
| `post_published` | newsletter publish (`platform: newsletter`) |
| `agent_thread_created` | agent workspace new-thread signal |

Completion events are de-duplicated (clips uses a per-project ref guard; the SSE branch closes the stream on fire).

## Gating contract

Resolved from the existing client-side deployment-mode helpers — `isCloudConnected()` (`NEXT_PUBLIC_GENFEED_CLOUD`) and `isDesktopShell()` (`NEXT_PUBLIC_DESKTOP_SHELL`) — plus a required `NEXT_PUBLIC_POSTHOG_KEY`. No new inconsistent cloud check is introduced.

## Config / infra

- New env vars (cloud-only, provisioned at deploy time — e.g. Vercel): `NEXT_PUBLIC_POSTHOG_KEY`, optional `NEXT_PUBLIC_POSTHOG_HOST` (defaults to `https://us.i.posthog.com`). Absent key ⇒ analytics silently disabled. Not added to any `.env*` file by design (the issue's Phase-1 infra note: key source is a cloud-deploy decision).
- `posthog-js@1.396.4` added to `apps/app` (latest, verified on npm at time of writing).

## Tests

12 cases in `posthog-client.test.ts`: enabled (cloud) vs disabled (self-hosted / desktop / no-key) init, idempotency, fire-and-forget capture, error swallowing, and taxonomy shape.

## Verification

- `bun run type-check` (app, `tsc --noEmit`) — clean
- `bunx biome check` — clean
- New analytics tests (12) + existing affected suites (compose/newsletters/clips/execution/SSE, 34) — **46 green**

## Scope notes / follow-ups

- Studio **image/video** generation and **social-post** publish live in shared packages (`packages/pages/studio/generate`, `packages/pages/posts/detail`) which cannot import the `apps/app`-local analytics lib. The taxonomy already supports `IMAGE`/`VIDEO` and platform-tagged publishes — a follow-up promoting the client to a shared package would let those emit too. Kept out here to honor #1178's `apps/app`-only scope.
- Unrelated pre-existing tech debt spotted: a stale tracked `apps/app/pnpm-lock.yaml` (repo is Bun). Left untouched — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)