### PR TITLE
fix(ci): prune stale encryption ratchet entry + widen DI guard to packages/libs

### DIFF
--- a/scripts/architecture/workers-api-imports.baseline.ts
+++ b/scripts/architecture/workers-api-imports.baseline.ts
@@ -216,6 +216,5 @@ export const WORKERS_API_IMPORT_BASELINE: readonly string[] = [
   '@api/shared/modules/prisma/prisma.module',
   '@api/shared/modules/prisma/prisma.service',
   '@api/shared/shared.module',
-  '@api/shared/utils/encryption/encryption.util',
   '@api/types/aggregate-paginate-result',
 ];

--- a/scripts/check-di-value-imports.ts
+++ b/scripts/check-di-value-imports.ts
@@ -20,7 +20,7 @@ import ts from 'typescript';
  * apps/server/api/src/collections/tasks/tasks.tokens.ts).
  */
 
-const INCLUDE_GLOBS = ['apps/server/**/*.ts'];
+const INCLUDE_GLOBS = ['apps/server/**/*.ts', 'packages/libs/**/*.ts'];
 
 const IGNORE_GLOBS = [
   '**/*.spec.ts',


### PR DESCRIPTION
Two guard-hygiene fixes:

1. **Ratchet baseline prune**: #1308 moved `encryption.util` to `@genfeedai/libs`, leaving a stale `@api/shared/utils/encryption/encryption.util` entry — `check:architecture` (Guards) has been failing on every PR since (same class as #1377's circuit-breaker prune). Verified: 206/206 entries pass after removal.

2. **DI guard blind spot**: `check:di-value-imports` only scanned `apps/server/**`, but `packages/libs` is server-tier DI code compiled under `emitDecoratorMetadata` via the `@libs/*` alias. Widened the glob — it immediately flagged a type-only `RedisService` import in `BaseJobService`'s decorated constructor (harmless today since the class is only manually super()'d, but converted to a value import to keep the invariant uniform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)