### PR TITLE
refactor(api): collapse /latest media routes into list query params (REST audit)

### DIFF
--- a/apps/extensions/browser/app/docs/SERVICE_REFACTOR.md
+++ b/apps/extensions/browser/app/docs/SERVICE_REFACTOR.md
@@ -78,19 +78,19 @@ The Chrome extension services have been refactored to follow the same pattern as
 
 ### 5. API Endpoints
 
-#### New `/latest` Endpoints
+#### Latest-media Endpoints (`?latest=true` shorthand)
 
-Added to all content controllers with comments indicating they're used by the extension:
+The former standalone `GET /*/latest` routes were collapsed into the list
+routes via a `latest=true` query param (REST audit #1354). The extension uses:
 
-- `GET /videos/latest?limit=10` - Get latest videos
-- `GET /images/latest?limit=10` - Get latest images
-- `GET /musics/latest?limit=10` - Get latest musics
+- `GET /videos?latest=true&limit=10` - Get latest videos
+- `GET /images?latest=true&limit=10` - Get latest images
 
 **Features**:
 
-- Cached responses (5 minutes TTL)
-- User-specific content filtering
-- Pagination support (limit capped at 50 for performance)
+- Cached responses (5 minutes TTL) on the `latest=true` path
+- User-specific content filtering (training sources excluded)
+- Latest results capped at 50 for performance
 - Excludes training source content by default
 
 ### 6. CORS Configuration

--- a/apps/extensions/browser/app/src/background.ts
+++ b/apps/extensions/browser/app/src/background.ts
@@ -506,7 +506,7 @@ async function createVideoFromPrompt(
 
 async function getLatestVideos(sendResponse: SendResponse): Promise<void> {
   await executeAuthenticatedRequest<{ videos: unknown[] }>(
-    '/videos/latest',
+    '/videos?latest=true',
     { method: 'GET' },
     sendResponse,
     (data) => sendResponse({ success: true, videos: data.videos }),

--- a/apps/extensions/ide/app/src/services/api.service.ts
+++ b/apps/extensions/ide/app/src/services/api.service.ts
@@ -94,7 +94,7 @@ export class ApiService {
   async getGeneratedImages(limit = 20): Promise<GeneratedImage[]> {
     const result = await this.request<ApiResponse<GeneratedImage[]>>(
       'GET',
-      `/images/latest?limit=${limit}`,
+      `/images?latest=true&limit=${limit}`,
     );
     return result.data;
   }
@@ -111,7 +111,7 @@ export class ApiService {
   async getGeneratedVideos(limit = 20): Promise<GeneratedVideo[]> {
     const result = await this.request<ApiResponse<GeneratedVideo[]>>(
       'GET',
-      `/videos/latest?limit=${limit}`,
+      `/videos?latest=true&limit=${limit}`,
     );
     return result.data;
   }

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -21402,6 +21402,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded, plus brand-default images), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -22575,6 +22585,16 @@
             "description": "Use lightweight mode (skip expensive lookups for masonry/gallery views)",
             "in": "query",
             "name": "lightweight",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
             "required": false,
             "schema": {
               "default": false,
@@ -29379,30 +29399,6 @@
         ]
       }
     },
-    "/gifs/latest": {
-      "get": {
-        "operationId": "GifsController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
-        "tags": [
-          "gifs"
-        ]
-      }
-    },
     "/gifs/{gifId}": {
       "delete": {
         "operationId": "GifsController.remove",
@@ -30029,6 +30025,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded, plus brand-default images), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -30060,30 +30066,6 @@
           }
         },
         "summary": "create",
-        "tags": [
-          "images"
-        ]
-      }
-    },
-    "/images/latest": {
-      "get": {
-        "operationId": "ImagesController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
         "tags": [
           "images"
         ]
@@ -30452,6 +30434,16 @@
             "description": "Filter by public gallery visibility (for getshareable.app)",
             "in": "query",
             "name": "isPublic",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded, plus brand-default images), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
             "required": false,
             "schema": {
               "default": false,
@@ -33075,30 +33067,6 @@
           }
         },
         "summary": "create",
-        "tags": [
-          "musics"
-        ]
-      }
-    },
-    "/musics/latest": {
-      "get": {
-        "operationId": "MusicsController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
         "tags": [
           "musics"
         ]
@@ -36798,6 +36766,16 @@
             "description": "Use lightweight mode (skip expensive lookups for masonry/gallery views)",
             "in": "query",
             "name": "lightweight",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
             "required": false,
             "schema": {
               "default": false,
@@ -46545,6 +46523,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded, plus brand-default images), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -48499,6 +48487,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -48580,30 +48578,6 @@
           }
         },
         "summary": "createBatchInterpolation",
-        "tags": [
-          "videos"
-        ]
-      }
-    },
-    "/videos/latest": {
-      "get": {
-        "operationId": "VideosController.findLatest",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "required": true,
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "findLatest",
         "tags": [
           "videos"
         ]
@@ -49045,6 +49019,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -49314,6 +49298,16 @@
             "description": "Use lightweight mode (skip expensive lookups for masonry/gallery views)",
             "in": "query",
             "name": "lightweight",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Return the most recent items using the legacy /latest filter (brand-scoped user assets, training sources excluded), ordered by createdAt desc and capped at 50. Bypasses the standard list filters (status/scope/folder/parent/search/organization).",
+            "in": "query",
+            "name": "latest",
             "required": false,
             "schema": {
               "default": false,

--- a/apps/server/api/src/cache/redis/redis-cache.interceptor.spec.ts
+++ b/apps/server/api/src/cache/redis/redis-cache.interceptor.spec.ts
@@ -215,6 +215,28 @@ describe('RedisCacheInterceptor', () => {
       expect(cacheService.get).toHaveBeenCalledWith(customKey);
     });
 
+    it('should skip caching when the key generator returns an empty key', async () => {
+      const cacheOptions: CacheOptions = {
+        keyGenerator: vi.fn().mockReturnValue(''),
+        ttl: 300,
+      };
+      reflector.get.mockReturnValue(cacheOptions);
+
+      const result$ = await interceptor.intercept(
+        mockExecutionContext,
+        mockCallHandler,
+      );
+
+      result$.subscribe((value) => {
+        expect(value).toEqual({ data: 'test' });
+      });
+
+      expect(cacheOptions.keyGenerator).toHaveBeenCalledWith(mockRequest);
+      expect(cacheService.get).not.toHaveBeenCalled();
+      expect(cacheService.set).not.toHaveBeenCalled();
+      expect(mockCallHandler.handle).toHaveBeenCalled();
+    });
+
     it('should generate default key for anonymous users', async () => {
       const cacheOptions: CacheOptions = { ttl: 300 };
       reflector.get.mockReturnValue(cacheOptions);

--- a/apps/server/api/src/cache/redis/redis-cache.interceptor.ts
+++ b/apps/server/api/src/cache/redis/redis-cache.interceptor.ts
@@ -74,6 +74,13 @@ export class RedisCacheInterceptor implements NestInterceptor {
 
     const cacheKey = this.generateCacheKey(context, cacheOptions, request);
 
+    // A keyGenerator may opt out of caching per-request by returning an empty
+    // key (e.g. the images list route caches only its `latest=true` shorthand).
+    if (!cacheKey) {
+      this.logger.debug('Skipping cache: empty cache key');
+      return next.handle();
+    }
+
     try {
       const cachedResult = await this.cacheService.get(cacheKey);
 

--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.spec.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.spec.ts
@@ -126,32 +126,6 @@ describe('GifsController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('findLatest', () => {
-    it('should return latest gifs', async () => {
-      const result = await controller.findLatest(mockRequest, mockUser, 10);
-      expect(gifsService.findAll).toHaveBeenCalledWith(
-        expect.objectContaining({
-          orderBy: { createdAt: -1 },
-          where: expect.any(Object),
-        }),
-        expect.objectContaining({ limit: 10, pagination: false }),
-      );
-      expect(result).toBeDefined();
-    });
-
-    it('should cap limit at 50', async () => {
-      await controller.findLatest(mockRequest, mockUser, 100);
-      const options = gifsService.findAll.mock.calls[0][1];
-      expect(options.limit).toBeLessThanOrEqual(50);
-    });
-
-    it('should use default limit of 10', async () => {
-      await controller.findLatest(mockRequest, mockUser);
-      const options = gifsService.findAll.mock.calls[0][1];
-      expect(options.limit).toBe(10);
-    });
-  });
-
   describe('findAll', () => {
     it('should return paginated gifs', async () => {
       const query = {} as Parameters<typeof controller.findAll>[2];

--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
@@ -2,7 +2,6 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { GifsQueryDto } from '@api/collections/gifs/dto/gifs-query.dto';
 import { GifsService } from '@api/collections/gifs/services/gifs.service';
 import { VotesService } from '@api/collections/votes/services/votes.service';
-import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -53,64 +52,6 @@ export class GifsController {
     private readonly loggerService: LoggerService,
     private readonly votesService: VotesService,
   ) {}
-
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `gifs:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['gifs'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        AND: [
-          {
-            OR: [
-              {
-                AND: [
-                  {
-                    brand,
-                    category: IngredientCategory.GIF,
-                    isDeleted,
-                    user: publicMetadata.user,
-                  },
-                ],
-              },
-              {
-                AND: [
-                  {
-                    // Filter default GIFs by brand when brand is specified
-                    brand,
-                    category: IngredientCategory.GIF,
-                    isDefault: true,
-                    isDeleted,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data = await this.gifsService.findAll(aggregate, {
-      limit: Math.min(Number(limit) || 10, 50),
-      pagination: false,
-    });
-
-    return serializeCollection(request, IngredientSerializer, data);
-  }
 
   @Get()
   @LogMethod({ logEnd: false, logError: true, logStart: true })

--- a/apps/server/api/src/collections/images/controllers/images.controller.spec.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.spec.ts
@@ -1,0 +1,194 @@
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  returnNotFound: vi.fn((name: string, id: string) => {
+    throw new HttpException(
+      { detail: `${name} ${id} not found`, title: `${name} not found` },
+      HttpStatus.NOT_FOUND,
+    );
+  }),
+  serializeCollection: vi.fn(
+    (_req: unknown, _serializer: unknown, data: unknown) => data,
+  ),
+  serializeSingle: vi.fn(
+    (_req: unknown, _serializer: unknown, data: unknown) => data,
+  ),
+}));
+
+vi.mock('@api/helpers/utils/sort/sort.util', () => ({
+  handleQuerySort: vi.fn(() => ({ createdAt: -1 })),
+}));
+
+vi.mock('@api/helpers/utils/pagination/pagination.util', () => ({
+  customLabels: {},
+}));
+
+vi.mock('@api/helpers/utils/query-defaults/query-defaults.util', () => ({
+  QueryDefaultsUtil: {
+    getIsDeletedDefault: vi.fn((val: boolean) => val ?? false),
+    getPaginationDefaults: vi.fn(() => ({ limit: 10, page: 1 })),
+    parseStatusFilter: vi.fn(
+      (val: unknown) => val ?? { in: ['draft', 'uploaded', 'completed'] },
+    ),
+  },
+}));
+
+vi.mock('@api/helpers/utils/collection-filter/collection-filter.util', () => ({
+  CollectionFilterUtil: {
+    buildBrandFilter: vi.fn(() => ({ not: null })),
+    buildScopeFilter: vi.fn(() => undefined),
+  },
+}));
+
+vi.mock('@api/helpers/utils/ingredient-filter/ingredient-filter.util', () => ({
+  IngredientFilterUtil: {
+    buildFolderFilter: vi.fn(() => ({})),
+    buildParentFilter: vi.fn(() => ({})),
+    buildTrainingFilter: vi.fn(() => ({})),
+  },
+}));
+
+import { BetterAuthGuard } from '@api/auth/better-auth/guards/better-auth.guard';
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { ImagesController } from '@api/collections/images/controllers/images.controller';
+import type { ImagesQueryDto } from '@api/collections/images/dto/images-query.dto';
+import { ImagesService } from '@api/collections/images/services/images.service';
+import { VotesService } from '@api/collections/votes/services/votes.service';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { LoggerService } from '@libs/logger/logger.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+
+describe('ImagesController', () => {
+  let controller: ImagesController;
+  let imagesService: {
+    findAll: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+
+  const mockRequest = {} as unknown as Request;
+  const mockUser = {
+    id: 'authProvider_user_1',
+    publicMetadata: {
+      brand: '507f1f77bcf86cd799439012',
+      organization: '507f1f77bcf86cd799439011',
+      user: '507f1f77bcf86cd799439013',
+    },
+  } as unknown as User;
+
+  const mockImage = {
+    _id: '507f191e810c19729de860ee',
+    category: 'image',
+    metadata: { label: 'Test image' },
+  };
+
+  beforeEach(async () => {
+    imagesService = {
+      findAll: vi.fn().mockResolvedValue({ docs: [mockImage], totalDocs: 1 }),
+      findOne: vi.fn().mockResolvedValue(mockImage),
+      remove: vi.fn().mockResolvedValue(mockImage),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ImagesController],
+      providers: [
+        { provide: ImagesService, useValue: imagesService },
+        {
+          provide: LoggerService,
+          useValue: {
+            debug: vi.fn(),
+            error: vi.fn(),
+            log: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+        { provide: VotesService, useValue: { findOne: vi.fn() } },
+      ],
+    })
+      .overrideGuard(BetterAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ImagesController>(ImagesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll (latest=true shorthand)', () => {
+    const latestQuery = {
+      isDeleted: false,
+      latest: true,
+      limit: 10,
+      page: 1,
+      pagination: true,
+      sort: 'createdAt: -1',
+    } as unknown as ImagesQueryDto;
+
+    it('should short-circuit to the legacy latest aggregate', async () => {
+      const result = await controller.findAll(
+        mockRequest,
+        mockUser,
+        latestQuery,
+      );
+
+      expect(result).toBeDefined();
+
+      const [aggregate, options] = imagesService.findAll.mock.calls[0] as [
+        {
+          where: {
+            AND: Array<{ OR: Array<{ AND: Array<Record<string, unknown>> }> }>;
+          };
+          orderBy: Record<string, number>;
+        },
+        { limit: number; pagination: boolean },
+      ];
+
+      expect(options).toMatchObject({ pagination: false });
+      expect(aggregate.orderBy).toEqual({ createdAt: -1 });
+
+      // Two OR branches: user-owned (training excluded) + brand defaults.
+      const orBranches = aggregate.where.AND[0].OR;
+      expect(orBranches).toHaveLength(2);
+
+      const userBranch = orBranches[0].AND[0];
+      expect(userBranch).toMatchObject({
+        training: { not: false },
+        user: mockUser.publicMetadata.user,
+      });
+      expect(userBranch).not.toHaveProperty('isDefault');
+
+      const defaultBranch = orBranches[1].AND[0];
+      expect(defaultBranch).toMatchObject({ isDefault: true });
+    });
+
+    it('should cap the latest limit at 50', async () => {
+      await controller.findAll(mockRequest, mockUser, {
+        ...latestQuery,
+        limit: 100,
+      } as unknown as ImagesQueryDto);
+
+      const options = imagesService.findAll.mock.calls[0][1] as {
+        limit: number;
+      };
+      expect(options.limit).toBe(50);
+    });
+  });
+
+  describe('findAll (standard list)', () => {
+    it('should build a Prisma AND query for the image list', async () => {
+      const query = { limit: 10, page: 1 } as unknown as ImagesQueryDto;
+
+      const result = await controller.findAll(mockRequest, mockUser, query);
+
+      expect(result).toBeDefined();
+      const aggregate = imagesService.findAll.mock.calls[0][0] as {
+        where: { AND?: unknown[] };
+      };
+      expect(aggregate.where.AND).toBeDefined();
+    });
+  });
+});

--- a/apps/server/api/src/collections/images/controllers/images.controller.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.ts
@@ -51,67 +51,19 @@ export class ImagesController {
     private readonly votesService: VotesService,
   ) {}
 
-  @Get('latest')
+  @Get()
+  // Cache only the `latest=true` shorthand (formerly GET /images/latest): the
+  // general image list is intentionally uncached to keep freshly generated
+  // images visible immediately. The keyGenerator returns '' for non-latest
+  // requests, which the RedisCacheInterceptor treats as "do not cache".
   @Cache({
     keyGenerator: (req) =>
-      `images:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
+      req.query.latest === 'true'
+        ? `images:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`
+        : '',
     tags: ['images'],
     ttl: 300, // 5 minutes
   })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        AND: [
-          {
-            OR: [
-              {
-                AND: [
-                  {
-                    brand,
-                    category: IngredientCategory.IMAGE,
-                    isDeleted,
-                    // Exclude training source images by default
-                    training: { not: false },
-                    user: publicMetadata.user,
-                  },
-                ],
-              },
-              {
-                AND: [
-                  {
-                    // Filter default images by brand when brand is specified
-                    brand,
-                    category: IngredientCategory.IMAGE,
-                    isDefault: true,
-                    isDeleted,
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data = await this.imagesService.findAll(aggregate, {
-      limit: Math.min(Number(limit) || 10, 50),
-      pagination: false,
-    });
-
-    return serializeCollection(request, IngredientSerializer, data);
-  }
-
-  @Get()
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async findAll(
     @Req() request: Request,
@@ -121,12 +73,63 @@ export class ImagesController {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(url, { query });
 
+    const publicMetadata = getPublicMetadata(user);
+
+    // `latest=true` shorthand — reproduces the exact WHERE clause of the former
+    // GET /images/latest route: brand-scoped user images with training sources
+    // excluded, plus the org's brand-default images, ordered by createdAt desc
+    // and capped at 50. Bypasses the standard list filters entirely.
+    if (query.latest) {
+      const latestIsDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
+      const latestBrand = publicMetadata.brand;
+
+      const latestAggregate = {
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  AND: [
+                    {
+                      brand: latestBrand,
+                      category: IngredientCategory.IMAGE,
+                      isDeleted: latestIsDeleted,
+                      // Exclude training source images by default
+                      training: { not: false },
+                      user: publicMetadata.user,
+                    },
+                  ],
+                },
+                {
+                  AND: [
+                    {
+                      // Filter default images by brand when brand is specified
+                      brand: latestBrand,
+                      category: IngredientCategory.IMAGE,
+                      isDefault: true,
+                      isDeleted: latestIsDeleted,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        orderBy: { createdAt: -1 },
+      };
+
+      const latestData = await this.imagesService.findAll(latestAggregate, {
+        limit: Math.min(Number(query.limit) || 10, 50),
+        pagination: false,
+      });
+
+      return serializeCollection(request, IngredientSerializer, latestData);
+    }
+
     const options = {
       customLabels,
       ...QueryDefaultsUtil.getPaginationDefaults(query),
     };
-
-    const publicMetadata = getPublicMetadata(user);
 
     // Handle multiple status values (comma-separated)
     const status = QueryDefaultsUtil.parseStatusFilter(query.status);

--- a/apps/server/api/src/collections/images/dto/images-query.dto.ts
+++ b/apps/server/api/src/collections/images/dto/images-query.dto.ts
@@ -154,4 +154,35 @@ export class ImagesQueryDto extends BaseQueryDto {
     return Boolean(value);
   })
   isPublic?: boolean;
+
+  @ApiProperty({
+    default: false,
+    description:
+      'Return the most recent items using the legacy /latest filter ' +
+      '(brand-scoped user assets, training sources excluded, plus brand-default ' +
+      'images), ordered by createdAt desc and capped at 50. Bypasses the standard ' +
+      'list filters (status/scope/folder/parent/search/organization).',
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === undefined || value === null) {
+      return false;
+    }
+    if (value === 'true' || value === true) {
+      return true;
+    }
+    if (value === 'false' || value === false) {
+      return false;
+    }
+    if (value === '0' || value === 0) {
+      return false;
+    }
+    if (value === '') {
+      return false;
+    }
+    return Boolean(value);
+  })
+  latest?: boolean;
 }

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
@@ -34,15 +34,6 @@ function createMockUser(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function createMockRequest(overrides: Record<string, unknown> = {}) {
-  return {
-    get: vi.fn().mockReturnValue('localhost'),
-    originalUrl: '/api/musics',
-    protocol: 'https',
-    ...overrides,
-  };
-}
-
 describe('MusicsController', () => {
   let controller: MusicsController;
   let musicsService: ReturnType<typeof createMockMusicsService>;
@@ -167,79 +158,6 @@ describe('MusicsController', () => {
 
       expect(query.where.OR[0]).toMatchObject({ brand: brandId });
       expect(query.where.OR[1]).toMatchObject({ brand: brandId });
-    });
-  });
-
-  describe('findLatest', () => {
-    it('should return serialized latest musics', async () => {
-      const user = createMockUser();
-      const request = createMockRequest();
-      const docs = [
-        {
-          _id: '507f191e810c19729de860ee',
-          category: 'music',
-          status: 'generated',
-        },
-      ];
-      musicsService.findAll.mockResolvedValue({
-        docs,
-        hasNextPage: false,
-        hasPrevPage: false,
-        limit: 10,
-        page: 1,
-        totalDocs: 1,
-        totalPages: 1,
-      });
-
-      const result = await controller.findLatest(
-        request as never,
-        user as never,
-        10,
-      );
-      expect(result).toBeDefined();
-      expect(musicsService.findAll).toHaveBeenCalled();
-    });
-
-    it('should exclude training-associated musics using trainingId: null', async () => {
-      const user = createMockUser();
-      const request = createMockRequest();
-      musicsService.findAll.mockResolvedValue({
-        docs: [],
-        hasNextPage: false,
-        hasPrevPage: false,
-        limit: 10,
-        page: 1,
-        totalDocs: 0,
-        totalPages: 1,
-      });
-
-      await controller.findLatest(request as never, user as never, 10);
-
-      const callArgs = musicsService.findAll.mock.calls[0];
-      const aggregate = callArgs[0];
-      const userBranch = aggregate.where.OR[0];
-      expect(userBranch).toHaveProperty('trainingId', null);
-      expect(userBranch).not.toHaveProperty('training');
-    });
-
-    it('should cap limit at 50', async () => {
-      const user = createMockUser();
-      const request = createMockRequest();
-      musicsService.findAll.mockResolvedValue({
-        docs: [],
-        hasNextPage: false,
-        hasPrevPage: false,
-        limit: 50,
-        page: 1,
-        totalDocs: 0,
-        totalPages: 1,
-      });
-
-      await controller.findLatest(request as never, user as never, 100);
-
-      const callArgs = musicsService.findAll.mock.calls[0];
-      const options = callArgs[1];
-      expect(options.limit).toBeLessThanOrEqual(50);
     });
   });
 });

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.ts
@@ -2,30 +2,20 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { CreateMusicDto } from '@api/collections/musics/dto/create-music.dto';
 import { MusicQueryDto } from '@api/collections/musics/dto/music-query.dto';
 import { UpdateMusicDto } from '@api/collections/musics/dto/update-music.dto';
-import {
-  Music,
-  type MusicDocument,
-} from '@api/collections/musics/schemas/music.schema';
+import type { MusicDocument } from '@api/collections/musics/schemas/music.schema';
 import { MusicsService } from '@api/collections/musics/services/musics.service';
-import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
-import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
-import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
-import { serializeCollection } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
-import { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
 import { IngredientCategory } from '@genfeedai/enums';
-import type { JsonApiCollectionResponse } from '@genfeedai/interfaces';
 import { MusicSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
-import type { Request } from 'express';
+import { Controller, UseGuards } from '@nestjs/common';
 
 @AutoSwagger()
 @Controller('musics')
@@ -38,7 +28,7 @@ export class MusicsController extends BaseCRUDController<
 > {
   constructor(
     readonly loggerService: LoggerService,
-    private readonly musicsService: MusicsService,
+    musicsService: MusicsService,
   ) {
     super(loggerService, musicsService, MusicSerializer, 'Music', [
       'metadata',
@@ -95,54 +85,5 @@ export class MusicsController extends BaseCRUDController<
       },
       orderBy: query.sort ? handleQuerySort(query.sort) : { createdAt: -1 },
     };
-  }
-
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `musics:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['musics'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: Request,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        OR: [
-          {
-            brand,
-            category: IngredientCategory.MUSIC,
-            isDeleted,
-            // Exclude training source musics by default
-            trainingId: null,
-            user: publicMetadata.user,
-          },
-          {
-            // Filter default musics by brand when brand is specified
-            brand,
-            category: IngredientCategory.MUSIC,
-            isDefault: true,
-            isDeleted,
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data: AggregatePaginateResult<MusicDocument> =
-      await this.musicsService.findAll(aggregate, {
-        limit: Math.min(Number(limit) || 10, 50),
-        pagination: false,
-      });
-
-    return serializeCollection(request, this.serializer, data);
   }
 }

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
@@ -434,61 +434,70 @@ describe('VideosController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('findLatest', () => {
-    it('should return latest videos', async () => {
-      const mockData = {
-        docs: [mockVideo],
-        limit: 10,
-        page: 1,
-        totalDocs: 1,
-      };
+  describe('findAll (latest=true shorthand)', () => {
+    const latestQuery = {
+      isDeleted: false,
+      latest: true,
+      limit: 10,
+      page: 1,
+      pagination: true,
+      sort: 'createdAt: -1',
+    } as unknown as VideosQueryDto;
 
+    it('should short-circuit to the user-scoped latest aggregate', async () => {
+      const mockData = { docs: [mockVideo], limit: 10, page: 1, totalDocs: 1 };
       videosService.findAll.mockResolvedValue(
         mockData as unknown as AggregatePaginateResult<IngredientDocument>,
       );
 
-      const result = await controller.findLatest(mockRequest, mockUser, 10);
-
-      expect(videosService.findAll).toHaveBeenCalled();
-      expect(result).toBeDefined();
-      expect(result.data).toBeDefined();
-    });
-
-    it('should limit results to maximum of 50', async () => {
-      const mockData = {
-        docs: [],
-        totalDocs: 0,
-      };
-
-      videosService.findAll.mockResolvedValue(
-        mockData as unknown as AggregatePaginateResult<IngredientDocument>,
-      );
-
-      await controller.findLatest(mockRequest, mockUser, 100);
-
-      const callArgs = videosService.findAll.mock.calls[0];
-      const options = callArgs[1];
-
-      expect(options.limit).toBe(50);
-    });
-
-    it('should use default limit of 10 if not provided', async () => {
-      const mockData = {
-        docs: [],
-        totalDocs: 0,
-      };
-
-      videosService.findAll.mockResolvedValue(
-        mockData as unknown as AggregatePaginateResult<IngredientDocument>,
-      );
-
-      await controller.findLatest(
+      const result = await controller.findAll(
         mockRequest,
         mockUser,
-        undefined as unknown as number,
+        latestQuery,
       );
 
-      expect(videosService.findAll).toHaveBeenCalled();
+      expect(result).toBeDefined();
+      expect(result.data).toBeDefined();
+
+      const [aggregate, options] = videosService.findAll.mock.calls[0] as [
+        {
+          where: { AND: Array<Record<string, unknown>> };
+          orderBy: Record<string, number>;
+        },
+        { limit: number; pagination: boolean },
+      ];
+
+      // pagination disabled, ordered newest-first
+      expect(options).toMatchObject({ pagination: false });
+      expect(aggregate.orderBy).toEqual({ createdAt: -1 });
+
+      // Exact legacy WHERE: single user-scoped branch, training excluded,
+      // NO organization OR-branch and NO isDefault branch (unlike the list route).
+      const branch = aggregate.where.AND[0];
+      expect(branch).toMatchObject({
+        training: { not: false },
+        user: mockUser.publicMetadata.user,
+      });
+      expect(branch).not.toHaveProperty('OR');
+      expect(branch).not.toHaveProperty('status');
+      expect(branch).not.toHaveProperty('organization');
+    });
+
+    it('should cap the latest limit at 50', async () => {
+      videosService.findAll.mockResolvedValue({
+        docs: [],
+        totalDocs: 0,
+      } as unknown as AggregatePaginateResult<IngredientDocument>);
+
+      await controller.findAll(mockRequest, mockUser, {
+        ...latestQuery,
+        limit: 100,
+      } as unknown as VideosQueryDto);
+
+      const options = videosService.findAll.mock.calls[0][1] as {
+        limit: number;
+      };
+      expect(options.limit).toBe(50);
     });
   });
 

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.ts
@@ -96,49 +96,6 @@ export class VideosController {
     private readonly videoGenerationService: VideoGenerationService,
   ) {}
 
-  @Get('latest')
-  @Cache({
-    keyGenerator: (req) =>
-      `videos:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`,
-    tags: ['videos'],
-    ttl: 300, // 5 minutes
-  })
-  @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findLatest(
-    @Req() request: ExpressRequest,
-    @CurrentUser() user: User,
-    @Query('limit') limit: number = 10,
-  ): Promise<JsonApiCollectionResponse> {
-    const publicMetadata = getPublicMetadata(user);
-    const isDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
-    const brand = publicMetadata.brand;
-
-    const aggregate = {
-      where: {
-        AND: [
-          {
-            brand,
-            category: CategoryPrismaUtil.toIngredientCategory(
-              IngredientCategory.VIDEO,
-            ),
-            isDeleted,
-            // Exclude training source videos by default
-            training: { not: false },
-            user: publicMetadata.user,
-          },
-        ],
-      },
-      orderBy: { createdAt: -1 },
-    };
-
-    const data = await this.videosService.findAll(aggregate, {
-      limit: Math.min(Number(limit) || 10, 50),
-      pagination: false,
-    });
-
-    return serializeCollection(request, VideoSerializer, data);
-  }
-
   @Get()
   @Cache({
     keyGenerator: (req) =>
@@ -152,12 +109,47 @@ export class VideosController {
     @CurrentUser() user: User,
     @Query() query: VideosQueryDto,
   ): Promise<JsonApiCollectionResponse> {
+    const publicMetadata = getPublicMetadata(user);
+
+    // `latest=true` shorthand — reproduces the exact WHERE clause of the former
+    // GET /videos/latest route: brand-scoped user videos with training sources
+    // excluded, ordered by createdAt desc and capped at 50. Unlike the standard
+    // list route there is no organization OR-branch and no isDefault branch;
+    // it is user-scoped only and bypasses status/scope/folder/parent/search.
+    if (query.latest) {
+      const latestIsDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
+      const latestBrand = publicMetadata.brand;
+
+      const latestAggregate = {
+        where: {
+          AND: [
+            {
+              brand: latestBrand,
+              category: CategoryPrismaUtil.toIngredientCategory(
+                IngredientCategory.VIDEO,
+              ),
+              isDeleted: latestIsDeleted,
+              // Exclude training source videos by default
+              training: { not: false },
+              user: publicMetadata.user,
+            },
+          ],
+        },
+        orderBy: { createdAt: -1 },
+      };
+
+      const latestData = await this.videosService.findAll(latestAggregate, {
+        limit: Math.min(Number(query.limit) || 10, 50),
+        pagination: false,
+      });
+
+      return serializeCollection(request, VideoSerializer, latestData);
+    }
+
     const options = {
       customLabels,
       ...QueryDefaultsUtil.getPaginationDefaults(query),
     };
-
-    const publicMetadata = getPublicMetadata(user);
 
     // Handle multiple status values (comma-separated)
     const status = QueryDefaultsUtil.parseStatusFilter(query.status);

--- a/apps/server/api/src/collections/videos/dto/videos-query.dto.ts
+++ b/apps/server/api/src/collections/videos/dto/videos-query.dto.ts
@@ -127,4 +127,35 @@ export class VideosQueryDto extends BaseQueryDto {
     return Boolean(value);
   })
   lightweight?: boolean;
+
+  @ApiProperty({
+    default: false,
+    description:
+      'Return the most recent items using the legacy /latest filter ' +
+      '(brand-scoped user assets, training sources excluded), ordered by ' +
+      'createdAt desc and capped at 50. Bypasses the standard list filters ' +
+      '(status/scope/folder/parent/search/organization).',
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === undefined || value === null) {
+      return false;
+    }
+    if (value === 'true' || value === true) {
+      return true;
+    }
+    if (value === 'false' || value === false) {
+      return false;
+    }
+    if (value === '0' || value === 0) {
+      return false;
+    }
+    if (value === '') {
+      return false;
+    }
+    return Boolean(value);
+  })
+  latest?: boolean;
 }


### PR DESCRIPTION
## Summary

Collapses the four `GET /*/latest` media routes flagged by REST audit #1354. Each hardcoded `orderBy createdAt desc` + `limit=min(n,50)` + a 5-min `@Cache`, duplicating their sibling list routes' concerns while diverging in their default WHERE filters.

This was **not** a pure query-param passthrough: each `/latest` route carried default WHERE filters (category, training exclusion, an `isDefault` OR-branch, user scope) that a bare `?sort=-createdAt&limit=N` would drop, and the four diverged from each other. Each route's exact default filter is preserved.

## Changes

**Deleted (zero product callers — verified across `packages/services`, `apps/app`, `apps/mobile`, `apps/desktop`, `apps/extensions`, `playwright`; only the OpenAPI spec + a stale extension doc referenced them):**
- `GET /gifs/latest`
- `GET /musics/latest`

**Collapsed into list routes via a `latest=true` shorthand on `ImagesQueryDto` / `VideosQueryDto`:**
- `GET /images/latest` → `GET /images?latest=true`
- `GET /videos/latest` → `GET /videos?latest=true`

The `findAll` short-circuit reproduces each route's **exact** legacy WHERE clause:
- **images**: brand-scoped user images (training sources excluded) + a brand-default `isDefault` OR-branch; user-scoped; capped at 50.
- **videos**: brand-scoped user videos (training sources excluded); user-scoped only — **no** organization OR-branch, **no** `isDefault` branch.
- Both bypass the standard list filters (status / scope / folder / parent / search / organization).

**Cache preservation.** The former routes had a 5-min `@Cache`.
- Videos' list route already caches on the full query, so `?latest=true` is cached automatically (tag `videos`).
- Images' list route is **intentionally uncached** (image generation is high-frequency; a blanket 5-min cache would stale the main-app gallery). To carry over the cache without regressing the general list, the `@Cache` keyGenerator returns a key only for `latest=true` and `''` otherwise, and `RedisCacheInterceptor` now treats an empty key as "do not cache". Net: the general image list stays uncached (fresh); the latest shorthand keeps its 5-min cache.

**Callers repointed** (extensions ship on their own release cadence):
- `apps/extensions/ide/app/src/services/api.service.ts` — `getGeneratedImages` / `getGeneratedVideos`
- `apps/extensions/browser/app/src/background.ts` — `getLatestVideos`
- Updated the stale `SERVICE_REFACTOR.md` reference.

**OpenAPI artifact** regenerated (`openapi:emit`) — drops the 4 `*/latest` paths, adds the `latest` query param. Deterministic double-emit matches the committed spec; `openapi:validate` passes (1192 ops, 1192 unique operationIds).

## Verification

- ✅ `vitest` — 86 tests across images/videos/gifs/musics controller specs + interceptor spec. Videos/images `findLatest` tests rewritten as `findAll` latest-branch tests asserting the exact collapsed WHERE; new images controller spec added; gifs/musics `findLatest` tests removed. New interceptor test for the empty-key skip.
- ✅ `turbo run type-check --filter=@genfeedai/api` (fresh, cache miss)
- ✅ `biome check` clean on all changed files
- ✅ OpenAPI deterministic + matches committed + validates

## Note (pre-existing, out of scope)

`getLatestVideos` in the browser extension reads `data.videos`, but the route returns a JSON:API collection (`{ data: [...] }`) — so `data.videos` was already `undefined` before this change. This PR preserves the response shape exactly (same serializer, same options), so behavior is unchanged; the latent unwrap bug is left as-is.

Refs #1354