### PR TITLE
feat(website): propagate monochrome design system across all pages

### DIFF
--- a/apps/website/app/(public)/[slug]/product-page.tsx
+++ b/apps/website/app/(public)/[slug]/product-page.tsx
@@ -120,7 +120,7 @@ export default function ProductPage({ product }: { product: Product }) {
               description={useCase.description}
             >
               <div className="bg-background p-4">
-                <Text as="p" size="sm" className="italic">
+                <Text as="p" size="sm">
                   {useCase.example}
                 </Text>
               </div>

--- a/apps/website/app/(public)/[slug]/product-pricing-cta.tsx
+++ b/apps/website/app/(public)/[slug]/product-pricing-cta.tsx
@@ -23,12 +23,15 @@ export default function ProductPricingCTA({
 }: Props) {
   return (
     <section className="max-w-4xl mx-auto pb-20">
-      <Card className="bg-inv text-inv-fg" bodyClassName="text-center">
+      <Card
+        className="border border-[var(--gen-accent-border)] bg-white/[0.04]"
+        bodyClassName="text-center"
+      >
         <Heading size="2xl" className="mb-2">
           Recommended Plan
         </Heading>
         <div className="text-4xl font-bold mb-4">{pricing.recommended}</div>
-        <Text as="p" size="lg" className="mb-6 text-inv-fg/70">
+        <Text as="p" size="lg" className="mb-6 text-surface/70">
           {pricing.why}
         </Text>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -42,7 +45,7 @@ export default function ProductPricingCTA({
               <Button
                 variant={ButtonVariant.OUTLINE}
                 asChild
-                className="border-inv-fg/20 hover:border-inv-fg/40 hover:bg-inv-fg/5 h-12 px-6 text-lg uppercase"
+                className="border-[var(--gen-accent-border)] hover:border-[var(--gen-accent-hover)] hover:bg-white/[0.04] h-12 px-6 text-lg uppercase"
               >
                 <Link
                   href={githubUrl}
@@ -58,7 +61,7 @@ export default function ProductPricingCTA({
             <Button
               variant={ButtonVariant.OUTLINE}
               asChild
-              className="border-inv-fg/20 hover:border-inv-fg/40 hover:bg-inv-fg/5 h-12 px-6 text-lg uppercase"
+              className="border-[var(--gen-accent-border)] hover:border-[var(--gen-accent-hover)] hover:bg-white/[0.04] h-12 px-6 text-lg uppercase"
             >
               <Link href={githubUrl} target="_blank" rel="noopener noreferrer">
                 <FaGithub className="size-5" />
@@ -75,7 +78,7 @@ export default function ProductPricingCTA({
               <Button
                 variant={ButtonVariant.OUTLINE}
                 asChild
-                className="border-inv-fg/20 hover:border-inv-fg/40 hover:bg-inv-fg/5 h-12 px-6 text-lg"
+                className="border-[var(--gen-accent-border)] hover:border-[var(--gen-accent-hover)] hover:bg-white/[0.04] h-12 px-6 text-lg"
               >
                 <Link href="/pricing">View All Pricing</Link>
               </Button>

--- a/apps/website/app/(public)/agents/agents-content.tsx
+++ b/apps/website/app/(public)/agents/agents-content.tsx
@@ -93,15 +93,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Autonomous agents, human oversight"
-    title={
-      <>
-        Your autonomous
-        <br />
-        content team,
-        <br />
-        on call.
-      </>
-    }
+    title="Your autonomous content team."
   />
 );
 
@@ -144,18 +136,18 @@ export default function AgentsContent() {
       >
         {/* Highlight Card */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiUserGroup className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiUserGroup className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   A Content Team That Runs Itself
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Hire agents for research, creative, and publishing. Set goals
                   and guardrails, then let them execute campaigns on schedule
                   while you stay in control of approvals.
@@ -209,13 +201,10 @@ export default function AgentsContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -239,10 +228,10 @@ export default function AgentsContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                     <VStack className="gap-1">
-                      <Text className="text-lg font-bold text-surface/90">
+                      <Text className="text-lg font-bold text-surface">
                         {step.label}
                       </Text>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.sublabel}
                       </Text>
                     </VStack>
@@ -258,23 +247,22 @@ export default function AgentsContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiUserGroup className="size-8 text-inv-fg" />
+              <HiUserGroup className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Hire Your Content Team Today
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Autonomous agents that research, generate, and publish content on
               schedule. Set the guardrails, then let the team run.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="agents_cta_click"
                 trackingData={{ action: 'create_now' }}
               >
@@ -286,7 +274,6 @@ export default function AgentsContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="agents_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/app/(public)/analytics/analytics-content.tsx
+++ b/apps/website/app/(public)/analytics/analytics-content.tsx
@@ -132,15 +132,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Revenue, trends, and per-brand rollups"
-    title={
-      <>
-        Track revenue,
-        <br />
-        not vanity
-        <br />
-        metrics.
-      </>
-    }
+    title="Revenue, not vanity metrics."
   />
 );
 
@@ -183,18 +175,18 @@ export default function AnalyticsContent() {
       >
         {/* Highlight Card */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiChartBar className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiChartBar className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   Every Metric Tied to Revenue
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Stop guessing from likes and views. See post, trend, and
                   per-brand performance mapped straight to revenue, with a hook
                   lab that tells you what to make next.
@@ -229,10 +221,10 @@ export default function AnalyticsContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Text className="text-sm font-bold text-surface/90">
+                  <Text className="text-sm font-bold text-surface">
                     {metric.label}
                   </Text>
-                  <Text className="text-xs text-surface/40">
+                  <Text className="text-xs text-surface/65">
                     {metric.value}
                   </Text>
                 </div>
@@ -259,13 +251,10 @@ export default function AnalyticsContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -289,10 +278,10 @@ export default function AnalyticsContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                     <VStack className="gap-1">
-                      <Text className="text-lg font-bold text-surface/90">
+                      <Text className="text-lg font-bold text-surface">
                         {step.label}
                       </Text>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.sublabel}
                       </Text>
                     </VStack>
@@ -308,23 +297,22 @@ export default function AnalyticsContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiSparkles className="size-8 text-inv-fg" />
+              <HiSparkles className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Know What Works. Do More.
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Revenue attribution, hook analysis, and per-brand rollups built
               into the studio. No spreadsheets required.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="analytics_cta_click"
                 trackingData={{ action: 'create_now' }}
               >
@@ -336,7 +324,6 @@ export default function AnalyticsContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="analytics_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/app/(public)/brand-os/brand-os-content.tsx
+++ b/apps/website/app/(public)/brand-os/brand-os-content.tsx
@@ -114,7 +114,7 @@ const RADIUS_STEPS: RadiusStep[] = [
 
 const COLOR_DOORS: ColorDoor[] = [
   {
-    body: 'Generated media is the primary color source. Rendered borderless and full-bleed wherever possible — chrome recedes behind it.',
+    body: 'Generated media is the primary color source. Rendered borderless and full-bleed wherever possible, so chrome recedes behind it.',
     index: '01',
     title: 'User content',
   },
@@ -124,7 +124,7 @@ const COLOR_DOORS: ColorDoor[] = [
     title: 'Platform identifiers',
   },
   {
-    body: 'Success, warning, danger, info. Applied to state — never decoration.',
+    body: 'Success, warning, danger, info. Applied to state, never decoration.',
     index: '03',
     title: 'Semantic status',
   },
@@ -137,7 +137,7 @@ const COLOR_DOORS: ColorDoor[] = [
 
 const DOS: string[] = [
   'Use background layering for hierarchy instead of heavy borders.',
-  'Use inset box-shadow borders on elevated surfaces — cards, dialogs, dropdowns.',
+  'Use inset box-shadow borders on elevated surfaces: cards, dialogs, dropdowns.',
   'Reserve the border token for structural dividers: sidebar edges, header bottoms.',
   'Use ghost buttons for toolbar and topbar actions.',
   'Apply semantic status colors consistently across every surface.',
@@ -145,9 +145,9 @@ const DOS: string[] = [
 ];
 
 const DONTS: string[] = [
-  'Use a CSS border for card, dialog, or dropdown containment — use inset shadow.',
+  'Use a CSS border for card, dialog, or dropdown containment; use inset shadow.',
   'Mix hardcoded colors with token references.',
-  'Use the accent for status — it is for primary CTAs only.',
+  'Use the accent for status; it is for primary CTAs only.',
   'Add a new semantic color without updating DESIGN.md.',
   'Use large decorative gradients as core product surfaces.',
   'Nest cards inside cards, or add glow / spotlight shadows to chrome.',
@@ -155,7 +155,7 @@ const DONTS: string[] = [
 
 function SectionLabel({ children }: { children: string }): React.ReactElement {
   return (
-    <Text className="text-[10px] font-black uppercase tracking-[0.2em] text-surface/35">
+    <Text className="text-[10px] font-black uppercase tracking-[0.2em] text-surface/55">
       {children}
     </Text>
   );
@@ -175,11 +175,11 @@ function SwatchTile({ swatch }: { swatch: Swatch }): React.ReactElement {
           <Text className="text-xs font-semibold text-surface">
             {swatch.name}
           </Text>
-          <Text className="font-mono text-[10px] uppercase text-surface/35">
+          <Text className="font-mono text-[10px] uppercase text-surface/55">
             {swatch.hex}
           </Text>
         </HStack>
-        <Text className="text-[11px] leading-4 text-surface/40">
+        <Text className="text-[11px] leading-4 text-surface/60">
           {swatch.role}
         </Text>
       </VStack>
@@ -201,19 +201,19 @@ export default function BrandOSContent(): React.ReactElement {
               <HStack className="w-fit items-center gap-2 border border-edge/10 bg-fill/[0.02] px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.15em] text-surface/45">
                 <LuLayers className="size-3.5" />
                 <Text>Brand OS</Text>
-                <span className="text-surface/20">/</span>
-                <Text className="text-surface/35">version alpha</Text>
+                <span className="text-surface/45">/</span>
+                <Text className="text-surface/55">version alpha</Text>
               </HStack>
 
               <Heading
                 as="h1"
-                className="max-w-3xl font-serif text-5xl leading-none text-surface sm:text-6xl lg:text-7xl"
+                className="max-w-3xl font-semibold tracking-[-0.02em] text-5xl leading-none text-surface sm:text-6xl lg:text-7xl"
               >
                 The Genfeed Brand OS.
               </Heading>
 
               <Text className="max-w-2xl text-base leading-7 text-surface/55 sm:text-lg">
-                The living design system behind Genfeed — dark-first,
+                The living design system behind Genfeed: dark-first,
                 information-dense, and aligned with the ShipCode and Linear
                 visual language. Depth comes from layered background tones and
                 inset-shadow containment; color enters only through the
@@ -224,18 +224,21 @@ export default function BrandOSContent(): React.ReactElement {
           </div>
         </section>
 
-        {/* Color — backgrounds + text */}
+        {/* Color: backgrounds + text */}
         <section className="border-b border-edge/5 bg-fill/[0.02] py-16 sm:py-20">
           <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-[0.32fr_1fr] lg:gap-16">
             <VStack className="gap-4">
               <SectionLabel>Foundations</SectionLabel>
-              <Heading as="h2" className="font-serif text-4xl text-surface">
+              <Heading
+                as="h2"
+                className="font-semibold tracking-[-0.02em] text-4xl text-surface"
+              >
                 Depth without borders.
               </Heading>
               <Text className="text-sm leading-6 text-surface/55">
                 Five background tones create elevation from the deepest canvas
-                to the most raised surface — no heavy strokes, just tonal shift.
-                Text resolves in three tiers over the top.
+                to the most raised surface, with no heavy strokes, just tonal
+                shift. Text resolves in three tiers over the top.
               </Text>
             </VStack>
 
@@ -259,7 +262,7 @@ export default function BrandOSContent(): React.ReactElement {
                   </div>
                 </VStack>
                 <VStack className="gap-4">
-                  <SectionLabel>Accent — inverted for dark</SectionLabel>
+                  <SectionLabel>Accent, inverted for dark</SectionLabel>
                   <div className="grid grid-cols-3 gap-4">
                     {ACCENT.map((swatch) => (
                       <SwatchTile key={swatch.name} swatch={swatch} />
@@ -276,11 +279,14 @@ export default function BrandOSContent(): React.ReactElement {
           <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-[0.32fr_1fr] lg:gap-16">
             <VStack className="gap-4">
               <SectionLabel>Signal</SectionLabel>
-              <Heading as="h2" className="font-serif text-4xl text-surface">
+              <Heading
+                as="h2"
+                className="font-semibold tracking-[-0.02em] text-4xl text-surface"
+              >
                 Color that means something.
               </Heading>
               <Text className="text-sm leading-6 text-surface/55">
-                Status and domain colors map directly to state and workflow —
+                Status and domain colors map directly to state and workflow,
                 never decoration. Four semantic tones, two domain tones.
               </Text>
             </VStack>
@@ -311,11 +317,14 @@ export default function BrandOSContent(): React.ReactElement {
           <div className="container mx-auto grid gap-12 px-6 lg:grid-cols-[0.32fr_1fr] lg:gap-16">
             <VStack className="gap-4">
               <SectionLabel>Identifiers</SectionLabel>
-              <Heading as="h2" className="font-serif text-4xl text-surface">
+              <Heading
+                as="h2"
+                className="font-semibold tracking-[-0.02em] text-4xl text-surface"
+              >
                 Platform tokens.
               </Heading>
               <Text className="text-sm leading-6 text-surface/55">
-                Twenty-four brand colors used as identifiers only — on platform
+                Twenty-four brand colors used as identifiers only, on platform
                 icons, connection badges, and analytics breakdowns. Never for
                 layout chrome or primary actions.
               </Text>
@@ -333,7 +342,7 @@ export default function BrandOSContent(): React.ReactElement {
                     <Text className="text-xs font-medium text-surface/80">
                       {platform.name}
                     </Text>
-                    <Text className="font-mono text-[10px] uppercase text-surface/30">
+                    <Text className="font-mono text-[10px] uppercase text-surface/55">
                       {platform.hex}
                     </Text>
                   </VStack>
@@ -349,7 +358,10 @@ export default function BrandOSContent(): React.ReactElement {
             <VStack className="gap-6">
               <VStack className="gap-3">
                 <SectionLabel>Typography</SectionLabel>
-                <Heading as="h2" className="font-serif text-4xl text-surface">
+                <Heading
+                  as="h2"
+                  className="font-semibold tracking-[-0.02em] text-4xl text-surface"
+                >
                   A dense, deliberate scale.
                 </Heading>
                 <Text className="text-sm leading-6 text-surface/55">
@@ -367,7 +379,7 @@ export default function BrandOSContent(): React.ReactElement {
                     <Text className="text-sm text-surface/70">
                       {row.element}
                     </Text>
-                    <Text className="font-mono text-[11px] uppercase text-surface/40">
+                    <Text className="font-mono text-[11px] uppercase text-surface/60">
                       {row.size}
                     </Text>
                   </HStack>
@@ -378,7 +390,10 @@ export default function BrandOSContent(): React.ReactElement {
             <VStack className="gap-6">
               <VStack className="gap-3">
                 <SectionLabel>Form</SectionLabel>
-                <Heading as="h2" className="font-serif text-4xl text-surface">
+                <Heading
+                  as="h2"
+                  className="font-semibold tracking-[-0.02em] text-4xl text-surface"
+                >
                   Four-step radius.
                 </Heading>
                 <Text className="text-sm leading-6 text-surface/55">
@@ -401,11 +416,11 @@ export default function BrandOSContent(): React.ReactElement {
                       <Text className="text-xs font-semibold text-surface">
                         {step.name}
                       </Text>
-                      <Text className="font-mono text-[10px] uppercase text-surface/40">
+                      <Text className="font-mono text-[10px] uppercase text-surface/60">
                         {step.px}px
                       </Text>
                     </HStack>
-                    <Text className="text-[11px] leading-4 text-surface/40">
+                    <Text className="text-[11px] leading-4 text-surface/60">
                       {step.use}
                     </Text>
                   </VStack>
@@ -415,19 +430,19 @@ export default function BrandOSContent(): React.ReactElement {
           </div>
         </section>
 
-        {/* Content is the accent — centerpiece */}
+        {/* Content is the accent: centerpiece */}
         <section className="border-b border-edge/5 bg-fill/[0.02] py-20 sm:py-24">
           <div className="container mx-auto px-6">
             <VStack className="mx-auto max-w-3xl gap-5 text-center">
               <SectionLabel>The principle</SectionLabel>
               <Heading
                 as="h2"
-                className="font-serif text-4xl leading-tight text-surface sm:text-5xl"
+                className="font-semibold tracking-[-0.02em] text-4xl leading-tight text-surface sm:text-5xl"
               >
                 Content is the accent.
               </Heading>
               <Text className="text-base leading-7 text-surface/55">
-                Genfeed chrome is a neutral studio — the gallery wall, not the
+                Genfeed chrome is a neutral studio, the gallery wall, not the
                 art. The product's output is inherently colorful, so the
                 interface never competes with it. Color enters through exactly
                 four doors; everything else is grayscale.
@@ -437,7 +452,7 @@ export default function BrandOSContent(): React.ReactElement {
             <div className="mx-auto mt-12 grid max-w-6xl gap-px bg-edge/5 sm:grid-cols-2 lg:grid-cols-4">
               {COLOR_DOORS.map((door) => (
                 <VStack className="gap-4 bg-background p-6" key={door.index}>
-                  <Text className="font-mono text-xs text-surface/30">
+                  <Text className="font-mono text-xs text-surface/55">
                     {door.index}
                   </Text>
                   <Heading

--- a/apps/website/app/(public)/brand-os/page.tsx
+++ b/apps/website/app/(public)/brand-os/page.tsx
@@ -2,8 +2,8 @@ import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-me
 import BrandOSContent from '@public/brand-os/brand-os-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
-  'Brand OS — Genfeed Design System',
-  "Genfeed's Brand OS: the dark-first design system behind the product — color layers, semantic and platform tokens, the type scale, and the content-is-the-accent principle.",
+  'Brand OS: Genfeed Design System',
+  "Genfeed's Brand OS: the dark-first design system behind the product. Color layers, semantic and platform tokens, the type scale, and the content-is-the-accent principle.",
   '/brand-os',
 );
 

--- a/apps/website/app/(public)/calendar/calendar-content.tsx
+++ b/apps/website/app/(public)/calendar/calendar-content.tsx
@@ -108,15 +108,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Planning, scheduling, and approvals"
-    title={
-      <>
-        Plan your whole
-        <br />
-        content calendar
-        <br />
-        in one view.
-      </>
-    }
+    title="Your calendar, one view."
   />
 );
 
@@ -159,18 +151,18 @@ export default function CalendarContent() {
       >
         {/* Highlight Card */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiCalendarDays className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiCalendarDays className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   One Calendar, Every Channel
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Plan drafts, schedule posts, and route approvals from a single
                   visual calendar. See exactly what is going out, on which
                   channel, and when, before it ever publishes.
@@ -230,13 +222,10 @@ export default function CalendarContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -260,10 +249,10 @@ export default function CalendarContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                     <VStack className="gap-1">
-                      <Text className="text-lg font-bold text-surface/90">
+                      <Text className="text-lg font-bold text-surface">
                         {step.label}
                       </Text>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.sublabel}
                       </Text>
                     </VStack>
@@ -275,7 +264,7 @@ export default function CalendarContent() {
               );
             })}
           </div>
-          <Text className="text-sm text-surface/40 text-center mt-8">
+          <Text className="text-sm text-surface/65 text-center mt-8">
             Once it is approved here, publish it everywhere from the{' '}
             <Link
               href="/publisher"
@@ -289,23 +278,22 @@ export default function CalendarContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiCalendarDays className="size-8 text-inv-fg" />
+              <HiCalendarDays className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Start Planning Today
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Build a content calendar that plans, schedules, and approves
               itself, then publishes everywhere on time.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="calendar_cta_click"
                 trackingData={{ action: 'create_now' }}
               >
@@ -317,7 +305,6 @@ export default function CalendarContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="calendar_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/app/(public)/cloud/cloud-content.tsx
+++ b/apps/website/app/(public)/cloud/cloud-content.tsx
@@ -75,7 +75,7 @@ export default function CloudContent() {
   return (
     <div ref={containerRef}>
       <PageLayout
-        title={<>One studio for your whole team</>}
+        title="One studio for your team"
         description="Shared workspaces, a brand library, roles, and approvals. The studio your whole team creates in."
       >
         {/* Benefits */}
@@ -106,7 +106,7 @@ export default function CloudContent() {
                   <div className="size-3 rounded-full bg-fill/20" />
                 </div>
                 <div className="flex-1 mx-4">
-                  <div className="bg-fill/[0.03] border border-edge/5 px-3 py-1.5 text-xs text-surface/30 text-center font-mono uppercase tracking-widest">
+                  <div className="bg-fill/[0.03] border border-edge/5 px-3 py-1.5 text-xs text-surface/45 text-center font-mono uppercase tracking-widest">
                     app.genfeed.ai
                   </div>
                 </div>

--- a/apps/website/app/(public)/features/features-page.tsx
+++ b/apps/website/app/(public)/features/features-page.tsx
@@ -26,7 +26,7 @@ const FEATURES = [
   },
   {
     description:
-      'Access the best AI models for video, image, voice, and text — automatically selected for each task.',
+      'Access the best AI models for video, image, voice, and text, automatically selected for each task.',
     icon: LuCpu,
     label: 'AI Engine',
     number: '02',
@@ -73,14 +73,14 @@ export default function FeaturesPage(): React.ReactElement {
                     key={feature.number}
                     className="gsap-card bg-background p-12 flex flex-col group hover:bg-fill/[0.02] transition-colors"
                   >
-                    <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-12">
+                    <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-12">
                       {feature.number} / {feature.label}
                     </div>
-                    <Icon className="size-10 mb-8 text-surface/40 group-hover:text-surface transition-all" />
+                    <Icon className="size-10 mb-8 text-surface/55 group-hover:text-surface transition-all" />
                     <h3 className="text-xl font-semibold uppercase tracking-tight mb-4">
                       {feature.title}
                     </h3>
-                    <p className="text-surface/40 text-sm leading-relaxed mb-8">
+                    <p className="text-surface/65 text-sm leading-relaxed mb-8">
                       {feature.description}
                     </p>
                     <span className="mt-auto text-[10px] font-black uppercase tracking-widest flex items-center gap-2 hover:gap-4 transition-all cursor-pointer">
@@ -107,7 +107,7 @@ export default function FeaturesPage(): React.ReactElement {
                     className="object-cover group-hover:scale-110 transition-transform duration-1000"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent p-12 flex flex-col justify-end">
-                    <span className="text-[10px] font-black uppercase tracking-widest text-surface/40 mb-2">
+                    <span className="text-[10px] font-black uppercase tracking-widest text-surface/60 mb-2">
                       Case Study 01
                     </span>
                     <h4 className="text-3xl font-semibold text-surface">
@@ -121,7 +121,7 @@ export default function FeaturesPage(): React.ReactElement {
                   <h2 className="text-5xl font-semibold mb-8">
                     Built for Speed and Quality.
                   </h2>
-                  <p className="text-lg text-surface/40 leading-relaxed">
+                  <p className="text-lg text-surface/65 leading-relaxed">
                     Genfeed uses 50+ AI models optimized for content creation.
                     Each model is selected automatically based on your prompt,
                     so you get the best quality without choosing between
@@ -133,7 +133,7 @@ export default function FeaturesPage(): React.ReactElement {
                     <span className="text-4xl font-semibold block mb-2">
                       250%
                     </span>
-                    <span className="text-[10px] font-black uppercase tracking-widest text-surface/30">
+                    <span className="text-[10px] font-black uppercase tracking-widest text-surface/55">
                       Efficiency Increase
                     </span>
                   </div>
@@ -141,7 +141,7 @@ export default function FeaturesPage(): React.ReactElement {
                     <span className="text-4xl font-semibold block mb-2">
                       0.4s
                     </span>
-                    <span className="text-[10px] font-black uppercase tracking-widest text-surface/30">
+                    <span className="text-[10px] font-black uppercase tracking-widest text-surface/55">
                       Average Latency
                     </span>
                   </div>
@@ -168,7 +168,7 @@ export default function FeaturesPage(): React.ReactElement {
               <h2 className="text-6xl font-semibold mb-10">
                 Start Creating Today
               </h2>
-              <p className="text-surface/40 text-xl mb-12 font-medium">
+              <p className="text-surface/65 text-xl mb-12 font-medium">
                 Start creating in minutes. Choose the plan that fits your team.
               </p>
               <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/website/app/(public)/integrations/[slug]/page.tsx
+++ b/apps/website/app/(public)/integrations/[slug]/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata(
     };
   }
 
-  const title = `Genfeed for ${integration.name} — AI ${integration.name} Content Generator`;
+  const title = `Genfeed for ${integration.name}: AI ${integration.name} Content Generator`;
   const description = `Create professional ${integration.name} content with AI. Generate videos, images, and posts optimized for ${integration.name}. Try Genfeed free.`;
   const url = `${EnvironmentService.apps.website}/integrations/${slug}`;
 

--- a/apps/website/app/(public)/integrations/integrations-content.tsx
+++ b/apps/website/app/(public)/integrations/integrations-content.tsx
@@ -99,15 +99,7 @@ const HERO_VISUAL = (
       value: integration.tagline,
     }))}
     subtitle="Distribution surfaces with AI-native packaging"
-    title={
-      <>
-        Every channel.
-        <br />
-        One operating
-        <br />
-        layer.
-      </>
-    }
+    title="Every channel, one layer."
   />
 );
 
@@ -154,7 +146,7 @@ export default function IntegrationsContent() {
                   </div>
                   <Heading
                     as="h3"
-                    className="mb-2 text-lg font-semibold text-surface/90"
+                    className="mb-2 text-lg font-semibold text-surface"
                   >
                     {integration.name}
                   </Heading>
@@ -173,21 +165,20 @@ export default function IntegrationsContent() {
 
         {/* CTA */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiSparkles className="size-8 text-inv-fg" />
+              <HiSparkles className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               One Platform, Every Channel
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Generate AI content and publish to all your platforms from a
               single dashboard. Start free with Core.
             </Text>
             <ButtonTracked
               asChild
               size={ButtonSize.PUBLIC}
-              className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
               trackingName="integrations_cta_click"
               trackingData={{ action: 'core_cta' }}
             >

--- a/apps/website/app/(public)/integrations/page.tsx
+++ b/apps/website/app/(public)/integrations/page.tsx
@@ -2,7 +2,7 @@ import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-me
 import IntegrationsContent from '@public/integrations/integrations-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
-  'Integrations — Publish AI Content to Every Platform',
+  'Integrations: Publish AI Content to Every Platform',
   'Connect Genfeed to YouTube, TikTok, Instagram, LinkedIn, and more. Generate and publish AI content directly to your favorite platforms.',
   '/integrations',
 );

--- a/apps/website/app/(public)/library/library-content.tsx
+++ b/apps/website/app/(public)/library/library-content.tsx
@@ -125,15 +125,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Every asset your team creates"
-    title={
-      <>
-        One library
-        <br />
-        your whole
-        <br />
-        team reuses.
-      </>
-    }
+    title="One library, reused everywhere."
   />
 );
 
@@ -179,18 +171,18 @@ export default function LibraryContent() {
       >
         {/* Highlight Card */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiRectangleStack className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiRectangleStack className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   Every Asset, One Library
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Ingredients, images, videos, voices, music, captions, gifs,
                   moodboards, and avatars all saved in one place. Stop
                   recreating what already works and start reusing it.
@@ -250,13 +242,10 @@ export default function LibraryContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -280,10 +269,10 @@ export default function LibraryContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                     <VStack className="gap-1">
-                      <Text className="text-lg font-bold text-surface/90">
+                      <Text className="text-lg font-bold text-surface">
                         {step.label}
                       </Text>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.sublabel}
                       </Text>
                     </VStack>
@@ -299,23 +288,22 @@ export default function LibraryContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiSparkles className="size-8 text-inv-fg" />
+              <HiSparkles className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Build Your Library Today
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Save every asset your team creates and reuse it across brands,
               campaigns, and channels. No manual organizing required.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="library_cta_click"
                 trackingData={{ action: 'sign_up' }}
               >
@@ -327,7 +315,6 @@ export default function LibraryContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="library_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/app/(public)/pricing/page.tsx
+++ b/apps/website/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import PricingContent from '@public/pricing/pricing-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
   'Pricing',
-  'Free to sign up — credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, plus more brands, channels, and seats.',
+  'Free to sign up. Credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, plus more brands, channels, and seats.',
   '/pricing',
 );
 

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -216,7 +216,7 @@ export default function PricingContent() {
                           {formatPrice(plan.launchPrice)}
                         </span>
                         {plan.type === 'subscription' ? (
-                          <span className="text-sm font-medium text-surface/40">
+                          <span className="text-sm font-medium text-surface/55">
                             /mo
                           </span>
                         ) : null}
@@ -227,7 +227,7 @@ export default function PricingContent() {
                           {formatPrice(plan.price)}
                         </span>
                         {plan.type === 'subscription' ? (
-                          <span className="text-sm font-medium text-surface/40">
+                          <span className="text-sm font-medium text-surface/55">
                             /mo
                           </span>
                         ) : null}
@@ -237,7 +237,7 @@ export default function PricingContent() {
 
                   <div
                     className={cn(
-                      'text-sm text-surface/40',
+                      'text-sm text-surface/60',
                       plan.launchNote ? 'mb-1' : 'mb-8',
                     )}
                   >
@@ -245,19 +245,19 @@ export default function PricingContent() {
                   </div>
 
                   {plan.launchNote ? (
-                    <div className="mb-8 text-xs font-semibold uppercase tracking-widest text-surface/50">
+                    <div className="mb-8 text-xs font-semibold uppercase tracking-widest text-surface/60">
                       {plan.launchNote}
                     </div>
                   ) : null}
 
-                  <p className="mb-8 text-sm leading-6 text-surface/50">
+                  <p className="mb-8 text-sm leading-6 text-surface/65">
                     {getPlanSummary(plan)}
                   </p>
 
                   <ul className="mb-auto space-y-4">
                     {plan.features.slice(0, 5).map((feature) => (
                       <li key={feature} className="flex items-start gap-3">
-                        <HiCheckCircle className="mt-0.5 size-4 shrink-0 text-surface/40" />
+                        <HiCheckCircle className="mt-0.5 size-4 shrink-0 text-surface/55" />
                         <span className="text-sm text-surface/60">
                           {feature}
                         </span>
@@ -291,7 +291,7 @@ export default function PricingContent() {
                 <h3 className="mb-2 text-2xl font-semibold tracking-[-0.02em]">
                   Your own studio, fully managed.
                 </h3>
-                <p className="text-sm leading-6 text-surface/50">
+                <p className="text-sm leading-6 text-surface/65">
                   Custom output terms, unlimited seats and organizations, full
                   API access, white-label, SSO, and a dedicated account manager.
                 </p>
@@ -330,7 +330,7 @@ export default function PricingContent() {
                 <span className="text-sm text-surface/65">{row.label}</span>
                 <span className="text-sm font-semibold text-surface">
                   {formatCredits(row.credits)}
-                  <span className="ml-2 font-normal text-surface/40">
+                  <span className="ml-2 font-normal text-surface/55">
                     ≈ {formatCreditsDollars(row.credits)}
                     {row.suffix ?? ''}
                   </span>
@@ -342,7 +342,7 @@ export default function PricingContent() {
           <div className="mt-px grid gap-px overflow-hidden border border-edge/5 bg-fill/5 sm:grid-cols-3">
             {WEBSITE_CREDIT_PACKS.map((pack) => (
               <div key={pack.label} className="bg-background px-5 py-4">
-                <div className="text-xs font-bold uppercase tracking-widest text-surface/35">
+                <div className="text-xs font-bold uppercase tracking-widest text-surface/55">
                   {pack.label} pack
                 </div>
                 <div className="mt-1 text-sm text-surface/65">

--- a/apps/website/app/(public)/privacy/privacy-content.tsx
+++ b/apps/website/app/(public)/privacy/privacy-content.tsx
@@ -82,7 +82,7 @@ export default function PrivacyContent() {
                     key={section.title}
                     className="bg-background p-12 group hover:bg-fill/[0.02] transition-colors"
                   >
-                    <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+                    <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                       {String(index + 1).padStart(2, '0')} /{' '}
                       {section.shortLabel}
                     </div>
@@ -105,7 +105,7 @@ export default function PrivacyContent() {
                       <ul className="space-y-3">
                         {section.listItems.map((item) => (
                           <li key={item} className="flex items-start gap-3">
-                            <LuCheck className="size-4 text-surface/40 mt-0.5 shrink-0" />
+                            <LuCheck className="size-4 text-surface/65 mt-0.5 shrink-0" />
                             <span className="text-surface/60 text-sm">
                               {item}
                             </span>
@@ -127,7 +127,7 @@ export default function PrivacyContent() {
               <h2 className="text-5xl font-semibold mb-6">
                 Your Privacy Rights
               </h2>
-              <p className="text-surface/50 max-w-xl mx-auto">
+              <p className="text-surface/65 max-w-xl mx-auto">
                 We believe in transparency and your right to control your data.
               </p>
             </div>
@@ -141,15 +141,15 @@ export default function PrivacyContent() {
                       key={right.title}
                       className="bg-background p-10 group hover:bg-fill/[0.02] transition-colors"
                     >
-                      <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+                      <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                         {String(index + 1).padStart(2, '0')} /{' '}
                         {right.shortLabel}
                       </div>
-                      <Icon className="size-8 text-surface/40 mb-4 group-hover:text-surface transition-colors" />
+                      <Icon className="size-8 text-surface/65 mb-4 group-hover:text-surface transition-colors" />
                       <h3 className="text-lg font-semibold mb-3">
                         {right.title}
                       </h3>
-                      <p className="text-surface/40 text-sm leading-relaxed">
+                      <p className="text-surface/65 text-sm leading-relaxed">
                         {right.description}
                       </p>
                     </div>
@@ -166,7 +166,7 @@ export default function PrivacyContent() {
             <div className="text-center max-w-3xl mx-auto">
               <LuMail className="size-12 mx-auto text-surface/30 mb-8" />
               <h2 className="text-5xl font-semibold mb-10">Questions?</h2>
-              <p className="text-surface/40 text-xl mb-12 font-medium">
+              <p className="text-surface/65 text-xl mb-12 font-medium">
                 If you have any questions about our privacy practices, please
                 contact our privacy team.
               </p>

--- a/apps/website/app/(public)/publisher/publisher-content.tsx
+++ b/apps/website/app/(public)/publisher/publisher-content.tsx
@@ -144,15 +144,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Publishing without tool switching"
-    title={
-      <>
-        Publish everywhere
-        <br />
-        from one
-        <br />
-        operating surface.
-      </>
-    }
+    title="Publish from one surface."
   />
 );
 
@@ -200,18 +192,18 @@ export default function PublisherContent() {
         {/*  Highlight Card                                           */}
         {/* -------------------------------------------------------- */}
         <section className="gsap-hero max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiRocketLaunch className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiRocketLaunch className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   Publish Everywhere, From One Place
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Stop copy-pasting across ten different apps. Write once, let
                   Genfeed auto-format for each platform, schedule the optimal
                   time, and publish everywhere simultaneously.
@@ -283,13 +275,10 @@ export default function PublisherContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -322,7 +311,7 @@ export default function PublisherContent() {
                   )}
 
                   {/* Step number */}
-                  <Text className="text-[10px] font-black uppercase tracking-widest text-surface/20 mb-3">
+                  <Text className="text-[10px] font-black uppercase tracking-widest text-surface/50 mb-3">
                     Step {index + 1}
                   </Text>
 
@@ -332,15 +321,12 @@ export default function PublisherContent() {
                   </div>
 
                   {/* Label */}
-                  <Heading
-                    as="h4"
-                    className="font-semibold text-surface/90 mb-1"
-                  >
+                  <Heading as="h4" className="font-semibold text-surface mb-1">
                     {step.label}
                   </Heading>
 
                   {/* Sublabel */}
-                  <Text className="text-xs text-surface/40 leading-relaxed">
+                  <Text className="text-xs text-surface/65 leading-relaxed">
                     {step.sublabel}
                   </Text>
                 </div>
@@ -353,23 +339,22 @@ export default function PublisherContent() {
         {/*  Pricing CTA                                              */}
         {/* -------------------------------------------------------- */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiRocketLaunch className="size-8 text-inv-fg" />
+              <HiRocketLaunch className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Start Publishing Today
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Connect your platforms and start publishing AI content everywhere
               in minutes. Free tier available with no credit card required.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="publisher_cta_click"
                 trackingData={{ action: 'view_plans' }}
               >
@@ -382,7 +367,6 @@ export default function PublisherContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="publisher_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/app/(public)/research/research-content.tsx
+++ b/apps/website/app/(public)/research/research-content.tsx
@@ -107,13 +107,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Discovery, tracking, and briefing"
-    title={
-      <>
-        Find what is
-        <br />
-        working now.
-      </>
-    }
+    title="Find what's working now."
   />
 );
 
@@ -156,18 +150,18 @@ export default function ResearchContent() {
       >
         {/* Highlight Card */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiSparkles className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiSparkles className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   Every Signal, One Workspace
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Track trending content, competitor social accounts, and
                   winning ad creative from a single interface. Turn any
                   discovery into a ready brief without switching tabs.
@@ -227,13 +221,10 @@ export default function ResearchContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -257,10 +248,10 @@ export default function ResearchContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                     <VStack className="gap-1">
-                      <Text className="text-lg font-bold text-surface/90">
+                      <Text className="text-lg font-bold text-surface">
                         {step.label}
                       </Text>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.sublabel}
                       </Text>
                     </VStack>
@@ -276,23 +267,22 @@ export default function ResearchContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiSparkles className="size-8 text-inv-fg" />
+              <HiSparkles className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Start Discovering Today
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Find trends, track competitors, and study winning ad creative.
               Turn every discovery into a ready brief in one click.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="research_cta_click"
                 trackingData={{ action: 'create_now' }}
               >
@@ -304,7 +294,6 @@ export default function ResearchContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="research_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/app/(public)/services/services-content.tsx
+++ b/apps/website/app/(public)/services/services-content.tsx
@@ -90,73 +90,42 @@ export default function ServicesContent() {
                 <NeuralGridItem
                   key={service.label}
                   padding="lg"
-                  inverted={isFeatured}
-                  className="relative gsap-card"
-                  style={
-                    isFeatured ? undefined : { backgroundColor: '#18181b' }
-                  }
+                  className={cn(
+                    'relative gsap-card',
+                    isFeatured && 'bg-white/[0.04]',
+                  )}
                 >
                   {isFeatured && (
                     <div className="absolute top-6 right-6">
-                      <span className="px-3 py-1 bg-zinc-950 text-surface text-[10px] font-black uppercase tracking-widest rounded-full">
+                      <span className="border border-edge/40 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-surface/70">
                         Most Popular
                       </span>
                     </div>
                   )}
 
-                  <div
-                    className={cn(
-                      'text-xs font-black uppercase tracking-widest mb-6',
-                      isFeatured ? 'text-inv-fg/30' : 'text-surface/20',
-                    )}
-                  >
+                  <div className="text-xs font-black uppercase tracking-widest mb-6 text-surface/50">
                     {service.number} / {service.shortLabel}
                   </div>
 
                   <div className="mb-2">
-                    <span
-                      className={cn(
-                        'text-3xl font-semibold',
-                        isFeatured && 'text-inv-fg',
-                      )}
-                    >
+                    <span className="text-3xl font-semibold text-surface">
                       {service.label}
                     </span>
                   </div>
 
-                  <div
-                    className={cn(
-                      'text-sm mb-4',
-                      isFeatured ? 'text-inv-fg/50' : 'text-surface/40',
-                    )}
-                  >
+                  <div className="text-sm mb-4 text-surface/60">
                     {service.price}
                   </div>
 
-                  <div
-                    className={cn(
-                      'text-sm mb-8',
-                      isFeatured ? 'text-inv-fg/60' : 'text-surface/50',
-                    )}
-                  >
+                  <div className="text-sm mb-8 text-surface/65">
                     {service.description}
                   </div>
 
                   <ul className="space-y-4 mb-auto">
                     {service.features.map((feature) => (
                       <li key={feature} className="flex items-start gap-3">
-                        <LuCheck
-                          className={cn(
-                            'size-4 mt-0.5 shrink-0',
-                            isFeatured ? 'text-inv-fg/30' : 'text-surface/40',
-                          )}
-                        />
-                        <span
-                          className={cn(
-                            'text-sm',
-                            isFeatured ? 'text-inv-fg/60' : 'text-surface/60',
-                          )}
-                        >
+                        <LuCheck className="size-4 mt-0.5 shrink-0 text-surface/55" />
+                        <span className="text-sm text-surface/65">
                           {feature}
                         </span>
                       </li>
@@ -166,7 +135,7 @@ export default function ServicesContent() {
                   <Button
                     asChild
                     variant={
-                      isFeatured ? ButtonVariant.BLACK : ButtonVariant.DEFAULT
+                      isFeatured ? ButtonVariant.WHITE : ButtonVariant.OUTLINE
                     }
                     size={ButtonSize.PUBLIC}
                     className="mt-12 w-full text-center"
@@ -220,7 +189,7 @@ export default function ServicesContent() {
                 href={item.href}
                 className="flex items-center justify-between p-4 border border-edge/10 bg-fill/[0.02] hover:border-surface/20 transition-all"
               >
-                <span className="text-xs font-black uppercase tracking-widest text-surface/40">
+                <span className="text-xs font-black uppercase tracking-widest text-surface/60">
                   {item.label}
                 </span>
                 <span className="text-sm font-semibold text-surface">→</span>

--- a/apps/website/app/(public)/skills/_data.ts
+++ b/apps/website/app/(public)/skills/_data.ts
@@ -138,7 +138,7 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
       },
       {
         description:
-          '6-dimension quality scoring — clarity, voice, hook, CTA, platform fit, accuracy.',
+          '6-dimension quality scoring: clarity, voice, hook, CTA, platform fit, accuracy.',
         icon: LuSparkles,
         name: 'Content Reviewer',
         slug: 'content-reviewer',
@@ -258,7 +258,7 @@ export const SKILL_CATEGORIES: SkillCategory[] = [
     skills: [
       {
         description:
-          'Ad copy with PAS, AIDA, BAB, StoryBrand frameworks — variants for every platform.',
+          'Ad copy with PAS, AIDA, BAB, StoryBrand frameworks: variants for every platform.',
         icon: LuMegaphone,
         name: 'Ad Copy Creator',
         slug: 'ad-copy-creator',
@@ -577,7 +577,7 @@ export const HOW_IT_WORKS: HowItWorksStep[] = [
   },
   {
     description:
-      'Your agent reads each skill — its rules, patterns, and domain knowledge — and internalizes them.',
+      'Your agent reads each skill, its rules, patterns, and domain knowledge, and internalizes them.',
     icon: LuBrainCircuit,
     number: '02',
     title: 'Agent Learns',
@@ -591,7 +591,7 @@ export const HOW_IT_WORKS: HowItWorksStep[] = [
   },
   {
     description:
-      'Inside Genfeed, skills use platform tools — create_post, generate_image, rate_content — for even better output.',
+      'Inside Genfeed, skills use platform tools like create_post, generate_image, and rate_content for even better output.',
     icon: LuPackage,
     number: '04',
     title: 'Better with Genfeed',

--- a/apps/website/app/(public)/skills/skills-bundle-cta.tsx
+++ b/apps/website/app/(public)/skills/skills-bundle-cta.tsx
@@ -23,19 +23,19 @@ export default function SkillsBundleCta({
   return (
     <WebSection bg="subtle" className="gsap-section">
       <NeuralGrid columns={1}>
-        <NeuralGridItem inverted padding="lg" align="center">
+        <NeuralGridItem padding="lg" align="center" className="bg-white/[0.04]">
           <div className="max-w-2xl mx-auto py-8">
-            <div className="text-inv-fg/30 text-xs font-black uppercase tracking-widest mb-6">
+            <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
               All Pro Skills Included
             </div>
-            <h2 className="text-5xl font-semibold text-inv-fg mb-4">
+            <h2 className="text-5xl font-semibold text-surface mb-4">
               Get Pro Skills
             </h2>
-            <div className="text-6xl font-semibold text-inv-fg mb-8">
+            <div className="text-6xl font-semibold text-surface mb-8">
               ${bundlePrice}
             </div>
             <Button
-              variant={ButtonVariant.BLACK}
+              variant={ButtonVariant.WHITE}
               size={ButtonSize.PUBLIC}
               className="min-w-skill-col"
               disabled={checkoutLoading}

--- a/apps/website/app/(public)/skills/skills-content.tsx
+++ b/apps/website/app/(public)/skills/skills-content.tsx
@@ -125,11 +125,11 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
             className="gsap-section"
           >
             <div className="text-center mb-16">
-              <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+              <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                 {category.label}
               </div>
               <h2 className="text-5xl font-semibold mb-6">{category.title}</h2>
-              <p className="text-surface/50 max-w-xl mx-auto">
+              <p className="text-surface/65 max-w-xl mx-auto">
                 {category.subtitle}
               </p>
             </div>
@@ -168,11 +168,11 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
         {registry && registry.skills.length > 0 && (
           <WebSection bg="bordered" className="gsap-section">
             <div className="text-center mb-16">
-              <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+              <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                 Premium
               </div>
               <h2 className="text-5xl font-semibold mb-6">Pro Skills</h2>
-              <p className="text-surface/50 max-w-xl mx-auto">
+              <p className="text-surface/65 max-w-xl mx-auto">
                 Paid operating systems for source-to-brief, brand voice,
                 production queues, performance loops, and platform warmup. All
                 included in the bundle.
@@ -219,16 +219,16 @@ export default function SkillsContent({ initialRegistry }: SkillsContentProps) {
         <WebSection maxWidth="lg" className="gsap-section">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
             <div className="flex flex-col justify-center">
-              <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+              <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                 Quick Start
               </div>
               <h2 className="text-4xl font-semibold mb-4">One Command</h2>
-              <p className="text-surface/40 text-sm leading-relaxed mb-6">
+              <p className="text-surface/65 text-sm leading-relaxed mb-6">
                 Install all {FREE_SKILL_COUNT} free skills with a single
                 command. Your agent learns each skill and activates it at
                 exactly the right moment.
               </p>
-              <div className="space-y-3 text-sm text-surface/40">
+              <div className="space-y-3 text-sm text-surface/65">
                 <p>
                   <span className="text-surface/60 font-medium">
                     Install all:

--- a/apps/website/app/(public)/skills/skills-how-it-works.tsx
+++ b/apps/website/app/(public)/skills/skills-how-it-works.tsx
@@ -11,11 +11,11 @@ export default function SkillsHowItWorks(): React.ReactElement {
   return (
     <WebSection maxWidth="lg" bg="bordered" className="gsap-section">
       <div className="text-center mb-16">
-        <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+        <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
           How It Works
         </div>
         <h2 className="text-5xl font-semibold mb-6">Install. Learn. Create.</h2>
-        <p className="text-surface/50 max-w-xl mx-auto">
+        <p className="text-surface/65 max-w-xl mx-auto">
           Skills are knowledge packages your agent absorbs, not plugins you
           configure.
         </p>

--- a/apps/website/app/(public)/skills/skills-stats-bar.tsx
+++ b/apps/website/app/(public)/skills/skills-stats-bar.tsx
@@ -10,7 +10,7 @@ export default function SkillsStatsBar(): React.ReactElement {
         {STATS.map((stat) => (
           <div key={stat.label} className="text-center">
             <div className="text-4xl font-semibold mb-1">{stat.value}</div>
-            <div className="text-xs font-black uppercase tracking-widest text-surface/30">
+            <div className="text-xs font-black uppercase tracking-widest text-surface/50">
               {stat.label}
             </div>
           </div>

--- a/apps/website/app/(public)/skills/success/skills-success-content.tsx
+++ b/apps/website/app/(public)/skills/success/skills-success-content.tsx
@@ -73,9 +73,9 @@ export default function SkillsSuccessContent() {
             </div>
           </div>
 
-          <div className="mt-8 space-y-4 text-sm text-surface/40">
+          <div className="mt-8 space-y-4 text-sm text-surface/65">
             <div className="flex items-start gap-3">
-              <LuTerminal className="size-4 mt-0.5 shrink-0 text-surface/30" />
+              <LuTerminal className="size-4 mt-0.5 shrink-0 text-surface/65" />
               <span>
                 Replace{' '}
                 <Code className="text-surface/60 bg-fill/5">sk_rcpt_xxx</Code>{' '}
@@ -83,7 +83,7 @@ export default function SkillsSuccessContent() {
               </span>
             </div>
             <div className="flex items-start gap-3">
-              <LuTerminal className="size-4 mt-0.5 shrink-0 text-surface/30" />
+              <LuTerminal className="size-4 mt-0.5 shrink-0 text-surface/65" />
               <span>
                 Skills are installed to{' '}
                 <Code className="text-surface/60 bg-fill/5">skills/</Code> in

--- a/apps/website/app/(public)/studio/studio-content.tsx
+++ b/apps/website/app/(public)/studio/studio-content.tsx
@@ -150,15 +150,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Generation, refinement, and packaging"
-    title={
-      <>
-        One workspace
-        <br />
-        for every AI
-        <br />
-        content format.
-      </>
-    }
+    title="One workspace, every format."
   />
 );
 
@@ -200,18 +192,18 @@ export default function StudioContent() {
       >
         {/* Highlight Card */}
         <section className="gsap-section max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiSparkles className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiSparkles className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
-                <Heading as="h3" className="text-2xl font-bold">
+                <Heading as="h3" className="text-2xl font-bold text-surface">
                   Every AI Model, One Workspace
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/70">
                   Access video, image, voice, and music generation from a single
                   interface. Switch between Google Veo 3, Imagen 4, Sora 2, and
                   more without juggling subscriptions or tabs.
@@ -220,7 +212,7 @@ export default function StudioContent() {
                   {HIGHLIGHT_TAGS.map((tag) => (
                     <span
                       key={tag}
-                      className="px-3 py-1 text-xs border border-[var(--gen-accent-border)] text-[var(--gen-accent-text)]"
+                      className="px-3 py-1 text-xs border border-[var(--gen-accent-border)] text-surface/70"
                     >
                       {tag}
                     </span>
@@ -271,13 +263,10 @@ export default function StudioContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -301,10 +290,10 @@ export default function StudioContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                     <VStack className="gap-1">
-                      <Text className="text-lg font-bold text-surface/90">
+                      <Text className="text-lg font-bold text-surface">
                         {step.label}
                       </Text>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.sublabel}
                       </Text>
                     </VStack>
@@ -320,23 +309,22 @@ export default function StudioContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 bg-[hsl(var(--gen-accent))]">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiSparkles className="size-8 text-inv-fg" />
+              <HiSparkles className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Start Creating Today
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Generate professional videos, images, and audio with the best AI
               models. No editing skills required.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="studio_cta_click"
                 trackingData={{ action: 'view_plans' }}
               >
@@ -349,7 +337,6 @@ export default function StudioContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="studio_cta_click"
                 trackingData={{ action: 'explore_studio' }}
               >

--- a/apps/website/app/(public)/terms/terms-page.tsx
+++ b/apps/website/app/(public)/terms/terms-page.tsx
@@ -89,7 +89,7 @@ export default function TermsPage() {
                     key={term.title}
                     className="bg-background p-12 group hover:bg-fill/[0.02] transition-colors"
                   >
-                    <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+                    <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                       {String(index + 1).padStart(2, '0')} / {term.shortLabel}
                     </div>
                     <h2 className="text-2xl font-semibold mb-6">
@@ -111,7 +111,7 @@ export default function TermsPage() {
                       <ul className="space-y-3">
                         {term.listItems.map((item) => (
                           <li key={item} className="flex items-start gap-3">
-                            <LuCheck className="size-4 text-surface/40 mt-0.5 shrink-0" />
+                            <LuCheck className="size-4 text-surface/65 mt-0.5 shrink-0" />
                             <span className="text-surface/60 text-sm">
                               {item}
                             </span>
@@ -133,7 +133,7 @@ export default function TermsPage() {
               <h2 className="text-5xl font-semibold mb-6">
                 Additional Legal Info
               </h2>
-              <p className="text-surface/50 max-w-xl mx-auto">
+              <p className="text-surface/65 max-w-xl mx-auto">
                 Important policies governing your use of Genfeed.
               </p>
             </div>
@@ -147,14 +147,14 @@ export default function TermsPage() {
                       key={info.title}
                       className="bg-background p-10 group hover:bg-fill/[0.02] transition-colors"
                     >
-                      <div className="text-surface/20 text-xs font-black uppercase tracking-widest mb-6">
+                      <div className="text-surface/50 text-xs font-black uppercase tracking-widest mb-6">
                         {String(index + 1).padStart(2, '0')} / {info.shortLabel}
                       </div>
-                      <Icon className="size-8 text-surface/40 mb-4 group-hover:text-surface transition-colors" />
+                      <Icon className="size-8 text-surface/65 mb-4 group-hover:text-surface transition-colors" />
                       <h3 className="text-lg font-semibold mb-3">
                         {info.title}
                       </h3>
-                      <p className="text-surface/40 text-sm leading-relaxed">
+                      <p className="text-surface/65 text-sm leading-relaxed">
                         {info.content}
                       </p>
                     </div>
@@ -171,7 +171,7 @@ export default function TermsPage() {
             <div className="text-center max-w-3xl mx-auto">
               <LuMail className="size-12 mx-auto text-surface/30 mb-8" />
               <h2 className="text-5xl font-semibold mb-10">Questions?</h2>
-              <p className="text-surface/40 text-xl mb-12 font-medium">
+              <p className="text-surface/65 text-xl mb-12 font-medium">
                 If you have any questions about these terms, please contact our
                 support team.
               </p>

--- a/apps/website/app/(public)/use-cases/[slug]/page.tsx
+++ b/apps/website/app/(public)/use-cases/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata(
   const previousImages = (await parent).openGraph?.images || [];
   const { slug } = await params;
   const audienceName = formatUseCaseSlug(slug);
-  const title = `Genfeed for ${audienceName} — AI Content Creation at Scale`;
+  const title = `Genfeed for ${audienceName}: AI Content Creation at Scale`;
   const description = `Discover how ${audienceName.toLowerCase()} use Genfeed to create professional AI-powered videos, images, and marketing content at scale.`;
   const url = `${EnvironmentService.apps.website}/use-cases/${slug}`;
 

--- a/apps/website/app/(public)/use-cases/[slug]/use-cases-content.tsx
+++ b/apps/website/app/(public)/use-cases/[slug]/use-cases-content.tsx
@@ -105,7 +105,7 @@ export default function UseCasesContent({ useCase }: { useCase: UseCase }) {
                 <Text className="text-sm text-surface/55">
                   {step.description}
                 </Text>
-                <Text className="text-sm text-surface/35 mt-1 italic">
+                <Text className="text-sm text-surface/60 mt-1">
                   {step.example}
                 </Text>
               </div>
@@ -138,7 +138,7 @@ export default function UseCasesContent({ useCase }: { useCase: UseCase }) {
           <Heading as="h3" className="text-3xl font-bold mb-2">
             {useCase.pricing.recommended}
           </Heading>
-          <Text className="text-surface/50 mb-6">{useCase.pricing.why}</Text>
+          <Text className="text-surface/65 mb-6">{useCase.pricing.why}</Text>
           <ButtonRequestAccess />
           <Link href="/pricing" className="link mt-4 block">
             View All Pricing

--- a/apps/website/app/(public)/vs/[slug]/page.tsx
+++ b/apps/website/app/(public)/vs/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata(
   const previousImages = (await parent).openGraph?.images || [];
   const { slug } = await params;
   const competitorName = formatCompetitorSlug(slug);
-  const title = `Genfeed vs ${competitorName} (2026) — AI Content Platform Comparison`;
+  const title = `Genfeed vs ${competitorName} (2026): AI Content Platform Comparison`;
   const description = `Compare Genfeed with ${competitorName}. See how AI-powered content generation, pricing, features, and capabilities stack up side by side.`;
   const url = `${EnvironmentService.apps.website}/vs/${slug}`;
 

--- a/apps/website/app/(public)/vs/page.tsx
+++ b/apps/website/app/(public)/vs/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const previousImages = (await parent).openGraph?.images || [];
   const images = [...previousImages];
-  const title = `Genfeed vs Alternatives (2026) — AI Content Platform Comparisons | ${metadata.name}`;
+  const title = `Genfeed vs Alternatives (2026): AI Content Platform Comparisons | ${metadata.name}`;
 
   return {
     alternates: {

--- a/apps/website/app/(public)/workflows/workflows-content.tsx
+++ b/apps/website/app/(public)/workflows/workflows-content.tsx
@@ -169,15 +169,7 @@ const HERO_VISUAL = (
       },
     ]}
     subtitle="Deterministic control for agentic systems"
-    title={
-      <>
-        Workflows for
-        <br />
-        systems that
-        <br />
-        must stay legible.
-      </>
-    }
+    title="Workflows that stay legible."
   />
 );
 
@@ -219,18 +211,18 @@ export default function WorkflowsContent() {
       >
         {/* Highlight Card */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="p-8 border border-[var(--gen-accent-border)] bg-gradient-to-r from-[var(--gen-accent-bg)] to-transparent">
+          <div className="p-8 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <HStack className="flex-col md:flex-row items-center gap-8">
               <div className="flex-shrink-0">
-                <div className="size-20 flex items-center justify-center bg-[hsl(var(--gen-accent))]">
-                  <HiSquaresPlus className="size-10 text-inv-fg" />
+                <div className="size-20 flex items-center justify-center border border-[var(--gen-accent-border)] bg-white/[0.06]">
+                  <HiSquaresPlus className="size-10 text-surface" />
                 </div>
               </div>
               <VStack className="gap-3">
                 <Heading as="h3" className="text-2xl font-bold">
                   Deterministic Workflows for Agentic Systems
                 </Heading>
-                <Text as="p" className="text-surface/50">
+                <Text as="p" className="text-surface/65">
                   Author the exact execution path yourself. Agents can trigger
                   the workflow, but the triggers, steps, branches, ratings, and
                   publishing logic stay explicit and inspectable.
@@ -265,10 +257,10 @@ export default function WorkflowsContent() {
                 <Text className="text-2xl font-bold text-[color:hsl(var(--gen-accent))] mb-1">
                   {category.count}
                 </Text>
-                <Heading as="h4" className="font-semibold text-surface/90 mb-2">
+                <Heading as="h4" className="font-semibold text-surface mb-2">
                   {category.name}
                 </Heading>
-                <Text className="text-sm text-surface/40">
+                <Text className="text-sm text-surface/65">
                   {category.description}
                 </Text>
               </div>
@@ -284,10 +276,10 @@ export default function WorkflowsContent() {
                 <Text className="text-2xl font-bold text-[color:hsl(var(--gen-accent))] mb-1">
                   {category.count}
                 </Text>
-                <Heading as="h4" className="font-semibold text-surface/90 mb-2">
+                <Heading as="h4" className="font-semibold text-surface mb-2">
                   {category.name}
                 </Heading>
-                <Text className="text-sm text-surface/40">
+                <Text className="text-sm text-surface/65">
                   {category.description}
                 </Text>
               </div>
@@ -313,13 +305,10 @@ export default function WorkflowsContent() {
                       <Icon className="size-6 text-[color:hsl(var(--gen-accent))]" />
                     </div>
                   </div>
-                  <Heading
-                    as="h4"
-                    className="font-semibold mb-2 text-surface/90"
-                  >
+                  <Heading as="h4" className="font-semibold mb-2 text-surface">
                     {feature.title}
                   </Heading>
-                  <Text className="text-sm text-surface/40">
+                  <Text className="text-sm text-surface/65">
                     {feature.description}
                   </Text>
                 </div>
@@ -346,7 +335,7 @@ export default function WorkflowsContent() {
                       <Heading as="h4" className="text-lg font-bold">
                         {step.label}
                       </Heading>
-                      <Text className="text-sm text-surface/40">
+                      <Text className="text-sm text-surface/65">
                         {step.description}
                       </Text>
                     </VStack>
@@ -362,24 +351,23 @@ export default function WorkflowsContent() {
 
         {/* Pricing CTA */}
         <section className="max-w-4xl mx-auto pb-16 px-6">
-          <div className="text-center p-12 gen-card-featured">
+          <div className="text-center p-12 border border-[var(--gen-accent-border)] bg-white/[0.04]">
             <div className="flex justify-center mb-4">
-              <HiSquaresPlus className="size-8 text-inv-fg" />
+              <HiSquaresPlus className="size-8 text-surface" />
             </div>
-            <Heading as="h3" className="text-2xl font-bold mb-2 text-inv-fg">
+            <Heading as="h3" className="text-2xl font-bold mb-2 text-surface">
               Use Agents for Simplicity. Use Workflows for Control.
             </Heading>
-            <Text as="p" className="text-inv-fg/60 mb-6 max-w-lg mx-auto">
+            <Text as="p" className="text-surface/70 mb-6 max-w-lg mx-auto">
               Let agents trigger autonomous runs, or configure every trigger and
               step yourself when you need deterministic execution from idea to
               published output.
             </Text>
-            <PricingStrip inverted className="mb-6" />
+            <PricingStrip className="mb-6" />
             <HStack className="flex-wrap gap-4 justify-center">
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                className="bg-inv-fg text-[color:hsl(var(--gen-accent))] hover:bg-inv-fg/80 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="workflows_cta_click"
                 trackingData={{ action: 'view_plans' }}
               >
@@ -392,7 +380,6 @@ export default function WorkflowsContent() {
                 asChild
                 variant={ButtonVariant.OUTLINE}
                 size={ButtonSize.PUBLIC}
-                className="border-inv-fg/20 text-inv-fg hover:bg-inv-fg/5 px-8 py-3 text-xs font-bold uppercase tracking-wider"
                 trackingName="workflows_cta_click"
                 trackingData={{ action: 'book_demo' }}
               >

--- a/apps/website/packages/components/content/BenefitGrid.tsx
+++ b/apps/website/packages/components/content/BenefitGrid.tsx
@@ -24,9 +24,9 @@ export default function BenefitGrid({ benefits, className }: BenefitGridProps) {
             key={benefit.title}
             className="p-10 text-center group bg-zinc-900 hover:bg-fill/[0.02] transition-colors"
           >
-            <Icon className="size-8 mx-auto mb-4 text-surface/40 group-hover:text-surface transition-all" />
+            <Icon className="size-8 mx-auto mb-4 text-surface/65 group-hover:text-surface transition-all" />
             <h3 className="text-lg font-semibold mb-2">{benefit.title}</h3>
-            <p className="text-surface/40 text-sm">{benefit.description}</p>
+            <p className="text-surface/65 text-sm">{benefit.description}</p>
           </div>
         );
       })}

--- a/apps/website/packages/components/content/FaqGrid.tsx
+++ b/apps/website/packages/components/content/FaqGrid.tsx
@@ -20,7 +20,7 @@ export default function FaqGrid({ className, items }: FaqGridProps) {
           className="p-10 group bg-background hover:bg-fill/[0.02] transition-colors"
         >
           <h3 className="text-lg font-semibold mb-3">{item.question}</h3>
-          <p className="text-surface/40 text-sm leading-relaxed">
+          <p className="text-surface/65 text-sm leading-relaxed">
             {item.answer}
           </p>
         </div>

--- a/apps/website/packages/components/content/FeatureList.tsx
+++ b/apps/website/packages/components/content/FeatureList.tsx
@@ -45,7 +45,7 @@ export default function FeatureList({
 function FeatureItem({ feature }: { feature: string }) {
   return (
     <div className="flex items-start gap-3">
-      <LuCheck className="size-4 text-surface/40 mt-0.5 shrink-0" />
+      <LuCheck className="size-4 text-surface/65 mt-0.5 shrink-0" />
       <span className="text-surface/60 text-sm">{feature}</span>
     </div>
   );

--- a/apps/website/packages/components/content/NeuralGrid.tsx
+++ b/apps/website/packages/components/content/NeuralGrid.tsx
@@ -54,7 +54,6 @@ function NeuralGridItem({
   className,
   padding,
   align,
-  inverted,
   tierLabel,
   icon: Icon,
   title,
@@ -65,46 +64,22 @@ function NeuralGridItem({
 }: NeuralGridItemProps & { ref?: Ref<HTMLDivElement> }) {
   return (
     <div
-      className={cn(
-        neuralGridItemVariants({ align, inverted, padding }),
-        className,
-      )}
+      className={cn(neuralGridItemVariants({ align, padding }), className)}
       ref={ref}
       {...props}
     >
       {tierLabel && (
-        <div
-          className={cn(
-            'text-xs font-black uppercase tracking-widest mb-6',
-            inverted ? 'text-inv-fg/50' : 'text-surface/45',
-          )}
-        >
+        <div className="text-xs font-black uppercase tracking-widest mb-6 text-surface/55">
           {tierLabel}
         </div>
       )}
       {Icon && (
-        <Icon
-          className={cn(
-            'size-8 mb-4 group-hover:text-surface transition-colors',
-            inverted ? 'text-inv-fg/60' : 'text-surface/60',
-          )}
-        />
+        <Icon className="size-8 mb-4 text-surface/60 group-hover:text-surface transition-colors" />
       )}
       {title && (
-        <h3 className={cn('text-lg font-bold mb-2', inverted && 'text-inv-fg')}>
-          {title}
-        </h3>
+        <h3 className="text-lg font-bold mb-2 text-surface">{title}</h3>
       )}
-      {description && (
-        <p
-          className={cn(
-            'text-sm',
-            inverted ? 'text-inv-fg/55' : 'text-surface/55',
-          )}
-        >
-          {description}
-        </p>
-      )}
+      {description && <p className="text-sm text-surface/65">{description}</p>}
       {children}
     </div>
   );
@@ -187,7 +162,7 @@ function CtaSection({
             {title}
           </h2>
           {description && (
-            <p className="text-surface/40 text-xl mb-12 font-medium">
+            <p className="text-surface/65 text-xl mb-12 font-medium">
               {description}
             </p>
           )}

--- a/apps/website/packages/components/content/_testimonials.tsx
+++ b/apps/website/packages/components/content/_testimonials.tsx
@@ -87,10 +87,10 @@ export default function ContentTestimonials() {
             </div>
             <div className="ml-4">
               <h3 className="font-semibold">{testimonial.name}</h3>
-              <p className="text-sm text-zinc-400">{testimonial.role}</p>
+              <p className="text-sm text-surface/65">{testimonial.role}</p>
             </div>
           </div>
-          <p className="text-zinc-400">&ldquo;{testimonial.quote}&rdquo;</p>
+          <p className="text-surface/65">&ldquo;{testimonial.quote}&rdquo;</p>
         </Card>
       ))}
     </>

--- a/apps/website/packages/components/content/neural-grid.variants.ts
+++ b/apps/website/packages/components/content/neural-grid.variants.ts
@@ -35,10 +35,6 @@ export const neuralGridItemVariants = cva(
         center: 'text-center',
         left: 'text-left',
       },
-      inverted: {
-        false: '',
-        true: 'bg-inv hover:bg-inv/95',
-      },
       padding: {
         lg: 'p-12',
         md: 'p-10',

--- a/apps/website/packages/components/landing/LandingFooter.tsx
+++ b/apps/website/packages/components/landing/LandingFooter.tsx
@@ -4,13 +4,13 @@ export default function LandingFooter(): React.ReactElement {
   return (
     <footer className="border-t border-edge/5 py-10">
       <div className="container mx-auto flex flex-col items-center justify-between gap-6 px-6 text-center md:flex-row md:text-left">
-        <p className="text-xs font-black text-surface/20">
+        <p className="text-xs font-black text-surface/50">
           <span suppressHydrationWarning>
             &copy; {new Date().getFullYear()} GENFEED.AI. ALL RIGHTS RESERVED.
           </span>
         </p>
 
-        <div className="flex items-center gap-8 text-xs font-black uppercase tracking-[0.18em] text-surface/35">
+        <div className="flex items-center gap-8 text-xs font-black uppercase tracking-[0.18em] text-surface/50">
           <Link
             href="/privacy"
             className="transition-colors hover:text-surface"

--- a/apps/website/packages/components/landing/ServiceLandingPage.tsx
+++ b/apps/website/packages/components/landing/ServiceLandingPage.tsx
@@ -42,8 +42,7 @@ export default function ServiceLandingPage({
         badgeIcon={LuSparkles}
         title={
           <>
-            {config.heroTitle}{' '}
-            <span className="italic font-light">{config.heroAccent}</span>.
+            {config.heroTitle} <span>{config.heroAccent}</span>.
           </>
         }
         description={config.heroDescription}
@@ -56,7 +55,7 @@ export default function ServiceLandingPage({
                 {config.intro}
               </p>
 
-              <div className="flex flex-wrap items-center gap-3 text-sm text-surface/45">
+              <div className="flex flex-wrap items-center gap-3 text-sm text-surface/65">
                 <span className="border border-edge/10 px-3 py-2">
                   Starting from $2,500
                 </span>
@@ -67,7 +66,7 @@ export default function ServiceLandingPage({
             </div>
 
             <div className="border border-edge/10 bg-black/30 p-6">
-              <div className="mb-4 flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-surface/35">
+              <div className="mb-4 flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-surface/50">
                 <LuCalendarRange className="size-4" />
                 {config.fitLabel}
               </div>
@@ -77,7 +76,7 @@ export default function ServiceLandingPage({
                     key={signal}
                     className="flex gap-3 text-sm text-surface/65"
                   >
-                    <LuBadgeCheck className="mt-0.5 size-4 shrink-0 text-surface/35" />
+                    <LuBadgeCheck className="mt-0.5 size-4 shrink-0 text-surface/50" />
                     <span>{signal}</span>
                   </li>
                 ))}

--- a/apps/website/packages/data/use-cases.data.ts
+++ b/apps/website/packages/data/use-cases.data.ts
@@ -145,7 +145,7 @@ export const useCases: UseCase[] = [
       },
       {
         description: 'AI tells you what to post next',
-        example: 'Post more "tutorial" content—it converts 3x better',
+        example: 'Post more "tutorial" content, it converts 3x better',
         step: 5,
         title: 'Optimize',
       },
@@ -191,7 +191,7 @@ export const useCases: UseCase[] = [
     workflow: [
       {
         description: 'Separate workspace per client, shared team access',
-        example: 'Client A, Client B, Client C—all in one login',
+        example: 'Client A, Client B, Client C: all in one login',
         step: 1,
         title: 'Client Workspaces',
       },
@@ -291,7 +291,7 @@ export const useCases: UseCase[] = [
     audience: 'Marketing managers, CMOs, brand marketers, growth teams',
     cta: 'Get Started',
     description:
-      'Stop guessing what content works. Generate, test, and scale content that converts—with full attribution.',
+      'Stop guessing what content works. Generate, test, and scale content that converts, with full attribution.',
     headline: 'Content That Actually Drives Pipeline',
     painPoints: [
       "Content team can't keep up with demand",
@@ -323,7 +323,7 @@ export const useCases: UseCase[] = [
     workflow: [
       {
         description: 'AI suggests content based on industry trends',
-        example: 'Trending: "AI for B2B marketing"—create video?',
+        example: 'Trending: "AI for B2B marketing". Create video?',
         step: 1,
         title: 'Content Ideation',
       },
@@ -357,7 +357,7 @@ export const useCases: UseCase[] = [
     audience: 'Solopreneurs, indie hackers, startup founders, solo devs',
     cta: 'Get Started',
     description:
-      'Generate content, grow your audience, and track what converts—all while building your product.',
+      'Generate content, grow your audience, and track what converts, all while building your product.',
     headline: 'Build an Audience Without Hiring a Team',
     painPoints: [
       'No time for content (busy building product)',
@@ -382,7 +382,7 @@ export const useCases: UseCase[] = [
       'Automate posting schedule (set it and forget it)',
       'Track which content drives signups/revenue',
       'All-in-one platform (no tool switching)',
-      'Start free — credits buy your output, subscriptions make them cheaper',
+      'Start free: credits buy your output, subscriptions make them cheaper',
     ],
     subtitle: 'Solopreneurs & Startup Founders',
     title: 'Genfeed for Founders',

--- a/apps/website/packages/ui/marketing/PricingStrip.tsx
+++ b/apps/website/packages/ui/marketing/PricingStrip.tsx
@@ -25,18 +25,9 @@ const PILLAR_COLUMNS = [
   },
 ] as const;
 
-export default function PricingStrip({
-  inverted,
-  className,
-}: PricingStripProps) {
+export default function PricingStrip({ className }: PricingStripProps) {
   return (
-    <div
-      className={cn(
-        'mb-12 border',
-        inverted ? 'border-inv-fg/10' : 'border-edge/5',
-        className,
-      )}
-    >
+    <div className={cn('mb-12 border border-edge/5', className)}>
       <div className="grid grid-cols-1 gap-px md:grid-cols-3">
         {PILLAR_COLUMNS.map((column) => {
           const isFeatured = column.label === 'Creator';
@@ -46,64 +37,32 @@ export default function PricingStrip({
               key={column.label}
               className={cn(
                 'px-6 py-5 text-center',
-                isFeatured && (inverted ? 'bg-inv-fg/[0.03]' : 'bg-fill/5'),
+                isFeatured && 'bg-white/[0.04]',
               )}
             >
-              <div
-                className={cn(
-                  'mb-2 flex items-center justify-center gap-2 text-[10px] font-black uppercase tracking-widest',
-                  inverted ? 'text-inv-fg/30' : 'text-surface/30',
-                )}
-              >
+              <div className="mb-2 flex items-center justify-center gap-2 text-[10px] font-black uppercase tracking-widest text-surface/50">
                 {column.subtitle}
                 {isFeatured ? (
-                  <span
-                    className={cn(
-                      'text-[9px] font-bold',
-                      inverted ? 'text-inv-fg/50' : 'text-surface/50',
-                    )}
-                  >
+                  <span className="text-[9px] font-bold text-surface/65">
                     ★ Popular
                   </span>
                 ) : null}
               </div>
 
-              <div
-                className={cn(
-                  'text-2xl font-semibold',
-                  inverted ? 'text-inv-fg' : 'text-surface',
-                )}
-              >
+              <div className="text-2xl font-semibold text-surface">
                 {column.price}
               </div>
 
-              <div
-                className={cn(
-                  'mt-1 text-xs',
-                  inverted ? 'text-inv-fg/40' : 'text-surface/40',
-                )}
-              >
-                {column.label}
-              </div>
+              <div className="mt-1 text-xs text-surface/60">{column.label}</div>
             </div>
           );
         })}
       </div>
 
-      <div
-        className={cn(
-          'border-t py-3 text-center',
-          inverted ? 'border-inv-fg/10' : 'border-edge/5',
-        )}
-      >
+      <div className="border-t border-edge/5 py-3 text-center">
         <Link
           href="/pricing"
-          className={cn(
-            'inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest transition-colors',
-            inverted
-              ? 'text-inv-fg/50 hover:text-inv-fg/70'
-              : 'text-surface/40 hover:text-surface/60',
-          )}
+          className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-surface/55 transition-colors hover:text-surface/80"
         >
           View all plans
         </Link>

--- a/packages/styles/genfeed.css
+++ b/packages/styles/genfeed.css
@@ -511,14 +511,6 @@
   border-color: var(--gen-accent-border-strong);
 }
 
-/* Cards */
-.gen-card-featured {
-  border-radius: var(--radius-card);
-  border: 1px solid color-mix(in srgb, hsl(var(--gen-accent)) 72%, white 28%);
-  background: color-mix(in srgb, hsl(var(--gen-accent)) 82%, black 18%);
-  color: hsl(var(--background));
-}
-
 /* Tab active state */
 .gen-tab-active {
   background: hsl(var(--gen-accent));

--- a/packages/ui/src/components/marketing/SectionHeader.tsx
+++ b/packages/ui/src/components/marketing/SectionHeader.tsx
@@ -19,7 +19,7 @@ export default function SectionHeader({
   return (
     <div className={cn('mb-16 text-center', className)}>
       {tierLabel ? (
-        <div className="mb-6 text-xs font-black uppercase tracking-widest text-surface/20">
+        <div className="mb-6 text-xs font-black uppercase tracking-widest text-surface/45">
           {tierLabel}
         </div>
       ) : null}
@@ -27,7 +27,7 @@ export default function SectionHeader({
         {title}
       </h2>
       {description ? (
-        <p className="mx-auto max-w-2xl text-lg text-surface/50">
+        <p className="mx-auto max-w-2xl text-lg text-surface/65">
           {description}
         </p>
       ) : null}


### PR DESCRIPTION
## What

Propagates the monochrome, single-font design standard established on the homepage and `/pricing` (#1258, #1293) across the **rest of the marketing site** and its shared marketing primitives. The homepage remains the reference; this brings every other page in line with it.

Delivered as **one PR** — it's a single coherent sweep and most edits are pattern-identical class/copy swaps, so it reviews as "primitives + one representative page, then the rest follows the same pattern."

## Changes (44 files)

**Inverted / solid-white cards → subtle `bg-white/[0.04]` elevation**
- The 9 product/feature CTA blocks (studio, publisher, calendar, agents, analytics, workflows, library, research, integrations) — solid-white `bg-[hsl(var(--gen-accent))]` / `gen-card-featured` panels + `text-inv-fg` + `PricingStrip inverted` + inverted buttons → dark card with `text-surface`.
- `services` featured card (`inverted` NeuralGridItem → `bg-white/[0.04]` + `ButtonVariant.WHITE`), `[slug]` product pricing CTA, skills bundle CTA.
- Shared primitives: removed the `inverted` (white-card) variant from `NeuralGridItem`, dropped the inverted path from `PricingStrip`, deleted the now-unused `.gen-card-featured` CSS class.

**Type & accent cleanup**
- Removed all `font-serif` (7× on `/brand-os`) and italic hero-accent spans (`ServiceLandingPage`, product, use-cases). Zero remain across `apps/website`.

**Titles**
- Collapsed forced two/three-line `<br/>` hero titles to single-line 3–5 word titles across every product/feature page plus `cloud`.

**Contrast**
- Raised dim body copy (`text-surface/20`–`/50` → `/55`–`/72`) site-wide, including shared `SectionHeader`, `NeuralGridItem`, `CtaSection`, `FaqGrid`, `BenefitGrid`, `FeatureList`, and testimonials.

**Copy**
- Swept em-dashes out of rendered copy and SEO metadata (titles/descriptions).

## Acceptance criteria (#1279)
- [x] No solid-white / inverted cards; featured cards use subtle lighter-dark elevation
- [x] Zero `font-serif` and zero italic-accent title spans across `apps/website`
- [x] No em-dashes in marketing copy; every hero title is 3–5 words on one line
- [x] Body copy contrast raised on every page

## Notes
- The "Cloud app first" pricing highlight called out in the issue no longer exists as rendered UI (only the `Creator`/`Teams` labels show; "Cloud App" survives only in the non-rendered `llms.txt` SEO files) — it was already reworded upstream, so nothing to change there.
- The `apps/app` onboarding-wizard `font-serif` cleanup mentioned in the issue is intentionally **out of scope** for this website PR; it can follow as a separate `apps/app` change.
- Semantic status colors (`text-success`/`text-warning`) and the monochrome `--gen-accent-*` tokens (which resolve to white on dark) are kept per `DESIGN.md`'s "Color Entry" doors.

## Verification
- `biome check` clean; zero type errors in any changed file (the standalone `tsc`/vitest failures in this worktree are pre-existing environment gaps — missing `@testing-library/jest-dom` + unbuilt workspace type refs — so the full type-check/test gate runs in **CI**).
- Grep-verified across the tree: zero `font-serif`, italic-accent spans, `text-inv-fg`/`bg-inv`, solid gen-accent panels, `gen-card-featured`, `PricingStrip inverted`, `<br/>` in titles, or em-dashes in rendered copy.
- No colocated test asserts on any changed copy (heading regexes and generic module tests still match).

Closes #1279