### PR TITLE
feat(ui): monochrome harmonization — shared chrome colour & tokens (#1335)

### DIFF
--- a/apps/app/src/components/cloud-sync-indicator/CloudSyncIndicator.tsx
+++ b/apps/app/src/components/cloud-sync-indicator/CloudSyncIndicator.tsx
@@ -64,7 +64,7 @@ export default function CloudSyncIndicator() {
           <span
             className={cn(
               'absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full border border-background',
-              isConnected ? 'bg-emerald-400' : 'bg-amber-400',
+              isConnected ? 'bg-success' : 'bg-warning',
             )}
           />
         </Button>
@@ -76,7 +76,7 @@ export default function CloudSyncIndicator() {
               aria-hidden="true"
               className={cn(
                 'h-2 w-2 rounded-full',
-                isConnected ? 'bg-emerald-400' : 'bg-amber-400',
+                isConnected ? 'bg-success' : 'bg-warning',
               )}
             />
             <span className="text-xs font-medium text-foreground/88">
@@ -102,7 +102,7 @@ export default function CloudSyncIndicator() {
               withWrapper={false}
               disabled={desktop && isLaunching}
               onClick={() => void handleConnect()}
-              className="w-full rounded px-2 py-1.5 text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/10 cursor-pointer"
+              className="w-full rounded px-2 py-1.5 text-xs font-medium text-foreground/72 transition-colors hover:bg-hover cursor-pointer"
             >
               {desktop && isLaunching
                 ? 'Opening Browser...'

--- a/apps/app/src/components/desktop/DesktopLocalProviderSettings.tsx
+++ b/apps/app/src/components/desktop/DesktopLocalProviderSettings.tsx
@@ -276,7 +276,7 @@ export default function DesktopLocalProviderSettings({
               onClick={() => applyPreset(key)}
               className={cn(
                 'rounded border border-white/[0.08] px-1.5 py-1 text-[10px] text-foreground/56',
-                provider === key && 'border-blue-400/40 text-blue-400',
+                provider === key && 'border-border bg-hover text-foreground',
                 isCard && 'py-2 text-xs',
               )}
             >

--- a/apps/app/src/components/models/ModelBrowserModal.tsx
+++ b/apps/app/src/components/models/ModelBrowserModal.tsx
@@ -138,7 +138,7 @@ function ModelBrowserModalComponent({
                 onClick={() => setUseCaseFilter('all')}
                 className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition ${
                   useCaseFilter === 'all'
-                    ? 'bg-purple-500/20 text-purple-300 border border-purple-500/40'
+                    ? 'bg-primary text-primary-foreground border border-transparent'
                     : 'bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-transparent'
                 }`}
                 icon={<Sparkles className="size-3" />}
@@ -156,7 +156,7 @@ function ModelBrowserModalComponent({
                     onClick={() => setUseCaseFilter(uc)}
                     className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition ${
                       useCaseFilter === uc
-                        ? 'bg-purple-500/20 text-purple-300 border border-purple-500/40'
+                        ? 'bg-primary text-primary-foreground border border-transparent'
                         : 'bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-transparent'
                     }`}
                     icon={<Icon className="size-3" />}
@@ -173,13 +173,13 @@ function ModelBrowserModalComponent({
         <div className="flex-1 overflow-auto p-6">
           {/* Warning when no providers configured */}
           {!isLoading && hasFetched && configuredProviders.length === 0 && (
-            <div className="mb-6 flex items-start gap-3 rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-4">
-              <AlertTriangle className="mt-0.5 size-5 shrink-0 text-yellow-600" />
+            <div className="mb-6 flex items-start gap-3 rounded-lg border border-warning/20 bg-warning/10 p-4">
+              <AlertTriangle className="mt-0.5 size-5 shrink-0 text-warning" />
               <div>
-                <p className="text-sm font-medium text-yellow-600">
+                <p className="text-sm font-medium text-warning">
                   No AI providers configured
                 </p>
-                <p className="mt-1 text-xs text-yellow-600/80">
+                <p className="mt-1 text-xs text-warning/80">
                   Add API keys to your .env file to enable model selection.
                   Supported providers: REPLICATE_API_TOKEN, FAL_API_KEY,
                   HF_API_TOKEN

--- a/apps/app/src/components/models/UseCaseBadge.tsx
+++ b/apps/app/src/components/models/UseCaseBadge.tsx
@@ -9,7 +9,7 @@ export function UseCaseBadge({ useCase }: { useCase: ModelUseCase }) {
   const Icon = config.icon;
 
   return (
-    <span className="inline-flex items-center gap-1 rounded bg-purple-500/10 px-1.5 py-0.5 text-[10px] font-medium text-purple-400 border border-purple-500/20">
+    <span className="inline-flex items-center gap-1 rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground border border-border">
       <Icon className="size-2.5" />
       {config.label}
     </span>

--- a/apps/app/src/components/settings/tabs/ApiKeysTab.tsx
+++ b/apps/app/src/components/settings/tabs/ApiKeysTab.tsx
@@ -60,10 +60,10 @@ const API_KEYS: ApiKeyStatus[] = [
 function StatusDot({ status }: { status: boolean | null }) {
   const color =
     status === true
-      ? 'bg-green-500'
+      ? 'bg-success'
       : status === false
-        ? 'bg-red-500'
-        : 'bg-gray-400';
+        ? 'bg-destructive'
+        : 'bg-muted-foreground';
   const label =
     status === true
       ? 'Configured'
@@ -278,7 +278,7 @@ export function ApiKeysTab() {
                   {key.description}
                 </p>
                 {key.isConfigured === false && (
-                  <p className="text-xs text-red-500 mt-1">
+                  <p className="text-xs text-destructive mt-1">
                     Add to apps/
                     {key.location === 'both'
                       ? 'api/.env & web/.env'

--- a/apps/app/src/components/settings/tabs/DeveloperTab.tsx
+++ b/apps/app/src/components/settings/tabs/DeveloperTab.tsx
@@ -20,11 +20,7 @@ export function DeveloperTab() {
           icon={Bug}
           description="Skip API calls and inspect payloads without paying for generations"
           action={
-            <ToggleSwitch
-              checked={debugMode}
-              onCheckedChange={setDebugMode}
-              activeColor="bg-amber-500"
-            />
+            <ToggleSwitch checked={debugMode} onCheckedChange={setDebugMode} />
           }
         />
 

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -182,7 +182,7 @@ function AppProtectedTopbarContent({
         <div className="flex min-w-0 items-center justify-end gap-1.5">
           {taskId ? (
             <div className="hidden items-center gap-2 rounded border border-border bg-background-secondary px-2 py-1 text-[11px] lg:flex">
-              <span className="font-semibold uppercase tracking-[0.14em] text-emerald-200/80">
+              <span className="font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                 Task context
               </span>
               {taskTitle ? (
@@ -193,7 +193,7 @@ function AppProtectedTopbarContent({
               {backToTaskHref ? (
                 <Link
                   href={backToTaskHref}
-                  className="font-semibold text-emerald-100 hover:text-white"
+                  className="font-semibold text-foreground hover:text-foreground/80"
                 >
                   Back to task
                 </Link>

--- a/apps/app/src/components/toolbar/BottomBar.tsx
+++ b/apps/app/src/components/toolbar/BottomBar.tsx
@@ -164,19 +164,21 @@ export function BottomBar() {
       role="toolbar"
       tabIndex={-1}
     >
-      <div className="flex items-center gap-1 rounded-md border border-neutral-700/80 bg-neutral-800/95 px-2 py-1 shadow-lg backdrop-blur-sm">
+      <div className="flex items-center gap-1 rounded-md border border-border bg-secondary/95 px-2 py-1 shadow-lg backdrop-blur-sm">
         {/* Batch Counter */}
         <div className="flex items-center gap-0.5">
-          <span className="mr-0.5 text-[11px] text-neutral-400">Batch</span>
+          <span className="mr-0.5 text-[11px] text-muted-foreground">
+            Batch
+          </span>
           <Button
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
             onClick={decrementBatch}
             isDisabled={batchCount <= MIN_BATCH || isActive}
-            className="flex size-5 items-center justify-center rounded text-neutral-400 transition hover:bg-neutral-700 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent"
+            className="flex size-5 items-center justify-center rounded text-muted-foreground transition hover:bg-hover hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent"
             icon={<Minus className="size-2.5" />}
           />
-          <span className="w-4 text-center text-xs font-medium tabular-nums text-white">
+          <span className="w-4 text-center text-xs font-medium tabular-nums text-foreground">
             {batchCount}
           </span>
           <Button
@@ -184,13 +186,13 @@ export function BottomBar() {
             withWrapper={false}
             onClick={incrementBatch}
             isDisabled={batchCount >= MAX_BATCH || isActive}
-            className="flex size-5 items-center justify-center rounded text-neutral-400 transition hover:bg-neutral-700 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent"
+            className="flex size-5 items-center justify-center rounded text-muted-foreground transition hover:bg-hover hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent"
             icon={<Plus className="size-2.5" />}
           />
         </div>
 
         {/* Divider */}
-        <div className="mx-1 h-4 w-px bg-neutral-600" />
+        <div className="mx-1 h-4 w-px bg-border" />
 
         {/* Run Button with Dropdown */}
         <div className="relative flex items-center">
@@ -204,10 +206,10 @@ export function BottomBar() {
             isDisabled={!isActive && !canRunWorkflow}
             className={`flex h-7 items-center gap-1.5 rounded-l px-3 text-xs font-medium transition ${
               isActive
-                ? 'bg-red-500/90 text-white hover:bg-red-500'
+                ? 'bg-destructive/90 text-white hover:bg-destructive'
                 : canRunWorkflow
-                  ? 'bg-white text-black hover:bg-neutral-200'
-                  : 'bg-neutral-600 text-neutral-400'
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'bg-tertiary text-muted-foreground'
             } disabled:cursor-not-allowed`}
           >
             {isActive ? (
@@ -236,10 +238,10 @@ export function BottomBar() {
             isDisabled={isActive}
             className={`flex h-7 items-center rounded-r border-l px-1.5 transition ${
               isActive
-                ? 'border-red-400/30 bg-red-500/90 text-white'
+                ? 'border-destructive/30 bg-destructive/90 text-white'
                 : canRunWorkflow
-                  ? 'border-neutral-300 bg-white text-black hover:bg-neutral-200'
-                  : 'border-neutral-500 bg-neutral-600 text-neutral-400'
+                  ? 'border-primary/30 bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'border-border bg-tertiary text-muted-foreground'
             } disabled:cursor-not-allowed`}
             icon={<ChevronUp className="size-3.5" />}
           />
@@ -260,7 +262,7 @@ export function BottomBar() {
                 onClick={(e) => e.stopPropagation()}
                 onKeyDown={(e) => e.stopPropagation()}
                 onPointerDown={(e) => e.stopPropagation()}
-                className="absolute bottom-full left-0 z-50 mb-1.5 min-w-[180px] rounded-md border border-neutral-700 bg-neutral-800 py-0.5 shadow-xl"
+                className="absolute bottom-full left-0 z-50 mb-1.5 min-w-[180px] rounded-md border border-border bg-secondary py-0.5 shadow-xl"
                 role="menu"
                 tabIndex={-1}
               >
@@ -272,7 +274,7 @@ export function BottomBar() {
                     setDropdownOpen(false);
                   }}
                   isDisabled={!canRunWorkflow}
-                  className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-neutral-200 transition hover:bg-neutral-700 disabled:text-neutral-500 disabled:hover:bg-transparent"
+                  className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-foreground/88 transition hover:bg-hover disabled:text-muted-foreground disabled:hover:bg-transparent"
                   icon={<Play className="size-3" />}
                 >
                   Run Workflow
@@ -282,19 +284,19 @@ export function BottomBar() {
                   withWrapper={false}
                   onClick={handleRunSelected}
                   isDisabled={!hasSelection || isRunning}
-                  className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-neutral-200 transition hover:bg-neutral-700 disabled:text-neutral-500 disabled:hover:bg-transparent"
+                  className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-foreground/88 transition hover:bg-hover disabled:text-muted-foreground disabled:hover:bg-transparent"
                   icon={<PlayCircle className="size-3" />}
                 >
                   Run Selected ({selectedNodeIds.length})
                 </Button>
                 {showResume && (
                   <>
-                    <div className="mx-2 my-0.5 h-px bg-neutral-700" />
+                    <div className="mx-2 my-0.5 h-px bg-border" />
                     <Button
                       variant={ButtonVariant.UNSTYLED}
                       withWrapper={false}
                       onClick={handleResume}
-                      className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-neutral-200 transition hover:bg-neutral-700"
+                      className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left text-xs text-foreground/88 transition hover:bg-hover"
                       icon={<RotateCcw className="size-3" />}
                     >
                       Resume from Failed
@@ -309,8 +311,8 @@ export function BottomBar() {
         {/* Batch Progress */}
         {isBatchRunning && (
           <>
-            <div className="mx-1 h-4 w-px bg-neutral-600" />
-            <span className="text-[11px] tabular-nums text-neutral-400">
+            <div className="mx-1 h-4 w-px bg-border" />
+            <span className="text-[11px] tabular-nums text-muted-foreground">
               {currentBatchRun}/{batchCount}
             </span>
           </>

--- a/apps/app/src/features/workflows/nodes/repurposing/ClipSelectorNode.tsx
+++ b/apps/app/src/features/workflows/nodes/repurposing/ClipSelectorNode.tsx
@@ -218,7 +218,7 @@ function ClipSelectorNodeComponent(props: NodeProps): React.JSX.Element {
                     title={`Score: ${(clip.score * 100).toFixed(0)}%`}
                   >
                     <div
-                      className="h-full rounded-full bg-green-500"
+                      className="h-full rounded-full bg-primary"
                       style={{ width: `${clip.score * 100}%` }}
                     />
                   </div>

--- a/apps/app/src/features/workflows/pages/executions/WorkflowExecutionsPage.tsx
+++ b/apps/app/src/features/workflows/pages/executions/WorkflowExecutionsPage.tsx
@@ -196,7 +196,9 @@ export default function WorkflowExecutionsPage() {
       <header className="border-b border-white/[0.08] bg-card px-6 py-4">
         <div className="mx-auto flex max-w-7xl items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold">Execution History</h1>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Execution History
+            </h1>
             <p className="text-sm text-muted-foreground">
               View past workflow executions and their results
             </p>

--- a/apps/app/src/features/workflows/utils/status-helpers.ts
+++ b/apps/app/src/features/workflows/utils/status-helpers.ts
@@ -38,15 +38,15 @@ export function getStatusIcon(status: ExecutionStatus | string): string {
 export function getStatusColor(status: ExecutionStatus | string): string {
   switch (status) {
     case 'completed':
-      return 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900';
+      return 'text-success bg-success/10';
     case 'failed':
-      return 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900';
+      return 'text-destructive bg-destructive/10';
     case 'running':
-      return 'text-yellow-600 dark:text-yellow-400 bg-yellow-100 dark:bg-yellow-900';
+      return 'text-warning bg-warning/10';
     case 'cancelled':
-      return 'text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-800';
+      return 'text-muted-foreground bg-secondary';
     case 'skipped':
-      return 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900';
+      return 'border-border bg-secondary';
     default:
       return 'text-muted-foreground bg-muted';
   }
@@ -58,13 +58,13 @@ export function getStatusColor(status: ExecutionStatus | string): string {
 export function getStatusBorderColor(status: ExecutionStatus | string): string {
   switch (status) {
     case 'completed':
-      return 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950';
+      return 'border-success/30 bg-success/10';
     case 'failed':
-      return 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950';
+      return 'border-destructive/30 bg-destructive/10';
     case 'running':
-      return 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950';
+      return 'border-warning/30 bg-warning/10';
     case 'skipped':
-      return 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900';
+      return 'border-border bg-secondary';
     default:
       return 'border-white/[0.08] bg-card';
   }
@@ -78,10 +78,10 @@ export function getLifecycleBadgeClass(
 ): string {
   switch (lifecycle) {
     case 'published':
-      return 'border border-emerald-500/20 bg-emerald-500/10 text-emerald-300';
+      return 'border border-success/20 bg-success/10 text-success';
     case 'archived':
       return 'border border-white/10 bg-white/[0.04] text-white/55';
     default:
-      return 'border border-amber-500/20 bg-amber-500/10 text-amber-300';
+      return 'border border-warning/20 bg-warning/10 text-warning';
   }
 }

--- a/packages/ui/src/components/analytics/cards/growth-trends/growth-trends-card.tsx
+++ b/packages/ui/src/components/analytics/cards/growth-trends/growth-trends-card.tsx
@@ -186,13 +186,13 @@ export function GrowthTrendsCard({
       </div>
 
       {/* Best Day */}
-      <div className="rounded-lg bg-purple-50 p-4 dark:bg-purple-900/20">
+      <div className="rounded-lg bg-secondary p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm font-medium text-purple-900 dark:text-purple-100 mb-1">
+            <p className="text-sm font-medium text-foreground mb-1">
               Best Performing Day
             </p>
-            <p className="text-lg font-bold text-purple-600 dark:text-purple-400">
+            <p className="text-lg font-bold text-foreground">
               <ClientDateTime
                 value={growthData.bestDay.date}
                 format={(date) =>
@@ -206,10 +206,8 @@ export function GrowthTrendsCard({
             </p>
           </div>
           <div className="text-right">
-            <p className="text-sm text-purple-700 dark:text-purple-300 mb-1">
-              Views
-            </p>
-            <p className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+            <p className="text-sm text-muted-foreground mb-1">Views</p>
+            <p className="text-2xl font-bold text-foreground">
               {formatCompactNumberIntl(growthData.bestDay.views)}
             </p>
           </div>

--- a/packages/ui/src/components/analytics/cards/metric/metric-card.tsx
+++ b/packages/ui/src/components/analytics/cards/metric/metric-card.tsx
@@ -43,9 +43,7 @@ function getChangeColor(change: number | undefined): string {
   if (change === undefined || change === 0) {
     return 'text-muted-foreground';
   }
-  return change > 0
-    ? 'text-green-600 dark:text-green-400'
-    : 'text-red-600 dark:text-red-400';
+  return change > 0 ? 'text-success' : 'text-destructive';
 }
 
 const BASE_CARD_CLASSES =
@@ -59,7 +57,7 @@ export function MetricCard({
   change,
   trend,
   icon: Icon,
-  iconColor = 'text-purple-600',
+  iconColor = 'text-muted-foreground',
   isLoading = false,
   className = '',
   subtitle,

--- a/packages/ui/src/components/analytics/cards/preview/quick-analytics-preview.tsx
+++ b/packages/ui/src/components/analytics/cards/preview/quick-analytics-preview.tsx
@@ -60,7 +60,7 @@ export function QuickAnalyticsPreview({
     return (
       <div className={cardClassName}>
         <div className="flex items-center gap-2 mb-6">
-          <HiChartBarSquare className="size-4 text-purple-600" />
+          <HiChartBarSquare className="size-4 text-muted-foreground" />
           <h3 className="text-lg font-semibold text-foreground">{title}</h3>
         </div>
         <div className="text-center py-8">
@@ -69,7 +69,7 @@ export function QuickAnalyticsPreview({
           </p>
           <Link
             href={moreLink}
-            className="inline-flex items-center gap-2 rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+            className="inline-flex items-center gap-2 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
           >
             Go to Analytics
             <HiArrowRight className="size-4" />
@@ -102,20 +102,20 @@ export function QuickAnalyticsPreview({
 
   const quickStats = [
     {
-      color: 'text-purple-600',
+      color: 'text-muted-foreground',
       icon: HiChartBarSquare,
       label: 'Total Posts',
       value: data.totalPosts,
     },
     {
-      color: 'text-blue-600',
+      color: 'text-muted-foreground',
       growth: data.viewsGrowth,
       icon: HiEye,
       label: 'Total Views',
       value: data.totalViews,
     },
     {
-      color: 'text-pink-600',
+      color: 'text-muted-foreground',
       growth: data.engagementGrowth,
       icon: HiHeart,
       label: 'Engagement',
@@ -128,7 +128,7 @@ export function QuickAnalyticsPreview({
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-2">
-          <HiChartBarSquare className="size-4 text-purple-600" />
+          <HiChartBarSquare className="size-4 text-muted-foreground" />
           <h3 className="text-lg font-semibold text-foreground">{title}</h3>
         </div>
         <span className="text-sm text-muted-foreground">Last 7 days</span>
@@ -160,14 +160,14 @@ export function QuickAnalyticsPreview({
       </div>
 
       {/* Mini Trend Chart */}
-      <div className="mb-6 rounded-lg border border-purple-100 bg-gradient-to-br from-purple-50 to-blue-50 p-4 dark:border-purple-900/50 dark:from-purple-900/20 dark:to-blue-900/20">
+      <div className="mb-6 rounded-lg border border-border bg-secondary p-4">
         <p className="text-sm font-medium text-foreground/80 mb-3">
           Views Trend
         </p>
         <ChartContainer
           config={{
             value: {
-              color: '#8b5cf6',
+              color: 'hsl(var(--muted-foreground))',
               label: 'Views',
             },
           }}
@@ -177,14 +177,22 @@ export function QuickAnalyticsPreview({
           <AreaChart data={trendData}>
             <defs>
               <linearGradient id="colorPreview" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.3} />
-                <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0} />
+                <stop
+                  offset="5%"
+                  stopColor="hsl(var(--muted-foreground))"
+                  stopOpacity={0.3}
+                />
+                <stop
+                  offset="95%"
+                  stopColor="hsl(var(--muted-foreground))"
+                  stopOpacity={0}
+                />
               </linearGradient>
             </defs>
             <Area
               type="monotone"
               dataKey="value"
-              stroke="#8b5cf6"
+              stroke="hsl(var(--muted-foreground))"
               strokeWidth={2}
               fillOpacity={1}
               fill="url(#colorPreview)"
@@ -203,7 +211,7 @@ export function QuickAnalyticsPreview({
             {data.activePlatforms.map((platform) => (
               <span
                 key={platform}
-                className="px-3 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                className="px-3 py-1 rounded-full text-xs font-medium bg-secondary text-secondary-foreground"
               >
                 {platform.charAt(0).toUpperCase() + platform.slice(1)}
               </span>
@@ -214,12 +222,12 @@ export function QuickAnalyticsPreview({
 
       {/* Best Performing Platform */}
       {data.bestPerformingPlatform && (
-        <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900/50 dark:bg-green-900/20">
+        <div className="mb-6 rounded-lg border border-border bg-secondary p-3">
           <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-green-900 dark:text-green-100">
+            <p className="text-sm font-medium text-foreground">
               Best Performing Platform
             </p>
-            <span className="px-3 py-1 rounded-full text-xs font-bold bg-green-200 dark:bg-green-900/50 text-green-800 dark:text-green-200">
+            <span className="px-3 py-1 rounded-full text-xs font-bold bg-primary text-primary-foreground">
               {data.bestPerformingPlatform.charAt(0).toUpperCase() +
                 data.bestPerformingPlatform.slice(1)}
             </span>
@@ -230,7 +238,7 @@ export function QuickAnalyticsPreview({
       {/* View More Button */}
       <Link
         href={moreLink}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-purple-600 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-foreground px-4 py-3 text-sm font-medium text-background transition-colors hover:bg-foreground/90"
       >
         View Detailed Analytics
         <HiArrowRight className="size-4" />

--- a/packages/ui/src/components/analytics/insights/content-optimization-card/ContentOptimizationCard.tsx
+++ b/packages/ui/src/components/analytics/insights/content-optimization-card/ContentOptimizationCard.tsx
@@ -32,22 +32,7 @@ const getTypeIcon = (type: string) => {
   }
 };
 
-const getTypeColor = (type: string) => {
-  switch (type) {
-    case 'timing':
-      return 'text-blue-500 bg-blue-500/10';
-    case 'format':
-      return 'text-purple-500 bg-purple-500/10';
-    case 'topic':
-      return 'text-green-500 bg-green-500/10';
-    case 'hashtag':
-      return 'text-pink-500 bg-pink-500/10';
-    case 'length':
-      return 'text-orange-500 bg-orange-500/10';
-    default:
-      return 'text-primary bg-primary/10';
-  }
-};
+const TYPE_ICON_CLASS = 'text-muted-foreground bg-muted';
 
 const ContentOptimizationCard = memo(function ContentOptimizationCard({
   suggestions,
@@ -114,14 +99,13 @@ const ContentOptimizationCard = memo(function ContentOptimizationCard({
       <div className="space-y-4 max-h-96 overflow-y-auto">
         {suggestions.map((suggestion) => {
           const Icon = getTypeIcon(suggestion.type);
-          const colorClass = getTypeColor(suggestion.type);
 
           return (
             <div
               key={suggestion.id}
               className="flex items-start gap-4 p-4 bg-background hover:bg-background/80 transition-colors"
             >
-              <div className={cn('p-2.5', colorClass)}>
+              <div className={cn('p-2.5', TYPE_ICON_CLASS)}>
                 <Icon className="size-5" />
               </div>
 

--- a/packages/ui/src/components/analytics/overview/analytics-overview.tsx
+++ b/packages/ui/src/components/analytics/overview/analytics-overview.tsx
@@ -49,7 +49,7 @@ export default function AnalyticsOverview({
       ? [
           {
             icon: FiVideo,
-            iconClassName: 'bg-blue-100 text-blue-600',
+            iconClassName: 'bg-muted text-muted-foreground',
             label: 'Posts',
             value: totals.totalPosts,
           },
@@ -57,31 +57,31 @@ export default function AnalyticsOverview({
       : []),
     {
       icon: FiEye,
-      iconClassName: 'bg-green-100 text-green-600',
+      iconClassName: 'bg-muted text-muted-foreground',
       label: 'Total Views',
       value: formatCompactNumber(totals.totalViews),
     },
     {
       icon: FiHeart,
-      iconClassName: 'bg-red-100 text-red-600',
+      iconClassName: 'bg-muted text-muted-foreground',
       label: 'Total Likes',
       value: formatCompactNumber(totals.totalLikes),
     },
     {
       icon: FiMessageCircle,
-      iconClassName: 'bg-purple-100 text-purple-600',
+      iconClassName: 'bg-muted text-muted-foreground',
       label: 'Comments',
       value: formatCompactNumber(totals.totalComments),
     },
     {
       icon: FiShare2,
-      iconClassName: 'bg-orange-100 text-orange-600',
+      iconClassName: 'bg-muted text-muted-foreground',
       label: 'Shares',
       value: formatCompactNumber(totals.totalShares),
     },
     {
       icon: FiTrendingUp,
-      iconClassName: 'bg-teal-100 text-teal-600',
+      iconClassName: 'bg-muted text-muted-foreground',
       label: 'Avg Engagement',
       value: `${totals.avgEngagementRate.toFixed(2)}%`,
     },

--- a/packages/ui/src/components/analytics/top-posts/TopPostsSection.tsx
+++ b/packages/ui/src/components/analytics/top-posts/TopPostsSection.tsx
@@ -144,11 +144,11 @@ export default function TopPostsSection({
                   {formatCompactNumber(featuredPost.totalViews)}
                 </span>
                 <span className="flex items-center gap-1.5">
-                  <HiHeart className="size-4 text-rose-400" />
+                  <HiHeart className="size-4" />
                   {formatCompactNumber(featuredPost.totalLikes)}
                 </span>
                 <span className="flex items-center gap-1.5">
-                  <HiChatBubbleLeftRight className="size-4 text-sky-400" />
+                  <HiChatBubbleLeftRight className="size-4" />
                   {formatCompactNumber(featuredPost.totalComments)}
                 </span>
               </div>

--- a/packages/ui/src/components/analytics/trends/trending-hashtags.tsx
+++ b/packages/ui/src/components/analytics/trends/trending-hashtags.tsx
@@ -72,7 +72,7 @@ export function TrendingHashtags({
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div className="space-y-1">
           <h3 className="text-lg font-semibold flex items-center gap-2">
-            <HiOutlineHashtag className="text-blue-500" />
+            <HiOutlineHashtag className="text-muted-foreground" />
             Trending Hashtags
           </h3>
           <p className="text-sm text-foreground/60">

--- a/packages/ui/src/components/analytics/trends/trending-sounds.tsx
+++ b/packages/ui/src/components/analytics/trends/trending-sounds.tsx
@@ -64,7 +64,7 @@ export function TrendingSounds({
     <div className={`space-y-4 ${className}`}>
       <div className="space-y-1">
         <h3 className="text-lg font-semibold flex items-center gap-2">
-          <HiOutlineMusicalNote className="text-pink-500" />
+          <HiOutlineMusicalNote className="text-muted-foreground" />
           Trending Sounds
           <Badge className="text-xs bg-transparent">
             <FaTiktok className="size-3 mr-1" />
@@ -90,7 +90,7 @@ export function TrendingSounds({
                 <Button
                   withWrapper={false}
                   variant={ButtonVariant.UNSTYLED}
-                  className="size-16 bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center overflow-hidden"
+                  className="size-16 bg-muted flex items-center justify-center overflow-hidden"
                   onClick={(e) => {
                     if (onPlaySound) {
                       e.stopPropagation();
@@ -109,7 +109,7 @@ export function TrendingSounds({
                       unoptimized
                     />
                   ) : (
-                    <HiOutlineMusicalNote className="size-8 text-white" />
+                    <HiOutlineMusicalNote className="size-8 text-muted-foreground" />
                   )}
                   {onPlaySound && (
                     <div className="absolute inset-0 bg-black/30 flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity">

--- a/packages/ui/src/components/analytics/trends/viral-video-leaderboard.tsx
+++ b/packages/ui/src/components/analytics/trends/viral-video-leaderboard.tsx
@@ -61,7 +61,7 @@ export function ViralVideoLeaderboard({
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div className="space-y-1">
           <h3 className="text-lg font-semibold flex items-center gap-2">
-            <HiOutlineFire className="text-orange-500" />
+            <HiOutlineFire className="text-muted-foreground" />
             Viral Video Leaderboard
           </h3>
           <p className="text-sm text-foreground/60">

--- a/packages/ui/src/components/banners/production-data/ProductionDataBanner.tsx
+++ b/packages/ui/src/components/banners/production-data/ProductionDataBanner.tsx
@@ -58,7 +58,7 @@ export default function ProductionDataBanner() {
     <div
       role="alert"
       data-testid="production-data-banner"
-      className="flex w-full items-center justify-center gap-2 bg-red-600 px-4 py-2 text-sm font-bold text-white"
+      className="flex w-full items-center justify-center gap-2 bg-destructive px-4 py-2 text-sm font-bold text-destructive-foreground"
     >
       <HiExclamationTriangle className="size-5 shrink-0" />
       <span>PRODUCTION DATA: Read carefully before making changes</span>

--- a/packages/ui/src/components/cards/streak-card/StreakCard.tsx
+++ b/packages/ui/src/components/cards/streak-card/StreakCard.tsx
@@ -49,13 +49,13 @@ export default function StreakCard() {
 
   return (
     <Card
-      className="mx-3 mb-3 overflow-visible shadow-[inset_0_0_0_1px_rgba(249,115,22,0.15)] bg-orange-500/[0.06]"
+      className="mx-3 mb-3 overflow-visible shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)] bg-white/[0.04]"
       bodyClassName="gap-0 p-3"
     >
       <StreakCelebrationBurst isVisible={isCelebrating} />
       <div className="mb-2 flex items-center justify-between">
         <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-orange-200/70">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
             Daily streak
           </p>
           <p className="text-lg font-semibold text-white">
@@ -64,7 +64,7 @@ export default function StreakCard() {
               : `${currentStreak} day${currentStreak === 1 ? '' : 's'}`}
           </p>
         </div>
-        <div className="rounded-full border border-orange-400/20 px-2 py-1 text-[11px] font-medium text-orange-100/80">
+        <div className="rounded-full border border-white/20 px-2 py-1 text-[11px] font-medium text-white/80">
           {streakFreezes} freeze{streakFreezes === 1 ? '' : 's'}
         </div>
       </div>
@@ -78,7 +78,7 @@ export default function StreakCard() {
               className={cn(
                 'h-7 rounded border text-[10px] flex items-center justify-center',
                 count > 0
-                  ? 'border-orange-300/30 bg-orange-300/25 text-orange-50'
+                  ? 'border-white/30 bg-white/25 text-white'
                   : 'border-white/8 bg-white/[0.03] text-white/25',
               )}
               title={`${dayKey}${count > 0 ? `: ${count} item${count === 1 ? '' : 's'}` : ''}`}

--- a/packages/ui/src/components/command-palette/command-palette-item/CommandPaletteItem.tsx
+++ b/packages/ui/src/components/command-palette/command-palette-item/CommandPaletteItem.tsx
@@ -51,7 +51,7 @@ export function CommandPaletteItem({
           )}
         </div>
         {command.description && (
-          <p className="truncate text-sm opacity-60">{command.description}</p>
+          <p className="truncate opacity-60">{command.description}</p>
         )}
       </div>
     </Button>

--- a/packages/ui/src/components/content/filters-button/FiltersButton.tsx
+++ b/packages/ui/src/components/content/filters-button/FiltersButton.tsx
@@ -200,7 +200,7 @@ export default function FiltersButton({
         createPortal(
           <div
             ref={dropdownRef}
-            className="fixed bg-[#141414] border border-white/[0.06] shadow-2xl z-[10000] p-6 pointer-events-auto"
+            className="fixed bg-secondary border border-white/[0.06] shadow-2xl z-[10000] p-6 pointer-events-auto"
             style={{
               left: portalCoords.left,
               top: portalCoords.top,

--- a/packages/ui/src/components/content/textarea-label-actions/TextareaLabelActions.tsx
+++ b/packages/ui/src/components/content/textarea-label-actions/TextareaLabelActions.tsx
@@ -63,7 +63,7 @@ export default function TextareaLabelActions({
             icon={<HiArrowUturnLeft className="size-3.5" />}
             variant={ButtonVariant.GHOST}
             size={ButtonSize.XS}
-            className="h-6 min-h-6 px-1.5 text-warning"
+            className="h-6 min-h-6 px-1.5 text-muted-foreground"
             tooltip={undoTooltip}
             tooltipPosition="top"
             onClick={onUndo}

--- a/packages/ui/src/components/display/badge/badge.variants.ts
+++ b/packages/ui/src/components/display/badge/badge.variants.ts
@@ -26,31 +26,32 @@ export const badgeVariants = cva(
       variant: {
         // Harmonized dark-mode palette with subtle backgrounds
         accent: 'bg-violet-500/15 text-violet-400 border-violet-500/30',
-        amber: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+        amber: 'bg-warning/10 text-warning border-warning/30',
+        // Content type badges (categorical — distinguishing media kinds)
         audio: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
         blue: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
         default: 'bg-primary/15 text-primary border-primary/30',
-        destructive: 'bg-rose-500/15 text-rose-400 border-rose-500/30',
-        // Semantic aliases with harmonized colors
-        error: 'bg-rose-500/15 text-rose-400 border-rose-500/30',
+        destructive: 'bg-destructive/10 text-destructive border-destructive/30',
+        // Semantic aliases routed through the canonical destructive token
+        error: 'bg-destructive/10 text-destructive border-destructive/30',
         ghost: 'bg-white/5 text-muted-foreground border-white/[0.08]',
-        // Content type badges (Neural Noir colorful badges)
+        // Content type badges (categorical — distinguishing media kinds)
         image: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-        info: 'bg-sky-500/15 text-sky-400 border-sky-500/30',
+        info: 'bg-info/10 text-info border-info/30',
         multimodal: 'bg-pink-500/20 text-pink-400 border-pink-500/30',
-        operational: 'bg-green-500/20 text-green-400 border-green-500/30',
+        operational: 'bg-success/10 text-success border-success/30',
         outline: 'border-white/[0.08] text-foreground bg-transparent',
         primary: 'bg-primary/15 text-primary border-primary/30',
         // Additional category colors
         purple: 'bg-violet-500/15 text-violet-400 border-violet-500/30',
         secondary: 'bg-slate-500/15 text-slate-400 border-slate-500/30',
         slate: 'bg-slate-500/15 text-slate-400 border-slate-500/30',
-        success: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
-        text: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
-        // Status badges with vivid colors
-        validated: 'bg-green-500/20 text-green-400 border-green-500/30',
+        success: 'bg-success/10 text-success border-success/30',
+        text: 'bg-success/10 text-success border-success/30',
+        // Status badges routed through canonical semantic tokens
+        validated: 'bg-success/10 text-success border-success/30',
         video: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-        warning: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+        warning: 'bg-warning/10 text-warning border-warning/30',
       },
     },
   },

--- a/packages/ui/src/components/display/table/Table.tsx
+++ b/packages/ui/src/components/display/table/Table.tsx
@@ -125,7 +125,7 @@ export default function AppTable<T>({
   return (
     <div className="relative overflow-hidden rounded bg-card shadow-border">
       <div className="overflow-x-auto rounded">
-        <table className="w-full caption-bottom text-sm">
+        <table className="w-full caption-bottom">
           <thead
             className={cn(
               'sticky top-0 z-10 bg-card/95 backdrop-blur-lg',

--- a/packages/ui/src/components/display/video-trim-timeline/VideoTrimTimeline.tsx
+++ b/packages/ui/src/components/display/video-trim-timeline/VideoTrimTimeline.tsx
@@ -91,8 +91,8 @@ export default function VideoTrimTimeline({
           className="custom-range-slider"
           styles={{
             handle: {
-              backgroundColor: 'hsl(var(--p))',
-              borderColor: 'hsl(var(--p))',
+              backgroundColor: 'hsl(var(--foreground))',
+              borderColor: 'hsl(var(--foreground))',
               height: 16,
               marginTop: -4,
               opacity: 1,

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorModelItem.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorModelItem.tsx
@@ -52,7 +52,7 @@ const ModelSelectorModelItem = memo(function ModelSelectorModelItem({
           name={`model-${model.key}`}
           isChecked={isSelected}
           onChange={() => {}}
-          className="size-3.5 !border-white/20 data-[state=checked]:!bg-blue-500 data-[state=checked]:!border-blue-500 data-[state=checked]:!text-white"
+          className="size-3.5 !border-white/20 data-[state=checked]:!bg-foreground data-[state=checked]:!border-foreground data-[state=checked]:!text-background"
         />
       </div>
 
@@ -98,7 +98,7 @@ const ModelSelectorModelItem = memo(function ModelSelectorModelItem({
         className={cn(
           'mt-0.5 p-0.5 rounded hover:bg-white/10 transition-colors shrink-0',
           isFavorite
-            ? 'text-yellow-400'
+            ? 'text-foreground'
             : 'text-foreground/20 hover:text-foreground/40',
         )}
       >

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorPopover.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorPopover.tsx
@@ -407,7 +407,7 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
         align="start"
         sideOffset={8}
         className={cn(
-          'p-0 bg-[#141414] border border-white/10 rounded-lg overflow-hidden',
+          'p-0 bg-popover border border-white/10 rounded-lg overflow-hidden',
           shouldShowManualCatalog ? 'w-[440px]' : 'w-[320px]',
         )}
       >
@@ -485,7 +485,7 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
                             className={cn(
                               'flex size-4 items-center justify-center rounded-sm border transition-colors',
                               isAutoSelected
-                                ? 'border-blue-500 bg-blue-500 text-white'
+                                ? 'border-foreground bg-foreground text-background'
                                 : 'border-white/20 bg-transparent text-transparent',
                             )}
                           >

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorProviderSidebar.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorProviderSidebar.tsx
@@ -29,7 +29,7 @@ const ModelSelectorProviderSidebar = memo(
             isActive={activeBrand === 'favorites'}
             onClick={() => handleBrandClick('favorites')}
             tooltip="Favorites"
-            color="#EAB308"
+            color="hsl(var(--foreground))"
           >
             <HiStar className="size-4" />
           </SidebarButton>

--- a/packages/ui/src/components/dropdowns/multiselect/DropdownMultiSelect.tsx
+++ b/packages/ui/src/components/dropdowns/multiselect/DropdownMultiSelect.tsx
@@ -271,7 +271,7 @@ export default function MultiSelectDropdown({
                     onChange={() => {
                       // Row click/keyboard handles selection state.
                     }}
-                    className="size-3.5 !border-white/20 data-[state=checked]:!bg-blue-500 data-[state=checked]:!border-blue-500 data-[state=checked]:!text-white"
+                    className="size-3.5 !border-white/20 data-[state=checked]:!bg-foreground data-[state=checked]:!border-foreground data-[state=checked]:!text-background"
                   />
                 </div>
                 All

--- a/packages/ui/src/components/dropdowns/multiselect/MultiSelectOptionsList.tsx
+++ b/packages/ui/src/components/dropdowns/multiselect/MultiSelectOptionsList.tsx
@@ -87,7 +87,7 @@ export default function MultiSelectOptionsList({
                 onChange={() => {
                   // Row click/keyboard handles selection state.
                 }}
-                className="size-3.5 !border-white/20 data-[state=checked]:!bg-blue-500 data-[state=checked]:!border-blue-500 data-[state=checked]:!text-white"
+                className="size-3.5 !border-white/20 data-[state=checked]:!bg-foreground data-[state=checked]:!border-foreground data-[state=checked]:!text-background"
               />
             </div>
           )}

--- a/packages/ui/src/components/dropdowns/multiselect/MultiSelectSearchBar.tsx
+++ b/packages/ui/src/components/dropdowns/multiselect/MultiSelectSearchBar.tsx
@@ -20,7 +20,7 @@ export default function MultiSelectSearchBar({
   onClear,
 }: MultiSelectSearchBarProps) {
   return (
-    <div className="sticky top-0 bg-[#141414] z-10 px-2 py-1.5 border-b border-white/10">
+    <div className="sticky top-0 bg-popover z-10 px-2 py-1.5 border-b border-white/10">
       <FormSearchbar
         value={searchTerm}
         onChange={onSearchChange}

--- a/packages/ui/src/components/evaluation/badge/EvaluationBadge.tsx
+++ b/packages/ui/src/components/evaluation/badge/EvaluationBadge.tsx
@@ -30,7 +30,7 @@ const getScoreLabel = (score: number) => {
 };
 
 const sizeClasses = {
-  md: 'text-sm px-2 py-1 min-w-badge-md',
+  md: 'text-xs px-2 py-1 min-w-badge-md',
   sm: 'text-xs px-1.5 py-0.5 min-w-badge-sm',
   xs: 'text-[10px] px-1 py-0.5 min-w-badge-xs',
 };

--- a/packages/ui/src/components/feedback/NotFoundState.tsx
+++ b/packages/ui/src/components/feedback/NotFoundState.tsx
@@ -22,7 +22,7 @@ export default function NotFoundState({
   return (
     <div className={containerClassName}>
       <div className={cn('mx-auto max-w-4xl py-20 text-center', className)}>
-        <h1 className="mb-4 text-4xl font-semibold">{title}</h1>
+        <h1 className="mb-4 text-4xl font-semibold tracking-tight">{title}</h1>
         <p className="mb-8 text-muted-foreground">{message}</p>
 
         <Button asChild>

--- a/packages/ui/src/components/feedback/alert/Alert.tsx
+++ b/packages/ui/src/components/feedback/alert/Alert.tsx
@@ -16,7 +16,7 @@ import {
  * CVA alert variants with semantic color options
  */
 const alertVariants = cva(
-  'relative w-full rounded-lg border px-4 py-3 text-sm flex items-center gap-3 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:shrink-0',
+  'relative w-full rounded-lg border px-4 py-3 flex items-center gap-3 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:shrink-0',
   {
     defaultVariants: {
       variant: 'default',

--- a/packages/ui/src/components/feedback/streak-celebration/StreakCelebrationBurst.tsx
+++ b/packages/ui/src/components/feedback/streak-celebration/StreakCelebrationBurst.tsx
@@ -33,7 +33,7 @@ export default function StreakCelebrationBurst({
         <span
           key={position}
           className={cn(
-            'absolute size-2.5 rounded-full bg-orange-300/80 opacity-0',
+            'absolute size-2.5 rounded-full bg-white/70 opacity-0',
             position,
             isVisible && 'animate-ping',
           )}

--- a/packages/ui/src/components/guards/onboarding/OnboardingGuard.tsx
+++ b/packages/ui/src/components/guards/onboarding/OnboardingGuard.tsx
@@ -132,7 +132,7 @@ function OnboardingGuardInner({ children }: OnboardingGuardProps) {
   ) {
     return (
       <div className="flex items-center justify-center min-h-[calc(100vh-4rem)]">
-        <div className="size-6 border-2 border-neutral-300 border-t-neutral-700 rounded-full animate-spin dark:border-neutral-600 dark:border-t-neutral-300" />
+        <div className="size-6 border-2 border-border border-t-foreground rounded-full animate-spin" />
       </div>
     );
   }

--- a/packages/ui/src/components/guards/subscription/SubscriptionGuard.tsx
+++ b/packages/ui/src/components/guards/subscription/SubscriptionGuard.tsx
@@ -50,7 +50,7 @@ export default function SubscriptionGuard({
   if (isLoading || !checked) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="size-6 border-2 border-neutral-300 border-t-neutral-700 rounded-full animate-spin dark:border-neutral-600 dark:border-t-neutral-300" />
+        <div className="size-6 border-2 border-border border-t-foreground rounded-full animate-spin" />
       </div>
     );
   }

--- a/packages/ui/src/components/ingredients/tabs/prompts/IngredientTabsPrompts.tsx
+++ b/packages/ui/src/components/ingredients/tabs/prompts/IngredientTabsPrompts.tsx
@@ -40,7 +40,9 @@ export default function IngredientTabsPrompts({
 
       {/* First row: full width */}
       <div className="flex flex-col rounded-2xl border border-white/8 bg-white/[0.025] p-4">
-        <span className="font-semibold opacity-50">{promptRows[0].label}</span>
+        <span className="font-semibold text-muted-foreground">
+          {promptRows[0].label}
+        </span>
         <span className="text-white mt-1 whitespace-pre-wrap">
           {promptRows[0].value}
         </span>
@@ -53,7 +55,9 @@ export default function IngredientTabsPrompts({
             key={row.label}
             className="flex flex-col rounded-2xl border border-white/8 bg-white/[0.025] p-4"
           >
-            <span className="font-semibold opacity-50">{row.label}</span>
+            <span className="font-semibold text-muted-foreground">
+              {row.label}
+            </span>
             <span className="text-white mt-1 whitespace-pre-wrap">
               {row.value}
             </span>

--- a/packages/ui/src/components/ingredients/tabs/tags/IngredientTabsTags.tsx
+++ b/packages/ui/src/components/ingredients/tabs/tags/IngredientTabsTags.tsx
@@ -150,8 +150,8 @@ export default function IngredientTabsTags({
                 key={tag.id}
                 size={ComponentSize.LG}
                 className="gap-2 px-3 py-2"
-                backgroundColor={tag.backgroundColor || '#e5e7eb'}
-                textColor={tag.textColor || '#374151'}
+                backgroundColor={tag.backgroundColor || 'hsl(var(--muted))'}
+                textColor={tag.textColor || 'hsl(var(--muted-foreground))'}
               >
                 <HiTag className="text-sm" />
                 <span>{tag.label}</span>
@@ -263,8 +263,8 @@ export default function IngredientTabsTags({
                     isDisabled={isUpdating}
                     className="inline-flex items-center justify-start gap-2 px-3 h-8 text-sm bg-secondary text-secondary-foreground border"
                     style={{
-                      borderColor: tag.backgroundColor || '#e5e7eb',
-                      color: tag.textColor || '#374151',
+                      borderColor: tag.backgroundColor || 'hsl(var(--muted))',
+                      color: tag.textColor || 'hsl(var(--muted-foreground))',
                     }}
                     ariaLabel={`Add tag ${tag.label}`}
                   >

--- a/packages/ui/src/components/kpi/kpi-card/KPICard.tsx
+++ b/packages/ui/src/components/kpi/kpi-card/KPICard.tsx
@@ -89,8 +89,8 @@ export default function KPICard({
             className={cn(
               'inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium',
               isPositiveTrend
-                ? 'bg-green-500/20 text-green-400'
-                : 'bg-red-500/20 text-red-400',
+                ? 'bg-success/20 text-success'
+                : 'bg-destructive/20 text-destructive',
             )}
           >
             <TrendIcon className="size-3" />

--- a/packages/ui/src/components/layout/container/Container.tsx
+++ b/packages/ui/src/components/layout/container/Container.tsx
@@ -73,7 +73,7 @@ export default function Container({
       {hasLeft && <div className="mb-4">{left}</div>}
 
       {tabs && tabs.length > 0 && (
-        <div className="mb-6 border-b border-white/5">
+        <div className="mb-6 border-b border-border">
           <Tabs
             tabs={tabs}
             className="mb-0"

--- a/packages/ui/src/components/layout/page-header/PageHeader.tsx
+++ b/packages/ui/src/components/layout/page-header/PageHeader.tsx
@@ -68,7 +68,7 @@ export default function PageHeader({
             />
           ) : (
             <div>
-              <h1 className="text-2xl font-semibold">{title}</h1>
+              <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
               {description && (
                 <p className="text-sm text-foreground/70 mt-1">{description}</p>
               )}

--- a/packages/ui/src/components/loading/fallback/LazyLoadingFallback.tsx
+++ b/packages/ui/src/components/loading/fallback/LazyLoadingFallback.tsx
@@ -47,7 +47,7 @@ export default function LazyLoadingFallback({
   return (
     <div
       className={cn(
-        'relative bg-gradient-to-br from-gray-200 to-gray-300 dark:from-gray-800 dark:to-gray-700 overflow-hidden',
+        'relative bg-secondary overflow-hidden',
         aspectClass,
         className,
       )}

--- a/packages/ui/src/components/masonry/video/MasonryVideoActionsBar.tsx
+++ b/packages/ui/src/components/masonry/video/MasonryVideoActionsBar.tsx
@@ -111,9 +111,7 @@ export default function MasonryVideoActionsBar({
               variant={ButtonVariant.DEFAULT}
               size={ButtonSize.SM}
               className={`${
-                video.hasVoted
-                  ? 'bg-green-500 hover:bg-green-600 text-white cursor-default'
-                  : ''
+                video.hasVoted ? 'bg-success text-white cursor-default' : ''
               } ${video.isVoteAnimating ? 'animate-vote' : ''}`}
               onClick={() => onVoteIngredient?.(video)}
             />

--- a/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.tsx
+++ b/packages/ui/src/components/menus/organization-switcher/OrganizationSwitcher.tsx
@@ -177,7 +177,7 @@ export default function OrganizationSwitcher() {
             <span
               className={cn(
                 'flex-1 text-left truncate text-sm font-medium',
-                error ? 'text-red-400' : 'text-foreground/90',
+                error ? 'text-destructive' : 'text-foreground/90',
               )}
             >
               {isSwitching ? 'Switching\u2026' : displayLabel}
@@ -228,7 +228,7 @@ export default function OrganizationSwitcher() {
                   htmlFor="org-switcher-name"
                   className="text-xs font-medium text-foreground/70"
                 >
-                  Name <span className="text-red-400">*</span>
+                  Name <span className="text-destructive">*</span>
                 </label>
                 <Input
                   id="org-switcher-name"
@@ -261,7 +261,7 @@ export default function OrganizationSwitcher() {
                 />
               </div>
               {createModal.createError && (
-                <p className="text-xs text-red-400">
+                <p className="text-xs text-destructive">
                   {createModal.createError}
                 </p>
               )}

--- a/packages/ui/src/components/menus/sidebar-back-row/SidebarBackRow.tsx
+++ b/packages/ui/src/components/menus/sidebar-back-row/SidebarBackRow.tsx
@@ -27,7 +27,7 @@ export default function SidebarBackRow({ label, href }: SidebarBackRowProps) {
         aria-label={`Back to ${label}`}
       >
         <HiArrowLeft className="size-4 text-foreground/60 group-hover:text-foreground transition-colors duration-200" />
-        <span className="text-sm font-medium text-foreground/90">{label}</span>
+        <span className="font-medium text-foreground/90">{label}</span>
       </Link>
     </div>
   );

--- a/packages/ui/src/components/menus/sidebar-nested/SidebarNested.tsx
+++ b/packages/ui/src/components/menus/sidebar-nested/SidebarNested.tsx
@@ -191,7 +191,7 @@ export default function SidebarNested({
           ariaLabel={`Back to ${backLabel ?? groupLabel}`}
         >
           <HiArrowLeft className="size-4 text-foreground/60 group-hover:text-foreground transition-colors duration-200" />
-          <span className="text-sm font-medium text-foreground/90">
+          <span className="font-medium text-foreground/90">
             {backLabel ?? groupLabel}
           </span>
         </Button>

--- a/packages/ui/src/components/menus/user-dropdown/UserDropdown.tsx
+++ b/packages/ui/src/components/menus/user-dropdown/UserDropdown.tsx
@@ -93,7 +93,7 @@ export default function UserDropdown({
               sizes="32px"
             />
           ) : (
-            <span className="flex size-8 items-center justify-center rounded-full bg-foreground/15 text-sm font-semibold text-foreground/80">
+            <span className="flex size-8 items-center justify-center rounded-full bg-foreground/15 font-semibold text-foreground/80">
               {initial}
             </span>
           )}
@@ -102,7 +102,7 @@ export default function UserDropdown({
       <DropdownMenuContent side={side} align="end" className="w-56">
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-1">
-            <p className="text-sm font-medium leading-none">{userName}</p>
+            <p className="font-medium leading-none">{userName}</p>
             <p className="text-xs leading-none text-muted-foreground">
               {userEmail}
             </p>

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.tsx
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.tsx
@@ -96,7 +96,7 @@ export default function BrandOverlay({
         badges={
           activeBrand ? (
             <>
-              <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] uppercase tracking-[0.22em] text-foreground/55">
+              <span className="gen-label rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-foreground/55">
                 Brand
               </span>
               <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-foreground/70">
@@ -107,7 +107,7 @@ export default function BrandOverlay({
               </span>
             </>
           ) : (
-            <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] uppercase tracking-[0.22em] text-foreground/55">
+            <span className="gen-label rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-foreground/55">
               New Brand
             </span>
           )

--- a/packages/ui/src/components/modals/content/generate-illustration/IllustrationActions.tsx
+++ b/packages/ui/src/components/modals/content/generate-illustration/IllustrationActions.tsx
@@ -30,15 +30,16 @@ export default function IllustrationActions({
 }: Props) {
   return (
     <ModalActions>
-      <Link
-        href={`${EnvironmentService.apps.app}/studio/image`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center justify-center gap-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground h-9 px-3"
-      >
-        <HiArrowTopRightOnSquare className="size-4" />
-        Studio
-      </Link>
+      <Button variant={ButtonVariant.SECONDARY} asChild>
+        <Link
+          href={`${EnvironmentService.apps.app}/studio/image`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <HiArrowTopRightOnSquare className="size-4" />
+          Studio
+        </Link>
+      </Button>
 
       <div className="flex-1" />
 

--- a/packages/ui/src/components/modals/content/post/ModalPostMetadata.tsx
+++ b/packages/ui/src/components/modals/content/post/ModalPostMetadata.tsx
@@ -137,7 +137,7 @@ export default function PostMetadataOverlay({
       onClose={handleOverlayClose}
       badges={
         <>
-          <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] uppercase tracking-[0.22em] text-foreground/55">
+          <span className="gen-label rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-foreground/55">
             Post
           </span>
           <span className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-foreground/70">

--- a/packages/ui/src/components/modals/gallery/ModalGalleryHeader.tsx
+++ b/packages/ui/src/components/modals/gallery/ModalGalleryHeader.tsx
@@ -90,7 +90,7 @@ export default function ModalGalleryHeader({
             {/* Format display - read-only, comes from promptbar */}
             {(activeTab === 'media' || activeTab === 'references') && (
               <div className="flex items-center gap-2">
-                <Badge variant="outline" className="text-sm font-medium">
+                <Badge variant="outline" className="font-medium">
                   Format:{' '}
                   {formatVideos.find((f) => f.id === localFormat)?.label ||
                     localFormat}

--- a/packages/ui/src/components/modals/ingredients/trim/ModalTrim.tsx
+++ b/packages/ui/src/components/modals/ingredients/trim/ModalTrim.tsx
@@ -60,7 +60,7 @@ export default function ModalTrim({
     >
       <div className="flex flex-col h-full gap-6">
         {/* Video Player Section */}
-        <div className="flex-1 min-h-0 flex items-center justify-center bg-neutral-950 overflow-hidden">
+        <div className="flex-1 min-h-0 flex items-center justify-center bg-background overflow-hidden">
           <div className="relative size-full max-h-full">
             <VideoPlayer
               videoRef={videoRef}

--- a/packages/ui/src/components/modals/models/ModalModelViewContent.tsx
+++ b/packages/ui/src/components/modals/models/ModalModelViewContent.tsx
@@ -98,12 +98,9 @@ export default function ModalModelViewContent({
             </h4>
             <div className="flex flex-wrap gap-2">
               {model.recommendedFor.map((item) => (
-                <span
-                  key={item}
-                  className="px-3 py-1 bg-background rounded-full text-sm"
-                >
+                <Badge key={item} variant="outline" size={ComponentSize.SM}>
                   {item}
-                </span>
+                </Badge>
               ))}
             </div>
           </div>

--- a/packages/ui/src/components/modals/onboarding/ModalOnboarding.tsx
+++ b/packages/ui/src/components/modals/onboarding/ModalOnboarding.tsx
@@ -255,9 +255,7 @@ function ModalOnboardingContent({
                   {num > 1 && (
                     <div
                       className={`w-8 h-0.5 ${
-                        num <= currentStep
-                          ? 'bg-gradient-to-r from-primary/40 to-primary/20'
-                          : 'bg-white/[0.08]'
+                        num <= currentStep ? 'bg-primary/30' : 'bg-white/[0.08]'
                       }`}
                     />
                   )}

--- a/packages/ui/src/components/modals/onboarding/steps/OnboardingStepProcessing.tsx
+++ b/packages/ui/src/components/modals/onboarding/steps/OnboardingStepProcessing.tsx
@@ -95,7 +95,7 @@ export default function OnboardingStepProcessing({
               <div
                 className={`size-6 rounded-full flex items-center justify-center transition-colors ${
                   isComplete
-                    ? 'bg-green-500 text-white'
+                    ? 'bg-success text-success-foreground'
                     : isCurrent
                       ? 'bg-primary text-primary-foreground'
                       : 'bg-muted'

--- a/packages/ui/src/components/modals/system/error-debug/ModalErrorDebug.tsx
+++ b/packages/ui/src/components/modals/system/error-debug/ModalErrorDebug.tsx
@@ -39,7 +39,7 @@ function ErrorSection({
   return (
     <Card
       variant={CardVariant.DEFAULT}
-      className="rounded-lg border-destructive/30 bg-destructive/10 text-red-50 hover:border-destructive/30"
+      className="rounded-lg border-destructive/30 bg-destructive/10 text-destructive-foreground hover:border-destructive/30"
       bodyClassName="gap-0 p-4"
     >
       {onToggle ? (
@@ -47,7 +47,7 @@ function ErrorSection({
           withWrapper={false}
           variant={ButtonVariant.UNSTYLED}
           onClick={onToggle}
-          className="flex w-full items-center gap-2 text-left text-red-50"
+          className="flex w-full items-center gap-2 text-left text-destructive-foreground"
         >
           {isExpanded ? (
             <HiChevronDown className="size-4 shrink-0" />
@@ -68,7 +68,7 @@ function ErrorSection({
 export default function ModalErrorDebug() {
   const clipboardService = ClipboardService.getInstance();
   const preClassName =
-    'mt-2 max-h-48 overflow-y-auto border-destructive/20 bg-black/30 text-red-50';
+    'mt-2 max-h-48 overflow-y-auto border-destructive/20 bg-black/30 text-destructive-foreground';
 
   const [errorInfo, setErrorInfo] = useState<IErrorDebugInfo | null>(null);
   const [isResponseExpanded, setIsResponseExpanded] = useState(false);
@@ -108,11 +108,11 @@ export default function ModalErrorDebug() {
       isError
       error={errorInfo?.message}
       onClose={handleModalClosed}
-      modalBoxClassName="rounded-lg border-destructive/50 bg-[#17080a] text-red-50"
+      modalBoxClassName="rounded-lg border-destructive/50 bg-[#17080a] text-destructive-foreground"
     >
       {errorInfo && (
         <>
-          <div className="space-y-4 text-red-50">
+          <div className="space-y-4 text-destructive-foreground">
             <ErrorSection title="Request Details">
               <div className="grid grid-cols-2 gap-2 text-sm">
                 {errorInfo.url && (
@@ -215,7 +215,7 @@ export default function ModalErrorDebug() {
               label="Copy"
               variant={ButtonVariant.SECONDARY}
               size={ButtonSize.LG}
-              className="border-destructive/30 bg-destructive/10 text-red-50 hover:bg-destructive/20 md:h-9 md:px-4 md:py-2"
+              className="border-destructive/30 bg-destructive/10 text-destructive-foreground hover:bg-destructive/20 md:h-9 md:px-4 md:py-2"
               onClick={handleCopy}
             />
 
@@ -223,7 +223,7 @@ export default function ModalErrorDebug() {
               label="Reload"
               variant={ButtonVariant.SECONDARY}
               size={ButtonSize.LG}
-              className="border-destructive/30 bg-destructive/10 text-red-50 hover:bg-destructive/20 md:h-9 md:px-4 md:py-2"
+              className="border-destructive/30 bg-destructive/10 text-destructive-foreground hover:bg-destructive/20 md:h-9 md:px-4 md:py-2"
               onClick={() => {
                 handleCancel();
                 refresh();

--- a/packages/ui/src/components/modals/upgrade/ModalUpgradePrompt.tsx
+++ b/packages/ui/src/components/modals/upgrade/ModalUpgradePrompt.tsx
@@ -109,8 +109,8 @@ export default function ModalUpgradePrompt({
     <Modal id={ModalEnum.UPGRADE_PROMPT} title="Upgrade Your Plan">
       <div className="space-y-6 py-2">
         {/* Lock message */}
-        <div className="flex items-start gap-3 p-4 bg-amber-500/5 shadow-border">
-          <HiLockClosed className="size-5 text-amber-500 flex-shrink-0 mt-0.5" />
+        <div className="flex items-start gap-3 p-4 bg-primary/5 shadow-border">
+          <HiLockClosed className="size-5 text-primary flex-shrink-0 mt-0.5" />
           <div>
             <p className="text-sm font-medium text-foreground">
               {lockedLabel

--- a/packages/ui/src/components/navigation/pagination/auto-pagination/AutoPagination.tsx
+++ b/packages/ui/src/components/navigation/pagination/auto-pagination/AutoPagination.tsx
@@ -92,7 +92,7 @@ function AutoPaginationContent({
       />
 
       {showTotal && totalDocs > 0 && (
-        <div className="text-sm text-foreground/60">
+        <div className="text-foreground/60">
           Showing page {currentPage} of {totalPages} ({totalDocs} {totalLabel})
         </div>
       )}

--- a/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.tsx
+++ b/packages/ui/src/components/posts/post-detail-sidebar/PostDetailSidebar.tsx
@@ -120,7 +120,7 @@ export default function PostDetailSidebar({
       {isPublished && post.ingredients?.length > 0 && (
         <Card>
           <div className="flex items-center gap-2">
-            <HiBolt className="size-4 text-warning" />
+            <HiBolt className="size-4 text-muted-foreground" />
             <h3 className="font-semibold text-lg">
               Ingredients ({post.ingredients?.length || 0})
             </h3>

--- a/packages/ui/src/components/posts/post-detail-sidebar/PostSidebarAnalyticsCard.tsx
+++ b/packages/ui/src/components/posts/post-detail-sidebar/PostSidebarAnalyticsCard.tsx
@@ -10,31 +10,12 @@ type PostSidebarAnalyticsCardProps = {
 export default function PostSidebarAnalyticsCard({
   analyticsStats,
 }: PostSidebarAnalyticsCardProps) {
-  const getIconBgClass = (accent: string) => {
-    if (accent.includes('primary')) {
-      return 'bg-green-100 text-green-600';
-    }
-    if (accent.includes('rose')) {
-      return 'bg-red-100 text-red-600';
-    }
-    if (accent.includes('secondary')) {
-      return 'bg-purple-100 text-purple-600';
-    }
-    if (accent.includes('warning')) {
-      return 'bg-orange-100 text-orange-600';
-    }
-    if (accent.includes('success')) {
-      return 'bg-teal-100 text-teal-600';
-    }
-    return 'bg-background text-foreground';
-  };
-
   return (
     <Card>
       <div className="grid grid-cols-2 gap-3">
         {analyticsStats.map((stat) => (
           <div key={stat.label} className="flex items-center gap-3">
-            <div className={`flex-shrink-0 p-2 ${getIconBgClass(stat.accent)}`}>
+            <div className="flex-shrink-0 p-2 bg-secondary text-foreground">
               <stat.icon size={18} />
             </div>
             <div className="flex-1 min-w-0">

--- a/packages/ui/src/components/pricing/card/PricingCard.tsx
+++ b/packages/ui/src/components/pricing/card/PricingCard.tsx
@@ -98,7 +98,7 @@ export default function PricingCard({
 
                 return (
                   <li key={feature} className="flex items-start">
-                    <FaCheck className="size-4 text-green-500 mr-2 mt-0.5 flex-shrink-0" />
+                    <FaCheck className="size-4 text-muted-foreground mr-2 mt-0.5 flex-shrink-0" />
                     <span>{feature}</span>
                   </li>
                 );

--- a/packages/ui/src/components/prompt-bars/base/use-prompt-bar-state.tsx
+++ b/packages/ui/src/components/prompt-bars/base/use-prompt-bar-state.tsx
@@ -636,7 +636,7 @@ export function usePromptBarState({
   }, [watchedFormat]);
 
   const controlClass =
-    'h-9 px-2.5 gap-1.5 text-sm flex-shrink-0 !border-transparent !bg-transparent !shadow-none text-white/70 hover:!bg-white/5 hover:!text-white';
+    'h-9 px-2.5 gap-1.5 flex-shrink-0 !border-transparent !bg-transparent !shadow-none text-white/70 hover:!bg-white/5 hover:!text-white';
   const iconButtonClass =
     'size-9 p-0 flex items-center justify-center !border-transparent !bg-transparent !shadow-none text-white/70 hover:!bg-white/5 hover:!text-white';
   const textareaRegister = form.register('text');

--- a/packages/ui/src/components/prompt-bars/components/collapsed-view/PromptBarCollapsedView.tsx
+++ b/packages/ui/src/components/prompt-bars/components/collapsed-view/PromptBarCollapsedView.tsx
@@ -186,7 +186,7 @@ const PromptBarCollapsedView = memo(function PromptBarCollapsedView({
             }
             className={cn(
               'absolute right-1.5 top-1/2 -translate-y-1/2 size-8 p-0 transition-all duration-300',
-              activeGenerationsCount > 0 && 'bg-yellow-500 hover:bg-yellow-600',
+              activeGenerationsCount > 0 && 'bg-warning hover:bg-warning/90',
             )}
             data-testid="generate-button"
           />
@@ -261,8 +261,8 @@ const PromptBarCollapsedView = memo(function PromptBarCollapsedView({
             tooltipPosition="top"
             icon={
               <HiMicrophone
-                className="size-4"
-                color={isRecording ? 'red' : undefined}
+                className={cn('size-4', isRecording && 'text-destructive')}
+                color={isRecording ? 'currentColor' : undefined}
               />
             }
           >

--- a/packages/ui/src/components/prompt-bars/post/PromptBarPost.tsx
+++ b/packages/ui/src/components/prompt-bars/post/PromptBarPost.tsx
@@ -50,7 +50,7 @@ const DEFAULT_PLATFORMS = [
 ] satisfies PostPlatform[];
 
 const CONTROL_CLASS =
-  'h-9 px-3 gap-2 text-sm flex-shrink-0 !border-white/10 !bg-white/[0.03] text-white/80 hover:!bg-white/[0.06] hover:text-white';
+  'h-9 px-3 gap-2 flex-shrink-0 !border-white/10 !bg-white/[0.03] text-white/80 hover:!bg-white/[0.06] hover:text-white';
 const COLLAPSE_BUTTON_CLASS =
   'size-8 bg-black/20 p-0 text-white/70 shadow-border backdrop-blur-sm hover:bg-black/30 hover:text-white';
 

--- a/packages/ui/src/components/quick-actions/config/quick-actions.config.tsx
+++ b/packages/ui/src/components/quick-actions/config/quick-actions.config.tsx
@@ -170,7 +170,7 @@ export const createFavoriteAction = (
   return {
     icon: (
       <HiStar
-        className={`size-4 ${ingredient.isFavorite ? 'fill-yellow-500' : ''}`}
+        className={`size-4 ${ingredient.isFavorite ? 'fill-foreground' : ''}`}
       />
     ),
     id: 'favorite',
@@ -603,7 +603,7 @@ export const createMarkValidatedAction = (
   return {
     icon: (
       <HiCheckCircle
-        className={`size-4 ${isValidated ? 'text-green-500' : 'text-white'}`}
+        className={`size-4 ${isValidated ? 'text-success' : 'text-white'}`}
       />
     ),
     id: 'mark-validated',
@@ -630,7 +630,7 @@ export const createMarkRejectedAction = (
   return {
     icon: (
       <HiXMark
-        className={`size-4 ${isRejected ? 'text-red-500' : 'text-white'}`}
+        className={`size-4 ${isRejected ? 'text-destructive' : 'text-white'}`}
       />
     ),
     id: 'mark-rejected',

--- a/packages/ui/src/components/shell/topbars/LandingTopbar.tsx
+++ b/packages/ui/src/components/shell/topbars/LandingTopbar.tsx
@@ -17,14 +17,7 @@ export default function LandingTopbar({
   logoHref = '/',
 }: LandingTopbarProps): React.ReactElement {
   return (
-    <header
-      className="fixed inset-x-0 top-0 z-50 w-full border-b border-white/10"
-      style={{
-        backdropFilter: 'blur(8px)',
-        backgroundColor: 'rgba(9, 9, 11, 0.72)',
-        WebkitBackdropFilter: 'blur(8px)',
-      }}
-    >
+    <header className="fixed inset-x-0 top-0 z-50 w-full border-b border-white/10 bg-primary/[0.72] backdrop-blur-md">
       <div className="container mx-auto flex h-20 items-center justify-between px-6">
         <TopbarLogo logoHref={logoHref} />
 

--- a/packages/ui/src/components/subscription/SubscriptionPlanChanger.tsx
+++ b/packages/ui/src/components/subscription/SubscriptionPlanChanger.tsx
@@ -93,7 +93,7 @@ export default function SubscriptionPlanChanger({
 
             <div className="flex items-center gap-2">
               {isMonthly && (
-                <span className="px-2 py-1 text-xs bg-green-100 text-green-800">
+                <span className="px-2 py-1 text-xs bg-secondary text-foreground">
                   Current
                 </span>
               )}
@@ -128,7 +128,7 @@ export default function SubscriptionPlanChanger({
 
             <div className="flex items-center gap-2">
               {isYearly && (
-                <span className="px-2 py-1 text-xs bg-green-100 text-green-800">
+                <span className="px-2 py-1 text-xs bg-secondary text-foreground">
                   Current
                 </span>
               )}
@@ -179,7 +179,7 @@ export default function SubscriptionPlanChanger({
                       <span className="text-muted-foreground">
                         Amount due today
                       </span>
-                      <span className="font-medium text-green-600">
+                      <span className="font-medium text-success">
                         {formatAmount(preview.prorationAmount)}
                       </span>
                     </p>
@@ -195,7 +195,7 @@ export default function SubscriptionPlanChanger({
                       <span className="text-muted-foreground">
                         Credit applied
                       </span>
-                      <span className="font-medium text-blue-600">
+                      <span className="font-medium text-info">
                         {formatAmount(Math.abs(preview.prorationAmount))}
                       </span>
                     </p>

--- a/packages/ui/src/components/tags/dropdown/DropdownTagsTrigger.tsx
+++ b/packages/ui/src/components/tags/dropdown/DropdownTagsTrigger.tsx
@@ -30,7 +30,7 @@ export default function DropdownTagsTrigger({
   const buttonContent: React.ReactNode = showLabel ? (
     <span>{tagCountLabel}</span>
   ) : hasSelectedTags ? (
-    <span className="absolute -top-0.5 -right-0.5 min-w-fit h-5 flex items-center justify-center px-1 text-[10px] font-bold text-white bg-orange-500 rounded-full border-2 border-white/20 shadow-lg z-10">
+    <span className="absolute -top-0.5 -right-0.5 min-w-fit h-5 flex items-center justify-center px-1 text-[10px] font-bold text-primary-foreground bg-primary rounded-full border-2 border-white/20 shadow-lg z-10">
       {selectedTagCount}
     </span>
   ) : null;

--- a/packages/ui/src/components/topbars/credits-bar/CreditsBarPanel.tsx
+++ b/packages/ui/src/components/topbars/credits-bar/CreditsBarPanel.tsx
@@ -65,9 +65,8 @@ export default function CreditsBarPanel({
             </div>
             <div className="flex h-2 w-full overflow-hidden rounded-full bg-foreground/[0.06]">
               <div
-                className="relative transition-all duration-300"
+                className="relative bg-foreground/[0.12] transition-all duration-300"
                 style={{
-                  background: 'rgba(255,255,255,0.12)',
                   width:
                     extraBalance > 0
                       ? `${(planLimit / (planLimit + extraBalance)) * 100}%`
@@ -75,9 +74,8 @@ export default function CreditsBarPanel({
                 }}
               >
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full transition-all duration-500"
+                  className="absolute inset-y-0 left-0 rounded-full bg-foreground/[0.55] transition-all duration-500"
                   style={{
-                    background: 'rgba(255,255,255,0.55)',
                     width: `${planUsagePercent}%`,
                   }}
                 />
@@ -144,7 +142,7 @@ export default function CreditsBarPanel({
                     <div
                       className={cn(
                         'text-sm font-semibold text-foreground',
-                        segment.status === 'unavailable' && 'text-amber-200/80',
+                        segment.status === 'unavailable' && 'text-warning',
                       )}
                     >
                       {segment.status === 'available' &&

--- a/packages/ui/src/components/topbars/credits-bar/CreditsBarTrigger.tsx
+++ b/packages/ui/src/components/topbars/credits-bar/CreditsBarTrigger.tsx
@@ -50,7 +50,7 @@ export default function CreditsBarTrigger({
               key={segment.provider}
               className={cn(
                 'inline-flex h-5 max-w-[5.5rem] items-center gap-1 rounded bg-foreground/[0.04] px-1.5 text-[11px] font-medium text-foreground/62',
-                segment.status === 'unavailable' && 'text-amber-200/70',
+                segment.status === 'unavailable' && 'text-warning',
               )}
               title={`${segment.label}: ${
                 segment.status === 'available' &&

--- a/packages/ui/src/components/topbars/inbox/TopbarInbox.tsx
+++ b/packages/ui/src/components/topbars/inbox/TopbarInbox.tsx
@@ -187,12 +187,12 @@ export default function TopbarInbox() {
 
                     <div className="flex items-center gap-2 text-xs text-foreground/45">
                       {item.reviewDecision === 'approved' ? (
-                        <HiCheckCircle className="size-4 text-emerald-300" />
+                        <HiCheckCircle className="size-4 text-success" />
                       ) : item.reviewDecision === 'request_changes' ? (
-                        <HiOutlineClipboardDocumentCheck className="size-4 text-amber-300" />
+                        <HiOutlineClipboardDocumentCheck className="size-4 text-warning" />
                       ) : item.reviewDecision === 'rejected' ||
                         item.status === 'failed' ? (
-                        <HiExclamationTriangle className="size-4 text-rose-300" />
+                        <HiExclamationTriangle className="size-4 text-destructive" />
                       ) : (
                         <HiOutlineInboxStack className="size-4 text-foreground/35" />
                       )}

--- a/packages/ui/src/components/topbars/public/TopbarPublic.tsx
+++ b/packages/ui/src/components/topbars/public/TopbarPublic.tsx
@@ -145,20 +145,9 @@ export default function TopbarPublic({
         className={cn(
           'fixed inset-x-0 top-0 z-50 w-full transition-all duration-300',
           isScrolled
-            ? 'border-b border-white/10'
-            : 'border-b border-transparent',
+            ? 'border-b border-white/10 bg-primary/60 backdrop-blur-2xl'
+            : 'border-b border-transparent bg-transparent',
         )}
-        style={
-          isScrolled
-            ? {
-                backdropFilter: 'blur(24px)',
-                backgroundColor: 'rgba(9, 9, 11, 0.6)',
-                WebkitBackdropFilter: 'blur(24px)',
-              }
-            : {
-                backgroundColor: 'transparent',
-              }
-        }
       >
         <div className="container mx-auto flex items-center justify-between h-20 px-6">
           {/* Left: Logo + Nav */}

--- a/packages/ui/src/components/topbars/public/TopbarPublicMobileMenu.tsx
+++ b/packages/ui/src/components/topbars/public/TopbarPublicMobileMenu.tsx
@@ -69,10 +69,7 @@ export default function TopbarPublicMobileMenu({
       />
 
       {/* Menu Panel */}
-      <div
-        className="relative z-10 w-full max-h-[80vh] overflow-y-auto mt-20 border-b border-white/10"
-        style={{ backgroundColor: '#09090b' }}
-      >
+      <div className="relative z-10 w-full max-h-[80vh] overflow-y-auto mt-20 border-b border-white/10 bg-primary">
         <nav className="container mx-auto p-6">
           <ul className="space-y-6">
             {/* Mobile Dropdowns */}

--- a/packages/ui/src/components/workflow-builder/WorkflowToolbar.tsx
+++ b/packages/ui/src/components/workflow-builder/WorkflowToolbar.tsx
@@ -101,7 +101,6 @@ export default function WorkflowToolbar({
           type="button"
           variant={ButtonVariant.DEFAULT}
           size={ButtonSize.SM}
-          className="bg-success hover:bg-success/90"
           onClick={onRun}
           ariaLabel="Run workflow"
           icon={<HiOutlinePlay className="size-4" />}

--- a/packages/ui/src/components/workflow-builder/nodes/BaseNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/BaseNode.tsx
@@ -85,7 +85,7 @@ function BaseNode({
           id={key}
           isConnectable={isConnectable}
           style={{
-            background: '#22c55e',
+            background: '#6b7280',
             height: 10,
             top: `${((index + 1) / (outputKeys.length + 1)) * 100}%`,
             width: 10,

--- a/packages/ui/src/components/workflow-builder/nodes/SocialPublishNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/SocialPublishNode.tsx
@@ -207,7 +207,7 @@ function SocialPublishNodeComponent({
           href={data.publishedUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 p-2 bg-green-500/10 border border-green-500/20 text-green-400 text-sm hover:bg-green-500/20 transition"
+          className="flex items-center gap-2 p-2 bg-success/10 border border-success/20 text-success text-sm hover:bg-success/20 transition"
         >
           <ExternalLink className="size-4" />
           View Published Video

--- a/packages/ui/src/components/workflow-builder/nodes/TrendHashtagInspirationNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/TrendHashtagInspirationNode.tsx
@@ -212,8 +212,8 @@ function TrendHashtagInspirationNodeComponent({
 
       {/* Generated Prompt */}
       {data.prompt && (
-        <div className="p-2 bg-green-500/10 border border-green-500/20">
-          <div className="text-xs text-green-400 font-medium mb-1">
+        <div className="p-2 bg-secondary border border-border">
+          <div className="text-xs text-muted-foreground font-medium mb-1">
             Generated Prompt
           </div>
           <div className="text-sm text-foreground">{data.prompt}</div>

--- a/packages/ui/src/components/workflow-builder/nodes/TrendSoundInspirationNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/TrendSoundInspirationNode.tsx
@@ -132,7 +132,7 @@ function TrendSoundInspirationNodeComponent({
 
       {/* Sound Result */}
       {data.soundId && (
-        <div className="p-3 bg-green-500/10 border border-green-500/20">
+        <div className="p-3 bg-secondary border border-border">
           <div className="flex items-start gap-3">
             {/* Cover Art */}
             {data.coverUrl && (
@@ -193,7 +193,7 @@ function TrendSoundInspirationNodeComponent({
 
       {/* No sound found */}
       {data.status === WorkflowNodeStatus.COMPLETE && !data.soundId && (
-        <div className="p-2 bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 text-sm">
+        <div className="p-2 bg-warning/10 border border-warning/20 text-warning text-sm">
           No trending sounds found matching criteria
         </div>
       )}

--- a/packages/ui/src/components/workflow-builder/nodes/TrendTriggerNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/TrendTriggerNode.tsx
@@ -237,7 +237,7 @@ function TrendTriggerNodeComponent({
                   onClick={() => handleRemoveKeyword(keyword)}
                   type="button"
                   variant={ButtonVariant.UNSTYLED}
-                  className="hover:text-red-500"
+                  className="hover:text-destructive"
                 >
                   <X className="size-3" />
                 </Button>

--- a/packages/ui/src/components/workflow-builder/nodes/TrendVideoInspirationNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/TrendVideoInspirationNode.tsx
@@ -240,8 +240,8 @@ function TrendVideoInspirationNodeComponent({
 
       {/* Generated Prompt */}
       {data.prompt && (
-        <div className="p-2 bg-green-500/10 border border-green-500/20">
-          <div className="text-xs text-green-400 font-medium mb-1">
+        <div className="p-2 bg-secondary border border-border">
+          <div className="text-xs text-muted-foreground font-medium mb-1">
             Generated Prompt
           </div>
           <div className="text-sm text-foreground">{data.prompt}</div>

--- a/packages/ui/src/components/workflow-builder/panels/ExecutionHistoryPanel.tsx
+++ b/packages/ui/src/components/workflow-builder/panels/ExecutionHistoryPanel.tsx
@@ -53,10 +53,10 @@ interface ExecutionHistoryPanelProps {
 
 const STATUS_ICONS: Record<string, React.ReactNode> = {
   cancelled: <HiOutlineXMark className="size-4 text-muted-foreground" />,
-  completed: <HiOutlineCheck className="size-4 text-green-500" />,
-  failed: <HiOutlineXMark className="size-4 text-red-500" />,
+  completed: <HiOutlineCheck className="size-4 text-success" />,
+  failed: <HiOutlineXMark className="size-4 text-destructive" />,
   pending: <HiOutlineClock className="size-4 text-muted-foreground" />,
-  running: <HiOutlineArrowPath className="size-4 text-blue-500 animate-spin" />,
+  running: <HiOutlineArrowPath className="size-4 text-info animate-spin" />,
 };
 
 const STATUS_VARIANTS: Record<string, 'ghost' | 'success' | 'error' | 'info'> =

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -196,7 +196,7 @@ function Button({
   const wrappedButton = withWrapper ? (
     <div className={cn('relative inline-flex', wrapperClassName)}>
       {isPingEnabled ? (
-        <span className="absolute -top-1 -right-1 size-3 animate-ping rounded-full bg-red-500" />
+        <span className="absolute -top-1 -right-1 size-3 animate-ping rounded-full bg-destructive" />
       ) : null}
       {buttonElement}
     </div>

--- a/packages/ui/src/primitives/editable-input.tsx
+++ b/packages/ui/src/primitives/editable-input.tsx
@@ -161,7 +161,7 @@ export default function EditableInput({
               label={<HiCheck />}
               onClick={() => void handleSave()}
               variant={ButtonVariant.DEFAULT}
-              className=" first: last: border-l-0 first:border-l bg-green-500 hover:bg-green-600 text-white"
+              className=" first: last: border-l-0 first:border-l"
               isLoading={isSaving}
               isDisabled={isSaving}
             />

--- a/packages/ui/src/sidebar/SidebarNavItem.tsx
+++ b/packages/ui/src/sidebar/SidebarNavItem.tsx
@@ -51,7 +51,7 @@ export function SidebarNavItem({
       <span className="relative shrink-0">
         <Icon className="size-4" />
         {alert && (
-          <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-red-500 shadow-[0_0_0_2px_hsl(var(--background))]" />
+          <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-destructive shadow-[0_0_0_2px_hsl(var(--background))]" />
         )}
       </span>
       <span className="flex-1 truncate">{label}</span>
@@ -60,7 +60,7 @@ export function SidebarNavItem({
           className={cn(
             'ml-auto rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none',
             textBadgeTone === 'amber'
-              ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'
+              ? 'bg-warning/10 text-warning'
               : 'bg-muted text-muted-foreground',
           )}
         >
@@ -70,10 +70,10 @@ export function SidebarNavItem({
       {liveCount != null && liveCount > 0 && (
         <span className="ml-auto flex items-center gap-1.5">
           <span className="relative flex size-2">
-            <span className="absolute inline-flex size-full animate-pulse rounded-full bg-blue-400 opacity-75" />
-            <span className="relative inline-flex size-2 rounded-full bg-blue-500" />
+            <span className="absolute inline-flex size-full animate-pulse rounded-full bg-foreground/40" />
+            <span className="relative inline-flex size-2 rounded-full bg-foreground/70" />
           </span>
-          <span className="text-[11px] font-medium text-blue-600 dark:text-blue-400">
+          <span className="text-[11px] font-medium text-muted-foreground">
             {liveCount} live
           </span>
         </span>
@@ -83,7 +83,7 @@ export function SidebarNavItem({
           className={cn(
             'ml-auto rounded-full px-1.5 py-0.5 text-xs leading-none',
             badgeTone === 'danger'
-              ? 'bg-red-600/90 text-red-50'
+              ? 'bg-destructive text-destructive-foreground'
               : 'bg-primary text-primary-foreground',
           )}
         >

--- a/packages/ui/src/static/surface.ts
+++ b/packages/ui/src/static/surface.ts
@@ -224,7 +224,7 @@ export const staticSurfaceCss = `
   border: 0;
   border-radius: var(--gf-surface-radius);
   background: var(--gf-bg-primary);
-  color: #dbeafe;
+  color: var(--gf-text-secondary);
   box-shadow: var(--gf-shadow-border);
   font-size: 12px;
   line-height: 1.7;
@@ -235,9 +235,9 @@ export const staticSurfaceCss = `
   display: grid;
   grid-template-columns: 20px minmax(0, 1fr);
   gap: 12px;
-  border: 1px solid rgba(245, 158, 11, 0.26);
+  border: 1px solid color-mix(in srgb, var(--gf-warning) 26%, transparent);
   border-radius: var(--gf-surface-radius);
-  background: rgba(245, 158, 11, 0.08);
+  background: color-mix(in srgb, var(--gf-warning) 8%, transparent);
   color: var(--gf-text-secondary);
   padding: 14px;
   font-size: 12px;

--- a/packages/ui/src/tokens/status-colors.ts
+++ b/packages/ui/src/tokens/status-colors.ts
@@ -5,14 +5,12 @@
 
 export const issueStatusIcon: Record<string, string> = {
   backlog: 'text-muted-foreground border-muted-foreground',
-  blocked: 'text-red-600 border-red-600 dark:text-red-400 dark:border-red-400',
-  cancelled: 'text-neutral-500 border-neutral-500',
-  done: 'text-green-600 border-green-600 dark:text-green-400 dark:border-green-400',
-  in_progress:
-    'text-yellow-600 border-yellow-600 dark:text-yellow-400 dark:border-yellow-400',
-  in_review:
-    'text-violet-600 border-violet-600 dark:text-violet-400 dark:border-violet-400',
-  todo: 'text-blue-600 border-blue-600 dark:text-blue-400 dark:border-blue-400',
+  blocked: 'text-destructive border-destructive',
+  cancelled: 'text-muted-foreground border-muted-foreground',
+  done: 'text-success border-success',
+  in_progress: 'text-warning border-warning',
+  in_review: 'text-info border-info',
+  todo: 'text-info border-info',
 };
 
 export const issueStatusIconDefault =
@@ -20,75 +18,63 @@ export const issueStatusIconDefault =
 
 export const issueStatusText: Record<string, string> = {
   backlog: 'text-muted-foreground',
-  blocked: 'text-red-600 dark:text-red-400',
-  cancelled: 'text-neutral-500',
-  done: 'text-green-600 dark:text-green-400',
-  in_progress: 'text-yellow-600 dark:text-yellow-400',
-  in_review: 'text-violet-600 dark:text-violet-400',
-  todo: 'text-blue-600 dark:text-blue-400',
+  blocked: 'text-destructive',
+  cancelled: 'text-muted-foreground',
+  done: 'text-success',
+  in_progress: 'text-warning',
+  in_review: 'text-info',
+  todo: 'text-info',
 };
 
 export const issueStatusTextDefault = 'text-muted-foreground';
 
 export const statusBadge: Record<string, string> = {
-  achieved:
-    'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
-  active:
-    'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
-  approved:
-    'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
+  achieved: 'bg-success/10 text-success',
+  active: 'bg-success/10 text-success',
+  approved: 'bg-success/10 text-success',
   archived: 'bg-muted text-muted-foreground',
   backlog: 'bg-muted text-muted-foreground',
-  blocked: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
+  blocked: 'bg-destructive/10 text-destructive',
   cancelled: 'bg-muted text-muted-foreground',
-  completed:
-    'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
-  done: 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
-  error: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
-  failed: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
-  idle: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300',
-  in_progress:
-    'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300',
-  in_review:
-    'bg-violet-100 text-violet-700 dark:bg-violet-900/50 dark:text-violet-300',
-  paused:
-    'bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300',
-  pending:
-    'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300',
-  pending_approval:
-    'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
+  completed: 'bg-success/10 text-success',
+  done: 'bg-success/10 text-success',
+  error: 'bg-destructive/10 text-destructive',
+  failed: 'bg-destructive/10 text-destructive',
+  idle: 'bg-warning/10 text-warning',
+  in_progress: 'bg-warning/10 text-warning',
+  in_review: 'bg-info/10 text-info',
+  paused: 'bg-warning/10 text-warning',
+  pending: 'bg-warning/10 text-warning',
+  pending_approval: 'bg-warning/10 text-warning',
   planned: 'bg-muted text-muted-foreground',
-  rejected: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
-  revision_requested:
-    'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
-  running: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300',
-  succeeded:
-    'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
-  terminated: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
-  timed_out:
-    'bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300',
-  todo: 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300',
+  rejected: 'bg-destructive/10 text-destructive',
+  revision_requested: 'bg-warning/10 text-warning',
+  running: 'bg-info/10 text-info',
+  succeeded: 'bg-success/10 text-success',
+  terminated: 'bg-destructive/10 text-destructive',
+  timed_out: 'bg-warning/10 text-warning',
+  todo: 'bg-info/10 text-info',
 };
 
 export const statusBadgeDefault = 'bg-muted text-muted-foreground';
 
 export const agentStatusDot: Record<string, string> = {
-  active: 'bg-green-400',
-  archived: 'bg-neutral-400',
-  error: 'bg-red-400',
-  idle: 'bg-yellow-400',
-  paused: 'bg-yellow-400',
-  pending_approval: 'bg-amber-400',
-  running: 'bg-cyan-400 animate-pulse',
+  active: 'bg-success',
+  archived: 'bg-muted-foreground',
+  error: 'bg-destructive',
+  idle: 'bg-warning',
+  paused: 'bg-warning',
+  pending_approval: 'bg-warning',
+  running: 'bg-[#38bdf8] animate-pulse',
 };
 
-export const agentStatusDotDefault = 'bg-neutral-400';
+export const agentStatusDotDefault = 'bg-muted-foreground';
 
 export const priorityColor: Record<string, string> = {
-  critical: 'text-red-600 dark:text-red-400',
-  high: 'text-orange-600 dark:text-orange-400',
-  low: 'text-blue-600 dark:text-blue-400',
-  medium: 'text-yellow-600 dark:text-yellow-400',
+  critical: 'text-destructive',
+  high: 'text-warning',
+  low: 'text-info',
+  medium: 'text-warning',
 };
 
-export const priorityColorDefault = 'text-yellow-600 dark:text-yellow-400';
+export const priorityColorDefault = 'text-warning';


### PR DESCRIPTION
## Summary

Phase 2b of #1335 — the **shared-foundation colour pass**, stacked on the containment PR (#1359). Recolours decorative hue chrome to grayscale and routes real state-driven colour through **semantic token classes** across `packages/ui`, `packages/helpers`, and `apps/app/src`.

> Stacked on `feat/monochrome-shared-containment-1335` (#1359) — this PR's base is that branch, so the diff is colour-only. GitHub will retarget it to `master` automatically once #1359 merges.

Scope is **colour/tokens/typography only** — no containment/shadow changes. The four `DESIGN.md` colour doors are preserved: **platform identifiers, chart series, real semantic status, and categorical palettes are untouched.**

## Highest-leverage shared fixes
- **`SidebarNavItem`, `status-colors`, `badge.variants`** → semantic tokens (`text-success`/`warning`/`destructive`/`info`); state branches preserved
- **`UseCaseBadge` / `ModelBrowser` / dropdowns** "one hue for every value" selection → grayscale (fake-categorical); **`DeveloperTab`** amber toggle → default
- **`BottomBar` / prompt-bars / topbars** hardcoded `neutral-*` and `#hex` → layer tokens
- **`metric-card`, KPI, analytics** decorative purples/rainbows → grayscale (chart series + platform colours intact)
- **`editable-input`, `button` ping, `workflow-builder`** fake-semantic greens → tokens
- **Streaks** decorative orange de-coloured (honours the *no new tokens* non-goal)

## Notes & judgment calls
- `--primary` is **achromatic** (`0% saturation`), so every grayscale substitution stays monochrome even where the token names are layered/confusing.
- Corrected two token-vocabulary quirks mid-pass (`--accent` is a hover surface, not the near-white CTA colour; the near-white CTA is `--ship-accent`/`Button`'s default) — CTAs use `bg-foreground/text-background`, not `bg-accent`.
- Left as noted **adoption** items (not force-adopted in a colour pass): a few "should be a platform/categorical token" cases, free-form `color` props on shared interfaces, and `ModalErrorDebug`'s two benign buttons inheriting destructive chrome.
- One pre-existing unused-param warning in `PromptBarCollapsedView` (not introduced here) left in place.

## Verification
`biome` clean · `design:lint` 0 errors · `lint-no-raw-html.sh` pass · type-check + tests in CI.

90 files. Refs #1335
