### PR TITLE
fix(workflows): narrow execution result reads

### DIFF
--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
@@ -1,3 +1,4 @@
+import { WorkflowExecutionStatus as SharedWorkflowExecutionStatus } from '@genfeedai/enums';
 import { WorkflowExecutionStatus as PrismaWorkflowExecutionStatus } from '@genfeedai/prisma';
 import { WorkflowExecutionsService } from './workflow-executions.service';
 
@@ -11,8 +12,7 @@ describe('WorkflowExecutionsService', () => {
   const makeService = () => {
     const workflowExecution = {
       create: vi.fn().mockResolvedValue({ id: 'execution-1' }),
-      findFirst: vi.fn().mockResolvedValue({
-        id: 'execution-1',
+      findUnique: vi.fn().mockResolvedValue({
         result: {},
         startedAt: new Date('2026-06-29T00:00:00.000Z'),
         workflowId: 'workflow-1',
@@ -113,5 +113,155 @@ describe('WorkflowExecutionsService', () => {
       failed: 1,
       total: 3,
     });
+    expect(prisma.workflowExecution.findMany).toHaveBeenCalledWith({
+      select: { result: true, status: true },
+      where: {
+        isDeleted: false,
+        organizationId: 'org-1',
+        workflowId: 'workflow-1',
+      },
+    });
+  });
+
+  it('completes executions with a narrow unique read before merging result JSON', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findUnique.mockResolvedValue({
+      result: {
+        metadata: {
+          eta: {
+            estimatedDurationMs: 1000,
+          },
+        },
+      },
+      startedAt: new Date('2026-06-29T00:00:00.000Z'),
+      workflowId: 'workflow-1',
+    });
+
+    await service.completeExecution('execution-1');
+
+    expect(prisma.workflowExecution.findUnique).toHaveBeenCalledWith({
+      select: { result: true, startedAt: true, workflowId: true },
+      where: { id: 'execution-1' },
+    });
+    expect(prisma.workflowExecution.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          result: expect.objectContaining({
+            metadata: expect.objectContaining({
+              eta: expect.objectContaining({
+                currentPhase: 'Completed',
+                remainingDurationMs: 0,
+              }),
+            }),
+            progress: 100,
+          }),
+          status: PrismaWorkflowExecutionStatus.COMPLETED,
+        }),
+        where: { id: 'execution-1' },
+      }),
+    );
+  });
+
+  it('updates node results by reading only the result column', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findUnique.mockResolvedValue({
+      result: {
+        metadata: { retained: true },
+        nodeResults: [
+          {
+            nodeId: 'node-1',
+            nodeType: 'input',
+            status: SharedWorkflowExecutionStatus.RUNNING,
+          },
+        ],
+      },
+    });
+
+    await service.updateNodeResult(
+      'execution-1',
+      {
+        nodeId: 'node-1',
+        nodeType: 'input',
+        status: SharedWorkflowExecutionStatus.COMPLETED,
+      },
+      2,
+    );
+
+    expect(prisma.workflowExecution.findUnique).toHaveBeenCalledWith({
+      select: { result: true },
+      where: { id: 'execution-1' },
+    });
+    expect(prisma.workflowExecution.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          result: expect.objectContaining({
+            metadata: { retained: true },
+            nodeResults: [
+              {
+                nodeId: 'node-1',
+                nodeType: 'input',
+                status: SharedWorkflowExecutionStatus.COMPLETED,
+              },
+            ],
+            progress: 50,
+          }),
+        }),
+        where: { id: 'execution-1' },
+      }),
+    );
+  });
+
+  it('narrows result-only void patch updates to the id return field', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findUnique.mockResolvedValue({
+      result: { metadata: { retained: true } },
+    });
+
+    await service.setFailedNodeId('execution-1', 'node-1');
+    await service.setCreditsUsed('execution-1', 17);
+
+    expect(prisma.workflowExecution.findUnique).toHaveBeenNthCalledWith(1, {
+      select: { result: true },
+      where: { id: 'execution-1' },
+    });
+    expect(prisma.workflowExecution.update).toHaveBeenNthCalledWith(1, {
+      data: {
+        result: {
+          failedNodeId: 'node-1',
+          metadata: { retained: true },
+        },
+      },
+      select: { id: true },
+      where: { id: 'execution-1' },
+    });
+    expect(prisma.workflowExecution.findUnique).toHaveBeenNthCalledWith(2, {
+      select: { result: true },
+      where: { id: 'execution-1' },
+    });
+    expect(prisma.workflowExecution.update).toHaveBeenNthCalledWith(2, {
+      data: {
+        result: {
+          creditsUsed: 17,
+          metadata: { retained: true },
+        },
+      },
+      select: { id: true },
+      where: { id: 'execution-1' },
+    });
+  });
+
+  it('skips result patch updates when the narrow unique read misses', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.updateExecutionMetadata('missing-execution', { phase: 'queued' }),
+    ).resolves.toBeNull();
+
+    expect(prisma.workflowExecution.findUnique).toHaveBeenCalledWith({
+      select: { result: true },
+      where: { id: 'missing-execution' },
+    });
+    expect(prisma.workflowExecution.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
@@ -35,6 +35,15 @@ function parseResult(raw: unknown): Record<string, unknown> {
   return {};
 }
 
+type WorkflowExecutionResultRow = {
+  result: unknown;
+};
+
+type WorkflowExecutionCompletionRow = WorkflowExecutionResultRow & {
+  startedAt: Date | null;
+  workflowId: string;
+};
+
 @Injectable()
 export class WorkflowExecutionsService extends BaseService<
   WorkflowExecutionDocument,
@@ -104,24 +113,19 @@ export class WorkflowExecutionsService extends BaseService<
     error?: string,
   ): Promise<WorkflowExecutionDocument | null> {
     const completedAt = new Date();
-    const execution = await this.prisma.workflowExecution.findFirst({
+    const execution = (await this.prisma.workflowExecution.findUnique({
+      select: { result: true, startedAt: true, workflowId: true },
       where: { id: executionId },
-    });
+    })) as WorkflowExecutionCompletionRow | null;
 
     if (!execution) {
       return null;
     }
 
-    const existingResult = parseResult(
-      (execution as unknown as Record<string, unknown>).result,
-    );
+    const existingResult = parseResult(execution.result);
 
-    const durationMs = (execution as unknown as Record<string, unknown>)
-      .startedAt
-      ? completedAt.getTime() -
-        (
-          (execution as unknown as Record<string, unknown>).startedAt as Date
-        ).getTime()
+    const durationMs = execution.startedAt
+      ? completedAt.getTime() - execution.startedAt.getTime()
       : 0;
 
     const existingMetadata =
@@ -145,9 +149,7 @@ export class WorkflowExecutionsService extends BaseService<
         estimatedDurationMs,
         executionId,
         observedDurationMs: durationMs,
-        workflowId: (
-          execution as unknown as Record<string, unknown>
-        ).workflowId?.toString(),
+        workflowId: execution.workflowId,
       });
     }
 
@@ -205,17 +207,16 @@ export class WorkflowExecutionsService extends BaseService<
     nodeResult: WorkflowNodeResult,
     totalNodes?: number,
   ): Promise<WorkflowExecutionDocument | null> {
-    const execution = await this.prisma.workflowExecution.findFirst({
+    const execution = (await this.prisma.workflowExecution.findUnique({
+      select: { result: true },
       where: { id: executionId },
-    });
+    })) as WorkflowExecutionResultRow | null;
 
     if (!execution) {
       return null;
     }
 
-    const existingResult = parseResult(
-      (execution as unknown as Record<string, unknown>).result,
-    );
+    const existingResult = parseResult(execution.result);
     const existingNodeResults = Array.isArray(existingResult.nodeResults)
       ? (existingResult.nodeResults as WorkflowNodeResult[])
       : [];
@@ -265,19 +266,19 @@ export class WorkflowExecutionsService extends BaseService<
     executionId: string,
     failedNodeId: string,
   ): Promise<void> {
-    const execution = await this.prisma.workflowExecution.findFirst({
+    const execution = (await this.prisma.workflowExecution.findUnique({
+      select: { result: true },
       where: { id: executionId },
-    });
+    })) as WorkflowExecutionResultRow | null;
     if (!execution) return;
 
-    const existingResult = parseResult(
-      (execution as unknown as Record<string, unknown>).result,
-    );
+    const existingResult = parseResult(execution.result);
 
     await this.prisma.workflowExecution.update({
       data: {
         result: { ...existingResult, failedNodeId } as never,
       } as never,
+      select: { id: true },
       where: { id: executionId },
     });
   }
@@ -287,19 +288,19 @@ export class WorkflowExecutionsService extends BaseService<
     executionId: string,
     creditsUsed: number,
   ): Promise<void> {
-    const execution = await this.prisma.workflowExecution.findFirst({
+    const execution = (await this.prisma.workflowExecution.findUnique({
+      select: { result: true },
       where: { id: executionId },
-    });
+    })) as WorkflowExecutionResultRow | null;
     if (!execution) return;
 
-    const existingResult = parseResult(
-      (execution as unknown as Record<string, unknown>).result,
-    );
+    const existingResult = parseResult(execution.result);
 
     await this.prisma.workflowExecution.update({
       data: {
         result: { ...existingResult, creditsUsed } as never,
       } as never,
+      select: { id: true },
       where: { id: executionId },
     });
   }
@@ -309,17 +310,16 @@ export class WorkflowExecutionsService extends BaseService<
     executionId: string,
     metadataUpdates: Record<string, unknown>,
   ): Promise<WorkflowExecutionDocument | null> {
-    const execution = await this.prisma.workflowExecution.findFirst({
+    const execution = (await this.prisma.workflowExecution.findUnique({
+      select: { result: true },
       where: { id: executionId },
-    });
+    })) as WorkflowExecutionResultRow | null;
 
     if (!execution) {
       return null;
     }
 
-    const existingResult = parseResult(
-      (execution as unknown as Record<string, unknown>).result,
-    );
+    const existingResult = parseResult(execution.result);
     const existingMetadata =
       existingResult.metadata && typeof existingResult.metadata === 'object'
         ? (existingResult.metadata as Record<string, unknown>)


### PR DESCRIPTION
## Summary
- replace ID-only `workflowExecution.findFirst` reads in execution mutation paths with `findUnique`
- add narrow `select` clauses for the fields each path consumes before merging `result` JSON
- avoid hydrating full rows after void result patch updates by selecting only `id`
- cover the optimized query shapes in the focused service spec

Closes #1332

## Verification
- `bunx biome check --write apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- staged token scan with `rg`
- `gitleaks protect --staged --redact --no-banner`
- commit hook reran Biome and secretlint successfully

## Not run locally
- `bun run test:file src/collections/workflow-executions/services/workflow-executions.service.spec.ts` could not run in this dependency-less worktree because `vitest` was not installed locally.
- `bunx vitest@4.1.9 ...` reached config loading but could not resolve the API Vitest SWC peer chain (`unplugin-swc` / `@swc/core`) from the transient package environment.

PR CI should run the focused/package test gates with the normal installed dependency set.
