### PR TITLE
feat(guards): block hand-rolled cards with lint-no-bespoke-card guard

### DIFF
--- a/apps/app/src/components/command-palette/CommandPalette.tsx
+++ b/apps/app/src/components/command-palette/CommandPalette.tsx
@@ -251,11 +251,12 @@ export function CommandPalette() {
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]">
       {/* Backdrop */}
-      <button
+      <Button
+        variant={ButtonVariant.UNSTYLED}
+        withWrapper={false}
         aria-label="Close command palette"
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
         onClick={close}
-        type="button"
       />
 
       {/* Palette */}

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -4,5 +4,8 @@ export default {
   ],
   '*.{js,ts,jsx,tsx,json,css}': (files) =>
     `biome check --write --config-path=biome-staged.json --no-errors-on-unmatched ${files.join(' ')}`,
-  '*.tsx': ['bash scripts/lint-no-raw-html.sh'],
+  '*.tsx': [
+    'bash scripts/lint-no-raw-html.sh',
+    'bash scripts/lint-no-bespoke-card.sh',
+  ],
 };

--- a/scripts/lint-no-bespoke-card.allowlist
+++ b/scripts/lint-no-bespoke-card.allowlist
@@ -1,0 +1,52 @@
+# Allowlist for scripts/lint-no-bespoke-card.sh
+#
+# One repo-relative path per line. A listed file is fully exempt from the
+# bespoke-card guard. `#` comments and blank lines are ignored.
+#
+# Two kinds of entries, split below:
+#   • PERMANENT — a legitimate non-card surface that should never be a Card.
+#   • BASELINE  — a real bespoke card frozen so the guard can ship green on
+#                 master. Migrate these to the shared Card and DELETE the line.
+#                 Tracked in: https://github.com/genfeedai/genfeed.ai/issues/1271
+#
+# Whole-file (not file:line) entries are used on purpose: line numbers drift as
+# files change and would make CI red on unrelated edits. This mirrors the
+# existing baseline convention in scripts/check-raw-button-usage.ts. The cost is
+# that a *new* bespoke card added to an already-listed file won't be caught —
+# acceptable, since the migration removes these files from the list and re-arms
+# them, and every other file in the tree is guarded.
+
+# ─── PERMANENT: ReactFlow node primitives ─────────────────────────────────────
+# A graph node is not a content card. Product decision (#1271): keep these as a
+# separate node primitive; they are not scheduled for Card migration.
+apps/app/src/features/workflows/nodes/UnknownWorkflowNode.tsx
+apps/app/src/features/workflows/nodes/TemplateCompatibilityNode.tsx
+apps/app/src/features/workflows/components/ui/card/NodeCard.tsx
+
+# ─── BASELINE: migrate to the shared Card, then remove the line (#1271) ────────
+apps/app/app/(protected)/admin/overview/analytics/business/business-dashboard.tsx
+apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/insights/insights-overview.tsx
+# workspace-dashboard lines 129/235 are the #1229 "Running Agents" cards; live on
+# master until that fix merges, at which point drop this line.
+apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
+apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
+apps/app/packages/components/research/ads/AdsResearchDetailSidebar.tsx
+apps/app/packages/components/research/ads/AdsResearchPageClient.tsx
+apps/app/src/features/workflows/pages/library/EmptyWorkflowState.tsx
+apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.tsx
+apps/app/src/features/workflows/pages/batch/BatchWorkflowPage.tsx
+packages/pages/studio/generate/components/StoryboardPanel.tsx
+packages/pages/brands/components/brand-kit/BrandKitReviewCard.tsx
+packages/pages/twitter-pipeline/components/tweet-card.tsx
+packages/pages/twitter-pipeline/twitter-pipeline-engage.tsx
+packages/pages/twitter-pipeline/components/opportunity-card.tsx
+
+# ─── Verified NON-tripping (documented; no entry needed) ──────────────────────
+# These were audited and do NOT match the signature (single-side borders, no
+# rounded corner, or a real Card), so they need no allowlist entry:
+#   apps/app/src/components/ui/card.tsx           (shadcn-API shim → canonical chrome)
+#   apps/app/app/error.tsx, apps/app/app/global-error.tsx   (full-screen overlays)
+#   EditorToolbar / EditorTimeline / EditorTextPanel / EditorEffectsPanel
+#   ExecutionPanel / StudioEditDetailHeader        (editor chrome panels)
+# If any later trips the guard after a refactor, add its path above with a reason.

--- a/scripts/lint-no-bespoke-card.sh
+++ b/scripts/lint-no-bespoke-card.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Enforce the shared Card — block hand-rolled "cards" in production .tsx files.
+#
+# The signature this catches is "someone rebuilt Card by hand": a raw block
+# element whose className combines a card surface token, a rounded corner, an
+# all-side border, and padding. That combination is the visual fingerprint of a
+# content card and should use the shared component instead:
+#
+#     import Card from '@ui/card/Card';
+#     import { CardVariant } from '@genfeedai/enums';
+#     <Card variant={CardVariant.DEFAULT} bodyClassName="...">…</Card>
+#
+# Canonical component: packages/ui/src/components/card/Card.tsx
+#
+# Modeled on scripts/lint-no-raw-html.sh. Two run modes:
+#   • lint-staged (pre-commit): file paths are passed as arguments; only those
+#     files are checked.
+#   • CI (no arguments): the whole in-scope tree is scanned.
+#
+# Baseline: scripts/lint-no-bespoke-card.allowlist freezes the surfaces that
+# legitimately (or, for now, historically) carry the signature so the gate is
+# green on master. New violations anywhere else fail. See that file's header for
+# the permanent-vs-migrate split and the tracking issue.
+#
+# Portability: pure POSIX ERE (grep -E). No `grep -P`, `\b`, or lookaheads — the
+# pre-commit hook runs on macOS (BSD grep) and CI runs on Linux (GNU grep).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ALLOWLIST_FILE="$SCRIPT_DIR/lint-no-bespoke-card.allowlist"
+
+# Scope: the two trees where product cards live and where the signature was
+# validated. Kept narrow on purpose — mirrors the detector that produced the
+# baseline. Extend deliberately, re-baselining as you go.
+SCAN_DIRS=(apps/app packages/pages)
+
+# ─── Detector token classes (all must co-occur on one className line) ──────────
+#   surface  : bg-card (incl. bg-card/NN), bg-background-secondary|tertiary
+#   rounded  : rounded-card|md|lg|xl|2xl
+#   border   : `border` as a standalone utility (NOT border-r/l/t/b/x/y/-color)
+#   padding  : p-N / px-N / py-N
+# The element must be a raw block (div/section/article/aside), so lines opening
+# an <input|textarea|button|Button|Card|Input|Textarea> are excluded.
+SURFACE_RE='className="[^"]*(bg-card|bg-background-secondary|bg-background-tertiary)[^"]*"'
+ROUNDED_RE='rounded-(card|md|lg|xl|2xl)'
+# Standalone `border` = word-boundary emulation via non-[word/dash] neighbours.
+BORDER_RE='(^|[^-A-Za-z0-9_])border([^-A-Za-z0-9_]|$)'
+PADDING_RE='(^|[^-A-Za-z0-9_])p[xy]?-[0-9]'
+EXCLUDE_ELEMENT_RE='<(input|textarea|button|Button|Card|Input|Textarea)([^A-Za-z0-9_]|$)'
+
+# ─── Load allowlist (repo-relative paths, one per line; `#` comments ignored) ──
+declare -a ALLOWLIST=()
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    line="${raw%%#*}"                       # strip trailing comment
+    line="${line#"${line%%[![:space:]]*}"}" # ltrim
+    line="${line%"${line##*[![:space:]]}"}" # rtrim
+    [[ -z "$line" ]] && continue
+    ALLOWLIST+=("$line")
+  done < "$ALLOWLIST_FILE"
+fi
+
+is_allowlisted() {
+  local file="$1"
+  local entry
+  for entry in "${ALLOWLIST[@]}"; do
+    [[ "$file" == "$entry" ]] && return 0
+  done
+  return 1
+}
+
+# Normalize an incoming path to repo-relative (handles absolute paths and ./).
+to_repo_relative() {
+  local file="$1"
+  file="${file#"$REPO_ROOT"/}"
+  file="${file#./}"
+  printf '%s' "$file"
+}
+
+detect_in_file() {
+  # Prints "LINE:content" for each offending line; empty if none.
+  grep -nE "$SURFACE_RE" -- "$1" 2>/dev/null \
+    | grep -E "$ROUNDED_RE" \
+    | grep -E "$BORDER_RE" \
+    | grep -E "$PADDING_RE" \
+    | grep -Ev "$EXCLUDE_ELEMENT_RE" || true
+}
+
+in_scope() {
+  local file="$1" dir
+  for dir in "${SCAN_DIRS[@]}"; do
+    [[ "$file" == "$dir"/* ]] && return 0
+  done
+  return 1
+}
+
+# ─── Collect candidate files ──────────────────────────────────────────────────
+declare -a FILES=()
+if [[ "$#" -gt 0 ]]; then
+  # lint-staged mode: check the passed files.
+  for arg in "$@"; do
+    rel="$(to_repo_relative "$arg")"
+    [[ "$rel" == *.tsx ]] || continue
+    FILES+=("$rel")
+  done
+else
+  # CI mode: scan the whole in-scope tree.
+  while IFS= read -r rel; do
+    FILES+=("$rel")
+  done < <(cd "$REPO_ROOT" && find "${SCAN_DIRS[@]}" -name '*.tsx' -type f 2>/dev/null | sort)
+fi
+
+violations=0
+declare -a offending_lines=()
+
+for rel in "${FILES[@]}"; do
+  # Skip test/spec/story files.
+  [[ "$rel" == *.test.* ]] && continue
+  [[ "$rel" == *.spec.* ]] && continue
+  [[ "$rel" == *.stories.* ]] && continue
+  in_scope "$rel" || continue
+  is_allowlisted "$rel" && continue
+
+  abs="$REPO_ROOT/$rel"
+  [[ -f "$abs" ]] || continue
+
+  matches="$(detect_in_file "$abs")"
+  [[ -z "$matches" ]] && continue
+
+  violations=$((violations + 1))
+  echo ""
+  echo "  ✘ $rel"
+  while IFS= read -r m; do
+    lineno="${m%%:*}"
+    offending_lines+=("$rel:$lineno")
+    echo "    $rel:$lineno"
+  done <<< "$matches"
+done
+
+if [[ "$violations" -gt 0 ]]; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  ✘ Found $violations file(s) with a hand-rolled card surface."
+  echo ""
+  echo "  A raw <div>/<section>/<article>/<aside> that combines a card"
+  echo "  surface + rounded corner + all-side border + padding is a Card"
+  echo "  rebuilt by hand. Use the shared component instead:"
+  echo ""
+  echo "    packages/ui/src/components/card/Card.tsx"
+  echo "    import Card from '@ui/card/Card';"
+  echo "    import { CardVariant } from '@genfeedai/enums';"
+  echo "    <Card variant={CardVariant.DEFAULT} bodyClassName=\"…\">…</Card>"
+  echo ""
+  echo "  If this surface is a legitimate non-card (editor chrome, a"
+  echo "  full-screen overlay, a graph-node primitive), add its path to"
+  echo "  scripts/lint-no-bespoke-card.allowlist with a reason."
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 1
+fi

--- a/scripts/lint-no-raw-html.sh
+++ b/scripts/lint-no-raw-html.sh
@@ -66,6 +66,28 @@ for rule in "${IMPORT_RULES[@]}"; do
   fi
 done
 
+# CI full-scan mode: with no file arguments, check the whole repo. lint-staged
+# passes staged files as arguments and skips this branch. Rather than looping
+# every tracked .ts/.tsx (10k+ files, ~2 greps each), a single repo-wide
+# `git grep -l` narrows to the handful of files that contain a raw element or a
+# banned import; the per-file logic below (exclusions, comment filtering) then
+# runs only on those candidates. Behaviour-preserving: a file matching neither
+# pattern can never produce a violation, and an over-inclusive filter only adds
+# candidates the per-file check then clears.
+#
+# The filter strips the `\b` anchors from PATTERN — `git grep -E` does not
+# honour `\b` (it would match nothing and silently pass). Dropping it just
+# widens the candidate set (e.g. `<input` also matches `<inputs`), which the
+# real `\b` per-file check re-narrows. git grep also respects .gitignore and
+# scans only tracked content, so node_modules/dist are skipped for free.
+if [ "$#" -eq 0 ]; then
+  cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  FILTER_PATTERN="${PATTERN//\\b/}|$IMPORT_PATTERN"
+  while IFS= read -r scan_file; do
+    set -- "$@" "$scan_file"
+  done < <(git grep -lE "$FILTER_PATTERN" -- '*.ts' '*.tsx' || true)
+fi
+
 violations=0
 violated_files=()
 

--- a/scripts/ui/check-ui-guards.ts
+++ b/scripts/ui/check-ui-guards.ts
@@ -27,6 +27,15 @@ const checks = [
     required: true,
   },
   {
+    // Repo-wide scan (no file args) — blocks hand-rolled card surfaces that
+    // bypass the shared Card. Baseline lives in the script's allowlist so this
+    // is green on master; new violations fail. Also runs in pre-commit via
+    // lint-staged.
+    command: ['bash', 'scripts/lint-no-bespoke-card.sh'],
+    name: 'Bespoke card surfaces',
+    required: true,
+  },
+  {
     command: ['bun', 'run', 'scripts/check-modal-standard-usage.ts'],
     name: 'Modal architecture',
     required: true,

--- a/scripts/ui/check-ui-guards.ts
+++ b/scripts/ui/check-ui-guards.ts
@@ -36,6 +36,14 @@ const checks = [
     required: true,
   },
   {
+    // Repo-wide scan (no file args) — blocks raw HTML elements that bypass
+    // @ui/primitives. Previously only gated staged files via lint-staged
+    // (skippable with --no-verify / non-hook commits); this enforces it in CI.
+    command: ['bash', 'scripts/lint-no-raw-html.sh'],
+    name: 'Raw HTML elements',
+    required: true,
+  },
+  {
     command: ['bun', 'run', 'scripts/check-modal-standard-usage.ts'],
     name: 'Modal architecture',
     required: true,


### PR DESCRIPTION
## What

Two deterministic UI guardrails, enforced in **pre-commit + CI**, so agents (and humans) stop bypassing shared components:

1. **Bespoke-card guard** — blocks hand-rolled "cards" (raw block elements rebuilt from surface + rounded + all-side border + padding) instead of the shared `Card` (`packages/ui/src/components/card/Card.tsx`).
2. **Raw-html guard, now in CI** — the existing `lint-no-raw-html.sh` was pre-commit-only (skippable via `--no-verify` / non-hook commits); it now also runs repo-wide as a required CI check.

Origin: follows #1229 (workspace-overview "Running Agents" cards hardcoded `bg-background-secondary/tertiary` instead of the shared `Card`'s `bg-card`). An audit found the pattern is widespread.

## Bespoke-card guard

New `scripts/lint-no-bespoke-card.sh`, modeled on `scripts/lint-no-raw-html.sh`. Flags a raw `<div>`/`<section>`/`<article>`/`<aside>` whose className combines **all** of — a card surface (`bg-card`, incl. `bg-card/NN`, `bg-background-secondary`, `bg-background-tertiary`), a rounded corner (`rounded-card|md|lg|xl|2xl`), an **all-side** `border` (never `border-r/l/t/b/x/y`), and padding (`p-N`/`px-N`/`py-N`). Lines opening `<input|textarea|button|Button|Card|Input|Textarea>` are excluded.

**Portability:** pure POSIX ERE — no `grep -P`, `\b`, or lookaheads — so it runs identically on macOS (BSD grep, pre-commit) and Linux (GNU grep, CI). File-args mode (lint-staged) + no-args full scan (CI).

**Non-breaking baseline:** `scripts/lint-no-bespoke-card.allowlist` freezes current offenders so the gate is green on master; new violations anywhere else fail. Whole-file (not `file:line`) entries mirror the existing `check-raw-button-usage.ts` convention and avoid CI going red on unrelated line drift. Split into **permanent** (ReactFlow node primitives — a graph node is not a content card) and **baseline** (~20 sites, migrate → #1271). The shadcn shim, editor chrome panels, and `error.tsx`/`global-error.tsx` overlays were verified non-tripping (documented in the allowlist header).

## Raw-html guard in CI

`scripts/lint-no-raw-html.sh` gains a **no-args full-scan mode**: a single repo-wide `git grep -l` narrows 10k+ tracked files to the handful containing a raw element / banned import, then the existing per-file logic runs only on those — **~1s** for the whole repo. (The filter strips `\b`, which `git grep -E` doesn't honour; over-inclusion is re-narrowed by the real per-file `\b` check.)

One pre-existing repo-wide offender was fixed so the gate lands green: the **command-palette backdrop** used a raw `<button>` → converted to the shared `Button` (`variant={ButtonVariant.UNSTYLED}`, `withWrapper={false}`), matching the pattern the file already uses for its command rows.

## Wiring

- **Pre-commit:** both guards run in `lint-staged.config.mjs` under `'*.tsx'`.
- **CI (required):** both added to `scripts/ui/check-ui-guards.ts`, which the required **Guards** job runs via `bun run check:ui-guards`.

## Verification

- ✅ Both guards green on master (full scan)
- ✅ Red on a planted bespoke card and a planted raw element (CI + file-arg modes)
- ✅ Allowlist genuinely drives suppression (removing an entry re-flags at the correct line)
- ✅ Raw-html full-scan: ~1s over 10k+ files; card guard ~5s over 1.3k tsx
- ✅ `bun run check:ui-guards` exit 0 — "Bespoke card surfaces (required)" + "Raw HTML elements (required)" both pass
- ✅ `bunx biome check` + `shellcheck` clean on changed files
- ✅ Pre-commit hook exercised end-to-end on the CommandPalette change (both guards passed)

## Follow-up

Migration of the 20 baselined bespoke-card offenders is tracked in #1271 (ReactFlow nodes marked "keep as node primitive"). Not migrated here — baseline only.
