### PR TITLE
fix(test): e2e factories emit id not _id so seeded org FK resolves

### DIFF
--- a/apps/server/api/test/e2e/e2e-test.utils.ts
+++ b/apps/server/api/test/e2e/e2e-test.utils.ts
@@ -217,7 +217,7 @@ export const createE2ETestApp = async (
 export const createTestOrganization = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   category: 'business',
   createdAt: new Date(),
   isDeleted: false,
@@ -457,7 +457,7 @@ export const createTestOrganizationSetting = (
 export const createTestIntegration = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   config: { allowedUserIds: [], defaultWorkflow: 'wf-test' },
   createdAt: new Date(),
   encryptedToken: 'encrypted:test-bot-token',

--- a/apps/server/api/test/e2e/integrations.e2e-spec.ts
+++ b/apps/server/api/test/e2e/integrations.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('Integrations E2E Tests', () => {
     await dbHelper.clearDatabase();
 
     testOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Integration Test Org',
     });
 


### PR DESCRIPTION
## Problem

The production deploy run [28658193934](https://github.com/genfeedai/genfeed.ai/actions/runs/28658193934) failed at the **QA before deploy / API E2E Tests** gate:

- `PrismaClientValidationError: Argument \`organization\` is missing` when seeding `OrgIntegration` (TELEGRAM).
- POST `/organizations/:id/integrations` returned 500.

## Root cause

The e2e test factories `createTestOrganization` / `createTestIntegration` returned an `_id` field, but **every spec consumer reads `.id`** (`orgPath()`, `organization:` overrides, `/:id` in PATCH/DELETE). No spec anywhere reads `._id`.

Result: `testOrganization.id` was `undefined`, so:
- The seeded `OrgIntegration` got `organizationId: undefined` — a **required** relation → validation error.
- Requests hit `/v1/organizations/undefined/integrations` → 500.

Only `integrations.e2e-spec.ts` runs in the CI e2e gate (`test:e2e:ci`), so it was the sole surface of a latent, repo-wide factory mismatch.

## Fix

Emit `id` directly from the two factories used by the gate and align the one `_id` override in the spec. `normalizeDocument`'s `_id → id` rename stays as a safety net for the remaining factories.

## Verification

- Focused change to test fixtures only; no runtime code touched.
- CI API E2E gate re-runs on this PR.