### PR TITLE
chore(brands): remove unused imports in brands.controller.ts

### DIFF
--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -12,10 +12,7 @@ import { ManualBrandKitDto } from '@api/collections/brands/dto/manual-brand-kit.
 import { ToggleBrandSkillDto } from '@api/collections/brands/dto/toggle-brand-skill.dto';
 import { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
 import { UpdateBrandAgentConfigDto } from '@api/collections/brands/dto/update-brand-agent-config.dto';
-import {
-  Brand,
-  type BrandDocument,
-} from '@api/collections/brands/schemas/brand.schema';
+import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { ImagesService } from '@api/collections/images/services/images.service';
@@ -40,7 +37,6 @@ import {
   getIsSuperAdmin,
   getPublicMetadata,
 } from '@api/helpers/utils/auth/auth.util';
-import { BrandFilterUtil } from '@api/helpers/utils/brand-filter/brand-filter.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
 import { serializeSingle } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';


### PR DESCRIPTION
## Summary

Removes two unused imports flagged by biome (`lint/correctness/noUnusedImports`, an "unsafe fix" not auto-applied by `biome check --write`) in `apps/server/api/src/collections/brands/controllers/brands.controller.ts`:

- `Brand` (class) from `@api/collections/brands/schemas/brand.schema` — only the sibling `BrandDocument` type is actually used; the import is narrowed to `import type { BrandDocument }`.
- `BrandFilterUtil` from `@api/helpers/utils/brand-filter/brand-filter.util` — no usages.

Both predate the brand-relocation/cloning feature (#1302, commit bd2e518aa) and are unrelated to it — pure lint cleanup.

## Verification

- Grep-confirmed **zero** usages of `Brand` (identifier) and `BrandFilterUtil` elsewhere in the file (remaining `'Brand'` matches are string literals).
- `bunx biome check` on the file: no warnings.
- `tsc -p tsconfig.typecheck.json` (api): no errors reference this file. (An unrelated pre-existing `TS2688 multer` env gap exists in the worktree install only; the change itself is type-clean and the main checkout type-checks green.)

No behavior change.