### PR TITLE
refactor(api): collapse social-inbox status routes into PATCH (REST audit #1354)

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -8538,16 +8538,11 @@
         },
         "type": "object"
       },
-      "SocialConversationAssignDto": {
+      "SocialConversationUpdateDto": {
         "properties": {
           "assignedOwnerId": {
             "type": "object"
-          }
-        },
-        "type": "object"
-      },
-      "SocialConversationStatusDto": {
-        "properties": {
+          },
           "status": {
             "enum": [
               "open",
@@ -8556,15 +8551,7 @@
               "archived"
             ],
             "type": "string"
-          }
-        },
-        "required": [
-          "status"
-        ],
-        "type": "object"
-      },
-      "SocialConversationTagsDto": {
-        "properties": {
+          },
           "tags": {
             "items": {
               "type": "string"
@@ -8572,9 +8559,6 @@
             "type": "array"
           }
         },
-        "required": [
-          "tags"
-        ],
         "type": "object"
       },
       "SocialDmDto": {
@@ -8634,12 +8618,22 @@
         ],
         "type": "object"
       },
-      "SocialDraftRejectDto": {
+      "SocialDraftUpdateDto": {
         "properties": {
           "reason": {
             "type": "string"
+          },
+          "status": {
+            "enum": [
+              "approved",
+              "rejected"
+            ],
+            "type": "string"
           }
         },
+        "required": [
+          "status"
+        ],
         "type": "object"
       },
       "SocialInboxYoutubeIngestDto": {
@@ -32062,11 +32056,9 @@
           "messages",
           "Messages"
         ]
-      }
-    },
-    "/messages/{conversationId}/assignment": {
+      },
       "patch": {
-        "operationId": "SocialInboxController.assignOwner",
+        "operationId": "SocialInboxController.updateConversation",
         "parameters": [
           {
             "in": "path",
@@ -32081,7 +32073,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SocialConversationAssignDto"
+                "$ref": "#/components/schemas/SocialConversationUpdateDto"
               }
             }
           },
@@ -32097,7 +32089,7 @@
             "bearer": []
           }
         ],
-        "summary": "Assign or unassign a social conversation",
+        "summary": "Update a social conversation (status, tags, and/or assignment)",
         "tags": [
           "messages",
           "Messages"
@@ -32184,47 +32176,9 @@
         ]
       }
     },
-    "/messages/{conversationId}/drafts/{messageId}/approve": {
-      "post": {
-        "operationId": "SocialInboxController.approveDraft",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "conversationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "messageId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "summary": "Approve and publish a draft reply or DM",
-        "tags": [
-          "messages",
-          "Messages"
-        ]
-      }
-    },
-    "/messages/{conversationId}/drafts/{messageId}/reject": {
-      "post": {
-        "operationId": "SocialInboxController.rejectDraft",
+    "/messages/{conversationId}/drafts/{messageId}": {
+      "patch": {
+        "operationId": "SocialInboxController.updateDraft",
         "parameters": [
           {
             "in": "path",
@@ -32247,7 +32201,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SocialDraftRejectDto"
+                "$ref": "#/components/schemas/SocialDraftUpdateDto"
               }
             }
           },
@@ -32263,7 +32217,7 @@
             "bearer": []
           }
         ],
-        "summary": "Reject a draft reply or DM without publishing",
+        "summary": "Approve (and publish) or reject a draft reply/DM",
         "tags": [
           "messages",
           "Messages"
@@ -32422,86 +32376,6 @@
           }
         ],
         "summary": "Post a reply through the connected account",
-        "tags": [
-          "messages",
-          "Messages"
-        ]
-      }
-    },
-    "/messages/{conversationId}/status": {
-      "patch": {
-        "operationId": "SocialInboxController.updateStatus",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "conversationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SocialConversationStatusDto"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "summary": "Update social conversation status",
-        "tags": [
-          "messages",
-          "Messages"
-        ]
-      }
-    },
-    "/messages/{conversationId}/tags": {
-      "patch": {
-        "operationId": "SocialInboxController.updateTags",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "conversationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SocialConversationTagsDto"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "summary": "Replace social conversation tags",
         "tags": [
           "messages",
           "Messages"

--- a/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.rbac.spec.ts
+++ b/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.rbac.spec.ts
@@ -17,18 +17,10 @@ describe('SocialInboxController RBAC', () => {
     expect(metadata).toEqual(['owner', 'admin', 'creator']);
   });
 
-  it('should require owner or admin role for approveDraft', () => {
+  it('should require owner or admin role for updateDraft', () => {
     const metadata = Reflect.getMetadata(
       'roles',
-      SocialInboxController.prototype.approveDraft,
-    );
-    expect(metadata).toEqual(['owner', 'admin']);
-  });
-
-  it('should require owner or admin role for rejectDraft', () => {
-    const metadata = Reflect.getMetadata(
-      'roles',
-      SocialInboxController.prototype.rejectDraft,
+      SocialInboxController.prototype.updateDraft,
     );
     expect(metadata).toEqual(['owner', 'admin']);
   });
@@ -49,26 +41,10 @@ describe('SocialInboxController RBAC', () => {
     expect(metadata).toEqual(['owner', 'admin']);
   });
 
-  it('should require owner or admin role for updateStatus', () => {
+  it('should require owner or admin role for updateConversation', () => {
     const metadata = Reflect.getMetadata(
       'roles',
-      SocialInboxController.prototype.updateStatus,
-    );
-    expect(metadata).toEqual(['owner', 'admin']);
-  });
-
-  it('should require owner or admin role for updateTags', () => {
-    const metadata = Reflect.getMetadata(
-      'roles',
-      SocialInboxController.prototype.updateTags,
-    );
-    expect(metadata).toEqual(['owner', 'admin']);
-  });
-
-  it('should require owner or admin role for assignOwner', () => {
-    const metadata = Reflect.getMetadata(
-      'roles',
-      SocialInboxController.prototype.assignOwner,
+      SocialInboxController.prototype.updateConversation,
     );
     expect(metadata).toEqual(['owner', 'admin']);
   });

--- a/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.ts
+++ b/apps/server/api/src/collections/social-inbox/controllers/social-inbox.controller.ts
@@ -1,11 +1,9 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import {
-  SocialConversationAssignDto,
-  SocialConversationStatusDto,
-  SocialConversationTagsDto,
+  SocialConversationUpdateDto,
   SocialDmDto,
   SocialDraftDto,
-  SocialDraftRejectDto,
+  SocialDraftUpdateDto,
   SocialReplyDto,
 } from '@api/collections/social-inbox/dto/social-inbox-action.dto';
 import { SocialInboxYoutubeIngestDto } from '@api/collections/social-inbox/dto/social-inbox-ingest.dto';
@@ -134,41 +132,30 @@ export class SocialInboxController {
     return serializeSingle(request, SocialMessageSerializer, data);
   }
 
-  @Post(':conversationId/drafts/:messageId/approve')
+  @Patch(':conversationId/drafts/:messageId')
   @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
-  @ApiOperation({ summary: 'Approve and publish a draft reply or DM' })
-  async approveDraft(
+  @ApiOperation({ summary: 'Approve (and publish) or reject a draft reply/DM' })
+  async updateDraft(
     @Req() request: Request,
     @CurrentUser() user: User,
     @Param('conversationId') conversationId: string,
     @Param('messageId') messageId: string,
+    @Body() body: SocialDraftUpdateDto,
   ): Promise<JsonApiSingleResponse> {
     const scope = this.buildScope(user);
-    const data = await this.socialInboxService.approveDraft(
-      scope,
-      conversationId,
-      messageId,
-    );
-    return serializeSingle(request, SocialMessageSerializer, data);
-  }
-
-  @Post(':conversationId/drafts/:messageId/reject')
-  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
-  @ApiOperation({ summary: 'Reject a draft reply or DM without publishing' })
-  async rejectDraft(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Param('conversationId') conversationId: string,
-    @Param('messageId') messageId: string,
-    @Body() body: SocialDraftRejectDto,
-  ): Promise<JsonApiSingleResponse> {
-    const scope = this.buildScope(user);
-    const data = await this.socialInboxService.rejectDraft(
-      scope,
-      conversationId,
-      messageId,
-      body.reason,
-    );
+    const data =
+      body.status === 'approved'
+        ? await this.socialInboxService.approveDraft(
+            scope,
+            conversationId,
+            messageId,
+          )
+        : await this.socialInboxService.rejectDraft(
+            scope,
+            conversationId,
+            messageId,
+            body.reason,
+          );
     return serializeSingle(request, SocialMessageSerializer, data);
   }
 
@@ -208,56 +195,26 @@ export class SocialInboxController {
     return serializeSingle(request, SocialMessageSerializer, data);
   }
 
-  @Patch(':conversationId/status')
+  @Patch(':conversationId')
   @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
-  @ApiOperation({ summary: 'Update social conversation status' })
-  async updateStatus(
+  @ApiOperation({
+    summary: 'Update a social conversation (status, tags, and/or assignment)',
+  })
+  async updateConversation(
     @Req() request: Request,
     @CurrentUser() user: User,
     @Param('conversationId') conversationId: string,
-    @Body() body: SocialConversationStatusDto,
+    @Body() body: SocialConversationUpdateDto,
   ): Promise<JsonApiSingleResponse> {
     const scope = this.buildScope(user);
-    const data = await this.socialInboxService.updateStatus(
+    const data = await this.socialInboxService.updateConversation(
       scope,
       conversationId,
-      body.status,
-    );
-    return serializeSingle(request, SocialConversationSerializer, data);
-  }
-
-  @Patch(':conversationId/tags')
-  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
-  @ApiOperation({ summary: 'Replace social conversation tags' })
-  async updateTags(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Param('conversationId') conversationId: string,
-    @Body() body: SocialConversationTagsDto,
-  ): Promise<JsonApiSingleResponse> {
-    const scope = this.buildScope(user);
-    const data = await this.socialInboxService.updateTags(
-      scope,
-      conversationId,
-      body.tags,
-    );
-    return serializeSingle(request, SocialConversationSerializer, data);
-  }
-
-  @Patch(':conversationId/assignment')
-  @RolesDecorator(MemberRole.OWNER, MemberRole.ADMIN)
-  @ApiOperation({ summary: 'Assign or unassign a social conversation' })
-  async assignOwner(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Param('conversationId') conversationId: string,
-    @Body() body: SocialConversationAssignDto,
-  ): Promise<JsonApiSingleResponse> {
-    const scope = this.buildScope(user);
-    const data = await this.socialInboxService.assignOwner(
-      scope,
-      conversationId,
-      body.assignedOwnerId,
+      {
+        assignedOwnerId: body.assignedOwnerId,
+        status: body.status,
+        tags: body.tags,
+      },
     );
     return serializeSingle(request, SocialConversationSerializer, data);
   }

--- a/apps/server/api/src/collections/social-inbox/dto/social-inbox-action.dto.ts
+++ b/apps/server/api/src/collections/social-inbox/dto/social-inbox-action.dto.ts
@@ -54,7 +54,19 @@ export class SocialDraftDto extends SocialDmDto {
   messageType?: 'dm' | 'reply';
 }
 
-export class SocialDraftRejectDto {
+const DRAFT_DECISIONS = ['approved', 'rejected'] as const;
+
+/**
+ * Draft review decision. Collapses the former
+ * `POST /drafts/:messageId/{approve,reject}` action routes into a single
+ * `PATCH /drafts/:messageId` status transition — the service still performs
+ * the publish side-effect behind the `approved` verb.
+ */
+export class SocialDraftUpdateDto {
+  @ApiProperty({ enum: DRAFT_DECISIONS })
+  @IsIn(DRAFT_DECISIONS)
+  status!: (typeof DRAFT_DECISIONS)[number];
+
   @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
@@ -62,21 +74,24 @@ export class SocialDraftRejectDto {
   reason?: string;
 }
 
-export class SocialConversationStatusDto {
-  @ApiProperty({ enum: CONVERSATION_STATUSES })
+/**
+ * Partial conversation update. Collapses the former single-field
+ * `PATCH /:conversationId/{status,tags,assignment}` routes into one
+ * `PATCH /:conversationId` accepting any subset of the mutable fields.
+ */
+export class SocialConversationUpdateDto {
+  @ApiProperty({ enum: CONVERSATION_STATUSES, required: false })
+  @IsOptional()
   @IsIn(CONVERSATION_STATUSES)
-  status!: string;
-}
+  status?: string;
 
-export class SocialConversationTagsDto {
-  @ApiProperty({ type: [String] })
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
   @IsArray()
   @ArrayMaxSize(20)
   @IsString({ each: true })
-  tags!: string[];
-}
+  tags?: string[];
 
-export class SocialConversationAssignDto {
   @ApiProperty({ required: false })
   @IsOptional()
   @IsEntityId()

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts
@@ -6,7 +6,6 @@ import {
   type SocialMessageDocument,
 } from '@api/collections/social-inbox/schemas/social-inbox.schema';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
-import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -73,6 +72,12 @@ export interface SocialActionInput {
   agentRunId?: string;
   recipientId?: string;
   messageType?: 'dm' | 'reply';
+}
+
+export interface SocialConversationPatch {
+  status?: string;
+  tags?: string[];
+  assignedOwnerId?: string | null;
 }
 
 export type SocialInboxPage<T> = {
@@ -534,49 +539,39 @@ export class SocialInboxService {
     return this.toMessageDocument(message);
   }
 
-  async updateStatus(
+  async updateConversation(
     scope: SocialInboxScope,
     conversationId: string,
-    status: string,
+    patch: SocialConversationPatch,
   ): Promise<SocialConversationDocument> {
     await this.getConversation(scope, conversationId);
+
+    const data: Prisma.SocialConversationUpdateInput = {};
+
+    if (patch.status !== undefined) {
+      data.status = patch.status;
+      data.needsReview = patch.status === 'needs_review';
+      if (patch.status === 'resolved') {
+        data.unreadCount = 0;
+      }
+    }
+
+    if (patch.tags !== undefined) {
+      data.tags = [
+        ...new Set(patch.tags.map((tag) => tag.trim()).filter(Boolean)),
+      ].slice(0, 20);
+    }
+
+    if (patch.assignedOwnerId !== undefined) {
+      data.assignedOwnerId = patch.assignedOwnerId ?? null;
+    }
+
+    if (Object.keys(data).length === 0) {
+      throw new BadRequestException('No conversation fields to update');
+    }
+
     const updated = await this.prisma.socialConversation.update({
-      data: {
-        needsReview: status === 'needs_review',
-        status,
-        unreadCount: status === 'resolved' ? 0 : undefined,
-      },
-      where: { id: conversationId },
-    });
-
-    return this.toConversationDocument(updated);
-  }
-
-  async updateTags(
-    scope: SocialInboxScope,
-    conversationId: string,
-    tags: string[],
-  ): Promise<SocialConversationDocument> {
-    await this.getConversation(scope, conversationId);
-    const normalizedTags = [
-      ...new Set(tags.map((tag) => tag.trim()).filter(Boolean)),
-    ].slice(0, 20);
-    const updated = await this.prisma.socialConversation.update({
-      data: { tags: normalizedTags },
-      where: { id: conversationId },
-    });
-
-    return this.toConversationDocument(updated);
-  }
-
-  async assignOwner(
-    scope: SocialInboxScope,
-    conversationId: string,
-    assignedOwnerId?: string | null,
-  ): Promise<SocialConversationDocument> {
-    await this.getConversation(scope, conversationId);
-    const updated = await this.prisma.socialConversation.update({
-      data: { assignedOwnerId: assignedOwnerId ?? null },
+      data,
       where: { id: conversationId },
     });
 

--- a/apps/server/mcp/src/services/client.service.spec.ts
+++ b/apps/server/mcp/src/services/client.service.spec.ts
@@ -1281,10 +1281,9 @@ describe('ClientService (MCP)', () => {
 
       const result = await service.updateSocialTags('conv-1', ['lead']);
 
-      expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
-        '/messages/conv-1/tags',
-        { tags: ['lead'] },
-      );
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith('/messages/conv-1', {
+        tags: ['lead'],
+      });
       expect(result).toMatchObject({ id: 'conv-1', tags: ['lead'] });
     });
   });

--- a/apps/server/mcp/src/services/client/social-messages.client.ts
+++ b/apps/server/mcp/src/services/client/social-messages.client.ts
@@ -129,11 +129,7 @@ export class SocialMessagesClient {
     conversationId: string,
     messageId: string,
   ): Promise<Record<string, unknown>> {
-    return this.postMessageAction(
-      conversationId,
-      `drafts/${messageId}/approve`,
-      {},
-    );
+    return this.patchDraft(conversationId, messageId, { status: 'approved' });
   }
 
   rejectDraft(
@@ -141,11 +137,10 @@ export class SocialMessagesClient {
     messageId: string,
     reason?: string,
   ): Promise<Record<string, unknown>> {
-    return this.postMessageAction(
-      conversationId,
-      `drafts/${messageId}/reject`,
-      reason ? { reason } : {},
-    );
+    return this.patchDraft(conversationId, messageId, {
+      status: 'rejected',
+      ...(reason ? { reason } : {}),
+    });
   }
 
   postReply(
@@ -166,22 +161,20 @@ export class SocialMessagesClient {
     conversationId: string,
     tags: string[],
   ): Promise<Record<string, unknown>> {
-    return this.patchConversation(conversationId, 'tags', { tags });
+    return this.patchConversation(conversationId, { tags });
   }
 
   assignConversation(
     conversationId: string,
     assignedOwnerId?: string | null,
   ): Promise<Record<string, unknown>> {
-    return this.patchConversation(conversationId, 'assignment', {
+    return this.patchConversation(conversationId, {
       assignedOwnerId: assignedOwnerId ?? null,
     });
   }
 
   markResolved(conversationId: string): Promise<Record<string, unknown>> {
-    return this.patchConversation(conversationId, 'status', {
-      status: 'resolved',
-    });
+    return this.patchConversation(conversationId, { status: 'resolved' });
   }
 
   private postMessageAction(
@@ -204,19 +197,36 @@ export class SocialMessagesClient {
 
   private patchConversation(
     conversationId: string,
-    action: string,
     payload: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     return this.base.request(
-      `patching social conversation ${action}`,
+      'patching social conversation',
       async (http) => {
         const response = await http.patch(
-          `/messages/${conversationId}/${action}`,
+          `/messages/${conversationId}`,
           payload,
         );
         return this.mapResource(response.data?.data);
       },
       this.base.failWithDetail('Failed to update social conversation'),
+    );
+  }
+
+  private patchDraft(
+    conversationId: string,
+    messageId: string,
+    payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.base.request(
+      'patching social draft',
+      async (http) => {
+        const response = await http.patch(
+          `/messages/${conversationId}/drafts/${messageId}`,
+          payload,
+        );
+        return this.mapResource(response.data?.data);
+      },
+      this.base.failWithDetail('Failed to update social draft'),
     );
   }
 

--- a/packages/services/social/messages.service.ts
+++ b/packages/services/social/messages.service.ts
@@ -309,11 +309,7 @@ export class SocialMessagesService extends BaseService<
     conversationId: string,
     messageId: string,
   ): Promise<SocialMessageModel> {
-    return this.postMessageAction(
-      conversationId,
-      `drafts/${messageId}/approve`,
-      {},
-    );
+    return this.patchDraft(conversationId, messageId, { status: 'approved' });
   }
 
   rejectDraft(
@@ -321,11 +317,10 @@ export class SocialMessagesService extends BaseService<
     messageId: string,
     reason?: string,
   ): Promise<SocialMessageModel> {
-    return this.postMessageAction(
-      conversationId,
-      `drafts/${messageId}/reject`,
-      reason ? { reason, text: reason } : {},
-    );
+    return this.patchDraft(conversationId, messageId, {
+      reason,
+      status: 'rejected',
+    });
   }
 
   postReply(
@@ -346,24 +341,26 @@ export class SocialMessagesService extends BaseService<
     conversationId: string,
     status: SocialConversationStatus,
   ): Promise<SocialConversationModel> {
-    return this.patch(`${conversationId}/status`, { status });
+    return this.patch(conversationId, { status });
   }
 
   updateTags(
     conversationId: string,
     tags: string[],
   ): Promise<SocialConversationModel> {
-    return this.patch(`${conversationId}/tags`, { tags });
+    return this.patch(conversationId, { tags });
   }
 
   assignOwner(
     conversationId: string,
     assignedOwnerId: string | null,
   ): Promise<SocialConversationModel> {
+    // Sent via the raw client rather than `patch()` because unassigning
+    // requires an explicit `null`, which `patch()` strips as an empty value.
     return this.executeWithErrorHandling(
-      `PATCH ${this.baseURL}/${conversationId}/assignment`,
+      `PATCH ${this.baseURL}/${conversationId}`,
       this.instance
-        .patch<JsonApiResponseDocument>(`/${conversationId}/assignment`, {
+        .patch<JsonApiResponseDocument>(`/${conversationId}`, {
           assignedOwnerId,
         })
         .then((response) => this.mapOne(response.data)),
@@ -388,6 +385,26 @@ export class SocialMessagesService extends BaseService<
       `POST ${this.baseURL}/${conversationId}/${action}`,
       this.instance
         .post<JsonApiResponseDocument>(`/${conversationId}/${action}`, input)
+        .then((response) => response.data)
+        .then(
+          (document) =>
+            new SocialMessageModel(
+              this.extractResource<Partial<SocialMessage>>(document),
+            ),
+        ),
+    );
+  }
+
+  private patchDraft(
+    conversationId: string,
+    messageId: string,
+    input: { status: 'approved' | 'rejected'; reason?: string },
+  ): Promise<SocialMessageModel> {
+    const path = `/${conversationId}/drafts/${messageId}`;
+    return this.executeWithErrorHandling(
+      `PATCH ${this.baseURL}${path}`,
+      this.instance
+        .patch<JsonApiResponseDocument>(path, input)
         .then((response) => response.data)
         .then(
           (document) =>


### PR DESCRIPTION
## Summary

Applies the REST-audit [#1354](https://github.com/genfeedai/genfeed.ai/issues/1354) Tier-2 social-inbox collapse, following the north-star PR #1302 lens: RPC verb routes become status/field transitions on a canonical `PATCH`, with every side-effect (publish, provenance stamp, review flags) kept **behind the standard verb** in the service layer.

## Route collapses

**Draft review** — 2 routes → 1
- `POST /messages/:conversationId/drafts/:messageId/approve`
- `POST /messages/:conversationId/drafts/:messageId/reject`
- → `PATCH /messages/:conversationId/drafts/:messageId { status: 'approved' | 'rejected', reason? }`

The controller dispatches on `status`: `approved` → `approveDraft` (still publishes the reply/DM), `rejected` → `rejectDraft` (stamps provenance + `failureReason`).

**Conversation mutation** — 3 routes → 1
- `PATCH /messages/:conversationId/status`
- `PATCH /messages/:conversationId/tags`
- `PATCH /messages/:conversationId/assignment`
- → `PATCH /messages/:conversationId { status?, tags?, assignedOwnerId? }`

A single `updateConversation()` applies any subset in **one write**, preserving:
- `status` → `needsReview` derivation + `unreadCount: 0` on `resolved`
- `tags` → trim/dedupe/cap-20 normalization
- `assignedOwnerId` → explicit `null` clears assignment (distinguished from field-absent)

## Named callers updated (appendix on #1354)

Client **method names are unchanged** — only their wire routes move — so the UI page and MCP tool wrappers need no changes:
- `packages/services/social/messages.service.ts` — used by the studio messages page (`apps/app/.../messages/messages-page.tsx`). `assignOwner` uses the raw client to preserve the `null` clear that `BaseService.patch()` would strip.
- `apps/server/mcp/src/services/client/social-messages.client.ts` — MCP tools (`approveSocialDraft`, `rejectSocialDraft`, `updateSocialTags`, `assignSocialConversation`, `markSocialConversationResolved`).

## Tests

- Updated `social-inbox.controller.rbac.spec.ts` for the new `updateDraft` / `updateConversation` methods (both `[owner, admin]`).
- Updated the MCP `client.service.spec.ts` route assertion to the collapsed `/messages/:conversationId` path. **MCP suite: 49/49 pass locally.**
- API-package unit specs (service/controller) rely on generated `@genfeedai/prisma/testing`, which isn't built in this worktree — deferred to CI.

Refs #1354