### PR TITLE
docs(sessions): 2026-07-05 session handoff

### DIFF
--- a/.agents/SESSIONS/2026-07-05.md
+++ b/.agents/SESSIONS/2026-07-05.md
@@ -1,0 +1,72 @@
+# 2026-07-05
+
+## Session 1 — Boot app + API in a fresh worktree; fix auth heading wrap
+
+### Context
+
+Vincent wanted to run `apps/app` (frontend) + the API locally to do a UI-harmonization
+pass on the studio (a separate session was harmonizing `apps/web`). The worktree
+`inspiring-sanderson-a15570` had never been provisioned, so most of the session was
+getting it to boot and getting an authenticated session, plus one login-screen UI fix he
+flagged live. The whole runtime setup is ad-hoc/session-only — nothing about the local run
+config is committed.
+
+### System flow
+
+```text
+Fresh worktree (no node_modules) → "Awaiting server…" / Turbopack can't resolve `next`
+  → bun install (7019 pkgs) + prisma db:generate (postinstall only wires skills, not prisma)
+  → API crash 1: BETTER_AUTH_SECRET missing (auth defaults ON; not in any committed env file)
+  → API crash 2: Prisma P2022 — local DB behind schema (missing organizations.authProviderOrganizationId)
+  → DB sync: prisma db push --url localhost/genfeed  (migrate deploy impossible: no _prisma_migrations + tables exist)
+  → API boots; frontend renders login wall (Better Auth is the baseline even self-hosted)
+  → Better Auth rejects origins: trustedOrigins empty (also not in env files)
+  → seed user admin@localhost has NO credential + invalid-for-BetterAuth email (no TLD)
+  → repoint seed user → vincent@genfeed.ai; magic-link dispatched but raw token only in the email
+  → temp-log the raw magic-link URL in the mailer (reverted after) → verify at API → session created
+  → cookie-origin mismatch (localhost cookie vs local.genfeed.ai app) → realign SAME-ORIGIN
+  → BETTER_AUTH_URL = app origin + NEXT_PUBLIC_API_ENDPOINT = app-origin/v1 (through the /v1 proxy)
+  → logged in → Workspace Dashboard (vincent@genfeed.ai, Default Workspace/Brand)
+```
+
+### Affected components
+
+- **Worktree runtime** (not committed): `node_modules` (bun install), Prisma client (`packages/prisma db:generate`), all `.env*` copied from the master checkout (git-ignored).
+- **Local DB** `localhost:5432/genfeed` (disposable homebrew seed skeleton): schema synced via `prisma db push`; seed user email repointed to `vincent@genfeed.ai`.
+- **API** `apps/server/api`: run directly (not via turbo) with session-only `BETTER_AUTH_SECRET` / `BETTER_AUTH_TRUSTED_ORIGINS` / `BETTER_AUTH_URL` in `process.env`.
+- **apps/app**: login UI fix (shipped, PR #1303); run with `NEXT_PUBLIC_API_ENDPOINT` pointed at the app origin's `/v1` proxy.
+
+### Key decisions
+
+1. **Fresh worktrees need manual provisioning**: `bun install` (worktrees inherit no `node_modules`) + `bun run --filter=@genfeedai/prisma db:generate` (root `postinstall` only builds skill symlinks — it does NOT generate the Prisma client).
+2. **Env vars reach Nest only when the API runs directly** (`cd apps/server/api && bun run dev`). Running through `bunx turbo run dev` **strips** any `process.env` var not declared in `turbo.json` — this silently ate an inline `BETTER_AUTH_SECRET`.
+3. **DB synced with `prisma db push`, not `migrate deploy`.** The local `genfeed` DB is a `db push`-seeded skeleton: it has tables but **no `_prisma_migrations` history**, so `migrate deploy` would fail on "table already exists." Targeted `--url postgresql://genfeed@localhost:5432/genfeed` explicitly (trust auth, `genfeed` owns the tables) — the Prisma CLI's own default `DATABASE_URL` (in `packages/prisma/prisma/.env`) still points at the `local-genfeedai...rds.amazonaws.com` RDS, which must NOT be the push target.
+4. **Auth config is entirely absent from committed env files** — `BETTER_AUTH_SECRET`, `BETTER_AUTH_ENABLED`, `BETTER_AUTH_TRUSTED_ORIGINS` are not in `../../.env.local`, `api/.env`, or `api/.env.local`. Provided them session-only via `process.env`. The secret was generated once and kept in the session scratchpad — never written to the repo.
+5. **Same-origin is required for the session cookie.** The app hard-redirects `localhost:3000` → `local.genfeed.ai:3000`, but the committed frontend env calls the API cross-site at `localhost:3010`, so the Better-Auth cookie never sticks. Fix: `BETTER_AUTH_URL=http://local.genfeed.ai:3000` + `NEXT_PUBLIC_API_ENDPOINT=http://local.genfeed.ai:3000/v1` so everything flows through the app's `/v1` proxy on one origin.
+6. **Magic-link completion**: `auth_tokens` stores a **hashed** token, so the DB row can't reconstruct the link. Temporarily logged the raw magic-link URL in `better-auth-mailer.service.ts` (dev only), used it, then **reverted** the edit. Session valid through **2026-07-12**.
+7. **Login heading fix (shipped)**: the magic-link/password/reset views capped their card at `max-w-[320px]`, narrower than the chooser's `max-w-sm`, so long headings wrapped ("Sign in with a magic link" needs 337px, "Sign in with email and password" 447px at `text-3xl`). Unified all auth cards to `max-w-sm` and dropped the shared `AuthHeader` h1 to `text-2xl` → every heading one line. **PR #1303.**
+8. **This handoff landed off `master`**, separate from the login-fix branch, since the runtime setup work isn't part of that scoped PR.
+
+### Files changed
+
+- **Shipped** (PR #1303, branch `claude/inspiring-sanderson-a15570`): `apps/app/app/(public)/login/login-better-auth.tsx`
+- **Local-only, intentionally not shipped**: `.claude/launch.json` (preview config), all `apps/**/.env*` + `packages/prisma/prisma/.env` (copied from master, git-ignored)
+- **Touched then reverted**: `apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts` (temp raw-link log)
+
+### Mistakes and fixes
+
+- Inline secret via `bunx turbo` → stripped by turbo's env sanitizer → ran the API script directly instead.
+- Almost `db push`ed to the CLI's default `DATABASE_URL` (remote RDS) → verified the target host was `localhost` first (masked-host check, credentials never surfaced).
+- Preview tool is pinned to `localhost:3000` and won't follow to `local.genfeed.ai` → switched to Vincent's Brave via the Chrome extension for the real origin.
+- Direct verify with the DB's hashed token failed (no session) → needed the raw token from the mailer.
+- Verified through the app-origin proxy set the cookie on the wrong host → same-origin realignment (decision 5).
+
+### Next steps / handoff
+
+- **Servers are up (background bash), session live.** Resume by opening `http://local.genfeed.ai:3000` in Brave — logged in as `vincent@genfeed.ai`, Default Workspace/Brand, session good to 2026-07-12.
+  - API: `apps/server/api` direct run on :3010 with `BETTER_AUTH_SECRET` (scratchpad), `BETTER_AUTH_TRUSTED_ORIGINS=http://local.genfeed.ai:3000`, `BETTER_AUTH_URL=http://local.genfeed.ai:3000`.
+  - Frontend: `apps/app` direct run on :3000 with `NEXT_PUBLIC_API_ENDPOINT=http://local.genfeed.ai:3000/v1`.
+- **The actual work — studio UI harmonization — has not started.** Dashboard/Inbox/Tasks/settings are all reachable now.
+- **Repro gap worth fixing**: a fresh worktree can't authenticate out of the box because `BETTER_AUTH_*` + the `local.genfeed.ai` endpoint config live nowhere committed (only `.env.example` hints at `local.genfeed.ai:3010`). Consider documenting/committing a local-run recipe so this isn't rediscovered each worktree.
+- **Stale memory flagged**: `.agents/memory/reference_postgres_rds.md` describes a shared dev RDS (`local-genfeedai`) as the local DB; Vincent says that's outdated and he no longer uses a remote shared RDS. The API's `DATABASE_URL` resolves to `localhost:5432/genfeed`. Re-verify and correct that memory before citing it.
+- PR **#1303** (login heading) awaiting review.


### PR DESCRIPTION
Session handoff for the local-run bootstrap of worktree `inspiring-sanderson-a15570` + the shipped login heading fix.

Captures (redacted, no secrets):
- Fresh-worktree provisioning gotchas: `bun install` (no inherited `node_modules`) + `db:generate` (postinstall only wires skills, not Prisma).
- Local DB synced via `prisma db push` against `localhost/genfeed` (no migration history → `migrate deploy` can't run); the Prisma CLI's default `DATABASE_URL` still points at a remote RDS and must not be the target.
- Better Auth config (`SECRET` / `TRUSTED_ORIGINS` / `URL`) absent from committed env → provided session-only; same-origin realignment so the session cookie sticks under `local.genfeed.ai`.
- Magic-link sign-in completion + the shipped auth-heading fix (PR #1303).
- Follow-ups: document a committed local-run recipe; re-verify stale `reference_postgres_rds.md`.

Landed off `master`, separate from the login-fix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)