### PR TITLE
feat(mcp): per-caller rate limiting on the MCP transport (PR 3/6)

### DIFF
--- a/apps/server/mcp/src/config/config.service.ts
+++ b/apps/server/mcp/src/config/config.service.ts
@@ -23,5 +23,9 @@ export class ConfigService extends createServiceConfig<IEnvConfig>({
   extend: {
     // MCP-specific
     GENFEEDAI_API_KEY: Joi.string().optional().allow(''),
+    // Per-caller request cap for the MCP transport (sliding window). Keyed by
+    // hashed bearer token, or client IP for unauthenticated requests.
+    MCP_RATE_LIMIT_PER_MINUTE: Joi.number().min(1).default(60),
+    MCP_RATE_LIMIT_WINDOW_MS: Joi.number().min(1000).default(60000),
   },
 }) {}

--- a/apps/server/mcp/src/guards/mcp-auth.guard.spec.ts
+++ b/apps/server/mcp/src/guards/mcp-auth.guard.spec.ts
@@ -1,7 +1,12 @@
 import { IS_PUBLIC_KEY } from '@libs/decorators/public.decorator';
 import { McpAuthGuard } from '@mcp/guards/mcp-auth.guard';
 import { AuthService } from '@mcp/services/auth.service';
-import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { RateLimitService } from '@mcp/services/rate-limit.service';
+import {
+  ExecutionContext,
+  HttpException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -19,11 +24,27 @@ describe('McpAuthGuard', () => {
     getAllAndOverride: vi.fn(),
   };
 
+  const allowedResult = {
+    allowed: true,
+    limit: 60,
+    remaining: 59,
+    resetAt: 0,
+    retryAfterSeconds: 0,
+  };
+
+  const mockRateLimitService = {
+    consume: vi.fn(),
+    keyFor: vi.fn().mockReturnValue('mcp:ratelimit:tok:abc'),
+  };
+
+  const mockResponse = { setHeader: vi.fn() };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         McpAuthGuard,
         { provide: AuthService, useValue: mockAuthService },
+        { provide: RateLimitService, useValue: mockRateLimitService },
         { provide: Reflector, useValue: mockReflector },
       ],
     }).compile();
@@ -31,6 +52,8 @@ describe('McpAuthGuard', () => {
     guard = module.get<McpAuthGuard>(McpAuthGuard);
     _authService = module.get<AuthService>(AuthService);
     _reflector = module.get<Reflector>(Reflector);
+    mockRateLimitService.consume.mockResolvedValue(allowedResult);
+    mockRateLimitService.keyFor.mockReturnValue('mcp:ratelimit:tok:abc');
   });
 
   afterEach(() => {
@@ -49,6 +72,7 @@ describe('McpAuthGuard', () => {
             authorization: authHeader,
           },
         }),
+        getResponse: vi.fn().mockReturnValue(mockResponse),
       }),
     } as unknown as ExecutionContext;
   };
@@ -116,6 +140,7 @@ describe('McpAuthGuard', () => {
         getHandler: vi.fn(),
         switchToHttp: vi.fn().mockReturnValue({
           getRequest: vi.fn().mockReturnValue(mockRequest),
+          getResponse: vi.fn().mockReturnValue(mockResponse),
         }),
       } as unknown as ExecutionContext;
 
@@ -148,6 +173,7 @@ describe('McpAuthGuard', () => {
         getHandler: vi.fn(),
         switchToHttp: vi.fn().mockReturnValue({
           getRequest: vi.fn().mockReturnValue(mockRequest),
+          getResponse: vi.fn().mockReturnValue(mockResponse),
         }),
       } as unknown as ExecutionContext;
 
@@ -166,6 +192,27 @@ describe('McpAuthGuard', () => {
       const context = createMockExecutionContext('Bearer bad-token');
 
       await expect(guard.canActivate(context)).rejects.toThrow('Invalid token');
+    });
+
+    it('throws 429 when the rate limit is exceeded, before auth runs', async () => {
+      mockReflector.getAllAndOverride.mockReturnValue(false);
+      mockAuthService.extractBearerToken.mockReturnValue('some-token');
+      mockRateLimitService.consume.mockResolvedValue({
+        allowed: false,
+        limit: 60,
+        remaining: 0,
+        resetAt: 123,
+        retryAfterSeconds: 42,
+      });
+      const context = createMockExecutionContext('Bearer some-token');
+
+      await expect(guard.canActivate(context)).rejects.toMatchObject({
+        status: 429,
+      });
+      expect(guard.canActivate(context)).rejects.toBeInstanceOf(HttpException);
+      // Auth must not run once the caller is over the limit.
+      expect(mockAuthService.authenticateRequest).not.toHaveBeenCalled();
+      expect(mockResponse.setHeader).toHaveBeenCalledWith('Retry-After', '42');
     });
   });
 

--- a/apps/server/mcp/src/guards/mcp-auth.guard.ts
+++ b/apps/server/mcp/src/guards/mcp-auth.guard.ts
@@ -1,9 +1,15 @@
 import { IS_PUBLIC_KEY } from '@libs/decorators/public.decorator';
 import { AuthService, type McpRole } from '@mcp/services/auth.service';
 import {
+  applyRateLimitHeaders,
+  RateLimitService,
+} from '@mcp/services/rate-limit.service';
+import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  HttpException,
+  HttpStatus,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -13,6 +19,7 @@ import { Reflector } from '@nestjs/core';
 export class McpAuthGuard implements CanActivate {
   constructor(
     private readonly authService: AuthService,
+    private readonly rateLimitService: RateLimitService,
     private readonly reflector: Reflector,
   ) {}
 
@@ -27,8 +34,22 @@ export class McpAuthGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest();
+    const response = context.switchToHttp().getResponse();
     const authHeader = request.headers.authorization;
     const token = this.authService.extractBearerToken(authHeader);
+
+    // Same sliding window as the raw /mcp transport; keyed by hashed token
+    // (or IP when absent) so both entry points share one budget per caller.
+    const rateLimit = await this.rateLimitService.consume(
+      this.rateLimitService.keyFor(token, request.ip),
+    );
+    applyRateLimitHeaders(response, rateLimit);
+    if (!rateLimit.allowed) {
+      throw new HttpException(
+        `Rate limit exceeded. Retry after ${rateLimit.retryAfterSeconds}s.`,
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
 
     if (!token) {
       throw new UnauthorizedException(

--- a/apps/server/mcp/src/main.ts
+++ b/apps/server/mcp/src/main.ts
@@ -14,6 +14,10 @@ import { AppModule } from '@mcp/app.module';
 import { ConfigService } from '@mcp/config/config.service';
 import { getPublicMcpUrl, renderSetupPage } from '@mcp/mcp/setup-page';
 import { AuthService, type McpRole } from '@mcp/services/auth.service';
+import {
+  applyRateLimitHeaders,
+  RateLimitService,
+} from '@mcp/services/rate-limit.service';
 import { ServerService } from '@mcp/services/server.service';
 import { StreamableHttpService } from '@mcp/services/streamable-http.service';
 import { Logger } from '@nestjs/common';
@@ -41,6 +45,10 @@ const MCP_CORS_ALLOWED_HEADERS = [
 const MCP_CORS_EXPOSED_HEADERS = [
   'Mcp-Protocol-Version',
   'Mcp-Session-Id',
+  'Retry-After',
+  'X-RateLimit-Limit',
+  'X-RateLimit-Remaining',
+  'X-RateLimit-Reset',
 ].join(', ');
 
 async function main(): Promise<void> {
@@ -54,6 +62,7 @@ async function main(): Promise<void> {
   const logger = app.get(LoggerService);
   const serverService = app.get(ServerService);
   const authService = app.get(AuthService);
+  const rateLimitService = app.get(RateLimitService);
   const streamableHttpService = app.get(StreamableHttpService);
 
   const port = configService.get('PORT');
@@ -78,6 +87,25 @@ async function main(): Promise<void> {
     next: NextFunction,
   ) => {
     const token = authService.extractBearerToken(req.headers.authorization);
+
+    // Per-caller request cap (sliding window), keyed by hashed token when
+    // present, else client IP. Checked before auth so a single client's request
+    // rate is bounded even while its identity is being resolved.
+    const rateLimit = await rateLimitService.consume(
+      rateLimitService.keyFor(token, req.ip),
+    );
+    applyRateLimitHeaders(res, rateLimit);
+    if (!rateLimit.allowed) {
+      res.status(429).json({
+        error: {
+          code: -32029,
+          message: `Rate limit exceeded. Retry after ${rateLimit.retryAfterSeconds}s.`,
+        },
+        id: null,
+        jsonrpc: '2.0',
+      });
+      return;
+    }
 
     if (!token) {
       res.setHeader('WWW-Authenticate', 'Bearer');

--- a/apps/server/mcp/src/mcp/mcp.module.ts
+++ b/apps/server/mcp/src/mcp/mcp.module.ts
@@ -5,6 +5,7 @@ import { McpController } from '@mcp/mcp/controllers/mcp.controller';
 import { MCPService } from '@mcp/mcp/services/mcp.service';
 import { AuthService } from '@mcp/services/auth.service';
 import { ClientService } from '@mcp/services/client.service';
+import { RateLimitService } from '@mcp/services/rate-limit.service';
 import { ServerService } from '@mcp/services/server.service';
 import { StreamableHttpService } from '@mcp/services/streamable-http.service';
 import { ToolRegistryService } from '@mcp/services/tool-registry.service';
@@ -20,6 +21,7 @@ import { APP_GUARD } from '@nestjs/core';
     ClientService,
     MCPService,
     McpAuthGuard,
+    RateLimitService,
     ServerService,
     StreamableHttpService,
     ToolRegistryService,

--- a/apps/server/mcp/src/services/auth.service.ts
+++ b/apps/server/mcp/src/services/auth.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { LoggerService } from '@libs/logger/logger.service';
 import { ConfigService } from '@mcp/config/config.service';
 import { resolveApiBaseUrl } from '@mcp/shared/utils/api-url.util';
@@ -15,19 +16,59 @@ export interface AuthResult {
   error?: string;
 }
 
+/** Short-lived identity cache to avoid a /auth/whoami hop on every MCP call. */
+const WHOAMI_CACHE_TTL_MS = 60_000;
+const WHOAMI_CACHE_MAX = 5_000;
+
 @Injectable()
 export class AuthService {
+  private readonly whoamiCache = new Map<
+    string,
+    { result: AuthResult; expiresAt: number }
+  >();
+
   constructor(
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
     private readonly logger: LoggerService,
   ) {}
 
+  private cacheGet(key: string): AuthResult | null {
+    const entry = this.whoamiCache.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      this.whoamiCache.delete(key);
+      return null;
+    }
+    return entry.result;
+  }
+
+  private cacheSet(key: string, result: AuthResult): void {
+    // Bounded LRU-ish: drop the oldest inserted key when at capacity.
+    if (this.whoamiCache.size >= WHOAMI_CACHE_MAX) {
+      const oldest = this.whoamiCache.keys().next().value;
+      if (oldest !== undefined) this.whoamiCache.delete(oldest);
+    }
+    this.whoamiCache.set(key, {
+      expiresAt: Date.now() + WHOAMI_CACHE_TTL_MS,
+      result,
+    });
+  }
+
   async authenticateRequest(bearerToken: string): Promise<AuthResult> {
     try {
       if (!bearerToken || bearerToken.length < 32) {
         this.logger.warn('Invalid token format');
         return { error: 'Invalid token format', valid: false };
+      }
+
+      // Only successful resolutions are cached (never failures — a fixed token
+      // must take effect immediately), keyed by a hash so raw tokens never sit
+      // in memory as map keys.
+      const cacheKey = createHash('sha256').update(bearerToken).digest('hex');
+      const cached = this.cacheGet(cacheKey);
+      if (cached) {
+        return cached;
       }
 
       const baseUrl = resolveApiBaseUrl(
@@ -59,12 +100,14 @@ export class AuthService {
           };
         }
 
-        return {
+        const result: AuthResult = {
           organizationId,
           role: this.resolveRole(data.role),
           userId,
           valid: true,
         };
+        this.cacheSet(cacheKey, result);
+        return result;
       }
 
       return { error: 'Invalid token', valid: false };

--- a/apps/server/mcp/src/services/rate-limit.service.spec.ts
+++ b/apps/server/mcp/src/services/rate-limit.service.spec.ts
@@ -1,0 +1,134 @@
+import { LoggerService } from '@libs/logger/logger.service';
+import { RedisService } from '@libs/redis/redis.service';
+import { ConfigService } from '@mcp/config/config.service';
+import {
+  applyRateLimitHeaders,
+  RateLimitService,
+} from '@mcp/services/rate-limit.service';
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    // The service runs the whole window check as one atomic Lua script.
+    eval: vi.fn().mockResolvedValue([1, 1, String(Date.now())]),
+    ...overrides,
+  };
+}
+
+function build(client: ReturnType<typeof makeClient> | null) {
+  const redis = { getPublisher: vi.fn().mockReturnValue(client) };
+  const config = {
+    get: vi.fn((key: string) =>
+      key === 'MCP_RATE_LIMIT_PER_MINUTE'
+        ? 3
+        : key === 'MCP_RATE_LIMIT_WINDOW_MS'
+          ? 60_000
+          : undefined,
+    ),
+  };
+  const logger = { error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+  const service = new RateLimitService(
+    redis as unknown as RedisService,
+    config as unknown as ConfigService,
+    logger as unknown as LoggerService,
+  );
+  return { client, logger, service };
+}
+
+describe('RateLimitService.keyFor', () => {
+  it('hashes the bearer token (raw token never becomes the key)', () => {
+    const { service } = build(makeClient());
+    const key = service.keyFor('super-secret-token', '1.2.3.4');
+    expect(key).toMatch(/^mcp:ratelimit:tok:[a-f0-9]{64}$/);
+    expect(key).not.toContain('super-secret-token');
+  });
+
+  it('falls back to IP when there is no token', () => {
+    const { service } = build(makeClient());
+    expect(service.keyFor(null, '1.2.3.4')).toBe('mcp:ratelimit:ip:1.2.3.4');
+    expect(service.keyFor(null, undefined)).toBe('mcp:ratelimit:ip:unknown');
+  });
+});
+
+describe('RateLimitService.consume', () => {
+  it('allows a request under the limit (atomic script reports new count)', async () => {
+    // Script returns [allowed, newCount, refScore]; newCount = 2 of a 3 limit.
+    const client = makeClient({
+      eval: vi.fn().mockResolvedValue([1, 2, String(Date.now())]),
+    });
+    const { service } = build(client);
+
+    const result = await service.consume('k');
+
+    expect(result.allowed).toBe(true);
+    expect(result.limit).toBe(3);
+    expect(result.remaining).toBe(1); // limit 3 - new count 2
+    expect(client.eval).toHaveBeenCalledOnce();
+  });
+
+  it('blocks when at the limit and surfaces a retry hint', async () => {
+    const now = Date.now();
+    const client = makeClient({
+      eval: vi.fn().mockResolvedValue([0, 3, String(now - 5_000)]),
+    });
+    const { service } = build(client);
+
+    const result = await service.consume('k');
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('fails open when Redis is unavailable', async () => {
+    const { logger, service } = build(null);
+    const result = await service.consume('k');
+    expect(result.allowed).toBe(true);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('fails open when the Lua script throws', async () => {
+    const client = makeClient({
+      eval: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    const { logger, service } = build(client);
+    const result = await service.consume('k');
+    expect(result.allowed).toBe(true);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe('applyRateLimitHeaders', () => {
+  it('sets the standard headers and Retry-After only when blocked', () => {
+    const setHeader = vi.fn();
+    applyRateLimitHeaders(
+      { setHeader },
+      {
+        allowed: true,
+        limit: 60,
+        remaining: 42,
+        resetAt: 99,
+        retryAfterSeconds: 0,
+      },
+    );
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', '60');
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '42');
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', '99');
+    expect(setHeader).not.toHaveBeenCalledWith(
+      'Retry-After',
+      expect.anything(),
+    );
+
+    const blockedSetHeader = vi.fn();
+    applyRateLimitHeaders(
+      { setHeader: blockedSetHeader },
+      {
+        allowed: false,
+        limit: 60,
+        remaining: 0,
+        resetAt: 99,
+        retryAfterSeconds: 30,
+      },
+    );
+    expect(blockedSetHeader).toHaveBeenCalledWith('Retry-After', '30');
+  });
+});

--- a/apps/server/mcp/src/services/rate-limit.service.ts
+++ b/apps/server/mcp/src/services/rate-limit.service.ts
@@ -1,0 +1,168 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { LoggerService } from '@libs/logger/logger.service';
+import { RedisService } from '@libs/redis/redis.service';
+import { ConfigService } from '@mcp/config/config.service';
+import { Injectable } from '@nestjs/common';
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  /** Unix epoch seconds when the current window frees up a slot. */
+  resetAt: number;
+  /** Seconds until the caller may retry; only meaningful when `allowed` is false. */
+  retryAfterSeconds: number;
+}
+
+/** Minimal response surface both the Express middleware and Nest guard share. */
+interface RateLimitHeaderSink {
+  setHeader(name: string, value: string): void;
+}
+
+/**
+ * Apply standard rate-limit headers to a response. `Retry-After` is only set
+ * when the request was blocked. Header shape mirrors the API's `RateLimitGuard`.
+ */
+export function applyRateLimitHeaders(
+  res: RateLimitHeaderSink,
+  result: RateLimitResult,
+): void {
+  res.setHeader('X-RateLimit-Limit', String(result.limit));
+  res.setHeader('X-RateLimit-Remaining', String(result.remaining));
+  res.setHeader('X-RateLimit-Reset', String(result.resetAt));
+  if (!result.allowed) {
+    res.setHeader('Retry-After', String(result.retryAfterSeconds));
+  }
+}
+
+/**
+ * Per-caller sliding-window rate limiter for the MCP transport, backed by a
+ * Redis sorted set (ports the proven `ApiKeysService.checkRateLimit` pattern).
+ * Fails OPEN: if Redis is unavailable or errors, requests are allowed rather
+ * than hard-blocking the whole transport — consistent with the rest of the
+ * codebase's Redis usage.
+ */
+@Injectable()
+export class RateLimitService {
+  private readonly limit: number;
+  private readonly windowMs: number;
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly configService: ConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    this.limit = Number(
+      this.configService.get('MCP_RATE_LIMIT_PER_MINUTE') ?? 60,
+    );
+    this.windowMs = Number(
+      this.configService.get('MCP_RATE_LIMIT_WINDOW_MS') ?? 60_000,
+    );
+  }
+
+  /**
+   * Build the sliding-window key for a request. Callers presenting a bearer
+   * token are keyed by a hash of it (never the raw token — it would otherwise
+   * sit in Redis as a map/key value); tokenless callers fall back to their IP.
+   *
+   * This caps the per-caller request rate (the product requirement, matching
+   * vitae's transport). It does NOT by itself defeat an attacker rotating many
+   * distinct bogus tokens to force `/auth/whoami` — that abuse is bounded by the
+   * `< 32` char fast-reject and the whoami cache in `AuthService`, plus the ALB
+   * in front of the service; a dedicated per-IP auth-attempt cap is possible
+   * future hardening.
+   */
+  keyFor(bearerToken: string | null, ip: string | undefined): string {
+    if (bearerToken) {
+      const hash = createHash('sha256').update(bearerToken).digest('hex');
+      return `mcp:ratelimit:tok:${hash}`;
+    }
+    return `mcp:ratelimit:ip:${ip ?? 'unknown'}`;
+  }
+
+  private allowResult(count: number): RateLimitResult {
+    const resetAt = Math.floor((Date.now() + this.windowMs) / 1000);
+    return {
+      allowed: true,
+      limit: this.limit,
+      remaining: Math.max(0, this.limit - count),
+      resetAt,
+      retryAfterSeconds: 0,
+    };
+  }
+
+  /**
+   * Record a request against `key` and report whether it is within the window
+   * limit. The whole check (prune → count → conditional add → refresh TTL) runs
+   * as ONE atomic Redis Lua script, so concurrent requests for the same key
+   * (the MCP server is stateless/multi-instance) can never all observe the same
+   * under-limit count and burst over the limit, and a blocked or allowed key is
+   * never left without a TTL. On any Redis problem the request is allowed
+   * (fail-open) rather than hard-blocking the transport.
+   *
+   * Returns `[allowed(1|0), count, referenceScoreMs]` where `referenceScoreMs`
+   * is the current time (allowed) or the oldest in-window entry (blocked).
+   */
+  private static readonly CONSUME_LUA = `
+    redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[2])
+    local count = redis.call('ZCARD', KEYS[1])
+    if count >= tonumber(ARGV[3]) then
+      local oldest = redis.call('ZRANGE', KEYS[1], 0, 0, 'WITHSCORES')
+      local ref = oldest[2] or ARGV[1]
+      return {0, count, ref}
+    end
+    redis.call('ZADD', KEYS[1], ARGV[1], ARGV[4])
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
+    return {1, count + 1, ARGV[1]}
+  `;
+
+  async consume(key: string): Promise<RateLimitResult> {
+    const client = this.redisService.getPublisher();
+    if (!client) {
+      this.logger.warn(
+        'Redis unavailable for MCP rate limiting, allowing request',
+      );
+      return this.allowResult(0);
+    }
+
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    const ttlSeconds = Math.ceil(this.windowMs / 1000) + 10;
+    const member = `${now}:${randomBytes(4).toString('hex')}`;
+
+    try {
+      const raw = (await client.eval(
+        RateLimitService.CONSUME_LUA,
+        1,
+        key,
+        String(now),
+        String(windowStart),
+        String(this.limit),
+        member,
+        String(ttlSeconds),
+      )) as [number, number, string];
+
+      const [allowedFlag, count, referenceScore] = raw;
+
+      if (allowedFlag === 1) {
+        return this.allowResult(count);
+      }
+
+      // Blocked: the oldest in-window entry determines when a slot frees up.
+      const oldestScore = Number(referenceScore) || now;
+      const resetAt = Math.floor((oldestScore + this.windowMs) / 1000);
+      return {
+        allowed: false,
+        limit: this.limit,
+        remaining: 0,
+        resetAt,
+        retryAfterSeconds: Math.max(1, resetAt - Math.floor(now / 1000)),
+      };
+    } catch (error: unknown) {
+      this.logger.error('MCP rate limit check failed, allowing request', {
+        error: (error as Error)?.message,
+      });
+      return this.allowResult(0);
+    }
+  }
+}


### PR DESCRIPTION
## Context

Part **3 of 6** of the MCP platform hardening effort. Independent of PR 1/2 (branches off `master`).

The MCP server had **no rate limiting** — a single client (or a runaway loop) could hammer the transport and, through it, the main API. This adds a per-caller sliding-window limiter (parity with vitae's production transport), reusing the codebase's proven Redis sorted-set pattern (`ApiKeysService.checkRateLimit`).

## What this PR does

- **`RateLimitService`** — sliding window keyed by **hashed** bearer token (never the raw token) or client IP. The whole check (prune → count → conditional add → refresh TTL) runs as **one atomic Redis Lua script**, so concurrent requests for the same key on a stateless/multi-instance server cannot burst past the limit and a key is never left without a TTL. **Fails OPEN** on any Redis problem (never hard-blocks the transport).
- **Enforced in both MCP entry points**: the raw `/mcp` transport middleware (`main.ts`) and `McpAuthGuard` for `/v1/*`. Returns **429** with `X-RateLimit-Limit/-Remaining/-Reset` + `Retry-After`, CORS-exposed so clients can read them.
- **Config**: `MCP_RATE_LIMIT_PER_MINUTE` (default 60), `MCP_RATE_LIMIT_WINDOW_MS` (default 60000).
- **Whoami cache** — a 60s in-memory `/auth/whoami` identity cache in `AuthService` (successful resolutions only, keyed by token hash, size-bounded) to cut the per-request auth hop.

## Tests
Sliding-window (allow / block / fail-open), token hashing, header shaping, guard-429-before-auth; existing auth/guard specs stay green (**38 passing** in touched files). Four MCP integration specs fail locally on the pre-existing `@genfeedai/tools` vitest-resolution issue (identical on the base branch; they run in CI).

## Adversarial review
Codex flagged the initial multi-command check as non-atomic (burst-over-limit under concurrency; possible missing TTL). **Fixed** by consolidating into a single Lua script. Token-vs-IP keying matches the agreed design; the residual (an attacker rotating many distinct bogus tokens to force `/auth/whoami`) is documented and bounded by the `<32`-char fast-reject + whoami cache + ALB — a dedicated per-IP auth-attempt cap is noted as future hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)