### PR TITLE
feat(app): monochrome harmonization — shared pages & workflow-ui chrome (#1335)

### DIFF
--- a/packages/pages/agents/campaigns/AgentCampaignAgentsList.tsx
+++ b/packages/pages/agents/campaigns/AgentCampaignAgentsList.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export default function AgentCampaignAgentsList({ agents }: Props) {
   return (
-    <div className="border border-white/[0.08] bg-background p-4">
+    <div className="bg-card p-4 shadow-border">
       <h3 className="mb-4 text-lg font-semibold">
         Agent Strategies ({agents.length})
       </h3>
@@ -19,7 +19,7 @@ export default function AgentCampaignAgentsList({ agents }: Props) {
           {agents.map((agentId) => (
             <div
               key={agentId}
-              className="flex items-center justify-between border border-white/[0.04] p-3"
+              className="flex items-center justify-between bg-secondary p-3"
             >
               <span className="text-sm font-mono text-foreground/70">
                 {agentId}

--- a/packages/pages/agents/campaigns/AgentCampaignContentQuota.tsx
+++ b/packages/pages/agents/campaigns/AgentCampaignContentQuota.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export default function AgentCampaignContentQuota({ contentQuota }: Props) {
   return (
-    <div className="border border-white/[0.08] bg-background p-4">
+    <div className="bg-card p-4 shadow-border">
       <h3 className="mb-4 text-lg font-semibold">Content Quota</h3>
       <div className="grid grid-cols-3 gap-4">
         {contentQuota.posts !== undefined && (

--- a/packages/pages/agents/campaigns/AgentCampaignsPage.tsx
+++ b/packages/pages/agents/campaigns/AgentCampaignsPage.tsx
@@ -38,10 +38,10 @@ const STATUS_BADGE_VARIANTS: Record<
 };
 
 const STATUS_DOT_CLASSES: Record<CampaignStatus, string> = {
-  active: 'bg-emerald-400 animate-pulse',
-  completed: 'bg-emerald-400',
-  draft: 'bg-zinc-400',
-  paused: 'bg-amber-400',
+  active: 'bg-success animate-pulse',
+  completed: 'bg-success',
+  draft: 'bg-muted-foreground',
+  paused: 'bg-warning',
 };
 
 function formatDate(dateStr: string | undefined): string {
@@ -94,19 +94,21 @@ function CampaignStatsStrip({ campaigns }: { campaigns: AgentCampaign[] }) {
     return [
       {
         accent: `${campaigns.length} total`,
-        icon: <HiOutlinePlayCircle className="size-4 text-emerald-400" />,
+        icon: <HiOutlinePlayCircle className="size-4 text-muted-foreground" />,
         label: 'Active Campaigns',
         value: String(activeCampaigns.length),
       },
       {
         accent: `of ${totalCreditsAllocated.toLocaleString()} allocated`,
-        icon: <HiOutlineCurrencyDollar className="size-4 text-purple-400" />,
+        icon: (
+          <HiOutlineCurrencyDollar className="size-4 text-muted-foreground" />
+        ),
         label: 'Total Credits Used',
         value: totalCreditsUsed.toLocaleString(),
       },
       {
         accent: `${Math.round(totalCreditsAllocated > 0 ? (totalCreditsUsed / totalCreditsAllocated) * 100 : 0)}% utilization`,
-        icon: <HiOutlineBolt className="size-4 text-amber-400" />,
+        icon: <HiOutlineBolt className="size-4 text-muted-foreground" />,
         label: 'Credits Allocated',
         value: totalCreditsAllocated.toLocaleString(),
       },
@@ -114,7 +116,7 @@ function CampaignStatsStrip({ campaigns }: { campaigns: AgentCampaign[] }) {
         accent: nextOrchestration
           ? formatRelativeTime(nextOrchestration)
           : 'no scheduled runs',
-        icon: <HiOutlineClock className="size-4 text-cyan-400" />,
+        icon: <HiOutlineClock className="size-4 text-muted-foreground" />,
         label: 'Next Orchestration',
         value: nextOrchestration ? formatDate(nextOrchestration) : '—',
       },
@@ -167,7 +169,7 @@ function CampaignCard({ campaign }: { campaign: AgentCampaign }) {
       : 0;
 
   return (
-    <div className="group relative flex flex-col gap-3 rounded-lg border border-white/[0.08] bg-white/[0.02] p-4 transition-colors hover:border-white/[0.14] hover:bg-white/[0.04]">
+    <div className="group relative flex flex-col gap-3 rounded-lg bg-card p-4 shadow-border transition-colors hover:shadow-border-strong">
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2.5">
           <div className="flex size-8 items-center justify-center rounded-full border border-white/[0.12] bg-white/[0.06]">
@@ -206,7 +208,7 @@ function CampaignCard({ campaign }: { campaign: AgentCampaign }) {
       </div>
 
       {campaign.brief && (
-        <div className="min-h-[40px] rounded border border-white/[0.06] bg-black/40 px-3 py-2">
+        <div className="min-h-[40px] rounded bg-secondary px-3 py-2">
           <p className="line-clamp-2 text-[11px] text-foreground/40 leading-relaxed">
             {campaign.brief}
           </p>
@@ -226,7 +228,7 @@ function CampaignCard({ campaign }: { campaign: AgentCampaign }) {
 
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/[0.06]">
         <div
-          className="h-full rounded-full bg-emerald-500/60 transition-all"
+          className="h-full rounded-full bg-foreground/60 transition-all"
           style={{ width: `${creditsPercent}%` }}
         />
       </div>
@@ -287,7 +289,7 @@ function ProgressBar({ allocated, used }: { allocated: number; used: number }) {
     <div className="flex items-center gap-2">
       <div className="h-1.5 w-16 overflow-hidden rounded-full bg-white/[0.06]">
         <div
-          className="h-full rounded-full bg-emerald-500/60 transition-all"
+          className="h-full rounded-full bg-foreground/60 transition-all"
           style={{ width: `${percent}%` }}
         />
       </div>
@@ -344,8 +346,8 @@ export default function AgentCampaignsPage() {
               className={cn(
                 'inline-block h-1.5 w-1.5 rounded-full',
                 campaign.orchestrationEnabled
-                  ? 'bg-emerald-400'
-                  : 'bg-zinc-500',
+                  ? 'bg-success'
+                  : 'bg-muted-foreground',
               )}
             />
             <span className="text-sm text-foreground/70">

--- a/packages/pages/agents/campaigns/OutreachCampaignAddTargets.tsx
+++ b/packages/pages/agents/campaigns/OutreachCampaignAddTargets.tsx
@@ -24,7 +24,7 @@ export default function OutreachCampaignAddTargets({
 }: Props) {
   if (campaignType === CampaignType.DM_OUTREACH) {
     return (
-      <div className="border border-white/[0.08] bg-background p-4">
+      <div className="bg-card p-4 shadow-border">
         <h3 className="mb-4 text-lg font-semibold">Add DM Recipients</h3>
         <Textarea
           placeholder="Paste usernames (one per line)&#10;@johndoe&#10;janedoe&#10;@creator123"
@@ -51,7 +51,7 @@ export default function OutreachCampaignAddTargets({
   }
 
   return (
-    <div className="border border-white/[0.08] bg-background p-4">
+    <div className="bg-card p-4 shadow-border">
       <h3 className="mb-4 text-lg font-semibold">Add Target URLs</h3>
       <Textarea
         placeholder="Paste tweet or Reddit URLs (one per line)&#10;https://twitter.com/user/status/123456789&#10;https://reddit.com/r/subreddit/comments/abc123/title"

--- a/packages/pages/agents/campaigns/OutreachCampaignWizardStep5.tsx
+++ b/packages/pages/agents/campaigns/OutreachCampaignWizardStep5.tsx
@@ -28,7 +28,7 @@ export default function OutreachCampaignWizardStep5({
 }: OutreachCampaignWizardStep5Props) {
   return (
     <div className="space-y-6">
-      <div className=" border border-white/[0.08] p-4">
+      <div className="bg-card p-4 shadow-border">
         <h3 className="mb-4 font-semibold">Review Your Campaign</h3>
 
         <div className="grid grid-cols-2 gap-4 text-sm">

--- a/packages/pages/agents/library/LivestreamChatBotPage.tsx
+++ b/packages/pages/agents/library/LivestreamChatBotPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ButtonVariant } from '@genfeedai/enums';
+import Card from '@ui/card/Card';
 import Textarea from '@ui/inputs/textarea/Textarea';
 import Container from '@ui/layout/container/Container';
 import { Button } from '@ui/primitives/button';
@@ -83,7 +84,7 @@ export default function LivestreamChatBotPage({
           twitchLastPostedAt={twitchStatus?.lastPostedAt}
         />
 
-        <div className="gen-glass rounded-xl p-6">
+        <Card className="p-6">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h2 className="text-lg font-semibold">Runtime Controls</h2>
@@ -184,7 +185,7 @@ export default function LivestreamChatBotPage({
               />
             </div>
           </div>
-        </div>
+        </Card>
 
         <LivestreamSessionPanels
           recentDeliveries={recentDeliveries}

--- a/packages/pages/agents/library/LivestreamSessionPanels.tsx
+++ b/packages/pages/agents/library/LivestreamSessionPanels.tsx
@@ -15,7 +15,7 @@ export default function LivestreamSessionPanels({
   return (
     <div className="grid gap-6 lg:grid-cols-2">
       <Card className="p-6">
-        <h2 className="text-lg font-semibold">Current Context</h2>
+        <h2 className="text-sm font-medium tracking-tight">Current Context</h2>
         <div className="mt-4 space-y-2 text-sm">
           <p>
             <span className="font-medium">Source:</span>{' '}
@@ -33,7 +33,9 @@ export default function LivestreamSessionPanels({
       </Card>
 
       <Card className="p-6">
-        <h2 className="text-lg font-semibold">Recent Deliveries</h2>
+        <h2 className="text-sm font-medium tracking-tight">
+          Recent Deliveries
+        </h2>
         <div className="mt-4 space-y-3">
           {recentDeliveries.length === 0 ? (
             <p className="text-sm text-muted-foreground">
@@ -43,7 +45,7 @@ export default function LivestreamSessionPanels({
             recentDeliveries.map((delivery) => (
               <div
                 key={delivery.id}
-                className="rounded-lg border border-white/[0.08] p-3 text-sm"
+                className="rounded-lg bg-secondary p-3 text-sm"
               >
                 <div className="flex items-center justify-between gap-3">
                   <span className="font-medium">

--- a/packages/pages/agents/tasks/CronJobForm.tsx
+++ b/packages/pages/agents/tasks/CronJobForm.tsx
@@ -76,12 +76,12 @@ export default function CronJobForm({
   workflowsHref,
 }: CronJobFormProps) {
   return (
-    <div className="mb-4 rounded border border-white/10 bg-white/[0.02] p-4">
+    <div className="mb-4 rounded bg-card p-4 shadow-border">
       <div className="mb-3 text-sm font-semibold">
         {form.id ? 'Edit Cron Job' : 'Create Cron Job'}
       </div>
       {form.jobType === 'workflow_execution' && (
-        <div className="mb-4 rounded border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-muted-foreground">
+        <div className="mb-4 rounded bg-secondary px-3 py-2 text-xs text-muted-foreground">
           Workflow schedules start in{' '}
           <Link
             href={workflowsHref}

--- a/packages/pages/agents/tasks/CronJobRunHistory.tsx
+++ b/packages/pages/agents/tasks/CronJobRunHistory.tsx
@@ -38,36 +38,36 @@ export default function CronJobRunHistory({
   onSetTriggerFilter,
 }: CronJobRunHistoryProps) {
   return (
-    <div className="mt-5 rounded border border-white/10 bg-white/[0.02] p-4">
+    <div className="mt-5 rounded bg-card p-4 shadow-border">
       <div className="mb-2 flex items-center justify-between">
         <div className="text-sm font-semibold">Run History: {jobName}</div>
         <Button label="Close" className="h-7 px-2 text-xs" onClick={onClose} />
       </div>
 
       {isRunsLoading ? (
-        <div className="text-xs text-white/60">Loading runs…</div>
+        <div className="text-xs text-muted-foreground">Loading runs…</div>
       ) : runs.length === 0 ? (
-        <div className="text-xs text-white/60">No runs yet.</div>
+        <div className="text-xs text-muted-foreground">No runs yet.</div>
       ) : (
         <div className="grid gap-2">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-white/50">Status:</span>
+            <span className="text-xs text-muted-foreground">Status:</span>
             {(['all', 'success', 'failed', 'running'] as const).map(
               (status) => (
                 <Button
                   key={status}
                   label={status}
-                  className={`h-7 px-2 text-xs ${runStatusFilter === status ? 'bg-white/20 text-white' : 'bg-white/5 text-white/60 hover:bg-white/10'}`}
+                  className={`h-7 px-2 text-xs ${runStatusFilter === status ? 'bg-accent text-foreground' : 'bg-secondary text-muted-foreground hover:bg-accent'}`}
                   onClick={() => onSetStatusFilter(status)}
                 />
               ),
             )}
-            <span className="ml-2 text-xs text-white/50">Trigger:</span>
+            <span className="ml-2 text-xs text-muted-foreground">Trigger:</span>
             {(['all', 'scheduled', 'manual'] as const).map((trigger) => (
               <Button
                 key={trigger}
                 label={trigger}
-                className={`h-7 px-2 text-xs ${runTriggerFilter === trigger ? 'bg-white/20 text-white' : 'bg-white/5 text-white/60 hover:bg-white/10'}`}
+                className={`h-7 px-2 text-xs ${runTriggerFilter === trigger ? 'bg-accent text-foreground' : 'bg-secondary text-muted-foreground hover:bg-accent'}`}
                 onClick={() => onSetTriggerFilter(trigger)}
               />
             ))}
@@ -75,7 +75,7 @@ export default function CronJobRunHistory({
           {filteredRuns.map((run) => (
             <Button
               key={run.id}
-              className="h-auto w-full justify-start rounded border border-white/10 px-3 py-2 text-left"
+              className="h-auto w-full justify-start rounded bg-secondary px-3 py-2 text-left shadow-border"
               onClick={() => onSelectRun(run)}
             >
               <div className="flex w-full items-center justify-between gap-3">
@@ -86,9 +86,11 @@ export default function CronJobRunHistory({
                   >
                     {run.status}
                   </Badge>
-                  <span className="text-xs text-white/70">{run.trigger}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {run.trigger}
+                  </span>
                 </div>
-                <span className="text-xs text-white/50">
+                <span className="text-xs text-muted-foreground">
                   {run.startedAt
                     ? new Date(run.startedAt).toLocaleString()
                     : '—'}
@@ -97,7 +99,7 @@ export default function CronJobRunHistory({
             </Button>
           ))}
           {filteredRuns.length === 0 && (
-            <div className="text-xs text-white/50">
+            <div className="text-xs text-muted-foreground">
               No runs for the selected filters.
             </div>
           )}
@@ -105,12 +107,12 @@ export default function CronJobRunHistory({
       )}
 
       {selectedRun && (
-        <div className="mt-3 rounded border border-white/10 bg-black/20 p-3">
-          <div className="mb-1 text-xs text-white/60">Run Detail</div>
+        <div className="mt-3 rounded bg-secondary p-3">
+          <div className="mb-1 text-xs text-muted-foreground">Run Detail</div>
           <Pre
             variant="ghost"
             size="sm"
-            className="max-h-72 overflow-y-auto text-white/75"
+            className="max-h-72 overflow-y-auto text-muted-foreground"
           >
             {JSON.stringify(selectedRun, null, 2)}
           </Pre>

--- a/packages/pages/agents/tasks/CronJobsList.tsx
+++ b/packages/pages/agents/tasks/CronJobsList.tsx
@@ -106,7 +106,7 @@ export default function CronJobsList() {
               {job.paused ? 'Paused' : 'Active'}
             </Badge>
             {job.failures > 0 && (
-              <span className="text-xs text-red-400">
+              <span className="text-xs text-destructive">
                 {job.failures} failures
               </span>
             )}
@@ -149,7 +149,7 @@ export default function CronJobsList() {
         </div>
       }
     >
-      <div className="mb-4 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-muted-foreground">
+      <div className="mb-4 rounded-lg bg-secondary px-4 py-3 text-sm text-muted-foreground shadow-border">
         Legacy cron jobs are read-only. Create and manage recurring automation
         in Workflows.
       </div>

--- a/packages/pages/analytics/overview/analytics-overview-hero.tsx
+++ b/packages/pages/analytics/overview/analytics-overview-hero.tsx
@@ -45,19 +45,19 @@ export default function AnalyticsOverviewHero({
   return (
     <div className="grid gap-8 lg:grid-cols-[minmax(0,1.7fr)_minmax(280px,0.9fr)]">
       <div className="space-y-5">
-        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-foreground/60">
+        <div className="inline-flex items-center gap-2 rounded-full bg-secondary px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-foreground/60 shadow-border">
           {dashboardState === 'active' ? (
-            <HiOutlineCheckCircle className="size-4 text-emerald-400" />
+            <HiOutlineCheckCircle className="size-4 text-success" />
           ) : dashboardState === 'warming_up' ? (
-            <HiMiniArrowTrendingUp className="size-4 text-amber-300" />
+            <HiMiniArrowTrendingUp className="size-4 text-warning" />
           ) : (
-            <HiOutlineInformationCircle className="size-4 text-sky-300" />
+            <HiOutlineInformationCircle className="size-4 text-info" />
           )}
           {heroContent.badge}
         </div>
 
         <div className="space-y-3">
-          <h1 className="text-3xl font-serif leading-tight text-foreground lg:text-4xl">
+          <h1 className="text-3xl font-serif leading-tight tracking-tight text-foreground lg:text-4xl">
             {heroContent.title}
           </h1>
           <p className="max-w-3xl text-sm leading-7 text-foreground/72 lg:text-base">

--- a/packages/pages/brands/components/brand-kit/BrandKitReviewCard.tsx
+++ b/packages/pages/brands/components/brand-kit/BrandKitReviewCard.tsx
@@ -398,7 +398,7 @@ export default function BrandKitReviewCard({
         ) : null}
 
         {draft ? (
-          <div className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm">
+          <div className="rounded-md bg-background-secondary px-3 py-2 text-sm shadow-border">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <span className="font-medium">
                 {draft.readiness.score}% readiness
@@ -444,7 +444,7 @@ export default function BrandKitReviewCard({
                       return (
                         <div
                           key={key}
-                          className="rounded-md border border-border p-3"
+                          className="rounded-md bg-background-secondary p-3 shadow-border"
                         >
                           <div className="flex flex-wrap items-start justify-between gap-3">
                             <div>
@@ -553,7 +553,7 @@ export default function BrandKitReviewCard({
             ) : null}
 
             {applyResult ? (
-              <div className="rounded-md border border-border bg-background-secondary px-3 py-2 text-sm">
+              <div className="rounded-md bg-background-secondary px-3 py-2 text-sm shadow-border">
                 Applied {applyResult.appliedFields.length} fields; preserved{' '}
                 {applyResult.preservedFields.length}. Status:{' '}
                 {applyResult.status}.

--- a/packages/pages/brands/components/sidebar/AgentProfilePlatformOverride.tsx
+++ b/packages/pages/brands/components/sidebar/AgentProfilePlatformOverride.tsx
@@ -43,7 +43,7 @@ export default function AgentProfilePlatformOverride({
   onChange,
 }: AgentProfilePlatformOverrideProps) {
   return (
-    <div className="space-y-4 rounded-lg border border-border p-4">
+    <div className="space-y-4 rounded-lg bg-background-secondary p-4 shadow-border">
       <div className="flex items-center justify-between gap-3">
         <h4 className="text-sm font-medium">{label}</h4>
         <span className="text-xs text-muted-foreground">Optional override</span>

--- a/packages/pages/brands/components/sidebar/AgentProfileSummaryCard.tsx
+++ b/packages/pages/brands/components/sidebar/AgentProfileSummaryCard.tsx
@@ -16,7 +16,7 @@ type AgentProfileSummaryCardProps = {
 
 function SummaryItem({ label, value }: SummaryItemData) {
   return (
-    <div className="rounded-lg border border-border/70 bg-background/30 p-3">
+    <div className="rounded-lg bg-background-secondary p-3 shadow-border">
       <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
         {label}
       </p>

--- a/packages/pages/brands/components/sidebar/BrandDetailExternalLinksCard.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailExternalLinksCard.tsx
@@ -19,14 +19,17 @@ export default function BrandDetailExternalLinksCard({
           links.length > 0 &&
           links.map((link) => (
             <div key={link.id} className="flex gap-2">
-              <Link
-                href={link.url}
-                className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-all duration-300 border border-dashed border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2 flex-1"
-                target="_blank"
+              <Button
+                asChild
+                variant={ButtonVariant.OUTLINE}
+                className="flex-1 gap-2"
+                wrapperClassName="flex-1"
               >
-                <HiLink />
-                {link.label}
-              </Link>
+                <Link href={link.url} target="_blank">
+                  <HiLink />
+                  {link.label}
+                </Link>
+              </Button>
 
               <Button
                 label={<HiPencil />}

--- a/packages/pages/brands/components/sidebar/BrandDetailLinkEditor.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailLinkEditor.tsx
@@ -51,7 +51,7 @@ export default function BrandDetailLinkEditor({
   onSubmit,
 }: BrandDetailLinkEditorProps) {
   return (
-    <div className="rounded-3xl border border-white/[0.08] bg-card/80 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-sm">
+    <div className="rounded-3xl bg-card/80 p-5 shadow-border backdrop-blur-sm">
       <div className="mb-4 flex items-center justify-between gap-3">
         <div>
           <p className="text-sm uppercase tracking-[0.22em] text-foreground/45">

--- a/packages/pages/brands/components/sidebar/BrandDetailManualKitCard.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailManualKitCard.tsx
@@ -500,7 +500,7 @@ export default function BrandDetailManualKitCard({
           />
         </div>
 
-        <div className="rounded-md border border-border p-3 text-sm">
+        <div className="rounded-md bg-background-secondary p-3 text-sm shadow-border">
           <div className="flex items-center justify-between gap-3">
             <span className="font-medium">Attached assets</span>
             <span className="text-muted-foreground">{attachedAssetCount}</span>
@@ -535,7 +535,7 @@ export default function BrandDetailManualKitCard({
 
         {draft ? (
           <div
-            className="space-y-3 rounded-md border border-border p-3"
+            className="space-y-3 rounded-md bg-background-secondary p-3 shadow-border"
             data-testid="manual-kit-draft-review"
           >
             <div className="flex items-center justify-between gap-3">
@@ -560,7 +560,7 @@ export default function BrandDetailManualKitCard({
                 return (
                   <label
                     key={key}
-                    className="flex items-start gap-2 rounded-md border border-border p-2 text-sm"
+                    className="flex items-start gap-2 rounded-md bg-background-secondary p-2 text-sm shadow-border"
                   >
                     <Checkbox
                       aria-label={`Select ${label}`}

--- a/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.tsx
@@ -361,7 +361,7 @@ export default function BrandDetailSocialMediaCard({
               ))}
             </div>
           ) : (
-            <div className="rounded-lg border border-dashed border-border/70 bg-background/30 px-4 py-5 text-sm text-muted-foreground">
+            <div className="rounded-lg bg-background-secondary px-4 py-5 text-sm text-muted-foreground shadow-border">
               No social accounts connected yet.
             </div>
           )}

--- a/packages/pages/brands/components/sidebar/BrandIdentityVoiceField.tsx
+++ b/packages/pages/brands/components/sidebar/BrandIdentityVoiceField.tsx
@@ -71,7 +71,7 @@ export default function BrandIdentityVoiceField({
       </Select>
       {previewVoice ? (
         <div
-          className="mt-3 rounded-md border border-border/60 bg-muted/20 p-3"
+          className="mt-3 rounded-md bg-background-secondary p-3 shadow-border"
           data-testid="brand-default-voice-preview"
         >
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/packages/pages/content-runs/detail/content-run-detail.tsx
+++ b/packages/pages/content-runs/detail/content-run-detail.tsx
@@ -155,18 +155,42 @@ function getTimelineSteps(run: ContentRunRecord): TimelineStep[] {
 
 function getStepClasses(state: TimelineStep['state']): string {
   if (state === 'complete') {
-    return 'border-emerald-400/35 bg-emerald-400/[0.08] text-emerald-100';
+    return 'bg-success/10 text-success shadow-border';
   }
 
   if (state === 'current') {
-    return 'border-sky-400/35 bg-sky-400/[0.08] text-sky-100';
+    return 'bg-info/10 text-info shadow-border';
   }
 
   if (state === 'error') {
-    return 'border-red-400/35 bg-red-400/[0.08] text-red-100';
+    return 'bg-destructive/10 text-destructive shadow-border';
   }
 
-  return 'border-white/10 bg-white/[0.03] text-foreground/65';
+  return 'bg-secondary text-foreground/65 shadow-border';
+}
+
+function Panel({
+  as: Tag = 'div',
+  children,
+  className,
+}: {
+  as?: 'div' | 'article';
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Tag className={`rounded-md bg-secondary shadow-border ${className ?? ''}`}>
+      {children}
+    </Tag>
+  );
+}
+
+function Pill({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full bg-secondary px-2 py-1 text-[11px] uppercase text-foreground/60 shadow-border">
+      {children}
+    </span>
+  );
 }
 
 function Section({
@@ -179,9 +203,9 @@ function Section({
   title: string;
 }) {
   return (
-    <section className="rounded-lg border border-white/10 bg-white/[0.03] p-5">
+    <section className="rounded-lg bg-secondary p-5 shadow-border">
       <div className="mb-4 flex items-center gap-2">
-        <span className="flex size-8 items-center justify-center rounded-md border border-white/10 bg-white/[0.05] text-foreground/75">
+        <span className="flex size-8 items-center justify-center rounded-md bg-card text-foreground/75 shadow-border">
           {icon}
         </span>
         <h2 className="text-sm font-semibold">{title}</h2>
@@ -193,7 +217,7 @@ function Section({
 
 function EmptyState({ label }: { label: string }) {
   return (
-    <div className="rounded-md border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-foreground/55">
+    <div className="rounded-md border border-dashed border-border px-4 py-6 text-sm text-foreground/55">
       {label}
     </div>
   );
@@ -201,7 +225,7 @@ function EmptyState({ label }: { label: string }) {
 
 function DetailRow({ label, value }: { label: string; value?: ReactNode }) {
   return (
-    <div className="flex items-start justify-between gap-4 border-white/8 border-t py-3 first:border-t-0">
+    <div className="flex items-start justify-between gap-4 border-border border-t py-3 first:border-t-0">
       <dt className="text-xs text-foreground/50">{label}</dt>
       <dd className="max-w-[70%] text-right text-sm text-foreground/82">
         {value ?? '-'}
@@ -235,12 +259,9 @@ function BriefSection({ brief }: { brief?: ContentRunBrief }) {
       {brief.evidence?.length ? (
         <div className="grid gap-2">
           {brief.evidence.map((item) => (
-            <div
-              key={item}
-              className="rounded-md border border-white/8 bg-black/10 px-3 py-2 text-sm text-foreground/75"
-            >
+            <Panel key={item} className="px-3 py-2 text-sm text-foreground/75">
               {item}
-            </div>
+            </Panel>
           ))}
         </div>
       ) : null}
@@ -256,22 +277,11 @@ function VariantsSection({ variants }: { variants?: ContentRunVariant[] }) {
   return (
     <div className="grid gap-3 md:grid-cols-2">
       {variants.map((variant) => (
-        <article
-          key={variant.id}
-          className="rounded-md border border-white/8 bg-black/10 p-4"
-        >
+        <Panel as="article" key={variant.id} className="p-4">
           <div className="mb-3 flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] uppercase text-foreground/60">
-              {variant.format ?? variant.type}
-            </span>
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] uppercase text-foreground/60">
-              {variant.platform}
-            </span>
-            {variant.status ? (
-              <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] uppercase text-foreground/60">
-                {variant.status}
-              </span>
-            ) : null}
+            <Pill>{variant.format ?? variant.type}</Pill>
+            <Pill>{variant.platform}</Pill>
+            {variant.status ? <Pill>{variant.status}</Pill> : null}
           </div>
           <h3 className="text-sm font-medium">{variant.angle ?? variant.id}</h3>
           {variant.hypothesis ? (
@@ -284,7 +294,7 @@ function VariantsSection({ variants }: { variants?: ContentRunVariant[] }) {
               {variant.content}
             </p>
           ) : null}
-        </article>
+        </Panel>
       ))}
     </div>
   );
@@ -304,9 +314,10 @@ function PublishSection({
   return (
     <div className="grid gap-3">
       {contexts.map((context, index) => (
-        <article
+        <Panel
+          as="article"
           key={`${context.variantId ?? context.platform ?? 'publish'}-${index}`}
-          className="rounded-md border border-white/8 bg-black/10 p-4"
+          className="p-4"
         >
           <dl>
             <DetailRow label="Platform" value={context.platform} />
@@ -326,7 +337,7 @@ function PublishSection({
               value={context.postIds?.length ? context.postIds.join(', ') : '-'}
             />
           </dl>
-        </article>
+        </Panel>
       ))}
     </div>
   );
@@ -343,30 +354,30 @@ function AnalyticsSection({
 
   return (
     <div className="grid gap-3 md:grid-cols-4">
-      <div className="rounded-md border border-white/8 bg-black/10 p-4">
+      <Panel className="p-4">
         <div className="text-xs text-foreground/50">Impressions</div>
         <div className="mt-2 text-xl font-semibold">
           {formatMetric(analytics.impressions)}
         </div>
-      </div>
-      <div className="rounded-md border border-white/8 bg-black/10 p-4">
+      </Panel>
+      <Panel className="p-4">
         <div className="text-xs text-foreground/50">Engagements</div>
         <div className="mt-2 text-xl font-semibold">
           {formatMetric(analytics.engagements)}
         </div>
-      </div>
-      <div className="rounded-md border border-white/8 bg-black/10 p-4">
+      </Panel>
+      <Panel className="p-4">
         <div className="text-xs text-foreground/50">Engagement rate</div>
         <div className="mt-2 text-xl font-semibold">
           {formatPercent(analytics.engagementRate)}
         </div>
-      </div>
-      <div className="rounded-md border border-white/8 bg-black/10 p-4">
+      </Panel>
+      <Panel className="p-4">
         <div className="text-xs text-foreground/50">Winning variant</div>
         <div className="mt-2 truncate text-sm font-medium">
           {analytics.winningVariantId ?? '-'}
         </div>
-      </div>
+      </Panel>
       {analytics.summary ? (
         <p className="md:col-span-4 text-sm text-foreground/72">
           {analytics.summary}
@@ -375,12 +386,12 @@ function AnalyticsSection({
       {analytics.topSignals?.length ? (
         <div className="grid gap-2 md:col-span-4">
           {analytics.topSignals.map((signal) => (
-            <div
+            <Panel
               key={signal}
-              className="rounded-md border border-white/8 bg-black/10 px-3 py-2 text-sm text-foreground/75"
+              className="px-3 py-2 text-sm text-foreground/75"
             >
               {signal}
-            </div>
+            </Panel>
           ))}
         </div>
       ) : null}
@@ -402,18 +413,15 @@ function RecommendationsSection({
   return (
     <div className="grid gap-3">
       {recommendations.map((recommendation, index) => (
-        <article
+        <Panel
+          as="article"
           key={`${recommendation.type}-${index}`}
-          className="rounded-md border border-white/8 bg-black/10 p-4"
+          className="p-4"
         >
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] uppercase text-foreground/60">
-              {recommendation.type}
-            </span>
+            <Pill>{recommendation.type}</Pill>
             {typeof recommendation.confidence === 'number' ? (
-              <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] uppercase text-foreground/60">
-                {formatPercent(recommendation.confidence * 100)}
-              </span>
+              <Pill>{formatPercent(recommendation.confidence * 100)}</Pill>
             ) : null}
           </div>
           <h3 className="mt-3 text-sm font-medium">
@@ -424,7 +432,7 @@ function RecommendationsSection({
               {recommendation.rationale}
             </p>
           ) : null}
-        </article>
+        </Panel>
       ))}
     </div>
   );
@@ -434,13 +442,13 @@ function TimelinePanel({ run }: { run: ContentRunRecord }) {
   const steps = useMemo(() => getTimelineSteps(run), [run]);
 
   return (
-    <aside className="rounded-lg border border-white/10 bg-white/[0.03] p-5">
+    <aside className="rounded-lg bg-secondary p-5 shadow-border">
       <h2 className="text-sm font-semibold">Lifecycle</h2>
       <div className="mt-4 space-y-3">
         {steps.map((step) => (
           <div
             key={step.key}
-            className={`rounded-md border px-3 py-3 ${getStepClasses(step.state)}`}
+            className={`rounded-md px-3 py-3 ${getStepClasses(step.state)}`}
           >
             <div className="flex items-center justify-between gap-3">
               <span className="text-sm font-medium">{step.label}</span>
@@ -469,7 +477,7 @@ function NavigationPanel() {
   ];
 
   return (
-    <aside className="rounded-lg border border-white/10 bg-white/[0.03] p-5">
+    <aside className="rounded-lg bg-secondary p-5 shadow-border">
       <h2 className="text-sm font-semibold">Open Subviews</h2>
       <div className="mt-4 grid gap-2">
         {links.map((item) => {
@@ -478,7 +486,7 @@ function NavigationPanel() {
             <Link
               key={item.href}
               href={item.href}
-              className="flex min-h-11 items-center justify-between rounded-md border border-white/10 bg-white/[0.04] px-3 text-sm text-foreground/82 transition hover:border-white/18 hover:bg-white/[0.07]"
+              className="flex min-h-11 items-center justify-between rounded-md bg-card px-3 text-sm text-foreground/82 shadow-border transition hover:bg-accent"
             >
               <span className="flex items-center gap-2">
                 <Icon className="size-4" />
@@ -531,7 +539,7 @@ export default function ContentRunDetailPage({
   if (state === 'loading' || state === 'idle') {
     return (
       <Container>
-        <div className="rounded-lg border border-white/10 bg-white/[0.03] p-8 text-sm text-foreground/60">
+        <div className="rounded-lg bg-secondary p-8 text-sm text-foreground/60 shadow-border">
           Loading content run…
         </div>
       </Container>
@@ -541,7 +549,7 @@ export default function ContentRunDetailPage({
   if (state === 'error' || !run) {
     return (
       <Container>
-        <div className="rounded-lg border border-red-400/25 bg-red-400/[0.08] p-8 text-sm text-red-100">
+        <div className="rounded-lg bg-destructive/10 p-8 text-sm text-destructive shadow-border">
           Content run could not be loaded.
         </div>
       </Container>
@@ -551,19 +559,11 @@ export default function ContentRunDetailPage({
   return (
     <Container>
       <div className="flex flex-col gap-6">
-        <header className="rounded-lg border border-white/10 bg-white/[0.03] p-5">
+        <header className="rounded-lg bg-secondary p-5 shadow-border">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] uppercase text-foreground/60">
-              {run.status ?? 'unknown'}
-            </span>
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] uppercase text-foreground/60">
-              {run.skillSlug ?? 'content-run'}
-            </span>
-            {run.source ? (
-              <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] uppercase text-foreground/60">
-                {run.source}
-              </span>
-            ) : null}
+            <Pill>{run.status ?? 'unknown'}</Pill>
+            <Pill>{run.skillSlug ?? 'content-run'}</Pill>
+            {run.source ? <Pill>{run.source}</Pill> : null}
           </div>
           <div className="mt-4 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>

--- a/packages/pages/library/landing/library-landing-visual-preview.tsx
+++ b/packages/pages/library/landing/library-landing-visual-preview.tsx
@@ -51,7 +51,6 @@ function LibraryPreviewTile({
           className,
         )}
       >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(245,158,11,0.14),transparent_45%)]" />
         <div className="relative flex h-full items-end">
           <div>
             <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/35">

--- a/packages/pages/models/list/components/ModelsTableColumns.tsx
+++ b/packages/pages/models/list/components/ModelsTableColumns.tsx
@@ -25,34 +25,34 @@ export function buildModelsTableColumns({
   const getRegistryStatus = (model: IModel) => {
     if (model.isLegacy || model.reviewStatus === 'legacy') {
       return {
-        className: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+        className: 'bg-warning/10 text-warning shadow-border',
         label: 'Legacy',
       };
     }
 
     if (model.reviewStatus === 'rejected') {
       return {
-        className: 'bg-red-500/15 text-red-400 border-red-500/30',
+        className: 'bg-destructive/10 text-destructive shadow-border',
         label: 'Rejected',
       };
     }
 
     if (model.isDiscovered && !model.isActive) {
       return {
-        className: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+        className: 'bg-info/10 text-info shadow-border',
         label: 'Pending',
       };
     }
 
     if (model.isDiscovered) {
       return {
-        className: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+        className: 'bg-success/10 text-success shadow-border',
         label: 'Approved',
       };
     }
 
     return {
-      className: 'bg-foreground/10 text-foreground/70',
+      className: 'bg-secondary text-foreground/70 shadow-border',
       label: 'Seeded',
     };
   };
@@ -115,10 +115,10 @@ export function buildModelsTableColumns({
           tier === 'high' ? 'Best' : tier === 'medium' ? 'Better' : 'Good';
         const tierClass =
           tier === 'high'
-            ? 'bg-emerald-500/20 text-emerald-400'
+            ? 'bg-foreground/15 text-foreground'
             : tier === 'medium'
-              ? 'bg-blue-500/20 text-blue-400'
-              : 'bg-foreground/10 text-foreground/70';
+              ? 'bg-muted-foreground/15 text-foreground/80'
+              : 'bg-secondary text-foreground/70';
         return <Badge className={`text-xs ${tierClass}`}>{tierLabel}</Badge>;
       },
     },

--- a/packages/pages/models/list/components/models-admin-header.helpers.ts
+++ b/packages/pages/models/list/components/models-admin-header.helpers.ts
@@ -49,7 +49,7 @@ export function buildDefaultModelCards(
   const allCards = [
     {
       categoryMatch: 'image',
-      colorClass: 'bg-purple-500/20 text-purple-400',
+      colorClass: 'bg-muted-foreground/20 text-muted-foreground',
       count: 0,
       description: defaultModels.image?.label || 'Not set',
       icon: HiPhoto as IconType,
@@ -57,7 +57,7 @@ export function buildDefaultModelCards(
     },
     {
       categoryMatch: 'video',
-      colorClass: 'bg-blue-500/20 text-blue-400',
+      colorClass: 'bg-muted-foreground/20 text-muted-foreground',
       count: 0,
       description: defaultModels.video?.label || 'Not set',
       icon: HiFilm as IconType,
@@ -65,7 +65,7 @@ export function buildDefaultModelCards(
     },
     {
       categoryMatch: 'music',
-      colorClass: 'bg-amber-500/20 text-amber-400',
+      colorClass: 'bg-muted-foreground/20 text-muted-foreground',
       count: 0,
       description: defaultModels.music?.label || 'Not set',
       icon: HiMusicalNote as IconType,
@@ -73,7 +73,7 @@ export function buildDefaultModelCards(
     },
     {
       categoryMatch: 'text',
-      colorClass: 'bg-green-500/20 text-green-400',
+      colorClass: 'bg-muted-foreground/20 text-muted-foreground',
       count: 0,
       description: defaultModels.text?.label || 'Not set',
       icon: HiDocumentText as IconType,

--- a/packages/pages/posts/[id]/ingredient-posts.tsx
+++ b/packages/pages/posts/[id]/ingredient-posts.tsx
@@ -127,10 +127,7 @@ export default function IngredientPosts({
 
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             {posts.map((post) => (
-              <Card
-                key={post.id}
-                className="p-4 hover:shadow-lg transition-shadow duration-300"
-              >
+              <Card key={post.id} className="p-4">
                 <div className="flex flex-col gap-y-3">
                   <div className="flex items-center justify-between">
                     <h3 className="font-semibold truncate flex-1">

--- a/packages/pages/posts/detail/PostDetailOverlay.tsx
+++ b/packages/pages/posts/detail/PostDetailOverlay.tsx
@@ -43,7 +43,7 @@ export default function PostDetailOverlay({
       <SheetContent
         side="right"
         className={cn(
-          'flex h-full w-full flex-col gap-0 overflow-hidden border-l border-white/8 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.06),transparent_32%),linear-gradient(180deg,rgba(15,15,18,0.985),rgba(8,8,10,0.985))] p-0 shadow-[0_36px_140px_rgba(0,0,0,0.58)] sm:max-w-[min(104rem,97vw)]',
+          'flex h-full w-full flex-col gap-0 overflow-hidden border-l border-border bg-background p-0 shadow-dialog sm:max-w-[min(104rem,97vw)]',
         )}
       >
         <div className="sticky top-0 z-10 border-b border-white/8 bg-background/92 px-6 pb-5 pt-6 backdrop-blur">

--- a/packages/pages/posts/detail/components/PostDetailCardBody.tsx
+++ b/packages/pages/posts/detail/components/PostDetailCardBody.tsx
@@ -149,7 +149,7 @@ export default function PostDetailCardBody({
                 </div>
                 {post.totalLikes !== undefined && (
                   <div className="flex items-center gap-1.5 text-xs text-foreground/60">
-                    <HiHeart className="size-3.5 text-rose-500" />
+                    <HiHeart className="size-3.5 text-muted-foreground" />
                     <span>{formatCompactNumber(post.totalLikes)}</span>
                   </div>
                 )}

--- a/packages/pages/posts/list/components/PostsGrid.tsx
+++ b/packages/pages/posts/list/components/PostsGrid.tsx
@@ -208,7 +208,7 @@ const PostsGrid = memo(
                   handleOpenPost(post);
                 }
               }}
-              className="group rounded-xl border border-white/[0.08] bg-background/80 p-4 text-left transition-all duration-200 hover:border-white/[0.16] hover:bg-background"
+              className="group rounded-xl bg-card p-4 text-left shadow-border transition-all duration-200 hover:bg-background hover:shadow-border-strong"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="flex min-w-0 items-start gap-3">

--- a/packages/pages/streaks/streaks-page.tsx
+++ b/packages/pages/streaks/streaks-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { APP_ROUTES } from '@genfeedai/constants';
+import { ButtonVariant } from '@genfeedai/enums';
 import type { IStreakMilestoneState } from '@genfeedai/types';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import { useStreak } from '@hooks/data/streaks/use-streak/use-streak';
@@ -8,6 +9,7 @@ import { STREAK_CELEBRATION_EVENT } from '@services/engagement/streak-events';
 import Badge from '@ui/display/badge/Badge';
 import KeyMetric from '@ui/display/key-metric/KeyMetric';
 import StreakCelebrationBurst from '@ui/feedback/streak-celebration/StreakCelebrationBurst';
+import { Button } from '@ui/primitives/button';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import {
@@ -94,11 +96,11 @@ export default function StreaksPage() {
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8">
-      <section className="relative overflow-hidden rounded-3xl border border-orange-500/20 bg-[radial-gradient(circle_at_top_left,_rgba(251,146,60,0.2),_transparent_45%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] p-6">
+      <section className="relative overflow-hidden rounded-3xl bg-secondary p-6 shadow-border">
         <StreakCelebrationBurst isVisible={isCelebrating} />
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="max-w-3xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-orange-200/80">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
               Daily retention
             </p>
             <h1 className="mt-2 text-3xl font-semibold text-foreground">
@@ -109,13 +111,12 @@ export default function StreaksPage() {
             </p>
           </div>
 
-          <Link
-            href={APP_ROUTES.STUDIO.IMAGE}
-            className="inline-flex items-center gap-2 rounded-full border border-orange-300/30 bg-orange-400/10 px-4 py-2 text-sm font-medium text-orange-100 transition-colors hover:bg-orange-400/15"
-          >
-            <HiOutlineSparkles className="size-4" />
-            Create content now
-          </Link>
+          <Button asChild variant={ButtonVariant.DEFAULT}>
+            <Link href={APP_ROUTES.STUDIO.IMAGE}>
+              <HiOutlineSparkles className="size-4" />
+              Create content now
+            </Link>
+          </Button>
         </div>
 
         <div className="mt-6 grid gap-4 md:grid-cols-4">
@@ -135,7 +136,7 @@ export default function StreaksPage() {
       </section>
 
       <section className="grid gap-6 lg:grid-cols-[1.4fr_0.9fr]">
-        <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
+        <div className="rounded-3xl bg-secondary p-5 shadow-border">
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>
               <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
@@ -155,18 +156,18 @@ export default function StreaksPage() {
               const count = calendar[dayKey]?.count ?? 0;
               const intensityClass =
                 count >= 4
-                  ? 'bg-orange-300/80 border-orange-200/60'
+                  ? 'bg-foreground/80'
                   : count >= 2
-                    ? 'bg-orange-300/45 border-orange-300/40'
+                    ? 'bg-foreground/45'
                     : count >= 1
-                      ? 'bg-orange-300/25 border-orange-300/25'
-                      : 'bg-white/[0.03] border-white/8';
+                      ? 'bg-foreground/25'
+                      : 'bg-secondary';
 
               return (
                 <div
                   key={dayKey}
                   className={cn(
-                    'aspect-square rounded border transition-colors',
+                    'aspect-square rounded transition-colors',
                     intensityClass,
                   )}
                   title={`${dayKey}${count > 0 ? `: ${count} item${count === 1 ? '' : 's'}` : ''}`}
@@ -176,7 +177,7 @@ export default function StreaksPage() {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5">
+        <div className="rounded-3xl bg-secondary p-5 shadow-border">
           <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
             Badge progress
           </p>
@@ -208,12 +209,12 @@ export default function StreaksPage() {
               <div
                 key={milestone.days}
                 className={cn(
-                  'rounded-2xl border p-4',
+                  'rounded-2xl p-4',
                   milestone.isAchieved
-                    ? 'border-emerald-400/20 bg-emerald-400/8'
+                    ? 'bg-success/10 shadow-border'
                     : milestone.isNext
-                      ? 'border-orange-400/20 bg-orange-400/8'
-                      : 'border-white/10 bg-black/10',
+                      ? 'bg-warning/10 shadow-border'
+                      : 'bg-secondary shadow-border',
                 )}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -223,11 +224,11 @@ export default function StreaksPage() {
                         {milestone.days} days
                       </span>
                       {milestone.days === 7 ? (
-                        <HiOutlineShieldCheck className="size-4 text-sky-300" />
+                        <HiOutlineShieldCheck className="size-4 text-muted-foreground" />
                       ) : milestone.rewardCredits > 0 ? (
-                        <HiOutlineGift className="size-4 text-emerald-300" />
+                        <HiOutlineGift className="size-4 text-muted-foreground" />
                       ) : (
-                        <HiOutlineFire className="size-4 text-orange-300" />
+                        <HiOutlineFire className="size-4 text-muted-foreground" />
                       )}
                     </div>
                     <p className="mt-1 text-sm text-foreground/65">

--- a/packages/pages/studio/generate/components/AssetControlsHeader.tsx
+++ b/packages/pages/studio/generate/components/AssetControlsHeader.tsx
@@ -43,7 +43,7 @@ export function AssetControlsHeader({
     : 'Generation';
   const showViewToggle = supportsMasonry;
   const controlGroupClassName =
-    'flex items-center rounded-xl border border-white/10 bg-white/[0.03] p-1';
+    'flex items-center rounded-xl bg-secondary p-1 shadow-border';
 
   return (
     <div className="w-full border-b border-white/[0.08] px-6 py-2">

--- a/packages/pages/studio/generate/components/StoryboardPanel.tsx
+++ b/packages/pages/studio/generate/components/StoryboardPanel.tsx
@@ -62,7 +62,7 @@ export function StoryboardPanel({
         />
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-white/[0.08] bg-card px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-md bg-card px-4 py-3 shadow-border">
         <div className="text-sm text-muted-foreground">
           <span className="font-medium text-foreground">{frames.length}</span>{' '}
           frame{frames.length === 1 ? '' : 's'}

--- a/packages/pages/studio/generate/components/StudioComposer.tsx
+++ b/packages/pages/studio/generate/components/StudioComposer.tsx
@@ -121,7 +121,7 @@ export function StudioComposer({
                 type="button"
                 variant={ButtonVariant.UNSTYLED}
                 withWrapper={false}
-                className="rounded-full border border-white/[0.12] bg-white/[0.04] px-3 py-1.5 text-xs text-foreground/70 transition-colors hover:bg-white/[0.07] hover:text-foreground disabled:opacity-50"
+                className="rounded-full bg-secondary px-3 py-1.5 text-xs text-foreground/70 shadow-border transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
                 isDisabled={isGenerating}
                 onClick={() => onTextChange(suggestion)}
               >

--- a/packages/pages/studio/generate/hooks/useTableColumns.tsx
+++ b/packages/pages/studio/generate/hooks/useTableColumns.tsx
@@ -409,7 +409,7 @@ export function useTableActions({
         icon: (item: IIngredient) => (
           <HiStar
             size={16}
-            className={item.isFavorite ? 'fill-yellow-500 text-yellow-500' : ''}
+            className={item.isFavorite ? 'fill-foreground text-foreground' : ''}
           />
         ),
         onClick: handleToggleFavorite,

--- a/packages/pages/trainings/list/components/TrainingsErrorState.tsx
+++ b/packages/pages/trainings/list/components/TrainingsErrorState.tsx
@@ -12,8 +12,8 @@ export default function TrainingsErrorState({ error, onRetry }: Props) {
   return (
     <div className="container mx-auto flex min-h-56 items-center justify-center px-4 py-8">
       <Card className="p-12 w-full max-w-md text-center">
-        <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
-          <span className="text-2xl">!</span>
+        <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-destructive/10">
+          <span className="text-2xl text-destructive">!</span>
         </div>
 
         <h3 className="mb-2 text-lg font-semibold text-foreground">

--- a/packages/pages/trends/shared/trend-content-card.tsx
+++ b/packages/pages/trends/shared/trend-content-card.tsx
@@ -183,9 +183,9 @@ export default function TrendContentCard({ item }: { item: TrendContentItem }) {
   ]);
 
   return (
-    <article className="overflow-hidden rounded-xl border border-white/[0.08] bg-background/80 transition-colors hover:border-white/[0.16]">
+    <article className="overflow-hidden rounded-xl bg-card shadow-border transition-colors hover:shadow-border-strong">
       {previewMediaUrl ? (
-        <div className="relative aspect-[16/9] overflow-hidden border-b border-white/[0.08] bg-white/[0.04]">
+        <div className="relative aspect-[16/9] overflow-hidden bg-secondary">
           <Image
             alt={previewTitle}
             className="object-cover"

--- a/packages/workflow-ui/src/canvas/EdgeToolbar.tsx
+++ b/packages/workflow-ui/src/canvas/EdgeToolbar.tsx
@@ -56,7 +56,7 @@ function EdgeToolbarComponent() {
 
   return (
     <div
-      className="fixed z-30 flex items-center gap-1 bg-[var(--background)] border border-[var(--border)] shadow-lg px-1.5 py-1"
+      className="fixed z-30 flex items-center gap-1 bg-[var(--background)] shadow-dropdown px-1.5 py-1"
       style={{
         left: position.x,
         top: position.y - 40,
@@ -81,7 +81,7 @@ function EdgeToolbarComponent() {
         size="icon-sm"
         onClick={handleDelete}
         title="Delete edge"
-        className="hover:bg-red-500/10 hover:text-red-500"
+        className="hover:bg-destructive/10 hover:text-destructive"
       >
         <Trash2 className="size-3.5" />
       </Button>

--- a/packages/workflow-ui/src/canvas/EditableEdge.tsx
+++ b/packages/workflow-ui/src/canvas/EditableEdge.tsx
@@ -89,7 +89,7 @@ function EditableEdgeComponent({
           y={labelY - 10}
           className="pointer-events-none"
         >
-          <div className="flex items-center justify-center size-5 rounded-full bg-amber-500 text-white shadow-sm">
+          <div className="flex items-center justify-center size-5 rounded-full bg-warning text-warning-foreground shadow-sm">
             <Pause className="size-3" />
           </div>
         </foreignObject>

--- a/packages/workflow-ui/src/canvas/HelperLines.tsx
+++ b/packages/workflow-ui/src/canvas/HelperLines.tsx
@@ -148,7 +148,7 @@ function HelperLinesComponent({ draggingNodeId }: HelperLinesProps) {
               y1={y1}
               x2={x}
               y2={y2}
-              stroke="#3b82f6"
+              stroke="hsl(var(--border-strong))"
               strokeWidth={1}
               strokeDasharray="4 2"
             />
@@ -165,7 +165,7 @@ function HelperLinesComponent({ draggingNodeId }: HelperLinesProps) {
               y1={y}
               x2={x2}
               y2={y}
-              stroke="#3b82f6"
+              stroke="hsl(var(--border-strong))"
               strokeWidth={1}
               strokeDasharray="4 2"
             />

--- a/packages/workflow-ui/src/canvas/PauseEdge.tsx
+++ b/packages/workflow-ui/src/canvas/PauseEdge.tsx
@@ -38,7 +38,7 @@ function PauseEdgeComponent({
         style={{
           ...style,
           ...(hasPause && {
-            stroke: '#f59e0b',
+            stroke: 'hsl(var(--warning))',
             strokeDasharray: '5 5',
           }),
         }}
@@ -51,7 +51,7 @@ function PauseEdgeComponent({
           y={labelY - 10}
           className="pointer-events-none"
         >
-          <div className="flex items-center justify-center size-5 rounded-full bg-amber-500 text-white">
+          <div className="flex items-center justify-center size-5 rounded-full bg-warning text-warning-foreground">
             <Pause className="size-3" />
           </div>
         </foreignObject>

--- a/packages/workflow-ui/src/canvas/ReferenceEdge.tsx
+++ b/packages/workflow-ui/src/canvas/ReferenceEdge.tsx
@@ -4,7 +4,7 @@ import { BaseEdge, type EdgeProps, getBezierPath } from '@xyflow/react';
 import { useMemo } from 'react';
 import { useWorkflowStore } from '../stores/workflow';
 
-const REFERENCE_COLOR = '#52525b';
+const REFERENCE_COLOR = 'hsl(var(--muted-foreground))';
 
 export function ReferenceEdge({
   id,

--- a/packages/workflow-ui/src/canvas/WorkflowCanvas.tsx
+++ b/packages/workflow-ui/src/canvas/WorkflowCanvas.tsx
@@ -52,7 +52,7 @@ import { NodeSearch } from './NodeSearch';
 import { ReferenceEdge } from './ReferenceEdge';
 import { ShortcutHelpModal } from './ShortcutHelpModal';
 
-const DEFAULT_NODE_COLOR = '#6b7280';
+const DEFAULT_NODE_COLOR = 'hsl(var(--muted-foreground))';
 
 /**
  * Check if the model's schema supports image input

--- a/packages/workflow-ui/src/components/CostModal.tsx
+++ b/packages/workflow-ui/src/components/CostModal.tsx
@@ -57,7 +57,7 @@ export function CostModal() {
       style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
     >
       <div
-        className="bg-[var(--background)] border border-[var(--border)] shadow-xl w-full max-w-lg"
+        className="bg-[var(--background)] shadow-dialog w-full max-w-lg"
         role="dialog"
         aria-label="Cost Breakdown"
       >
@@ -133,7 +133,7 @@ export function CostModal() {
                       <span className="text-[var(--muted-foreground)]">
                         Actual Cost
                       </span>
-                      <span className="font-mono font-medium text-green-500">
+                      <span className="font-mono font-medium text-foreground">
                         {formatCost(actualCost)}
                       </span>
                     </div>

--- a/packages/workflow-ui/src/components/GlobalImageHistory.tsx
+++ b/packages/workflow-ui/src/components/GlobalImageHistory.tsx
@@ -51,7 +51,7 @@ function FanItem({
       variant="ghost"
       draggable
       onDragStart={(e) => onDragStart(e, item)}
-      className="absolute size-14 overflow-hidden border-2 border-neutral-600 hover:border-blue-500 shadow-lg cursor-grab active:cursor-grabbing transition-colors duration-150 animate-fan-enter group p-0"
+      className="absolute size-14 overflow-hidden border-2 border-border hover:border-border-strong shadow-dropdown cursor-grab active:cursor-grabbing transition-colors duration-150 animate-fan-enter group p-0"
       style={
         {
           '--fan-x': `${x}px`,
@@ -128,11 +128,11 @@ function HistorySidebar({
   return createPortal(
     <div
       ref={sidebarRef}
-      className="w-80 max-h-[420px] bg-neutral-800 border border-neutral-600 shadow-xl flex flex-col"
+      className="w-80 max-h-[420px] bg-secondary shadow-dropdown flex flex-col"
       style={sidebarStyle}
     >
-      <div className="px-4 py-3 border-b border-neutral-700 flex items-center justify-between shrink-0">
-        <span className="text-sm text-neutral-200 font-medium">
+      <div className="px-4 py-3 border-b border-border flex items-center justify-between shrink-0">
+        <span className="text-sm text-foreground font-medium">
           All History ({history.length})
         </span>
         <div className="flex items-center gap-2">
@@ -140,7 +140,7 @@ function HistorySidebar({
             variant="ghost"
             size="sm"
             onClick={onClear}
-            className="text-[10px] text-neutral-500 hover:text-red-400 p-0 h-auto"
+            className="text-[10px] text-muted-foreground hover:text-destructive p-0 h-auto"
             title="Clear all history"
           >
             Clear All
@@ -149,7 +149,7 @@ function HistorySidebar({
             variant="ghost"
             size="icon-sm"
             onClick={onClose}
-            className="size-5 text-neutral-400 hover:bg-neutral-700 hover:text-white"
+            className="size-5 text-muted-foreground hover:bg-muted hover:text-foreground"
             title="Close"
           >
             <X className="size-3" />
@@ -165,9 +165,9 @@ function HistorySidebar({
             variant="ghost"
             draggable
             onDragStart={(e) => onDragStart(e, item)}
-            className="flex h-auto w-full justify-start gap-3 p-2 hover:bg-neutral-700/50 cursor-grab active:cursor-grabbing group transition-colors"
+            className="flex h-auto w-full justify-start gap-3 p-2 hover:bg-muted cursor-grab active:cursor-grabbing group transition-colors"
           >
-            <div className="relative size-14 rounded overflow-hidden shrink-0 border border-neutral-600 group-hover:border-blue-500 transition-colors">
+            <div className="relative size-14 rounded overflow-hidden shrink-0 border border-border group-hover:border-border-strong transition-colors">
               <Image
                 src={item.image}
                 alt={`History ${index + 1}`}
@@ -178,10 +178,10 @@ function HistorySidebar({
               />
             </div>
             <div className="flex-1 min-w-0 flex flex-col justify-center">
-              <p className="text-[11px] text-neutral-300 truncate">
+              <p className="text-[11px] text-foreground truncate">
                 {item.prompt?.substring(0, 60) || 'No prompt'}
               </p>
-              <p className="text-[10px] text-neutral-500 mt-0.5">
+              <p className="text-[10px] text-muted-foreground mt-0.5">
                 {formatRelativeTime(item.timestamp)}
                 {item.model ? ` · ${item.model}` : ''}
               </p>
@@ -190,8 +190,8 @@ function HistorySidebar({
         ))}
       </div>
 
-      <div className="px-4 py-2 border-t border-neutral-700 bg-neutral-900/50 shrink-0">
-        <span className="text-[10px] text-neutral-500">
+      <div className="px-4 py-2 border-t border-border bg-secondary/50 shrink-0">
+        <span className="text-[10px] text-muted-foreground">
           Drag images to canvas to create nodes
         </span>
       </div>
@@ -293,11 +293,11 @@ export function GlobalImageHistory() {
         variant="outline"
         size="icon-sm"
         onClick={() => setIsOpen(!isOpen)}
-        className="relative bg-neutral-800 hover:bg-neutral-700 border-neutral-600 text-neutral-400 hover:text-white shadow-lg"
+        className="relative bg-secondary hover:bg-muted border-border text-muted-foreground hover:text-foreground shadow-dropdown"
         title={`${history.length} image${history.length > 1 ? 's' : ''} in history`}
       >
         <Clock3 className="size-4" />
-        <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 bg-blue-500 rounded-full text-[10px] text-white flex items-center justify-center font-bold">
+        <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 bg-muted-foreground rounded-full text-[10px] text-background flex items-center justify-center font-bold">
           {history.length > 99 ? '99+' : history.length}
         </span>
       </Button>
@@ -330,7 +330,7 @@ export function GlobalImageHistory() {
                   variant="outline"
                   size="sm"
                   onClick={handleShowAll}
-                  className="absolute animate-fan-enter bg-neutral-800 hover:bg-neutral-700 border-neutral-600 text-[10px] text-neutral-300 hover:text-white shadow-lg whitespace-nowrap px-2 py-1 h-auto"
+                  className="absolute animate-fan-enter bg-secondary hover:bg-muted border-border text-[10px] text-foreground hover:text-foreground shadow-dropdown whitespace-nowrap px-2 py-1 h-auto"
                   style={
                     {
                       '--fan-x': `${topItemPos.x}px`,

--- a/packages/workflow-ui/src/components/NotificationToast.tsx
+++ b/packages/workflow-ui/src/components/NotificationToast.tsx
@@ -14,10 +14,10 @@ import { useUIStore } from '../stores/uiStore';
 import { Button } from '../ui/button';
 
 const typeStyles = {
-  error: 'bg-red-900 border-red-700 text-red-100',
-  info: 'bg-neutral-800 border-neutral-600 text-neutral-100',
-  success: 'bg-green-900 border-green-700 text-green-100',
-  warning: 'bg-orange-900 border-orange-600 text-orange-100',
+  error: 'bg-destructive/10 border-destructive/30 text-destructive',
+  info: 'bg-secondary border-border text-foreground',
+  success: 'bg-success/10 border-success/30 text-success',
+  warning: 'bg-warning/10 border-warning/30 text-warning',
 } as const;
 
 const typeIcons = {

--- a/packages/workflow-ui/src/components/context-menu/ContextMenu.tsx
+++ b/packages/workflow-ui/src/components/context-menu/ContextMenu.tsx
@@ -145,7 +145,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[200px] py-1 bg-[var(--card)] border border-[var(--border)] shadow-lg backdrop-blur-sm"
+      className="fixed z-50 min-w-[200px] py-1 bg-[var(--card)] shadow-dropdown backdrop-blur-sm"
       style={{ left: position.x, top: position.y }}
     >
       {items.map((item, index) => {

--- a/packages/workflow-ui/src/nodes/BaseNode.tsx
+++ b/packages/workflow-ui/src/nodes/BaseNode.tsx
@@ -570,7 +570,7 @@ function BaseNodeComponent({
     toggleNodeLock(id);
   };
 
-  // Category CSS variables (for processing glow, resizer handles)
+  // Category CSS variables (node identity color: border, resizer handles)
   const categoryCssVars: Record<string, string> = {
     ai: 'var(--category-ai)',
     composition: 'var(--category-composition)',
@@ -597,26 +597,25 @@ function BaseNodeComponent({
       <div
         ref={nodeRef}
         className={clsx(
-          'relative flex flex-col bg-[var(--card)] shadow-lg transition-all duration-200',
+          'relative flex flex-col bg-[var(--card)] shadow-border hover:shadow-border-strong transition-all duration-200',
           // Only apply min/max width if node hasn't been manually resized
           // Output nodes get larger minimums for better preview visibility
           !isResized && type === 'download' && 'min-w-[200px] min-h-[280px]',
           !isResized && type !== 'download' && 'min-w-[220px] max-w-[320px]',
           isSelected && 'ring-1',
           isLocked && 'opacity-60',
-          isProcessing && 'node-processing',
           !isHighlighted && !isSelected && 'opacity-40',
-          // Use custom border color when set, otherwise default border
-          customColor ? 'border-2' : 'border border-[var(--border)]',
+          // Use custom border color when set, otherwise default identity-color border
+          customColor ? 'border-2' : 'border',
         )}
         style={
           {
-            // Category color used for processing glow animation
+            // Category color used for the node's identity (border hue, resizer handles)
             '--node-color': effectiveColor,
             // Selection ring matches effective color
             ...(isSelected && { '--tw-ring-color': effectiveColor }),
-            // Custom border color when set
-            ...(customColor && { borderColor: customColor }),
+            // Node identity color on the border (custom color takes precedence)
+            borderColor: customColor || effectiveColor,
             // When resized, use explicit dimensions
             ...(isResized && {
               height: height ? `${height}px` : undefined,
@@ -721,7 +720,7 @@ function arePropsEqual(prev: BaseNodeProps, next: BaseNodeProps): boolean {
   const prevData = prev.data as Record<string, unknown>;
   const nextData = next.data as Record<string, unknown>;
 
-  // Status affects StatusIndicator and processing glow
+  // Status affects StatusIndicator and header stop/retry controls
   if (prevData.status !== nextData.status) return false;
 
   // Progress affects progress bar

--- a/packages/workflow-ui/src/nodes/ai/ImageGenNode.tsx
+++ b/packages/workflow-ui/src/nodes/ai/ImageGenNode.tsx
@@ -146,7 +146,7 @@ function ImageGenNodeComponent(props: NodeProps) {
 
         {/* Hint when model doesn't support image input */}
         {!modelSupportsImageInput && nodeData.inputImages.length > 0 && (
-          <div className="text-xs text-amber-500 flex items-center gap-1">
+          <div className="text-xs text-warning flex items-center gap-1">
             <AlertCircle className="size-3" />
             This model doesn&apos;t use image inputs
           </div>

--- a/packages/workflow-ui/src/nodes/ai/TextToSpeechNode.tsx
+++ b/packages/workflow-ui/src/nodes/ai/TextToSpeechNode.tsx
@@ -132,14 +132,14 @@ function TextToSpeechNodeComponent(props: NodeProps) {
       <div className="space-y-3">
         {/* API Key Warning */}
         {!TTS_ENABLED && (
-          <div className="flex items-start gap-2 p-2 bg-amber-500/10 border border-amber-500/30 rounded text-xs">
-            <AlertTriangle className="size-4 text-amber-500 flex-shrink-0 mt-0.5" />
-            <div className="text-amber-500">
+          <div className="flex items-start gap-2 p-2 bg-warning/10 border border-warning/30 rounded text-xs">
+            <AlertTriangle className="size-4 text-warning flex-shrink-0 mt-0.5" />
+            <div className="text-warning">
               <p className="font-medium">ElevenLabs not configured</p>
-              <p className="text-amber-500/80 mt-0.5">
-                Set <Code className="bg-amber-500/20">ELEVENLABS_API_KEY</Code>{' '}
-                in API and{' '}
-                <Code className="bg-amber-500/20">
+              <p className="text-warning/80 mt-0.5">
+                Set <Code className="bg-warning/20">ELEVENLABS_API_KEY</Code> in
+                API and{' '}
+                <Code className="bg-warning/20">
                   NEXT_PUBLIC_TTS_ENABLED=true
                 </Code>{' '}
                 in web

--- a/packages/workflow-ui/src/nodes/ai/VideoGenNode.tsx
+++ b/packages/workflow-ui/src/nodes/ai/VideoGenNode.tsx
@@ -125,7 +125,7 @@ function VideoGenNodeComponent(props: NodeProps) {
 
         {/* Hint when model doesn't support image input */}
         {!modelSupportsImageInput && nodeData.inputImage && (
-          <div className="text-xs text-amber-500 flex items-center gap-1">
+          <div className="text-xs text-warning flex items-center gap-1">
             <AlertCircle className="size-3" />
             This model doesn&apos;t use image inputs
           </div>

--- a/packages/workflow-ui/src/nodes/composition/WorkflowRefNode.tsx
+++ b/packages/workflow-ui/src/nodes/composition/WorkflowRefNode.tsx
@@ -447,10 +447,9 @@ function WorkflowRefNodeComponent(props: NodeProps) {
   return (
     <div
       className={clsx(
-        'relative min-w-[220px] border shadow-lg transition-all',
+        'relative min-w-[220px] border shadow-border hover:shadow-border-strong transition-all',
         'border-[var(--category-composition)] bg-card',
         isSelected && 'ring-1',
-        isProcessing && 'node-processing',
       )}
       style={
         {

--- a/packages/workflow-ui/src/nodes/input/PromptConstructorNode.tsx
+++ b/packages/workflow-ui/src/nodes/input/PromptConstructorNode.tsx
@@ -152,7 +152,7 @@ function PromptConstructorNodeComponent(props: NodeProps) {
       <div className="relative flex flex-col gap-2 flex-1">
         {/* Warning badge for unresolved variables */}
         {unresolvedVars.length > 0 && (
-          <div className="px-2 py-1 bg-amber-900/30 border border-amber-700/50 rounded text-[10px] text-amber-400">
+          <div className="px-2 py-1 bg-warning/10 border border-warning/30 rounded text-[10px] text-warning">
             <span className="font-semibold">Unresolved:</span>{' '}
             {unresolvedVars.map((v) => `@${v}`).join(', ')}
           </div>

--- a/packages/workflow-ui/src/panels/DebugPanel.tsx
+++ b/packages/workflow-ui/src/panels/DebugPanel.tsx
@@ -66,7 +66,7 @@ function PayloadCard({ payload }: PayloadCardProps) {
             <span className="text-xs font-medium text-[var(--foreground)] truncate">
               {payload.nodeName || payload.nodeId}
             </span>
-            <span className="text-[10px] px-1.5 py-0.5 bg-amber-500/10 text-amber-500 rounded">
+            <span className="text-[10px] px-1.5 py-0.5 bg-muted text-muted-foreground rounded">
               {payload.nodeType}
             </span>
           </div>
@@ -116,10 +116,10 @@ function DebugPanelComponent() {
       {/* Header */}
       <div className="flex items-center justify-between p-3 border-b border-[var(--border)]">
         <div className="flex items-center gap-2">
-          <Bug className="size-4 text-amber-500" />
+          <Bug className="size-4 text-muted-foreground" />
           <span className="font-medium text-sm">Debug Console</span>
           {debugPayloads.length > 0 && (
-            <span className="text-[10px] px-1.5 py-0.5 bg-amber-500/10 text-amber-500 rounded-full">
+            <span className="text-[10px] px-1.5 py-0.5 bg-muted text-muted-foreground rounded-full">
               {debugPayloads.length}
             </span>
           )}
@@ -145,7 +145,7 @@ function DebugPanelComponent() {
       <div className="flex-1 overflow-y-auto p-3 space-y-2">
         {debugPayloads.length === 0 ? (
           <div className="text-center py-8 text-[var(--muted-foreground)]">
-            <Bug className="size-12 mx-auto mb-3 opacity-50 text-amber-500/50" />
+            <Bug className="size-12 mx-auto mb-3 opacity-50 text-muted-foreground" />
             <p className="text-sm font-medium mb-2">No payloads captured</p>
             <p className="text-xs">
               Run a workflow with debug mode enabled to capture API payloads.

--- a/packages/workflow-ui/src/panels/NodePalette.tsx
+++ b/packages/workflow-ui/src/panels/NodePalette.tsx
@@ -153,7 +153,7 @@ function NodeCard({ type, label, description, icon, category }: NodeCardProps) {
       type="button"
       draggable
       onDragStart={handleDragStart}
-      className={`p-3 bg-[var(--card)] border border-[var(--border)] cursor-grab transition-colors group ${colors.hover}`}
+      className={`p-3 bg-[var(--card)] border border-transparent shadow-border cursor-grab transition-colors group ${colors.hover}`}
     >
       <div className="flex items-start gap-3">
         <div className={`p-2 rounded ${colors.icon}`}>

--- a/packages/workflow-ui/src/styles/workflow-ui.css
+++ b/packages/workflow-ui/src/styles/workflow-ui.css
@@ -85,10 +85,10 @@
   stroke: var(--handle-audio);
 }
 
-/* Selected edge - highlight with glow (preserves type color) */
+/* Selected edge - highlight (preserves type color) */
 .react-flow__edge.selected .react-flow__edge-path {
   stroke-width: 3px;
-  filter: drop-shadow(0 0 6px currentColor) brightness(1.3);
+  filter: brightness(1.3);
   transition:
     stroke-width 0.15s ease,
     filter 0.15s ease;
@@ -102,7 +102,7 @@
 
 /* Highlighted edges (connected to selection) - brighten the type color */
 .react-flow__edge.highlighted .react-flow__edge-path {
-  filter: drop-shadow(0 0 4px currentColor) brightness(1.2);
+  filter: brightness(1.2);
   transition:
     opacity 0.2s ease,
     filter 0.2s ease;
@@ -111,15 +111,14 @@
 /* Executing edges (during workflow execution) - pipe flow effect */
 .react-flow__edge.executing .react-flow__edge-path {
   stroke-width: 2.5px;
-  filter: drop-shadow(0 0 8px currentColor) brightness(1.3);
+  filter: brightness(1.3);
   stroke-dasharray: 8 4;
   animation: edge-flow 0.5s linear infinite;
 }
 
-/* Active pipe - all edges glow during execution */
+/* Active pipe - all edges animate during execution */
 .react-flow__edge.active-pipe .react-flow__edge-path {
   stroke-width: 2px;
-  filter: drop-shadow(0 0 4px currentColor);
   stroke-dasharray: 6 3;
   animation: edge-flow 0.8s linear infinite;
   opacity: 0.8;
@@ -196,21 +195,6 @@
 /* ==========================================================================
    Animation Keyframes
    ========================================================================== */
-
-/* Processing node glow animation */
-@keyframes processing-glow {
-  0%,
-  100% {
-    box-shadow: 0 0 8px 2px var(--node-color, var(--primary));
-  }
-  50% {
-    box-shadow: 0 0 20px 6px var(--node-color, var(--primary));
-  }
-}
-
-.node-processing {
-  animation: processing-glow 1.5s ease-in-out infinite;
-}
 
 /* Edge flow animation - simulates data flowing through pipes */
 @keyframes edge-flow {

--- a/packages/workflow-ui/src/toolbar/BottomBar.tsx
+++ b/packages/workflow-ui/src/toolbar/BottomBar.tsx
@@ -32,17 +32,17 @@ function BatchCounter({
 }: BatchCounterProps) {
   return (
     <div className="flex items-center gap-0.5">
-      <span className="mr-0.5 text-[11px] text-neutral-400">Batch</span>
+      <span className="mr-0.5 text-[11px] text-muted-foreground">Batch</span>
       <Button
         variant="ghost"
         size="icon-sm"
         onClick={onDecrement}
         disabled={batchCount <= MIN_BATCH || isActive}
-        className="size-5 text-neutral-400 hover:bg-neutral-700 hover:text-white"
+        className="size-5 text-muted-foreground hover:bg-muted hover:text-foreground"
       >
         <Minus className="size-2.5" />
       </Button>
-      <span className="w-4 text-center text-xs font-medium tabular-nums text-white">
+      <span className="w-4 text-center text-xs font-medium tabular-nums text-foreground">
         {batchCount}
       </span>
       <Button
@@ -50,7 +50,7 @@ function BatchCounter({
         size="icon-sm"
         onClick={onIncrement}
         disabled={batchCount >= MAX_BATCH || isActive}
-        className="size-5 text-neutral-400 hover:bg-neutral-700 hover:text-white"
+        className="size-5 text-muted-foreground hover:bg-muted hover:text-foreground"
       >
         <Plus className="size-2.5" />
       </Button>
@@ -98,14 +98,14 @@ function RunOptionsDropdown({
       />
       <div
         ref={dropdownRef}
-        className="absolute bottom-full left-0 z-50 mb-1.5 min-w-[180px] border border-neutral-700 bg-neutral-800 py-0.5 shadow-xl"
+        className="absolute bottom-full left-0 z-50 mb-1.5 min-w-[180px] bg-secondary py-0.5 shadow-dropdown"
       >
         <Button
           variant="ghost"
           size="sm"
           onClick={onRunWorkflow}
           disabled={!canRunWorkflow}
-          className="w-full justify-start gap-1.5 px-2.5 py-1.5 text-xs text-neutral-200 hover:bg-neutral-700"
+          className="w-full justify-start gap-1.5 px-2.5 py-1.5 text-xs text-foreground hover:bg-muted"
         >
           <Play className="size-3" />
           Run Workflow
@@ -115,19 +115,19 @@ function RunOptionsDropdown({
           size="sm"
           onClick={onRunSelected}
           disabled={!hasSelection || isRunning}
-          className="w-full justify-start gap-1.5 px-2.5 py-1.5 text-xs text-neutral-200 hover:bg-neutral-700"
+          className="w-full justify-start gap-1.5 px-2.5 py-1.5 text-xs text-foreground hover:bg-muted"
         >
           <PlayCircle className="size-3" />
           Run Selected ({selectedCount})
         </Button>
         {showResume && (
           <>
-            <div className="mx-2 my-0.5 h-px bg-neutral-700" />
+            <div className="mx-2 my-0.5 h-px bg-border" />
             <Button
               variant="ghost"
               size="sm"
               onClick={onResume}
-              className="w-full justify-start gap-1.5 px-2.5 py-1.5 text-xs text-neutral-200 hover:bg-neutral-700"
+              className="w-full justify-start gap-1.5 px-2.5 py-1.5 text-xs text-foreground hover:bg-muted"
             >
               <RotateCcw className="size-3" />
               Resume from Failed
@@ -193,10 +193,10 @@ function RunControls({
         disabled={!isActive && !canRunWorkflow}
         className={`rounded-l rounded-r-none px-3 text-xs font-medium ${
           isActive
-            ? 'bg-red-500/90 hover:bg-red-500'
+            ? 'bg-destructive/90 hover:bg-destructive'
             : canRunWorkflow
               ? ''
-              : 'bg-neutral-600 text-neutral-400'
+              : 'bg-muted text-muted-foreground'
         }`}
       >
         {isActive ? (
@@ -225,10 +225,10 @@ function RunControls({
         disabled={isActive}
         className={`rounded-l-none rounded-r border-l px-1.5 ${
           isActive
-            ? 'border-red-400/30 bg-red-500/90'
+            ? 'border-destructive/30 bg-destructive/90'
             : canRunWorkflow
-              ? 'border-neutral-300'
-              : 'border-neutral-500 bg-neutral-600 text-neutral-400'
+              ? 'border-border-strong'
+              : 'border-border bg-muted text-muted-foreground'
         }`}
       >
         <ChevronUp className="size-3.5" />
@@ -263,8 +263,8 @@ function BatchProgress({
 }) {
   return (
     <>
-      <div className="mx-1 h-4 w-px bg-neutral-600" />
-      <span className="text-[11px] tabular-nums text-neutral-400">
+      <div className="mx-1 h-4 w-px bg-border" />
+      <span className="text-[11px] tabular-nums text-muted-foreground">
         {currentBatchRun}/{batchCount}
       </span>
     </>
@@ -422,14 +422,14 @@ export function BottomBar() {
 
   return (
     <div className="fixed bottom-5 left-1/2 z-50 -translate-x-1/2">
-      <div className="flex items-center gap-1 border border-neutral-700/80 bg-neutral-800/95 px-2 py-1 shadow-lg backdrop-blur-sm">
+      <div className="flex items-center gap-1 bg-secondary/95 px-2 py-1 shadow-dropdown backdrop-blur-sm">
         <BatchCounter
           batchCount={batchCount}
           isActive={isActive}
           onDecrement={decrementBatch}
           onIncrement={incrementBatch}
         />
-        <div className="mx-1 h-4 w-px bg-neutral-600" />
+        <div className="mx-1 h-4 w-px bg-border" />
         <RunControls
           dropdownRef={dropdownRef}
           onCloseDropdown={closeDropdown}

--- a/packages/workflow-ui/src/toolbar/CostIndicator.tsx
+++ b/packages/workflow-ui/src/toolbar/CostIndicator.tsx
@@ -32,7 +32,7 @@ export function CostIndicator() {
       <DollarSign className="size-3.5" />
       <span className="font-mono text-xs">{formatCost(displayCost)}</span>
       {isRunning && actualCost > 0 && (
-        <span className="size-1.5 rounded-full bg-green-500 animate-pulse" />
+        <span className="size-1.5 rounded-full bg-success" />
       )}
     </Button>
   );

--- a/packages/workflow-ui/src/toolbar/SaveIndicator.tsx
+++ b/packages/workflow-ui/src/toolbar/SaveIndicator.tsx
@@ -42,8 +42,8 @@ export function SaveIndicator({
       <div
         className={
           isPill
-            ? 'flex items-center gap-1.5 rounded-full border border-blue-500/20 bg-blue-500/10 px-2.5 py-1 text-xs text-blue-400'
-            : 'flex items-center gap-1.5 text-xs text-blue-500'
+            ? 'flex items-center gap-1.5 rounded-full border border-info/20 bg-info/10 px-2.5 py-1 text-xs text-info'
+            : 'flex items-center gap-1.5 text-xs text-info'
         }
       >
         <Loader2 className="size-3.5 animate-spin" />
@@ -75,8 +75,8 @@ export function SaveIndicator({
       title="Click to disable auto-save"
       className={
         isPill
-          ? 'rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-400 hover:text-emerald-300'
-          : 'text-xs text-green-500 hover:text-green-400 h-auto p-0'
+          ? 'rounded-full border border-success/20 bg-success/10 px-2.5 py-1 text-xs text-success hover:text-success/80'
+          : 'text-xs text-success hover:text-success/80 h-auto p-0'
       }
     >
       <Check className="size-3.5" />

--- a/packages/workflow-ui/src/toolbar/Toolbar.tsx
+++ b/packages/workflow-ui/src/toolbar/Toolbar.tsx
@@ -350,7 +350,7 @@ export function Toolbar({
           size="sm"
           onClick={() => openModal('settings')}
           title="Debug mode active - API calls are mocked"
-          className="border-amber-500/30 bg-amber-500/10 text-amber-500 hover:bg-amber-500/20"
+          className="border-warning/30 bg-warning/10 text-warning hover:bg-warning/20"
         >
           <Bug className="size-4" />
           <span className="font-medium">Debug</span>

--- a/packages/workflow-ui/src/ui/comparison-slider.tsx
+++ b/packages/workflow-ui/src/ui/comparison-slider.tsx
@@ -149,7 +149,10 @@ function ComparisonSliderComponent({
         style={{ left: `${position}%`, transform: 'translateX(-50%)' }}
       >
         <div className="absolute top-1/2 left-1/2 flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-lg">
-          <ChevronsLeftRight className="size-3 text-neutral-600" aria-hidden />
+          <ChevronsLeftRight
+            className="size-3 text-muted-foreground"
+            aria-hidden
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Phase 2 of #1335 — propagate the monochrome design system across the remaining **shared `packages/pages` surfaces** and the **`packages/workflow-ui` node/canvas/toolbar chrome**. Restyle-in-place against the Phase-1 audit findings. App chrome stays 100% grayscale; colour is retained only through the four sanctioned DESIGN.md doors (user content · platform brand · state-switching semantic status · categorical palettes).

**Scope:** 58 files (34 `packages/pages`, 24 `packages/workflow-ui`). **No new tokens.** `DESIGN.md`, `packages/ui`, and `packages/styles` token files were **not** touched — existing tokens (`bg-card`, `shadow-border`/`shadow-border-strong`, `shadow-dropdown`/`shadow-dialog`, `text-success`/`text-warning`/`text-destructive`/`text-info`, `text-muted-foreground`, `border-border`) only.

## Findings addressed by category

- **card-layering** — CSS-border card containment → `bg-card`/`bg-secondary` + inset `shadow-border` (hover `shadow-border-strong`); floating overlays (modals, dropdowns, context menus) → `shadow-dialog`/`shadow-dropdown`; nested bordered boxes inside Cards flattened to background-layer tokens; hand-rolled clickable tiles → `Card`/`bg-secondary`; raw `Link`-styled-as-button → `Button` primitive. In `content-run-detail.tsx` the ~25 repeated hand-rolled containers collapse into one local `Panel`/`Pill` wrapper (local component, no new token).
- **chrome-color** — decorative rainbow KPI icons, hardcoded `neutral-*`/`zinc-*` hues, SVG/minimap gray hex, and decorative snap-guide blue (`#3b82f6`) → grayscale tokens / `hsl(var(--…))`. **State-driven** hues (run/model/save/toast status, failure counts, delete/pause actions) → semantic token classes with the state branch preserved.
- **glow-shadow** — removed decorative radial glows (brand link-editor drop-shadow, library empty-tile amber wash, post-overlay gradient), arbitrary `shadow-[0_18px_50px_…]`, and `animate-pulse` on chrome status dots.
- **typography** — `tracking-tight` on large hero titles; livestream section headings aligned toward the 14px card-title scale.

## Two explicit decisions

- **Workflow-node palettes STAY, glows STRIPPED.** Categorical node/edge type colours are preserved (identity now carried on the node border via `borderColor: customColor || effectiveColor` and per-type edge `stroke`). Removed only the halo/pulse: the `processing-glow` keyframe + `.node-processing` class, the coloured `drop-shadow(currentColor)` edge filters (kept `brightness()`), and `shadow-lg` → inset `shadow-border`. Edge stroke colours and `brightness`/dash animations unchanged.
- **Streaks = DE-COLOURED** (per the issue's "no new tokens" non-goal). Orange radial-gradient hero and orange CTA removed → grayscale `bg-secondary`/`shadow-border` + accent `Button`. The flame remains as a plain icon glyph, not a hero gradient or coloured CTA.

## Verification (focused — no full suite)

- `bunx biome check` on all 58 touched files — **clean** (only pre-existing warnings on untouched lines).
- `bun run design:lint` — **0 errors**, no new tokens.
- `bun type-check --filter=@genfeedai/app` (the real gate for `@genfeedai/pages`, which is source-only) — **green** (`next typegen && tsc --noEmit`).
- `bun type-check --filter=@genfeedai/workflow-ui` — **green**; `turbo run build --filter=@genfeedai/workflow-ui` — **green** (ships to npm; `dist/*.mjs` + DTS emitted).
- Colocated tests (workflow-ui + CI-wired *and* non-wired pages tests) — **zero regressions**: the failing-test set is byte-identical to clean `master` (pre-existing brittle "apply correct styles and classes" fixtures), confirmed by stash-baseline comparison. `BaseNode` processing test still passes (spinner fallback).
- Pre-commit hooks (`lint-no-raw-html`, `lint-no-bespoke-card`, secretlint) — **pass**.

## Judgment calls / deferred (noted, not applied)

- **Model value-tier badge** (Good/Better/Best) and **Twitter opportunity-type badge** — treated as static editorial rankings, rendered as a grayscale intensity ramp rather than colour (opportunity-type left as its existing categorical hues where it reads as door-4 identification; flagged for design review).
- **Favourite-star** (studio table) — de-coloured to `text-foreground` (boolean toggle, not one of the four doors).
- **`StudioGenerateLayout`** — adoption note only (no chrome of its own); a follow-up sweep of `GenerateContentArea`/`GenerateEmptyState`/`AssetDisplayGrid` (out of this bundle's file list) is recommended for a later phase.
- **`CostModal` variance display** (state-driven red/green on `variance` sign) — genuinely semantic, left as-is; not in the cited findings.
- Unflagged structural dividers and out-of-scope tile borders were intentionally left per the minimal-edit rule.

Refs #1335
