### PR TITLE
ci(deploy): harden three flake sources that gate production deploys

### DIFF
--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -56,28 +56,33 @@ runs:
         restore-keys: |
           ${{ runner.os }}-turbo-
 
-    # Retry with backoff: a postinstall script (notably ffmpeg-static, which
-    # pulls its binary from the GitHub releases CDN) can fail transiently and
+    # Retry with exponential backoff: a postinstall script (notably ffmpeg-static,
+    # which pulls its binary from the GitHub releases CDN) can fail transiently and
     # take the whole `bun install` down with it. bun install is idempotent, so
-    # re-running re-attempts only the missing download. 3 attempts, 15s/30s
-    # backoff — turns a flaky CDN into a self-healing step for every caller.
+    # re-running re-attempts only the missing download. A cold-cache release/deploy
+    # runs this step across ~15 parallel jobs, so with only 3 attempts a single
+    # persistently-flaky CDN window would fail a job and (via cancel-doomed-run)
+    # cancel the entire production deploy. 5 attempts with 10/20/40/80s backoff
+    # turns a flaky CDN into a self-healing step even under sustained transients.
     - name: Install dependencies
       shell: bash
+      env:
+        MAX_ATTEMPTS: '5'
       run: |
-        for attempt in 1 2 3; do
-          echo "::group::install attempt ${attempt}/3: ${{ inputs.install-command }}"
+        for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+          echo "::group::install attempt ${attempt}/${MAX_ATTEMPTS}: ${{ inputs.install-command }}"
           if ${{ inputs.install-command }}; then
             echo "::endgroup::"
             exit 0
           fi
           echo "::endgroup::"
-          if [ "${attempt}" -lt 3 ]; then
-            backoff=$((attempt * 15))
-            echo "::warning::install attempt ${attempt} failed; retrying in ${backoff}s"
+          if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
+            backoff=$((10 * 2 ** (attempt - 1)))
+            echo "::warning::install attempt ${attempt}/${MAX_ATTEMPTS} failed; retrying in ${backoff}s"
             sleep "${backoff}"
           fi
         done
-        echo "::error::install failed after 3 attempts"
+        echo "::error::install failed after ${MAX_ATTEMPTS} attempts"
         exit 1
 
     # Playwright browser binaries — key matches the strategy used by the inline

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,7 +153,13 @@ jobs:
           CI: true
           APP_BASE_URL: http://localhost:3000
           E2E_EXPECT_TIMEOUT_MS: "15000"
-          E2E_RETRIES: "0"
+          # Retry flaky specs twice in CI (Playwright only retries on failure, so
+          # a green shard pays zero cost). On the deploy path this suite gates the
+          # whole production release via cancel-doomed-run, so one browser/timing
+          # flake across 12 shards would otherwise cancel the entire deploy. A
+          # single flake taking up to 3x on its shard is an acceptable trade to
+          # stop losing green deploys to luck.
+          E2E_RETRIES: "2"
           E2E_SHARD_INDEX: ${{ matrix.shard }}
           E2E_TOTAL_SHARDS: "12"
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'test-better-auth-secret' }}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-page-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-page-content.test.tsx
@@ -544,6 +544,18 @@ describe('EditorPageContent', () => {
   it('supports keyboard shortcuts without hijacking form inputs', async () => {
     await renderLoadedEditor();
 
+    // The shortcut handler seeks via previewRef.current?.seekToFrame(...),
+    // which is optional-chained: it silently no-ops until the preview ref is
+    // populated (a commit after the loaded UI text appears). Probe with Home
+    // (deterministic seek to 0) until the handler actually fires, then reset so
+    // the assertions below start from a known-wired state. Without this, the
+    // first ArrowRight can land before the ref is set and the test flakes.
+    await waitFor(() => {
+      fireEvent.keyDown(window, { key: 'Home' });
+      expect(mocks.seekToFrame).toHaveBeenCalledWith(0);
+    });
+    mocks.seekToFrame.mockClear();
+
     fireEvent.keyDown(window, { key: 'ArrowRight' });
     fireEvent.keyDown(window, { key: 'ArrowLeft', shiftKey: true });
     fireEvent.keyDown(window, { key: 'Home' });


### PR DESCRIPTION
## Why

v0.4.5 shipped, but the deploy only went green on flake luck after ~10 failed attempts. Each fix below removes a **single transient** that — via `cancel-doomed-run` — cancels the *entire* production release. "Boil the ocean" so future deploys aren't luck-dependent.

## Changes

| Fix | File | Flake it kills |
|-----|------|----------------|
| `bun install` retries 3 → 5, 10/20/40/80s backoff | `.github/actions/setup-bun-env/action.yml` | ffmpeg-static CDN download flake, fanned across ~15 parallel cold-cache jobs |
| Sharded core E2E `E2E_RETRIES` 0 → 2 | `.github/workflows/e2e.yml` | one browser/timing flake across 12 shards. Playwright retries **only on failure**, so green shards pay zero cost |
| Deterministic keyboard-shortcut spec | `apps/app/.../editor/[id]/editor-page-content.test.tsx` | real race: keydown fired before `previewRef.current` wired, so the optional-chained `seekToFrame` silently no-op'd |

## Notes

- The E2E shard job explicitly pinned `E2E_RETRIES: "0"`, overriding the config's own `isCI ? 2` default — this restores retries on the deploy path only.
- Editor test now probes with `Home` until the handler responds, then `mockClear()`s and asserts. Verified locally: 7/7 pass.
- CI/test-only; no runtime code changed. v0.4.5 is already live — this is forward reliability, not a hotfix.