### PR TITLE
fix(prisma): build #1194 hot-table unique indexes CONCURRENTLY (#1185)

### DIFF
--- a/packages/prisma/prisma/hot-path-indexes.test.ts
+++ b/packages/prisma/prisma/hot-path-indexes.test.ts
@@ -44,3 +44,53 @@ describe('app shell hot-path Prisma indexes', () => {
     );
   });
 });
+
+// UNIQUE indexes added in #1194 (#1185) on hot, continuously-written tables
+// (post_analytics ingestion, Stripe billing). These MUST build CONCURRENTLY too:
+// a plain `CREATE UNIQUE INDEX` takes an ACCESS EXCLUSIVE lock for the whole
+// build and would stall live Stripe webhooks / analytics ingestion on prod. The
+// original #1194 migrations shipped the plain form — this guard exists so that
+// regression fails CI. Partial (Stripe) indexes are raw-SQL-only and the
+// post_analytics one is Prisma's default `@@unique` name, so we assert against
+// the migration SQL rather than schema.prisma.
+const concurrentUniqueIndexMigrations = [
+  {
+    file: 'migrations/20260703120100_add_post_analytics_daily_unique/migration.sql',
+    indexes: ['post_analytics_postId_platform_date_key'],
+  },
+  {
+    file: 'migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql',
+    indexes: [
+      'customers_stripeCustomerId_live_key',
+      'subscriptions_stripeSubscriptionId_live_key',
+    ],
+  },
+] as const;
+
+describe('hot-path unique indexes build CONCURRENTLY (#1185/#1194)', () => {
+  for (const { file, indexes } of concurrentUniqueIndexMigrations) {
+    const source = readFileSync(join(prismaDir, file), 'utf8');
+
+    describe(file, () => {
+      it.each(indexes)('builds %s CONCURRENTLY', (indexName) => {
+        // The create MUST be CONCURRENTLY (IF NOT EXISTS is optional after it).
+        expect(source).toMatch(
+          new RegExp(
+            `CREATE UNIQUE INDEX CONCURRENTLY (IF NOT EXISTS )?"${indexName}"`,
+          ),
+        );
+        // Regression guard: no plain, non-CONCURRENTLY create of this index.
+        // (In the CONCURRENTLY form "CONCURRENTLY" sits between INDEX and the
+        // name, so this pattern only matches the write-blocking plain form.)
+        expect(source).not.toMatch(
+          new RegExp(`CREATE UNIQUE INDEX (IF NOT EXISTS )?"${indexName}"`),
+        );
+      });
+    });
+
+    it(`${file} keeps its dedup preflight guard`, () => {
+      // Do NOT weaken the pre-existing-duplicate safety when fixing locking.
+      expect(source).toContain('RAISE EXCEPTION');
+    });
+  }
+});

--- a/packages/prisma/prisma/migrations/20260703120100_add_post_analytics_daily_unique/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120100_add_post_analytics_daily_unique/migration.sql
@@ -10,19 +10,39 @@
 -- in the schema or a migration: classic drift. Without the DB constraint the
 -- upsert's `where` is not a valid unique locator and the P2002 catch can never
 -- fire. This aligns the DB with the code's assumption and mirrors the existing
--- `ArticleAnalytics @@unique([articleId, date])`. `date` is always normalized to
--- UTC midnight by the writer, so the tuple is a true per-day natural key.
+-- `ArticleAnalytics @@unique([articleId, date])`. `date` is normalized to
+-- local-server midnight by the writer (`new Date()` then `.setHours(0, 0, 0, 0)`
+-- in `PostAnalyticsService`), so for a fixed server timezone the tuple is a true
+-- per-day natural key.
+--
+-- Built CONCURRENTLY: locking
+-- ---------------------------
+-- `post_analytics` is a hot, continuously-written table — every metrics refresh
+-- upserts today's row. A plain `CREATE UNIQUE INDEX` takes an ACCESS EXCLUSIVE
+-- lock for the whole build and would stall live analytics ingestion, so the
+-- index is built CONCURRENTLY: concurrent reads and writes keep running while it
+-- builds. CONCURRENTLY cannot run inside a transaction block; Prisma 7.8.0+
+-- executes each migration statement without wrapping the migration in a
+-- transaction (including shadow-database replay during `migrate dev`), so the
+-- preflight `DO` block and the index build below run as two separate,
+-- autocommitted statements. See prisma/prisma#14456 and the 7.8.0 release notes.
 --
 -- Safety against existing duplicates
 -- ----------------------------------
 -- `post_analytics` has NO soft-delete column, so duplicates cannot be collapsed
 -- by soft-deleting losers, and silently hard-deleting analytics rows would be
--- data loss. Instead we abort loudly if any duplicate group exists: the whole
--- migration is transactional, so RAISE rolls it back cleanly and leaves the data
--- untouched for a reviewed manual dedupe before re-apply. On production the
+-- data loss. Instead the preflight below aborts loudly if any duplicate group
+-- exists: it is its own statement and only reads (SELECT COUNT), so the RAISE
+-- fails the migration before the index build is ever attempted and leaves the
+-- data untouched for a reviewed manual dedupe before re-apply. On production the
 -- unique index is expected to already exist (the app has been running against
 -- it), so `IF NOT EXISTS` makes this a no-op there and a real create only on
 -- databases that lack it.
+--
+-- NOTE: a CONCURRENTLY build that fails midway leaves an INVALID index of the
+-- same name and marks this migration failed. Because of `IF NOT EXISTS` a blind
+-- re-run would skip rebuilding it — DROP the invalid index, then
+-- `prisma migrate resolve` + re-deploy. Do not blindly re-run.
 DO $$
 DECLARE
   dup_count integer;
@@ -41,5 +61,5 @@ END$$;
 
 -- Name MUST match Prisma's default for `@@unique([postId, platform, date])` on
 -- `@@map("post_analytics")` so the schema and database stay drift-free.
-CREATE UNIQUE INDEX IF NOT EXISTS "post_analytics_postId_platform_date_key"
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "post_analytics_postId_platform_date_key"
   ON "post_analytics" ("postId", "platform", "date");

--- a/packages/prisma/prisma/migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql
@@ -20,11 +20,31 @@
 -- they live in raw SQL only, exactly like the #892 default-recurring-workflow
 -- partial unique index. There is deliberately no schema.prisma counterpart.
 --
+-- Built CONCURRENTLY: locking
+-- ---------------------------
+-- `customers` and `subscriptions` are hot, continuously-written billing tables
+-- (every Stripe webhook upserts against them). A plain `CREATE UNIQUE INDEX`
+-- takes an ACCESS EXCLUSIVE lock for the whole build and would stall live
+-- webhook processing, so each index is built CONCURRENTLY — reads and writes
+-- keep running throughout. CONCURRENTLY cannot run inside a transaction block;
+-- Prisma 7.8.0+ executes each migration statement without wrapping the migration
+-- in a transaction (including shadow-database replay during `migrate dev`), so
+-- each preflight `DO` block and its `CREATE UNIQUE INDEX CONCURRENTLY` run as
+-- separate, autocommitted statements. See prisma/prisma#14456 and the 7.8.0
+-- release notes.
+--
 -- Safety against existing duplicates
 -- ----------------------------------
--- Each index is preceded by a preflight that aborts the (transactional)
--- migration if a live duplicate already exists, surfacing the pre-existing bug
--- for a reviewed manual merge rather than failing mid-build or corrupting data.
+-- Each index is preceded by a preflight (its own statement) that aborts the
+-- migration if a live duplicate already exists. The preflight only reads
+-- (SELECT COUNT), so its RAISE fails the migration before that index is built,
+-- surfacing the pre-existing bug for a reviewed manual merge rather than failing
+-- mid-build or corrupting data.
+--
+-- NOTE: a CONCURRENTLY build that fails midway leaves an INVALID index of the
+-- same name and marks this migration failed. Because of `IF NOT EXISTS` a blind
+-- re-run would skip rebuilding it — DROP the invalid index, then
+-- `prisma migrate resolve` + re-deploy. Do not blindly re-run.
 
 -- ── customers.stripeCustomerId ──────────────────────────────────────────────
 DO $$
@@ -45,7 +65,7 @@ BEGIN
   END IF;
 END$$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS "customers_stripeCustomerId_live_key"
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "customers_stripeCustomerId_live_key"
   ON "customers" ("stripeCustomerId")
   WHERE "stripeCustomerId" IS NOT NULL AND "isDeleted" = false;
 
@@ -68,6 +88,6 @@ BEGIN
   END IF;
 END$$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS "subscriptions_stripeSubscriptionId_live_key"
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "subscriptions_stripeSubscriptionId_live_key"
   ON "subscriptions" ("stripeSubscriptionId")
   WHERE "stripeSubscriptionId" IS NOT NULL AND "isDeleted" = false;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1958,8 +1958,9 @@ model PostAnalytics {
   // One analytics snapshot per post, per platform, per day. The ingestion
   // service (`upsertTodaysAnalytics`) upserts on this exact tuple and relies on
   // a P2002 to serialize concurrent writers — mirrors ArticleAnalytics'
-  // `@@unique([articleId, date])`. `date` is always normalized to UTC midnight
-  // by the writer, so the tuple is a true daily natural key.
+  // `@@unique([articleId, date])`. `date` is normalized to local-server midnight
+  // by the writer (`.setHours(0, 0, 0, 0)`), so the tuple is a true daily natural
+  // key for a fixed server timezone.
   @@unique([postId, platform, date])
   @@index([date(sort: Desc)])
   @@index([organizationId, date(sort: Desc)])


### PR DESCRIPTION
## Why (hotfix — must land before #1194's migration reaches prod)

PR #1194 (merged to `master` 2026-07-03) added unique indexes on **hot, continuously-written production tables** using plain `CREATE UNIQUE INDEX`:

| table | index | risk when applied to prod |
|---|---|---|
| `post_analytics` | `post_analytics_postId_platform_date_key` | ACCESS EXCLUSIVE lock stalls live analytics ingestion |
| `customers` | `customers_stripeCustomerId_live_key` (partial) | stalls live Stripe webhook processing |
| `subscriptions` | `subscriptions_stripeSubscriptionId_live_key` (partial) | stalls live Stripe webhook processing |

A plain `CREATE UNIQUE INDEX` takes an `ACCESS EXCLUSIVE` lock for the entire build, blocking all writes on the table. On these tables that means stalled Stripe webhooks and analytics writes for the duration of the build.

## Fix

1. **All three creates → `CREATE UNIQUE INDEX CONCURRENTLY`** (`IF NOT EXISTS` preserved). Concurrent reads/writes keep running during the build.
2. **Non-transactional structure.** `CONCURRENTLY` cannot run inside a transaction block. Prisma **7.8.0+** executes migration statements one-by-one without a wrapping transaction (incl. `migrate dev` shadow-DB replay), so each dedup-preflight `DO $$ … RAISE EXCEPTION … $$` block and its index build run as separate autocommitted statements — matching the established safe pattern in [`20260618130000_add_app_shell_hot_path_indexes`](../blob/master/packages/prisma/prisma/migrations/20260618130000_add_app_shell_hot_path_indexes/migration.sql).
3. **Safety preserved — nothing weakened.** The duplicate-detection preflights are untouched; the Stripe partial indexes keep their `WHERE … IS NOT NULL AND isDeleted = false` predicate; `post_analytics` (no soft-delete) keeps its abort-on-dup guard.
4. **Guardrail test extended.** `hot-path-indexes.test.ts` previously covered only the earlier 16 named indexes and did not catch this regression. It now asserts `CONCURRENTLY` on the three new indexes, that no plain non-concurrent create of them exists, and that the dedup preflight survives. **21 tests pass.**
5. **Comment accuracy fix (review nit).** `PostAnalytics.date` is **local-server midnight** (`new Date()` + `.setHours(0,0,0,0)` in `PostAnalyticsService`), **not** "UTC midnight" — corrected in both the migration comment and `schema.prisma`.

## Scope note

#1194's third migration (`20260703120000_consolidate_asset_soft_delete`) creates no indexes — unaffected. Older already-applied migrations with plain `CREATE INDEX` are intentionally left alone (editing applied migrations breaks checksums; out of scope).

## Verification (local, no real DB)

- ✅ `hot-path-indexes.test.ts` — 21 passed (via workspace vitest)
- ✅ biome check clean on changed TS
- ✅ pre-commit secretlint + biome hooks passed
- ✅ `schema.prisma` change is comment-only
- ⏭️ Authoritative `prisma validate` / type-check / full guard run happen in CI

**Do not apply #1194's migration to any prod DB until this is merged.**

Refs #1194 #1185