### PR TITLE
fix(next): harden buildId against empty-string env vars in SPA frontends

### DIFF
--- a/.github/workflows/deploy-vercel-frontends.yml
+++ b/.github/workflows/deploy-vercel-frontends.yml
@@ -33,6 +33,12 @@ jobs:
           - label: docs.genfeed.ai
             project_id: prj_SdDiBAjBgxhqmsbDBZ6mmIOAnqUL
     env:
+      # Git auto-deploy is disabled in each vercel.json, so `vercel build` runs
+      # without Git deployment context and Vercel leaves VERCEL_GIT_COMMIT_SHA="".
+      # An empty buildId makes the App Router hard-reload on every navigation, so
+      # feed the real master commit SHA as BUILD_ID (apps/app's next.config reads
+      # it first). website/docs ignore this and keep Next's default buildId.
+      BUILD_ID: ${{ github.sha }}
       VERCEL_ORG_ID: team_hFVCbNU4RnfEpQOeSWRxmhEJ
       VERCEL_PROJECT_ID: ${{ matrix.project_id }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/apps/app/app/api/version/route.ts
+++ b/apps/app/app/api/version/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+
+// Always render at request time and never cache: a stale CDN copy would report
+// the old build id and hide a fresh deployment from clients polling for updates.
+export const dynamic = 'force-dynamic';
+
+/**
+ * Reports the build id baked into THIS deployment. The client compares it to the
+ * NEXT_PUBLIC_BUILD_ID it was served with; a mismatch means a newer deployment
+ * is live behind the alias and the user should refresh to load it.
+ */
+export function GET(): NextResponse {
+  const buildId = process.env.NEXT_PUBLIC_BUILD_ID ?? '';
+
+  return NextResponse.json(
+    { buildId },
+    {
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
+      },
+    },
+  );
+}

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -12,6 +12,7 @@ import { createAppMetadata, createPwaMetadata } from '@ui/shell/metadata';
 import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import DesktopDragStrip from '@/components/desktop/DesktopDragStrip';
+import DeploymentVersionWatcher from '@/components/version/DeploymentVersionWatcher';
 
 const { name, description } = metadataHelper;
 const pwaConfig = createPwaMetadata('app');
@@ -64,6 +65,9 @@ export default async function RootLayout({ children }: LayoutProps) {
           {createRuntimeConfigScript()}
         </Script>
         <DesktopDragStrip />
+        {/* Desktop ships as a bundled app with its own update path; the deploy
+            skew watcher only applies to the Vercel-hosted studio. */}
+        {!isDesktopShell ? <DeploymentVersionWatcher /> : null}
         {children}
       </AppProviders>
     </AppHtmlDocument>

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -4,6 +4,24 @@ import { createAppNextConfig } from '@genfeedai/next-config';
 import bundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
 
+// Deterministic, empty-string-safe build id. A plain `??` chain does NOT skip
+// empty strings, and Vercel sets VERCEL_GIT_COMMIT_SHA="" on CLI deploys with no
+// git metadata. An empty buildId makes Next.js embed "b":"" in RSC flight
+// payloads, so the App Router treats every navigation as a cross-deployment
+// change and forces a full hard reload (and silently disables version checks).
+// firstNonBlank skips blank/whitespace values; the dev-* fallback guarantees the
+// id is never empty so generateBuildId never returns "".
+const firstNonBlank = (
+  ...values: Array<string | undefined>
+): string | undefined => values.find((value) => value?.trim());
+
+const buildId =
+  firstNonBlank(
+    process.env.BUILD_ID,
+    process.env.VERCEL_GIT_COMMIT_SHA,
+    process.env.NEXT_PUBLIC_BUILD_ID,
+  ) ?? `dev-${Date.now()}`;
+
 const withBundleAnalyzer = bundleAnalyzer({
   analyzerMode: process.env.BUNDLE_ANALYZE === 'json' ? 'json' : 'static',
   enabled: process.env.ANALYZE === 'true',
@@ -164,7 +182,17 @@ const config = createAppNextConfig({
 
 config.env = {
   ...(config.env ?? {}),
+  NEXT_PUBLIC_BUILD_ID: buildId,
   NEXT_PUBLIC_GENFEED_CLOUD,
+};
+
+config.generateBuildId = async () => {
+  if (!buildId.trim()) {
+    throw new Error(
+      'generateBuildId: computed buildId is empty; refusing to build.',
+    );
+  }
+  return buildId;
 };
 
 config.experimental = {

--- a/apps/app/src/components/version/DeploymentVersionWatcher.tsx
+++ b/apps/app/src/components/version/DeploymentVersionWatcher.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+type VersionResponse = {
+  buildId?: string;
+};
+
+// The build id this session was served with, inlined at build time via
+// next.config `env`. Empty in local dev without the var — then there is nothing
+// to compare and the watcher stays idle.
+const CURRENT_BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? '';
+const VERSION_ENDPOINT = '/api/version';
+const POLL_INTERVAL_MS = 60_000;
+
+async function fetchServerBuildId(
+  signal: AbortSignal,
+): Promise<string | undefined> {
+  try {
+    const response = await fetch(VERSION_ENDPOINT, {
+      cache: 'no-store',
+      signal,
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+    const data = (await response.json()) as VersionResponse;
+    return typeof data.buildId === 'string' ? data.buildId : undefined;
+  } catch {
+    // Network blips / aborts are non-fatal — just try again next tick.
+    return undefined;
+  }
+}
+
+/**
+ * Prompts the user to refresh when a newer deployment is live. Polls the
+ * deployment's own build id (plus a check on tab refocus) and compares it to the
+ * id this session loaded. On a mismatch it shows a persistent, dismissible toast
+ * with a Refresh action — never a forced reload, so an in-progress edit in the
+ * studio is never discarded. Renders nothing.
+ */
+export default function DeploymentVersionWatcher() {
+  const hasPromptedRef = useRef(false);
+
+  useEffect(() => {
+    if (!CURRENT_BUILD_ID) {
+      return;
+    }
+
+    let isActive = true;
+    const controller = new AbortController();
+
+    async function checkForUpdate() {
+      if (!isActive || hasPromptedRef.current || document.hidden) {
+        return;
+      }
+
+      const serverBuildId = await fetchServerBuildId(controller.signal);
+      if (
+        !isActive ||
+        !serverBuildId ||
+        serverBuildId === CURRENT_BUILD_ID ||
+        hasPromptedRef.current
+      ) {
+        return;
+      }
+
+      hasPromptedRef.current = true;
+      toast('A new version is available', {
+        action: {
+          label: 'Refresh',
+          onClick: () => window.location.reload(),
+        },
+        closeButton: true,
+        description: 'Refresh to load the latest updates.',
+        duration: Number.POSITIVE_INFINITY,
+      });
+    }
+
+    const handleForeground = () => {
+      void checkForUpdate();
+    };
+
+    const intervalId = window.setInterval(handleForeground, POLL_INTERVAL_MS);
+    window.addEventListener('focus', handleForeground);
+    document.addEventListener('visibilitychange', handleForeground);
+
+    // Check once shortly after mount instead of waiting a full interval.
+    void checkForUpdate();
+
+    return () => {
+      isActive = false;
+      controller.abort();
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', handleForeground);
+      document.removeEventListener('visibilitychange', handleForeground);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/desktop/app/next.config.ts
+++ b/apps/desktop/app/next.config.ts
@@ -6,8 +6,36 @@ const desktopDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(desktopDir, '../../..');
 const packagesRoot = path.join(repoRoot, 'packages');
 
+// Deterministic, empty-string-safe build id. A plain `??` chain does NOT skip
+// empty strings, and CI/packaging envs can export these vars set-but-empty. An
+// empty buildId makes Next.js embed "b":"" in RSC flight payloads, so the App
+// Router treats every navigation as a cross-deployment change and forces a full
+// hard reload. firstNonBlank skips blank/whitespace values; the dev-* fallback
+// guarantees the id is never empty so generateBuildId never returns "".
+const firstNonBlank = (
+  ...values: Array<string | undefined>
+): string | undefined => values.find((value) => value?.trim());
+
+const buildId =
+  firstNonBlank(
+    process.env.BUILD_ID,
+    process.env.VERCEL_GIT_COMMIT_SHA,
+    process.env.NEXT_PUBLIC_BUILD_ID,
+  ) ?? `dev-${Date.now()}`;
+
 const nextConfig: NextConfig = {
   assetPrefix: './',
+  env: {
+    NEXT_PUBLIC_BUILD_ID: buildId,
+  },
+  generateBuildId: async () => {
+    if (!buildId.trim()) {
+      throw new Error(
+        'generateBuildId: computed buildId is empty; refusing to build.',
+      );
+    }
+    return buildId;
+  },
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Problem

Next.js 16 only regenerates the build id when `generateBuildId` returns `null`. A `??` chain over `BUILD_ID` / `VERCEL_GIT_COMMIT_SHA` / `NEXT_PUBLIC_BUILD_ID` does **not** skip empty strings — and Vercel sets `VERCEL_GIT_COMMIT_SHA=""` on CLI deploys without git metadata. An empty buildId means:

- RSC flight payloads embed `"b":""`
- hydration stores no deployment id
- the App Router treats **every navigation as a cross-deployment change** → full hard reload on every nav
- any client-vs-server version check is silently disabled

There was no live `??` buildId chain in this repo (no `generateBuildId` existed anywhere), so this is **preventative hardening** mirroring vitae.ai #1776/#1828 — plus an env fix that closes the actual trigger for `apps/app`.

## Per-app classification

| App | Domain | Class | Deploy | Action |
|---|---|---|---|---|
| `apps/app` | studio dashboard + admin (SPA) | **(a)** | Vercel **CLI** (`vercel build`/`deploy --prebuilt`), git auto-deploy disabled | deterministic empty-string-safe buildId |
| `apps/desktop/app` | Electron studio shell (SPA) | **(a)** | local Electron bundle | deterministic empty-string-safe buildId (defensive; guarantees non-empty) |
| `apps/website` | marketing site | **(b)** | Vercel | left on Next default random buildId (can never be empty) |
| `apps/docs` | Nextra docs site | **(b)** | Vercel | left on Next default random buildId (can never be empty) |

Both category-(a) apps now compute:

```ts
const firstNonBlank = (...values: Array<string | undefined>): string | undefined =>
  values.find((value) => value?.trim());

const buildId =
  firstNonBlank(process.env.BUILD_ID, process.env.VERCEL_GIT_COMMIT_SHA, process.env.NEXT_PUBLIC_BUILD_ID)
  ?? `dev-${Date.now()}`;
```

wired via `env: { NEXT_PUBLIC_BUILD_ID: buildId }` and a `generateBuildId` that **throws** if the id is ever blank. Neither app compute a Sentry release in `next.config` (release detection is left to `withSentryConfig`), so there was no release chain to fold in.

## Env audit (step 4)

- All three `vercel.json` files have **git auto-deploy disabled** (`deploymentEnabled: false`), and `deploy-vercel-frontends.yml` deploys via `vercel build --prod` + `vercel deploy --prebuilt`. That CLI path runs **without git deployment context**, which is exactly when Vercel leaves `VERCEL_GIT_COMMIT_SHA=""` → the empty-string trigger for `apps/app`. **Structurally confirmed.**
- No in-repo file assigns any of the three vars to `""`. The actual pulled Vercel project-env values live in `.vercel/.env.production.local` (secrets, pulled at deploy time) and were **not** inspected. **To verify in the Vercel dashboard:** ensure `NEXT_PUBLIC_BUILD_ID` / `BUILD_ID` for the `app.genfeed.ai` project are either unset or non-empty (a set-but-empty value would still be skipped by `firstNonBlank`, but is worth cleaning up).
- **Fix beyond the audit:** the deploy workflow now exports `BUILD_ID=${{ github.sha }}` so production `apps/app` gets the real master commit SHA instead of the `dev-<timestamp>` fallback. `website`/`docs` don't read `BUILD_ID` (no `generateBuildId`), so they're unaffected.

## Verification

- `bunx biome check` on the three touched files: clean (also passed the staged pre-commit biome + secretlint hooks).
- No local typecheck / build / test — deferred to CI per repo policy.

## Post-deploy check

`apps/app` has no `/api/version` route (it proxies `/v1/*` to the backend), so verify the buildId directly:

```bash
# buildId must be non-empty (the deployed commit SHA, not "")
curl -s https://app.genfeed.ai/ | grep -o '"buildId":"[^"]*"'
# or the static asset path — the <id> segment must be non-empty:
curl -s https://app.genfeed.ai/ | grep -o '/_next/static/[^/]*/' | head -1
```

Then confirm window/router state **survives a sidebar navigation** (no full hard reload) between two in-app routes. Desktop: after packaging, an in-app nav must not trigger a full reload.

---

## Release freshness (idle users) — follow-up commit

The buildId fix already makes the App Router hard-reload into the new app on the **next navigation** after a deploy (Next's built-in version-skew behavior). This adds a **prompt-to-refresh** path so a user sitting idle on one page also learns about a new release:

- **`apps/app/app/api/version/route.ts`** — `GET` returns this deployment's baked `NEXT_PUBLIC_BUILD_ID`. `force-dynamic` + `Cache-Control: no-store` so a stale CDN copy can't mask a release.
- **`DeploymentVersionWatcher`** — client component mounted in the app shell. Polls `/api/version` every 60s **and on tab refocus** (`focus` + `visibilitychange`), compares to the id this session loaded, and on a mismatch shows a **persistent, dismissible sonner toast with a Refresh action**. It **never force-reloads** — safe for the content editor, an in-progress draft is never discarded. Prompts once per session; `AbortController`-cleaned.
- Mounted **Vercel studio only** (`!isDesktopShell`); desktop ships bundled with its own update path, so the watcher is skipped there (it would never fire anyway — the local standalone server always reports its own buildId).

Note: `pwa: { enabled: true }` in `apps/app` is currently a **dead option** — the shared `createAppNextConfig` factory declares `pwa` in its type but never reads it, and there's no service worker (only `manifest.ts`). Flagging separately; not changed here.

### Behavior matrix (apps/app)

| Scenario | Result |
|---|---|
| Navigate within the same release | client-side soft nav, no reload |
| Navigate after a new release | Next hard-navigates → new app loaded (built-in) |
| Idle on a page after a new release | toast: "A new version is available — Refresh" |
| Empty/blank buildId env | `generateBuildId` throws at build; never ships `"b":""` |
