### PR TITLE
feat(agents): deterministic guardrail hooks + nested CLAUDE.md context

### DIFF
--- a/.agents/SESSIONS/2026-07-03.md
+++ b/.agents/SESSIONS/2026-07-03.md
@@ -231,3 +231,61 @@ Stripe controllers still do `findOne({ authProviderId: user.id })` (`stripe.cont
 - Verify #738 acceptance (migrated-user Google login) → close it.
 - Implement #1199 (offered to ship it + PR on request; kept this session PRD-only per header).
 - When #739 opens: fix #1199 → confirm no `authProviderId` readers → drop column → delete dead resolver (coordinate single deletion with #1041).
+
+---
+
+## Session 4 — Agent guardrails: deterministic hooks + nested CLAUDE.md (model Fable 5 high)
+
+Vincent asked what guardrails would stop agents repeating the same mistakes and cut token cost. Assessment: rules lived as ~15–20k tokens of always-loaded prose (stated 3–4× each) while `.claude/settings.json` had only 4 deny rules and zero blocking hooks. Approved scope: deterministic enforcement + push detail into nested CLAUDE.md files. (Context dedupe of global `~/.claude` files deferred as its own pass.)
+
+### System flow
+
+```
+Bash tool call
+  → PreToolUse hook: .claude/hooks/pre-bash-guard.py (stdin JSON, exit 2 = block, stderr → agent)
+      ├── git push targeting master/main (token-exact refspec match, incl. HEAD:master; bare push while on trunk)
+      ├── npm/npx/yarn/pnpm in command position (bun-only)
+      ├── unscoped `bun test` / `turbo run test` without --filter (full suites → CI)
+      ├── `vercel` when .vercel/project.json missing
+      └── `git add`/`git commit` touching .env* (checks staged files on commit)
+Edit/Write tool call
+  → PostToolUse hook: .claude/hooks/post-edit-biome.sh
+      → bunx biome check --write <file> (ts/tsx/js/jsx/json only)
+      → auto-fixes in place; error-level issues → exit 2, stderr → agent fixes immediately
+CLAUDE.md loading
+  → nested files load only when working in that dir:
+      packages/serializers/CLAUDE.md · packages/prisma/CLAUDE.md · apps/app/CLAUDE.md
+```
+
+### What was done
+
+- [x] `pre-bash-guard.py`: 5 rule groups above; fail-open on parse/subprocess errors so a broken hook never bricks the shell.
+- [x] `post-edit-biome.sh`: mirrors repo gate semantics — biome *warnings* (this config has `noUnusedVariables`/`noExplicitAny` as warnings) pass, error-level issues surface to the agent with exit 2.
+- [x] `.claude/settings.json`: registered both hooks; deny list extended with `Edit(**/.env*)`, `Write(**/.env*)`, `Read(**/*.pem)`.
+- [x] Nested CLAUDE.md ×3, grounded in real code: serializer triplet (reference: `management/tag.*`), prisma schema/migration rules (CONCURRENTLY lesson from #1212, `hot-path-indexes.test.ts`), apps/app page/component rules.
+- [x] Verified: 31-case block/pass matrix green (scratchpad script); vercel block path tested against a dir without project.json; biome hook tested live (fired on this session's own Write and auto-formatted), plus exit-2 parse-error path.
+
+### Key decisions
+
+- **Hook in Python stdlib, not repo TS** — must be dependency-free and fast; no bun/node startup or install state needed for the shell gate.
+- **Token-exact refspec matching for trunk protection** — regex `\bmaster\b` would false-block branches like `feat/master-fix`; instead split push args and compare the `src:dest` destination token exactly.
+- **Biome hook stays error-only** — matching `biome check` exit semantics keeps the hook consistent with lint-staged and the pre-push checklist; exit-2 on warnings would make every legacy-file edit noisy.
+- **`.env*` staging blocked strictly** (including `.env.example`) — per the global rule "never stage a file matching `.env*` regardless".
+- **npm/yarn/pnpm blocked only in command position** (after `^ ; | & (`), so `grep npm README.md` and quoted mentions pass.
+
+### Files changed
+
+- New: `.claude/hooks/pre-bash-guard.py`, `.claude/hooks/post-edit-biome.sh`, `packages/serializers/CLAUDE.md`, `packages/prisma/CLAUDE.md`, `apps/app/CLAUDE.md`
+- Modified: `.claude/settings.json`
+
+### Mistakes and fixes
+
+- First hook test blocked itself — the test harness command *contained* `git push origin master` as a string, and the just-registered hook (live immediately) matched the outer command. Moved the matrix into a scratchpad script so banned patterns aren't in the outer command text. (Also proof the hook activates without a session restart.)
+- Initial trunk regex missed `git push origin HEAD:master` — caught by the test matrix; fixed with token-based refspec destination matching.
+- The guard blocked its own `gh pr create` — the PR *body text* mentioned "git add … .env" and rules scanned quoted content. Fixed by blanking quoted spans before matching command rules (the `.env` rules keep the raw string so `git add ".env"` still blocks); matrix extended to 34 cases with quoted-mention regressions.
+- First commit landed on the wrong branch and silently dropped the session doc: a concurrent process had switched the shared checkout (shared-checkout-automation rule strikes again), and lint-staged's restage of `.agents/SESSIONS/` failed on the gitignore rule (dir is ignored; the files are force-tracked). Recovered via branch surgery + `git add -f` + rebase onto origin/master.
+
+### Next steps
+
+- [ ] Context-dedupe pass over global `~/.claude` + repo CLAUDE.md/@imports (one canonical location per rule; shrink always-loaded prose now that gates enforce the NEVERs) — separate session.
+- [ ] Adopt the capture policy: a rule violated twice graduates from prose to hook/deny/check-script.

--- a/.claude/hooks/post-edit-biome.sh
+++ b/.claude/hooks/post-edit-biome.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# PostToolUse hook (Edit|Write): format + lint the just-edited file with Biome.
+# Auto-fixes what it can in place; exit 2 surfaces remaining issues to the agent
+# immediately instead of at the pre-push checklist. Fail-open on infra errors.
+set -u
+
+export PATH="$HOME/.bun/bin:$PATH"
+command -v bunx >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+file=$(printf '%s' "$input" | python3 -c 'import json,sys; print((json.load(sys.stdin).get("tool_input") or {}).get("file_path",""))' 2>/dev/null) || exit 0
+
+case "$file" in
+  *.ts | *.tsx | *.js | *.jsx | *.json | *.jsonc) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file" ] || exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+if ! output=$(bunx biome check --write --no-errors-on-unmatched "$file" 2>&1); then
+  {
+    echo "Biome found unfixable issues in $file — fix them now:"
+    printf '%s\n' "$output" | tail -40
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pre-bash-guard.py
+++ b/.claude/hooks/pre-bash-guard.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""PreToolUse guard for Bash tool calls in genfeed.ai.
+
+Deterministically enforces working agreements that used to live only as prose:
+  1. Trunk is PR-only — no pushes to master/main.
+  2. Bun only — npm/npx/yarn/pnpm are blocked.
+  3. No full test suites locally — scoped/--filter runs only; full suites go to CI.
+  4. No `vercel` without an existing .vercel/project.json link.
+  5. .env* files never get staged or committed (public repo).
+
+Contract: stdin receives {"tool_name","tool_input":{"command"}}. Exit 2 blocks
+the call and feeds stderr back to the agent so it can self-correct.
+Fail-open on parse/subprocess errors — a broken hook must never brick the shell.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+# Matches only at command position (start of string or after && || ; | \( ),
+# so quoted mentions — commit messages, PR bodies — don't false-positive.
+COMMAND_POSITION = r"(?:^|&&|\|\||[;|(])\s*"
+
+
+def block(message: str) -> None:
+    print(f"BLOCKED by .claude/hooks/pre-bash-guard.py: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def git(project_dir: str, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", project_dir, *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not command:
+        return
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+    # Command rules (1–4) match with quoted spans blanked out, so commit
+    # messages / PR bodies that *mention* forbidden commands don't trip them.
+    # The .env rules (5) keep the raw string: `git add ".env"` must still match.
+    sanitized = re.sub(r"\"[^\"]*\"|'[^']*'", '""', command)
+
+    # 1. Trunk protection — no pushes to master/main, ever.
+    if re.search(COMMAND_POSITION + r"git\b[^;&|]*\bpush\b", sanitized):
+        push_tail = re.search(r"\bpush\b([^;&|]*)", sanitized).group(1).split()
+        refspecs = [
+            arg
+            for arg in push_tail
+            if not arg.startswith("-") and arg not in ("origin", "upstream")
+        ]
+        # A refspec targets trunk if it IS master/main or its destination
+        # (`src:dest`) is — exact token match, so feat/master-fix stays pushable.
+        for refspec in refspecs:
+            destination = refspec.rsplit(":", 1)[-1].removeprefix("refs/heads/")
+            if destination in ("master", "main"):
+                block(
+                    "pushing master/main is forbidden — trunk is PR-only. "
+                    "Push a feature branch and open a PR to master."
+                )
+        if not refspecs and git(project_dir, "symbolic-ref", "--short", "HEAD") in (
+            "master",
+            "main",
+        ):
+            block(
+                "bare `git push` while checked out on trunk would push master/main. "
+                "Create a feature branch first."
+            )
+
+    # 2. Bun only — block npm/npx/yarn/pnpm in command position.
+    package_manager = re.search(
+        COMMAND_POSITION + r"(npm|npx|yarn|pnpm)\b", sanitized
+    )
+    if package_manager:
+        block(
+            f"`{package_manager.group(1)}` is forbidden in this workspace — "
+            "use `bun` / `bunx` instead (bun-not-npm rule)."
+        )
+
+    # 3. No full test suites locally.
+    if (
+        re.search(COMMAND_POSITION + r"(bunx\s+)?turbo\s+(run\s+)?test\b", sanitized)
+        and "--filter" not in command
+    ):
+        block(
+            "unfiltered `turbo run test` runs the full suite — never locally. "
+            "Scope with --filter=@genfeedai/<pkg> or dispatch CI (gh workflow run)."
+        )
+    if (
+        re.search(
+            COMMAND_POSITION + r"bun\s+(run\s+)?test\s*(?:$|&&|\|\||[;|)])", sanitized
+        )
+        and "--filter" not in command
+    ):
+        block(
+            "bare `bun test` / `bun run test` runs the full suite — never locally. "
+            "Scope it: `bun run test <file>` or `bun run test --filter=@genfeedai/<pkg>`."
+        )
+
+    # 4. Vercel deploys require an existing project link.
+    if re.search(COMMAND_POSITION + r"(?:bunx\s+)?vercel\b", sanitized):
+        if not os.path.isfile(os.path.join(project_dir, ".vercel", "project.json")):
+            block(
+                "`vercel` without .vercel/project.json — STOP. Do not run "
+                "`vercel link` unattended; ask Vincent first (www/CLAUDE.md rule)."
+            )
+
+    # 5. .env* never staged or committed — this repo is public.
+    if re.search(COMMAND_POSITION + r"git\b[^;&|]*\badd\b[^;&|]*\.env", command):
+        block(
+            "staging .env* files is forbidden — never commit env files "
+            "(public repo; a leak is indexed before rotation)."
+        )
+    if re.search(COMMAND_POSITION + r"git\b[^;&|]*\bcommit\b", command):
+        staged = git(project_dir, "diff", "--cached", "--name-only")
+        env_files = [
+            line
+            for line in staged.splitlines()
+            if re.search(r"(^|/)\.env", line)
+        ]
+        if env_files:
+            block(
+                f"staged files include env files ({', '.join(env_files)}) — "
+                "unstage them before committing (`git restore --staged <file>`)."
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,37 @@
 {
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-biome.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-bash-guard.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  },
   "permissions": {
     "deny": [
       "Bash(curl:*)",
       "Bash(wget:*)",
+      "Edit(**/.env*)",
+      "Read(**/*.pem)",
       "Read(**/.env*)",
-      "Read(**/secrets/**)"
+      "Read(**/secrets/**)",
+      "Write(**/.env*)"
     ]
   }
 }

--- a/apps/app/CLAUDE.md
+++ b/apps/app/CLAUDE.md
@@ -1,0 +1,22 @@
+# @genfeedai/app — Main Studio App
+
+Next.js App Router. Next 16: the middleware file is `proxy.ts`, not `middleware.ts`. Tailwind v4 syntax only.
+
+## Routing
+
+- Route groups: `(protected)` (authed; org/brand-scoped work lives under `[orgSlug]/[brandSlug]/`), `(public)`, `(onboarding)`. Admin is `(protected)/admin`.
+- New pages use the server/client split: `page.tsx` (server component: metadata + `Suspense` wrapper) + `content.tsx` (client component with the actual UI).
+- Navigation uses `Link` semantics; actions use `Button` semantics.
+
+## Component rules
+
+- `function` declarations (not arrow), default export. Colocated `*.test.tsx`.
+- Never raw HTML elements (`<button>`, `<input>`, `<table>`, …) — use `@ui/primitives/*`. Enforced by `scripts/lint-no-raw-html.sh` pre-commit. Unstyled usage: `Button` with `variant={ButtonVariant.UNSTYLED}` + `withWrapper={false}`. Never nest `Button` inside `Button` — restructure as siblings.
+- Every `useEffect` with async calls uses an `AbortController`.
+- Prop interfaces live in `packages/props/`, never inline.
+- Card sizing via `size` prop; padding via `bodyClassName`. Premium surfaces use `gen-*` design classes.
+
+## Verify
+
+- Build: `bunx turbo run build --filter=@genfeedai/app`
+- Tests: `bun run test --filter=@genfeedai/app`

--- a/packages/prisma/CLAUDE.md
+++ b/packages/prisma/CLAUDE.md
@@ -1,0 +1,16 @@
+# @genfeedai/prisma
+
+PostgreSQL schema, migrations, and generated client for all `apps/server/*` services. (Desktop has its own separate `packages/desktop-prisma/`.)
+
+## Schema rules
+
+- Soft deletes: `isDeleted Boolean` — never `deletedAt`.
+- Compound indexes: `@@index` directives in `prisma/schema.prisma`, or explicit migration SQL for anything `@@index` can't express.
+- Tenant-scoped models carry `organizationId`; API queries filter `{ organizationId, isDeleted: false }`.
+
+## Migrations
+
+- `CREATE INDEX CONCURRENTLY` cannot run inside a transaction: keep CONCURRENTLY statements in their own migration file, separate from any preflight/dedup DML. Mixing them blocked a production deploy (#1212).
+- Hot-path index expectations are asserted in `prisma/hot-path-indexes.test.ts` — update it when adding or removing indexes.
+- Never edit an already-applied migration; add a new one.
+- Verify: `bun run test --filter=@genfeedai/prisma`.

--- a/packages/serializers/CLAUDE.md
+++ b/packages/serializers/CLAUDE.md
@@ -1,0 +1,40 @@
+# @genfeedai/serializers
+
+Every entity is a three-file triplet. Never return raw Prisma records from an API — flow is DB record → serializer → response. Serializers live ONLY in this package, never in API modules.
+
+## Triplet pattern (copy a sibling in the same domain)
+
+1. `src/attributes/{domain}/{name}.attributes.ts`
+
+   ```ts
+   export const tagAttributes = createEntityAttributes(['organization', 'brand', 'label']);
+   ```
+
+   `createEntityAttributes()` (from `@genfeedai/helpers`) auto-adds id, timestamps, and `isDeleted` — list only entity-specific fields.
+
+2. `src/configs/{domain}/{name}.config.ts`
+
+   ```ts
+   export const tagSerializerConfig = {
+     attributes: tagAttributes,
+     brand: BRAND_REL,
+     organization: ORGANIZATION_REL,
+     type: 'tag',
+     user: USER_REL,
+   };
+   ```
+
+   Relationships come from `@serializers/relationships` (`ORGANIZATION_REL`, `BRAND_REL`, `USER_REL`) or spread `STANDARD_ENTITY_RELS` / `CONTENT_ENTITY_RELS`. Simple entities can use `simpleConfig()`.
+
+3. `src/server/{domain}/{name}.serializer.ts`
+
+   ```ts
+   export const { TagSerializer } = buildSerializer('server', tagSerializerConfig);
+   ```
+
+## Rules
+
+- Export every new file from its domain `index.ts` barrel, at all three layers.
+- Object keys sorted — Biome sorted-keys is enforced.
+- Reference triplet: `attributes/management/tag.attributes.ts` → `configs/management/tag.config.ts` → `server/management/tag.serializer.ts`.
+- Verify: `bun run test --filter=@genfeedai/serializers`.


### PR DESCRIPTION
## Summary

Converts agent working agreements from always-loaded prose into deterministic enforcement, and pushes directory-specific conventions into nested `CLAUDE.md` files that load on demand.

### PreToolUse guard — `.claude/hooks/pre-bash-guard.py`

Blocks (exit 2, reason fed back to the agent for self-correction):
- `git push` targeting `master`/`main` — token-exact refspec matching (catches `HEAD:master`, doesn't false-block `feat/master-fix`), plus bare `git push` while checked out on trunk
- `npm` / `npx` / `yarn` / `pnpm` in command position (bun-only workspace; `grep npm README.md` still passes)
- Unscoped `bun test` / `turbo run test` without `--filter` (full suites belong in CI)
- `vercel` when `.vercel/project.json` is missing
- `git add`/`git commit` touching `.env*` (checks actual staged files on commit)

Command rules match against a quote-sanitized string, so commit messages and PR bodies that merely *mention* forbidden commands don't trip the guard (the `.env` rules keep the raw string so quoted env paths still block). Fail-open on parse/subprocess errors — a broken hook never bricks the shell.

### PostToolUse biome hook — `.claude/hooks/post-edit-biome.sh`

Runs `biome check --write` on each edited `ts/tsx/js/jsx/json` file the moment it's written. Auto-fixes format issues in place; error-level issues surface to the agent immediately (exit 2) instead of at the pre-push checklist. Warnings follow repo gate semantics (same as lint-staged).

### Settings

Deny list extended: `Edit(**/.env*)`, `Write(**/.env*)`, `Read(**/*.pem)`.

### Nested CLAUDE.md (on-demand context instead of root-context prose)

- `packages/serializers/CLAUDE.md` — triplet pattern with the real `management/tag.*` reference
- `packages/prisma/CLAUDE.md` — schema rules, CONCURRENTLY-migration lesson from #1212, `hot-path-indexes.test.ts` pointer
- `apps/app/CLAUDE.md` — routing groups, page/content split, component rules

## Verification

- 34-case block/pass matrix for the guard hook (all green), including refspec edge cases, quoted-mention regressions, and false-positive checks
- Vercel block path tested against a directory without `.vercel/project.json`
- Biome hook verified live: it fired on this branch's own file writes and auto-formatted them; exit-2 path confirmed with a parse-error file
- Hooks activate immediately on settings load (the guard blocked its own test command mid-session) — no restart needed
- No TS/runtime code touched — hooks are Python stdlib + POSIX shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)