### PR TITLE
refactor(ui): rebuild SwitcherDropdown on shadcn Command (cmdk)

### DIFF
--- a/packages/ui/src/components/menus/switcher-dropdown/SwitcherDropdown.test.tsx
+++ b/packages/ui/src/components/menus/switcher-dropdown/SwitcherDropdown.test.tsx
@@ -37,6 +37,9 @@ describe('SwitcherDropdown', () => {
 
     globalThis.ResizeObserver =
       MockResizeObserver as unknown as typeof ResizeObserver;
+
+    // cmdk calls scrollIntoView on the highlighted item; jsdom lacks it.
+    Element.prototype.scrollIntoView = vi.fn();
   });
 
   it('renders the trigger', () => {
@@ -66,6 +69,38 @@ describe('SwitcherDropdown', () => {
     fireEvent.click(screen.getByText('Open'));
     fireEvent.click(screen.getByText('Alpha'));
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('exposes listbox/option roles and marks the active row non-selectable', () => {
+    renderDropdown();
+    fireEvent.click(screen.getByText('Open'));
+
+    // cmdk renders a listbox of options (was a plain list of buttons before).
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(3);
+
+    // The active row (Alpha) is disabled and shows the check.
+    const activeOption = options.find((option) =>
+      option.textContent?.includes('Alpha'),
+    );
+    expect(activeOption).toHaveAttribute('aria-disabled', 'true');
+    expect(activeOption?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('selects the highlighted item via arrow-down + Enter (cmdk keyboard nav)', () => {
+    const onSelect = vi.fn();
+    renderDropdown({ hasSearch: true, onSelect });
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByPlaceholderText('Search…');
+    // Active row (Alpha) is skipped by cmdk, so the initial highlight is Beta.
+    // ArrowDown moves it to Gamma; Enter selects the highlighted item.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('3');
   });
 
   it('calls onOpenChange when opening', () => {

--- a/packages/ui/src/components/menus/switcher-dropdown/SwitcherDropdown.tsx
+++ b/packages/ui/src/components/menus/switcher-dropdown/SwitcherDropdown.tsx
@@ -7,7 +7,13 @@ import type {
   SwitcherDropdownProps,
 } from '@genfeedai/props/ui/menus/switcher-dropdown.props';
 import { Button } from '@ui/primitives/button';
-import { Input } from '@ui/primitives/input';
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@ui/primitives/command';
 import {
   Popover,
   PopoverPanelContent,
@@ -15,15 +21,8 @@ import {
 } from '@ui/primitives/popover';
 import Image from 'next/image';
 import type React from 'react';
-import {
-  cloneElement,
-  isValidElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { HiCheck, HiMagnifyingGlass, HiPlus } from 'react-icons/hi2';
+import { cloneElement, isValidElement, useCallback, useState } from 'react';
+import { HiCheck, HiPlus } from 'react-icons/hi2';
 // Relative import: @ui/lib/* isn't aliased (the @ui test alias maps to
 // src/components), and accordion.tsx sources this same hook the same way.
 import { useMounted } from '../../../lib/hooks';
@@ -48,7 +47,6 @@ export default function SwitcherDropdown({
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
 
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const resolvedFooterActions =
     footerActions && footerActions.length > 0
       ? footerActions
@@ -56,6 +54,10 @@ export default function SwitcherDropdown({
         ? [footerAction]
         : [];
 
+  // cmdk owns keyboard nav, type-ahead highlight, and listbox ARIA, but we
+  // keep filtering/ordering explicit (shouldFilter={false}) to preserve the
+  // existing substring match + alphabetical label sort rather than cmdk's
+  // fuzzy command-score ranking.
   const filteredItems = items
     .filter((item) =>
       item.label.toLowerCase().includes(searchTerm.toLowerCase()),
@@ -67,16 +69,6 @@ export default function SwitcherDropdown({
     setSearchTerm('');
     onOpenChange?.(false);
   }, [onOpenChange]);
-
-  // Focus search on open
-  useEffect(() => {
-    if (isOpen && hasSearch) {
-      const timeoutId = setTimeout(() => {
-        searchInputRef.current?.focus();
-      }, 50);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [isOpen, hasSearch]);
 
   const handleSelect = useCallback(
     (id: string) => {
@@ -143,27 +135,23 @@ export default function SwitcherDropdown({
           width: `max(var(--radix-popover-trigger-width), ${minWidth}px)`,
         }}
       >
-        {/* Search */}
-        {hasSearch && (
-          <div className="px-2 pt-1.5 pb-1">
-            <div className="relative">
-              <HiMagnifyingGlass className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-foreground/40" />
-              <Input
-                ref={searchInputRef}
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder={searchPlaceholder}
-                className="py-1.5 pl-8 pr-3"
-              />
-            </div>
-          </div>
-        )}
+        <Command shouldFilter={false} className="bg-transparent">
+          {/* Search — Radix focuses the first focusable child on open, so the
+              input is focused automatically without a manual timeout. */}
+          {hasSearch && (
+            <CommandInput
+              value={searchTerm}
+              onValueChange={setSearchTerm}
+              placeholder={searchPlaceholder}
+            />
+          )}
 
-        {/* Items */}
-        <div className="max-h-64 overflow-y-auto py-0.5">
-          {filteredItems.length > 0 ? (
-            filteredItems.map((item) => (
+          <CommandList className="max-h-64 py-0.5">
+            <CommandEmpty>
+              {items.length === 0 ? 'Loading…' : 'No results'}
+            </CommandEmpty>
+
+            {filteredItems.map((item) => (
               <SwitcherItem
                 key={item.id}
                 item={item}
@@ -173,13 +161,9 @@ export default function SwitcherDropdown({
                   item.trailingAction?.onAction();
                 }}
               />
-            ))
-          ) : (
-            <div className="p-3 text-xs text-foreground/40 text-center">
-              {items.length === 0 ? 'Loading…' : 'No results'}
-            </div>
-          )}
-        </div>
+            ))}
+          </CommandList>
+        </Command>
 
         {/* Footer */}
         {resolvedFooterActions.length > 0 && (
@@ -227,17 +211,19 @@ function SwitcherItem({
 
   return (
     <div className="group flex w-full items-center">
-      <Button
-        variant={ButtonVariant.UNSTYLED}
-        withWrapper={false}
-        onClick={() => !item.isActive && onSelect(item.id)}
-        isDisabled={item.isActive}
+      {/* cmdk Item = the selectable row. The active row is `disabled` so cmdk
+          skips it in keyboard nav and never fires onSelect for it. The gear is
+          a sibling (below), not nested here, to avoid interactive-in-interactive. */}
+      <CommandItem
+        value={item.id}
+        disabled={item.isActive}
+        onSelect={() => onSelect(item.id)}
         className={cn(
-          'flex min-w-0 flex-1 items-center gap-2.5 py-2 pl-3 text-sm transition-colors duration-150',
+          'flex min-w-0 flex-1 items-center gap-2.5 rounded-none py-2 pl-3 text-sm transition-colors duration-150',
           item.trailingAction ? 'pr-1' : 'pr-3',
           item.isActive
-            ? 'text-foreground cursor-default'
-            : 'text-foreground/70 hover:text-foreground hover:bg-foreground/[0.06] cursor-pointer',
+            ? 'cursor-default text-foreground data-[disabled=true]:opacity-100'
+            : 'cursor-pointer text-foreground/70 data-[selected=true]:bg-foreground/[0.06] data-[selected=true]:text-foreground',
         )}
       >
         {/* Avatar */}
@@ -271,7 +257,7 @@ function SwitcherItem({
         {item.isActive && (
           <HiCheck className="size-3.5 text-primary flex-shrink-0" />
         )}
-      </Button>
+      </CommandItem>
 
       {item.trailingAction && TrailingIcon ? (
         <Button

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -5,13 +5,18 @@ import {
   Command as ShipCommand,
   CommandEmpty as ShipCommandEmpty,
   CommandGroup as ShipCommandGroup,
+  CommandInput as ShipCommandInput,
   CommandItem as ShipCommandItem,
   CommandList as ShipCommandList,
   CommandSeparator as ShipCommandSeparator,
   CommandShortcut as ShipCommandShortcut,
 } from '@shipshitdev/ui/primitives';
-import { Command as CommandPrimitive } from 'cmdk';
-import { Search } from 'lucide-react';
+// Types only: cmdk's prop shapes are identical to ship's bundled copy, but ship
+// bundles its OWN cmdk instance — so every RENDERED command part must come from
+// @shipshitdev/ui/primitives to share one context. Using the standalone package
+// for rendering (e.g. CommandPrimitive.Input) mounts a detached context and
+// throws "Cannot read properties of undefined (reading 'subscribe')".
+import type { Command as CommandPrimitive } from 'cmdk';
 import type { ComponentPropsWithRef, HTMLAttributes } from 'react';
 import { cn } from '../lib/utils';
 import { Dialog, DialogContent } from './dialog';
@@ -43,23 +48,14 @@ function CommandInput({
   ...props
 }: ComponentPropsWithRef<typeof CommandPrimitive.Input>) {
   return (
-    <div
-      className="ship-ui flex items-center border-b border-border px-3"
-      data-cmdk-input-wrapper=""
-    >
-      <Search className="mr-2 size-4 shrink-0 text-muted" />
-      <CommandPrimitive.Input
-        ref={ref}
-        className={cn(
-          'flex h-11 w-full rounded-md bg-transparent py-3 text-sm text-primary outline-none placeholder:text-muted disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
-        {...props}
-      />
-    </div>
+    <ShipCommandInput
+      ref={ref}
+      className={cn('ship-ui', className)}
+      {...props}
+    />
   );
 }
-CommandInput.displayName = CommandPrimitive.Input.displayName;
+CommandInput.displayName = 'CommandInput';
 
 function CommandList({
   ref,


### PR DESCRIPTION
## What

Rebuilds the shared `SwitcherDropdown` internals on the repo's `Popover` + `Command` (cmdk) primitive, replacing the hand-rolled searchable combobox (raw `<Input>` + manual `.filter()`/`.sort()` + a `setTimeout` focus hack + a `<div>` of `<Button>` rows).

Follow-up to #1227 / #1268 — that PR was a focused org-switcher bug fix; this is the deliberately-deferred quality refactor it called out.

**The public API is unchanged**, so both consumers — `OrganizationSwitcher` and `MenuBrandSwitcher` — gain the improvements at once with **zero call-site changes**.

## Why it's better

- **Keyboard nav** — ↑/↓/Enter between items (was: none).
- **Type-ahead** active-descendant highlight (was: none).
- **Real combobox/listbox ARIA** — `role=listbox`/`option`, `aria-selected`, `aria-disabled`, `aria-activedescendant` from cmdk. Screen readers previously heard only a list of buttons.
- **No `setTimeout` focus hack** — Radix auto-focuses the `CommandInput` on open.
- Duplicate filter/sort scaffolding folded into cmdk's item model.

## How

- `Command` with `shouldFilter={false}` + the **existing substring match + alphabetical label sort** — preserves prior behavior instead of cmdk's fuzzy command-score ranking (mirrors the `ModelSelectorPopover` reference).
- Active row is a **`disabled` `CommandItem`** — cmdk skips it in keyboard nav and never fires `onSelect`; the trailing settings gear stays a **reachable sibling**, not nested inside the selectable item (no interactive-in-interactive).
- `CommandEmpty` keeps the **"Loading…"** (`items.length === 0`) vs **"No results"** distinction.
- Footer actions (New Organization / New Brand) render **outside `CommandList`** as a fixed footer, same styling.
- Visuals preserved: `PopoverPanelContent`, `minWidth` widths, rounded panel, check icon, avatars.

## Latent bug fixed along the way

`packages/ui/src/primitives/command.tsx` rendered `Command` from ship's **bundled** cmdk but built `CommandInput` from the **standalone** `cmdk` package — two separate cmdk React contexts. `CommandInput` therefore threw `Cannot read properties of undefined (reading 'subscribe')` whenever mounted under the real `Command`. It was masked only because `ModelSelectorPopover`'s test mocks the entire primitive.

Fixed by pointing `CommandInput` at ship's exported `CommandInput` (`@shipshitdev/ui/primitives`), consistent with every other command part in that file. **This also unbreaks `ModelSelectorPopover`'s runtime search path.** `SwitcherDropdown`'s tests exercise the real `Command` + `CommandInput` pairing, directly verifying the fix.

## Tests

- `SwitcherDropdown` — **16/16**, adds: listbox/option roles + active-row `aria-disabled`, and arrow-down + Enter selects the highlighted item (cmdk keyboard nav). All prior cases (filter, `onSelect`, `trailingAction`, footer, loading, disabled) retained.
- Consumers + `ModelSelectorPopover` + command-palette suites — **27/27**, no call-site regression.
- `tsc --noEmit` clean · Biome clean · pre-commit `lint-no-raw-html` + secretlint pass.

Does not reopen or block on #1227 / #1268.