### PR TITLE
fix: stop calendar refetch loop

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.test.tsx
@@ -8,7 +8,23 @@ import '@testing-library/jest-dom/vitest';
 const findPostsMock = vi.fn();
 const findArticlesMock = vi.fn();
 const pushMock = vi.fn();
+const setDateRangeMock = vi.fn();
 const useAuthedServiceMock = vi.fn();
+const getPostsServiceMock = vi.fn(async () => ({ findAll: findPostsMock }));
+const getArticlesServiceMock = vi.fn(async () => ({
+  findAll: findArticlesMock,
+}));
+const calendarRenderProps: Array<{
+  getEventColor: (item: {
+    id: string;
+    itemType: string;
+    status: string;
+  }) => string;
+  items: Array<{ id: string }>;
+  modal: ReactNode;
+  onDatesChange: (start: Date, end: Date) => void;
+  onEventClick: (item: { id: string }) => void;
+}> = [];
 let useAuthedServiceCallCount = 0;
 
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
@@ -28,7 +44,7 @@ vi.mock('@hooks/utils/use-calendar-week-range/use-calendar-week-range', () => ({
       end: new Date('2026-03-16T00:00:00.000Z'),
       start: new Date('2026-03-10T00:00:00.000Z'),
     },
-    vi.fn(),
+    setDateRangeMock,
   ]),
 }));
 
@@ -51,20 +67,38 @@ vi.mock('next/navigation', () => ({
 vi.mock('@ui/calendar/content-calendar/ContentCalendar', () => ({
   default: ({
     items,
+    getEventColor,
     modal,
+    onDatesChange,
     onEventClick,
   }: {
+    getEventColor: (item: {
+      id: string;
+      itemType: string;
+      status: string;
+    }) => string;
     items: Array<{ id: string }>;
     modal: ReactNode;
+    onDatesChange: (start: Date, end: Date) => void;
     onEventClick: (item: { id: string }) => void;
-  }) => (
-    <div>
-      <button type="button" onClick={() => onEventClick(items[0])}>
-        Open first item
-      </button>
-      {modal}
-    </div>
-  ),
+  }) => {
+    calendarRenderProps.push({
+      getEventColor,
+      items,
+      modal,
+      onDatesChange,
+      onEventClick,
+    });
+
+    return (
+      <div>
+        <button type="button" onClick={() => onEventClick(items[0])}>
+          Open first item
+        </button>
+        {modal}
+      </div>
+    );
+  },
 }));
 
 vi.mock('@pages/posts/detail/PostDetailOverlay', () => ({
@@ -78,15 +112,16 @@ vi.mock('@pages/posts/detail/PostDetailOverlay', () => ({
 describe('ContentCalendarPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    calendarRenderProps.length = 0;
     useAuthedServiceCallCount = 0;
     useAuthedServiceMock.mockImplementation(() => {
       useAuthedServiceCallCount += 1;
 
       if (useAuthedServiceCallCount % 2 === 1) {
-        return vi.fn(async () => ({ findAll: findPostsMock }));
+        return getPostsServiceMock;
       }
 
-      return vi.fn(async () => ({ findAll: findArticlesMock }));
+      return getArticlesServiceMock;
     });
     findPostsMock.mockResolvedValue([
       {
@@ -106,12 +141,39 @@ describe('ContentCalendarPage', () => {
     await waitFor(() => {
       expect(findPostsMock).toHaveBeenCalled();
       expect(findArticlesMock).toHaveBeenCalled();
+      expect(
+        calendarRenderProps[calendarRenderProps.length - 1]?.items,
+      ).toHaveLength(1);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Open first item' }));
 
     expect(screen.getByTestId('post-detail-overlay')).toHaveTextContent(
       `post-456:${PageScope.PUBLISHER}`,
+    );
+  });
+
+  it('keeps calendar callback props stable after content loads', async () => {
+    render(<ContentCalendarPage />);
+
+    await waitFor(() => {
+      expect(findPostsMock).toHaveBeenCalled();
+      expect(findArticlesMock).toHaveBeenCalled();
+      expect(calendarRenderProps.length).toBeGreaterThan(1);
+    });
+
+    const firstRenderProps = calendarRenderProps[0];
+    const latestRenderProps =
+      calendarRenderProps[calendarRenderProps.length - 1];
+
+    expect(latestRenderProps?.onEventClick).toBe(
+      firstRenderProps?.onEventClick,
+    );
+    expect(latestRenderProps?.onDatesChange).toBe(
+      firstRenderProps?.onDatesChange,
+    );
+    expect(latestRenderProps?.getEventColor).toBe(
+      firstRenderProps?.getEventColor,
     );
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.tsx
@@ -23,7 +23,7 @@ import { NotificationsService } from '@services/core/notifications.service';
 import ContentCalendar from '@ui/calendar/content-calendar/ContentCalendar';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HiDocumentText, HiListBullet } from 'react-icons/hi2';
 
 const DEFAULT_COLOR = '#8b5cf6';
@@ -171,18 +171,32 @@ export default function ContentCalendarPage(): React.JSX.Element {
     return [...postItems, ...articleItems];
   }, [posts, articles]);
 
-  const handleEventClick = (item: ContentCalendarItem) => {
+  const handleEventClick = useCallback(
+    (item: ContentCalendarItem) => {
+      if (item.itemType === 'article') {
+        push(`${COMPOSE_ROUTES.ARTICLE}?id=${item.article.id}`);
+        return;
+      }
+
+      setSelectedPostId(item.post.id);
+    },
+    [push],
+  );
+
+  const handleDatesChange = useCallback(
+    (start: Date, end: Date) => {
+      setDateRange({ end, start });
+    },
+    [setDateRange],
+  );
+
+  const getEventColor = useCallback((item: ContentCalendarItem) => {
     if (item.itemType === 'article') {
-      push(`${COMPOSE_ROUTES.ARTICLE}?id=${item.article.id}`);
-      return;
+      return getArticleColor(item.status);
     }
 
-    setSelectedPostId(item.post.id);
-  };
-
-  const handleDatesChange = (start: Date, end: Date) => {
-    setDateRange({ end, start });
-  };
+    return getPlatformColor(item.status);
+  }, []);
 
   const filterControls = (
     <div className="flex items-center gap-2">
@@ -214,11 +228,7 @@ export default function ContentCalendarPage(): React.JSX.Element {
       items={calendarItems}
       onEventClick={handleEventClick}
       onDatesChange={handleDatesChange}
-      getEventColor={(item) =>
-        item.itemType === 'article'
-          ? getArticleColor(item.status)
-          : getPlatformColor(item.status)
-      }
+      getEventColor={getEventColor}
       filterControls={filterControls}
       modal={modal}
     />

--- a/packages/pages/calendar/posts/posts-calendar-page.tsx
+++ b/packages/pages/calendar/posts/posts-calendar-page.tsx
@@ -18,7 +18,7 @@ import { NotificationsService } from '@services/core/notifications.service';
 import ContentCalendar from '@ui/calendar/content-calendar/ContentCalendar';
 import Link from 'next/link';
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HiListBullet } from 'react-icons/hi2';
 
 const DEFAULT_COLOR = '#8b5cf6';
@@ -100,22 +100,34 @@ export default function PostsCalendarPage({
     loadPosts();
   }, [dateRange, brandId, scope, getPostsService, notificationsService]);
 
-  const calendarItems: PostCalendarItem[] = posts.map((post) => ({
-    id: post.id,
-    isDisabled: isPostDisabled(post),
-    post,
-    scheduledDate: post.scheduledDate ?? undefined,
-    status: post.platform || '',
-    title: getEventTitle(post),
-  }));
+  const calendarItems: PostCalendarItem[] = useMemo(
+    () =>
+      posts.map((post) => ({
+        id: post.id,
+        isDisabled: isPostDisabled(post),
+        post,
+        scheduledDate: post.scheduledDate ?? undefined,
+        status: post.platform || '',
+        title: getEventTitle(post),
+      })),
+    [posts],
+  );
 
-  const handleEventClick = (item: PostCalendarItem) => {
+  const handleEventClick = useCallback((item: PostCalendarItem) => {
     setSelectedPostId(item.post.id);
-  };
+  }, []);
 
-  const handleDatesChange = (start: Date, end: Date) => {
-    setDateRange({ end, start });
-  };
+  const handleDatesChange = useCallback(
+    (start: Date, end: Date) => {
+      setDateRange({ end, start });
+    },
+    [setDateRange],
+  );
+
+  const getEventColor = useCallback(
+    (item: PostCalendarItem) => getPlatformColor(item.status),
+    [],
+  );
 
   const filterControls = (
     <Link
@@ -139,7 +151,7 @@ export default function PostsCalendarPage({
       items={calendarItems}
       onEventClick={handleEventClick}
       onDatesChange={handleDatesChange}
-      getEventColor={(item) => getPlatformColor(item.status)}
+      getEventColor={getEventColor}
       filterControls={filterControls}
       modal={modal}
     />

--- a/packages/ui/src/components/calendar/content-calendar/ContentCalendar.test.tsx
+++ b/packages/ui/src/components/calendar/content-calendar/ContentCalendar.test.tsx
@@ -1,0 +1,98 @@
+import type { CalendarOptions } from '@fullcalendar/core';
+import { act, render, waitFor } from '@testing-library/react';
+import ContentCalendar from '@ui/calendar/content-calendar/ContentCalendar';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const calendarMocks = vi.hoisted(() => {
+  const instances: Array<{
+    destroy: ReturnType<typeof vi.fn>;
+    options: CalendarOptions;
+    render: () => void;
+  }> = [];
+
+  class MockCalendar {
+    destroy = vi.fn();
+    options: CalendarOptions;
+
+    constructor(_element: HTMLElement, options: CalendarOptions) {
+      this.options = options;
+      instances.push(this);
+    }
+
+    render() {
+      this.options.datesSet?.(createDatesSetArg('2026-03-09', '2026-03-16'));
+    }
+  }
+
+  function createDatesSetArg(startDate: string, endDate: string) {
+    const start = new Date(`${startDate}T00:00:00.000Z`);
+    const end = new Date(`${endDate}T00:00:00.000Z`);
+
+    return {
+      end,
+      endStr: end.toISOString(),
+      start,
+      startStr: start.toISOString(),
+      timeZone: 'UTC',
+      view: {},
+    } as Parameters<NonNullable<CalendarOptions['datesSet']>>[0];
+  }
+
+  return {
+    Calendar: MockCalendar,
+    createDatesSetArg,
+    instances,
+  };
+});
+
+vi.mock('@fullcalendar/core/index.js', () => ({
+  Calendar: calendarMocks.Calendar,
+}));
+
+vi.mock('@fullcalendar/timegrid/index.js', () => ({
+  default: {},
+}));
+
+vi.mock('@fullcalendar/interaction/index.js', () => ({
+  default: {},
+}));
+
+describe('ContentCalendar', () => {
+  beforeEach(() => {
+    calendarMocks.instances.length = 0;
+  });
+
+  it('skips duplicate datesSet notifications for the same visible range', async () => {
+    const onDatesChange = vi.fn();
+
+    render(
+      <ContentCalendar
+        items={[]}
+        onEventClick={vi.fn()}
+        onDatesChange={onDatesChange}
+        getEventColor={() => '#8b5cf6'}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(calendarMocks.instances).toHaveLength(1);
+      expect(onDatesChange).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      calendarMocks.instances[0]?.options.datesSet?.(
+        calendarMocks.createDatesSetArg('2026-03-09', '2026-03-16'),
+      );
+    });
+
+    expect(onDatesChange).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      calendarMocks.instances[0]?.options.datesSet?.(
+        calendarMocks.createDatesSetArg('2026-03-16', '2026-03-23'),
+      );
+    });
+
+    expect(onDatesChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui/src/components/calendar/content-calendar/ContentCalendar.tsx
+++ b/packages/ui/src/components/calendar/content-calendar/ContentCalendar.tsx
@@ -18,6 +18,23 @@ interface FullCalendarHostProps {
   options: CalendarOptions;
 }
 
+interface CalendarDateRange {
+  end: Date;
+  start: Date;
+}
+
+function isSameDateRange(
+  dateRange: CalendarDateRange | null,
+  start: Date,
+  end: Date,
+): boolean {
+  return (
+    dateRange !== null &&
+    dateRange.start.getTime() === start.getTime() &&
+    dateRange.end.getTime() === end.getTime()
+  );
+}
+
 function FullCalendarHost({ options }: FullCalendarHostProps) {
   const [loadError, setLoadError] = useState<Error | null>(null);
   const calendarRef = useRef<FullCalendarInstance | null>(null);
@@ -90,7 +107,8 @@ export default function ContentCalendar<T extends CalendarItem>({
   filterControls,
   modal,
 }: ContentCalendarProps<T>) {
-  const [, setDateRange] = useState<{ start: Date; end: Date } | null>(null);
+  const dateRangeRef = useRef<CalendarDateRange | null>(null);
+  const [, setDateRange] = useState<CalendarDateRange | null>(null);
 
   const events: EventInput[] = useMemo(
     () =>
@@ -127,11 +145,18 @@ export default function ContentCalendar<T extends CalendarItem>({
 
   const handleDatesSet = useCallback(
     (arg: DatesSetArg) => {
-      setDateRange({
-        end: arg.end,
-        start: arg.start,
-      });
-      onDatesChange(arg.start, arg.end);
+      if (isSameDateRange(dateRangeRef.current, arg.start, arg.end)) {
+        return;
+      }
+
+      const nextDateRange = {
+        end: new Date(arg.end),
+        start: new Date(arg.start),
+      };
+
+      dateRangeRef.current = nextDateRange;
+      setDateRange(nextDateRange);
+      onDatesChange(nextDateRange.start, nextDateRange.end);
     },
     [onDatesChange],
   );


### PR DESCRIPTION
Fixes #1225.

## Summary
- Memoize the Calendar page callbacks passed into `ContentCalendar`, including `getEventColor`, `onDatesChange`, and `onEventClick`.
- Guard duplicate FullCalendar `datesSet` ranges in `ContentCalendar` by comparing start/end timestamps before updating range state or calling `onDatesChange`.
- Stabilize the older shared posts calendar caller as well so the same shared component is not fed fresh callback/item refs unnecessarily.

## Verification
- `bunx biome check --write .` (exit 0; reported existing migration-script warnings)
- `bun run --cwd packages/ui test src/components/calendar/content-calendar/ContentCalendar.test.tsx`
- `bun run --cwd apps/app test "app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.test.tsx"`
- `bunx vitest run --config packages/pages/vitest.config.ts packages/pages/calendar/posts/posts-calendar-page.test.tsx` could not run because that config excludes this spec.
- `bunx tsc --noEmit --project packages/pages/tsconfig.json` is blocked by existing standalone package alias-resolution failures before reaching this change.
- Workspace `bun type-check` and package-wide test filters were left to PR CI per the repo local verification rule against heavy local gates.