### PR TITLE
fix(api): correct /v1/v1 double-prefix on goals & projects controllers

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -29449,6 +29449,127 @@
         ]
       }
     },
+    "/goals": {
+      "get": {
+        "operationId": "GoalsController.findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "findAll",
+        "tags": [
+          "goals",
+          "Goals"
+        ]
+      },
+      "post": {
+        "operationId": "GoalsController.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGoalDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "create",
+        "tags": [
+          "goals",
+          "Goals"
+        ]
+      }
+    },
+    "/goals/{id}": {
+      "delete": {
+        "operationId": "GoalsController.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "remove",
+        "tags": [
+          "goals",
+          "Goals"
+        ]
+      },
+      "get": {
+        "operationId": "GoalsController.findOne",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "findOne",
+        "tags": [
+          "goals",
+          "Goals"
+        ]
+      },
+      "patch": {
+        "operationId": "GoalsController.patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGoalDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "patch",
+        "tags": [
+          "goals",
+          "Goals"
+        ]
+      }
+    },
     "/gpt-actions.json": {
       "get": {
         "operationId": "DocsController.getGptActionsSpec",
@@ -38598,6 +38719,127 @@
         "summary": "applyProfile",
         "tags": [
           "Profiles"
+        ]
+      }
+    },
+    "/projects": {
+      "get": {
+        "operationId": "ProjectsController.findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "findAll",
+        "tags": [
+          "projects",
+          "Projects"
+        ]
+      },
+      "post": {
+        "operationId": "ProjectsController.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProjectDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "create",
+        "tags": [
+          "projects",
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{id}": {
+      "delete": {
+        "operationId": "ProjectsController.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "remove",
+        "tags": [
+          "projects",
+          "Projects"
+        ]
+      },
+      "get": {
+        "operationId": "ProjectsController.findOne",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "findOne",
+        "tags": [
+          "projects",
+          "Projects"
+        ]
+      },
+      "patch": {
+        "operationId": "ProjectsController.patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProjectDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "patch",
+        "tags": [
+          "projects",
+          "Projects"
         ]
       }
     },
@@ -48073,248 +48315,6 @@
         "summary": "updateSettings",
         "tags": [
           "users"
-        ]
-      }
-    },
-    "/v1/goals": {
-      "get": {
-        "operationId": "GoalsController.findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findAll",
-        "tags": [
-          "v1/goals",
-          "Goals"
-        ]
-      },
-      "post": {
-        "operationId": "GoalsController.create",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateGoalDto"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "create",
-        "tags": [
-          "v1/goals",
-          "Goals"
-        ]
-      }
-    },
-    "/v1/goals/{id}": {
-      "delete": {
-        "operationId": "GoalsController.remove",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "remove",
-        "tags": [
-          "v1/goals",
-          "Goals"
-        ]
-      },
-      "get": {
-        "operationId": "GoalsController.findOne",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findOne",
-        "tags": [
-          "v1/goals",
-          "Goals"
-        ]
-      },
-      "patch": {
-        "operationId": "GoalsController.patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateGoalDto"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "patch",
-        "tags": [
-          "v1/goals",
-          "Goals"
-        ]
-      }
-    },
-    "/v1/projects": {
-      "get": {
-        "operationId": "ProjectsController.findAll",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findAll",
-        "tags": [
-          "v1/projects",
-          "Projects"
-        ]
-      },
-      "post": {
-        "operationId": "ProjectsController.create",
-        "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateProjectDto"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "create",
-        "tags": [
-          "v1/projects",
-          "Projects"
-        ]
-      }
-    },
-    "/v1/projects/{id}": {
-      "delete": {
-        "operationId": "ProjectsController.remove",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "remove",
-        "tags": [
-          "v1/projects",
-          "Projects"
-        ]
-      },
-      "get": {
-        "operationId": "ProjectsController.findOne",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findOne",
-        "tags": [
-          "v1/projects",
-          "Projects"
-        ]
-      },
-      "patch": {
-        "operationId": "ProjectsController.patch",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateProjectDto"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "patch",
-        "tags": [
-          "v1/projects",
-          "Projects"
         ]
       }
     },

--- a/apps/server/api/src/collections/goals/controllers/goals.controller.ts
+++ b/apps/server/api/src/collections/goals/controllers/goals.controller.ts
@@ -2,10 +2,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { CreateGoalDto } from '@api/collections/goals/dto/create-goal.dto';
 import { GoalQueryDto } from '@api/collections/goals/dto/goal-query.dto';
 import { UpdateGoalDto } from '@api/collections/goals/dto/update-goal.dto';
-import {
-  Goal,
-  type GoalDocument,
-} from '@api/collections/goals/schemas/goal.schema';
+import type { GoalDocument } from '@api/collections/goals/schemas/goal.schema';
 import { GoalsService } from '@api/collections/goals/services/goals.service';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -22,7 +19,7 @@ import type { Request } from 'express';
 
 @ApiTags('Goals')
 @AutoSwagger()
-@Controller('v1/goals')
+@Controller('goals')
 export class GoalsController extends BaseCRUDController<
   GoalDocument,
   CreateGoalDto,

--- a/apps/server/api/src/collections/projects/controllers/projects.controller.ts
+++ b/apps/server/api/src/collections/projects/controllers/projects.controller.ts
@@ -2,10 +2,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { CreateProjectDto } from '@api/collections/projects/dto/create-project.dto';
 import { ProjectQueryDto } from '@api/collections/projects/dto/project-query.dto';
 import { UpdateProjectDto } from '@api/collections/projects/dto/update-project.dto';
-import {
-  Project,
-  type ProjectDocument,
-} from '@api/collections/projects/schemas/project.schema';
+import type { ProjectDocument } from '@api/collections/projects/schemas/project.schema';
 import { ProjectsService } from '@api/collections/projects/services/projects.service';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -22,7 +19,7 @@ import type { Request } from 'express';
 
 @ApiTags('Projects')
 @AutoSwagger()
-@Controller('v1/projects')
+@Controller('projects')
 export class ProjectsController extends BaseCRUDController<
   ProjectDocument,
   CreateProjectDto,


### PR DESCRIPTION
## Summary

`GoalsController` and `ProjectsController` declared `@Controller('v1/goals')` and `@Controller('v1/projects')` while [`main.ts:140`](apps/server/api/src/main.ts) already calls `app.setGlobalPrefix('v1')`. The two prefixes stacked, registering the routes at **`/v1/v1/goals`** and **`/v1/v1/projects`** instead of the intended `/v1/goals` and `/v1/projects`.

Fixes the double-prefix flagged by REST audit #1354.

## Which case was this? — Unreachable at the intended path (not a compensating-caller case)

I verified how these endpoints are actually consumed before changing anything:

- **Convention check** — every other controller in `apps/server/api` uses a **bare** resource name (`videos`, `posts`, `brands`, …) and relies on the global prefix. `v1/goals` and `v1/projects` were the **only two** anomalies out of ~90 controllers.
- **Caller check** — swept `packages/services`, `apps/app`, `apps/mobile`, `apps/desktop`, and `playwright`. **No client calls `/v1/goals` or `/v1/projects` at all** (neither single- nor double-prefixed). The frontend's `AgentGoalsService` targets the unrelated `/v1/agent/goals`, and `EditorProjectsService` targets `/v1/editor-projects` — different controllers entirely.
- **Not dead code** — both `GoalsModule` and `ProjectsModule` are registered in `app.module.ts`, so the routes are live; they were simply mounted at the wrong path with zero consumers.

Because no caller exists, there was **nothing to update atomically** — this PR only corrects the controller prefix. The client base URL (`EnvironmentService.apiEndpoint`) already includes `/v1`, so a future/consumer request to `${apiEndpoint}/goals` now resolves correctly to `/v1/goals`.

## Changes

- `goals.controller.ts`: `@Controller('v1/goals')` → `@Controller('goals')`
- `projects.controller.ts`: `@Controller('v1/projects')` → `@Controller('projects')`
- Dropped the unused `Goal` / `Project` value imports Biome flagged on the touched files (only the `type *Document` variants are used).

## Verification

- `bunx biome check` on both files — clean (also enforced by pre-commit hook).
- Secret scan (pre-commit secretlint) — clean.
- Full type-check / lint / tests run in CI.

Refs #1354