### PR TITLE
test(api): fix feature-flag guard 404 assertion blocking v0.4.4 deploy

### DIFF
--- a/apps/server/api/src/feature-flag/feature-flag.guard.spec.ts
+++ b/apps/server/api/src/feature-flag/feature-flag.guard.spec.ts
@@ -67,8 +67,9 @@ describe('FeatureFlagGuard', () => {
       featureFlagService as never,
     );
 
+    // Canonical 404 shape (#1147): NotFoundException('Route') → "Route not found".
     expect(() => guard.canActivate(createContext() as never)).toThrowError(
-      'Not Found',
+      'Route not found',
     );
   });
 


### PR DESCRIPTION
## Why (v0.4.4 deploy blocker)

After the ioredis `setex` fixes (#1210), the re-deploy's QA gate failed on **Test API shard 1**: `feature-flag.guard.spec.ts` asserted the error message `'Not Found'`, but #1147 (one canonical 404 shape) makes `NotFoundException('Route')` produce `'Route not found'`. Latent — heavy tests only run at release-cut.

## Fix
Assert the canonical message `'Route not found'`. Test-only.

## Verification
Ran the **full `apps/server/api` suite locally** against origin/master + this fix: **9417 passed, 1 skipped, 0 failed.** So this was the only remaining latent API failure; nothing else hiding. Server-service tests already green after #1210.

Once merged → re-cut v0.4.4 (same version) → re-deploy.

Refs #1147.