### PR TITLE
refactor(workers): extract circuit-breaker util into @genfeedai/libs (#1090)

### DIFF
--- a/apps/server/workers/src/processors/api/queues/analytics-facebook/analytics-facebook.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-facebook/analytics-facebook.processor.ts
@@ -2,11 +2,6 @@ import { CredentialsService } from '@api/collections/credentials/services/creden
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { FacebookService } from '@api/services/integrations/facebook/services/facebook.service';
-import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import {
@@ -14,6 +9,11 @@ import {
   FacebookAnalyticsJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/analytics-social/analytics-social.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-social/analytics-social.processor.ts
@@ -5,17 +5,17 @@ import { LinkedInService } from '@api/services/integrations/linkedin/services/li
 import { MastodonService } from '@api/services/integrations/mastodon/services/mastodon.service';
 import { PinterestService } from '@api/services/integrations/pinterest/services/pinterest.service';
 import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok.service';
-import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import {
   ANALYTICS_SOCIAL_QUEUE,
   SocialAnalyticsJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/analytics-sync/analytics-sync.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-sync/analytics-sync.processor.ts
@@ -3,15 +3,15 @@ import {
   AnalyticsSyncService,
 } from '@api/collections/content-performance/services/analytics-sync.service';
 import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
-import {
   ANALYTICS_SYNC_QUEUE,
   AnalyticsSyncJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/analytics-threads/analytics-threads.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-threads/analytics-threads.processor.ts
@@ -1,17 +1,17 @@
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { ThreadsService } from '@api/services/integrations/threads/services/threads.service';
-import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import {
   ANALYTICS_THREADS_QUEUE,
   ThreadsAnalyticsJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/analytics-twitter/analytics-twitter.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-twitter/analytics-twitter.processor.ts
@@ -1,11 +1,6 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
-import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import {
@@ -13,6 +8,11 @@ import {
   TwitterAnalyticsJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/analytics-youtube/analytics-youtube.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-youtube/analytics-youtube.processor.spec.ts
@@ -1,9 +1,9 @@
 vi.mock(
-  '@api/shared/utils/circuit-breaker/circuit-breaker.util',
+  '@libs/utils/circuit-breaker/circuit-breaker.util',
   async (importOriginal) => {
     const actual =
       await importOriginal<
-        typeof import('@api/shared/utils/circuit-breaker/circuit-breaker.util')
+        typeof import('@libs/utils/circuit-breaker/circuit-breaker.util')
       >();
     return {
       ...actual,
@@ -16,8 +16,8 @@ vi.mock(
 
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
-import { BrokenCircuitError } from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BrokenCircuitError } from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   AnalyticsYouTubeProcessor,
@@ -171,7 +171,7 @@ describe('AnalyticsYouTubeProcessor', () => {
 
     it('throws BrokenCircuitError when circuit breaker is open', async () => {
       const { createProcessorCircuitBreaker } = await import(
-        '@api/shared/utils/circuit-breaker/circuit-breaker.util'
+        '@libs/utils/circuit-breaker/circuit-breaker.util'
       );
       const circuitErr = new BrokenCircuitError('analytics-youtube', 5);
       (

--- a/apps/server/workers/src/processors/api/queues/analytics-youtube/analytics-youtube.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/analytics-youtube/analytics-youtube.processor.ts
@@ -1,15 +1,15 @@
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
 import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
-import {
   ANALYTICS_YOUTUBE_QUEUE,
   YouTubeAnalyticsJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/campaign/campaign.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/campaign/campaign.processor.ts
@@ -9,11 +9,6 @@
 import { OutreachCampaignsService } from '@api/collections/outreach-campaigns/services/outreach-campaigns.service';
 import { CampaignExecutorService } from '@api/services/campaign/campaign-executor.service';
 import { DmCampaignExecutorService } from '@api/services/campaign/dm-campaign-executor.service';
-import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { CampaignStatus, CampaignType } from '@genfeedai/enums';
 import {
   CAMPAIGN_PROCESSING_QUEUE,
@@ -21,6 +16,11 @@ import {
   CampaignProcessingResult,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/email-digest/email-digest.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/email-digest/email-digest.processor.ts
@@ -3,15 +3,15 @@ import {
   EmailDigestService,
 } from '@api/collections/content-performance/services/email-digest.service';
 import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
-import {
   EMAIL_DIGEST_QUEUE,
   EmailDigestJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/reply-bot/reply-bot-polling.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/reply-bot/reply-bot-polling.processor.spec.ts
@@ -1,11 +1,11 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/services/reply-bot-configs.service';
 import { ReplyBotOrchestratorService } from '@api/services/reply-bot/reply-bot-orchestrator.service';
+import { LoggerService } from '@libs/logger/logger.service';
 import {
   BrokenCircuitError,
   ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
-import { LoggerService } from '@libs/logger/logger.service';
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type { Job } from 'bullmq';
 
@@ -14,7 +14,7 @@ import {
   ReplyBotPollingProcessor,
 } from './reply-bot-polling.processor';
 
-vi.mock('@api/shared/utils/circuit-breaker/circuit-breaker.util', () => {
+vi.mock('@libs/utils/circuit-breaker/circuit-breaker.util', () => {
   const mockExecute = vi.fn();
   return {
     BrokenCircuitError: class BrokenCircuitError extends Error {
@@ -59,7 +59,7 @@ describe('ReplyBotPollingProcessor', () => {
 
   beforeEach(async () => {
     const { createProcessorCircuitBreaker } = await import(
-      '@api/shared/utils/circuit-breaker/circuit-breaker.util'
+      '@libs/utils/circuit-breaker/circuit-breaker.util'
     );
     circuitExecute = vi.fn();
     vi.mocked(createProcessorCircuitBreaker).mockReturnValue({

--- a/apps/server/workers/src/processors/api/queues/reply-bot/reply-bot-polling.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/reply-bot/reply-bot-polling.processor.ts
@@ -1,11 +1,6 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/services/reply-bot-configs.service';
 import { ReplyBotOrchestratorService } from '@api/services/reply-bot/reply-bot-orchestrator.service';
-import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
 import { EncryptionUtil } from '@api/shared/utils/encryption/encryption.util';
 import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import {
@@ -14,6 +9,11 @@ import {
   ReplyBotPollingResult,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/apps/server/workers/src/processors/api/queues/telegram-distribute/telegram-distribute.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/telegram-distribute/telegram-distribute.processor.ts
@@ -1,14 +1,14 @@
 import { TelegramDistributionService } from '@api/services/distribution/telegram/telegram-distribution.service';
 import {
-  BrokenCircuitError,
-  createProcessorCircuitBreaker,
-  type ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
-import {
   TELEGRAM_DISTRIBUTE_QUEUE,
   TelegramDistributeJobData,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BrokenCircuitError,
+  createProcessorCircuitBreaker,
+  type ProcessorCircuitBreaker,
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 

--- a/packages/libs/utils/circuit-breaker/circuit-breaker.util.spec.ts
+++ b/packages/libs/utils/circuit-breaker/circuit-breaker.util.spec.ts
@@ -2,7 +2,7 @@ import {
   BrokenCircuitError,
   createProcessorCircuitBreaker,
   ProcessorCircuitBreaker,
-} from '@api/shared/utils/circuit-breaker/circuit-breaker.util';
+} from '@libs/utils/circuit-breaker/circuit-breaker.util';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@libs/logger/logger.service', () => ({

--- a/packages/libs/utils/circuit-breaker/circuit-breaker.util.ts
+++ b/packages/libs/utils/circuit-breaker/circuit-breaker.util.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from '@libs/logger/logger.service';
+import type { LoggerService } from '@libs/logger/logger.service';
 
 /**
  * Error thrown when the circuit breaker is open (too many consecutive failures).


### PR DESCRIPTION
## What

First reviewable slice of the workers ↔ API decoupling in #1090 (successor to #84). Moves the processor **circuit-breaker** utility out of the API source tree into the shared `@genfeedai/libs` package, so the `workers` app stops compiling it through the `@api/*` path alias.

- `git mv apps/server/api/src/shared/utils/circuit-breaker/{circuit-breaker.util.ts,.spec.ts}` → `packages/libs/utils/circuit-breaker/`
- Rewire the **12** workers processors + spec that import it: `@api/shared/utils/circuit-breaker/circuit-breaker.util` → `@libs/utils/circuit-breaker/circuit-breaker.util`
- The util keeps its only dependency (`@libs/logger`), which already lives in the same package — **no new cross-package edges**

## Why this slice first

- The util had **zero API runtime consumers** — every importer was a workers processor — so extracting it is a clean leaf move with a bounded (~13-file) blast radius.
- `circuit-breaker` is shared by every analytics processor (+ campaign, email-digest, reply-bot, telegram-distribute), so this unblocks the deeper analytics-family service extractions that follow.
- Leaf-up extraction is the only order that keeps each PR green: you can't cleanly extract `post-analytics`/`analytics-sync` services while they still reach into `@api/shared/utils`.

## Scope boundary

Only the circuit-breaker util. Phase 1 (queue contracts, #1113) is already merged. The remaining `@api/*` surface in `workers/src` (domain services, integration services, `encryption` util) and the final CI guard forbidding `@api/*` from `apps/server/workers/src` are **follow-up slices** per the issue direction — not bundled here.

## Verification

- ✅ `biome check` clean (import ordering auto-applied; `LoggerService` narrowed to `import type`)
- ✅ Moved spec passes **10/10** under `@genfeedai/libs` vitest (proves `@libs/utils/circuit-breaker` resolves + executes)
- ✅ `@genfeedai/workers` per-app type-check (`tsc -p tsconfig.typecheck.json`) **green, 0 errors**
- ✅ Alias resolves in all three layers: workers `tsconfig.app.json`, `webpack.base.config.js` (`@libs`→`packages/libs`), and libs/workers vitest configs
- ✅ No dangling references to the old path; file moves recorded as renames (history preserved); lockfile unchanged

Refs #1090, #84