### PR TITLE
feat(app): monochrome harmonization — analytics, admin & public surfaces (#1335)

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-workspace-sidebar.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-workspace-sidebar.tsx
@@ -96,7 +96,7 @@ export default function ProactiveWorkspaceSidebar({ workspace }: Props) {
               >
                 <div className="flex size-5 items-center justify-center">
                   {isComplete ? (
-                    <HiCheckCircle className="size-5 text-emerald-300" />
+                    <HiCheckCircle className="size-5 text-success" />
                   ) : (
                     <div
                       className={`size-3 rounded-full ${

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-action-bar.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-action-bar.tsx
@@ -18,11 +18,11 @@ type Props = {
   onBack: () => void;
 };
 
-const CURRENT_RING = 'ring-1 ring-emerald-400/40';
+const CURRENT_RING = 'ring-1 ring-border-strong';
 
 function CurrentBadge() {
   return (
-    <span className="absolute -top-2 right-3 z-10 rounded-full border border-emerald-400/30 bg-emerald-400/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+    <span className="absolute -top-2 right-3 z-10 rounded-full bg-hover px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground">
       Current
     </span>
   );

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-row-item.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-row-item.tsx
@@ -25,9 +25,7 @@ export default function ProvidersRowItem({
       </div>
       <div
         className={`inline-flex w-fit items-center gap-2 rounded-full px-3 py-1 text-xs ${
-          enabled
-            ? 'bg-emerald-500/10 text-emerald-300'
-            : 'bg-white/[0.06] text-white/45'
+          enabled ? 'bg-hover text-foreground' : 'bg-white/[0.06] text-white/45'
         }`}
       >
         {enabled ? (

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-status-card.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-status-card.tsx
@@ -17,8 +17,8 @@ export default function ProvidersStatusCard({ accessStatusLabel }: Props) {
         </p>
       </div>
 
-      <div className="rounded-2xl border border-emerald-400/15 bg-emerald-500/5 p-4 text-sm text-white/55">
-        <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-200">
+      <div className="rounded-2xl bg-hover p-4 text-sm text-white/55">
+        <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-secondary shadow-border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground">
           <HiSparkles className="size-3.5" />
           Server Defaults First
         </div>
@@ -27,7 +27,7 @@ export default function ProvidersStatusCard({ accessStatusLabel }: Props) {
           from Organization → API Keys if you want provider control or BYOK
           billing.
         </p>
-        <p className="mt-3 text-xs uppercase tracking-[0.18em] text-emerald-200/80">
+        <p className="mt-3 text-xs uppercase tracking-[0.18em] text-muted-foreground">
           {accessStatusLabel}
         </p>
       </div>

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-tool-list.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-tool-list.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export default function ProvidersToolList({ localToolRows }: Props) {
   return (
-    <div className="provider-card opacity-0 border border-white/[0.08] bg-white/[0.02] p-5 md:p-6">
+    <div className="provider-card opacity-0 bg-secondary shadow-border p-5 md:p-6">
       <div className="mb-5">
         <h2 className="text-lg font-semibold text-white">Local agent tools</h2>
         <p className="mt-2 text-sm text-white/45">

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
@@ -150,8 +150,8 @@ export default function SuccessContent() {
     <div ref={sectionRef} className="max-w-lg mx-auto text-center pt-24">
       {/* Success icon */}
       <div className="success-icon opacity-0 flex justify-center mb-8">
-        <div className="size-20 bg-white/5 border border-white/10 rounded-full flex items-center justify-center">
-          <HiCheckCircle className="size-10 text-green-400" />
+        <div className="size-20 bg-secondary shadow-border rounded-full flex items-center justify-center">
+          <HiCheckCircle className="size-10 text-success" />
         </div>
       </div>
 
@@ -160,10 +160,10 @@ export default function SuccessContent() {
         Welcome to <span className="font-light italic">Genfeed!</span>
       </h1>
 
-      <div className="success-credit-reveal opacity-0 mb-8 inline-flex items-center gap-3 rounded-full border border-emerald-400/20 bg-emerald-500/10 px-5 py-3 text-left">
-        <HiSparkles className="size-5 text-emerald-300" />
+      <div className="success-credit-reveal opacity-0 mb-8 inline-flex items-center gap-3 rounded-full bg-secondary shadow-border px-5 py-3 text-left">
+        <HiSparkles className="size-5 text-foreground" />
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-200/80">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
             Starter Credits Ready
           </p>
           <p className="text-sm text-white">
@@ -203,7 +203,7 @@ export default function SuccessContent() {
                 onClick={() => toggleType(id)}
                 className={`inline-flex items-center gap-2 px-4 py-2 border text-sm transition-all ${
                   isSelected
-                    ? 'border-white/30 bg-white/[0.08] text-white'
+                    ? 'ring-1 ring-border-strong bg-hover text-white border-transparent'
                     : 'border-white/[0.08] bg-white/[0.02] text-white/50 hover:border-white/20'
                 }`}
               >

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.tsx
@@ -123,11 +123,11 @@ function formatSelectedAccessLabel(
     : 'No server defaults detected yet';
 }
 
-const CURRENT_RING = 'ring-1 ring-emerald-400/40';
+const CURRENT_RING = 'ring-1 ring-border-strong';
 
 function CurrentBadge() {
   return (
-    <span className="absolute -top-2 right-3 z-10 rounded-full border border-emerald-400/30 bg-emerald-400/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+    <span className="absolute -top-2 right-3 z-10 rounded-full bg-hover px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground">
       Current
     </span>
   );

--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.tsx
@@ -11,7 +11,7 @@ function PostSignupPageContent() {
 
   return (
     <PageLoadingState
-      className="bg-neutral-950"
+      className="bg-primary"
       fullScreen={true}
       message={statusMessage}
     >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/hooks/HookAnalysisSection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/hooks/HookAnalysisSection.tsx
@@ -11,15 +11,15 @@ type Props = {
 export default function HookAnalysisSection({ analysisData }: Props) {
   return (
     <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-      <Card className="border border-white/[0.08] bg-card/80">
+      <Card>
         <div className="p-6 space-y-4">
-          <h3 className="text-lg font-semibold">Hook Type Effectiveness</h3>
+          <h3 className="text-sm font-semibold">Hook Type Effectiveness</h3>
           <div className="space-y-3">
             {analysisData.hookEffectiveness.length > 0 ? (
               analysisData.hookEffectiveness.map((hook) => (
                 <div
                   key={hook.type}
-                  className="flex items-center justify-between border border-white/[0.08] p-3"
+                  className="flex items-center justify-between bg-tertiary p-3"
                 >
                   <div>
                     <p className="font-medium capitalize">{hook.type} Hooks</p>
@@ -46,9 +46,9 @@ export default function HookAnalysisSection({ analysisData }: Props) {
         </div>
       </Card>
 
-      <Card className="border border-white/[0.08] bg-card/80">
+      <Card>
         <div className="p-6 space-y-4">
-          <h3 className="text-lg font-semibold">
+          <h3 className="text-sm font-semibold">
             Top Performing Hook Patterns
           </h3>
           <div className="space-y-3">
@@ -56,7 +56,7 @@ export default function HookAnalysisSection({ analysisData }: Props) {
               analysisData.topHooks.map((hook, idx) => (
                 <div
                   key={hook}
-                  className="flex items-start gap-3 border border-white/[0.08] p-3"
+                  className="flex items-start gap-3 bg-tertiary p-3"
                 >
                   <Badge className="bg-primary text-primary-foreground text-xs mt-1">
                     #{idx + 1}
@@ -70,7 +70,7 @@ export default function HookAnalysisSection({ analysisData }: Props) {
               </p>
             )}
           </div>
-          <div className="mt-4 bg-background/40 p-3">
+          <div className="mt-4 bg-tertiary p-3">
             <p className="text-xs text-foreground/60">
               <strong>Pro tip</strong> Videos with pattern interrupts in the
               first 3 seconds show 45% higher completion rates across all

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/hooks/PlatformPerformanceSection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/hooks/PlatformPerformanceSection.tsx
@@ -26,7 +26,7 @@ export default function PlatformPerformanceSection({
 }: Props) {
   return (
     <section>
-      <h2 className="mb-4 text-xl font-semibold">
+      <h2 className="mb-4 text-xl font-semibold tracking-tight">
         Platform Performance Overview
       </h2>
 
@@ -39,10 +39,7 @@ export default function PlatformPerformanceSection({
           const Icon = config.icon;
 
           return (
-            <Card
-              key={config.id}
-              className="border border-white/[0.08] backdrop-blur"
-            >
+            <Card key={config.id} className="backdrop-blur">
               <div className="p-4 space-y-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/hooks/analytics-hooks.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/hooks/analytics-hooks.tsx
@@ -180,9 +180,11 @@ export default function AnalyticsHooks({
         />
 
         <section>
-          <Card className="border border-white/[0.08] bg-card/80">
+          <Card>
             <div className="p-6 space-y-4">
-              <h2 className="text-xl font-semibold">Video Hook Breakdown</h2>
+              <h2 className="text-xl font-semibold tracking-tight">
+                Video Hook Breakdown
+              </h2>
               <Table<IViralHookVideo>
                 items={videos ?? []}
                 columns={[
@@ -228,9 +230,7 @@ export default function AnalyticsHooks({
 
                       return (
                         <div className="flex items-center gap-2">
-                          <Badge className="bg-info text-info-foreground text-xs">
-                            {hookCount} hooks
-                          </Badge>
+                          <Badge className="text-xs">{hookCount} hooks</Badge>
                           <span className="text-xs text-foreground/60">
                             Avg: {averageEffectiveness}% effective
                           </span>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/insights/insights-overview.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/insights/insights-overview.tsx
@@ -161,19 +161,19 @@ const InsightsOverview = memo(function InsightsOverview({
       <div className="space-y-6">
         {/* Summary Cards */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          <Card className="bg-error/5 border-error/20">
+          <Card className="bg-error/5">
             <div className="text-center py-2">
               <p className="text-3xl font-bold text-error">{criticalAlerts}</p>
               <p className="text-sm text-foreground/70">Critical Alerts</p>
             </div>
           </Card>
-          <Card className="bg-warning/5 border-warning/20">
+          <Card className="bg-warning/5">
             <div className="text-center py-2">
               <p className="text-3xl font-bold text-warning">{warningAlerts}</p>
               <p className="text-sm text-foreground/70">Warnings</p>
             </div>
           </Card>
-          <Card className="bg-success/5 border-success/20">
+          <Card className="bg-success/5">
             <div className="text-center py-2">
               <p className="text-3xl font-bold text-success">
                 {positiveTrends}
@@ -181,7 +181,7 @@ const InsightsOverview = memo(function InsightsOverview({
               <p className="text-sm text-foreground/70">Positive Trends</p>
             </div>
           </Card>
-          <Card className="bg-info/5 border-info/20">
+          <Card className="bg-info/5">
             <div className="text-center py-2">
               <p className="text-3xl font-bold text-info">
                 {activeSuggestions}
@@ -229,7 +229,7 @@ const InsightsOverview = memo(function InsightsOverview({
             label="AI Analysis Summary"
             icon={HiLightBulb}
             iconClassName="text-warning"
-            className="bg-gradient-to-br from-muted to-background"
+            className="bg-secondary"
           >
             <div className="prose prose-sm max-w-none">
               {criticalAlerts === 0 && warningAlerts === 0 ? (

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trend-turnover/analytics-trend-turnover.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trend-turnover/analytics-trend-turnover.tsx
@@ -137,7 +137,7 @@ export default function AnalyticsTrendTurnover() {
       />
 
       <Card
-        className="border border-white/[0.08] bg-card/80 backdrop-blur"
+        className="backdrop-blur"
         bodyClassName="space-y-4"
         label="Trend Flow"
       >
@@ -148,7 +148,7 @@ export default function AnalyticsTrendTurnover() {
       </Card>
 
       <Card
-        className="border border-white/[0.08] bg-card/80 backdrop-blur"
+        className="backdrop-blur"
         bodyClassName="space-y-4"
         label="Platform Breakdown"
       >
@@ -226,7 +226,7 @@ export default function AnalyticsTrendTurnover() {
       </Card>
 
       <Card
-        className="border border-white/[0.08] bg-card/80 backdrop-blur"
+        className="backdrop-blur"
         bodyClassName="space-y-4"
         label="Platform Volatility"
       >
@@ -255,7 +255,7 @@ export default function AnalyticsTrendTurnover() {
                     {item.turnoverRate}%
                   </span>
                 </div>
-                <div className="h-1.5 w-full bg-white/[0.06] overflow-hidden">
+                <div className="h-1.5 w-full bg-tertiary overflow-hidden">
                   <div
                     className="h-full bg-primary transition-all duration-500"
                     style={{ width: `${item.turnoverRate}%` }}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/CrossPlatformLeaderboardSection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/CrossPlatformLeaderboardSection.tsx
@@ -34,10 +34,7 @@ export default function CrossPlatformLeaderboardSection({
   return (
     <section className="grid grid-cols-1 gap-6 xl:grid-cols-3">
       {viralLeaderboard.length > 0 && (
-        <Card
-          className="xl:col-span-2 border border-white/[0.08] bg-card/80 backdrop-blur"
-          bodyClassName="space-y-6"
-        >
+        <Card className="xl:col-span-2 backdrop-blur" bodyClassName="space-y-6">
           <VStack gap={2}>
             <Heading size="xl">Cross-Platform Leaderboard</Heading>
             <Text as="p" size="sm" color="subtle-60">
@@ -148,10 +145,7 @@ export default function CrossPlatformLeaderboardSection({
       )}
 
       {creatorLeaderboard.length > 0 && (
-        <Card
-          className="border border-white/[0.08] bg-card/80 backdrop-blur"
-          bodyClassName="space-y-6"
-        >
+        <Card className="backdrop-blur" bodyClassName="space-y-6">
           <VStack gap={2}>
             <Heading size="xl">Creator watchlist</Heading>
             <Text as="p" size="sm" color="subtle-60">
@@ -166,11 +160,11 @@ export default function CrossPlatformLeaderboardSection({
               return (
                 <li
                   key={brand.id}
-                  className="flex items-start justify-between gap-4 border-b border-white/[0.08] pb-4 last:border-b-0 last:pb-0"
+                  className="flex items-start justify-between gap-4 border-b border-border pb-4 last:border-b-0 last:pb-0"
                 >
                   <div className="flex items-start gap-3">
                     {Icon && (
-                      <span className="mt-1 flex size-8 items-center justify-center rounded-full bg-background/60 text-base text-foreground/70">
+                      <span className="mt-1 flex size-8 items-center justify-center rounded-full bg-tertiary text-base text-foreground/70">
                         <Icon />
                       </span>
                     )}
@@ -179,7 +173,10 @@ export default function CrossPlatformLeaderboardSection({
                         <span className="font-semibold text-foreground">
                           {brand.handle}
                         </span>
-                        <Badge className="bg-transparent text-xs border border-white/[0.08] text-[10px] uppercase tracking-wide">
+                        <Badge
+                          variant="outline"
+                          className="text-xs text-[10px] uppercase tracking-wide"
+                        >
                           +{brand.growthRate}% 30d
                         </Badge>
                       </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/PlaybookSection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/PlaybookSection.tsx
@@ -27,10 +27,7 @@ export default function PlaybookSection({
 
   return (
     <section>
-      <Card
-        className="border border-white/[0.08] bg-card/80 backdrop-blur"
-        bodyClassName="space-y-6"
-      >
+      <Card className="backdrop-blur" bodyClassName="space-y-6">
         <VStack gap={2}>
           <Heading size="xl">Viral format playbook</Heading>
           <Text as="p" size="sm" color="subtle-60">
@@ -40,10 +37,7 @@ export default function PlaybookSection({
         </VStack>
         <ul className="space-y-4">
           {playbooks.map((pattern: ITrendPlaybook) => (
-            <li
-              key={pattern.id}
-              className=" border border-white/[0.08] bg-card/70 p-4"
-            >
+            <li key={pattern.id} className="bg-tertiary p-4">
               <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                 <div className="space-y-2">
                   <h3 className="font-semibold text-foreground">
@@ -66,7 +60,8 @@ export default function PlaybookSection({
                     return (
                       <Badge
                         key={`${pattern.id}-${platformId}`}
-                        className="bg-transparent text-xs border border-white/[0.08] text-[10px] uppercase tracking-wide"
+                        variant="outline"
+                        className="text-xs text-[10px] uppercase tracking-wide"
                       >
                         <span className="flex items-center gap-2">
                           {Icon && <Icon className="text-sm" />}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/TrendsPageHeader.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/TrendsPageHeader.tsx
@@ -25,7 +25,7 @@ export default function TrendsPageHeader({
     <header>
       <VStack gap={3}>
         <div className="flex flex-wrap items-center gap-3">
-          <Badge className="bg-info text-info-foreground text-xs uppercase tracking-wide">
+          <Badge variant="default" className="text-xs uppercase tracking-wide">
             Live sync
           </Badge>
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.tsx
@@ -62,7 +62,7 @@ export default function AnalyticsTrends() {
       {/* Trending Topics Section */}
       <section>
         <Card
-          className="border border-white/[0.08] bg-card/80 backdrop-blur"
+          className="backdrop-blur"
           bodyClassName="space-y-6"
           label="Trending Topics"
           icon={HiOutlineFire}
@@ -78,10 +78,7 @@ export default function AnalyticsTrends() {
 
       {/* Viral Video Leaderboard Section */}
       <section>
-        <Card
-          className="border border-white/[0.08] bg-card/80 backdrop-blur"
-          bodyClassName="space-y-6"
-        >
+        <Card className="backdrop-blur" bodyClassName="space-y-6">
           <ViralVideoLeaderboard
             videos={viralVideos}
             isLoading={isLoadingVideos}
@@ -95,7 +92,7 @@ export default function AnalyticsTrends() {
       {/* Trending Hashtags Section */}
       <section>
         <Card
-          className="border border-white/[0.08] bg-card/80 backdrop-blur"
+          className="backdrop-blur"
           bodyClassName="space-y-6"
           label="Trending Hashtags"
           icon={HiOutlineHashtag}
@@ -113,7 +110,7 @@ export default function AnalyticsTrends() {
       {/* Trending Sounds Section */}
       <section>
         <Card
-          className="border border-white/[0.08] bg-card/80 backdrop-blur"
+          className="backdrop-blur"
           bodyClassName="space-y-6"
           label="Trending Sounds"
           icon={HiOutlineMusicalNote}

--- a/apps/app/app/(protected)/admin/administration/announcements/announcement-compose-form.tsx
+++ b/apps/app/app/(protected)/admin/administration/announcements/announcement-compose-form.tsx
@@ -37,11 +37,11 @@ export default function AnnouncementComposeForm({
           htmlFor="announcement-body"
           className="text-sm font-medium text-foreground"
         >
-          Body <span className="text-rose-400">*</span>
+          Body <span className="text-muted-foreground">*</span>
         </label>
         <Textarea
           id="announcement-body"
-          className="w-full min-h-[160px] bg-background border border-white/10 px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 resize-y focus:outline-none focus:border-white/25 transition-colors"
+          className="w-full min-h-[160px] bg-background shadow-border px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 resize-y focus:outline-none transition-colors"
           placeholder="Write your announcement here — supports Markdown for Discord…"
           value={form.body}
           onChange={(e) => onFieldChange('body', e.target.value)}
@@ -62,7 +62,7 @@ export default function AnnouncementComposeForm({
         <div className="relative">
           <Textarea
             id="announcement-tweet"
-            className="w-full min-h-[100px] bg-background border border-white/10 px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 resize-y focus:outline-none focus:border-white/25 transition-colors"
+            className="w-full min-h-[100px] bg-background shadow-border px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 resize-y focus:outline-none transition-colors"
             placeholder="Short version for Twitter/X…"
             value={form.tweetText}
             onChange={(e) => onFieldChange('tweetText', e.target.value)}
@@ -70,7 +70,7 @@ export default function AnnouncementComposeForm({
           />
           <span
             className={`absolute bottom-2 right-3 text-xs tabular-nums ${
-              tweetOverLimit ? 'text-rose-400' : 'text-foreground/40'
+              tweetOverLimit ? 'text-error' : 'text-foreground/40'
             }`}
           >
             {tweetCharCount}/{TWEET_MAX_CHARS}
@@ -81,7 +81,7 @@ export default function AnnouncementComposeForm({
       {/* Channels */}
       <div className="flex flex-col gap-3">
         <span className="text-sm font-medium text-foreground">
-          Channels <span className="text-rose-400">*</span>
+          Channels <span className="text-muted-foreground">*</span>
         </span>
 
         <span className="flex items-center gap-3 cursor-pointer select-none">
@@ -102,12 +102,13 @@ export default function AnnouncementComposeForm({
               htmlFor="discord-channel-id"
               className="text-xs text-foreground/60"
             >
-              Discord channel ID <span className="text-rose-400">*</span>
+              Discord channel ID{' '}
+              <span className="text-muted-foreground">*</span>
             </label>
             <Input
               id="discord-channel-id"
               type="text"
-              className="w-full max-w-xs bg-background border border-white/10 px-3 py-1.5 text-sm text-foreground placeholder:text-foreground/40 focus:outline-none focus:border-white/25 transition-colors"
+              className="w-full max-w-xs bg-background shadow-border px-3 py-1.5 text-sm text-foreground placeholder:text-foreground/40 focus:outline-none transition-colors"
               placeholder="e.g. 1234567890"
               value={form.discordChannelId}
               onChange={(e) =>

--- a/apps/app/app/(protected)/admin/administration/announcements/announcement-history-list.tsx
+++ b/apps/app/app/(protected)/admin/administration/announcements/announcement-history-list.tsx
@@ -52,7 +52,7 @@ export default function AnnouncementHistoryList({
         announcements.map((announcement) => (
           <div
             key={announcement.id}
-            className="border border-white/5 bg-card p-4 space-y-3"
+            className="shadow-border bg-card p-4 space-y-3"
           >
             {/* Body preview */}
             <p className="text-sm text-foreground leading-relaxed">
@@ -76,7 +76,7 @@ export default function AnnouncementHistoryList({
 
             {/* Links row */}
             {(announcement.discordMessageUrl || announcement.tweetUrl) && (
-              <div className="flex items-center gap-3 pt-1 border-t border-white/5">
+              <div className="flex items-center gap-3 pt-1 border-t border-border">
                 {announcement.discordMessageUrl && (
                   <Button asChild variant={ButtonVariant.GHOST}>
                     <a

--- a/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.tsx
+++ b/apps/app/app/(protected)/admin/administration/warmup-accounts/warmup-accounts-page.tsx
@@ -418,7 +418,7 @@ function Field({
     <div className="flex flex-col gap-2">
       <label htmlFor={htmlFor} className="text-sm font-medium text-foreground">
         {label}
-        {required ? <span className="text-rose-400"> *</span> : null}
+        {required ? <span className="text-muted-foreground"> *</span> : null}
       </label>
       {children}
     </div>
@@ -463,10 +463,10 @@ function WarmupAccountList({
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
             onClick={() => onSelectAccount(account.id)}
-            className={`w-full border p-4 text-left transition-colors ${
+            className={`w-full p-4 text-left transition-colors ${
               isSelected
-                ? 'border-primary/50 bg-primary/5'
-                : 'border-white/5 bg-card hover:border-white/15'
+                ? 'shadow-border-strong bg-primary/5'
+                : 'shadow-border bg-card hover:shadow-border-strong'
             }`}
           >
             <div className="flex flex-wrap items-start justify-between gap-3">
@@ -494,7 +494,7 @@ function WarmupAccountList({
 function WarmupAccountDetail({ account }: { account?: IWarmupAccount }) {
   if (!account) {
     return (
-      <div className="border border-white/5 bg-card p-5">
+      <div className="shadow-border bg-card p-5">
         <CardEmpty label="Select a warm-up account" />
       </div>
     );
@@ -504,7 +504,7 @@ function WarmupAccountDetail({ account }: { account?: IWarmupAccount }) {
   const diagnostics = account.diagnostics?.steps ?? [];
 
   return (
-    <aside className="border border-white/5 bg-card p-5">
+    <aside className="shadow-border bg-card p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-base font-semibold text-foreground">
@@ -525,7 +525,7 @@ function WarmupAccountDetail({ account }: { account?: IWarmupAccount }) {
         <DetailRow label="Operator ID" value={account.operatorUserId} />
       </dl>
 
-      <div className="mt-6 border-t border-white/5 pt-5">
+      <div className="mt-6 border-t border-border pt-5">
         <h3 className="text-sm font-semibold text-foreground">Diagnostics</h3>
         {diagnostics.length === 0 ? (
           <p className="mt-2 text-sm text-foreground/50">
@@ -553,7 +553,7 @@ function WarmupAccountDetail({ account }: { account?: IWarmupAccount }) {
           </ol>
         )}
         {account.diagnostics?.error ? (
-          <p className="mt-4 border border-rose-500/20 bg-rose-500/5 p-3 text-sm text-rose-200">
+          <p className="mt-4 bg-error/10 p-3 text-sm text-error">
             {account.diagnostics.error}
           </p>
         ) : null}

--- a/apps/app/app/(protected)/admin/automation/bots/bots-page.tsx
+++ b/apps/app/app/(protected)/admin/automation/bots/bots-page.tsx
@@ -125,7 +125,9 @@ export default function BotsPage() {
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
-                        <h3 className="card-label text-lg">{bot.label}</h3>
+                        <h3 className="card-label text-sm font-semibold">
+                          {bot.label}
+                        </h3>
                         <Badge variant={getBotStatusVariant(bot.status)}>
                           {bot.status}
                         </Badge>
@@ -192,11 +194,7 @@ export default function BotsPage() {
                           </Button>
                         </li>
                         <li>
-                          <Button
-                            asChild
-                            variant={ButtonVariant.SOFT}
-                            className="text-error"
-                          >
+                          <Button asChild variant={ButtonVariant.GHOST}>
                             <Link href={`/bots/${bot.id}/delete`}>
                               <HiTrash className="size-4" />
                               Delete

--- a/apps/app/app/(protected)/admin/automation/trainings/[id]/training-detail.tsx
+++ b/apps/app/app/(protected)/admin/automation/trainings/[id]/training-detail.tsx
@@ -119,8 +119,8 @@ export default function TrainingDetail({
     return (
       <Container>
         <Card className="p-12 text-center">
-          <div className="mx-auto mb-4 size-12 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
-            <span className="text-2xl">!</span>
+          <div className="mx-auto mb-4 size-12 rounded-full bg-error/10 flex items-center justify-center">
+            <span className="text-2xl text-error">!</span>
           </div>
 
           <h3 className="text-lg font-semibold text-foreground mb-2">

--- a/apps/app/app/(protected)/admin/automation/workflows/workflows-page.tsx
+++ b/apps/app/app/(protected)/admin/automation/workflows/workflows-page.tsx
@@ -155,7 +155,7 @@ export default function WorkflowsPage() {
                     <div className="flex justify-between items-start">
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-2">
-                          <h3 className="card-label text-lg">
+                          <h3 className="card-label text-sm font-semibold">
                             {workflow.label}
                           </h3>
                           <Badge
@@ -209,9 +209,7 @@ export default function WorkflowsPage() {
                           </li>
                           <li>
                             <Button
-                              variant={ButtonVariant.UNSTYLED}
-                              withWrapper={false}
-                              className="text-error"
+                              variant={ButtonVariant.GHOST}
                               onClick={() => handleDelete(workflow)}
                             >
                               <HiTrash className="size-4" />

--- a/apps/app/app/(protected)/admin/configuration/presets/presets-list-columns.tsx
+++ b/apps/app/app/(protected)/admin/configuration/presets/presets-list-columns.tsx
@@ -28,7 +28,7 @@ export function PresetOrganizationCell({ preset }: { preset: Preset }) {
   return (
     <Badge
       className={`text-xs border border-white/[0.08] bg-transparent uppercase ${
-        isOrgPreset ? 'text-primary' : 'text-warning'
+        isOrgPreset ? 'text-primary' : 'text-muted-foreground'
       }`}
     >
       {orgLabel}

--- a/apps/app/app/(protected)/admin/content/prompts/list/prompts-page.tsx
+++ b/apps/app/app/(protected)/admin/content/prompts/list/prompts-page.tsx
@@ -158,7 +158,7 @@ function PromptsPageContent() {
                       </div>
 
                       {prompt.label && (
-                        <h3 className="text-lg font-semibold mb-2">
+                        <h3 className="text-sm font-semibold mb-2">
                           {prompt.label}
                         </h3>
                       )}
@@ -219,9 +219,7 @@ function PromptsPageContent() {
                         )}
                         <li>
                           <Button
-                            variant={ButtonVariant.UNSTYLED}
-                            withWrapper={false}
-                            className="text-error"
+                            variant={ButtonVariant.GHOST}
                             onClick={() => prompt.id && handleDelete(prompt)}
                           >
                             <HiTrash className="size-4" />

--- a/apps/app/app/(protected)/admin/content/templates/[id]/template-detail-helpers.tsx
+++ b/apps/app/app/(protected)/admin/content/templates/[id]/template-detail-helpers.tsx
@@ -15,7 +15,7 @@ export function DetailCard({
   children: ReactNode;
 }) {
   return (
-    <Card className="border border-white/[0.08]">
+    <Card>
       <VStack gap={4} className="p-6">
         <Heading size="lg">{title}</Heading>
         {children}

--- a/apps/app/app/(protected)/admin/content/templates/[id]/template-detail.tsx
+++ b/apps/app/app/(protected)/admin/content/templates/[id]/template-detail.tsx
@@ -196,7 +196,7 @@ export default function TemplateDetail({ templateId }: TemplateDetailProps) {
                 </MetadataRow>
               )}
               {template.content.structure && (
-                <Collapsible className="rounded-lg border border-white/[0.08] bg-background/50">
+                <Collapsible className="rounded-lg bg-tertiary">
                   <CollapsibleTrigger className="w-full cursor-pointer list-none px-4 py-3 text-left text-sm font-medium">
                     Structure
                   </CollapsibleTrigger>

--- a/apps/app/app/(protected)/admin/content/templates/templates-page.tsx
+++ b/apps/app/app/(protected)/admin/content/templates/templates-page.tsx
@@ -82,12 +82,12 @@ export default function TemplatesPage() {
                 >
                   <Card
                     data-testid="template-card"
-                    className="h-full transition-[transform,box-shadow,border-color] duration-200 group-hover:-translate-y-0.5 group-hover:border-white/[0.14] group-hover:shadow-[0_22px_44px_-28px_rgba(0,0,0,0.72)]"
+                    className="h-full transition-[transform,box-shadow] duration-200 group-hover:-translate-y-0.5 group-hover:shadow-border-strong"
                     bodyClassName="flex h-full flex-col gap-4 p-6"
                   >
                     <div className="space-y-4">
                       <div className="flex items-center gap-3">
-                        <h3 className="text-lg font-semibold">
+                        <h3 className="text-sm font-semibold">
                           {template.name}
                         </h3>
                         {template.isActive !== undefined && (

--- a/apps/app/app/(protected)/admin/fleet/_components/image-grid.tsx
+++ b/apps/app/app/(protected)/admin/fleet/_components/image-grid.tsx
@@ -147,9 +147,8 @@ export default function ImageGrid({
 
               {onDelete && (
                 <Button
-                  variant={ButtonVariant.UNSTYLED}
-                  withWrapper={false}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded bg-error/10 text-error hover:bg-error/20 transition-colors"
+                  variant={ButtonVariant.GHOST}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium"
                   onClick={() => onDelete(Array.from(selectedIds))}
                 >
                   <HiOutlineTrash className="size-4" />

--- a/apps/app/app/(protected)/admin/fleet/characters/characters-list.tsx
+++ b/apps/app/app/(protected)/admin/fleet/characters/characters-list.tsx
@@ -93,7 +93,7 @@ export default function CharactersList() {
               key={character.id}
               href={`/admin/fleet/characters/${character.slug}`}
             >
-              <Card className="hover:shadow-lg transition-shadow cursor-pointer h-full">
+              <Card className="hover:shadow-border-strong transition-shadow cursor-pointer h-full">
                 <div className="p-6">
                   {/* Header: Emoji + Label */}
                   <div className="flex items-center gap-3 mb-4">

--- a/apps/app/app/(protected)/admin/fleet/infrastructure/EC2InstancesSection.tsx
+++ b/apps/app/app/(protected)/admin/fleet/infrastructure/EC2InstancesSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ButtonVariant } from '@genfeedai/enums';
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { IEC2Instance } from '@genfeedai/interfaces';
 import type { TableColumn } from '@props/ui/display/table.props';
 import CardEmpty from '@ui/card/empty/CardEmpty';
@@ -35,6 +36,13 @@ export default function EC2InstancesSection({
   onEC2ActionAll,
   onRefresh,
 }: Props) {
+  const hasStartableInstance = (instances ?? []).some(
+    (instance) => instance.state === 'stopped',
+  );
+  const hasStoppableInstance = (instances ?? []).some(
+    (instance) => instance.state === 'running',
+  );
+
   return (
     <WorkspaceSurface
       className="mb-8"
@@ -46,7 +54,12 @@ export default function EC2InstancesSection({
           <Button
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
-            className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded bg-success/10 text-success hover:bg-success/20 disabled:opacity-40"
+            className={cn(
+              'flex items-center gap-1 px-3 py-2 text-sm font-medium rounded disabled:opacity-40',
+              hasStartableInstance
+                ? 'bg-success/10 text-success hover:bg-success/20'
+                : 'bg-secondary text-muted-foreground',
+            )}
             isDisabled={isActioningAll}
             onClick={() => onEC2ActionAll('start')}
           >
@@ -57,7 +70,12 @@ export default function EC2InstancesSection({
           <Button
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
-            className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded bg-error/10 text-error hover:bg-error/20 disabled:opacity-40"
+            className={cn(
+              'flex items-center gap-1 px-3 py-2 text-sm font-medium rounded disabled:opacity-40',
+              hasStoppableInstance
+                ? 'bg-destructive/10 text-destructive hover:bg-destructive/20'
+                : 'bg-secondary text-muted-foreground',
+            )}
             isDisabled={isActioningAll}
             onClick={() => onEC2ActionAll('stop')}
           >

--- a/apps/app/app/(protected)/admin/fleet/infrastructure/infrastructure-page.tsx
+++ b/apps/app/app/(protected)/admin/fleet/infrastructure/infrastructure-page.tsx
@@ -27,13 +27,6 @@ const STATE_BADGE_COLORS = {
   terminated: 'bg-foreground/5 text-foreground/40',
 } as const;
 
-const ROLE_BADGE_COLORS = {
-  images: 'bg-violet-500/10 text-violet-500',
-  training: 'bg-amber-500/10 text-amber-500',
-  videos: 'bg-blue-500/10 text-blue-500',
-  voices: 'bg-emerald-500/10 text-emerald-500',
-} as const;
-
 const POLL_INTERVAL_MS = 30_000;
 
 export default function InfrastructurePage() {
@@ -208,15 +201,7 @@ export default function InfrastructurePage() {
       header: 'Role',
       key: 'role',
       render: (instance: IEC2Instance) => (
-        <Badge
-          className={
-            ROLE_BADGE_COLORS[
-              instance.role as keyof typeof ROLE_BADGE_COLORS
-            ] ?? 'bg-foreground/5 text-foreground/60'
-          }
-        >
-          {instance.role}
-        </Badge>
+        <Badge variant="default">{instance.role}</Badge>
       ),
     },
     {

--- a/apps/app/app/(protected)/admin/fleet/pipeline/pipeline-page.tsx
+++ b/apps/app/app/(protected)/admin/fleet/pipeline/pipeline-page.tsx
@@ -160,7 +160,7 @@ export default function PipelinePage() {
       )}
 
       {/* Campaigns Table */}
-      <h3 className="text-lg font-semibold mb-4">Campaigns</h3>
+      <h3 className="text-sm font-semibold mb-4">Campaigns</h3>
 
       {!isLoadingCampaigns && (!campaigns || campaigns.length === 0) ? (
         <CardEmpty label="No campaigns found" />

--- a/apps/app/app/(protected)/admin/library/voices/voice-catalog-card.tsx
+++ b/apps/app/app/(protected)/admin/library/voices/voice-catalog-card.tsx
@@ -60,7 +60,7 @@ export default function VoiceCatalogCard({
             ) : null}
           </div>
           <div>
-            <h3 className="text-base font-semibold text-foreground">
+            <h3 className="text-sm font-semibold text-foreground">
               {getVoiceName(voice)}
             </h3>
             <p className="truncate text-xs text-foreground/50">

--- a/apps/app/app/(protected)/admin/overview/analytics/business/business-dashboard.tsx
+++ b/apps/app/app/(protected)/admin/overview/analytics/business/business-dashboard.tsx
@@ -60,7 +60,7 @@ function LeaderTable({
   valueLabel,
 }: LeaderTableProps) {
   return (
-    <Card bodyClassName="gap-0 p-4" className="border-border">
+    <Card bodyClassName="gap-0 p-4">
       <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
       {leaders.length === 0 ? (
         <p className="text-sm text-muted-foreground">No data available</p>
@@ -121,7 +121,7 @@ function ComparisonCard({
   difference,
 }: ComparisonCardProps) {
   return (
-    <Card bodyClassName="gap-0 p-4" className="border-border">
+    <Card bodyClassName="gap-0 p-4">
       <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
       <div className="flex items-end justify-between gap-4">
         <div>
@@ -160,7 +160,7 @@ function DailySeriesChart({
 }: DailySeriesChartProps) {
   if (data.length === 0) {
     return (
-      <Card bodyClassName="gap-0 p-4" className="border-border">
+      <Card bodyClassName="gap-0 p-4">
         <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
         <p className="text-sm text-muted-foreground">No data available</p>
       </Card>
@@ -171,7 +171,7 @@ function DailySeriesChart({
   const maxValue = Math.max(...values, 1);
 
   return (
-    <Card bodyClassName="gap-0 p-4" className="border-border">
+    <Card bodyClassName="gap-0 p-4">
       <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
       <div className="flex h-32 items-end gap-px">
         {data.map((point) => {
@@ -206,7 +206,7 @@ interface ProjectionCardProps {
 function ProjectionCard({ projections }: ProjectionCardProps) {
   if (projections.insufficientData) {
     return (
-      <Card bodyClassName="gap-0 p-4" className="border-border">
+      <Card bodyClassName="gap-0 p-4">
         <h3 className="mb-2 text-sm font-semibold text-foreground">
           30-Day Projections
         </h3>
@@ -219,7 +219,7 @@ function ProjectionCard({ projections }: ProjectionCardProps) {
   }
 
   return (
-    <Card bodyClassName="gap-0 p-4" className="border-border">
+    <Card bodyClassName="gap-0 p-4">
       <h3 className="mb-1 text-sm font-semibold text-foreground">
         30-Day Projections
       </h3>
@@ -372,7 +372,7 @@ export default function BusinessDashboard() {
 
       {/* Category Breakdown */}
       {data.ingredients.categoryBreakdown.length > 0 && (
-        <div className="rounded-card border border-border bg-card p-4">
+        <Card bodyClassName="gap-0 p-4">
           <h3 className="mb-3 text-sm font-semibold text-foreground">
             Ingredient Category Breakdown
           </h3>
@@ -392,7 +392,7 @@ export default function BusinessDashboard() {
               </div>
             ))}
           </div>
-        </div>
+        </Card>
       )}
 
       {/* Daily Series Charts */}

--- a/apps/app/app/(protected)/admin/overview/dashboard/overview-page.tsx
+++ b/apps/app/app/(protected)/admin/overview/dashboard/overview-page.tsx
@@ -159,9 +159,9 @@ function LeaderboardCard({ data, isLoading }: LeaderboardCardProps) {
                   className={cn(
                     'px-2 py-0.5 rounded-full text-xs font-medium',
                     org.growth > 0
-                      ? 'bg-green-500/20 text-green-400'
+                      ? 'bg-success/10 text-success'
                       : org.growth < 0
-                        ? 'bg-red-500/20 text-red-400'
+                        ? 'bg-destructive/10 text-destructive'
                         : 'bg-white/10 text-white/60',
                   )}
                 >
@@ -245,7 +245,7 @@ function StatsGrid({ stats, isLoading }: StatsGridProps) {
           return (
             <div
               key={stat.label}
-              className="rounded border border-white/[0.08] bg-white/[0.02] p-4 transition-colors hover:bg-white/[0.04]"
+              className="rounded bg-secondary shadow-border p-4 transition-colors hover:bg-hover"
             >
               <div className="text-white/30 mb-3">
                 <Icon className="size-5" />
@@ -291,7 +291,7 @@ function QuickActionsGrid() {
               bodyClassName="flex h-full flex-col justify-between p-6"
               icon={card.icon}
               iconWrapperClassName={cn('p-3', card.color)}
-              className="h-full text-left transition-[transform,box-shadow,border-color] duration-200 group-hover:-translate-y-0.5 group-hover:border-white/[0.14] group-hover:shadow-[0_22px_44px_-28px_rgba(0,0,0,0.72)]"
+              className="h-full text-left transition-[transform,box-shadow] duration-200 group-hover:-translate-y-0.5 group-hover:shadow-border-strong"
               data-testid="admin-overview-quick-action"
             >
               <div className="mt-6 flex items-center justify-between border-t border-white/[0.08] pt-4 text-sm text-white/55">
@@ -309,9 +309,7 @@ function QuickActionsGrid() {
 }
 
 function GradientDivider() {
-  return (
-    <div className="h-px bg-gradient-to-r from-transparent via-white/6 to-transparent my-8" />
-  );
+  return <div className="h-px bg-border my-8" />;
 }
 
 export default function OverviewPage() {

--- a/apps/app/app/(public)/managed-credits/success/success-content.tsx
+++ b/apps/app/app/(public)/managed-credits/success/success-content.tsx
@@ -191,7 +191,7 @@ function ManagedCreditsSuccessContentInner() {
           </p>
         </div>
 
-        <Card className="border-white/[0.08]">
+        <Card className="shadow-border border-transparent">
           <CardContent className="p-8">
             {state.isLoading ? (
               <StepDisplay
@@ -203,9 +203,7 @@ function ManagedCreditsSuccessContentInner() {
 
             {!state.isLoading && state.error ? (
               <StepDisplay
-                icon={
-                  <HiExclamationTriangle className="size-8 text-amber-500" />
-                }
+                icon={<HiExclamationTriangle className="size-8 text-warning" />}
                 title="Provisioning result not ready"
                 description={state.error}
               />
@@ -213,7 +211,7 @@ function ManagedCreditsSuccessContentInner() {
 
             {!state.isLoading && hasRecoverableExistingKey ? (
               <StepDisplay
-                icon={<HiCheckCircle className="size-8 text-emerald-500" />}
+                icon={<HiCheckCircle className="size-8 text-success" />}
                 title="Credits added"
                 description="This account already has a managed API key, so the secret cannot be shown again. Use your existing key or create a new one in Genfeed Cloud."
               />
@@ -222,7 +220,7 @@ function ManagedCreditsSuccessContentInner() {
             {!state.isLoading && apiKey ? (
               <div className="space-y-6">
                 <StepDisplay
-                  icon={<HiCheckCircle className="size-8 text-emerald-500" />}
+                  icon={<HiCheckCircle className="size-8 text-success" />}
                   title="Credits added"
                   description={`Provisioned for ${state.result?.email ?? 'your account'}. Copy this key now and store it in your local environment.`}
                 />
@@ -242,7 +240,7 @@ function ManagedCreditsSuccessContentInner() {
                 />
 
                 {state.copyError ? (
-                  <p className="text-sm text-amber-500">{state.copyError}</p>
+                  <p className="text-sm text-warning">{state.copyError}</p>
                 ) : null}
               </div>
             ) : null}
@@ -276,7 +274,7 @@ function KeyBlock({
           onClick={onCopy}
         >
           {copied ? (
-            <HiClipboardDocumentCheck className="size-4 text-emerald-500" />
+            <HiClipboardDocumentCheck className="size-4 text-success" />
           ) : (
             <HiClipboard className="size-4" />
           )}

--- a/apps/app/app/(public)/oauth/cli/content.tsx
+++ b/apps/app/app/(public)/oauth/cli/content.tsx
@@ -597,7 +597,7 @@ function CliAuthPageContent() {
           </p>
         </div>
 
-        <Card className="border-white/[0.08]">
+        <Card className="shadow-border border-transparent">
           <CardContent className="p-8">
             {(!isLoaded || flowState.step === 'validating') && (
               <StepDisplay
@@ -610,7 +610,9 @@ function CliAuthPageContent() {
             {isLoaded && flowState.step === 'signing-in' && (
               <div className="space-y-4">
                 <StepDisplay
-                  icon={<HiCommandLine className="size-8 text-blue-400" />}
+                  icon={
+                    <HiCommandLine className="size-8 text-muted-foreground" />
+                  }
                   title="Sign in required"
                   description="Sign in to authorize this device."
                 />
@@ -670,7 +672,7 @@ function CliAuthPageContent() {
             {flowState.step === 'success' && (
               <div className="space-y-6">
                 <StepDisplay
-                  icon={<HiCheckCircle className="size-8 text-emerald-500" />}
+                  icon={<HiCheckCircle className="size-8 text-success" />}
                   title="Authentication complete"
                   description={
                     isDesktopMode
@@ -767,7 +769,7 @@ function CopyKeyFallback({
           onClick={onCopy}
         >
           {copied ? (
-            <HiClipboardDocumentCheck className="size-4 text-emerald-500" />
+            <HiClipboardDocumentCheck className="size-4 text-success" />
           ) : (
             <HiClipboard className="size-4" />
           )}


### PR DESCRIPTION
## Summary

Phase 2 of #1335 — propagates the grayscale design-system contract (root `DESIGN.md`) across three app-surface groups: **analytics dashboards**, **admin/operator**, and **public/onboarding**. Restyle-in-place only — no logic, behavior, data, or copy changes. Every edit is a `className`/`variant` swap except one small state-derivation on EC2 controls (below).

**38 files** across `apps/app`. No new tokens; `DESIGN.md` / `packages/ui` / `packages/styles` untouched. Chart-series and platform-breakdown colours left intact (legal color doors).

## Fix categories

- **card-layering** — CSS-border containment (`border border-white/[0.08]`, redundant `border-border`/`shadow-[...]` stacked on `Card` primitives) → `shadow-border` inset (`hover:shadow-border-strong`). Nested cards flattened to background-layer tokens (`bg-tertiary`/`bg-hover`). Raw card-`div`s → `Card`/`bg-secondary shadow-border`. The shared `DetailCard` helper fix heals ~7 template-detail usages at once.
- **chrome-color** — decorative raw hues → grayscale tokens; **real state-driven** colour → semantic status tokens (`text-success`/`text-warning`/`text-destructive`/`text-info`, `bg-error/10` etc.) with the state branch preserved; static "Delete" actions with no error state → ghost buttons; emerald "currently-selected/default" indicators → grayscale selection (`ring-border`/`bg-hover`); `bg-neutral-950` loading → `bg-primary`; decorative/permanent `info`/`warning` label badges → grayscale `default`.
- **glow-shadow** — `hover:shadow-lg` / ad-hoc box-shadows on cards → `shadow-border-strong`; grayscale decorative gradients (cards, dividers) → flat background-layer tokens.
- **typography** — systematic `text-lg`/`text-base` card titles → 14px card-title scale (`text-sm font-semibold`); oversized headings → `tracking-tight`.

### Per-surface
- **Analytics** (9): hooks (`HookAnalysisSection`, `PlatformPerformanceSection`, `analytics-hooks`), `insights-overview`, `analytics-trend-turnover`, trends (`analytics-trends`, `CrossPlatformLeaderboardSection`, `PlaybookSection`, `TrendsPageHeader`). Alert-summary tint colours (real-count-driven) kept; only containment fixed.
- **Admin** (17): templates (`template-detail-helpers` shared card, `template-detail`, `templates-page`), `characters-list`, `business-dashboard`, `overview-page` (growth pill → success/destructive, gradient divider → flat), `infrastructure-page` + `EC2InstancesSection`, automation (`training-detail`, `bots`, `workflows`, `prompts`), announcements (compose-form, history-list), `warmup-accounts`, `presets-list-columns`, `image-grid`, `pipeline-page`, `voice-catalog-card`.
- **Public/onboarding** (12): wizard providers (`tool-list`, `action-bar`, `row-item`, `status-card`), `success-content`, `summary-content`, `proactive-workspace-sidebar`, `post-signup`, `oauth/cli/content`, `managed-credits/success`.

## Notable decisions
- **EC2 Start/Stop All** (`EC2InstancesSection`): buttons were *always* success/error tinted regardless of fleet state. Tint is now conditional on real state (`hasStartableInstance`/`hasStoppableInstance` derived from `instance.state`); `isDisabled` left unchanged to preserve behavior — only the colour now reflects state.
- **Instance-role badges** (`infrastructure-page`): no categorical role-token set exists in the theme, so role badges are grayscale (`variant="default"`); roles remain distinguishable by their text label.

## Deferred (noted, out of restyle scope)
- `confetti-celebration.tsx` — left as-is: already sources its palette from design-system CSS vars (`--success`/`--warning`/`--accent-*`), celebratory content, routes through the categorical-palette door.
- `providers-action-bar` / `providers-status-card` — outer `provider-card` wrapper border left untouched (that card-layering finding was scoped to `providers-tool-list` only).
- `gallery-page` / `generated-images-grid` — adoption note only: chrome already grayscale-clean. `generated-images-grid` is a candidate for the #1280 shared media-grid primitive (structural refactor, deliberately not bundled here).
- Path correction: the audit listed `admin/fleet/library/voices/voice-catalog-card.tsx`; the actual file is `admin/library/voices/voice-catalog-card.tsx` — the `text-base` title fix was applied there.

## Verification
- `bun run design:lint` — **0 errors** (12 pre-existing unused-token warnings unchanged)
- `bunx turbo run type-check --filter=@genfeedai/app` — **✓ 18/18**
- `biome check` (38 files), `secretlint`, `lint-no-raw-html`, `lint-no-bespoke-card` — all clean
- No colocated test asserts on the changed classes/variants; full suite runs in CI.

Refs #1335.