### PR TITLE
docs(memory): #1090 alias amendment — @server-domain/* replaces @domain/*

### DIFF
--- a/.agents/memory/rules/server_domain_not_core.md
+++ b/.agents/memory/rules/server_domain_not_core.md
@@ -1,11 +1,16 @@
 # Server-tier extraction lib is `@genfeedai/server-domain` — "core" is retired
 
-**last_verified: 2026-07-05**
+**last_verified: 2026-07-06**
 
 The #1090 extraction target for entangled NestJS domain/integration services is
 **`apps/server/domain`** (package **`@genfeedai/server-domain`**, alias
-`@domain/*` in `apps/server/tsconfig.json`). The earlier draft name
-`apps/server/core` / `@genfeedai/core` is **cancelled**:
+**`@server-domain/*`** in `apps/server/tsconfig.json`). The earlier alias draft
+`@domain/*` is **rejected** (Vincent, 2026-07-06): too generic — "domain" reads
+as DDD boilerplate at import sites and says nothing about which package it is.
+The alias mirrors the package name 1:1 (`@genfeedai/server-domain` →
+`@server-domain/*`), is uniquely greppable, and was verified zero-cost at
+rename time (0 existing `@domain/` imports; directory not yet scaffolded).
+The earlier draft name `apps/server/core` / `@genfeedai/core` is **cancelled**:
 
 - `@genfeedai/core` is already taken — `packages/core`, the old workflows-OSS
   "Core utilities for Genfeed workflow engine" (live consumer: `workflow-ui`).


### PR DESCRIPTION
Memory-rule sync for the #1090 decision amendment (https://github.com/genfeedai/genfeed.ai/issues/1090#issuecomment-4890437018): the server-domain tsconfig alias is `@server-domain/*`, not `@domain/*`. #1344's body already updated. Zero code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)