### PR TITLE
fix(agent): real cancellation + diagnosable publish failures in token streaming (#1182)

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -1526,6 +1526,108 @@ describe('AgentOrchestratorService', () => {
     );
   });
 
+  it('cancels mid-stream and tears down the round when the run is cancelled during streaming', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+    configService.get.mockImplementation((key: string) =>
+      key === 'AGENT_TOKEN_STREAMING_ENABLED' ? 'true' : '',
+    );
+
+    // Not cancelled at the round boundary, but cancelled once the first delta
+    // arrives — flag flips only after streaming has begun, so it's robust to
+    // however many cancellation checks run before the stream starts.
+    let streamingStarted = false;
+    llmDispatcher.streamChatCompletionAggregated.mockImplementation(
+      async (
+        _params: unknown,
+        _organizationId: unknown,
+        onToken?: (delta: string) => Promise<void>,
+      ) => {
+        streamingStarted = true;
+        if (onToken) {
+          await onToken('Hello ');
+          await onToken('streamed');
+        }
+        return {
+          choices: [{ message: { content: 'Hello streamed' } }],
+          usage: {
+            completion_tokens: 20,
+            prompt_tokens: 20,
+            total_tokens: 40,
+          },
+        };
+      },
+    );
+    agentRunsService.isCancelled.mockImplementation(
+      async () => streamingStarted,
+    );
+
+    await service.chatStream(
+      { content: 'Stop me mid-stream', threadId: CONVERSATION_ID },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    for (let i = 0; i < 20; i++) {
+      if (
+        streamPublisher.publishWorkEvent.mock.calls.some(
+          (call) => (call[0] as { event?: string }).event === 'cancelled',
+        )
+      ) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    // Cancelled-stream handler ran...
+    expect(streamPublisher.publishWorkEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'cancelled', status: 'cancelled' }),
+    );
+    // ...the round short-circuited before emitting a final response...
+    expect(streamPublisher.publishDone).not.toHaveBeenCalled();
+    // ...and the cancel check fired before the first token was published.
+    expect(streamPublisher.publishToken).not.toHaveBeenCalled();
+  });
+
+  it('logs but swallows token-publish failures so a live stream still completes', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+    configService.get.mockImplementation((key: string) =>
+      key === 'AGENT_TOKEN_STREAMING_ENABLED' ? 'true' : '',
+    );
+    // Simulate a Redis publish outage for the duration of the stream.
+    streamPublisher.publishToken.mockRejectedValue(
+      new Error('redis unavailable'),
+    );
+
+    // loggerMock is injected as the service's logger; reach it to assert the
+    // throttled diagnostic without exposing a new outer binding.
+    const { loggerService } = service as unknown as {
+      loggerService: { warn: ReturnType<typeof vi.fn> };
+    };
+
+    await service.chatStream(
+      { content: 'Stream through a publish outage', threadId: CONVERSATION_ID },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    for (let i = 0; i < 20; i++) {
+      if (streamPublisher.publishDone.mock.calls.length > 0) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    // Publish failures were swallowed — the stream still completed...
+    expect(streamPublisher.publishDone).toHaveBeenCalled();
+    // ...but surfaced a throttled diagnostic instead of dropping silently.
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stream token publish failed'),
+      expect.objectContaining({ error: 'redis unavailable' }),
+    );
+  });
+
   it('keeps the simulated word-split path when the streaming flag is off', async () => {
     organizationsService.findOne.mockResolvedValue({
       onboardingCompleted: true,

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -362,6 +362,27 @@ export interface AgentThreadUiActionRequest {
 const MAX_PAGE_CONTEXT_FIELD_LENGTH = 4_000;
 const RESULT_SUMMARY_MAX_LENGTH = 500;
 
+// During live token streaming, cancellation cannot be checked per token
+// (isRunCancelled is a Redis lookup); throttle it to at most once per this
+// interval so a cancelled run tears down the upstream stream promptly without
+// a lookup on every delta.
+const STREAM_CANCEL_CHECK_INTERVAL_MS = 750;
+// Per-token publish failures are swallowed to avoid aborting a live stream on a
+// transient Redis hiccup, but a sustained outage should be diagnosable — log at
+// most once per this interval per turn instead of once per dropped token.
+const STREAM_PUBLISH_LOG_INTERVAL_MS = 5_000;
+
+// Thrown from the streaming onToken callback when the run has been cancelled.
+// It unwinds the provider's for-await loop (tearing down the upstream HTTP/SDK
+// stream) and is caught at the dispatch site, which routes it to the
+// cancelled-stream handler rather than treating it as a generation error.
+class StreamCancelledError extends Error {
+  constructor() {
+    super('agent stream cancelled');
+    this.name = 'StreamCancelledError';
+  }
+}
+
 function clampPageContextField(value?: string): string | null {
   const normalized = value?.replace(/\s+/g, ' ').trim();
 
@@ -1590,26 +1611,86 @@ export class AgentOrchestratorService {
         // Real deltas published live during this round; drives whether the
         // final branch re-simulates word-split streaming or not.
         let roundStreamedTokenCount = 0;
-        const response = canStreamLiveTokens
-          ? await this.llmDispatcher.streamChatCompletionAggregated(
-              chatParams,
-              context.organizationId,
-              async (delta: string) => {
-                roundStreamedTokenCount++;
-                await runEffectPromise(
-                  this.publishStreamTokenEffect({
-                    runId: context.runId,
-                    threadId,
-                    token: delta,
-                    userId: context.userId,
-                  }).pipe(Effect.catchAll(() => Effect.void)),
+        let lastCancelCheckAt = 0;
+        let lastPublishErrorLoggedAt = 0;
+
+        const onStreamToken = async (delta: string): Promise<void> => {
+          roundStreamedTokenCount++;
+
+          // Throttled cancellation check — unwinds the provider stream (and its
+          // upstream connection) instead of burning the whole generation after
+          // the user has already stopped the run.
+          const now = Date.now();
+          if (now - lastCancelCheckAt >= STREAM_CANCEL_CHECK_INTERVAL_MS) {
+            lastCancelCheckAt = now;
+            if (await this.isRunCancelled(context)) {
+              throw new StreamCancelledError();
+            }
+          }
+
+          await runEffectPromise(
+            this.publishStreamTokenEffect({
+              runId: context.runId,
+              threadId,
+              token: delta,
+              userId: context.userId,
+            }).pipe(
+              // Keep swallowing publish failures (a transient Redis hiccup must
+              // not abort a live stream) but surface a throttled log so a
+              // sustained outage is diagnosable rather than silent.
+              Effect.tapError((error) =>
+                Effect.sync(() => {
+                  const errorAt = Date.now();
+                  if (
+                    errorAt - lastPublishErrorLoggedAt >=
+                    STREAM_PUBLISH_LOG_INTERVAL_MS
+                  ) {
+                    lastPublishErrorLoggedAt = errorAt;
+                    this.loggerService.warn(
+                      `${this.constructorName} stream token publish failed (throttled)`,
+                      {
+                        error:
+                          error instanceof Error
+                            ? error.message
+                            : String(error),
+                        threadId,
+                      },
+                    );
+                  }
+                }),
+              ),
+              Effect.catchAll(() => Effect.void),
+            ),
+          );
+        };
+
+        // IIFE so a mid-stream cancellation (StreamCancelledError thrown from
+        // onStreamToken) is caught here and routed to the cancelled-stream
+        // handler; any other error still propagates as a real failure.
+        const response = await (async () => {
+          try {
+            return canStreamLiveTokens
+              ? await this.llmDispatcher.streamChatCompletionAggregated(
+                  chatParams,
+                  context.organizationId,
+                  onStreamToken,
+                )
+              : await this.llmDispatcher.chatCompletion(
+                  chatParams,
+                  context.organizationId,
                 );
-              },
-            )
-          : await this.llmDispatcher.chatCompletion(
-              chatParams,
-              context.organizationId,
-            );
+          } catch (error) {
+            if (error instanceof StreamCancelledError) {
+              return null;
+            }
+            throw error;
+          }
+        })();
+
+        if (!response) {
+          await this.handleCancelledStream(context, threadId);
+          return;
+        }
         const actualModel = await this.recordAgentResponseModel({
           actualModels: Array.from(actualModels),
           context,


### PR DESCRIPTION
## What

The two non-blocking follow-ups from the #1198 review, both scoped inside the existing `AGENT_TOKEN_STREAMING_ENABLED` (default-off) path — so no behavior change for anyone until the flag is flipped.

### 1. Per-token cancellation
Cancellation was only checked at round boundaries (`:1575`, `:1634`), never *during* a stream — so a run stopped mid-generation burned the entire LLM response server-side. Now a **throttled** `isRunCancelled` check (≤ once / 750ms, since it's a Redis lookup) runs inside the token callback and throws `StreamCancelledError`, which unwinds the provider's `for await` loop (tearing down the upstream HTTP/SDK stream) and is caught at the dispatch site and routed to `handleCancelledStream` — not treated as a generation error.

### 2. Diagnosable publish failures
Per-token publish failures were swallowed silently (`Effect.catchAll(() => Effect.void)`). Still swallowed (a transient Redis hiccup must not abort a live stream) but now a **throttled** `warn` (≤ once / 5s / turn) fires via `Effect.tapError`, so a sustained outage is diagnosable instead of invisible.

## Tests (added, all green locally — 41/41 in the orchestrator spec)
- **cancel mid-stream** → routes to the cancelled-stream handler (`publishWorkEvent event:'cancelled'`), short-circuits before the final response, no token published.
- **publish outage** → logged once (throttled), but the stream still completes (`publishDone` fires).

## Verification
Ran `vitest` on `agent-orchestrator.service.spec.ts` locally: **41 passed**. Biome clean. CI covers type-check.

Refs #1182, #1198.