### PR TITLE
design(shell): topbar layout — credits far-right, group app-switcher + settings, tighten brand switcher (#1232)

### DIFF
--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -168,6 +168,7 @@ describe('AppProtectedTopbar', () => {
     });
     const switcher = screen.getByTestId('app-switcher');
     const cloudSyncIndicator = screen.getByTestId('cloud-sync-indicator');
+    const credits = screen.getByTestId('topbar-credits-bar');
 
     expect(brandSwitcher).toHaveTextContent('labeled');
     expect(breadcrumbs).toHaveTextContent('Studio');
@@ -178,11 +179,17 @@ describe('AppProtectedTopbar', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      breadcrumbs.compareDocumentPosition(switcher) &
+      breadcrumbs.compareDocumentPosition(cloudSyncIndicator) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    // Cloud-sync sits before the grouped app-switcher/settings cluster.
     expect(
-      switcher.compareDocumentPosition(cloudSyncIndicator) &
+      cloudSyncIndicator.compareDocumentPosition(switcher) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // Credits are pinned to the far right, after the app-switcher cluster.
+    expect(
+      switcher.compareDocumentPosition(credits) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
@@ -267,14 +274,22 @@ describe('AppProtectedTopbar', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders credit balances before the topbar end slot', () => {
+  it('groups the app switcher beside the settings menu and pins credits to the far right', () => {
     render(<AppProtectedTopbar />);
 
-    const credits = screen.getByTestId('topbar-credits-bar');
+    const switcher = screen.getByTestId('app-switcher');
     const topbarEnd = screen.getByTestId('topbar-end');
+    const credits = screen.getByTestId('topbar-credits-bar');
 
+    // App switcher renders immediately before the settings/user menu so they
+    // read as one grouped cluster.
     expect(
-      credits.compareDocumentPosition(topbarEnd) &
+      switcher.compareDocumentPosition(topbarEnd) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // Credits render after the settings menu, at the far right of the bar.
+    expect(
+      topbarEnd.compareDocumentPosition(credits) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -129,7 +129,7 @@ function AppProtectedTopbarContent({
   return (
     <header className="ship-ui h-full w-full bg-transparent">
       <div className="grid h-full w-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2.5 pl-3 pr-2 sm:px-4 lg:px-5">
-        <div className="flex min-w-0 items-center gap-2.5 justify-self-start">
+        <div className="flex min-w-0 items-center gap-2 justify-self-start">
           {onMenuToggle ? (
             <Button
               type="button"
@@ -160,7 +160,7 @@ function AppProtectedTopbarContent({
           ) : null}
 
           {brands.length > 0 ? (
-            <div className="w-40 min-w-0 sm:w-56 md:w-[14.5rem]">
+            <div className="w-36 min-w-0 sm:w-44 md:w-48">
               <MenuBrandSwitcher
                 variant="labeled"
                 brands={brands}
@@ -201,17 +201,6 @@ function AppProtectedTopbarContent({
             </div>
           ) : null}
 
-          {effectiveOrgSlug ? (
-            <AppSwitcher
-              variant="icon"
-              currentApp={currentApp ?? 'workspace'}
-              currentPath={pathname}
-              orgSlug={effectiveOrgSlug}
-              brandSlug={effectiveBrandSlug}
-              showAdmin={isSuperAdmin}
-            />
-          ) : null}
-
           {shouldRenderAgentToggle ? (
             <Button
               type="button"
@@ -230,9 +219,24 @@ function AppProtectedTopbarContent({
 
           <CloudSyncIndicator />
 
-          <TopbarCreditsBar />
+          {/* Grouped account controls: section switcher sits directly beside
+              the settings/user menu so they read as one cluster. */}
+          <div className="flex items-center gap-0.5">
+            {effectiveOrgSlug ? (
+              <AppSwitcher
+                variant="icon"
+                currentApp={currentApp ?? 'workspace'}
+                currentPath={pathname}
+                orgSlug={effectiveOrgSlug}
+                brandSlug={effectiveBrandSlug}
+                showAdmin={isSuperAdmin}
+              />
+            ) : null}
 
-          <TopbarEnd />
+            <TopbarEnd />
+          </div>
+
+          <TopbarCreditsBar />
         </div>
       </div>
     </header>

--- a/packages/ui/src/components/menus/shared/SidebarUserProfile.tsx
+++ b/packages/ui/src/components/menus/shared/SidebarUserProfile.tsx
@@ -21,6 +21,7 @@ export default function SidebarUserProfile({
     return (
       <div className="border-t border-border p-3 flex justify-center">
         <UserDropdown
+          imageUrl={user.imageUrl}
           userName={user.fullName ?? 'User'}
           userEmail={user.primaryEmailAddress?.emailAddress ?? ''}
         />
@@ -37,6 +38,7 @@ export default function SidebarUserProfile({
           </p>
         </div>
         <UserDropdown
+          imageUrl={user.imageUrl}
           userName={user.fullName ?? 'User'}
           userEmail={user.primaryEmailAddress?.emailAddress ?? ''}
         />

--- a/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.test.tsx
+++ b/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.test.tsx
@@ -137,7 +137,7 @@ describe('MenuBrandSwitcher', () => {
     expect(
       screen.getByRole('button', { name: 'Switch brand' }),
     ).toHaveTextContent('Test Brand');
-    expect(capturedMinWidth).toBe(260);
+    expect(capturedMinWidth).toBe(224);
   });
 
   it('exposes the brand-switcher-trigger testid showing the brand label (E2E contract)', () => {

--- a/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.tsx
+++ b/packages/ui/src/components/menus/switchers/MenuBrandSwitcher.tsx
@@ -97,7 +97,7 @@ export default function MenuBrandSwitcher({
             'transition-all',
             'hover:bg-foreground/10 transition-colors duration-200',
             variant === 'labeled'
-              ? 'flex h-7 min-w-0 w-full items-center gap-2 rounded-md px-2 text-left'
+              ? 'flex h-7 min-w-0 w-full items-center gap-1.5 rounded-md px-2 text-left'
               : 'flex items-center justify-center p-1',
             isUpdating && 'opacity-50 cursor-not-allowed',
             isOpen && 'bg-foreground/10',
@@ -150,7 +150,7 @@ export default function MenuBrandSwitcher({
       onSelect={(id) => void handleSelect(id)}
       isDisabled={isUpdating}
       hasSearch={brands.length >= 5}
-      minWidth={variant === 'labeled' ? 260 : 220}
+      minWidth={variant === 'labeled' ? 224 : 220}
       searchPlaceholder="Search brands…"
       footerActions={[
         {

--- a/packages/ui/src/components/menus/user-dropdown/UserDropdown.test.tsx
+++ b/packages/ui/src/components/menus/user-dropdown/UserDropdown.test.tsx
@@ -6,7 +6,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@genfeedai/hooks/navigation/use-org-url', () => ({
   useOrgUrl: () => ({
-    orgHref: (href: string) => `/acme/~${href.replace(/^\//, '')}`,
+    // Mirrors the real orgHref: prefixes the `/:orgSlug/~` scope, keeping the
+    // leading slash so org settings resolve to the canonical `/:org/~/settings`.
+    orgHref: (href: string) => `/acme/~${href}`,
   }),
 }));
 
@@ -25,8 +27,36 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} />
+  ),
+}));
+
 describe('UserDropdown', () => {
-  it('limits topbar user settings to personal destinations', () => {
+  it('renders an initials avatar trigger when no image is provided', () => {
+    render(<UserDropdown userName="Test User" userEmail="test@example.com" />);
+
+    const trigger = screen.getByRole('button', { name: 'Open account menu' });
+    expect(trigger).toHaveTextContent('T');
+  });
+
+  it('renders the user avatar image when provided', () => {
+    render(
+      <UserDropdown
+        userName="Test User"
+        userEmail="test@example.com"
+        imageUrl="https://cdn.example.com/avatar.png"
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'Test User' })).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/avatar.png',
+    );
+  });
+
+  it('limits topbar user settings to personal destinations plus sign out', () => {
     render(
       <UserDropdown
         settingsScope="user"
@@ -35,18 +65,53 @@ describe('UserDropdown', () => {
       />,
     );
 
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'Settings' }));
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: 'Open account menu' }),
+    );
 
     expect(screen.getByRole('menuitem', { name: /Personal/i })).toHaveAttribute(
       'href',
       '/settings',
     );
-    expect(screen.getByRole('menuitem', { name: /Help/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Help/i })).toHaveAttribute(
+      'href',
+      '/acme/~/settings/help',
+    );
+    expect(screen.getByRole('menuitem', { name: /Sign out/i })).toHaveAttribute(
+      'href',
+      '/logout',
+    );
     expect(
       screen.queryByRole('menuitem', { name: /Organization/i }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('menuitem', { name: /Brands/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('exposes organization and brand settings in the full-scope menu', () => {
+    render(
+      <UserDropdown
+        settingsScope="all"
+        userName="Test User"
+        userEmail="test@example.com"
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: 'Open account menu' }),
+    );
+
+    expect(
+      screen.getByRole('menuitem', { name: /Organization/i }),
+    ).toHaveAttribute('href', '/acme/~/settings');
+    expect(screen.getByRole('menuitem', { name: /Brands/i })).toHaveAttribute(
+      'href',
+      '/acme/~/settings/brands',
+    );
+    expect(screen.getByRole('menuitem', { name: /Sign out/i })).toHaveAttribute(
+      'href',
+      '/logout',
+    );
   });
 });

--- a/packages/ui/src/components/menus/user-dropdown/UserDropdown.tsx
+++ b/packages/ui/src/components/menus/user-dropdown/UserDropdown.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant } from '@genfeedai/enums';
 import { useOrgUrl } from '@genfeedai/hooks/navigation/use-org-url';
 import { Button } from '@ui/primitives/button';
@@ -11,11 +12,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@ui/primitives/dropdown-menu';
+import Image from 'next/image';
 import Link from 'next/link';
 import type { ComponentType } from 'react';
 import {
+  HiOutlineArrowRightOnRectangle,
   HiOutlineBuildingOffice2,
-  HiOutlineCog6Tooth,
   HiOutlineQuestionMarkCircle,
   HiOutlineTag,
   HiOutlineUser,
@@ -30,27 +32,34 @@ interface DropdownItem {
 interface UserDropdownProps {
   userName: string;
   userEmail: string;
+  imageUrl?: string | null;
   settingsScope?: 'all' | 'user';
   side?: 'top' | 'bottom';
 }
 
 export default function UserDropdown({
+  imageUrl,
   settingsScope = 'all',
   side = 'top',
   userName,
   userEmail,
 }: UserDropdownProps) {
   const { orgHref } = useOrgUrl();
+  const initial = userName.trim().charAt(0).toUpperCase() || 'U';
   const allDropdownItems: DropdownItem[] = [
-    { href: '/settings', icon: HiOutlineUser, label: 'Personal' },
+    { href: APP_ROUTES.SETTINGS.ROOT, icon: HiOutlineUser, label: 'Personal' },
     {
-      href: orgHref('/settings'),
+      href: orgHref(APP_ROUTES.SETTINGS.ROOT),
       icon: HiOutlineBuildingOffice2,
       label: 'Organization',
     },
-    { href: orgHref('/settings/brands'), icon: HiOutlineTag, label: 'Brands' },
     {
-      href: orgHref('/settings/help'),
+      href: orgHref(APP_ROUTES.SETTINGS.BRANDS),
+      icon: HiOutlineTag,
+      label: 'Brands',
+    },
+    {
+      href: orgHref(APP_ROUTES.SETTINGS.HELP),
       icon: HiOutlineQuestionMarkCircle,
       label: 'Help',
     },
@@ -68,10 +77,23 @@ export default function UserDropdown({
         <Button
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
-          className="size-8 rounded-lg flex items-center justify-center text-foreground/30 hover:text-foreground/60 hover:bg-foreground/[0.06] transition-colors flex-shrink-0 cursor-pointer"
-          ariaLabel="Settings"
+          className="size-8 flex-shrink-0 cursor-pointer overflow-hidden rounded-full transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20"
+          ariaLabel="Open account menu"
         >
-          <HiOutlineCog6Tooth className="size-4" />
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt={userName}
+              width={32}
+              height={32}
+              className="size-8 rounded-full object-cover object-center"
+              sizes="32px"
+            />
+          ) : (
+            <span className="flex size-8 items-center justify-center rounded-full bg-foreground/15 text-sm font-semibold text-foreground/80">
+              {initial}
+            </span>
+          )}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent side={side} align="end" className="w-56">
@@ -92,6 +114,13 @@ export default function UserDropdown({
             </Link>
           </DropdownMenuItem>
         ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href={APP_ROUTES.LOGOUT} className="cursor-pointer">
+            <HiOutlineArrowRightOnRectangle className="size-4" />
+            Sign out
+          </Link>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/ui/src/components/topbars/end/TopbarEnd.test.tsx
+++ b/packages/ui/src/components/topbars/end/TopbarEnd.test.tsx
@@ -67,6 +67,7 @@ describe('TopbarEnd', () => {
     expect(screen.getByTestId('topbar-user-button')).toBeInTheDocument();
     expect(userDropdownSpy).toHaveBeenCalledWith(
       expect.objectContaining({
+        imageUrl: null,
         settingsScope: 'user',
         side: 'bottom',
         userEmail: 'test@example.com',

--- a/packages/ui/src/components/topbars/end/TopbarEnd.tsx
+++ b/packages/ui/src/components/topbars/end/TopbarEnd.tsx
@@ -17,6 +17,7 @@ export default function TopbarEnd() {
       <UserDropdown
         settingsScope="user"
         side="bottom"
+        imageUrl={user.imageUrl}
         userName={user.fullName ?? 'User'}
         userEmail={user.primaryEmailAddress?.emailAddress ?? ''}
       />


### PR DESCRIPTION
## Summary

Reworks the authenticated topbar right-hand controls, the topbar brand switcher, and the user/account menu, per #1232 (live production QA).

### 1. Topbar layout (`AppProtectedTopbar.tsx`)
- **Credits pinned far right** — `TopbarCreditsBar` renders last instead of sitting mid-row.
- **App-switcher + account menu grouped** — `AppSwitcher` (grid-dots) and the account menu (`TopbarEnd`) are wrapped in a tight `gap-0.5` cluster; the terminal-dock toggle and cloud-sync indicator sit to their left.

### 2. Brand switcher (`MenuBrandSwitcher.tsx` + topbar container)
- Container width `w-40 sm:w-56 md:w-[14.5rem]` → `w-36 sm:w-44 md:w-48`.
- Left-group gap `2.5` → `2`; labeled trigger internal gap `2` → `1.5`.
- Labeled dropdown min-width `260px` → `224px` (labeled variant is topbar-only; sidebar `avatar` variant untouched at 220px).

### 3. Account menu (`UserDropdown.tsx`, `TopbarEnd.tsx`, `SidebarUserProfile.tsx`)
The control grouped with the app-switcher is the **user/account** menu, so it should read as the user — not a settings gear.
- **Trigger is now a user avatar** (`imageUrl` → initials fallback, mirroring `MenuBrandSwitcher`'s logo/initials pattern) instead of the `HiOutlineCog6Tooth` cog; `aria-label="Open account menu"`. `imageUrl` plumbed through `TopbarEnd` + `SidebarUserProfile` from `useAuthUser()`.
- **Added "Sign out"** (links to `APP_ROUTES.LOGOUT`) — the menu previously had no sign-out affordance.
- **Constant-backed hrefs** — replaced hardcoded `'/settings'`, `'/settings/brands'`, `'/settings/help'` strings with `APP_ROUTES.SETTINGS.*`, removing a second source of truth. Routes verified against the canonical shapes in `.agents/memory/project_settings_routing.md` and the on-disk App Router dirs.

## Acceptance criteria (#1232)
- [x] Credits rendered at the far right of the topbar
- [x] Settings/account and app-switcher icons grouped adjacently
- [x] Brand-switcher width/spacing reduced
- [x] Org-brand switchers visually balanced
- [x] Uses `@ui/primitives`

## Design notes
- The issue's "settings gear" was, on current `master`, the `UserDropdown` cog with `aria-label="Settings"` — but it opens a user menu (name/email + Personal + Help). This PR fixes that semantic mismatch by making it an avatar and giving it a real account menu (incl. Sign out).
- **Org/brand settings IA is unchanged** (sidebar Settings section + brand-switcher per-brand cog already cover org/brand scopes correctly). The topbar account menu stays scoped to Personal + Help + Sign out.
- Built on current `master`'s reworked `AppSwitcher` (post #1233/#1220).

## Testing
- `@genfeedai/app` — `AppProtectedTopbar` → 11 passed.
- `@genfeedai/ui` — `UserDropdown` (4) + `TopbarEnd` (1) + `MenuBrandSwitcher` (5) → 10 passed.
- `bunx turbo type-check --filter=@genfeedai/ui` → clean.
- `biome check` clean on all changed files.

Closes #1232
