### PR TITLE
fix(scheduler): count SKIPPED targets as terminal in release status roll-up

### DIFF
--- a/packages/api-types/__tests__/scheduler.contract.test.ts
+++ b/packages/api-types/__tests__/scheduler.contract.test.ts
@@ -193,6 +193,54 @@ describe('deriveReleaseStatusFromTargets', () => {
       ]),
     ).toBe(ReleaseStatus.SCHEDULED);
   });
+
+  // SKIPPED is terminal + benign (intentionally excluded target). It has no
+  // ReleaseStatus counterpart, so it rolls up like CANCELLED. Every skipped
+  // combination must land on a terminal status, never fall through to SCHEDULED.
+  test('all skipped -> cancelled (terminal, not left as scheduled)', () => {
+    expect(
+      deriveReleaseStatusFromTargets([
+        TargetExecutionState.SKIPPED,
+        TargetExecutionState.SKIPPED,
+      ]),
+    ).toBe(ReleaseStatus.CANCELLED);
+  });
+
+  test('skipped + failed (no publish) -> failed', () => {
+    expect(
+      deriveReleaseStatusFromTargets([
+        TargetExecutionState.SKIPPED,
+        TargetExecutionState.FAILED,
+      ]),
+    ).toBe(ReleaseStatus.FAILED);
+  });
+
+  test('skipped + published -> partially-published', () => {
+    expect(
+      deriveReleaseStatusFromTargets([
+        TargetExecutionState.SKIPPED,
+        TargetExecutionState.PUBLISHED,
+      ]),
+    ).toBe(ReleaseStatus.PARTIALLY_PUBLISHED);
+  });
+
+  test('skipped + cancelled -> cancelled', () => {
+    expect(
+      deriveReleaseStatusFromTargets([
+        TargetExecutionState.SKIPPED,
+        TargetExecutionState.CANCELLED,
+      ]),
+    ).toBe(ReleaseStatus.CANCELLED);
+  });
+
+  test('skipped + still-scheduled -> scheduled (one target still pending)', () => {
+    expect(
+      deriveReleaseStatusFromTargets([
+        TargetExecutionState.SKIPPED,
+        TargetExecutionState.SCHEDULED,
+      ]),
+    ).toBe(ReleaseStatus.SCHEDULED);
+  });
 });
 
 describe('terminal-state predicates', () => {

--- a/packages/api-types/src/contracts/scheduler.contract.ts
+++ b/packages/api-types/src/contracts/scheduler.contract.ts
@@ -224,13 +224,21 @@ export function isTerminalTargetExecutionState(
  * Derive the release-level status from the execution states of its targets.
  * Encapsulates the aggregate rules so composer, calendar, workers, and API all
  * report the same roll-up:
- *   - no targets              -> DRAFT
- *   - any still publishing    -> PUBLISHING
- *   - all published           -> PUBLISHED
- *   - all cancelled           -> CANCELLED
- *   - all failed/cancelled    -> FAILED
- *   - some published, some not -> PARTIALLY_PUBLISHED
- *   - otherwise (still queued) -> SCHEDULED
+ *   - no targets                    -> DRAFT
+ *   - any still publishing          -> PUBLISHING
+ *   - all published                 -> PUBLISHED
+ *   - all cancelled/skipped         -> CANCELLED
+ *   - some published, some not      -> PARTIALLY_PUBLISHED
+ *   - all failed/cancelled/skipped  -> FAILED
+ *   - otherwise (still queued)      -> SCHEDULED
+ *
+ * `SKIPPED` is a terminal, benign non-publish — a target intentionally
+ * excluded from the run (e.g. a disabled credential), never an error (see the
+ * {@link TargetExecutionState} doc and {@link isTerminalTargetExecutionState}).
+ * `ReleaseStatus` has no `skipped` value, so at the roll-up level a skipped
+ * target behaves like a cancelled one: it did not publish, did not fail, and is
+ * done. Folding skipped into cancelled keeps every terminal combination landing
+ * on a real terminal status instead of falling through to `SCHEDULED`.
  */
 export function deriveReleaseStatusFromTargets(
   targetStates: readonly TargetExecutionState[],
@@ -252,17 +260,24 @@ export function deriveReleaseStatusFromTargets(
   const failed = targetStates.filter(
     (state) => state === TargetExecutionState.FAILED,
   ).length;
+  const skipped = targetStates.filter(
+    (state) => state === TargetExecutionState.SKIPPED,
+  ).length;
+
+  // A skipped target is a terminal non-publish with no error, so it rolls up
+  // the same way a cancelled target does.
+  const cancelledOrSkipped = cancelled + skipped;
 
   if (published === targetStates.length) {
     return ReleaseStatus.PUBLISHED;
   }
-  if (cancelled === targetStates.length) {
+  if (cancelledOrSkipped === targetStates.length) {
     return ReleaseStatus.CANCELLED;
   }
   if (published > 0) {
     return ReleaseStatus.PARTIALLY_PUBLISHED;
   }
-  if (failed + cancelled === targetStates.length) {
+  if (failed + cancelledOrSkipped === targetStates.length) {
     return ReleaseStatus.FAILED;
   }
 


### PR DESCRIPTION
## Problem

`deriveReleaseStatusFromTargets` (`packages/api-types/src/contracts/scheduler.contract.ts`), added in #1195 as the single status source-of-truth for every scheduler surface (composer, calendar, workers, API) and the #1126–#1140 epic issues, does **not** account for `TargetExecutionState.SKIPPED` in its roll-up.

A release whose targets are all `SKIPPED` (e.g. both channel credentials disabled) fell through every branch — `published===0`, `cancelled===0`, `failed+cancelled !== length` — and returned `ReleaseStatus.SCHEDULED`: a **terminal outcome reported as still-pending**. Any mix containing `SKIPPED` without offsetting published/cancelled/failed counts mislanded the same way (`[SKIPPED, FAILED]` → `SCHEDULED` instead of `FAILED`).

This contradicted `isTerminalTargetExecutionState` in the same file, which explicitly treats `SKIPPED` as terminal.

## Fix

`SKIPPED` is a **benign terminal non-publish** — a target intentionally excluded from the run (disabled credential, recurrence occurrence with no eligible content), never an error. `ReleaseStatus` has no `skipped` value, so at the roll-up level a skipped target folds into `cancelled`: it did not publish, did not fail, and is done. This is the correct existing terminal status — not `PUBLISHED` (nothing went out) and not `FAILED` (no error occurred).

Resulting behavior:

| targets | before | after |
|---|---|---|
| all `SKIPPED` | `SCHEDULED` ❌ | `CANCELLED` ✅ |
| `SKIPPED` + `FAILED` | `SCHEDULED` ❌ | `FAILED` ✅ |
| `SKIPPED` + `PUBLISHED` | `PARTIALLY_PUBLISHED` | `PARTIALLY_PUBLISHED` ✅ |
| `SKIPPED` + `CANCELLED` | `SCHEDULED` ❌ | `CANCELLED` ✅ |
| `SKIPPED` + `SCHEDULED` | `SCHEDULED` | `SCHEDULED` ✅ (still pending) |

All pre-existing buckets (all-published, partial, all-failed, all-cancelled, publishing, still-queued) are unchanged.

## Tests

Adds `SKIPPED`-combination coverage to `packages/api-types/__tests__/scheduler.contract.test.ts` — the suite previously fed every other bucket but never `SKIPPED`. 28/28 pass.

## Verification

- `bun run test --filter=@genfeedai/api-types` — 28 passed
- `bunx turbo run type-check --filter=@genfeedai/api-types` — clean
- `bunx biome check` — clean

Scoped to the roll-up bug + its tests only; everything else in #1195 was reviewed clean.

Refs #1195, #1124.