### PR TITLE
fix: prevent blank workspace login screen

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/error.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/error.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import WorkspaceError from './error';
+
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: mocks.captureException,
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: {
+    error: mocks.loggerError,
+  },
+}));
+
+describe('workspace error boundary', () => {
+  it('renders a visible retry fallback and reports the segment error', async () => {
+    const reset = vi.fn();
+    const error = new Error('workspace exploded');
+
+    render(<WorkspaceError error={error} reset={reset} />);
+
+    expect(screen.getByText('Something went wrong')).toBeVisible();
+    expect(
+      screen.getByText('The workspace could not finish loading. Try again.'),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mocks.loggerError).toHaveBeenCalledWith(
+        'Workspace route segment error',
+        expect.objectContaining({ error }),
+      );
+      expect(mocks.captureException).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/error.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { ErrorProps } from '@props/ui/feedback/error.props';
+import * as Sentry from '@sentry/nextjs';
+import { logger } from '@services/core/logger.service';
+import { ErrorFallback } from '@ui/error';
+import { useEffect } from 'react';
+
+export default function WorkspaceError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    logger.error('Workspace route segment error', {
+      error,
+      tags: {
+        app: 'app',
+        errorType: 'route-error',
+        segment: 'workspace',
+      },
+    });
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <ErrorFallback
+      error={error}
+      resetErrorBoundary={reset}
+      title="Something went wrong"
+      description="The workspace could not finish loading. Try again."
+    />
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
@@ -8,6 +8,7 @@ import type { AgentRunStats } from '@genfeedai/types';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useSocketManager } from '@hooks/utils/use-socket-manager/use-socket-manager';
 import type { PlatformTimeSeriesDataPoint } from '@props/analytics/charts.props';
+import * as Sentry from '@sentry/nextjs';
 import { AgentRunsService } from '@services/ai/agent-runs.service';
 import { Task, TasksService } from '@services/management/tasks.service';
 import { WebSocketPaths } from '@utils/network/websocket.util';
@@ -33,6 +34,31 @@ import {
   type WorkspaceSection,
   type WorkspaceTaskRealtimePayload,
 } from './workspace-task.helpers';
+
+const WORKSPACE_OVERVIEW_LOAD_TIMEOUT_MS = 15_000;
+const WORKSPACE_OVERVIEW_LOAD_WARNING =
+  'Workspace data is taking longer than expected. You can keep this page open or try again.';
+
+type WorkspaceOverviewLoadScope = 'runs' | 'tasks';
+type WorkspaceLoadWarningState = Partial<
+  Record<WorkspaceOverviewLoadScope, true>
+>;
+
+function addWorkspaceLoadTimeoutBreadcrumb(
+  scope: WorkspaceOverviewLoadScope,
+  pathname: string,
+) {
+  Sentry.addBreadcrumb({
+    category: 'workspace.overview',
+    data: {
+      pathname,
+      scope,
+      timeoutMs: WORKSPACE_OVERVIEW_LOAD_TIMEOUT_MS,
+    },
+    level: 'warning',
+    message: 'Workspace overview data load timed out',
+  });
+}
 
 export interface UseWorkspacePageContentParams {
   defaultInboxView?: InboxView;
@@ -79,11 +105,45 @@ export function useWorkspacePageContent({
   const [agentStats, setAgentStats] = useState<AgentRunStats | null>(
     initialStats,
   );
+  const [workspaceLoadWarnings, setWorkspaceLoadWarnings] =
+    useState<WorkspaceLoadWarningState>({});
   const [isWorkspaceRunsLoading, setWorkspaceRunsLoading] = useState(
     section === 'overview',
   );
   const [isWorkspaceTasksLoading, setWorkspaceTasksLoading] = useState(true);
   const [workspaceTasks, setWorkspaceTasks] = useState<Task[]>([]);
+
+  const markWorkspaceLoadWarning = useCallback(
+    (scope: WorkspaceOverviewLoadScope) => {
+      setWorkspaceLoadWarnings((current) =>
+        current[scope] ? current : { ...current, [scope]: true },
+      );
+    },
+    [],
+  );
+
+  const clearWorkspaceLoadWarning = useCallback(
+    (scope: WorkspaceOverviewLoadScope) => {
+      setWorkspaceLoadWarnings((current) => {
+        if (!current[scope]) {
+          return current;
+        }
+
+        const next = { ...current };
+        delete next[scope];
+        return next;
+      });
+    },
+    [],
+  );
+
+  const workspaceLoadWarning = useMemo(
+    () =>
+      workspaceLoadWarnings.tasks || workspaceLoadWarnings.runs
+        ? WORKSPACE_OVERVIEW_LOAD_WARNING
+        : null,
+    [workspaceLoadWarnings],
+  );
 
   const reviewInboxTasks = useMemo(
     () =>
@@ -242,7 +302,20 @@ export function useWorkspacePageContent({
 
   useEffect(() => {
     const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     setWorkspaceTasksLoading(true);
+    clearWorkspaceLoadWarning('tasks');
+
+    if (section === 'overview') {
+      timeoutId = setTimeout(() => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        markWorkspaceLoadWarning('tasks');
+        addWorkspaceLoadTimeoutBreadcrumb('tasks', pathname);
+      }, WORKSPACE_OVERVIEW_LOAD_TIMEOUT_MS);
+    }
 
     const loadWorkspaceTasks = async () => {
       try {
@@ -263,6 +336,10 @@ export function useWorkspacePageContent({
       } finally {
         if (!controller.signal.aborted) {
           setWorkspaceTasksLoading(false);
+          clearWorkspaceLoadWarning('tasks');
+        }
+        if (timeoutId) {
+          clearTimeout(timeoutId);
         }
       }
     };
@@ -271,8 +348,17 @@ export function useWorkspacePageContent({
 
     return () => {
       controller.abort();
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     };
-  }, [getToken]);
+  }, [
+    clearWorkspaceLoadWarning,
+    getToken,
+    markWorkspaceLoadWarning,
+    pathname,
+    section,
+  ]);
 
   useEffect(() => {
     if (section !== 'overview') {
@@ -281,7 +367,18 @@ export function useWorkspacePageContent({
     }
 
     let isMounted = true;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     setWorkspaceRunsLoading(true);
+    clearWorkspaceLoadWarning('runs');
+
+    timeoutId = setTimeout(() => {
+      if (!isMounted) {
+        return;
+      }
+
+      markWorkspaceLoadWarning('runs');
+      addWorkspaceLoadTimeoutBreadcrumb('runs', pathname);
+    }, WORKSPACE_OVERVIEW_LOAD_TIMEOUT_MS);
 
     const loadWorkspaceRuns = async () => {
       try {
@@ -318,6 +415,10 @@ export function useWorkspacePageContent({
       } finally {
         if (isMounted) {
           setWorkspaceRunsLoading(false);
+          clearWorkspaceLoadWarning('runs');
+        }
+        if (timeoutId) {
+          clearTimeout(timeoutId);
         }
       }
     };
@@ -326,8 +427,17 @@ export function useWorkspacePageContent({
 
     return () => {
       isMounted = false;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     };
-  }, [getToken, section]);
+  }, [
+    clearWorkspaceLoadWarning,
+    getToken,
+    markWorkspaceLoadWarning,
+    pathname,
+    section,
+  ]);
 
   useEffect(() => {
     if (!organizationId) {
@@ -503,6 +613,7 @@ export function useWorkspacePageContent({
     unreadInboxTasks,
     visibleInboxTasks,
     workspaceActionError,
+    workspaceLoadWarning,
     workspaceTasks,
   };
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -137,6 +137,10 @@ vi.mock('@services/management/tasks.service', async () => {
   };
 });
 
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
 vi.mock('@tiptap/react', () => ({
   EditorContent: ({
     editor,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -27,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   replace: vi.fn(),
   requestChanges: vi.fn(),
   resolveAuthToken: vi.fn(),
+  sentryAddBreadcrumb: vi.fn(),
   subscribe: vi.fn(),
   trashOutput: vi.fn(),
   unkeepOutput: vi.fn(),
@@ -96,6 +98,10 @@ vi.mock('@services/core/logger.service', () => ({
   logger: {
     warn: mocks.loggerWarn,
   },
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: mocks.sentryAddBreadcrumb,
 }));
 
 vi.mock('@services/management/tasks.service', async (importOriginal) => {
@@ -436,5 +442,43 @@ describe('WorkspacePageContent', () => {
     expect(
       within(inbox).getByText('Latest items waiting on your review.'),
     ).toBeInTheDocument();
+  });
+
+  it('surfaces a visible warning and Sentry breadcrumb when overview task loading stalls', async () => {
+    vi.useFakeTimers();
+    mocks.list.mockReturnValueOnce(new Promise(() => undefined));
+
+    try {
+      render(<WorkspacePageContent section="overview" />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mocks.list).toHaveBeenCalledWith({});
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+
+      expect(
+        screen.getByText(
+          'Workspace data is taking longer than expected. You can keep this page open or try again.',
+        ),
+      ).toBeVisible();
+      expect(mocks.sentryAddBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'workspace.overview',
+          data: expect.objectContaining({
+            scope: 'tasks',
+            timeoutMs: 15_000,
+          }),
+          level: 'warning',
+          message: 'Workspace overview data load timed out',
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { AlertCategory, ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { IAgentRun, IAnalytics } from '@genfeedai/interfaces';
 import type { AgentRunStats } from '@genfeedai/types';
 import { useTrends } from '@hooks/data/trends/use-trends/use-trends';
@@ -11,7 +11,9 @@ import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
 import Card from '@ui/card/Card';
 import { Skeleton } from '@ui/display/skeleton/skeleton';
 import AppTable from '@ui/display/table/Table';
+import Alert from '@ui/feedback/alert/Alert';
 import Container from '@ui/layout/container/Container';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
 import { Button } from '@ui/primitives/button';
 import dynamic from 'next/dynamic';
 import { Suspense, startTransition, useMemo } from 'react';
@@ -95,6 +97,7 @@ function WorkspacePageContentContent({
     visibleInboxTasks,
     sectionCopy,
     workspaceActionError,
+    workspaceLoadWarning,
     workspaceTasks,
   } = useWorkspacePageContent({
     defaultInboxView,
@@ -202,6 +205,12 @@ function WorkspacePageContentContent({
         <p className="mb-4 rounded-md border border-rose-400/30 bg-rose-400/8 px-3 py-2 text-xs text-rose-200">
           {workspaceActionError}
         </p>
+      ) : null}
+
+      {workspaceLoadWarning ? (
+        <Alert type={AlertCategory.WARNING} className="mb-4">
+          {workspaceLoadWarning}
+        </Alert>
       ) : null}
 
       {isTaskComposerOpen ? (
@@ -360,7 +369,7 @@ export default function WorkspacePageContent(
   props: Parameters<typeof WorkspacePageContentContent>[0],
 ) {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
       <WorkspacePageContentContent {...props} />
     </Suspense>
   );

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -12,6 +12,7 @@ import ProductionDataBanner from '@ui/banners/production-data/ProductionDataBann
 import { CommandPaletteInitializer } from '@ui/command-palette/command-palette-initializer/CommandPaletteInitializer';
 import OnboardingGuard from '@ui/guards/onboarding/OnboardingGuard';
 import AppLayout from '@ui/layouts/app/AppLayout';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
 import AdminTopbar from '@ui/shell/topbars/AdminTopbar';
 import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
@@ -361,7 +362,7 @@ export default function AppProtectedLayout(
   props: Parameters<typeof AppProtectedLayoutContent>[0],
 ) {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
       <AppProtectedLayoutContent {...props} />
     </Suspense>
   );

--- a/apps/app/tests/login-blank-screen-source-contract.test.ts
+++ b/apps/app/tests/login-blank-screen-source-contract.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readAppSource(path: string) {
+  return readFileSync(join(process.cwd(), path), 'utf8');
+}
+
+describe('post-login blank screen source contracts', () => {
+  it('keeps the protected app Suspense boundary visible while it resolves', () => {
+    const source = readAppSource(
+      'packages/components/app-protected-layout.tsx',
+    );
+
+    expect(source).toContain('LazyLoadingFallback');
+    expect(source).toContain(
+      'fallback={<LazyLoadingFallback variant="grid" />}',
+    );
+    expect(source).not.toContain('fallback={null}');
+  });
+
+  it('keeps the workspace Suspense boundary visible while it resolves', () => {
+    const source = readAppSource(
+      'app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx',
+    );
+
+    expect(source).toContain('LazyLoadingFallback');
+    expect(source).toContain(
+      'fallback={<LazyLoadingFallback variant="grid" />}',
+    );
+    expect(source).not.toContain('fallback={null}');
+  });
+
+  it('keeps an App Router error boundary on the workspace segment', () => {
+    const source = readAppSource(
+      'app/(protected)/[orgSlug]/[brandSlug]/workspace/error.tsx',
+    );
+
+    expect(source).toContain('ErrorFallback');
+    expect(source).toContain('resetErrorBoundary={reset}');
+    expect(source).toContain('Something went wrong');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the two production-critical `fallback={null}` Suspense boundaries with visible `LazyLoadingFallback` skeletons.
- Add a workspace App Router `error.tsx` that renders the shared `ErrorFallback` with a retry action and reports the segment error.
- Surface a visible warning plus a Sentry breadcrumb if overview task/run data remains unresolved past 15s.
- Add focused regression coverage for the Suspense contracts, the workspace route error boundary, and the slow overview task-load state.

## Root cause
Post-login redirects land on `/{org}/{brand}/workspace/overview`, where nested Suspense boundaries rendered `null` while a child suspended or stayed unresolved. Under degraded API latency that made the authenticated app appear as a black/blank screen instead of showing loading or error UI.

## Validation
- `bunx biome check --write` on the changed files
- `bun --cwd apps/app test 'app/(protected)/[orgSlug]/[brandSlug]/workspace/error.test.tsx' 'app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx' 'tests/login-blank-screen-source-contract.test.ts'`
- `bun --cwd apps/app test 'app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx'`
- `git diff --check`
- staged secret filename/content scan
- commit hook `lint-staged`: staged Biome, `scripts/run-secretlint.ts --no-glob`, and `scripts/lint-no-raw-html.sh`

Package-wide `@genfeedai/app` tests and workspace type-check were not run locally because the repo memory routes heavy local gates to PR CI.

Closes #1226