### PR TITLE
fix(workflows): harden BullMQ scheduler sync

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.spec.ts
@@ -6,6 +6,8 @@ import type {
   DelayResumeJobData,
   TriggerEvent,
 } from '@api/collections/workflows/services/workflow-executor.service';
+import { buildSystemWorkflowMetadata } from '@api/collections/workflows/system-workflow.contract';
+import { WorkflowStatus } from '@genfeedai/enums';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 function createMockQueue() {
@@ -205,6 +207,66 @@ describe('WorkflowExecutionQueueService', () => {
 
       expect(mockQueue.removeJobScheduler).toHaveBeenCalledWith(
         'workflow-schedule:wf-1',
+      );
+    });
+  });
+
+  describe('syncWorkflowScheduler', () => {
+    it('should upsert an active enabled workflow schedule', async () => {
+      await service.syncWorkflowScheduler({
+        id: 'wf-1',
+        isDeleted: false,
+        isScheduleEnabled: true,
+        schedule: '0 7 * * *',
+        status: WorkflowStatus.ACTIVE,
+        timezone: 'Europe/Amsterdam',
+      });
+
+      expect(mockQueue.upsertJobScheduler).toHaveBeenCalledWith(
+        'workflow-schedule:wf-1',
+        { pattern: '0 7 * * *', tz: 'Europe/Amsterdam' },
+        expect.objectContaining({
+          data: { type: 'scheduled-fire', workflowId: 'wf-1' },
+          name: 'scheduled-fire',
+        }),
+      );
+      expect(mockQueue.removeJobScheduler).not.toHaveBeenCalled();
+    });
+
+    it('should remove instead of upserting protected system workflow rows', async () => {
+      await service.syncWorkflowScheduler({
+        id: 'wf-system',
+        isDeleted: false,
+        isScheduleEnabled: true,
+        metadata: {
+          systemWorkflow: buildSystemWorkflowMetadata({
+            canonicalId: 'scheduled-post-publishing',
+          }),
+        },
+        schedule: '*/15 * * * *',
+        status: WorkflowStatus.ACTIVE,
+        timezone: 'UTC',
+      });
+
+      expect(mockQueue.upsertJobScheduler).not.toHaveBeenCalled();
+      expect(mockQueue.removeJobScheduler).toHaveBeenCalledWith(
+        'workflow-schedule:wf-system',
+      );
+    });
+
+    it('should remove when a row is no longer schedulable', async () => {
+      await service.syncWorkflowScheduler({
+        id: 'wf-disabled',
+        isDeleted: false,
+        isScheduleEnabled: false,
+        schedule: '0 7 * * *',
+        status: WorkflowStatus.ACTIVE,
+        timezone: 'UTC',
+      });
+
+      expect(mockQueue.upsertJobScheduler).not.toHaveBeenCalled();
+      expect(mockQueue.removeJobScheduler).toHaveBeenCalledWith(
+        'workflow-schedule:wf-disabled',
       );
     });
   });

--- a/apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.ts
@@ -2,6 +2,7 @@ import type {
   DelayResumeJobData,
   TriggerEvent,
 } from '@api/collections/workflows/services/workflow-executor.service';
+import { isProtectedSystemWorkflowMetadata } from '@api/collections/workflows/system-workflow.contract';
 import { WorkflowStatus } from '@genfeedai/enums';
 import { WORKFLOW_EXECUTION_QUEUE } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -37,6 +38,7 @@ export interface WorkflowSchedulerSyncRow {
   timezone?: string | null;
   isScheduleEnabled?: boolean | null;
   isDeleted?: boolean | null;
+  metadata?: unknown;
   status?: string | null;
 }
 
@@ -195,13 +197,18 @@ export class WorkflowExecutionQueueService {
       return;
     }
 
-    const isSchedulable =
-      !workflow.isDeleted &&
-      Boolean(workflow.schedule) &&
-      workflow.isScheduleEnabled === true &&
-      workflow.status === WorkflowStatus.ACTIVE;
-
     try {
+      if (isProtectedSystemWorkflowMetadata(workflow.metadata)) {
+        await this.removeWorkflowScheduler(workflowId);
+        return;
+      }
+
+      const isSchedulable =
+        !workflow.isDeleted &&
+        Boolean(workflow.schedule) &&
+        workflow.isScheduleEnabled === true &&
+        workflow.status === WorkflowStatus.ACTIVE;
+
       if (isSchedulable) {
         await this.upsertWorkflowScheduler({
           cronExpression: workflow.schedule as string,

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.double-fire.integration.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.double-fire.integration.spec.ts
@@ -129,6 +129,15 @@ describe.skipIf(!redisAvailable)(
           (scheduler) => scheduler.key === workflowSchedulerId('wf-remove-me'),
         ),
       ).toHaveLength(0);
+
+      const delayedJobs = await producer.queue.getDelayed();
+      expect(
+        delayedJobs.filter(
+          (job) =>
+            job.name === 'scheduled-fire' &&
+            job.data.workflowId === 'wf-remove-me',
+        ),
+      ).toHaveLength(0);
     });
   },
 );

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { WorkflowTemplateSeederService } from '@api/collections/workflows/services/workflow-template-seeder.service';
 import {
+  buildSystemWorkflowMetadata,
   SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
   SYSTEM_WORKFLOW_TEMPLATE_VERSION,
 } from '@api/collections/workflows/system-workflow.contract';
@@ -19,9 +20,17 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
   };
   const prisma = {
     $transaction: vi.fn(),
-    workflow: {
+    contentSchedule: {
       findFirst: vi.fn(),
     },
+    workflow: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+  const workflowExecutionQueueService = {
+    syncWorkflowScheduler: vi.fn(),
   };
   const logger = {
     debug: vi.fn(),
@@ -34,7 +43,13 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
 
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.contentSchedule.findFirst.mockResolvedValue(null);
     prisma.workflow.findFirst.mockResolvedValue(null);
+    prisma.workflow.findMany.mockResolvedValue([]);
+    prisma.workflow.update.mockResolvedValue({});
+    workflowExecutionQueueService.syncWorkflowScheduler.mockResolvedValue(
+      undefined,
+    );
     tx.workflow.findFirst.mockResolvedValue(null);
     tx.workflow.create.mockResolvedValue({});
     prisma.$transaction.mockImplementation(
@@ -46,6 +61,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
     service = new WorkflowTemplateSeederService(
       prisma as never,
       logger as never,
+      workflowExecutionQueueService as never,
     );
   });
 
@@ -146,5 +162,172 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
         schedule: undefined,
       }),
     });
+  });
+
+  it('loads workflow metadata when syncing organization schedulers', async () => {
+    const systemWorkflow = buildSystemWorkflowMetadata({
+      canonicalId: 'scheduled-post-publishing',
+    });
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        id: 'wf-system',
+        isDeleted: false,
+        isScheduleEnabled: true,
+        metadata: { systemWorkflow },
+        schedule: '*/15 * * * *',
+        status: WorkflowStatus.ACTIVE,
+        timezone: 'UTC',
+      },
+    ]);
+
+    await service.syncOrganizationWorkflowSchedulers('org-1');
+
+    expect(prisma.workflow.findMany).toHaveBeenCalledWith({
+      select: expect.objectContaining({
+        id: true,
+        isDeleted: true,
+        isScheduleEnabled: true,
+        metadata: true,
+        schedule: true,
+        status: true,
+        timezone: true,
+      }),
+      where: expect.objectContaining({
+        isDeleted: false,
+        isScheduleEnabled: true,
+        organizationId: 'org-1',
+        schedule: { not: null },
+        status: WorkflowStatus.ACTIVE,
+      }),
+    });
+    expect(
+      workflowExecutionQueueService.syncWorkflowScheduler,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'wf-system',
+        metadata: { systemWorkflow },
+      }),
+    );
+  });
+
+  it('resyncs the BullMQ scheduler after updating an existing content schedule workflow', async () => {
+    prisma.contentSchedule.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      cronExpression: '0 9 * * *',
+      id: 'cs-1',
+      isEnabled: true,
+      name: 'Morning posts',
+      timezone: 'Europe/Malta',
+    });
+    prisma.workflow.findFirst.mockResolvedValue({ id: 'wf-existing' });
+    prisma.workflow.update.mockResolvedValue({
+      id: 'wf-existing',
+      isDeleted: false,
+      isScheduleEnabled: true,
+      metadata: { contentScheduleId: 'cs-1' },
+      schedule: '0 9 * * *',
+      status: WorkflowStatus.ACTIVE,
+      timezone: 'Europe/Malta',
+    });
+
+    await service.ensureContentScheduleWorkflow('user-1', 'org-1', 'cs-1');
+
+    expect(prisma.workflow.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        isScheduleEnabled: true,
+        schedule: '0 9 * * *',
+        timezone: 'Europe/Malta',
+      }),
+      select: expect.objectContaining({
+        id: true,
+        isDeleted: true,
+        isScheduleEnabled: true,
+        metadata: true,
+        schedule: true,
+        status: true,
+        timezone: true,
+      }),
+      where: { id: 'wf-existing' },
+    });
+    expect(
+      workflowExecutionQueueService.syncWorkflowScheduler,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'wf-existing',
+        isScheduleEnabled: true,
+        schedule: '0 9 * * *',
+      }),
+    );
+  });
+
+  it('passes disabled post-write content schedule rows to scheduler sync for removal', async () => {
+    prisma.contentSchedule.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      cronExpression: '0 9 * * *',
+      id: 'cs-1',
+      isEnabled: false,
+      name: 'Morning posts',
+      timezone: 'Europe/Malta',
+    });
+    prisma.workflow.findFirst.mockResolvedValue({ id: 'wf-existing' });
+    prisma.workflow.update.mockResolvedValue({
+      id: 'wf-existing',
+      isDeleted: false,
+      isScheduleEnabled: false,
+      metadata: { contentScheduleId: 'cs-1' },
+      schedule: '0 9 * * *',
+      status: WorkflowStatus.ACTIVE,
+      timezone: 'Europe/Malta',
+    });
+
+    await service.ensureContentScheduleWorkflow('user-1', 'org-1', 'cs-1');
+
+    expect(
+      workflowExecutionQueueService.syncWorkflowScheduler,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'wf-existing',
+        isScheduleEnabled: false,
+      }),
+    );
+  });
+
+  it('syncs from the winning row after a serializable content schedule upsert conflict', async () => {
+    prisma.contentSchedule.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      cronExpression: '0 9 * * *',
+      id: 'cs-1',
+      isEnabled: true,
+      name: 'Morning posts',
+      timezone: 'Europe/Malta',
+    });
+    prisma.workflow.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'wf-concurrent',
+        isDeleted: false,
+        isScheduleEnabled: true,
+        metadata: { contentScheduleId: 'cs-1' },
+        schedule: '0 9 * * *',
+        status: WorkflowStatus.ACTIVE,
+        timezone: 'Europe/Malta',
+      });
+    prisma.$transaction.mockRejectedValue({ code: 'P2034' });
+
+    await service.ensureContentScheduleWorkflow('user-1', 'org-1', 'cs-1');
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'ensureContentScheduleWorkflow: serialization conflict - workflow already synced by concurrent request',
+      { contentScheduleId: 'cs-1', organizationId: 'org-1' },
+    );
+    expect(
+      workflowExecutionQueueService.syncWorkflowScheduler,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'wf-concurrent',
+        isScheduleEnabled: true,
+        schedule: '0 9 * * *',
+      }),
+    );
   });
 });

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
@@ -28,6 +28,16 @@ import { Injectable, Optional } from '@nestjs/common';
 /** Template id for the predetermined per-org Daily Trends Digest workflow. */
 const DAILY_TRENDS_DIGEST_TEMPLATE_ID = 'daily-trends-digest';
 
+const WORKFLOW_SCHEDULER_SYNC_SELECT = {
+  id: true,
+  isDeleted: true,
+  isScheduleEnabled: true,
+  metadata: true,
+  schedule: true,
+  status: true,
+  timezone: true,
+} as const;
+
 type SeedableWorkflowTemplate = WorkflowTemplate & { schedule?: string };
 
 /**
@@ -567,10 +577,12 @@ export class WorkflowTemplateSeederService {
     const data = this.buildContentScheduleWorkflowData(schedule);
 
     if (existing) {
-      await this.prisma.workflow.update({
+      const synced = await this.prisma.workflow.update({
         data,
+        select: WORKFLOW_SCHEDULER_SYNC_SELECT,
         where: { id: existing.id },
       });
+      await this.workflowExecutionQueueService?.syncWorkflowScheduler(synced);
       return;
     }
 
@@ -602,14 +614,7 @@ export class WorkflowTemplateSeederService {
     }
 
     const workflows = await this.prisma.workflow.findMany({
-      select: {
-        id: true,
-        isDeleted: true,
-        isScheduleEnabled: true,
-        schedule: true,
-        status: true,
-        timezone: true,
-      },
+      select: WORKFLOW_SCHEDULER_SYNC_SELECT,
       where: {
         isDeleted: false,
         isScheduleEnabled: true,
@@ -666,27 +671,20 @@ export class WorkflowTemplateSeederService {
       );
     } catch (error) {
       const errorCode = (error as { code?: string }).code;
-      if (errorCode === 'P2034') {
-        this.logger?.debug(
-          'ensureContentScheduleWorkflow: serialization conflict - workflow already synced by concurrent request',
-          { contentScheduleId, organizationId },
-        );
-        return;
+      if (errorCode !== 'P2034') {
+        throw error;
       }
-      throw error;
+
+      this.logger?.debug(
+        'ensureContentScheduleWorkflow: serialization conflict - workflow already synced by concurrent request',
+        { contentScheduleId, organizationId },
+      );
     }
 
     // Sync the BullMQ job scheduler from the row's post-write state (covers
     // both the update and create paths, including a concurrent writer's row).
     const synced = await this.prisma.workflow.findFirst({
-      select: {
-        id: true,
-        isDeleted: true,
-        isScheduleEnabled: true,
-        schedule: true,
-        status: true,
-        timezone: true,
-      },
+      select: WORKFLOW_SCHEDULER_SYNC_SELECT,
       where: where as never,
     });
 


### PR DESCRIPTION
## Summary
- skip and heal BullMQ workflow schedulers for protected immutable system workflows in queue-level scheduler sync
- include workflow metadata in scheduler sync row selection and org-level scheduler sync
- resync content-schedule-backed workflows from the post-write row, including existing-row updates, disabled rows, and serializable upsert conflicts
- assert removed BullMQ schedulers also remove delayed `scheduled-fire` jobs

## Verification
- `bunx biome check --write apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-scheduler.double-fire.integration.spec.ts` (passes with existing non-null assertion warnings in `workflow-execution-queue.service.ts`)
- `bunx secretlint apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts apps/server/api/src/collections/workflows/services/workflow-execution-queue.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-scheduler.double-fire.integration.spec.ts`
- `bun run --cwd apps/server/api test:file -- src/collections/workflows/services/workflow-execution-queue.service.spec.ts src/collections/workflows/services/workflow-template-seeder.service.spec.ts src/collections/workflows/services/workflow-scheduler.service.spec.ts src/collections/workflows/services/workflow-scheduler.double-fire.integration.spec.ts`

## Open PR overlap
- #1368 touches workflow controllers/services broadly, but not these scheduler producer files.
- #1325 and #1339 touch `workflow-scheduler.service.ts`; this PR leaves that file unchanged.

Closes #1316