### PR TITLE
feat(api,mcp): enforce org-role RBAC on MCP-proxied endpoints (PR 1/6)

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -41865,21 +41865,6 @@
         ]
       }
     },
-    "/services/google-ads/oauth/callback": {
-      "post": {
-        "operationId": "GoogleAdsController.handleOAuthCallback",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "handleOAuthCallback",
-        "tags": [
-          "services/google-ads"
-        ]
-      }
-    },
     "/services/google-ads/oauth/url": {
       "get": {
         "operationId": "GoogleAdsController.getOAuthUrl",

--- a/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.rbac.spec.ts
+++ b/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.rbac.spec.ts
@@ -1,0 +1,96 @@
+import { SocialInboxController } from '@api/collections/social-inbox/controllers/social-inbox.controller';
+
+describe('SocialInboxController RBAC', () => {
+  it('should require owner, admin, or creator role for syncYoutubeComments', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.syncYoutubeComments,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for createDraft', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.createDraft,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner or admin role for approveDraft', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.approveDraft,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for rejectDraft', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.rejectDraft,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for postReply', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.postReply,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for sendDm', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.sendDm,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for updateStatus', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.updateStatus,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for updateTags', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.updateTags,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for assignOwner', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      SocialInboxController.prototype.assignOwner,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should not require a role for listConversations, getConversation, or listMessages', () => {
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        SocialInboxController.prototype.listConversations,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        SocialInboxController.prototype.getConversation,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        SocialInboxController.prototype.listMessages,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.ts
+++ b/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.ts
@@ -17,13 +17,16 @@ import {
   type SocialInboxScope,
   SocialInboxService,
 } from '@api/collections/social-inbox/services/social-inbox.service';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import {
   serializeCollection,
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
+import { MemberRole } from '@genfeedai/enums';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
@@ -42,6 +45,7 @@ import {
   Query,
   Req,
   UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { Request } from 'express';
@@ -50,6 +54,7 @@ import type { Request } from 'express';
 @AutoSwagger()
 @ApiBearerAuth()
 @Controller('messages')
+@UseGuards(RolesGuard)
 export class SocialInboxController {
   constructor(private readonly socialInboxService: SocialInboxService) {}
 
@@ -66,6 +71,7 @@ export class SocialInboxController {
   }
 
   @Post('youtube/sync')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @ApiOperation({ summary: 'Sync recent YouTube comments into messages' })
   async syncYoutubeComments(
     @CurrentUser() user: User,
@@ -111,6 +117,7 @@ export class SocialInboxController {
   }
 
   @Post(':conversationId/drafts')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @ApiOperation({ summary: 'Create a local reply draft for review' })
   async createDraft(
     @Req() request: Request,
@@ -128,6 +135,7 @@ export class SocialInboxController {
   }
 
   @Post(':conversationId/drafts/:messageId/approve')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Approve and publish a draft reply or DM' })
   async approveDraft(
     @Req() request: Request,
@@ -145,6 +153,7 @@ export class SocialInboxController {
   }
 
   @Post(':conversationId/drafts/:messageId/reject')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Reject a draft reply or DM without publishing' })
   async rejectDraft(
     @Req() request: Request,
@@ -164,6 +173,7 @@ export class SocialInboxController {
   }
 
   @Post(':conversationId/replies')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Post a reply through the connected account' })
   async postReply(
     @Req() request: Request,
@@ -181,6 +191,7 @@ export class SocialInboxController {
   }
 
   @Post(':conversationId/dms')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Send a DM through a supported connected account' })
   async sendDm(
     @Req() request: Request,
@@ -198,6 +209,7 @@ export class SocialInboxController {
   }
 
   @Patch(':conversationId/status')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Update social conversation status' })
   async updateStatus(
     @Req() request: Request,
@@ -215,6 +227,7 @@ export class SocialInboxController {
   }
 
   @Patch(':conversationId/tags')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Replace social conversation tags' })
   async updateTags(
     @Req() request: Request,
@@ -232,6 +245,7 @@ export class SocialInboxController {
   }
 
   @Patch(':conversationId/assignment')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   @ApiOperation({ summary: 'Assign or unassign a social conversation' })
   async assignOwner(
     @Req() request: Request,

--- a/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.rbac.spec.ts
+++ b/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.rbac.spec.ts
@@ -1,0 +1,46 @@
+import { WorkflowExecutionsController } from '@api/collections/workflow-executions/controllers/workflow-executions.controller';
+
+describe('WorkflowExecutionsController RBAC', () => {
+  it('should require owner, admin, or creator role for create', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionsController.prototype.create,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for cancel', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionsController.prototype.cancel,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should not require a role for findAll, getWorkflowExecutions, getExecutionStats, or findOne', () => {
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowExecutionsController.prototype.findAll,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowExecutionsController.prototype.getWorkflowExecutions,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowExecutionsController.prototype.getExecutionStats,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowExecutionsController.prototype.findOne,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.ts
+++ b/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.ts
@@ -5,8 +5,10 @@ import {
 } from '@api/collections/workflow-executions/dto/create-workflow-execution.dto';
 import { WorkflowExecutionsService } from '@api/collections/workflow-executions/services/workflow-executions.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
@@ -16,8 +18,18 @@ import {
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import type { PrismaFindAllInput } from '@api/shared/services/base/base.service';
+import { MemberRole } from '@genfeedai/enums';
 import { WorkflowExecutionSerializer } from '@genfeedai/serializers';
-import { Body, Controller, Get, Param, Post, Query, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -31,6 +43,7 @@ import type { Request } from 'express';
 @ApiTags('Workflow Executions')
 @ApiBearerAuth()
 @Controller('workflow-executions')
+@UseGuards(RolesGuard)
 export class WorkflowExecutionsController {
   constructor(
     private readonly workflowExecutionsService: WorkflowExecutionsService,
@@ -169,6 +182,7 @@ export class WorkflowExecutionsController {
   }
 
   @Post()
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @ApiOperation({ summary: 'Create and start a new workflow execution' })
   @ApiResponse({ description: 'Execution created', status: 201 })
   async create(
@@ -194,6 +208,7 @@ export class WorkflowExecutionsController {
   }
 
   @Post(':id/cancel')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @ApiOperation({ summary: 'Cancel a running execution' })
   @ApiParam({ description: 'Execution ID', name: 'id' })
   @ApiResponse({ description: 'Execution cancelled', status: 200 })

--- a/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.rbac.spec.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.rbac.spec.ts
@@ -1,0 +1,56 @@
+import { WorkflowCrudController } from '@api/collections/workflows/controllers/workflow-crud.controller';
+
+describe('WorkflowCrudController RBAC', () => {
+  it('should require owner, admin, or creator role for create', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowCrudController.prototype.create,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for cloneWorkflow', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowCrudController.prototype.cloneWorkflow,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for update', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowCrudController.prototype.update,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for remove', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowCrudController.prototype.remove,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should not require a role for findAll, getStatistics, exportComfyUI, or findOne', () => {
+    expect(
+      Reflect.getMetadata('roles', WorkflowCrudController.prototype.findAll),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowCrudController.prototype.getStatistics,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowCrudController.prototype.exportComfyUI,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata('roles', WorkflowCrudController.prototype.findOne),
+    ).toBeUndefined();
+  });
+});

--- a/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.ts
@@ -5,9 +5,11 @@ import type { WorkflowDocument } from '@api/collections/workflows/schemas/workfl
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { SYSTEM_WORKFLOW_METADATA_KEY } from '@api/collections/workflows/system-workflow.contract';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { wrapError } from '@api/helpers/utils/controller/wrap-error.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
@@ -19,6 +21,7 @@ import {
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
+import { MemberRole } from '@genfeedai/enums';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
@@ -37,6 +40,7 @@ import {
   Post,
   Query,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
 
@@ -53,6 +57,7 @@ type WorkflowStatistics = Awaited<
  */
 @AutoSwagger()
 @Controller('workflows')
+@UseGuards(RolesGuard)
 export class WorkflowCrudController {
   private readonly constructorName: string = String(this.constructor.name);
 
@@ -62,6 +67,7 @@ export class WorkflowCrudController {
   ) {}
 
   @Post()
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async create(
     @Req() request: Request,
@@ -175,6 +181,7 @@ export class WorkflowCrudController {
   }
 
   @Post(':workflowId/clone')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async cloneWorkflow(
     @Req() request: Request,
@@ -196,6 +203,7 @@ export class WorkflowCrudController {
   }
 
   @Patch(':workflowId')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async update(
     @Req() request: Request,
@@ -221,6 +229,7 @@ export class WorkflowCrudController {
   }
 
   @Delete(':workflowId')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async remove(
     @Req() request: Request,

--- a/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.rbac.spec.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.rbac.spec.ts
@@ -1,0 +1,98 @@
+import { WorkflowExecutionController } from '@api/collections/workflows/controllers/workflow-execution.controller';
+
+describe('WorkflowExecutionController RBAC', () => {
+  it('should require owner, admin, or creator role for setSchedule', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.setSchedule,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for removeSchedule', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.removeSchedule,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for executePartial', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.executePartial,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for resumeExecution', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.resumeExecution,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for publishWorkflowLifecycle', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.publishWorkflowLifecycle,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for archiveWorkflow', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.archiveWorkflow,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for submitApproval', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.submitApproval,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for lockNodes', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.lockNodes,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for unlockNodes', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.unlockNodes,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should require owner, admin, or creator role for setThumbnail', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      WorkflowExecutionController.prototype.setThumbnail,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'creator']);
+  });
+
+  it('should not require a role for getCreditsEstimate or getExecutionLogs', () => {
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowExecutionController.prototype.getCreditsEstimate,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(
+        'roles',
+        WorkflowExecutionController.prototype.getExecutionLogs,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.ts
@@ -13,14 +13,17 @@ import { WorkflowRunControlService } from '@api/collections/workflows/services/w
 import { WorkflowSchedulerService } from '@api/collections/workflows/services/workflow-scheduler.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { wrapError } from '@api/helpers/utils/controller/wrap-error.util';
 import {
   returnNotFound,
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
+import { MemberRole } from '@genfeedai/enums';
 import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import {
   WorkflowExecutionSerializer,
@@ -38,6 +41,7 @@ import {
   Post,
   Query,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
 
@@ -48,6 +52,7 @@ import type { Request } from 'express';
  */
 @AutoSwagger()
 @Controller('workflows')
+@UseGuards(RolesGuard)
 export class WorkflowExecutionController {
   private readonly constructorName: string = String(this.constructor.name);
 
@@ -60,6 +65,7 @@ export class WorkflowExecutionController {
   ) {}
 
   @Post(':workflowId/schedule')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async setSchedule(
     @Param('workflowId') workflowId: string,
@@ -88,6 +94,7 @@ export class WorkflowExecutionController {
   }
 
   @Delete(':workflowId/schedule')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async removeSchedule(
     @Param('workflowId') workflowId: string,
@@ -115,6 +122,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/execute/partial')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async executePartial(
     @Req() request: Request,
@@ -146,6 +154,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/execute/resume/:runId')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async resumeExecution(
     @Param('workflowId') workflowId: string,
@@ -186,6 +195,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/lifecycle/publish')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async publishWorkflowLifecycle(
     @Req() request: Request,
@@ -204,6 +214,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/lifecycle/archive')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async archiveWorkflow(
     @Req() request: Request,
@@ -241,6 +252,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/executions/:executionId/approve')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async submitApproval(
     @Param('workflowId') workflowId: string,
@@ -275,6 +287,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/nodes/lock')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async lockNodes(
     @Req() request: Request,
@@ -300,6 +313,7 @@ export class WorkflowExecutionController {
   }
 
   @Post(':workflowId/nodes/unlock')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async unlockNodes(
     @Req() request: Request,
@@ -325,6 +339,7 @@ export class WorkflowExecutionController {
   }
 
   @Patch(':workflowId/thumbnail')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.CREATOR)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async setThumbnail(
     @Req() request: Request,

--- a/apps/server/api/src/config/openapi-internal-routes.json
+++ b/apps/server/api/src/config/openapi-internal-routes.json
@@ -18,10 +18,6 @@
       "reason": "OAuth provider browser-redirect callback"
     },
     {
-      "pathPrefix": "/services/google-ads/oauth/callback",
-      "reason": "OAuth provider browser-redirect callback"
-    },
-    {
       "pathPrefix": "/internal/",
       "reason": "Service-to-service internal endpoints (API-key guarded, not user-callable)"
     },

--- a/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.rbac.spec.ts
+++ b/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.rbac.spec.ts
@@ -1,0 +1,75 @@
+import { GoogleAdsController } from '@api/services/integrations/google-ads/controllers/google-ads.controller';
+
+describe('GoogleAdsController RBAC', () => {
+  it('should require owner or admin role for connect', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.connect,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for verify', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.verify,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for getOAuthUrl', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.getOAuthUrl,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner, admin, or analytics role for listCustomers', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.listCustomers,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for listCampaigns', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.listCampaigns,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for getCampaignMetrics', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.getCampaignMetrics,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for getAdGroupInsights', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.getAdGroupInsights,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for getKeywordPerformance', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.getKeywordPerformance,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for getSearchTerms', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      GoogleAdsController.prototype.getSearchTerms,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+});

--- a/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.spec.ts
@@ -1,5 +1,6 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -110,7 +111,10 @@ describe('GoogleAdsController', () => {
         { provide: GoogleAdsOAuthService, useValue: googleAdsOAuthService },
         { provide: LoggerService, useValue: loggerService },
       ],
-    }).compile();
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<GoogleAdsController>(GoogleAdsController);
   });

--- a/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.spec.ts
@@ -130,23 +130,6 @@ describe('GoogleAdsController', () => {
     });
   });
 
-  describe('handleOAuthCallback', () => {
-    it('exchanges code for tokens', async () => {
-      const result = await controller.handleOAuthCallback({
-        code: 'auth-code',
-      });
-      expect(
-        googleAdsOAuthService.exchangeAuthCodeForAccessToken,
-      ).toHaveBeenCalledWith('auth-code');
-      expect(result).toEqual({
-        accessToken: 'tok',
-        expiresIn: 3600,
-        refreshToken: 'ref',
-        tokenType: 'Bearer',
-      });
-    });
-  });
-
   describe('verify', () => {
     it('persists verified credential using access token', async () => {
       googleAdsService.listAccessibleCustomers.mockResolvedValue([
@@ -159,7 +142,7 @@ describe('GoogleAdsController', () => {
         },
       ] as never);
 
-      const result = await controller.verify({} as never, {
+      const result = await controller.verify({} as never, mockUser, {
         code: 'auth-code',
         state: JSON.stringify({
           brandId: 'test-object-id',
@@ -176,8 +159,25 @@ describe('GoogleAdsController', () => {
 
     it('throws when code or state is missing', async () => {
       await expect(
-        controller.verify({} as never, { code: 'auth-code' }),
+        controller.verify({} as never, mockUser, { code: 'auth-code' }),
       ).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it("rejects when the state's organization does not match the caller", async () => {
+      await expect(
+        controller.verify({} as never, mockUser, {
+          code: 'auth-code',
+          state: JSON.stringify({
+            brandId: 'test-object-id',
+            organizationId: 'a-different-org',
+          }),
+        }),
+      ).rejects.toBeInstanceOf(HttpException);
+
+      // The token exchange must never run for a cross-org state.
+      expect(
+        googleAdsOAuthService.exchangeAuthCodeForAccessToken,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.ts
+++ b/apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.ts
@@ -5,15 +5,17 @@ import {
   CreateCredentialVerifyDto,
 } from '@api/collections/credentials/dto/create-credential.dto';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { serializeSingle } from '@api/helpers/utils/response/response.util';
 import { GoogleAdsMetricsParams } from '@api/services/integrations/google-ads/interfaces/google-ads.interface';
 import { GoogleAdsService } from '@api/services/integrations/google-ads/services/google-ads.service';
 import { GoogleAdsOAuthService } from '@api/services/integrations/google-ads/services/google-ads-oauth.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
-import { CredentialPlatform } from '@genfeedai/enums';
+import { CredentialPlatform, MemberRole } from '@genfeedai/enums';
 import {
   CredentialOAuthSerializer,
   CredentialSerializer,
@@ -30,11 +32,13 @@ import {
   Post,
   Query,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
 
 @AutoSwagger()
 @Controller('services/google-ads')
+@UseGuards(RolesGuard)
 export class GoogleAdsController {
   private readonly constructorName: string = String(this.constructor.name);
 
@@ -47,6 +51,7 @@ export class GoogleAdsController {
   ) {}
 
   @Post('connect')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async connect(
     @Req() request: Request,
     @CurrentUser() user: User,
@@ -91,8 +96,10 @@ export class GoogleAdsController {
   }
 
   @Post('verify')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async verify(
     @Req() request: Request,
+    @CurrentUser() user: User,
     @Body() body: Partial<CreateCredentialVerifyDto>,
   ) {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
@@ -109,6 +116,21 @@ export class GoogleAdsController {
     }
 
     const { brandId, organizationId } = JSON.parse(body.state);
+
+    // Bind the OAuth state to the caller: the org encoded in the state must
+    // match the authenticated caller's active organization. Prevents a member
+    // of org A from completing a credential exchange scoped to org B.
+    const callerOrganizationId = getPublicMetadata(user).organization;
+    if (organizationId !== callerOrganizationId) {
+      throw new HttpException(
+        {
+          detail: 'OAuth state does not match your organization',
+          title: 'OAuth Error',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     const credential = await this.credentialsService.findOne({
       brand: brandId,
       isDeleted: false,
@@ -155,24 +177,13 @@ export class GoogleAdsController {
   }
 
   @Get('oauth/url')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   getOAuthUrl(@Query('state') state: string) {
     return { url: this.googleAdsOAuthService.generateAuthUrl(state) };
   }
 
-  @Post('oauth/callback')
-  async handleOAuthCallback(@Body() body: { code: string; state?: string }) {
-    if (body.state) {
-      const tokens =
-        await this.googleAdsOAuthService.exchangeAuthCodeForAccessToken(
-          body.code,
-        );
-      return tokens;
-    }
-
-    return this.googleAdsOAuthService.exchangeAuthCodeForAccessToken(body.code);
-  }
-
   @Get('customers')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async listCustomers(@CurrentUser() user: User) {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${caller} started`);
@@ -182,6 +193,7 @@ export class GoogleAdsController {
   }
 
   @Get('campaigns')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async listCampaigns(
     @CurrentUser() user: User,
     @Query('customerId') customerId: string,
@@ -202,6 +214,7 @@ export class GoogleAdsController {
   }
 
   @Get('campaigns/:id/metrics')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getCampaignMetrics(
     @CurrentUser() user: User,
     @Param('id') campaignId: string,
@@ -232,6 +245,7 @@ export class GoogleAdsController {
   }
 
   @Get('ad-groups/:id/insights')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getAdGroupInsights(
     @CurrentUser() user: User,
     @Param('id') adGroupId: string,
@@ -258,6 +272,7 @@ export class GoogleAdsController {
   }
 
   @Get('keywords')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getKeywordPerformance(
     @CurrentUser() user: User,
     @Query('customerId') customerId: string,
@@ -286,6 +301,7 @@ export class GoogleAdsController {
   }
 
   @Get('search-terms/:campaignId')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getSearchTerms(
     @CurrentUser() user: User,
     @Param('campaignId') campaignId: string,

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-bulk.controller.rbac.spec.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-bulk.controller.rbac.spec.ts
@@ -1,0 +1,35 @@
+import { MetaAdsBulkController } from '@api/services/integrations/meta-ads/controllers/meta-ads-bulk.controller';
+
+describe('MetaAdsBulkController RBAC', () => {
+  it('should require owner or admin role for createBulkUpload', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsBulkController.prototype.createBulkUpload,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for cancelJob', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsBulkController.prototype.cancelJob,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner, admin, or analytics role for listJobs', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsBulkController.prototype.listJobs,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for getJobStatus', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsBulkController.prototype.getJobStatus,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+});

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-bulk.controller.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-bulk.controller.ts
@@ -5,19 +5,29 @@ import type {
 } from '@api/collections/ad-bulk-upload-jobs/schemas/ad-bulk-upload-job.schema';
 import { AdBulkUploadJobsService } from '@api/collections/ad-bulk-upload-jobs/services/ad-bulk-upload-jobs.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import {
   extractRequestContext,
   getPublicMetadata,
 } from '@api/helpers/utils/auth/auth.util';
 import { AdBulkUploadService } from '@api/services/integrations/meta-ads/services/ad-bulk-upload.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
-import { CredentialPlatform } from '@genfeedai/enums';
+import { CredentialPlatform, MemberRole } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 
 interface CreateBulkUploadBody {
   credentialId: string;
@@ -35,6 +45,7 @@ interface CreateBulkUploadBody {
 
 @AutoSwagger()
 @Controller('services/meta-ads/bulk')
+@UseGuards(RolesGuard)
 export class MetaAdsBulkController {
   private readonly constructorName: string = String(this.constructor.name);
 
@@ -46,6 +57,7 @@ export class MetaAdsBulkController {
   ) {}
 
   @Post('upload')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async createBulkUpload(
     @CurrentUser() user: User,
     @Body() body: CreateBulkUploadBody,
@@ -74,6 +86,7 @@ export class MetaAdsBulkController {
   }
 
   @Get('jobs')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async listJobs(
     @CurrentUser() user: User,
     @Query('status') status?: BulkUploadStatus,
@@ -93,6 +106,7 @@ export class MetaAdsBulkController {
   }
 
   @Get('jobs/:id')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getJobStatus(@CurrentUser() user: User, @Param('id') id: string) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);
@@ -111,6 +125,7 @@ export class MetaAdsBulkController {
   }
 
   @Post('jobs/:id/cancel')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async cancelJob(@CurrentUser() user: User, @Param('id') id: string) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-optimization.controller.rbac.spec.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-optimization.controller.rbac.spec.ts
@@ -1,0 +1,59 @@
+import { MetaAdsOptimizationController } from '@api/services/integrations/meta-ads/controllers/meta-ads-optimization.controller';
+
+describe('MetaAdsOptimizationController RBAC', () => {
+  it('should require owner or admin role for approveRecommendation', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.approveRecommendation,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for rejectRecommendation', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.rejectRecommendation,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for executeRecommendation', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.executeRecommendation,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner or admin role for updateConfig', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.updateConfig,
+    );
+    expect(metadata).toEqual(['owner', 'admin']);
+  });
+
+  it('should require owner, admin, or analytics role for listRecommendations', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.listRecommendations,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for getConfig', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.getConfig,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+
+  it('should require owner, admin, or analytics role for listAuditLogs', () => {
+    const metadata = Reflect.getMetadata(
+      'roles',
+      MetaAdsOptimizationController.prototype.listAuditLogs,
+    );
+    expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+  });
+});

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-optimization.controller.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads-optimization.controller.ts
@@ -9,16 +9,18 @@ import type {
 } from '@api/collections/ad-optimization-recommendations/schemas/ad-optimization-recommendation.schema';
 import { AdOptimizationRecommendationsService } from '@api/collections/ad-optimization-recommendations/services/ad-optimization-recommendations.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import {
   extractRequestContext,
   getPublicMetadata,
 } from '@api/helpers/utils/auth/auth.util';
 import { MetaAdsService } from '@api/services/integrations/meta-ads/services/meta-ads.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
-import { CredentialPlatform } from '@genfeedai/enums';
+import { CredentialPlatform, MemberRole } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
@@ -30,10 +32,12 @@ import {
   Post,
   Put,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 
 @AutoSwagger()
 @Controller('services/meta-ads/optimization')
+@UseGuards(RolesGuard)
 export class MetaAdsOptimizationController {
   private readonly constructorName: string = String(this.constructor.name);
 
@@ -49,6 +53,7 @@ export class MetaAdsOptimizationController {
   // ─── Recommendations ──────────────────────────────────────────────────────
 
   @Get('recommendations')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async listRecommendations(
     @CurrentUser() user: User,
     @Query('status') status?: RecommendationStatus,
@@ -70,6 +75,7 @@ export class MetaAdsOptimizationController {
   }
 
   @Post('recommendations/:id/approve')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async approveRecommendation(
     @CurrentUser() user: User,
     @Param('id') id: string,
@@ -91,6 +97,7 @@ export class MetaAdsOptimizationController {
   }
 
   @Post('recommendations/:id/reject')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async rejectRecommendation(
     @CurrentUser() user: User,
     @Param('id') id: string,
@@ -113,6 +120,7 @@ export class MetaAdsOptimizationController {
   }
 
   @Post('recommendations/:id/execute')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async executeRecommendation(
     @CurrentUser() user: User,
     @Param('id') id: string,
@@ -198,6 +206,7 @@ export class MetaAdsOptimizationController {
   // ─── Config ───────────────────────────────────────────────────────────────
 
   @Get('config')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getConfig(@CurrentUser() user: User) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);
@@ -211,6 +220,7 @@ export class MetaAdsOptimizationController {
   }
 
   @Put('config')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async updateConfig(
     @CurrentUser() user: User,
     @Body() body: Partial<AdOptimizationConfigDocument>,
@@ -226,6 +236,7 @@ export class MetaAdsOptimizationController {
   // ─── Audit Logs ───────────────────────────────────────────────────────────
 
   @Get('audit-logs')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async listAuditLogs(
     @CurrentUser() user: User,
     @Query('limit') limit?: string,

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads.controller.rbac.spec.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads.controller.rbac.spec.ts
@@ -1,0 +1,48 @@
+import { MetaAdsController } from '@api/services/integrations/meta-ads/controllers/meta-ads.controller';
+
+describe('MetaAdsController RBAC', () => {
+  it('should require owner, admin, or analytics role for read endpoints', () => {
+    const readMethods = [
+      'getAdAccounts',
+      'listCampaigns',
+      'compareCampaigns',
+      'getCampaignInsights',
+      'getAdSetInsights',
+      'getAdInsights',
+      'getAdCreatives',
+      'getTopPerformers',
+    ] as const;
+
+    for (const method of readMethods) {
+      const metadata = Reflect.getMetadata(
+        'roles',
+        MetaAdsController.prototype[method],
+      );
+      expect(metadata).toEqual(['owner', 'admin', 'analytics']);
+    }
+  });
+
+  it('should require owner or admin role for write endpoints', () => {
+    const writeMethods = [
+      'createCampaign',
+      'updateCampaign',
+      'pauseCampaign',
+      'updateCampaignBudget',
+      'createAdSet',
+      'updateAdSet',
+      'createAd',
+      'pauseAd',
+      'deleteAd',
+      'uploadAdImage',
+      'uploadAdVideo',
+    ] as const;
+
+    for (const method of writeMethods) {
+      const metadata = Reflect.getMetadata(
+        'roles',
+        MetaAdsController.prototype[method],
+      );
+      expect(metadata).toEqual(['owner', 'admin']);
+    }
+  });
+});

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads.controller.spec.ts
@@ -13,6 +13,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { MetaAdsController } from '@api/services/integrations/meta-ads/controllers/meta-ads.controller';
 import { MetaAdsService } from '@api/services/integrations/meta-ads/services/meta-ads.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
@@ -101,7 +102,10 @@ describe('MetaAdsController', () => {
         { provide: LoggerService, useValue: loggerService },
         { provide: MetaAdsService, useValue: metaAdsService },
       ],
-    }).compile();
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get(MetaAdsController);
   });

--- a/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads.controller.ts
+++ b/apps/server/api/src/services/integrations/meta-ads/controllers/meta-ads.controller.ts
@@ -1,9 +1,11 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import type {
   CreateAdParams,
@@ -15,7 +17,7 @@ import type {
 } from '@api/services/integrations/meta-ads/interfaces/meta-ads.interface';
 import { MetaAdsService } from '@api/services/integrations/meta-ads/services/meta-ads.service';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
-import { CredentialPlatform } from '@genfeedai/enums';
+import { CredentialPlatform, MemberRole } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
@@ -27,10 +29,12 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 
 @AutoSwagger()
 @Controller('services/meta-ads')
+@UseGuards(RolesGuard)
 export class MetaAdsController {
   private readonly constructorName: string = String(this.constructor.name);
 
@@ -42,6 +46,7 @@ export class MetaAdsController {
   ) {}
 
   @Get('accounts')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getAdAccounts(@CurrentUser() user: User) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);
@@ -51,6 +56,7 @@ export class MetaAdsController {
   }
 
   @Get('campaigns')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async listCampaigns(
     @CurrentUser() user: User,
     @Query('adAccountId') adAccountId: string,
@@ -68,6 +74,7 @@ export class MetaAdsController {
   }
 
   @Get('campaigns/compare')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async compareCampaigns(
     @CurrentUser() user: User,
     @Query('campaignIds') campaignIds: string,
@@ -85,6 +92,7 @@ export class MetaAdsController {
   }
 
   @Get('campaigns/:id/insights')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getCampaignInsights(
     @CurrentUser() user: User,
     @Param('id') campaignId: string,
@@ -108,6 +116,7 @@ export class MetaAdsController {
   }
 
   @Get('adsets/:id/insights')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getAdSetInsights(
     @CurrentUser() user: User,
     @Param('id') adSetId: string,
@@ -127,6 +136,7 @@ export class MetaAdsController {
   }
 
   @Get('ads/:id/insights')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getAdInsights(
     @CurrentUser() user: User,
     @Param('id') adId: string,
@@ -146,6 +156,7 @@ export class MetaAdsController {
   }
 
   @Get('creatives')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getAdCreatives(
     @CurrentUser() user: User,
     @Query('adAccountId') adAccountId: string,
@@ -161,6 +172,7 @@ export class MetaAdsController {
   }
 
   @Get('top-performers')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN, MemberRole.ANALYTICS)
   async getTopPerformers(
     @CurrentUser() user: User,
     @Query('adAccountId') adAccountId: string,
@@ -182,6 +194,7 @@ export class MetaAdsController {
   // ─── Write Endpoints ──────────────────────────────────────────────────────
 
   @Post('campaigns')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async createCampaign(
     @CurrentUser() user: User,
     @Body() body: { adAccountId: string } & CreateCampaignParams,
@@ -200,6 +213,7 @@ export class MetaAdsController {
   }
 
   @Patch('campaigns/:id')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async updateCampaign(
     @CurrentUser() user: User,
     @Param('id') campaignId: string,
@@ -214,6 +228,7 @@ export class MetaAdsController {
   }
 
   @Post('campaigns/:id/pause')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async pauseCampaign(
     @CurrentUser() user: User,
     @Param('id') campaignId: string,
@@ -227,6 +242,7 @@ export class MetaAdsController {
   }
 
   @Patch('campaigns/:id/budget')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async updateCampaignBudget(
     @CurrentUser() user: User,
     @Param('id') campaignId: string,
@@ -246,6 +262,7 @@ export class MetaAdsController {
   }
 
   @Post('adsets')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async createAdSet(
     @CurrentUser() user: User,
     @Body() body: { adAccountId: string } & CreateAdSetParams,
@@ -264,6 +281,7 @@ export class MetaAdsController {
   }
 
   @Patch('adsets/:id')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async updateAdSet(
     @CurrentUser() user: User,
     @Param('id') adSetId: string,
@@ -278,6 +296,7 @@ export class MetaAdsController {
   }
 
   @Post('ads')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async createAd(
     @CurrentUser() user: User,
     @Body() body: { adAccountId: string } & CreateAdParams,
@@ -296,6 +315,7 @@ export class MetaAdsController {
   }
 
   @Post('ads/:id/pause')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async pauseAd(@CurrentUser() user: User, @Param('id') adId: string) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);
@@ -306,6 +326,7 @@ export class MetaAdsController {
   }
 
   @Delete('ads/:id')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async deleteAd(@CurrentUser() user: User, @Param('id') adId: string) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);
@@ -316,6 +337,7 @@ export class MetaAdsController {
   }
 
   @Post('media/image')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async uploadAdImage(
     @CurrentUser() user: User,
     @Body() body: { adAccountId: string; imageUrl: string },
@@ -332,6 +354,7 @@ export class MetaAdsController {
   }
 
   @Post('media/video')
+  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
   async uploadAdVideo(
     @CurrentUser() user: User,
     @Body() body: { adAccountId: string; videoUrl: string; title?: string },

--- a/apps/server/mcp/src/mcp/controllers/mcp.controller.spec.ts
+++ b/apps/server/mcp/src/mcp/controllers/mcp.controller.spec.ts
@@ -206,8 +206,11 @@ describe('McpController', () => {
   });
 
   describe('getTools', () => {
-    it('should return list of available tools', () => {
-      const result = controller.getTools();
+    it('should return role-filtered list of available tools', () => {
+      const request = {
+        authContext: { role: 'superadmin' },
+      } as unknown as Parameters<typeof controller.getTools>[0];
+      const result = controller.getTools(request);
       expect(result).toHaveProperty('tools');
       expect(Array.isArray(result.tools)).toBe(true);
       expect(result.tools.length).toBeGreaterThan(0);
@@ -218,6 +221,27 @@ describe('McpController', () => {
       );
       expect(createVideoTool).toBeDefined();
       expect(createVideoTool?.inputSchema).toBeDefined();
+    });
+
+    it('applies role filtering so a user never sees more than a superadmin', () => {
+      const userRequest = {
+        authContext: { role: 'user' },
+      } as unknown as Parameters<typeof controller.getTools>[0];
+      const superRequest = {
+        authContext: { role: 'superadmin' },
+      } as unknown as Parameters<typeof controller.getTools>[0];
+
+      const userTools = controller
+        .getTools(userRequest)
+        .tools.map((tool) => tool.name);
+      const superTools = controller
+        .getTools(superRequest)
+        .tools.map((tool) => tool.name);
+
+      // Whatever a user can discover, a superadmin can too (subset invariant).
+      for (const name of userTools) {
+        expect(superTools).toContain(name);
+      }
     });
   });
 

--- a/apps/server/mcp/src/mcp/controllers/mcp.controller.ts
+++ b/apps/server/mcp/src/mcp/controllers/mcp.controller.ts
@@ -4,13 +4,16 @@ import { LoggerService } from '@libs/logger/logger.service';
 import * as appMetadata from '@mcp/config/app-metadata.json';
 import { MCPService } from '@mcp/mcp/services/mcp.service';
 import { getPublicMcpUrl, renderSetupPage } from '@mcp/mcp/setup-page';
+import { type McpRole } from '@mcp/services/auth.service';
 import { ClientService } from '@mcp/services/client.service';
 import { ServerService } from '@mcp/services/server.service';
+import { ToolRegistryService } from '@mcp/services/tool-registry.service';
+import type { McpTool } from '@mcp/shared/interfaces/mcp-server.interface';
 import { Body, Controller, Get, Param, Post, Req, Res } from '@nestjs/common';
 import type { Request, Response } from 'express';
 
 interface AuthenticatedRequest extends Request {
-  authContext?: { token?: string };
+  authContext?: { token?: string; role?: McpRole };
 }
 
 @Controller()
@@ -108,9 +111,11 @@ export class McpController {
   }
 
   @Get('tools')
-  getTools() {
+  getTools(@Req() request: AuthenticatedRequest) {
+    const role: McpRole = request?.authContext?.role ?? 'user';
+    const tools = toMcpTools(getToolsForSurface('mcp')) as McpTool[];
     return {
-      tools: toMcpTools(getToolsForSurface('mcp')),
+      tools: ToolRegistryService.filterToolsByRole(tools, role),
     };
   }
 
@@ -159,9 +164,9 @@ export class McpController {
     toolName: string,
     args: Record<string, unknown> | null,
   ) {
-    const isKnownTool = this.getTools().tools.some(
-      (tool: { name: string }) => tool.name === toolName,
-    );
+    const isKnownTool = (
+      toMcpTools(getToolsForSurface('mcp')) as McpTool[]
+    ).some((tool) => tool.name === toolName);
     if (!isKnownTool) {
       throw new Error(`Unknown tool: ${toolName}`);
     }

--- a/apps/server/mcp/src/services/tool-registry.listing.spec.ts
+++ b/apps/server/mcp/src/services/tool-registry.listing.spec.ts
@@ -1,0 +1,104 @@
+import { LoggerService } from '@libs/logger/logger.service';
+import { ClientService } from '@mcp/services/client.service';
+import { ToolRegistryService } from '@mcp/services/tool-registry.service';
+import type { McpTool } from '@mcp/shared/interfaces/mcp-server.interface';
+
+/**
+ * Unit coverage for the role-aware `tools/list` filter. This is the UX gate that
+ * hides tools a caller cannot invoke from discovery (the authoritative gate is
+ * the per-call role check in `handleToolCall`). Both the JSON-RPC path
+ * (`getTools`) and the REST mirror (`GET /v1/tools`) must go through the same
+ * filter, so we assert the shared primitive `filterToolsByRole` plus the
+ * per-instance `getToolsForRole`.
+ */
+
+const USER_TOOL = {
+  description: 'user tool',
+  inputSchema: { properties: {}, type: 'object' },
+  name: 'list_posts',
+  requiredRole: 'user',
+} as McpTool;
+
+const ADMIN_TOOL = {
+  description: 'admin tool',
+  inputSchema: { properties: {}, type: 'object' },
+  name: 'get_darkroom_health',
+  requiredRole: 'admin',
+} as McpTool;
+
+const SUPERADMIN_TOOL = {
+  description: 'superadmin tool',
+  inputSchema: { properties: {}, type: 'object' },
+  name: 'control_comfyui',
+  requiredRole: 'superadmin',
+} as McpTool;
+
+const ALL_TOOLS = [USER_TOOL, ADMIN_TOOL, SUPERADMIN_TOOL];
+
+vi.mock('@genfeedai/tools', () => ({
+  getToolByName: vi.fn(),
+  getToolsForSurface: vi.fn(() => ALL_TOOLS),
+  toMcpTools: vi.fn((tools) => tools),
+}));
+
+function build(role: 'user' | 'admin' | 'superadmin') {
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  return new ToolRegistryService(
+    {} as unknown as ClientService,
+    logger as unknown as LoggerService,
+    role,
+  );
+}
+
+const names = (tools: McpTool[]): string[] => tools.map((t) => t.name).sort();
+
+describe('ToolRegistryService.filterToolsByRole', () => {
+  it('gives a user only user-tier tools', () => {
+    expect(
+      names(ToolRegistryService.filterToolsByRole(ALL_TOOLS, 'user')),
+    ).toEqual(['list_posts']);
+  });
+
+  it('gives an admin user- and admin-tier tools, not superadmin', () => {
+    expect(
+      names(ToolRegistryService.filterToolsByRole(ALL_TOOLS, 'admin')),
+    ).toEqual(['get_darkroom_health', 'list_posts']);
+  });
+
+  it('gives a superadmin every tool', () => {
+    expect(
+      names(ToolRegistryService.filterToolsByRole(ALL_TOOLS, 'superadmin')),
+    ).toEqual(['control_comfyui', 'get_darkroom_health', 'list_posts']);
+  });
+});
+
+describe('ToolRegistryService listing filters by the caller role', () => {
+  it('getToolsForRole scopes discovery to the requested role', () => {
+    const registry = build('user');
+    expect(names(registry.getToolsForRole('admin'))).toEqual([
+      'get_darkroom_health',
+      'list_posts',
+    ]);
+  });
+
+  it('getTools defaults to the per-request role threaded into the constructor', () => {
+    expect(names(build('user').getTools())).toEqual(['list_posts']);
+    expect(names(build('admin').getTools())).toEqual([
+      'get_darkroom_health',
+      'list_posts',
+    ]);
+  });
+
+  it('getAllTools returns the unfiltered surface for internal checks', () => {
+    expect(names(build('user').getAllTools())).toEqual([
+      'control_comfyui',
+      'get_darkroom_health',
+      'list_posts',
+    ]);
+  });
+});

--- a/apps/server/mcp/src/services/tool-registry.service.ts
+++ b/apps/server/mcp/src/services/tool-registry.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@genfeedai/tools';
 import { LoggerService } from '@libs/logger/logger.service';
 import { McpAuthGuard } from '@mcp/guards/mcp-auth.guard';
-import { type McpRole } from '@mcp/services/auth.service';
+import { AuthService, type McpRole } from '@mcp/services/auth.service';
 import { ClientService } from '@mcp/services/client.service';
 import type { McpApprovalResource } from '@mcp/shared/interfaces/approval.interface';
 import type {
@@ -100,8 +100,35 @@ export class ToolRegistryService {
     @Optional() private readonly requestRole: McpRole = 'user',
   ) {}
 
-  getTools(): McpTool[] {
+  /**
+   * Every MCP-surfaced tool, unfiltered. Prefer {@link getToolsForRole} for
+   * anything a client sees — an unfiltered list advertises tools the caller
+   * cannot invoke.
+   */
+  getAllTools(): McpTool[] {
     return toMcpTools(getToolsForSurface('mcp')) as McpTool[];
+  }
+
+  /**
+   * Tools the given role is allowed to invoke. This is a UX/least-surprise
+   * filter for `tools/list` (and the REST mirror) — the authoritative gate is
+   * the per-call {@link McpAuthGuard.checkToolRole} in {@link handleToolCall}
+   * and, ultimately, the API's own role guards.
+   */
+  static filterToolsByRole(tools: McpTool[], role: McpRole): McpTool[] {
+    return tools.filter(
+      (tool) =>
+        !tool.requiredRole ||
+        AuthService.hasRequiredRole(role, tool.requiredRole),
+    );
+  }
+
+  getToolsForRole(role: McpRole): McpTool[] {
+    return ToolRegistryService.filterToolsByRole(this.getAllTools(), role);
+  }
+
+  getTools(): McpTool[] {
+    return this.getToolsForRole(this.requestRole);
   }
 
   getResources(): McpResource[] {


### PR DESCRIPTION
## Context

Part **1 of 6** in the MCP platform hardening & catalog-harmonization effort (comparison against vitae.ai's production MCP surfaced auth/rate-limit/drift gaps + a bypassable RBAC model).

The MCP server (`apps/server/mcp`) is a thin, **bypassable** HTTP proxy to the main API. Any org member holding a `gf_` API key can call the underlying API endpoints directly, so the MCP-layer `requiredRole` check was the *only* gate on several mutating surfaces. An audit found three tiers: properly-guarded controllers, dead routes (404, no live gap), and a **genuine bypass class** — social-inbox and workflow controllers with no role guard at all.

**Principle:** authoritative RBAC lives at the API (the only real boundary). The MCP `requiredRole` is retained purely as a UX/least-surprise catalog filter.

## What this PR does

**API — make the API authoritative for roles** (existing opt-in pattern: class-level `@UseGuards(RolesGuard)` + per-route `@RolesDecorator`; superadmin bypass and org-membership resolution already live in `RolesGuard`):
- **social-inbox** — drafts/reply/DM/status/tags/assignment gated (creators can draft; owners/admins publish/manage)
- **workflows** (`WorkflowExecutionController`, `WorkflowCrudController`) + **`WorkflowExecutionsController`** — create/execute/cancel/schedule/lifecycle gated to owner/admin/creator
- **meta-ads** (+ **bulk**, + **optimization**) and **google-ads** — reads gated to owner/admin/analytics, writes to owner/admin
- **google-ads** — bind OAuth `verify()` state to the caller's active org (reject cross-org completion); **delete the dead `oauth/callback` endpoint** that exchanged a code and returned raw Google tokens (no API caller; the extension only string-matches the redirect URL)

Reads on these controllers now also require **active org membership** (previously authentication-only) — a deliberate tightening consistent with their org-scoped nature.

**MCP — centralize role-aware tool listing** so both the JSON-RPC `tools/list` path and the REST `GET /v1/tools` mirror hide tools the caller cannot invoke (`ToolRegistryService.filterToolsByRole` / `getToolsForRole`, consumed by both). Filtering only one would leak the catalog via the other.

## Tests
- Role-metadata `*.rbac.spec.ts` per touched controller (canonical `Reflect.getMetadata('roles', …)` pattern, mirrors `scenes.controller.spec.ts`)
- MCP role-filter unit specs (`tool-registry.listing.spec.ts`) + controller `GET /v1/tools` subset-invariant test — **pass locally (25 green)**
- `google-ads.controller.spec.ts` updated for the new `verify()` signature + a cross-org rejection test

## Verification notes
- MCP package specs pass locally; API unit suite runs in CI (the worktree's `@genfeedai/prisma` client isn't generated locally — the pre-existing `scenes` spec fails identically, so this is environmental, not from this change).
- Adversarially reviewed with Codex (read-only); the one blocker it found — stale `handleOAuthCallback`/`verify` references in the google-ads spec — is fixed.

## Reviewer focus
Auth-critical diff. Confirm the owner/admin/creator/analytics splits match product intent, and that the google-ads org-binding check can't be bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)