### PR TITLE
feat(brands): move a brand between organizations with full org-scope cascade

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -9719,6 +9719,142 @@
         ],
         "type": "object"
       },
+      "UpdateBrandDto": {
+        "properties": {
+          "agentConfig": {
+            "description": "Agent configuration overrides for the brand",
+            "type": "object"
+          },
+          "backgroundColor": {
+            "default": "#000000",
+            "description": "The background color theme for the brand",
+            "type": "string"
+          },
+          "defaultImageModel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelKey"
+              }
+            ],
+            "description": "The default model to use for image generation"
+          },
+          "defaultImageToVideoModel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelKey"
+              }
+            ],
+            "description": "The default model to use for image-to-video conversion"
+          },
+          "defaultMusicModel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelKey"
+              }
+            ],
+            "description": "The default model to use for music generation"
+          },
+          "defaultVideoModel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelKey"
+              }
+            ],
+            "description": "The default model to use for video generation"
+          },
+          "description": {
+            "description": "A description of the brand",
+            "type": "string"
+          },
+          "fontFamily": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FontFamily"
+              }
+            ],
+            "default": "montserrat-black",
+            "description": "The font family to use for text overlays"
+          },
+          "isActive": {
+            "default": true,
+            "description": "Whether this brand is currently active",
+            "type": "boolean"
+          },
+          "isDarkroomEnabled": {
+            "default": false,
+            "description": "Whether this brand can access darkroom fleet features and assets",
+            "type": "boolean"
+          },
+          "isDeleted": {
+            "description": "Whether the brand is marked as deleted",
+            "type": "boolean"
+          },
+          "isHighlighted": {
+            "default": false,
+            "description": "Whether this brand is highlighted on the website",
+            "type": "boolean"
+          },
+          "isSelected": {
+            "description": "Whether this brand is currently selected",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "The display name of the brand",
+            "type": "string"
+          },
+          "music": {
+            "description": "Optional music ID to use for this brand",
+            "type": "string"
+          },
+          "organizationId": {
+            "description": "Destination organization identifier. Providing a different value than the brand's current organization relocates the brand — cascading organizationId across all brand-owned records in one transaction. Superadmin, or an owner/admin of both the source and destination organizations, only.",
+            "type": "string"
+          },
+          "primaryColor": {
+            "default": "#000000",
+            "description": "The primary color theme for the brand",
+            "type": "string"
+          },
+          "referenceImages": {
+            "description": "Reference images used for generation consistency",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "scope": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AssetScope"
+              }
+            ],
+            "default": "user",
+            "description": "Brand access scope"
+          },
+          "secondaryColor": {
+            "default": "#FFFFFF",
+            "description": "The secondary color theme for the brand",
+            "type": "string"
+          },
+          "slug": {
+            "description": "The unique slug for the brand",
+            "type": "string"
+          },
+          "text": {
+            "description": "Text prompt for content generation",
+            "type": "string"
+          },
+          "user": {
+            "description": "Owning user identifier",
+            "type": "string"
+          },
+          "voice": {
+            "description": "Optional voice ID to use for this brand",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "UpdateBrandNameDto": {
         "properties": {
           "brandName": {
@@ -22492,6 +22628,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBrandDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": ""

--- a/apps/server/api/src/collections/brands/constants/brand-org-cascade.constants.ts
+++ b/apps/server/api/src/collections/brands/constants/brand-org-cascade.constants.ts
@@ -1,0 +1,542 @@
+/**
+ * Brand → Organization relocation cascade configuration.
+ *
+ * A brand is NOT self-contained: the schema denormalizes `organizationId` across
+ * many tables that also carry a brand key. Moving only `Brand.organizationId`
+ * leaves those rows stamped with the old org — invisible to the destination org's
+ * tenant-scoped reads (which filter by `organizationId` directly), yet still
+ * reachable by id. This module is the single source of truth for which tables the
+ * relocation must rewrite.
+ *
+ * Correctness rests on THREE mechanisms, in order of trust:
+ *   1. FIRST_ORDER_TARGETS  — tables carrying both a brand key and an org key.
+ *   2. SECOND_ORDER_TARGETS — org-scoped children with NO brand key, owned by a
+ *      first-order parent (would orphan if only the parent moves).
+ *   3. The runtime orphan auditor (see brands.service) — after the cascade, it
+ *      scans every dual-keyed table and rolls back if ANY brand-owned row still
+ *      points at a stale org. This is the backstop for tables static analysis
+ *      cannot see (unmanaged FKs, non-standard names, future schema additions).
+ *
+ * The staleness guard test (brand-org-cascade.spec.ts) parses schema.prisma and
+ * fails CI if a new dual-keyed model is added without being listed or excluded.
+ *
+ * Delegate names are camelCase (Prisma client delegates are `prisma.brandInterview`,
+ * NOT `prisma.BrandInterview` — the PascalCase form is `undefined` and would throw).
+ */
+
+export interface FirstOrderCascadeTarget {
+  /** camelCase Prisma delegate name, e.g. `prisma[delegate].updateMany(...)`. */
+  readonly delegate: string;
+  /** Physical table name (@@map) — used by the raw-SQL orphan auditor. */
+  readonly table: string;
+  /** Scalar field on this model that references the Brand. */
+  readonly brandField: string;
+  /** Scalar org field to rewrite to the destination org. */
+  readonly orgField: string;
+}
+
+export interface SecondOrderParentLink {
+  /** camelCase delegate of the first-order parent whose brand we filter by. */
+  readonly parentDelegate: string;
+  /** Brand field on the parent (matches a FIRST_ORDER_TARGETS entry). */
+  readonly parentBrandField: string;
+  /** Scalar FK on the child pointing at the parent's id. */
+  readonly fkField: string;
+}
+
+export interface SecondOrderCascadeTarget {
+  readonly delegate: string;
+  readonly table: string;
+  readonly orgField: string;
+  /** A child row is relocated if it points at ANY moved parent. */
+  readonly parents: readonly SecondOrderParentLink[];
+}
+
+/**
+ * Models with both a brand key and an org key. Rewrite `orgField` → destination.
+ *
+ * Excluded on purpose (see KNOWN_EXCLUDED): `Member` (its brand link is
+ * `lastUsedBrandId`, a per-user UI pointer — the member row belongs to its own org
+ * and must NOT move) and `Workflow` (brand link is the `workflow_brands` M2M plus a
+ * `defaultRecurringBrandId` marker — handled by the sever step, not org-rewrite).
+ *
+ * Non-standard field names are hand-mapped: `Asset` (parentBrandId/parentOrgId),
+ * `ContextBase` (sourceBrandId), `Lead` (proactiveBrandId → proactiveOrganizationId,
+ * NOT its plain `organizationId`, which is the lead-gen org and stays put).
+ */
+export const FIRST_ORDER_TARGETS: readonly FirstOrderCascadeTarget[] = [
+  {
+    delegate: 'brandInterview',
+    table: 'brand_interviews',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'moodBoard',
+    table: 'mood_boards',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'warmupAccount',
+    table: 'warmup_accounts',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'credential',
+    table: 'credentials',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'ingredient',
+    table: 'ingredients',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'prompt',
+    table: 'prompts',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'folder',
+    table: 'folders',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'tag',
+    table: 'tags',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'bookmark',
+    table: 'bookmarks',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'asset',
+    table: 'assets',
+    brandField: 'parentBrandId',
+    orgField: 'parentOrgId',
+  },
+  {
+    delegate: 'trackedLink',
+    table: 'tracked_links',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'post',
+    table: 'posts',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'postAnalytics',
+    table: 'post_analytics',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'schedule',
+    table: 'schedules',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contentSchedule',
+    table: 'content_schedules',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'distribution',
+    table: 'distributions',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'article',
+    table: 'articles',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'articleAnalytics',
+    table: 'article_analytics',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'newsletter',
+    table: 'newsletters',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'training',
+    table: 'trainings',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'persona',
+    table: 'personas',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentMessage',
+    table: 'agent_messages',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'socialConversation',
+    table: 'social_conversations',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'socialMessage',
+    table: 'social_messages',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentStrategy',
+    table: 'agent_strategies',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentStrategyOpportunity',
+    table: 'agent_strategy_opportunities',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentStrategyReport',
+    table: 'agent_strategy_reports',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentCampaign',
+    table: 'agent_campaigns',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentGoal',
+    table: 'agent_goals',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'agentMemory',
+    table: 'agent_memories',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contentRun',
+    table: 'content_runs',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'task',
+    table: 'tasks',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'bot',
+    table: 'bots',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'botActivity',
+    table: 'bot_activities',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'replyBotConfig',
+    table: 'reply_bot_configs',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'monitoredAccount',
+    table: 'monitored_accounts',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contentPerformance',
+    table: 'content_performance',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'creativePattern',
+    table: 'creative_patterns',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contentDraft',
+    table: 'content_drafts',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contentPlan',
+    table: 'content_plans',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contentPlanItem',
+    table: 'content_plan_items',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'activity',
+    table: 'activities',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'adBulkUploadJob',
+    table: 'ad_bulk_upload_jobs',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'adCreativeMapping',
+    table: 'ad_creative_mappings',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'adPerformance',
+    table: 'ad_performance',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'trend',
+    table: 'trends',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'trendPreferences',
+    table: 'trend_preferences',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'trendRemixLineage',
+    table: 'trend_remix_lineages',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'outreachCampaign',
+    table: 'outreach_campaigns',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'preset',
+    table: 'presets',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'clipProject',
+    table: 'clip_projects',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'editorProject',
+    table: 'editor_projects',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'brandMemory',
+    table: 'brand_memories',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'contextBase',
+    table: 'context_bases',
+    brandField: 'sourceBrandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'watchlist',
+    table: 'watchlists',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'lead',
+    table: 'leads',
+    brandField: 'proactiveBrandId',
+    orgField: 'proactiveOrganizationId',
+  },
+  {
+    delegate: 'batch',
+    table: 'batches',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+  {
+    delegate: 'run',
+    table: 'runs',
+    brandField: 'brandId',
+    orgField: 'organizationId',
+  },
+];
+
+/**
+ * Org-scoped children with no brand key of their own. Their org must follow a moved
+ * first-order parent, joined by scalar FK (no relation-name guessing — FK fields are
+ * verified against the schema by the staleness test).
+ *
+ * Intentionally NOT relocated (org- or execution-level history, ambiguous ownership):
+ * `SubscriptionAttribution` (revenue, keyed to the subscriber org), `WorkflowExecution`
+ * / `BatchWorkflowJob` (workflows are severed, not moved), `AgentThread` / `AgentRun` /
+ * `AgentThreadEvent` (agent conversation/execution history — no brand key, indirect
+ * ownership), `Invitation` (org-level). These stay in the source org by design.
+ */
+export const SECOND_ORDER_TARGETS: readonly SecondOrderCascadeTarget[] = [
+  {
+    delegate: 'taskComment',
+    table: 'task_comments',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'task',
+        parentBrandField: 'brandId',
+        fkField: 'taskId',
+      },
+    ],
+  },
+  {
+    delegate: 'contextEntry',
+    table: 'context_entries',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'contextBase',
+        parentBrandField: 'sourceBrandId',
+        fkField: 'contextBaseId',
+      },
+    ],
+  },
+  {
+    delegate: 'campaignTarget',
+    table: 'campaign_targets',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'outreachCampaign',
+        parentBrandField: 'brandId',
+        fkField: 'campaignId',
+      },
+    ],
+  },
+  {
+    delegate: 'transcript',
+    table: 'transcripts',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'article',
+        parentBrandField: 'brandId',
+        fkField: 'articleId',
+      },
+    ],
+  },
+  {
+    delegate: 'model',
+    table: 'models',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'training',
+        parentBrandField: 'brandId',
+        fkField: 'trainingId',
+      },
+    ],
+  },
+  {
+    delegate: 'caption',
+    table: 'captions',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'ingredient',
+        parentBrandField: 'brandId',
+        fkField: 'ingredientId',
+      },
+    ],
+  },
+  {
+    delegate: 'processedTweet',
+    table: 'processed_tweets',
+    orgField: 'organizationId',
+    parents: [
+      {
+        parentDelegate: 'replyBotConfig',
+        parentBrandField: 'brandId',
+        fkField: 'replyBotConfigId',
+      },
+      {
+        parentDelegate: 'monitoredAccount',
+        parentBrandField: 'brandId',
+        fkField: 'monitoredAccountId',
+      },
+      {
+        parentDelegate: 'botActivity',
+        parentBrandField: 'brandId',
+        fkField: 'botActivityId',
+      },
+    ],
+  },
+];
+
+/**
+ * Dual-keyed models intentionally NOT in FIRST_ORDER_TARGETS. The staleness test
+ * asserts every schema model with a brand+org key is either a first-order target or
+ * listed here — so a new one can't slip through unreviewed.
+ */
+export const KNOWN_EXCLUDED_MODELS: readonly string[] = ['Member', 'Workflow'];
+
+/**
+ * Physical tables the orphan auditor's "unknown table" scan should ignore, because
+ * they are handled elsewhere or intentionally excluded. Everything in
+ * FIRST_ORDER_TARGETS is auto-added; these are the extras (excluded models whose org
+ * is deliberately left untouched). Keep in sync with KNOWN_EXCLUDED_MODELS.
+ */
+export const AUDITOR_IGNORED_TABLES: readonly string[] = [
+  'members',
+  'workflows',
+];

--- a/apps/server/api/src/collections/brands/constants/brand-org-cascade.spec.ts
+++ b/apps/server/api/src/collections/brands/constants/brand-org-cascade.spec.ts
@@ -1,0 +1,167 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  FIRST_ORDER_TARGETS,
+  KNOWN_EXCLUDED_MODELS,
+  SECOND_ORDER_TARGETS,
+} from './brand-org-cascade.constants';
+
+/**
+ * Staleness guard: the brand→org relocation cascade hardcodes which tables carry a
+ * denormalized `organizationId` alongside a brand key. If a new dual-keyed model is
+ * added to the schema, this test fails until it is either added to
+ * FIRST_ORDER_TARGETS or explicitly excluded — preventing a silent tenancy
+ * split-brain on the next brand move.
+ */
+
+const BRAND_FIELD_RE = /brandId$/i;
+const ORG_FIELD_RE = /(organizationId|OrgId)$/i;
+const SCALAR_TYPE_RE =
+  /^(String|Int|BigInt|Float|Decimal|Boolean|DateTime|Json|Bytes)$/;
+
+function findSchemaPath(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    const candidate = join(dir, 'packages/prisma/prisma/schema.prisma');
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = resolve(dir, '..');
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  throw new Error('Could not locate packages/prisma/prisma/schema.prisma');
+}
+
+interface ParsedModel {
+  name: string;
+  brandFields: string[];
+  orgFields: string[];
+}
+
+function parseDualKeyedModels(schema: string): ParsedModel[] {
+  const lines = schema.split('\n');
+  const models: ParsedModel[] = [];
+  let current: {
+    name: string;
+    brandFields: string[];
+    orgFields: string[];
+  } | null = null;
+
+  for (const rawLine of lines) {
+    const modelMatch = rawLine.match(/^model\s+(\w+)\s*\{/);
+    if (modelMatch) {
+      current = { name: modelMatch[1], brandFields: [], orgFields: [] };
+      continue;
+    }
+    if (current && /^\}/.test(rawLine)) {
+      if (current.brandFields.length > 0 && current.orgFields.length > 0) {
+        models.push(current);
+      }
+      current = null;
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    const line = rawLine.trim();
+    if (!line || line.startsWith('//') || line.startsWith('@@')) {
+      continue;
+    }
+    const fieldMatch = line.match(/^(\w+)\s+([\w[\]?.]+)/);
+    if (!fieldMatch) {
+      continue;
+    }
+    const [, fieldName, fieldType] = fieldMatch;
+    const baseType = fieldType.replace(/[[\]?]/g, '');
+    if (!SCALAR_TYPE_RE.test(baseType)) {
+      continue;
+    }
+    if (BRAND_FIELD_RE.test(fieldName)) {
+      current.brandFields.push(fieldName);
+    }
+    if (ORG_FIELD_RE.test(fieldName)) {
+      current.orgFields.push(fieldName);
+    }
+  }
+
+  return models;
+}
+
+describe('brand-org-cascade config', () => {
+  const schema = readFileSync(findSchemaPath(), 'utf8');
+  const dualKeyed = parseDualKeyedModels(schema);
+
+  // Map delegate name back to a model name (camelCase → PascalCase) for coverage checks.
+  const coveredDelegates = new Set(FIRST_ORDER_TARGETS.map((t) => t.delegate));
+  const excluded = new Set(KNOWN_EXCLUDED_MODELS);
+  const delegateOf = (model: string): string =>
+    model.charAt(0).toLowerCase() + model.slice(1);
+
+  it('finds dual-keyed models in the schema (sanity)', () => {
+    // If this ever hits zero, the parser broke — not the config.
+    expect(dualKeyed.length).toBeGreaterThan(40);
+  });
+
+  it('covers or explicitly excludes every dual-keyed model', () => {
+    const uncovered = dualKeyed
+      .map((m) => m.name)
+      .filter(
+        (name) =>
+          !coveredDelegates.has(delegateOf(name)) && !excluded.has(name),
+      );
+
+    expect(
+      uncovered,
+      `New dual-keyed model(s) found in schema.prisma with no cascade handling: ` +
+        `${uncovered.join(', ')}. Add each to FIRST_ORDER_TARGETS (with the correct ` +
+        `brand/org field pairing) or to KNOWN_EXCLUDED_MODELS in ` +
+        `brand-org-cascade.constants.ts.`,
+    ).toEqual([]);
+  });
+
+  it('every first-order target names fields that exist on its model', () => {
+    const byDelegate = new Map(dualKeyed.map((m) => [delegateOf(m.name), m]));
+    for (const target of FIRST_ORDER_TARGETS) {
+      const model = byDelegate.get(target.delegate);
+      expect(
+        model,
+        `no schema model for delegate ${target.delegate}`,
+      ).toBeDefined();
+      if (!model) {
+        continue;
+      }
+      expect(
+        model.brandFields,
+        `${target.delegate}.${target.brandField} not a brand scalar`,
+      ).toContain(target.brandField);
+      expect(
+        model.orgFields,
+        `${target.delegate}.${target.orgField} not an org scalar`,
+      ).toContain(target.orgField);
+    }
+  });
+
+  it('has no duplicate first-order delegates', () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const t of FIRST_ORDER_TARGETS) {
+      if (seen.has(t.delegate)) {
+        dupes.push(t.delegate);
+      }
+      seen.add(t.delegate);
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it('second-order targets do not overlap first-order delegates', () => {
+    const overlap = SECOND_ORDER_TARGETS.filter((s) =>
+      coveredDelegates.has(s.delegate),
+    ).map((s) => s.delegate);
+    expect(overlap).toEqual([]);
+  });
+});

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -112,6 +112,59 @@ export class BrandsController extends BaseCRUDController<
   }
 
   /**
+   * Update a brand. Overrides the base handler to detect an organization change:
+   * when `organizationId` differs from the brand's current org, the update becomes a
+   * relocation — cascading the denormalized org id across all brand-owned records in
+   * one transaction (authorized as superadmin, or owner/admin of both orgs). All
+   * other updates fall through to the default CRUD patch unchanged.
+   */
+  @Patch(':id')
+  async patch(
+    @Req() request: Request,
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() updateDto: UpdateBrandDto,
+  ): Promise<JsonApiSingleResponse> {
+    const requestedOrgId = (updateDto as { organizationId?: string })
+      .organizationId;
+
+    // No org change requested → default CRUD patch.
+    if (!requestedOrgId) {
+      return super.patch(request, user, id, updateDto);
+    }
+
+    const existing = (await this.brandsService.findOne({ _id: id })) as
+      | (BrandDocument & { organizationId?: string })
+      | null;
+    if (!existing) {
+      throw new HttpException(
+        { detail: `Brand ${id} not found`, title: 'Not Found' },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // Same org → not a relocation; apply the remaining fields via the default patch.
+    if (existing.organizationId === requestedOrgId) {
+      const { organizationId: _omit, ...rest } = updateDto as Record<
+        string,
+        unknown
+      >;
+      return super.patch(request, user, id, rest as UpdateBrandDto);
+    }
+
+    const publicMetadata = getPublicMetadata(user);
+    const moved = await this.brandsService.relocateToOrganization(
+      id,
+      updateDto,
+      {
+        isSuperAdmin: getIsSuperAdmin(user, request),
+        userId: publicMetadata.user,
+      },
+    );
+    return serializeSingle(request, BrandSerializer, moved);
+  }
+
+  /**
    * Verify user has access to this brand
    * Throws HttpException if access is denied
    */

--- a/apps/server/api/src/collections/brands/dto/update-brand.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/update-brand.dto.ts
@@ -41,4 +41,16 @@ export class UpdateBrandDto extends PartialType(CreateBrandDto) {
     required: false,
   })
   readonly user?: string;
+
+  @IsOptional()
+  @IsEntityId()
+  @ApiProperty({
+    description:
+      'Destination organization identifier. Providing a different value than the ' +
+      "brand's current organization relocates the brand — cascading organizationId " +
+      'across all brand-owned records in one transaction. Superadmin, or an owner/' +
+      'admin of both the source and destination organizations, only.',
+    required: false,
+  })
+  readonly organizationId?: string;
 }

--- a/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
@@ -47,7 +47,7 @@ const USER_ID = 'user_1';
 
 describe('BrandsService.relocateToOrganization', () => {
   let delegates: Map<string, Delegate>;
-  let queryRawUnsafe: ReturnType<typeof vi.fn>;
+  let queryRaw: ReturnType<typeof vi.fn>;
   let transactionSpy: ReturnType<typeof vi.fn>;
   let cacheInvalidationService: {
     invalidate: ReturnType<typeof vi.fn>;
@@ -70,7 +70,7 @@ describe('BrandsService.relocateToOrganization', () => {
   beforeEach(() => {
     delegates = new Map();
     // information_schema scan → no unknown dual-keyed tables.
-    queryRawUnsafe = vi.fn().mockResolvedValue([]);
+    queryRaw = vi.fn().mockResolvedValue([]);
     transactionSpy = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn(prismaProxy),
     );
@@ -90,8 +90,8 @@ describe('BrandsService.relocateToOrganization', () => {
           if (prop === '$transaction') {
             return transactionSpy;
           }
-          if (prop === '$queryRawUnsafe') {
-            return queryRawUnsafe;
+          if (prop === '$queryRaw') {
+            return queryRaw;
           }
           return getDelegate(prop);
         },
@@ -141,7 +141,7 @@ describe('BrandsService.relocateToOrganization', () => {
     );
 
     expect(transactionSpy).not.toHaveBeenCalled();
-    expect(queryRawUnsafe).not.toHaveBeenCalled();
+    expect(queryRaw).not.toHaveBeenCalled();
     // Falls through to a normal field patch.
     expect(getDelegate('brand').update).toHaveBeenCalled();
   });
@@ -265,7 +265,7 @@ describe('BrandsService.relocateToOrganization', () => {
       expect(getDelegate(target.delegate).count).toHaveBeenCalled();
     }
     // Auditor part B scanned information_schema.
-    expect(queryRawUnsafe).toHaveBeenCalled();
+    expect(queryRaw).toHaveBeenCalled();
 
     // Both orgs' caches invalidated.
     const invalidatedKeys =
@@ -317,7 +317,8 @@ describe('BrandsService.relocateToOrganization', () => {
 
   it('blocks the move when an unhandled dual-keyed table would be orphaned', async () => {
     primeBrand();
-    queryRawUnsafe.mockImplementation((sql: string) => {
+    queryRaw.mockImplementation((strings: TemplateStringsArray) => {
+      const sql = Array.from(strings).join('');
       if (sql.includes('information_schema')) {
         return Promise.resolve([
           {

--- a/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
@@ -1,0 +1,347 @@
+// Real enums + schema-derived metadata via the light @genfeedai/prisma/testing
+// subpath, plus a runtime Prisma.PrismaClientKnownRequestError for the P2002 path.
+vi.mock('@genfeedai/prisma', async () => {
+  const { canonicalPrismaMock } = await import(
+    '@api/shared/testing/prisma-mock'
+  );
+  return canonicalPrismaMock();
+});
+
+import {
+  FIRST_ORDER_TARGETS,
+  SECOND_ORDER_TARGETS,
+} from '@api/collections/brands/constants/brand-org-cascade.constants';
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Prisma } from '@genfeedai/prisma';
+import { LoggerService } from '@libs/logger/logger.service';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+
+type Delegate = {
+  count: ReturnType<typeof vi.fn>;
+  findFirst: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  updateMany: ReturnType<typeof vi.fn>;
+};
+
+function makeDelegate(): Delegate {
+  return {
+    count: vi.fn().mockResolvedValue(0),
+    findFirst: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+    update: vi.fn().mockResolvedValue({}),
+    updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+  };
+}
+
+const BRAND_ID = 'brand_abc';
+const SOURCE_ORG = 'org_source';
+const DEST_ORG = 'org_dest';
+const USER_ID = 'user_1';
+
+describe('BrandsService.relocateToOrganization', () => {
+  let delegates: Map<string, Delegate>;
+  let queryRawUnsafe: ReturnType<typeof vi.fn>;
+  let transactionSpy: ReturnType<typeof vi.fn>;
+  let cacheInvalidationService: {
+    invalidate: ReturnType<typeof vi.fn>;
+    invalidateByTags: ReturnType<typeof vi.fn>;
+    invalidatePattern: ReturnType<typeof vi.fn>;
+  };
+  let prismaProxy: unknown;
+  let service: BrandsService;
+
+  const getDelegate = (name: string): Delegate => {
+    const existing = delegates.get(name);
+    if (existing) {
+      return existing;
+    }
+    const created = makeDelegate();
+    delegates.set(name, created);
+    return created;
+  };
+
+  beforeEach(() => {
+    delegates = new Map();
+    // information_schema scan → no unknown dual-keyed tables.
+    queryRawUnsafe = vi.fn().mockResolvedValue([]);
+    transactionSpy = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn(prismaProxy),
+    );
+    cacheInvalidationService = {
+      invalidate: vi.fn(),
+      invalidateByTags: vi.fn(),
+      invalidatePattern: vi.fn(),
+    };
+
+    prismaProxy = new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (typeof prop !== 'string') {
+            return undefined;
+          }
+          if (prop === '$transaction') {
+            return transactionSpy;
+          }
+          if (prop === '$queryRawUnsafe') {
+            return queryRawUnsafe;
+          }
+          return getDelegate(prop);
+        },
+      },
+    );
+
+    service = new BrandsService(
+      prismaProxy as unknown as PrismaService,
+      {
+        debug: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+        warn: vi.fn(),
+      } as unknown as LoggerService,
+      { invalidateByTags: vi.fn() } as unknown as CacheService,
+      {} as unknown as BrandScraperService,
+      {} as unknown as LlmDispatcherService,
+      cacheInvalidationService as unknown as CacheInvalidationService,
+      {} as unknown as FilesClientService,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function primeBrand(currentOrg = SOURCE_ORG): void {
+    getDelegate('brand').findFirst.mockResolvedValue({
+      id: BRAND_ID,
+      isDeleted: false,
+      organizationId: currentOrg,
+    });
+    getDelegate('organization').findFirst.mockResolvedValue({ id: DEST_ORG });
+  }
+
+  it('does not relocate (or open a transaction) when the org is unchanged', async () => {
+    getDelegate('brand').findFirst.mockResolvedValue({
+      id: BRAND_ID,
+      isDeleted: false,
+      organizationId: SOURCE_ORG,
+    });
+
+    await service.relocateToOrganization(
+      BRAND_ID,
+      { organizationId: SOURCE_ORG, label: 'Renamed' },
+      { isSuperAdmin: false, userId: USER_ID },
+    );
+
+    expect(transactionSpy).not.toHaveBeenCalled();
+    expect(queryRawUnsafe).not.toHaveBeenCalled();
+    // Falls through to a normal field patch.
+    expect(getDelegate('brand').update).toHaveBeenCalled();
+  });
+
+  it('throws NotFound when the destination organization does not exist', async () => {
+    getDelegate('brand').findFirst.mockResolvedValue({
+      id: BRAND_ID,
+      isDeleted: false,
+      organizationId: SOURCE_ORG,
+    });
+    getDelegate('organization').findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: true, userId: USER_ID },
+      ),
+    ).rejects.toThrow(/Organization/);
+    expect(transactionSpy).not.toHaveBeenCalled();
+  });
+
+  it('forbids a non-superadmin who is not an active member of both orgs', async () => {
+    primeBrand();
+    getDelegate('member').findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: false, userId: USER_ID },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(transactionSpy).not.toHaveBeenCalled();
+  });
+
+  it('forbids a member whose role is not owner/admin in both orgs', async () => {
+    primeBrand();
+    getDelegate('member').findFirst.mockImplementation(
+      (args: { where: { organizationId: string } }) =>
+        Promise.resolve(
+          args.where.organizationId === SOURCE_ORG
+            ? { role: { key: 'owner' }, roleKey: 'owner' }
+            : { role: { key: 'creator' }, roleKey: 'creator' },
+        ),
+    );
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: false, userId: USER_ID },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('cascades org across first- and second-order targets and invalidates both orgs', async () => {
+    getDelegate('brand')
+      .findFirst.mockResolvedValueOnce({
+        id: BRAND_ID,
+        isDeleted: false,
+        organizationId: SOURCE_ORG,
+      })
+      .mockResolvedValueOnce({ id: BRAND_ID, organizationId: DEST_ORG });
+    getDelegate('organization').findFirst.mockResolvedValue({ id: DEST_ORG });
+    // A moved Task exists → its TaskComment children must follow.
+    getDelegate('task').findMany.mockResolvedValue([{ id: 'task_1' }]);
+
+    const result = await service.relocateToOrganization(
+      BRAND_ID,
+      { organizationId: DEST_ORG },
+      { isSuperAdmin: true, userId: USER_ID },
+    );
+
+    // Brand row moved.
+    expect(getDelegate('brand').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: { id: BRAND_ID },
+    });
+
+    // Standard first-order target.
+    expect(getDelegate('post').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: { brandId: BRAND_ID, organizationId: { not: DEST_ORG } },
+    });
+
+    // Non-standard field names.
+    expect(getDelegate('lead').updateMany).toHaveBeenCalledWith({
+      data: { proactiveOrganizationId: DEST_ORG },
+      where: {
+        proactiveBrandId: BRAND_ID,
+        proactiveOrganizationId: { not: DEST_ORG },
+      },
+    });
+    expect(getDelegate('asset').updateMany).toHaveBeenCalledWith({
+      data: { parentOrgId: DEST_ORG },
+      where: { parentBrandId: BRAND_ID, parentOrgId: { not: DEST_ORG } },
+    });
+
+    // Second-order child followed its moved parent by scalar FK.
+    expect(getDelegate('taskComment').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: {
+        OR: [{ taskId: { in: ['task_1'] } }],
+        organizationId: { not: DEST_ORG },
+      },
+    });
+
+    // Sever: cleared stale lastUsedBrand pointers + default-recurring markers.
+    expect(getDelegate('member').updateMany).toHaveBeenCalledWith({
+      data: { lastUsedBrandId: null },
+      where: { lastUsedBrandId: BRAND_ID, organizationId: { not: DEST_ORG } },
+    });
+    expect(getDelegate('workflow').updateMany).toHaveBeenCalledWith({
+      data: { defaultRecurringBrandId: null },
+      where: { defaultRecurringBrandId: BRAND_ID },
+    });
+
+    // Auditor part A ran against every first-order target.
+    for (const target of FIRST_ORDER_TARGETS) {
+      expect(getDelegate(target.delegate).count).toHaveBeenCalled();
+    }
+    // Auditor part B scanned information_schema.
+    expect(queryRawUnsafe).toHaveBeenCalled();
+
+    // Both orgs' caches invalidated.
+    const invalidatedKeys =
+      cacheInvalidationService.invalidate.mock.calls.flat();
+    expect(invalidatedKeys).toContain(`brands:list:${SOURCE_ORG}`);
+    expect(invalidatedKeys).toContain(`brands:list:${DEST_ORG}`);
+    expect(cacheInvalidationService.invalidateByTags).toHaveBeenCalled();
+
+    expect(result).toEqual({ id: BRAND_ID, organizationId: DEST_ORG });
+  });
+
+  it('translates a P2002 unique violation into a ConflictException', async () => {
+    primeBrand();
+    getDelegate('brand').updateMany.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('duplicate', {
+        clientVersion: 'test',
+        code: 'P2002',
+        meta: {
+          target: ['organizationId', 'platform', 'externalConversationId'],
+        },
+      }),
+    );
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: true, userId: USER_ID },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(cacheInvalidationService.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('rolls back (throws) when the orphan auditor finds a stale row', async () => {
+    primeBrand();
+    // A first-order table still reports rows in the old org after the cascade.
+    getDelegate('post').count.mockResolvedValue(3);
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: true, userId: USER_ID },
+      ),
+    ).rejects.toThrow(/left stale organization id/);
+    // Move aborted → caches untouched.
+    expect(cacheInvalidationService.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('blocks the move when an unhandled dual-keyed table would be orphaned', async () => {
+    primeBrand();
+    queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes('information_schema')) {
+        return Promise.resolve([
+          {
+            brand_col: 'brand_id',
+            org_col: 'organization_id',
+            table_name: 'future_table',
+          },
+        ]);
+      }
+      // Per-table orphan count for the unknown table.
+      return Promise.resolve([{ n: 5 }]);
+    });
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: true, userId: USER_ID },
+      ),
+    ).rejects.toThrow(/unhandled dual-keyed table/);
+  });
+
+  it('keeps first- and second-order target lists non-empty (guard against empty config)', () => {
+    expect(FIRST_ORDER_TARGETS.length).toBeGreaterThan(40);
+    expect(SECOND_ORDER_TARGETS.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -67,6 +67,7 @@ import {
   ConflictException,
   ForbiddenException,
   Injectable,
+  InternalServerErrorException,
 } from '@nestjs/common';
 
 const BRAND_KIT_IMPORT_MAX_BYTES = 50 * 1024 * 1024;
@@ -1857,7 +1858,7 @@ Respond ONLY with the JSON array.`;
       }
     }
     if (stale.length > 0) {
-      throw new Error(
+      throw new InternalServerErrorException(
         `Brand relocation aborted: cascade left stale organization id on ${stale.join(', ')}.`,
       );
     }
@@ -1867,17 +1868,16 @@ Respond ONLY with the JSON array.`;
       ...AUDITOR_IGNORED_TABLES,
     ]);
 
-    const candidates = await tx.$queryRawUnsafe<
+    // sql-risk-audit: ignore raw-sql-review -- static information_schema introspection, no caller input interpolated.
+    const candidates = await tx.$queryRaw<
       { table_name: string; brand_col: string; org_col: string }[]
-    >(
-      `SELECT c1.table_name AS table_name, c1.column_name AS brand_col, c2.column_name AS org_col
+    >`SELECT c1.table_name AS table_name, c1.column_name AS brand_col, c2.column_name AS org_col
        FROM information_schema.columns c1
        JOIN information_schema.columns c2
          ON c1.table_name = c2.table_name AND c1.table_schema = c2.table_schema
        WHERE c1.table_schema = 'public'
          AND c1.column_name LIKE '%brand_id'
-         AND (c2.column_name LIKE '%organization_id' OR c2.column_name LIKE '%org_id')`,
-    );
+         AND (c2.column_name LIKE '%organization_id' OR c2.column_name LIKE '%org_id')`;
 
     const IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
     const unhandled: string[] = [];
@@ -1892,11 +1892,10 @@ Respond ONLY with the JSON array.`;
       ) {
         continue;
       }
-      const rows = await tx.$queryRawUnsafe<{ n: number }[]>(
-        `SELECT COUNT(*)::int AS n FROM "${candidate.table_name}" WHERE "${candidate.brand_col}" = $1 AND "${candidate.org_col}" IS DISTINCT FROM $2`,
-        brandId,
-        destOrgId,
-      );
+      // sql-risk-audit: ignore raw-sql-review -- table/column identifiers are regex-validated to /^[a-z_][a-z0-9_]*$/ above and injected via Prisma.raw; brandId/destOrgId are bound as parameters.
+      const rows = await tx.$queryRaw<
+        { n: number }[]
+      >`SELECT COUNT(*)::int AS n FROM ${Prisma.raw(`"${candidate.table_name}"`)} WHERE ${Prisma.raw(`"${candidate.brand_col}"`)} = ${brandId} AND ${Prisma.raw(`"${candidate.org_col}"`)} IS DISTINCT FROM ${destOrgId}`;
       const count = rows[0]?.n ?? 0;
       if (count > 0) {
         unhandled.push(
@@ -1905,7 +1904,7 @@ Respond ONLY with the JSON array.`;
       }
     }
     if (unhandled.length > 0) {
-      throw new Error(
+      throw new InternalServerErrorException(
         `Brand relocation aborted: unhandled dual-keyed table(s) would be orphaned in the source org: ${unhandled.join(', ')}. Add them to FIRST_ORDER_TARGETS in brand-org-cascade.constants.ts.`,
       );
     }

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -1,4 +1,9 @@
 import { randomUUID } from 'node:crypto';
+import {
+  AUDITOR_IGNORED_TABLES,
+  FIRST_ORDER_TARGETS,
+  SECOND_ORDER_TARGETS,
+} from '@api/collections/brands/constants/brand-org-cascade.constants';
 import type { ApplyBrandKitDto } from '@api/collections/brands/dto/apply-brand-kit.dto';
 import type { CrawlBrandKitDto } from '@api/collections/brands/dto/crawl-brand-kit.dto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
@@ -32,7 +37,7 @@ import { FilesClientService } from '@api/services/files-microservice/client/file
 import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import { FileInputType, FontFamily } from '@genfeedai/enums';
+import { FileInputType, FontFamily, MemberRole } from '@genfeedai/enums';
 import {
   type BrandKitSourceBrand,
   buildBrandKitDraftFromBrand,
@@ -57,7 +62,12 @@ import type {
 import { BRAND_KIT_FIELD_OWNERSHIP } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
 
 const BRAND_KIT_IMPORT_MAX_BYTES = 50 * 1024 * 1024;
 
@@ -141,6 +151,23 @@ const BRAND_KIT_STRING_LIST_FIELDS = new Set<BrandKitFieldKey>([
 ]);
 
 const SUPPORTED_FONT_FAMILIES = new Set<string>(Object.values(FontFamily));
+
+/**
+ * Minimal structural view of a Prisma model delegate, used to drive the brand→org
+ * relocation cascade generically over the config in `brand-org-cascade.constants`.
+ * The concrete `Prisma.TransactionClient` delegates satisfy this shape.
+ */
+interface CascadeDelegate {
+  updateMany(args: {
+    where: Record<string, unknown>;
+    data: Record<string, unknown>;
+  }): Promise<{ count: number }>;
+  findMany(args: {
+    where: Record<string, unknown>;
+    select: Record<string, boolean>;
+  }): Promise<{ id: string }[]>;
+  count(args: { where: Record<string, unknown> }): Promise<number>;
+}
 
 @Injectable()
 export class BrandsService extends BaseService<
@@ -1509,6 +1536,395 @@ Respond ONLY with the JSON array.`;
     );
 
     return brand;
+  }
+
+  // ───────────────────────── Brand → organization relocation ─────────────────────────
+
+  private static readonly RELOCATION_ELEVATED_ROLES: ReadonlySet<string> =
+    new Set([MemberRole.OWNER, MemberRole.ADMIN]);
+
+  /**
+   * Brand scalar columns that may be co-updated during a relocation PATCH. Relation
+   * fields (voice/music/user/organization) are intentionally excluded — they need
+   * their own handling and would break a raw scalar update.
+   */
+  private static readonly RELOCATION_PASSTHROUGH_FIELDS: readonly string[] = [
+    'label',
+    'description',
+    'slug',
+    'text',
+    'fontFamily',
+    'primaryColor',
+    'secondaryColor',
+    'backgroundColor',
+    'scope',
+    'isActive',
+    'isHighlighted',
+    'isSelected',
+    'isDarkroomEnabled',
+    'isDeleted',
+    'defaultVideoModel',
+    'defaultImageModel',
+    'defaultImageToVideoModel',
+    'defaultMusicModel',
+  ];
+
+  /**
+   * Relocate a brand to another organization, cascading the denormalized
+   * `organizationId` across every brand-owned record in one transaction. A runtime
+   * orphan auditor rolls the whole move back if any dual-keyed table is left stale,
+   * so an unhandled/new table fails loudly instead of splitting tenancy.
+   *
+   * Authorization: platform superadmin, OR an owner/admin of BOTH the source and
+   * destination organizations (guarantees the caller keeps access to the brand).
+   */
+  async relocateToOrganization(
+    brandId: string,
+    updateBrandDto: Partial<UpdateBrandDto> & { organizationId?: string },
+    actingUser: { userId: string; isSuperAdmin: boolean },
+  ): Promise<BrandDocument> {
+    const destOrgId = updateBrandDto.organizationId;
+    if (!destOrgId) {
+      throw new BadRequestException(
+        'organizationId is required to relocate a brand',
+      );
+    }
+
+    const brand = (await this.delegate.findFirst({
+      where: { id: brandId, isDeleted: false },
+    })) as (BrandDocument & { organizationId: string }) | null;
+    if (!brand) {
+      throw new NotFoundException('Brand', brandId);
+    }
+    const sourceOrgId = brand.organizationId;
+
+    // Same org → not a relocation; apply the other fields via the normal patch.
+    if (sourceOrgId === destOrgId) {
+      return this.patch(brandId, this.stripRelocationField(updateBrandDto));
+    }
+
+    const destOrg = await this.prisma.organization.findFirst({
+      select: { id: true },
+      where: { id: destOrgId, isDeleted: false },
+    });
+    if (!destOrg) {
+      throw new NotFoundException('Organization', destOrgId);
+    }
+
+    await this.assertCanRelocate(actingUser, sourceOrgId, destOrgId);
+
+    const passthrough = this.pickRelocationPassthrough(updateBrandDto);
+
+    this.logger.log('Relocating brand between organizations', {
+      brandId,
+      destOrgId,
+      operation: 'relocateToOrganization',
+      service: this.constructorName,
+      sourceOrgId,
+    });
+
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await this.runBrandOrgCascade(tx, brandId, destOrgId, passthrough);
+        await this.assertNoBrandOrgOrphans(tx, brandId, destOrgId);
+      });
+    } catch (error: unknown) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const target = Array.isArray(error.meta?.target)
+          ? (error.meta?.target as string[]).join(', ')
+          : 'a unique constraint';
+        throw new ConflictException(
+          `Cannot move brand: a record in the destination organization already conflicts on ${target}.`,
+        );
+      }
+      throw error;
+    }
+
+    await this.invalidateRelocationCaches(brandId, sourceOrgId, destOrgId);
+
+    const moved = (await this.delegate.findFirst({
+      where: { id: brandId },
+    })) as BrandDocument | null;
+    if (!moved) {
+      throw new NotFoundException('Brand', brandId);
+    }
+    return moved;
+  }
+
+  private stripRelocationField<T extends { organizationId?: string }>(
+    dto: T,
+  ): Omit<T, 'organizationId'> {
+    const { organizationId: _omit, ...rest } = dto;
+    return rest;
+  }
+
+  private pickRelocationPassthrough(
+    dto: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const key of BrandsService.RELOCATION_PASSTHROUGH_FIELDS) {
+      if (Object.hasOwn(dto, key) && dto[key] !== undefined) {
+        out[key] = dto[key];
+      }
+    }
+    return out;
+  }
+
+  private async assertCanRelocate(
+    actingUser: { userId: string; isSuperAdmin: boolean },
+    sourceOrgId: string,
+    destOrgId: string,
+  ): Promise<void> {
+    if (actingUser.isSuperAdmin) {
+      return;
+    }
+    if (!actingUser.userId) {
+      throw new ForbiddenException(
+        'You are not allowed to move this brand between organizations.',
+      );
+    }
+    const [sourceElevated, destElevated] = await Promise.all([
+      this.hasElevatedMembership(actingUser.userId, sourceOrgId),
+      this.hasElevatedMembership(actingUser.userId, destOrgId),
+    ]);
+    if (!sourceElevated || !destElevated) {
+      throw new ForbiddenException(
+        'Moving a brand between organizations requires an owner or admin role in both the source and destination organizations.',
+      );
+    }
+  }
+
+  private async hasElevatedMembership(
+    userId: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    const member = await this.prisma.member.findFirst({
+      select: { role: { select: { key: true } }, roleKey: true },
+      where: { isActive: true, isDeleted: false, organizationId, userId },
+    });
+    if (!member) {
+      return false;
+    }
+    const roleKey = member.roleKey ?? member.role?.key ?? undefined;
+    return (
+      roleKey !== undefined &&
+      BrandsService.RELOCATION_ELEVATED_ROLES.has(roleKey)
+    );
+  }
+
+  /**
+   * Rewrite the denormalized organization id across the brand and everything it owns.
+   * Runs entirely inside the caller's transaction.
+   */
+  private async runBrandOrgCascade(
+    tx: Prisma.TransactionClient,
+    brandId: string,
+    destOrgId: string,
+    passthrough: Record<string, unknown>,
+  ): Promise<void> {
+    const client = tx as unknown as Record<string, CascadeDelegate>;
+
+    // 1. The brand row itself (+ any co-patched scalar fields).
+    await client.brand.updateMany({
+      data: { ...passthrough, organizationId: destOrgId },
+      where: { id: brandId },
+    });
+
+    // 2. First-order tables: rewrite the denormalized org key.
+    for (const target of FIRST_ORDER_TARGETS) {
+      await client[target.delegate].updateMany({
+        data: { [target.orgField]: destOrgId },
+        where: {
+          [target.brandField]: brandId,
+          [target.orgField]: { not: destOrgId },
+        },
+      });
+    }
+
+    // 3. Second-order children (no brand key): follow a moved parent by scalar FK.
+    for (const child of SECOND_ORDER_TARGETS) {
+      const orClauses: Record<string, unknown>[] = [];
+      for (const parent of child.parents) {
+        const parentRows = await client[parent.parentDelegate].findMany({
+          select: { id: true },
+          where: { [parent.parentBrandField]: brandId },
+        });
+        if (parentRows.length > 0) {
+          orClauses.push({
+            [parent.fkField]: { in: parentRows.map((row) => row.id) },
+          });
+        }
+      }
+      if (orClauses.length === 0) {
+        continue;
+      }
+      await client[child.delegate].updateMany({
+        data: { [child.orgField]: destOrgId },
+        where: { OR: orClauses, [child.orgField]: { not: destOrgId } },
+      });
+    }
+
+    // 4. Sever associations that would become cross-org.
+    await this.severCrossOrgLinks(tx, brandId, destOrgId);
+  }
+
+  /**
+   * Detach source-org associations that would be invalid after the move. The acting
+   * user keeps access to the brand because relocation requires membership in the
+   * destination org; only stale, now-cross-org links are removed.
+   */
+  private async severCrossOrgLinks(
+    tx: Prisma.TransactionClient,
+    brandId: string,
+    destOrgId: string,
+  ): Promise<void> {
+    const client = tx as unknown as Record<string, CascadeDelegate> & {
+      brand: {
+        update(args: {
+          where: Record<string, unknown>;
+          data: Record<string, unknown>;
+        }): Promise<unknown>;
+      };
+    };
+
+    const staleMembers = await client.member.findMany({
+      select: { id: true },
+      where: {
+        brands: { some: { id: brandId } },
+        organizationId: { not: destOrgId },
+      },
+    });
+    const staleWorkflows = await client.workflow.findMany({
+      select: { id: true },
+      where: {
+        brands: { some: { id: brandId } },
+        organizationId: { not: destOrgId },
+      },
+    });
+
+    if (staleMembers.length > 0 || staleWorkflows.length > 0) {
+      await client.brand.update({
+        data: {
+          members: { disconnect: staleMembers.map((m) => ({ id: m.id })) },
+          workflows: {
+            disconnect: staleWorkflows.map((w) => ({ id: w.id })),
+          },
+        },
+        where: { id: brandId },
+      });
+    }
+
+    // Clear per-member "last used brand" pointers left in other orgs.
+    await client.member.updateMany({
+      data: { lastUsedBrandId: null },
+      where: { lastUsedBrandId: brandId, organizationId: { not: destOrgId } },
+    });
+
+    // Clear default-recurring markers on workflows that did not move.
+    await client.workflow.updateMany({
+      data: { defaultRecurringBrandId: null },
+      where: { defaultRecurringBrandId: brandId },
+    });
+  }
+
+  /**
+   * Safety net: after the cascade, assert no brand-owned row still points at a stale
+   * org. Part A verifies every configured table (correct field pairing). Part B
+   * discovers ANY other dual-keyed table via information_schema and blocks the move
+   * if it would orphan rows — so a forgotten/future table rolls back loudly instead
+   * of silently splitting tenancy.
+   */
+  private async assertNoBrandOrgOrphans(
+    tx: Prisma.TransactionClient,
+    brandId: string,
+    destOrgId: string,
+  ): Promise<void> {
+    const client = tx as unknown as Record<string, CascadeDelegate>;
+
+    const stale: string[] = [];
+    for (const target of FIRST_ORDER_TARGETS) {
+      const remaining = await client[target.delegate].count({
+        where: {
+          [target.brandField]: brandId,
+          [target.orgField]: { not: destOrgId },
+        },
+      });
+      if (remaining > 0) {
+        stale.push(`${target.delegate} (${remaining})`);
+      }
+    }
+    if (stale.length > 0) {
+      throw new Error(
+        `Brand relocation aborted: cascade left stale organization id on ${stale.join(', ')}.`,
+      );
+    }
+
+    const knownTables = new Set<string>([
+      ...FIRST_ORDER_TARGETS.map((target) => target.table),
+      ...AUDITOR_IGNORED_TABLES,
+    ]);
+
+    const candidates = await tx.$queryRawUnsafe<
+      { table_name: string; brand_col: string; org_col: string }[]
+    >(
+      `SELECT c1.table_name AS table_name, c1.column_name AS brand_col, c2.column_name AS org_col
+       FROM information_schema.columns c1
+       JOIN information_schema.columns c2
+         ON c1.table_name = c2.table_name AND c1.table_schema = c2.table_schema
+       WHERE c1.table_schema = 'public'
+         AND c1.column_name LIKE '%brand_id'
+         AND (c2.column_name LIKE '%organization_id' OR c2.column_name LIKE '%org_id')`,
+    );
+
+    const IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+    const unhandled: string[] = [];
+    for (const candidate of candidates) {
+      if (knownTables.has(candidate.table_name)) {
+        continue;
+      }
+      if (
+        !IDENTIFIER.test(candidate.table_name) ||
+        !IDENTIFIER.test(candidate.brand_col) ||
+        !IDENTIFIER.test(candidate.org_col)
+      ) {
+        continue;
+      }
+      const rows = await tx.$queryRawUnsafe<{ n: number }[]>(
+        `SELECT COUNT(*)::int AS n FROM "${candidate.table_name}" WHERE "${candidate.brand_col}" = $1 AND "${candidate.org_col}" IS DISTINCT FROM $2`,
+        brandId,
+        destOrgId,
+      );
+      const count = rows[0]?.n ?? 0;
+      if (count > 0) {
+        unhandled.push(
+          `${candidate.table_name}.${candidate.brand_col}/${candidate.org_col} (${count})`,
+        );
+      }
+    }
+    if (unhandled.length > 0) {
+      throw new Error(
+        `Brand relocation aborted: unhandled dual-keyed table(s) would be orphaned in the source org: ${unhandled.join(', ')}. Add them to FIRST_ORDER_TARGETS in brand-org-cascade.constants.ts.`,
+      );
+    }
+  }
+
+  private async invalidateRelocationCaches(
+    brandId: string,
+    sourceOrgId: string,
+    destOrgId: string,
+  ): Promise<void> {
+    await this.cacheInvalidationService.invalidate(
+      CACHE_PATTERNS.BRANDS_SINGLE(brandId),
+      CACHE_PATTERNS.BRANDS_LIST(sourceOrgId),
+      CACHE_PATTERNS.BRANDS_LIST(destOrgId),
+    );
+    await this.cacheInvalidationService.invalidateByTags([CACHE_TAGS.BRANDS]);
+    await this.cacheInvalidationService.invalidatePattern(
+      `${CACHE_TAGS.BRANDS}:*`,
+    );
   }
 
   /**

--- a/packages/services/organization/organizations.service.ts
+++ b/packages/services/organization/organizations.service.ts
@@ -363,6 +363,29 @@ export class OrganizationsService extends BaseService<Organization> {
   }
 
   /**
+   * Returns all organizations on the platform. Backed by the superadmin-gated
+   * `GET /organizations` list endpoint — callers must be a platform superadmin, or
+   * the request 403s. Used to populate the destination picker when a superadmin
+   * relocates a brand to any organization.
+   */
+  public async getAllOrganizations(): Promise<
+    { id: string; label: string; slug: string }[]
+  > {
+    return await this.instance
+      .get<JsonApiResponseDocument>('', { params: { limit: 500 } })
+      .then((res) => {
+        const organizations = this.extractCollection<Partial<Organization>>(
+          res.data,
+        );
+        return organizations.map((organization) => ({
+          id: String(organization.id),
+          label: organization.label ?? '',
+          slug: organization.slug ?? '',
+        }));
+      });
+  }
+
+  /**
    * Switch the active organization. Call window.location.reload() after this to
    * re-sync session-scoped workspace data.
    */

--- a/packages/ui/src/components/modals/brands/brand/BrandEditorForm.tsx
+++ b/packages/ui/src/components/modals/brands/brand/BrandEditorForm.tsx
@@ -24,9 +24,11 @@ import type {
   BrandFormValues,
   BrandOverlayRecord,
 } from './ModalBrand.types';
+import type { OrganizationOption } from './useModalBrand';
 
 export type BrandEditorFormProps = {
   activeBrand: BrandOverlayRecord | null;
+  canMoveOrganization: boolean;
   editorTab: BrandEditorTab;
   error: string | null;
   fontFamilies: IFontFamily[];
@@ -50,6 +52,7 @@ export type BrandEditorFormProps = {
     defaultMusicModel?: string | null;
     defaultVideoModel?: string | null;
   };
+  organizationOptions: OrganizationOption[];
   previousPrompt: string | null;
   videoModels: IModel[];
 };
@@ -67,6 +70,7 @@ function getInheritedModelOptionLabel(
 
 export default function BrandEditorForm({
   activeBrand,
+  canMoveOrganization,
   editorTab,
   error,
   fontFamilies,
@@ -83,6 +87,7 @@ export default function BrandEditorForm({
   onUndo,
   onCopyPrompt,
   organizationDefaults,
+  organizationOptions,
   previousPrompt,
   videoModels,
 }: BrandEditorFormProps) {
@@ -154,6 +159,26 @@ export default function BrandEditorForm({
                 isDisabled={isSubmitting || isGenerating}
               />
             </FormControl>
+
+            {canMoveOrganization ? (
+              <FormControl
+                label="Organization"
+                helpText="Move this brand to another organization. Its content moves with it."
+              >
+                <SelectField
+                  name="organizationId"
+                  control={form.control}
+                  onChange={onChange}
+                  isDisabled={isSubmitting || isGenerating}
+                >
+                  {organizationOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </SelectField>
+              </FormControl>
+            ) : null}
           </div>
         ) : null}
 

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.test.tsx
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.test.tsx
@@ -181,6 +181,14 @@ vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
   }),
 }));
 
+vi.mock(
+  '@genfeedai/contexts/providers/access-state/access-state.provider',
+  () => ({
+    __esModule: true,
+    useAccessState: () => ({ isSuperAdmin: false }),
+  }),
+);
+
 vi.mock('@ui/lazy/modal/LazyModal', () => ({
   __esModule: true,
   LazyModalBrandGenerate: () => <div data-testid="brand-generate-modal" />,

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.tsx
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.tsx
@@ -25,6 +25,7 @@ export default function BrandOverlay({
 }: BrandOverlayProps) {
   const {
     activeBrand,
+    canMoveOrganization,
     connectedPlatformsCount,
     editorTab,
     error,
@@ -43,6 +44,7 @@ export default function BrandOverlay({
     musicModels,
     navigateToBrandSettings,
     organizationDefaults,
+    organizationOptions,
     overlayDescription,
     overlayTitle,
     overlayView,
@@ -143,6 +145,7 @@ export default function BrandOverlay({
             <div className="mx-auto w-full max-w-5xl">
               <BrandEditorForm
                 activeBrand={activeBrand}
+                canMoveOrganization={canMoveOrganization}
                 editorTab={editorTab}
                 error={error}
                 fontFamilies={fontFamilies}
@@ -151,6 +154,7 @@ export default function BrandOverlay({
                 isGenerating={isGenerating}
                 isSubmitting={isSubmitting}
                 musicModels={musicModels}
+                organizationOptions={organizationOptions}
                 onCancel={() => {
                   if (activeBrand) {
                     setOverlayView('overview');

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.types.ts
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.types.ts
@@ -82,6 +82,7 @@ export type BrandFormValues = {
   defaultVideoModel: string;
   description: string;
   fontFamily: string;
+  organizationId: string;
   slug: string;
   label: string;
   primaryColor: string;

--- a/packages/ui/src/components/modals/brands/brand/useModalBrand.ts
+++ b/packages/ui/src/components/modals/brands/brand/useModalBrand.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { createBrandAppRoute, MODEL_KEYS } from '@genfeedai/constants';
+import { useAccessState } from '@genfeedai/contexts/providers/access-state/access-state.provider';
 import {
   useConfirmModal,
   useUploadModal,
@@ -9,6 +10,7 @@ import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
 import {
   type AssetCategory,
   LinkCategory,
+  MemberRole,
   ModalEnum,
   PromptCategory,
   SystemPromptKey,
@@ -18,13 +20,14 @@ import {
   openModal,
 } from '@genfeedai/helpers/ui/modal/modal.helper';
 import { useAuthedService } from '@genfeedai/hooks/auth/use-authed-service/use-authed-service';
+import { useUserRole } from '@genfeedai/hooks/auth/use-user-role/use-user-role';
 import { useElements } from '@genfeedai/hooks/data/elements/use-elements/use-elements';
 import { useOrganization } from '@genfeedai/hooks/data/organization/use-organization/use-organization';
 import { useOrgUrl } from '@genfeedai/hooks/navigation/use-org-url';
 import { useModalAutoOpen } from '@genfeedai/hooks/ui/use-modal-auto-open/use-modal-auto-open';
 import { useFormSubmitWithState } from '@genfeedai/hooks/utils/use-form-submit/use-form-submit';
 import { useSocketManager } from '@genfeedai/hooks/utils/use-socket-manager/use-socket-manager';
-import type { IBrand, ILink } from '@genfeedai/interfaces';
+import type { IBrand, ILink, IStructuredError } from '@genfeedai/interfaces';
 import { Prompt } from '@genfeedai/models/content/prompt.model';
 import { Brand } from '@genfeedai/models/organization/brand.model';
 import type { Link } from '@genfeedai/models/social/link.model';
@@ -34,6 +37,7 @@ import { PromptsService } from '@genfeedai/services/content/prompts.service';
 import { ClipboardService } from '@genfeedai/services/core/clipboard.service';
 import { logger } from '@genfeedai/services/core/logger.service';
 import { createPromptHandler } from '@genfeedai/services/core/socket-manager.service';
+import { OrganizationsService } from '@genfeedai/services/organization/organizations.service';
 import { BrandsService } from '@genfeedai/services/social/brands.service';
 import { LinksService } from '@genfeedai/services/social/links.service';
 import { hasErrorDetail } from '@genfeedai/utils/error/error-handler.util';
@@ -60,6 +64,14 @@ import {
   buildSocialConnections,
 } from './ModalBrand.types';
 
+function getStructuredErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+  const status = (error as IStructuredError).status;
+  return typeof status === 'number' ? status : undefined;
+}
+
 const DEFAULT_BRAND_FORM_VALUES: BrandFormValues = {
   backgroundColor: THEME_COLORS.PRIMARY,
   defaultImageModel: '',
@@ -69,10 +81,16 @@ const DEFAULT_BRAND_FORM_VALUES: BrandFormValues = {
   description: '',
   fontFamily: 'montserrat-regular',
   label: '',
+  organizationId: '',
   primaryColor: THEME_COLORS.PRIMARY,
   secondaryColor: THEME_COLORS.SECONDARY,
   slug: '',
   text: '',
+};
+
+export type OrganizationOption = {
+  id: string;
+  label: string;
 };
 
 const DEFAULT_BRAND_LINK_FORM_VALUES: BrandLinkEditorValues = {
@@ -83,7 +101,9 @@ const DEFAULT_BRAND_LINK_FORM_VALUES: BrandLinkEditorValues = {
 
 export type UseModalBrandReturn = {
   activeBrand: BrandOverlayRecord | null;
+  canMoveOrganization: boolean;
   connectedPlatformsCount: number;
+  currentOrganizationId: string | null;
   editorTab: BrandEditorTab;
   error: string | null;
   fontFamilies: ReturnType<typeof useElements>['fontFamilies'];
@@ -106,6 +126,7 @@ export type UseModalBrandReturn = {
     defaultMusicModel: string | null;
     defaultVideoModel: string | null;
   };
+  organizationOptions: OrganizationOption[];
   overlayBrandId: string | null;
   overlayDescription: string;
   overlayTitle: string;
@@ -164,7 +185,11 @@ export function useModalBrand(
     initialView = 'edit',
   } = props;
 
-  const { organizationId } = useBrand();
+  const { organizationId, refreshBrands } = useBrand();
+  const { isSuperAdmin } = useAccessState();
+  const role = useUserRole();
+  const hasElevatedRole =
+    role === MemberRole.OWNER || role === MemberRole.ADMIN;
   const { push } = useRouter();
   const { orgSlug } = useOrgUrl();
   const { settings } = useOrganization();
@@ -194,6 +219,9 @@ export function useModalBrand(
   );
   const getLinksService = useAuthedService((token: string) =>
     LinksService.getInstance(token),
+  );
+  const getOrgsService = useAuthedService((token: string) =>
+    OrganizationsService.getInstance(token),
   );
 
   const { imageModels, musicModels, videoModels, fontFamilies } = useElements();
@@ -262,6 +290,31 @@ export function useModalBrand(
       ? initialBrand
       : null);
 
+  const currentOrganizationId = activeBrand?.organization?.id ?? null;
+
+  const { data: organizationOptionsData } = useQuery({
+    queryKey: ['brand-modal-organization-options', isSuperAdmin],
+    queryFn: async (): Promise<OrganizationOption[]> => {
+      const service = await getOrgsService();
+      if (isSuperAdmin) {
+        const organizations = await service.getAllOrganizations();
+        return organizations.map((organization) => ({
+          id: organization.id,
+          label: organization.label,
+        }));
+      }
+      const organizations = await service.getMyOrganizations();
+      return organizations.map((organization) => ({
+        id: organization.id,
+        label: organization.label,
+      }));
+    },
+  });
+
+  const organizationOptions = organizationOptionsData ?? [];
+  const canMoveOrganization =
+    isSuperAdmin || (hasElevatedRole && organizationOptions.length >= 2);
+
   useEffect(() => {
     setOverlayBrandId(brand?.id ?? null);
     setOverlayView(brand ? initialView : 'edit');
@@ -292,6 +345,7 @@ export function useModalBrand(
       fontFamily:
         activeBrand.fontFamily || DEFAULT_BRAND_FORM_VALUES.fontFamily,
       label: activeBrand.label || '',
+      organizationId: activeBrand.organization?.id || '',
       primaryColor:
         activeBrand.primaryColor || DEFAULT_BRAND_FORM_VALUES.primaryColor,
       secondaryColor:
@@ -634,51 +688,119 @@ export function useModalBrand(
     onConfirm?.(true);
   }, [onConfirm, refreshBrand]);
 
+  const performBrandSubmit = useCallback(
+    async (isOrganizationChange: boolean) => {
+      try {
+        const service = await getBrandsService();
+        const formData = {
+          ...form.getValues(),
+          isDeleted: false,
+          isSelected: false,
+        };
+
+        if (overlayBrandId) {
+          const updatedBrand = await service.patch(overlayBrandId, formData);
+          mutateBrand(overlayBrandId, updatedBrand as BrandOverlayRecord);
+          await refreshBrand();
+          if (isOrganizationChange) {
+            await refreshBrands();
+          }
+          onConfirm?.(true);
+          setOverlayView('overview');
+        } else {
+          const createdBrand = await service.post(
+            new Brand(formData as Partial<IBrand>),
+          );
+          const createdBrandDetail = await service.findOne(createdBrand.id);
+
+          setOverlayBrandId(createdBrand.id);
+          mutateBrand(
+            createdBrand.id,
+            createdBrandDetail as BrandOverlayRecord,
+          );
+          onConfirm?.(true, createdBrand.id);
+          setOverlayView('overview');
+        }
+      } catch (submitError) {
+        logger.error('Failed to save brand', submitError);
+
+        if (hasErrorDetail(submitError, 'brand limit')) {
+          setError(
+            'Credits have been deducted for an additional brand. Please try creating the brand again.',
+          );
+          return;
+        }
+
+        const status = getStructuredErrorStatus(submitError);
+        if (status === 409) {
+          setError(
+            "Couldn't move the brand — the destination organization has a conflicting record.",
+          );
+          return;
+        }
+        if (status === 403) {
+          setError(
+            "You don't have permission to move this brand to that organization.",
+          );
+          return;
+        }
+
+        setError('Failed to save brand');
+      }
+    },
+    [
+      form,
+      getBrandsService,
+      mutateBrand,
+      onConfirm,
+      overlayBrandId,
+      refreshBrand,
+      refreshBrands,
+    ],
+  );
+
   const submitModalBrand = useCallback(async () => {
-    try {
-      const service = await getBrandsService();
-      const formData = {
-        ...form.getValues(),
-        isDeleted: false,
-        isSelected: false,
-      };
+    const nextOrganizationId = form.getValues().organizationId;
+    const isOrganizationChange =
+      !!overlayBrandId &&
+      !!currentOrganizationId &&
+      !!nextOrganizationId &&
+      nextOrganizationId !== currentOrganizationId;
 
-      if (overlayBrandId) {
-        const updatedBrand = await service.patch(overlayBrandId, formData);
-        mutateBrand(overlayBrandId, updatedBrand as BrandOverlayRecord);
-        await refreshBrand();
-        onConfirm?.(true);
-        setOverlayView('overview');
-      } else {
-        const createdBrand = await service.post(
-          new Brand(formData as Partial<IBrand>),
-        );
-        const createdBrandDetail = await service.findOne(createdBrand.id);
-
-        setOverlayBrandId(createdBrand.id);
-        mutateBrand(createdBrand.id, createdBrandDetail as BrandOverlayRecord);
-        onConfirm?.(true, createdBrand.id);
-        setOverlayView('overview');
-      }
-    } catch (submitError) {
-      logger.error('Failed to save brand', submitError);
-
-      if (hasErrorDetail(submitError, 'brand limit')) {
-        setError(
-          'Credits have been deducted for an additional brand. Please try creating the brand again.',
-        );
-        return;
-      }
-
-      setError('Failed to save brand');
+    if (!isOrganizationChange) {
+      await performBrandSubmit(false);
+      return;
     }
+
+    const destinationOrganization = organizationOptions.find(
+      (option) => option.id === nextOrganizationId,
+    );
+    const destinationLabel =
+      destinationOrganization?.label ?? 'that organization';
+    const brandLabel = form.getValues().label || 'This brand';
+
+    openConfirm({
+      cancelLabel: 'Cancel',
+      confirmLabel: 'Move brand',
+      isError: true,
+      label: 'Move brand to another organization?',
+      message: `${brandLabel} and all its content, credentials, and history will move to ${destinationLabel}. This cannot be easily undone.`,
+      onConfirm: async () => {
+        await performBrandSubmit(true);
+      },
+      onClose: () => {
+        form.setValue('organizationId', currentOrganizationId ?? '', {
+          shouldValidate: true,
+        });
+      },
+    });
   }, [
+    currentOrganizationId,
     form,
-    getBrandsService,
-    mutateBrand,
-    onConfirm,
+    openConfirm,
+    organizationOptions,
     overlayBrandId,
-    refreshBrand,
+    performBrandSubmit,
   ]);
 
   const { isSubmitting, onSubmit } = useFormSubmitWithState(() =>
@@ -742,7 +864,9 @@ export function useModalBrand(
 
   return {
     activeBrand,
+    canMoveOrganization,
     connectedPlatformsCount,
+    currentOrganizationId,
     editorTab,
     error,
     fontFamilies,
@@ -760,6 +884,7 @@ export function useModalBrand(
     musicModels,
     navigateToBrandSettings,
     organizationDefaults,
+    organizationOptions,
     overlayBrandId,
     overlayDescription,
     overlayTitle,


### PR DESCRIPTION
## What

Adds the ability to **reassign a brand to another organization** (e.g. migrating brands into a demo org used for leads). Surfaced as an editable **Organization** field on the existing brand edit modal — no new endpoint: a changed `organizationId` on `PATCH /brands/:id` triggers a relocation.

## Why it's non-trivial

A brand is not self-contained. The schema **denormalizes `organizationId` across 58 first-order tables** that also carry a brand key, plus org-scoped **second-order children** with no brand key. A naive org flip would leave that data stamped with the old org — invisible to the destination org's tenant-scoped reads (which filter by `organizationId` directly). That's a **tenancy split-brain**.

## How correctness is guaranteed

Two mechanisms, working together:

1. **Explicit cascade** (`brand-org-cascade.constants.ts`) — 58 first-order targets (incl. non-standard names: `Asset.parentBrandId/parentOrgId`, `ContextBase.sourceBrandId`, `Lead.proactiveBrandId → proactiveOrganizationId`) + 7 second-order children joined to a moved parent by scalar FK. `Member` and `Workflow` are excluded by design (their cross-org links are *severed*, not moved).
2. **Runtime orphan auditor** — after the cascade, inside the same transaction, it scans **every** dual-keyed table via `information_schema` and **rolls the whole move back** if any brand-owned row is left in the old org. So a forgotten or future table fails loudly instead of silently corrupting tenancy.

A **staleness test** parses `schema.prisma` and fails CI if a new dual-keyed model is added without cascade handling.

## Authorization

- Platform **superadmin** → move to any org, **or**
- **owner/admin of BOTH** the source and destination orgs (guarantees the caller keeps access to the brand).

`P2002` unique-constraint conflicts (e.g. destination org already tracks the same external thread) → `409 Conflict`, surfaced inline.

## Frontend

Role-aware **Organization** `SelectField` in the brand modal Info tab — visible only to superadmins or elevated members of ≥2 orgs. Superadmins list all orgs; members list their own. A confirm dialog precedes any move; both orgs' brand lists refresh on success.

## Product decision (flag if wrong)

Source-org **workflows and non-destination members are severed** from the brand (they'd be cross-org). Also intentionally left in the source org: execution/revenue history (`WorkflowExecution`, `SubscriptionAttribution`, agent threads/runs). If you'd rather workflows move *with* the brand, it's a scoped change to one step.

## Testing

- 9 relocation unit tests + 5 staleness tests (new); full brands suite **123 green**.
- Type-check clean (api, ui, services); biome/lint clean.
- **Manual E2E deferred to a real environment**: verifying a cross-org move end-to-end needs a running API + Postgres seeded with multi-org data + an authenticated owner/admin session — beyond local single-file verification. CI runs the suite; recommend a manual smoke in staging (move a brand between two orgs, confirm a Post + Credential appear under the destination org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)