### PR TITLE
feat(website): align pricing with vault model + add high-ticket pitch pages

### DIFF
--- a/apps/website/app/(landing)/dfy/page.tsx
+++ b/apps/website/app/(landing)/dfy/page.tsx
@@ -1,0 +1,12 @@
+import { pitchLandingConfigBySlug } from '@web-components/landing/pitch-pages.data';
+import ServiceLandingPage from '@web-components/landing/ServiceLandingPage';
+import { createServiceLandingMetadata } from '@web-components/landing/service-landing-metadata';
+import type { ServiceLandingConfig } from '@web-components/landing/service-landings.data';
+
+const config = pitchLandingConfigBySlug.dfy as ServiceLandingConfig;
+
+export const metadata = createServiceLandingMetadata(config);
+
+export default function DfyPage() {
+  return <ServiceLandingPage slug="dfy" />;
+}

--- a/apps/website/app/(landing)/fleet/page.tsx
+++ b/apps/website/app/(landing)/fleet/page.tsx
@@ -1,0 +1,12 @@
+import { pitchLandingConfigBySlug } from '@web-components/landing/pitch-pages.data';
+import ServiceLandingPage from '@web-components/landing/ServiceLandingPage';
+import { createServiceLandingMetadata } from '@web-components/landing/service-landing-metadata';
+import type { ServiceLandingConfig } from '@web-components/landing/service-landings.data';
+
+const config = pitchLandingConfigBySlug.fleet as ServiceLandingConfig;
+
+export const metadata = createServiceLandingMetadata(config);
+
+export default function FleetPage() {
+  return <ServiceLandingPage slug="fleet" />;
+}

--- a/apps/website/app/(landing)/retainer/page.tsx
+++ b/apps/website/app/(landing)/retainer/page.tsx
@@ -1,0 +1,12 @@
+import { pitchLandingConfigBySlug } from '@web-components/landing/pitch-pages.data';
+import ServiceLandingPage from '@web-components/landing/ServiceLandingPage';
+import { createServiceLandingMetadata } from '@web-components/landing/service-landing-metadata';
+import type { ServiceLandingConfig } from '@web-components/landing/service-landings.data';
+
+const config = pitchLandingConfigBySlug.retainer as ServiceLandingConfig;
+
+export const metadata = createServiceLandingMetadata(config);
+
+export default function RetainerPage() {
+  return <ServiceLandingPage slug="retainer" />;
+}

--- a/apps/website/app/(public)/pricing/pricing-content.test.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.test.tsx
@@ -53,7 +53,9 @@ describe('PricingContent launch pricing', () => {
     render(<PricingContent />);
 
     expect(
-      screen.getByText(/launch pricing — first 12 months, then \$49\/month/i),
+      screen.getByText(
+        /launch pricing \(code earlygenfeed\) — first 12 months, then \$49\/month/i,
+      ),
     ).toBeInTheDocument();
   });
 

--- a/apps/website/app/(public)/self-hosted/page.tsx
+++ b/apps/website/app/(public)/self-hosted/page.tsx
@@ -1,0 +1,12 @@
+import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-metadata.helper';
+import SelfHostedContent from '@public/self-hosted/self-hosted-content';
+
+export const generateMetadata = createPageMetadataWithCanonical(
+  'Self-Host Genfeed',
+  'Genfeed is open source. Self-host the full content OS on your own infrastructure with Docker — or skip the ops and start free on managed cloud.',
+  '/self-hosted',
+);
+
+export default function SelfHosted() {
+  return <SelfHostedContent />;
+}

--- a/apps/website/app/(public)/self-hosted/self-hosted-content.tsx
+++ b/apps/website/app/(public)/self-hosted/self-hosted-content.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { cn } from '@helpers/formatting/cn/cn.util';
+import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
+import { EnvironmentService } from '@services/core/environment.service';
+import SectionHeader from '@ui/marketing/SectionHeader';
+import { Button } from '@ui/primitives/button';
+import FaqGrid from '@web-components/content/FaqGrid';
+import {
+  CtaSection,
+  NeuralGrid,
+  NeuralGridItem,
+  WebSection,
+} from '@web-components/content/NeuralGrid';
+import PageLayout from '@web-components/PageLayout';
+import {
+  LuCloud,
+  LuCpu,
+  LuGitBranch,
+  LuServer,
+  LuShieldCheck,
+  LuTerminal,
+} from 'react-icons/lu';
+
+const DOCS_URL = 'https://docs.genfeed.ai';
+
+const WHY_SELF_HOST = [
+  {
+    description:
+      'Deploy the full content OS on your own servers with Docker. Your models, your storage, your network — no vendor lock-in.',
+    icon: LuServer,
+    title: 'Own Your Infrastructure',
+  },
+  {
+    description:
+      'Everything runs inside your environment. Nothing leaves your infrastructure unless you decide it does.',
+    icon: LuShieldCheck,
+    title: 'Own Your Data',
+  },
+  {
+    description:
+      'Bring your own keys or run open-source models locally. Route generation however you want, with no per-credit meter.',
+    icon: LuCpu,
+    title: 'Run Your Own Models',
+  },
+] as const;
+
+const QUICKSTART = [
+  {
+    description: 'Clone the AGPL-licensed monorepo from GitHub.',
+    step: 'Clone',
+  },
+  {
+    description:
+      'Copy the example env, add your keys, and pick your models and storage.',
+    step: 'Configure',
+  },
+  {
+    description: 'Bring it up with Docker Compose — API, workers, and app.',
+    step: 'Deploy',
+  },
+  {
+    description: 'Connect your channels and start publishing.',
+    step: 'Connect',
+  },
+] as const;
+
+const FAQ_ITEMS = [
+  {
+    answer:
+      'Yes. The core is open source under AGPL-3.0. Clone it, run it on your own infrastructure, and use it for free — you cover your own hosting and model costs.',
+    question: 'Is self-hosting really free?',
+  },
+  {
+    answer:
+      'The repository is licensed AGPL-3.0. Enterprise features under ee/ carry a separate commercial license. Self-hosting the core for your own use is fully covered by the open-source license.',
+    question: 'What is the license?',
+  },
+  {
+    answer:
+      'Self-host gives you full control and zero platform fees, but you run the infrastructure, updates, and models yourself. Managed cloud handles all of that, adds managed credits and support, and starts free — most teams self-host to evaluate, then move to cloud to skip the ops.',
+    question: 'Self-host or managed cloud?',
+  },
+  {
+    answer:
+      'Community support lives on GitHub — issues, discussions, and the docs. Managed cloud plans add direct support and SLAs.',
+    question: 'Do I get support?',
+  },
+  {
+    answer:
+      'Anytime. Start self-hosted, then move to managed cloud whenever the operational overhead outweighs the control — your workflows and content model carry over.',
+    question: 'Can I move to cloud later?',
+  },
+];
+
+export default function SelfHostedContent() {
+  const containerRef = useMarketingEntrance({ hero: false, sections: false });
+  const repoHref = EnvironmentService.github.core;
+  const cloudSignUpHref = `${EnvironmentService.apps.app}/sign-up?plan=payg`;
+
+  return (
+    <div ref={containerRef}>
+      <PageLayout
+        badge="Open Source"
+        badgeIcon={LuGitBranch}
+        title={
+          <>
+            Open source. Self-host on{' '}
+            <span className="italic font-light">your own infra</span>.
+          </>
+        }
+        description="The full Genfeed content OS is open source. Clone it, run it with Docker, and own your stack end to end — or skip the ops and start free on managed cloud."
+      >
+        <WebSection maxWidth="lg" py="md">
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size={ButtonSize.PUBLIC}
+              variant={ButtonVariant.WHITE}
+            >
+              <a href={repoHref} target="_blank" rel="noopener noreferrer">
+                View on GitHub
+              </a>
+            </Button>
+            <Button
+              asChild
+              size={ButtonSize.PUBLIC}
+              variant={ButtonVariant.OUTLINE}
+            >
+              <a
+                href={cloudSignUpHref}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Start free on cloud
+              </a>
+            </Button>
+          </div>
+        </WebSection>
+
+        <WebSection maxWidth="xl" className="gsap-section">
+          <SectionHeader
+            title="Why self-host"
+            description="Full control over your infrastructure, data, and models — with no platform fees and no lock-in."
+            className="[&_h2]:text-5xl"
+          />
+
+          <NeuralGrid columns={3} className="gsap-grid">
+            {WHY_SELF_HOST.map((item) => (
+              <NeuralGridItem
+                key={item.title}
+                icon={item.icon}
+                title={item.title}
+                description={item.description}
+                className="gsap-card"
+                padding="lg"
+              />
+            ))}
+          </NeuralGrid>
+        </WebSection>
+
+        <WebSection bg="bordered" maxWidth="xl" className="gsap-section">
+          <SectionHeader
+            title="Up and running in four steps"
+            description="A standard Docker deployment. Full instructions live in the docs."
+            className="[&_h2]:text-5xl"
+          />
+
+          <NeuralGrid columns={4}>
+            {QUICKSTART.map((item, index) => (
+              <NeuralGridItem
+                key={item.step}
+                tierLabel={`0${index + 1} / ${item.step}`}
+                padding="lg"
+                className={cn(index === 0 && 'bg-fill/[0.02]')}
+              >
+                <p className="text-sm leading-relaxed text-surface/60">
+                  {item.description}
+                </p>
+              </NeuralGridItem>
+            ))}
+          </NeuralGrid>
+
+          <div className="mt-8 flex justify-center">
+            <Button
+              asChild
+              size={ButtonSize.PUBLIC}
+              variant={ButtonVariant.OUTLINE}
+            >
+              <a href={DOCS_URL} target="_blank" rel="noopener noreferrer">
+                Read the self-hosting docs
+              </a>
+            </Button>
+          </div>
+        </WebSection>
+
+        <WebSection maxWidth="lg" className="gsap-section">
+          <SectionHeader
+            title="Self-host or managed cloud"
+            description="Same product. Self-host for control; move to cloud when you would rather not run the infrastructure."
+            className="[&_h2]:text-5xl"
+          />
+
+          <NeuralGrid columns={2}>
+            <NeuralGridItem
+              icon={LuTerminal}
+              title="Self-host"
+              tierLabel="Free / open source"
+              padding="lg"
+            >
+              <ul className="space-y-3">
+                {[
+                  'Run it on your own infrastructure',
+                  'Full control of data and models',
+                  'No platform fees, no credit meter',
+                  'You handle hosting, updates, and support',
+                  'Community support on GitHub',
+                ].map((item) => (
+                  <li
+                    key={item}
+                    className="border-b border-edge/5 pb-3 text-sm text-surface/60 last:border-b-0 last:pb-0"
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </NeuralGridItem>
+
+            <NeuralGridItem
+              icon={LuCloud}
+              title="Managed cloud"
+              tierLabel="Free to start"
+              padding="lg"
+              className="bg-white/[0.03]"
+            >
+              <ul className="space-y-3">
+                {[
+                  'We run the infrastructure and updates',
+                  'Managed credits — pay only for output',
+                  'No ops, no scaling to manage',
+                  'Direct support and SLAs on paid plans',
+                  'Start free on Pay As You Go',
+                ].map((item) => (
+                  <li
+                    key={item}
+                    className="border-b border-edge/5 pb-3 text-sm text-surface/60 last:border-b-0 last:pb-0"
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </NeuralGridItem>
+          </NeuralGrid>
+        </WebSection>
+
+        <WebSection bg="bordered" maxWidth="md" className="gsap-section">
+          <SectionHeader
+            title="Common Questions"
+            description="Open source for control, managed cloud for convenience."
+            className="[&_h2]:text-5xl"
+          />
+
+          <FaqGrid items={FAQ_ITEMS} />
+        </WebSection>
+
+        <CtaSection
+          bg="subtle"
+          title="Ship it your way."
+          description="Start free on managed cloud, or deploy the open-source core on your own infrastructure."
+        >
+          <Button size={ButtonSize.PUBLIC} asChild>
+            <a href={cloudSignUpHref} target="_blank" rel="noopener noreferrer">
+              Start free on cloud
+            </a>
+          </Button>
+          <Button
+            variant={ButtonVariant.SECONDARY}
+            size={ButtonSize.PUBLIC}
+            asChild
+          >
+            <a href={repoHref} target="_blank" rel="noopener noreferrer">
+              View on GitHub
+            </a>
+          </Button>
+        </CtaSection>
+      </PageLayout>
+    </div>
+  );
+}

--- a/apps/website/app/(public)/services/services-content.tsx
+++ b/apps/website/app/(public)/services/services-content.tsx
@@ -25,7 +25,7 @@ const SERVICE_CARDS = [
     features: contentServiceOffering.includes,
     label: 'Done-For-You',
     number: '01',
-    price: 'From $2,500/mo',
+    price: 'Custom',
     shortLabel: 'Content',
   },
   {

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -54,6 +54,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
       url: 'https://genfeed.ai/launch-content',
     },
+    // High-ticket pitch pages: unlinked from nav/footer (direct-send sales
+    // collateral) but kept indexable so a shared link can still rank.
+    {
+      changeFrequency: 'monthly',
+      lastModified: new Date(),
+      priority: 0.6,
+      url: 'https://genfeed.ai/retainer',
+    },
+    {
+      changeFrequency: 'monthly',
+      lastModified: new Date(),
+      priority: 0.6,
+      url: 'https://genfeed.ai/dfy',
+    },
+    {
+      changeFrequency: 'monthly',
+      lastModified: new Date(),
+      priority: 0.6,
+      url: 'https://genfeed.ai/fleet',
+    },
     {
       changeFrequency: 'weekly',
       lastModified: new Date(),
@@ -149,6 +169,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date(),
       priority: 0.7,
       url: 'https://genfeed.ai/services',
+    },
+    {
+      changeFrequency: 'weekly',
+      lastModified: new Date(),
+      priority: 0.8,
+      url: 'https://genfeed.ai/self-hosted',
     },
     {
       changeFrequency: 'weekly',

--- a/apps/website/packages/components/home/_footer.tsx
+++ b/apps/website/packages/components/home/_footer.tsx
@@ -46,11 +46,7 @@ const WEBSITE_SECTIONS: FooterSection[] = [
       { href: '/chatgpt', label: 'ChatGPT' },
       { href: '/skills', label: 'Skills' },
       { href: '/docs', label: 'Docs' },
-      {
-        external: true,
-        href: 'https://github.com/genfeedai/genfeed.ai',
-        label: 'GitHub',
-      },
+      { href: '/self-hosted', label: 'Self-host' },
     ],
     title: 'Developers',
   },

--- a/apps/website/packages/components/landing/ServiceLandingPage.tsx
+++ b/apps/website/packages/components/landing/ServiceLandingPage.tsx
@@ -14,6 +14,7 @@ import {
   WebSection,
 } from '@web-components/content/NeuralGrid';
 import LandingFooter from '@web-components/landing/LandingFooter';
+import { pitchLandingConfigBySlug } from '@web-components/landing/pitch-pages.data';
 import {
   type ServiceLandingConfig,
   serviceLandingConfigBySlug,
@@ -32,7 +33,8 @@ export interface ServiceLandingPageProps {
 export default function ServiceLandingPage({
   slug,
 }: ServiceLandingPageProps): React.ReactElement {
-  const config = serviceLandingConfigBySlug[slug] as ServiceLandingConfig;
+  const config = (serviceLandingConfigBySlug[slug] ??
+    pitchLandingConfigBySlug[slug]) as ServiceLandingConfig;
   const containerRef = useMarketingEntrance({ cards: false });
 
   return (
@@ -56,11 +58,16 @@ export default function ServiceLandingPage({
               </p>
 
               <div className="flex flex-wrap items-center gap-3 text-sm text-surface/65">
-                <span className="border border-edge/10 px-3 py-2">
-                  Starting from $2,500
+                <span className="border border-edge/10 px-3 py-2 text-surface/70">
+                  {config.priceLabel ?? 'Custom — scoped on a call'}
                 </span>
+                {config.priceNote ? (
+                  <span className="border border-edge/10 px-3 py-2">
+                    {config.priceNote}
+                  </span>
+                ) : null}
                 <span className="border border-edge/10 px-3 py-2">
-                  Primary CTA: Book a Call
+                  {config.priceCtaHint ?? 'Book a call to scope it'}
                 </span>
               </div>
             </div>

--- a/apps/website/packages/components/landing/pitch-pages.data.ts
+++ b/apps/website/packages/components/landing/pitch-pages.data.ts
@@ -1,0 +1,470 @@
+import type { ServiceLandingConfig } from '@web-components/landing/service-landings.data';
+import {
+  LuBot,
+  LuClapperboard,
+  LuCpu,
+  LuFileText,
+  LuGauge,
+  LuRepeat,
+  LuServer,
+} from 'react-icons/lu';
+
+/**
+ * High-ticket pitch pages — direct-send sales collateral, NOT the self-serve
+ * funnel.
+ *
+ * These reuse the ServiceLandingPage renderer and the `(landing)` chrome, but
+ * are deliberately kept out of the site nav and footer. They are reachable by
+ * their URL and listed in the sitemap (indexable), so a link can be shared with
+ * a lead and still rank — but the public funnel never routes to them.
+ *
+ * Pricing lives here on purpose: the public site keeps retainer/DFY pricing off
+ * the page (see the vault "Offers And Pricing" note), while these pitch pages
+ * carry the real numbers because they are sent to qualified buyers.
+ */
+export const pitchLandingConfigs: ServiceLandingConfig[] = [
+  // ── Retainer ───────────────────────────────────────────────────────────────
+  {
+    badge: 'Retainer',
+    closingDescription:
+      'If content is a revenue channel but you do not want to build a team to run it, the next step is a call.',
+    closingTitle: 'A Content Operation, Not Another Freelancer',
+    deliverableBuckets: [
+      {
+        items: [
+          'Monthly content strategy and themes',
+          'Weekly production priorities',
+          'Channel-level publishing plan',
+          'Approval and review cadence',
+        ],
+        title: 'Strategy',
+      },
+      {
+        items: [
+          'Short-form video, images, and clips',
+          'Scripts, hooks, captions, and articles',
+          'Repurposing from your source material',
+          'On-brand variations at volume',
+        ],
+        title: 'Production',
+      },
+      {
+        items: [
+          'Publishing coordination across channels',
+          'Content calendar management',
+          'Revision rounds',
+          'Performance review and iteration',
+        ],
+        title: 'Operations',
+      },
+    ],
+    deliverablesDescription:
+      'A full content operation run on Genfeed — strategy, production, and publishing handled end to end so your brand ships consistently.',
+    deliverablesTitle: 'What The Retainer Covers',
+    faqDescription: 'Straight answers before the call.',
+    faqs: [
+      {
+        answer:
+          'Founder-led companies and high-end SMBs where content drives real revenue but building an internal content team is not the right move yet.',
+        question: 'Who is this for?',
+      },
+      {
+        answer:
+          'A one-time $5,000 setup covers strategy, brand and voice calibration, workflow build, and the first production cycle. After that it is $2,000/month for ongoing execution. Scope scales with volume and channels.',
+        question: 'How does pricing work?',
+      },
+      {
+        answer:
+          'No. You stay at the direction and approval level. The whole point is to remove content from your plate without adding meetings.',
+        question: 'Do I have to be involved every week?',
+      },
+      {
+        answer:
+          'Everything runs on Genfeed, so you keep full visibility, own every asset, and can take the operation in-house or self-serve whenever you want.',
+        question: 'What happens to the work if we stop?',
+      },
+      {
+        answer:
+          'Compared to an ~$8k/month content agency or a full-time hire, this is a smaller commitment that ships more, faster, because the production runs on our own platform.',
+        question: 'How does this compare to an agency?',
+      },
+    ],
+    faqTitle: 'Common Questions',
+    fitLabel: 'Engagement Fit',
+    fitSignals: [
+      'Content is a revenue channel, not a side project.',
+      'You want an operator who turns rough ideas into shipped content.',
+      'You are replacing fragmented freelancers or an inconsistent agency.',
+    ],
+    heroAccent: 'content operation',
+    heroDescription:
+      'A high-touch content retainer for founders and high-end SMBs — strategy, production, and publishing run for you on Genfeed.',
+    heroTitle: 'We run your',
+    includes: [
+      'Content strategy and monthly planning',
+      'Brand voice and messaging calibration',
+      'Multi-format production',
+      'Publishing coordination',
+      'Revision rounds',
+      'Performance review',
+      'Shared approval workflow',
+      'Dedicated operator',
+    ],
+    intro:
+      'You bring the expertise, context, and final approvals. We handle strategy, production, and publishing so your brand shows up consistently — without another internal function to manage.',
+    metaDescription:
+      'High-touch content retainer for founders and high-end SMBs. $5,000 setup, then $2,000/month. Strategy, production, and publishing run for you on Genfeed.',
+    metaTitle: 'Content Retainer | Genfeed.ai',
+    outcomes: [
+      {
+        description:
+          'Turn founder insight, product updates, and customer conversations into a reliable weekly publishing system.',
+        icon: LuFileText,
+        title: 'Strategy Into Output',
+      },
+      {
+        description:
+          'Ship video, images, scripts, and publishing-ready assets across channels without hiring.',
+        icon: LuClapperboard,
+        title: 'Multi-Format At Volume',
+      },
+      {
+        description:
+          'Keep one consistent voice while moving fast enough to support launches and ongoing demand.',
+        icon: LuRepeat,
+        title: 'Consistent Presence',
+      },
+    ],
+    outcomesDescription:
+      'For businesses that know content matters but do not want to run it internally.',
+    outcomesTitle: 'What This Solves',
+    priceCtaHint: 'Book a call to start',
+    priceLabel: '$5,000 setup',
+    priceNote: 'then $2,000 / month',
+    process: [
+      {
+        description:
+          'Discovery call to map goals, channels, audience, and the content already trapped in your calls and notes.',
+        step: 'Scope',
+      },
+      {
+        description:
+          'One-time setup: brand voice, workflows, and calendar built on Genfeed, plus the first production cycle.',
+        step: 'Build',
+      },
+      {
+        description:
+          'Monthly execution — production, publishing, and revisions on a clear operating rhythm.',
+        step: 'Run',
+      },
+      {
+        description:
+          'Review what performed, then iterate themes and cadence against real engagement.',
+        step: 'Iterate',
+      },
+    ],
+    processDescription:
+      'Clear operating rhythm. Minimal coordination overhead.',
+    processTitle: 'How It Works',
+    slug: 'retainer',
+    title: 'Content Retainer',
+  },
+
+  // ── Done-For-You (lighter, smaller-ticket twin of the Retainer) ──────────────
+  {
+    badge: 'Done-For-You',
+    closingDescription:
+      'If you want content handled without stepping up to a full retainer, book a call and we will scope a lighter engagement.',
+    closingTitle: 'Done-For-You, Right-Sized',
+    deliverableBuckets: [
+      {
+        items: [
+          'Focused monthly content themes',
+          'Weekly priorities on your core channels',
+          'Simple publishing plan',
+          'Lightweight approvals',
+        ],
+        title: 'Planning',
+      },
+      {
+        items: [
+          'Short-form video, images, and clips',
+          'Scripts, hooks, and captions',
+          'Repurposing from your source material',
+          'On-brand output at a steady cadence',
+        ],
+        title: 'Production',
+      },
+      {
+        items: [
+          'Publishing coordination',
+          'Content calendar upkeep',
+          'Revision rounds',
+          'Light performance review',
+        ],
+        title: 'Publishing',
+      },
+    ],
+    deliverablesDescription:
+      'A lighter done-for-you content service: we plan, produce, and publish a focused stream of content for you — without the full retainer commitment.',
+    deliverablesTitle: 'What You Get',
+    faqDescription: 'Straight answers before the call.',
+    faqs: [
+      {
+        answer:
+          'Smaller teams and earlier-stage founders who want content handled but are not ready for a full content operation. It is the lighter, lower-commitment version of the retainer.',
+        question: 'Who is this for?',
+      },
+      {
+        answer:
+          'Pricing is custom and sits below the full retainer — it scales with how many channels and how much output you need. We size it on the call.',
+        question: 'How is it priced?',
+      },
+      {
+        answer:
+          'Scope. Done-For-You runs a focused stream of content on your core channels; the retainer is a full operation across more channels, higher volume, and deeper strategy.',
+        question: 'How is this different from the retainer?',
+      },
+      {
+        answer:
+          'No. You stay at the direction and approval level — we handle production and publishing so content is off your plate.',
+        question: 'Do I have to be involved every week?',
+      },
+      {
+        answer:
+          'Yes. When output outgrows this scope, it rolls straight into the full retainer — same team, no restart.',
+        question: 'Can we scale up later?',
+      },
+    ],
+    faqTitle: 'Common Questions',
+    fitLabel: 'Good Fit',
+    fitSignals: [
+      'You want content handled but not a full retainer yet.',
+      'You have a smaller budget or a few core channels to cover.',
+      'You want to see done-for-you content work before scaling it up.',
+    ],
+    heroAccent: 'content',
+    heroDescription:
+      'A lighter done-for-you content service — we plan, produce, and publish for you, sized for smaller budgets and earlier-stage teams.',
+    heroTitle: 'We run your',
+    includes: [
+      'Content planning',
+      'Brand voice calibration',
+      'Multi-format production',
+      'Publishing coordination',
+      'Revision rounds',
+      'Monthly calendar',
+      'Hands-off execution',
+      'Upgrade path to the retainer',
+    ],
+    intro:
+      'Not every team needs a full content operation yet. Done-For-You is the lighter version: we handle a focused stream of content end to end, so you show up consistently without the retainer-level commitment.',
+    metaDescription:
+      'Lighter done-for-you content service. We plan, produce, and publish a focused content stream for you — sized for smaller budgets. Custom scope.',
+    metaTitle: 'Done-For-You Content | Genfeed.ai',
+    outcomes: [
+      {
+        description:
+          'Ship video, images, and posts on your core channels without hiring or managing freelancers.',
+        icon: LuClapperboard,
+        title: 'Content, Handled',
+      },
+      {
+        description:
+          'A commitment sized to where you are now — real output without full-operation overhead.',
+        icon: LuGauge,
+        title: 'Right-Sized Commitment',
+      },
+      {
+        description:
+          'Keep a consistent voice and cadence so your brand shows up week after week.',
+        icon: LuRepeat,
+        title: 'Consistent Presence',
+      },
+    ],
+    outcomesDescription:
+      'For teams that want content done for them without stepping up to a full retainer.',
+    outcomesTitle: 'What This Solves',
+    priceCtaHint: 'Book a call to scope it',
+    priceLabel: 'Custom',
+    process: [
+      {
+        description:
+          'Quick call to map your core channels, output goals, and the material we can work from.',
+        step: 'Scope',
+      },
+      {
+        description:
+          'Produce a focused stream of on-brand content across your priority channels.',
+        step: 'Produce',
+      },
+      {
+        description:
+          'Publish and coordinate on a steady cadence, with light revisions.',
+        step: 'Publish',
+      },
+      {
+        description:
+          'Review what lands and adjust — scale into the full retainer whenever you are ready.',
+        step: 'Iterate',
+      },
+    ],
+    processDescription: 'A lighter operating rhythm, same hands-off execution.',
+    processTitle: 'How It Works',
+    slug: 'dfy',
+    title: 'Done-For-You Content',
+  },
+
+  // ── Fleet ────────────────────────────────────────────────────────────────────
+  {
+    badge: 'Fleet',
+    closingDescription:
+      'If you need owned models and AI influencers running at scale, book a call and we will design the fleet.',
+    closingTitle: 'Your Own Models. Your Own AI Influencers.',
+    deliverableBuckets: [
+      {
+        items: [
+          'Custom LoRA training on your subjects',
+          'Character and identity consistency',
+          'Style and brand fine-tuning',
+          'Model versioning and updates',
+        ],
+        title: 'Models',
+      },
+      {
+        items: [
+          'AI influencer creation and personas',
+          'Dedicated image and video generation',
+          'Voice and avatar pipelines',
+          'High-volume batch production',
+        ],
+        title: 'Production',
+      },
+      {
+        items: [
+          'Dedicated GPU inference capacity',
+          'Delivery pipeline and scheduling',
+          'Ongoing model and fleet operation',
+          'Managed, hands-off runtime',
+        ],
+        title: 'Operation',
+      },
+    ],
+    deliverablesDescription:
+      'A managed model fleet: custom LoRAs, AI influencers, and dedicated inference — designed, trained, and run for you on our GPU estate.',
+    deliverablesTitle: 'What The Fleet Delivers',
+    faqDescription: 'For operators running owned models at scale.',
+    faqs: [
+      {
+        answer:
+          'Creators, agencies, and brands that want owned models and AI influencers — custom LoRAs, consistent characters, and dedicated generation — without operating GPU infrastructure themselves.',
+        question: 'Who is this for?',
+      },
+      {
+        answer:
+          'Pricing is custom and depends on model count, training scope, inference volume, and how much of the operation we run. We scope it on the call.',
+        question: 'How is it priced?',
+      },
+      {
+        answer:
+          'We train custom LoRAs for your subjects, styles, or brand, keep characters consistent, and run generation on dedicated capacity so quality and identity hold at volume.',
+        question: 'What can the models do?',
+      },
+      {
+        answer:
+          'Both. We can build and run your own AI influencers end to end, or deliver a fleet your team directs while we handle training and infrastructure.',
+        question: 'Do you run the influencers or do we?',
+      },
+      {
+        answer:
+          'It is fully managed. You get the output and the control; we handle training, inference capacity, and the delivery pipeline.',
+        question: 'Do we need our own GPUs?',
+      },
+    ],
+    faqTitle: 'Common Questions',
+    fitLabel: 'Strong Fit',
+    fitSignals: [
+      'You need consistent characters or brand identity across large volumes.',
+      'You want owned models, not per-generation tool credits.',
+      'You are building AI influencers or a high-volume visual operation.',
+    ],
+    heroAccent: 'model fleet',
+    heroDescription:
+      'Custom LoRAs, AI influencers, and dedicated inference — designed, trained, and operated for you on our GPU fleet.',
+    heroTitle: 'We run your',
+    includes: [
+      'Custom LoRA training',
+      'Character and identity consistency',
+      'AI influencer personas',
+      'Dedicated image and video generation',
+      'Voice and avatar pipelines',
+      'Dedicated GPU capacity',
+      'Delivery pipeline',
+      'Managed operation',
+    ],
+    intro:
+      'Generic models drift and credits meter every frame. A fleet is different: your own trained models, consistent identities, and dedicated capacity — built and run so you can produce at scale without touching infrastructure.',
+    metaDescription:
+      'Managed model fleet: custom LoRAs, AI influencers, and dedicated inference — trained and operated for you on GPU infrastructure. Custom scope.',
+    metaTitle: 'Model Fleet | Genfeed.ai',
+    outcomes: [
+      {
+        description:
+          'Train models on your subjects, styles, and brand so identity stays consistent across every asset.',
+        icon: LuCpu,
+        title: 'Owned Custom Models',
+      },
+      {
+        description:
+          'Create and run AI influencers with consistent faces, voices, and personas at production volume.',
+        icon: LuBot,
+        title: 'AI Influencers At Scale',
+      },
+      {
+        description:
+          'Dedicated GPU capacity and a managed delivery pipeline — output at volume without running infrastructure.',
+        icon: LuServer,
+        title: 'Dedicated, Managed Inference',
+      },
+    ],
+    outcomesDescription:
+      'For operators who need owned models and consistent identities, not per-generation tool credits.',
+    outcomesTitle: 'What This Solves',
+    priceCtaHint: 'Book a call to design it',
+    priceLabel: 'Custom',
+    process: [
+      {
+        description:
+          'Define the subjects, styles, characters, and output volume the fleet needs to deliver.',
+        step: 'Design',
+      },
+      {
+        description:
+          'Train custom LoRAs and build the generation, voice, and avatar pipelines on dedicated capacity.',
+        step: 'Train',
+      },
+      {
+        description:
+          'Produce at volume with consistent identity, scheduled and delivered through a managed pipeline.',
+        step: 'Produce',
+      },
+      {
+        description:
+          'Operate and update the fleet over time — new models, refreshed styles, and scaling as you grow.',
+        step: 'Operate',
+      },
+    ],
+    processDescription: 'Owned models, run for you end to end.',
+    processTitle: 'How It Works',
+    slug: 'fleet',
+    title: 'Model Fleet',
+  },
+];
+
+export const pitchLandingConfigBySlug = Object.fromEntries(
+  pitchLandingConfigs.map((config) => [config.slug, config]),
+) satisfies Record<string, ServiceLandingConfig>;
+
+export const pitchLandingSlugs = pitchLandingConfigs.map(
+  (config) => config.slug,
+);

--- a/apps/website/packages/components/landing/service-landings.data.ts
+++ b/apps/website/packages/components/landing/service-landings.data.ts
@@ -60,6 +60,16 @@ export interface ServiceLandingConfig {
   faqs: ServiceLandingFaq[];
   closingTitle: string;
   closingDescription: string;
+  /**
+   * Price shown in the hero pill. Omit for public/funnel service pages — the
+   * vault keeps retainer pricing off the public site, so they fall back to a
+   * soft "scoped on a call" label. Set it only on direct-send pitch pages.
+   */
+  priceLabel?: string;
+  /** Secondary price line under {@link priceLabel} (e.g. "then $2,000 / month"). */
+  priceNote?: string;
+  /** Hero pill CTA hint. Defaults to "Book a call to scope it". */
+  priceCtaHint?: string;
 }
 
 const COMMON_SERVICE_PROCESS = contentServiceOffering.process;
@@ -126,7 +136,7 @@ export const serviceLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         answer:
-          'Engagements start at $2,500 per month and scale with content volume, channel complexity, and review requirements.',
+          'Pricing is scoped on the call around content volume, channel mix, and review load, so the engagement is sized to what you actually need.',
         question: 'What does pricing look like?',
       },
       {

--- a/apps/website/packages/data/faq.data.ts
+++ b/apps/website/packages/data/faq.data.ts
@@ -86,7 +86,7 @@ export const FAQ_CATEGORIES: Omit<FAQCategory, 'icon'>[] = [
       },
       {
         answer:
-          'Yes. Signing up costs nothing and there is no monthly fee on Pay As You Go: you buy credits and spend them on output. Developers can also self-host the open-source core from GitHub.',
+          'Yes. Signing up costs nothing and there is no monthly fee on Pay As You Go: you buy credits and spend them on output.',
         question: 'Is there a free option?',
       },
       {

--- a/apps/website/scripts/check-orphans.ts
+++ b/apps/website/scripts/check-orphans.ts
@@ -54,8 +54,17 @@ const REQUEST_TIMEOUT_MS = 15_000;
  * Sitemap URLs that are intentionally not reachable by crawling <a> links, so
  * they must not be reported as orphans:
  * - llms.txt / llms-full.txt are plain-text AI resources, not linked HTML pages.
+ * - /retainer, /dfy, /fleet are high-ticket pitch pages: deliberately kept out
+ *   of nav/footer (direct-send sales collateral + ad landing pages) but listed
+ *   in the sitemap so a shared link stays indexable.
  */
-const ORPHAN_ALLOWLIST = new Set<string>(['/llms.txt', '/llms-full.txt']);
+const ORPHAN_ALLOWLIST = new Set<string>([
+  '/llms.txt',
+  '/llms-full.txt',
+  '/retainer',
+  '/dfy',
+  '/fleet',
+]);
 
 /**
  * Route prefixes whose content depends on the live backend API. In CI the API

--- a/packages/helpers/src/business/pricing/pricing.helper.test.ts
+++ b/packages/helpers/src/business/pricing/pricing.helper.test.ts
@@ -162,7 +162,7 @@ describe('pricing.helper', () => {
       const plan = getProPlan();
       expect(plan.launchPrice).toBe(39);
       expect(plan.launchNote).toBe(
-        'Launch pricing — first 12 months, then $49/month',
+        'Launch pricing (code EARLYGENFEED) — first 12 months, then $49/month',
       );
     });
 

--- a/packages/pricing/src/plans-pricing.ts
+++ b/packages/pricing/src/plans-pricing.ts
@@ -263,7 +263,8 @@ export const websitePlans: PricingPlanProps[] = [
     includedCredits: 8_000,
     interval: 'month',
     label: 'Pro',
-    launchNote: 'Launch pricing — first 12 months, then $49/month',
+    launchNote:
+      'Launch pricing (code EARLYGENFEED) — first 12 months, then $49/month',
     launchPrice: 39,
     outputs: null,
     price: 49,


### PR DESCRIPTION
Aligns `apps/website` with the vault business model (credit-first, unlimited team seats), adds **direct-send pitch pages** for the high-ticket offers, and adds a **dev-facing open-source / self-hosted page**.

## Part A — align public site with the vault model
| Vault rule | Before | After |
|---|---|---|
| Teams = **unlimited seats** | "5 seats, then $49/seat" ×6 surfaces | **Unlimited seats** everywhere |
| Self-host not pitched **in the SaaS funnel** | `/faq` advertised self-host | Line removed (self-host now has its own dev page — Part C) |
| Retainer/DFY **not priced** on public pages | hardcoded "$2,500" | Data-driven → **Custom / scoped on a call** |
| `EARLYGENFEED` launch code | absent | surfaced on the Creator launch note |

## Part B — high-ticket pitch pages (direct-send, unlinked-but-indexable, ad-ready)
| URL | Offer | Price |
|---|---|---|
| `/retainer` | Full content operation run for you | **$5,000 setup + $2,000/mo** |
| `/dfy` | **Smaller-ticket twin of the retainer** (same offer, scaled down) | **Custom** |
| `/fleet` | Custom LoRAs, AI influencers, dedicated inference | **Custom** |

Not in nav/footer; in the sitemap + indexable, so an ad can point straight at the URL. `/dfy` was repositioned from a "build-and-hand-over setup" to a lighter retainer twin so Retainer vs DFY can be A/B'd on socials/ads.

## Part C — open-source / self-hosted page (`/self-hosted`)
- Public page, **full site chrome**. Leads with **open source + Docker**, a **self-host vs managed-cloud** comparison, and CTAs that funnel to cloud (**self-host → cloud convert**).
- Linked from the **footer Developers** section (replaces the bare GitHub link); added to the sitemap; **kept out of the main SaaS nav**. This is the one sanctioned OSS landing surface — the SaaS self-serve funnel still never pitches self-host.

## Vault (separate repo, not pushed)
`vault/20_BUSINESS/{offers-and-pricing,icp-and-positioning,business-overview}.md` updated to sanction the `/self-hosted` page and reframe DFY. **Heads-up:** that vault commit also swept in concurrent working-tree pricing edits (flat PAYG, API "Model B", volume-discount removal) — the commit message documents both; left local for your review.

## Verification
- Biome + secretlint + no-raw-html + no-bespoke-card pre-commit gates pass on all files.
- New routes mirror the proven `(landing)`/`(public)` patterns; confirmed no product-slug collisions (`retainer`/`dfy`/`fleet`/`self-hosted`).
- **Not run locally** — `next` isn't installed in this worktree (heavy verification is CI's job here). CI runs type-check + build + Playwright; **please eyeball the 4 new pages in the Vercel preview.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
