### PR TITLE
fix(ci): distinct ci.yml concurrency group — unblocks every production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,16 @@ on:
         required: false
         default: false
 
+# The `ci-` prefix is REQUIRED. `github.workflow` resolves to the top-level
+# workflow name even inside a `workflow_call`, so without a distinct prefix this
+# group collides with a caller that uses the same `${{ github.workflow }}-${{
+# github.ref }}` shape (full-suite.yml → deploy-ecs.yml). On the release/deploy
+# path `ci` runs UNDER full-suite, both computed the same group with
+# cancel-in-progress, and the nested `ci` cancelled itself at startup (0 jobs) —
+# tripping cancel-doomed-run and silently killing every production deploy. The
+# prefix keeps push-CI dedup ("ci-CI-<ref>") while never matching a caller group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Root cause of the ~8 cancelled v0.4.5 deploys. ci.yml + full-suite.yml shared the identical `${{ github.workflow }}-${{ github.ref }}` concurrency group; in a workflow_call github.workflow = the top-level name, so nested `ci` matched its parent full-suite's group with cancel-in-progress and cancelled itself at startup (0 jobs) → cancel-doomed-run killed the deploy. Prefix ci's group with `ci-` so it never matches a caller. Force-merged; verified by a full-suite dispatch.