### PR TITLE
feat(brands): move sole-brand workflows with a relocated brand

### DIFF
--- a/apps/server/api/src/collections/brands/constants/brand-org-cascade.constants.ts
+++ b/apps/server/api/src/collections/brands/constants/brand-org-cascade.constants.ts
@@ -57,8 +57,11 @@ export interface SecondOrderCascadeTarget {
  *
  * Excluded on purpose (see KNOWN_EXCLUDED): `Member` (its brand link is
  * `lastUsedBrandId`, a per-user UI pointer — the member row belongs to its own org
- * and must NOT move) and `Workflow` (brand link is the `workflow_brands` M2M plus a
- * `defaultRecurringBrandId` marker — handled by the sever step, not org-rewrite).
+ * and must NOT move) and `Workflow` (brand link is the `workflow_brands` M2M, not a
+ * scalar brand key — a workflow can drive several brands at once, so it cannot be
+ * rewritten by the generic cascade). Workflows are reconciled by the bespoke
+ * `severCrossOrgLinks` step: sole-brand workflows MOVE with the brand, multi-brand
+ * workflows are SEVERED. See that method for the full ownership split.
  *
  * Non-standard field names are hand-mapped: `Asset` (parentBrandId/parentOrgId),
  * `ContextBase` (sourceBrandId), `Lead` (proactiveBrandId → proactiveOrganizationId,
@@ -420,11 +423,16 @@ export const FIRST_ORDER_TARGETS: readonly FirstOrderCascadeTarget[] = [
  * first-order parent, joined by scalar FK (no relation-name guessing — FK fields are
  * verified against the schema by the staleness test).
  *
- * Intentionally NOT relocated (org- or execution-level history, ambiguous ownership):
- * `SubscriptionAttribution` (revenue, keyed to the subscriber org), `WorkflowExecution`
- * / `BatchWorkflowJob` (workflows are severed, not moved), `AgentThread` / `AgentRun` /
- * `AgentThreadEvent` (agent conversation/execution history — no brand key, indirect
- * ownership), `Invitation` (org-level). These stay in the source org by design.
+ * Intentionally NOT relocated here (org- or execution-level history, ambiguous
+ * ownership): `SubscriptionAttribution` (revenue, keyed to the subscriber org),
+ * `AgentThread` / `AgentRun` / `AgentThreadEvent` (agent conversation/execution history
+ * — no brand key, indirect ownership), `Invitation` (org-level). These stay in the
+ * source org by design.
+ *
+ * `WorkflowExecution` / `BatchWorkflowJob` are NOT listed here because they have no
+ * brand key and are not owned by a first-order parent — they hang off a `Workflow`.
+ * They are moved conditionally by `severCrossOrgLinks`, but only for the sole-brand
+ * workflows that actually move; multi-brand workflows (and their history) stay put.
  */
 export const SECOND_ORDER_TARGETS: readonly SecondOrderCascadeTarget[] = [
   {
@@ -534,7 +542,18 @@ export const KNOWN_EXCLUDED_MODELS: readonly string[] = ['Member', 'Workflow'];
  * Physical tables the orphan auditor's "unknown table" scan should ignore, because
  * they are handled elsewhere or intentionally excluded. Everything in
  * FIRST_ORDER_TARGETS is auto-added; these are the extras (excluded models whose org
- * is deliberately left untouched). Keep in sync with KNOWN_EXCLUDED_MODELS.
+ * the generic cascade deliberately leaves untouched). Keep in sync with
+ * KNOWN_EXCLUDED_MODELS.
+ *
+ * `workflows` stays ignored even though sole-brand workflows now move: the auditor
+ * scans scalar `%brand_id` columns, but a workflow's brand link is the `workflow_brands`
+ * M2M — invisible to that scan. Its only scalar brand-ish column is
+ * `default_recurring_brand_id`, which `severCrossOrgLinks` either moves (sole-brand) or
+ * nulls (severed), so it can never be left stale anyway. The M2M split itself gets its
+ * own runtime backstop — `BrandsService.assertNoCrossOrgBrandLinks` recomputes the
+ * `workflow_brands` / `member_brands` post-state inside the transaction and rolls the
+ * move back on any surviving cross-org link — so the scalar auditor does not need to
+ * (and cannot) cover it.
  */
 export const AUDITOR_IGNORED_TABLES: readonly string[] = [
   'members',

--- a/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
@@ -127,6 +127,31 @@ describe('BrandsService.relocateToOrganization', () => {
     getDelegate('organization').findFirst.mockResolvedValue({ id: DEST_ORG });
   }
 
+  // Brand read returns SOURCE_ORG first (pre-move), then the moved row (post-move).
+  function primeRelocatableBrand(): void {
+    getDelegate('brand')
+      .findFirst.mockResolvedValueOnce({
+        id: BRAND_ID,
+        isDeleted: false,
+        organizationId: SOURCE_ORG,
+      })
+      .mockResolvedValueOnce({ id: BRAND_ID, organizationId: DEST_ORG });
+    getDelegate('organization').findFirst.mockResolvedValue({ id: DEST_ORG });
+  }
+
+  // `severCrossOrgLinks` issues two workflow.findMany queries: the first (no `AND`)
+  // returns every cross-org workflow on the brand; the second (with `AND`) returns
+  // only the multi-brand subset. Route each by the presence of `where.AND`.
+  function mockWorkflowSplit(opts: {
+    cross: { id: string }[];
+    shared: { id: string }[];
+  }): void {
+    getDelegate('workflow').findMany.mockImplementation(
+      (args: { where?: { AND?: unknown } }) =>
+        Promise.resolve(args.where?.AND ? opts.shared : opts.cross),
+    );
+  }
+
   it('does not relocate (or open a transaction) when the org is unchanged', async () => {
     getDelegate('brand').findFirst.mockResolvedValue({
       id: BRAND_ID,
@@ -275,6 +300,123 @@ describe('BrandsService.relocateToOrganization', () => {
     expect(cacheInvalidationService.invalidateByTags).toHaveBeenCalled();
 
     expect(result).toEqual({ id: BRAND_ID, organizationId: DEST_ORG });
+  });
+
+  it('moves a sole-brand workflow (with its execution + batch history) with the brand', async () => {
+    primeRelocatableBrand();
+    // wf_sole is attached only to the moving brand → it should move, not sever.
+    mockWorkflowSplit({ cross: [{ id: 'wf_sole' }], shared: [] });
+
+    await service.relocateToOrganization(
+      BRAND_ID,
+      { organizationId: DEST_ORG },
+      { isSuperAdmin: true, userId: USER_ID },
+    );
+
+    // Workflow definition re-homed to the destination org.
+    expect(getDelegate('workflow').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: { id: { in: ['wf_sole'] }, organizationId: { not: DEST_ORG } },
+    });
+    // Org-keyed execution + batch history followed the workflow.
+    expect(getDelegate('workflowExecution').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: {
+        organizationId: { not: DEST_ORG },
+        workflowId: { in: ['wf_sole'] },
+      },
+    });
+    expect(getDelegate('batchWorkflowJob').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: {
+        organizationId: { not: DEST_ORG },
+        workflowId: { in: ['wf_sole'] },
+      },
+    });
+    // A moved workflow keeps its brand link (never disconnected)...
+    expect(getDelegate('brand').update).not.toHaveBeenCalled();
+    // ...and keeps its default-recurring marker (excluded from the null-out).
+    expect(getDelegate('workflow').updateMany).toHaveBeenCalledWith({
+      data: { defaultRecurringBrandId: null },
+      where: { defaultRecurringBrandId: BRAND_ID, id: { notIn: ['wf_sole'] } },
+    });
+  });
+
+  it('severs a multi-brand workflow, leaving it and its org in the source org', async () => {
+    primeRelocatableBrand();
+    // wf_shared drives another brand too → it must stay; only the brand link is cut.
+    mockWorkflowSplit({
+      cross: [{ id: 'wf_shared' }],
+      shared: [{ id: 'wf_shared' }],
+    });
+
+    await service.relocateToOrganization(
+      BRAND_ID,
+      { organizationId: DEST_ORG },
+      { isSuperAdmin: true, userId: USER_ID },
+    );
+
+    // Brand link severed for the shared workflow.
+    expect(getDelegate('brand').update).toHaveBeenCalledWith({
+      data: {
+        members: { disconnect: [] },
+        workflows: { disconnect: [{ id: 'wf_shared' }] },
+      },
+      where: { id: BRAND_ID },
+    });
+    // A severed workflow is NOT re-homed and its history stays put.
+    expect(getDelegate('workflowExecution').updateMany).not.toHaveBeenCalled();
+    expect(getDelegate('batchWorkflowJob').updateMany).not.toHaveBeenCalled();
+    expect(getDelegate('workflow').updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: { organizationId: DEST_ORG } }),
+    );
+    // Nothing moved → default-recurring null-out carries no move-exclusion.
+    expect(getDelegate('workflow').updateMany).toHaveBeenCalledWith({
+      data: { defaultRecurringBrandId: null },
+      where: { defaultRecurringBrandId: BRAND_ID },
+    });
+  });
+
+  it('rolls back when a brand-linked workflow/member is left stranded in the source org', async () => {
+    primeRelocatableBrand();
+    mockWorkflowSplit({ cross: [], shared: [] });
+    // The M2M backstop recomputes the post-state and finds a workflow still attached to
+    // the moved brand from a source org (e.g. a concurrent re-link the scalar auditor
+    // cannot see).
+    getDelegate('workflow').count.mockImplementation(
+      (args: { where?: { brands?: { some?: { id?: string } } } }) =>
+        Promise.resolve(args.where?.brands?.some?.id === BRAND_ID ? 1 : 0),
+    );
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: true, userId: USER_ID },
+      ),
+    ).rejects.toThrow(/cross-org association/);
+    // Aborted → caches untouched.
+    expect(cacheInvalidationService.invalidate).not.toHaveBeenCalled();
+  });
+
+  it('rolls back when a moved workflow is still linked to a source-org brand', async () => {
+    primeRelocatableBrand();
+    mockWorkflowSplit({ cross: [{ id: 'wf_sole' }], shared: [] });
+    // Post-move recheck: the moved workflow is scoped by `id: { in: [...] }` and turns
+    // out to still reference a brand outside the destination org.
+    getDelegate('workflow').count.mockImplementation(
+      (args: { where?: { id?: unknown } }) =>
+        Promise.resolve(args.where?.id ? 1 : 0),
+    );
+
+    await expect(
+      service.relocateToOrganization(
+        BRAND_ID,
+        { organizationId: DEST_ORG },
+        { isSuperAdmin: true, userId: USER_ID },
+      ),
+    ).rejects.toThrow(/cross-org association/);
+    expect(cacheInvalidationService.invalidate).not.toHaveBeenCalled();
   });
 
   it('translates a P2002 unique violation into a ConflictException', async () => {

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -1773,9 +1773,23 @@ Respond ONLY with the JSON array.`;
   }
 
   /**
-   * Detach source-org associations that would be invalid after the move. The acting
-   * user keeps access to the brand because relocation requires membership in the
-   * destination org; only stale, now-cross-org links are removed.
+   * Reconcile source-org associations that become cross-org after the move.
+   *
+   * `Member` and `Workflow` link to a brand through many-to-many join tables, not a
+   * scalar brand key, so the generic cascade cannot touch them. They are handled here:
+   *
+   *   • Members always belong to their own org and never move — their brand link is
+   *     severed (and stale `lastUsedBrandId` pointers cleared).
+   *   • Workflows are split by ownership. A workflow can drive several brands at once,
+   *     so it cannot be blindly re-homed:
+   *       – sole-brand  (this brand is its ONLY brand) → MOVED with the brand, together
+   *         with its org-keyed execution/batch history, so the relocated brand keeps its
+   *         automation intact.
+   *       – multi-brand (also drives other brands)     → SEVERED; it must stay in the
+   *         source org for the brands that remain there.
+   *
+   * The acting user keeps access to the brand because relocation requires membership in
+   * the destination org.
    */
   private async severCrossOrgLinks(
     tx: Prisma.TransactionClient,
@@ -1798,23 +1812,87 @@ Respond ONLY with the JSON array.`;
         organizationId: { not: destOrgId },
       },
     });
-    const staleWorkflows = await client.workflow.findMany({
+
+    // Workflows attached to the moving brand but sitting in a source (non-dest) org.
+    const crossOrgWorkflows = await client.workflow.findMany({
       select: { id: true },
       where: {
         brands: { some: { id: brandId } },
         organizationId: { not: destOrgId },
       },
     });
+    // Of those, the ones ALSO linked to a different brand — anchored to the source org,
+    // so they cannot move (a soft-deleted sibling brand still counts: sever is the safe
+    // direction, we never over-move a workflow that has any other association).
+    const sharedWorkflows = await client.workflow.findMany({
+      select: { id: true },
+      where: {
+        brands: { some: { id: brandId } },
+        AND: [{ brands: { some: { id: { not: brandId } } } }],
+        organizationId: { not: destOrgId },
+      },
+    });
+    const sharedWorkflowIds = new Set(sharedWorkflows.map((w) => w.id));
+    const workflowsToSever = crossOrgWorkflows
+      .filter((w) => sharedWorkflowIds.has(w.id))
+      .map((w) => w.id);
+    const workflowsToMove = crossOrgWorkflows
+      .filter((w) => !sharedWorkflowIds.has(w.id))
+      .map((w) => w.id);
 
-    if (staleMembers.length > 0 || staleWorkflows.length > 0) {
+    // Sever multi-brand workflows + all stale members from the brand.
+    if (staleMembers.length > 0 || workflowsToSever.length > 0) {
       await client.brand.update({
         data: {
           members: { disconnect: staleMembers.map((m) => ({ id: m.id })) },
           workflows: {
-            disconnect: staleWorkflows.map((w) => ({ id: w.id })),
+            disconnect: workflowsToSever.map((id) => ({ id })),
           },
         },
         where: { id: brandId },
+      });
+    }
+
+    // Clear default-recurring markers on workflows that will NOT move — done BEFORE the
+    // move so a marker already parked in the destination org (the partial unique index
+    // keys on organizationId, so such a row is technically permitted) is nulled out
+    // before a mover could collide with it on
+    // (defaultRecurringBrandId, organizationId, contentType). Moved sole-brand workflows
+    // are excluded and keep their marker: the brand moves with them, so the (brand, org)
+    // default-recurring pairing stays valid in the destination org.
+    await client.workflow.updateMany({
+      data: { defaultRecurringBrandId: null },
+      where: {
+        defaultRecurringBrandId: brandId,
+        ...(workflowsToMove.length > 0
+          ? { id: { notIn: workflowsToMove } }
+          : {}),
+      },
+    });
+
+    // Move sole-brand workflows (definition + org-keyed execution/batch history) into
+    // the destination org. The brand M2M link is intentionally kept.
+    if (workflowsToMove.length > 0) {
+      await client.workflow.updateMany({
+        data: { organizationId: destOrgId },
+        where: {
+          id: { in: workflowsToMove },
+          organizationId: { not: destOrgId },
+        },
+      });
+      await client.workflowExecution.updateMany({
+        data: { organizationId: destOrgId },
+        where: {
+          workflowId: { in: workflowsToMove },
+          organizationId: { not: destOrgId },
+        },
+      });
+      await client.batchWorkflowJob.updateMany({
+        data: { organizationId: destOrgId },
+        where: {
+          workflowId: { in: workflowsToMove },
+          organizationId: { not: destOrgId },
+        },
       });
     }
 
@@ -1824,11 +1902,67 @@ Respond ONLY with the JSON array.`;
       where: { lastUsedBrandId: brandId, organizationId: { not: destOrgId } },
     });
 
-    // Clear default-recurring markers on workflows that did not move.
-    await client.workflow.updateMany({
-      data: { defaultRecurringBrandId: null },
-      where: { defaultRecurringBrandId: brandId },
+    // Runtime backstop for the many-to-many links the scalar orphan auditor cannot see
+    // (`workflow_brands` / `member_brands`). Still inside the transaction, recompute the
+    // post-state and roll the whole move back if any cross-org link survived — closing
+    // the window where a concurrent `workflow_brands` edit races the sole-vs-shared
+    // classification above.
+    await this.assertNoCrossOrgBrandLinks(
+      client,
+      brandId,
+      destOrgId,
+      workflowsToMove,
+    );
+  }
+
+  /**
+   * Post-sever invariant for brand-linked M2M resources (workflows, members), which the
+   * scalar-column orphan auditor is structurally blind to. Throws (rolling back the
+   * transaction) if any survived cross-org.
+   */
+  private async assertNoCrossOrgBrandLinks(
+    client: Record<string, CascadeDelegate>,
+    brandId: string,
+    destOrgId: string,
+    movedWorkflowIds: string[],
+  ): Promise<void> {
+    // Nothing should still be attached to the moved brand from a source org: sole-brand
+    // workflows moved into the destination org, every other link was severed.
+    const strandedWorkflows = await client.workflow.count({
+      where: {
+        brands: { some: { id: brandId } },
+        organizationId: { not: destOrgId },
+      },
     });
+    const strandedMembers = await client.member.count({
+      where: {
+        brands: { some: { id: brandId } },
+        organizationId: { not: destOrgId },
+      },
+    });
+    // A workflow we MOVED must not still be linked to a brand left in a source org —
+    // that would make a destination-org workflow drive a foreign-org brand.
+    const crossOrgMovedWorkflows =
+      movedWorkflowIds.length > 0
+        ? await client.workflow.count({
+            where: {
+              id: { in: movedWorkflowIds },
+              brands: { some: { organizationId: { not: destOrgId } } },
+            },
+          })
+        : 0;
+
+    if (
+      strandedWorkflows > 0 ||
+      strandedMembers > 0 ||
+      crossOrgMovedWorkflows > 0
+    ) {
+      throw new InternalServerErrorException(
+        `Brand relocation aborted: cross-org association(s) survived the move ` +
+          `(workflows stranded in source org: ${strandedWorkflows}, members: ${strandedMembers}, ` +
+          `moved workflows still linked to a source-org brand: ${crossOrgMovedWorkflows}).`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Follow-up to #1302. Refines what happens to **workflows** when a brand moves between organizations.

## Problem

A workflow links to brands through the `workflow_brands` **many-to-many** join — not a scalar brand key — so the generic org cascade can't touch it. #1302 severed *every* cross-org workflow unconditionally. That's correct for a workflow shared across brands, but wrong for a workflow whose **only** brand is the one moving: it left that automation orphaned in the source org. Concretely, moving a brand into a demo org gutted its dedicated workflows.

## Change

`severCrossOrgLinks` now splits cross-org workflows by ownership:

| Case | Behavior |
|---|---|
| **sole-brand** (moved brand is its only brand) | **MOVED** into the destination org with its org-keyed history (`WorkflowExecution` + `BatchWorkflowJob` — the only two tables keyed on `workflowId`). Brand M2M link and `defaultRecurringBrandId` marker kept. |
| **multi-brand** (also drives other brands) | **SEVERED** (unchanged) — must stay in the source org for the brands that remain. A soft-deleted sibling brand still counts as shared; sever is the safe direction. |

## Hardening (from Codex + Opus adversarial review)

- **P2002 ordering**: the `defaultRecurringBrandId` null-out now runs **before** the org move, so a marker already parked in the destination org can't collide on the `(defaultRecurringBrandId, organizationId, contentType)` partial unique index mid-move.
- **`assertNoCrossOrgBrandLinks` runtime backstop**: still inside the transaction, recomputes the `workflow_brands` / `member_brands` post-state and **rolls the whole move back** if any cross-org link survived. This closes the gap the scalar orphan auditor is structurally blind to (M2M edges) — including a concurrent `workflow_brands` edit racing the sole-vs-shared classification. The reviewers' one real finding was this auditor blind spot; this is the fix.

## Verification

- **127 brands tests green** (+4 new: sole-brand moves with history, multi-brand severs, backstop rolls back on a stranded link and on a moved workflow still tied to a source-org brand). Biome clean.
- Full workspace type-check is left to CI — a fresh worktree can't resolve unbuilt workspace type declarations locally; none of the errors were in changed files.
- **Manual E2E not run locally** (needs a running API + Postgres seeded with two orgs + an auth session). Staging smoke-test runbook handed to the author separately.

## Decision documented

Rationale for the sole-vs-shared split and the M2M-backstop is inline in `severCrossOrgLinks` and `brand-org-cascade.constants.ts`.