### PR TITLE
test(app): stop Better Auth timer leaking past teardown (unblocks v0.4.5 deploy)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -35,6 +35,23 @@ vi.mock('@genfeedai/auth-client/react', () => ({
   }),
 }));
 
+// Stop the real Better Auth browser client (a module-level `createAuthClient`
+// singleton in @genfeedai/auth-client) from mounting its nanostores session
+// store. That store schedules a broadcast-channel session-refresh timer that
+// fires AFTER this test's jsdom `window` is torn down, throwing
+// "ReferenceError: window is not defined" from cleanupBroadcastSetup — a benign
+// teardown race that vitest v4 counts as a fatal unhandled error.
+vi.mock('better-auth/react', () => ({
+  createAuthClient: () => ({
+    $fetch: vi.fn().mockResolvedValue({ data: null }),
+    getSession: vi.fn().mockResolvedValue({ data: null }),
+    signIn: { magicLink: vi.fn() },
+    signOut: vi.fn(),
+    signUp: {},
+    useSession: vi.fn(() => ({ data: null, isPending: false })),
+  }),
+}));
+
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => ({
     brandId: 'brand-1',


### PR DESCRIPTION
Fixes the v0.4.5 deploy blocker. `workspace-page.spec.tsx` mounted the real Better Auth `createAuthClient` singleton, whose nanostores session store schedules a broadcast-channel timer that fires after the jsdom env is torn down → `window is not defined` → vitest v4 counts 2 fatal unhandled errors → app-test run exits 1 (despite 717/717 passing) → cancel-doomed-run kills the deploy.

Scoped fix: mock `better-auth/react` `createAuthClient` in this spec so the real client + timer never mount. Verified locally: spec 12/12, **0 unhandled errors**.

Force-merged past CI per explicit instruction; the deploy QA gate re-validates.