### PR TITLE
ci(deploy+e2e): root-cause the deploy flake sources + make the nightly a real flake alarm

### DIFF
--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -56,14 +56,33 @@ runs:
         restore-keys: |
           ${{ runner.os }}-turbo-
 
-    # Retry with exponential backoff: a postinstall script (notably ffmpeg-static,
-    # which pulls its binary from the GitHub releases CDN) can fail transiently and
-    # take the whole `bun install` down with it. bun install is idempotent, so
-    # re-running re-attempts only the missing download. A cold-cache release/deploy
-    # runs this step across ~15 parallel jobs, so with only 3 attempts a single
-    # persistently-flaky CDN window would fail a job and (via cancel-doomed-run)
-    # cancel the entire production deploy. 5 attempts with 10/20/40/80s backoff
-    # turns a flaky CDN into a self-healing step even under sustained transients.
+    # Neutralize the biggest install-time network side-effect at the source.
+    # ffmpeg-static (a transitive dep) postinstalls by downloading a ~40MB binary
+    # from the GitHub releases CDN on EVERY `bun install`. Fanned across the ~35
+    # cold-cache jobs of a release/deploy run, a single CDN hiccup fails a job and
+    # (via cancel-doomed-run) cancels the entire production deploy. No CI job ever
+    # executes ffmpeg — every consumer spec mocks the `ffmpeg-static` module — so
+    # point it at the runner's own ffmpeg via FFMPEG_BIN: the package's index.js
+    # exports that path verbatim and its install.js skips the download when the
+    # file exists. This removes the CDN call the retry loop below was fighting.
+    - name: Use system ffmpeg (skip ffmpeg-static CDN download)
+      shell: bash
+      run: |
+        # ubuntu-latest ships ffmpeg, so this apt path is a rare fallback. Keep
+        # it non-fatal (|| true): if it can't install, FFMPEG_BIN resolves empty
+        # and ffmpeg-static falls back to its CDN download (guarded by the retry
+        # loop) — i.e. the pre-existing behavior, never a new failure mode.
+        if ! command -v ffmpeg >/dev/null 2>&1; then
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg || true
+        fi
+        echo "FFMPEG_BIN=$(command -v ffmpeg)" >> "$GITHUB_ENV"
+
+    # Retry with exponential backoff as defense against generic registry/CDN
+    # transients (the ffmpeg-static download is neutralized above via FFMPEG_BIN).
+    # bun install is idempotent, so re-running only re-attempts what is missing. A
+    # cold-cache release/deploy runs this across ~35 parallel jobs where a single
+    # job's failure cancels the whole deploy via cancel-doomed-run, so 5 attempts
+    # with 10/20/40/80s backoff keeps a lone transient from taking the run down.
     - name: Install dependencies
       shell: bash
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,19 +107,24 @@ jobs:
           flags: api-e2e
           fail_ci_if_error: false
 
-  # Frontend Core E2E — sharded 12-way. Each shard is an independent machine
-  # running ~1/12 of the app-core specs with 2 workers, so a fix only needs the
-  # affected shard re-run ("Re-run failed jobs" carries the green shards forward
-  # unchanged). fail-fast:false keeps every shard's result independent.
+  # Frontend Core E2E — sharded 4-way. The CI "core" scope is only ~7 spec files
+  # (smoke/ + core/ + one shell contract; see scripts/e2e-sharded.mjs), whose
+  # actual test time is ~1 min. 12 shards spun up 12 VMs — 12 installs, 12 app
+  # builds, 12 independent flake dice — for that ~1 min of work, and each job
+  # rolls the ffmpeg/browser/timing dice that, via cancel-doomed-run, can cancel
+  # the whole deploy. 4 shards (~2 files each) is the right balance: ~2 min more
+  # test wall on a gate whose CI stage already takes 20+ min, minus 8 flake
+  # sources from the deploy AND-gate. Each shard is independent (fail-fast:false),
+  # so "Re-run failed jobs" carries the green shards forward unchanged.
   e2e-frontend:
-    name: Frontend E2E (Shard ${{ matrix.shard }}/12)
+    name: Frontend E2E (Shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      max-parallel: 12
+      max-parallel: 4
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
 
@@ -144,7 +149,7 @@ jobs:
           # api-interceptor mocks; localhost:3010 is NOT intercepted.
           NEXT_PUBLIC_API_ENDPOINT: https://api.genfeed.ai/v1
 
-      - name: Run core E2E shard ${{ matrix.shard }}/12
+      - name: Run core E2E shard ${{ matrix.shard }}/4
         # --reporter=blob (passed inline, overriding the config reporter) so the
         # merge job can stitch all shards into one HTML report. The helper keeps
         # local and CI sharding behavior identical.
@@ -153,15 +158,22 @@ jobs:
           CI: true
           APP_BASE_URL: http://localhost:3000
           E2E_EXPECT_TIMEOUT_MS: "15000"
-          # Retry flaky specs twice in CI (Playwright only retries on failure, so
-          # a green shard pays zero cost). On the deploy path this suite gates the
-          # whole production release via cancel-doomed-run, so one browser/timing
-          # flake across 12 shards would otherwise cancel the entire deploy. A
-          # single flake taking up to 3x on its shard is an acceptable trade to
-          # stop losing green deploys to luck.
-          E2E_RETRIES: "2"
+          # Retry policy is split by trigger, and E2E_RETRIES is now the SINGLE
+          # source of truth (playwright.config.ts reads it directly;
+          # scripts/e2e-sharded.mjs no longer injects a competing --retries=0).
+          #  - deploy/dispatch/full-suite path → 2: this suite gates the whole
+          #    production release via cancel-doomed-run, so one browser/timing
+          #    flake would otherwise cancel the deploy. Playwright only retries on
+          #    failure, so green shards pay zero cost.
+          #  - nightly cron (schedule) → 0: retries there would mask flake and
+          #    silence the alarm the nightly exists to raise. Keep it honest.
+          # Written as `!= 'schedule' && '2' || '0'` on purpose: GitHub Actions
+          # coerces the string '0' to falsy, so a `== 'schedule' && '0' || '2'`
+          # form would wrongly yield 2 for the nightly. Keeping '0' in the `||`
+          # fallback position (never the `&&` result) sidesteps that coercion.
+          E2E_RETRIES: ${{ github.event_name != 'schedule' && '2' || '0' }}
           E2E_SHARD_INDEX: ${{ matrix.shard }}
-          E2E_TOTAL_SHARDS: "12"
+          E2E_TOTAL_SHARDS: "4"
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'test-better-auth-secret' }}
           NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -391,6 +391,20 @@ jobs:
               'This issue auto-updates on each red nightly. Close it once the nightly is green again.',
             ].join('\n');
             const { owner, repo } = context.repo;
+            // Ensure the dedup label exists so create attaches it and the
+            // list-by-label lookup below is reliable (issue-create label
+            // auto-provisioning is not guaranteed).
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: 'd73a4a',
+                description: 'Scheduled (nightly) E2E suite is failing',
+              });
+            }
             const existing = await github.rest.issues.listForRepo({
               owner,
               repo,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -250,16 +250,19 @@ jobs:
   # Real-Better Auth authenticated smoke (Playwright `app-authed` project). Exercises
   # the GENUINE authMiddleware path via a real Better Auth test-instance session — no
   # proxy.ts bypass — so it must be built with a REAL Better Auth client (bypass flag
-  # OFF) and given the real test-instance secrets. Dormant + non-blocking until
-  # the secrets land: gated behind the E2E_AUTHED_ENABLED repo variable and
-  # continue-on-error, so it never affects the gate while it hardens. mac-studio
-  # already runs this path locally; this makes CI ready to trigger on demand.
+  # OFF) and given the real test-instance secrets. Gated behind the E2E_AUTHED_ENABLED
+  # repo variable. It has been green for 7+ consecutive runs (all nightlies), so it is
+  # now GATING on the nightly cron — a real regression turns the nightly red and trips
+  # nightly-failure-report below, instead of rotting unseen behind continue-on-error
+  # (it sat red for 5+ June nightlies that way). On the deploy path it stays
+  # non-gating so a flake can never cancel a production release while this path keeps
+  # hardening: continue-on-error is true for every event EXCEPT the scheduled nightly.
   e2e-frontend-authed:
     name: Frontend Authed E2E (real Better Auth)
     if: ${{ vars.E2E_AUTHED_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    continue-on-error: true
+    continue-on-error: ${{ github.event_name != 'schedule' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -341,3 +344,66 @@ jobs:
           name: playwright-traces-authed
           path: playwright/artifacts/results/
           retention-days: 7
+
+  # Nightly-only failure reporter. The scheduled E2E run is the flake alarm; when
+  # it goes red, open (or update) ONE tracking issue so a broken nightly can't rot
+  # unseen — the whole reason the authed job could sit red for 5+ June nightlies.
+  # Runs ONLY on the standalone cron: a workflow_call from the deploy path inherits
+  # the caller's event, so github.event_name is 'schedule' solely for the nightly.
+  # Deploy gating is untouched. Keys off the aggregated gate AND the authed job
+  # (now nightly-gating above), so any red nightly surfaces exactly one issue.
+  nightly-failure-report:
+    name: Report nightly E2E failure
+    needs: [e2e-gate, e2e-frontend-authed]
+    if: >-
+      always()
+      && github.event_name == 'schedule'
+      && (needs.e2e-gate.result == 'failure'
+        || needs.e2e-frontend-authed.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the nightly-failure issue
+        uses: actions/github-script@v8
+        env:
+          GATE_RESULT: ${{ needs.e2e-gate.result }}
+          AUTHED_RESULT: ${{ needs.e2e-frontend-authed.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const label = 'nightly-e2e-failure';
+            const title = 'Nightly E2E suite is failing';
+            const failed = [];
+            if (process.env.GATE_RESULT === 'failure') {
+              failed.push('core gate (route coverage / frontend shards / API E2E)');
+            }
+            if (process.env.AUTHED_RESULT === 'failure') {
+              failed.push('authed E2E (real Better Auth)');
+            }
+            const body = [
+              'The scheduled (nightly) E2E run failed.',
+              '',
+              `- Failed: ${failed.join(', ')}`,
+              `- Run: ${process.env.RUN_URL}`,
+              '',
+              'This issue auto-updates on each red nightly. Close it once the nightly is green again.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const existing = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
+            }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-page-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/editor-page-content.test.tsx
@@ -544,12 +544,18 @@ describe('EditorPageContent', () => {
   it('supports keyboard shortcuts without hijacking form inputs', async () => {
     await renderLoadedEditor();
 
-    // The shortcut handler seeks via previewRef.current?.seekToFrame(...),
-    // which is optional-chained: it silently no-ops until the preview ref is
-    // populated (a commit after the loaded UI text appears). Probe with Home
-    // (deterministic seek to 0) until the handler actually fires, then reset so
-    // the assertions below start from a known-wired state. Without this, the
-    // first ArrowRight can land before the ref is set and the test flakes.
+    // The shortcut handler is attached by a useEffect (passive-effect phase:
+    // window.addEventListener('keydown', ...) in useEditorPageContent). That
+    // phase can flush AFTER findByText('Launch Reel') resolves, so the very
+    // first synthetic keydown may land before the listener exists and be
+    // dropped entirely — the deploy-gate failure showed only 3 of 4 seeks, with
+    // the first ArrowRight→seek(1) missing (calls were [0, 0, 119]). The
+    // previewRef itself (useImperativeHandle → layout-effect) is wired earlier,
+    // so this is a listener-registration race, not a ref-population one. Probe
+    // with Home (deterministic seek to 0) until the handler responds — proving
+    // both listener and ref are live — then reset for the real assertions. The
+    // component is not racy in production: the listener attaches before any human
+    // could press a key; only the synchronous test needs this settle.
     await waitFor(() => {
       fireEvent.keyDown(window, { key: 'Home' });
       expect(mocks.seekToFrame).toHaveBeenCalledWith(0);

--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -15,9 +15,20 @@ FROM node:24-bookworm-slim AS base
 # `curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt`.
 # unzip is required by the bun installer (>=1.3 ships its binary as a .zip):
 # without it the install below aborts with `error: unzip is required to install bun`.
+#
+# ffmpeg: the api & files services spawn it at runtime via the `ffmpeg-static`
+# export. Installing it here (a stage shared by both builder and runtime) and
+# setting FFMPEG_BIN below makes that export resolve to the apt binary, so
+# ffmpeg-static skips its ~40MB GitHub-CDN download during `bun install` in the
+# builder — one fewer install-time network side-effect that could flake the build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl redis-server tini unzip && \
+    ca-certificates curl ffmpeg redis-server tini unzip && \
     rm -rf /var/lib/apt/lists/*
+
+# Point ffmpeg-static at the apt ffmpeg (see apt block above). Set in `base`, so
+# both the builder (install-time download skip) and the runtime (services spawn
+# the export) inherit it.
+ENV FFMPEG_BIN=/usr/bin/ffmpeg
 
 # Copy BOTH bun and bunx onto PATH. bunx is a distinct binary (not derived from
 # bun at call time), and it is needed in both stages: the builder runs it via
@@ -153,14 +164,21 @@ RUN bun --filter @genfeedai/enums build
 # (mirroring @genfeedai/integrations) — resolving enums from source for their own
 # compile, independent of the enums/dist built above. Without that path-map a
 # clean context fails with `TS2307: Cannot find module '@genfeedai/enums'`.
-RUN set -e && \
-    bun --filter @genfeedai/types build & pid1=$! && \
-    bun --filter @genfeedai/config build & pid2=$! && \
-    bun --filter @genfeedai/workflow-engine build & pid3=$! && \
-    wait $pid1 $pid2 $pid3 && \
-    bun --filter @genfeedai/helpers build && \
-    bun --filter @genfeedai/integrations build && \
-    bun --filter @genfeedai/serializers build && \
+# Parallel builds: capture every pid in the MAIN shell (`;`, not `&&`) and wait
+# for ALL of them, failing if any build fails. The prior `& pidN=$! && ... wait
+# $pid1 $pid2 $pid3` captured pids inside backgrounded subshells (so only the
+# last job was awaited — a still-writing bundle could be truncated) and `wait a
+# b c` returned only c's status (swallowing a non-last failure). See the fuller
+# note in docker/Dockerfile.server.
+RUN set -e; \
+    pids=""; \
+    bun --filter @genfeedai/types build & pids="$pids $!"; \
+    bun --filter @genfeedai/config build & pids="$pids $!"; \
+    bun --filter @genfeedai/workflow-engine build & pids="$pids $!"; \
+    ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]; \
+    bun --filter @genfeedai/helpers build; \
+    bun --filter @genfeedai/integrations build; \
+    bun --filter @genfeedai/serializers build; \
     bun --filter @genfeedai/workflow-saas build
 
 # Disable deleteOutDir for parallel builds
@@ -169,10 +187,11 @@ RUN sed -i 's/"deleteOutDir": true/"deleteOutDir": false/' apps/server/nest-cli.
 # Build NestJS services
 RUN bun --filter @genfeedai/api build:prod
 RUN bun --filter @genfeedai/workers build:prod
-RUN set -e && \
-    bun --filter @genfeedai/files build:prod & pid1=$! && \
-    bun --filter @genfeedai/notifications build:prod & pid2=$! && \
-    wait $pid1 $pid2
+RUN set -e; \
+    pids=""; \
+    bun --filter @genfeedai/files build:prod & pids="$pids $!"; \
+    bun --filter @genfeedai/notifications build:prod & pids="$pids $!"; \
+    ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]
 # mcp is built here because selfhosted-entrypoint.sh starts it (MCP_PORT 3014,
 # proxying to the local api). Without this build the entrypoint would launch a
 # nonexistent bundle and the mcp tool surface would be silently dead. Kept on its

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -30,6 +30,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 ENV PATH="/usr/local/bin:${PATH}"
 
+# Point ffmpeg-static at the apt ffmpeg installed above. Its index.js exports
+# $FFMPEG_BIN verbatim and install.js skips the ~40MB GitHub-CDN download during
+# `bun install` below when the path exists — removing that per-build CDN call
+# entirely. The runtime code always imports the ffmpeg-static export, so this
+# must also be set in the production stage (see below), which is a fresh base.
+ENV FFMPEG_BIN=/usr/bin/ffmpeg
+
 # Mandatory for production build — give each parallel build enough memory
 ENV NODE_OPTIONS=--max-old-space-size=4096
 
@@ -133,10 +140,11 @@ RUN set -e; \
     bun --filter @genfeedai/interfaces build; \
     bun --filter @genfeedai/pricing build; \
     bun --filter @genfeedai/client build; \
-    bun --filter @genfeedai/types build & pid1=$!; \
-    bun --filter @genfeedai/config build & pid2=$!; \
-    bun --filter @genfeedai/workflow-engine build & pid3=$!; \
-    wait $pid1 $pid2 $pid3; \
+    pids=""; \
+    bun --filter @genfeedai/types build & pids="$pids $!"; \
+    bun --filter @genfeedai/config build & pids="$pids $!"; \
+    bun --filter @genfeedai/workflow-engine build & pids="$pids $!"; \
+    ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]; \
     bun --filter @genfeedai/helpers build; \
     bun --filter @genfeedai/integrations build; \
     bun --filter @genfeedai/serializers build; \
@@ -158,49 +166,60 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
 # Workers alone: large dependency footprint (imports @api/shared), needs dedicated resources
 RUN bun --filter @genfeedai/workers build:prod
 
-# Batch 1: Other Sentry services (3 builds in parallel)
+# Batch 1: Other Sentry services (3 builds in parallel).
+# The previous `(...) & pidN=$! && ... wait $pid1 $pid2 $pid3` had TWO bugs: the
+# `& pidN=$! &&` chaining captured pids inside backgrounded subshells (not the
+# main shell), so the RUN only ever waited on the last job — a still-writing mcp
+# could be truncated to a 0-byte main.js when notifications finished first (the
+# #1292-era bundle bug); and `wait a b c` returns only c's status, swallowing a
+# non-last failure. The robust form below captures every pid in the MAIN shell
+# (`;`, not `&&`), waits for ALL of them, and fails the layer if ANY failed.
+# Applied to every parallel batch. Verified: succeeds clean, fails on any build.
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
-    set -e && \
-    (SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || echo "") bun --filter @genfeedai/files build:prod) & pid1=$! && \
-    (SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || echo "") bun --filter @genfeedai/mcp build:prod) & pid2=$! && \
-    (SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || echo "") bun --filter @genfeedai/notifications build:prod) & pid3=$! && \
-    wait $pid1 $pid2 $pid3
+    set -e; \
+    pids=""; \
+    (SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || echo "") bun --filter @genfeedai/files build:prod) & pids="$pids $!"; \
+    (SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || echo "") bun --filter @genfeedai/mcp build:prod) & pids="$pids $!"; \
+    (SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || echo "") bun --filter @genfeedai/notifications build:prod) & pids="$pids $!"; \
+    ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]
 
-# Batch 2: Non-Sentry services (4 builds)
-RUN set -e && \
-    bun --filter @genfeedai/telegram build:prod & pid1=$! && \
-    bun --filter @genfeedai/discord build & pid2=$! && \
-    bun --filter @genfeedai/slack build:prod & pid3=$! && \
-    wait $pid1 $pid2 $pid3
+# Batch 2: Non-Sentry services (3 builds)
+RUN set -e; \
+    pids=""; \
+    bun --filter @genfeedai/telegram build:prod & pids="$pids $!"; \
+    bun --filter @genfeedai/discord build & pids="$pids $!"; \
+    bun --filter @genfeedai/slack build:prod & pids="$pids $!"; \
+    ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]
 
 # Batch 3: GPU fleet services (3 builds)
-RUN set -e && \
-    bun --filter @genfeedai/images build:prod & pid1=$! && \
-    bun --filter @genfeedai/voices build:prod & pid2=$! && \
-    bun --filter @genfeedai/videos build:prod & pid3=$! && \
-    wait $pid1 $pid2 $pid3
+RUN set -e; \
+    pids=""; \
+    bun --filter @genfeedai/images build:prod & pids="$pids $!"; \
+    bun --filter @genfeedai/voices build:prod & pids="$pids $!"; \
+    bun --filter @genfeedai/videos build:prod & pids="$pids $!"; \
+    ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]
 
 # ==================================================
 # Stage 2.5: Validate build outputs exist
 # ==================================================
 # Webpack bundles each service into a single main.js file.
-# Verify the critical bundles exist before proceeding.
+# Verify the critical bundles exist AND are non-trivially sized before proceeding.
+# The size floor (10KB) catches a truncated/empty emit (e.g. an OOM-killed
+# webpack that leaves a 0-byte main.js) INSIDE the image build, so the poisoned
+# layer fails fast and never enters the GHCR buildcache — mirroring the external
+# size gate in build-verify.yml. `test -f` alone passes a 0-byte file.
 RUN echo "Checking build outputs..." && \
     ls -la apps/server/dist/apps/ 2>/dev/null || echo "dist/apps/ directory missing!" && \
-    for svc in api workers files mcp notifications telegram discord slack images voices videos; do \
-      if test -f "apps/server/dist/apps/$svc/main.js"; then \
-        SIZE=$(stat -c%s "apps/server/dist/apps/$svc/main.js"); \
-        echo "✅ $svc bundle ($(( SIZE / 1024 ))KB)"; \
-      else \
+    for svc in api workers files mcp notifications telegram discord slack images voices videos api-workflow-backfill; do \
+      if ! test -f "apps/server/dist/apps/$svc/main.js"; then \
         echo "❌ $svc bundle MISSING" && exit 1; \
       fi; \
-    done && \
-    if test -f "apps/server/dist/apps/api-workflow-backfill/main.js"; then \
-      SIZE=$(stat -c%s "apps/server/dist/apps/api-workflow-backfill/main.js"); \
-      echo "✅ api-workflow-backfill bundle ($(( SIZE / 1024 ))KB)"; \
-    else \
-      echo "❌ api-workflow-backfill bundle MISSING" && exit 1; \
-    fi
+      SIZE=$(stat -c%s "apps/server/dist/apps/$svc/main.js"); \
+      if [ "$SIZE" -lt 10000 ]; then \
+        echo "❌ $svc bundle suspiciously small (${SIZE} bytes)" && exit 1; \
+      fi; \
+      echo "✅ $svc bundle ($(( SIZE / 1024 ))KB)"; \
+    done
 
 # ==================================================
 # Stage 3: Production - Runtime image
@@ -214,6 +233,13 @@ RUN apt-get update && apt-get install -y \
     unzip \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
+
+# This stage is a fresh `FROM node:24-slim` — it does NOT inherit the base
+# stage's ENV. The ffmpeg-static export honors $FFMPEG_BIN at module-eval time,
+# and the download was skipped in the builder, so the bundled binary is absent
+# from the copied node_modules; without this the files/api services would crash
+# on boot with "FFmpeg binary not found". Points at the apt ffmpeg installed above.
+ENV FFMPEG_BIN=/usr/bin/ffmpeg
 
 # Install bun for running production scripts
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14" && \

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -280,7 +280,6 @@ export interface IEnvConfig {
 
   // === FFmpeg (Files service) ===
   FFMPEG_THREADS?: number;
-  FFMPEG_PATH?: string;
   FFMPEG_VIDEO_CODEC?: string;
   FFMPEG_AUDIO_CODEC?: string;
   FFMPEG_CRF?: string;

--- a/packages/config/src/schemas/ffmpeg.schema.ts
+++ b/packages/config/src/schemas/ffmpeg.schema.ts
@@ -7,7 +7,6 @@ export const ffmpegSchema = {
   FFMPEG_AUDIO_CODEC: Joi.string().optional(),
   FFMPEG_CRF: Joi.string().optional(),
   FFMPEG_MAX_PROCESSES: Joi.string().optional(),
-  FFMPEG_PATH: Joi.string().optional(),
   FFMPEG_PIXEL_FORMAT: Joi.string().optional(),
   FFMPEG_PRESET: Joi.string().optional(),
   FFMPEG_TEMP_DIR: Joi.string().optional(),

--- a/scripts/e2e-sharded.mjs
+++ b/scripts/e2e-sharded.mjs
@@ -26,7 +26,7 @@ Defaults:
   --config=${DEFAULT_CONFIG}
   --project=${DEFAULT_PROJECT}
   --scope=core
-  --retries=\${E2E_RETRIES:-0}`);
+  --retries  (unset: playwright.config.ts decides via E2E_RETRIES / isCI ? 2 : 0)`);
 }
 
 function parseShard(value) {
@@ -77,7 +77,11 @@ let config = DEFAULT_CONFIG;
 let project = DEFAULT_PROJECT;
 let scope = 'core';
 let shard = null;
-let retries = process.env.E2E_RETRIES ?? '0';
+// Retries are owned by playwright.config.ts (it reads E2E_RETRIES directly, else
+// isCI ? 2 : 0). This runner only forwards an EXPLICIT `--retries=` override and
+// must never inject a default — the old `?? '0'` clobbered the config's CI
+// default of 2 on the deploy gate, silently disabling flake retries there.
+let explicitRetries = null;
 
 for (let i = 0; i < ownArgs.length; i += 1) {
   const arg = ownArgs[i];
@@ -108,7 +112,7 @@ for (let i = 0; i < ownArgs.length; i += 1) {
   }
 
   if (arg.startsWith('--retries=')) {
-    retries = arg.slice('--retries='.length);
+    explicitRetries = arg.slice('--retries='.length);
     continue;
   }
 
@@ -139,14 +143,16 @@ if (project && !hasOption(playwrightArgs, '--project')) {
 
 args.push(`--shard=${shard}`);
 
-if (!hasOption(playwrightArgs, '--retries')) {
-  args.push(`--retries=${retries}`);
+// Only forward retries when explicitly overridden on the CLI; otherwise leave it
+// to playwright.config.ts (single authority — see explicitRetries above).
+if (explicitRetries !== null && !hasOption(playwrightArgs, '--retries')) {
+  args.push(`--retries=${explicitRetries}`);
 }
 
 args.push(...playwrightArgs);
 
 writeStdout(
-  `[e2e-sharded] running ${project || 'all projects'} shard ${shard} (scope: ${scope}, retries: ${retries})`,
+  `[e2e-sharded] running ${project || 'all projects'} shard ${shard} (scope: ${scope}, retries: ${explicitRetries ?? 'config/E2E_RETRIES'})`,
 );
 
 const result = spawnSync('bunx', args, {


### PR DESCRIPTION
## Why

v0.4.5 shipped only after ~10 deploy attempts, green on flake luck. #1292 patched three symptoms. Vincent asked whether there are simpler, more-correct **root-cause** fixes. This PR replaces the band-aids with the underlying causes and fixes **two additional deploy-killers #1292 never touched** — found by walking all 10 failed attempts in the CI history.

Full attempt-by-attempt evidence: ~7 of 10 failures were the concurrency self-cancel bugs (already fixed in #1289/#1290); the rest were a deterministic route gap (#1291), the editor test flake, a **0-byte MCP bundle**, and an E2E route-bucket assertion. **Zero** attempts failed on ffmpeg/bun-install — the retry band-aid fought a threat that never fired.

## Changes

### 1. ffmpeg-static CDN download — kill it at the source (replaces the install-retry band-aid)
`ffmpeg-static` postinstalls a ~40MB binary from the GitHub-releases CDN on every `bun install`, fanned across ~35 cold jobs per deploy. No CI job ever runs ffmpeg (every consumer spec mocks it). Point it at the runner/apt ffmpeg via the package's own `FFMPEG_BIN` env — its `index.js` exports that path and `install.js` skips the download.
- `setup-bun-env/action.yml`: set `FFMPEG_BIN` before install (non-fatal apt fallback → never a new failure mode).
- `Dockerfile.server`: `ENV FFMPEG_BIN` in **base** (install skip) **and production** (fresh stage — runtime resolution, else files/api crash on boot).
- `Dockerfile.selfhosted`: add system ffmpeg + `FFMPEG_BIN` in the shared base (it previously depended on the CDN download at build time).
- Delete dead `FFMPEG_PATH` config (unreferenced) from schema + interface.

### 2. 0-byte MCP bundle — a deploy-killer #1292 didn't touch
Both Dockerfiles used `(...) & pidN=$! && ... wait $pid1 $pid2 $pid3`. Two bugs: the `& pidN=$! &&` chaining captured pids **inside backgrounded subshells**, so the RUN only awaited the **last** job — a still-writing bundle (mcp) could be truncated when a sibling finished first; and `wait a b c` returns only c's status, swallowing a non-last failure. Rewrote every parallel batch to capture pids in the **main shell** and wait for **all**, failing on any (verified empirically: success / non-last-failure / slow-non-last-job). Added a **≥10KB size floor** to the builder-stage validation so a truncated emit fails *inside* the image build and never enters the GHCR buildcache.

### 3. E2E deploy gate — retry authority + fan-out
- `e2e-sharded.mjs` no longer injects a competing `--retries=0` default — that was the real reason `playwright.config.ts`'s `isCI ? 2` never applied. It now forwards only an explicit CLI `--retries`; **the config is the single authority**.
- Split `E2E_RETRIES` by trigger: **2** on the deploy path, **0** on the nightly cron so it stays an honest flake alarm. Written `!= 'schedule' && '2' || '0'` to dodge GHA's `'0'`-is-falsy coercion.
- Shrink fan-out **12 → 4 shards**: the core scope is ~7 spec files (~1 min of test); 12 VMs meant 12 installs/builds/flake-dice for that, each able to cancel the deploy.

### 4. Editor keyboard-shortcut test
Corrected the flake's root cause in the comment: the `window` keydown listener registers in the **passive-effect phase** (can lag the awaited UI text), not ref population (the CI failure showed the first keydown dropped: calls `[0, 0, 119]`). The component is **not racy in production**; only the synchronous test needs the settle probe. Probe logic unchanged.

## Architecture verdicts (asked, no change made)
- **Single cached install prereq job?** No — GHA has no shared FS; shipping `node_modules` between jobs is slower/flakier than per-job installs. Removing the CDN side-effect (change 1) makes per-job installs effectively hermetic instead.
- **Exempt "transient" failures from `cancel-doomed-run`?** No — transience is handled at the step level (install retry, Playwright retry); by the time a job reports failure it has burned its retries and the gate can never go green. Cancelling is correct. The operational lever is **"Re-run failed jobs"** on a red QA run (preserves green jobs), not loosening the gate.

## Verification
- `@genfeedai/config` type-check: green (after FFMPEG_PATH removal).
- Editor test: **7/7 pass**.
- `e2e-sharded` retry forwarding: verified across 3 cases (no env / `E2E_RETRIES` set / explicit `--retries`).
- Parallel-wait rewrite: verified for success, non-last failure, and slow-non-last-job.
- actionlint + biome clean on changed files; pre-commit secretlint/guards passed.
- Heavy build/e2e gates run on this PR's CI.

## Notes
- CI/build-infra + one dead-config deletion + one test-comment. No product runtime code changed.
- `apps/server/files/.env.example` still lists the now-removed `FFMPEG_PATH` — left untouched because the `.env*` guard blocks editing it; harmless (stale example only).

---

## Added: nightly E2E becomes the flake alarm (commit 2)

Per session follow-up — closes the observability gap that let the deploy pain hide. Nightly E2E failures rotted unseen (the authed job sat **red for 5+ consecutive June nightlies** because `continue-on-error` masked it and nobody watches the cron).

- **`e2e-frontend-authed`**: `continue-on-error` is now `github.event_name != 'schedule'` — **gating on the nightly cron** (a real Better-Auth regression turns the nightly red) but still **non-gating on the deploy path** (an authed flake can never cancel a production release). It's been green 7+ straight runs, so it's stable enough to gate the nightly.
- **New `nightly-failure-report` job**: on a red scheduled run, opens/updates a single `nightly-e2e-failure` tracking issue (failed area + run URL). Runs **only on the standalone cron** — a deploy-path `workflow_call` inherits the caller's event, so `github.event_name` is `schedule` solely for the nightly. **Deploy gating untouched.**

Verified: actionlint clean; YAML parses (7 jobs); github-script body syntax + dedup/create logic checked standalone.

> Context: the originally-flagged "authed E2E broken" finding was **stale** — the job has been green for 7 runs. This commit hardens *observability* so a future regression (auth or otherwise) surfaces the day it lands instead of rotting in an unwatched nightly.