### PR TITLE
fix(shell): make org switcher mark active org and actually switch (#1227)

### DIFF
--- a/apps/server/api/src/collections/users/services/user-setup.service.spec.ts
+++ b/apps/server/api/src/collections/users/services/user-setup.service.spec.ts
@@ -325,6 +325,28 @@ describe('UserSetupService', () => {
         );
       });
 
+      it('should reuse the org from an existing membership even when the legacy user-owned lookup misses (#1227 no duplicate org)', async () => {
+        // Membership points at the org, but the legacy `Organization.user`
+        // ownership lookup returns nothing — the old dedup path would have
+        // created a second "Default Organization".
+        mockMembersService.findOne.mockResolvedValue(mockMember);
+        mockOrganizationsService.findOne.mockImplementation(
+          (filter: Record<string, unknown>) =>
+            Promise.resolve(filter._id ? mockOrg : null),
+        );
+
+        const result = await service.initializeUserResources(userId);
+
+        expect(result.organization).toBe(mockOrg);
+        expect(mockOrganizationsService.create).not.toHaveBeenCalled();
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Organization already exists (via membership)',
+          ),
+          expect.any(String),
+        );
+      });
+
       it('should return existing org settings without creating new ones', async () => {
         mockOrganizationSettingsService.findOne.mockResolvedValue(
           mockOrgSettings,

--- a/apps/server/api/src/collections/users/services/user-setup.service.ts
+++ b/apps/server/api/src/collections/users/services/user-setup.service.ts
@@ -144,10 +144,52 @@ export class UserSetupService {
     }
   }
 
+  /**
+   * Resolve the organization a user already belongs to via the `members`
+   * collection — the source of truth that findMine and switchOrganization use.
+   * Returns null when the user has no active membership or the referenced org
+   * is missing/deleted.
+   */
+  private async findMembershipOrganization(
+    userId: string,
+  ): Promise<OrganizationDocument | null> {
+    const membership = await this.membersService.findOne({
+      isActive: true,
+      isDeleted: false,
+      user: userId,
+    });
+
+    if (!membership?.organization) {
+      return null;
+    }
+
+    return this.organizationsService.findOne({
+      _id: membership.organization,
+      isDeleted: false,
+    });
+  }
+
   private async getOrCreateOrganization(
     userId: string,
     category?: OrganizationCategory,
   ): Promise<{ organization: OrganizationDocument; wasCreated: boolean }> {
+    // Membership is the source of truth for org access — findMine and
+    // switchOrganization both resolve a user's orgs via the `members`
+    // collection. Dedupe on membership first so a stale or missing legacy
+    // `Organization.user` ownership field can't spawn a second
+    // "Default Organization" for a user who already belongs to one (#1227).
+    const memberOrganization = await this.findMembershipOrganization(userId);
+
+    if (memberOrganization) {
+      this.logger.warn(
+        `Organization already exists (via membership) for user ${userId}`,
+        this.context,
+      );
+      return { organization: memberOrganization, wasCreated: false };
+    }
+
+    // Legacy fallback: organizations created before membership became the
+    // source of truth are keyed by the `user` ownership field.
     const existing = await this.organizationsService.findOne({
       isDeleted: false,
       user: userId,

--- a/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.test.tsx
+++ b/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.test.tsx
@@ -4,28 +4,20 @@ import type {
 } from '@genfeedai/props/ui/menus/switcher-dropdown.props';
 import { render, waitFor } from '@testing-library/react';
 import OrganizationSwitcher from '@ui/menus/organization-switcher/OrganizationSwitcher';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPush = vi.fn();
 const mockGetMyOrganizations = vi.fn();
+const mockSwitchOrganization = vi.fn();
+let mockParams: { orgSlug?: string } = { orgSlug: 'acme-org' };
 let capturedFooterActions: SwitcherDropdownFooterAction[] = [];
 let capturedItems: SwitcherDropdownItem[] = [];
+let capturedOnSelect: ((id: string) => void) | undefined;
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({
-    orgSlug: 'acme-org',
-  }),
+  useParams: () => mockParams,
   useRouter: () => ({
     push: mockPush,
-  }),
-}));
-
-vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
-  useBrand: () => ({
-    selectedBrand: {
-      organization: { slug: 'acme-org' },
-      slug: 'acme-brand',
-    },
   }),
 }));
 
@@ -33,7 +25,7 @@ vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({
   useAuthedService: () => async () => ({
     createOrganization: vi.fn(),
     getMyOrganizations: mockGetMyOrganizations,
-    switchOrganization: vi.fn(),
+    switchOrganization: mockSwitchOrganization,
   }),
 }));
 
@@ -47,21 +39,50 @@ vi.mock('@ui/menus/switcher-dropdown/SwitcherDropdown', () => ({
   default: ({
     footerActions = [],
     items = [],
+    onSelect,
   }: {
     footerActions?: SwitcherDropdownFooterAction[];
     items?: SwitcherDropdownItem[];
+    onSelect?: (id: string) => void;
   }) => {
     capturedFooterActions = footerActions;
     capturedItems = items;
+    capturedOnSelect = onSelect;
     return <div data-testid="switcher-dropdown" />;
   },
 }));
+
+const TWO_ORGS = [
+  {
+    brand: null,
+    id: 'org_alpha',
+    // Server marks Bravo active (lastUsedOrganizationId), but the URL is Alpha —
+    // the URL must win so the checkmark tracks what the user is viewing.
+    isActive: false,
+    label: 'Alpha',
+    slug: 'alpha',
+  },
+  {
+    brand: null,
+    id: 'org_bravo',
+    isActive: true,
+    label: 'Bravo',
+    slug: 'bravo',
+  },
+];
 
 describe('OrganizationSwitcher', () => {
   beforeEach(() => {
     capturedFooterActions = [];
     capturedItems = [];
+    capturedOnSelect = undefined;
+    mockParams = { orgSlug: 'acme-org' };
     mockGetMyOrganizations.mockReset();
+    mockSwitchOrganization.mockReset();
+    mockSwitchOrganization.mockResolvedValue({
+      brand: { id: 'brand_1', label: 'Default' },
+      organization: { id: 'org_1', label: 'Acme Org' },
+    });
     mockPush.mockReset();
     mockGetMyOrganizations.mockResolvedValue([
       {
@@ -72,6 +93,17 @@ describe('OrganizationSwitcher', () => {
         slug: 'acme-org',
       },
     ]);
+
+    // jsdom does not implement navigation; provide sp'able assign/reload.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { assign: vi.fn(), reload: vi.fn() },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it('loads organizations and exposes contextual row settings action', async () => {
@@ -92,5 +124,76 @@ describe('OrganizationSwitcher', () => {
     capturedItems[0]?.trailingAction?.onAction();
 
     expect(mockPush).toHaveBeenCalledWith('/acme-org/~/settings');
+  });
+
+  it('marks the org matching the current URL slug active, overriding stale server isActive', async () => {
+    mockParams = { orgSlug: 'alpha' };
+    mockGetMyOrganizations.mockResolvedValue(TWO_ORGS);
+
+    render(<OrganizationSwitcher />);
+
+    await waitFor(() => {
+      expect(capturedItems).toHaveLength(2);
+    });
+
+    const alpha = capturedItems.find((item) => item.id === 'org_alpha');
+    const bravo = capturedItems.find((item) => item.id === 'org_bravo');
+    expect(alpha?.isActive).toBe(true);
+    expect(bravo?.isActive).toBe(false);
+  });
+
+  it('falls back to server isActive when no orgSlug is in the route', async () => {
+    mockParams = {};
+    mockGetMyOrganizations.mockResolvedValue(TWO_ORGS);
+
+    render(<OrganizationSwitcher />);
+
+    await waitFor(() => {
+      expect(capturedItems).toHaveLength(2);
+    });
+
+    const alpha = capturedItems.find((item) => item.id === 'org_alpha');
+    const bravo = capturedItems.find((item) => item.id === 'org_bravo');
+    expect(alpha?.isActive).toBe(false);
+    expect(bravo?.isActive).toBe(true);
+  });
+
+  it('persists the switch and navigates to the target org slug', async () => {
+    mockParams = { orgSlug: 'alpha' };
+    mockGetMyOrganizations.mockResolvedValue(TWO_ORGS);
+
+    render(<OrganizationSwitcher />);
+
+    await waitFor(() => {
+      expect(capturedOnSelect).toBeDefined();
+    });
+
+    capturedOnSelect?.('org_bravo');
+
+    await waitFor(() => {
+      expect(mockSwitchOrganization).toHaveBeenCalledWith('org_bravo');
+    });
+    expect(window.location.assign).toHaveBeenCalledWith('/bravo');
+    // Never reloads the current (old) org URL.
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it('ignores selecting the already-active org', async () => {
+    mockParams = { orgSlug: 'alpha' };
+    mockGetMyOrganizations.mockResolvedValue(TWO_ORGS);
+
+    render(<OrganizationSwitcher />);
+
+    await waitFor(() => {
+      expect(capturedOnSelect).toBeDefined();
+    });
+
+    capturedOnSelect?.('org_alpha');
+
+    await waitFor(() => {
+      expect(capturedItems).toHaveLength(2);
+    });
+    expect(mockSwitchOrganization).not.toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.tsx
+++ b/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.tsx
@@ -202,7 +202,17 @@ export default function OrganizationSwitcher() {
 
       {/* Create Organization Modal */}
       <Modal.Root open={createModal.isOpen} onOpenChange={createModal.setOpen}>
-        <Modal.Content size="sm">
+        {/*
+          Don't restore focus to the "New Organization" footer button on close —
+          Radix's default focus return leaves a blue :focus-visible ring on that
+          button (#1227). The brand switcher's "New Brand" overlay renders
+          globally and never returns focus to its button, so it has no such ring;
+          this mirrors that behavior.
+        */}
+        <Modal.Content
+          size="sm"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+        >
           <Modal.Header>
             <Modal.Title>Create Organization</Modal.Title>
             <Modal.Description>

--- a/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.tsx
+++ b/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.tsx
@@ -9,7 +9,7 @@ import { Modal } from '@ui/modals/compound/modal.compound';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
 import { Textarea } from '@ui/primitives/textarea';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useReducer } from 'react';
 import { HiChevronDown, HiOutlineCog6Tooth } from 'react-icons/hi2';
 import { useCreateOrganizationModal } from './use-create-organization-modal';
@@ -67,6 +67,9 @@ export default function OrganizationSwitcher() {
     OrganizationsService.getInstance(token),
   );
   const { push } = useRouter();
+  const params = useParams<{ orgSlug?: string }>();
+  const currentOrgSlug =
+    typeof params?.orgSlug === 'string' ? params.orgSlug : undefined;
 
   const [{ error, isSwitching, orgs }, dispatch] = useReducer(
     switcherReducer,
@@ -97,24 +100,45 @@ export default function OrganizationSwitcher() {
     };
   }, [getOrgsService]);
 
+  // Mirror the brand switcher: the active org is the one you're actually
+  // viewing (URL slug), so the checkmark and trigger label stay in sync with
+  // the route. Fall back to the server's isActive (derived from
+  // lastUsedOrganizationId) on non-org routes like /admin or /settings where no
+  // orgSlug param exists.
+  const activeOrgId =
+    (currentOrgSlug && orgs.find((o) => o.slug === currentOrgSlug)?.id) ||
+    orgs.find((o) => o.isActive)?.id ||
+    null;
+  const activeOrg = orgs.find((o) => o.id === activeOrgId);
+
   const handleSwitch = useCallback(
     async (orgId: string) => {
-      if (isSwitching) {
+      if (isSwitching || orgId === activeOrgId) {
         return;
       }
       dispatch({ type: 'SWITCH_START' });
       try {
         const svc = await getOrgsService();
         await svc.switchOrganization(orgId);
-        window.location.reload();
+        // Navigate to the target org's landing route so the URL reflects the
+        // now-active org. The previous flow reloaded the *current* URL, which
+        // still carried the old org slug, so the app rebooted on the same org
+        // and nothing appeared to switch (#1227). A full navigation (matching
+        // the create-organization flow) re-syncs session-scoped workspace data
+        // across the org boundary; org-landing then routes to the default brand.
+        const target = orgs.find((o) => o.id === orgId);
+        if (target?.slug) {
+          window.location.assign(`/${target.slug}`);
+        } else {
+          window.location.reload();
+        }
       } catch {
         dispatch({ type: 'SWITCH_FAILED' });
       }
     },
-    [getOrgsService, isSwitching],
+    [activeOrgId, getOrgsService, isSwitching, orgs],
   );
 
-  const activeOrg = orgs.find((o) => o.isActive);
   const displayLabel = error ?? activeOrg?.label ?? 'Organization';
   const handleOpenOrganizationSettings = useCallback(
     (organizationSlug: string) => {
@@ -129,7 +153,7 @@ export default function OrganizationSwitcher() {
         className="w-full"
         items={orgs.map((o) => ({
           id: o.id,
-          isActive: o.isActive,
+          isActive: o.id === activeOrgId,
           label: o.label,
           trailingAction: {
             ariaLabel: `Open ${o.label} settings`,


### PR DESCRIPTION
Closes #1227.

## Problem
The organization switcher never marked the active org, clicking a different org just reloaded the same one, duplicate "Default Organization" entries appeared, and the "New Organization" button had an odd blue outline. The brand switcher behaves correctly, so this mirrors it.

## Re-verification (before fixing)
Re-confirmed the bug reproduces on current `master`. The refactor in #1220 was behaviour-neutral — the pre-#1220 org switcher already used server `isActive` + `window.location.reload()`, so the bug **predates** #1220.

**The issue's stated backend root cause is wrong.** A trace of the auth layer confirms `publicMetadata.organization` *is* derived from `users.lastUsedOrganizationId` (via `BetterAuthIdentityResolverService`), and `switchOrganization` invalidates the identity cache — so the backend already honours the switch. `findMine`'s `isActive` was **not** reading a dead legacy field. The real switch bug is purely client-side: navigation + active-detection.

## Fixes

### 1 & 2 — checkmark + navigation (`OrganizationSwitcher.tsx`)
Mirrors the working brand switcher:
- **Active detection** now derives from the current route's `orgSlug` (what you're actually viewing), with the server `isActive` as a fallback on non-org routes like `/admin` and `/settings`. Previously the server value could desync from the URL, so no row matched.
- **Switch action** now navigates to the target org's landing route (`/<slug>`) instead of `window.location.reload()`. The old reload re-loaded the *current* URL — still carrying the old org slug — so the app rebooted on the same org and nothing appeared to change. `/[orgSlug]` (org-landing) then redirects to the org's default brand workspace. A full navigation preserves the existing cross-org re-sync contract the create-organization flow already relies on.

### 3 — duplicate "Default Organization" (`user-setup.service.ts`)
`getOrCreateOrganization` deduped on the legacy `Organization.user` ownership field while membership actually lives in the `members` collection (the source of truth `findMine`/`switch` use). A stale/missing `user` field spawned a second org. It now resolves the user's existing org via membership first (extracted into `findMembershipOrganization`), falling back to the legacy lookup.

### 4 — "New Organization" blue outline (`OrganizationSwitcher.tsx`)
Root cause is **focus-return, not styling**. The create-org `Modal` is a Radix Dialog rendered inline next to the footer button; on close, Radix restores focus to the trigger — the "New Organization" button — leaving a blue `:focus-visible` ring on it. The brand switcher's "New Brand" overlay renders through the global `GlobalModalsRenderer` and never returns focus to its button, so it has no such ring. Fixed with `onCloseAutoFocus={(e) => e.preventDefault()}` on the modal content, mirroring the brand flow.

## Acceptance criteria
- [x] Active org shows the checkmark (URL-derived, brand-switcher parity)
- [x] Selecting a different org actually navigates to it
- [x] No duplicate "Default Organization" (dedupe via membership)
- [x] "New Organization" no longer shows the stray blue focus ring

## Tests
- **UI** (`OrganizationSwitcher.test.tsx`): URL-slug active detection overriding stale server `isActive`; server fallback when no `orgSlug`; switch persists + navigates to `/<targetSlug>` and never reloads the current URL; selecting the already-active org is a no-op. 5 passed.
- **Backend** (`user-setup.service.spec.ts`): reuses the membership org when the legacy `user` lookup misses (no duplicate org created). 24 passed.
- Type-check clean (api + ui, 0 errors), Biome clean.

Note: the blue-outline fix is a focus-behaviour change not easily covered by a jsdom unit test (it's a `:focus-visible` paint after Radix restores focus). Verified by tracing the focus-return asymmetry between the inline Modal and the global brand overlay.