### PR TITLE
fix(auth): remove GitHub beta login option

### DIFF
--- a/.agents/memory/captured-rules.md
+++ b/.agents/memory/captured-rules.md
@@ -1,0 +1,19 @@
+---
+status: temporary
+last_verified: 2026-07-03
+---
+
+### [2026-07-03 15:00] - Auth UI: Do Not Expose Unconfigured OAuth Providers
+
+**User said (redacted):**
+
+> "provider is not even set up properly on beta auth"
+
+**Rule extracted:**
+
+- **Type**: AVOID
+- **Action**: Do not expose OAuth providers in public login or sign-up UI unless that provider is actually configured and verified for the target auth environment.
+- **Context**: Beta Better Auth login/sign-up surfaces and tests.
+- **Category**: coding
+
+**Status**: PENDING_REVIEW

--- a/apps/app/app/(public)/login/content.test.tsx
+++ b/apps/app/app/(public)/login/content.test.tsx
@@ -64,8 +64,8 @@ describe('LoginPage', () => {
     expect(screen.queryByRole('textbox', { name: /^Email/ })).toBeNull();
     expect(screen.getByRole('button', { name: 'Google' })).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Sign in with GitHub' }),
-    ).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Sign in with GitHub' }),
+    ).toBeNull();
     expect(screen.getByRole('link', { name: 'Magic Link' })).toHaveAttribute(
       'href',
       '/login/magic-link',
@@ -124,21 +124,6 @@ describe('LoginPage', () => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
         callbackURL: absoluteCallback('/onboarding'),
         provider: 'google',
-      });
-    });
-  });
-
-  it('starts GitHub sign-in with the default callback URL', async () => {
-    render(<LoginPage />);
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Sign in with GitHub' }),
-    );
-
-    await waitFor(() => {
-      expect(authClientMocks.social).toHaveBeenCalledWith({
-        callbackURL: absoluteCallback('/'),
-        provider: 'github',
       });
     });
   });

--- a/apps/app/app/(public)/login/login-better-auth.tsx
+++ b/apps/app/app/(public)/login/login-better-auth.tsx
@@ -15,7 +15,6 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
-import { FaGithub } from 'react-icons/fa6';
 import { FcGoogle } from 'react-icons/fc';
 import {
   getAuthCallbackURL,
@@ -130,7 +129,7 @@ export default function LoginBetterAuth({
     }
   }
 
-  async function handleSocialSignIn(provider: 'github' | 'google') {
+  async function handleSocialSignIn(provider: 'google') {
     setSocialErrorMessage(null);
     setErrorMessage(null);
     setPasswordErrorMessage(null);
@@ -142,16 +141,14 @@ export default function LoginBetterAuth({
         provider,
       });
       if (result?.error) {
-        const label = provider === 'google' ? 'Google' : 'GitHub';
         setSocialErrorMessage(
           result.error.message ??
-            `Failed to continue with ${label}. Please try again.`,
+            'Failed to continue with Google. Please try again.',
         );
       }
     } catch {
-      const label = provider === 'google' ? 'Google' : 'GitHub';
       setSocialErrorMessage(
-        `Failed to continue with ${label}. Please try again.`,
+        'Failed to continue with Google. Please try again.',
       );
     } finally {
       setIsSocialSubmitting(false);
@@ -315,18 +312,6 @@ export default function LoginBetterAuth({
             withWrapper={false}
           >
             Google
-          </Button>
-
-          <Button
-            type="button"
-            variant={ButtonVariant.OUTLINE}
-            onClick={() => handleSocialSignIn('github')}
-            icon={<FaGithub className="size-4" aria-hidden="true" />}
-            isLoading={isSocialSubmitting}
-            className={AUTH_BUTTON_CLASS_NAME}
-            withWrapper={false}
-          >
-            Sign in with GitHub
           </Button>
 
           <Button

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -15,7 +15,6 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
-import { FaGithub } from 'react-icons/fa6';
 import { persistOnboardingHandoffParams } from '@/lib/onboarding/onboarding-access.util';
 import {
   getAuthCallbackURL,
@@ -70,7 +69,7 @@ export default function SignUpBetterAuth() {
     }
   }
 
-  async function handleSocialSignUp(provider: 'github' | 'google') {
+  async function handleSocialSignUp(provider: 'google') {
     setErrorMessage(null);
     try {
       const result = await signIn.social({
@@ -80,11 +79,11 @@ export default function SignUpBetterAuth() {
       if (result?.error) {
         setErrorMessage(
           result.error.message ??
-            `Failed to sign up with ${provider}. Please try again.`,
+            'Failed to sign up with Google. Please try again.',
         );
       }
     } catch {
-      setErrorMessage(`Failed to sign up with ${provider}. Please try again.`);
+      setErrorMessage('Failed to sign up with Google. Please try again.');
     }
   }
 
@@ -156,17 +155,6 @@ export default function SignUpBetterAuth() {
           withWrapper={false}
         >
           Continue with Google
-        </Button>
-
-        <Button
-          type="button"
-          variant={ButtonVariant.OUTLINE}
-          onClick={() => handleSocialSignUp('github')}
-          icon={<FaGithub className="size-4" aria-hidden="true" />}
-          className="w-full"
-          withWrapper={false}
-        >
-          Continue with GitHub
         </Button>
 
         <p className="text-center text-sm text-muted-foreground">

--- a/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
@@ -76,8 +76,11 @@ describe('SignUpForm', () => {
       screen.getByRole('button', { name: 'Continue with email' }),
     ).toBeDisabled();
     expect(
-      screen.getByRole('button', { name: 'Continue with GitHub' }),
+      screen.getByRole('button', { name: 'Continue with Google' }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Continue with GitHub' }),
+    ).toBeNull();
   });
 
   it('sends a sign-up magic link with the callback URL', async () => {
@@ -133,19 +136,19 @@ describe('SignUpForm', () => {
     );
   });
 
-  it('starts GitHub sign-up with the callback URL', async () => {
+  it('starts Google sign-up with the callback URL', async () => {
     window.history.replaceState({}, '', '/sign-up?callbackUrl=%2Fonboarding');
 
     render(<SignUpForm />);
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with GitHub' }),
+      screen.getByRole('button', { name: 'Continue with Google' }),
     );
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
         callbackURL: absoluteCallback('/onboarding'),
-        provider: 'github',
+        provider: 'google',
       });
     });
   });

--- a/playwright/e2e/pages/login.page.ts
+++ b/playwright/e2e/pages/login.page.ts
@@ -25,7 +25,6 @@ export class LoginPage {
 
   // Social login buttons
   readonly googleButton: Locator;
-  readonly githubButton: Locator;
 
   // Error messages
   readonly errorMessage: Locator;
@@ -62,9 +61,6 @@ export class LoginPage {
     // Social login
     this.googleButton = page.locator(
       'button:has-text("Google"), [data-localization-key="socialButtonsBlockButton__google"]',
-    );
-    this.githubButton = page.locator(
-      'button:has-text("GitHub"), [data-localization-key="socialButtonsBlockButton__github"]',
     );
 
     // Error messages
@@ -170,13 +166,6 @@ export class LoginPage {
    */
   async loginWithGoogle(): Promise<void> {
     await this.googleButton.click();
-  }
-
-  /**
-   * Click GitHub sign in button
-   */
-  async loginWithGithub(): Promise<void> {
-    await this.githubButton.click();
   }
 
   /**

--- a/playwright/e2e/tests/auth/login.spec.ts
+++ b/playwright/e2e/tests/auth/login.spec.ts
@@ -143,18 +143,14 @@ test.describe('Login Page', () => {
       const hasGoogleButton = await loginPage.googleButton
         .isVisible()
         .catch(() => false);
-      const hasGithubButton = await loginPage.githubButton
-        .isVisible()
-        .catch(() => false);
-
-      if (!hasGoogleButton && !hasGithubButton) {
+      if (!hasGoogleButton) {
         test.skip(
           true,
           'Social login is not enabled in the current Better Auth configuration',
         );
       }
 
-      expect(hasGoogleButton || hasGithubButton).toBe(true);
+      expect(hasGoogleButton).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- remove GitHub OAuth buttons from beta login and sign-up screens
- narrow social auth handlers/tests to Google only
- remove stale Playwright GitHub login page-object support
- capture the auth-provider UI rule as a pending project memory note

## Verification
- (from apps/app) bun run test -- "app/(public)/login/content.test.tsx" "app/(public)/sign-up/sign-up-form.test.tsx"
- bunx biome check "apps/app/app/(public)/login/login-better-auth.tsx" "apps/app/app/(public)/sign-up/sign-up-better-auth.tsx" "apps/app/app/(public)/login/content.test.tsx" "apps/app/app/(public)/sign-up/sign-up-form.test.tsx" "playwright/e2e/pages/login.page.ts" "playwright/e2e/tests/auth/login.spec.ts" ".agents/memory/captured-rules.md"
- git diff --check