### PR TITLE
test(libs): wire vitest test script so @genfeedai/libs specs run in CI

### DIFF
--- a/packages/libs/events/events.service.spec.ts
+++ b/packages/libs/events/events.service.spec.ts
@@ -48,7 +48,7 @@ describe('EventsService', () => {
       service.onModuleInit();
 
       expect(loggerService.log).toHaveBeenCalledWith(
-        'EventsService initialized - ready for event publishing',
+        'EventsService initialized',
         { service: 'EventsService' },
       );
     });

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -11,6 +11,11 @@
   },
   "name": "@genfeedai/libs",
   "private": true,
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts",
+    "test:cov": "vitest run --coverage --config vitest.config.ts",
+    "test:watch": "vitest watch --config vitest.config.ts"
+  },
   "sideEffects": false,
   "type": "module",
   "version": "0.1.0"


### PR DESCRIPTION
## Problem

`packages/libs/package.json` had **no `scripts` block at all**, so the turbo `test` task had no `test` script to invoke. `bun run test --filter=@genfeedai/libs` ran **nothing** — the entire package's vitest suite (29 files, incl. `utils/encryption`, `utils/circuit-breaker`) was silently absent from CI despite the specs existing.

The vitest `include` glob (`**/*.spec.ts`) already covered every spec; the package was just never being executed.

## Changes

- **`packages/libs/package.json`** — add `test` / `test:cov` / `test:watch` scripts, mirroring the sibling source-level packages (`packages/helpers`, `ee/packages/billing`).
- **`packages/libs/events/events.service.spec.ts`** — fix a stale assertion the now-running suite surfaced: the source logs `'EventsService initialized'`, but the spec still expected the old `'EventsService initialized - ready for event publishing'`.

## Verification

```
bun run test --filter=@genfeedai/libs
→ Test Files  29 passed (29)
→      Tests  244 passed (244)
→ Tasks:    8 successful, 8 total
```

Now includes the previously-orphaned `utils/encryption/encryption.util.spec.ts` and `utils/circuit-breaker/circuit-breaker.util.spec.ts`, plus the rest of the package.