### PR TITLE
feat(pricing): launch pricing display + auto-applied promo at checkout

### DIFF
--- a/apps/server/api/src/services/integrations/stripe/services/stripe.service.spec.ts
+++ b/apps/server/api/src/services/integrations/stripe/services/stripe.service.spec.ts
@@ -168,6 +168,114 @@ describe('StripeService', () => {
     });
   });
 
+  describe('launch promotion code on Creator/Pro subscription checkout', () => {
+    it('uses allow_promotion_codes when STRIPE_PROMOTION_CODE_LAUNCH is unset', async () => {
+      const createSpy = vi
+        .spyOn(service.stripe.checkout.sessions, 'create')
+        .mockResolvedValue({
+          id: 'sess',
+        } as unknown as Stripe.Checkout.Session);
+
+      await service.createPaymentSession('cust', 'pro_id', 'http://origin');
+
+      const callArg = createSpy.mock.calls[0][0];
+      expect(callArg.allow_promotion_codes).toBe(true);
+      expect(callArg).not.toHaveProperty('discounts');
+    });
+
+    it('applies discounts with the configured promotion code when set for the Pro price', async () => {
+      const configGetMock = vi.fn((key: string) => {
+        const map: Record<string, string> = {
+          GENFEEDAI_APP_URL: 'http://localhost:3000',
+          STRIPE_API_VERSION: '2026-01-28.clover',
+          STRIPE_PRICE_PAYG: 'payg_id',
+          STRIPE_PRICE_SUBSCRIPTION_ENTERPRISE_MONTHLY: 'enterprise_id',
+          STRIPE_PRICE_SUBSCRIPTION_PRO_MONTHLY: 'pro_id',
+          STRIPE_PRICE_SUBSCRIPTION_SCALE_MONTHLY: 'scale_id',
+          STRIPE_PROMOTION_CODE_LAUNCH: 'promo_launch123',
+          STRIPE_SECRET_KEY: 'sk_test',
+        };
+        return map[key];
+      });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          StripeService,
+          { provide: ConfigService, useValue: { get: configGetMock } },
+          {
+            provide: LoggerService,
+            useValue: { error: vi.fn(), log: vi.fn() },
+          },
+        ],
+      }).compile();
+
+      const scopedService = module.get<StripeService>(StripeService);
+
+      const createSpy = vi
+        .spyOn(scopedService.stripe.checkout.sessions, 'create')
+        .mockResolvedValue({
+          id: 'sess',
+        } as unknown as Stripe.Checkout.Session);
+
+      await scopedService.createPaymentSession(
+        'cust',
+        'pro_id',
+        'http://origin',
+      );
+
+      const callArg = createSpy.mock.calls[0][0];
+      expect(callArg.discounts).toEqual([
+        { promotion_code: 'promo_launch123' },
+      ]);
+      expect(callArg).not.toHaveProperty('allow_promotion_codes');
+    });
+
+    it('does not apply the launch promotion code to other subscription tiers', async () => {
+      const configGetMock = vi.fn((key: string) => {
+        const map: Record<string, string> = {
+          GENFEEDAI_APP_URL: 'http://localhost:3000',
+          STRIPE_API_VERSION: '2026-01-28.clover',
+          STRIPE_PRICE_PAYG: 'payg_id',
+          STRIPE_PRICE_SUBSCRIPTION_ENTERPRISE_MONTHLY: 'enterprise_id',
+          STRIPE_PRICE_SUBSCRIPTION_PRO_MONTHLY: 'pro_id',
+          STRIPE_PRICE_SUBSCRIPTION_SCALE_MONTHLY: 'scale_id',
+          STRIPE_PROMOTION_CODE_LAUNCH: 'promo_launch123',
+          STRIPE_SECRET_KEY: 'sk_test',
+        };
+        return map[key];
+      });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          StripeService,
+          { provide: ConfigService, useValue: { get: configGetMock } },
+          {
+            provide: LoggerService,
+            useValue: { error: vi.fn(), log: vi.fn() },
+          },
+        ],
+      }).compile();
+
+      const scopedService = module.get<StripeService>(StripeService);
+
+      const createSpy = vi
+        .spyOn(scopedService.stripe.checkout.sessions, 'create')
+        .mockResolvedValue({
+          id: 'sess',
+        } as unknown as Stripe.Checkout.Session);
+
+      await scopedService.createPaymentSession(
+        'cust',
+        'enterprise_id',
+        'http://origin',
+      );
+
+      const callArg = createSpy.mock.calls[0][0];
+      expect(callArg.allow_promotion_codes).toBe(true);
+      expect(callArg).not.toHaveProperty('discounts');
+    });
+  });
+
   describe('createManagedPaymentSession', () => {
     it('creates a public managed checkout with customer_email and managed metadata', async () => {
       const createSpy = vi

--- a/apps/server/api/src/services/integrations/stripe/services/stripe.service.ts
+++ b/apps/server/api/src/services/integrations/stripe/services/stripe.service.ts
@@ -428,6 +428,31 @@ export class StripeService {
     };
   }
 
+  /**
+   * Apply the configured launch promotion code to a subscription checkout
+   * session for the Creator/Pro plan, falling back to `allow_promotion_codes`
+   * when no promotion code is configured. Stripe rejects sessions that set
+   * both `discounts` and `allow_promotion_codes`, so exactly one is set.
+   */
+  private applyPromotionCode(
+    sessionConfig: NonNullable<StripeCheckoutSessionCreateParams>,
+    stripePriceId: string,
+  ): void {
+    const isCreatorSubscription =
+      stripePriceId ===
+      this.configService.get('STRIPE_PRICE_SUBSCRIPTION_PRO_MONTHLY');
+
+    const promotionCodeId = isCreatorSubscription
+      ? this.configService.get('STRIPE_PROMOTION_CODE_LAUNCH')
+      : undefined;
+
+    if (promotionCodeId) {
+      sessionConfig.discounts = [{ promotion_code: promotionCodeId }];
+    } else {
+      sessionConfig.allow_promotion_codes = true;
+    }
+  }
+
   public async createPaymentSession(
     customerId: string,
     stripePriceId: string,
@@ -460,7 +485,6 @@ export class StripeService {
 
         // Monthly subscription
         sessionConfig = {
-          allow_promotion_codes: true,
           automatic_tax: {
             enabled: true,
           },
@@ -488,6 +512,8 @@ export class StripeService {
             enabled: true,
           },
         };
+
+        this.applyPromotionCode(sessionConfig, stripePriceId);
       } else if (isPayg) {
         // Pay as you go credits — bonus delivered via metadata, not coupons
         const pack = PAYG_CREDIT_PACKS.find((p) => p.credits === quantity);

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -207,24 +207,58 @@ export default function PricingContent() {
                   ) : null}
 
                   <div className="mb-2">
-                    <span
-                      className={cn(
-                        'text-5xl font-semibold tracking-[-0.03em]',
-                        isFeatured && 'text-inv-fg',
-                      )}
-                    >
-                      {isEnterprise ? 'Custom' : formatPrice(plan.price)}
-                    </span>
+                    {plan.launchPrice != null ? (
+                      <div className="flex items-baseline gap-2">
+                        <span
+                          className={cn(
+                            'text-2xl font-medium line-through',
+                            isFeatured ? 'text-inv-fg/40' : 'text-surface/40',
+                          )}
+                        >
+                          {formatPrice(plan.price)}
+                        </span>
+                        <span
+                          className={cn(
+                            'text-5xl font-semibold tracking-[-0.03em]',
+                            isFeatured && 'text-inv-fg',
+                          )}
+                        >
+                          {formatPrice(plan.launchPrice)}
+                        </span>
+                      </div>
+                    ) : (
+                      <span
+                        className={cn(
+                          'text-5xl font-semibold tracking-[-0.03em]',
+                          isFeatured && 'text-inv-fg',
+                        )}
+                      >
+                        {isEnterprise ? 'Custom' : formatPrice(plan.price)}
+                      </span>
+                    )}
                   </div>
 
                   <div
                     className={cn(
-                      'mb-8 text-sm',
+                      'text-sm',
                       isFeatured ? 'text-inv-fg/50' : 'text-surface/40',
                     )}
                   >
                     {getPriceQualifier(plan)}
                   </div>
+
+                  {plan.launchNote ? (
+                    <div
+                      className={cn(
+                        'mb-8 mt-1 text-xs font-semibold uppercase tracking-widest',
+                        isFeatured ? 'text-inv-fg/60' : 'text-surface/50',
+                      )}
+                    >
+                      {plan.launchNote}
+                    </div>
+                  ) : (
+                    <div className="mb-8" />
+                  )}
 
                   <p
                     className={cn(

--- a/apps/website/packages/components/home/_pricing.tsx
+++ b/apps/website/packages/components/home/_pricing.tsx
@@ -119,12 +119,34 @@ export default function HomePricing(): React.ReactElement {
                     <Text>{isCloudApp ? 'Cloud App' : plan.label}</Text>
                   </HStack>
 
-                  <Heading as="h3" className="text-3xl font-black text-surface">
-                    {formatPlanPrice(plan.price)}
-                  </Heading>
+                  {plan.launchPrice != null ? (
+                    <HStack className="items-baseline gap-2">
+                      <Text className="text-lg font-semibold text-surface/40 line-through">
+                        {formatPlanPrice(plan.price)}
+                      </Text>
+                      <Heading
+                        as="h3"
+                        className="text-3xl font-black text-surface"
+                      >
+                        {formatPlanPrice(plan.launchPrice)}
+                      </Heading>
+                    </HStack>
+                  ) : (
+                    <Heading
+                      as="h3"
+                      className="text-3xl font-black text-surface"
+                    >
+                      {formatPlanPrice(plan.price)}
+                    </Heading>
+                  )}
                   <Text className="text-xs leading-5 text-surface/45">
                     {priceQualifier}
                   </Text>
+                  {plan.launchNote ? (
+                    <Text className="text-xs font-semibold uppercase tracking-widest text-surface/50">
+                      {plan.launchNote}
+                    </Text>
+                  ) : null}
                 </VStack>
 
                 <Text className="text-sm leading-6 text-surface/55">

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -80,6 +80,7 @@ export interface IEnvConfig {
   STRIPE_API_VERSION?: string;
   STRIPE_PRICE_PAYG?: string;
   STRIPE_PRICE_SKILLS_PRO?: string;
+  STRIPE_PROMOTION_CODE_LAUNCH?: string;
   STRIPE_PROMOTION_CODE_SKILLS_PRO?: string;
   STRIPE_PAYG_CREDITS?: number;
   STRIPE_MONTHLY_CREDITS?: number;

--- a/packages/config/src/schemas/stripe.schema.ts
+++ b/packages/config/src/schemas/stripe.schema.ts
@@ -19,6 +19,7 @@ export const stripeSchema = {
   STRIPE_PAYG_CREDITS: Joi.number().default(1_000),
   STRIPE_PRICE_PAYG: conditionalRequired(),
   STRIPE_PRICE_SKILLS_PRO: Joi.string().optional(),
+  STRIPE_PROMOTION_CODE_LAUNCH: Joi.string().optional().allow(''),
   STRIPE_PROMOTION_CODE_SKILLS_PRO: Joi.string().optional().allow(''),
   STRIPE_PRICE_SUBSCRIPTION_CREATOR_MONTHLY: Joi.string().optional(),
   STRIPE_PRICE_SUBSCRIPTION_ENTERPRISE_MONTHLY: Joi.string().optional(),

--- a/packages/helpers/src/business/pricing/pricing.helper.test.ts
+++ b/packages/helpers/src/business/pricing/pricing.helper.test.ts
@@ -161,6 +161,32 @@ describe('pricing.helper', () => {
       expect(plan.label).toBe('Hosted');
       expect(plan.price).toBe(49);
     });
+
+    it('should expose launch pricing for the Hosted plan', () => {
+      const plan = getHostedPlan();
+      expect(plan.launchPrice).toBe(39);
+      expect(plan.launchNote).toBe(
+        'Launch pricing — first 12 months, then $49/month',
+      );
+    });
+
+    it('should not mention any redemption cap or limit in the launch note', () => {
+      const plan = getHostedPlan();
+      const note = plan.launchNote?.toLowerCase() ?? '';
+      expect(note).not.toMatch(/cap/);
+      expect(note).not.toMatch(/limited/);
+      expect(note).not.toMatch(/first \d+ (subscribers|customers|users)/);
+    });
+  });
+
+  describe('launchPrice scoping', () => {
+    it('should only set launchPrice on the Hosted plan', () => {
+      const plansWithLaunchPrice = websitePlans.filter(
+        (plan) => plan.launchPrice != null,
+      );
+      expect(plansWithLaunchPrice).toHaveLength(1);
+      expect(plansWithLaunchPrice[0]?.label).toBe('Hosted');
+    });
   });
 
   describe('getCloudTeamsPlan', () => {

--- a/packages/pricing/src/plans-pricing.ts
+++ b/packages/pricing/src/plans-pricing.ts
@@ -62,6 +62,10 @@ interface PricingPlanProps {
   target?: string;
   /** Value proposition one-liner */
   valueProposition?: string;
+  /** Discounted monthly price shown alongside the standard price (launch pricing) */
+  launchPrice?: number;
+  /** Explanatory note shown under launch pricing (e.g. duration/terms) */
+  launchNote?: string;
 }
 
 const CALENDLY_URL =
@@ -201,6 +205,8 @@ export const websitePlans: PricingPlanProps[] = [
     includedCredits: 8_000,
     interval: 'month',
     label: 'Hosted',
+    launchNote: 'Launch pricing — first 12 months, then $49/month',
+    launchPrice: 39,
     outputs: null,
     price: 49,
     stripePriceId: STRIPE_PRICE_IDS.pro,


### PR DESCRIPTION
## Summary

- Adds launch pricing display to the Hosted/Creator plan: original price struck through, launch price shown prominently, plus a short note, on both the website pricing page (`apps/website/app/(public)/pricing/pricing-content.tsx`) and the homepage pricing strip (`apps/website/packages/components/home/_pricing.tsx`). Only the Hosted plan has `launchPrice`/`launchNote` set — all other plans render unchanged.
- Adds an optional `STRIPE_PROMOTION_CODE_LAUNCH` env var. When set, the Creator/Pro subscription checkout session applies that promotion code automatically via `discounts: [{ promotion_code }]` instead of `allow_promotion_codes: true` (Stripe rejects sessions with both set). When unset, checkout behavior is unchanged. Other subscription tiers (Scale, Enterprise, unlisted Creator) and the credit-pack/skills-pro checkout paths are untouched.

## How to enable

1. Create the Stripe promotion code for the Creator/Pro price (coupon + code already provisioned separately).
2. Set `STRIPE_PROMOTION_CODE_LAUNCH=<promotion_code_id>` in the API environment.
3. No other config changes needed — the pricing display config (`launchPrice`/`launchNote` on the Hosted plan in `packages/pricing/src/plans-pricing.ts`) is already live pricing copy, independent of the env var.

## Test plan

- [x] `bun run test src/business/pricing/pricing.helper.test.ts` (packages/helpers) — added coverage for `launchPrice`/`launchNote` on the Hosted plan, and that no other plan has `launchPrice` set.
- [x] `bun run test src/services/integrations/stripe/services/stripe.service.spec.ts` (apps/server/api) — added coverage for: promo code applied when configured for the Pro price, `allow_promotion_codes` fallback when unset, and other subscription tiers unaffected by the launch promo env var.
- [x] `bunx turbo run type-check --filter=@genfeedai/api --filter=@genfeedai/helpers --filter=@genfeedai/pricing --filter=@genfeedai/config --filter=@genfeedai/website`
- [x] Pre-commit hooks (biome, secretlint, no-raw-html, no-bespoke-card lints) passed clean.

## Intentionally out of scope

- `packages/ui/src/components/pricing/card/PricingCard.tsx` — confirmed unused in any app (`grep -rln "PricingCard" apps/` returns nothing), left untouched.
- `scripts/env-spec.ts` — the existing analogous var `STRIPE_PROMOTION_CODE_SKILLS_PRO` is not registered there either; followed that precedent rather than introducing new scope.

Screenshots not included per task scope (copy/logic change, no new visual pattern beyond the existing strikethrough-price treatment already used elsewhere in the app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)