### PR TITLE
fix(api): org switcher rendered a foreign org — findMine mapped the undefined Mongo-era alias

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -39,6 +39,7 @@
 - [Production deploys master-only](production_deploy_master_only.md) — Never deploy any non-master ref to production unless Vincent explicitly overrides; production deploys run from GitHub CI on master
 - [Vercel release gate](feedback_vercel_release_gate.md) — SaaS Vercel frontends deploy only through the API-first production release workflow; Vercel Git auto-deploy stays disabled
 - [PRD-pass verify state first](prd_pass_verify_state_first.md) — On any epic PRD pass, verify child issue states via `gh` + audit real code before trusting the epic body; never rewrite closed/shipped cards
+- [Prisma legacy alias fields](rules/prisma_legacy_alias_fields.md) — Mongo-era `*Document` aliases (`organization`/`user`/`_id`) are undefined on Prisma rows; read scalar FKs (`organizationId`/`userId`); `BaseService.findOne` guards empty ids (canonical: docs/identity-resolution.md)
 
 ## References
 

--- a/.agents/memory/rules/prisma_legacy_alias_fields.md
+++ b/.agents/memory/rules/prisma_legacy_alias_fields.md
@@ -1,0 +1,19 @@
+# Prisma rows: never read Mongo-era alias fields
+
+**last_verified: 2026-07-05**
+
+`*Document` types (`MemberDocument`, etc.) add optional legacy aliases
+(`_id`, `organization`, `user`, `role`) on top of Prisma rows. They
+type-check but are **undefined at runtime** — live data is in the scalar FKs
+(`organizationId`, `userId`, `roleId`).
+
+- Read scalar FKs; defensive fallback pattern: `row.organizationId || row.organization`.
+- Filters are fine (`processSearchParams` maps `user`→`userId` etc.), but
+  `normalizeWhere` drops `undefined` values — a lookup built from an undefined
+  alias silently widens the query. `BaseService.findOne` guards `_id`/`id`
+  explicitly passed as `undefined`/`null`/`''` (returns `null`, never an
+  unscoped first-row read).
+- Observed blast radius (2026-07): org switcher rendered a foreign org,
+  duplicated, from `findMine` mapping `member.organization`.
+
+Canonical doc: [docs/identity-resolution.md](../../../docs/identity-resolution.md)

--- a/apps/server/api/src/collections/organizations/controllers/organizations.controller.spec.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations.controller.spec.ts
@@ -1,0 +1,251 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { ActivitiesService } from '@api/collections/activities/services/activities.service';
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { DefaultRecurringContentService } from '@api/collections/brands/services/default-recurring-content.service';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { MembersService } from '@api/collections/members/services/members.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { OrganizationsController } from '@api/collections/organizations/controllers/organizations.controller';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { RolesService } from '@api/collections/roles/services/roles.service';
+import { TagsService } from '@api/collections/tags/services/tags.service';
+import { UsersService } from '@api/collections/users/services/users.service';
+import { VideosService } from '@api/collections/videos/services/videos.service';
+import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
+import { BetterAuthIdentityCacheService } from '@api/common/services/better-auth-identity-cache.service';
+import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, TestingModule } from '@nestjs/testing';
+
+interface FindMineEntry {
+  brand: { id: string; label: string } | null;
+  id: string;
+  isActive: boolean;
+  label: string;
+  slug: string;
+}
+
+describe('OrganizationsController', () => {
+  let controller: OrganizationsController;
+
+  const mockLoggerService = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  const mockMembersService = {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    setLastUsedBrand: vi.fn(),
+  };
+
+  const mockOrganizationsService = {
+    findOne: vi.fn(),
+    generateUniqueSlug: vi.fn(),
+  };
+
+  const mockBrandsService = {
+    findOne: vi.fn(),
+  };
+
+  const mockUsersService = {
+    findOne: vi.fn(),
+    patch: vi.fn(),
+  };
+
+  const mockRolesService = {
+    findOne: vi.fn(),
+  };
+
+  const mockOrganizationSettingsService = {
+    create: vi.fn(),
+    getLatestMajorVersionModelIds: vi.fn(),
+  };
+
+  const mockInvalidatingCache = {
+    invalidateForUser: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const currentUser = {
+    publicMetadata: {
+      brand: 'brand_active',
+      isSuperAdmin: false,
+      organization: 'org_active',
+      user: 'user_1',
+    },
+  } as unknown as User;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrganizationsController],
+      providers: [
+        { provide: LoggerService, useValue: mockLoggerService },
+        { provide: BrandsService, useValue: mockBrandsService },
+        { provide: ActivitiesService, useValue: {} },
+        { provide: MembersService, useValue: mockMembersService },
+        { provide: OrganizationsService, useValue: mockOrganizationsService },
+        { provide: DefaultRecurringContentService, useValue: {} },
+        { provide: PostsService, useValue: {} },
+        { provide: TagsService, useValue: {} },
+        { provide: VideosService, useValue: {} },
+        { provide: IngredientsService, useValue: {} },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: RolesService, useValue: mockRolesService },
+        {
+          provide: OrganizationSettingsService,
+          useValue: mockOrganizationSettingsService,
+        },
+        {
+          provide: RequestContextCacheService,
+          useValue: mockInvalidatingCache,
+        },
+        {
+          provide: AccessBootstrapCacheService,
+          useValue: mockInvalidatingCache,
+        },
+        {
+          provide: BetterAuthIdentityCacheService,
+          useValue: mockInvalidatingCache,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrganizationsController>(OrganizationsController);
+  });
+
+  describe('findMine', () => {
+    it('resolves organizations from Prisma-shaped membership rows (organizationId scalar)', async () => {
+      // Regression: rows carry `organizationId`; the legacy `organization`
+      // alias is undefined. Mapping the alias sent findOne({ _id: undefined })
+      // downstream, which returned the first org in the table for every row.
+      mockMembersService.find.mockResolvedValue([
+        { id: 'member_1', isActive: true, organizationId: 'org_a' },
+        { id: 'member_2', isActive: true, organizationId: 'org_b' },
+      ]);
+      mockOrganizationsService.findOne.mockImplementation(
+        async ({ _id }: { _id: string }) => ({
+          id: _id,
+          label: `label ${_id}`,
+          slug: `slug-${_id}`,
+        }),
+      );
+      mockBrandsService.findOne.mockResolvedValue(null);
+
+      const result = (await controller.findMine(
+        currentUser,
+      )) as FindMineEntry[];
+
+      expect(mockOrganizationsService.findOne).toHaveBeenCalledWith({
+        _id: 'org_a',
+        isDeleted: false,
+      });
+      expect(mockOrganizationsService.findOne).toHaveBeenCalledWith({
+        _id: 'org_b',
+        isDeleted: false,
+      });
+      expect(result.map((entry) => entry.id)).toEqual(['org_a', 'org_b']);
+    });
+
+    it('dedups multiple membership rows pointing at the same organization', async () => {
+      mockMembersService.find.mockResolvedValue([
+        { id: 'member_1', isActive: true, organizationId: 'org_a' },
+        { id: 'member_2', isActive: true, organizationId: 'org_a' },
+      ]);
+      mockOrganizationsService.findOne.mockResolvedValue({
+        id: 'org_a',
+        label: 'Org A',
+        slug: 'org-a',
+      });
+      mockBrandsService.findOne.mockResolvedValue(null);
+
+      const result = (await controller.findMine(
+        currentUser,
+      )) as FindMineEntry[];
+
+      expect(result).toHaveLength(1);
+      expect(mockOrganizationsService.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips membership rows without a resolvable organization id', async () => {
+      mockMembersService.find.mockResolvedValue([
+        { id: 'member_1', isActive: true, organizationId: 'org_a' },
+        { id: 'member_broken', isActive: true, organizationId: undefined },
+      ]);
+      mockOrganizationsService.findOne.mockResolvedValue({
+        id: 'org_a',
+        label: 'Org A',
+        slug: 'org-a',
+      });
+      mockBrandsService.findOne.mockResolvedValue(null);
+
+      const result = (await controller.findMine(
+        currentUser,
+      )) as FindMineEntry[];
+
+      expect(result).toHaveLength(1);
+      expect(mockOrganizationsService.findOne).toHaveBeenCalledTimes(1);
+      expect(mockOrganizationsService.findOne).not.toHaveBeenCalledWith({
+        _id: undefined,
+        isDeleted: false,
+      });
+    });
+
+    it('still honours legacy `organization` alias rows as a fallback', async () => {
+      mockMembersService.find.mockResolvedValue([
+        { id: 'member_legacy', isActive: true, organization: 'org_legacy' },
+      ]);
+      mockOrganizationsService.findOne.mockResolvedValue({
+        id: 'org_legacy',
+        label: 'Legacy',
+        slug: 'legacy',
+      });
+      mockBrandsService.findOne.mockResolvedValue(null);
+
+      const result = (await controller.findMine(
+        currentUser,
+      )) as FindMineEntry[];
+
+      expect(result.map((entry) => entry.id)).toEqual(['org_legacy']);
+    });
+
+    it('marks only the active organization from publicMetadata', async () => {
+      mockMembersService.find.mockResolvedValue([
+        { id: 'member_1', isActive: true, organizationId: 'org_active' },
+        { id: 'member_2', isActive: true, organizationId: 'org_other' },
+      ]);
+      mockOrganizationsService.findOne.mockImplementation(
+        async ({ _id }: { _id: string }) => ({
+          id: _id,
+          label: `label ${_id}`,
+          slug: `slug-${_id}`,
+        }),
+      );
+      mockBrandsService.findOne.mockResolvedValue(null);
+
+      const result = (await controller.findMine(
+        currentUser,
+      )) as FindMineEntry[];
+
+      expect(
+        result.map((entry) => ({ id: entry.id, isActive: entry.isActive })),
+      ).toEqual([
+        { id: 'org_active', isActive: true },
+        { id: 'org_other', isActive: false },
+      ]);
+    });
+
+    it('returns an empty list when the user has no memberships', async () => {
+      mockMembersService.find.mockResolvedValue([]);
+
+      const result = await controller.findMine(currentUser);
+
+      expect(result).toEqual([]);
+      expect(mockOrganizationsService.findOne).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
@@ -486,7 +486,19 @@ export class OrganizationsController extends BaseCRUDController<
       return [];
     }
 
-    const orgIds = members.map((m) => m.organization);
+    // Membership rows are Prisma-shaped (`organizationId`); the legacy
+    // `organization` alias is optional-typed and undefined at runtime, so
+    // mapping it sent `findOne({ _id: undefined })` downstream — which
+    // normalized to an unscoped findFirst and returned the first organization
+    // in the table once per membership row (#switcher duplicate/wrong-org).
+    // Dedup so multiple memberships in one org can't render duplicate entries.
+    const orgIds = [
+      ...new Set(
+        members
+          .map((member) => member.organizationId || member.organization || '')
+          .filter(Boolean),
+      ),
+    ];
 
     // Fetch all organizations
     const orgs = await Promise.all(

--- a/apps/server/api/src/shared/services/base/base.service.spec.ts
+++ b/apps/server/api/src/shared/services/base/base.service.spec.ts
@@ -755,6 +755,43 @@ describe('BaseService', () => {
         where: { id: 'abc123' },
       });
     });
+
+    // normalizeWhere drops undefined values, so without the guard a lookup
+    // like findOne({ _id: undefined }) degrades to an unscoped findFirst and
+    // returns the first row in the table — a cross-tenant read.
+    it('returns null (without querying) when _id is undefined', async () => {
+      const result = await service.findOne({
+        _id: undefined,
+        isDeleted: false,
+      });
+
+      expect(result).toBeNull();
+      expect(delegate.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('returns null (without querying) when id is null', async () => {
+      const result = await service.findOne({ id: null, isDeleted: false });
+
+      expect(result).toBeNull();
+      expect(delegate.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('returns null (without querying) when id is an empty string', async () => {
+      const result = await service.findOne({ id: '', isDeleted: false });
+
+      expect(result).toBeNull();
+      expect(delegate.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('still queries when a non-id filter value is undefined', async () => {
+      delegate.findFirst.mockResolvedValue(null);
+
+      await service.findOne({ id: 'id_1', status: undefined });
+
+      expect(delegate.findFirst).toHaveBeenCalledWith({
+        where: { id: 'id_1' },
+      });
+    });
   });
 
   describe('patch', () => {

--- a/apps/server/api/src/shared/services/base/base.service.ts
+++ b/apps/server/api/src/shared/services/base/base.service.ts
@@ -894,6 +894,26 @@ export abstract class BaseService<
         throw new ValidationException('Search parameters are required');
       }
 
+      // Guard: a primary-key lookup with a missing id must never fall through
+      // to an unscoped findFirst. normalizeWhere drops undefined values, so
+      // `findOne({ _id: undefined })` would silently return the first row in
+      // the table — a cross-tenant read. Treat it as "not found" instead.
+      const voidableIdKeys = ['_id', 'id'] as const;
+      const hasVoidIdParam = voidableIdKeys.some(
+        (key) =>
+          key in params &&
+          (params[key] === undefined ||
+            params[key] === null ||
+            params[key] === ''),
+      );
+      if (hasVoidIdParam) {
+        this.logger?.warn(
+          'findOne called with an empty identifier — returning null instead of an unscoped first-row read',
+          { model: this.modelName, params },
+        );
+        return null;
+      }
+
       this.logger?.debug('Finding document', { params, populate });
 
       const where = this.normalizeWhere(params);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,7 @@ collaboration, and governance layer.
 
 ## Boundary Documents
 
+- [Identity & Request Resolution](./identity-resolution.md)
 - [Core and Cloud Execution Boundaries](./execution-boundaries.md)
 - [PLG Boundary ADR](../.agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md)
 - [Skills, Routines, and Memory Boundary ADR](../.agents/memory/architecture/ADR-SKILLS-ROUTINES-MEMORY-BOUNDARY.md)

--- a/docs/identity-resolution.md
+++ b/docs/identity-resolution.md
@@ -1,0 +1,127 @@
+# Identity & Request Resolution
+
+How a Better Auth session becomes an authorized, org-scoped API request — and
+the legacy hazards to avoid when touching this path. Written for contributors
+and coding agents; every path below is a real code location.
+
+## The flow (SaaS / community with auth)
+
+```
+Browser cookie (better-auth.session_token, httpOnly)
+  │
+  ├─ apps/app/proxy.ts ── GET /v1/auth/token (cookie → short-lived JWT)
+  │                        └─ JWT `sub` = genfeed User.id
+  │
+  └─ API request with Bearer JWT
+       │
+       BetterAuthStrategy.validate()            apps/server/api/src/auth/better-auth/passport/
+       ├─ verifyToken(token) → claims
+       ├─ BetterAuthIdentityResolverService.resolve(claims.sub)
+       │    ├─ BetterAuthIdentityCacheService (Redis) — cache-first
+       │    └─ resolveFromDatabase(): User → Members → org/brand pointers
+       │         • active org = User.lastUsedOrganizationId, validated against
+       │           live membership/ownership (never trusted blindly)
+       │         • isSuperAdmin = users.platformRole (user-global, org-independent)
+       └─ shapes request.user with a legacy-compatible publicMetadata:
+            { user, organization, brand, isSuperAdmin }
+```
+
+Two consumers of the result:
+
+- **Controllers** read `getPublicMetadata(user)` (`helpers/utils/auth/auth.util.ts`)
+  — the legacy metadata shim. `publicMetadata.user` is the resolved genfeed
+  `User.id`, `publicMetadata.organization` the validated active org.
+- **`/v1/auth/bootstrap`** (`auth/services/auth-bootstrap.service.ts`) returns
+  `access { userId, organizationId, brandId, isSuperAdmin }` to the frontend;
+  `apps/app/packages/server/protected-bootstrap.server.ts` maps it into
+  `accessState` for layouts (e.g. the `/admin` gate).
+
+Both paths resolve from the same tables. If they ever disagree, suspect a
+stale `BetterAuthIdentityCacheService` entry — `invalidateForUser` must be
+called on any write that changes a user's org/brand pointers (org create,
+org switch, membership changes).
+
+## Caches on this path
+
+| Cache | Keyed by | Invalidation |
+|---|---|---|
+| `BetterAuthIdentityCacheService` | JWT `sub` (User.id) | `invalidateForUser` on org create/switch, membership writes |
+| `AccessBootstrapCacheService` | User.id | same call sites |
+| `RequestContextCacheService` | request identity | same call sites |
+| `gf_ws` cookie + in-memory map (`apps/app/proxy.ts`) | session cookie | 5-min TTL; HMAC-signed |
+
+When adding a write that changes who a user is or which org/brand they point
+at, invalidate **all three** API caches (see `createOrganization` in
+`organizations.controller.ts` for the reference call site).
+
+## Legacy Mongo-era hazards (the important part)
+
+The codebase migrated Mongo → Prisma/Postgres. Compatibility shims remain, and
+they bite in two specific ways:
+
+### 1. `*Document` alias fields are types, not data
+
+`MemberDocument` (and friends) extend the Prisma row type with **optional**
+legacy aliases: `_id`, `organization`, `user`, `role`. These exist so old
+call sites type-check. **Prisma rows do not populate them** — the live fields
+are the scalar FKs: `organizationId`, `userId`, `roleId`.
+
+- Reading `row.organization` compiles and returns `undefined` at runtime.
+- Write new code against the scalar FKs. When consuming rows defensively, use
+  `row.organizationId || row.organization` (the resolver's
+  `getMemberOrganizationId` pattern).
+
+### 2. Filters are mapped, and dropped filters widen queries
+
+`BaseService.processSearchParams` maps legacy filter keys (`user` → `userId`,
+`organization` → `organizationId`, `_id` → `id`/`mongoId`), and
+`normalizeWhere` **drops `undefined` values**. Consequences:
+
+- `find({ user: id })` works — the alias is mapped before Prisma sees it.
+- `findOne({ _id: undefined })` used to normalize to an **unscoped
+  `findFirst`** and return the first row in the table — a cross-tenant read.
+  `BaseService.findOne` now guards this: an explicitly-passed `_id`/`id` that
+  is `undefined`/`null`/`''` returns `null` without querying.
+- The same widening applies to any optional filter: `{ organization: undefined }`
+  means "all orgs", not "no org". That is load-bearing for single-tenant
+  (community) mode — do not "fix" it globally; scope queries explicitly at the
+  call site when tenancy matters.
+
+Case study (2026-07): the org switcher showed another account's organization,
+duplicated, with two active checkmarks. Root cause: `findMine` mapped
+`member.organization` (undefined) → `findOne({ _id: undefined })` → first org
+in the table, once per membership row. Fixed by mapping `organizationId`,
+dedup, and the `findOne` id-guard.
+
+## Multi-tenancy invariants
+
+- Org enforcement lives in the OSS API: `CombinedAuthGuard` (global) +
+  inline `{ organizationId, isDeleted: false }` filters (see #1093).
+- `isSuperAdmin` comes from `users.platformRole` and is **org-independent**:
+  a superadmin keeps `/admin` access whatever org/brand the URL points at
+  (`apps/app/app/(protected)/admin/layout.tsx` gates on
+  `accessState.isSuperAdmin`; the app-switcher shows the Administration
+  section on the same flag).
+- Soft deletes are `isDeleted: boolean`; every tenant query filters it.
+
+## Production runtime access (for debugging sessions)
+
+- Backend runs on ECS Fargate (`genfeed-production`, us-west-1); RDS
+  (`genfeed-data`) and Redis are **VPC-only**. There is no direct DB/Redis
+  path from a laptop, and ECS Exec is disabled on the `api` service.
+- Practical implication: debug production identity issues from the **outside
+  in** — `/v1/auth/get-session`, `/v1/auth/token`, `/v1/auth/bootstrap`,
+  `/v1/organizations/mine` against `api.genfeed.ai` with a real session tell
+  you what each resolution path believes. Disagreement between them localizes
+  the bug (cache vs resolver vs endpoint query).
+- Deploys: `Deploy ECS (production)` workflow, dispatch-only, master-only.
+  See `.agents/memory/reference_prod_aws_runtime.md` and
+  `.agents/memory/reference_postgres_rds.md`.
+
+## Related documents
+
+- [Better Auth Organization Bridge](./better-auth-organization-bridge.md) —
+  ownership boundary between Better Auth org compat and Genfeed domain rows
+- [Platform Admin Role](./platform-admin-role.md) — `users.platformRole`
+- [Deployment Modes](./deployment-modes.md) — SaaS / Community / Desktop axes
+- [ADR-DEPLOYMENT-MODES](../.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md)

--- a/packages/services/organization/organizations.service.ts
+++ b/packages/services/organization/organizations.service.ts
@@ -359,7 +359,16 @@ export class OrganizationsService extends BaseService<Organization> {
           brand: { id: string; label: string } | null;
         }[]
       >('/mine')
-      .then((res) => res.data);
+      .then((res) =>
+        // Defensive dedup by org id: a duplicate entry here renders twice in
+        // the org switcher with the active checkmark on both rows (the
+        // checkmark matches by id). The API dedups too; this guards consumers
+        // against any regression in that contract.
+        res.data.filter(
+          (org, index, list) =>
+            list.findIndex((candidate) => candidate.id === org.id) === index,
+        ),
+      );
   }
 
   /**


### PR DESCRIPTION
## Problem

The org switcher rendered **another account's organization**, duplicated, with the active checkmark on both rows — while the user's real organization was missing entirely. Reproduced live on production (session resolved correctly everywhere else: `/auth/get-session`, `/auth/bootstrap`, and `/admin` gating all agreed on the right user).

Completes the duplicate-entry symptom of #1227 — the earlier fix addressed switch navigation and focus-ring behavior; the duplicate/foreign rows had a separate root cause in the API.

## Root cause

`GET /organizations/mine` (`findMine`) mapped `member.organization` — a Mongo-era **optional alias that Prisma rows never populate** (the live field is `organizationId`):

```
members.map((m) => m.organization)          // undefined for every row
  → findOne({ _id: undefined, isDeleted: false })
    → normalizeWhere drops undefined → where = { isDeleted: false }
      → findFirst → FIRST organization in the table, once per membership row
```

So every membership row rendered as the first org in the DB: duplicate entries, both matching the same id (→ double checkmark), real org never fetched. The identity resolver was immune (it reads `organizationId || organization`), which is why bootstrap/access stayed correct — two resolution paths disagreeing was the key diagnostic.

Falsified along the way (documented in `docs/identity-resolution.md`): stale Clerk cookies (inert), duplicate membership rows (none exist), stale identity cache (cache-bust changed nothing — deterministic).

## Fix

- **`findMine`**: map `member.organizationId || member.organization`, dedup via `Set`, drop empties.
- **`BaseService.findOne` guard (systemic)**: an explicitly-passed `_id`/`id` that is `undefined`/`null`/`''` returns `null` without querying — an unscoped `findFirst` fallback is a **cross-tenant first-row read**, and this closes the landmine for the entire service layer. Scoped to id keys only: widening it to `organization`/`user` would break single-tenant call sites that rely on undefined-ignored semantics.
- **Client `getMyOrganizations`**: defensive dedup by org id so a regression can never render duplicate/double-checked rows.

## Docs

- New canonical `docs/identity-resolution.md`: session→JWT→resolver flow, the three identity caches + invalidation contract, Mongo-era alias/filters hazards, and outside-in production debugging (VPC-only RDS/Redis, ECS Exec off).
- Agent memory rule `.agents/memory/rules/prisma_legacy_alias_fields.md` + MEMORY.md index.

## Tests

- New `organizations.controller.spec.ts`: 6 `findMine` cases — Prisma-shaped rows, same-org dedup, unresolvable-row skip, legacy-alias fallback, active-org marking, empty memberships.
- `base.service.spec.ts`: 4 guard cases (undefined `_id`, null/empty `id`, non-id undefined still queries).
- `bunx vitest run` (both files): 76/76 ✅ · `bun run test --filter=@genfeedai/services`: 903 ✅ · `bun type-check`: 59/59 ✅ · biome clean on changed files.

## Follow-ups (not in this PR)

- Audit remaining `.organization`/`.user` alias **reads** on Prisma rows across `apps/server/*` (same defect class).
- Stale Clerk cookie reaper for pre-migration browsers.
- URL org-switch UX: editing the org slug in a scoped URL should re-scope or redirect to the user's workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)