### PR TITLE
fix(app): workspace overview agent cards use shared Card tokens (#1229)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.test.tsx
@@ -117,7 +117,7 @@ function makeTask(overrides: Record<string, unknown> = {}) {
 
 describe('workspace dashboard sections', () => {
   it('renders agent cards with live, queued, completed, and view-all states', () => {
-    render(
+    const { container } = render(
       <DashboardAgentCards
         activeRuns={[
           makeRun(),
@@ -156,6 +156,11 @@ describe('workspace dashboard sections', () => {
       'href',
       '/orchestration/runs',
     );
+
+    // Regression (#1229): agent-run cards must use the shared Card tokens,
+    // never the lighter bespoke background-secondary/tertiary grays.
+    expect(container.querySelector('.bg-background-secondary')).toBeNull();
+    expect(container.querySelector('.bg-background-tertiary')).toBeNull();
   });
 
   it('returns no agent cards when there are no runs', () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
@@ -4,6 +4,7 @@ import {
   AgentExecutionStatus,
   ButtonSize,
   ButtonVariant,
+  CardVariant,
 } from '@genfeedai/enums';
 import type { IAgentRun } from '@genfeedai/interfaces';
 import type { TrendItem } from '@genfeedai/props/trends/trends-page.props';
@@ -126,10 +127,14 @@ function AgentRunCard({ run }: { run: IAgentRun }) {
       : (run.label?.split(' ')?.[0] ?? 'Agent');
 
   return (
-    <div className="group relative flex flex-col gap-2 rounded-md border border-border bg-background-secondary p-3 transition-colors hover:border-border-strong hover:bg-background-tertiary">
+    <Card
+      variant={CardVariant.DEFAULT}
+      className="group"
+      bodyClassName="gap-2 p-3"
+    >
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2">
-          <div className="flex size-6 items-center justify-center rounded border border-border bg-background-tertiary">
+          <div className="flex size-6 items-center justify-center rounded border border-border bg-muted">
             <HiOutlineCpuChip className="size-3.5 text-foreground/60" />
           </div>
           <div>
@@ -164,7 +169,7 @@ function AgentRunCard({ run }: { run: IAgentRun }) {
         </Button>
       </div>
 
-      <div className="rounded border border-border bg-background-tertiary/50 px-2.5 py-2">
+      <div className="rounded border border-border bg-muted/50 px-2.5 py-2">
         <p className="line-clamp-1 text-[12px] font-medium text-foreground/75">
           {run.label}
         </p>
@@ -175,7 +180,7 @@ function AgentRunCard({ run }: { run: IAgentRun }) {
             : (run.summary ?? run.objective ?? 'Run completed')}
         </p>
       </div>
-    </div>
+    </Card>
   );
 }
 
@@ -230,12 +235,9 @@ export function DashboardAgentCards({
               'agent-run-skeleton-2',
               'agent-run-skeleton-3',
             ].map((key) => (
-              <div
-                key={key}
-                className="rounded-md border border-border bg-background-secondary p-3"
-              >
+              <Card key={key} variant={CardVariant.DEFAULT} bodyClassName="p-3">
                 <WorkspaceTaskRowsSkeleton rows={1} />
-              </div>
+              </Card>
             ))
           : displayRuns.map((run) => <AgentRunCard key={run.id} run={run} />)}
       </div>


### PR DESCRIPTION
## Summary

On `/workspace/overview`, the "Running Agents" mini-cards hardcoded `bg-background-secondary` / `bg-background-tertiary`, rendering **lighter grays** than every other card on the page (all `bg-card` via the shared `Card`) and inconsistent with the Analytics overview. This fixes the visual inconsistency Vincent flagged in live QA.

## Changes

- **`AgentRunCard`** now wraps its content in the shared `Card` (`CardVariant.DEFAULT`, padding via `bodyClassName="gap-2 p-3"`) instead of a bespoke `<div>` with off-brand background tokens — mirroring how `analytics-overview-*` compose `Card`. Hover state now comes from the Card's standard `hover:shadow-border-strong` rather than a custom border/bg swap.
- **Loading skeleton** container (same section) switched from `bg-background-secondary` to the shared `Card`, so loading and loaded states match.
- **Inner chips** (agent icon box + objective box) move from `bg-background-tertiary` to the semantic **`bg-muted`** token used by the analytics leaderboard chips.

Net: the workspace overview now reads visually consistent with the analytics overview — a single card gray across the page.

## Token reference (dark mode)

| token | value | before / after |
|---|---|---|
| `--card` | `0 0% 3%` | now used by agent cards (was not) |
| `--background-secondary` | `0 0% 6%` | removed from agent cards |
| `--background-tertiary` | `0 0% 10%` | removed from agent cards |
| `--muted` | `0 0% 11%` | inner chips (matches analytics) |

## Testing

- `workspace-dashboard.test.tsx` — 7 passed. Added a regression guard asserting the agent-run section carries **no** `bg-background-secondary` / `bg-background-tertiary` classes.
- Biome check + `lint-no-raw-html.sh` clean. No raw HTML introduced; all UI via `@ui/primitives` / shared `Card`.

## Acceptance criteria

- [x] Agent-run cards use the shared `Card`/`bg-card`
- [x] Workspace overview reads visually consistent with analytics overview
- [x] No raw HTML elements introduced

Closes #1229