### PR TITLE
feat(website): Brand OS public SEO page + footer link

### DIFF
--- a/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
@@ -1,24 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import BrandOSContent from './brand-os-content';
-
-vi.mock('next/image', () => ({
-  default: ({
-    fill: _fill,
-    priority: _priority,
-    ...props
-  }: ImgHTMLAttributes<HTMLImageElement> & {
-    fill?: boolean;
-    priority?: boolean;
-  }) => (
-    <span
-      aria-label={props.alt ?? ''}
-      data-src={typeof props.src === 'string' ? props.src : undefined}
-      role="img"
-    />
-  ),
-}));
 
 vi.mock('next/link', () => ({
   default: ({
@@ -44,61 +27,49 @@ vi.mock('@web-components/home/_footer', () => ({
   default: () => <footer>Footer</footer>,
 }));
 
-vi.mock('@ui/buttons/tracked/ButtonTracked', () => ({
-  default: ({
-    asChild: _asChild,
-    children,
-  }: {
-    asChild?: boolean;
-    children: ReactNode;
-  }) => <>{children}</>,
-}));
-
 describe('BrandOSContent', () => {
-  it('renders the public Brand OS CTA and preview states', () => {
+  it('renders the Genfeed Brand OS design-system heading', () => {
     render(<BrandOSContent />);
 
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /turn source evidence into a usable brand system/i,
+        name: /the genfeed brand os/i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/public website url/i)).toHaveValue(
-      'genfeed.ai',
-    );
-    expect(screen.getByTestId('brand-os-preview')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /ready/i })).toBeInTheDocument();
+  });
+
+  it('surfaces the core design-system sections', () => {
+    render(<BrandOSContent />);
+
     expect(
-      screen.getByRole('link', { name: /save in genfeed/i }),
-    ).toHaveAttribute('href', 'https://app.genfeed.ai/sign-up?source=brand-os');
+      screen.getByRole('heading', { name: /content is the accent/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /depth without borders/i }),
+    ).toBeInTheDocument();
   });
 
-  it('updates the preview status from the visitor input', () => {
+  it('renders real DESIGN.md tokens with hex values', () => {
     render(<BrandOSContent />);
 
-    fireEvent.change(screen.getByLabelText(/public website url/i), {
-      target: { value: 'https://example.com' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /ready/i }));
-
-    expect(screen.getByText(/preview ready: example.com/i)).toBeInTheDocument();
+    // Background layer token from DESIGN.md
+    expect(screen.getByText('bg-primary')).toBeInTheDocument();
+    expect(screen.getAllByText('#050607').length).toBeGreaterThan(0);
+    // Platform identifier token from DESIGN.md
+    expect(screen.getByText('Discord')).toBeInTheDocument();
   });
 
-  it('submits the Refresh Preview form on first load without typing https://', () => {
+  it('links to the studio and back home without a lead-capture form', () => {
     render(<BrandOSContent />);
 
-    // Input starts with bare "genfeed.ai" (no scheme) — form must fire without
-    // browser native-URL-validation blocking it.
-    const submitButton = screen.getByRole('button', {
-      name: /refresh preview/i,
-    });
-    const form = submitButton.closest('form');
-    expect(form).not.toBeNull();
-    fireEvent.submit(form as HTMLFormElement);
-
-    // After submit the preview transitions away from idle; with guidance present
-    // (initial state has guidance) it should move to "ready".
-    expect(screen.getByText(/preview ready:/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /open the studio/i }),
+    ).toHaveAttribute('href', 'https://app.genfeed.ai');
+    expect(
+      screen.getByRole('link', { name: /back to genfeed\.ai/i }),
+    ).toHaveAttribute('href', '/');
+    // The intake form was removed — no public website URL field remains.
+    expect(screen.queryByLabelText(/public website url/i)).toBeNull();
   });
 });

--- a/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import BrandOSContent from './brand-os-content';
+
+vi.mock('next/image', () => ({
+  default: ({
+    fill: _fill,
+    priority: _priority,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    priority?: boolean;
+  }) => (
+    <span
+      aria-label={props.alt ?? ''}
+      data-src={typeof props.src === 'string' ? props.src : undefined}
+      role="img"
+    />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    apps: {
+      app: 'https://app.genfeed.ai',
+    },
+  },
+}));
+
+vi.mock('@web-components/home/_footer', () => ({
+  default: () => <footer>Footer</footer>,
+}));
+
+vi.mock('@ui/buttons/tracked/ButtonTracked', () => ({
+  default: ({
+    asChild: _asChild,
+    children,
+  }: {
+    asChild?: boolean;
+    children: ReactNode;
+  }) => <>{children}</>,
+}));
+
+describe('BrandOSContent', () => {
+  it('renders the public Brand OS CTA and preview states', () => {
+    render(<BrandOSContent />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /turn source evidence into a usable brand system/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/public website url/i)).toHaveValue(
+      'genfeed.ai',
+    );
+    expect(screen.getByTestId('brand-os-preview')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ready/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /save in genfeed/i }),
+    ).toHaveAttribute('href', 'https://app.genfeed.ai/sign-up?source=brand-os');
+  });
+
+  it('updates the preview status from the visitor input', () => {
+    render(<BrandOSContent />);
+
+    fireEvent.change(screen.getByLabelText(/public website url/i), {
+      target: { value: 'https://example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /ready/i }));
+
+    expect(screen.getByText(/preview ready: example.com/i)).toBeInTheDocument();
+  });
+
+  it('submits the Refresh Preview form on first load without typing https://', () => {
+    render(<BrandOSContent />);
+
+    // Input starts with bare "genfeed.ai" (no scheme) — form must fire without
+    // browser native-URL-validation blocking it.
+    const submitButton = screen.getByRole('button', {
+      name: /refresh preview/i,
+    });
+    const form = submitButton.closest('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    // After submit the preview transitions away from idle; with guidance present
+    // (initial state has guidance) it should move to "ready".
+    expect(screen.getByText(/preview ready:/i)).toBeInTheDocument();
+  });
+});

--- a/apps/website/app/(public)/brand-os/brand-os-content.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.tsx
@@ -3,467 +3,498 @@
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
 import { EnvironmentService } from '@services/core/environment.service';
-import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
 import { HStack, VStack } from '@ui/layout/stack';
 import { Button } from '@ui/primitives/button';
-import { Input } from '@ui/primitives/input';
-import { Label } from '@ui/primitives/label';
-import { Textarea } from '@ui/primitives/textarea';
 import { Heading } from '@ui/typography/heading';
 import { Text } from '@ui/typography/text';
 import HomeFooter from '@web-components/home/_footer';
-import Image from 'next/image';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
-import {
-  LuArrowRight,
-  LuBadgeCheck,
-  LuFileText,
-  LuLayers,
-  LuPalette,
-  LuSearchCheck,
-  LuTriangleAlert,
-} from 'react-icons/lu';
+import { LuLayers } from 'react-icons/lu';
 
-const PREVIEW_MODES = [
-  {
-    icon: LuFileText,
-    key: 'idle',
-    label: 'Idle',
-    status: 'Waiting for source',
-  },
-  {
-    icon: LuSearchCheck,
-    key: 'partial',
-    label: 'Partial',
-    status: 'Evidence found',
-  },
-  {
-    icon: LuBadgeCheck,
-    key: 'ready',
-    label: 'Ready',
-    status: 'Preview ready',
-  },
-  {
-    icon: LuTriangleAlert,
-    key: 'blocked',
-    label: 'Blocked',
-    status: 'Needs public source',
-  },
-] as const;
+interface Swatch {
+  hex: string;
+  name: string;
+  role: string;
+}
 
-const SOURCE_EVIDENCE = [
+interface ScaleRow {
+  element: string;
+  size: string;
+}
+
+interface RadiusStep {
+  name: string;
+  px: number;
+  use: string;
+}
+
+interface ColorDoor {
+  body: string;
+  index: string;
+  title: string;
+}
+
+const BACKGROUND_LAYERS: Swatch[] = [
+  { hex: '#050607', name: 'bg-primary', role: 'Main canvas, sidebar' },
+  { hex: '#0c0d10', name: 'bg-secondary', role: 'Cards, panels' },
+  { hex: '#131518', name: 'bg-tertiary', role: 'Inputs, nested surfaces' },
+  { hex: '#1a1c21', name: 'bg-elevated', role: 'Popovers, dropdowns' },
+  { hex: '#20232a', name: 'bg-hover', role: 'Interactive hover states' },
+];
+
+const TEXT_TIERS: Swatch[] = [
+  { hex: '#f4f4f5', name: 'text-primary', role: 'Primary content' },
+  { hex: '#b4b4bc', name: 'text-secondary', role: 'Secondary labels' },
+  { hex: '#6b6b78', name: 'text-muted', role: 'Muted / metadata' },
+];
+
+const ACCENT: Swatch[] = [
+  { hex: '#fafafa', name: 'accent', role: 'Primary CTA on dark' },
+  { hex: '#050607', name: 'accent-foreground', role: 'Text on accent' },
+  { hex: '#e4e4e7', name: 'accent-hover', role: 'CTA hover' },
+];
+
+const SEMANTIC: Swatch[] = [
+  { hex: '#10b981', name: 'Success', role: 'Completed, passing, published' },
   {
-    confidence: 'High',
-    label: 'Positioning',
-    value: 'AI content OS for founders and teams shipping across channels.',
+    hex: '#f59e0b',
+    name: 'Warning',
+    role: 'Needs attention, awaiting approval',
+  },
+  { hex: '#ef4444', name: 'Danger', role: 'Failed, errored, rejected' },
+  { hex: '#3b82f6', name: 'Info', role: 'Informational, neutral status' },
+];
+
+const DOMAIN: Swatch[] = [
+  { hex: '#38bdf8', name: 'Agent', role: 'AI agent activity states' },
+  { hex: '#a855f7', name: 'Done', role: 'Completed workflows' },
+];
+
+const PLATFORMS: { hex: string; name: string }[] = [
+  { hex: '#FCD34D', name: 'Beehiiv' },
+  { hex: '#5865F2', name: 'Discord' },
+  { hex: '#1877F2', name: 'Facebook' },
+  { hex: '#6C63FF', name: 'Fanvue' },
+  { hex: '#15171A', name: 'Ghost' },
+  { hex: '#E1306C', name: 'Instagram' },
+  { hex: '#0A66C2', name: 'LinkedIn' },
+  { hex: '#6364FF', name: 'Mastodon' },
+  { hex: '#00AB6C', name: 'Medium' },
+  { hex: '#000000', name: 'Notion' },
+  { hex: '#E60023', name: 'Pinterest' },
+  { hex: '#FF4500', name: 'Reddit' },
+  { hex: '#96BF48', name: 'Shopify' },
+  { hex: '#4A154B', name: 'Slack' },
+  { hex: '#FFFC00', name: 'Snapchat' },
+  { hex: '#FF6719', name: 'Substack' },
+  { hex: '#26A5E4', name: 'Telegram' },
+  { hex: '#000000', name: 'Threads' },
+  { hex: '#FE2C55', name: 'TikTok' },
+  { hex: '#9146FF', name: 'Twitch' },
+  { hex: '#1DA1F2', name: 'Twitter' },
+  { hex: '#25D366', name: 'WhatsApp' },
+  { hex: '#21759B', name: 'WordPress' },
+  { hex: '#FF0000', name: 'YouTube' },
+];
+
+const TYPE_SCALE: ScaleRow[] = [
+  { element: 'Badge / chip', size: '10px' },
+  { element: 'Table head', size: '11px' },
+  { element: 'Table cell', size: '12px' },
+  { element: 'Body / button', size: '13px' },
+  { element: 'Card title', size: '14px' },
+];
+
+const RADIUS_STEPS: RadiusStep[] = [
+  { name: 'sm', px: 2, use: 'Badges, tags, inline chips' },
+  { name: 'md', px: 6, use: 'Cards, buttons, inputs, tooltips, popovers' },
+  { name: 'lg', px: 8, use: 'Toasts, overlay panels' },
+  { name: 'xl', px: 10, use: 'Dialogs, command palette' },
+];
+
+const COLOR_DOORS: ColorDoor[] = [
+  {
+    body: 'Generated media is the primary color source. Rendered borderless and full-bleed wherever possible — chrome recedes behind it.',
+    index: '01',
+    title: 'User content',
   },
   {
-    confidence: 'Medium',
-    label: 'Voice',
-    value: 'Direct, operational, and anti-fluff. Short nouns beat slogans.',
+    body: 'Platform brand tokens, scoped to badges and icons only. Never layout chrome or primary actions.',
+    index: '02',
+    title: 'Platform identifiers',
   },
   {
-    confidence: 'Missing',
-    label: 'Motion',
-    value: 'No public evidence yet. Keep motion rules empty until sourced.',
-  },
-] as const;
-
-const CONTENT_PILLARS = [
-  'Founder proof',
-  'Launch systems',
-  'Content operations',
-  'Model leverage',
-] as const;
-
-const PALETTE_CANDIDATES = [
-  { hex: '#f4f4f5', label: 'Primary ink', source: 'Current product token' },
-  { hex: '#10b981', label: 'Proof green', source: 'Status token' },
-  { hex: '#f59e0b', label: 'Missing amber', source: 'Diagnostic token' },
-  { hex: '#3b82f6', label: 'Evidence blue', source: 'Status token' },
-] as const;
-
-const SCALE_ROLES = [
-  {
-    description: 'Dense controls, tables, source rows, and review fields.',
-    label: 'Product',
-    value: '32px control baseline',
+    body: 'Success, warning, danger, info. Applied to state — never decoration.',
+    index: '03',
+    title: 'Semantic status',
   },
   {
-    description: 'CTA modules and preview panels that need public scanning.',
-    label: 'Block',
-    value: '1x campaign unit',
+    body: 'Workflow-node and tag colors, for identification and function. Never chrome.',
+    index: '04',
+    title: 'Categorical palettes',
   },
-  {
-    description: 'Primary Brand OS promise, public proof, and conversion copy.',
-    label: 'Hero',
-    value: '1.618x block',
-  },
-  {
-    description: 'Single launch artifact or proof object. Use once per page.',
-    label: 'Monument',
-    value: '2.618x block',
-  },
-] as const;
+];
 
-type PreviewModeKey = (typeof PREVIEW_MODES)[number]['key'];
+const DOS: string[] = [
+  'Use background layering for hierarchy instead of heavy borders.',
+  'Use inset box-shadow borders on elevated surfaces — cards, dialogs, dropdowns.',
+  'Reserve the border token for structural dividers: sidebar edges, header bottoms.',
+  'Use ghost buttons for toolbar and topbar actions.',
+  'Apply semantic status colors consistently across every surface.',
+  'Use −0.01em letter-spacing on body, tighter on headings.',
+];
 
-function getSourceName(value: string): string {
-  const trimmed = value.trim();
+const DONTS: string[] = [
+  'Use a CSS border for card, dialog, or dropdown containment — use inset shadow.',
+  'Mix hardcoded colors with token references.',
+  'Use the accent for status — it is for primary CTAs only.',
+  'Add a new semantic color without updating DESIGN.md.',
+  'Use large decorative gradients as core product surfaces.',
+  'Nest cards inside cards, or add glow / spotlight shadows to chrome.',
+];
 
-  if (!trimmed) {
-    return 'No public URL yet';
-  }
+function SectionLabel({ children }: { children: string }): React.ReactElement {
+  return (
+    <Text className="text-[10px] font-black uppercase tracking-[0.2em] text-surface/35">
+      {children}
+    </Text>
+  );
+}
 
-  try {
-    const url = new URL(
-      trimmed.startsWith('http') ? trimmed : `https://${trimmed}`,
-    );
-    return url.hostname.replace(/^www\./, '');
-  } catch {
-    return 'Manual source';
-  }
+function SwatchTile({ swatch }: { swatch: Swatch }): React.ReactElement {
+  return (
+    <VStack className="gap-2">
+      <span
+        aria-label={`${swatch.name} ${swatch.hex}`}
+        className="block h-16 border border-edge/10"
+        role="img"
+        style={{ backgroundColor: swatch.hex }}
+      />
+      <VStack className="gap-0.5">
+        <HStack className="items-center justify-between gap-2">
+          <Text className="text-xs font-semibold text-surface">
+            {swatch.name}
+          </Text>
+          <Text className="font-mono text-[10px] uppercase text-surface/35">
+            {swatch.hex}
+          </Text>
+        </HStack>
+        <Text className="text-[11px] leading-4 text-surface/40">
+          {swatch.role}
+        </Text>
+      </VStack>
+    </VStack>
+  );
 }
 
 export default function BrandOSContent(): React.ReactElement {
   const containerRef = useMarketingEntrance({ cards: false });
-  const signUpHref = `${EnvironmentService.apps.app}/sign-up?source=brand-os`;
-  const [websiteUrl, setWebsiteUrl] = useState('genfeed.ai');
-  const [guidance, setGuidance] = useState(
-    'Keep the brand system operational: cite evidence, mark assumptions, and never copy a competitor kit.',
-  );
-  const [previewMode, setPreviewMode] = useState<PreviewModeKey>('partial');
-
-  const sourceName = useMemo(() => getSourceName(websiteUrl), [websiteUrl]);
-  const hasGuidance = guidance.trim().length > 0;
-  const activeMode = PREVIEW_MODES.find((mode) => mode.key === previewMode);
-  const previewStatus = activeMode?.status ?? 'Preview ready';
+  const appHref = EnvironmentService.apps.app;
 
   return (
     <div ref={containerRef}>
       <main>
-        <section className="border-b border-edge/5 bg-background py-14 sm:py-16 lg:py-20">
+        {/* Hero */}
+        <section className="border-b border-edge/5 bg-background py-16 sm:py-20 lg:py-24">
           <div className="container mx-auto px-6">
-            <div className="grid gap-10 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)] lg:items-start">
-              <VStack className="gap-8">
-                <VStack className="gap-5">
-                  <HStack className="w-fit items-center gap-2 border border-edge/10 bg-fill/[0.02] px-3 py-1.5 text-[10px] font-black uppercase text-surface/45">
-                    <LuLayers className="size-3.5" />
-                    <Text>Brand OS</Text>
-                  </HStack>
+            <VStack className="max-w-4xl gap-6">
+              <HStack className="w-fit items-center gap-2 border border-edge/10 bg-fill/[0.02] px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.15em] text-surface/45">
+                <LuLayers className="size-3.5" />
+                <Text>Brand OS</Text>
+                <span className="text-surface/20">/</span>
+                <Text className="text-surface/35">version alpha</Text>
+              </HStack>
 
-                  <Heading
-                    as="h1"
-                    className="max-w-3xl text-5xl font-serif leading-none text-surface sm:text-6xl lg:text-7xl"
-                  >
-                    Turn source evidence into a usable brand system.
-                  </Heading>
+              <Heading
+                as="h1"
+                className="max-w-3xl font-serif text-5xl leading-none text-surface sm:text-6xl lg:text-7xl"
+              >
+                The Genfeed Brand OS.
+              </Heading>
 
-                  <Text className="max-w-2xl text-base leading-7 text-surface/55 sm:text-lg">
-                    The Brand OS surface separates evidence, assumptions,
-                    missing fields, scale roles, and save actions before it
-                    enters a brand workspace.
-                  </Text>
-                </VStack>
+              <Text className="max-w-2xl text-base leading-7 text-surface/55 sm:text-lg">
+                The living design system behind Genfeed — dark-first,
+                information-dense, and aligned with the ShipCode and Linear
+                visual language. Depth comes from layered background tones and
+                inset-shadow containment; color enters only through the
+                product's content. This page is the system itself, drawn from{' '}
+                <span className="font-mono text-surface/70">DESIGN.md</span>.
+              </Text>
+            </VStack>
+          </div>
+        </section>
 
-                <form
-                  className="grid gap-5 border border-edge/5 bg-fill/[0.02] p-5 sm:p-6"
-                  noValidate
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    const raw = websiteUrl.trim();
-                    const normalized =
-                      raw && !raw.startsWith('http') ? `https://${raw}` : raw;
-                    if (normalized !== websiteUrl) {
-                      setWebsiteUrl(normalized);
-                    }
-                    setPreviewMode(hasGuidance ? 'ready' : 'partial');
-                  }}
-                >
-                  <Input
-                    aria-describedby="brand-os-url-help"
-                    label="Public website URL"
-                    onChange={(event) => setWebsiteUrl(event.target.value)}
-                    placeholder="https://example.com"
-                    type="text"
-                    value={websiteUrl}
-                  />
-                  <Text
-                    as="p"
-                    className="text-xs leading-5 text-surface/35"
-                    id="brand-os-url-help"
-                  >
-                    Private, loopback, and authenticated URLs stay blocked by
-                    the eventual extraction service.
-                  </Text>
+        {/* Color — backgrounds + text */}
+        <section className="border-b border-edge/5 bg-fill/[0.02] py-16 sm:py-20">
+          <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-[0.32fr_1fr] lg:gap-16">
+            <VStack className="gap-4">
+              <SectionLabel>Foundations</SectionLabel>
+              <Heading as="h2" className="font-serif text-4xl text-surface">
+                Depth without borders.
+              </Heading>
+              <Text className="text-sm leading-6 text-surface/55">
+                Five background tones create elevation from the deepest canvas
+                to the most raised surface — no heavy strokes, just tonal shift.
+                Text resolves in three tiers over the top.
+              </Text>
+            </VStack>
 
-                  <div className="space-y-1.5">
-                    <Label
-                      className="text-sm font-medium text-foreground"
-                      htmlFor="brand-os-guidance"
-                    >
-                      Manual guidance
-                    </Label>
-                    <Textarea
-                      id="brand-os-guidance"
-                      maxHeight={180}
-                      onChange={(event) => setGuidance(event.target.value)}
-                      placeholder="Voice, audience, product, proof, or launch notes"
-                      rows={4}
-                      value={guidance}
-                    />
-                  </div>
-
-                  <div className="grid gap-2 sm:grid-cols-4">
-                    {PREVIEW_MODES.map((mode) => {
-                      const Icon = mode.icon;
-                      const isActive = previewMode === mode.key;
-
-                      return (
-                        <Button
-                          className="justify-center gap-2"
-                          key={mode.key}
-                          onClick={() => setPreviewMode(mode.key)}
-                          size={ButtonSize.SM}
-                          type="button"
-                          variant={
-                            isActive
-                              ? ButtonVariant.SECONDARY
-                              : ButtonVariant.GHOST
-                          }
-                        >
-                          <Icon className="size-4" />
-                          {mode.label}
-                        </Button>
-                      );
-                    })}
-                  </div>
-
-                  <div
-                    aria-live="polite"
-                    className="border border-edge/5 bg-background px-4 py-3 text-sm text-surface/55"
-                  >
-                    {previewStatus}: {sourceName}
-                  </div>
-
-                  <HStack className="flex-wrap gap-3">
-                    <Button type="submit" size={ButtonSize.PUBLIC}>
-                      Refresh Preview
-                    </Button>
-                    <ButtonTracked
-                      asChild
-                      size={ButtonSize.PUBLIC}
-                      trackingData={{ action: 'save_brand_os_preview' }}
-                      trackingName="brand_os_cta_click"
-                      variant={ButtonVariant.OUTLINE}
-                    >
-                      <a
-                        href={signUpHref}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Save in Genfeed
-                        <LuArrowRight className="size-4" />
-                      </a>
-                    </ButtonTracked>
-                  </HStack>
-                </form>
+            <VStack className="gap-10">
+              <VStack className="gap-4">
+                <SectionLabel>Background layers</SectionLabel>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+                  {BACKGROUND_LAYERS.map((swatch) => (
+                    <SwatchTile key={swatch.name} swatch={swatch} />
+                  ))}
+                </div>
               </VStack>
 
-              <div
-                className="border border-edge/5 bg-fill/[0.02]"
-                data-testid="brand-os-preview"
-              >
-                <div className="grid border-b border-edge/5 md:grid-cols-[0.9fr_1.1fr]">
-                  <div className="relative min-h-64 overflow-hidden border-b border-edge/5 md:border-b-0 md:border-r">
-                    <Image
-                      alt="Color and layout reference board"
-                      className="object-cover"
-                      fill
-                      priority
-                      sizes="(max-width: 768px) 100vw, 42vw"
-                      src="https://images.unsplash.com/photo-1518005020951-eccb494ad742?w=1000&q=80&fit=crop"
-                    />
-                    <div className="absolute inset-0 bg-black/45" />
-                    <div className="absolute inset-x-0 bottom-0 p-5">
-                      <Text className="text-[10px] font-black uppercase text-white/55">
-                        Preview source
-                      </Text>
-                      <Heading as="h2" className="mt-2 text-3xl text-white">
-                        {sourceName}
-                      </Heading>
-                    </div>
+              <div className="grid gap-10 sm:grid-cols-2">
+                <VStack className="gap-4">
+                  <SectionLabel>Text hierarchy</SectionLabel>
+                  <div className="grid grid-cols-3 gap-4">
+                    {TEXT_TIERS.map((swatch) => (
+                      <SwatchTile key={swatch.name} swatch={swatch} />
+                    ))}
                   </div>
-
-                  <VStack className="gap-5 p-5 sm:p-6">
-                    <HStack className="items-center justify-between gap-4">
-                      <Text className="text-[10px] font-black uppercase text-surface/35">
-                        {previewStatus}
-                      </Text>
-                      <span className="text-[10px] font-black uppercase text-success">
-                        Source backed
-                      </span>
-                    </HStack>
-
-                    <VStack className="gap-3">
-                      {SOURCE_EVIDENCE.map((item) => (
-                        <div
-                          className="grid gap-2 border-t border-edge/5 pt-3 sm:grid-cols-[0.55fr_1fr]"
-                          key={item.label}
-                        >
-                          <VStack className="gap-1">
-                            <Text className="text-xs font-semibold text-surface">
-                              {item.label}
-                            </Text>
-                            <Text className="text-[10px] font-black uppercase text-surface/30">
-                              {item.confidence}
-                            </Text>
-                          </VStack>
-                          <Text className="text-sm leading-6 text-surface/60">
-                            {item.value}
-                          </Text>
-                        </div>
-                      ))}
-                    </VStack>
-                  </VStack>
-                </div>
-
-                <div className="grid gap-px bg-edge/5 lg:grid-cols-3">
-                  <VStack className="gap-4 bg-background p-5">
-                    <Text className="text-[10px] font-black uppercase text-surface/30">
-                      Palette candidates
-                    </Text>
-                    <div className="grid grid-cols-2 gap-3">
-                      {PALETTE_CANDIDATES.map((color) => (
-                        <VStack className="gap-2" key={color.label}>
-                          <span
-                            aria-label={`${color.label} ${color.hex}`}
-                            className="block h-12 border border-edge/10"
-                            role="img"
-                            style={{ backgroundColor: color.hex }}
-                          />
-                          <VStack className="gap-0.5">
-                            <Text className="text-xs font-semibold text-surface">
-                              {color.label}
-                            </Text>
-                            <Text className="text-[10px] text-surface/35">
-                              {color.source}
-                            </Text>
-                          </VStack>
-                        </VStack>
-                      ))}
-                    </div>
-                  </VStack>
-
-                  <VStack className="gap-4 bg-background p-5">
-                    <Text className="text-[10px] font-black uppercase text-surface/30">
-                      Content pillars
-                    </Text>
-                    <ul className="space-y-3">
-                      {CONTENT_PILLARS.map((pillar) => (
-                        <li
-                          className="flex items-center gap-3 border-b border-edge/5 pb-3 text-sm text-surface/65 last:border-b-0 last:pb-0"
-                          key={pillar}
-                        >
-                          <LuBadgeCheck className="size-4 shrink-0 text-success" />
-                          {pillar}
-                        </li>
-                      ))}
-                    </ul>
-                  </VStack>
-
-                  <VStack className="gap-4 bg-background p-5">
-                    <Text className="text-[10px] font-black uppercase text-surface/30">
-                      Diagnostics
-                    </Text>
-                    <Text className="text-sm leading-6 text-surface/60">
-                      {previewMode === 'blocked'
-                        ? 'The preview blocks private or unreachable sources and keeps the save action unavailable until public evidence exists.'
-                        : 'The preview keeps low-confidence fields visible, preserves missing evidence, and carries source notes into the save prompt.'}
-                    </Text>
-                    <Text className="text-sm leading-6 text-surface/60">
-                      {hasGuidance
-                        ? guidance
-                        : 'Manual guidance is empty, so the saved draft would ask for voice and positioning before apply.'}
-                    </Text>
-                  </VStack>
-                </div>
+                </VStack>
+                <VStack className="gap-4">
+                  <SectionLabel>Accent — inverted for dark</SectionLabel>
+                  <div className="grid grid-cols-3 gap-4">
+                    {ACCENT.map((swatch) => (
+                      <SwatchTile key={swatch.name} swatch={swatch} />
+                    ))}
+                  </div>
+                </VStack>
               </div>
+            </VStack>
+          </div>
+        </section>
+
+        {/* Semantic + domain */}
+        <section className="border-b border-edge/5 py-16 sm:py-20">
+          <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-[0.32fr_1fr] lg:gap-16">
+            <VStack className="gap-4">
+              <SectionLabel>Signal</SectionLabel>
+              <Heading as="h2" className="font-serif text-4xl text-surface">
+                Color that means something.
+              </Heading>
+              <Text className="text-sm leading-6 text-surface/55">
+                Status and domain colors map directly to state and workflow —
+                never decoration. Four semantic tones, two domain tones.
+              </Text>
+            </VStack>
+
+            <VStack className="gap-10">
+              <VStack className="gap-4">
+                <SectionLabel>Semantic status</SectionLabel>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                  {SEMANTIC.map((swatch) => (
+                    <SwatchTile key={swatch.name} swatch={swatch} />
+                  ))}
+                </div>
+              </VStack>
+              <VStack className="gap-4">
+                <SectionLabel>Domain</SectionLabel>
+                <div className="grid grid-cols-2 gap-4 sm:max-w-md">
+                  {DOMAIN.map((swatch) => (
+                    <SwatchTile key={swatch.name} swatch={swatch} />
+                  ))}
+                </div>
+              </VStack>
+            </VStack>
+          </div>
+        </section>
+
+        {/* Platform identifiers */}
+        <section className="border-b border-edge/5 bg-fill/[0.02] py-16 sm:py-20">
+          <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-[0.32fr_1fr] lg:gap-16">
+            <VStack className="gap-4">
+              <SectionLabel>Identifiers</SectionLabel>
+              <Heading as="h2" className="font-serif text-4xl text-surface">
+                Platform tokens.
+              </Heading>
+              <Text className="text-sm leading-6 text-surface/55">
+                Twenty-four brand colors used as identifiers only — on platform
+                icons, connection badges, and analytics breakdowns. Never for
+                layout chrome or primary actions.
+              </Text>
+            </VStack>
+
+            <div className="grid grid-cols-3 gap-x-4 gap-y-5 sm:grid-cols-4 lg:grid-cols-6">
+              {PLATFORMS.map((platform) => (
+                <HStack className="items-center gap-2.5" key={platform.name}>
+                  <span
+                    aria-hidden
+                    className="size-6 shrink-0 rounded-sm border border-edge/10"
+                    style={{ backgroundColor: platform.hex }}
+                  />
+                  <VStack className="gap-0">
+                    <Text className="text-xs font-medium text-surface/80">
+                      {platform.name}
+                    </Text>
+                    <Text className="font-mono text-[10px] uppercase text-surface/30">
+                      {platform.hex}
+                    </Text>
+                  </VStack>
+                </HStack>
+              ))}
             </div>
           </div>
         </section>
 
-        <section
-          className="border-b border-edge/5 bg-fill/[0.02] py-20"
-          id="brand-os-rules"
-        >
-          <div className="container mx-auto px-6">
-            <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.72fr_1.28fr]">
-              <VStack className="gap-4">
-                <HStack className="items-center gap-2 text-[10px] font-black uppercase text-surface/35">
-                  <LuPalette className="size-4" />
-                  <Text>Design contract</Text>
-                </HStack>
-                <Heading as="h2" className="text-4xl font-serif text-surface">
-                  Source-backed, not style-matched.
+        {/* Typography + radius */}
+        <section className="border-b border-edge/5 py-16 sm:py-20">
+          <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-2 lg:gap-16">
+            <VStack className="gap-6">
+              <VStack className="gap-3">
+                <SectionLabel>Typography</SectionLabel>
+                <Heading as="h2" className="font-serif text-4xl text-surface">
+                  A dense, deliberate scale.
                 </Heading>
-                <Text className="text-base leading-7 text-surface/55">
-                  Brand OS output labels every recommendation as extracted,
-                  inferred, missing, or candidate. Product screens stay compact;
-                  public campaign objects can scale up when they carry proof.
+                <Text className="text-sm leading-6 text-surface/55">
+                  System sans for the interface, mono for code and tokens. Body
+                  sits at 13px with −0.01em tracking; headings tighten to
+                  −0.03em.
                 </Text>
               </VStack>
+              <div className="border border-edge/5 bg-fill/[0.02]">
+                {TYPE_SCALE.map((row) => (
+                  <HStack
+                    className="items-center justify-between gap-4 border-b border-edge/5 px-5 py-3.5 last:border-b-0"
+                    key={row.element}
+                  >
+                    <Text className="text-sm text-surface/70">
+                      {row.element}
+                    </Text>
+                    <Text className="font-mono text-[11px] uppercase text-surface/40">
+                      {row.size}
+                    </Text>
+                  </HStack>
+                ))}
+              </div>
+            </VStack>
 
-              <div className="grid gap-px bg-edge/5 sm:grid-cols-2">
-                {SCALE_ROLES.map((role) => (
-                  <VStack className="gap-4 bg-background p-5" key={role.label}>
-                    <HStack className="items-center justify-between gap-4">
-                      <Text className="text-lg font-semibold text-surface">
-                        {role.label}
+            <VStack className="gap-6">
+              <VStack className="gap-3">
+                <SectionLabel>Form</SectionLabel>
+                <Heading as="h2" className="font-serif text-4xl text-surface">
+                  Four-step radius.
+                </Heading>
+                <Text className="text-sm leading-6 text-surface/55">
+                  Corners map to purpose, matching the ShipCode and Linear
+                  language. Elevated surfaces use inset box-shadow for
+                  containment instead of a CSS border.
+                </Text>
+              </VStack>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {RADIUS_STEPS.map((step) => (
+                  <VStack
+                    className="gap-3 border border-edge/5 bg-fill/[0.02] p-5"
+                    key={step.name}
+                  >
+                    <div
+                      className="h-16 w-full bg-surface/[0.06] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]"
+                      style={{ borderRadius: `${step.px}px` }}
+                    />
+                    <HStack className="items-center justify-between gap-2">
+                      <Text className="text-xs font-semibold text-surface">
+                        {step.name}
                       </Text>
-                      <Text className="text-[10px] font-black uppercase text-surface/35">
-                        {role.value}
+                      <Text className="font-mono text-[10px] uppercase text-surface/40">
+                        {step.px}px
                       </Text>
                     </HStack>
-                    <Text className="text-sm leading-6 text-surface/55">
-                      {role.description}
+                    <Text className="text-[11px] leading-4 text-surface/40">
+                      {step.use}
                     </Text>
                   </VStack>
                 ))}
               </div>
+            </VStack>
+          </div>
+        </section>
+
+        {/* Content is the accent — centerpiece */}
+        <section className="border-b border-edge/5 bg-fill/[0.02] py-20 sm:py-24">
+          <div className="container mx-auto px-6">
+            <VStack className="mx-auto max-w-3xl gap-5 text-center">
+              <SectionLabel>The principle</SectionLabel>
+              <Heading
+                as="h2"
+                className="font-serif text-4xl leading-tight text-surface sm:text-5xl"
+              >
+                Content is the accent.
+              </Heading>
+              <Text className="text-base leading-7 text-surface/55">
+                Genfeed chrome is a neutral studio — the gallery wall, not the
+                art. The product's output is inherently colorful, so the
+                interface never competes with it. Color enters through exactly
+                four doors; everything else is grayscale.
+              </Text>
+            </VStack>
+
+            <div className="mx-auto mt-12 grid max-w-6xl gap-px bg-edge/5 sm:grid-cols-2 lg:grid-cols-4">
+              {COLOR_DOORS.map((door) => (
+                <VStack className="gap-4 bg-background p-6" key={door.index}>
+                  <Text className="font-mono text-xs text-surface/30">
+                    {door.index}
+                  </Text>
+                  <Heading
+                    as="h3"
+                    className="text-base font-semibold text-surface"
+                  >
+                    {door.title}
+                  </Heading>
+                  <Text className="text-sm leading-6 text-surface/55">
+                    {door.body}
+                  </Text>
+                </VStack>
+              ))}
             </div>
           </div>
         </section>
 
-        <section className="py-20">
+        {/* Do's and Don'ts */}
+        <section className="py-16 sm:py-20">
           <div className="container mx-auto px-6">
-            <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-3">
-              {[
-                'Current Genfeed tokens remain the product palette until a source-backed palette is accepted.',
-                'Candidate Wada/Sanzo-inspired color outputs are labeled as candidates, never product defaults.',
-                'Authenticated review screens use dense controls, evidence rows, and explicit apply/discard states.',
-              ].map((rule) => (
-                <div className="border border-edge/5 p-5" key={rule}>
-                  <Text className="text-sm leading-6 text-surface/60">
-                    {rule}
-                  </Text>
-                </div>
-              ))}
+            <div className="mx-auto grid max-w-6xl gap-px bg-edge/5 lg:grid-cols-2">
+              <VStack className="gap-5 bg-background p-6 sm:p-8">
+                <SectionLabel>Do</SectionLabel>
+                <ul className="space-y-3.5">
+                  {DOS.map((item) => (
+                    <li
+                      className="flex gap-3 text-sm leading-6 text-surface/65"
+                      key={item}
+                    >
+                      <span className="mt-2 size-1.5 shrink-0 rounded-full bg-success" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </VStack>
+              <VStack className="gap-5 bg-background p-6 sm:p-8">
+                <SectionLabel>Don't</SectionLabel>
+                <ul className="space-y-3.5">
+                  {DONTS.map((item) => (
+                    <li
+                      className="flex gap-3 text-sm leading-6 text-surface/65"
+                      key={item}
+                    >
+                      <span className="mt-2 size-1.5 shrink-0 rounded-full bg-danger" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </VStack>
             </div>
 
-            <HStack className="mt-10 flex-wrap justify-center gap-3">
-              <ButtonTracked
-                asChild
-                size={ButtonSize.PUBLIC}
-                trackingData={{ action: 'brand_os_signup_bottom' }}
-                trackingName="brand_os_cta_click"
-              >
-                <a href={signUpHref} rel="noopener noreferrer" target="_blank">
-                  Save a Brand OS
-                  <LuArrowRight className="size-4" />
+            <HStack className="mt-12 flex-wrap justify-center gap-3">
+              <Button asChild size={ButtonSize.PUBLIC}>
+                <a href={appHref} rel="noopener noreferrer" target="_blank">
+                  Open the studio
                 </a>
-              </ButtonTracked>
+              </Button>
               <Button
                 asChild
                 size={ButtonSize.PUBLIC}

--- a/apps/website/app/(public)/brand-os/brand-os-content.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.tsx
@@ -1,0 +1,481 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
+import { EnvironmentService } from '@services/core/environment.service';
+import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
+import { HStack, VStack } from '@ui/layout/stack';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import { Label } from '@ui/primitives/label';
+import { Textarea } from '@ui/primitives/textarea';
+import { Heading } from '@ui/typography/heading';
+import { Text } from '@ui/typography/text';
+import HomeFooter from '@web-components/home/_footer';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  LuArrowRight,
+  LuBadgeCheck,
+  LuFileText,
+  LuLayers,
+  LuPalette,
+  LuSearchCheck,
+  LuTriangleAlert,
+} from 'react-icons/lu';
+
+const PREVIEW_MODES = [
+  {
+    icon: LuFileText,
+    key: 'idle',
+    label: 'Idle',
+    status: 'Waiting for source',
+  },
+  {
+    icon: LuSearchCheck,
+    key: 'partial',
+    label: 'Partial',
+    status: 'Evidence found',
+  },
+  {
+    icon: LuBadgeCheck,
+    key: 'ready',
+    label: 'Ready',
+    status: 'Preview ready',
+  },
+  {
+    icon: LuTriangleAlert,
+    key: 'blocked',
+    label: 'Blocked',
+    status: 'Needs public source',
+  },
+] as const;
+
+const SOURCE_EVIDENCE = [
+  {
+    confidence: 'High',
+    label: 'Positioning',
+    value: 'AI content OS for founders and teams shipping across channels.',
+  },
+  {
+    confidence: 'Medium',
+    label: 'Voice',
+    value: 'Direct, operational, and anti-fluff. Short nouns beat slogans.',
+  },
+  {
+    confidence: 'Missing',
+    label: 'Motion',
+    value: 'No public evidence yet. Keep motion rules empty until sourced.',
+  },
+] as const;
+
+const CONTENT_PILLARS = [
+  'Founder proof',
+  'Launch systems',
+  'Content operations',
+  'Model leverage',
+] as const;
+
+const PALETTE_CANDIDATES = [
+  { hex: '#f4f4f5', label: 'Primary ink', source: 'Current product token' },
+  { hex: '#10b981', label: 'Proof green', source: 'Status token' },
+  { hex: '#f59e0b', label: 'Missing amber', source: 'Diagnostic token' },
+  { hex: '#3b82f6', label: 'Evidence blue', source: 'Status token' },
+] as const;
+
+const SCALE_ROLES = [
+  {
+    description: 'Dense controls, tables, source rows, and review fields.',
+    label: 'Product',
+    value: '32px control baseline',
+  },
+  {
+    description: 'CTA modules and preview panels that need public scanning.',
+    label: 'Block',
+    value: '1x campaign unit',
+  },
+  {
+    description: 'Primary Brand OS promise, public proof, and conversion copy.',
+    label: 'Hero',
+    value: '1.618x block',
+  },
+  {
+    description: 'Single launch artifact or proof object. Use once per page.',
+    label: 'Monument',
+    value: '2.618x block',
+  },
+] as const;
+
+type PreviewModeKey = (typeof PREVIEW_MODES)[number]['key'];
+
+function getSourceName(value: string): string {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return 'No public URL yet';
+  }
+
+  try {
+    const url = new URL(
+      trimmed.startsWith('http') ? trimmed : `https://${trimmed}`,
+    );
+    return url.hostname.replace(/^www\./, '');
+  } catch {
+    return 'Manual source';
+  }
+}
+
+export default function BrandOSContent(): React.ReactElement {
+  const containerRef = useMarketingEntrance({ cards: false });
+  const signUpHref = `${EnvironmentService.apps.app}/sign-up?source=brand-os`;
+  const [websiteUrl, setWebsiteUrl] = useState('genfeed.ai');
+  const [guidance, setGuidance] = useState(
+    'Keep the brand system operational: cite evidence, mark assumptions, and never copy a competitor kit.',
+  );
+  const [previewMode, setPreviewMode] = useState<PreviewModeKey>('partial');
+
+  const sourceName = useMemo(() => getSourceName(websiteUrl), [websiteUrl]);
+  const hasGuidance = guidance.trim().length > 0;
+  const activeMode = PREVIEW_MODES.find((mode) => mode.key === previewMode);
+  const previewStatus = activeMode?.status ?? 'Preview ready';
+
+  return (
+    <div ref={containerRef}>
+      <main>
+        <section className="border-b border-edge/5 bg-background py-14 sm:py-16 lg:py-20">
+          <div className="container mx-auto px-6">
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)] lg:items-start">
+              <VStack className="gap-8">
+                <VStack className="gap-5">
+                  <HStack className="w-fit items-center gap-2 border border-edge/10 bg-fill/[0.02] px-3 py-1.5 text-[10px] font-black uppercase text-surface/45">
+                    <LuLayers className="size-3.5" />
+                    <Text>Brand OS</Text>
+                  </HStack>
+
+                  <Heading
+                    as="h1"
+                    className="max-w-3xl text-5xl font-serif leading-none text-surface sm:text-6xl lg:text-7xl"
+                  >
+                    Turn source evidence into a usable brand system.
+                  </Heading>
+
+                  <Text className="max-w-2xl text-base leading-7 text-surface/55 sm:text-lg">
+                    The Brand OS surface separates evidence, assumptions,
+                    missing fields, scale roles, and save actions before it
+                    enters a brand workspace.
+                  </Text>
+                </VStack>
+
+                <form
+                  className="grid gap-5 border border-edge/5 bg-fill/[0.02] p-5 sm:p-6"
+                  noValidate
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    const raw = websiteUrl.trim();
+                    const normalized =
+                      raw && !raw.startsWith('http') ? `https://${raw}` : raw;
+                    if (normalized !== websiteUrl) {
+                      setWebsiteUrl(normalized);
+                    }
+                    setPreviewMode(hasGuidance ? 'ready' : 'partial');
+                  }}
+                >
+                  <Input
+                    aria-describedby="brand-os-url-help"
+                    label="Public website URL"
+                    onChange={(event) => setWebsiteUrl(event.target.value)}
+                    placeholder="https://example.com"
+                    type="text"
+                    value={websiteUrl}
+                  />
+                  <Text
+                    as="p"
+                    className="text-xs leading-5 text-surface/35"
+                    id="brand-os-url-help"
+                  >
+                    Private, loopback, and authenticated URLs stay blocked by
+                    the eventual extraction service.
+                  </Text>
+
+                  <div className="space-y-1.5">
+                    <Label
+                      className="text-sm font-medium text-foreground"
+                      htmlFor="brand-os-guidance"
+                    >
+                      Manual guidance
+                    </Label>
+                    <Textarea
+                      id="brand-os-guidance"
+                      maxHeight={180}
+                      onChange={(event) => setGuidance(event.target.value)}
+                      placeholder="Voice, audience, product, proof, or launch notes"
+                      rows={4}
+                      value={guidance}
+                    />
+                  </div>
+
+                  <div className="grid gap-2 sm:grid-cols-4">
+                    {PREVIEW_MODES.map((mode) => {
+                      const Icon = mode.icon;
+                      const isActive = previewMode === mode.key;
+
+                      return (
+                        <Button
+                          className="justify-center gap-2"
+                          key={mode.key}
+                          onClick={() => setPreviewMode(mode.key)}
+                          size={ButtonSize.SM}
+                          type="button"
+                          variant={
+                            isActive
+                              ? ButtonVariant.SECONDARY
+                              : ButtonVariant.GHOST
+                          }
+                        >
+                          <Icon className="size-4" />
+                          {mode.label}
+                        </Button>
+                      );
+                    })}
+                  </div>
+
+                  <div
+                    aria-live="polite"
+                    className="border border-edge/5 bg-background px-4 py-3 text-sm text-surface/55"
+                  >
+                    {previewStatus}: {sourceName}
+                  </div>
+
+                  <HStack className="flex-wrap gap-3">
+                    <Button type="submit" size={ButtonSize.PUBLIC}>
+                      Refresh Preview
+                    </Button>
+                    <ButtonTracked
+                      asChild
+                      size={ButtonSize.PUBLIC}
+                      trackingData={{ action: 'save_brand_os_preview' }}
+                      trackingName="brand_os_cta_click"
+                      variant={ButtonVariant.OUTLINE}
+                    >
+                      <a
+                        href={signUpHref}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        Save in Genfeed
+                        <LuArrowRight className="size-4" />
+                      </a>
+                    </ButtonTracked>
+                  </HStack>
+                </form>
+              </VStack>
+
+              <div
+                className="border border-edge/5 bg-fill/[0.02]"
+                data-testid="brand-os-preview"
+              >
+                <div className="grid border-b border-edge/5 md:grid-cols-[0.9fr_1.1fr]">
+                  <div className="relative min-h-64 overflow-hidden border-b border-edge/5 md:border-b-0 md:border-r">
+                    <Image
+                      alt="Color and layout reference board"
+                      className="object-cover"
+                      fill
+                      priority
+                      sizes="(max-width: 768px) 100vw, 42vw"
+                      src="https://images.unsplash.com/photo-1518005020951-eccb494ad742?w=1000&q=80&fit=crop"
+                    />
+                    <div className="absolute inset-0 bg-black/45" />
+                    <div className="absolute inset-x-0 bottom-0 p-5">
+                      <Text className="text-[10px] font-black uppercase text-white/55">
+                        Preview source
+                      </Text>
+                      <Heading as="h2" className="mt-2 text-3xl text-white">
+                        {sourceName}
+                      </Heading>
+                    </div>
+                  </div>
+
+                  <VStack className="gap-5 p-5 sm:p-6">
+                    <HStack className="items-center justify-between gap-4">
+                      <Text className="text-[10px] font-black uppercase text-surface/35">
+                        {previewStatus}
+                      </Text>
+                      <span className="text-[10px] font-black uppercase text-success">
+                        Source backed
+                      </span>
+                    </HStack>
+
+                    <VStack className="gap-3">
+                      {SOURCE_EVIDENCE.map((item) => (
+                        <div
+                          className="grid gap-2 border-t border-edge/5 pt-3 sm:grid-cols-[0.55fr_1fr]"
+                          key={item.label}
+                        >
+                          <VStack className="gap-1">
+                            <Text className="text-xs font-semibold text-surface">
+                              {item.label}
+                            </Text>
+                            <Text className="text-[10px] font-black uppercase text-surface/30">
+                              {item.confidence}
+                            </Text>
+                          </VStack>
+                          <Text className="text-sm leading-6 text-surface/60">
+                            {item.value}
+                          </Text>
+                        </div>
+                      ))}
+                    </VStack>
+                  </VStack>
+                </div>
+
+                <div className="grid gap-px bg-edge/5 lg:grid-cols-3">
+                  <VStack className="gap-4 bg-background p-5">
+                    <Text className="text-[10px] font-black uppercase text-surface/30">
+                      Palette candidates
+                    </Text>
+                    <div className="grid grid-cols-2 gap-3">
+                      {PALETTE_CANDIDATES.map((color) => (
+                        <VStack className="gap-2" key={color.label}>
+                          <span
+                            aria-label={`${color.label} ${color.hex}`}
+                            className="block h-12 border border-edge/10"
+                            role="img"
+                            style={{ backgroundColor: color.hex }}
+                          />
+                          <VStack className="gap-0.5">
+                            <Text className="text-xs font-semibold text-surface">
+                              {color.label}
+                            </Text>
+                            <Text className="text-[10px] text-surface/35">
+                              {color.source}
+                            </Text>
+                          </VStack>
+                        </VStack>
+                      ))}
+                    </div>
+                  </VStack>
+
+                  <VStack className="gap-4 bg-background p-5">
+                    <Text className="text-[10px] font-black uppercase text-surface/30">
+                      Content pillars
+                    </Text>
+                    <ul className="space-y-3">
+                      {CONTENT_PILLARS.map((pillar) => (
+                        <li
+                          className="flex items-center gap-3 border-b border-edge/5 pb-3 text-sm text-surface/65 last:border-b-0 last:pb-0"
+                          key={pillar}
+                        >
+                          <LuBadgeCheck className="size-4 shrink-0 text-success" />
+                          {pillar}
+                        </li>
+                      ))}
+                    </ul>
+                  </VStack>
+
+                  <VStack className="gap-4 bg-background p-5">
+                    <Text className="text-[10px] font-black uppercase text-surface/30">
+                      Diagnostics
+                    </Text>
+                    <Text className="text-sm leading-6 text-surface/60">
+                      {previewMode === 'blocked'
+                        ? 'The preview blocks private or unreachable sources and keeps the save action unavailable until public evidence exists.'
+                        : 'The preview keeps low-confidence fields visible, preserves missing evidence, and carries source notes into the save prompt.'}
+                    </Text>
+                    <Text className="text-sm leading-6 text-surface/60">
+                      {hasGuidance
+                        ? guidance
+                        : 'Manual guidance is empty, so the saved draft would ask for voice and positioning before apply.'}
+                    </Text>
+                  </VStack>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="border-b border-edge/5 bg-fill/[0.02] py-20"
+          id="brand-os-rules"
+        >
+          <div className="container mx-auto px-6">
+            <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.72fr_1.28fr]">
+              <VStack className="gap-4">
+                <HStack className="items-center gap-2 text-[10px] font-black uppercase text-surface/35">
+                  <LuPalette className="size-4" />
+                  <Text>Design contract</Text>
+                </HStack>
+                <Heading as="h2" className="text-4xl font-serif text-surface">
+                  Source-backed, not style-matched.
+                </Heading>
+                <Text className="text-base leading-7 text-surface/55">
+                  Brand OS output labels every recommendation as extracted,
+                  inferred, missing, or candidate. Product screens stay compact;
+                  public campaign objects can scale up when they carry proof.
+                </Text>
+              </VStack>
+
+              <div className="grid gap-px bg-edge/5 sm:grid-cols-2">
+                {SCALE_ROLES.map((role) => (
+                  <VStack className="gap-4 bg-background p-5" key={role.label}>
+                    <HStack className="items-center justify-between gap-4">
+                      <Text className="text-lg font-semibold text-surface">
+                        {role.label}
+                      </Text>
+                      <Text className="text-[10px] font-black uppercase text-surface/35">
+                        {role.value}
+                      </Text>
+                    </HStack>
+                    <Text className="text-sm leading-6 text-surface/55">
+                      {role.description}
+                    </Text>
+                  </VStack>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-20">
+          <div className="container mx-auto px-6">
+            <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-3">
+              {[
+                'Current Genfeed tokens remain the product palette until a source-backed palette is accepted.',
+                'Candidate Wada/Sanzo-inspired color outputs are labeled as candidates, never product defaults.',
+                'Authenticated review screens use dense controls, evidence rows, and explicit apply/discard states.',
+              ].map((rule) => (
+                <div className="border border-edge/5 p-5" key={rule}>
+                  <Text className="text-sm leading-6 text-surface/60">
+                    {rule}
+                  </Text>
+                </div>
+              ))}
+            </div>
+
+            <HStack className="mt-10 flex-wrap justify-center gap-3">
+              <ButtonTracked
+                asChild
+                size={ButtonSize.PUBLIC}
+                trackingData={{ action: 'brand_os_signup_bottom' }}
+                trackingName="brand_os_cta_click"
+              >
+                <a href={signUpHref} rel="noopener noreferrer" target="_blank">
+                  Save a Brand OS
+                  <LuArrowRight className="size-4" />
+                </a>
+              </ButtonTracked>
+              <Button
+                asChild
+                size={ButtonSize.PUBLIC}
+                variant={ButtonVariant.OUTLINE}
+              >
+                <Link href="/">Back to Genfeed.ai</Link>
+              </Button>
+            </HStack>
+          </div>
+        </section>
+      </main>
+      <HomeFooter />
+    </div>
+  );
+}

--- a/apps/website/app/(public)/brand-os/page.spec.tsx
+++ b/apps/website/app/(public)/brand-os/page.spec.tsx
@@ -1,0 +1,4 @@
+import * as PageModule from '@public/brand-os/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests('apps/website/app/(public)/brand-os/page', PageModule);

--- a/apps/website/app/(public)/brand-os/page.tsx
+++ b/apps/website/app/(public)/brand-os/page.tsx
@@ -2,8 +2,8 @@ import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-me
 import BrandOSContent from '@public/brand-os/brand-os-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
-  'Brand OS',
-  'Build a source-backed Brand OS preview with evidence, diagnostics, scale roles, and save-to-Genfeed conversion states.',
+  'Brand OS — Genfeed Design System',
+  "Genfeed's Brand OS: the dark-first design system behind the product — color layers, semantic and platform tokens, the type scale, and the content-is-the-accent principle.",
   '/brand-os',
 );
 

--- a/apps/website/app/(public)/brand-os/page.tsx
+++ b/apps/website/app/(public)/brand-os/page.tsx
@@ -1,0 +1,12 @@
+import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-metadata.helper';
+import BrandOSContent from '@public/brand-os/brand-os-content';
+
+export const generateMetadata = createPageMetadataWithCanonical(
+  'Brand OS',
+  'Build a source-backed Brand OS preview with evidence, diagnostics, scale roles, and save-to-Genfeed conversion states.',
+  '/brand-os',
+);
+
+export default function BrandOSPage() {
+  return <BrandOSContent />;
+}

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -129,6 +129,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     {
       changeFrequency: 'weekly',
       lastModified: new Date(),
+      priority: 0.9,
+      url: 'https://genfeed.ai/brand-os',
+    },
+    {
+      changeFrequency: 'weekly',
+      lastModified: new Date(),
       priority: 0.8,
       url: 'https://genfeed.ai/integrations',
     },

--- a/apps/website/packages/components/home/_footer.tsx
+++ b/apps/website/packages/components/home/_footer.tsx
@@ -20,6 +20,7 @@ const WEBSITE_SECTIONS: FooterSection[] = [
       { href: '/integrations', label: 'Integrations' },
       { href: '/features', label: 'Features' },
       { href: '/mobile', label: 'Mobile App' },
+      { href: '/brand-os', label: 'Brand OS' },
     ],
     title: 'Platform',
   },


### PR DESCRIPTION
## Summary
- Adds the public `/brand-os` page (source-backed brand preview: evidence, diagnostics, palette candidates, scale roles, save-to-Genfeed CTA), recovered from the closed PR #903.
- No homepage entry point — per product decision, `/brand-os` is discoverable for SEO and via a footer link only, for now.
- Adds a "Brand OS" link to the site footer's Products section (`apps/website/packages/components/home/_footer.tsx`), which renders on every public page including the brand-os page itself.
- Adds `/brand-os` to the static sitemap (priority 0.9, weekly).
- Page ships with proper SEO metadata via `createPageMetadataWithCanonical()`.

Closes #902

## Explicitly excluded (per product decision)
- `apps/website/packages/components/home/_brand-os.tsx` and its spec (homepage entry component) — not brought in.
- `apps/website/app/(public)/(home)/home-content.tsx` wiring — untouched, no `HomeBrandOS` import/render added.
- Stray `/core` and `/host` sitemap entries present in the stale source branch's sitemap diff — not brought in (unrelated to brand-os).
- `DESIGN.md` diff from the source branch — skipped; it was a stale revert against tokens/sections that master's `DESIGN.md` already carries correctly (the "Brand OS Surfaces" design section already exists on master).

## Validation
- `bunx turbo run type-check --filter=@genfeedai/website` — 10/10 tasks pass.
- `bun run test --filter=@genfeedai/website` scoped to `app/(public)/brand-os` — 2 test files, 6 tests pass.
- `bun run test --filter=@genfeedai/website` scoped to the footer spec — 1 test passes (no regression).
- `bunx biome check --write` on all 6 changed files — clean.
- `bash scripts/lint-no-raw-html.sh` on changed files — clean.
- `bunx turbo run lint --filter=@genfeedai/website` — clean.

## Test plan
- [ ] CI green on this PR
- [ ] Visit `/brand-os` and confirm the page renders (hero, source-evidence preview, palette/scale-role sections, save CTA)
- [ ] Confirm the footer "Brand OS" link appears under Products on any public page and routes to `/brand-os`
- [ ] Confirm the homepage is unchanged (no Brand OS section between Hero and Pricing)