### PR TITLE
docs(design): sync DESIGN.md radius scale to the canonical 9-step token source

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,10 +86,14 @@ typography:
 
 rounded:
   none: 0px
-  sm: 2px
+  xs: 2px
+  sm: 4px
   md: 6px
   lg: 8px
   xl: 10px
+  2xl: 12px
+  3xl: 16px
+  full: 9999px
 
 spacing:
   base: 4px
@@ -127,19 +131,19 @@ components:
   badge-default:
     backgroundColor: "{colors.bg-hover}"
     textColor: "{colors.text-secondary}"
-    rounded: "{rounded.sm}"
+    rounded: "{rounded.full}"
   badge-success:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.success}"
-    rounded: "{rounded.sm}"
+    rounded: "{rounded.full}"
   badge-warning:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.warning}"
-    rounded: "{rounded.sm}"
+    rounded: "{rounded.full}"
   badge-danger:
     backgroundColor: "{colors.bg-secondary}"
     textColor: "{colors.danger}"
-    rounded: "{rounded.sm}"
+    rounded: "{rounded.full}"
   tooltip:
     backgroundColor: "{colors.bg-elevated}"
     textColor: "{colors.text-primary}"
@@ -282,11 +286,17 @@ Body text uses `-0.01em` letter-spacing. Headings use `-0.03em`.
 
 ### Border radius
 
-Four-step scale matching ShipCode/Linear:
-- `sm` (2px) -- badges, tags, inline chips
-- `md` (6px) -- cards, buttons, inputs, tooltips, popovers, dropdowns
-- `lg` (8px) -- toasts, overlay panels
-- `xl` (10px) -- dialogs, command palette
+Nine-step scale — the canonical source is `packages/ui/src/core/radius.ts`
+(`radiusTokens`), mirrored 1:1 as `--radius-*` in `packages/ui/web-tokens.css`:
+- `none` (0px) -- cards and flat surfaces (`--radius-card` resolves to 0px)
+- `xs` (2px) -- smallest chip corners and hairline insets
+- `sm` (4px) -- menu and dropdown items
+- `md` (6px) -- buttons, inputs, tooltips, selects, dropdown panels
+- `lg` (8px) -- toasts and overlay panels
+- `xl` (10px) -- dialogs and command palette
+- `2xl` (12px) -- large modals and feature surfaces
+- `3xl` (16px) -- oversized media and promo surfaces
+- `full` (9999px) -- badges, pills, avatars, and circular controls
 
 ### Shadows
 
@@ -328,7 +338,7 @@ trigger button. Grouped into Content and Tools sections with a subtle divider.
 
 ### Dropdown
 
-`bg-secondary` with `shadow-dropdown`. Items use `rounded-sm` (2px) with `hover:bg-hover`.
+`bg-secondary` with `shadow-dropdown`. Items use `rounded-sm` (4px) with `hover:bg-hover`.
 Inline margin `mx-1` insets items from panel edges.
 
 ## Brand OS Surfaces


### PR DESCRIPTION
## What

Doc-accuracy fix: sync the root `DESIGN.md` border-radius scale to the canonical token source. **No component or token code changed** — this is a documentation follow-up to the #1335 monochrome audit.

## Stale vs. real

`DESIGN.md` described a **4-step** scale that disagreed with the actual source of truth:

| step | DESIGN.md (before) | `radiusTokens` / `--radius-*` (real) |
|------|--------------------|--------------------------------------|
| none | 0px | 0px |
| xs   | *(missing)* | **2px** |
| sm   | **2px** ❌ | **4px** |
| md   | 6px | 6px |
| lg   | 8px | 8px |
| xl   | 10px | 10px |
| 2xl  | *(missing)* | 12px |
| 3xl  | *(missing)* | 16px |
| full | *(missing)* | 9999px |

Canonical source: `packages/ui/src/core/radius.ts` (`radiusTokens`), mirrored 1:1 as `--radius-*` in `packages/ui/web-tokens.css`, and exposed as `rounded-*` utilities via the `@theme inline` block in `packages/styles/globals.css`.

## Changes (DESIGN.md only)

- **`rounded:` frontmatter** → all 9 steps with correct values (`sm` corrected 2px → 4px; added `xs`, `2xl`, `3xl`, `full`).
- **"Border radius" prose** → rewritten from 4-step to the 9-step scale, citing the token source.
- **Dropdown prose** → `rounded-sm` corrected `(2px)` → `(4px)`. The class literally resolves to `--radius-sm`, which the synced scale defines as 4px.
- **`badge-default/success/warning/danger`** → retargeted `{rounded.sm}` → **`{rounded.full}`**. See note below.

## Note on the badge reference (divergence from the task's hypothesis)

The task hypothesized badges are "visually 2px" and, if so, should move to `{rounded.xs}`. Verified against the actual primitive — they are **not** 2px. The composed Badge renders `rounded-full` (pill):

```
packages/ui/src/components/display/badge/badge.variants.ts:14
  'rounded-full gap-2 px-2.5 py-0.5 text-xs font-medium ...'
```

Since this is a doc-accuracy fix and the mandate is to match the real render, the badge entries now reference `{rounded.full}` (9999px), which is what actually ships. No badge code was touched.

## Verify

- `bun run design:lint` → **0 errors** (reports "9 rounding levels"; every `{rounded.*}` reference resolves).
- `bun run check:design-system` → **passed**.
- No `.ts/.tsx` touched, so biome is N/A.

## Relationship to #1335

All six monochrome PRs (#1357, #1358, #1359, #1361, #1366, #1367) are still **open** at time of writing, so this PR says **Refs #1335** rather than "Closes". It can legitimately be the one that closes #1335 once a reviewer confirms all six have merged.

Refs #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
