### PR TITLE
refactor(studio): grayscale GenerateEmptyState badge — sibling sweep (#1335)

### DIFF
--- a/packages/pages/studio/generate/components/GenerateEmptyState.tsx
+++ b/packages/pages/studio/generate/components/GenerateEmptyState.tsx
@@ -3,7 +3,7 @@
 export function GenerateEmptyState() {
   return (
     <div className="flex min-h-[55vh] flex-col items-center justify-center gap-3 px-6 text-center">
-      <span className="rounded-full border border-white/[0.1] bg-white/[0.03] px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-foreground/45">
+      <span className="rounded-full bg-secondary px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-foreground/45 shadow-border">
         Studio
       </span>
       <h2 className="text-2xl font-semibold text-foreground">


### PR DESCRIPTION
## Summary

Small sibling-sweep **follow-up to #1361** (Phase 2 of #1335, "propagate the monochrome design system"). #1361 restyled `StudioGenerateLayout`'s composed children `AssetControlsHeader`, `StoryboardPanel`, and `StudioComposer`, but the layout's other siblings in `packages/pages/studio/generate` were outside that PR's locked file list. This sweeps the rest of the tree for grayscale consistency.

## Audit + changes

**Changed (1 line):**
- `GenerateEmptyState.tsx` — the decorative "Studio" pill used `border border-white/[0.1]` + `bg-white/[0.03]` card containment → `bg-secondary` + `shadow-border`, matching #1361's **exact** token idiom (same swap it applied to `AssetControlsHeader`'s control group and `StudioComposer`'s suggestion pills). `text-foreground/45` is already grayscale — kept.

**Audited, already grayscale-clean (no change):**
- `GenerateContentArea.tsx` — layout-only classes (`flex`, `overflow`, padding), no borders/hues/glows.
- `AssetDisplayGrid.tsx` — only `text-foreground/*` opacities.

**Audited across the rest of `studio/generate/**`, intentionally kept:**
- `useTableColumns.tsx` media scrims (`bg-black/60`, `bg-white/30`, `bg-foreground/20` skeleton pulse) — grayscale affordances layered over user media/loading, not chrome containment.
- Yellow favorite star (`useTableColumns.tsx:412`) — identical to the shared `packages/ui/.../quick-actions.config.tsx` that drives the sibling **masonry** view's favorite action. Regrayscaling only the table view would desync the two views and exceed #1361's scope, which left favorites untouched. Deferred as a separate cross-view decision.

## Contract compliance
App chrome grayscale; colour only through the four DESIGN.md doors. **No new tokens** — `bg-secondary`/`shadow-border` are existing utilities (`packages/styles/globals.css`). DESIGN.md and `packages/ui`/`packages/styles` token files untouched.

## Verification
- `bunx biome check` (touched file) — clean
- `bun run design:lint` — **0 errors**, no new tokens (warnings are pre-existing unused-token notices)
- `bun run type-check --filter=@genfeedai/app` — **no new errors in scope**; the app baseline is already red for unrelated reasons in `packages/workflow-ui` (missing `@radix-ui/react-label`, implicit-any params). No error references `packages/pages/studio/generate`.
- Pre-commit hooks (secretlint, biome, lint-no-raw-html, lint-no-bespoke-card) — passed
- No colocated test asserts on `GenerateEmptyState` classes (baseline-compare: nothing wired)

Refs #1335. Follows #1361.