### PR TITLE
docs(memory): system workflow boundary + codex/claude queue-label conventions

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -33,6 +33,7 @@
 - [Console managed inference control plane](console_managed_inference_control_plane.md) — Private console owns Genfeed-managed Fleet/model/customer assignment
 - [Shared checkout automation](shared_checkout_automation.md) — Treat shared checkout state as moving; path-scope git add
 - [Genfeed project kanban](genfeed_project_kanban.md) — Use project #12 Genfeed.ai as canonical
+- [System Workflows Content OS](system_workflows_content_os.md) — Content automation uses immutable system workflows instead of hard-coded publish/action/cron paths
 - [Positive memory framing](positive_memory_framing.md) — Write memory as target-state guidance with active sources of truth
 - [Epic status on child start](epic_status_on_child_start.md) — Move parent epics to In Progress as soon as a child starts
 - [Failed deploys never burn a version](release_tag_after_green_deploy.md) — pre-gate release cutting is normal; on deploy failure fix master and re-cut the SAME version (delete unconsumed tag), never bump

--- a/.agents/memory/genfeed_project_kanban.md
+++ b/.agents/memory/genfeed_project_kanban.md
@@ -3,7 +3,7 @@ name: genfeed_project_kanban
 description: Use Genfeed.ai project #12 as the canonical kanban
 type: feedback
 status: active
-last_verified: 2026-06-25
+last_verified: 2026-06-30
 topics: [github, project-board, automation, workflow]
 ---
 
@@ -14,5 +14,6 @@ topics: [github, project-board, automation, workflow]
 **How to apply:**
 - For Genfeed issue selection and board audits, start from `https://github.com/orgs/genfeedai/projects/12`.
 - Treat #12 status/priority/area/surface fields as canonical.
-- Prefer issue labels such as `shipcode:agent:codex` and project Priority/Status for issue selection.
+- Prefer queue labels first, then project metadata: `codex:automation` for Codex pickup, `claude:routine` for Claude routine pickup, then milestone, Release/Start dates, Priority, Status, and readiness evidence. `shipcode:agent:codex` is for ShipCode routing only.
+- When automation opens or audits a PR linked to an issue, mirror the issue's queue labels (`codex:automation` / `claude:routine`) and existing classification labels onto the PR for list-view filtering. Do not invent labels from project fields.
 - When writing memory, prompts, summaries, or reports, state the active target directly.

--- a/.agents/memory/p0_priority_not_label.md
+++ b/.agents/memory/p0_priority_not_label.md
@@ -3,7 +3,7 @@ name: p0_priority_not_label
 description: P0/P1/P2/P3 are GitHub Project Priority values, not labels
 type: feedback
 status: active
-last_verified: 2026-06-25
+last_verified: 2026-06-30
 topics: [github, issue-tracking, workflow]
 ---
 
@@ -13,5 +13,5 @@ topics: [github, issue-tracking, workflow]
 
 **How to apply:**
 - When Vincent says P0/P1/P2/P3, update Project #12 `Priority`.
-- Use labels only for routing/classification such as `shipcode:agent:codex` or `release-e2e`.
+- Use labels only for routing/classification. `codex:automation` marks Codex queue work, `claude:routine` marks Claude routine work, and `shipcode:agent:codex` is reserved for ShipCode routing.
 - If project-field tooling is unavailable, leave a short issue comment noting the intended Project Priority update, then apply it when project access is available.

--- a/.agents/memory/system_workflows_content_os.md
+++ b/.agents/memory/system_workflows_content_os.md
@@ -1,0 +1,30 @@
+---
+name: system_workflows_content_os
+description: Content automation uses immutable system workflows instead of hard-coded publish/action/cron paths
+type: project
+status: active
+last_verified: 2026-07-01
+topics: [workflows, automation, publishing, social, agent, messages]
+---
+
+**Rule:** Genfeed content automation should be modeled as system workflows by default. System workflows are app-owned, immutable canonical workflows that users can inspect and duplicate, but cannot delete or mutate in place.
+
+**Why:** Vincent wants Genfeed to become a content-specific n8n. Hidden publish actions, social reply/DM actions, agent handoffs, and product crons make automation opaque and impossible for users to duplicate or customize safely.
+
+**How to apply:**
+- Use workflows as the canonical executable unit for scheduled content work, publish actions, social reply/DM actions, comment-trigger automation, and recurring agent/product automations.
+- Seed canonical system workflows idempotently and protect them from normal user update/delete paths.
+- Let users duplicate system workflows into user/brand-owned editable workflows; duplicated workflows should resolve credentials through the selected user/brand account.
+- Record workflow provenance on downstream content, messages, agent runs, and social actions.
+- New hard-coded content cron/action/publish paths need an explicit documented exception. Infrastructure maintenance can still use platform cron when it is not tenant/product automation.
+- UI, API, MCP, and agent controls should expose list, inspect, duplicate, trigger, run status, and run history for eligible workflows without allowing mutation of canonical system records.
+
+**Canonical tracking:**
+- Epic #1011: Productize System Workflows
+- Epic #1009: Build Agent App Surface
+- Epic #1010: Build Social Messages Surface
+- PR #1008: Recovered workflow-backed social comment triggers
+
+**Related architecture:**
+- `architecture/ADR-DYNAMIC-SCHEDULING-WORKFLOW-CANONICAL.md`
+- `architecture/ADR-WORKFLOW-BACKED-RECURRING-AGENT-AUTOMATION.md`

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ apps/desktop/app/release/
 *.dump
 .env.*.bak
 .claude/worktrees/
+.codex/worktrees/
 .claude/skills/
 .worktrees/
 .agents/SESSIONS/


### PR DESCRIPTION
## Summary
- Adds `.agents/memory/system_workflows_content_os.md`: content automation (scheduled work, publish actions, social reply/DM actions, comment triggers, recurring agent automation) should be modeled as immutable, app-owned system workflows by default — inspectable/duplicatable but not user-mutable — instead of new hard-coded publish/action/cron paths.
- Updates `genfeed_project_kanban.md` and `p0_priority_not_label.md`: documents the `codex:automation` (Codex pickup) / `claude:routine` (Claude routine pickup) queue-label scheme, layered ahead of project metadata for issue selection, with `shipcode:agent:codex` reserved for ShipCode routing only.
- Adds `.codex/worktrees/` to `.gitignore`.

Recovers the content of no-PR branch `codex/document-system-workflows-content-os` (single commit `dd574853a`) via clean cherry-pick onto current `master`.

Docs-only — no code changes.

## Test plan
- [x] `git diff origin/master --stat` shows only `.agents/memory/*` + `.gitignore` touched (5 files, +37/-4)
- [x] No code files in diff