### PR TITLE
chore(memory): refresh Genfeed architecture context

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -6,7 +6,7 @@
 - [One API Epic](project_one_api_epic.md) — Epic #95: consolidate self-hosted + cloud into one NestJS API, 20 issues, 8 phases
 - [Fallow Health](project_fallow.md) — Fallow codebase health analysis (#83), weekly CI, score 72/100
 - [BullMQ Processor Placement](project_bullmq.md) — API no longer owns BullMQ processors; add new processors to workers or the owning runtime service
-- [Backend type-check pattern](project_backend_typecheck.md) — dedicated `tsconfig.typecheck.json` per `apps/server/*` (never the runtime config); shared base, `useDefineForClassFields:false`, cross-app `$TURBO_ROOT$` inputs. 10/12 green (#1148); notifications+files follow-ups on #1145
+- [Backend type-check pattern](project_backend_typecheck.md) — dedicated `tsconfig.typecheck.json` for all 11 backend service workspaces (never the runtime config); shared base, `useDefineForClassFields:false`, cross-app `$TURBO_ROOT$` inputs. #1145 closed by #1148 + #1221.
 - [Migration Status](project_migration.md) — cloud + core → genfeed.ai migration complete, all pages/tests present
 - [Settings Routing](project_settings_routing.md) — canonical personal/org/brand settings URL shapes
 - [Desktop BYOK Generation](project_desktop_byok_generation.md) — desktop local/BYOK generation is local-first; cloud connect is optional
@@ -39,7 +39,7 @@
 - [Failed deploys never burn a version](release_tag_after_green_deploy.md) — pre-gate release cutting is normal; on deploy failure fix master and re-cut the SAME version (delete unconsumed tag), never bump
 - [Production deploys master-only](production_deploy_master_only.md) — Never deploy any non-master ref to production unless Vincent explicitly overrides; production deploys run from GitHub CI on master
 - [Vercel release gate](feedback_vercel_release_gate.md) — SaaS Vercel frontends deploy only through the API-first production release workflow; Vercel Git auto-deploy stays disabled
-- [PRD-pass verify state first](prd_pass_verify_state_first.md) — On any epic PRD pass, verify child issue states via `gh` + audit real code before trusting the epic body; never rewrite closed/shipped cards
+- [PRD-pass verify state first](rules/prd_pass_verify_state_first.md) — On any epic PRD pass, verify child issue states via `gh` + audit real code before trusting the epic body; never rewrite closed/shipped cards
 - [Prisma legacy alias fields](rules/prisma_legacy_alias_fields.md) — Mongo-era `*Document` aliases (`organization`/`user`/`_id`) are undefined on Prisma rows; read scalar FKs (`organizationId`/`userId`); `BaseService.findOne` guards empty ids (canonical: docs/identity-resolution.md)
 - [server-domain, not core](rules/server_domain_not_core.md) — #1090 server-tier lib = `apps/server/domain` / `@genfeedai/server-domain`; the name "core" is retired (collides with `packages/core`); workflow cluster consolidates 5→2
 
@@ -53,7 +53,7 @@
 ## Context (loaded via CLAUDE.md @import)
 
 - [System Patterns](context/system-patterns.md) — architecture patterns, serializers, multi-tenancy
-- [Project Structure](context/project-structure.md) — directory layout, 12 backend services, 6 frontends
+- [Project Structure](context/project-structure.md) — directory layout, 11 backend service workspaces, 7 frontend/client workspaces
 - [Style Guide](context/project-style-guide.md) — TypeScript, git, formatting, naming conventions
 - [Skills Architecture](context/skills-architecture.md) — skills/ vs .agents/skills/ vs .claude/skills/
 - [Progress](context/progress.md) — migration status, active work areas

--- a/.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md
+++ b/.agents/memory/architecture/ADR-DEPLOYMENT-MODES.md
@@ -6,11 +6,11 @@ Accepted
 
 ## Spec Version
 
-v1.2.0
+v1.2.1
 
 ## Last Updated
 
-2026-06-29
+2026-07-06
 
 ## Canonical Source
 
@@ -60,7 +60,7 @@ The **brand** is the unit of content context (a brand owns one or more social ac
 
 **One self-hostable auth system across all three modes: [Better Auth](https://better-auth.com)** (MIT, free). It runs **in-process** against our existing Postgres — no separate instance, no SaaS vendor, no call-home.
 
-Better Auth ships **magic link, Google/GitHub OAuth, organizations/teams, and admin impersonation** as first-party plugins, with a Prisma/Postgres adapter and NestJS + Electron integrations.
+Better Auth ships **magic link, social OAuth, organizations/teams, and admin impersonation** as first-party plugins, with a Prisma/Postgres adapter and NestJS + Electron integrations. Current surfaced login UI is Google + magic link; GitHub provider config remains in the server factory but the beta GitHub login button was removed in #1253.
 
 | Mode | Auth |
 |---|---|

--- a/.agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md
+++ b/.agents/memory/architecture/ADR-PLG-BOUNDARY-OSS-CLOUD.md
@@ -6,11 +6,11 @@ Accepted
 
 ## Boundary Spec Version
 
-v1.3.0
+v1.3.1
 
 ## Last Updated
 
-2026-06-02
+2026-07-06
 
 ## Canonical Source
 
@@ -56,7 +56,7 @@ Genfeed follows a hybrid OSS + SaaS model:
 
 ## Enterprise Multi-Tenancy
 
-Multi-tenant organization controls are available via `ee/packages/` under commercial license. All multi-tenant data access code must live under `ee/` or import from `ee/packages/`.
+Multi-tenant organization controls are a SaaS/EE product boundary. Current implementation after #1093 keeps deployment-mode-agnostic org enforcement in the OSS API (`CombinedAuthGuard`, request context, inline `organizationId` filters); there is no separable `ee/packages/multi-tenancy` package. Commercial-only entitlements, billing, quotas, and advanced org controls remain in `ee/`.
 
 ## Related ADRs
 
@@ -78,3 +78,4 @@ Multi-tenant organization controls are available via `ee/packages/` under commer
 | v1.1.1  | 2026-03-15 | Added CI check script, revision log                                                    |
 | v1.2.0  | 2026-05-03 | Added V1 execution modes, account-sync contract, and managed inference bridge boundary |
 | v1.3.0  | 2026-06-02 | Added skills, routines, feedback memory, and collaborative learning boundary summary   |
+| v1.3.1  | 2026-07-06 | Aligned multi-tenancy text with #1093 OSS API enforcement boundary                     |

--- a/.agents/memory/context/project-overview.md
+++ b/.agents/memory/context/project-overview.md
@@ -1,13 +1,13 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-06-29T00:00:00Z
-version: 1.1
+last_updated: 2026-07-06T00:00:00Z
+version: 1.2
 author: Claude Code PM System
 ---
 
 # Project Overview — Genfeed.ai
 
-Genfeed.ai is an open-source AI operating system for content creation — a self-hosted monorepo providing autonomous agent orchestration, multi-platform distribution, workflow automation, and GPU-powered media generation. Enterprise features (multi-tenancy, billing, SSO) live in the `ee/` directory under a commercial license.
+Genfeed.ai is an open-source AI operating system for content creation — a self-hosted monorepo providing autonomous agent orchestration, multi-platform distribution, workflow automation, and GPU-powered media generation. Enterprise packages live in `ee/` under a commercial license; multi-tenant enforcement is currently shared OSS API infrastructure, while multi-tenancy as a product boundary remains SaaS/EE.
 
 ## Key Capabilities
 
@@ -21,10 +21,10 @@ Genfeed.ai is an open-source AI operating system for content creation — a self
 
 ## Architecture Summary
 
-- **12 backend services** (NestJS): api, clips, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers
-- **6 app surfaces**: app (studio), docs, website, desktop, mobile, extensions
-- **42 shared packages**: serializers, UI components, hooks, services, types, enums, workflow engine, integrations, Prisma, etc.
-- **5 enterprise packages** (`ee/`): analytics, billing, harness, multi-tenancy, teams
+- **11 backend service workspaces** (NestJS): api, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers. `apps/server/clips/` is not currently a package workspace.
+- **7 frontend/client workspaces**: app (studio), docs, website, desktop, mobile, browser extension, IDE extension
+- **43 shared packages**: serializers, UI components, hooks, services, types, enums, workflow engine, integrations, Prisma, auth client, harness, etc.
+- **2 enterprise packages** (`ee/`): billing and harness
 - **Infrastructure**: Docker self-hosted, PostgreSQL (Prisma ORM), Redis + BullMQ, Better Auth
 
 ## Current State

--- a/.agents/memory/context/project-structure.md
+++ b/.agents/memory/context/project-structure.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-06-29T00:00:00Z
-version: 1.1
+last_updated: 2026-07-06T00:00:00Z
+version: 1.2
 author: Claude Code PM System
 ---
 
@@ -12,13 +12,13 @@ author: Claude Code PM System
 ```
 genfeed.ai/
 ├── apps/
-│   ├── server/              # 12 NestJS backend services
+│   ├── server/              # 11 NestJS backend service workspaces
 │   │   ├── api/             # Main API (port 3010)
 │   │   ├── notifications/   # Notification service (3011)
 │   │   ├── files/           # File processing (3012)
 │   │   ├── workers/         # Background jobs (3013)
 │   │   ├── mcp/             # MCP server (3014)
-│   │   ├── clips/           # Clips processing (3015)
+│   │   ├── clips/           # Not currently a package workspace; re-verify before treating as a service
 │   │   ├── discord/         # Discord integration (3016)
 │   │   ├── slack/           # Slack integration (3018)
 │   │   ├── telegram/        # Telegram bot (3019)
@@ -33,9 +33,10 @@ genfeed.ai/
 │   └── extensions/          # Browser & IDE extensions (v2 milestone)
 │       ├── browser/app/
 │       └── ide/app/
-├── packages/                # 42 shared packages (@genfeedai/*)
+├── packages/                # 43 shared packages (@genfeedai/*)
 │   ├── agent/               # Agent logic
 │   ├── api-types/           # Generated API types
+│   ├── auth-client/         # Better Auth client wrappers
 │   ├── cli/                 # CLI tooling
 │   ├── client/              # API client
 │   ├── config/              # ConfigService
@@ -48,6 +49,7 @@ genfeed.ai/
 │   ├── enums/               # Shared enums
 │   ├── errors/              # Error types
 │   ├── fonts/               # Font assets
+│   ├── harness/             # Test/content harness support
 │   ├── helpers/             # Utility helpers
 │   ├── hooks/               # React hooks
 │   ├── integrations/        # Platform integrations
@@ -88,11 +90,11 @@ genfeed.ai/
 
 ## Key Conventions
 
-- **Backend service structure**: `apps/server/{service}/src/` with NestJS modules
+- **Backend service structure**: `apps/server/{service}/src/` with NestJS modules for service workspaces that have `package.json`
 - **API services**: `apps/server/api/src/services/{service-name}/` — 30+ domain services
 - **Integrations**: `apps/server/api/src/services/integrations/{platform}/` — 48+ platforms
 - **Frontend app structure**: `apps/app/app/`, `apps/docs/app/`, and `apps/website/app/` use Next.js App Router. Admin routes are inside `apps/app/app/(protected)/admin`.
 - **Shared packages**: `packages/{name}/src/index.ts` barrel exports
 - **Serializers**: `packages/serializers/src/{attributes,configs,server}/{category}/`
-- **Enterprise packages**: `ee/packages/{name}/` — commercial license, multi-tenancy features
+- **Enterprise packages**: `ee/packages/{name}/` — commercial license packages; current workspace packages are `billing` and `harness`
 - **Tests**: Colocated `*.test.ts` / `*.spec.ts` next to source files

--- a/.agents/memory/project_backend_typecheck.md
+++ b/.agents/memory/project_backend_typecheck.md
@@ -1,12 +1,12 @@
 # Backend type-check pattern (`apps/server/*`)
 
-last_verified: 2026-07-02
-Source: PR #1148 (#1145). Verified against local `turbo run type-check` + committed configs.
+last_verified: 2026-07-06
+Source: PR #1148 and PR #1221 (#1145). Verified against committed `package.json` scripts and `tsconfig.typecheck.json` files on `origin/master`.
 
 ## Invariant
 
 `nest build` uses swc/webpack with `typeCheck: false`, so tsc never runs during build.
-Each backend app gets standalone coverage via a **dedicated** `tsconfig.typecheck.json`
+Each backend service workspace gets standalone coverage via a **dedicated** `tsconfig.typecheck.json`
 that is **never** the runtime config.
 
 - **Runtime path is untouched:** `start:prod` → `node -r tsconfig-paths/register` reads the
@@ -24,7 +24,7 @@ that is **never** the runtime config.
   superset, `exclude` specs.
 - Per app: `apps/server/<app>/tsconfig.typecheck.json` = `extends` base + `include: ["src/**/*"]`.
   Add `types: ["node","vitest/globals","multer"]` only where the graph reaches
-  `Express.Multer` (api; workers, which imports `@api/*`). `@types/multer` is NOT hoisted to
+  `Express.Multer` (api; workers still has grandfathered `@api/*` imports). `@types/multer` is NOT hoisted to
   root — only apps declaring it resolve `multer` in `types`.
 - Script: `"type-check": "tsc --noEmit -p tsconfig.typecheck.json"`.
 
@@ -40,8 +40,17 @@ that is **never** the runtime config.
   billing contract via `@api/*`, which api's own (OSS-flavor) task does not subsume, and
   `--affected` won't select it on api-only changes.
 
-## Status (2026-07-02)
+## Worker API-import ratchet (2026-07-06)
 
-Green: `api, clips, discord, images, mcp, slack, telegram, videos, voices, workers` (10/12).
-Follow-ups on #1145: `notifications` (discord.js payload typing + `NotificationEvent.payload`
-narrowing), `files` (per-endpoint request-body interfaces for `@Body() body: unknown`).
+PR #1342 added `scripts/architecture/check-no-api-imports-in-workers.ts` and the root
+`check:architecture` gate. Existing worker `@api/*` imports are frozen in
+`scripts/architecture/workers-api-imports.baseline.ts`; new worker code should import from
+`@genfeedai/queue-contracts`, `@genfeedai/libs`, or the planned `@genfeedai/server-domain`
+surface instead of adding more API deep imports.
+
+## Status (2026-07-06)
+
+Green coverage is present for all current backend service workspaces:
+`api, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers`
+(11/11). `apps/server/clips/` is not currently a package workspace and has no
+`tsconfig.typecheck.json`; re-verify before treating it as an active service.

--- a/.agents/memory/system/ARCHITECTURE.md
+++ b/.agents/memory/system/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Primary architecture references for planning/reporting.
 
 ## Repo Structure
 
-- **Apps (server):** `apps/server/{api,clips,discord,files,images,mcp,notifications,slack,telegram,videos,voices,workers}`
+- **Apps (server):** `apps/server/{api,discord,files,images,mcp,notifications,slack,telegram,videos,voices,workers}` are current service workspaces. `apps/server/clips/` exists in the tree but is not currently a package workspace.
 - **Apps (frontend):** `apps/app`, `apps/docs`, `apps/website`, `apps/desktop/app`, `apps/mobile/app`, `apps/extensions/{browser,ide}/app`
 - **Packages:** `packages/*` (`@genfeedai/*` scope)
 - **Enterprise:** `ee/packages/*` (commercial license)

--- a/.agents/memory/system/OPEN-SOURCE-CONTEXT.md
+++ b/.agents/memory/system/OPEN-SOURCE-CONTEXT.md
@@ -11,13 +11,13 @@ Genfeed.ai is a self-hosted single-tenant application by default. One organizati
 
 ## Enterprise Multi-Tenancy
 
-Multi-tenant organization controls are available under commercial license in `ee/packages/`.
+Multi-tenant organization controls are a SaaS/EE product boundary. Current source truth after #1093: request auth, request context, and org-scoped query enforcement live in the OSS API because they are deployment-mode-agnostic infrastructure. There is no `ee/packages/multi-tenancy` package on `origin/master`.
 
-**Repo invariant:** All multi-tenant data access code must live under `ee/` or import from `ee/packages/`.
+**Repo invariant:** do not add a new separable `ee/packages/multi-tenancy` scaffold. Put deployment-mode-agnostic auth/query enforcement in the OSS API and keep product entitlements, billing, quotas, and commercial-only controls in `ee/`.
 
 This means:
 
-- Organization-scoped query enforcement for data isolation belongs in `ee/`
+- Organization-scoped query enforcement belongs with the OSS API request/auth path unless a concrete commercial-only feature needs an `ee/` adapter
 - Billing, quotas, and team management belong in `ee/`
 - The core OSS code should work with a single implicit organization
 
@@ -47,7 +47,7 @@ Key points:
 | Routine engine + workflow-backed scheduling | Yes | --                 |
 | Personal feedback memory                    | Yes | --                 |
 | Single-tenant deployment                    | Yes | --                 |
-| Multi-tenant org isolation                  | --  | Yes                |
+| Multi-tenant product surface                | --  | Yes                |
 | Team/role management                        | --  | Yes                |
 | Shared review queue                         | --  | Yes                |
 | Org-shared memory + governance              | --  | Yes                |

--- a/.agents/memory/system/SELF-HOSTED-GUIDE.md
+++ b/.agents/memory/system/SELF-HOSTED-GUIDE.md
@@ -14,9 +14,9 @@ This file provides context for AI agents working on deployment-related tasks. It
 
 ## Architecture Notes
 
-- **Single-tenant default:** One organization per deployment. No tenant isolation logic needed outside `ee/`.
-- **Enterprise multi-tenancy:** Available via `ee/packages/`. All multi-tenant data access code must live under `ee/` or import from `ee/packages/`.
-- **Server apps:** `apps/server/{api,clips,discord,files,images,mcp,notifications,slack,telegram,videos,voices,workers}`
+- **Single-tenant default:** One organization per deployment. Auth/request context still flows through the OSS API guard stack; self-hosted product behavior should not expose org switching as a multi-tenant product surface.
+- **Enterprise multi-tenancy:** SaaS/EE product controls belong in `ee/`; deployment-mode-agnostic org guards and query filters live in the OSS API. There is no `ee/packages/multi-tenancy` package on `origin/master`.
+- **Server apps:** `apps/server/{api,discord,files,images,mcp,notifications,slack,telegram,videos,voices,workers}`. `apps/server/clips/` is not currently a package workspace.
 - **Frontend apps:** `apps/app`, `apps/docs`, `apps/website`, `apps/desktop/app`, `apps/mobile/app`, and `apps/extensions/{browser,ide}/app`
 - **Database:** PostgreSQL via Prisma
 - **Queue:** BullMQ via Redis

--- a/.agents/memory/system/SUMMARY.md
+++ b/.agents/memory/system/SUMMARY.md
@@ -17,7 +17,7 @@ Project planning/reporting summary.
 
 ```
 apps/
-  server/     api, clips, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers
+  server/     api, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers
   app/        Next.js studio UI
   website/    Marketing site
   desktop/app/ Electron desktop shell embedding apps/app with local IPC backend actions
@@ -28,6 +28,8 @@ ee/packages/  Enterprise features (commercial license)
 docker/       Self-hosted deployment
 docs/         Documentation
 ```
+
+`apps/server/clips/` exists in the tree but is not currently a Bun workspace or Nest service package.
 
 ## Current Desktop Boundary
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Last Verified
 
-- **Date:** 2026-07-02
-- **Sources:** local monorepo structure (memory/skills symlinks, trunk rules, pre-push commands)
+- **Date:** 2026-07-06
+- **Sources:** fetched `origin/master`, local monorepo structure, package manifests, trunk rules, pre-push commands
 
 ## Project Memory — READ AT SESSION START
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 @.agents/memory/context/project-style-guide.md
 @.agents/memory/context/skills-architecture.md
 
-TypeScript monorepo: 6 app surfaces, 12 backend services, 42 shared packages.
+TypeScript monorepo: 7 app workspaces, 11 backend service workspaces, 43 shared packages.
 Stack: Next.js + NestJS + PostgreSQL (Prisma) + Redis + BullMQ
 
 ## Git Workflow
@@ -107,13 +107,14 @@ bun run test --filter=@genfeedai/[name]  # Run specific package tests
 | `files/` | 3012 | File processing service |
 | `workers/` | 3013 | Background job processors |
 | `mcp/` | 3014 | MCP server for AI tools |
-| `clips/` | 3015 | Clips processing |
 | `discord/` | 3016 | Discord integration |
 | `slack/` | 3018 | Slack integration |
 | `telegram/` | 3019 | Telegram bot |
 | `images/` | 3020 | Image generation pipeline |
 | `videos/` | 3021 | Video generation pipeline |
 | `voices/` | 3022 | Voice generation pipeline |
+
+`apps/server/clips/` is not currently a Bun workspace or Nest service package on `origin/master`; clip generation/runtime code is currently under API/packages/files paths. Re-verify before reintroducing a separate clips service.
 
 ### Frontend
 | App | Purpose |

--- a/CODEX.md
+++ b/CODEX.md
@@ -2,15 +2,15 @@
 
 ## Last Verified
 
-- **Date:** 2026-06-29
+- **Date:** 2026-07-06
 
 Codex-specific fast reference. See `AGENTS.md` for full project context.
 
 ## Reality Snapshot
 
 - Frontend workspaces: `apps/app`, `apps/docs`, `apps/website`, `apps/desktop/app`, `apps/mobile/app`, `apps/extensions/browser/app`, `apps/extensions/ide/app`
-- Backend services: 12 on `apps/server/` (api, clips, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers)
-- Shared packages: 42 directories under `packages/`
+- Backend service workspaces: 11 on `apps/server/` (api, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers). `apps/server/clips/` is not currently a package workspace.
+- Shared packages: 43 directories under `packages/`
 - Admin routes live inside `apps/app/app/(protected)/admin`; there is no separate `apps/admin` workspace.
 - Enterprise features: `ee/packages/` (commercial license)
 


### PR DESCRIPTION
## Summary
- refresh Genfeed memory/instruction counts from `origin/master`: 11 backend service workspaces, 7 frontend/client workspaces, 43 shared packages, 2 `ee` package workspaces
- align OSS/SaaS multi-tenancy memory with #1093: auth/request/query enforcement lives in OSS API; SaaS/EE remains the product boundary; no `ee/packages/multi-tenancy` package
- update backend type-check memory for #1148 + #1221 and add the #1342 workers `@api/*` import ratchet
- clarify Better Auth surfaced login state after #1253 and fix a stale `MEMORY.md` link

## Evidence
- fetched `origin/master` at `21cccdb7b6561cb43f07b4c947f7e81e394f7da6`
- inspected `package.json` workspaces and current `apps/server/*`, `packages/*`, `ee/packages/*` layout
- inspected recent commits from the last 7 days, including #1221, #1253, #1342, #1093 follow-up memory, and #1110
- duplicate-work gate found no open memory-hygiene PR targeting `master`

## Validation
- `git diff --check`
- memory index markdown link/path check
- stale-claim grep for old backend/package/EE/type-check/auth claims
- staged secret path/content scan plus pre-commit `secretlint`

## Notes
- `.agents/SESSIONS/2026-04-16.md` still contains historical `develop` narration, but session logs are outside this automation's writable memory/instruction scope and were left unchanged.
