### PR TITLE
fix(deploy): register WorkflowTemplateSeederService in workflow-backfill module

### DIFF
--- a/apps/server/api/src/migrations/workflow-backfill.module.ts
+++ b/apps/server/api/src/migrations/workflow-backfill.module.ts
@@ -3,6 +3,7 @@ import { DefaultRecurringContentService } from '@api/collections/brands/services
 import type { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { CronJobsService } from '@api/collections/cron-jobs/services/cron-jobs.service';
 import type { LegacyWorkflowStepRunner } from '@api/collections/workflows/services/legacy-workflow-step-runner.service';
+import { WorkflowTemplateSeederService } from '@api/collections/workflows/services/workflow-template-seeder.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { ConfigModule } from '@api/config/config.module';
 import type { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
@@ -22,6 +23,11 @@ import { Module } from '@nestjs/common';
     WorkflowsService,
     DefaultRecurringContentService,
     WorkflowDeploymentBackfillService,
+    // Seeding moved out of WorkflowsService in #754; the backfill service
+    // resolves this via ModuleRef per-org. Its only required deps (Prisma,
+    // Logger) come from the imported modules; WorkflowExecutionQueueService is
+    // @Optional and guarded in the seeder, so it's safe to omit here.
+    WorkflowTemplateSeederService,
     {
       inject: [PrismaService, WorkflowsService, LoggerService],
       provide: CronJobsService,


### PR DESCRIPTION
## Problem

Production deploy [run 28659555206](https://github.com/genfeedai/genfeed.ai/actions/runs/28659555206) passed all QA (including the E2E fix from #1213) but failed at the **workflow-backfill** one-off ECS task (`migrate:workflows`), which gates *before* services roll. Every organization failed:

```
Failed to backfill organization workflows
  error: Nest could not find WorkflowTemplateSeederService element
         (this provider does not exist in the current context)
...
Deployment workflow backfill failed: orgFailures=7, brandFailures=0, legacyCronFailed=0
```

(Confirmed via the `/ecs/genfeed-production/workflow-backfill` CloudWatch stream. Brand backfill — which doesn't use the seeder — succeeded 25/0.)

## Root cause

#754 (`refactor(api): split WorkflowsService into focused workflow services`) moved seeding out of `WorkflowsService` into `WorkflowTemplateSeederService` and changed `WorkflowDeploymentBackfillService.provisionOrganizationWorkflows` to resolve the seeder via `ModuleRef.get(WorkflowTemplateSeederService, { strict: false })`. The lean standalone `WorkflowBackfillModule` was never updated to register that provider, so every org backfill throws.

## Fix

Register `WorkflowTemplateSeederService` in `WorkflowBackfillModule`. Its required constructor deps — `PrismaService` (PrismaModule) and `LoggerService` (LoggerModule) — are already imported; `WorkflowExecutionQueueService` is `@Optional` and guarded in the seeder (early-return + optional-chaining), so it's safe to omit in this one-off task context.

## Impact / safety

- The failed task gates **before** the ECS service roll, so production was never rolled — no live impact.
- Change is a single provider registration on an already-valid import path (the backfill service dynamic-imports the same module).