### PR TITLE
fix(app): remove onboarding wizard serif headings

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-step-header.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-step-header.tsx
@@ -10,8 +10,8 @@ export default function BrandStepHeader() {
         Step 1 of 3
       </div>
 
-      <h1 className="step-headline opacity-0 text-4xl md:text-5xl font-serif leading-none tracking-tighter text-white mb-4">
-        Set up your <span className="font-light italic">brand.</span>
+      <h1 className="step-headline opacity-0 mb-4 text-4xl font-semibold leading-none tracking-tight text-white md:text-5xl">
+        Set up your brand.
       </h1>
 
       <p className="step-description opacity-0 text-lg text-white/40 mb-8 max-w-lg">

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-error-state.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-error-state.tsx
@@ -23,7 +23,7 @@ export default function ProactiveErrorState({
         <p className="text-sm uppercase tracking-[0.24em] text-white/35">
           Proactive Onboarding
         </p>
-        <h1 className="mt-4 text-4xl font-serif text-white">
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white">
           Your workspace is almost ready.
         </h1>
         <p className="mt-4 max-w-xl text-white/55">

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-hero-card.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-hero-card.tsx
@@ -35,7 +35,7 @@ export default function ProactiveHeroCard({
             <HiSparkles className="size-3" />
             Prepared Before You Arrived
           </Badge>
-          <h1 className="mt-5 text-4xl font-serif leading-none tracking-tight text-white md:text-5xl">
+          <h1 className="mt-5 text-4xl font-semibold leading-none tracking-tight text-white md:text-5xl">
             {workspace.organization?.label || 'Your workspace'} is ready.
           </h1>
           <p className="mt-4 max-w-xl text-lg text-white/55">

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-outputs-card.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-outputs-card.tsx
@@ -26,7 +26,7 @@ export default function ProactiveOutputsCard({ outputs }: Props) {
           <p className="text-sm uppercase tracking-[0.24em] text-white/30">
             Starter Outputs
           </p>
-          <h2 className="mt-2 text-2xl font-serif text-white">
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white">
             Drafts ready on first login
           </h2>
         </div>

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.tsx
@@ -263,8 +263,8 @@ export default function ProvidersContent() {
 
   return (
     <div ref={sectionRef}>
-      <h1 className="step-headline opacity-0 mb-4 text-4xl font-serif leading-none tracking-tighter text-white md:text-5xl">
-        Configure your <span className="font-light italic">access.</span>
+      <h1 className="step-headline opacity-0 mb-4 text-4xl font-semibold leading-none tracking-tight text-white md:text-5xl">
+        Configure your access.
       </h1>
 
       <p className="step-description opacity-0 mb-10 max-w-2xl text-lg text-white/40">

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
@@ -156,8 +156,8 @@ export default function SuccessContent() {
       </div>
 
       {/* Headline */}
-      <h1 className="success-headline opacity-0 text-4xl md:text-5xl font-serif leading-none tracking-tighter text-white mb-4">
-        Welcome to <span className="font-light italic">Genfeed!</span>
+      <h1 className="success-headline opacity-0 mb-4 text-4xl font-semibold leading-none tracking-tight text-white md:text-5xl">
+        Welcome to Genfeed!
       </h1>
 
       <div className="success-credit-reveal opacity-0 mb-8 inline-flex items-center gap-3 rounded-full bg-secondary shadow-border px-5 py-3 text-left">

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/summary/summary-content.tsx
@@ -299,9 +299,8 @@ export default function SummaryContent() {
 
   return (
     <div ref={sectionRef}>
-      <h1 className="step-headline opacity-0 mb-4 text-4xl font-serif leading-none tracking-tighter text-white md:text-5xl">
-        Finish with the setup{' '}
-        <span className="font-light italic">that fits.</span>
+      <h1 className="step-headline opacity-0 mb-4 text-4xl font-semibold leading-none tracking-tight text-white md:text-5xl">
+        Finish with the setup that fits.
       </h1>
 
       <p className="step-description opacity-0 mb-10 max-w-2xl text-lg text-white/40">


### PR DESCRIPTION
## Summary
- Removes the remaining hardcoded serif/italic onboarding wizard headings under apps/app/app/(onboarding).
- Applies the existing sans heading treatment with font-semibold and tight tracking.
- Leaves wizard card surfaces translucent; no solid/inverted white cards were added.

## Verification
- gh issue view 1340 and open PR overlap checks (#1364 overlaps onboarding behavior files; #1359 no wizard overlap)
- rg -n "font-serif" "apps/app/app/(onboarding)" -g "*.tsx" (no matches)
- rg -n "font-light italic|italic" "apps/app/app/(onboarding)/onboarding/(wizard)" -g "*.tsx" (no matches)
- bunx biome check --write <7 touched wizard files>
- bun run design:lint (0 errors; existing DESIGN.md warnings only)
- commit hooks: staged Biome, raw HTML lint, bespoke-card lint, secretlint

Closes #1340