### PR TITLE
refactor(api): collapse media */latest endpoints into findAll (REST audit)

### DIFF
--- a/apps/extensions/browser/app/src/background.ts
+++ b/apps/extensions/browser/app/src/background.ts
@@ -505,11 +505,14 @@ async function createVideoFromPrompt(
 }
 
 async function getLatestVideos(sendResponse: SendResponse): Promise<void> {
-  await executeAuthenticatedRequest<{ videos: unknown[] }>(
-    '/videos/latest',
+  await executeAuthenticatedRequest<{ data: unknown[] }>(
+    '/videos?limit=10',
     { method: 'GET' },
     sendResponse,
-    (data) => sendResponse({ success: true, videos: data.videos }),
+    // GET /videos returns a JSON:API collection envelope — newest-first by
+    // default — so the array lives under `data` (the `/videos/latest` shortcut
+    // was collapsed into this endpoint in the REST audit).
+    (data) => sendResponse({ success: true, videos: data.data }),
     'fetch videos',
   );
 }

--- a/apps/extensions/ide/app/src/services/api.service.ts
+++ b/apps/extensions/ide/app/src/services/api.service.ts
@@ -94,7 +94,7 @@ export class ApiService {
   async getGeneratedImages(limit = 20): Promise<GeneratedImage[]> {
     const result = await this.request<ApiResponse<GeneratedImage[]>>(
       'GET',
-      `/images/latest?limit=${limit}`,
+      `/images?limit=${limit}`,
     );
     return result.data;
   }
@@ -111,7 +111,7 @@ export class ApiService {
   async getGeneratedVideos(limit = 20): Promise<GeneratedVideo[]> {
     const result = await this.request<ApiResponse<GeneratedVideo[]>>(
       'GET',
-      `/videos/latest?limit=${limit}`,
+      `/videos?limit=${limit}`,
     );
     return result.data;
   }

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -29379,30 +29379,6 @@
         ]
       }
     },
-    "/gifs/latest": {
-      "get": {
-        "operationId": "GifsController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
-        "tags": [
-          "gifs"
-        ]
-      }
-    },
     "/gifs/{gifId}": {
       "delete": {
         "operationId": "GifsController.remove",
@@ -30060,30 +30036,6 @@
           }
         },
         "summary": "create",
-        "tags": [
-          "images"
-        ]
-      }
-    },
-    "/images/latest": {
-      "get": {
-        "operationId": "ImagesController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
         "tags": [
           "images"
         ]
@@ -33075,30 +33027,6 @@
           }
         },
         "summary": "create",
-        "tags": [
-          "musics"
-        ]
-      }
-    },
-    "/musics/latest": {
-      "get": {
-        "operationId": "MusicsController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
         "tags": [
           "musics"
         ]
@@ -48580,30 +48508,6 @@
           }
         },
         "summary": "createBatchInterpolation",
-        "tags": [
-          "videos"
-        ]
-      }
-    },
-    "/videos/latest": {
-      "get": {
-        "operationId": "VideosController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
         "tags": [
           "videos"
         ]

--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.spec.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.spec.ts
@@ -126,32 +126,6 @@ describe('GifsController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('findLatest', () => {
-    it('should return latest gifs', async () => {
-      const result = await controller.findLatest(mockRequest, mockUser, 10);
-      expect(gifsService.findAll).toHaveBeenCalledWith(
-        expect.objectContaining({
-          orderBy: { createdAt: -1 },
-          where: expect.any(Object),
-        }),
-        expect.objectContaining({ limit: 10, pagination: false }),
-      );
-      expect(result).toBeDefined();
-    });
-
-    it('should cap limit at 50', async () => {
-      await controller.findLatest(mockRequest, mockUser, 100);
-      const options = gifsService.findAll.mock.calls[0][1];
-      expect(options.limit).toBeLessThanOrEqual(50);
-    });
-
-    it('should use default limit of 10', async () => {
-      await controller.findLatest(mockRequest, mockUser);
-      const options = gifsService.findAll.mock.calls[0][1];
-      expect(options.limit).toBe(10);
-    });
-  });
-
   describe('findAll', () => {
     it('should return paginated gifs', async () => {
       const query = {} as Parameters<typeof controller.findAll>[2];

--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
@@ -2,7 +2,6 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { GifsQueryDto } from '@api/collections/gifs/dto/gifs-query.dto';
 import { GifsService } from '@api/collections/gifs/services/gifs.service';
 import { VotesService } from '@api/collections/votes/services/votes.service';
-import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -53,64 +52,6 @@ export class GifsController {
     private readonly loggerService: LoggerService,
     private readonly votesService: VotesService,
   ) {}
-
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `gifs:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['gifs'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        AND: [
-          {
-            OR: [
-              {
-                AND: [
-                  {
-                    brand,
-                    category: IngredientCategory.GIF,
-                    isDeleted,
-                    user: publicMetadata.user,
-                  },
-                ],
-              },
-              {
-                AND: [
-                  {
-                    // Filter default GIFs by brand when brand is specified
-                    brand,
-                    category: IngredientCategory.GIF,
-                    isDefault: true,
-                    isDeleted,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data = await this.gifsService.findAll(aggregate, {
-      limit: Math.min(Number(limit) || 10, 50),
-      pagination: false,
-    });
-
-    return serializeCollection(request, IngredientSerializer, data);
-  }
 
   @Get()
   @LogMethod({ logEnd: false, logError: true, logStart: true })

--- a/apps/server/api/src/collections/images/controllers/images.controller.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.ts
@@ -2,7 +2,6 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { ImagesQueryDto } from '@api/collections/images/dto/images-query.dto';
 import { ImagesService } from '@api/collections/images/services/images.service';
 import { VotesService } from '@api/collections/votes/services/votes.service';
-import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -50,66 +49,6 @@ export class ImagesController {
     private readonly loggerService: LoggerService,
     private readonly votesService: VotesService,
   ) {}
-
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `images:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['images'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        AND: [
-          {
-            OR: [
-              {
-                AND: [
-                  {
-                    brand,
-                    category: IngredientCategory.IMAGE,
-                    isDeleted,
-                    // Exclude training source images by default
-                    training: { not: false },
-                    user: publicMetadata.user,
-                  },
-                ],
-              },
-              {
-                AND: [
-                  {
-                    // Filter default images by brand when brand is specified
-                    brand,
-                    category: IngredientCategory.IMAGE,
-                    isDefault: true,
-                    isDeleted,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data = await this.imagesService.findAll(aggregate, {
-      limit: Math.min(Number(limit) || 10, 50),
-      pagination: false,
-    });
-
-    return serializeCollection(request, IngredientSerializer, data);
-  }
 
   @Get()
   @LogMethod({ logEnd: false, logError: true, logStart: true })

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
@@ -34,15 +34,6 @@ function createMockUser(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function createMockRequest(overrides: Record<string, unknown> = {}) {
-  return {
-    get: vi.fn().mockReturnValue('localhost'),
-    originalUrl: '/api/musics',
-    protocol: 'https',
-    ...overrides,
-  };
-}
-
 describe('MusicsController', () => {
   let controller: MusicsController;
   let musicsService: ReturnType<typeof createMockMusicsService>;
@@ -167,79 +158,6 @@ describe('MusicsController', () => {
 
       expect(query.where.OR[0]).toMatchObject({ brand: brandId });
       expect(query.where.OR[1]).toMatchObject({ brand: brandId });
-    });
-  });
-
-  describe('findLatest', () => {
-    it('should return serialized latest musics', async () => {
-      const user = createMockUser();
-      const request = createMockRequest();
-      const docs = [
-        {
-          _id: '507f191e810c19729de860ee',
-          category: 'music',
-          status: 'generated',
-        },
-      ];
-      musicsService.findAll.mockResolvedValue({
-        docs,
-        hasNextPage: false,
-        hasPrevPage: false,
-        limit: 10,
-        page: 1,
-        totalDocs: 1,
-        totalPages: 1,
-      });
-
-      const result = await controller.findLatest(
-        request as never,
-        user as never,
-        10,
-      );
-      expect(result).toBeDefined();
-      expect(musicsService.findAll).toHaveBeenCalled();
-    });
-
-    it('should exclude training-associated musics using trainingId: null', async () => {
-      const user = createMockUser();
-      const request = createMockRequest();
-      musicsService.findAll.mockResolvedValue({
-        docs: [],
-        hasNextPage: false,
-        hasPrevPage: false,
-        limit: 10,
-        page: 1,
-        totalDocs: 0,
-        totalPages: 1,
-      });
-
-      await controller.findLatest(request as never, user as never, 10);
-
-      const callArgs = musicsService.findAll.mock.calls[0];
-      const aggregate = callArgs[0];
-      const userBranch = aggregate.where.OR[0];
-      expect(userBranch).toHaveProperty('trainingId', null);
-      expect(userBranch).not.toHaveProperty('training');
-    });
-
-    it('should cap limit at 50', async () => {
-      const user = createMockUser();
-      const request = createMockRequest();
-      musicsService.findAll.mockResolvedValue({
-        docs: [],
-        hasNextPage: false,
-        hasPrevPage: false,
-        limit: 50,
-        page: 1,
-        totalDocs: 0,
-        totalPages: 1,
-      });
-
-      await controller.findLatest(request as never, user as never, 100);
-
-      const callArgs = musicsService.findAll.mock.calls[0];
-      const options = callArgs[1];
-      expect(options.limit).toBeLessThanOrEqual(50);
     });
   });
 });

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.ts
@@ -2,30 +2,20 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { CreateMusicDto } from '@api/collections/musics/dto/create-music.dto';
 import { MusicQueryDto } from '@api/collections/musics/dto/music-query.dto';
 import { UpdateMusicDto } from '@api/collections/musics/dto/update-music.dto';
-import {
-  Music,
-  type MusicDocument,
-} from '@api/collections/musics/schemas/music.schema';
+import type { MusicDocument } from '@api/collections/musics/schemas/music.schema';
 import { MusicsService } from '@api/collections/musics/services/musics.service';
-import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
-import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
-import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
-import { serializeCollection } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
-import { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
 import { IngredientCategory } from '@genfeedai/enums';
-import type { JsonApiCollectionResponse } from '@genfeedai/interfaces';
 import { MusicSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
-import type { Request } from 'express';
+import { Controller, UseGuards } from '@nestjs/common';
 
 @AutoSwagger()
 @Controller('musics')
@@ -47,7 +37,11 @@ export class MusicsController extends BaseCRUDController<
   }
 
   /**
-   * Override buildFindAllQuery to add music-specific filtering
+   * Override buildFindAllQuery to add music-specific filtering.
+   *
+   * Newest-first by default (`orderBy: { createdAt: -1 }`), so `GET /musics`
+   * is the canonical "latest musics" list (the former `/musics/latest` shortcut
+   * was collapsed into this endpoint in the REST audit).
    */
   public buildFindAllQuery(user: User, query: MusicQueryDto) {
     const publicMetadata = getPublicMetadata(user);
@@ -95,54 +89,5 @@ export class MusicsController extends BaseCRUDController<
       },
       orderBy: query.sort ? handleQuerySort(query.sort) : { createdAt: -1 },
     };
-  }
-
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `musics:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['musics'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        OR: [
-          {
-            brand,
-            category: IngredientCategory.MUSIC,
-            isDeleted,
-            // Exclude training source musics by default
-            trainingId: null,
-            user: publicMetadata.user,
-          },
-          {
-            // Filter default musics by brand when brand is specified
-            brand,
-            category: IngredientCategory.MUSIC,
-            isDefault: true,
-            isDeleted,
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data: AggregatePaginateResult<MusicDocument> =
-      await this.musicsService.findAll(aggregate, {
-        limit: Math.min(Number(limit) || 10, 50),
-        pagination: false,
-      });
-
-    return serializeCollection(request, this.serializer, data);
   }
 }

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
@@ -434,64 +434,6 @@ describe('VideosController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('findLatest', () => {
-    it('should return latest videos', async () => {
-      const mockData = {
-        docs: [mockVideo],
-        limit: 10,
-        page: 1,
-        totalDocs: 1,
-      };
-
-      videosService.findAll.mockResolvedValue(
-        mockData as unknown as AggregatePaginateResult<IngredientDocument>,
-      );
-
-      const result = await controller.findLatest(mockRequest, mockUser, 10);
-
-      expect(videosService.findAll).toHaveBeenCalled();
-      expect(result).toBeDefined();
-      expect(result.data).toBeDefined();
-    });
-
-    it('should limit results to maximum of 50', async () => {
-      const mockData = {
-        docs: [],
-        totalDocs: 0,
-      };
-
-      videosService.findAll.mockResolvedValue(
-        mockData as unknown as AggregatePaginateResult<IngredientDocument>,
-      );
-
-      await controller.findLatest(mockRequest, mockUser, 100);
-
-      const callArgs = videosService.findAll.mock.calls[0];
-      const options = callArgs[1];
-
-      expect(options.limit).toBe(50);
-    });
-
-    it('should use default limit of 10 if not provided', async () => {
-      const mockData = {
-        docs: [],
-        totalDocs: 0,
-      };
-
-      videosService.findAll.mockResolvedValue(
-        mockData as unknown as AggregatePaginateResult<IngredientDocument>,
-      );
-
-      await controller.findLatest(
-        mockRequest,
-        mockUser,
-        undefined as unknown as number,
-      );
-
-      expect(videosService.findAll).toHaveBeenCalled();
-    });
-  });
-
   describe('findAll', () => {
     const baseQuery: VideosQueryDto = {
       isDeleted: false,

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.ts
@@ -96,49 +96,6 @@ export class VideosController {
     private readonly videoGenerationService: VideoGenerationService,
   ) {}
 
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `videos:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['videos'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: ExpressRequest,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        AND: [
-          {
-            brand,
-            category: CategoryPrismaUtil.toIngredientCategory(
-              IngredientCategory.VIDEO,
-            ),
-            isDeleted,
-            // Exclude training source videos by default
-            training: { not: false },
-            user: publicMetadata.user,
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data = await this.videosService.findAll(aggregate, {
-      limit: Math.min(Number(limit) || 10, 50),
-      pagination: false,
-    });
-
-    return serializeCollection(request, VideoSerializer, data);
-  }
-
   @Get()
   @Cache({
     keyGenerator: (req) =>


### PR DESCRIPTION
## What

Removes the four redundant `GET /{gifs,images,videos,musics}/latest` shortcut routes and migrates their only consumers to `GET /{collection}` (findAll).

## Why

`findAll` already returns newest-first — `handleQuerySort` defaults to `{ createdAt: -1 }` — with `limit` + pagination. The `/latest` variants were pure duplication whose only extra was a bolted-on 5-min cache. This continues the REST audit (#1354) collapse pattern.

## Changes

**API — routes removed**
- `gifs`, `images`, `videos`, `musics`: deleted `findLatest` handlers + their controller-spec blocks.
- `musics` inherits `GET /musics` from `BaseCRUDController`; its `buildFindAllQuery` override already defaults to newest-first, so nothing new was added — just pruned the now-dead imports.
- Dropped unused `@Cache` imports left behind on `gifs` and `images` controllers.

**Consumers migrated**
- **IDE extension** (`apps/extensions/ide/app/src/services/api.service.ts`): `/images/latest?limit=N` → `/images?limit=N`, `/videos/latest?limit=N` → `/videos?limit=N`. Response shape (`ApiResponse.data`) is unchanged.
- **Browser extension** (`apps/extensions/browser/app/src/background.ts`): `getLatestVideos` now calls `/videos?limit=10` and reads the JSON:API `data` array. It previously read a non-existent `videos` key off the collection envelope — **latent bug fixed in passing**.

**Spec**
- `openapi.json`: removed the three `/latest` path blocks (`/gifs/latest` had already been pruned earlier this branch). Surgical edit — the emitter needs a full workspace build this worktree can't run; validated the result is still well-formed JSON and no `*/latest` media paths remain.

## Verification

- No remaining `@Get('latest')` / `findLatest` on the four controllers.
- No consumer anywhere still references a media `*/latest` endpoint (only doc comments).
- Pre-commit biome check + secretlint passed on all 10 files.
- Type-check / unit tests / openapi-drift gate delegated to CI.