### PR TITLE
feat(workflows): link agent runs to workflow executions

### DIFF
--- a/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts
@@ -147,6 +147,65 @@ describe('AgentAutopilotWorkflowService', () => {
     });
   });
 
+  it('records workflow handoff provenance on queued proactive agent runs', async () => {
+    prisma.agentStrategy.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          brandId: null,
+          config: {
+            creditsUsedThisWeek: 0,
+            creditsUsedToday: 0,
+            dailyCreditBudget: 100,
+            dailyCreditsUsed: 0,
+            dailyResetAt: '2026-06-25T00:00:00.000Z',
+            minCreditThreshold: 10,
+            nextRunAt: '2026-06-24T08:59:00.000Z',
+            postsPerWeek: 3,
+            runFrequency: AgentRunFrequency.DAILY,
+            weeklyCreditBudget: 300,
+            weeklyResetAt: '2026-06-29T00:00:00.000Z',
+          },
+          goalId: null,
+          id: 'strategy-1',
+          label: 'Growth strategy',
+          organizationId: 'org-1',
+          userId: 'user-1',
+        },
+      ]);
+
+    const result = await service.runProactiveStrategies('org-1', {
+      workflowExecutionId: 'exec-1',
+      workflowId: 'workflow-1',
+      workflowNodeId: 'node-1',
+      workflowNodeType: 'proactiveAgentStrategies',
+      workflowRunId: 'engine-run-1',
+    });
+
+    expect(agentRunsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          workflowHandoff: {
+            agentStrategyId: 'strategy-1',
+            workflowExecutionId: 'exec-1',
+            workflowId: 'workflow-1',
+            workflowNodeId: 'node-1',
+            workflowNodeType: 'proactiveAgentStrategies',
+            workflowRunId: 'engine-run-1',
+          },
+        },
+      }),
+    );
+    expect(result).toMatchObject({
+      agentRunIds: ['run-1'],
+      enqueued: 1,
+      status: 'enqueued',
+      workflowExecutionId: 'exec-1',
+      workflowId: 'workflow-1',
+      workflowRunId: 'engine-run-1',
+    });
+  });
+
   it('returns skipped when no proactive strategies are due', async () => {
     prisma.agentStrategy.findMany
       .mockResolvedValueOnce([])

--- a/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts
+++ b/apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts
@@ -59,12 +59,24 @@ type AgentStrategyWithConfig = AgentStrategy & {
 
 export interface AgentAutopilotWorkflowResult {
   action: AgentAutopilotWorkflowAction;
+  agentRunIds?: string[];
   enqueued: number;
   generated: number;
   organizationId: string;
   reason?: string;
   skipped: number;
   status: 'completed' | 'enqueued' | 'skipped';
+  workflowExecutionId?: string;
+  workflowId?: string;
+  workflowRunId?: string;
+}
+
+export interface AgentWorkflowHandoffContext {
+  workflowExecutionId?: string;
+  workflowId?: string;
+  workflowNodeId?: string;
+  workflowNodeType?: string;
+  workflowRunId?: string;
 }
 
 const MAX_CONSECUTIVE_FAILURES = 5;
@@ -92,6 +104,7 @@ export class AgentAutopilotWorkflowService {
 
   async runProactiveStrategies(
     organizationId: string,
+    workflowHandoff?: AgentWorkflowHandoffContext,
   ): Promise<AgentAutopilotWorkflowResult> {
     const action: AgentAutopilotWorkflowAction = 'proactiveAgentStrategies';
     const lockKey = this.lockKey(action, organizationId);
@@ -105,6 +118,8 @@ export class AgentAutopilotWorkflowService {
         action,
         organizationId,
         'proactive_agent_already_running',
+        0,
+        workflowHandoff,
       );
     }
 
@@ -127,10 +142,15 @@ export class AgentAutopilotWorkflowService {
 
       let enqueued = 0;
       let skipped = 0;
+      const agentRunIds: string[] = [];
 
       for (const strategy of dueStrategies) {
-        const queued = await this.executeStrategy(strategy);
-        if (queued) {
+        const queuedRunId = await this.executeStrategy(
+          strategy,
+          workflowHandoff,
+        );
+        if (queuedRunId) {
+          agentRunIds.push(queuedRunId);
           enqueued++;
         } else {
           skipped++;
@@ -144,6 +164,8 @@ export class AgentAutopilotWorkflowService {
         0,
         skipped,
         dueStrategies.length === 0 ? 'no_due_strategies' : undefined,
+        workflowHandoff,
+        agentRunIds,
       );
     } catch (error) {
       this.logger.error(`${this.logContext} proactive agent cycle failed`, {
@@ -154,6 +176,8 @@ export class AgentAutopilotWorkflowService {
         action,
         organizationId,
         'proactive_agent_cycle_failed',
+        0,
+        workflowHandoff,
       );
     } finally {
       await this.cacheService.releaseLock(lockKey);
@@ -162,6 +186,7 @@ export class AgentAutopilotWorkflowService {
 
   async runAiInfluencerDailyPosts(
     organizationId: string,
+    workflowHandoff?: AgentWorkflowHandoffContext,
   ): Promise<AgentAutopilotWorkflowResult> {
     const action: AgentAutopilotWorkflowAction = 'aiInfluencerDailyPosts';
     const lockKey = this.lockKey(action, organizationId);
@@ -175,6 +200,8 @@ export class AgentAutopilotWorkflowService {
         action,
         organizationId,
         'ai_influencer_already_running',
+        0,
+        workflowHandoff,
       );
     }
 
@@ -190,13 +217,20 @@ export class AgentAutopilotWorkflowService {
         results.length,
         0,
         results.length === 0 ? 'no_ai_influencer_posts_generated' : undefined,
+        workflowHandoff,
       );
     } catch (error) {
       this.logger.error(`${this.logContext} AI influencer cycle failed`, {
         error,
         organizationId,
       });
-      return this.skipped(action, organizationId, 'ai_influencer_cycle_failed');
+      return this.skipped(
+        action,
+        organizationId,
+        'ai_influencer_cycle_failed',
+        0,
+        workflowHandoff,
+      );
     } finally {
       await this.cacheService.releaseLock(lockKey);
     }
@@ -218,7 +252,8 @@ export class AgentAutopilotWorkflowService {
 
   private async executeStrategy(
     strategy: AgentStrategyWithConfig,
-  ): Promise<boolean> {
+    workflowHandoff?: AgentWorkflowHandoffContext,
+  ): Promise<string | null> {
     const organizationId = strategy.organizationId;
     const userId = strategy.userId;
     const strategyId = strategy.id;
@@ -250,13 +285,13 @@ export class AgentAutopilotWorkflowService {
 
     if (dailyCreditsUsed >= effectiveDailyBudget) {
       await this.scheduleNextRun(strategyId, config.runFrequency);
-      return false;
+      return null;
     }
 
     const creditsUsedThisWeek = config.creditsUsedThisWeek ?? 0;
     if (creditsUsedThisWeek >= weeklyCreditBudget) {
       await this.scheduleNextRun(strategyId, config.runFrequency);
-      return false;
+      return null;
     }
 
     if (brandDailyCap && strategy.brandId) {
@@ -267,7 +302,7 @@ export class AgentAutopilotWorkflowService {
 
       if (brandCreditsUsedToday >= brandDailyCap) {
         await this.scheduleNextRun(strategyId, config.runFrequency);
-        return false;
+        return null;
       }
     }
 
@@ -282,7 +317,7 @@ export class AgentAutopilotWorkflowService {
         data: { isActive: false },
         where: { id: strategyId },
       });
-      return false;
+      return null;
     }
 
     const remainingBudget = Math.min(
@@ -297,6 +332,7 @@ export class AgentAutopilotWorkflowService {
         label: `Proactive: ${strategy.label}`,
         objective,
         organization: organizationId,
+        ...this.buildAgentRunMetadata(strategy, workflowHandoff),
         strategy: strategyId,
         trigger: AgentExecutionTrigger.CRON,
         user: userId,
@@ -315,7 +351,7 @@ export class AgentAutopilotWorkflowService {
       });
 
       await this.scheduleNextRun(strategyId, config.runFrequency);
-      return true;
+      return String(run.id);
     } catch (error) {
       const consecutiveFailures = config.consecutiveFailures ?? 0;
       const newFailureCount = consecutiveFailures + 1;
@@ -356,8 +392,44 @@ export class AgentAutopilotWorkflowService {
         organizationId,
         strategyId,
       });
-      return false;
+      return null;
     }
+  }
+
+  private buildAgentRunMetadata(
+    strategy: AgentStrategyWithConfig,
+    workflowHandoff?: AgentWorkflowHandoffContext,
+  ): { metadata?: Record<string, unknown> } {
+    const workflowHandoffMetadata =
+      this.buildWorkflowHandoffMetadata(workflowHandoff);
+
+    if (!workflowHandoffMetadata) {
+      return {};
+    }
+
+    return {
+      metadata: {
+        workflowHandoff: {
+          ...workflowHandoffMetadata,
+          agentStrategyId: strategy.id,
+        },
+      },
+    };
+  }
+
+  private buildWorkflowHandoffMetadata(
+    workflowHandoff?: AgentWorkflowHandoffContext,
+  ): Record<string, string> | null {
+    if (!workflowHandoff) {
+      return null;
+    }
+
+    const entries = Object.entries(workflowHandoff).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === 'string' && entry[1].length > 0,
+    );
+
+    return entries.length > 0 ? Object.fromEntries(entries) : null;
   }
 
   private async buildSyntheticUserMessage(
@@ -501,6 +573,8 @@ export class AgentAutopilotWorkflowService {
     generated: number,
     skipped: number,
     emptyReason?: string,
+    workflowHandoff?: AgentWorkflowHandoffContext,
+    agentRunIds: string[] = [],
   ): AgentAutopilotWorkflowResult {
     if (enqueued === 0 && generated === 0) {
       return this.skipped(
@@ -508,16 +582,19 @@ export class AgentAutopilotWorkflowService {
         organizationId,
         emptyReason ?? 'no_agent_autopilot_work_enqueued',
         skipped,
+        workflowHandoff,
       );
     }
 
     return {
       action,
+      ...(agentRunIds.length > 0 ? { agentRunIds } : {}),
       enqueued,
       generated,
       organizationId,
       skipped,
       status: enqueued > 0 ? 'enqueued' : 'completed',
+      ...this.buildWorkflowResultMetadata(workflowHandoff),
     };
   }
 
@@ -526,6 +603,7 @@ export class AgentAutopilotWorkflowService {
     organizationId: string,
     reason: string,
     skipped: number = 0,
+    workflowHandoff?: AgentWorkflowHandoffContext,
   ): AgentAutopilotWorkflowResult {
     return {
       action,
@@ -535,6 +613,26 @@ export class AgentAutopilotWorkflowService {
       reason,
       skipped,
       status: 'skipped',
+      ...this.buildWorkflowResultMetadata(workflowHandoff),
+    };
+  }
+
+  private buildWorkflowResultMetadata(
+    workflowHandoff?: AgentWorkflowHandoffContext,
+  ): Pick<
+    AgentAutopilotWorkflowResult,
+    'workflowExecutionId' | 'workflowId' | 'workflowRunId'
+  > {
+    return {
+      ...(workflowHandoff?.workflowExecutionId
+        ? { workflowExecutionId: workflowHandoff.workflowExecutionId }
+        : {}),
+      ...(workflowHandoff?.workflowId
+        ? { workflowId: workflowHandoff.workflowId }
+        : {}),
+      ...(workflowHandoff?.workflowRunId
+        ? { workflowRunId: workflowHandoff.workflowRunId }
+        : {}),
     };
   }
 

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts
@@ -5,6 +5,7 @@ import { GENERATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templa
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('WorkflowEngineAdapterService', () => {
+  const AGENT_AUTOPILOT_SERVICE_INDEX = 30;
   const SOCIAL_ADAPTER_FACTORY_INDEX = 2;
   const SOCIAL_INBOX_SERVICE_INDEX = 40;
   let service: WorkflowEngineAdapterService;
@@ -39,6 +40,17 @@ describe('WorkflowEngineAdapterService', () => {
     args[0] = { ingredientsEndpoint: 'https://ingredients.example.com' };
     args[1] = loggerService;
     args[SOCIAL_INBOX_SERVICE_INDEX] = socialInboxService;
+    return new WorkflowEngineAdapterService(...args);
+  }
+
+  function createAdapterWithAgentAutopilot(agentAutopilotService: {
+    runAiInfluencerDailyPosts?: ReturnType<typeof vi.fn>;
+    runProactiveStrategies?: ReturnType<typeof vi.fn>;
+  }): WorkflowEngineAdapterService {
+    const args = new Array(41).fill(undefined);
+    args[0] = { ingredientsEndpoint: 'https://ingredients.example.com' };
+    args[1] = loggerService;
+    args[AGENT_AUTOPILOT_SERVICE_INDEX] = agentAutopilotService;
     return new WorkflowEngineAdapterService(...args);
   }
 
@@ -592,6 +604,52 @@ describe('WorkflowEngineAdapterService', () => {
         expect.stringContaining('fallback executor invoked'),
         expect.objectContaining({ nodeType: 'hookGenerator' }),
       );
+    });
+
+    it('passes workflow execution context into agent autopilot nodes', async () => {
+      const agentAutopilotService = {
+        runProactiveStrategies: vi.fn().mockResolvedValue({
+          action: 'proactiveAgentStrategies',
+          agentRunIds: ['run-1'],
+          enqueued: 1,
+          generated: 0,
+          organizationId: 'org-1',
+          skipped: 0,
+          status: 'enqueued',
+          workflowExecutionId: 'exec-1',
+        }),
+      };
+      const adapter = createAdapterWithAgentAutopilot(agentAutopilotService);
+      const workflow = adapter.convertToExecutableWorkflow({
+        id: 'wf-agent',
+        nodes: [
+          {
+            data: { config: {}, label: 'Proactive Agent Strategies' },
+            id: 'agent-node',
+            type: 'proactiveAgentStrategies',
+          },
+        ],
+        organization: { toString: () => 'org-1' },
+        user: { toString: () => 'user-1' },
+      });
+
+      const result = await adapter.executeWorkflow(workflow, {
+        executionId: 'exec-1',
+      });
+
+      expect(agentAutopilotService.runProactiveStrategies).toHaveBeenCalledWith(
+        'org-1',
+        expect.objectContaining({
+          workflowExecutionId: 'exec-1',
+          workflowId: 'wf-agent',
+          workflowNodeId: 'agent-node',
+          workflowNodeType: 'proactiveAgentStrategies',
+        }),
+      );
+      expect(result.nodeResults.get('agent-node')?.output).toMatchObject({
+        agentRunIds: ['run-1'],
+        workflowExecutionId: 'exec-1',
+      });
     });
 
     it('executes trend trigger with analytics keywords when no social trend adapter is available', async () => {

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts
@@ -942,6 +942,13 @@ export class WorkflowEngineAdapterService {
         this.agentAutopilotWorkflowService
           ? this.agentAutopilotWorkflowService.runProactiveStrategies(
               context.organizationId,
+              {
+                workflowExecutionId: context.executionId,
+                workflowId: context.workflowId,
+                workflowNodeId: _node.id,
+                workflowNodeType: _node.type,
+                workflowRunId: context.runId,
+              },
             )
           : this.agentAutopilotUnavailable('proactiveAgentStrategies', context),
     );
@@ -952,6 +959,13 @@ export class WorkflowEngineAdapterService {
         this.agentAutopilotWorkflowService
           ? this.agentAutopilotWorkflowService.runAiInfluencerDailyPosts(
               context.organizationId,
+              {
+                workflowExecutionId: context.executionId,
+                workflowId: context.workflowId,
+                workflowNodeId: _node.id,
+                workflowNodeType: _node.type,
+                workflowRunId: context.runId,
+              },
             )
           : this.agentAutopilotUnavailable('aiInfluencerDailyPosts', context),
     );

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
@@ -515,6 +515,7 @@ export class WorkflowExecutorService {
     const result = await this.engineAdapter.executeWorkflow(
       executableWorkflow,
       {
+        executionId,
         nodeIds: remainingNodeIds,
         onNodeStatusChange: async (changeEvent: NodeStatusChangeEvent) => {
           const node =
@@ -984,6 +985,7 @@ export class WorkflowExecutorService {
     const result = await this.engineAdapter.executeWorkflow(
       executableWorkflow,
       {
+        executionId,
         nodeIds: remainingNodeIds,
         onNodeStatusChange: async (changeEvent: NodeStatusChangeEvent) => {
           const node =
@@ -1427,7 +1429,12 @@ export class WorkflowExecutorService {
 
       try {
         // Execute the node via the engine adapter
-        const nodeResult = await this.executeSingleNode(node, inputs, workflow);
+        const nodeResult = await this.executeSingleNode(
+          node,
+          inputs,
+          workflow,
+          executionId,
+        );
 
         nodeResults.set(nodeId, nodeResult);
         totalCreditsUsed += nodeResult.creditsUsed;
@@ -1701,6 +1708,7 @@ export class WorkflowExecutorService {
     node: ExecutableNode,
     inputs: Map<string, unknown>,
     workflow: ExecutableWorkflow,
+    executionId: string,
   ): Promise<NodeExecutionResult> {
     const startedAt = new Date();
 
@@ -1740,7 +1748,7 @@ export class WorkflowExecutorService {
 
     const result = await this.engineAdapter.executeWorkflow(
       singleNodeWorkflow,
-      { maxRetries: 3 },
+      { executionId, maxRetries: 3 },
     );
 
     const nodeResult = result.nodeResults.get(node.id);

--- a/apps/server/api/src/collections/workflows/services/workflow-run-control.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-run-control.service.ts
@@ -158,6 +158,7 @@ export class WorkflowRunControlService {
       const result = await this.workflowEngineAdapter.executeWorkflow(
         executableWorkflow,
         {
+          executionId: runId,
           nodeIds,
           onNodeStatusChange: (event: NodeStatusChangeEvent) =>
             this.recordNodeStatusChange(

--- a/packages/workflow-engine/src/execution/__tests__/engine.spec.ts
+++ b/packages/workflow-engine/src/execution/__tests__/engine.spec.ts
@@ -107,6 +107,32 @@ describe('WorkflowEngine', () => {
       expect(result.nodeResults.get('n1')?.status).toBe('completed');
     });
 
+    it('should pass persisted execution id into node context', async () => {
+      const contextExecutor: NodeExecutor = vi.fn(
+        async (_node, _inputs, ctx) => ({
+          executionId: ctx.executionId,
+          runId: ctx.runId,
+          workflowId: ctx.workflowId,
+        }),
+      );
+      engine.registerExecutor('generate', contextExecutor);
+
+      const workflow = makeWorkflow([makeNode('n1')]);
+
+      await engine.execute(workflow, { executionId: 'exec-1' });
+
+      expect(contextExecutor).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Map),
+        expect.objectContaining({
+          executionId: 'exec-1',
+          organizationId: 'org-1',
+          userId: 'user-1',
+          workflowId: 'wf-1',
+        }),
+      );
+    });
+
     it('should execute nodes in dependency order', async () => {
       const executionOrder: string[] = [];
       const trackingExecutor: NodeExecutor = vi.fn(async (node) => {

--- a/packages/workflow-engine/src/execution/engine.ts
+++ b/packages/workflow-engine/src/execution/engine.ts
@@ -33,6 +33,7 @@ export interface ExecutionContext {
   runId: string;
   organizationId: string;
   userId: string;
+  executionId?: string;
   abortSignal?: AbortSignal;
 }
 
@@ -84,6 +85,7 @@ export class WorkflowEngine {
 
     const context: ExecutionContext = {
       abortSignal: options.abortSignal,
+      executionId: options.executionId,
       organizationId: workflow.organizationId,
       runId,
       userId: workflow.userId,

--- a/packages/workflow-engine/src/workflows-contracts-shim.ts
+++ b/packages/workflow-engine/src/workflows-contracts-shim.ts
@@ -35,6 +35,7 @@ export interface NodeStatusChangeEvent {
 }
 
 export interface ExecutionOptions {
+  executionId?: string;
   nodeIds?: string[];
   resumeFromNodeId?: string;
   respectLocks?: boolean;


### PR DESCRIPTION
## Summary
- Thread persisted workflow execution ids through workflow-engine node context.
- Pass workflow handoff metadata into agent autopilot workflow nodes.
- Store workflow provenance on queued agent runs and expose linked run ids in node output.

Closes #1016

## Validation
- `bunx biome check --write apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflow-executor.service.ts apps/server/api/src/collections/workflows/services/workflow-run-control.service.ts packages/workflow-engine/src/execution/__tests__/engine.spec.ts packages/workflow-engine/src/execution/engine.ts packages/workflow-engine/src/workflows-contracts-shim.ts`
- `bunx secretlint apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts apps/server/api/src/collections/workflows/services/agent-autopilot-workflow.service.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-engine-adapter.service.ts apps/server/api/src/collections/workflows/services/workflow-executor.service.ts apps/server/api/src/collections/workflows/services/workflow-run-control.service.ts packages/workflow-engine/src/execution/__tests__/engine.spec.ts packages/workflow-engine/src/execution/engine.ts packages/workflow-engine/src/workflows-contracts-shim.ts`
- `git diff --check`
- `bun run --cwd packages/workflow-engine test src/execution/__tests__/engine.spec.ts`
- `bun run --cwd apps/server/api test:file src/collections/workflows/services/agent-autopilot-workflow.service.spec.ts src/collections/workflows/services/workflow-engine-adapter.service.spec.ts`
- `bun run --cwd packages/workflow-engine build`
- `bun run --cwd apps/server/api type-check`