### PR TITLE
fix(api): address #1153 task memory and prisma mock follow-ups

### DIFF
--- a/apps/server/api/src/collections/tasks/services/task-actions.service.spec.ts
+++ b/apps/server/api/src/collections/tasks/services/task-actions.service.spec.ts
@@ -170,4 +170,22 @@ describe('TaskActionsService', () => {
       }),
     );
   });
+
+  it('omits feedback memory user id when optional actor and assignee are missing', async () => {
+    delete currentTask.assigneeUserId;
+
+    await service.approve(taskId, organizationId);
+    await service.keepOutput(taskId, outputId, organizationId);
+    await service.trashOutput(taskId, outputId, organizationId);
+
+    const captureInputs =
+      taskFeedbackMemoryAdapter.captureFromTaskReview.mock.calls.map(
+        ([input]) => input,
+      );
+
+    expect(captureInputs).toHaveLength(3);
+    for (const input of captureInputs) {
+      expect(input).not.toHaveProperty('userId');
+    }
+  });
 });

--- a/apps/server/api/src/collections/tasks/services/task-actions.service.ts
+++ b/apps/server/api/src/collections/tasks/services/task-actions.service.ts
@@ -81,15 +81,20 @@ export class TaskActionsService {
       failureReason: null,
       requestedChangesReason: null,
     });
-    const actorUserId = userId ?? task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, actorUserId, {
-      type: 'task_approved',
-    });
+    const actorUserId = this.resolveActorUserId(userId, task.assigneeUserId);
+    await this.appendEventAndBroadcast(
+      updated,
+      organizationId,
+      actorUserId ?? '',
+      {
+        type: 'task_approved',
+      },
+    );
     await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
       decision: 'approved',
       organizationId,
       task: updated,
-      userId: actorUserId,
+      ...this.buildActorUserIdPayload(actorUserId),
     });
     return updated;
   }
@@ -168,17 +173,22 @@ export class TaskActionsService {
       'add',
       outputId,
     );
-    const actorUserId = userId ?? task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, actorUserId, {
-      payload: { outputId },
-      type: 'output_kept',
-    });
+    const actorUserId = this.resolveActorUserId(userId, task.assigneeUserId);
+    await this.appendEventAndBroadcast(
+      updated,
+      organizationId,
+      actorUserId ?? '',
+      {
+        payload: { outputId },
+        type: 'output_kept',
+      },
+    );
     await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
       decision: 'output_kept',
       organizationId,
       outputId,
       task: updated,
-      userId: actorUserId,
+      ...this.buildActorUserIdPayload(actorUserId),
     });
     return updated;
   }
@@ -233,17 +243,22 @@ export class TaskActionsService {
       'remove',
       outputId,
     );
-    const actorUserId = userId ?? task.assigneeUserId ?? '';
-    await this.appendEventAndBroadcast(updated, organizationId, actorUserId, {
-      payload: { outputId },
-      type: 'output_trashed',
-    });
+    const actorUserId = this.resolveActorUserId(userId, task.assigneeUserId);
+    await this.appendEventAndBroadcast(
+      updated,
+      organizationId,
+      actorUserId ?? '',
+      {
+        payload: { outputId },
+        type: 'output_trashed',
+      },
+    );
     await this.taskFeedbackMemoryAdapter.captureFromTaskReview({
       decision: 'output_trashed',
       organizationId,
       outputId,
       task: updated,
-      userId: actorUserId,
+      ...this.buildActorUserIdPayload(actorUserId),
     });
     return updated;
   }
@@ -363,6 +378,23 @@ export class TaskActionsService {
         'This output is not linked to the requested task.',
       );
     return task;
+  }
+
+  private buildActorUserIdPayload(userId?: string): { userId?: string } {
+    return userId ? { userId } : {};
+  }
+
+  private resolveActorUserId(
+    ...candidates: Array<string | undefined>
+  ): string | undefined {
+    for (const candidate of candidates) {
+      const normalized = candidate?.trim();
+      if (normalized) {
+        return normalized;
+      }
+    }
+
+    return undefined;
   }
 
   private createTaskEventEntry(input: TaskEventInput): {

--- a/apps/server/api/src/shared/testing/prisma-mock.spec.ts
+++ b/apps/server/api/src/shared/testing/prisma-mock.spec.ts
@@ -1,0 +1,24 @@
+import { MockPrismaClient } from './prisma-mock';
+
+describe('MockPrismaClient', () => {
+  it('preserves configured delegates in callback transactions', async () => {
+    const row = { id: 'task-1' };
+    const taskDelegate = {
+      findFirst: vi.fn().mockResolvedValue(row),
+    };
+    const prisma = new MockPrismaClient() as MockPrismaClient & {
+      task: typeof taskDelegate;
+    };
+    prisma.task = taskDelegate;
+
+    const result = await prisma.$transaction(
+      async (tx: MockPrismaClient & { task: typeof taskDelegate }) =>
+        tx.task.findFirst({ where: { id: row.id } }),
+    );
+
+    expect(result).toBe(row);
+    expect(taskDelegate.findFirst).toHaveBeenCalledWith({
+      where: { id: row.id },
+    });
+  });
+});

--- a/apps/server/api/src/shared/testing/prisma-mock.ts
+++ b/apps/server/api/src/shared/testing/prisma-mock.ts
@@ -109,7 +109,7 @@ export const mockPrismaNamespace = {
  * Stub `PrismaClient` — matches the real class shape closely enough for
  * services that construct/inject it directly (e.g. `PrismaService`).
  * `$transaction` supports both the array form (`Promise.all`) and the
- * callback form (invoked with a fresh client instance).
+ * callback form (invoked with this configured mock instance).
  */
 export class MockPrismaClient {
   $connect = vi.fn().mockResolvedValue(undefined);
@@ -122,9 +122,7 @@ export class MockPrismaClient {
       Array.isArray(arg)
         ? Promise.all(arg)
         : typeof arg === 'function'
-          ? (arg as (client: MockPrismaClient) => unknown)(
-              new MockPrismaClient(),
-            )
+          ? (arg as (client: MockPrismaClient) => unknown)(this)
           : Promise.resolve(arg),
     );
 }

--- a/scripts/architecture/workers-api-imports.baseline.ts
+++ b/scripts/architecture/workers-api-imports.baseline.ts
@@ -216,6 +216,5 @@ export const WORKERS_API_IMPORT_BASELINE: readonly string[] = [
   '@api/shared/modules/prisma/prisma.module',
   '@api/shared/modules/prisma/prisma.service',
   '@api/shared/shared.module',
-  '@api/shared/utils/encryption/encryption.util',
   '@api/types/aggregate-paginate-result',
 ];


### PR DESCRIPTION
Refs #1153.

## Summary
- Fix task-review feedback memory capture so optional review actors are trimmed and omitted when absent instead of passing an empty string into memory capture.
- Fix the canonical Prisma mock callback `$transaction` path so it passes the configured mock client into the callback, preserving delegates/spies attached by the outer test.
- Remove one stale worker `@api` import baseline entry after CI confirmed the ratchet should shrink.
- Add focused specs for both fixed #1153 follow-ups.

## Verification
- `bunx biome check --write apps/server/api/src/collections/tasks/services/task-actions.service.ts apps/server/api/src/collections/tasks/services/task-actions.service.spec.ts apps/server/api/src/shared/testing/prisma-mock.ts apps/server/api/src/shared/testing/prisma-mock.spec.ts`
- `bunx biome check --write scripts/architecture/workers-api-imports.baseline.ts`
- `bun run scripts/architecture/check-no-api-imports-in-workers.ts`
- `git diff --check`
- Pre-commit `lint-staged` passed on both commits: staged `run-secretlint` plus staged Biome.

Focused Vitest was attempted locally but this worktree does not have workspace test dependencies installed: `bun run --cwd apps/server/api test:file src/collections/tasks/services/task-actions.service.spec.ts` failed with `vitest: command not found`, and `bunx vitest@4.1.9 ...` failed loading the repo config because `unplugin-swc` / local `vitest/config` were unavailable. Dependency-backed test execution is left to PR CI.

## #1153 validation notes
Fixed in this PR:
- PR #1003: avoid passing empty-string `actorUserId` into task-review memory capture.
- PR #1037: preserve outer mock configuration for callback-form `$transaction`.

Rechecked as stale or already addressed:
- PR #974 manual brand-kit input reset on brand reference change: current component only resets when `brandId` changes.
- PR #1004 positive-score filtering: current scoring always adds positive rank factors, so the filter is redundant rather than hiding expected memories today.

Still valid but deferred to keep this PR reviewable:
- PR #1008 social polling/comment-trigger items: newest-first YouTube cursor skip, empty `contentIds` fallback, unsupported comment-trigger platforms, category metadata mismatch.
- PR #974 brand-kit/service items: oversized guidance file warning and plain `{ data: draft }` envelope handling.
- PR #954 onboarding billing fetch error/fallback state.
- PR #1004 prompt-derived platform scoring and fuller `memoryInfluence` ranking explanation.

This PR intentionally does not close #1153 because several validated items remain.