### PR TITLE
feat(scheduler): normalize channel capabilities

### DIFF
--- a/apps/server/api/credential-backfill.webpack.config.cjs
+++ b/apps/server/api/credential-backfill.webpack.config.cjs
@@ -1,7 +1,7 @@
 const path = require('node:path');
 const createWebpackConfig = require('../../../webpack.base.config');
 
-module.exports = createWebpackConfig({
+const config = createWebpackConfig({
   appDir: __dirname,
   appName: 'api-credential-backfill',
   distPath: 'apps/api-credential-backfill',
@@ -9,3 +9,10 @@ module.exports = createWebpackConfig({
   entryFile: 'scripts/backfill-credential-encryption.ts',
   nodeModulesDir: path.resolve(__dirname, '../../../node_modules'),
 });
+
+config.resolve.alias['@api-types'] = path.resolve(
+  __dirname,
+  '../../../packages/api-types/src',
+);
+
+module.exports = config;

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -41454,6 +41454,77 @@
         ]
       }
     },
+    "/schedules/channel-capabilities": {
+      "get": {
+        "operationId": "SchedulesController.listChannelCapabilities",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "includeHidden",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "includePlanned",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "listChannelCapabilities",
+        "tags": [
+          "Schedules"
+        ]
+      }
+    },
+    "/schedules/channel-capabilities/validate": {
+      "post": {
+        "operationId": "SchedulesController.validateChannelTargetSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "validateChannelTargetSettings",
+        "tags": [
+          "Schedules"
+        ]
+      }
+    },
+    "/schedules/channel-capabilities/{platform}": {
+      "get": {
+        "operationId": "SchedulesController.getChannelCapability",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "platform",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "getChannelCapability",
+        "tags": [
+          "Schedules"
+        ]
+      }
+    },
     "/schedules/optimal": {
       "post": {
         "operationId": "SchedulesController.getOptimalTime",

--- a/apps/server/api/src/collections/schedules/controllers/schedules.controller.spec.ts
+++ b/apps/server/api/src/collections/schedules/controllers/schedules.controller.spec.ts
@@ -35,9 +35,12 @@ describe('SchedulesController', () => {
   const mockSchedulesService = {
     bulkSchedule: vi.fn(),
     getCalendar: vi.fn(),
+    getChannelCapability: vi.fn(),
+    listChannelCapabilities: vi.fn(),
     getOptimalTime: vi.fn(),
     getRepurposingStatus: vi.fn(),
     repurposeContent: vi.fn(),
+    validateChannelTargetSettings: vi.fn(),
   };
 
   beforeEach(async () => {
@@ -97,6 +100,55 @@ describe('SchedulesController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('channel capabilities', () => {
+    it('should list channel capabilities with discovery flags', async () => {
+      const capabilities = [{ label: 'YouTube', platform: 'youtube' }];
+      mockSchedulesService.listChannelCapabilities.mockReturnValue(
+        capabilities,
+      );
+
+      const result = await controller.listChannelCapabilities('true', 'false');
+
+      expect(service.listChannelCapabilities).toHaveBeenCalledWith({
+        includeHidden: true,
+        includePlanned: false,
+      });
+      expect(result).toEqual(capabilities);
+    });
+
+    it('should return one channel capability', async () => {
+      const capability = { label: 'TikTok', platform: 'tiktok' };
+      mockSchedulesService.getChannelCapability.mockReturnValue(capability);
+
+      const result = await controller.getChannelCapability('tiktok');
+
+      expect(service.getChannelCapability).toHaveBeenCalledWith('tiktok');
+      expect(result).toEqual(capability);
+    });
+
+    it('should validate channel target settings through the shared service', async () => {
+      const input = {
+        platform: 'youtube',
+        settings: { privacyStatus: 'public' },
+      };
+      const validation = {
+        errors: [],
+        platform: 'youtube',
+        valid: true,
+        validationState: 'valid',
+        warnings: [],
+      };
+      mockSchedulesService.validateChannelTargetSettings.mockReturnValue(
+        validation,
+      );
+
+      const result = await controller.validateChannelTargetSettings(input);
+
+      expect(service.validateChannelTargetSettings).toHaveBeenCalledWith(input);
+      expect(result).toEqual(validation);
+    });
   });
 
   describe('getOptimalTime', () => {

--- a/apps/server/api/src/collections/schedules/controllers/schedules.controller.ts
+++ b/apps/server/api/src/collections/schedules/controllers/schedules.controller.ts
@@ -20,6 +20,7 @@ import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.in
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { serializeCollection } from '@api/helpers/utils/response/response.util';
 import { getMinimumTextCredits } from '@api/helpers/utils/text-pricing/text-pricing.util';
+import type { ValidateChannelTargetSettingsInput } from '@api-types/contracts/channel-capabilities.contract';
 import { ActivitySource } from '@genfeedai/enums';
 import { ScheduleSerializer } from '@genfeedai/serializers';
 import {
@@ -50,6 +51,32 @@ export class SchedulesController {
     private readonly creditsUtilsService: CreditsUtilsService,
     private readonly modelsService: ModelsService,
   ) {}
+
+  @Get('channel-capabilities')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  listChannelCapabilities(
+    @Query('includeHidden') includeHidden?: string,
+    @Query('includePlanned') includePlanned?: string,
+  ) {
+    return this.schedulesService.listChannelCapabilities({
+      includeHidden: this.parseBooleanQuery(includeHidden),
+      includePlanned: this.parseBooleanQuery(includePlanned),
+    });
+  }
+
+  @Get('channel-capabilities/:platform')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  getChannelCapability(@Param('platform') platform: string) {
+    return this.schedulesService.getChannelCapability(platform);
+  }
+
+  @Post('channel-capabilities/validate')
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  validateChannelTargetSettings(
+    @Body() input: ValidateChannelTargetSettingsInput,
+  ) {
+    return this.schedulesService.validateChannelTargetSettings(input);
+  }
 
   /**
    * Get optimal posting time
@@ -218,5 +245,13 @@ export class SchedulesController {
       deferred: false,
       maxOverdraftCredits: SchedulesController.TEXT_MAX_OVERDRAFT_CREDITS,
     };
+  }
+
+  private parseBooleanQuery(value?: string): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return ['1', 'true', 'yes'].includes(value.toLowerCase());
   }
 }

--- a/apps/server/api/src/collections/schedules/services/schedules.service.spec.ts
+++ b/apps/server/api/src/collections/schedules/services/schedules.service.spec.ts
@@ -3,6 +3,7 @@ import { SchedulesService } from '@api/collections/schedules/services/schedules.
 import { ConfigService } from '@api/config/config.service';
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { CredentialPlatform, TargetValidationState } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -95,5 +96,56 @@ describe('SchedulesService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('channel capabilities', () => {
+    it('should expose supported scheduler channels', () => {
+      expect(
+        service
+          .listChannelCapabilities()
+          .map((capability) => capability.platform),
+      ).toEqual([
+        CredentialPlatform.YOUTUBE,
+        CredentialPlatform.TIKTOK,
+        CredentialPlatform.INSTAGRAM,
+        CredentialPlatform.TWITTER,
+        CredentialPlatform.LINKEDIN,
+      ]);
+    });
+
+    it('should expose hidden channel stubs when requested', () => {
+      expect(
+        service
+          .listChannelCapabilities({ includeHidden: true })
+          .map((capability) => capability.platform),
+      ).toContain(CredentialPlatform.REDDIT);
+    });
+
+    it('should resolve a single channel capability', () => {
+      expect(service.getChannelCapability(CredentialPlatform.YOUTUBE)).toEqual(
+        expect.objectContaining({
+          label: 'YouTube',
+          platform: CredentialPlatform.YOUTUBE,
+        }),
+      );
+    });
+
+    it('should validate channel target settings through the shared contract', () => {
+      const result = service.validateChannelTargetSettings({
+        media: [{ id: 'asset_1', kind: 'video' }],
+        platform: CredentialPlatform.YOUTUBE,
+        settings: {},
+      });
+
+      expect(result.validationState).toBe(TargetValidationState.INVALID);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'channel_target.required_setting',
+            field: 'settings.privacyStatus',
+          }),
+        ]),
+      );
+    });
   });
 });

--- a/apps/server/api/src/collections/schedules/services/schedules.service.ts
+++ b/apps/server/api/src/collections/schedules/services/schedules.service.ts
@@ -13,6 +13,17 @@ import { calculateEstimatedTextCredits } from '@api/helpers/utils/text-pricing/t
 import { ReplicateService } from '@api/services/integrations/replicate/replicate.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { findOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util';
+import type {
+  ChannelCapability,
+  ChannelCapabilityListOptions,
+  ChannelTargetValidationResult,
+  ValidateChannelTargetSettingsInput,
+} from '@api-types/contracts/channel-capabilities.contract';
+import {
+  listChannelCapabilities as resolveChannelCapabilities,
+  getChannelCapability as resolveChannelCapability,
+  validateChannelTargetSettings as resolveChannelTargetValidation,
+} from '@api-types/contracts/channel-capabilities.contract';
 import type { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -28,6 +39,28 @@ export class SchedulesService {
     private readonly modelsService: ModelsService,
     private readonly replicateService: ReplicateService,
   ) {}
+
+  listChannelCapabilities(
+    options: ChannelCapabilityListOptions = {},
+  ): ChannelCapability[] {
+    return resolveChannelCapabilities(options);
+  }
+
+  getChannelCapability(platform: string): ChannelCapability {
+    const capability = resolveChannelCapability(platform);
+
+    if (!capability) {
+      throw new NotFoundException('Channel capability', platform);
+    }
+
+    return capability;
+  }
+
+  validateChannelTargetSettings(
+    input: ValidateChannelTargetSettingsInput,
+  ): ChannelTargetValidationResult {
+    return resolveChannelTargetValidation(input);
+  }
 
   /**
    * Get optimal posting time

--- a/apps/server/api/src/config/openapi-parity-baseline.json
+++ b/apps/server/api/src/config/openapi-parity-baseline.json
@@ -3907,6 +3907,11 @@
       "path": "/schedules/calendar"
     },
     {
+      "method": "get",
+      "operationId": "SchedulesController.getChannelCapability",
+      "path": "/schedules/channel-capabilities/{platform}"
+    },
+    {
       "method": "post",
       "operationId": "SchedulesController.getOptimalTime",
       "path": "/schedules/optimal"
@@ -3917,9 +3922,19 @@
       "path": "/schedules/repurpose/{id}"
     },
     {
+      "method": "get",
+      "operationId": "SchedulesController.listChannelCapabilities",
+      "path": "/schedules/channel-capabilities"
+    },
+    {
       "method": "post",
       "operationId": "SchedulesController.repurposeContent",
       "path": "/schedules/repurpose"
+    },
+    {
+      "method": "post",
+      "operationId": "SchedulesController.validateChannelTargetSettings",
+      "path": "/schedules/channel-capabilities/validate"
     },
     {
       "method": "post",

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-analytics.service.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-analytics.service.ts
@@ -1,3 +1,7 @@
+import {
+  asYoutubeRequestAuth,
+  type YoutubeRequestAuth,
+} from '@api/services/integrations/youtube/services/modules/youtube-api-auth.util';
 import { YoutubeAuthService } from '@api/services/integrations/youtube/services/modules/youtube-auth.service';
 import type { IYouTubeVideoStats } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -44,22 +48,25 @@ export class YoutubeAnalyticsService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      let auth: youtube_v3.Params$Resource$Channels$List['auth'];
+      let auth: YoutubeRequestAuth;
       if (typeof authOrSkipRefresh === 'boolean') {
         this.loggerService.log(
           `${url} started (skipRefresh ignored for safety)`,
           { organizationId },
         );
-        auth = await this.authService.refreshToken(organizationId, brandId);
+        auth = asYoutubeRequestAuth(
+          await this.authService.refreshToken(organizationId, brandId),
+        );
       } else if (authOrSkipRefresh) {
         this.loggerService.log(`${url} started with per-request auth`, {
           organizationId,
         });
-        auth =
-          authOrSkipRefresh as youtube_v3.Params$Resource$Channels$List['auth'];
+        auth = authOrSkipRefresh as YoutubeRequestAuth;
       } else {
         this.loggerService.log(`${url} started`, { organizationId });
-        auth = await this.authService.refreshToken(organizationId, brandId);
+        auth = asYoutubeRequestAuth(
+          await this.authService.refreshToken(organizationId, brandId),
+        );
       }
 
       const response = await this.youtubeAPI.channels.list({
@@ -144,7 +151,9 @@ export class YoutubeAnalyticsService {
     }
 
     try {
-      const auth = await this.authService.refreshToken(organizationId, brandId);
+      const auth = asYoutubeRequestAuth(
+        await this.authService.refreshToken(organizationId, brandId),
+      );
 
       const videoData = await this.youtubeAPI.videos.list({
         auth,

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-api-auth.util.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-api-auth.util.ts
@@ -1,0 +1,11 @@
+import type { OAuth2Client } from 'google-auth-library';
+import type { youtube_v3 } from 'googleapis';
+
+export type YoutubeRequestAuth =
+  youtube_v3.Params$Resource$Channels$List['auth'];
+
+export function asYoutubeRequestAuth(auth: OAuth2Client): YoutubeRequestAuth {
+  // googleapis and google-auth-library can resolve duplicate type identities in
+  // the monorepo, but the OAuth2 client instance is the runtime auth object.
+  return auth as unknown as YoutubeRequestAuth;
+}

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-comments.service.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-comments.service.ts
@@ -1,7 +1,11 @@
+import {
+  asYoutubeRequestAuth,
+  type YoutubeRequestAuth,
+} from '@api/services/integrations/youtube/services/modules/youtube-api-auth.util';
 import { YoutubeAuthService } from '@api/services/integrations/youtube/services/modules/youtube-auth.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
-import { google, youtube_v3 } from 'googleapis';
+import { google, type youtube_v3 } from 'googleapis';
 
 @Injectable()
 export class YoutubeCommentsService {
@@ -19,10 +23,12 @@ export class YoutubeCommentsService {
     organizationId: string,
     brandId: string,
   ): Promise<{
-    auth: Awaited<ReturnType<YoutubeAuthService['refreshToken']>>;
+    auth: YoutubeRequestAuth;
     channelId: string;
   }> {
-    const auth = await this.authService.refreshToken(organizationId, brandId);
+    const auth = asYoutubeRequestAuth(
+      await this.authService.refreshToken(organizationId, brandId),
+    );
 
     const channelResponse = await this.youtubeAPI.channels.list({
       auth,
@@ -190,7 +196,9 @@ export class YoutubeCommentsService {
         textLength: text.length,
       });
 
-      const auth = await this.authService.refreshToken(organizationId, brandId);
+      const auth = asYoutubeRequestAuth(
+        await this.authService.refreshToken(organizationId, brandId),
+      );
 
       const response = await this.youtubeAPI.comments.insert({
         auth,
@@ -241,7 +249,9 @@ export class YoutubeCommentsService {
     const url = `${this.constructorName} listVideoComments`;
 
     try {
-      const auth = await this.authService.refreshToken(organizationId, brandId);
+      const auth = asYoutubeRequestAuth(
+        await this.authService.refreshToken(organizationId, brandId),
+      );
       const response = await this.youtubeAPI.commentThreads.list({
         auth,
         maxResults: Math.min(Math.max(maxResults, 1), 100),
@@ -312,7 +322,9 @@ export class YoutubeCommentsService {
         textLength: text.length,
       });
 
-      const auth = await this.authService.refreshToken(organizationId, brandId);
+      const auth = asYoutubeRequestAuth(
+        await this.authService.refreshToken(organizationId, brandId),
+      );
       const response = await this.youtubeAPI.comments.insert({
         auth,
         part: ['snippet'],

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-metadata.service.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-metadata.service.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@api/config/config.service';
+import { asYoutubeRequestAuth } from '@api/services/integrations/youtube/services/modules/youtube-api-auth.util';
 import { YoutubeAuthService } from '@api/services/integrations/youtube/services/modules/youtube-auth.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
@@ -97,9 +98,8 @@ export class YoutubeMetadataService {
     try {
       this.loggerService.log(`${url} started`);
 
-      const auth = await this.youtubeAuthService.refreshToken(
-        organizationId,
-        brandId,
+      const auth = asYoutubeRequestAuth(
+        await this.youtubeAuthService.refreshToken(organizationId, brandId),
       );
 
       const response = await this.youtubeAPI.videos.list({

--- a/apps/server/api/vitest.config.ts
+++ b/apps/server/api/vitest.config.ts
@@ -146,6 +146,13 @@ export default defineConfig({
         replacement: path.resolve(serviceDir, './src'),
       },
       {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/api-types/src/$1',
+        ),
+      },
+      {
         // Mirrors the webpack/tsconfig `@billing-providers` alias for the api's
         // own unit tests: with ee/packages/billing out of the api graph, the
         // billing collection modules resolve to the in-tree OSS fragment. The EE

--- a/apps/server/api/webpack.config.cjs
+++ b/apps/server/api/webpack.config.cjs
@@ -1,10 +1,17 @@
 const path = require('node:path');
 const createWebpackConfig = require('../../../webpack.base.config');
 
-module.exports = createWebpackConfig({
+const config = createWebpackConfig({
   appDir: __dirname,
   appName: 'api',
   distPath: 'apps/api',
   distRoot: path.resolve(__dirname, '..'),
   nodeModulesDir: path.resolve(__dirname, '../../../node_modules'),
 });
+
+config.resolve.alias['@api-types'] = path.resolve(
+  __dirname,
+  '../../../packages/api-types/src',
+);
+
+module.exports = config;

--- a/apps/server/api/workflow-backfill.webpack.config.cjs
+++ b/apps/server/api/workflow-backfill.webpack.config.cjs
@@ -1,7 +1,7 @@
 const path = require('node:path');
 const createWebpackConfig = require('../../../webpack.base.config');
 
-module.exports = createWebpackConfig({
+const config = createWebpackConfig({
   appDir: __dirname,
   appName: 'api-workflow-backfill',
   distPath: 'apps/api-workflow-backfill',
@@ -9,3 +9,10 @@ module.exports = createWebpackConfig({
   entryFile: 'src/migrations/workflow-backfill.ts',
   nodeModulesDir: path.resolve(__dirname, '../../../node_modules'),
 });
+
+config.resolve.alias['@api-types'] = path.resolve(
+  __dirname,
+  '../../../packages/api-types/src',
+);
+
+module.exports = config;

--- a/apps/server/mcp/src/services/client.service.spec.ts
+++ b/apps/server/mcp/src/services/client.service.spec.ts
@@ -892,8 +892,19 @@ describe('ClientService (MCP)', () => {
 
   describe('setWorkflowSchedule', () => {
     it('should enable or update a workflow schedule', async () => {
-      (mockAxiosInstance.post as Mock).mockResolvedValue({
-        data: { data: { id: 'workflow-123', message: 'Schedule updated' } },
+      (mockAxiosInstance.patch as Mock).mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              isScheduleEnabled: true,
+              name: 'Scheduled workflow',
+              schedule: '0 9 * * *',
+              status: 'active',
+              timezone: 'UTC',
+            },
+            id: 'workflow-123',
+          },
+        },
       });
 
       const result = await service.setWorkflowSchedule('workflow-123', {
@@ -902,9 +913,13 @@ describe('ClientService (MCP)', () => {
         timezone: 'UTC',
       });
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        '/workflows/workflow-123/schedule',
-        { enabled: true, schedule: '0 9 * * *', timezone: 'UTC' },
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
+        '/workflows/workflow-123',
+        {
+          isScheduleEnabled: true,
+          schedule: '0 9 * * *',
+          timezone: 'UTC',
+        },
       );
       expect(result).toMatchObject({
         enabled: true,
@@ -913,17 +928,30 @@ describe('ClientService (MCP)', () => {
       });
     });
 
-    it('should disable a workflow schedule through the delete endpoint when no new schedule is provided', async () => {
-      (mockAxiosInstance.delete as Mock).mockResolvedValue({
-        data: { data: { id: 'workflow-123', message: 'Schedule removed' } },
+    it('should disable a workflow schedule through the collapsed patch endpoint when no new schedule is provided', async () => {
+      (mockAxiosInstance.patch as Mock).mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              isScheduleEnabled: false,
+              name: 'Scheduled workflow',
+              status: 'active',
+            },
+            id: 'workflow-123',
+          },
+        },
       });
 
       const result = await service.setWorkflowSchedule('workflow-123', {
         enabled: false,
       });
 
-      expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
-        '/workflows/workflow-123/schedule',
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
+        '/workflows/workflow-123',
+        {
+          isScheduleEnabled: false,
+          schedule: null,
+        },
       );
       expect(result).toMatchObject({ enabled: false, id: 'workflow-123' });
     });

--- a/apps/server/mcp/src/services/client/workflow.client.ts
+++ b/apps/server/mcp/src/services/client/workflow.client.ts
@@ -226,38 +226,31 @@ export class WorkflowClient {
     return this.base.request(
       'updating workflow schedule',
       async (http) => {
-        if (params.enabled === false && !params.schedule) {
-          const response = await http.delete(
-            `/workflows/${encodeURIComponent(workflowId)}/schedule`,
-          );
-          const data =
-            this.base.unwrapObject<Record<string, unknown>>(response);
-          return {
-            enabled: false,
-            id: String(data.id ?? workflowId),
-            message: asString(data.message),
-          };
-        }
-
-        if (!params.schedule) {
+        if (params.enabled !== false && !params.schedule) {
           throw new Error('schedule is required when enabling a workflow');
         }
 
-        const response = await http.post(
-          `/workflows/${encodeURIComponent(workflowId)}/schedule`,
-          {
-            enabled: params.enabled,
-            schedule: params.schedule,
-            timezone: params.timezone ?? 'UTC',
-          },
+        const response = await http.patch(
+          `/workflows/${encodeURIComponent(workflowId)}`,
+          params.enabled === false && !params.schedule
+            ? {
+                isScheduleEnabled: false,
+                schedule: null,
+              }
+            : {
+                isScheduleEnabled: params.enabled,
+                schedule: params.schedule,
+                timezone: params.timezone ?? 'UTC',
+              },
         );
-        const data = this.base.unwrapObject<Record<string, unknown>>(response);
+        const workflow = mapWorkflowResource(
+          this.base.unwrapData<JsonApiResource>(response),
+        );
         return {
-          enabled: params.enabled,
-          id: String(data.id ?? workflowId),
-          message: asString(data.message),
-          schedule: params.schedule,
-          timezone: params.timezone ?? 'UTC',
+          enabled: workflow.isScheduleEnabled ?? params.enabled,
+          id: workflow.id || workflowId,
+          schedule: workflow.schedule,
+          timezone: workflow.timezone,
         };
       },
       this.base.failWithDetail('Failed to update workflow schedule'),

--- a/apps/server/mcp/src/services/route-contract.spec.ts
+++ b/apps/server/mcp/src/services/route-contract.spec.ts
@@ -319,15 +319,9 @@ const ROUTE_CONTRACT: ContractRoute[] = [
     tools: ['list_workflow_templates'],
   },
   {
-    method: 'Post',
-    sub: ':workflowId/schedule',
-    controller: 'workflowExecution',
-    tools: ['set_workflow_schedule'],
-  },
-  {
-    method: 'Delete',
-    sub: ':workflowId/schedule',
-    controller: 'workflowExecution',
+    method: 'Patch',
+    sub: ':workflowId',
+    controller: 'workflowCrud',
     tools: ['set_workflow_schedule'],
   },
   {

--- a/packages/api-types/__tests__/channel-capabilities.contract.test.ts
+++ b/packages/api-types/__tests__/channel-capabilities.contract.test.ts
@@ -176,4 +176,40 @@ describe('validateChannelTargetSettings', () => {
       ]),
     );
   });
+
+  test('flags a valid enum platform with no registered capability', () => {
+    const result = validateChannelTargetSettings({
+      caption: 'Discord announcement',
+      platform: CredentialPlatform.DISCORD,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.validationState).toBe(TargetValidationState.INVALID);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'channel_target.missing_capability',
+          field: 'platform',
+        }),
+      ]),
+    );
+  });
+
+  test('rejects an unsupported platform string', () => {
+    const result = validateChannelTargetSettings({
+      caption: 'Unknown network post',
+      platform: 'myspace',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.validationState).toBe(TargetValidationState.INVALID);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'channel_target.unsupported_platform',
+          field: 'platform',
+        }),
+      ]),
+    );
+  });
 });

--- a/packages/api-types/__tests__/channel-capabilities.contract.test.ts
+++ b/packages/api-types/__tests__/channel-capabilities.contract.test.ts
@@ -1,0 +1,179 @@
+import {
+  getChannelCapability,
+  listChannelCapabilities,
+  PRODUCTIZED_SCHEDULER_PLATFORMS,
+  validateChannelTargetSettings,
+} from '@api-types/contracts/channel-capabilities.contract';
+import { CredentialPlatform, TargetValidationState } from '@genfeedai/enums';
+import { describe, expect, test } from 'vitest';
+
+describe('channel capability catalog', () => {
+  test('reconciles the productized scheduler channels', () => {
+    expect(PRODUCTIZED_SCHEDULER_PLATFORMS).toEqual([
+      CredentialPlatform.YOUTUBE,
+      CredentialPlatform.TIKTOK,
+      CredentialPlatform.INSTAGRAM,
+      CredentialPlatform.TWITTER,
+      CredentialPlatform.LINKEDIN,
+    ]);
+
+    expect(
+      listChannelCapabilities().map((capability) => capability.platform),
+    ).toEqual([
+      CredentialPlatform.YOUTUBE,
+      CredentialPlatform.TIKTOK,
+      CredentialPlatform.INSTAGRAM,
+      CredentialPlatform.TWITTER,
+      CredentialPlatform.LINKEDIN,
+    ]);
+  });
+
+  test('keeps backend integration stubs hidden unless explicitly requested', () => {
+    expect(
+      listChannelCapabilities().some(
+        (capability) => capability.platform === CredentialPlatform.REDDIT,
+      ),
+    ).toBe(false);
+
+    expect(
+      listChannelCapabilities({ includeHidden: true }).map(
+        (capability) => capability.platform,
+      ),
+    ).toContain(CredentialPlatform.REDDIT);
+
+    expect(
+      listChannelCapabilities({ includePlanned: true }).map(
+        (capability) => capability.platform,
+      ),
+    ).toContain(CredentialPlatform.THREADS);
+  });
+
+  test('exposes helper lookup contracts for supported and stubbed platforms', () => {
+    expect(getChannelCapability(CredentialPlatform.YOUTUBE)?.helpers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'youtube.channels',
+          lookupPath: '/integrations/youtube/channels',
+        }),
+      ]),
+    );
+
+    expect(getChannelCapability(CredentialPlatform.TIKTOK)?.helpers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'tiktok.audio_styles' }),
+      ]),
+    );
+
+    expect(getChannelCapability(CredentialPlatform.PINTEREST)?.helpers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'pinterest.boards' }),
+      ]),
+    );
+  });
+});
+
+describe('validateChannelTargetSettings', () => {
+  test('accepts a valid YouTube target', () => {
+    const result = validateChannelTargetSettings({
+      caption: 'Launch video',
+      media: [{ id: 'asset_1', kind: 'video' }],
+      platform: CredentialPlatform.YOUTUBE,
+      publishMode: 'scheduled',
+      settings: {
+        privacyStatus: 'unlisted',
+      },
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.validationState).toBe(TargetValidationState.VALID);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('returns the same required-setting failure shape for YouTube privacy', () => {
+    const result = validateChannelTargetSettings({
+      caption: 'Launch video',
+      media: [{ id: 'asset_1', kind: 'video' }],
+      platform: CredentialPlatform.YOUTUBE,
+      publishMode: 'scheduled',
+      settings: {},
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.validationState).toBe(TargetValidationState.INVALID);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'channel_target.required_setting',
+          field: 'settings.privacyStatus',
+        }),
+      ]),
+    );
+  });
+
+  test('rejects invalid TikTok privacy values', () => {
+    const result = validateChannelTargetSettings({
+      caption: 'Short video',
+      media: [{ id: 'asset_2', kind: 'short_video' }],
+      platform: CredentialPlatform.TIKTOK,
+      settings: {
+        privacyLevel: 'organization',
+      },
+    });
+
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'channel_target.invalid_setting_option',
+          field: 'settings.privacyLevel',
+        }),
+      ]),
+    );
+  });
+
+  test('enforces text limits and media compatibility', () => {
+    const result = validateChannelTargetSettings({
+      caption: 'x'.repeat(281),
+      media: [
+        { id: 'asset_1', kind: 'image' },
+        { id: 'asset_2', kind: 'image' },
+        { id: 'asset_3', kind: 'image' },
+        { id: 'asset_4', kind: 'image' },
+        { id: 'asset_5', kind: 'image' },
+      ],
+      platform: CredentialPlatform.TWITTER,
+      publishMode: 'publish_now',
+    });
+
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'channel_target.caption_too_long' }),
+        expect.objectContaining({
+          code: 'channel_target.too_many_media_items',
+        }),
+      ]),
+    );
+  });
+
+  test('marks hidden and planned channel stubs invalid for publishing', () => {
+    expect(
+      validateChannelTargetSettings({
+        platform: CredentialPlatform.REDDIT,
+      }).errors,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'channel_target.hidden_channel' }),
+      ]),
+    );
+
+    expect(
+      validateChannelTargetSettings({
+        caption: 'Thread draft',
+        platform: CredentialPlatform.THREADS,
+      }).errors,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'channel_target.planned_channel' }),
+      ]),
+    );
+  });
+});

--- a/packages/api-types/src/contracts/channel-capabilities.contract.ts
+++ b/packages/api-types/src/contracts/channel-capabilities.contract.ts
@@ -1,0 +1,906 @@
+/**
+ * Shared channel capability catalog for scheduler targets.
+ *
+ * This keeps platform-specific limits, required channel settings, and helper
+ * lookup contracts in one request-side contract so composer UI, API validation,
+ * workers, CLI, and MCP can present and enforce the same scheduler failures.
+ * Foundation for epic #1123, issue #1125.
+ */
+
+import { CredentialPlatform, TargetValidationState } from '@genfeedai/enums';
+import { z } from 'zod';
+
+export const channelCapabilityStatusValues = [
+  'supported',
+  'hidden',
+  'planned',
+] as const;
+
+export const channelMediaKindValues = [
+  'image',
+  'video',
+  'short_video',
+  'carousel',
+  'link',
+] as const;
+
+export const channelPublishModeValues = [
+  'draft',
+  'publish_now',
+  'scheduled',
+] as const;
+
+export const channelSettingFieldTypeValues = [
+  'string',
+  'text',
+  'number',
+  'boolean',
+  'select',
+  'multi_select',
+  'url',
+] as const;
+
+export const channelHelperKindValues = [
+  'credential',
+  'account',
+  'page',
+  'board',
+  'subreddit',
+  'audio_style',
+] as const;
+
+export const channelValidationSeverityValues = ['error', 'warning'] as const;
+
+export const channelCapabilityStatusSchema = z.enum(
+  channelCapabilityStatusValues,
+);
+export const channelMediaKindSchema = z.enum(channelMediaKindValues);
+export const channelPublishModeSchema = z.enum(channelPublishModeValues);
+export const channelSettingFieldTypeSchema = z.enum(
+  channelSettingFieldTypeValues,
+);
+export const channelHelperKindSchema = z.enum(channelHelperKindValues);
+export const channelValidationSeveritySchema = z.enum(
+  channelValidationSeverityValues,
+);
+
+const channelTargetSettingsSchema = z
+  .record(z.string(), z.unknown())
+  .default({});
+
+const settingDefaultValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+]);
+
+export const channelSettingOptionSchema = z.object({
+  label: z.string().min(1),
+  value: z.string().min(1),
+});
+
+export const channelSettingDefinitionSchema = z.object({
+  defaultValue: settingDefaultValueSchema.optional(),
+  description: z.string().min(1).optional(),
+  helper: z.string().min(1).optional(),
+  key: z.string().min(1),
+  label: z.string().min(1),
+  options: z.array(channelSettingOptionSchema).optional(),
+  required: z.boolean().optional(),
+  type: channelSettingFieldTypeSchema,
+});
+
+export const channelHelperDefinitionSchema = z.object({
+  description: z.string().min(1).optional(),
+  key: z.string().min(1),
+  kind: channelHelperKindSchema,
+  label: z.string().min(1),
+  lookupPath: z.string().min(1).optional(),
+  required: z.boolean().optional(),
+});
+
+export const channelCaptionCapabilitySchema = z.object({
+  maxLength: z.number().int().positive(),
+  required: z.boolean().optional(),
+});
+
+export const channelMediaCapabilitySchema = z.object({
+  kinds: z.array(channelMediaKindSchema).min(1),
+  maxItems: z.number().int().positive().optional(),
+  minItems: z.number().int().min(0).optional(),
+});
+
+export const channelCapabilitySchema = z.object({
+  caption: channelCaptionCapabilitySchema,
+  description: z.string().min(1),
+  helpers: z.array(channelHelperDefinitionSchema),
+  label: z.string().min(1),
+  media: channelMediaCapabilitySchema,
+  platform: z.nativeEnum(CredentialPlatform),
+  publishModes: z.array(channelPublishModeSchema).min(1),
+  settings: z.array(channelSettingDefinitionSchema),
+  status: channelCapabilityStatusSchema,
+});
+
+export const channelTargetValidationMediaSchema = z.object({
+  id: z.string().min(1).optional(),
+  kind: channelMediaKindSchema,
+});
+
+export const validateChannelTargetSettingsInputSchema = z.object({
+  caption: z.string().optional(),
+  media: z.array(channelTargetValidationMediaSchema).optional(),
+  platform: z.union([z.nativeEnum(CredentialPlatform), z.string().min(1)]),
+  publishMode: channelPublishModeSchema.optional(),
+  settings: channelTargetSettingsSchema.optional(),
+});
+
+export const channelValidationIssueSchema = z.object({
+  code: z.string().min(1),
+  field: z.string().min(1).optional(),
+  message: z.string().min(1),
+  severity: channelValidationSeveritySchema,
+});
+
+export const channelTargetValidationResultSchema = z.object({
+  capability: channelCapabilitySchema.optional(),
+  errors: z.array(channelValidationIssueSchema),
+  platform: z.union([z.nativeEnum(CredentialPlatform), z.string().min(1)]),
+  valid: z.boolean(),
+  validationState: z.nativeEnum(TargetValidationState),
+  warnings: z.array(channelValidationIssueSchema),
+});
+
+export const channelCapabilityListOptionsSchema = z.object({
+  includeHidden: z.boolean().optional(),
+  includePlanned: z.boolean().optional(),
+});
+
+export type ChannelCapabilityStatus = z.infer<
+  typeof channelCapabilityStatusSchema
+>;
+export type ChannelMediaKind = z.infer<typeof channelMediaKindSchema>;
+export type ChannelPublishMode = z.infer<typeof channelPublishModeSchema>;
+export type ChannelSettingFieldType = z.infer<
+  typeof channelSettingFieldTypeSchema
+>;
+export type ChannelSettingDefinition = z.infer<
+  typeof channelSettingDefinitionSchema
+>;
+export type ChannelHelperDefinition = z.infer<
+  typeof channelHelperDefinitionSchema
+>;
+export type ChannelCapability = z.infer<typeof channelCapabilitySchema>;
+export type ValidateChannelTargetSettingsInput = z.infer<
+  typeof validateChannelTargetSettingsInputSchema
+>;
+export type ChannelValidationIssue = z.infer<
+  typeof channelValidationIssueSchema
+>;
+export type ChannelTargetValidationResult = z.infer<
+  typeof channelTargetValidationResultSchema
+>;
+export type ChannelCapabilityListOptions = z.infer<
+  typeof channelCapabilityListOptionsSchema
+>;
+
+export const PRODUCTIZED_SCHEDULER_PLATFORMS = [
+  CredentialPlatform.YOUTUBE,
+  CredentialPlatform.TIKTOK,
+  CredentialPlatform.INSTAGRAM,
+  CredentialPlatform.TWITTER,
+  CredentialPlatform.LINKEDIN,
+] as const;
+
+export type ProductizedSchedulerPlatform =
+  (typeof PRODUCTIZED_SCHEDULER_PLATFORMS)[number];
+
+const channelCapabilities = [
+  {
+    caption: { maxLength: 5_000, required: false },
+    description:
+      'Long-form or Shorts video publishing with explicit visibility settings.',
+    helpers: [
+      {
+        key: 'youtube.credential',
+        kind: 'credential',
+        label: 'YouTube credential',
+        required: true,
+      },
+      {
+        key: 'youtube.channels',
+        kind: 'account',
+        label: 'YouTube channel',
+        lookupPath: '/integrations/youtube/channels',
+        required: true,
+      },
+    ],
+    label: 'YouTube',
+    media: { kinds: ['video', 'short_video'], maxItems: 1, minItems: 1 },
+    platform: CredentialPlatform.YOUTUBE,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [
+      {
+        defaultValue: 'private',
+        helper: 'youtube.channels',
+        key: 'privacyStatus',
+        label: 'Privacy',
+        options: [
+          { label: 'Public', value: 'public' },
+          { label: 'Unlisted', value: 'unlisted' },
+          { label: 'Private', value: 'private' },
+        ],
+        required: true,
+        type: 'select',
+      },
+      {
+        defaultValue: false,
+        key: 'madeForKids',
+        label: 'Made for kids',
+        type: 'boolean',
+      },
+      {
+        key: 'playlistId',
+        label: 'Playlist',
+        type: 'string',
+      },
+    ],
+    status: 'supported',
+  },
+  {
+    caption: { maxLength: 2_200, required: false },
+    description:
+      'Short-form vertical video publishing with privacy and interaction controls.',
+    helpers: [
+      {
+        key: 'tiktok.credential',
+        kind: 'credential',
+        label: 'TikTok credential',
+        required: true,
+      },
+      {
+        key: 'tiktok.accounts',
+        kind: 'account',
+        label: 'TikTok account',
+        lookupPath: '/integrations/tiktok/accounts',
+        required: true,
+      },
+      {
+        key: 'tiktok.audio_styles',
+        kind: 'audio_style',
+        label: 'TikTok audio style',
+      },
+    ],
+    label: 'TikTok',
+    media: { kinds: ['short_video', 'video'], maxItems: 1, minItems: 1 },
+    platform: CredentialPlatform.TIKTOK,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [
+      {
+        defaultValue: 'public',
+        helper: 'tiktok.accounts',
+        key: 'privacyLevel',
+        label: 'Privacy',
+        options: [
+          { label: 'Public', value: 'public' },
+          { label: 'Friends', value: 'friends' },
+          { label: 'Private', value: 'private' },
+        ],
+        required: true,
+        type: 'select',
+      },
+      {
+        defaultValue: true,
+        key: 'allowComments',
+        label: 'Allow comments',
+        type: 'boolean',
+      },
+      {
+        defaultValue: true,
+        key: 'allowDuet',
+        label: 'Allow duet',
+        type: 'boolean',
+      },
+      {
+        defaultValue: true,
+        key: 'allowStitch',
+        label: 'Allow stitch',
+        type: 'boolean',
+      },
+    ],
+    status: 'supported',
+  },
+  {
+    caption: { maxLength: 2_200, required: false },
+    description:
+      'Feed, Reel, Story, or carousel publishing for professional Instagram accounts.',
+    helpers: [
+      {
+        key: 'instagram.credential',
+        kind: 'credential',
+        label: 'Instagram credential',
+        required: true,
+      },
+      {
+        key: 'instagram.accounts',
+        kind: 'account',
+        label: 'Instagram professional account',
+        lookupPath: '/integrations/instagram/accounts',
+        required: true,
+      },
+    ],
+    label: 'Instagram',
+    media: {
+      kinds: ['image', 'video', 'short_video', 'carousel'],
+      maxItems: 10,
+      minItems: 1,
+    },
+    platform: CredentialPlatform.INSTAGRAM,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [
+      {
+        defaultValue: 'feed',
+        helper: 'instagram.accounts',
+        key: 'placement',
+        label: 'Placement',
+        options: [
+          { label: 'Feed', value: 'feed' },
+          { label: 'Reel', value: 'reel' },
+          { label: 'Story', value: 'story' },
+        ],
+        required: true,
+        type: 'select',
+      },
+    ],
+    status: 'supported',
+  },
+  {
+    caption: { maxLength: 280, required: true },
+    description:
+      'Text, media, and link posts for X with a bounded attachment count.',
+    helpers: [
+      {
+        key: 'twitter.credential',
+        kind: 'credential',
+        label: 'X credential',
+        required: true,
+      },
+      {
+        key: 'twitter.accounts',
+        kind: 'account',
+        label: 'X account',
+        lookupPath: '/integrations/twitter/accounts',
+        required: true,
+      },
+    ],
+    label: 'X (Twitter)',
+    media: { kinds: ['image', 'video', 'link'], maxItems: 4, minItems: 0 },
+    platform: CredentialPlatform.TWITTER,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [
+      {
+        defaultValue: 'everyone',
+        key: 'replyPolicy',
+        label: 'Who can reply',
+        options: [
+          { label: 'Everyone', value: 'everyone' },
+          { label: 'Mentioned accounts', value: 'mentioned' },
+          { label: 'Following', value: 'following' },
+        ],
+        type: 'select',
+      },
+    ],
+    status: 'supported',
+  },
+  {
+    caption: { maxLength: 3_000, required: true },
+    description:
+      'Text, media, or link publishing to an organization or member LinkedIn feed.',
+    helpers: [
+      {
+        key: 'linkedin.credential',
+        kind: 'credential',
+        label: 'LinkedIn credential',
+        required: true,
+      },
+      {
+        key: 'linkedin.accounts',
+        kind: 'account',
+        label: 'LinkedIn profile or organization',
+        lookupPath: '/integrations/linkedin/accounts',
+        required: true,
+      },
+    ],
+    label: 'LinkedIn',
+    media: { kinds: ['image', 'video', 'link'], maxItems: 1, minItems: 0 },
+    platform: CredentialPlatform.LINKEDIN,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [
+      {
+        defaultValue: 'PUBLIC',
+        key: 'visibility',
+        label: 'Visibility',
+        options: [
+          { label: 'Public', value: 'PUBLIC' },
+          { label: 'Connections', value: 'CONNECTIONS' },
+        ],
+        type: 'select',
+      },
+    ],
+    status: 'supported',
+  },
+  {
+    caption: { maxLength: 63_206, required: false },
+    description:
+      'Backend integration stub for Facebook pages; hidden until scheduler publishing is productized.',
+    helpers: [
+      {
+        key: 'facebook.pages',
+        kind: 'page',
+        label: 'Facebook page',
+        lookupPath: '/integrations/facebook/pages',
+        required: true,
+      },
+    ],
+    label: 'Facebook',
+    media: { kinds: ['image', 'video', 'link'], maxItems: 10, minItems: 0 },
+    platform: CredentialPlatform.FACEBOOK,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [],
+    status: 'hidden',
+  },
+  {
+    caption: { maxLength: 500, required: false },
+    description:
+      'Backend integration stub for Pinterest boards; hidden until scheduler publishing is productized.',
+    helpers: [
+      {
+        key: 'pinterest.boards',
+        kind: 'board',
+        label: 'Pinterest board',
+        lookupPath: '/integrations/pinterest/boards',
+        required: true,
+      },
+    ],
+    label: 'Pinterest',
+    media: { kinds: ['image', 'video'], maxItems: 1, minItems: 1 },
+    platform: CredentialPlatform.PINTEREST,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [],
+    status: 'hidden',
+  },
+  {
+    caption: { maxLength: 40_000, required: false },
+    description:
+      'Backend integration stub for subreddit posts; hidden until scheduler publishing is productized.',
+    helpers: [
+      {
+        key: 'reddit.subreddits',
+        kind: 'subreddit',
+        label: 'Subreddit',
+        lookupPath: '/integrations/reddit/subreddits',
+        required: true,
+      },
+    ],
+    label: 'Reddit',
+    media: { kinds: ['image', 'video', 'link'], maxItems: 1, minItems: 0 },
+    platform: CredentialPlatform.REDDIT,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [],
+    status: 'hidden',
+  },
+  {
+    caption: { maxLength: 500, required: true },
+    description:
+      'Planned scheduler surface for Threads once publishing support is exposed.',
+    helpers: [
+      {
+        key: 'threads.accounts',
+        kind: 'account',
+        label: 'Threads account',
+        required: true,
+      },
+    ],
+    label: 'Threads',
+    media: { kinds: ['image', 'video', 'link'], maxItems: 10, minItems: 0 },
+    platform: CredentialPlatform.THREADS,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [],
+    status: 'planned',
+  },
+  {
+    caption: { maxLength: 100_000, required: true },
+    description: 'Planned scheduler surface for Medium article publishing.',
+    helpers: [
+      {
+        key: 'medium.accounts',
+        kind: 'account',
+        label: 'Medium account',
+        required: true,
+      },
+    ],
+    label: 'Medium',
+    media: { kinds: ['image', 'link'], maxItems: 10, minItems: 0 },
+    platform: CredentialPlatform.MEDIUM,
+    publishModes: ['draft', 'publish_now', 'scheduled'],
+    settings: [],
+    status: 'planned',
+  },
+] satisfies ChannelCapability[];
+
+export const CHANNEL_CAPABILITIES: readonly ChannelCapability[] =
+  channelCapabilities.map((capability) =>
+    channelCapabilitySchema.parse(capability),
+  );
+
+const channelCapabilitiesByPlatform = new Map<
+  CredentialPlatform,
+  ChannelCapability
+>(CHANNEL_CAPABILITIES.map((capability) => [capability.platform, capability]));
+
+export function listChannelCapabilities(
+  options: ChannelCapabilityListOptions = {},
+): ChannelCapability[] {
+  return CHANNEL_CAPABILITIES.filter((capability) => {
+    if (capability.status === 'supported') {
+      return true;
+    }
+
+    if (capability.status === 'hidden') {
+      return options.includeHidden === true;
+    }
+
+    return options.includePlanned === true;
+  }).map(cloneChannelCapability);
+}
+
+export function getChannelCapability(
+  platform: CredentialPlatform | string,
+): ChannelCapability | undefined {
+  const normalizedPlatform = normalizeCredentialPlatform(platform);
+  if (!normalizedPlatform) {
+    return undefined;
+  }
+
+  const capability = channelCapabilitiesByPlatform.get(normalizedPlatform);
+  return capability ? cloneChannelCapability(capability) : undefined;
+}
+
+export function validateChannelTargetSettings(
+  input: ValidateChannelTargetSettingsInput,
+): ChannelTargetValidationResult {
+  const parsedInput = validateChannelTargetSettingsInputSchema.safeParse(input);
+  const platform = extractInputPlatform(input);
+
+  if (!parsedInput.success) {
+    return invalidResult(
+      platform,
+      parsedInput.error.issues.map((issue) => ({
+        code: 'channel_target.invalid_payload',
+        field: issue.path.join('.') || undefined,
+        message: issue.message,
+        severity: 'error',
+      })),
+    );
+  }
+
+  const normalizedPlatform = normalizeCredentialPlatform(
+    parsedInput.data.platform,
+  );
+
+  if (!normalizedPlatform) {
+    return invalidResult(String(parsedInput.data.platform), [
+      {
+        code: 'channel_target.unsupported_platform',
+        field: 'platform',
+        message: `Platform "${parsedInput.data.platform}" is not supported by scheduler channel validation.`,
+        severity: 'error',
+      },
+    ]);
+  }
+
+  const capability = channelCapabilitiesByPlatform.get(normalizedPlatform);
+
+  if (!capability) {
+    return invalidResult(normalizedPlatform, [
+      {
+        code: 'channel_target.missing_capability',
+        field: 'platform',
+        message: `No scheduler channel capability is registered for ${normalizedPlatform}.`,
+        severity: 'error',
+      },
+    ]);
+  }
+
+  const errors: ChannelValidationIssue[] = [];
+  const warnings: ChannelValidationIssue[] = [];
+
+  if (capability.status === 'hidden') {
+    errors.push({
+      code: 'channel_target.hidden_channel',
+      field: 'platform',
+      message: `${capability.label} is hidden from scheduler publishing.`,
+      severity: 'error',
+    });
+  }
+
+  if (capability.status === 'planned') {
+    errors.push({
+      code: 'channel_target.planned_channel',
+      field: 'platform',
+      message: `${capability.label} is planned but not yet enabled for scheduler publishing.`,
+      severity: 'error',
+    });
+  }
+
+  errors.push(...validateCaption(parsedInput.data, capability));
+  errors.push(...validateMedia(parsedInput.data, capability));
+  errors.push(...validatePublishMode(parsedInput.data, capability));
+  errors.push(...validateSettings(parsedInput.data, capability));
+
+  return {
+    capability: cloneChannelCapability(capability),
+    errors,
+    platform: normalizedPlatform,
+    valid: errors.length === 0,
+    validationState:
+      errors.length === 0
+        ? TargetValidationState.VALID
+        : TargetValidationState.INVALID,
+    warnings,
+  };
+}
+
+function cloneChannelCapability(
+  capability: ChannelCapability,
+): ChannelCapability {
+  return {
+    ...capability,
+    caption: { ...capability.caption },
+    helpers: capability.helpers.map((helper) => ({ ...helper })),
+    media: {
+      ...capability.media,
+      kinds: [...capability.media.kinds],
+    },
+    publishModes: [...capability.publishModes],
+    settings: capability.settings.map((setting) => ({
+      ...setting,
+      options: setting.options?.map((option) => ({ ...option })),
+    })),
+  };
+}
+
+function normalizeCredentialPlatform(
+  platform: CredentialPlatform | string,
+): CredentialPlatform | undefined {
+  const parsed = z.nativeEnum(CredentialPlatform).safeParse(platform);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function extractInputPlatform(input: unknown): CredentialPlatform | string {
+  if (!input || typeof input !== 'object' || !('platform' in input)) {
+    return 'unknown';
+  }
+
+  const platform = (input as { platform?: unknown }).platform;
+  return typeof platform === 'string' ? platform : 'unknown';
+}
+
+function invalidResult(
+  platform: CredentialPlatform | string,
+  errors: ChannelValidationIssue[],
+): ChannelTargetValidationResult {
+  return {
+    errors,
+    platform,
+    valid: false,
+    validationState: TargetValidationState.INVALID,
+    warnings: [],
+  };
+}
+
+function validateCaption(
+  input: ValidateChannelTargetSettingsInput,
+  capability: ChannelCapability,
+): ChannelValidationIssue[] {
+  const caption = input.caption ?? '';
+  const captionLength = Array.from(caption).length;
+  const errors: ChannelValidationIssue[] = [];
+
+  if (capability.caption.required && caption.trim().length === 0) {
+    errors.push({
+      code: 'channel_target.caption_required',
+      field: 'caption',
+      message: `${capability.label} requires caption text.`,
+      severity: 'error',
+    });
+  }
+
+  if (captionLength > capability.caption.maxLength) {
+    errors.push({
+      code: 'channel_target.caption_too_long',
+      field: 'caption',
+      message: `${capability.label} captions must be ${capability.caption.maxLength} characters or fewer.`,
+      severity: 'error',
+    });
+  }
+
+  return errors;
+}
+
+function validateMedia(
+  input: ValidateChannelTargetSettingsInput,
+  capability: ChannelCapability,
+): ChannelValidationIssue[] {
+  const media = input.media ?? [];
+  const errors: ChannelValidationIssue[] = [];
+
+  if (
+    typeof capability.media.minItems === 'number' &&
+    media.length < capability.media.minItems
+  ) {
+    errors.push({
+      code: 'channel_target.media_required',
+      field: 'media',
+      message: `${capability.label} requires at least ${capability.media.minItems} media item(s).`,
+      severity: 'error',
+    });
+  }
+
+  if (
+    typeof capability.media.maxItems === 'number' &&
+    media.length > capability.media.maxItems
+  ) {
+    errors.push({
+      code: 'channel_target.too_many_media_items',
+      field: 'media',
+      message: `${capability.label} allows at most ${capability.media.maxItems} media item(s).`,
+      severity: 'error',
+    });
+  }
+
+  const supportedKinds = new Set(capability.media.kinds);
+  for (const [index, item] of media.entries()) {
+    if (!supportedKinds.has(item.kind)) {
+      errors.push({
+        code: 'channel_target.unsupported_media_kind',
+        field: `media.${index}.kind`,
+        message: `${capability.label} does not support ${item.kind} media.`,
+        severity: 'error',
+      });
+    }
+  }
+
+  return errors;
+}
+
+function validatePublishMode(
+  input: ValidateChannelTargetSettingsInput,
+  capability: ChannelCapability,
+): ChannelValidationIssue[] {
+  if (!input.publishMode) {
+    return [];
+  }
+
+  if (capability.publishModes.includes(input.publishMode)) {
+    return [];
+  }
+
+  return [
+    {
+      code: 'channel_target.unsupported_publish_mode',
+      field: 'publishMode',
+      message: `${capability.label} does not support ${input.publishMode} publishing.`,
+      severity: 'error',
+    },
+  ];
+}
+
+function validateSettings(
+  input: ValidateChannelTargetSettingsInput,
+  capability: ChannelCapability,
+): ChannelValidationIssue[] {
+  const settings = input.settings ?? {};
+  const errors: ChannelValidationIssue[] = [];
+
+  for (const setting of capability.settings) {
+    const value = settings[setting.key];
+    const field = `settings.${setting.key}`;
+
+    if (isMissingValue(value)) {
+      if (setting.required) {
+        errors.push({
+          code: 'channel_target.required_setting',
+          field,
+          message: `${capability.label} requires ${setting.label}.`,
+          severity: 'error',
+        });
+      }
+
+      continue;
+    }
+
+    errors.push(
+      ...validateSettingType(setting, value, capability.label, field),
+    );
+    errors.push(
+      ...validateSettingOptions(setting, value, capability.label, field),
+    );
+  }
+
+  return errors;
+}
+
+function validateSettingType(
+  setting: ChannelSettingDefinition,
+  value: unknown,
+  label: string,
+  field: string,
+): ChannelValidationIssue[] {
+  const typeMatches =
+    (setting.type === 'boolean' && typeof value === 'boolean') ||
+    (setting.type === 'number' && typeof value === 'number') ||
+    (setting.type === 'multi_select' &&
+      Array.isArray(value) &&
+      value.every((item) => typeof item === 'string')) ||
+    (setting.type !== 'boolean' &&
+      setting.type !== 'number' &&
+      setting.type !== 'multi_select' &&
+      typeof value === 'string');
+
+  if (typeMatches) {
+    return [];
+  }
+
+  return [
+    {
+      code: 'channel_target.invalid_setting_type',
+      field,
+      message: `${label} setting ${setting.label} must be a valid ${setting.type} value.`,
+      severity: 'error',
+    },
+  ];
+}
+
+function validateSettingOptions(
+  setting: ChannelSettingDefinition,
+  value: unknown,
+  label: string,
+  field: string,
+): ChannelValidationIssue[] {
+  if (!setting.options || setting.options.length === 0) {
+    return [];
+  }
+
+  const allowedValues = new Set(setting.options.map((option) => option.value));
+  const submittedValues = Array.isArray(value) ? value : [value];
+
+  for (const submittedValue of submittedValues) {
+    if (
+      typeof submittedValue !== 'string' ||
+      !allowedValues.has(submittedValue)
+    ) {
+      return [
+        {
+          code: 'channel_target.invalid_setting_option',
+          field,
+          message: `${label} setting ${setting.label} must use one of: ${[
+            ...allowedValues,
+          ].join(', ')}.`,
+          severity: 'error',
+        },
+      ];
+    }
+  }
+
+  return [];
+}
+
+function isMissingValue(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === 'string' && value.trim().length === 0)
+  );
+}

--- a/packages/api-types/src/contracts/index.ts
+++ b/packages/api-types/src/contracts/index.ts
@@ -8,6 +8,7 @@
  * - Inferred form data types (e.g., CreatePostFormData)
  */
 
+export * from '@api-types/contracts/channel-capabilities.contract';
 export * from '@api-types/contracts/ingredients.contract';
 export * from '@api-types/contracts/posts.contract';
 export * from '@api-types/contracts/scheduler.contract';

--- a/packages/api-types/src/contracts/scheduler.contract.ts
+++ b/packages/api-types/src/contracts/scheduler.contract.ts
@@ -62,8 +62,8 @@ const idempotencyKeySchema = z.string().min(1).max(255);
 
 /**
  * Provider-specific channel settings. Kept as an open, string-keyed map so the
- * shared contract stays platform-agnostic; the per-platform capability schema
- * (a later #1123 issue) narrows and validates these. `unknown`, never `any`.
+ * shared contract stays platform-agnostic; channel-capabilities.contract narrows
+ * and validates these per platform. `unknown`, never `any`.
  */
 export const channelTargetSettingsSchema = z.record(z.string(), z.unknown());
 

--- a/packages/libs/jobs/base-job.service.ts
+++ b/packages/libs/jobs/base-job.service.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
-import type { RedisService } from '@libs/redis/redis.service';
+// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
+import { RedisService } from '@libs/redis/redis.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 import type Redis from 'ioredis';

--- a/packages/services/content/schedules.service.test.ts
+++ b/packages/services/content/schedules.service.test.ts
@@ -1,7 +1,10 @@
+import type { ValidateChannelTargetSettingsInput } from '@api-types/contracts';
 import { API_ENDPOINTS } from '@genfeedai/constants';
+import { CredentialPlatform } from '@genfeedai/enums';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGet = vi.fn();
+const mockPost = vi.fn();
 
 vi.mock('@services/core/environment.service', () => ({
   EnvironmentService: {
@@ -13,7 +16,7 @@ vi.mock('@services/core/interceptor.service', () => ({
   HTTPBaseService: class MockHTTPBaseService {
     public baseURL: string;
     public token: string;
-    public instance = { get: mockGet };
+    public instance = { get: mockGet, post: mockPost };
 
     constructor(baseURL: string, token: string) {
       this.baseURL = baseURL;
@@ -93,5 +96,63 @@ describe('SchedulesService', () => {
     expect(result[1].createdAt.getTime()).toBe(now.getTime());
     expect(result[1].scheduledAt).toBeInstanceOf(Date);
     expect(result[1].schedulingMethod).toBe('manual');
+  });
+
+  it('fetches channel capabilities with discovery flags', async () => {
+    const capabilities = [{ label: 'YouTube', platform: 'youtube' }];
+    mockGet.mockResolvedValue({ data: capabilities });
+
+    const service = new SchedulesService(token);
+    const result = await service.getChannelCapabilities({
+      includeHidden: true,
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/channel-capabilities', {
+      params: { includeHidden: true },
+    });
+    expect(result).toEqual(capabilities);
+  });
+
+  it('fetches one channel capability', async () => {
+    const capability = { label: 'TikTok', platform: 'tiktok' };
+    mockGet.mockResolvedValue({ data: capability });
+
+    const service = new SchedulesService(token);
+    const result = await service.getChannelCapability('tiktok');
+
+    expect(mockGet).toHaveBeenCalledWith('/channel-capabilities/tiktok');
+    expect(result).toEqual(capability);
+  });
+
+  it('validates channel target settings through the API', async () => {
+    const input: ValidateChannelTargetSettingsInput = {
+      media: [{ id: 'asset_1', kind: 'video' }],
+      platform: CredentialPlatform.YOUTUBE,
+      settings: {},
+    };
+    const validation = {
+      errors: [
+        {
+          code: 'channel_target.required_setting',
+          field: 'settings.privacyStatus',
+          message: 'YouTube requires Privacy.',
+          severity: 'error',
+        },
+      ],
+      platform: CredentialPlatform.YOUTUBE,
+      valid: false,
+      validationState: 'invalid',
+      warnings: [],
+    };
+    mockPost.mockResolvedValue({ data: validation });
+
+    const service = new SchedulesService(token);
+    const result = await service.validateChannelTargetSettings(input);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/channel-capabilities/validate',
+      input,
+    );
+    expect(result).toEqual(validation);
   });
 });

--- a/packages/services/content/schedules.service.ts
+++ b/packages/services/content/schedules.service.ts
@@ -1,3 +1,9 @@
+import type {
+  ChannelCapability,
+  ChannelCapabilityListOptions,
+  ChannelTargetValidationResult,
+  ValidateChannelTargetSettingsInput,
+} from '@api-types/contracts';
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type { Schedule } from '@genfeedai/props/publisher/schedule.props';
 import { EnvironmentService } from '@services/core/environment.service';
@@ -19,5 +25,37 @@ export class SchedulesService extends HTTPBaseService {
       scheduledAt: new Date(schedule.scheduledAt),
       schedulingMethod: schedule.schedulingMethod || 'manual',
     }));
+  }
+
+  async getChannelCapabilities(
+    options: ChannelCapabilityListOptions = {},
+  ): Promise<ChannelCapability[]> {
+    const response = await this.instance.get<ChannelCapability[]>(
+      '/channel-capabilities',
+      {
+        params: options,
+      },
+    );
+
+    return response.data;
+  }
+
+  async getChannelCapability(platform: string): Promise<ChannelCapability> {
+    const response = await this.instance.get<ChannelCapability>(
+      `/channel-capabilities/${platform}`,
+    );
+
+    return response.data;
+  }
+
+  async validateChannelTargetSettings(
+    input: ValidateChannelTargetSettingsInput,
+  ): Promise<ChannelTargetValidationResult> {
+    const response = await this.instance.post<ChannelTargetValidationResult>(
+      '/channel-capabilities/validate',
+      input,
+    );
+
+    return response.data;
   }
 }

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 const CONSTANTS_SRC = path.resolve(__dirname, '../constants/src');
 const ENUMS_SRC = path.resolve(__dirname, '../enums/src');
+const API_TYPES_SRC = path.resolve(__dirname, '../api-types/src');
 
 export default defineConfig({
   resolve: {
@@ -32,6 +33,10 @@ export default defineConfig({
       {
         find: '@genfeedai/enums',
         replacement: ENUMS_SRC,
+      },
+      {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(API_TYPES_SRC, '$1'),
       },
       {
         find: '@genfeedai/client',

--- a/packages/tools/src/registry/generated/mcp-tools.generated.ts
+++ b/packages/tools/src/registry/generated/mcp-tools.generated.ts
@@ -3,7 +3,7 @@
 // Source of truth: apps/server/api/openapi/openapi.json (Phase 1 / #1247).
 // Regenerate:      bun run --filter=@genfeedai/tools generate:mcp-tools
 //
-// 1045 MCP tools, one per non-internal OpenAPI operation (#1248).
+// 1023 MCP tools, one per non-internal OpenAPI operation (#1248).
 // Dispatch/execution and approval-gating are intentionally not wired here
 // (that is #1249 / #1250); these definitions only populate the mcp surface.
 
@@ -771,32 +771,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "Execute a campaign — activates all agent strategies (POST /agent-campaigns/{id}/execute)",
-    "name": "agent_campaigns__execute_campaign",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "agent_campaigns"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "findAll (GET /agent-campaigns)",
     "name": "agent_campaigns__find_all",
     "parameters": {
@@ -872,33 +846,139 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "name": "agent_campaigns__patch",
     "parameters": {
       "properties": {
+        "agents": {
+          "description": "Agent strategy IDs included in this campaign",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "brand": {
+          "description": "Brand ID",
+          "type": "string"
+        },
+        "brief": {
+          "description": "Campaign brief / description",
+          "type": "string"
+        },
+        "campaignLeadStrategyId": {
+          "description": "Optional presentation-only lead strategy ID",
+          "type": "string"
+        },
+        "contentQuota": {
+          "allOf": [
+            {
+              "properties": {
+                "images": {
+                  "description": "Number of images quota",
+                  "type": "number"
+                },
+                "posts": {
+                  "description": "Number of posts quota",
+                  "type": "number"
+                },
+                "videos": {
+                  "description": "Number of videos quota",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Content production quotas"
+        },
+        "contentRotation": {
+          "allOf": [
+            {
+              "properties": {
+                "enabled": {
+                  "description": "Whether weighted content rotation is enabled",
+                  "type": "boolean"
+                },
+                "lookbackDays": {
+                  "description": "Recent run lookback window in days",
+                  "type": "number"
+                },
+                "targets": {
+                  "description": "Campaign/topic/platform target weights",
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "description": "Stable target key",
+                        "type": "string"
+                      },
+                      "label": {
+                        "description": "Human-readable target label",
+                        "type": "string"
+                      },
+                      "platform": {
+                        "description": "Optional platform scope",
+                        "type": "string"
+                      },
+                      "strategyId": {
+                        "description": "Optional strategy scope",
+                        "type": "string"
+                      },
+                      "topic": {
+                        "description": "Optional topic bucket scope",
+                        "type": "string"
+                      },
+                      "weight": {
+                        "description": "Target share weight",
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "weight"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Weighted campaign/topic rotation rules"
+        },
+        "creditsAllocated": {
+          "description": "Credits allocated to this campaign",
+          "type": "number"
+        },
+        "endDate": {
+          "description": "Campaign end date",
+          "format": "date-time",
+          "type": "string"
+        },
         "id": {
           "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "agent_campaigns"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "Pause a running campaign (POST /agent-campaigns/{id}/pause)",
-    "name": "agent_campaigns__pause_campaign",
-    "parameters": {
-      "properties": {
-        "id": {
+        },
+        "label": {
+          "description": "Campaign label",
+          "type": "string"
+        },
+        "orchestrationEnabled": {
+          "description": "Whether campaign orchestration is enabled",
+          "type": "boolean"
+        },
+        "orchestrationIntervalHours": {
+          "description": "Campaign orchestration cadence in hours",
+          "type": "number"
+        },
+        "startDate": {
+          "description": "Campaign start date",
+          "format": "date-time",
+          "type": "string"
+        },
+        "status": {
+          "description": "Campaign status",
+          "enum": [
+            "draft",
+            "active",
+            "paused",
+            "completed"
+          ],
           "type": "string"
         }
       },
@@ -4171,6 +4251,10 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "example": "2025-10-16T12:00:00Z",
           "type": "string"
         },
+        "restoreFromVersionId": {
+          "description": "Restore the article content from a prior version (prompt) id. When set, the article is reverted to that version and other update fields are ignored.",
+          "type": "string"
+        },
         "scope": {
           "allOf": [
             {
@@ -4251,36 +4335,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       },
       "required": [
         "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "articles"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "restoreVersion (POST /articles/{articleId}/versions/{promptId}/restore)",
-    "name": "articles__restore_version",
-    "parameters": {
-      "properties": {
-        "articleId": {
-          "type": "string"
-        },
-        "promptId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "articleId",
-        "promptId"
       ],
       "type": "object"
     },
@@ -5119,32 +5173,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "Cancel a batch (POST /batches/{id}/cancel)",
-    "name": "batch_generation__cancel_batch",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "batch_generation"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "Create a new batch generation job (POST /batches)",
     "name": "batch_generation__create_batch",
     "parameters": {
@@ -5376,6 +5404,32 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "Approve or reject batch items (POST /batches/{id}/items/action)",
     "name": "batch_generation__item_action",
+    "parameters": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "batch_generation"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "Update a batch (e.g. cancel via status) (PATCH /batches/{id})",
+    "name": "batch_generation__patch",
     "parameters": {
       "properties": {
         "id": {
@@ -6339,16 +6393,31 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "pauseLivestreamSession (POST /bots/{id}/livestream-session/pause)",
-    "name": "bots__pause_livestream_session",
+    "description": "patchLivestreamSession (PATCH /bots/{id}/livestream-session)",
+    "name": "bots__patch_livestream_session",
     "parameters": {
       "properties": {
         "id": {
           "type": "string"
+        },
+        "status": {
+          "allOf": [
+            {
+              "description": "Target livestream session status. \"active\" starts the session when stopped, or resumes it when paused.",
+              "enum": [
+                "active",
+                "paused",
+                "stopped"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Target livestream session status. \"active\" starts the session when stopped, or resumes it when paused."
         }
       },
       "required": [
-        "id"
+        "id",
+        "status"
       ],
       "type": "object"
     },
@@ -6367,32 +6436,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "remove (DELETE /bots/{id})",
     "name": "bots__remove",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "bots"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "resumeLivestreamSession (POST /bots/{id}/livestream-session/resume)",
-    "name": "bots__resume_livestream_session",
     "parameters": {
       "properties": {
         "id": {
@@ -6450,58 +6493,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       "required": [
         "id",
         "platform"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "bots"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "startLivestreamSession (POST /bots/{id}/livestream-session/start)",
-    "name": "bots__start_livestream_session",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "bots"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "stopLivestreamSession (POST /bots/{id}/livestream-session/stop)",
-    "name": "bots__stop_livestream_session",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
       ],
       "type": "object"
     },
@@ -8438,6 +8429,10 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           },
           "type": "array"
         },
+        "relocationAck": {
+          "description": "Server-verified confirmation token from GET /brands/:id/relocation-preview, required whenever the relocation would clone shared workflows into the destination organization. A stale or missing token is rejected with 409 so a client cannot bypass the consent modal or move against an outdated preview.",
+          "type": "string"
+        },
         "scope": {
           "allOf": [
             {
@@ -8478,6 +8473,36 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       },
       "required": [
         "id"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "brands"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "previewRelocation (GET /brands/{id}/relocation-preview)",
+    "name": "brands__preview_relocation",
+    "parameters": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "organizationId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "organizationId"
       ],
       "type": "object"
     },
@@ -8995,6 +9020,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -10747,6 +10773,19 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "description": "Whether the clip is selected",
           "type": "boolean"
         },
+        "mode": {
+          "allOf": [
+            {
+              "description": "Clip generation mode (defaults to avatar)",
+              "enum": [
+                "avatar",
+                "raw-cut"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Clip generation mode (defaults to avatar)"
+        },
         "organization": {
           "description": "The organization ID that owns this resource",
           "type": "string"
@@ -10922,6 +10961,19 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
         "isSelected": {
           "description": "Whether the clip is selected",
           "type": "boolean"
+        },
+        "mode": {
+          "allOf": [
+            {
+              "description": "Clip generation mode (defaults to avatar)",
+              "enum": [
+                "avatar",
+                "raw-cut"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Clip generation mode (defaults to avatar)"
         },
         "providerJobId": {
           "description": "External provider job ID",
@@ -11774,6 +11826,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -12029,6 +12082,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
                   "shopify",
                   "beehiiv",
                   "unipile",
+                  "devto",
                   "product_hunt",
                   "hacker_news"
                 ],
@@ -12126,6 +12180,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -12242,6 +12297,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
                   "shopify",
                   "beehiiv",
                   "unipile",
+                  "devto",
                   "product_hunt",
                   "hacker_news"
                 ],
@@ -12348,6 +12404,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -14134,6 +14191,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
                 "shopify",
                 "beehiiv",
                 "unipile",
+                "devto",
                 "product_hunt",
                 "hacker_news"
               ],
@@ -14510,8 +14568,8 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "DiscordController.connect (POST /services/discord/connect)",
-    "name": "discord__connect",
+    "description": "connect (POST /services/devto/connect)",
+    "name": "devto__connect",
     "parameters": {
       "properties": {},
       "type": "object"
@@ -14523,14 +14581,56 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       "mcp": true
     },
     "tags": [
-      "discord"
+      "devto"
     ]
   },
   {
     "category": "other",
     "creditCost": 0,
-    "description": "DiscordController.disconnect (POST /services/discord/disconnect)",
-    "name": "discord__disconnect",
+    "description": "publishArticle (POST /services/devto/publish/{articleId})",
+    "name": "devto__publish_article",
+    "parameters": {
+      "properties": {
+        "articleId": {
+          "type": "string"
+        },
+        "brandId": {
+          "type": "string"
+        },
+        "canonicalUrl": {
+          "type": "string"
+        },
+        "published": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "articleId",
+        "brandId",
+        "canonicalUrl",
+        "published",
+        "tags"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "devto"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "DiscordController.connect (POST /services/discord/connect)",
+    "name": "discord__connect",
     "parameters": {
       "properties": {},
       "type": "object"
@@ -14577,6 +14677,77 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       },
       "required": [
         "id"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "distributions"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "create (POST /distributions)",
+    "name": "distributions__create",
+    "parameters": {
+      "properties": {
+        "brandId": {
+          "description": "Brand ID",
+          "type": "string"
+        },
+        "caption": {
+          "description": "Caption for photo/video",
+          "type": "string"
+        },
+        "chatId": {
+          "description": "Telegram chat/channel ID",
+          "type": "string"
+        },
+        "contentType": {
+          "allOf": [
+            {
+              "enum": [
+                "text",
+                "photo",
+                "video"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "mediaUrl": {
+          "description": "Media URL for photo/video",
+          "type": "string"
+        },
+        "platform": {
+          "allOf": [
+            {
+              "enum": [
+                "telegram"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "scheduledAt": {
+          "description": "ISO 8601 date string to schedule the send; omit to send immediately",
+          "type": "string"
+        },
+        "text": {
+          "description": "Text content for text messages",
+          "type": "string"
+        }
+      },
+      "required": [
+        "chatId",
+        "contentType",
+        "platform"
       ],
       "type": "object"
     },
@@ -14646,123 +14817,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "type": "string"
         }
       },
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "distributions"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "scheduleTelegram (POST /distributions/telegram/schedule)",
-    "name": "distributions__schedule_telegram",
-    "parameters": {
-      "properties": {
-        "brandId": {
-          "description": "Brand ID",
-          "type": "string"
-        },
-        "caption": {
-          "description": "Caption for photo/video",
-          "type": "string"
-        },
-        "chatId": {
-          "description": "Telegram chat/channel ID",
-          "type": "string"
-        },
-        "contentType": {
-          "allOf": [
-            {
-              "enum": [
-                "text",
-                "photo",
-                "video"
-              ],
-              "type": "string"
-            }
-          ]
-        },
-        "mediaUrl": {
-          "description": "Media URL for photo/video",
-          "type": "string"
-        },
-        "scheduledAt": {
-          "description": "ISO 8601 date string for scheduled send",
-          "type": "string"
-        },
-        "text": {
-          "description": "Text content for text messages",
-          "type": "string"
-        }
-      },
-      "required": [
-        "chatId",
-        "contentType",
-        "scheduledAt"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "distributions"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "sendTelegram (POST /distributions/telegram)",
-    "name": "distributions__send_telegram",
-    "parameters": {
-      "properties": {
-        "brandId": {
-          "description": "Brand ID",
-          "type": "string"
-        },
-        "caption": {
-          "description": "Caption for photo/video",
-          "type": "string"
-        },
-        "chatId": {
-          "description": "Telegram chat/channel ID",
-          "type": "string"
-        },
-        "contentType": {
-          "allOf": [
-            {
-              "enum": [
-                "text",
-                "photo",
-                "video"
-              ],
-              "type": "string"
-            }
-          ]
-        },
-        "mediaUrl": {
-          "description": "Media URL for photo/video",
-          "type": "string"
-        },
-        "text": {
-          "description": "Text content for text messages",
-          "type": "string"
-        }
-      },
-      "required": [
-        "chatId",
-        "contentType"
-      ],
       "type": "object"
     },
     "requiredRole": "user",
@@ -22969,32 +23023,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "pauseCampaign (POST /services/meta-ads/campaigns/{id}/pause)",
-    "name": "meta_ads__pause_campaign",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "meta_ads"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "updateAdSet (PATCH /services/meta-ads/adsets/{id})",
     "name": "meta_ads__update_ad_set",
     "parameters": {
@@ -23023,32 +23051,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "updateCampaign (PATCH /services/meta-ads/campaigns/{id})",
     "name": "meta_ads__update_campaign",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "meta_ads"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "updateCampaignBudget (PATCH /services/meta-ads/campaigns/{id}/budget)",
-    "name": "meta_ads__update_campaign_budget",
     "parameters": {
       "properties": {
         "id": {
@@ -23106,32 +23108,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     },
     "tags": [
       "meta_ads"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "cancelJob (POST /services/meta-ads/bulk/jobs/{id}/cancel)",
-    "name": "meta_ads_bulk__cancel_job",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "meta_ads_bulk"
     ]
   },
   {
@@ -23212,8 +23188,8 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "approveRecommendation (POST /services/meta-ads/optimization/recommendations/{id}/approve)",
-    "name": "meta_ads_optimization__approve_recommendation",
+    "description": "updateJob (PATCH /services/meta-ads/bulk/jobs/{id})",
+    "name": "meta_ads_bulk__update_job",
     "parameters": {
       "properties": {
         "id": {
@@ -23232,7 +23208,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       "mcp": true
     },
     "tags": [
-      "meta_ads_optimization"
+      "meta_ads_bulk"
     ]
   },
   {
@@ -23343,17 +23319,10 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "rejectRecommendation (POST /services/meta-ads/optimization/recommendations/{id}/reject)",
-    "name": "meta_ads_optimization__reject_recommendation",
+    "description": "updateConfig (PATCH /services/meta-ads/optimization/config)",
+    "name": "meta_ads_optimization__update_config",
     "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
+      "properties": {},
       "type": "object"
     },
     "requiredRole": "user",
@@ -23369,10 +23338,17 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "updateConfig (PUT /services/meta-ads/optimization/config)",
-    "name": "meta_ads_optimization__update_config",
+    "description": "updateRecommendation (PATCH /services/meta-ads/optimization/recommendations/{id})",
+    "name": "meta_ads_optimization__update_recommendation",
     "parameters": {
-      "properties": {},
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
       "type": "object"
     },
     "requiredRole": "user",
@@ -24497,32 +24473,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "archive (POST /newsletters/{id}/archive)",
-    "name": "newsletters__archive",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "newsletters"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "context (GET /newsletters/{id}/context)",
     "name": "newsletters__context",
     "parameters": {
@@ -25291,37 +25241,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "Set organization prefix (POST /onboarding/prefix)",
-    "name": "onboarding__set_prefix",
-    "parameters": {
-      "properties": {
-        "prefix": {
-          "description": "Unique 3-letter uppercase prefix for issue identifiers (e.g., GEN)",
-          "example": "GEN",
-          "maxLength": 3,
-          "minLength": 3,
-          "pattern": "^[A-Z]{3}$",
-          "type": "string"
-        }
-      },
-      "required": [
-        "prefix"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "onboarding"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "Setup brand from website URL (POST /onboarding/brand-setup)",
     "name": "onboarding__setup_brand",
     "parameters": {
@@ -25926,32 +25845,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "switchOrganization (POST /organizations/switch/{id})",
     "name": "organizations__switch_organization",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "organizations"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "updateSlug (PATCH /organizations/{id}/slug)",
-    "name": "organizations__update_slug",
     "parameters": {
       "properties": {
         "id": {
@@ -26635,6 +26528,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -27757,38 +27651,42 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "Add DM recipients to a campaign (POST /outreach-campaigns/{id}/dm-recipients)",
-    "name": "outreach_campaigns__add_dm_recipients",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "outreach_campaigns"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "Add targets to a campaign (POST /outreach-campaigns/{id}/targets)",
     "name": "outreach_campaigns__add_targets",
     "parameters": {
       "properties": {
         "id": {
           "type": "string"
+        },
+        "targetType": {
+          "allOf": [
+            {
+              "description": "Discriminator for how targets are added. Defaults to URL-based target detection. Use DM_RECIPIENT to add DM recipients by username.",
+              "enum": [
+                "tweet",
+                "reddit_post",
+                "reddit_comment",
+                "dm_recipient"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": "tweet",
+          "description": "Discriminator for how targets are added. Defaults to URL-based target detection. Use DM_RECIPIENT to add DM recipients by username."
+        },
+        "urls": {
+          "description": "Content URLs to add as targets (manual URL addition)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "usernames": {
+          "description": "Usernames to add as DM recipients (requires targetType: dm_recipient)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -28770,32 +28668,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "assignMembers (POST /personas/{id}/assign)",
-    "name": "personas__assign_members",
-    "parameters": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "personas"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "create (POST /personas)",
     "name": "personas__create",
     "parameters": {
@@ -28864,8 +28736,164 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "name": "personas__patch",
     "parameters": {
       "properties": {
+        "assignedMembers": {
+          "description": "Assigned team member user IDs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "avatarExternalId": {
+          "description": "Provider-side avatar ID",
+          "type": "string"
+        },
+        "avatarIngredientId": {
+          "description": "Avatar ingredient ID",
+          "type": "string"
+        },
+        "avatarProvider": {
+          "allOf": [
+            {
+              "description": "Avatar provider",
+              "enum": [
+                "heygen",
+                "hedra"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Avatar provider"
+        },
+        "contentStrategy": {
+          "allOf": [
+            {
+              "properties": {
+                "formats": {
+                  "description": "Preferred content formats",
+                  "items": {
+                    "description": "Preferred content formats",
+                    "enum": [
+                      "photo",
+                      "video",
+                      "reel",
+                      "story",
+                      "article",
+                      "audio",
+                      "text"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "frequency": {
+                  "description": "Posting cadence (e.g., daily, weekly)",
+                  "type": "string"
+                },
+                "platforms": {
+                  "description": "Priority platform ordering",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tone": {
+                  "description": "Brand voice tone descriptor",
+                  "type": "string"
+                },
+                "topics": {
+                  "description": "Content topics/themes",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Content strategy configuration"
+        },
+        "credentials": {
+          "description": "Linked credential IDs for social accounts",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Bio/description",
+          "type": "string"
+        },
+        "handle": {
+          "description": "Social handle",
+          "type": "string"
+        },
         "id": {
           "type": "string"
+        },
+        "isDeleted": {
+          "description": "Whether the persona is marked as deleted",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "Display name of the persona",
+          "type": "string"
+        },
+        "memberIds": {
+          "description": "Assigned team member user IDs to set on the persona",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "profileImageUrl": {
+          "description": "CDN URL for profile image",
+          "type": "string"
+        },
+        "status": {
+          "allOf": [
+            {
+              "description": "Persona status",
+              "enum": [
+                "draft",
+                "active",
+                "paused",
+                "archived"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": "draft",
+          "description": "Persona status"
+        },
+        "tags": {
+          "description": "Tag IDs",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "voiceExternalId": {
+          "description": "Provider-side voice ID",
+          "type": "string"
+        },
+        "voiceIngredientId": {
+          "description": "Voice ID",
+          "type": "string"
+        },
+        "voiceProvider": {
+          "allOf": [
+            {
+              "enum": [
+                "heygen",
+                "elevenlabs",
+                "hedra",
+                "genfeed-ai"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Voice provider"
         }
       },
       "required": [
@@ -29726,6 +29754,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -30645,6 +30674,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
                 "shopify",
                 "beehiiv",
                 "unipile",
+                "devto",
                 "product_hunt",
                 "hacker_news"
               ],
@@ -30896,6 +30926,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
                 "shopify",
                 "beehiiv",
                 "unipile",
+                "devto",
                 "product_hunt",
                 "hacker_news"
               ],
@@ -34023,6 +34054,32 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
+    "description": "getChannelCapability (GET /schedules/channel-capabilities/{platform})",
+    "name": "schedules__get_channel_capability",
+    "parameters": {
+      "properties": {
+        "platform": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "platform"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "schedules"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
     "description": "getOptimalTime (POST /schedules/optimal)",
     "name": "schedules__get_optimal_time",
     "parameters": {
@@ -34068,8 +34125,57 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
+    "description": "listChannelCapabilities (GET /schedules/channel-capabilities)",
+    "name": "schedules__list_channel_capabilities",
+    "parameters": {
+      "properties": {
+        "includeHidden": {
+          "type": "string"
+        },
+        "includePlanned": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "includeHidden",
+        "includePlanned"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "schedules"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
     "description": "repurposeContent (POST /schedules/repurpose)",
     "name": "schedules__repurpose_content",
+    "parameters": {
+      "properties": {},
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "schedules"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "validateChannelTargetSettings (POST /schedules/channel-capabilities/validate)",
+    "name": "schedules__validate_channel_target_settings",
     "parameters": {
       "properties": {},
       "type": "object"
@@ -35422,8 +35528,8 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "useFreeze (POST /organizations/{organizationId}/streaks/me/freeze)",
-    "name": "streaks__use_freeze",
+    "description": "patchMyStreak (PATCH /organizations/{organizationId}/streaks/me)",
+    "name": "streaks__patch_my_streak",
     "parameters": {
       "properties": {
         "organizationId": {
@@ -35612,6 +35718,25 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "findAll (GET /subscriptions)",
     "name": "subscriptions__find_all",
+    "parameters": {
+      "properties": {},
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "subscriptions"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "getCreditUsage (GET /subscriptions/admin/credit-usage)",
+    "name": "subscriptions__get_credit_usage",
     "parameters": {
       "properties": {},
       "type": "object"
@@ -36549,25 +36674,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     },
     "tags": [
       "tasks"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "TelegramController.disconnect (POST /services/telegram/disconnect)",
-    "name": "telegram__disconnect",
-    "parameters": {
-      "properties": {},
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "telegram"
     ]
   },
   {
@@ -38383,6 +38489,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -38608,6 +38715,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
             "shopify",
             "beehiiv",
             "unipile",
+            "devto",
             "product_hunt",
             "hacker_news"
           ],
@@ -38658,7 +38766,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "savePreferences (POST /trends/preferences)",
+    "description": "savePreferences (PUT /trends/preferences)",
     "name": "trends__save_preferences",
     "parameters": {
       "properties": {
@@ -39210,25 +39318,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "clearBrandSelection (DELETE /users/me/brand-selection)",
     "name": "users__clear_brand_selection",
-    "parameters": {
-      "properties": {},
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "users"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "confirmAvatarUpload (POST /users/me/avatar/confirm)",
-    "name": "users__confirm_avatar_upload",
     "parameters": {
       "properties": {},
       "type": "object"
@@ -42690,16 +42779,16 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "remove (DELETE /votes/{entityId})",
+    "description": "remove (DELETE /votes)",
     "name": "votes__remove",
     "parameters": {
       "properties": {
-        "entityId": {
+        "entity": {
           "type": "string"
         }
       },
       "required": [
-        "entityId"
+        "entity"
       ],
       "type": "object"
     },
@@ -42791,25 +42880,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       "required": [
         "watchlistId"
       ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "watchlists"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "quickAdd (POST /watchlists/quick-add)",
-    "name": "watchlists__quick_add",
-    "parameters": {
-      "properties": {},
       "type": "object"
     },
     "requiredRole": "user",
@@ -43819,6 +43889,10 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "description": "Enable or disable pagination",
           "type": "boolean"
         },
+        "referencable": {
+          "description": "Return every workflow in the organization (for reference pickers) instead of the caller-scoped set",
+          "type": "boolean"
+        },
         "sort": {
           "default": "createdAt: -1",
           "description": "Sort field(s) and order (e.g., \"createdAt: -1\" or \"category: 1, createdAt: -1\")",
@@ -44063,6 +44137,20 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "description": "Last execution timestamp",
           "format": "date-time",
           "type": "string"
+        },
+        "lifecycle": {
+          "allOf": [
+            {
+              "description": "Lifecycle status (draft / published / archived)",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Lifecycle status (draft / published / archived)"
         },
         "metadata": {
           "description": "Additional metadata for the workflow",
@@ -44351,32 +44439,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "archiveWorkflow (POST /workflows/{workflowId}/lifecycle/archive)",
-    "name": "workflow_execution__archive_workflow",
-    "parameters": {
-      "properties": {
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "executePartial (POST /workflows/{workflowId}/execute/partial)",
     "name": "workflow_execution__execute_partial",
     "parameters": {
@@ -44488,12 +44550,12 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "lockNodes (POST /workflows/{workflowId}/nodes/lock)",
-    "name": "workflow_execution__lock_nodes",
+    "description": "patchNodes (PATCH /workflows/{workflowId}/nodes)",
+    "name": "workflow_execution__patch_nodes",
     "parameters": {
       "properties": {
-        "nodeIds": {
-          "description": "Node IDs to lock",
+        "lock": {
+          "description": "Node IDs to lock (skip execution, use cached output)",
           "example": [
             "node-1",
             "node-2"
@@ -44503,59 +44565,16 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           },
           "type": "array"
         },
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "nodeIds",
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "publishWorkflowLifecycle (POST /workflows/{workflowId}/lifecycle/publish)",
-    "name": "workflow_execution__publish_workflow_lifecycle",
-    "parameters": {
-      "properties": {
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "removeSchedule (DELETE /workflows/{workflowId}/schedule)",
-    "name": "workflow_execution__remove_schedule",
-    "parameters": {
-      "properties": {
+        "unlock": {
+          "description": "Node IDs to unlock",
+          "example": [
+            "node-3"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "workflowId": {
           "type": "string"
         }
@@ -44596,68 +44615,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
       },
       "required": [
         "runId",
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "setSchedule (POST /workflows/{workflowId}/schedule)",
-    "name": "workflow_execution__set_schedule",
-    "parameters": {
-      "properties": {
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "setThumbnail (PATCH /workflows/{workflowId}/thumbnail)",
-    "name": "workflow_execution__set_thumbnail",
-    "parameters": {
-      "properties": {
-        "nodeId": {
-          "description": "Node ID whose output is used as the workflow thumbnail",
-          "type": "string"
-        },
-        "thumbnailUrl": {
-          "description": "Media URL to persist as the workflow thumbnail",
-          "type": "string"
-        },
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "nodeId",
-        "thumbnailUrl",
         "workflowId"
       ],
       "type": "object"
@@ -44717,71 +44674,6 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     },
     "tags": [
       "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "unlockNodes (POST /workflows/{workflowId}/nodes/unlock)",
-    "name": "workflow_execution__unlock_nodes",
-    "parameters": {
-      "properties": {
-        "nodeIds": {
-          "description": "Node IDs to unlock",
-          "example": [
-            "node-1",
-            "node-2"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "nodeIds",
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_execution"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "Cancel a running execution (POST /workflow-executions/{id}/cancel)",
-    "name": "workflow_executions__cancel",
-    "parameters": {
-      "properties": {
-        "id": {
-          "description": "Execution ID",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_executions"
     ]
   },
   {
@@ -44980,23 +44872,36 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "Get executions for a specific workflow (GET /workflow-executions/workflow/{workflowId})",
-    "name": "workflow_executions__get_workflow_executions",
+    "description": "Update an execution (cancel a running execution) (PATCH /workflow-executions/{id})",
+    "name": "workflow_executions__update",
     "parameters": {
       "properties": {
-        "limit": {
-          "type": "number"
-        },
-        "offset": {
-          "type": "number"
-        },
-        "workflowId": {
-          "description": "Workflow ID",
+        "error": {
+          "description": "Error message if failed",
           "type": "string"
+        },
+        "id": {
+          "description": "Execution ID",
+          "type": "string"
+        },
+        "status": {
+          "allOf": [
+            {
+              "enum": [
+                "pending",
+                "running",
+                "completed",
+                "failed",
+                "cancelled"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Execution status"
         }
       },
       "required": [
-        "workflowId"
+        "id"
       ],
       "type": "object"
     },
@@ -45073,81 +44978,10 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "getReferencableWorkflows (GET /workflows/referencable)",
-    "name": "workflow_marketplace__get_referencable_workflows",
-    "parameters": {
-      "properties": {},
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_marketplace"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
     "description": "getTemplates (GET /workflows/templates)",
     "name": "workflow_marketplace__get_templates",
     "parameters": {
       "properties": {},
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_marketplace"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "publishToMarketplace (POST /workflows/{workflowId}/publish)",
-    "name": "workflow_marketplace__publish_to_marketplace",
-    "parameters": {
-      "properties": {
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "workflowId"
-      ],
-      "type": "object"
-    },
-    "requiredRole": "user",
-    "surfaces": {
-      "agent": false,
-      "cliAgentVisible": false,
-      "mcp": true
-    },
-    "tags": [
-      "workflow_marketplace"
-    ]
-  },
-  {
-    "category": "other",
-    "creditCost": 0,
-    "description": "unpublishFromMarketplace (DELETE /workflows/{workflowId}/publish)",
-    "name": "workflow_marketplace__unpublish_from_marketplace",
-    "parameters": {
-      "properties": {
-        "workflowId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "workflowId"
-      ],
       "type": "object"
     },
     "requiredRole": "user",
@@ -45241,10 +45075,14 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
   {
     "category": "other",
     "creditCost": 0,
-    "description": "regenerateWebhookSecret (POST /workflows/{workflowId}/webhook/regenerate-secret)",
-    "name": "workflow_webhook_management__regenerate_webhook_secret",
+    "description": "patchWebhook (PATCH /workflows/{workflowId}/webhook)",
+    "name": "workflow_webhook_management__patch_webhook",
     "parameters": {
       "properties": {
+        "rotateSecret": {
+          "description": "Rotate (regenerate) the webhook secret in place",
+          "type": "boolean"
+        },
         "workflowId": {
           "type": "string"
         }

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -199,7 +199,6 @@ module.exports = function createWebpackConfig({
           /^@fanvue\//,
           /^@workflow-engine\//,
           /^@workflow-saas\//,
-          /^@api-types\//,
           /^@cloud-types\//,
         ],
         modulesDir: nodeModulesDir,


### PR DESCRIPTION
## Summary
- Add a shared scheduler channel capability catalog for YouTube, TikTok, Instagram, X, and LinkedIn
- Add hidden/planned capability stubs and helper lookup contracts for backend integrations
- Expose schedule channel capability discovery and validation through the API and shared services client

## Validation
- bun run --cwd packages/api-types test -- __tests__/channel-capabilities.contract.test.ts __tests__/scheduler.contract.test.ts
- bun run --cwd apps/server/api test:file -- src/collections/schedules/controllers/schedules.controller.spec.ts src/collections/schedules/services/schedules.service.spec.ts
- bun run --cwd packages/services test -- content/schedules.service.test.ts
- bun run --cwd packages/api-types type-check
- bun run --cwd packages/api-types build
- bunx biome check <touched files>
- bunx secretlint --secretlintrc .secretlintrc.json <touched files>
- git diff --check

## Notes
- packages/services type-check still fails on existing unresolved @genfeedai/auth-client from helpers.
- apps/server/api raw type-check still fails on existing local dist/package resolution errors for @genfeedai/constants, @genfeedai/helpers, @genfeedai/queue-contracts, and @genfeedai/tools.

Closes #1125
Refs #1123