### PR TITLE
feat(workflow-ui): inject workflow persistence + applyEditOperations (#1151)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -43,8 +43,10 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { workflowsApi } from '@/lib/api';
 import { apiClient } from '@/lib/api/client';
 import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
+import { applyEditOperations } from '@/lib/chat/editOperations';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 interface WorkflowDetailPageClientProps {
@@ -138,6 +140,7 @@ export default function WorkflowDetailPageClient({
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      applyEditOperations,
       executionHeaders: getExecutionProviderHeaders,
       executionHttpClient: {
         post: <T,>(
@@ -147,6 +150,14 @@ export default function WorkflowDetailPageClient({
         ): Promise<T> => apiClient.post<T>(path, body, options),
       },
       logger,
+      workflowPersistence: {
+        create: workflowsApi.create,
+        delete: workflowsApi.delete,
+        duplicate: workflowsApi.duplicate,
+        getAll: workflowsApi.getAll,
+        getById: workflowsApi.getById,
+        update: workflowsApi.update,
+      },
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {
           const service = await getWorkflowService();

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -44,8 +44,10 @@ import {
   type WorkflowGraphEdgeLike,
   type WorkflowGraphNodeLike,
 } from '@/features/workflows/utils/workflow-graph';
+import { workflowsApi } from '@/lib/api';
 import { apiClient } from '@/lib/api/client';
 import { getExecutionProviderHeaders } from '@/lib/api/execution-headers';
+import { applyEditOperations } from '@/lib/chat/editOperations';
 import WorkflowEditorToolbarNavigation from '../components/WorkflowEditorToolbarNavigation';
 
 type WorkflowStoreState = ReturnType<typeof useWorkflowStore.getState>;
@@ -191,6 +193,7 @@ export default function WorkflowNewPageClient() {
 
   const workflowUiConfig = useMemo<WorkflowUIConfig>(
     () => ({
+      applyEditOperations,
       executionHeaders: getExecutionProviderHeaders,
       executionHttpClient: {
         post: <T,>(
@@ -200,6 +203,14 @@ export default function WorkflowNewPageClient() {
         ): Promise<T> => apiClient.post<T>(path, body, options),
       },
       logger,
+      workflowPersistence: {
+        create: workflowsApi.create,
+        delete: workflowsApi.delete,
+        duplicate: workflowsApi.duplicate,
+        getAll: workflowsApi.getAll,
+        getById: workflowsApi.getById,
+        update: workflowsApi.update,
+      },
       workflowsApi: {
         setThumbnail: async (selectedWorkflowId, thumbnailUrl, nodeId) => {
           const service = await getWorkflowService();

--- a/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
+++ b/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
@@ -90,20 +90,7 @@ export function useCloudWorkflow({
 
   const bindSharedWorkflowApi = useCallback((service: WorkflowApiService) => {
     useWorkflowStore.setState({
-      listWorkflows: async () => {
-        const workflows = await service.list();
-
-        return workflows.map((workflow) => ({
-          _id: workflow._id,
-          createdAt: workflow.createdAt,
-          edgeStyle: 'default',
-          edges: [],
-          groups: [],
-          name: workflow.name,
-          nodes: [],
-          updatedAt: workflow.updatedAt,
-        }));
-      },
+      listWorkflows: async () => service.list(),
       loadWorkflowById: async (id: string) => {
         await useCloudWorkflowStore.getState().loadFromCloud(id, service);
       },

--- a/packages/workflow-ui/src/index.ts
+++ b/packages/workflow-ui/src/index.ts
@@ -68,7 +68,25 @@ export { useSettingsStore } from './stores/settingsStore';
 // Stores
 export { useUIStore } from './stores/uiStore';
 export { useWorkflowStore } from './stores/workflow';
-export type { ImageHistoryItem } from './stores/workflow/types';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './stores/workflow/applyEditOperations';
+export type {
+  ApplyEditOperations,
+  ApplyEditResult,
+  EditOperation,
+} from './stores/workflow/slices/types';
+export type {
+  ImageHistoryItem,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowSummary,
+} from './stores/workflow/types';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './stores/workflow/workflowPersistence';
 export type {
   DropdownItem,
   OverflowMenuProps,

--- a/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
+++ b/packages/workflow-ui/src/provider/WorkflowUIProvider.tsx
@@ -7,6 +7,8 @@ import {
 } from '../stores/execution/executionApi';
 import { configureWorkflowLogger } from '../stores/executionLogger';
 import { configurePromptLibrary } from '../stores/promptLibraryStore';
+import { configureApplyEditOperations } from '../stores/workflow/applyEditOperations';
+import { configureWorkflowPersistence } from '../stores/workflow/workflowPersistence';
 import type { WorkflowUIConfig } from './types';
 
 const WorkflowUIContext = createContext<WorkflowUIConfig>({});
@@ -52,6 +54,18 @@ export function WorkflowUIProvider({
   useEffect(() => {
     configureExecutionHeaders(config.executionHeaders);
   }, [config.executionHeaders]);
+
+  // Register the workflow persistence backend. Resets to a throwing
+  // "not configured" stub when unset so saves are never silently dropped.
+  useEffect(() => {
+    configureWorkflowPersistence(config.workflowPersistence);
+  }, [config.workflowPersistence]);
+
+  // Register the chat/agent edit-operations applier. Resets to a no-op when
+  // unset (matching the package's standalone behavior).
+  useEffect(() => {
+    configureApplyEditOperations(config.applyEditOperations);
+  }, [config.applyEditOperations]);
 
   return (
     <WorkflowUIContext.Provider value={config}>

--- a/packages/workflow-ui/src/provider/index.ts
+++ b/packages/workflow-ui/src/provider/index.ts
@@ -1,4 +1,14 @@
 export type {
+  ApplyEditOperations,
+  ApplyEditResult,
+  EditOperation,
+} from '../stores/workflow/slices/types';
+export type {
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowSummary,
+} from '../stores/workflow/types';
+export type {
   ExecutionHeaderProvider,
   FileUploadService,
   ModelBrowserModalProps,

--- a/packages/workflow-ui/src/provider/types.ts
+++ b/packages/workflow-ui/src/provider/types.ts
@@ -6,6 +6,8 @@ import type {
   ProviderModel,
 } from '@genfeedai/types';
 import type { ComponentType } from 'react';
+import type { ApplyEditOperations } from '../stores/workflow/slices/types';
+import type { WorkflowPersistenceService } from '../stores/workflow/types';
 
 // =============================================================================
 // File Upload
@@ -148,4 +150,15 @@ export interface WorkflowUIConfig {
   ModelBrowserModal?: ComponentType<ModelBrowserModalProps> | null;
   /** Injected PromptPicker component (complex, app-specific) */
   PromptPicker?: ComponentType<PromptPickerProps> | null;
+  /**
+   * Persistence backend for workflow CRUD (create/update/getById/getAll/delete/
+   * duplicate). Defaults to a throwing "not configured" stub so saves are never
+   * silently dropped when the consuming app forgets to inject it.
+   */
+  workflowPersistence?: WorkflowPersistenceService;
+  /**
+   * Applies chat/agent-generated edit operations to the workflow graph. Defaults
+   * to a no-op when omitted (matching the package's standalone behavior).
+   */
+  applyEditOperations?: ApplyEditOperations;
 }

--- a/packages/workflow-ui/src/stores/index.ts
+++ b/packages/workflow-ui/src/stores/index.ts
@@ -54,9 +54,20 @@ export { PROVIDER_INFO, useSettingsStore } from './settingsStore';
 export type { ModalType, NodeDetailTab } from './uiStore';
 export { useUIStore } from './uiStore';
 // Store types
-export type { WorkflowData, WorkflowState, WorkflowStore } from './workflow';
+export type {
+  WorkflowData,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowState,
+  WorkflowStore,
+  WorkflowSummary,
+} from './workflow';
 // Store hooks
 export { useWorkflowStore } from './workflow';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './workflow/applyEditOperations';
 // Workflow selectors
 export {
   createSelectGroupByNodeId,
@@ -93,3 +104,7 @@ export {
   selectWorkflowId,
   selectWorkflowName,
 } from './workflow/selectors';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflow/workflowPersistence';

--- a/packages/workflow-ui/src/stores/workflow/applyEditOperations.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/applyEditOperations.test.ts
@@ -1,0 +1,51 @@
+import type { WorkflowEdge, WorkflowNode } from '@genfeedai/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './applyEditOperations';
+import type { EditOperation } from './slices/types';
+
+const nodes = [
+  { data: {}, id: 'a', position: { x: 0, y: 0 }, type: 'prompt' },
+] as unknown as WorkflowNode[];
+const edges = [] as WorkflowEdge[];
+
+describe('applyEditOperations', () => {
+  afterEach(() => {
+    // Reset to the no-op default so tests don't leak an implementation.
+    configureApplyEditOperations(undefined);
+  });
+
+  it('defaults to a no-op that leaves the graph untouched', () => {
+    const operations: EditOperation[] = [{ nodeId: 'a', type: 'removeNode' }];
+
+    const result = getApplyEditOperations()(operations, { edges, nodes });
+
+    expect(result).toEqual({ applied: 0, edges, nodes, skipped: [] });
+  });
+
+  it('routes to the configured implementation with operations + state', () => {
+    const apply = vi
+      .fn()
+      .mockReturnValue({ applied: 1, edges, nodes: [], skipped: [] });
+    configureApplyEditOperations(apply);
+
+    const operations: EditOperation[] = [{ nodeId: 'a', type: 'removeNode' }];
+    const result = getApplyEditOperations()(operations, { edges, nodes });
+
+    expect(apply).toHaveBeenCalledWith(operations, { edges, nodes });
+    expect(result.applied).toBe(1);
+  });
+
+  it('reverts to the no-op when reconfigured with undefined', () => {
+    configureApplyEditOperations(
+      vi.fn().mockReturnValue({ applied: 5, edges, nodes: [], skipped: [] }),
+    );
+    configureApplyEditOperations(undefined);
+
+    const result = getApplyEditOperations()([], { edges, nodes });
+
+    expect(result.applied).toBe(0);
+  });
+});

--- a/packages/workflow-ui/src/stores/workflow/applyEditOperations.ts
+++ b/packages/workflow-ui/src/stores/workflow/applyEditOperations.ts
@@ -1,0 +1,42 @@
+import type { ApplyEditOperations } from './slices/types';
+
+// =============================================================================
+// Module-level applyEditOperations configuration
+// =============================================================================
+
+/**
+ * Injected `applyEditOperations` implementation for the snapshot slice (used by
+ * the chat/agent edit pipeline to mutate the graph). Registered at module scope
+ * via {@link configureApplyEditOperations} because the workflow store lives
+ * outside the React tree.
+ *
+ * Defaults to a no-op that leaves the graph untouched (0 applied) so the package
+ * stays functional standalone; the consuming app injects the real graph-diffing
+ * implementation through `WorkflowUIConfig.applyEditOperations`.
+ */
+const NOOP_APPLY_EDIT_OPERATIONS: ApplyEditOperations = (
+  _operations,
+  state,
+) => ({
+  applied: 0,
+  edges: state.edges,
+  nodes: state.nodes,
+  skipped: [],
+});
+
+let _apply: ApplyEditOperations = NOOP_APPLY_EDIT_OPERATIONS;
+
+/**
+ * Register the `applyEditOperations` implementation the snapshot slice uses.
+ * Called by WorkflowUIProvider; resets to the no-op default when unset.
+ */
+export function configureApplyEditOperations(
+  apply: ApplyEditOperations | undefined,
+): void {
+  _apply = apply ?? NOOP_APPLY_EDIT_OPERATIONS;
+}
+
+/** Read the currently-configured applyEditOperations (no-op until configured). */
+export function getApplyEditOperations(): ApplyEditOperations {
+  return _apply;
+}

--- a/packages/workflow-ui/src/stores/workflow/index.ts
+++ b/packages/workflow-ui/src/stores/workflow/index.ts
@@ -5,5 +5,20 @@
  * Internal implementation uses slices for organization.
  */
 
-export type { WorkflowData, WorkflowState, WorkflowStore } from './types';
+export {
+  configureApplyEditOperations,
+  getApplyEditOperations,
+} from './applyEditOperations';
+export type {
+  WorkflowData,
+  WorkflowPersistenceService,
+  WorkflowSaveInput,
+  WorkflowState,
+  WorkflowStore,
+  WorkflowSummary,
+} from './types';
+export {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflowPersistence';
 export { useWorkflowStore } from './workflowStore';

--- a/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
@@ -1,4 +1,5 @@
 import type {
+  EdgeStyle,
   NodeType,
   ValidationResult,
   WorkflowEdge,
@@ -9,9 +10,15 @@ import type {
 } from '@genfeedai/types';
 import { NODE_DEFINITIONS } from '@genfeedai/types';
 import type { StateCreator } from 'zustand';
-import { getConnectedInputsForNode, getUpstreamNodeIds } from '../../../lib';
+import {
+  calculateWorkflowCost,
+  getConnectedInputsForNode,
+  getUpstreamNodeIds,
+} from '../../../lib';
+import { useExecutionStore } from '../../execution/executionStore';
 import { propagateExistingOutputs } from '../helpers/propagation';
-import type { WorkflowData, WorkflowStore } from '../types';
+import type { WorkflowData, WorkflowStore, WorkflowSummary } from '../types';
+import { getWorkflowPersistence } from '../workflowPersistence';
 
 /**
  * Normalize edges loaded from storage to use React Flow edge types.
@@ -50,7 +57,7 @@ export interface PersistenceSlice {
   exportWorkflow: () => WorkflowFile;
   saveWorkflow: (signal?: AbortSignal) => Promise<WorkflowData>;
   loadWorkflowById: (id: string, signal?: AbortSignal) => Promise<void>;
-  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowData[]>;
+  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowSummary[]>;
   deleteWorkflow: (id: string, signal?: AbortSignal) => Promise<void>;
   duplicateWorkflowApi: (
     id: string,
@@ -87,23 +94,50 @@ export const createPersistenceSlice: StateCreator<
     });
   },
 
-  createNewWorkflow: async () => {
-    throw new Error(
-      'createNewWorkflow not implemented - consuming app must provide API integration',
+  createNewWorkflow: async (signal) => {
+    const { edgeStyle } = get();
+
+    const workflow = await getWorkflowPersistence().create(
+      {
+        edgeStyle,
+        edges: [],
+        groups: [],
+        name: 'Untitled Workflow',
+        nodes: [],
+      },
+      signal,
     );
+
+    set({
+      edges: [],
+      groups: [],
+      isDirty: false,
+      nodes: [],
+      selectedNodeIds: [],
+      workflowId: workflow._id,
+      workflowName: workflow.name,
+    });
+
+    return workflow._id;
   },
 
-  deleteWorkflow: async () => {
-    throw new Error(
-      'deleteWorkflow not implemented - consuming app must provide API integration',
-    );
+  deleteWorkflow: async (id, signal) => {
+    await getWorkflowPersistence().delete(id, signal);
+
+    const { workflowId } = get();
+    if (workflowId === id) {
+      set({
+        edges: [],
+        isDirty: false,
+        nodes: [],
+        workflowId: null,
+        workflowName: 'Untitled Workflow',
+      });
+    }
   },
 
-  duplicateWorkflowApi: async () => {
-    throw new Error(
-      'duplicateWorkflowApi not implemented - consuming app must provide API integration',
-    );
-  },
+  duplicateWorkflowApi: (id, signal) =>
+    getWorkflowPersistence().duplicate(id, signal),
 
   exportWorkflow: () => {
     const { nodes, edges, edgeStyle, workflowName, groups } = get();
@@ -157,11 +191,7 @@ export const createPersistenceSlice: StateCreator<
     }).length;
   },
 
-  listWorkflows: async () => {
-    throw new Error(
-      'listWorkflows not implemented - consuming app must provide API integration',
-    );
-  },
+  listWorkflows: (signal) => getWorkflowPersistence().getAll(undefined, signal),
   loadWorkflow: (workflow) => {
     const hydratedNodes = hydrateWorkflowNodes(workflow.nodes);
 
@@ -176,6 +206,9 @@ export const createPersistenceSlice: StateCreator<
       workflowName: workflow.name,
     });
 
+    const estimatedCost = calculateWorkflowCost(hydratedNodes);
+    useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
+
     // Propagate existing outputs to downstream nodes after load
     propagateExistingOutputs(hydratedNodes, get().propagateOutputsDownstream);
 
@@ -183,10 +216,36 @@ export const createPersistenceSlice: StateCreator<
     set({ isDirty: false });
   },
 
-  loadWorkflowById: async () => {
-    throw new Error(
-      'loadWorkflowById not implemented - consuming app must provide API integration',
-    );
+  loadWorkflowById: async (id, signal) => {
+    set({ isLoading: true });
+
+    try {
+      const workflow = await getWorkflowPersistence().getById(id, signal);
+      const nodes = hydrateWorkflowNodes(workflow.nodes);
+
+      set({
+        edgeStyle: workflow.edgeStyle as EdgeStyle,
+        edges: normalizeEdgeTypes(workflow.edges),
+        groups: workflow.groups ?? [],
+        isDirty: false,
+        isLoading: false,
+        nodes,
+        workflowId: workflow._id,
+        workflowName: workflow.name,
+      });
+
+      const estimatedCost = calculateWorkflowCost(nodes);
+      useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
+
+      // Propagate existing outputs to downstream nodes after load
+      propagateExistingOutputs(nodes, get().propagateOutputsDownstream);
+
+      // Propagation after load is idempotent; don't trigger save cycle
+      set({ isDirty: false });
+    } catch (error) {
+      set({ isLoading: false });
+      throw error;
+    }
   },
 
   markCommentViewed: (nodeId: string) => {
@@ -197,12 +256,34 @@ export const createPersistenceSlice: StateCreator<
     });
   },
 
-  // API operations - stubs that throw by default.
-  // Consuming apps override these via the store creator or by extending the slice.
-  saveWorkflow: async () => {
-    throw new Error(
-      'saveWorkflow not implemented - consuming app must provide API integration',
-    );
+  saveWorkflow: async (signal) => {
+    const { nodes, edges, edgeStyle, workflowName, workflowId, groups } = get();
+    set({ isSaving: true });
+
+    try {
+      const input = {
+        edgeStyle,
+        edges,
+        groups,
+        name: workflowName,
+        nodes,
+      };
+
+      const workflow = workflowId
+        ? await getWorkflowPersistence().update(workflowId, input, signal)
+        : await getWorkflowPersistence().create(input, signal);
+
+      set({
+        isDirty: false,
+        isSaving: false,
+        workflowId: workflow._id,
+      });
+
+      return workflow;
+    } catch (error) {
+      set({ isSaving: false });
+      throw error;
+    }
   },
 
   setDirty: (dirty) => {

--- a/packages/workflow-ui/src/stores/workflow/slices/snapshotSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/snapshotSlice.ts
@@ -1,24 +1,7 @@
-import type { WorkflowEdge, WorkflowNode } from '@genfeedai/types';
 import type { StateCreator } from 'zustand';
+import { getApplyEditOperations } from '../applyEditOperations';
 import type { WorkflowStore } from '../types';
-import type { EditOperation, SnapshotSlice, WorkflowSnapshot } from './types';
-
-/**
- * EditOperation type inlined from @/lib/chat/editOperations.
- * The consuming app provides the actual applyEditOperations implementation.
- */
-// Stub applyEditOperations - consuming app should override via the store creator.
-function defaultApplyEditOperations(
-  _operations: EditOperation[],
-  state: { nodes: WorkflowNode[]; edges: WorkflowEdge[] },
-): {
-  nodes: WorkflowNode[];
-  edges: WorkflowEdge[];
-  applied: number;
-  skipped: string[];
-} {
-  return { applied: 0, edges: state.edges, nodes: state.nodes, skipped: [] };
-}
+import type { SnapshotSlice, WorkflowSnapshot } from './types';
 
 export const createSnapshotSlice: StateCreator<
   WorkflowStore & SnapshotSlice,
@@ -28,7 +11,7 @@ export const createSnapshotSlice: StateCreator<
 > = (set, get) => ({
   applyEditOperations: (operations) => {
     const state = get();
-    const result = defaultApplyEditOperations(operations, {
+    const result = getApplyEditOperations()(operations, {
       edges: state.edges,
       nodes: state.nodes,
     });

--- a/packages/workflow-ui/src/stores/workflow/slices/types.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/types.ts
@@ -1,14 +1,52 @@
 import type {
   EdgeStyle,
   NodeGroup,
+  NodeType,
   WorkflowEdge,
   WorkflowNode,
 } from '@genfeedai/types';
 
-export interface EditOperation {
-  type: 'add_node' | 'remove_node' | 'update_node' | 'add_edge' | 'remove_edge';
-  [key: string]: unknown;
+/**
+ * A single atomic change to the workflow graph. Canonical shape shared with the
+ * app's chat/agent edit pipeline — the `applyEditOperations` implementation is
+ * injected (see WorkflowUIConfig.applyEditOperations); this package defaults to
+ * a no-op when unconfigured.
+ */
+export type EditOperation =
+  | {
+      type: 'addNode';
+      nodeType: NodeType;
+      position?: { x: number; y: number };
+      data?: Record<string, unknown>;
+    }
+  | { type: 'removeNode'; nodeId: string }
+  | { type: 'updateNode'; nodeId: string; data: Record<string, unknown> }
+  | {
+      type: 'addEdge';
+      source: string;
+      target: string;
+      sourceHandle?: string;
+      targetHandle?: string;
+    }
+  | { type: 'removeEdge'; edgeId: string };
+
+/** Result of applying a batch of {@link EditOperation}s. */
+export interface ApplyEditResult {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  applied: number;
+  skipped: string[];
 }
+
+/**
+ * Applies a batch of edit operations to the current graph and returns the new
+ * nodes/edges plus how many applied / which were skipped. Injected by the app;
+ * defaults to a no-op that leaves the graph untouched.
+ */
+export type ApplyEditOperations = (
+  operations: EditOperation[],
+  state: { nodes: WorkflowNode[]; edges: WorkflowEdge[] },
+) => ApplyEditResult;
 
 export interface ChatMessage {
   id: string;

--- a/packages/workflow-ui/src/stores/workflow/types.ts
+++ b/packages/workflow-ui/src/stores/workflow/types.ts
@@ -44,6 +44,53 @@ export interface WorkflowData {
   updatedAt?: string;
 }
 
+/** Payload sent to the persistence service on create / update. */
+export interface WorkflowSaveInput {
+  name: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  edgeStyle?: string;
+  groups?: NodeGroup[];
+  tags?: string[];
+}
+
+/** Lightweight workflow projection returned by the list endpoint (no graph). */
+export interface WorkflowSummary {
+  _id: string;
+  name: string;
+  description?: string;
+  lifecycle: 'draft' | 'published' | 'archived';
+  thumbnail?: string | null;
+  thumbnailNodeId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Persistence backend the workflow store's CRUD actions delegate to. Injected by
+ * the consuming app (see WorkflowUIConfig.workflowPersistence); when unconfigured
+ * the package throws a clear "not configured" error — its prior standalone
+ * behavior — rather than silently dropping saves.
+ */
+export interface WorkflowPersistenceService {
+  create: (
+    input: WorkflowSaveInput,
+    signal?: AbortSignal,
+  ) => Promise<WorkflowData>;
+  update: (
+    id: string,
+    input: WorkflowSaveInput,
+    signal?: AbortSignal,
+  ) => Promise<WorkflowData>;
+  getById: (id: string, signal?: AbortSignal) => Promise<WorkflowData>;
+  getAll: (
+    params?: { search?: string; tag?: string },
+    signal?: AbortSignal,
+  ) => Promise<WorkflowSummary[]>;
+  delete: (id: string, signal?: AbortSignal) => Promise<void>;
+  duplicate: (id: string, signal?: AbortSignal) => Promise<WorkflowData>;
+}
+
 // =============================================================================
 // STATE TYPES
 // =============================================================================
@@ -137,7 +184,7 @@ export interface LocalWorkflowActions {
 export interface ApiActions {
   saveWorkflow: (signal?: AbortSignal) => Promise<WorkflowData>;
   loadWorkflowById: (id: string, signal?: AbortSignal) => Promise<void>;
-  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowData[]>;
+  listWorkflows: (signal?: AbortSignal) => Promise<WorkflowSummary[]>;
   deleteWorkflow: (id: string, signal?: AbortSignal) => Promise<void>;
   duplicateWorkflowApi: (
     id: string,

--- a/packages/workflow-ui/src/stores/workflow/workflowPersistence.test.ts
+++ b/packages/workflow-ui/src/stores/workflow/workflowPersistence.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowData, WorkflowPersistenceService } from './types';
+import {
+  configureWorkflowPersistence,
+  getWorkflowPersistence,
+} from './workflowPersistence';
+
+const workflow: WorkflowData = {
+  _id: 'wf-1',
+  edgeStyle: 'default',
+  edges: [],
+  name: 'Test',
+  nodes: [],
+};
+
+function makeService(): WorkflowPersistenceService {
+  return {
+    create: vi.fn().mockResolvedValue(workflow),
+    delete: vi.fn().mockResolvedValue(undefined),
+    duplicate: vi.fn().mockResolvedValue(workflow),
+    getAll: vi.fn().mockResolvedValue([]),
+    getById: vi.fn().mockResolvedValue(workflow),
+    update: vi.fn().mockResolvedValue(workflow),
+  };
+}
+
+describe('workflowPersistence', () => {
+  afterEach(() => {
+    // Reset to the throwing default so tests don't leak a service into each other.
+    configureWorkflowPersistence(undefined);
+  });
+
+  it('throws a clear "not configured" error for every method by default', async () => {
+    const service = getWorkflowPersistence();
+
+    await expect(
+      service.create({ edges: [], name: 'x', nodes: [] }),
+    ).rejects.toThrow(/not configured/);
+    await expect(service.getById('id')).rejects.toThrow(/not configured/);
+    await expect(service.getAll()).rejects.toThrow(/not configured/);
+    await expect(service.delete('id')).rejects.toThrow(/not configured/);
+    await expect(service.duplicate('id')).rejects.toThrow(/not configured/);
+    await expect(
+      service.update('id', { edges: [], name: 'x', nodes: [] }),
+    ).rejects.toThrow(/not configured/);
+  });
+
+  it('routes calls to the configured service', async () => {
+    const service = makeService();
+    configureWorkflowPersistence(service);
+
+    const result = await getWorkflowPersistence().getById('wf-1');
+
+    expect(service.getById).toHaveBeenCalledWith('wf-1');
+    expect(result).toEqual(workflow);
+  });
+
+  it('reverts to the throwing default when reconfigured with undefined', async () => {
+    configureWorkflowPersistence(makeService());
+    configureWorkflowPersistence(undefined);
+
+    await expect(getWorkflowPersistence().getById('id')).rejects.toThrow(
+      /not configured/,
+    );
+  });
+});

--- a/packages/workflow-ui/src/stores/workflow/workflowPersistence.ts
+++ b/packages/workflow-ui/src/stores/workflow/workflowPersistence.ts
@@ -1,0 +1,50 @@
+import type { WorkflowPersistenceService } from './types';
+
+// =============================================================================
+// Module-level workflow persistence configuration
+// =============================================================================
+
+/**
+ * Injected persistence backend for the workflow store's CRUD actions
+ * (`saveWorkflow`, `loadWorkflowById`, `listWorkflows`, `deleteWorkflow`,
+ * `duplicateWorkflowApi`, `createNewWorkflow`).
+ *
+ * The workflow store is a plain Zustand store outside the React tree, so the
+ * service is registered at module scope via {@link configureWorkflowPersistence}
+ * — the same pattern the execution HTTP client and logger use.
+ *
+ * When unconfigured, every method throws a clear "not configured" error. This
+ * preserves the package's prior standalone behavior (the stubs threw
+ * "not implemented") — a save must never silently no-op and drop the user's work.
+ */
+function notConfigured(method: string): never {
+  throw new Error(
+    `WorkflowPersistenceService.${method} is not configured — the consuming app must inject workflowPersistence via WorkflowUIConfig`,
+  );
+}
+
+const DEFAULT_PERSISTENCE: WorkflowPersistenceService = {
+  create: async () => notConfigured('create'),
+  delete: async () => notConfigured('delete'),
+  duplicate: async () => notConfigured('duplicate'),
+  getAll: async () => notConfigured('getAll'),
+  getById: async () => notConfigured('getById'),
+  update: async () => notConfigured('update'),
+};
+
+let _persistence: WorkflowPersistenceService = DEFAULT_PERSISTENCE;
+
+/**
+ * Register the persistence backend the workflow store delegates to.
+ * Called by WorkflowUIProvider; resets to the throwing default when unset.
+ */
+export function configureWorkflowPersistence(
+  service: WorkflowPersistenceService | undefined,
+): void {
+  _persistence = service ?? DEFAULT_PERSISTENCE;
+}
+
+/** Read the currently-configured persistence backend (throws until configured). */
+export function getWorkflowPersistence(): WorkflowPersistenceService {
+  return _persistence;
+}


### PR DESCRIPTION
## Summary

Re-lands the persistence-injection payload from closed PR #1155. That PR's stacked base branch was deleted after merge, so it could not be reopened once `master` diverged further. This PR reconstructs the minimal delta on top of current `master`.

- Replaces the throwing `not implemented` stubs in `packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts` (`createNewWorkflow` / `deleteWorkflow` / `duplicateWorkflowApi` / `listWorkflows` / `loadWorkflowById` / `saveWorkflow`) with implementations that delegate to an injected `WorkflowPersistenceService`, matching the existing `configureX`/`getX` injection seam already used for the execution HTTP client, headers, and logger.
- Adds `packages/workflow-ui/src/stores/workflow/workflowPersistence.ts` (+ test) — `configureWorkflowPersistence` / `getWorkflowPersistence`, defaulting to a throwing "not configured" stub so saves are never silently dropped if a consuming app forgets to inject the backend.
- Adds `packages/workflow-ui/src/stores/workflow/applyEditOperations.ts` (+ test) — `configureApplyEditOperations` / `getApplyEditOperations`, defaulting to a no-op to preserve the package's standalone behavior.
- Wires both through `WorkflowUIProvider`, `WorkflowUIConfig`, and the package's public barrels (`provider/index.ts`, `stores/index.ts`, `stores/workflow/index.ts`, top-level `index.ts`).
- `apps/app`'s workflow detail and new-workflow page clients now inject their real `workflowsApi` CRUD methods and the chat/agent `applyEditOperations` implementation via these seams.

Part of #1151 (workflow-ui fork unification). The fork deletion for `apps/app`'s own legacy workflow store (`apps/app/src/store/workflow/`) is tracked separately as #1157 and is explicitly out of scope here — that file is untouched by this PR.

## Test plan

- [x] `bunx turbo run type-check --filter=@genfeedai/workflow-ui` — 12/12 tasks successful
- [x] `bunx turbo run type-check --filter=@genfeedai/app` — 18/18 tasks successful
- [x] `bun run test --filter=@genfeedai/workflow-ui` — 28 test files, 358 tests passed (including new `workflowPersistence.test.ts` and `applyEditOperations.test.ts`)
- [x] `bunx biome check --write` on all changed files — clean
- [x] Confirmed `apps/app/src/store/workflow/slices/persistenceSlice.ts` (the fork's own legacy store), `brand-persistence.service.ts`, and `use-agent-dashboard-persistence.ts` are untouched by this diff