### PR TITLE
test(api): cover desktop-sync soft-deleted asset tombstone contract (#1185)

### DIFF
--- a/apps/server/api/src/services/sync/desktop-sync.service.spec.ts
+++ b/apps/server/api/src/services/sync/desktop-sync.service.spec.ts
@@ -330,4 +330,52 @@ describe('DesktopSyncService', () => {
       }),
     ).rejects.toMatchObject({ status: 415 });
   });
+
+  it('rejects a push against a soft-deleted cloud asset and surfaces updatedAt as the tombstone instant', async () => {
+    const { prisma, service } = buildService();
+    // deletedAt is no longer stored on Asset (isDeleted is the sole soft-delete
+    // signal); the desktop tombstone timeline must therefore be fed from
+    // updatedAt. This locks that wire contract so a future refactor can't
+    // silently drop or repoint the tombstone instant.
+    const deletedInstant = new Date('2026-05-01T12:00:00.000Z');
+    prisma.asset.findFirst.mockResolvedValue({
+      cloudObjectKey: `${organizationId}/hash/logo.png`,
+      id: 'asset-cloud',
+      isDeleted: true,
+      residency: 'synced',
+      updatedAt: deletedInstant,
+      uploadPolicy: 'full',
+    });
+
+    const result = await service.pushAssets(makeUser(), {
+      assets: [
+        {
+          displayName: 'logo.png',
+          id: 'asset-local',
+          kind: 'image',
+          mimeType: 'image/png',
+          origin: 'local-import',
+          originalFileName: 'logo.png',
+          residency: 'local-only',
+          sha256: 'hash',
+          sizeBytes: 128,
+          uploadPolicy: 'full',
+        },
+      ],
+    });
+
+    expect(result.data).toMatchObject({ accepted: 0, rejected: 1 });
+    expect(result.data.assets[0]).toMatchObject({
+      cloudAssetId: 'asset-cloud',
+      deletedAt: deletedInstant,
+      localAssetId: 'asset-local',
+      reason: 'cloud-deleted',
+      residency: 'synced',
+      status: 'rejected',
+      updatedAt: deletedInstant,
+    });
+    // Soft-deleted match short-circuits before any write.
+    expect(prisma.asset.create).not.toHaveBeenCalled();
+    expect(prisma.asset.update).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What

Adds the regression test flagged (non-blocking) in the #1194 review but never landed.

#1194 consolidated Asset soft-delete to `isDeleted`-only, dropped the `deletedAt` column, and repointed the desktop tombstone instant to `updatedAt` (`desktop-sync.service.ts:505-521`). That is a cross-client sync-protocol change that shipped with **zero** coverage — the existing spec tested quota / MIME / thread-owner rejections but never a soft-deleted asset.

## The test

Feeds a soft-deleted (`isDeleted: true`) existing cloud asset into `pushAssets` and locks the wire contract:
- `reason: 'cloud-deleted'`, `status: 'rejected'`, `accepted: 0 / rejected: 1`
- **`deletedAt === existing.updatedAt`** — the crux, since `deletedAt` is no longer stored on Asset
- short-circuits before any write (`asset.create` / `asset.update` not called)

## Verification

Test-only, mirrors the existing passing tests in the same file. Biome clean. Local execution blocked by an un-generated prisma client in the fresh worktree (`@genfeedai/prisma/testing` unresolved — affects the whole file, not this test); **CI is the execution gate.**

Refs #1185, #1194.