### PR TITLE
feat(app): monochrome harmonization — brand content routes (#1335)

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/newsletter/newsletter-composer-panel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/newsletter/newsletter-composer-panel.tsx
@@ -139,6 +139,9 @@ function composerReducer(
   }
 }
 
+const FIELD_INPUT_CLASSNAME =
+  'rounded-xl border border-white/10 bg-black/20 px-3 py-2.5 text-sm text-foreground outline-none transition focus:border-white/20';
+
 export default function NewsletterComposerPanel() {
   const { push } = useRouter();
   const notificationsService = NotificationsService.getInstance();
@@ -299,7 +302,7 @@ export default function NewsletterComposerPanel() {
                 })
               }
               placeholder="What should this issue cover?"
-              className="rounded-xl border border-white/10 bg-black/20 px-3 py-2.5 text-sm text-foreground outline-none transition focus:border-white/20"
+              className={FIELD_INPUT_CLASSNAME}
             />
           </label>
 
@@ -319,7 +322,7 @@ export default function NewsletterComposerPanel() {
                 })
               }
               placeholder="Optional framing or thesis"
-              className="rounded-xl border border-white/10 bg-black/20 px-3 py-2.5 text-sm text-foreground outline-none transition focus:border-white/20"
+              className={FIELD_INPUT_CLASSNAME}
             />
           </label>
 
@@ -354,7 +357,7 @@ export default function NewsletterComposerPanel() {
                 })
               }
               placeholder="Newsletter title"
-              className="rounded-xl border border-white/10 bg-black/20 px-3 py-2.5 text-sm text-foreground outline-none transition focus:border-white/20"
+              className={FIELD_INPUT_CLASSNAME}
             />
           </label>
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-account-bar.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-account-bar.tsx
@@ -123,7 +123,7 @@ export default function PostsWriteAccountBar({
     <>
       {hasPrefilledIngredient ? (
         <InsetSurface
-          className="border-primary/20 bg-primary/10 text-sm text-foreground/80"
+          className="bg-tertiary text-sm text-muted-foreground"
           tone="default"
         >
           A generated asset is preselected for supervised review. Save a draft

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.tsx
@@ -59,10 +59,7 @@ function PostsWritePageContent() {
       id="post-compose-workspace"
       className="grid gap-6 lg:grid-cols-[1.25fr_0.75fr]"
     >
-      <Card
-        bodyClassName="gap-0 p-6"
-        className="border-white/10 bg-white/[0.03]"
-      >
+      <Card bodyClassName="gap-0 p-6">
         <div className="grid gap-5">
           <PostsWriteAccountBar
             connectedCredentials={connectedCredentials}
@@ -148,7 +145,7 @@ function PostsWritePageContent() {
           </div>
 
           {error ? (
-            <p role="alert" className="text-sm text-red-400">
+            <p role="alert" className="text-sm text-destructive">
               {error}
             </p>
           ) : null}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx
@@ -48,7 +48,7 @@ export default function PostsWritePreviewPanel({
   selectedFormat,
 }: PostsWritePreviewPanelProps) {
   return (
-    <Card bodyClassName="gap-0 p-6" className="border-white/10 bg-white/[0.03]">
+    <Card bodyClassName="gap-0 p-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="text-lg font-medium">Preview</h2>
@@ -84,7 +84,7 @@ export default function PostsWritePreviewPanel({
                 </span>
                 <span
                   className={
-                    isOverLimit ? 'text-red-400' : 'text-foreground/40'
+                    isOverLimit ? 'text-destructive' : 'text-foreground/40'
                   }
                 >
                   {characterLimit ? `${count}/${characterLimit}` : count}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-thread-editor.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-thread-editor.tsx
@@ -42,7 +42,7 @@ export default function PostsWriteThreadEditor({
           return (
             <div
               key={`thread-segment-${index.toString()}`}
-              className="rounded-xl border border-white/10 bg-black/20 p-3"
+              className="rounded-xl bg-tertiary p-3"
             >
               <div className="mb-2 flex items-center justify-between gap-3">
                 <span className="text-xs font-medium text-foreground">
@@ -52,7 +52,7 @@ export default function PostsWriteThreadEditor({
                   <span
                     className={
                       isOverLimit
-                        ? 'text-xs text-red-400'
+                        ? 'text-xs text-destructive'
                         : 'text-xs text-foreground/45'
                     }
                   >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorPropertiesPanel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorPropertiesPanel.tsx
@@ -122,7 +122,7 @@ function EditorPropertiesPanel({
             <span className="text-xs text-muted-foreground block mb-1">
               Start
             </span>
-            <div className="text-sm font-mono bg-background border border-white/[0.08] rounded px-2 py-1">
+            <div className="text-sm font-mono bg-background shadow-border rounded px-2 py-1">
               {formatPreciseFrameTime(selectedClip.startFrame, fps)}
             </div>
           </div>
@@ -130,7 +130,7 @@ function EditorPropertiesPanel({
             <span className="text-xs text-muted-foreground block mb-1">
               Duration
             </span>
-            <div className="text-sm font-mono bg-background border border-white/[0.08] rounded px-2 py-1">
+            <div className="text-sm font-mono bg-background shadow-border rounded px-2 py-1">
               {formatPreciseFrameTime(selectedClip.durationFrames, fps)}
             </div>
           </div>
@@ -150,7 +150,7 @@ function EditorPropertiesPanel({
                   startFrame: Math.max(0, Number(e.target.value)),
                 })
               }
-              className="w-full bg-background border border-white/[0.08] rounded px-2 py-1 text-sm font-mono"
+              className="w-full bg-background shadow-border rounded px-2 py-1 text-sm font-mono"
             />
           </div>
           <div>
@@ -169,7 +169,7 @@ function EditorPropertiesPanel({
                     Math.max(1, Number(e.target.value)),
                 })
               }
-              className="w-full bg-background border border-white/[0.08] rounded px-2 py-1 text-sm font-mono"
+              className="w-full bg-background shadow-border rounded px-2 py-1 text-sm font-mono"
             />
           </div>
         </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorTimeline.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/[id]/EditorTimeline.tsx
@@ -233,10 +233,10 @@ function ClipBlock({
 
   const bgColor =
     trackType === EditorTrackType.VIDEO
-      ? 'bg-blue-500/80'
+      ? 'bg-foreground/70'
       : trackType === EditorTrackType.AUDIO
-        ? 'bg-green-500/80'
-        : 'bg-purple-500/80';
+        ? 'bg-foreground/50'
+        : 'bg-foreground/30';
 
   return (
     /* biome-ignore lint/a11y/useSemanticElements: complex drag-and-drop timeline clip with ref */
@@ -398,11 +398,11 @@ function EditorTimeline({
           withWrapper={false}
           tabIndex={-1}
           ariaLabel="Timeline playhead"
-          className="absolute top-0 bottom-0 w-0.5 bg-red-500 z-10 cursor-ew-resize"
+          className="absolute top-0 bottom-0 w-0.5 bg-foreground z-10 cursor-ew-resize"
           style={{ left: `${192 + currentFrame * zoom}px` }}
           onMouseDown={handlePlayheadDrag}
         >
-          <div className="absolute -top-1 left-1/2 -translate-x-1/2 size-3 bg-red-500 rounded-full" />
+          <div className="absolute -top-1 left-1/2 -translate-x-1/2 size-3 bg-foreground rounded-full" />
         </Button>
       </div>
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.tsx
@@ -23,27 +23,27 @@ import { ANALYTICS_EVENTS, captureAnalyticsEvent } from '@/lib/analytics';
 
 const features = [
   {
-    color: 'bg-blue-500/20 text-blue-400',
+    color: 'bg-muted text-muted-foreground',
     description:
       'Professional timeline-based video editing with multi-track support',
     icon: HiOutlineFilm,
     title: 'Timeline Editor',
   },
   {
-    color: 'bg-green-500/20 text-green-400',
+    color: 'bg-muted text-muted-foreground',
     description: 'Cut, trim, and splice clips with frame-accurate precision',
     icon: HiOutlineScissors,
     title: 'Precise Trimming',
   },
   {
-    color: 'bg-purple-500/20 text-purple-400',
+    color: 'bg-muted text-muted-foreground',
     description:
       'Synchronize audio tracks, add music, and adjust volume levels',
     icon: HiOutlineMusicalNote,
     title: 'Audio Sync',
   },
   {
-    color: 'bg-orange-500/20 text-orange-400',
+    color: 'bg-muted text-muted-foreground',
     description: 'Apply effects, transitions, and color grading to your videos',
     icon: HiOutlineSparkles,
     title: 'Effects & Transitions',
@@ -130,7 +130,9 @@ export default function EditorProjectsPage() {
             >
               <HiOutlineArrowLeft className="size-4" />
             </Link>
-            <h1 className="text-3xl font-semibold">Video Editor</h1>
+            <h1 className="text-3xl font-semibold tracking-tight">
+              Video Editor
+            </h1>
           </div>
           <p className="text-foreground/60">
             Advanced video editing with timeline, transitions, and professional
@@ -245,13 +247,12 @@ export default function EditorProjectsPage() {
               the Studio can be imported directly.
             </p>
 
-            <Link
-              href={href('/editor/new')}
-              className="inline-flex items-center gap-2 bg-primary px-6 py-3 font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-            >
-              <HiOutlinePlus className="size-5" />
-              Start New Project
-            </Link>
+            <Button asChild variant={ButtonVariant.DEFAULT}>
+              <Link href={href('/editor/new')}>
+                <HiOutlinePlus className="size-5" />
+                Start New Project
+              </Link>
+            </Button>
           </div>
         </Card>
       )}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/ingredients/library-landing-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/library/ingredients/library-landing-page.tsx
@@ -38,7 +38,7 @@ const VISUAL_CATEGORY_CARDS: LibraryCategoryCardConfig[] = [
     id: 'videos',
     kicker: 'Motion',
     label: 'Videos',
-    toneClassName: 'bg-amber-500/12 text-amber-300',
+    toneClassName: 'bg-white/[0.05] text-white/80',
   },
   {
     description: 'Stills, references, and brand visual building blocks.',
@@ -47,7 +47,7 @@ const VISUAL_CATEGORY_CARDS: LibraryCategoryCardConfig[] = [
     id: 'images',
     kicker: 'Still',
     label: 'Images',
-    toneClassName: 'bg-sky-500/12 text-sky-300',
+    toneClassName: 'bg-white/[0.05] text-white/80',
   },
   {
     description: 'Short-form loops and reaction-ready motion snippets.',
@@ -56,7 +56,7 @@ const VISUAL_CATEGORY_CARDS: LibraryCategoryCardConfig[] = [
     id: 'gifs',
     kicker: 'Loop',
     label: 'GIFs',
-    toneClassName: 'bg-emerald-500/12 text-emerald-300',
+    toneClassName: 'bg-white/[0.05] text-white/80',
   },
   {
     description: 'Character presets and presenter surfaces for video creation.',
@@ -65,7 +65,7 @@ const VISUAL_CATEGORY_CARDS: LibraryCategoryCardConfig[] = [
     id: 'avatars',
     kicker: 'Persona',
     label: 'Avatars',
-    toneClassName: 'bg-fuchsia-500/12 text-fuchsia-300',
+    toneClassName: 'bg-white/[0.05] text-white/80',
   },
 ];
 
@@ -118,8 +118,8 @@ function LibraryCategoryTile({
       aria-describedby={descriptionId}
       data-testid={testId}
       className={cn(
-        'group block h-full rounded-card border border-white/[0.08] bg-card text-card-foreground shadow-[0_24px_60px_-40px_rgba(0,0,0,0.8)] transition-[border-color,background-color,box-shadow,transform] duration-200 ease-out',
-        'hover:-translate-y-0.5 hover:border-white/[0.16] hover:bg-white/[0.02] hover:shadow-[0_28px_70px_-44px_rgba(0,0,0,0.9)]',
+        'group block h-full rounded-card bg-card text-card-foreground shadow-border transition-[background-color,box-shadow,transform] duration-200 ease-out',
+        'hover:-translate-y-0.5 hover:bg-white/[0.02] hover:shadow-border-strong',
         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
       )}
     >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx
@@ -85,9 +85,9 @@ const STATUS_LABELS: Record<string, string> = {
 
 const STATUS_STYLES: Record<string, string> = {
   archived: 'bg-white/5 text-white/38',
-  needs_review: 'bg-amber-500/15 text-amber-300',
-  open: 'bg-blue-500/15 text-blue-300',
-  resolved: 'bg-emerald-500/15 text-emerald-300',
+  needs_review: 'bg-warning/10 text-warning',
+  open: 'bg-info/10 text-info',
+  resolved: 'bg-success/10 text-success',
 };
 
 const MESSAGE_TIME = new Intl.DateTimeFormat('en', {
@@ -712,17 +712,17 @@ export default function MessagesPage() {
       </div>
 
       {error ? (
-        <div className="mb-4 rounded border border-red-500/25 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+        <div className="mb-4 rounded border border-destructive/25 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {error}
         </div>
       ) : null}
       {notice ? (
-        <div className="mb-4 rounded border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300">
+        <div className="mb-4 rounded border border-success/20 bg-success/10 px-3 py-2 text-sm text-success">
           {notice}
         </div>
       ) : null}
 
-      <div className="grid min-h-[680px] overflow-hidden rounded border border-white/[0.08] bg-card lg:grid-cols-[380px_minmax(0,1fr)]">
+      <div className="grid min-h-[680px] overflow-hidden rounded bg-card shadow-border lg:grid-cols-[380px_minmax(0,1fr)]">
         <div className="border-b border-white/[0.08] lg:border-b-0 lg:border-r">
           <div className="flex h-12 items-center justify-between border-b border-white/[0.08] px-4">
             <div className="flex items-center gap-2 text-sm font-medium text-white/76">
@@ -769,7 +769,7 @@ export default function MessagesPage() {
                       <PlatformPill platform={selectedConversation.platform} />
                       <StatusPill status={selectedConversation.status} />
                       {selectedConversation.needsReview ? (
-                        <span className="inline-flex items-center rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">
+                        <span className="inline-flex items-center rounded bg-warning/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-warning">
                           Review
                         </span>
                       ) : null}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/ContentTeamCampaignsSection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/ContentTeamCampaignsSection.tsx
@@ -95,7 +95,7 @@ export default function ContentTeamCampaignsSection({
           bodyClassName="flex flex-col items-start gap-4 p-6"
           description="Create a main orchestrator campaign to coordinate goals, budgets, and active specialists."
           icon={HiOutlineRectangleGroup}
-          iconWrapperClassName="bg-indigo-500/12 text-indigo-300"
+          iconWrapperClassName="bg-tertiary text-muted-foreground"
           label="No orchestrators launched yet"
         >
           <PrimitiveButton
@@ -118,7 +118,7 @@ export default function ContentTeamCampaignsSection({
                 campaign.brief ?? 'Coordinated multi-agent initiative.'
               }
               headerAction={
-                <span className="inline-flex rounded-full bg-blue-500/12 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-300">
+                <span className="inline-flex rounded-full bg-tertiary px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                   {campaign.status}
                 </span>
               }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/ContentTeamPage.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/ContentTeamPage.tsx
@@ -111,7 +111,7 @@ export default function ContentTeamPage() {
             bodyClassName="flex flex-col items-start gap-4 p-6"
             description="Use the hire flow to spin up specialist agents for short-form, X, image, script, and avatar work."
             icon={HiOutlineUserGroup}
-            iconWrapperClassName="bg-cyan-500/12 text-cyan-300"
+            iconWrapperClassName="bg-tertiary text-muted-foreground"
             label="No team members yet"
           >
             <PrimitiveButton

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillCatalogCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillCatalogCard.tsx
@@ -72,10 +72,7 @@ export default function SkillCatalogCard({
   stageFilter,
 }: Props) {
   return (
-    <Card
-      bodyClassName="gap-0 p-5"
-      className="rounded-3xl border-white/10 bg-black/20"
-    >
+    <Card bodyClassName="gap-0 p-5" className="rounded-3xl">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-foreground">Catalog</h2>
@@ -135,10 +132,8 @@ export default function SkillCatalogCard({
 
           return (
             <div
-              className={`relative rounded-2xl border ${
-                isSelected
-                  ? 'border-white/30 bg-white/[0.06]'
-                  : 'border-white/10 bg-white/[0.03] hover:border-white/20'
+              className={`relative rounded-2xl ${
+                isSelected ? 'bg-tertiary' : 'hover:bg-tertiary/60'
               } ${!isEnabled ? 'opacity-50' : ''}`}
               key={skill.id}
             >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillDetailCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillDetailCard.tsx
@@ -44,10 +44,7 @@ export default function SkillDetailCard({
   skillDraft,
 }: Props) {
   return (
-    <Card
-      bodyClassName="gap-0 p-5"
-      className="rounded-3xl border-white/10 bg-black/20"
-    >
+    <Card bodyClassName="gap-0 p-5" className="rounded-3xl">
       {selectedSkill ? (
         <div className="space-y-5">
           <div className="space-y-2">
@@ -127,7 +124,7 @@ export default function SkillDetailCard({
             <span className="grid gap-2 text-sm text-foreground/70">
               Name
               <Input
-                className="rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-foreground outline-none"
+                className="rounded-2xl px-3 py-2"
                 disabled={!selectedSkill.organization}
                 onChange={(event) =>
                   onSkillDraftChange((current) => ({
@@ -142,7 +139,7 @@ export default function SkillDetailCard({
             <span className="grid gap-2 text-sm text-foreground/70">
               Description
               <Textarea
-                className="min-h-24 rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-foreground outline-none"
+                className="min-h-24 rounded-2xl px-3 py-2"
                 disabled={!selectedSkill.organization}
                 onChange={(event) =>
                   onSkillDraftChange((current) => ({
@@ -157,7 +154,7 @@ export default function SkillDetailCard({
             <span className="grid gap-2 text-sm text-foreground/70">
               Default instructions
               <Textarea
-                className="min-h-28 rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-sm font-mono text-foreground outline-none"
+                className="min-h-28 rounded-2xl px-3 py-2 text-sm font-mono"
                 disabled={!selectedSkill.organization}
                 onChange={(event) =>
                   onSkillDraftChange((current) => ({
@@ -180,7 +177,7 @@ export default function SkillDetailCard({
                     runtime. Falls back to Default Instructions if empty.
                   </p>
                   <Textarea
-                    className="min-h-32 w-full rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-sm font-mono text-foreground outline-none"
+                    className="min-h-32 w-full rounded-2xl px-3 py-2 text-sm font-mono"
                     disabled={!selectedSkill.organization}
                     onChange={(event) =>
                       onSkillDraftChange((current) => ({

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillsPageHeader.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/SkillsPageHeader.tsx
@@ -22,16 +22,13 @@ export default function SkillsPageHeader({
   sourceFilter,
 }: Props) {
   return (
-    <Card
-      bodyClassName="gap-4 p-6"
-      className="rounded-3xl border-white/10 bg-black/20"
-    >
+    <Card bodyClassName="gap-4 p-6" className="rounded-3xl">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-foreground/50">
             Agent Skills
           </p>
-          <h1 className="text-3xl font-semibold text-foreground">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
             Brand content behavior
           </h1>
           <p className="max-w-3xl text-sm text-foreground/60">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunContentGrid.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunContentGrid.tsx
@@ -115,7 +115,7 @@ function ContentCard({ item }: { item: IAgentRunContentItem }) {
     );
 
   return (
-    <div className="flex flex-col gap-2 rounded border border-foreground/10 bg-background p-3">
+    <div className="flex flex-col gap-2 rounded bg-secondary p-3 shadow-border">
       <div className="flex items-center justify-between">
         <span className="flex items-center gap-1.5 text-xs text-foreground/50">
           {icon}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunHistorySection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunHistorySection.tsx
@@ -51,19 +51,19 @@ export default function AgentRunHistorySection({
             <TableHeader>
               <TableRow className="border-b border-white/5">
                 <TableHead className="h-12 w-10 px-2 text-left" />
-                <TableHead className="h-12 px-4 text-left text-[10px] font-black uppercase tracking-widest text-white/20">
+                <TableHead className="h-12 px-4 text-left text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
                   Status
                 </TableHead>
-                <TableHead className="h-12 px-4 text-left text-[10px] font-black uppercase tracking-widest text-white/20">
+                <TableHead className="h-12 px-4 text-left text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
                   Credits
                 </TableHead>
-                <TableHead className="h-12 px-4 text-left text-[10px] font-black uppercase tracking-widest text-white/20">
+                <TableHead className="h-12 px-4 text-left text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
                   Model
                 </TableHead>
-                <TableHead className="h-12 px-4 text-left text-[10px] font-black uppercase tracking-widest text-white/20">
+                <TableHead className="h-12 px-4 text-left text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
                   Duration
                 </TableHead>
-                <TableHead className="h-12 px-4 text-left text-[10px] font-black uppercase tracking-widest text-white/20">
+                <TableHead className="h-12 px-4 text-left text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
                   Started
                 </TableHead>
               </TableRow>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunRow.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunRow.tsx
@@ -90,17 +90,17 @@ export default function AgentRunRow({
           >
             <div className="space-y-4 p-4">
               <div className="flex flex-wrap gap-2 text-xs text-foreground/65">
-                <span className="rounded border border-white/10 bg-black/20 px-2 py-1">
+                <span className="rounded bg-tertiary px-2 py-1">
                   Model: {getRunModelLabel(run)}
                 </span>
                 {getRunMetadataString(run.metadata, 'routingPolicy') && (
-                  <span className="rounded border border-white/10 bg-black/20 px-2 py-1">
+                  <span className="rounded bg-tertiary px-2 py-1">
                     Routing:{' '}
                     {getRunMetadataString(run.metadata, 'routingPolicy')}
                   </span>
                 )}
                 {run.metadata?.webSearchEnabled === true && (
-                  <span className="rounded border border-white/10 bg-black/20 px-2 py-1">
+                  <span className="rounded bg-tertiary px-2 py-1">
                     Web enabled
                   </span>
                 )}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategiesEmptyState.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategiesEmptyState.tsx
@@ -14,7 +14,7 @@ export default function AgentStrategiesEmptyState({
   onAddClick,
 }: AgentStrategiesEmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-white/10 p-10 text-center">
+    <div className="flex flex-col items-center justify-center gap-4 rounded-lg bg-secondary p-10 text-center shadow-border">
       <span className="flex size-14 items-center justify-center rounded-full bg-white/5 text-white/40">
         <HiOutlineCpuChip className="size-7" />
       </span>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategiesInfoBanner.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategiesInfoBanner.tsx
@@ -10,7 +10,7 @@ export default function AgentStrategiesInfoBanner({
   workflowsHref,
 }: AgentStrategiesInfoBannerProps) {
   return (
-    <div className="mb-4 rounded-lg border border-white/10 bg-white/[0.03] p-4 text-sm text-foreground/70">
+    <div className="mb-4 rounded-lg bg-secondary p-4 text-sm text-foreground/70 shadow-border">
       <span className="font-medium text-foreground">Autopilot policies</span>{' '}
       are agent policies: they decide when an agent runs, its budget, and its
       direction. Use autopilot when the agent should adapt each run. For fixed

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategyPublishToggles.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategyPublishToggles.tsx
@@ -14,7 +14,7 @@ export default function AgentStrategyPublishToggles({
   setForm,
 }: AgentStrategyPublishTogglesProps) {
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-white/10 p-4">
+    <div className="flex flex-col gap-3 rounded-lg bg-secondary p-4 shadow-border">
       <span className="flex items-center gap-3 text-sm text-foreground">
         <Checkbox
           checked={form.autoPublishEnabled}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategySourceToggles.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/autopilot/AgentStrategySourceToggles.tsx
@@ -14,7 +14,7 @@ export default function AgentStrategySourceToggles({
   setForm,
 }: AgentStrategySourceTogglesProps) {
   return (
-    <div className="grid gap-3 rounded-lg border border-white/10 p-4 md:grid-cols-2">
+    <div className="grid gap-3 rounded-lg bg-secondary p-4 shadow-border md:grid-cols-2">
       <span className="flex items-center gap-3 text-sm text-foreground">
         <Checkbox
           checked={form.trendWatchersEnabled}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/library/AgentHubPage.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/library/AgentHubPage.tsx
@@ -79,7 +79,7 @@ function AgentCard({
     : 'Never';
 
   return (
-    <div className="rounded border border-foreground/10 bg-background p-4 flex flex-col gap-3">
+    <div className="rounded bg-secondary p-4 shadow-border flex flex-col gap-3">
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
           <span className="flex size-8 items-center justify-center rounded bg-foreground/5 text-foreground/70">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/new/AgentWizardHelpers.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/new/AgentWizardHelpers.tsx
@@ -57,10 +57,10 @@ export function SelectCardButton({
       withWrapper={false}
       variant={ButtonVariant.UNSTYLED}
       onClick={onClick}
-      className={`w-full rounded border p-4 text-left transition-colors ${
+      className={`w-full rounded p-4 text-left transition-colors ${
         isSelected
-          ? 'border-foreground bg-foreground/5'
-          : 'border-foreground/10 hover:border-foreground/30'
+          ? 'bg-tertiary shadow-border-strong'
+          : 'shadow-border hover:shadow-border-strong'
       }`}
     >
       {children}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/new/AgentWizardStepReview.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/new/AgentWizardStepReview.tsx
@@ -69,7 +69,7 @@ export default function AgentWizardStepReview({
         Review your agent configuration before launching
       </p>
 
-      <div className="rounded border border-foreground/10 divide-y divide-foreground/10">
+      <div className="rounded bg-tertiary shadow-border divide-y divide-foreground/10">
         {rows.map(({ label, value }) => (
           <div
             key={label}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestration-skills-page.tsx
@@ -319,7 +319,7 @@ export default function OrchestrationSkillsPage() {
       />
 
       {error ? (
-        <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+        <div className="rounded-2xl bg-destructive/10 px-4 py-3 text-sm text-destructive">
           {error}
         </div>
       ) : null}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestrator/OrchestratorSpecialistsSection.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/orchestrator/OrchestratorSpecialistsSection.tsx
@@ -17,7 +17,7 @@ export default function OrchestratorSpecialistsSection({
       <p className="text-sm font-medium text-foreground">
         Existing Specialists
       </p>
-      <div className="space-y-2 rounded border border-white/[0.08] p-4">
+      <div className="space-y-2 rounded bg-secondary p-4 shadow-border">
         {strategies.length === 0 ? (
           <p className="text-sm text-foreground/50">
             No existing strategies found. The blueprint can still create the
@@ -27,7 +27,7 @@ export default function OrchestratorSpecialistsSection({
           strategies.map((strategy) => (
             <span
               key={strategy.id}
-              className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-white/[0.06] px-3 py-2"
+              className="flex cursor-pointer items-center justify-between gap-3 rounded-lg bg-tertiary px-3 py-2"
             >
               <div>
                 <p className="text-sm font-medium text-foreground">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/RunRoutingInsights.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/RunRoutingInsights.tsx
@@ -65,7 +65,7 @@ export default function RunRoutingInsights({ stats }: RunRoutingInsightsProps) {
                 </div>
                 <div className="h-2 w-full overflow-hidden rounded bg-muted">
                   <div
-                    className="h-full rounded bg-emerald-500/80"
+                    className="h-full rounded bg-muted-foreground"
                     style={{ width: `${Math.max(share, 4)}%` }}
                   />
                 </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-dashboard-sections.tsx
@@ -133,7 +133,7 @@ export function OverviewTopStatStrip({
         <Card
           key={item.label}
           className={cn(
-            'ship-ui gen-shell-panel min-h-[136px] rounded-[1.25rem] border-white/[0.06] bg-background/88 shadow-[0_24px_64px_-44px_rgba(0,0,0,0.88)]',
+            'ship-ui gen-shell-panel min-h-[136px] rounded-[1.25rem]',
             item.tone,
           )}
           bodyClassName="flex h-full flex-col justify-between gap-6 p-5"

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/overview/overview-page.tsx
@@ -116,7 +116,7 @@ function SectionSummaryCard({
 }: SectionSummaryCardProps) {
   return (
     <Card
-      className="ship-ui gen-shell-panel flex h-full flex-col justify-between gap-5 rounded-[1.25rem] border-white/[0.06] bg-background/88 shadow-[0_24px_64px_-44px_rgba(0,0,0,0.88)]"
+      className="ship-ui gen-shell-panel flex h-full flex-col justify-between gap-5 rounded-[1.25rem]"
       bodyClassName="flex h-full flex-col justify-between gap-5 p-5"
     >
       <div>
@@ -124,7 +124,7 @@ function SectionSummaryCard({
           <CardIcon
             icon={Icon}
             className={cn(
-              'gen-shell-surface flex h-10 w-10 items-center justify-center rounded-2xl border-white/[0.08]',
+              'flex h-10 w-10 items-center justify-center rounded-2xl bg-secondary',
               color,
             )}
             iconClassName="h-5 w-5"
@@ -172,7 +172,7 @@ function buildSectionSummaries(
 ): SectionSummaryCardProps[] {
   return [
     {
-      color: 'bg-blue-500/12 text-blue-300',
+      color: 'text-muted-foreground',
       href: hrefFn(getPublisherPostsHref()),
       icon: HiOutlineDocumentText,
       kicker: 'Create',
@@ -193,7 +193,7 @@ function buildSectionSummaries(
       ],
     },
     {
-      color: 'bg-emerald-500/12 text-emerald-300',
+      color: 'text-muted-foreground',
       href: APP_ROUTES.ANALYTICS.OVERVIEW,
       icon: HiOutlineChartBar,
       kicker: 'Measure',
@@ -214,7 +214,7 @@ function buildSectionSummaries(
       ],
     },
     {
-      color: 'bg-violet-500/12 text-violet-300',
+      color: 'text-muted-foreground',
       href: APP_ROUTES.ORCHESTRATION.OVERVIEW,
       icon: HiOutlineCog6Tooth,
       kicker: 'Automate',
@@ -235,7 +235,7 @@ function buildSectionSummaries(
       ],
     },
     {
-      color: 'bg-amber-500/12 text-amber-300',
+      color: 'text-muted-foreground',
       href: APP_ROUTES.LIBRARY.IMAGES,
       icon: HiOutlinePhoto,
       kicker: 'Reuse',
@@ -301,13 +301,11 @@ export default function OverviewPageContent({
       {
         accent: `${stats?.completedToday ?? 0} completed today`,
         label: 'Live Runs',
-        tone: 'border-sky-400/12 bg-sky-400/[0.04]',
         value: String(stats?.activeRuns ?? activeRuns.length),
       },
       {
         accent: `${reviewInbox.pendingCount} still generating`,
         label: 'Ready To Review',
-        tone: 'border-emerald-400/12 bg-emerald-400/[0.04]',
         value: String(reviewInbox.readyCount),
       },
       {
@@ -315,13 +313,11 @@ export default function OverviewPageContent({
           ? `${analytics.bestPerformingPlatform} leads performance`
           : 'Connect more channels for ranking',
         label: 'Connected Platforms',
-        tone: 'border-violet-400/12 bg-violet-400/[0.04]',
         value: String(analytics.totalCredentialsConnected ?? 0),
       },
       {
         accent: `${stats?.failedToday ?? 0} failed today`,
         label: 'Credits Today',
-        tone: 'border-amber-400/12 bg-amber-400/[0.04]',
         value: formatCompactNumber(stats?.totalCreditsToday ?? 0),
       },
     ],
@@ -356,7 +352,7 @@ export default function OverviewPageContent({
   const cards = useMemo<OverviewCard[]>(
     () => [
       {
-        color: 'bg-sky-500/18 text-sky-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'Open Research',
         description: 'Start with the strongest live signals',
         href: APP_ROUTES.RESEARCH.DISCOVERY,
@@ -365,7 +361,7 @@ export default function OverviewPageContent({
         label: 'Research',
       },
       {
-        color: 'bg-emerald-500/18 text-emerald-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'Create Posts',
         description: 'Draft new posts, articles, and campaign assets',
         href: COMPOSE_ROUTES.ROOT,
@@ -374,7 +370,7 @@ export default function OverviewPageContent({
         label: 'Posts',
       },
       {
-        color: 'bg-amber-500/18 text-amber-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'Open Inbox',
         description:
           reviewInbox.readyCount > 0
@@ -386,7 +382,7 @@ export default function OverviewPageContent({
         label: 'Publishing Inbox',
       },
       {
-        color: 'bg-cyan-500/18 text-cyan-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'Open Schedule',
         description: 'Manage drafts, scheduled posts, and publishing windows',
         href: APP_ROUTES.POSTS.SCHEDULED,
@@ -395,7 +391,7 @@ export default function OverviewPageContent({
         label: 'Schedule',
       },
       {
-        color: 'bg-violet-500/18 text-violet-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'View Analytics',
         description: 'Track cross-platform performance',
         href: APP_ROUTES.ANALYTICS.OVERVIEW,
@@ -404,7 +400,7 @@ export default function OverviewPageContent({
         label: 'Analytics',
       },
       {
-        color: 'bg-fuchsia-500/18 text-fuchsia-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'Open Remix',
         description: 'Turn winners into follow-ups and fresh variants',
         href: APP_ROUTES.POSTS.REMIX,
@@ -413,7 +409,7 @@ export default function OverviewPageContent({
         label: 'Remix',
       },
       {
-        color: 'bg-rose-500/18 text-rose-200',
+        color: 'bg-secondary text-muted-foreground',
         cta: 'Open Agents',
         description: 'Monitor agent runs, workflows, and brand operations',
         href: APP_ROUTES.ORCHESTRATION.RUNS,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-context-review.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-context-review.tsx
@@ -29,7 +29,7 @@ export default function NewsletterContextReview({ contextPreview }: Props) {
 
       {contextPreview ? (
         <div className="space-y-4">
-          <div className="rounded-lg border border-border p-3">
+          <div className="rounded-lg bg-tertiary p-3">
             <div className="text-sm font-medium text-foreground">
               Selected continuity issues
             </div>
@@ -63,7 +63,7 @@ export default function NewsletterContextReview({ contextPreview }: Props) {
             </div>
           </div>
 
-          <div className="rounded-lg border border-border p-3">
+          <div className="rounded-lg bg-tertiary p-3">
             <div className="text-sm font-medium text-foreground">
               Context sources
             </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-editor.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-editor.tsx
@@ -57,7 +57,7 @@ export default function NewsletterEditor({
   onSave,
 }: Props) {
   return (
-    <div className="space-y-4 rounded-lg border border-border p-4">
+    <div className="space-y-4 rounded-lg bg-tertiary p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">
           <div className="flex items-center gap-2">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-generate-panel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-generate-panel.tsx
@@ -99,10 +99,10 @@ export default function NewsletterGeneratePanel({
                   key={`${proposal.title}-${proposal.angle}`}
                   variant={ButtonVariant.UNSTYLED}
                   withWrapper={false}
-                  className={`rounded-lg border p-4 text-left transition-colors ${
+                  className={`rounded-lg p-4 text-left transition-colors ${
                     isSelected
-                      ? 'border-primary bg-primary/5'
-                      : 'border-border hover:border-primary/40'
+                      ? 'shadow-border-strong bg-tertiary'
+                      : 'bg-tertiary/50 hover:bg-tertiary'
                   }`}
                   onClick={() => onSelectProposal(proposal)}
                 >
@@ -164,7 +164,7 @@ export default function NewsletterGeneratePanel({
             {publishedNewsletters.map((newsletter) => (
               <span
                 key={newsletter.id}
-                className="flex items-start gap-3 rounded-lg border border-border p-3 text-sm"
+                className="flex items-start gap-3 rounded-lg bg-tertiary p-3 text-sm"
               >
                 <Checkbox
                   checked={selectedContextSet.has(newsletter.id)}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/newsletters/newsletters-page.tsx
@@ -192,10 +192,10 @@ function NewslettersPageContent() {
                   key={newsletter.id}
                   variant={ButtonVariant.UNSTYLED}
                   withWrapper={false}
-                  className={`w-full rounded-lg border p-4 text-left transition-colors ${
+                  className={`w-full rounded-lg p-4 text-left transition-colors ${
                     newsletter.id === selectedNewsletterId
-                      ? 'border-primary bg-primary/5'
-                      : 'border-border hover:border-primary/40'
+                      ? 'shadow-border-strong bg-tertiary'
+                      : 'bg-tertiary/50 hover:bg-tertiary'
                   }`}
                   onClick={async () => {
                     setSelectedNewsletterId(newsletter.id);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/harness/HarnessHeader.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/harness/HarnessHeader.tsx
@@ -18,7 +18,7 @@ export default function HarnessHeader({
   onSave,
 }: HarnessHeaderProps) {
   return (
-    <Card className="border-border/70 bg-background/80 p-6">
+    <Card className="p-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.tsx
@@ -184,8 +184,8 @@ export default function BrandSettingsInterviewPage() {
             </div>
           )}
 
-          <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
-            <p className="text-sm text-amber-400/90">
+          <div className="rounded-md bg-secondary px-4 py-3">
+            <p className="text-sm text-muted-foreground">
               Starting a new interview uses{' '}
               <strong>{INTERVIEW_CREDIT_COST} credits</strong>. Resuming an
               existing session is free.

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetailAssetPreview.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetailAssetPreview.tsx
@@ -19,7 +19,7 @@ export default function StudioEditDetailAssetPreview({
 }: StudioEditDetailAssetPreviewProps) {
   if (!selectedIngredient.ingredientUrl) {
     return (
-      <div className="aspect-video bg-muted shadow-lg flex items-center justify-center p-16">
+      <div className="aspect-video bg-muted shadow-border flex items-center justify-center p-16">
         <span className="text-foreground/50 text-lg">No preview available</span>
       </div>
     );
@@ -51,7 +51,7 @@ export default function StudioEditDetailAssetPreview({
         <Image
           src={selectedIngredient.ingredientUrl}
           alt={selectedIngredient.metadataLabel || 'Image'}
-          className="max-w-full max-h-sidebar w-auto h-auto object-contain shadow-lg"
+          className="max-w-full max-h-sidebar w-auto h-auto object-contain shadow-border"
           width={selectedIngredient.width || 1920}
           height={selectedIngredient.height || 1080}
           priority
@@ -61,7 +61,7 @@ export default function StudioEditDetailAssetPreview({
   }
 
   return (
-    <div className="aspect-video bg-muted shadow-lg flex items-center justify-center p-16">
+    <div className="aspect-video bg-muted shadow-border flex items-center justify-center p-16">
       <span className="text-foreground/50 text-lg">No preview available</span>
     </div>
   );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetailVersionHistory.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetailVersionHistory.tsx
@@ -76,7 +76,7 @@ export default function StudioEditDetailVersionHistory({
             onClick={() => onResultClick(result.id)}
             className="cursor-pointer w-full text-left bg-transparent border-0 p-0"
           >
-            <Card className="p-3 bg-card hover:shadow-lg transition-all">
+            <Card className="p-3 bg-card transition-all">
               <div className="aspect-video bg-background overflow-hidden mb-2">
                 {result.thumbnailUrl ? (
                   <Image

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
@@ -29,32 +29,32 @@ interface ClipResultCardProps {
 
 const STATUS_CONFIG: Record<ClipStatus, { label: string; color: string }> = {
   captioning: {
-    color: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    color: 'bg-info/10 text-info border-transparent',
     label: 'Captioning',
   },
   completed: {
-    color: 'bg-green-500/20 text-green-400 border-green-500/30',
+    color: 'bg-success/10 text-success border-transparent',
     label: 'Ready',
   },
   extracting: {
-    color: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+    color: 'bg-warning/10 text-warning border-transparent',
     label: 'Generating',
   },
   failed: {
-    color: 'bg-red-500/20 text-red-400 border-red-500/30',
+    color: 'bg-destructive/10 text-destructive border-transparent',
     label: 'Failed',
   },
   pending: {
-    color: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30',
+    color: 'bg-secondary text-muted-foreground border-transparent',
     label: 'Queued',
   },
 };
 
 function ViralityBadge({ score }: ViralityBadgeProps) {
-  let color = 'text-zinc-400';
-  if (score >= 80) color = 'text-green-400';
-  else if (score >= 60) color = 'text-yellow-400';
-  else if (score >= 40) color = 'text-orange-400';
+  let color = 'text-muted-foreground';
+  if (score >= 80) color = 'text-success';
+  else if (score >= 60) color = 'text-warning';
+  else if (score >= 40) color = 'text-warning';
 
   return (
     <span className={`font-mono text-xs ${color}`} title="Virality score">
@@ -253,7 +253,7 @@ export default function ClipResultCard({
       {/* Failed state */}
       {clip.status === 'failed' && (
         <div className="mt-auto pt-2">
-          <p className="text-xs text-red-400/70">
+          <p className="text-xs text-destructive/70">
             Generation failed. The clip will be retried automatically.
           </p>
         </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx
@@ -46,7 +46,7 @@ export default function ClipsInputForm({
         </p>
       </div>
 
-      <div className="space-y-5 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6">
+      <div className="space-y-5 rounded-xl bg-secondary p-6 shadow-border">
         {/* YouTube URL */}
         <div>
           <label
@@ -116,7 +116,7 @@ export default function ClipsInputForm({
 
         {/* Error */}
         {error && (
-          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2.5 text-sm text-red-400">
+          <div className="rounded-lg bg-destructive/10 px-4 py-2.5 text-sm text-destructive">
             {error}
           </div>
         )}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
@@ -63,7 +63,7 @@ export default function ClipsProgressView({
         </div>
       ) : (
         project.status !== 'completed' && (
-          <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-800 py-20">
+          <div className="flex flex-col items-center justify-center rounded-xl bg-secondary py-20 shadow-border">
             <Spinner size={ComponentSize.LG} className="mb-4 text-primary" />
             <p className="text-sm text-zinc-500">
               Generating avatar clips for selected highlights…

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/HighlightReviewCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/HighlightReviewCard.tsx
@@ -28,15 +28,8 @@ interface HighlightReviewCardProps {
   clipsService?: ClipsApiService;
 }
 
-const CLIP_TYPE_COLORS: Record<string, string> = {
-  controversial: 'bg-red-500/20 text-red-400 border-red-500/30',
-  educational: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  hook: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-  quote: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
-  reaction: 'bg-pink-500/20 text-pink-400 border-pink-500/30',
-  story: 'bg-green-500/20 text-green-400 border-green-500/30',
-  tutorial: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
-};
+const CLIP_TYPE_BADGE_CLASSES =
+  'bg-secondary text-muted-foreground border-transparent';
 
 const PLATFORM_OPTIONS = [
   { label: 'TikTok', value: 'tiktok' },
@@ -62,10 +55,9 @@ function formatDuration(startTime: number, endTime: number): string {
 }
 
 function getViralityColor(score: number): string {
-  if (score >= 80) return 'bg-green-500/20 text-green-400 border-green-500/30';
-  if (score >= 60)
-    return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
-  return 'bg-red-500/20 text-red-400 border-red-500/30';
+  if (score >= 80) return 'bg-success/10 text-success border-transparent';
+  if (score >= 60) return 'bg-warning/10 text-warning border-transparent';
+  return 'bg-destructive/10 text-destructive border-transparent';
 }
 
 type RewriteState = {
@@ -123,9 +115,6 @@ export default function HighlightReviewCard({
 }: HighlightReviewCardProps) {
   const duration = formatDuration(highlight.start_time, highlight.end_time);
   const viralityColor = getViralityColor(highlight.virality_score);
-  const clipTypeColor =
-    CLIP_TYPE_COLORS[highlight.clip_type] ||
-    'bg-zinc-500/20 text-zinc-400 border-zinc-500/30';
 
   // Viral rewrite state
   const [
@@ -176,10 +165,8 @@ export default function HighlightReviewCard({
 
   return (
     <div
-      className={`rounded-xl border p-4 transition-all ${
-        selected
-          ? 'border-primary/50 bg-primary/5'
-          : 'border-zinc-800 bg-zinc-900/50 opacity-60'
+      className={`rounded-xl border p-4 shadow-border transition-all ${
+        selected ? 'border-primary/50 bg-primary/5' : 'bg-secondary opacity-60'
       }`}
     >
       {/* Header: checkbox + title + badges */}
@@ -192,7 +179,7 @@ export default function HighlightReviewCard({
           <Input
             value={highlight.title}
             onChange={(e) => onTitleEdit(e.target.value)}
-            className="w-full bg-transparent text-sm font-medium text-zinc-100 outline-none placeholder-zinc-600 focus:border-b focus:border-primary"
+            className="w-full bg-transparent text-sm font-medium text-foreground outline-none placeholder-muted-foreground focus:border-b focus:border-primary"
           />
 
           <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -207,7 +194,7 @@ export default function HighlightReviewCard({
             {/* Clip type */}
             <Badge
               variant="outline"
-              className={`rounded-full px-2 py-0.5 text-[10px] font-medium capitalize ${clipTypeColor}`}
+              className={`rounded-full px-2 py-0.5 text-[10px] font-medium capitalize ${CLIP_TYPE_BADGE_CLASSES}`}
             >
               {highlight.clip_type}
             </Badge>
@@ -215,7 +202,7 @@ export default function HighlightReviewCard({
             {/* Duration */}
             <Badge
               variant="outline"
-              className="rounded-full border-zinc-700 bg-zinc-800/50 px-2 py-0.5 text-[10px] font-medium text-zinc-400"
+              className="rounded-full border-transparent bg-secondary px-2 py-0.5 text-[10px] font-medium text-muted-foreground"
             >
               {duration}
             </Badge>
@@ -273,13 +260,16 @@ export default function HighlightReviewCard({
 
           {/* Make it viral button */}
           <Button
-            variant={ButtonVariant.UNSTYLED}
-            className="flex items-center gap-1 rounded bg-gradient-to-r from-purple-600 to-pink-600 px-3 py-1 text-[11px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            variant={ButtonVariant.DEFAULT}
+            className="flex items-center gap-1 rounded px-3 py-1 text-[11px] font-medium"
             onClick={handleViralRewrite}
             disabled={isRewriting}
           >
             {isRewriting ? (
-              <Spinner size={ComponentSize.XS} className="text-white" />
+              <Spinner
+                size={ComponentSize.XS}
+                className="text-primary-foreground"
+              />
             ) : null}
             <span>{isRewriting ? 'Rewriting...' : 'Make it viral'}</span>
           </Button>
@@ -288,7 +278,7 @@ export default function HighlightReviewCard({
           {hasBeenRewritten && (
             <Button
               variant={ButtonVariant.UNSTYLED}
-              className="text-[11px] text-zinc-500 hover:text-zinc-300"
+              className="text-[11px] text-muted-foreground hover:text-foreground"
               onClick={handleRestoreOriginal}
             >
               Restore original
@@ -299,7 +289,9 @@ export default function HighlightReviewCard({
 
       {/* Rewrite error */}
       {rewriteError && (
-        <div className="mt-1.5 text-[11px] text-red-400">{rewriteError}</div>
+        <div className="mt-1.5 text-[11px] text-destructive">
+          {rewriteError}
+        </div>
       )}
 
       {/* Tags */}
@@ -309,7 +301,7 @@ export default function HighlightReviewCard({
             <Badge
               key={tag}
               variant="secondary"
-              className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-500"
+              className="rounded bg-secondary px-1.5 py-0.5 text-[10px] text-muted-foreground"
             >
               #{tag}
             </Badge>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
@@ -115,7 +115,7 @@ export default function StudioClipsPage() {
             </p>
           </div>
         ) : project.status === 'failed' ? (
-          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+          <div className="rounded-lg border border-transparent bg-destructive/10 px-4 py-3 text-sm text-destructive">
             Analysis failed. Check the YouTube URL and try again.
           </div>
         ) : (
@@ -140,7 +140,7 @@ export default function StudioClipsPage() {
             </div>
 
             {/* Avatar & Voice config */}
-            <div className="mt-6 space-y-4 rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
+            <div className="mt-6 space-y-4 rounded-xl bg-secondary p-4 shadow-border">
               <h3 className="text-sm font-medium text-zinc-300">
                 Avatar Configuration
               </h3>
@@ -214,7 +214,7 @@ export default function StudioClipsPage() {
 
             {/* Error */}
             {error && (
-              <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2.5 text-sm text-red-400">
+              <div className="mt-4 rounded-lg bg-destructive/10 px-4 py-2.5 text-sm text-destructive">
                 {error}
               </div>
             )}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-comments-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-comments-card.tsx
@@ -54,7 +54,7 @@ export default function IssueCommentsCard({
             type="button"
             variant={ButtonVariant.GHOST}
             size={ButtonSize.XS}
-            className="flex items-center gap-1 text-[10px] text-blue-400 hover:text-blue-300"
+            className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
             onClick={onScrollToLatest}
           >
             <HiOutlineChevronDoubleDown className="size-3" />

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-detail.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-detail.tsx
@@ -314,7 +314,7 @@ export default function IssueDetail({
             <p className="text-sm text-white/50">Issue not found</p>
             <Link
               href={APP_ROUTES.TASKS.ROOT}
-              className="mt-3 text-xs text-blue-400 hover:text-blue-300"
+              className="mt-3 text-xs text-muted-foreground hover:text-foreground"
             >
               Back to issues
             </Link>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-sidebar.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-sidebar.tsx
@@ -98,7 +98,7 @@ export default function IssueSidebar({
                 <DefinitionDetail variant="inline">
                   <Link
                     href={`/tasks/${issue.parentId}`}
-                    className="text-blue-400 hover:text-blue-300"
+                    className="text-muted-foreground hover:text-foreground"
                   >
                     View parent
                   </Link>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issue-overlay.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issue-overlay.tsx
@@ -183,7 +183,7 @@ export default function IssueOverlay({ issue, onClose }: IssueOverlayProps) {
       openDetailLabel="Open full page"
       onClose={onClose}
       width="xl"
-      surface="gradient"
+      surface="flat"
     >
       <div className="space-y-4 p-4">
         {issue.description && (

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
@@ -408,10 +408,10 @@ function RunActivityChart({ trends }: { trends: AgentRunTrendPoint[] }) {
         />
         <Tooltip
           contentStyle={{
-            background: '#111111',
-            border: '1px solid rgba(255,255,255,0.08)',
+            background: 'hsl(var(--popover))',
+            border: '1px solid hsl(var(--border))',
             borderRadius: '12px',
-            color: '#fff',
+            color: 'hsl(var(--foreground))',
             fontSize: '12px',
           }}
         />
@@ -457,10 +457,10 @@ function RunsByStatusChart({ runs }: { runs: IAgentRun[] }) {
         />
         <Tooltip
           contentStyle={{
-            background: '#111111',
-            border: '1px solid rgba(255,255,255,0.08)',
+            background: 'hsl(var(--popover))',
+            border: '1px solid hsl(var(--border))',
             borderRadius: '12px',
-            color: '#fff',
+            color: 'hsl(var(--foreground))',
             fontSize: '12px',
           }}
         />
@@ -509,10 +509,10 @@ function SuccessRateChart({ trends }: { trends: AgentRunTrendPoint[] }) {
         />
         <Tooltip
           contentStyle={{
-            background: '#111111',
-            border: '1px solid rgba(255,255,255,0.08)',
+            background: 'hsl(var(--popover))',
+            border: '1px solid hsl(var(--border))',
             borderRadius: '12px',
-            color: '#fff',
+            color: 'hsl(var(--foreground))',
             fontSize: '12px',
           }}
           formatter={(value: unknown) => [`${String(value ?? 0)}%`, 'Rate']}
@@ -558,10 +558,10 @@ function CreditsByDayChart({ trends }: { trends: AgentRunTrendPoint[] }) {
         />
         <Tooltip
           contentStyle={{
-            background: '#111111',
-            border: '1px solid rgba(255,255,255,0.08)',
+            background: 'hsl(var(--popover))',
+            border: '1px solid hsl(var(--border))',
             borderRadius: '12px',
-            color: '#fff',
+            color: 'hsl(var(--foreground))',
             fontSize: '12px',
           }}
         />

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-composer.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-composer.tsx
@@ -61,7 +61,7 @@ export function WorkspaceTaskComposer({
 
   return (
     <Modal.Root open={open} onOpenChange={handleModalOpenChange}>
-      <Modal.Content size="lg" className="border-white/10 bg-[#111111]">
+      <Modal.Content size="lg" className="border-white/10 bg-secondary">
         <Modal.Header>
           <Modal.Title>New Task</Modal.Title>
           <Modal.Description>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-inspector-body.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-inspector-body.tsx
@@ -112,7 +112,7 @@ export function WorkspaceTaskInspectorBody({
       {linkedRunSummary.reportThreadId ? (
         <Card
           label="Report location"
-          bodyClassName="space-y-3 border-l border-sky-400/30 p-4 text-sm text-foreground/75"
+          bodyClassName="space-y-3 border-l border-border p-4 text-sm text-foreground/75"
         >
           <p>
             This task&apos;s report lives in the linked agent thread, not in the

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-inspector.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-inspector.tsx
@@ -63,7 +63,7 @@ export function WorkspaceTaskInspector({
     <Sheet open={Boolean(task)} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
-        className="w-full overflow-y-auto border-white/10 bg-[#090909] p-0 sm:max-w-2xl"
+        className="w-full overflow-y-auto border-white/10 bg-background p-0 sm:max-w-2xl"
       >
         {task ? (
           <div

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-outputs-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-outputs-card.tsx
@@ -39,7 +39,7 @@ export function WorkspaceTaskOutputsCard({
   return (
     <Card
       label="Generated outputs"
-      bodyClassName="space-y-3 border-l border-emerald-400/25 p-4 text-sm text-foreground/75"
+      bodyClassName="space-y-3 border-l border-border p-4 text-sm text-foreground/75"
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="text-sm text-foreground/70">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-thread-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-task-thread-card.tsx
@@ -18,7 +18,7 @@ export function WorkspaceTaskThreadCard({
   return (
     <Card
       label="Task thread"
-      bodyClassName="space-y-3 border-l border-sky-400/30 p-4 text-sm text-foreground/75"
+      bodyClassName="space-y-3 border-l border-border p-4 text-sm text-foreground/75"
     >
       <div
         className="divide-y divide-white/10"

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -25,7 +25,7 @@ function BrandCard({ brand, orgSlug }: { brand: Brand; orgSlug: string }) {
   return (
     <Link
       href={cardHref}
-      className="group flex flex-col gap-4 rounded-card border border-border bg-card p-5 transition hover:border-border-strong hover:bg-foreground/[0.04]"
+      className="group flex flex-col gap-4 rounded-card bg-card p-5 shadow-border transition hover:shadow-border-strong hover:bg-foreground/[0.04]"
     >
       <div className="flex items-center gap-3">
         {brand.logoUrl ? (
@@ -116,7 +116,7 @@ export default function OrgLandingContent() {
         </div>
         <Link
           href={orgHref('/settings/brands')}
-          className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.03] px-3.5 py-2 text-sm font-medium text-foreground/70 transition hover:border-border-strong hover:bg-foreground/[0.06] hover:text-foreground"
+          className="inline-flex items-center gap-2 rounded-lg bg-foreground/[0.03] px-3.5 py-2 text-sm font-medium text-foreground/70 shadow-border transition hover:shadow-border-strong hover:bg-foreground/[0.06] hover:text-foreground"
         >
           <HiPlus className="size-4" />
           New Brand

--- a/apps/app/app/(protected)/root-resolver-client.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.tsx
@@ -98,7 +98,5 @@ export default function ProtectedRootResolver() {
     selectedBrand,
   ]);
 
-  return (
-    <PageLoadingState className="bg-neutral-950" message={statusMessage} />
-  );
+  return <PageLoadingState className="bg-background" message={statusMessage} />;
 }

--- a/apps/app/app/oauth/[platform]/oauth-platform-form.tsx
+++ b/apps/app/app/oauth/[platform]/oauth-platform-form.tsx
@@ -109,7 +109,7 @@ function OAuthPlatformFormContent({ platform }: OAuthPlatformFormProps) {
 
         {result.status === 'success' && (
           <div className="space-y-4">
-            <HiCheckCircle className="mx-auto text-5xl text-green-500" />
+            <HiCheckCircle className="mx-auto text-5xl text-success" />
             <h2 className="text-lg font-semibold">{platformLabel} Connected</h2>
             <p className="text-sm text-muted-foreground">
               Redirecting you back…
@@ -119,7 +119,7 @@ function OAuthPlatformFormContent({ platform }: OAuthPlatformFormProps) {
 
         {result.status === 'error' && (
           <div className="space-y-4">
-            <HiXCircle className="mx-auto text-5xl text-red-500" />
+            <HiXCircle className="mx-auto text-5xl text-destructive" />
             <h2 className="text-lg font-semibold">Connection Failed</h2>
             <p className="text-sm text-muted-foreground">
               {result.errorMessage}


### PR DESCRIPTION
## Summary

**Phase 2 of #1335** — scoped restyle-in-place across **56 brand content route files** so Genfeed app chrome is fully grayscale (the neutral studio / gallery wall). Colour now enters only through the four legal `DESIGN.md` doors: **user content**, **platform identifiers**, **state-driven semantic status**, **categorical palettes**.

This is a Phase PR (one of several); it does **not** close #1335.

## Categories fixed

| Category | What changed | ~count |
|---|---|---|
| **card-layering** | Dropped className `border`/`bg`/`shadow-[…]` overrides on `Card` primitives (`CardVariant.DEFAULT` already renders `shadow-border bg-card hover:shadow-border-strong`). Swapped raw `border-white/…` / `border-border` / `bg-black/20` / raw-zinc containment on card-like panels for `bg-card`/`bg-secondary` + `shadow-border`. Flattened nested cards to `bg-tertiary` (single ring). | ~26 files |
| **chrome-color** | Replaced decorative raw Tailwind hues (blue/emerald/amber/sky/fuchsia/indigo/cyan/violet/zinc, 7-hue rainbows, per-metric tints) and hardcoded hex (`#111111`/`#090909`/`neutral-950`, recharts `contentStyle`) on chrome with grayscale layer/text tokens. **State-driven** badges/banners kept their meaning via semantic tokens (`text-destructive`/`success`/`warning`/`info`, `bg-*/10`) branching by real state; single-hue "always-on" badges grayscaled. | ~24 files |
| **glow-shadow** | Purple→pink gradient CTA → accent `Button`; `EntityOverlayShell` `gradient` surface → `flat`; removed `hover:shadow-lg` and halo shadow literals. | ~4 files |
| **typography** | `tracking-tight` on oversized page/card titles. | ~3 files |

## Notable judgment calls (verified against real state)
- **Campaign status badge**, **clip-type badges**, **overview stat "tone"**, **credit-cost box**, **section-identity `border-l` accents** — confirmed one fixed hue regardless of value → **grayscaled** (decoration, not state).
- **Score-threshold**, **clip status**, **conversation status**, **oauth success/fail** — genuinely branch by runtime state → kept meaning via **semantic tokens**.
- **Editor track chips / playhead** — grayscaled via achromatic opacity ramp / `bg-foreground` (chrome, not state).
- **`bg-primary` correction** — two agents mapped a deepest-background hex to `bg-primary` (the achromatic *accent* token that inverts to white in light mode); corrected to `bg-background` (theme-relative background layer).

## Scope
`apps/app` brand content routes only (overview, orchestration, compose, newsletters, library, studio/clips, editor, messages, tasks, workspace, settings) + `org-landing`, `root-resolver`, `oauth` form. **No token / `DESIGN.md` / `packages/ui` / `packages/styles` changes.**

## Verification
- `bun run design:lint` — **0 errors, no new tokens** (12 pre-existing DESIGN.md unused-token warnings, unrelated).
- `biome check` — clean (56 files).
- Pre-commit hooks — `lint-no-raw-html`, `lint-no-bespoke-card`, secretlint all pass.
- **96 colocated component tests pass** (23 test files) — restyle + structural changes (Link→`Button asChild`, const-map renames, `tone` removal) are behavior-safe.
- Full `type-check` deferred to CI per repo local-verification policy (OOMs locally).

## Deferred to shared-foundation PR
None required — every fix used existing tokens. `StudioEditDetailAssetPreview` `MediaCanvasShell`/`AmbientColorWash` adoption deferred (those components do not yet exist in the repo); chrome grayscaled in the interim.

Refs #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)