### PR TITLE
fix(api): optimize ad performance benchmark queries

### DIFF
--- a/apps/server/api/src/collections/ad-performance/services/ad-performance.service.spec.ts
+++ b/apps/server/api/src/collections/ad-performance/services/ad-performance.service.spec.ts
@@ -1,0 +1,153 @@
+import type { AdPerformance } from '@api/collections/ad-performance/schemas/ad-performance.schema';
+import { AdPerformanceService } from '@api/collections/ad-performance/services/ad-performance.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockAdPerformanceDelegate = {
+  findFirst: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+};
+
+const buildRecord = (
+  overrides: Partial<AdPerformance> & { data?: Record<string, unknown> } = {},
+): AdPerformance =>
+  ({
+    adPlatform: 'meta',
+    brandId: null,
+    conversionRate: 0.08,
+    cpa: 12,
+    cpc: 1.5,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    credentialId: null,
+    ctr: 0.04,
+    ctaPatternCategories: [],
+    ctaText: 'Shop now',
+    data: {},
+    dataConfidence: 0.9,
+    headlinePatternCategories: [],
+    headlineText: 'Save 20 today',
+    id: 'ad-1',
+    industry: 'fitness',
+    isDeleted: false,
+    mongoId: null,
+    organizationId: 'org-1',
+    performanceScore: 80,
+    roas: 2.4,
+    scope: 'public',
+    spend: 150,
+    spendBucket: '$50-200/day',
+    updatedAt: new Date('2026-06-02T00:00:00.000Z'),
+    ...overrides,
+  }) as AdPerformance;
+
+describe('AdPerformanceService', () => {
+  let adPerformance: MockAdPerformanceDelegate;
+  let service: AdPerformanceService;
+
+  beforeEach(() => {
+    adPerformance = {
+      findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    };
+    service = new AdPerformanceService({
+      adPerformance,
+    } as unknown as PrismaService);
+  });
+
+  describe('findTopPerformers', () => {
+    it('pushes platform, industry, scope, metric ordering, and limit into Prisma', async () => {
+      adPerformance.findMany.mockResolvedValue([
+        buildRecord({ id: 'ad-roas', roas: 3.1 }),
+      ]);
+
+      const result = await service.findTopPerformers({
+        adPlatform: 'meta',
+        industry: 'fitness',
+        limit: 3,
+        metric: 'roas',
+        scope: 'public',
+      });
+
+      expect(adPerformance.findMany).toHaveBeenCalledWith({
+        orderBy: [{ roas: 'desc' }, { updatedAt: 'desc' }],
+        take: 3,
+        where: {
+          adPlatform: 'meta',
+          industry: 'fitness',
+          isDeleted: false,
+          roas: { not: null },
+          scope: 'public',
+        },
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('ad-roas');
+    });
+
+    it('defaults to performanceScore and a ten-row Prisma limit', async () => {
+      await service.findTopPerformers({});
+
+      expect(adPerformance.findMany).toHaveBeenCalledWith({
+        orderBy: [{ performanceScore: 'desc' }, { updatedAt: 'desc' }],
+        take: 10,
+        where: {
+          isDeleted: false,
+          performanceScore: { not: null },
+        },
+      });
+    });
+
+    it('uses a bounded candidate query for JSON-backed metrics', async () => {
+      adPerformance.findMany.mockResolvedValue([
+        buildRecord({
+          data: { conversions: 1 },
+          id: 'low-conversions',
+          performanceScore: 99,
+        }),
+        buildRecord({
+          data: { conversions: 15 },
+          id: 'high-conversions',
+          performanceScore: 70,
+        }),
+      ]);
+
+      const result = await service.findTopPerformers({
+        limit: 1,
+        metric: 'conversions',
+        scope: 'public',
+      });
+
+      expect(adPerformance.findMany).toHaveBeenCalledWith({
+        orderBy: [{ performanceScore: 'desc' }, { updatedAt: 'desc' }],
+        take: 500,
+        where: {
+          isDeleted: false,
+          performanceScore: { not: null },
+          scope: 'public',
+        },
+      });
+      expect(result.map((record) => record.id)).toEqual(['high-conversions']);
+    });
+
+    it('does not query when the requested limit is zero', async () => {
+      const result = await service.findTopPerformers({ limit: 0 });
+
+      expect(result).toEqual([]);
+      expect(adPerformance.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findPublicById', () => {
+    it('requires public scope for public ad detail lookups', async () => {
+      adPerformance.findFirst.mockResolvedValue(
+        buildRecord({ id: 'public-ad' }),
+      );
+
+      const result = await service.findPublicById('public-ad');
+
+      expect(adPerformance.findFirst).toHaveBeenCalledWith({
+        where: { id: 'public-ad', isDeleted: false, scope: 'public' },
+      });
+      expect(result?.id).toBe('public-ad');
+    });
+  });
+});

--- a/apps/server/api/src/collections/ad-performance/services/ad-performance.service.ts
+++ b/apps/server/api/src/collections/ad-performance/services/ad-performance.service.ts
@@ -7,17 +7,36 @@ import {
   buildAdPerformanceBenchmarkFields,
 } from '@api/collections/ad-performance/utils/ad-performance-benchmark.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { LoggerService } from '@libs/logger/logger.service';
+import type { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';
+
+const DEFAULT_TOP_PERFORMER_LIMIT = 10;
+const JSON_METRIC_CANDIDATE_LIMIT = 500;
+
+const SCALAR_TOP_PERFORMER_METRICS = [
+  'performanceScore',
+  'ctr',
+  'roas',
+  'cpc',
+  'cpa',
+  'conversionRate',
+  'spend',
+  'dataConfidence',
+] as const;
+
+type ScalarTopPerformerMetric = (typeof SCALAR_TOP_PERFORMER_METRICS)[number];
+
+type TopPerformerParams = {
+  adPlatform?: string;
+  industry?: string;
+  scope?: string;
+  metric?: string;
+  limit?: number;
+};
 
 @Injectable()
 export class AdPerformanceService {
-  private readonly constructorName = this.constructor.name;
-
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly logger: LoggerService,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   private readObjectRecord(value: unknown): Record<string, unknown> {
     return typeof value === 'object' && value !== null
@@ -46,6 +65,66 @@ export class AdPerformanceService {
     }
 
     return undefined;
+  }
+
+  private isScalarTopPerformerMetric(
+    metric: string,
+  ): metric is ScalarTopPerformerMetric {
+    return SCALAR_TOP_PERFORMER_METRICS.includes(
+      metric as ScalarTopPerformerMetric,
+    );
+  }
+
+  private resolveTopPerformerLimit(limit: number | undefined): number {
+    if (limit === undefined || !Number.isFinite(limit)) {
+      return DEFAULT_TOP_PERFORMER_LIMIT;
+    }
+
+    return Math.max(0, Math.trunc(limit));
+  }
+
+  private buildTopPerformerWhere(
+    params: TopPerformerParams,
+  ): Prisma.AdPerformanceWhereInput {
+    const where: Prisma.AdPerformanceWhereInput = {
+      isDeleted: false,
+    };
+    const adPlatform = this.readString(params.adPlatform);
+    const industry = this.readString(params.industry);
+    const scope = this.readString(params.scope);
+
+    if (adPlatform) {
+      where.adPlatform = adPlatform;
+    }
+
+    if (industry) {
+      where.industry = industry;
+    }
+
+    if (scope) {
+      where.scope = scope;
+    }
+
+    return where;
+  }
+
+  private buildScalarMetricWhere(
+    where: Prisma.AdPerformanceWhereInput,
+    metric: ScalarTopPerformerMetric,
+  ): Prisma.AdPerformanceWhereInput {
+    return {
+      ...where,
+      [metric]: { not: null },
+    } as Prisma.AdPerformanceWhereInput;
+  }
+
+  private buildMetricOrderBy(
+    metric: ScalarTopPerformerMetric,
+  ): Prisma.AdPerformanceOrderByWithRelationInput[] {
+    return [
+      { [metric]: 'desc' },
+      { updatedAt: 'desc' },
+    ] as Prisma.AdPerformanceOrderByWithRelationInput[];
   }
 
   private normalizeRecord(record: AdPerformance): AdPerformanceDocument {
@@ -119,6 +198,7 @@ export class AdPerformanceService {
   async upsert(data: Record<string, unknown>): Promise<AdPerformanceDocument> {
     const key = this.buildUpsertKey(data);
     const payload = this.toPersistencePayload(data);
+    // sql-risk-audit: documented unbounded-read -- Upsert key fields are still JSON-backed; organizationId/isDeleted bounds this sync-path lookup until scalar key columns exist.
     const existing = (
       await this.prisma.adPerformance.findMany({
         where: {
@@ -178,6 +258,7 @@ export class AdPerformanceService {
       offset?: number;
     },
   ): Promise<AdPerformanceDocument[]> {
+    // sql-risk-audit: documented unbounded-read -- This org-scoped optimization path still filters JSON-only date/granularity fields until those fields are scalarized.
     const records = await this.prisma.adPerformance.findMany({
       where: {
         isDeleted: false,
@@ -221,49 +302,47 @@ export class AdPerformanceService {
       .slice(params.offset ?? 0, (params.offset ?? 0) + (params.limit ?? 50));
   }
 
-  async findTopPerformers(params: {
-    adPlatform?: string;
-    industry?: string;
-    scope?: string;
-    metric?: string;
-    limit?: number;
-  }): Promise<AdPerformanceDocument[]> {
+  async findTopPerformers(
+    params: TopPerformerParams,
+  ): Promise<AdPerformanceDocument[]> {
     const metric = params.metric ?? 'performanceScore';
+    const limit = this.resolveTopPerformerLimit(params.limit);
+    if (limit === 0) {
+      return [];
+    }
+
+    const where = this.buildTopPerformerWhere(params);
+
+    if (this.isScalarTopPerformerMetric(metric)) {
+      const records = await this.prisma.adPerformance.findMany({
+        orderBy: this.buildMetricOrderBy(metric),
+        take: limit,
+        where: this.buildScalarMetricWhere(where, metric),
+      });
+
+      return records.map((record) => this.normalizeRecord(record));
+    }
+
+    // JSON-backed metrics, such as conversions, cannot be ordered by Prisma
+    // without a new scalar column. Keep this fallback bounded so it never reads
+    // the whole benchmark corpus for a normal top-performer request.
     const records = await this.prisma.adPerformance.findMany({
+      orderBy: this.buildMetricOrderBy('performanceScore'),
+      take: Math.max(limit, JSON_METRIC_CANDIDATE_LIMIT),
       where: {
-        isDeleted: false,
+        ...where,
+        performanceScore: { not: null },
       },
     });
 
     return records
       .map((record) => this.normalizeRecord(record))
-      .filter((record) => {
-        if (
-          params.adPlatform &&
-          this.readString(record.adPlatform) !== params.adPlatform
-        ) {
-          return false;
-        }
-
-        if (
-          params.industry &&
-          this.readString(record.industry) !== params.industry
-        ) {
-          return false;
-        }
-
-        if (params.scope && this.readString(record.scope) !== params.scope) {
-          return false;
-        }
-
-        return true;
-      })
       .sort((a, b) => {
         const aMetric = this.readNumber(a[metric]) ?? 0;
         const bMetric = this.readNumber(b[metric]) ?? 0;
         return bMetric - aMetric;
       })
-      .slice(0, params.limit ?? 10);
+      .slice(0, limit);
   }
 
   async findById(id: string): Promise<AdPerformanceDocument | null> {
@@ -274,9 +353,18 @@ export class AdPerformanceService {
     return record ? this.normalizeRecord(record) : null;
   }
 
+  async findPublicById(id: string): Promise<AdPerformanceDocument | null> {
+    const record = await this.prisma.adPerformance.findFirst({
+      where: { id, isDeleted: false, scope: 'public' },
+    });
+
+    return record ? this.normalizeRecord(record) : null;
+  }
+
   async findLatestSyncDateForCredential(
     credentialId: string,
   ): Promise<Date | null> {
+    // sql-risk-audit: documented unbounded-read -- Latest sync date is JSON-backed, so the scheduler needs the credential slice until date becomes scalar/indexed.
     const records = await this.prisma.adPerformance.findMany({
       where: { credentialId, isDeleted: false },
     });
@@ -290,6 +378,7 @@ export class AdPerformanceService {
   }
 
   async removeOrgFromAggregation(organizationId: string): Promise<number> {
+    // sql-risk-audit: documented unbounded-read -- Privacy revocation intentionally rewrites every ad performance row for one organization.
     const records = await this.prisma.adPerformance.findMany({
       where: { organizationId },
     });

--- a/apps/server/api/src/collections/ad-performance/utils/ad-performance-benchmark.util.spec.ts
+++ b/apps/server/api/src/collections/ad-performance/utils/ad-performance-benchmark.util.spec.ts
@@ -1,0 +1,92 @@
+import {
+  buildAdPerformanceBenchmarkFields,
+  CTA_PATTERN_CATEGORIES,
+  HEADLINE_PATTERN_CATEGORIES,
+  SPEND_BUCKETS,
+} from '@api/collections/ad-performance/utils/ad-performance-benchmark.util';
+import { describe, expect, it } from 'vitest';
+
+describe('buildAdPerformanceBenchmarkFields', () => {
+  it('extracts scalar benchmark dimensions and metrics', () => {
+    const result = buildAdPerformanceBenchmarkFields({
+      adPlatform: 'meta',
+      conversionRate: 0.12,
+      cpa: 14,
+      cpc: 1.2,
+      ctr: 0.05,
+      dataConfidence: 0.9,
+      industry: 'fitness',
+      performanceScore: 88,
+      roas: 3.2,
+      scope: 'public',
+      spend: 120,
+    });
+
+    expect(result).toMatchObject({
+      adPlatform: 'meta',
+      conversionRate: 0.12,
+      cpa: 14,
+      cpc: 1.2,
+      ctr: 0.05,
+      dataConfidence: 0.9,
+      industry: 'fitness',
+      performanceScore: 88,
+      roas: 3.2,
+      scope: 'public',
+      spend: 120,
+      spendBucket: '$50-200/day',
+    });
+  });
+
+  it('maps spend values onto the configured spend buckets', () => {
+    expect(SPEND_BUCKETS.map((bucket) => bucket.label)).toEqual([
+      '$0-50/day',
+      '$50-200/day',
+      '$200-500/day',
+      '$500-1000/day',
+      '$1000+/day',
+    ]);
+
+    expect(buildAdPerformanceBenchmarkFields({ spend: 49 }).spendBucket).toBe(
+      '$0-50/day',
+    );
+    expect(buildAdPerformanceBenchmarkFields({ spend: 50 }).spendBucket).toBe(
+      '$50-200/day',
+    );
+    expect(buildAdPerformanceBenchmarkFields({ spend: 1000 }).spendBucket).toBe(
+      '$1000+/day',
+    );
+    expect(
+      buildAdPerformanceBenchmarkFields({ spend: 0 }).spendBucket,
+    ).toBeNull();
+  });
+
+  it('extracts headline and CTA pattern categories', () => {
+    expect(Object.keys(HEADLINE_PATTERN_CATEGORIES)).toContain('urgency');
+    expect(Object.keys(CTA_PATTERN_CATEGORIES)).toContain('shop-now');
+
+    const result = buildAdPerformanceBenchmarkFields({
+      ctaText: 'Shop now',
+      headlineText: 'Save 20 today',
+    });
+
+    expect(result.headlinePatternCategories).toEqual(
+      expect.arrayContaining(['benefit-focused', 'number-driven', 'urgency']),
+    );
+    expect(result.ctaPatternCategories).toEqual(['shop-now']);
+  });
+
+  it('normalizes invalid values to null benchmark fields', () => {
+    const result = buildAdPerformanceBenchmarkFields({
+      adPlatform: '',
+      ctr: Number.NaN,
+      industry: 42,
+      roas: Number.POSITIVE_INFINITY,
+    });
+
+    expect(result.adPlatform).toBeNull();
+    expect(result.ctr).toBeNull();
+    expect(result.industry).toBeNull();
+    expect(result.roas).toBeNull();
+  });
+});

--- a/apps/server/api/src/endpoints/ads-research/ads-research.service.spec.ts
+++ b/apps/server/api/src/endpoints/ads-research/ads-research.service.spec.ts
@@ -1,0 +1,113 @@
+import type { AdPerformanceDocument } from '@api/collections/ad-performance/schemas/ad-performance.schema';
+import { AdsResearchService } from '@api/endpoints/ads-research/ads-research.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildPublicAd = (
+  overrides: Partial<AdPerformanceDocument> = {},
+): AdPerformanceDocument =>
+  ({
+    _id: 'public-ad',
+    adPlatform: 'meta',
+    bodyText: 'Primary text',
+    brandId: null,
+    campaignName: 'Public campaign',
+    conversionRate: 0.07,
+    cpa: 11,
+    cpc: 1.1,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    credentialId: null,
+    ctr: 0.04,
+    ctaPatternCategories: [],
+    ctaText: 'Shop now',
+    data: {},
+    dataConfidence: 0.9,
+    headlinePatternCategories: [],
+    headlineText: 'Save today',
+    id: 'public-ad',
+    industry: 'fitness',
+    isDeleted: false,
+    mongoId: null,
+    organizationId: 'org-public',
+    performanceScore: 91,
+    roas: 3.4,
+    scope: 'public',
+    spend: 120,
+    spendBucket: '$50-200/day',
+    updatedAt: new Date('2026-06-02T00:00:00.000Z'),
+    ...overrides,
+  }) as AdPerformanceDocument;
+
+describe('AdsResearchService', () => {
+  const adPerformanceService = {
+    findById: vi.fn(),
+    findPublicById: vi.fn(),
+    findTopPerformers: vi.fn(),
+  };
+  const creativePatternsService = {
+    findAll: vi.fn(),
+  };
+  const credentialsService = {
+    findOne: vi.fn(),
+  };
+  const adsGatewayService = {
+    getAdapter: vi.fn(),
+  };
+  const workflowsService = {
+    create: vi.fn(),
+  };
+
+  let service: AdsResearchService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adPerformanceService.findTopPerformers.mockResolvedValue([]);
+    creativePatternsService.findAll.mockResolvedValue([]);
+
+    service = new AdsResearchService(
+      adPerformanceService as never,
+      creativePatternsService as never,
+      credentialsService as never,
+      adsGatewayService as never,
+      workflowsService as never,
+    );
+  });
+
+  it('normalizes public top-performer filters before querying ad performance', async () => {
+    await service.listAds('org-1', {
+      industry: 'fitness',
+      limit: 999,
+      metric: 'spendEfficiency',
+      platform: 'meta',
+      source: 'public',
+    });
+
+    expect(adPerformanceService.findTopPerformers).toHaveBeenCalledWith({
+      adPlatform: 'meta',
+      industry: 'fitness',
+      limit: 24,
+      metric: 'performanceScore',
+      scope: 'public',
+    });
+    expect(adsGatewayService.getAdapter).not.toHaveBeenCalled();
+  });
+
+  it('uses a public-scoped lookup for public ad detail', async () => {
+    adPerformanceService.findPublicById.mockResolvedValue(buildPublicAd());
+
+    const result = await service.getAdDetail('org-1', {
+      id: 'public-ad',
+      source: 'public',
+    });
+
+    expect(adPerformanceService.findPublicById).toHaveBeenCalledWith(
+      'public-ad',
+    );
+    expect(adPerformanceService.findById).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      id: 'public-ad',
+      platform: 'meta',
+      source: 'public',
+      title: 'Public campaign',
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/ads-research/ads-research.service.ts
+++ b/apps/server/api/src/endpoints/ads-research/ads-research.service.ts
@@ -338,7 +338,7 @@ export class AdsResearchService {
   private async getPublicAdDetail(
     id: string,
   ): Promise<AdsResearchDetail | null> {
-    const item = await this.adPerformanceService.findById(id);
+    const item = await this.adPerformanceService.findPublicById(id);
     if (!item) {
       return null;
     }
@@ -365,9 +365,11 @@ export class AdsResearchService {
       return [];
     }
 
+    const adAccountId = filters.adAccountId;
+    const credentialId = filters.credentialId;
     const context = await this.buildContext(organizationId, {
-      adAccountId: filters.adAccountId,
-      credentialId: filters.credentialId,
+      adAccountId,
+      credentialId,
       loginCustomerId: filters.loginCustomerId,
       platform: filters.platform,
     });
@@ -385,9 +387,9 @@ export class AdsResearchService {
     return topPerformers.map((performer) =>
       this.mapConnectedItem({
         ad: adMap.get(performer.id),
-        adAccountId: filters.adAccountId!,
+        adAccountId,
         channel: filters.channel,
-        credentialId: filters.credentialId!,
+        credentialId,
         insightMetric: performer.metric,
         loginCustomerId: filters.loginCustomerId,
         metricValue: performer.value,
@@ -730,7 +732,6 @@ export class AdsResearchService {
         return 'last_90d';
       case 'all_time':
         return 'maximum';
-      case 'last_30_days':
       default:
         return 'last_30d';
     }


### PR DESCRIPTION
## Summary

- Move `findTopPerformers` dimension filtering, scalar metric ordering, and limits into Prisma queries.
- Keep JSON-backed metric sorting, such as `conversions`, on a documented 500-row candidate cap instead of scanning the whole benchmark corpus.
- Add a public-scoped ad detail lookup so public ads cannot resolve non-public `AdPerformance` rows by id.
- Add focused coverage for benchmark field extraction, top-performer query shape, ads-research caller normalization, and public detail scope.

## Verification

- `bun install --frozen-lockfile`
- `bun run --cwd apps/server/api test:file -- src/collections/ad-performance/services/ad-performance.service.spec.ts src/collections/ad-performance/utils/ad-performance-benchmark.util.spec.ts src/endpoints/ads-research/ads-research.service.spec.ts`
- `bunx biome check apps/server/api/src/collections/ad-performance/services/ad-performance.service.ts apps/server/api/src/endpoints/ads-research/ads-research.service.ts apps/server/api/src/collections/ad-performance/services/ad-performance.service.spec.ts apps/server/api/src/collections/ad-performance/utils/ad-performance-benchmark.util.spec.ts apps/server/api/src/endpoints/ads-research/ads-research.service.spec.ts`
- `bun scripts/api-audit/sql-risk-audit.ts --json | jq '[.findings[] | select(.file | test("ad-performance|ads-research"))] | {count: length, findings: .}'`

The SQL audit no longer reports the `findTopPerformers` benchmark path. It still reports four older non-benchmark `AdPerformance` reads; this PR documents each reason in code because those paths still depend on JSON-only date/granularity/upsert-key fields or intentionally touch every row for an organization-level privacy revocation.

Closes #630