### PR TITLE
test(app): globally neutralise Better Auth teardown timer (unblocks v0.4.5 deploy)

### DIFF
--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -1,7 +1,27 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import './tests/server-only.stub';
+
+// Global: stop the real Better Auth browser client from mounting. `@genfeedai/
+// auth-client` creates a module-level `createAuthClient` singleton whose
+// nanostores session store schedules a broadcast-channel refresh timer. That
+// timer fires AFTER a test's jsdom `window` is torn down, throwing
+// "ReferenceError: window is not defined" from cleanupBroadcastSetup — which
+// vitest v4 counts as a fatal unhandled error and fails the whole run even when
+// every test passes. Mocking createAuthClient here neutralises the timer across
+// the entire app suite; per-file hook mocks (@genfeedai/auth-client/react) are a
+// different module and still take precedence where present.
+vi.mock('better-auth/react', () => ({
+  createAuthClient: () => ({
+    $fetch: vi.fn().mockResolvedValue({ data: null }),
+    getSession: vi.fn().mockResolvedValue({ data: null }),
+    signIn: { email: vi.fn(), magicLink: vi.fn(), social: vi.fn() },
+    signOut: vi.fn(),
+    signUp: { email: vi.fn() },
+    useSession: vi.fn(() => ({ data: null, error: null, isPending: false })),
+  }),
+}));
 
 // Explicitly unmount React trees and clear the jsdom document after every test.
 // RTL auto-cleanup already runs when a global afterEach exists, but making it


### PR DESCRIPTION
The per-spec fix (#1287) only covered workspace-page; the full deploy QA matrix runs ALL app specs. Any spec importing @genfeedai/auth-client mounts the module-level createAuthClient singleton whose nanostores timer fires post-teardown → 'window is not defined' → vitest v4 fatal unhandled error → Test App shards exit 1 → cancel-doomed-run kills the deploy (while changed-scope push CI passed).

Global fix in vitest.setup.ts. **Verified locally: full app suite 456 files / 1777 tests, 0 unhandled errors** (was Errors: 2, exit 1). Force-merged per instruction; deploy QA re-validates.