### PR TITLE
fix(prisma): split CONCURRENTLY builds from dedup preflight (unblocks v0.4.4 migrate)

### DIFF
--- a/packages/prisma/prisma/hot-path-indexes.test.ts
+++ b/packages/prisma/prisma/hot-path-indexes.test.ts
@@ -53,6 +53,17 @@ describe('app shell hot-path Prisma indexes', () => {
 // regression fails CI. Partial (Stripe) indexes are raw-SQL-only and the
 // post_analytics one is Prisma's default `@@unique` name, so we assert against
 // the migration SQL rather than schema.prisma.
+const dedupePreflightMigration =
+  'migrations/20260703120050_preflight_hot_table_unique_dedupe/migration.sql';
+
+// Strip `--` comment lines so structural checks inspect executable SQL only —
+// the migration comments legitimately mention `DO $$` and `CONCURRENTLY`.
+const stripSqlComments = (sql: string): string =>
+  sql
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('--'))
+    .join('\n');
+
 const concurrentUniqueIndexMigrations = [
   {
     file: 'migrations/20260703120100_add_post_analytics_daily_unique/migration.sql',
@@ -86,11 +97,32 @@ describe('hot-path unique indexes build CONCURRENTLY (#1185/#1194)', () => {
           new RegExp(`CREATE UNIQUE INDEX (IF NOT EXISTS )?"${indexName}"`),
         );
       });
-    });
 
-    it(`${file} keeps its dedup preflight guard`, () => {
-      // Do NOT weaken the pre-existing-duplicate safety when fixing locking.
-      expect(source).toContain('RAISE EXCEPTION');
+      // A CONCURRENTLY build cannot share a file with a `DO $$ … $$` block:
+      // Prisma wraps a mixed-statement migration in a transaction and
+      // CONCURRENTLY cannot run inside one. Guard against reintroducing it.
+      it('carries no in-file transaction block that would break CONCURRENTLY', () => {
+        expect(stripSqlComments(source)).not.toContain('DO $$');
+      });
     });
   }
+
+  // The pre-existing-duplicate safety is NOT weakened — it lives in a dedicated,
+  // transaction-safe preflight migration that runs before the index builds.
+  it('keeps the dedup preflight guard in its own migration', () => {
+    const preflight = readFileSync(
+      join(prismaDir, dedupePreflightMigration),
+      'utf8',
+    );
+    const preflightSql = stripSqlComments(preflight);
+    // Preflight must be transaction-safe (no CONCURRENTLY) and cover all three
+    // hot tables with an aborting duplicate check.
+    expect(preflightSql).not.toContain('CONCURRENTLY');
+    for (const table of ['post_analytics', 'customers', 'subscriptions']) {
+      expect(preflightSql).toContain(`FROM "${table}"`);
+    }
+    expect(
+      (preflightSql.match(/RAISE EXCEPTION/g) ?? []).length,
+    ).toBeGreaterThanOrEqual(3);
+  });
 });

--- a/packages/prisma/prisma/migrations/20260703120050_preflight_hot_table_unique_dedupe/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120050_preflight_hot_table_unique_dedupe/migration.sql
@@ -1,0 +1,75 @@
+-- Pre-flight duplicate guard for the hot-table UNIQUE indexes built CONCURRENTLY
+-- in the next two migrations (post_analytics daily key; live Stripe
+-- customer/subscription ids). #1185, epic #1176.
+--
+-- Why this is its own migration
+-- -----------------------------
+-- A `CREATE INDEX CONCURRENTLY` statement cannot share a migration file with a
+-- `DO $$ … $$` block: Prisma wraps a mixed-statement migration in an implicit
+-- transaction, and CONCURRENTLY cannot run inside one — the index build then
+-- fails at deploy time with "CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction block" (observed in release-gate E2E). A DO-block-only migration
+-- is transaction-safe, so the dedup guard runs HERE and the following two
+-- migrations contain ONLY bare CONCURRENTLY builds (matching the proven
+-- precedent 20260618130000_add_app_shell_hot_path_indexes). See prisma/prisma#14456.
+--
+-- Each check only reads (SELECT COUNT). If a live duplicate exists it RAISEs and
+-- aborts the deploy BEFORE any index is built, surfacing the pre-existing bug for
+-- a reviewed manual dedupe/merge rather than leaving an INVALID index behind. On
+-- databases where the unique index already exists there can be no duplicates, so
+-- these are no-ops.
+
+-- post_analytics: one snapshot per (postId, platform, date). No soft-delete column.
+DO $$
+DECLARE
+  dup_count integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT 1
+    FROM "post_analytics"
+    GROUP BY "postId", "platform", "date"
+    HAVING COUNT(*) > 1
+  ) AS dupes;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Migration aborted (#1185): % duplicate (postId, platform, date) group(s) in post_analytics. Dedupe these before applying the unique constraint.', dup_count;
+  END IF;
+END$$;
+
+-- customers: one live row per stripeCustomerId (isDeleted = false, non-null id).
+DO $$
+DECLARE
+  dup_count integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT 1
+    FROM "customers"
+    WHERE "stripeCustomerId" IS NOT NULL
+      AND "isDeleted" = false
+    GROUP BY "stripeCustomerId"
+    HAVING COUNT(*) > 1
+  ) AS dupes;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Migration aborted (#1185): % live duplicate stripeCustomerId group(s) in customers. Merge them before applying the unique index.', dup_count;
+  END IF;
+END$$;
+
+-- subscriptions: one live row per stripeSubscriptionId (isDeleted = false, non-null id).
+DO $$
+DECLARE
+  dup_count integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT 1
+    FROM "subscriptions"
+    WHERE "stripeSubscriptionId" IS NOT NULL
+      AND "isDeleted" = false
+    GROUP BY "stripeSubscriptionId"
+    HAVING COUNT(*) > 1
+  ) AS dupes;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Migration aborted (#1185): % live duplicate stripeSubscriptionId group(s) in subscriptions. Merge them before applying the unique index.', dup_count;
+  END IF;
+END$$;

--- a/packages/prisma/prisma/migrations/20260703120100_add_post_analytics_daily_unique/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120100_add_post_analytics_daily_unique/migration.sql
@@ -1,65 +1,24 @@
 -- Enforce one analytics snapshot per (post, platform, day) on `post_analytics`
--- (#1185, epic #1176).
---
--- Why this is a natural key
--- -------------------------
--- `PostAnalyticsService.upsertTodaysAnalytics` / `updateFromMetrics` already
--- upsert on `where: { postId_platform_date: { postId, platform, date } }` and
--- catch a P2002 to serialize concurrent writers — but the constraint was only
--- ever expressed in application code (with an `as never` cast) and never existed
--- in the schema or a migration: classic drift. Without the DB constraint the
--- upsert's `where` is not a valid unique locator and the P2002 catch can never
--- fire. This aligns the DB with the code's assumption and mirrors the existing
--- `ArticleAnalytics @@unique([articleId, date])`. `date` is normalized to
--- local-server midnight by the writer (`new Date()` then `.setHours(0, 0, 0, 0)`
--- in `PostAnalyticsService`), so for a fixed server timezone the tuple is a true
--- per-day natural key.
---
--- Built CONCURRENTLY: locking
--- ---------------------------
--- `post_analytics` is a hot, continuously-written table — every metrics refresh
--- upserts today's row. A plain `CREATE UNIQUE INDEX` takes an ACCESS EXCLUSIVE
--- lock for the whole build and would stall live analytics ingestion, so the
--- index is built CONCURRENTLY: concurrent reads and writes keep running while it
--- builds. CONCURRENTLY cannot run inside a transaction block; Prisma 7.8.0+
--- executes each migration statement without wrapping the migration in a
--- transaction (including shadow-database replay during `migrate dev`), so the
--- preflight `DO` block and the index build below run as two separate,
--- autocommitted statements. See prisma/prisma#14456 and the 7.8.0 release notes.
---
--- Safety against existing duplicates
--- ----------------------------------
--- `post_analytics` has NO soft-delete column, so duplicates cannot be collapsed
--- by soft-deleting losers, and silently hard-deleting analytics rows would be
--- data loss. Instead the preflight below aborts loudly if any duplicate group
--- exists: it is its own statement and only reads (SELECT COUNT), so the RAISE
--- fails the migration before the index build is ever attempted and leaves the
--- data untouched for a reviewed manual dedupe before re-apply. On production the
--- unique index is expected to already exist (the app has been running against
--- it), so `IF NOT EXISTS` makes this a no-op there and a real create only on
--- databases that lack it.
---
--- NOTE: a CONCURRENTLY build that fails midway leaves an INVALID index of the
--- same name and marks this migration failed. Because of `IF NOT EXISTS` a blind
--- re-run would skip rebuilding it — DROP the invalid index, then
--- `prisma migrate resolve` + re-deploy. Do not blindly re-run.
-DO $$
-DECLARE
-  dup_count integer;
-BEGIN
-  SELECT COUNT(*) INTO dup_count FROM (
-    SELECT 1
-    FROM "post_analytics"
-    GROUP BY "postId", "platform", "date"
-    HAVING COUNT(*) > 1
-  ) AS dupes;
-
-  IF dup_count > 0 THEN
-    RAISE EXCEPTION 'Migration aborted (#1185): % duplicate (postId, platform, date) group(s) in post_analytics. Dedupe these before applying the unique constraint.', dup_count;
-  END IF;
-END$$;
-
+-- (#1185, epic #1176). Mirrors the existing `ArticleAnalytics @@unique([articleId, date])`.
 -- Name MUST match Prisma's default for `@@unique([postId, platform, date])` on
--- `@@map("post_analytics")` so the schema and database stay drift-free.
+-- `@@map("post_analytics")` so schema and database stay drift-free.
+--
+-- Built CONCURRENTLY: `post_analytics` is a hot, continuously-written table, so a
+-- plain `CREATE UNIQUE INDEX` would take an ACCESS EXCLUSIVE lock for the whole
+-- build and stall live ingestion. CONCURRENTLY keeps reads/writes running.
+--
+-- CONCURRENTLY must run OUTSIDE a transaction block. Prisma runs a migration's
+-- statements without a wrapping transaction ONLY when the file contains just
+-- CONCURRENTLY index builds — an earlier `DO $$ … $$` dedup preflight in this
+-- file made Prisma wrap the whole migration in an implicit transaction, so the
+-- index build failed with "CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction block". This file therefore contains ONLY the bare CONCURRENTLY
+-- index, matching the proven precedent
+-- 20260618130000_add_app_shell_hot_path_indexes. See prisma/prisma#14456.
+--
+-- `IF NOT EXISTS` makes this a no-op where the index already exists (prod, where
+-- the app has run against this natural key). If duplicates exist on a populated
+-- DB the CONCURRENTLY build fails and leaves an INVALID index of the same name —
+-- DROP it, dedupe, then `prisma migrate resolve` + re-deploy. Do not blindly re-run.
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "post_analytics_postId_platform_date_key"
   ON "post_analytics" ("postId", "platform", "date");

--- a/packages/prisma/prisma/migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql
+++ b/packages/prisma/prisma/migrations/20260703120200_add_billing_stripe_live_uniques/migration.sql
@@ -1,92 +1,32 @@
 -- Enforce one LIVE local record per Stripe identity (#1185, epic #1176).
+-- Partial unique indexes on `customers.stripeCustomerId` and
+-- `subscriptions.stripeSubscriptionId`, scoped to `isDeleted = false` and non-null
+-- ids so soft-deleted history / not-yet-provisioned rows never block a legitimate
+-- resubscribe/relink. Partial predicates can't be expressed as `@@unique`, so
+-- these live in raw SQL only (like the #892 default-recurring-workflow index) —
+-- there is deliberately no schema.prisma counterpart.
 --
--- Why these are natural keys
--- --------------------------
--- Stripe customer ids (`cus_…`) and subscription ids (`sub_…`) are globally
--- unique and never reused by Stripe. The billing webhook resolves a SINGLE local
--- row by them — `CustomersService.findByStripeCustomerId` (findFirst) and
--- `subscriptionsService.findOne({ stripeSubscriptionId })` — so two live rows
--- sharing one Stripe id is a latent data-integrity bug (double-processed
--- webhook, re-link race). The app already assumes at-most-one; this makes the
--- database guarantee it.
+-- Built CONCURRENTLY: `customers` and `subscriptions` are hot billing tables
+-- written by every Stripe webhook, so a plain `CREATE UNIQUE INDEX` would take an
+-- ACCESS EXCLUSIVE lock for the whole build and stall webhook processing.
+-- CONCURRENTLY keeps reads/writes running.
 --
--- Scope: live rows only
--- ---------------------
--- Uniqueness is scoped to `isDeleted = false` and non-null ids. Soft-deleted
--- history and not-yet-provisioned rows (null id) are intentionally excluded so a
--- legitimate resubscribe/relink after a soft delete cannot be blocked. Because
--- the predicate carries a WHERE clause, these are PARTIAL unique indexes, which
--- Prisma cannot represent as `@@unique` and ignores during introspection — so
--- they live in raw SQL only, exactly like the #892 default-recurring-workflow
--- partial unique index. There is deliberately no schema.prisma counterpart.
+-- CONCURRENTLY must run OUTSIDE a transaction block. Prisma runs a migration's
+-- statements without a wrapping transaction ONLY when the file contains just
+-- CONCURRENTLY index builds — the earlier `DO $$ … $$` dedup preflights in this
+-- file made Prisma wrap the whole migration in an implicit transaction, so the
+-- builds failed with "CREATE INDEX CONCURRENTLY cannot run inside a transaction
+-- block". This file therefore contains ONLY the bare CONCURRENTLY indexes,
+-- matching the proven precedent 20260618130000_add_app_shell_hot_path_indexes.
+-- See prisma/prisma#14456.
 --
--- Built CONCURRENTLY: locking
--- ---------------------------
--- `customers` and `subscriptions` are hot, continuously-written billing tables
--- (every Stripe webhook upserts against them). A plain `CREATE UNIQUE INDEX`
--- takes an ACCESS EXCLUSIVE lock for the whole build and would stall live
--- webhook processing, so each index is built CONCURRENTLY — reads and writes
--- keep running throughout. CONCURRENTLY cannot run inside a transaction block;
--- Prisma 7.8.0+ executes each migration statement without wrapping the migration
--- in a transaction (including shadow-database replay during `migrate dev`), so
--- each preflight `DO` block and its `CREATE UNIQUE INDEX CONCURRENTLY` run as
--- separate, autocommitted statements. See prisma/prisma#14456 and the 7.8.0
--- release notes.
---
--- Safety against existing duplicates
--- ----------------------------------
--- Each index is preceded by a preflight (its own statement) that aborts the
--- migration if a live duplicate already exists. The preflight only reads
--- (SELECT COUNT), so its RAISE fails the migration before that index is built,
--- surfacing the pre-existing bug for a reviewed manual merge rather than failing
--- mid-build or corrupting data.
---
--- NOTE: a CONCURRENTLY build that fails midway leaves an INVALID index of the
--- same name and marks this migration failed. Because of `IF NOT EXISTS` a blind
--- re-run would skip rebuilding it — DROP the invalid index, then
+-- `IF NOT EXISTS` makes these no-ops where the index already exists (prod). If
+-- live duplicates exist on a populated DB the CONCURRENTLY build fails and leaves
+-- an INVALID index of the same name — DROP it, merge the duplicates, then
 -- `prisma migrate resolve` + re-deploy. Do not blindly re-run.
-
--- ── customers.stripeCustomerId ──────────────────────────────────────────────
-DO $$
-DECLARE
-  dup_count integer;
-BEGIN
-  SELECT COUNT(*) INTO dup_count FROM (
-    SELECT 1
-    FROM "customers"
-    WHERE "stripeCustomerId" IS NOT NULL
-      AND "isDeleted" = false
-    GROUP BY "stripeCustomerId"
-    HAVING COUNT(*) > 1
-  ) AS dupes;
-
-  IF dup_count > 0 THEN
-    RAISE EXCEPTION 'Migration aborted (#1185): % live duplicate stripeCustomerId group(s) in customers. Merge them before applying the unique index.', dup_count;
-  END IF;
-END$$;
-
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "customers_stripeCustomerId_live_key"
   ON "customers" ("stripeCustomerId")
   WHERE "stripeCustomerId" IS NOT NULL AND "isDeleted" = false;
-
--- ── subscriptions.stripeSubscriptionId ──────────────────────────────────────
-DO $$
-DECLARE
-  dup_count integer;
-BEGIN
-  SELECT COUNT(*) INTO dup_count FROM (
-    SELECT 1
-    FROM "subscriptions"
-    WHERE "stripeSubscriptionId" IS NOT NULL
-      AND "isDeleted" = false
-    GROUP BY "stripeSubscriptionId"
-    HAVING COUNT(*) > 1
-  ) AS dupes;
-
-  IF dup_count > 0 THEN
-    RAISE EXCEPTION 'Migration aborted (#1185): % live duplicate stripeSubscriptionId group(s) in subscriptions. Merge them before applying the unique index.', dup_count;
-  END IF;
-END$$;
 
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "subscriptions_stripeSubscriptionId_live_key"
   ON "subscriptions" ("stripeSubscriptionId")


### PR DESCRIPTION
## Why (v0.4.4 deploy blocker — the migration itself)

The v0.4.4 release-gate **E2E** failed applying the #1194/#1205 migrations:

```
Error: P3018 — A migration failed to apply
ERROR: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

## Root cause
#1205 kept a `DO $$ … $$` dedup preflight in the **same file** as the `CREATE UNIQUE INDEX CONCURRENTLY` builds. Prisma wraps a mixed-statement migration in an implicit transaction, and `CONCURRENTLY` forbids that. The proven precedent `20260618130000_add_app_shell_hot_path_indexes` applies fine precisely because it contains **only** bare CONCURRENTLY statements.

## Fix (root-cause; safety preserved, not weakened)
- **New `20260703120050_preflight_hot_table_unique_dedupe`** holds all three DO dedup checks (post_analytics, customers, subscriptions). DO blocks are transaction-safe, so it runs first and aborts before any index build if live duplicates exist.
- **`120100` / `120200`** now carry **only** the bare `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` builds — structurally identical to the working precedent, so they apply outside a transaction.
- **Guardrail updated** (`hot-path-indexes.test.ts`): index files must build CONCURRENTLY **and** contain no in-file transaction block; the dedup guard is now asserted against the preflight migration (≥3 `RAISE EXCEPTION`, no CONCURRENTLY). Duplicate safety is relocated, not removed.

## Verification
- Guardrail test **22/22**, `prisma validate` clean.
- Docker unavailable locally, so the actual apply is verified by the release-gate E2E on deploy (fast PR CI doesn't run it).

Once merged → re-cut v0.4.4 → re-deploy; the E2E confirms the migration applies.

Refs #1194, #1205, #1185.