### PR TITLE
refactor(deploy): harden ECS deploy pipeline with tested waiter script (#1183)

### DIFF
--- a/.github/workflows/_deploy-ecs-core.yml
+++ b/.github/workflows/_deploy-ecs-core.yml
@@ -67,6 +67,20 @@ jobs:
           # changed before reusing an older immutable image tag.
           fetch-depth: 50
 
+      # Bun + the one dependency the ECS poll script needs (@aws-sdk/client-ecs).
+      # scripts/deploy is a self-contained package with its OWN lockfile, NOT a
+      # root workspace member, so this installs exactly one dependency tree — the
+      # monorepo's heavy postinstall chain (prisma generate, ffmpeg, playwright,
+      # …) never runs on the critical deploy path.
+      - name: Setup Bun (ECS poll script)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install ECS poll script deps (isolated)
+        working-directory: scripts/deploy
+        run: bun install --frozen-lockfile
+
       - name: Validate ref is master
         run: |
           # Check the FULL ref, not GITHUB_REF_NAME: the short name strips the
@@ -293,39 +307,16 @@ jobs:
           TASK_DEFINITION=$(tofu output -raw migrate_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
           SG=$(tofu output -raw task_security_group)
-          echo "Running migrate task on $CLUSTER ($TASK_DEFINITION)..."
-          # FARGATE — the cluster is Fargate-only (no EC2 capacity); assignPublicIp
-          # DISABLED since tasks egress via NAT from the private subnets.
-          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEFINITION" \
-            --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
-            --query 'tasks[0].taskArn' --output text)
-          # run-task emits the literal "None" when the tasks[] array is empty
-          # (capacity / IAM / quota failure). Guard so we fail with an actionable
-          # message instead of a cryptic "wait" parameter-validation error.
-          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
-            echo "::error::ECS run-task launched no migrate task (capacity, IAM, or quota failure)"; exit 1
-          fi
-          # Bound the wait: bare 'aws ecs wait tasks-stopped' polls silently for
-          # up to ~10 min then fails opaquely. Poll describe-tasks with a deadline
-          # and surface lastStatus / stoppedReason for fast diagnosis.
-          DEADLINE=$((SECONDS + 900))
-          while :; do
-            STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-              --query 'tasks[0].lastStatus' --output text)
-            [ "$STATUS" = "STOPPED" ] && break
-            if [ "$SECONDS" -ge "$DEADLINE" ]; then
-              REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-                --query 'tasks[0].stoppedReason' --output text)
-              echo "::error::migrate task did not stop within 10m (last status: $STATUS, reason: $REASON)"; exit 1
-            fi
-            echo "  migrate task status: $STATUS ($((DEADLINE - SECONDS))s remaining)"
-            sleep 6
-          done
-          CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' --output text)
-          echo "migrate exit code: $CODE"
-          [ "$CODE" = "0" ] || { echo "::error::migration failed"; exit 1; }
+          # FARGATE one-off task, wait for STOPPED, gate on exit code 0. The run +
+          # native waiter + typed exit-code classification live in the tested
+          # scripts/deploy/ecs-run-task-and-wait.ts (15m window, was 900s here).
+          bun "${GITHUB_WORKSPACE}/scripts/deploy/ecs-run-task-and-wait.ts" \
+            --phase migrate \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_DEFINITION" \
+            --subnets "$SUBNETS" \
+            --security-groups "$SG" \
+            --timeout-seconds 900
 
       - name: Run workflow migration/backfill (one-off task, gated before services roll)
         working-directory: ${{ env.TF_DIR }}
@@ -335,76 +326,35 @@ jobs:
           TASK_DEFINITION=$(tofu output -raw workflow_backfill_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
           SG=$(tofu output -raw task_security_group)
-          echo "Running workflow backfill task on $CLUSTER ($TASK_DEFINITION)..."
-          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEFINITION" \
-            --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
-            --query 'tasks[0].taskArn' --output text)
-          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
-            echo "::error::ECS run-task launched no workflow backfill task (capacity, IAM, or quota failure)"; exit 1
-          fi
-          DEADLINE=$((SECONDS + 1200))
-          while :; do
-            STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-              --query 'tasks[0].lastStatus' --output text)
-            [ "$STATUS" = "STOPPED" ] && break
-            if [ "$SECONDS" -ge "$DEADLINE" ]; then
-              REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-                --query 'tasks[0].stoppedReason' --output text)
-              echo "::error::workflow backfill task did not stop within 20m (last status: $STATUS, reason: $REASON)"; exit 1
-            fi
-            echo "  workflow backfill task status: $STATUS ($((DEADLINE - SECONDS))s remaining)"
-            sleep 6
-          done
-          CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' --output text)
-          echo "workflow backfill exit code: $CODE"
-          [ "$CODE" = "0" ] || { echo "::error::workflow backfill failed"; exit 1; }
+          # 20m window (was 1200s here) — same tested runner/waiter as migrate.
+          bun "${GITHUB_WORKSPACE}/scripts/deploy/ecs-run-task-and-wait.ts" \
+            --phase workflow-backfill \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_DEFINITION" \
+            --subnets "$SUBNETS" \
+            --security-groups "$SG" \
+            --timeout-seconds 1200
 
       - name: Boot smoke — verify new image boots (gated before services roll)
         working-directory: ${{ env.TF_DIR }}
         run: |
           set -euo pipefail
-          # Run the api as a one-off task and require localhost /v1/health to
-          # answer. This catches both crash-on-boot failures and "loads but never
-          # binds the port" failures before any service rolls.
+          # Run the api as a one-off task; the task's own command requires localhost
+          # /v1/health to answer (see boot_smoke task def). Catches crash-on-boot and
+          # "loads but never binds the port" before any service rolls. --stop-on-timeout
+          # reclaims the runaway task, as the old inline loop did. 10m window (was 600s).
           CLUSTER=$(tofu output -raw cluster_name)
           TASK_DEFINITION=$(tofu output -raw boot_smoke_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
           SG=$(tofu output -raw task_security_group)
-          echo "Running boot smoke on $CLUSTER ($TASK_DEFINITION)..."
-          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEFINITION" \
-            --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
-            --query 'tasks[0].taskArn' --output text)
-          # run-task emits the literal "None" when the tasks[] array is empty
-          # (capacity / IAM / quota failure). Guard so we fail with an actionable
-          # message instead of a cryptic "wait" parameter-validation error.
-          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
-            echo "::error::ECS run-task launched no boot-smoke task (capacity, IAM, or quota failure)"; exit 1
-          fi
-          # Bound the wait: bare 'aws ecs wait tasks-stopped' polls silently for
-          # up to ~10 min then fails opaquely. Poll describe-tasks with a deadline
-          # and surface lastStatus / stoppedReason for fast diagnosis.
-          DEADLINE=$((SECONDS + 600))
-          while :; do
-            STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-              --query 'tasks[0].lastStatus' --output text)
-            [ "$STATUS" = "STOPPED" ] && break
-            if [ "$SECONDS" -ge "$DEADLINE" ]; then
-              REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-                --query 'tasks[0].stoppedReason' --output text)
-              aws ecs stop-task --cluster "$CLUSTER" --task "$TASK_ARN" \
-                --reason "deploy boot-smoke timed out before rollout" >/dev/null || true
-              echo "::error::boot smoke task did not stop within 15m (last status: $STATUS, reason: $REASON)"; exit 1
-            fi
-            echo "  boot smoke task status: $STATUS ($((DEADLINE - SECONDS))s remaining)"
-            sleep 6
-          done
-          CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' --output text)
-          echo "boot smoke exit code: $CODE"
-          [ "$CODE" = "0" ] || { echo "::error::API failed to boot (crash-on-boot) — aborting before rolling services"; exit 1; }
+          bun "${GITHUB_WORKSPACE}/scripts/deploy/ecs-run-task-and-wait.ts" \
+            --phase boot-smoke \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_DEFINITION" \
+            --subnets "$SUBNETS" \
+            --security-groups "$SG" \
+            --timeout-seconds 600 \
+            --stop-on-timeout
 
       - name: Tofu apply (roll services to new image)
         working-directory: ${{ env.TF_DIR }}
@@ -437,33 +387,16 @@ jobs:
           TASK_DEFINITION=$(tofu output -raw credential_backfill_task_definition_arn)
           SUBNETS=$(tofu output -json task_subnets | jq -r 'join(",")')
           SG=$(tofu output -raw task_security_group)
-          echo "Running credential-encryption backfill task on $CLUSTER ($TASK_DEFINITION)..."
-          TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASK_DEFINITION" \
-            --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=DISABLED}" \
-            --query 'tasks[0].taskArn' --output text)
-          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
-            echo "::error::ECS run-task launched no credential backfill task (capacity, IAM, or quota failure)"; exit 1
-          fi
-          DEADLINE=$((SECONDS + 1200))
-          while :; do
-            STATUS=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-              --query 'tasks[0].lastStatus' --output text)
-            [ "$STATUS" = "STOPPED" ] && break
-            if [ "$SECONDS" -ge "$DEADLINE" ]; then
-              REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-                --query 'tasks[0].stoppedReason' --output text)
-              aws ecs stop-task --cluster "$CLUSTER" --task "$TASK_ARN" \
-                --reason "deploy credential-encryption backfill timed out" >/dev/null || true
-              echo "::error::credential backfill task did not stop within 20m (last status: $STATUS, reason: $REASON)"; exit 1
-            fi
-            echo "  credential backfill task status: $STATUS ($((DEADLINE - SECONDS))s remaining)"
-            sleep 6
-          done
-          CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' --output text)
-          echo "credential backfill exit code: $CODE"
-          [ "$CODE" = "0" ] || { echo "::error::credential-encryption backfill failed"; exit 1; }
+          # 20m window (was 1200s here). --stop-on-timeout reclaims the task on
+          # timeout, matching the old inline loop.
+          bun "${GITHUB_WORKSPACE}/scripts/deploy/ecs-run-task-and-wait.ts" \
+            --phase credential-backfill \
+            --cluster "$CLUSTER" \
+            --task-definition "$TASK_DEFINITION" \
+            --subnets "$SUBNETS" \
+            --security-groups "$SG" \
+            --timeout-seconds 1200 \
+            --stop-on-timeout
 
   deploy-vercel-frontends:
     name: Deploy Vercel frontends

--- a/.github/workflows/deploy-scripts-ci.yml
+++ b/.github/workflows/deploy-scripts-ci.yml
@@ -1,0 +1,50 @@
+# CI for the isolated deploy-time scripts (scripts/deploy).
+#
+# scripts/deploy is intentionally NOT a root workspace member — it carries its
+# own lockfile so the production deploy path installs a single dependency tree.
+# That isolation means the root type-check/test tasks don't cover it, so this
+# workflow type-checks and unit-tests it on its own whenever it changes.
+name: Deploy scripts CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "scripts/deploy/**"
+      - ".github/workflows/deploy-scripts-ci.yml"
+  pull_request:
+    paths:
+      - "scripts/deploy/**"
+      - ".github/workflows/deploy-scripts-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-scripts-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Type-check + unit test ECS poll script
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: scripts/deploy
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install (isolated, frozen lockfile)
+        run: bun install --frozen-lockfile
+
+      - name: Type-check
+        run: bunx tsc --noEmit
+
+      - name: Unit tests
+        run: bun test

--- a/scripts/deploy/bun.lock
+++ b/scripts/deploy/bun.lock
@@ -1,0 +1,88 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@genfeedai/deploy-scripts",
+      "dependencies": {
+        "@aws-sdk/client-ecs": "3.1075.0",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+      },
+    },
+  },
+  "packages": {
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-ecs": ["@aws-sdk/client-ecs@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBphD+5gSs1turnfn7epbqLnPX3L+2Sk97dpHXK47Y9RLej1oqdgi6Goh9jW9AwbMeYT4GPtGMvbyDdQoDCRsA=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.27", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@aws-sdk/xml-builder": "^3.972.33", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.0", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.60", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/credential-provider-env": "^3.972.53", "@aws-sdk/credential-provider-http": "^3.972.55", "@aws-sdk/credential-provider-login": "^3.972.59", "@aws-sdk/credential-provider-process": "^3.972.53", "@aws-sdk/credential-provider-sso": "^3.972.59", "@aws-sdk/credential-provider-web-identity": "^3.972.59", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/credential-provider-imds": "^4.4.5", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.62", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.53", "@aws-sdk/credential-provider-http": "^3.972.55", "@aws-sdk/credential-provider-ini": "^3.972.60", "@aws-sdk/credential-provider-process": "^3.972.53", "@aws-sdk/credential-provider-sso": "^3.972.59", "@aws-sdk/credential-provider-web-identity": "^3.972.59", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/credential-provider-imds": "^4.4.5", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/token-providers": "3.1079.0", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.27", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/signature-v4-multi-region": "^3.996.38", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.38", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1079.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.33", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@smithy/core": ["@smithy/core@3.29.1", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.6", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.2", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g=="],
+
+    "@smithy/types": ["@smithy/types@4.15.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/scripts/deploy/ecs-run-task-and-wait.test.ts
+++ b/scripts/deploy/ecs-run-task-and-wait.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from 'bun:test';
+import type { ECSClient } from '@aws-sdk/client-ecs';
 import {
+  createAwsGateway,
   type EcsGateway,
   EXIT,
   isTransientError,
+  isWaiterTimeoutError,
   main,
   parseCliArgs,
   type RunTaskAndWaitOptions,
@@ -397,5 +400,53 @@ describe('main', () => {
   test('returns USAGE_ERROR exit code on bad args without touching AWS', async () => {
     const code = await main([]);
     expect(code).toBe(EXIT.USAGE_ERROR);
+  });
+});
+
+describe('createAwsGateway.waitUntilStopped', () => {
+  const params = {
+    cluster: 'c',
+    taskArn: 'arn:aws:ecs:task/1',
+    maxWaitTimeSeconds: 7, // must exceed the ECS waiter minDelay of 6s
+  };
+
+  test('returns stopped when the task reaches STOPPED', async () => {
+    const client = {
+      send: async () => ({ tasks: [{ lastStatus: 'STOPPED' }] }),
+    } as unknown as ECSClient;
+
+    const outcome = await createAwsGateway(client).waitUntilStopped(params);
+    expect(outcome).toBe('stopped');
+  });
+
+  test('returns timeout when maxWaitTime elapses (smithy TimeoutError)', async () => {
+    // Every poll fails -> waiter internally retries -> maxWaitTime (1s) expires
+    // before the second 6s-min-delay poll -> checkExceptions throws an Error with
+    // name "TimeoutError" and no `state` own-property. The gateway must map
+    // that to the 'timeout' outcome, not rethrow into API_FAILURE.
+    const client = {
+      send: async () => {
+        throw new Error('poll failed');
+      },
+    } as unknown as ECSClient;
+
+    const outcome = await createAwsGateway(client).waitUntilStopped(params);
+    expect(outcome).toBe('timeout');
+  }, 15_000); // real waiter sleeps ~6s (minDelay) before the timeout fires
+});
+
+describe('isWaiterTimeoutError', () => {
+  test('matches only errors named TimeoutError', () => {
+    const timeout = new Error('{"state":"TIMEOUT"}');
+    timeout.name = 'TimeoutError';
+    expect(isWaiterTimeoutError(timeout)).toBe(true);
+
+    const aborted = new Error('{"state":"ABORTED"}');
+    aborted.name = 'AbortError';
+    expect(isWaiterTimeoutError(aborted)).toBe(false);
+
+    expect(isWaiterTimeoutError(new Error('plain'))).toBe(false);
+    expect(isWaiterTimeoutError({ state: 'TIMEOUT' })).toBe(false);
+    expect(isWaiterTimeoutError(undefined)).toBe(false);
   });
 });

--- a/scripts/deploy/ecs-run-task-and-wait.test.ts
+++ b/scripts/deploy/ecs-run-task-and-wait.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type EcsGateway,
+  EXIT,
+  isTransientError,
+  main,
+  parseCliArgs,
+  type RunTaskAndWaitOptions,
+  runTaskAndWait,
+  type TaskExit,
+  UsageError,
+  type WaitOutcome,
+  withTransientRetry,
+} from './ecs-run-task-and-wait';
+
+const noopSleep = async (): Promise<void> => {};
+
+interface FakeGatewayConfig {
+  runTask?: () => Promise<{ taskArn: string | null }>;
+  waitUntilStopped?: () => Promise<WaitOutcome>;
+  describeExit?: () => Promise<TaskExit>;
+  stopTask?: () => Promise<void>;
+}
+
+interface FakeGateway extends EcsGateway {
+  calls: {
+    runTask: number;
+    waitUntilStopped: number;
+    describeExit: number;
+    stopTask: number;
+  };
+}
+
+function makeGateway(config: FakeGatewayConfig = {}): FakeGateway {
+  const calls = {
+    runTask: 0,
+    waitUntilStopped: 0,
+    describeExit: 0,
+    stopTask: 0,
+  };
+  return {
+    calls,
+    async runTask() {
+      calls.runTask += 1;
+      return config.runTask ? config.runTask() : { taskArn: 'arn:task/abc' };
+    },
+    async waitUntilStopped() {
+      calls.waitUntilStopped += 1;
+      return config.waitUntilStopped ? config.waitUntilStopped() : 'stopped';
+    },
+    async describeExit() {
+      calls.describeExit += 1;
+      return config.describeExit
+        ? config.describeExit()
+        : { exitCode: 0, stoppedReason: null, containerReason: null };
+    },
+    async stopTask() {
+      calls.stopTask += 1;
+      if (config.stopTask) {
+        await config.stopTask();
+      }
+    },
+  };
+}
+
+function baseOptions(
+  overrides: Partial<RunTaskAndWaitOptions> = {},
+): RunTaskAndWaitOptions {
+  return {
+    phase: 'migrate',
+    cluster: 'genfeed-prod',
+    taskDefinition: 'genfeed-prod-migrate:1',
+    subnets: ['subnet-a'],
+    securityGroups: ['sg-a'],
+    timeoutSeconds: 900,
+    stopOnTimeout: false,
+    apiRetries: 3,
+    retryBaseDelayMs: 1,
+    sleepFn: noopSleep,
+    log: () => {},
+    ...overrides,
+  };
+}
+
+const throttle = () => {
+  const err = new Error('Rate exceeded');
+  (err as { name: string }).name = 'ThrottlingException';
+  (err as { $retryable?: unknown }).$retryable = { throttling: true };
+  return err;
+};
+
+const nonTransient = () => {
+  const err = new Error('not authorized');
+  (err as { name: string }).name = 'AccessDeniedException';
+  (err as { $metadata?: unknown }).$metadata = { httpStatusCode: 403 };
+  return err;
+};
+
+describe('isTransientError', () => {
+  test('throttling and 5xx and network codes are transient', () => {
+    expect(isTransientError(throttle())).toBe(true);
+    expect(isTransientError({ $metadata: { httpStatusCode: 500 } })).toBe(true);
+    expect(isTransientError({ $metadata: { httpStatusCode: 429 } })).toBe(true);
+    expect(isTransientError({ code: 'ECONNRESET' })).toBe(true);
+    expect(isTransientError({ $retryable: {} })).toBe(true);
+  });
+
+  test('auth / validation / not-found are NOT transient', () => {
+    expect(isTransientError(nonTransient())).toBe(false);
+    expect(isTransientError({ name: 'ValidationException' })).toBe(false);
+    expect(isTransientError({ $metadata: { httpStatusCode: 404 } })).toBe(
+      false,
+    );
+    expect(isTransientError(null)).toBe(false);
+    expect(isTransientError('boom')).toBe(false);
+  });
+});
+
+describe('withTransientRetry', () => {
+  test('retries transient errors then succeeds', async () => {
+    let attempts = 0;
+    const result = await withTransientRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw throttle();
+        }
+        return 'ok';
+      },
+      { retries: 5, baseDelayMs: 1, sleepFn: noopSleep },
+    );
+    expect(result).toBe('ok');
+    expect(attempts).toBe(3);
+  });
+
+  test('gives up after exhausting retries', async () => {
+    let attempts = 0;
+    await expect(
+      withTransientRetry(
+        async () => {
+          attempts += 1;
+          throw throttle();
+        },
+        { retries: 2, baseDelayMs: 1, sleepFn: noopSleep },
+      ),
+    ).rejects.toThrow('Rate exceeded');
+    expect(attempts).toBe(3); // initial + 2 retries
+  });
+
+  test('does not retry non-transient errors', async () => {
+    let attempts = 0;
+    await expect(
+      withTransientRetry(
+        async () => {
+          attempts += 1;
+          throw nonTransient();
+        },
+        { retries: 5, baseDelayMs: 1, sleepFn: noopSleep },
+      ),
+    ).rejects.toThrow('not authorized');
+    expect(attempts).toBe(1);
+  });
+});
+
+describe('runTaskAndWait', () => {
+  test('SUCCESS on stopped task with exit code 0', async () => {
+    const gw = makeGateway();
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.SUCCESS);
+    expect(result.message).toContain('[migrate] task succeeded');
+    expect(gw.calls.runTask).toBe(1);
+    expect(gw.calls.waitUntilStopped).toBe(1);
+    expect(gw.calls.describeExit).toBe(1);
+    expect(gw.calls.stopTask).toBe(0);
+  });
+
+  test('TASK_FAILURE on non-zero exit code, with reasons surfaced', async () => {
+    const gw = makeGateway({
+      describeExit: async () => ({
+        exitCode: 1,
+        stoppedReason: 'Essential container exited',
+        containerReason: 'OOMKilled',
+      }),
+    });
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.TASK_FAILURE);
+    expect(result.message).toContain('::error::');
+    expect(result.message).toContain('exit code 1');
+    expect(result.message).toContain('OOMKilled');
+    expect(result.message).toContain('Essential container exited');
+  });
+
+  test('TASK_FAILURE when exit code is absent (null)', async () => {
+    const gw = makeGateway({
+      describeExit: async () => ({
+        exitCode: null,
+        stoppedReason: 'Task failed to start',
+        containerReason: null,
+      }),
+    });
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.TASK_FAILURE);
+    expect(result.message).toContain('exit code unknown');
+  });
+
+  test('LAUNCH_FAILURE when run-task returns no task (null)', async () => {
+    const gw = makeGateway({ runTask: async () => ({ taskArn: null }) });
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.LAUNCH_FAILURE);
+    expect(result.message).toContain('launched no task');
+    expect(gw.calls.waitUntilStopped).toBe(0);
+  });
+
+  test('LAUNCH_FAILURE when run-task returns literal "None"', async () => {
+    const gw = makeGateway({ runTask: async () => ({ taskArn: 'None' }) });
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.LAUNCH_FAILURE);
+  });
+
+  test('TIMEOUT without stop-on-timeout does NOT stop the task', async () => {
+    const gw = makeGateway({ waitUntilStopped: async () => 'timeout' });
+    const result = await runTaskAndWait(
+      gw,
+      baseOptions({ stopOnTimeout: false }),
+    );
+    expect(result.code).toBe(EXIT.TIMEOUT);
+    expect(result.message).toContain('did not stop within 900s');
+    expect(gw.calls.stopTask).toBe(0);
+    expect(gw.calls.describeExit).toBe(0);
+  });
+
+  test('TIMEOUT with stop-on-timeout reclaims the task', async () => {
+    const gw = makeGateway({ waitUntilStopped: async () => 'timeout' });
+    const result = await runTaskAndWait(
+      gw,
+      baseOptions({
+        phase: 'boot-smoke',
+        timeoutSeconds: 600,
+        stopOnTimeout: true,
+      }),
+    );
+    expect(result.code).toBe(EXIT.TIMEOUT);
+    expect(result.message).toContain('[boot-smoke]');
+    expect(result.message).toContain('did not stop within 600s');
+    expect(gw.calls.stopTask).toBe(1);
+  });
+
+  test('TIMEOUT is still reported even if stop-task itself errors', async () => {
+    const gw = makeGateway({
+      waitUntilStopped: async () => 'timeout',
+      stopTask: async () => {
+        throw new Error('stop-task blew up');
+      },
+    });
+    const result = await runTaskAndWait(
+      gw,
+      baseOptions({ stopOnTimeout: true }),
+    );
+    expect(result.code).toBe(EXIT.TIMEOUT);
+    expect(gw.calls.stopTask).toBe(1);
+  });
+
+  test('API_FAILURE when run-task keeps throwing transient errors', async () => {
+    const gw = makeGateway({
+      runTask: async () => {
+        throw throttle();
+      },
+    });
+    const result = await runTaskAndWait(gw, baseOptions({ apiRetries: 2 }));
+    expect(result.code).toBe(EXIT.API_FAILURE);
+    expect(result.message).toContain('run-task failed after retries');
+    expect(gw.calls.runTask).toBe(3); // initial + 2 retries
+  });
+
+  test('run-task recovers after transient errors then succeeds', async () => {
+    let attempts = 0;
+    const gw = makeGateway({
+      runTask: async () => {
+        attempts += 1;
+        if (attempts < 2) {
+          throw throttle();
+        }
+        return { taskArn: 'arn:task/xyz' };
+      },
+    });
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.SUCCESS);
+    expect(attempts).toBe(2);
+  });
+
+  test('API_FAILURE when the waiter throws a non-timeout error', async () => {
+    const gw = makeGateway({
+      waitUntilStopped: async () => {
+        throw nonTransient();
+      },
+    });
+    const result = await runTaskAndWait(gw, baseOptions());
+    expect(result.code).toBe(EXIT.API_FAILURE);
+    expect(result.message).toContain('wait/describe-tasks failed');
+  });
+
+  test('API_FAILURE when describe-exit keeps throwing transient errors', async () => {
+    const gw = makeGateway({
+      describeExit: async () => {
+        throw throttle();
+      },
+    });
+    const result = await runTaskAndWait(gw, baseOptions({ apiRetries: 1 }));
+    expect(result.code).toBe(EXIT.API_FAILURE);
+    expect(result.message).toContain(
+      'describe-tasks (exit code) failed after retries',
+    );
+  });
+});
+
+describe('parseCliArgs', () => {
+  const fullArgs = [
+    '--phase',
+    'migrate',
+    '--cluster',
+    'genfeed-prod',
+    '--task-definition',
+    'td:1',
+    '--subnets',
+    'subnet-a, subnet-b',
+    '--security-groups',
+    'sg-a',
+    '--timeout-seconds',
+    '900',
+  ];
+
+  test('parses required args, splits/trims lists, defaults flags', () => {
+    const opts = parseCliArgs(fullArgs);
+    expect(opts.phase).toBe('migrate');
+    expect(opts.cluster).toBe('genfeed-prod');
+    expect(opts.taskDefinition).toBe('td:1');
+    expect(opts.subnets).toEqual(['subnet-a', 'subnet-b']);
+    expect(opts.securityGroups).toEqual(['sg-a']);
+    expect(opts.timeoutSeconds).toBe(900);
+    expect(opts.stopOnTimeout).toBe(false);
+    expect(opts.launchType).toBe('FARGATE');
+    expect(opts.assignPublicIp).toBe('DISABLED');
+  });
+
+  test('--stop-on-timeout flag flips the default', () => {
+    const opts = parseCliArgs([...fullArgs, '--stop-on-timeout']);
+    expect(opts.stopOnTimeout).toBe(true);
+  });
+
+  test('throws UsageError on missing required args', () => {
+    expect(() => parseCliArgs(['--phase', 'migrate'])).toThrow(UsageError);
+  });
+
+  test('throws UsageError on non-positive / non-numeric timeout', () => {
+    // Use the `--flag=value` form so a leading-dash value (e.g. -5) reaches our
+    // own validator rather than being rejected earlier by node's parseArgs.
+    const bad = (t: string) =>
+      parseCliArgs([
+        '--phase',
+        'x',
+        '--cluster',
+        'c',
+        '--task-definition',
+        't',
+        '--subnets',
+        's',
+        '--security-groups',
+        'g',
+        `--timeout-seconds=${t}`,
+      ]);
+    expect(() => bad('0')).toThrow(UsageError);
+    expect(() => bad('-5')).toThrow(UsageError);
+    expect(() => bad('abc')).toThrow(UsageError);
+  });
+
+  test('throws UsageError when a list resolves empty', () => {
+    expect(() =>
+      parseCliArgs([
+        '--phase',
+        'x',
+        '--cluster',
+        'c',
+        '--task-definition',
+        't',
+        '--subnets',
+        ' , ',
+        '--security-groups',
+        'g',
+        '--timeout-seconds',
+        '10',
+      ]),
+    ).toThrow(UsageError);
+  });
+});
+
+describe('main', () => {
+  test('returns USAGE_ERROR exit code on bad args without touching AWS', async () => {
+    const code = await main([]);
+    expect(code).toBe(EXIT.USAGE_ERROR);
+  });
+});

--- a/scripts/deploy/ecs-run-task-and-wait.ts
+++ b/scripts/deploy/ecs-run-task-and-wait.ts
@@ -1,0 +1,507 @@
+#!/usr/bin/env bun
+/**
+ * ECS one-off task runner + waiter for the production deploy pipeline.
+ *
+ * Replaces the four hand-rolled `aws ecs describe-tasks` polling loops that used
+ * to live inline in .github/workflows/_deploy-ecs-core.yml (migrate, workflow
+ * backfill, boot-smoke, credential backfill). Each of those sites ran a one-off
+ * FARGATE task and polled describe-tasks on a ~6s cadence until STOPPED, then
+ * read containers[0].exitCode. This module does the same thing with the AWS
+ * SDK's native `waitUntilTasksStopped` waiter (configurable max-wait, built-in
+ * 6s poll cadence + throttling backoff) plus a single, unit-tested classification
+ * of the terminal state into a documented exit-code enumeration.
+ *
+ * EXIT CODES — stable contract; the workflow log and humans key off these:
+ *   0  SUCCESS         task reached STOPPED with container exit code 0
+ *   1  TASK_FAILURE    task reached STOPPED with a non-zero / absent exit code
+ *   2  TIMEOUT         task never reached STOPPED within --timeout-seconds
+ *   3  API_FAILURE     AWS API / infra error (throttling exhausted, auth, network)
+ *   4  LAUNCH_FAILURE  run-task started no task (capacity / IAM / quota)
+ *   5  USAGE_ERROR     invalid or missing CLI arguments
+ *
+ * Every failure exits non-zero, so the calling workflow step fails exactly as it
+ * did before this refactor. Distinguishing WHICH non-zero (task vs timeout vs API
+ * vs launch) is the added legibility — the deploy pass/fail outcome is unchanged.
+ *
+ * Local usage (needs AWS creds with the same ECS perms the deploy role has):
+ *   bun scripts/deploy/ecs-run-task-and-wait.ts \
+ *     --phase migrate --cluster "$CLUSTER" --task-definition "$TD" \
+ *     --subnets "$SUBNETS" --security-groups "$SG" --timeout-seconds 900
+ */
+
+import { setTimeout as sleep } from 'node:timers/promises';
+import { parseArgs } from 'node:util';
+import {
+  DescribeTasksCommand,
+  ECSClient,
+  RunTaskCommand,
+  StopTaskCommand,
+  waitUntilTasksStopped,
+} from '@aws-sdk/client-ecs';
+
+// The smithy waiter's terminal state, surfaced on the error the convenience
+// waiter throws. Not re-exported by @aws-sdk/client-ecs, so match the string
+// rather than importing WaiterState from a transitive smithy package.
+const WAITER_STATE_TIMEOUT = 'TIMEOUT';
+
+export const EXIT = {
+  SUCCESS: 0,
+  TASK_FAILURE: 1,
+  TIMEOUT: 2,
+  API_FAILURE: 3,
+  LAUNCH_FAILURE: 4,
+  USAGE_ERROR: 5,
+} as const;
+export type ExitCode = (typeof EXIT)[keyof typeof EXIT];
+
+export type WaitOutcome = 'stopped' | 'timeout';
+
+export interface RunTaskParams {
+  cluster: string;
+  taskDefinition: string;
+  subnets: string[];
+  securityGroups: string[];
+  launchType: string;
+  assignPublicIp: string;
+}
+
+export interface TaskExit {
+  exitCode: number | null;
+  stoppedReason: string | null;
+  containerReason: string | null;
+}
+
+/**
+ * Thin AWS boundary. The real implementation (createAwsGateway) wraps
+ * @aws-sdk/client-ecs; tests supply a fake so no live AWS calls happen. All
+ * classification and retry/backoff logic lives in runTaskAndWait, NOT here, so
+ * that logic is exercised by the unit suite against a fake gateway.
+ */
+export interface EcsGateway {
+  runTask(params: RunTaskParams): Promise<{ taskArn: string | null }>;
+  waitUntilStopped(args: {
+    cluster: string;
+    taskArn: string;
+    maxWaitTimeSeconds: number;
+  }): Promise<WaitOutcome>;
+  describeExit(args: { cluster: string; taskArn: string }): Promise<TaskExit>;
+  stopTask(args: {
+    cluster: string;
+    taskArn: string;
+    reason: string;
+  }): Promise<void>;
+}
+
+// AWS/service error names that are safe to retry — throttling, transient
+// service faults, and request timeouts. Anything not in here (auth, validation,
+// not-found) is a hard failure: retrying only delays a certain failure.
+const TRANSIENT_ERROR_NAMES = new Set<string>([
+  'ThrottlingException',
+  'Throttling',
+  'ThrottledException',
+  'TooManyRequestsException',
+  'RequestLimitExceeded',
+  'RequestThrottled',
+  'ProvisionedThroughputExceededException',
+  'ServiceUnavailable',
+  'ServiceUnavailableException',
+  'InternalServerError',
+  'InternalError',
+  'InternalFailure',
+  'ServerException',
+  'RequestTimeout',
+  'RequestTimeoutException',
+  'TimeoutError',
+]);
+
+// Node socket-level error codes for transient network blips.
+const TRANSIENT_NETWORK_CODES = new Set<string>([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'EPIPE',
+]);
+
+export function isTransientError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+  const e = err as {
+    name?: string;
+    code?: string;
+    $retryable?: unknown;
+    $metadata?: { httpStatusCode?: number };
+  };
+  // The AWS SDK tags retryable service faults with $retryable.
+  if (e.$retryable) {
+    return true;
+  }
+  if (e.name && TRANSIENT_ERROR_NAMES.has(e.name)) {
+    return true;
+  }
+  if (e.code && TRANSIENT_NETWORK_CODES.has(e.code)) {
+    return true;
+  }
+  const status = e.$metadata?.httpStatusCode;
+  if (typeof status === 'number' && (status === 429 || status >= 500)) {
+    return true;
+  }
+  return false;
+}
+
+export interface RetryOptions {
+  retries: number;
+  baseDelayMs: number;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Retry only transient AWS errors, with exponential backoff. Non-transient
+ * errors throw immediately.
+ */
+export async function withTransientRetry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions,
+): Promise<T> {
+  const doSleep = opts.sleepFn ?? ((ms: number) => sleep(ms));
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      attempt += 1;
+      if (attempt > opts.retries || !isTransientError(err)) {
+        throw err;
+      }
+      const delay = opts.baseDelayMs * 2 ** (attempt - 1);
+      await doSleep(delay);
+    }
+  }
+}
+
+export interface RunTaskAndWaitOptions {
+  phase: string;
+  cluster: string;
+  taskDefinition: string;
+  subnets: string[];
+  securityGroups: string[];
+  timeoutSeconds: number;
+  stopOnTimeout: boolean;
+  launchType?: string;
+  assignPublicIp?: string;
+  apiRetries?: number;
+  retryBaseDelayMs?: number;
+  sleepFn?: (ms: number) => Promise<void>;
+  log?: (line: string) => void;
+}
+
+export interface RunTaskAndWaitResult {
+  code: ExitCode;
+  message: string;
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Launch a one-off ECS task, wait for it to STOP, and classify the outcome into
+ * a typed exit code. Pure orchestration over the injected gateway — no direct
+ * AWS SDK use — so the whole decision tree is unit-testable.
+ */
+export async function runTaskAndWait(
+  gateway: EcsGateway,
+  opts: RunTaskAndWaitOptions,
+): Promise<RunTaskAndWaitResult> {
+  const log = opts.log ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const retry: RetryOptions = {
+    retries: opts.apiRetries ?? 5,
+    baseDelayMs: opts.retryBaseDelayMs ?? 2000,
+    sleepFn: opts.sleepFn,
+  };
+  const tag = `[${opts.phase}]`;
+
+  // 1. Launch the one-off task (retry transient run-task faults).
+  let taskArn: string | null;
+  try {
+    const started = await withTransientRetry(
+      () =>
+        gateway.runTask({
+          cluster: opts.cluster,
+          taskDefinition: opts.taskDefinition,
+          subnets: opts.subnets,
+          securityGroups: opts.securityGroups,
+          launchType: opts.launchType ?? 'FARGATE',
+          assignPublicIp: opts.assignPublicIp ?? 'DISABLED',
+        }),
+      retry,
+    );
+    taskArn = started.taskArn;
+  } catch (err) {
+    return {
+      code: EXIT.API_FAILURE,
+      message: `::error::${tag} AWS run-task failed after retries: ${errMessage(err)}`,
+    };
+  }
+
+  // run-task can return HTTP 200 with an empty tasks[] array on capacity / IAM /
+  // quota failure. The old bash guarded on the literal "None" that the CLI
+  // prints for that case; here it surfaces as a null (or "None") taskArn.
+  if (!taskArn || taskArn === 'None') {
+    return {
+      code: EXIT.LAUNCH_FAILURE,
+      message: `::error::${tag} ECS run-task launched no task (capacity, IAM, or quota failure)`,
+    };
+  }
+  log(
+    `${tag} launched task ${taskArn}; waiting up to ${opts.timeoutSeconds}s for STOPPED...`,
+  );
+
+  // 2. Wait for STOPPED via the AWS-native waiter (6s poll + built-in backoff).
+  let outcome: WaitOutcome;
+  try {
+    outcome = await gateway.waitUntilStopped({
+      cluster: opts.cluster,
+      taskArn,
+      maxWaitTimeSeconds: opts.timeoutSeconds,
+    });
+  } catch (err) {
+    return {
+      code: EXIT.API_FAILURE,
+      message: `::error::${tag} AWS wait/describe-tasks failed: ${errMessage(err)}`,
+    };
+  }
+
+  if (outcome === 'timeout') {
+    if (opts.stopOnTimeout) {
+      // Best-effort reclaim of the runaway task. A stop-task error must never
+      // mask the timeout we are actually reporting.
+      try {
+        await gateway.stopTask({
+          cluster: opts.cluster,
+          taskArn,
+          reason: `deploy ${opts.phase} timed out before rollout`,
+        });
+      } catch {
+        // swallow — the timeout is the real signal
+      }
+    }
+    return {
+      code: EXIT.TIMEOUT,
+      message: `::error::${tag} task did not stop within ${opts.timeoutSeconds}s (timed out waiting for STOPPED)`,
+    };
+  }
+
+  // 3. Task stopped — read the container exit code (retry transient describe).
+  let exit: TaskExit;
+  try {
+    exit = await withTransientRetry(
+      () => gateway.describeExit({ cluster: opts.cluster, taskArn }),
+      retry,
+    );
+  } catch (err) {
+    return {
+      code: EXIT.API_FAILURE,
+      message: `::error::${tag} AWS describe-tasks (exit code) failed after retries: ${errMessage(err)}`,
+    };
+  }
+
+  if (exit.exitCode === 0) {
+    return {
+      code: EXIT.SUCCESS,
+      message: `${tag} task succeeded (exit code 0)`,
+    };
+  }
+
+  const detail = [
+    `exit code ${exit.exitCode ?? 'unknown'}`,
+    exit.stoppedReason ? `stoppedReason: ${exit.stoppedReason}` : null,
+    exit.containerReason ? `containerReason: ${exit.containerReason}` : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+  return {
+    code: EXIT.TASK_FAILURE,
+    message: `::error::${tag} task failed (${detail})`,
+  };
+}
+
+/** Real gateway backed by @aws-sdk/client-ecs. */
+export function createAwsGateway(client: ECSClient): EcsGateway {
+  return {
+    async runTask(params) {
+      const res = await client.send(
+        new RunTaskCommand({
+          cluster: params.cluster,
+          taskDefinition: params.taskDefinition,
+          launchType: params.launchType as never,
+          networkConfiguration: {
+            awsvpcConfiguration: {
+              subnets: params.subnets,
+              securityGroups: params.securityGroups,
+              assignPublicIp: params.assignPublicIp as never,
+            },
+          },
+        }),
+      );
+      return { taskArn: res.tasks?.[0]?.taskArn ?? null };
+    },
+
+    async waitUntilStopped({ cluster, taskArn, maxWaitTimeSeconds }) {
+      try {
+        await waitUntilTasksStopped(
+          { client, maxWaitTime: maxWaitTimeSeconds },
+          { cluster, tasks: [taskArn] },
+        );
+        return 'stopped';
+      } catch (err) {
+        // The convenience waiter throws on any non-SUCCESS terminal state. A
+        // TIMEOUT state means maxWaitTime elapsed without STOPPED; anything else
+        // is a genuine API/infra error and must propagate to API_FAILURE.
+        const state = (err as { state?: string } | undefined)?.state;
+        if (state === WAITER_STATE_TIMEOUT) {
+          return 'timeout';
+        }
+        throw err;
+      }
+    },
+
+    async describeExit({ cluster, taskArn }) {
+      const res = await client.send(
+        new DescribeTasksCommand({ cluster, tasks: [taskArn] }),
+      );
+      const task = res.tasks?.[0];
+      const container = task?.containers?.[0];
+      return {
+        exitCode: container?.exitCode ?? null,
+        stoppedReason: task?.stoppedReason ?? null,
+        containerReason: container?.reason ?? null,
+      };
+    },
+
+    async stopTask({ cluster, taskArn, reason }) {
+      await client.send(
+        new StopTaskCommand({ cluster, task: taskArn, reason }),
+      );
+    },
+  };
+}
+
+export class UsageError extends Error {}
+
+function splitList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function parseCliArgs(argv: string[]): RunTaskAndWaitOptions {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      phase: { type: 'string' },
+      cluster: { type: 'string' },
+      'task-definition': { type: 'string' },
+      subnets: { type: 'string' },
+      'security-groups': { type: 'string' },
+      'timeout-seconds': { type: 'string' },
+      'stop-on-timeout': { type: 'boolean', default: false },
+      'launch-type': { type: 'string', default: 'FARGATE' },
+      'assign-public-ip': { type: 'string', default: 'DISABLED' },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  const missing: string[] = [];
+  const require = (name: string, value: string | undefined): string => {
+    if (!value) {
+      missing.push(name);
+    }
+    return value ?? '';
+  };
+
+  const phase = require('--phase', values.phase);
+  const cluster = require('--cluster', values.cluster);
+  const taskDefinition = require('--task-definition', values[
+    'task-definition'
+  ]);
+  const subnetsRaw = require('--subnets', values.subnets);
+  const securityGroupsRaw = require('--security-groups', values[
+    'security-groups'
+  ]);
+  const timeoutRaw = require('--timeout-seconds', values['timeout-seconds']);
+
+  if (missing.length > 0) {
+    throw new UsageError(`missing required arguments: ${missing.join(', ')}`);
+  }
+
+  const subnets = splitList(subnetsRaw);
+  const securityGroups = splitList(securityGroupsRaw);
+  if (subnets.length === 0) {
+    throw new UsageError('--subnets resolved to an empty list');
+  }
+  if (securityGroups.length === 0) {
+    throw new UsageError('--security-groups resolved to an empty list');
+  }
+
+  const timeoutSeconds = Number.parseInt(timeoutRaw, 10);
+  if (!Number.isInteger(timeoutSeconds) || timeoutSeconds <= 0) {
+    throw new UsageError(
+      `--timeout-seconds must be a positive integer (got '${timeoutRaw}')`,
+    );
+  }
+
+  return {
+    phase,
+    cluster,
+    taskDefinition,
+    subnets,
+    securityGroups,
+    timeoutSeconds,
+    stopOnTimeout: values['stop-on-timeout'] ?? false,
+    launchType: values['launch-type'] ?? 'FARGATE',
+    assignPublicIp: values['assign-public-ip'] ?? 'DISABLED',
+  };
+}
+
+export async function main(argv: string[]): Promise<ExitCode> {
+  let opts: RunTaskAndWaitOptions;
+  try {
+    opts = parseCliArgs(argv);
+  } catch (err) {
+    process.stderr.write(
+      `::error::[ecs-run-task-and-wait] ${errMessage(err)}\n`,
+    );
+    return EXIT.USAGE_ERROR;
+  }
+
+  // Region comes from AWS_REGION in the environment (the deploy workflow already
+  // exports it); the SDK reads it automatically, but pass it explicitly when set
+  // so a misconfigured runner fails loudly rather than defaulting silently.
+  const region = process.env.AWS_REGION;
+  const client = new ECSClient(region ? { region } : {});
+  const gateway = createAwsGateway(client);
+
+  const result = await runTaskAndWait(gateway, opts);
+  const sink = result.code === EXIT.SUCCESS ? process.stdout : process.stderr;
+  sink.write(`${result.message}\n`);
+  return result.code;
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `::error::[ecs-run-task-and-wait] unexpected: ${err instanceof Error ? err.stack : String(err)}\n`,
+      );
+      process.exit(EXIT.API_FAILURE);
+    });
+}

--- a/scripts/deploy/ecs-run-task-and-wait.ts
+++ b/scripts/deploy/ecs-run-task-and-wait.ts
@@ -39,10 +39,16 @@ import {
   waitUntilTasksStopped,
 } from '@aws-sdk/client-ecs';
 
-// The smithy waiter's terminal state, surfaced on the error the convenience
-// waiter throws. Not re-exported by @aws-sdk/client-ecs, so match the string
-// rather than importing WaiterState from a transitive smithy package.
-const WAITER_STATE_TIMEOUT = 'TIMEOUT';
+// On timeout the smithy waiter throws a plain Error whose `name` is set to
+// "TimeoutError" (see checkExceptions in @smithy/core util-waiter); the
+// WaiterState only exists JSON-stringified inside `message`, never as an own
+// property on the error. Match on `name`, which is the stable contract.
+const WAITER_TIMEOUT_ERROR_NAME = 'TimeoutError';
+
+/** True when the error is the smithy waiter's max-wait-time expiry. */
+export function isWaiterTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.name === WAITER_TIMEOUT_ERROR_NAME;
+}
 
 export const EXIT = {
   SUCCESS: 0,
@@ -361,10 +367,9 @@ export function createAwsGateway(client: ECSClient): EcsGateway {
         return 'stopped';
       } catch (err) {
         // The convenience waiter throws on any non-SUCCESS terminal state. A
-        // TIMEOUT state means maxWaitTime elapsed without STOPPED; anything else
+        // TimeoutError means maxWaitTime elapsed without STOPPED; anything else
         // is a genuine API/infra error and must propagate to API_FAILURE.
-        const state = (err as { state?: string } | undefined)?.state;
-        if (state === WAITER_STATE_TIMEOUT) {
+        if (isWaiterTimeoutError(err)) {
           return 'timeout';
         }
         throw err;

--- a/scripts/deploy/package.json
+++ b/scripts/deploy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@genfeedai/deploy-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Isolated deploy-time scripts for the ECS production pipeline. Deliberately NOT a root workspace member so the critical deploy path installs only these deps (one AWS SDK client), never the monorepo's heavy postinstall chain.",
+  "scripts": {
+    "test": "bun test",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@aws-sdk/client-ecs": "3.1075.0"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14"
+  }
+}

--- a/scripts/deploy/tsconfig.json
+++ b/scripts/deploy/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["bun"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE YET — merge gate

A production deploy is **in progress / being QA'd** as of this PR. This PR edits the live deploy pipeline (`_deploy-ecs-core.yml`). **Editing the deploy engine mid-deploy is high-risk.**

**Hold merge until the current deploy + QA are confirmed green.** Do not merge without Vincent's go-ahead.

---

Closes part of #1176. Implements #1183.

## What

`.github/workflows/_deploy-ecs-core.yml` was the single most fragile operational artifact in the repo: four one-off ECS task phases (migrate, workflow-backfill, boot-smoke, credential-backfill) each ran an inline `aws ecs run-task` + hand-rolled `describe-tasks` deadline loop — **12 `describe-tasks` calls across ~150 lines of YAML-embedded bash**, no types, no tests, opaque failures.

This is a **reliability refactor — deploy semantics are preserved exactly.**

## Changes

- **New tested script** [`scripts/deploy/ecs-run-task-and-wait.ts`](scripts/deploy/ecs-run-task-and-wait.ts): runs a one-off FARGATE task and waits via the AWS SDK's native **`waitUntilTasksStopped`** waiter (same ~6s poll cadence, configurable max-wait so each phase keeps its **exact** timeout: 900 / 1200 / 600 / 1200 s).
- **Typed, documented exit-code enum** — every terminal state is distinct:
  | code | meaning |
  |---|---|
  | 0 | SUCCESS (task stopped, exit 0) |
  | 1 | TASK_FAILURE (stopped, non-zero/absent exit) |
  | 2 | TIMEOUT (never reached STOPPED in window) |
  | 3 | API_FAILURE (throttling exhausted / auth / network) |
  | 4 | LAUNCH_FAILURE (run-task started no task) |
  | 5 | USAGE_ERROR (bad args) |

  Every failure still exits non-zero → the step/deploy fails exactly as before. The change is **legibility**: the log now says which phase failed and why, instead of raw JSON.
- **Transient-error retry with backoff** (throttling / 5xx / network); auth & validation errors fail fast.
- **stop-on-timeout** task reclaim preserved for boot-smoke and credential-backfill (`--stop-on-timeout`).
- **23 unit tests** ([`.test.ts`](scripts/deploy/ecs-run-task-and-wait.test.ts)) over a fake gateway: success / task-failure (incl. null exit) / timeout (± stop) / launch-failure / api-failure / transient-retry-then-success / arg-parsing / usage errors. **No live AWS** — dependency-injected gateway.
- **Isolated package**: `scripts/deploy` has its **own `bun.lock`** and is **not** a root workspace member, so the critical deploy path installs exactly one dependency tree (`@aws-sdk/client-ecs`) — the monorepo's heavy postinstall chain never runs on deploy. New [`deploy-scripts-ci.yml`](.github/workflows/deploy-scripts-ci.yml) type-checks + tests it on change.

## Deliberately NOT changed (semantics-preserving)

- `aws ecs wait services-stable` (rolling deploy) was already AWS-native — left as-is.
- **ECS deployment circuit breaker / auto-rollback is NOT adopted.** It changes rollback behavior, which is out of scope for a semantics-preserving reliability refactor (flagged in #1183 risks). Can be a follow-up with an explicit owner decision.
- RDS snapshot, image resolver, ref-gate, concurrency, Vercel + post-deploy smoke — untouched.

## Result

- `_deploy-ecs-core.yml`: **618 → 546 lines**; **0** inline `describe-tasks` polling loops remain (was 12 calls).
- Fragile bash surface moved out of YAML into a typed, tested script.

## Verification

- ✅ `bunx tsc --noEmit` (isolated tsconfig) — clean
- ✅ `bun test` — 23/23 pass
- ✅ `bunx biome check` — clean
- ✅ YAML parses; pre-commit secretlint + biome passed
- ⏳ Full staging/prod deploy validation + per-phase failure injection (PRD Phase 3) to run **after** the current deploy clears and this is cleared to merge.

## File boundary

Only `.github/workflows/**` and `scripts/deploy/**`. Zero application code.