### PR TITLE
[codex] fix(clips): harden raw-cut validation

### DIFF
--- a/apps/server/api/src/collections/clip-projects/services/clip-srt.util.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-srt.util.spec.ts
@@ -23,6 +23,10 @@ describe('formatSrtTimestamp', () => {
   it('formats minutes and hours with zero padding', () => {
     expect(formatSrtTimestamp(3661.5)).toBe('01:01:01,500');
   });
+
+  it('rolls rounded millisecond overflow into the next second', () => {
+    expect(formatSrtTimestamp(59.9995)).toBe('00:01:00,000');
+  });
 });
 
 describe('generateClipSrt', () => {

--- a/apps/server/api/src/collections/clip-projects/services/clip-srt.util.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-srt.util.ts
@@ -42,10 +42,11 @@ export function generateClipSrt(
  * Formats a duration in seconds as an `HH:MM:SS,mmm` SRT timestamp.
  */
 export function formatSrtTimestamp(seconds: number): string {
-  const hours = Math.floor(seconds / 3600);
-  const mins = Math.floor((seconds % 3600) / 60);
-  const secs = Math.floor(seconds % 60);
-  const ms = Math.round((seconds % 1) * 1000);
+  const totalMilliseconds = Math.round(seconds * 1000);
+  const hours = Math.floor(totalMilliseconds / 3_600_000);
+  const mins = Math.floor((totalMilliseconds % 3_600_000) / 60_000);
+  const secs = Math.floor((totalMilliseconds % 60_000) / 1000);
+  const ms = totalMilliseconds % 1000;
 
   return `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')},${ms.toString().padStart(3, '0')}`;
 }

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts
@@ -1,5 +1,6 @@
 import type { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import type { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import type { Mocked } from 'vitest';
 import {
   RawCutClipService,
@@ -122,7 +123,23 @@ describe('RawCutClipService', () => {
       service.dispatchClip(
         makeInput({ sourceVideoS3Key: undefined, sourceVideoUrl: undefined }),
       ),
-    ).rejects.toThrow(/source video/i);
+    ).rejects.toThrow(BadRequestException);
+    expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+  });
+
+  it('rejects a zero-length cut window before dispatching a trim job', async () => {
+    await expect(
+      service.dispatchClip(makeInput({ endTime: 15, startTime: 15 })),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+  });
+
+  it('rejects a negative cut window before dispatching a trim job', async () => {
+    await expect(
+      service.dispatchClip(makeInput({ endTime: 14.5, startTime: 15 })),
+    ).rejects.toThrow(BadRequestException);
+
     expect(fileQueueService.processVideo).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
@@ -1,6 +1,6 @@
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 
 /** Provider name recorded on deterministic clip-results. */
 export const RAW_CUT_PROVIDER_NAME = 'raw-cut';
@@ -66,8 +66,14 @@ export class RawCutClipService {
     } = input;
 
     if (!sourceVideoS3Key && !sourceVideoUrl) {
-      throw new Error(
+      throw new BadRequestException(
         'Raw-cut clip requires a source video reference (s3Key or url).',
+      );
+    }
+
+    if (endTime <= startTime) {
+      throw new BadRequestException(
+        'Raw-cut clip requires endTime to be greater than startTime.',
       );
     }
 


### PR DESCRIPTION
## Summary

- derive SRT timestamp components from a single rounded total millisecond value so rollover is valid
- throw `BadRequestException` for missing raw-cut source video references
- reject zero-length and negative raw-cut windows before computing duration or queuing `clip-trim`

Closes #1320.

## Validation

- `bun run --cwd apps/server/api test:file src/collections/clip-projects/services/clip-srt.util.spec.ts src/collections/clip-projects/services/raw-cut-clip.service.spec.ts`
- `bunx biome check --write apps/server/api/src/collections/clip-projects/services/clip-srt.util.ts apps/server/api/src/collections/clip-projects/services/clip-srt.util.spec.ts apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts`
- staged secret scan via commit hook