### PR TITLE
fix(website): support compact proof page layouts

### DIFF
--- a/apps/website/packages/components/PageLayout.spec.tsx
+++ b/apps/website/packages/components/PageLayout.spec.tsx
@@ -47,6 +47,28 @@ describe('PageLayout Component', () => {
     expect(screen.getByTestId('proof-visual')).toBeInTheDocument();
   });
 
+  it('applies compact density to proof hero layouts', () => {
+    renderPageLayout({
+      compact: true,
+      variant: 'proof',
+    });
+
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'Studio',
+    });
+    const heroGrid = heading.parentElement?.parentElement;
+
+    if (!heroGrid) {
+      throw new Error('Expected proof hero grid to render');
+    }
+
+    expect(heroGrid).toHaveClass('items-start', 'pt-16', 'pb-4');
+    expect(heroGrid).not.toHaveClass('min-h-[calc(100vh-8rem)]');
+    expect(heading).toHaveClass('text-4xl', 'sm:text-5xl');
+    expect(heading).not.toHaveClass('lg:text-[5.2rem]');
+  });
+
   it('omits footer when showFooter is false', () => {
     renderPageLayout({ showFooter: false, variant: 'poster' });
 

--- a/apps/website/packages/components/PageLayout.tsx
+++ b/apps/website/packages/components/PageLayout.tsx
@@ -31,6 +31,7 @@ export default function PageLayout({
       <ProofHeroPage
         badge={badge}
         badgeIcon={BadgeIcon}
+        compact={compact}
         description={description}
         heroActions={heroActions}
         heroProof={heroProof}

--- a/packages/ui/src/components/marketing/ProofHeroPage.tsx
+++ b/packages/ui/src/components/marketing/ProofHeroPage.tsx
@@ -5,6 +5,7 @@ export interface ProofHeroPageProps {
   badge?: string;
   badgeIcon?: ComponentType<IconBaseProps>;
   children: ReactNode;
+  compact?: boolean;
   description?: ReactNode;
   heroActions?: ReactNode;
   heroProof?: ReactNode;
@@ -14,6 +15,7 @@ export interface ProofHeroPageProps {
 
 export default function ProofHeroPage({
   children,
+  compact = false,
   description,
   heroActions,
   heroProof,
@@ -26,14 +28,22 @@ export default function ProofHeroPage({
         <div className="container mx-auto px-6">
           <div
             className={[
-              'grid min-h-[calc(100vh-8rem)] items-center gap-10 py-8 lg:gap-14',
+              compact
+                ? 'grid items-start gap-10 pt-16 pb-4 lg:gap-14'
+                : 'grid min-h-[calc(100vh-8rem)] items-center gap-10 py-8 lg:gap-14',
               heroVisual
                 ? 'lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]'
                 : 'lg:grid-cols-1',
             ].join(' ')}
           >
             <div className="max-w-2xl">
-              <h1 className="text-5xl font-semibold leading-[0.95] tracking-[-0.03em] text-foreground sm:text-6xl md:text-7xl lg:text-[5.2rem]">
+              <h1
+                className={
+                  compact
+                    ? 'text-4xl font-semibold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-5xl'
+                    : 'text-5xl font-semibold leading-[0.95] tracking-[-0.03em] text-foreground sm:text-6xl md:text-7xl lg:text-[5.2rem]'
+                }
+              >
                 {title}
               </h1>
 


### PR DESCRIPTION
## Summary
- forward `PageLayout` compact density into the `variant="proof"` branch
- add explicit compact grid and heading classes to `ProofHeroPage` while preserving the existing full-height default
- add focused `PageLayout` coverage for proof compact density so it is no longer silently ignored

Closes #1323

## Verification
- `bunx biome check apps/website/packages/components/PageLayout.tsx apps/website/packages/components/PageLayout.spec.tsx packages/ui/src/components/marketing/ProofHeroPage.tsx`
- `bun run design:lint` (0 errors; existing DESIGN.md warnings only)
- `git diff --check`
- pre-commit lint-staged hooks passed on commit: Biome write, raw HTML guard, bespoke card guard, repo secretlint wrapper

## Not run locally
- `bun run --cwd apps/website test packages/components/PageLayout.spec.tsx` could not start because this worktree has no `node_modules`, so `vitest/config` cannot resolve. PR CI should run the installed test environment.