### PR TITLE
fix(api): posts list returns a JSON:API collection + is reachable by normal users (#1223)

### DIFF
--- a/apps/server/api/src/collections/posts/controllers/posts.controller.spec.ts
+++ b/apps/server/api/src/collections/posts/controllers/posts.controller.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { PostsController } from '@api/collections/posts/controllers/posts.controller';
 import { CredentialPlatform, PostCategory, PostStatus } from '@genfeedai/enums';
@@ -143,5 +144,101 @@ describe('PostsController.create account-health warmup gate', () => {
       }),
     );
     expect(postsService.handleYoutubePost).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostsController.findAll (#1223)', () => {
+  const request = {
+    get: vi.fn().mockReturnValue('localhost'),
+    headers: {},
+    originalUrl: '/v1/posts',
+    path: '/posts',
+    protocol: 'https',
+  } as never;
+
+  const makeController = (findAll: ReturnType<typeof vi.fn>) =>
+    new PostsController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { findAll } as never,
+      { debug: vi.fn(), error: vi.fn(), log: vi.fn() } as never,
+    );
+
+  const paginated = (docs: Array<Record<string, unknown>>) => ({
+    docs,
+    hasNextPage: false,
+    hasPrevPage: false,
+    limit: 20,
+    nextPage: null,
+    page: 1,
+    pages: 1,
+    pagingCounter: 1,
+    prevPage: null,
+    total: docs.length,
+    totalDocs: docs.length,
+    totalPages: 1,
+  });
+
+  it('returns a JSON:API collection document ({ data: [...] }), not a raw docs array', async () => {
+    const findAll = vi.fn().mockResolvedValue(
+      paginated([
+        {
+          id: 'ckpost0000000000000000001',
+          label: 'A',
+          status: PostStatus.DRAFT,
+        },
+        {
+          id: 'ckpost0000000000000000002',
+          label: 'B',
+          status: PostStatus.SCHEDULED,
+        },
+      ]),
+    );
+    const controller = makeController(findAll);
+
+    const result = (await controller.findAll(
+      request,
+      makeUser(),
+      {} as PostsQueryDto,
+    )) as { data: Array<{ id: string; type: string }> };
+
+    // Before the fix, `PostListSerializer` was `undefined`, so
+    // `serializeCollection` returned the raw `docs` array — the exact shape the
+    // calendar client rejects with "expected collection data".
+    expect(Array.isArray(result)).toBe(false);
+    expect(Array.isArray(result.data)).toBe(true);
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toMatchObject({
+      id: 'ckpost0000000000000000001',
+      type: 'post',
+    });
+  });
+
+  it('serializes an empty result set as { data: [] }', async () => {
+    const findAll = vi.fn().mockResolvedValue(paginated([]));
+    const controller = makeController(findAll);
+
+    const result = (await controller.findAll(
+      request,
+      makeUser(),
+      {} as PostsQueryDto,
+    )) as { data: unknown[] };
+
+    expect(result.data).toEqual([]);
+  });
+
+  it('is no longer restricted to superadmins (no roles metadata on the handler)', () => {
+    // The prior `@RolesDecorator('superadmin')` 403'd every non-superadmin,
+    // breaking the normal-user calendar. Removing it falls back to the
+    // class-level RolesGuard (org-membership) + ownership-scoped query.
+    const roles = Reflect.getMetadata(
+      'roles',
+      PostsController.prototype.findAll,
+    );
+    expect(roles).toBeUndefined();
   });
 });

--- a/apps/server/api/src/collections/posts/controllers/posts.controller.ts
+++ b/apps/server/api/src/collections/posts/controllers/posts.controller.ts
@@ -26,7 +26,6 @@ import {
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
-import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
@@ -438,7 +437,12 @@ export class PostsController extends BaseCRUDController<
   }
 
   @Get()
-  @RolesDecorator('superadmin')
+  // No @RolesDecorator here: the posts list backs normal-user surfaces (e.g. the
+  // brand calendar). `buildFindAllQuery` already scopes results to the caller via
+  // `buildOwnershipFilter` (own/org posts) or, for superadmins passing explicit
+  // org/brand params, `buildAdminFilter`. The class-level RolesGuard still
+  // enforces org membership. The prior `@RolesDecorator('superadmin')` was a
+  // carried-over migration artifact that 403'd every non-superadmin (#1223).
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async findAll(
     @Req() request: Request,

--- a/packages/serializers/__tests__/server-serializers.test.ts
+++ b/packages/serializers/__tests__/server-serializers.test.ts
@@ -54,7 +54,10 @@ import { BookmarkSerializer } from '@serializers/server/content/bookmark.seriali
 import { LinkSerializer } from '@serializers/server/content/link.serializer';
 import { NewsSerializer } from '@serializers/server/content/news.serializer';
 import { PersonaSerializer } from '@serializers/server/content/persona.serializer';
-import { PostSerializer } from '@serializers/server/content/post.serializer';
+import {
+  PostListSerializer,
+  PostSerializer,
+} from '@serializers/server/content/post.serializer';
 import { PresignedUploadSerializer } from '@serializers/server/content/presigned-upload.serializer';
 import { TemplateSerializer } from '@serializers/server/content/template.serializer';
 import { TranscriptSerializer } from '@serializers/server/content/transcript.serializer';
@@ -679,6 +682,45 @@ describe('Server Serializers', () => {
 
     it('should have a serialize method', () => {
       expect(typeof PostSerializer.serialize).toBe('function');
+    });
+  });
+
+  // Regression for #1223: `PostListSerializer` was previously destructured as
+  // `const { PostListSerializer } = buildSerializer('server', postListSerializerConfig)`.
+  // Because `buildSerializer` keys its return object by the config `type`
+  // (`post`), that destructure resolved to `undefined`, and the posts list
+  // endpoint silently returned a raw `docs` array instead of a JSON:API
+  // collection document — breaking the calendar client. It was never imported
+  // here, so the "is defined" smoke test never caught it.
+  describe('PostListSerializer (#1223)', () => {
+    it('is defined (not undefined — the destructured name must match the type-derived key)', () => {
+      expect(PostListSerializer).toBeTruthy();
+    });
+
+    it('should be a function (serializer)', () => {
+      expect(typeof PostListSerializer).toBe('object');
+    });
+
+    it('should have a serialize method', () => {
+      expect(typeof PostListSerializer.serialize).toBe('function');
+    });
+
+    it('serializes an array into a JSON:API collection document ({ data: [...] })', () => {
+      const output = PostListSerializer.serialize([
+        { id: 'ckpost0000000000000000001', label: 'A', status: 'draft' },
+        { id: 'ckpost0000000000000000002', label: 'B', status: 'published' },
+      ]) as { data: Array<{ id: string; type: string }> };
+
+      expect(Array.isArray(output.data)).toBe(true);
+      expect(output.data).toHaveLength(2);
+      expect(output.data[0]).toMatchObject({
+        id: 'ckpost0000000000000000001',
+        type: 'post',
+      });
+    });
+
+    it('serializes an empty list into { data: [] }', () => {
+      expect(PostListSerializer.serialize([])).toEqual({ data: [] });
     });
   });
 

--- a/packages/serializers/src/server/content/post.serializer.ts
+++ b/packages/serializers/src/server/content/post.serializer.ts
@@ -1,15 +1,23 @@
-import { buildSerializer } from '@serializers/builders';
+import { buildSingleSerializer } from '@serializers/builders';
 import {
   postListSerializerConfig,
   postSerializerConfig,
 } from '@serializers/configs';
 
-export const { PostSerializer } = buildSerializer(
+// NOTE: `buildSingleSerializer` (not destructured `buildSerializer`) is required
+// here. `buildSerializer` keys its return object by the config `type`, so both
+// `postSerializerConfig` and `postListSerializerConfig` — which share
+// `type: 'post'` (a post list is still JSON:API resource type `post`) — return
+// `{ PostSerializer }`. Destructuring `{ PostListSerializer }` from that object
+// yielded `undefined`, and `serializeCollection(req, undefined, data)` then fell
+// back to returning the raw `docs` array instead of a `{ data: [...] }`
+// collection document, breaking the calendar client (#1223).
+export const PostSerializer = buildSingleSerializer(
   'server',
   postSerializerConfig,
 );
 
-export const { PostListSerializer } = buildSerializer(
+export const PostListSerializer = buildSingleSerializer(
   'server',
   postListSerializerConfig,
 );


### PR DESCRIPTION
Closes #1223.

## Problem
`GET /v1/posts` returned an **HTTP 200 whose body was a raw array**, not a JSON:API collection document. The calendar client's `deserializeCollection` rejected it with `Invalid JSON:API document: expected collection data` (surfaced as a client-side "500"). Amplified by the refetch loop from #1225 (already fixed via #1243) into a DB-hammering flood.

## Root causes (two, on the same surface)

### 1. `PostListSerializer` was `undefined` → raw array leaked out
`buildSerializer` keys its return object by the config `type`:
```ts
return { [`${typeCapitalized}Serializer`]: getSerializer(...) };
```
`postListSerializerConfig` **must** keep `type: 'post'` (a list of posts is still JSON:API resource type `post`), so it collides with `postSerializerConfig` — both return `{ PostSerializer }`. The list file then did:
```ts
export const { PostListSerializer } = buildSerializer('server', postListSerializerConfig); // ← undefined
```
`serializeCollection(req, undefined, data)` hits its `if (!serializer) return data.docs` passthrough and returns the **raw `docs` array**. Every other multi-serializer file avoids this because its variant has a distinct hyphenated `type` (`api-key-full`, `video-edit`, …) that round-trips through the capitalize-split logic; `post` is the only genuine collision.

The `undefined` slipped through because the "every server serializer is defined" smoke test only imported `PostSerializer`, never `PostListSerializer`.

**Fix:** `post.serializer.ts` now uses `buildSingleSerializer` (the existing helper built for exactly this), which returns the serializer directly regardless of the type-derived key. This also repairs three generation/batch endpoints in `posts-operations.controller.ts` that were silently mis-enveloped by the same `undefined`.

### 2. `findAll` was `@RolesDecorator('superadmin')`-only → 403 for normal users
The posts list backs a **normal-user** surface (the brand calendar), but `findAll` carried `@RolesDecorator('superadmin')` since the original `cloud` migration commit — a carried-over artifact. A superadmin hit the malformed-200 above; every non-superadmin got a **403**. So the calendar was broken for everyone, two different ways.

The query is already caller-scoped: `buildFindAllQuery` uses `buildOwnershipFilter` (own/org posts) or, for superadmins passing explicit org/brand params, `buildAdminFilter`. The class-level `RolesGuard` still enforces org membership. Removing the decorator makes posts' `findAll` behave like every other collection's (authenticated + ownership-scoped).

## Tests
- **serializers** (`server-serializers.test.ts`): `PostListSerializer` is defined, has `serialize`, turns an array into `{ data: [...] }`, and an empty list into `{ data: [] }`. Closes the coverage gap that let the `undefined` through. → 202 passed
- **api** (`posts.controller.spec.ts`): `findAll` returns a collection document (not a raw array), handles the empty set, and no longer carries `superadmin` roles metadata on the handler. → 7 passed

## Acceptance criteria
- [x] Identify why the 200 body isn't a JSON:API collection → `PostListSerializer` was `undefined`.
- [x] `GET /v1/posts` returns a valid `{ data: [...] }` collection for a normal brand/org user.
- [x] Calendar loads posts with no `expected collection data` error.
- [x] Reviewed `@RolesDecorator('superadmin')` on `findAll` → removed (calendar is a normal-user surface; query already caller-scoped).
- [ ] No `APP-GENFEED-AI-5` recurrence for 24h — to confirm post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)