### PR TITLE
test(e2e): bucket personal /settings/* in all-app-pages smoke (unblocks v0.4.5)

### DIFF
--- a/playwright/e2e/tests/smoke/all-app-pages.spec.ts
+++ b/playwright/e2e/tests/smoke/all-app-pages.spec.ts
@@ -120,7 +120,11 @@ const protectedRouteBuckets: RouteBucket[] = [
   routeBucket(
     'protected root',
     protectedRoutes,
-    (route) => route === '/' || route === '/settings' || route === '/test-org',
+    (route) =>
+      route === '/' ||
+      route === '/settings' ||
+      route.startsWith('/settings/') ||
+      route === '/test-org',
   ),
   routeBucket('protected analytics', protectedRoutes, (route) =>
     route.startsWith('/test-org/brand-1/analytics'),


### PR DESCRIPTION
The E2E route-coverage smoke (first run since the concurrency bug is fixed) flagged /settings/help as unbucketed. Extend the 'protected root' bucket to personal /settings/* routes. Route + page are valid; test-only. Force-merged.