### PR TITLE
feat(studio): content-derived ambient canvas + reusable media shell

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetail.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetail.tsx
@@ -7,7 +7,9 @@ import {
   IngredientFormat,
   IngredientStatus,
 } from '@genfeedai/enums';
+import { useDominantColor } from '@genfeedai/hooks/ui/use-dominant-color/use-dominant-color';
 import type { IStudioEditDetailContentProps } from '@genfeedai/interfaces/content/studio-edit-detail.interface';
+import AmbientColorWash from '@ui/ambient/AmbientColorWash';
 import Card from '@ui/card/Card';
 import Loading from '@ui/loading/default/Loading';
 import { Button, Button as PrimitiveButton } from '@ui/primitives/button';
@@ -98,6 +100,11 @@ export default function StudioEditDetail({
     studioHref,
     videoRef,
   } = useStudioEditDetail({ ingredientId });
+
+  // The detail pane takes on the colour of the single asset being viewed.
+  const ambientColor = useDominantColor(
+    selectedIngredient?.ingredientUrl ?? selectedIngredient?.thumbnailUrl,
+  );
 
   if (loadError && !isLoading) {
     return (
@@ -233,8 +240,12 @@ export default function StudioEditDetail({
               </div>
             </div>
 
-            <div className="flex-1 flex flex-col overflow-hidden">
-              <div className="flex-1 overflow-y-auto p-6">
+            <div className="relative flex-1 flex flex-col overflow-hidden">
+              <AmbientColorWash
+                color={ambientColor?.rgb ?? null}
+                position="center"
+              />
+              <div className="relative z-[1] flex-1 overflow-y-auto p-6">
                 <div className="flex flex-col items-center justify-center h-full">
                   <h3 className="text-lg font-semibold mb-4">Current Asset</h3>
                   <div className="relative max-w-full max-h-sidebar flex items-center justify-center">

--- a/apps/app/src/features/moodboard/MoodBoardCanvas.tsx
+++ b/apps/app/src/features/moodboard/MoodBoardCanvas.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { ButtonVariant } from '@genfeedai/enums';
+import { useDominantColor } from '@genfeedai/hooks/ui/use-dominant-color/use-dominant-color';
 import MediaLightbox from '@ui/layouts/lightbox/MediaLightbox';
 import { Button } from '@ui/primitives/button';
+import { MediaCanvasShell } from '@ui/shell';
 import {
   Background,
   BackgroundVariant,
@@ -39,6 +41,12 @@ function MoodBoardCanvasInner({
     [assets],
   );
 
+  const focusedAsset =
+    lightboxIndex !== null ? assets[lightboxIndex] : undefined;
+  const ambientColor = useDominantColor(
+    focusedAsset?.ingredientUrl ?? focusedAsset?.thumbnailUrl,
+  );
+
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: MediaAssetFlowNode) => {
       const index = assetIndexById.get(node.id);
@@ -50,59 +58,54 @@ function MoodBoardCanvasInner({
   );
 
   return (
-    <div className="relative h-full w-full gen-grain gen-vignette">
-      <ReactFlow<MediaAssetFlowNode>
-        nodes={nodes}
-        edges={[]}
-        nodeTypes={NODE_TYPES}
-        onNodesChange={onNodesChange}
-        onNodeDragStop={onNodeDragStop}
-        onNodeClick={handleNodeClick}
-        nodesConnectable={false}
-        nodesFocusable={false}
-        elementsSelectable
-        fitView
-        minZoom={0.05}
-        maxZoom={4}
-        proOptions={{ hideAttribution: true }}
-        onlyRenderVisibleElements={nodes.length > 50}
+    <>
+      <MediaCanvasShell
+        title="Mood board"
+        meta={isTruncated ? `showing first ${assets.length}` : undefined}
+        ambientColor={ambientColor?.rgb ?? null}
+        actions={
+          <>
+            <Button
+              variant={ButtonVariant.GHOST}
+              icon={<HiArrowsPointingOut className="text-lg" />}
+              label="Fit"
+              onClick={() => fitView({ duration: 300 })}
+            />
+            <Button
+              variant={ButtonVariant.GHOST}
+              icon={<HiXMark className="text-lg" />}
+              label="Close"
+              onClick={onClose}
+            />
+          </>
+        }
       >
-        <Background
-          variant={BackgroundVariant.Dots}
-          gap={24}
-          size={1}
-          color="rgba(255,255,255,0.06)"
-        />
-        <Controls showInteractive={false} />
-        <MiniMap nodeStrokeWidth={0} pannable zoomable />
-      </ReactFlow>
-
-      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-4">
-        <div className="pointer-events-auto gen-glass flex items-center gap-2 rounded-full px-3 py-1.5">
-          <span className="text-sm font-medium text-foreground/90">
-            Mood board
-          </span>
-          {isTruncated && (
-            <span className="text-xs text-foreground/55">
-              showing first {assets.length}
-            </span>
-          )}
-        </div>
-        <div className="pointer-events-auto flex items-center gap-2">
-          <Button
-            variant={ButtonVariant.GHOST}
-            icon={<HiArrowsPointingOut className="text-lg" />}
-            label="Fit"
-            onClick={() => fitView({ duration: 300 })}
+        <ReactFlow<MediaAssetFlowNode>
+          nodes={nodes}
+          edges={[]}
+          nodeTypes={NODE_TYPES}
+          onNodesChange={onNodesChange}
+          onNodeDragStop={onNodeDragStop}
+          onNodeClick={handleNodeClick}
+          nodesConnectable={false}
+          nodesFocusable={false}
+          elementsSelectable
+          fitView
+          minZoom={0.05}
+          maxZoom={4}
+          proOptions={{ hideAttribution: true }}
+          onlyRenderVisibleElements={nodes.length > 50}
+        >
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={24}
+            size={1}
+            color="rgba(255,255,255,0.06)"
           />
-          <Button
-            variant={ButtonVariant.GHOST}
-            icon={<HiXMark className="text-lg" />}
-            label="Close"
-            onClick={onClose}
-          />
-        </div>
-      </div>
+          <Controls showInteractive={false} />
+          <MiniMap nodeStrokeWidth={0} pannable zoomable />
+        </ReactFlow>
+      </MediaCanvasShell>
 
       <MediaLightbox
         items={assets}
@@ -110,7 +113,7 @@ function MoodBoardCanvasInner({
         open={lightboxIndex !== null}
         onClose={() => setLightboxIndex(null)}
       />
-    </div>
+    </>
   );
 }
 

--- a/packages/hooks/ui/use-dominant-color/use-dominant-color.test.ts
+++ b/packages/hooks/ui/use-dominant-color/use-dominant-color.test.ts
@@ -1,0 +1,156 @@
+import { useDominantColor } from '@hooks/ui/use-dominant-color/use-dominant-color';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ImageBehavior = 'load' | 'error';
+
+let nextImageBehavior: ImageBehavior = 'load';
+let fixedPixels: number[] = [];
+let getImageDataThrows = false;
+
+class MockImage {
+  crossOrigin = '';
+  decoding = '';
+  private listeners: Record<string, Array<() => void>> = {};
+  private internalSrc = '';
+
+  addEventListener(type: string, cb: () => void): void {
+    const existing = this.listeners[type] ?? [];
+    existing.push(cb);
+    this.listeners[type] = existing;
+  }
+
+  removeEventListener(type: string, cb: () => void): void {
+    this.listeners[type] = (this.listeners[type] ?? []).filter(
+      (fn) => fn !== cb,
+    );
+  }
+
+  set src(value: string) {
+    this.internalSrc = value;
+    queueMicrotask(() => {
+      const type = nextImageBehavior === 'load' ? 'load' : 'error';
+      for (const cb of this.listeners[type] ?? []) {
+        cb();
+      }
+    });
+  }
+
+  get src(): string {
+    return this.internalSrc;
+  }
+}
+
+function makePixels(rgba: [number, number, number, number], count: number) {
+  return Array.from({ length: count }, () => rgba).flat();
+}
+
+describe('useDominantColor', () => {
+  beforeEach(() => {
+    nextImageBehavior = 'load';
+    getImageDataThrows = false;
+    fixedPixels = makePixels([255, 0, 0, 255], 4);
+
+    vi.stubGlobal('Image', MockImage);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      (() => ({
+        drawImage: vi.fn(),
+        getImageData: () => {
+          if (getImageDataThrows) {
+            throw new Error('tainted canvas');
+          }
+          return { data: new Uint8ClampedArray(fixedPixels) };
+        },
+      })) as unknown as typeof HTMLCanvasElement.prototype.getContext,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when no url is provided', () => {
+    const { result } = renderHook(() => useDominantColor(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null for an empty string url', () => {
+    const { result } = renderHook(() => useDominantColor(''));
+    expect(result.current).toBeNull();
+  });
+
+  it('extracts the dominant colour from a loaded image', async () => {
+    const { result } = renderHook(() =>
+      useDominantColor('https://cdn.example.com/red.png'),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        b: 0,
+        g: 0,
+        r: 255,
+        rgb: 'rgb(255 0 0)',
+      });
+    });
+  });
+
+  it('weights saturated pixels above a neutral field', async () => {
+    // Half mid-grey, half saturated blue — the blue subject should dominate.
+    fixedPixels = [
+      ...makePixels([128, 128, 128, 255], 4),
+      ...makePixels([0, 0, 255, 255], 4),
+    ];
+
+    const { result } = renderHook(() =>
+      useDominantColor('https://cdn.example.com/blue.png'),
+    );
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
+    const dominant = result.current;
+    expect(dominant).not.toBeNull();
+    if (dominant) {
+      expect(dominant.b).toBeGreaterThan(dominant.r);
+      expect(dominant.b).toBeGreaterThan(dominant.g);
+    }
+  });
+
+  it('returns null when the image fails to load', async () => {
+    nextImageBehavior = 'error';
+
+    const { result } = renderHook(() =>
+      useDominantColor('https://cdn.example.com/missing.png'),
+    );
+
+    // Give the microtask a chance to run; result stays null.
+    await Promise.resolve();
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the canvas is tainted (cross-origin without CORS)', async () => {
+    getImageDataThrows = true;
+
+    const { result } = renderHook(() =>
+      useDominantColor('https://cdn.example.com/tainted.png'),
+    );
+
+    await Promise.resolve();
+    expect(result.current).toBeNull();
+  });
+
+  it('clears the colour when the url is removed', async () => {
+    const { result, rerender } = renderHook(
+      ({ url }: { url: string | null }) => useDominantColor(url),
+      { initialProps: { url: 'https://cdn.example.com/red.png' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
+
+    rerender({ url: null });
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/hooks/ui/use-dominant-color/use-dominant-color.ts
+++ b/packages/hooks/ui/use-dominant-color/use-dominant-color.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface DominantColor {
+  r: number;
+  g: number;
+  b: number;
+  /** CSS-ready `rgb(r g b)` string derived from the sampled pixels. */
+  rgb: string;
+}
+
+export interface UseDominantColorOptions {
+  /** Edge length (px) of the square offscreen canvas the image is drawn onto before sampling. */
+  sampleSize?: number;
+  /** Pixels below this alpha (0-255) are ignored so transparent padding does not muddy the result. */
+  minAlpha?: number;
+}
+
+const DEFAULT_SAMPLE_SIZE = 24;
+const DEFAULT_MIN_ALPHA = 16;
+
+/**
+ * Client-side dominant-color extraction for a single media URL.
+ *
+ * Draws the image onto a tiny offscreen canvas and returns a saturation-weighted
+ * average so a vivid subject reads through a neutral background. Purely for the
+ * ambient content wash — colour is derived FROM focused content, never imposed on
+ * chrome (see DESIGN.md → "Color Entry — Content Is the Accent").
+ *
+ * Degrades gracefully to `null` when:
+ * - no URL is provided,
+ * - running on the server / without canvas support,
+ * - the image fails to load, or
+ * - the canvas is tainted by a cross-origin image without CORS headers.
+ */
+export function useDominantColor(
+  imageUrl: string | null | undefined,
+  options: UseDominantColorOptions = {},
+): DominantColor | null {
+  const { sampleSize = DEFAULT_SAMPLE_SIZE, minAlpha = DEFAULT_MIN_ALPHA } =
+    options;
+
+  const [color, setColor] = useState<DominantColor | null>(null);
+
+  useEffect(() => {
+    if (!imageUrl || typeof window === 'undefined') {
+      setColor(null);
+      return;
+    }
+
+    let isCancelled = false;
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.decoding = 'async';
+
+    const handleLoad = () => {
+      if (isCancelled) {
+        return;
+      }
+
+      const extracted = extractDominantColor(image, sampleSize, minAlpha);
+      if (!isCancelled) {
+        setColor(extracted);
+      }
+    };
+
+    const handleError = () => {
+      if (!isCancelled) {
+        setColor(null);
+      }
+    };
+
+    image.addEventListener('load', handleLoad);
+    image.addEventListener('error', handleError);
+    image.src = imageUrl;
+
+    return () => {
+      isCancelled = true;
+      image.removeEventListener('load', handleLoad);
+      image.removeEventListener('error', handleError);
+    };
+  }, [imageUrl, sampleSize, minAlpha]);
+
+  return color;
+}
+
+function extractDominantColor(
+  image: HTMLImageElement,
+  sampleSize: number,
+  minAlpha: number,
+): DominantColor | null {
+  const canvas = document.createElement('canvas');
+  canvas.width = sampleSize;
+  canvas.height = sampleSize;
+
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) {
+    return null;
+  }
+
+  context.drawImage(image, 0, 0, sampleSize, sampleSize);
+
+  let pixels: Uint8ClampedArray;
+  try {
+    pixels = context.getImageData(0, 0, sampleSize, sampleSize).data;
+  } catch {
+    // Cross-origin image without CORS headers taints the canvas — bail silently.
+    return null;
+  }
+
+  let rSum = 0;
+  let gSum = 0;
+  let bSum = 0;
+  let weightSum = 0;
+
+  for (let i = 0; i < pixels.length; i += 4) {
+    const alpha = pixels[i + 3] ?? 0;
+    if (alpha < minAlpha) {
+      continue;
+    }
+
+    const r = pixels[i] ?? 0;
+    const g = pixels[i + 1] ?? 0;
+    const b = pixels[i + 2] ?? 0;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const saturation = max === 0 ? 0 : (max - min) / max;
+
+    // Favour opaque, saturated pixels so the subject's hue survives a neutral field.
+    const weight = (alpha / 255) * (1 + saturation * 3);
+
+    rSum += r * weight;
+    gSum += g * weight;
+    bSum += b * weight;
+    weightSum += weight;
+  }
+
+  if (weightSum === 0) {
+    return null;
+  }
+
+  const r = Math.round(rSum / weightSum);
+  const g = Math.round(gSum / weightSum);
+  const b = Math.round(bSum / weightSum);
+
+  return { b, g, r, rgb: `rgb(${r} ${g} ${b})` };
+}

--- a/packages/pages/studio/generate/components/GenerateContentArea.tsx
+++ b/packages/pages/studio/generate/components/GenerateContentArea.tsx
@@ -6,6 +6,7 @@ import {
   type IngredientStatus,
   ViewType,
 } from '@genfeedai/enums';
+import { useDominantColor } from '@genfeedai/hooks/ui/use-dominant-color/use-dominant-color';
 import type { IImage, IIngredient } from '@genfeedai/interfaces';
 import type { CameraMovementPreset } from '@genfeedai/interfaces/studio/camera-movement.interface';
 import { AssetDisplayGrid } from '@pages/studio/generate/components/AssetDisplayGrid';
@@ -13,7 +14,9 @@ import { GenerateEmptyState } from '@pages/studio/generate/components/GenerateEm
 import { StoryboardPanel } from '@pages/studio/generate/components/StoryboardPanel';
 import StudioSelectionActionsBar from '@pages/studio/selection/StudioSelectionActionsBar';
 import type { TableAction, TableColumn } from '@props/ui/display/table.props';
+import AmbientColorWash from '@ui/ambient/AmbientColorWash';
 import InfiniteScroll from '@ui/feedback/infinite-scroll/InfiniteScroll';
+import { useMemo } from 'react';
 
 interface GenerateContentAreaProps {
   // Category flags
@@ -123,9 +126,36 @@ export function GenerateContentArea({
   onCreateVariation,
   onTableSelectionChange,
 }: GenerateContentAreaProps) {
+  // Ambient wash derives from the media the user is focused on — the scroll-
+  // focused asset, else the first selection, else the newest result. When the
+  // studio is empty there is no focus, so the wash disables gracefully.
+  const focusedAsset = useMemo<IIngredient | undefined>(() => {
+    if (scrollFocusedAssetId) {
+      const focused = allAssets.find(
+        (asset) => asset.id === scrollFocusedAssetId,
+      );
+      if (focused) {
+        return focused;
+      }
+    }
+    const firstSelectedId = selectedIngredientIds[0];
+    if (firstSelectedId) {
+      const selected = allAssets.find((asset) => asset.id === firstSelectedId);
+      if (selected) {
+        return selected;
+      }
+    }
+    return allAssets[0];
+  }, [allAssets, scrollFocusedAssetId, selectedIngredientIds]);
+
+  const ambientColor = useDominantColor(
+    focusedAsset?.ingredientUrl ?? focusedAsset?.thumbnailUrl,
+  );
+
   return (
     <div className="flex flex-1 overflow-hidden relative w-full">
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <AmbientColorWash color={ambientColor?.rgb ?? null} />
+      <div className="relative z-[1] flex flex-1 flex-col overflow-hidden">
         <div className="flex-1 overflow-auto px-6 pt-6 pb-40 md:pb-40">
           {isVideoCategory && (
             <StoryboardPanel

--- a/packages/props/layout/media-canvas-shell.props.ts
+++ b/packages/props/layout/media-canvas-shell.props.ts
@@ -1,0 +1,28 @@
+import type { AmbientWashIntensity } from '@props/ui/ambient-color-wash.props';
+import type { ReactNode } from 'react';
+
+export interface MediaCanvasShellProps {
+  /** Full-bleed canvas content (grid, flow, single asset, …). */
+  children: ReactNode;
+  /** Convenience title rendered inside the standard floating glass pill. Ignored when `startSlot` is set. */
+  title?: string;
+  /** Secondary text shown next to `title` in the glass pill (e.g. "showing first 60"). */
+  meta?: ReactNode;
+  /** Custom leading toolbar content; replaces the default `title` pill entirely. */
+  startSlot?: ReactNode;
+  /** Trailing toolbar actions (ghost buttons), floated top-right. */
+  actions?: ReactNode;
+  /**
+   * Dominant colour of the focused content for the ambient wash behind the canvas.
+   * `null`/`undefined` disables the wash. Chrome is never tinted.
+   */
+  ambientColor?: string | null;
+  /** Ambient wash strength. Defaults to `default`. */
+  ambientIntensity?: AmbientWashIntensity;
+  /** Apply the cinematic `gen-grain` + `gen-vignette` texture. Defaults to `true`. */
+  hasTexture?: boolean;
+  /** Extra classes on the floating toolbar row. */
+  toolbarClassName?: string;
+  /** Extra classes on the outer canvas container. */
+  className?: string;
+}

--- a/packages/props/ui/ambient-color-wash.props.ts
+++ b/packages/props/ui/ambient-color-wash.props.ts
@@ -1,0 +1,15 @@
+export type AmbientWashIntensity = 'subtle' | 'default' | 'bold';
+
+export interface AmbientColorWashProps {
+  /**
+   * CSS colour string (e.g. `rgb(120 80 200)`) derived from the focused content.
+   * `null`/`undefined` renders nothing so the wash disables gracefully when no
+   * media is focused.
+   */
+  color?: string | null;
+  /** Wash strength. Opacity is resolved per-theme in CSS. Defaults to `default`. */
+  intensity?: AmbientWashIntensity;
+  /** Radial anchor: `top` (default) hangs the wash from the top edge; `center` blooms from the middle. */
+  position?: 'top' | 'center';
+  className?: string;
+}

--- a/packages/styles/genfeed.css
+++ b/packages/styles/genfeed.css
@@ -383,6 +383,65 @@
   }
 }
 
+/* Ambient content wash — a low-opacity radial tint DERIVED from the focused
+   media's dominant colour (set via the inline `--gen-ambient-color` custom
+   property). Sits behind content, never on chrome. This is the sanctioned
+   content-derived ambient treatment from DESIGN.md → "Color Entry", not a
+   chrome glow: it is a background radial, carries no box-shadow, and disables
+   when no colour is supplied. Opacity is theme-aware (dark-first). */
+.gen-ambient-wash {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.16;
+  background: radial-gradient(
+    120% 120% at 50% 0%,
+    var(--gen-ambient-color, transparent) 0%,
+    transparent 62%
+  );
+  transition:
+    opacity 700ms ease,
+    background 700ms ease;
+
+  :root[data-theme="light"] &,
+  .light & {
+    opacity: 0.09;
+  }
+}
+
+.gen-ambient-wash--center {
+  background: radial-gradient(
+    100% 100% at 50% 50%,
+    var(--gen-ambient-color, transparent) 0%,
+    transparent 60%
+  );
+}
+
+.gen-ambient-wash--subtle {
+  opacity: 0.09;
+
+  :root[data-theme="light"] &,
+  .light & {
+    opacity: 0.05;
+  }
+}
+
+.gen-ambient-wash--bold {
+  opacity: 0.24;
+
+  :root[data-theme="light"] &,
+  .light & {
+    opacity: 0.14;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gen-ambient-wash {
+    transition: none;
+  }
+}
+
 .gen-contact-sheet {
   box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.5);
   border: 1px solid var(--gen-accent-border);

--- a/packages/ui/src/components/ambient/AmbientColorWash.test.tsx
+++ b/packages/ui/src/components/ambient/AmbientColorWash.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import AmbientColorWash from '@ui/ambient/AmbientColorWash';
+import { describe, expect, it } from 'vitest';
+
+describe('AmbientColorWash', () => {
+  it('renders nothing when no colour is supplied', () => {
+    const { container } = render(<AmbientColorWash color={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for undefined colour', () => {
+    const { container } = render(<AmbientColorWash />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a decorative wash carrying the colour custom property', () => {
+    const { container } = render(<AmbientColorWash color="rgb(120 80 200)" />);
+    const wash = container.firstChild as HTMLElement;
+
+    expect(wash).not.toBeNull();
+    expect(wash).toHaveClass('gen-ambient-wash');
+    expect(wash.getAttribute('aria-hidden')).toBe('true');
+    expect(wash.style.getPropertyValue('--gen-ambient-color')).toBe(
+      'rgb(120 80 200)',
+    );
+  });
+
+  it('applies the intensity modifier', () => {
+    const { container } = render(
+      <AmbientColorWash color="rgb(0 0 0)" intensity="bold" />,
+    );
+    expect(container.firstChild).toHaveClass('gen-ambient-wash--bold');
+  });
+
+  it('applies the center position modifier', () => {
+    const { container } = render(
+      <AmbientColorWash color="rgb(0 0 0)" position="center" />,
+    );
+    expect(container.firstChild).toHaveClass('gen-ambient-wash--center');
+  });
+
+  it('does not apply a modifier class for default intensity', () => {
+    const { container } = render(<AmbientColorWash color="rgb(0 0 0)" />);
+    const wash = container.firstChild as HTMLElement;
+    expect(wash).not.toHaveClass('gen-ambient-wash--bold');
+    expect(wash).not.toHaveClass('gen-ambient-wash--subtle');
+  });
+});

--- a/packages/ui/src/components/ambient/AmbientColorWash.tsx
+++ b/packages/ui/src/components/ambient/AmbientColorWash.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
+import type { AmbientColorWashProps } from '@genfeedai/props/ui/ambient-color-wash.props';
+import type { CSSProperties } from 'react';
+
+const INTENSITY_CLASS: Record<
+  NonNullable<AmbientColorWashProps['intensity']>,
+  string
+> = {
+  bold: 'gen-ambient-wash--bold',
+  default: '',
+  subtle: 'gen-ambient-wash--subtle',
+};
+
+/**
+ * Low-opacity radial wash rendered BEHIND media content, tinted by the dominant
+ * colour of the focused asset. The app literally takes on the content's colour
+ * while every control stays grayscale (DESIGN.md → "Color Entry"). Returns
+ * `null` when no colour is supplied so the wash disables gracefully.
+ */
+export default function AmbientColorWash({
+  color,
+  intensity = 'default',
+  position = 'top',
+  className,
+}: AmbientColorWashProps): React.JSX.Element | null {
+  if (!color) {
+    return null;
+  }
+
+  const style = { '--gen-ambient-color': color } as CSSProperties;
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        'gen-ambient-wash',
+        position === 'center' && 'gen-ambient-wash--center',
+        INTENSITY_CLASS[intensity],
+        className,
+      )}
+      style={style}
+    />
+  );
+}

--- a/packages/ui/src/components/layouts/lightbox/MediaLightbox.tsx
+++ b/packages/ui/src/components/layouts/lightbox/MediaLightbox.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { IngredientCategory } from '@genfeedai/enums';
+import { useDominantColor } from '@genfeedai/hooks/ui/use-dominant-color/use-dominant-color';
 import type { IIngredient } from '@genfeedai/interfaces';
 import type { MediaLightboxProps } from '@genfeedai/props/layout/media-lightbox.props';
 import dynamic from 'next/dynamic';
@@ -42,6 +43,31 @@ export default function MediaLightbox({
   onClose,
 }: MediaLightboxProps) {
   const [plugins, setPlugins] = useState<Plugin[]>([]);
+  const [activeIndex, setActiveIndex] = useState(startIndex);
+
+  useEffect(() => {
+    setActiveIndex(startIndex);
+  }, [startIndex]);
+
+  // Tint the viewer backdrop with a heavily-darkened version of the focused
+  // slide's dominant colour so the viewer takes on the content's colour while
+  // the lightbox chrome (buttons, captions) stays grayscale.
+  const activeItem = items[activeIndex] ?? items[startIndex];
+  const dominant = useDominantColor(
+    activeItem?.ingredientUrl ?? activeItem?.thumbnailUrl,
+  );
+
+  const backdropStyles = useMemo(() => {
+    if (!dominant) {
+      return undefined;
+    }
+    const darken = (channel: number) => Math.round(channel * 0.16);
+    return {
+      container: {
+        backgroundColor: `rgb(${darken(dominant.r)} ${darken(dominant.g)} ${darken(dominant.b)})`,
+      },
+    };
+  }, [dominant]);
 
   useEffect(() => {
     // Dynamically import ESM plugins on the client side
@@ -157,6 +183,10 @@ export default function MediaLightbox({
       }}
       controller={{
         closeOnBackdropClick: true,
+      }}
+      styles={backdropStyles}
+      on={{
+        view: ({ index }) => setActiveIndex(index),
       }}
       render={{
         buttonNext: slides.length <= 1 ? () => null : undefined,

--- a/packages/ui/src/components/shell/index.ts
+++ b/packages/ui/src/components/shell/index.ts
@@ -4,6 +4,7 @@ export {
 } from '@ui/shell/AppHtmlDocument';
 export { default as AppShell } from '@ui/shell/AppShell';
 export { AppSwitcher } from '@ui/shell/app-switcher/AppSwitcher';
+export { default as MediaCanvasShell } from '@ui/shell/media-canvas/MediaCanvasShell';
 export {
   type CreateAppMetadataOptions,
   createAppMetadata,

--- a/packages/ui/src/components/shell/media-canvas/MediaCanvasShell.test.tsx
+++ b/packages/ui/src/components/shell/media-canvas/MediaCanvasShell.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import MediaCanvasShell from '@ui/shell/media-canvas/MediaCanvasShell';
+import { describe, expect, it } from 'vitest';
+
+describe('MediaCanvasShell', () => {
+  it('renders the canvas children', () => {
+    render(
+      <MediaCanvasShell>
+        <div data-testid="canvas-content">content</div>
+      </MediaCanvasShell>,
+    );
+    expect(screen.getByTestId('canvas-content')).toBeInTheDocument();
+  });
+
+  it('renders the title and meta inside the floating pill', () => {
+    render(
+      <MediaCanvasShell title="Mood board" meta="showing first 60">
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(screen.getByText('Mood board')).toBeInTheDocument();
+    expect(screen.getByText('showing first 60')).toBeInTheDocument();
+  });
+
+  it('renders trailing actions', () => {
+    render(
+      <MediaCanvasShell
+        title="Canvas"
+        actions={<button type="button">Close</button>}
+      >
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('prefers startSlot over the default title pill', () => {
+    render(
+      <MediaCanvasShell
+        title="Ignored title"
+        startSlot={<span>Custom leading</span>}
+      >
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(screen.getByText('Custom leading')).toBeInTheDocument();
+    expect(screen.queryByText('Ignored title')).not.toBeInTheDocument();
+  });
+
+  it('applies the cinematic texture by default and omits it when disabled', () => {
+    const { container, rerender } = render(
+      <MediaCanvasShell>
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(container.firstChild).toHaveClass('gen-grain');
+    expect(container.firstChild).toHaveClass('gen-vignette');
+
+    rerender(
+      <MediaCanvasShell hasTexture={false}>
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(container.firstChild).not.toHaveClass('gen-grain');
+  });
+
+  it('renders the ambient wash only when a colour is supplied', () => {
+    const { container, rerender } = render(
+      <MediaCanvasShell>
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(
+      container.querySelector('.gen-ambient-wash'),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <MediaCanvasShell ambientColor="rgb(10 20 30)">
+        <div>content</div>
+      </MediaCanvasShell>,
+    );
+    expect(container.querySelector('.gen-ambient-wash')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/shell/media-canvas/MediaCanvasShell.tsx
+++ b/packages/ui/src/components/shell/media-canvas/MediaCanvasShell.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
+import type { MediaCanvasShellProps } from '@genfeedai/props/layout/media-canvas-shell.props';
+import AmbientColorWash from '@ui/ambient/AmbientColorWash';
+
+/**
+ * Full-bleed media canvas with a floating glass toolbar and an optional
+ * content-derived ambient wash — the moodboard composition generalised for any
+ * media-heavy surface (generate results, library detail, mood board).
+ *
+ * The canvas recedes so generated content carries the colour: chrome stays
+ * grayscale, the wash tints only the backdrop (DESIGN.md → "Color Entry").
+ */
+export default function MediaCanvasShell({
+  children,
+  title,
+  meta,
+  startSlot,
+  actions,
+  ambientColor,
+  ambientIntensity,
+  hasTexture = true,
+  toolbarClassName,
+  className,
+}: MediaCanvasShellProps): React.JSX.Element {
+  const hasToolbar = Boolean(startSlot ?? title ?? actions);
+
+  return (
+    <div
+      className={cn(
+        'relative h-full w-full overflow-hidden',
+        hasTexture && 'gen-grain gen-vignette',
+        className,
+      )}
+    >
+      <AmbientColorWash color={ambientColor} intensity={ambientIntensity} />
+
+      <div className="relative z-[1] h-full w-full">{children}</div>
+
+      {hasToolbar && (
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between gap-2 p-4',
+            toolbarClassName,
+          )}
+        >
+          <div className="pointer-events-auto flex items-center gap-2">
+            {startSlot ??
+              (title && (
+                <div className="gen-glass flex items-center gap-2 rounded-full px-3 py-1.5">
+                  <span className="text-sm font-medium text-foreground/90">
+                    {title}
+                  </span>
+                  {meta && (
+                    <span className="text-xs text-foreground/55">{meta}</span>
+                  )}
+                </div>
+              ))}
+          </div>
+          {actions && (
+            <div className="pointer-events-auto flex items-center gap-2">
+              {actions}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Studio half of #1280 — **the app recedes behind generated content, and content is the only colour source** (DESIGN.md → "Color Entry — Content Is the Accent"). Chrome stays 100% grayscale; a low-opacity radial wash *derived from the focused media* lets the app take on the content's colour.

This is the **shell/chrome + studio surfaces** PR. The website homepage content wall (work item 2) lands in a follow-up so review stays scoped.

## What's in it

**New primitives**
- **`useDominantColor`** (`packages/hooks`) — dependency-free, saturation-weighted canvas sampling of a single media URL. Weights opaque, saturated pixels so a vivid subject reads through a neutral field. Degrades to `null` on SSR, empty URL, image load error, or a tainted cross-origin canvas (no CORS headers) — so the wash always disables gracefully.
- **`AmbientColorWash`** (`packages/ui`) + **`.gen-ambient-wash`** (`packages/styles`) — the wash layer. A `pointer-events-none` radial-gradient **background** (not a `box-shadow` glow) tinted via an inline `--gen-ambient-color` custom property. Opacity is theme-aware (dark-first) with `subtle`/`bold` variants and a `prefers-reduced-motion` guard. Renders `null` when no colour is supplied.
- **`MediaCanvasShell`** (`packages/ui/shell`) — generalises the mood board's *full-bleed canvas + floating glass toolbar* composition (work item 3) into a reusable shell with `title`/`meta`/`startSlot`/`actions` slots, optional ambient wash, and the cinematic `gen-grain`+`gen-vignette` texture.

**Surfaces wired (work item 1)**
- **Mood board** — refactored onto `MediaCanvasShell` (behaviour-identical), plus a content wash when a slide is focused in the lightbox.
- **Generate results** — wash behind the grid, derived from the focused/selected/newest asset; disabled when the studio is empty.
- **Library detail** — the asset pane takes on the single viewed asset's colour (centre bloom).
- **Media lightbox** — backdrop tinted with a heavily-darkened version of the focused slide's dominant colour; the lightbox chrome (buttons, captions) stays grayscale.

## Design contract

Validated against DESIGN.md via `bun run design:lint` (0 errors; no new tokens added):
- ✅ Chrome remains 100% grayscale on every touched surface — the wash is a separate layer behind content, never on a control.
- ✅ Ambient tint is **content-derived only** (`useDominantColor`), never a hardcoded hue; falls back to `transparent`.
- ✅ Radial-gradient background, **no** `box-shadow`/glow/spotlight on chrome.
- ✅ Disables gracefully when no media is focused.
- ✅ No new accent tokens, no colored CTAs, no changes to platform/status/workflow-node palettes.

## Verification

- `bun type-check` — `@genfeedai/{hooks,ui,props,pages,app}` all green.
- Tests: `useDominantColor` (7), `AmbientColorWash` (6), `MediaCanvasShell` (7), mood board (8), `MediaLightbox` (3) — all passing.
- `bunx biome check` clean on all touched files; pre-commit guards (secretlint, no-raw-html, no-bespoke-card) pass.

_Studio surfaces are auth+data-gated so they aren't exercised by the public preview; behaviour is covered by unit tests + type-check. The follow-up website PR is publicly previewable and will include live verification._

Part of #1280.