### PR TITLE
fix(extension): unwrap JSON:API collection in browser getLatestVideos

### DIFF
--- a/apps/extensions/browser/app/src/background.ts
+++ b/apps/extensions/browser/app/src/background.ts
@@ -505,11 +505,21 @@ async function createVideoFromPrompt(
 }
 
 async function getLatestVideos(sendResponse: SendResponse): Promise<void> {
-  await executeAuthenticatedRequest<{ videos: unknown[] }>(
+  await executeAuthenticatedRequest<{
+    data?: Array<{ id: string; attributes: Record<string, unknown> }>;
+  }>(
     '/videos?latest=true',
     { method: 'GET' },
     sendResponse,
-    (data) => sendResponse({ success: true, videos: data.videos }),
+    // The list route returns a JSON:API collection ({ data: [...] }), so flatten
+    // resources to plain objects the same way the threads/messages handlers do.
+    (data) => {
+      const videos = (data.data ?? []).map((item) => ({
+        id: item.id,
+        ...item.attributes,
+      }));
+      sendResponse({ success: true, videos });
+    },
     'fetch videos',
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #1370 (REST audit `/latest` collapse). The browser extension's `getLatestVideos` reads `data.videos`, but the videos list route returns a JSON:API collection (`{ data: [...] }`) — so the field was always `undefined`. This was a latent pre-existing bug, called out as out-of-scope in #1370; fixing it here so the extension caller is fully correct.

Flatten the resources to plain objects the same way the existing `threads` / `messages` handlers in `background.ts` already do:

```ts
const videos = (data.data ?? []).map((item) => ({ id: item.id, ...item.attributes }));
```

## Verification
- ✅ `biome check` clean
- ✅ `tsc --noEmit` — no errors in the changed region (remaining errors are pre-existing plasmo/`chrome`-global + unbuilt-dep artifacts unrelated to this change)

Refs #1354