### PR TITLE
fix(billing): resolve Stripe controller users by User.id, not authProviderId (#1199)

### DIFF
--- a/.agents/SESSIONS/2026-07-03.md
+++ b/.agents/SESSIONS/2026-07-03.md
@@ -59,3 +59,73 @@ Invalidation (org/brand switch, onboarding, member invite):
 
 - After deploy, re-check Sentry p95 for `/v1/agent/threads`, `/v1/public/articles/slug/:slug`, `/v1/elements`.
 - `pg.connect` / `pg-pool.connect` spans still show heavy connection-acquisition time (avg 234ms) on the articles endpoint — worth a follow-up on Prisma `connection_limit` / pool sizing for the ECS task count.
+
+---
+
+## Session 2 — PRD pass on Epic #740 (deployment modes); model Opus 4.8 high
+
+Planning/PRD session — **no code changed**; GitHub Issues only (canonical per repo policy).
+
+### What was done
+
+- [x] Flagged model chip: session ran on **Opus 4.8 high**, not Fable 5 (routing rule wants Fable through 2026-07-07); user approved proceeding on Opus.
+- [x] Read epic #740 + ADR-DEPLOYMENT-MODES + `docs/deployment-modes.md`; pulled all listed children/loose items.
+- [x] **Discovered the task premise was stale**: 4 of 5 "open children" (#743/#744/#745/#746) were already **CLOSED/Completed** with merged PRs; #732/#702 also done. Only **#742** genuinely open. Surfaced before editing; user chose *PRD only #742*.
+- [x] Audited #742's real surface (Explore agent, ~40 consumer files): **8 mode-detection modules** + ~6 inline re-derivations, **5 comparison styles** for `GENFEED_CLOUD`, name collisions (`isCloudConnected`/`isEEEnabled` with contradictory logic), a real split-brain (`GENFEED_CLOUD=1` → cloud in 4 sites, not-cloud in `terminal.service.ts:181`/`AgentCliTerminal.tsx:103`), no two-axes model, mode inferred from raw auth signals.
+- [x] Rewrote **#742** body as a grounded PRD (Exec Summary / Problem / Goals / Non-Goals / Surface / Acceptance / Dependencies), every claim cited to a path.
+- [x] Corrected **#740** checklist (checked off shipped children + PRs, added Status line, reclassified #573 as EE/#87 not a real child) and moved the epic to the **v0.6 — Publish Loop** milestone (was Backlog/Deferred).
+
+### Key decisions
+
+- **Did not rewrite closed/Done issues** — forward PRDs on shipped, closed cards mislead readers. Left #741/#743/#744/#745/#746/#732/#702 untouched.
+- **No new card created** — the full mode-consolidation surface folds into #742's acceptance criteria; the CI-hardening remnant stays in #573. A new card would duplicate.
+- **#742 sequenced before #739** (auth epic #735 Phase 4) — the `isSignedIn`-as-mode call sites are exactly where Clerk removal breaks; #742 gives #739 a stable mode read and removes `HYBRID`-as-mode confusion.
+
+### Cross-dependencies (auth epic #735)
+
+- #742 de-risks #739 (Clerk removal); aligns mode model with Better-Auth-as-baseline (ADR §3); de-duplicated `isCloudConnected`/admin gates should land with #792 (BA orgs bridge) and #806 (`users.platformRole`).
+
+### Next steps
+
+- Implement #742 (own issue) before #739 opens.
+- Optional: pick up #573 item 5 (least-privilege perms + SHA-pinned actions on `build-verify-selfhosted.yml`) alongside any EE-extraction (#87) work.
+
+---
+
+## Session 3 — PRD pass on Epic #735 (Clerk→Better Auth); model Opus 4.8 high
+
+Planning/PRD session — **no code changed**; GitHub Issues only (canonical per repo policy). Same shape as Session 2, different epic.
+
+### What was done
+
+- [x] Flagged model chip: ran on **Opus 4.8 high**, not Fable 5 (routing wants Fable through 2026-07-07); user approved proceeding on Opus.
+- [x] Read epic #735 + ADR-DEPLOYMENT-MODES + `docs/deployment-modes.md`; pulled all children + folded-in cards + #769/#866/#878/#1041.
+- [x] **Task premise was stale**: prompt listed #738/#792/#739/#806 as "open children" — but **#792 and #806 are CLOSED/Done** with full PRDs (left untouched). Only **#738** (Human Review) and **#739** (In Progress) genuinely open.
+- [x] **Codebase far ahead of issue text** (3 parallel `sonnet` audit agents + grep): `@clerk` fully gone (0 imports/deps/env), Clerk FKs renamed→`authProviderId` (migration `20260625085045`), `isSuperAdmin`→`PlatformRole` shipped (#806, migration `20260624120000`), Better Auth `^1.6.21` is the active path (factory/resolver/guard/desktop-PKCE/mobile/CLI). The epic's "~537 @clerk sites" surface was fiction.
+- [x] Rewrote **#738** → verify-and-close (all 4 deliverables implemented; the `emailVerified` backfill `20260628200000` is the #866 Google-login fix).
+- [x] Rewrote **#739** → scoped to real remainder: prod cutover ceremony + dead-shim cleanup (10 zero-writer `IAuthPublicMetadata` fields, orphaned `AuthIdentityResolverService`, frozen `authProviderId` column).
+- [x] Reconciled **#735** body: phase checklist (#792/#806 checked), true surface, per-card verdicts, mongoId/#1041 note.
+- [x] **(a)** De-Clerked SSO children **#41/#42/#44/#45** (stripped "Clerk-first / keep clerkId / Mongo canonical"; re-anchored on Better Auth files; #42 notes SSO is greenfield — no OIDC/SAML plugin at `better-auth.factory.ts:525`).
+- [x] **(b)** Split the Stripe `authProviderId` bug into **#1199** (created, linked as sub-issue of #735, implementation-ready); repointed #739 to depend on it.
+
+### Key decisions
+
+- **Did not rewrite closed/Done issues** (#792/#806/#315/#747) — forward PRDs on shipped cards mislead. Same rule as Session 2.
+- **mongoId/#1041 is over-scoped** — #1041 names `auth/services/auth-identity-resolver.service.ts` (mongoId fallback) as "Auth — highest risk," but that file is **dead/unregistered**; the live `better-auth/services/better-auth-identity-resolver.service.ts` resolves by `User.id` with **zero mongoId dependency**. The Better Auth cutover already decoupled auth from mongoId → #1041 Phase-2 auth risk largely neutralized. Documented in #735/#739.
+- **Split the Stripe bug out** (#1199) rather than fold into #739 — lets the live billing-lookup fix land ahead of the careful prod cutover; the `authProviderId` column drop (#739) is now gated on #1199.
+
+### Live bug found (now #1199)
+
+Stripe controllers still do `findOne({ authProviderId: user.id })` (`stripe.controller.ts:84,186`; `user-stripe.controller.ts:100,185,227`) where `user.id` is now the Genfeed PK → silently misses for every post-cutover signup. Fix: repoint to `{ _id: user.id }` + regression test for `authProviderId = NULL`.
+
+### Cross-dependencies
+
+- SSO cluster (#39/#41/#42/#44/#45/#46) hard-blocked on Better Auth baseline (#738+#739); #42 must not harden code #739 is deleting.
+- #323/#324 belong to desktop-sync epic #313, not #735 (kept as "relates to").
+
+### Next steps
+
+- **#1041 body should be updated** to reflect the dead-resolver correction (out of this epic's scope; not done here).
+- Verify #738 acceptance (migrated-user Google login) → close it.
+- Implement #1199 (offered to ship it + PR on request; kept this session PRD-only per header).
+- When #739 opens: fix #1199 → confirm no `authProviderId` readers → drop column → delete dead resolver (coordinate single deletion with #1041).

--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -38,6 +38,7 @@
 - [Failed deploys never burn a version](release_tag_after_green_deploy.md) — pre-gate release cutting is normal; on deploy failure fix master and re-cut the SAME version (delete unconsumed tag), never bump
 - [Production deploys master-only](production_deploy_master_only.md) — Never deploy any non-master ref to production unless Vincent explicitly overrides; production deploys run from GitHub CI on master
 - [Vercel release gate](feedback_vercel_release_gate.md) — SaaS Vercel frontends deploy only through the API-first production release workflow; Vercel Git auto-deploy stays disabled
+- [PRD-pass verify state first](prd_pass_verify_state_first.md) — On any epic PRD pass, verify child issue states via `gh` + audit real code before trusting the epic body; never rewrite closed/shipped cards
 
 ## References
 

--- a/.agents/memory/rules/prd_pass_verify_state_first.md
+++ b/.agents/memory/rules/prd_pass_verify_state_first.md
@@ -1,0 +1,22 @@
+# PRD pass: verify issue state + audit code before trusting the epic body
+
+**last_verified: 2026-07-03**
+
+When doing a PRD/planning pass over an epic and its children, the epic body is a **stale narrative**, not ground truth. Establish reality first, then write.
+
+## Do this first, every time
+
+1. **Verify every issue's real state** — `gh issue view <n> --json state,stateReason,closedAt,projects`. Epic bodies routinely list already-**closed/Done** cards as "open children." Never rewrite a closed, shipped issue's body — a forward-looking PRD on shipped work misleads readers.
+2. **Audit the real code surface** the card claims to touch — grep for the actual symbols/imports/counts. Epic "Surface (from code audit)" numbers go stale fast; treat them as hypotheses to re-measure, not facts to repeat.
+3. **Ground every claim in a path you read.** Cite `file:line`. If the code contradicts the issue text, the code wins — surface the delta.
+
+## Why (observed twice)
+
+- Epic #740 pass (2026-07-03 S2): 4 of 5 "open children" were already closed/merged; only 1 genuinely open.
+- Epic #735 pass (2026-07-03 S3): #792/#806 listed as open were closed/Done; the "~537 @clerk sites" surface was fiction (0 remained); #1041's "highest-risk" auth file was dead/unregistered code.
+
+In both, the stated surface and child list were wrong in ways that would have produced misleading PRDs if taken at face value.
+
+## Output shape for each rewritten child
+
+Executive Summary · Problem Statement · Goals · Non-Goals · Surface (concrete files/counts from the audit) · Acceptance Criteria · Dependencies/Sequencing. GitHub Issues are canonical — no local task markdown, no YAML frontmatter in issue bodies.

--- a/apps/server/api/src/services/integrations/stripe/controllers/stripe.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/stripe/controllers/stripe.controller.spec.ts
@@ -62,9 +62,11 @@ describe('StripeController', () => {
   const mockRequestNoOrigin = { headers: {} } as unknown as Request;
   const orgId = '507f1f77bcf86cd799439011';
   const userId = 'test-object-id';
+  // Better Auth: request.user.id is the Genfeed User.id (JWT sub), not a
+  // legacy external auth-provider id.
   const mockUser = {
     emailAddresses: [{ emailAddress: 'test@example.com' }],
-    id: 'authProvider_user_123',
+    id: userId,
     publicMetadata: { organization: orgId, user: userId.toString() },
   } as unknown as User;
 
@@ -92,8 +94,9 @@ describe('StripeController', () => {
     };
 
     usersService = {
+      // Post-cutover user: authProviderId is NULL; identity is the Genfeed id.
       findOne: vi.fn().mockResolvedValue({
-        authProviderId: 'authProvider_user_123',
+        authProviderId: null,
         id: userId,
       }),
     };
@@ -133,6 +136,12 @@ describe('StripeController', () => {
         mockRequest,
       );
       expect(result).toEqual({ url: 'https://checkout.stripe.com/session' });
+      // Regression (#1199): resolve the DB user by Genfeed User.id, never the
+      // frozen authProviderId column (NULL for post-cutover Better Auth users).
+      expect(usersService.findOne).toHaveBeenCalledWith({
+        _id: userId,
+        isDeleted: false,
+      });
       expect(stripeService.createPaymentSession).toHaveBeenCalledWith(
         'cus_test123',
         'price_abc123',

--- a/apps/server/api/src/services/integrations/stripe/controllers/stripe.controller.ts
+++ b/apps/server/api/src/services/integrations/stripe/controllers/stripe.controller.ts
@@ -79,9 +79,11 @@ export class StripeController {
         });
       }
 
-      // Find user by authProviderId to get user ObjectId
+      // Load the current user's DB record by id.
+      // Post-Better-Auth cutover, user.id is the Genfeed User.id (JWT sub),
+      // not a legacy external auth-provider id.
       const dbUser = await this.usersService.findOne({
-        authProviderId: user.id,
+        _id: user.id,
         isDeleted: false,
       });
       if (!dbUser) {
@@ -183,7 +185,7 @@ export class StripeController {
       }
 
       const dbUser = await this.usersService.findOne({
-        authProviderId: user.id,
+        _id: user.id,
         isDeleted: false,
       });
       if (!dbUser) {

--- a/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.spec.ts
@@ -68,15 +68,18 @@ describe('UserStripeController', () => {
     headers: { origin: 'https://app.genfeed.ai' },
   } as unknown as Request;
   const mockRequestNoOrigin = { headers: {} } as unknown as Request;
+  // Better Auth: request.user.id is the Genfeed User.id (JWT sub), not a
+  // legacy external auth-provider id.
   const mockUser = {
     emailAddresses: [{ emailAddress: 'user@test.com' }],
     firstName: 'John',
-    id: 'authProvider_user_1',
+    id: dbUserId,
     lastName: 'Doe',
   } as unknown as User;
 
+  // Post-cutover user: authProviderId is NULL; identity is the Genfeed id.
   const mockDbUser = {
-    authProviderId: 'authProvider_user_1',
+    authProviderId: null,
     id: dbUserId,
     stripeCustomerId: 'cus_existing',
   };
@@ -153,6 +156,12 @@ describe('UserStripeController', () => {
         mockRequest,
       );
       expect(result).toEqual({ url: 'https://checkout.stripe.com/pay' });
+      // Regression (#1199): resolve the DB user by Genfeed User.id, never the
+      // frozen authProviderId column (NULL for post-cutover Better Auth users).
+      expect(usersService.findOne).toHaveBeenCalledWith({
+        _id: dbUserId,
+        isDeleted: false,
+      });
       expect(stripeService.createUserCustomer).not.toHaveBeenCalled();
     });
 

--- a/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.ts
+++ b/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.ts
@@ -95,9 +95,9 @@ export class UserStripeController {
         });
       }
 
-      // Find user by authProviderId
+      // Load the current user's DB record by id (Better Auth: user.id is the Genfeed User.id).
       const dbUser = await this.usersService.findOne({
-        authProviderId: user.id,
+        _id: user.id,
         isDeleted: false,
       });
       if (!dbUser) {
@@ -180,9 +180,9 @@ export class UserStripeController {
     }
 
     try {
-      // Find user by authProviderId
+      // Load the current user's DB record by id (Better Auth: user.id is the Genfeed User.id).
       const dbUser = await this.usersService.findOne({
-        authProviderId: user.id,
+        _id: user.id,
         isDeleted: false,
       });
       if (!dbUser) {
@@ -222,9 +222,9 @@ export class UserStripeController {
     this.loggerService.log(url);
 
     try {
-      // Find user by authProviderId
+      // Load the current user's DB record by id (Better Auth: user.id is the Genfeed User.id).
       const dbUser = await this.usersService.findOne({
-        authProviderId: user.id,
+        _id: user.id,
         isDeleted: false,
       });
       if (!dbUser) {


### PR DESCRIPTION
## Problem

Post Better Auth cutover (#735), `request.user.id` is the Genfeed `User.id` (JWT `sub`), and the frozen `authProviderId` column is `NULL` for every Better-Auth-native signup. Five Stripe controller handlers still resolved the DB user by `findOne({ authProviderId: user.id })` — which **silently misses for every post-cutover user**, breaking checkout / setup-intent / billing-portal / subscription resolution. The stale comments ("Find user by authProviderId to get user ObjectId") confirm the intent predates the migration.

Found during the epic #735 PRD audit; split out of #739 (Phase 4) so it lands ahead of the careful production cutover. The `authProviderId` column drop in #739 is gated on this.

## Change

- Repoint all 5 lookups to `findOne({ _id: user.id, isDeleted: false })`, matching `BetterAuthIdentityResolverService` (which resolves identity by `User.id`):
  - `stripe.controller.ts:84,186`
  - `user-stripe.controller.ts:100,185,227`
- Refresh stale comments.
- Update specs to Better Auth reality: `mockUser.id === User.id`, DB user `authProviderId: null` (post-cutover), plus **regression assertions** that the lookup uses `{ _id: user.id }` — the old mocks encoded the bug (`mockUser.id = 'authProvider_user_1'`) and would have kept passing.

## Verification

- Focused specs: `stripe.controller.spec.ts` + `user-stripe.controller.spec.ts` → **34/34 pass**.
- Type-check + lint deferred to CI (change is a query-key swap on the same Prisma where-input).

Closes #1199. Refs #735, #739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)