### PR TITLE
fix(api): complete _id→id rename in e2e test factories (unblocks API E2E gate)

### DIFF
--- a/apps/server/api/test/e2e/auth.e2e-spec.ts
+++ b/apps/server/api/test/e2e/auth.e2e-spec.ts
@@ -67,14 +67,14 @@ describe('Authentication E2E Tests', () => {
 
     // Create test user
     testUser = createTestUser({
-      _id: generateIdString(),
+      id: generateIdString(),
       authProviderId: 'authProvider_test_user_123',
       email: 'auth-test@example.com',
     });
 
     // Create test organization
     testOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Auth Test Organization',
       user: testUser.id,
     });
@@ -158,7 +158,7 @@ describe('Authentication E2E Tests', () => {
   describe('Multi-Organization Access', () => {
     it('should create multiple organizations for same user', async () => {
       const secondOrg = createTestOrganization({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Second Organization',
         user: testUser.id,
       });
@@ -181,7 +181,7 @@ describe('Authentication E2E Tests', () => {
 
     it('should verify user can be member of different organizations with different roles', async () => {
       const anotherUser = createTestUser({
-        _id: generateIdString(),
+        id: generateIdString(),
         authProviderId: 'authProvider_another_user',
         email: 'another@example.com',
       });

--- a/apps/server/api/test/e2e/brands.e2e-spec.ts
+++ b/apps/server/api/test/e2e/brands.e2e-spec.ts
@@ -88,21 +88,21 @@ describe('Brands E2E Tests', () => {
 
     // Create test user
     testUser = createTestUser({
-      _id: generateIdString(),
+      id: generateIdString(),
       authProviderId: 'authProvider_brand_test_user',
       email: 'brand-test@example.com',
     });
 
     // Create test organization
     testOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Brand Test Organization',
       user: testUser.id,
     });
 
     // Create test member (owner)
     testMember = createTestMember({
-      _id: generateIdString(),
+      id: generateIdString(),
       organization: testOrganization.id,
       role: 'owner',
       user: testUser.id,
@@ -110,7 +110,7 @@ describe('Brands E2E Tests', () => {
 
     // Create test brand
     testBrand = createTestBrand({
-      _id: generateIdString(),
+      id: generateIdString(),
       description: 'A test brand for E2E testing',
       label: 'Test Brand',
       organization: testOrganization.id,
@@ -125,13 +125,13 @@ describe('Brands E2E Tests', () => {
     await dbHelper.seedCollection('brands', [testBrand]);
     await dbHelper.seedCollection('organization-settings', [
       createTestOrganizationSetting({
-        _id: generateIdString(),
+        id: generateIdString(),
         organization: testOrganization.id,
       }),
     ]);
     await dbHelper.seedCollection('credit-balances', [
       createTestCredit({
-        _id: generateIdString(),
+        id: generateIdString(),
         balance: 50000,
         organization: testOrganization.id,
       }),
@@ -154,14 +154,14 @@ describe('Brands E2E Tests', () => {
       // Add more brands for testing
       const additionalBrands = [
         createTestBrand({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Alpha Brand',
           organization: testOrganization.id,
           slug: `brand-alpha-${Date.now()}`,
           user: testUser.id,
         }),
         createTestBrand({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Beta Brand',
           organization: testOrganization.id,
           slug: `brand-beta-${Date.now()}`,
@@ -212,7 +212,7 @@ describe('Brands E2E Tests', () => {
     it('should filter out deleted brands by default', async () => {
       // Create a deleted brand
       const deletedBrand = createTestBrand({
-        _id: generateIdString(),
+        id: generateIdString(),
         isDeleted: true,
         label: 'Deleted Brand',
         organization: testOrganization.id,
@@ -309,7 +309,7 @@ describe('Brands E2E Tests', () => {
     it('should return brand with populated assets', async () => {
       // Create logo asset
       const logoAsset = createTestAsset({
-        _id: generateIdString(),
+        id: generateIdString(),
         category: 'image',
         organization: testOrganization.id,
         type: 'logo',
@@ -584,7 +584,7 @@ describe('Brands E2E Tests', () => {
     it('should not affect other brands when deleting', async () => {
       // Create another brand
       const anotherBrand = createTestBrand({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Another Brand',
         organization: testOrganization.id,
         slug: `another-brand-${Date.now()}`,
@@ -610,7 +610,7 @@ describe('Brands E2E Tests', () => {
       // Create credentials for the brand
       const credentials = [
         createTestCredential({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           externalHandle: '@testchannel',
           isConnected: true,
@@ -619,7 +619,7 @@ describe('Brands E2E Tests', () => {
           user: testUser.id,
         }),
         createTestCredential({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           externalHandle: '@testtiktok',
           isConnected: true,
@@ -651,26 +651,26 @@ describe('Brands E2E Tests', () => {
     beforeEach(async () => {
       // Create another organization with a brand
       otherUser = createTestUser({
-        _id: generateIdString(),
+        id: generateIdString(),
         authProviderId: 'authProvider_other_brand_user',
         email: 'other-brand@example.com',
       });
 
       otherOrganization = createTestOrganization({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Other Organization',
         user: otherUser.id,
       });
 
       const otherMember = createTestMember({
-        _id: generateIdString(),
+        id: generateIdString(),
         organization: otherOrganization.id,
         role: 'owner',
         user: otherUser.id,
       });
 
       otherBrand = createTestBrand({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Other Org Brand',
         organization: otherOrganization.id,
         slug: `other-org-brand-${Date.now()}`,
@@ -683,7 +683,7 @@ describe('Brands E2E Tests', () => {
       await dbHelper.seedCollection('brands', [otherBrand]);
       await dbHelper.seedCollection('organization-settings', [
         createTestOrganizationSetting({
-          _id: generateIdString(),
+          id: generateIdString(),
           organization: otherOrganization.id,
         }),
       ]);
@@ -745,7 +745,7 @@ describe('Brands E2E Tests', () => {
       // Create brands with searchable names
       const searchableBrands = [
         createTestBrand({
-          _id: generateIdString(),
+          id: generateIdString(),
           description: 'A technology focused startup',
           label: 'Tech Startup Brand',
           organization: testOrganization.id,
@@ -753,7 +753,7 @@ describe('Brands E2E Tests', () => {
           user: testUser.id,
         }),
         createTestBrand({
-          _id: generateIdString(),
+          id: generateIdString(),
           description: 'A food and beverage company',
           label: 'Food Company Brand',
           organization: testOrganization.id,

--- a/apps/server/api/test/e2e/e2e-test.utils.ts
+++ b/apps/server/api/test/e2e/e2e-test.utils.ts
@@ -217,7 +217,7 @@ export const createE2ETestApp = async (
 export const createTestOrganization = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   category: 'business',
   createdAt: new Date(),
   isDeleted: false,
@@ -232,7 +232,7 @@ export const createTestOrganization = (
  * Create test brand data
  */
 export const createTestBrand = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   backgroundColor: 'transparent',
   createdAt: new Date(),
   description: 'Test brand description',
@@ -256,7 +256,7 @@ export const createTestBrand = (overrides: Record<string, unknown> = {}) => ({
  * Create test user data
  */
 export const createTestUser = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   authProviderId: `authProvider_${generateIdString()}`,
   createdAt: new Date(),
   email: `test-${Date.now()}@example.com`,
@@ -273,7 +273,7 @@ export const createTestUser = (overrides: Record<string, unknown> = {}) => ({
  * Create test member data
  */
 export const createTestMember = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   createdAt: new Date(),
   isActive: true,
   isDeleted: false,
@@ -290,7 +290,7 @@ export const createTestMember = (overrides: Record<string, unknown> = {}) => ({
 export const createTestCredential = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   accessToken: 'mock-access-token',
   brand: generateIdString(),
   createdAt: new Date(),
@@ -311,7 +311,7 @@ export const createTestCredential = (
  * Create test video data
  */
 export const createTestVideo = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   brand: generateIdString(),
   createdAt: new Date(),
   description: 'Test video description',
@@ -331,7 +331,7 @@ export const createTestVideo = (overrides: Record<string, unknown> = {}) => ({
  * Create test post data
  */
 export const createTestPost = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   brand: generateIdString(),
   caption: 'Test post caption',
   createdAt: new Date(),
@@ -353,7 +353,7 @@ export const createTestPost = (overrides: Record<string, unknown> = {}) => ({
 export const createTestIngredient = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   brand: generateIdString(),
   category: 'video',
   createdAt: new Date(),
@@ -372,7 +372,7 @@ export const createTestIngredient = (
  * Create test tag data
  */
 export const createTestTag = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   color: '#FF0000',
   createdAt: new Date(),
   isDeleted: false,
@@ -387,7 +387,7 @@ export const createTestTag = (overrides: Record<string, unknown> = {}) => ({
  * Create test asset data
  */
 export const createTestAsset = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   category: 'image',
   createdAt: new Date(),
   isDeleted: false,
@@ -403,7 +403,7 @@ export const createTestAsset = (overrides: Record<string, unknown> = {}) => ({
  * Create test credit data
  */
 export const createTestCredit = (overrides: Record<string, unknown> = {}) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   balance: 10000,
   createdAt: new Date(),
   isDeleted: false,
@@ -418,7 +418,7 @@ export const createTestCredit = (overrides: Record<string, unknown> = {}) => ({
 export const createTestOrganizationSetting = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   brandsLimit: 10,
   createdAt: new Date(),
   enabledModels: [],
@@ -457,7 +457,7 @@ export const createTestOrganizationSetting = (
 export const createTestIntegration = (
   overrides: Record<string, unknown> = {},
 ) => ({
-  _id: generateIdString(),
+  id: generateIdString(),
   config: { allowedUserIds: [], defaultWorkflow: 'wf-test' },
   createdAt: new Date(),
   encryptedToken: 'encrypted:test-bot-token',

--- a/apps/server/api/test/e2e/integrations.e2e-spec.ts
+++ b/apps/server/api/test/e2e/integrations.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('Integrations E2E Tests', () => {
     await dbHelper.clearDatabase();
 
     testOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Integration Test Org',
     });
 

--- a/apps/server/api/test/e2e/organizations.e2e-spec.ts
+++ b/apps/server/api/test/e2e/organizations.e2e-spec.ts
@@ -96,21 +96,21 @@ describe('Organizations E2E Tests', () => {
 
     // Create test user
     testUser = createTestUser({
-      _id: generateIdString(),
+      id: generateIdString(),
       authProviderId: 'authProvider_org_test_user',
       email: 'org-test@example.com',
     });
 
     // Create test organization
     testOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Test Organization for E2E',
       user: testUser.id,
     });
 
     // Create test member (owner)
     testMember = createTestMember({
-      _id: generateIdString(),
+      id: generateIdString(),
       organization: testOrganization.id,
       role: 'owner',
       user: testUser.id,
@@ -118,7 +118,7 @@ describe('Organizations E2E Tests', () => {
 
     // Create test brand
     testBrand = createTestBrand({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Test Brand',
       organization: testOrganization.id,
       user: testUser.id,
@@ -131,13 +131,13 @@ describe('Organizations E2E Tests', () => {
     await dbHelper.seedCollection('brands', [testBrand]);
     await dbHelper.seedCollection('organization-settings', [
       createTestOrganizationSetting({
-        _id: generateIdString(),
+        id: generateIdString(),
         organization: testOrganization.id,
       }),
     ]);
     await dbHelper.seedCollection('credit-balances', [
       createTestCredit({
-        _id: generateIdString(),
+        id: generateIdString(),
         balance: 50000,
         organization: testOrganization.id,
       }),
@@ -160,14 +160,14 @@ describe('Organizations E2E Tests', () => {
       // Add more brands for testing
       const additionalBrands = [
         createTestBrand({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Brand Two',
           organization: testOrganization.id,
           slug: `brand-two-${Date.now()}`,
           user: testUser.id,
         }),
         createTestBrand({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Brand Three',
           organization: testOrganization.id,
           slug: `brand-three-${Date.now()}`,
@@ -202,7 +202,7 @@ describe('Organizations E2E Tests', () => {
     it('should filter deleted brands by default', async () => {
       // Create a deleted brand
       const deletedBrand = createTestBrand({
-        _id: generateIdString(),
+        id: generateIdString(),
         isDeleted: true,
         label: 'Deleted Brand',
         organization: testOrganization.id,
@@ -237,20 +237,20 @@ describe('Organizations E2E Tests', () => {
       // Create tags
       const tags = [
         createTestTag({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Tag One',
           organization: testOrganization.id,
           user: testUser.id,
         }),
         createTestTag({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Tag Two',
           organization: testOrganization.id,
           user: testUser.id,
         }),
         // Global tag (no user, no organization)
         createTestTag({
-          _id: generateIdString(),
+          id: generateIdString(),
           label: 'Global Tag',
           organization: undefined,
           user: undefined,
@@ -298,7 +298,7 @@ describe('Organizations E2E Tests', () => {
     beforeEach(async () => {
       // Create credentials for posts
       const credential = createTestCredential({
-        _id: generateIdString(),
+        id: generateIdString(),
         brand: testBrand.id,
         organization: testOrganization.id,
         platform: 'youtube',
@@ -308,7 +308,7 @@ describe('Organizations E2E Tests', () => {
       // Create posts
       const posts = [
         createTestPost({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           credential: credential.id,
           label: 'Post One',
@@ -317,7 +317,7 @@ describe('Organizations E2E Tests', () => {
           user: testUser.id,
         }),
         createTestPost({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           credential: credential.id,
           label: 'Post Two',
@@ -357,7 +357,7 @@ describe('Organizations E2E Tests', () => {
     it('should filter out deleted posts', async () => {
       // Create a deleted post
       const deletedPost = createTestPost({
-        _id: generateIdString(),
+        id: generateIdString(),
         brand: testBrand.id,
         isDeleted: true,
         label: 'Deleted Post',
@@ -380,7 +380,7 @@ describe('Organizations E2E Tests', () => {
       // Create ingredients
       const ingredients = [
         createTestIngredient({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           category: 'video',
           label: 'Video Ingredient',
@@ -389,7 +389,7 @@ describe('Organizations E2E Tests', () => {
           user: testUser.id,
         }),
         createTestIngredient({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           category: 'image',
           label: 'Image Ingredient',
@@ -398,7 +398,7 @@ describe('Organizations E2E Tests', () => {
           user: testUser.id,
         }),
         createTestIngredient({
-          _id: generateIdString(),
+          id: generateIdString(),
           brand: testBrand.id,
           category: 'audio',
           label: 'Audio Ingredient',
@@ -460,7 +460,7 @@ describe('Organizations E2E Tests', () => {
     it('should deny access to non-member users', async () => {
       // Create another user who is not a member
       const otherUser = createTestUser({
-        _id: generateIdString(),
+        id: generateIdString(),
         authProviderId: 'authProvider_other_user',
         email: 'other@example.com',
       });
@@ -482,13 +482,13 @@ describe('Organizations E2E Tests', () => {
     it('should allow access to organization members', async () => {
       // Create another user who IS a member
       const memberUser = createTestUser({
-        _id: generateIdString(),
+        id: generateIdString(),
         authProviderId: 'authProvider_member_user',
         email: 'member@example.com',
       });
 
       const membership = createTestMember({
-        _id: generateIdString(),
+        id: generateIdString(),
         organization: testOrganization.id,
         role: 'member',
         user: memberUser.id,
@@ -515,26 +515,26 @@ describe('Organizations E2E Tests', () => {
     beforeEach(async () => {
       // Create another organization with different user
       otherUser = createTestUser({
-        _id: generateIdString(),
+        id: generateIdString(),
         authProviderId: 'authProvider_other_org_user',
         email: 'other-org@example.com',
       });
 
       otherOrganization = createTestOrganization({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Other Organization',
         user: otherUser.id,
       });
 
       const otherMember = createTestMember({
-        _id: generateIdString(),
+        id: generateIdString(),
         organization: otherOrganization.id,
         role: 'owner',
         user: otherUser.id,
       });
 
       const otherBrand = createTestBrand({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Other Brand',
         organization: otherOrganization.id,
         slug: `other-brand-${Date.now()}`,
@@ -547,7 +547,7 @@ describe('Organizations E2E Tests', () => {
       await dbHelper.seedCollection('brands', [otherBrand]);
       await dbHelper.seedCollection('organization-settings', [
         createTestOrganizationSetting({
-          _id: generateIdString(),
+          id: generateIdString(),
           organization: otherOrganization.id,
         }),
       ]);
@@ -571,7 +571,7 @@ describe('Organizations E2E Tests', () => {
     it('should not return ingredients from other organizations', async () => {
       // Create ingredient in other organization
       const otherIngredient = createTestIngredient({
-        _id: generateIdString(),
+        id: generateIdString(),
         label: 'Other Ingredient',
         organization: otherOrganization.id,
         user: otherUser.id,

--- a/apps/server/api/test/e2e/tasks.e2e-spec.ts
+++ b/apps/server/api/test/e2e/tasks.e2e-spec.ts
@@ -121,19 +121,19 @@ describe('Tasks E2E Tests', () => {
     await dbHelper.clearDatabase();
 
     testUser = createTestUser({
-      _id: generateIdString(),
+      id: generateIdString(),
       authProviderId: 'authProvider_task_test_user',
       email: 'tasks-test@example.com',
     });
 
     testOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Tasks Test Organization',
       user: testUser.id,
     });
 
     otherOrganization = createTestOrganization({
-      _id: generateIdString(),
+      id: generateIdString(),
       label: 'Other Tasks Organization',
       user: generateIdString(),
     });
@@ -147,7 +147,7 @@ describe('Tasks E2E Tests', () => {
     ]);
     await dbHelper.seedCollection('tasks', [
       {
-        _id: scopedTaskId,
+        id: scopedTaskId,
         assigneeAgentId: 'agent-1',
         createdAt: new Date('2026-04-01T10:00:00.000Z'),
         identifier: 'GENA-20',
@@ -161,7 +161,7 @@ describe('Tasks E2E Tests', () => {
         updatedAt: new Date('2026-04-01T10:00:00.000Z'),
       },
       {
-        _id: generateIdString(),
+        id: generateIdString(),
         createdAt: new Date('2026-04-01T11:00:00.000Z'),
         identifier: 'GENA-99',
         isDeleted: false,


### PR DESCRIPTION
## Problem

The nightly **E2E Tests** run ([28641811737](https://github.com/genfeedai/genfeed.ai/actions/runs/28641811737)) is red: **API E2E Tests** fails 9/14 cases in `integrations.e2e-spec.ts` with:

```
PrismaClientValidationError: Argument `organization` is missing.
  at TestDatabaseHelper.seedCollection (test/e2e-test.module.ts:255)
```

## Root cause

PR #1114 (Mongo→Postgres cleanup) renamed the **reads** in every e2e spec from `obj._id` → `obj.id`, but left the factory defaults (`createTestOrganization`, `createTestIntegration`, …) and the spec **overrides** still emitting `_id`.

So at runtime `testOrganization.id` and `integration.id` were `undefined` — masked at compile time by the index signature that `...overrides` adds to the factory return type. Concretely in `integrations.e2e-spec.ts`:

- `orgPath()` → `/v1/organizations/undefined/integrations`
- `createTestIntegration({ organization: testOrganization.id })` → `organization: undefined`, which `normalizeDocument` strips, producing a `create()` payload with **no `organizationId`** → the Prisma error above.

The #1114 author read the local failure as `platformRole` schema drift; the real cause was this half-done rename, which only surfaces on CI's fresh DB.

## Fix

Complete the rename: factory defaults **and** all spec `_id:` overrides now emit `id`, matching the `.id` reads. The `_id`→`id` seed-normalizer in `e2e-test.module.ts` is kept as a harmless safety net. `integration/*` specs (MongoIdFactory / mocked service calls) are intentionally left untouched.

Also repairs `auth`/`tasks`/`organizations`/`brands` e2e specs, which carried the same latent defect but aren't in the `test:e2e:ci` smoke subset.

## Why it matters beyond the nightly

`deploy-ecs.yml` runs `full-suite.yml` as the `qa-before-deploy` gate, and full-suite includes this E2E job — so a red API E2E blocks **production deploys**, not just the nightly.

## Verification

Pure test-harness change (no product code). E2E doesn't run on PRs, so verified by dispatching the E2E workflow against this branch (link in PR comment).