### PR TITLE
fix(api): correct credit charging on video/voice generation routes

### DIFF
--- a/apps/server/api/src/collections/videos/controllers/relationships/videos-relationships.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/relationships/videos-relationships.controller.ts
@@ -153,6 +153,14 @@ export class VideosRelationshipsController {
     return serializeCollection(request, PostSerializer, data);
   }
 
+  // Intentionally uncredited: video merge runs entirely on the internal
+  // files-queue (JOB_TYPES.MERGE_VIDEOS — ffmpeg concat/transitions/captions),
+  // with no external AI/provider call, so there is no per-call cost to bill.
+  // This matches every other local ffmpeg transform (resize/gif/effects/edits),
+  // which are likewise uncharged; only provider-backed transforms (upscale/
+  // reframe/lip-sync/avatar) carry @Credits. Verified free-by-design in the
+  // #1354 REST audit — do not add a CreditsGuard/@Credits here without a
+  // corresponding provider cost. Class-level RolesGuard still applies.
   @Post('merge')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async mergeVideos(

--- a/apps/server/api/src/collections/videos/controllers/transformations/lip-sync/videos-lip-sync.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/transformations/lip-sync/videos-lip-sync.controller.spec.ts
@@ -25,16 +25,17 @@ vi.mock('@api/helpers/utils/response/response.util', () => ({
 
 import { BetterAuthGuard } from '@api/auth/better-auth/guards/better-auth.guard';
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
-import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { VideosLipSyncController } from '@api/collections/videos/controllers/transformations/lip-sync/videos-lip-sync.controller';
 import { CreateLipSyncDto } from '@api/collections/videos/dto/create-lip-sync.dto';
 import { VideosService } from '@api/collections/videos/services/videos.service';
 import { ConfigService } from '@api/config/config.service';
+import { CREDITS_KEY } from '@api/helpers/decorators/credits/credits.decorator';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { SubscriptionGuard } from '@api/helpers/guards/subscription/subscription.guard';
+import { CreditDeductionQueueService } from '@api/queues/credit-deduction/credit-deduction-queue.service';
 import { ByokService } from '@api/services/byok/byok.service';
 import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -43,6 +44,7 @@ import { SharedService } from '@api/shared/services/shared/shared.service';
 import { IngredientCategory, IngredientStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
 
@@ -89,9 +91,6 @@ describe('VideosLipSyncController', () => {
   };
 
   let byokService: { resolveApiKey: ReturnType<typeof vi.fn> };
-  let creditsUtilsService: {
-    deductCreditsFromOrganization: ReturnType<typeof vi.fn>;
-  };
   let failedGenerationService: {
     handleFailedVideoGeneration: ReturnType<typeof vi.fn>;
   };
@@ -105,9 +104,6 @@ describe('VideosLipSyncController', () => {
 
   beforeEach(async () => {
     byokService = { resolveApiKey: vi.fn().mockResolvedValue(null) };
-    creditsUtilsService = {
-      deductCreditsFromOrganization: vi.fn().mockResolvedValue(undefined),
-    };
     failedGenerationService = {
       handleFailedVideoGeneration: vi.fn().mockResolvedValue(undefined),
     };
@@ -137,13 +133,16 @@ describe('VideosLipSyncController', () => {
       controllers: [VideosLipSyncController],
       providers: [
         { provide: ByokService, useValue: byokService },
+        // CreditsInterceptor is now bound to the handler (@UseInterceptors); Nest
+        // instantiates it at module compile, so its queue dependency must resolve.
+        // It never runs here — controller methods are invoked directly.
+        {
+          provide: CreditDeductionQueueService,
+          useValue: { queueByokUsage: vi.fn(), queueDeduction: vi.fn() },
+        },
         {
           provide: ConfigService,
           useValue: { get: vi.fn(), ingredientsEndpoint: 'http://localhost' },
-        },
-        {
-          provide: CreditsUtilsService,
-          useValue: creditsUtilsService,
         },
         {
           provide: FailedGenerationService,
@@ -187,6 +186,21 @@ describe('VideosLipSyncController', () => {
     expect(controller).toBeDefined();
   });
 
+  it('charges a fixed 1-credit @Credits config (no modelKey) so CreditsInterceptor deducts a flat 1', () => {
+    // Locks the #1354 fix: the route must charge a fixed amount via the
+    // standard guard+interceptor path, NOT a modelKey (which would re-introduce
+    // the models-table lookup) and NOT a manual inline deduction.
+    const reflector = new Reflector();
+    const config = reflector.get<{ amount?: number; modelKey?: string }>(
+      CREDITS_KEY,
+      controller.createLipSyncVideo,
+    );
+
+    expect(config).toBeDefined();
+    expect(config.amount).toBe(1);
+    expect(config.modelKey).toBeUndefined();
+  });
+
   describe('createLipSyncVideo', () => {
     describe('happy path', () => {
       it('should return ingredient data on successful generation', async () => {
@@ -218,20 +232,6 @@ describe('VideosLipSyncController', () => {
         expect(metadataService.patch).toHaveBeenCalledWith(
           mockMetadataData.id,
           expect.objectContaining({ externalId: 'heygen-video-id-abc' }),
-        );
-      });
-
-      it('should deduct credits after successful generation', async () => {
-        await controller.createLipSyncVideo(mockReq, mockUser, mockDto);
-
-        expect(
-          creditsUtilsService.deductCreditsFromOrganization,
-        ).toHaveBeenCalledWith(
-          '507f1f77bcf86cd799439013',
-          '507f1f77bcf86cd799439012',
-          1,
-          expect.stringContaining('heygen'),
-          expect.any(String),
         );
       });
 

--- a/apps/server/api/src/collections/videos/controllers/transformations/lip-sync/videos-lip-sync.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/transformations/lip-sync/videos-lip-sync.controller.ts
@@ -1,5 +1,4 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
-import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
@@ -12,6 +11,7 @@ import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decora
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { SubscriptionGuard } from '@api/helpers/guards/subscription/subscription.guard';
+import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { serializeSingle } from '@api/helpers/utils/response/response.util';
 import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
@@ -43,6 +43,7 @@ import {
   Post,
   Req,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import type { Request } from 'express';
 
@@ -55,7 +56,6 @@ export class VideosLipSyncController {
   constructor(
     private readonly byokService: ByokService,
     private readonly configService: ConfigService,
-    private readonly creditsUtilsService: CreditsUtilsService,
     private readonly failedGenerationService: FailedGenerationService,
     private readonly heygenService: HeyGenService,
     private readonly ingredientsService: IngredientsService,
@@ -67,11 +67,19 @@ export class VideosLipSyncController {
   ) {}
 
   @Post('lip-sync')
+  // Fixed 1-credit charge, matching the sibling HeyGen route POST /videos/avatar.
+  // Charged through the standard CreditsGuard (balance gate) + CreditsInterceptor
+  // (deducts on success) path used across the API — replacing the previous
+  // manual inline deductCreditsFromOrganization call, which double-tracked the
+  // charge outside the interceptor and diverged from every other credited route.
+  // Using a fixed `amount` (not `modelKey`) also avoids the CreditsGuard model
+  // lookup, so the route no longer depends on a `heygen/avatar` models-table row.
   @Credits({
+    amount: 1,
     description: 'Lip-sync photo avatar video generation',
-    modelKey: MODEL_KEYS.HEYGEN_AVATAR,
     source: ActivitySource.VIDEO_GENERATION,
   })
+  @UseInterceptors(CreditsInterceptor)
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async createLipSyncVideo(
     @Req() request: Request,
@@ -226,19 +234,9 @@ export class VideosLipSyncController {
         }),
       );
 
-      // 7. Deduct credits
-      const creditsToDeduct = 1; // Adjust based on pricing model
-      if (creditsToDeduct > 0) {
-        await this.creditsUtilsService.deductCreditsFromOrganization(
-          publicMetadata.organization,
-          publicMetadata.user,
-          creditsToDeduct,
-          `Lip-sync video generation - ${MODEL_KEYS.HEYGEN_AVATAR}`,
-          ActivitySource.VIDEO_GENERATION,
-        );
-      }
-
-      // 8. Publish initial WebSocket status
+      // 7. Publish initial WebSocket status
+      // Credits (1) are deducted by CreditsInterceptor on successful response —
+      // see the @Credits decorator above. No manual deduction here.
       const websocketUrl = WebSocketPaths.video(ingredientId);
       // @ts-expect-error TS2554
       await this.websocketService.publishFileProcessing(
@@ -252,7 +250,7 @@ export class VideosLipSyncController {
         getUserRoomName(user.id),
       );
 
-      // 9. Return serialized ingredient for frontend subscription
+      // 8. Return serialized ingredient for frontend subscription
       return serializeSingle(request, IngredientSerializer, ingredientData);
     } catch (error: unknown) {
       this.loggerService.error(`${url} failed`, error);

--- a/apps/server/api/src/collections/voices/controllers/voices.controller.spec.ts
+++ b/apps/server/api/src/collections/voices/controllers/voices.controller.spec.ts
@@ -1,7 +1,12 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { VoicesController } from '@api/collections/voices/controllers/voices.controller';
 import { ExternalVoiceCatalogService } from '@api/collections/voices/services/external-voice-catalog.service';
 import { VoicesService } from '@api/collections/voices/services/voices.service';
+import {
+  CREDITS_DEFER_MODEL_RESOLUTION_KEY,
+  CREDITS_KEY,
+} from '@api/helpers/decorators/credits/credits.decorator';
 import { ByokService } from '@api/services/byok/byok.service';
 import { ElevenLabsService } from '@api/services/integrations/elevenlabs/elevenlabs.service';
 import { FleetService } from '@api/services/integrations/fleet/fleet.service';
@@ -12,6 +17,7 @@ import { IngredientCategory, VoiceProvider } from '@genfeedai/enums';
 import { VoiceProvider as DbVoiceProvider } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 function createMockLogger() {
@@ -51,6 +57,7 @@ describe('VoicesController', () => {
   let externalVoiceCatalogService: Record<string, ReturnType<typeof vi.fn>>;
   let sharedService: Record<string, ReturnType<typeof vi.fn>>;
   let byokService: Record<string, ReturnType<typeof vi.fn>>;
+  let creditsUtilsService: Record<string, ReturnType<typeof vi.fn>>;
   let fleetService: Record<string, ReturnType<typeof vi.fn>>;
   let heygenService: Record<string, ReturnType<typeof vi.fn>>;
   let metadataService: Record<string, ReturnType<typeof vi.fn>>;
@@ -84,6 +91,10 @@ describe('VoicesController', () => {
     byokService = {
       resolveApiKey: vi.fn(),
     };
+    creditsUtilsService = {
+      checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
+      getOrganizationCreditsBalance: vi.fn().mockResolvedValue(1000),
+    };
     fleetService = {
       cloneVoice: vi.fn(),
       isAvailable: vi.fn(),
@@ -104,6 +115,7 @@ describe('VoicesController', () => {
 
     controller = new VoicesController(
       byokService as unknown as ByokService,
+      creditsUtilsService as unknown as CreditsUtilsService,
       elevenLabsService as unknown as ElevenLabsService,
       externalVoiceCatalogService as unknown as ExternalVoiceCatalogService,
       fleetService as unknown as FleetService,
@@ -439,6 +451,65 @@ describe('VoicesController', () => {
       );
     });
 
+    it('settles duration-based credits (17/min) onto request.creditsConfig after render', async () => {
+      const user = createMockUser();
+      // CreditsGuard defers by setting this; the handler must resolve the amount.
+      const request = {
+        ...createMockRequest(),
+        creditsConfig: {
+          amount: 0,
+          deferred: true,
+          source: 'voice_generation',
+        },
+      };
+      const ingredientId = '507f191e810c19729de860ee';
+
+      sharedService.saveDocuments.mockResolvedValue({
+        ingredientData: { id: ingredientId },
+      });
+      elevenLabsService.generateAndUploadAudio.mockResolvedValue({
+        audioUrl: 'https://cdn.example.com/audio.mp3',
+        duration: 90, // 1.5 min -> ceil(1.5 * 17) = 26 credits
+      });
+      voicesService.patchAll.mockResolvedValue({});
+      voicesService.findOne.mockResolvedValue({
+        id: ingredientId,
+        status: 'generated',
+      });
+
+      await controller.generate(
+        request as never,
+        user as never,
+        { text: 'Hello world', voiceId: 'voice123' } as never,
+      );
+
+      expect(request.creditsConfig).toMatchObject({
+        amount: 26,
+        deferred: false,
+      });
+    });
+
+    it('rejects with InsufficientCreditsException before rendering when the org cannot afford the floor', async () => {
+      const user = createMockUser();
+      const request = createMockRequest();
+      creditsUtilsService.checkOrganizationCreditsAvailable.mockResolvedValue(
+        false,
+      );
+      creditsUtilsService.getOrganizationCreditsBalance.mockResolvedValue(0);
+
+      await expect(
+        controller.generate(
+          request as never,
+          user as never,
+          { text: 'Hello world', voiceId: 'voice123' } as never,
+        ),
+      ).rejects.toMatchObject({ errorCode: 'INSUFFICIENT_CREDITS' });
+
+      // Floor gate runs before any provider call or ingredient creation.
+      expect(elevenLabsService.generateAndUploadAudio).not.toHaveBeenCalled();
+      expect(sharedService.saveDocuments).not.toHaveBeenCalled();
+    });
+
     it('should mark ingredient as failed when generation errors', async () => {
       const user = createMockUser();
       const request = createMockRequest();
@@ -467,6 +538,35 @@ describe('VoicesController', () => {
         expect.objectContaining({ OR: expect.any(Array) }),
         { status: 'failed' },
       );
+    });
+  });
+
+  describe('credit decorators (#1354)', () => {
+    const reflector = new Reflector();
+
+    it('defers voice-generation credits (duration-based, no fixed amount) so the guard never throws InsufficientCreditsException(0,0)', () => {
+      const config = reflector.get<{ amount?: number }>(
+        CREDITS_KEY,
+        controller.generate,
+      );
+      const deferred = reflector.get(
+        CREDITS_DEFER_MODEL_RESOLUTION_KEY,
+        controller.generate,
+      );
+
+      expect(config).toBeDefined();
+      expect(config.amount).toBeUndefined();
+      expect(deferred).toBe(true);
+    });
+
+    it('charges a fixed 17-credit @Credits config for voice cloning', () => {
+      const config = reflector.get<{ amount?: number }>(
+        CREDITS_KEY,
+        controller.cloneVoice,
+      );
+
+      expect(config).toBeDefined();
+      expect(config.amount).toBe(17);
     });
   });
 

--- a/apps/server/api/src/collections/voices/controllers/voices.controller.ts
+++ b/apps/server/api/src/collections/voices/controllers/voices.controller.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { type IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { CloneVoiceDto } from '@api/collections/voices/dto/clone-voice.dto';
@@ -8,10 +9,14 @@ import { UpdateVoiceCatalogDto } from '@api/collections/voices/dto/update-voice-
 import { VoicesQueryDto } from '@api/collections/voices/dto/voices-query.dto';
 import { ExternalVoiceCatalogService } from '@api/collections/voices/services/external-voice-catalog.service';
 import { VoicesService } from '@api/collections/voices/services/voices.service';
-import { Credits } from '@api/helpers/decorators/credits/credits.decorator';
+import {
+  Credits,
+  DeferCreditsUntilModelResolution,
+} from '@api/helpers/decorators/credits/credits.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { InsufficientCreditsException } from '@api/helpers/exceptions/business/business-logic.exception';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { SubscriptionGuard } from '@api/helpers/guards/subscription/subscription.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
@@ -143,6 +148,23 @@ function toWireFormat(voice: ExternalVoice): VoiceCatalogEntryDocument {
   };
 }
 
+/**
+ * Voice TTS credit cost per output minute. Canonical source of truth:
+ * `INTERNAL_CREDIT_COSTS.voicePerMinute` in `@genfeedai/pricing` (17 credits =
+ * $0.17, ~70% margin on ~$0.05 provider cost). Mirrored here as a backend-local
+ * constant because `@genfeedai/pricing` is a shared/frontend package the API
+ * runtime does not depend on — keep this value in sync with the canonical one.
+ */
+const VOICE_CREDITS_PER_MINUTE = 17;
+
+/**
+ * Flat credit charge for a one-time voice clone (ElevenLabs synchronous, or
+ * Genfeed Fleet asynchronous). Fleet clones are billed at job acceptance today;
+ * true compute-time metering (Replicate/Fal-style, on job completion) is tracked
+ * as a follow-up — see #1354.
+ */
+const VOICE_CLONE_CREDITS = 17;
+
 @AutoSwagger()
 @Controller('voices')
 export class VoicesController {
@@ -150,6 +172,7 @@ export class VoicesController {
 
   constructor(
     private readonly byokService: ByokService,
+    private readonly creditsUtilsService: CreditsUtilsService,
     private readonly elevenLabsService: ElevenLabsService,
     private readonly externalVoiceCatalogService: ExternalVoiceCatalogService,
     private readonly fleetService: FleetService,
@@ -377,10 +400,18 @@ export class VoicesController {
   @Post('generate')
   @UseGuards(SubscriptionGuard, CreditsGuard)
   @UseInterceptors(CreditsInterceptor)
+  // TTS cost is duration-based (VOICE_CREDITS_PER_MINUTE per output minute) and
+  // the rendered audio length is unknown until generation completes, so the
+  // charge is deferred: CreditsGuard skips the up-front amount/balance check
+  // (previously this route had no amount/modelKey and fell through to
+  // `throw InsufficientCreditsException(0,0)` on every call — #1354), the
+  // handler settles the exact amount from result.duration, and CreditsInterceptor
+  // deducts it on the successful response.
   @Credits({
     description: 'Voice generation (TTS)',
     source: ActivitySource.VOICE_GENERATION,
   })
+  @DeferCreditsUntilModelResolution()
   @RateLimit({ limit: 30, windowMs: 60 * 1000 })
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async generate(
@@ -411,6 +442,12 @@ export class VoicesController {
     }
 
     const publicMetadata = getPublicMetadata(user);
+
+    // Up-front floor gate: since the exact charge is deferred until after
+    // render, block organizations that cannot afford even the 1-credit minimum
+    // before we spend a provider (ElevenLabs) call. The exact duration-based
+    // amount is settled post-render below.
+    await this.assertOrganizationCanAfford(publicMetadata.organization, 1);
 
     // Create ingredient record with PROCESSING status
     const { ingredientData } = await this.sharedService.saveDocuments(user, {
@@ -447,6 +484,16 @@ export class VoicesController {
         },
       );
 
+      // Settle the deferred credit charge from the actual rendered duration.
+      // Throws InsufficientCreditsException (surfaced by the catch below) if the
+      // org cannot afford the settled amount; otherwise CreditsInterceptor
+      // deducts it on the successful response.
+      await this.settleVoiceGenerationCredits(
+        request,
+        publicMetadata.organization,
+        result.duration,
+      );
+
       // Fetch the updated ingredient with population
       const completedIngredient = await this.voicesService.findOne(
         { _id: ingredientData.id },
@@ -478,6 +525,12 @@ export class VoicesController {
         { status: IngredientStatus.FAILED },
       );
 
+      // Preserve typed HTTP errors (e.g. InsufficientCreditsException from the
+      // credit settlement above) instead of masking them as a generic 500.
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       throw new HttpException(
         {
           detail: (error as Error)?.message || 'Voice generation failed',
@@ -494,7 +547,15 @@ export class VoicesController {
     CreditsInterceptor,
     FileInterceptor('file', { limits: { fileSize: 25 * 1024 * 1024 } }),
   )
+  // Flat per-clone charge. Cloning creates a one-time reusable voice (not
+  // duration-priced output), so a fixed `amount` is checked up-front by
+  // CreditsGuard and deducted by CreditsInterceptor on success — replacing the
+  // previous amount-less config that fell through to
+  // `throw InsufficientCreditsException(0,0)` on every call (#1354). Fleet
+  // (async) clones are billed here at acceptance; compute-time metering on job
+  // completion is a follow-up (see #1354).
   @Credits({
+    amount: VOICE_CLONE_CREDITS,
     description: 'Voice cloning',
     source: ActivitySource.VOICE_GENERATION,
   })
@@ -686,6 +747,68 @@ export class VoicesController {
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
+    }
+  }
+
+  /**
+   * Assert the organization can afford `credits`, throwing a typed
+   * InsufficientCreditsException (422) carrying the current balance otherwise.
+   */
+  private async assertOrganizationCanAfford(
+    organizationId: string,
+    credits: number,
+  ): Promise<void> {
+    const hasCredits =
+      await this.creditsUtilsService.checkOrganizationCreditsAvailable(
+        organizationId,
+        credits,
+      );
+
+    if (!hasCredits) {
+      const balance =
+        await this.creditsUtilsService.getOrganizationCreditsBalance(
+          organizationId,
+        );
+      throw new InsufficientCreditsException(credits, balance);
+    }
+  }
+
+  /**
+   * Resolve the deferred voice-generation charge from the rendered audio
+   * duration (VOICE_CREDITS_PER_MINUTE per minute, minimum 1 credit) and write
+   * it onto `request.creditsConfig` so CreditsInterceptor deducts it on the
+   * successful response. Throws InsufficientCreditsException if the organization
+   * cannot afford the settled amount (blocking both the deduction and the
+   * response). Mirrors the deferred-credit finalization used by video
+   * generation (`VideoGenerationService.ensureDeferredCredits`).
+   */
+  private async settleVoiceGenerationCredits(
+    request: Request,
+    organizationId: string,
+    durationSeconds: number,
+  ): Promise<void> {
+    const seconds = Number(durationSeconds) || 0;
+    const credits = Math.max(
+      1,
+      Math.ceil((seconds / 60) * VOICE_CREDITS_PER_MINUTE),
+    );
+
+    await this.assertOrganizationCanAfford(organizationId, credits);
+
+    const requestWithCredits = request as unknown as {
+      creditsConfig?: {
+        amount?: number;
+        deferred?: boolean;
+        [key: string]: unknown;
+      };
+    };
+
+    if (requestWithCredits.creditsConfig) {
+      requestWithCredits.creditsConfig = {
+        ...requestWithCredits.creditsConfig,
+        amount: credits,
+        deferred: false,
+      };
     }
   }
 


### PR DESCRIPTION
Fixes the three credit-integrity bugs flagged in the **BONUS** section of the #1354 REST-audit Tier-3 decision doc. Each was verified against the runtime `CreditsGuard` / `CreditsInterceptor` / manual-deduction stack (not assumed from the audit text).

## What I found & changed

### 1. `POST /videos/lip-sync` — REAL (mechanism inconsistency, not a double charge)
**Found:** `CreditsInterceptor` is not global and was **not** wired to this controller, so the `@Credits({ modelKey: HEYGEN_AVATAR })` decorator only drove the `CreditsGuard` *balance gate* — nothing deducted from it. The **manual inline `deductCreditsFromOrganization(…, 1, …)` was the sole real charge** (flat 1). Not double-charged, but off the standard path, and the `modelKey` gate depended on a `heygen/avatar` models-table row existing (else the guard throws `InsufficientCreditsException(0,0)` — a latent break).

**Changed:** Normalized to the standard `@Credits({ amount: 1 }) + @UseInterceptors(CreditsInterceptor)` path (matching sibling `POST /videos/avatar`'s flat 1-credit charge). Removed the manual deduction and the now-unused `CreditsUtilsService` dependency. Using a fixed `amount` (not `modelKey`) also removes the models-table dependency. Charge is unchanged (1 credit); only the mechanism is corrected.

### 2. `POST /videos/merge` — INTENTIONALLY FREE (confirmed, documented)
**Found:** No credit guard/interceptor/charge — only class-level `RolesGuard`. Verified it dispatches entirely to the internal files-queue (`JOB_TYPES.MERGE_VIDEOS`, ffmpeg concat/transitions/captions) with **no external AI/provider cost**. Every sibling local ffmpeg transform (resize/gif/effects/edits) is likewise uncharged; only provider-backed transforms (upscale/reframe/lip-sync/avatar) carry `@Credits`.

**Changed:** Added a documenting comment on `@Post('merge')` so future audits don't re-flag it. No functional change.

### 3. `POST /voices/generate` + `POST /voices/clone` — REAL & SEVERE (both routes broken)
**Found:** Both carried `@Credits({ source })` with **no `amount`/`modelKey`/defer**, and neither DTO has a `model` field, so `CreditsGuard.canActivate` fell to the final `else` → **`throw new InsufficientCreditsException(0,0)` on every call**. Both routes 500'd for every caller, including the live agent-tool caller (`agent-tool-executor.service.ts` → `/v1/voices/generate`, which sends only `{ text, voiceId }`).

**Changed (post-process, usage-based — per review discussion):**
- **generate:** duration-based charge. `@DeferCreditsUntilModelResolution()` stops the guard throw; after render the handler settles `ceil(duration_sec / 60 × 17)` credits (min 1) from the actual audio duration onto `request.creditsConfig`, and `CreditsInterceptor` deducts on success. `17` = `INTERNAL_CREDIT_COSTS.voicePerMinute` (canonical). An up-front floor gate blocks zero-balance orgs before a provider call; a post-render affordability check surfaces insufficient credits as `422` (not a generic `500`).
- **clone:** fixed **17-credit** charge via `@Credits({ amount: 17 })`, gated up-front by the guard and deducted by the interceptor on success (both ElevenLabs sync and Fleet async-accept paths). Fleet clones bill at acceptance today.

## Pricing notes (for review)
- `INTERNAL_CREDIT_COSTS` (`voicePerMinute: 17`, `avatarPerSecond: 100`) currently lives only in `@genfeedai/pricing` (a frontend/shared package the API does **not** depend on) and is not wired into any API charge. The voice rate is mirrored as a backend-local constant with a comment; the avatar/lip-sync `avatarPerSecond` intent (100/sec) remains unwired platform-wide and is out of scope here (lip-sync keeps its existing flat 1 to match `/videos/avatar`).
- **Follow-up (to be filed):** true compute-time metering for **Fleet** voice clones (Replicate/Fal-style: job-completion → measured seconds → deduction). No such subsystem exists today; building it for one async route was out of scope for this bug-fix.

## Verification
- Focused unit tests (51 passing) across all three changed controllers, incl. new tests: lip-sync `@Credits({amount:1})` metadata lock, voices duration-settlement (26 credits for 90 s), floor-gate `422` before any provider call, and generate-defer / clone-`amount:17` metadata locks.
- `bunx turbo run type-check --filter=@genfeedai/api` ✅
- `bunx turbo run lint --filter=@genfeedai/api` ✅ · secretlint (pre-commit) ✅

Refs #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
