### PR TITLE
test(ui): sync surface/card/gallery specs with monochrome token idiom

### DIFF
--- a/packages/ui/src/components/analytics/cards/metric/metric-card.test.tsx
+++ b/packages/ui/src/components/analytics/cards/metric/metric-card.test.tsx
@@ -79,7 +79,7 @@ describe('MetricCard', () => {
 
     it('uses default icon color when not specified', () => {
       render(<MetricCard title="Test" value={100} icon={HiChartBar} />);
-      const iconContainer = document.querySelector('.text-purple-600');
+      const iconContainer = document.querySelector('.text-muted-foreground');
       expect(iconContainer).toBeInTheDocument();
     });
   });
@@ -104,7 +104,7 @@ describe('MetricCard', () => {
       const { container } = render(
         <MetricCard title="Test" value={100} change={5} />,
       );
-      const changeElement = container.querySelector('.text-green-600');
+      const changeElement = container.querySelector('.text-success');
       expect(changeElement).toBeInTheDocument();
     });
 
@@ -112,7 +112,7 @@ describe('MetricCard', () => {
       const { container } = render(
         <MetricCard title="Test" value={100} change={-5} />,
       );
-      const changeElement = container.querySelector('.text-red-600');
+      const changeElement = container.querySelector('.text-destructive');
       expect(changeElement).toBeInTheDocument();
     });
 
@@ -135,7 +135,7 @@ describe('MetricCard', () => {
           change={5}
         />,
       );
-      const trendContainer = container.querySelector('.text-green-600');
+      const trendContainer = container.querySelector('.text-success');
       expect(trendContainer).toBeInTheDocument();
       expect(trendContainer?.querySelector('svg')).toBeInTheDocument();
     });
@@ -149,7 +149,7 @@ describe('MetricCard', () => {
           change={-5}
         />,
       );
-      const trendContainer = container.querySelector('.text-red-600');
+      const trendContainer = container.querySelector('.text-destructive');
       expect(trendContainer).toBeInTheDocument();
       expect(trendContainer?.querySelector('svg')).toBeInTheDocument();
     });
@@ -201,7 +201,7 @@ describe('MetricCard', () => {
         <MetricCard title="Test" value={100} onClick={() => {}} />,
       );
       expect(container.firstChild).toHaveClass('cursor-pointer');
-      expect(container.firstChild).toHaveClass('hover:shadow-lg');
+      expect(container.firstChild).toHaveClass('hover:shadow-border-strong');
     });
 
     it('does not apply hover styles when onClick is not provided', () => {

--- a/packages/ui/src/components/display/inset-surface/InsetSurface.test.tsx
+++ b/packages/ui/src/components/display/inset-surface/InsetSurface.test.tsx
@@ -9,7 +9,7 @@ describe('InsetSurface', () => {
     const surface = container.firstElementChild;
 
     expect(surface).toHaveClass('rounded-2xl');
-    expect(surface).toHaveClass('border');
+    expect(surface).toHaveClass('shadow-border');
     expect(surface).toHaveClass('bg-white/[0.03]');
     expect(surface).toHaveTextContent('Body');
   });

--- a/packages/ui/src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx
+++ b/packages/ui/src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx
@@ -64,9 +64,10 @@ describe('ModalGalleryItemMusic', () => {
     const { container } = render(
       <ModalGalleryItemMusic {...defaultProps} isSelected={true} />,
     );
-    // The root div has the border-primary class when selected
+    // The root div uses the strong shadow-border ring + tinted background when selected
     const rootDiv = container.firstChild as HTMLElement;
-    expect(rootDiv).toHaveClass('border-primary');
+    expect(rootDiv).toHaveClass('shadow-border-strong');
+    expect(rootDiv).toHaveClass('bg-primary/5');
   });
 
   it('calls onSelect when clicked', async () => {

--- a/packages/ui/src/components/overview/OverviewLayout.test.tsx
+++ b/packages/ui/src/components/overview/OverviewLayout.test.tsx
@@ -46,7 +46,12 @@ describe('OverviewLayout', () => {
     );
     const rootElement = container.firstChild as HTMLElement;
     expect(rootElement).toBeInTheDocument();
-    expect(container.querySelector('.gen-shell-panel')).toBeInTheDocument();
-    expect(container.querySelector('.ship-ui')).toBeInTheDocument();
+    // Quick-action cards use the canonical Card surface treatment:
+    // rounded-card + shadow-border (monochrome token idiom), not the
+    // retired gen-shell-panel/ship-ui shell classes.
+    const quickActionCard = container.querySelector('[data-card-index="0"]');
+    expect(quickActionCard).toHaveClass('rounded-card');
+    expect(quickActionCard).toHaveClass('shadow-border');
+    expect(quickActionCard).toHaveClass('bg-card');
   });
 });

--- a/packages/ui/src/components/overview/WorkspaceSurface.test.tsx
+++ b/packages/ui/src/components/overview/WorkspaceSurface.test.tsx
@@ -7,7 +7,8 @@ describe('WorkspaceSurface', () => {
     const { container } = render(<WorkspaceSurface>Body</WorkspaceSurface>);
     expect(container.querySelector('section')).toHaveClass('rounded');
     expect(container.querySelector('section')).toHaveClass('ship-ui');
-    expect(container.querySelector('section')).toHaveClass('gen-shell-panel');
+    expect(container.querySelector('section')).toHaveClass('bg-card');
+    expect(container.querySelector('section')).toHaveClass('shadow-border');
   });
 
   it('renders eyebrow, title, and actions', () => {
@@ -39,7 +40,8 @@ describe('WorkspaceSurface', () => {
 
     const section = container.querySelector('section');
     expect(section).toHaveClass('ship-ui');
-    expect(section).toHaveClass('gen-shell-panel');
+    expect(section).toHaveClass('bg-secondary');
+    expect(section).toHaveClass('shadow-border');
     expect(container.querySelector('.px-4')).toBeInTheDocument();
   });
 
@@ -52,18 +54,19 @@ describe('WorkspaceSurface', () => {
     expect(section).toHaveClass('bg-card');
     expect(section).toHaveClass('shadow-border');
     expect(section).toHaveClass('rounded-card');
-    expect(section).not.toHaveClass('gen-shell-panel');
+    expect(section).not.toHaveClass('rounded-md');
   });
 
-  it('does not change the shell-panel treatment of existing tones', () => {
+  it('does not change the frame treatment of existing tones', () => {
     for (const tone of ['default', 'muted', 'elevated'] as const) {
       const { container, unmount } = render(
         <WorkspaceSurface tone={tone}>Body</WorkspaceSurface>,
       );
 
       const section = container.querySelector('section');
-      expect(section).toHaveClass('gen-shell-panel');
-      expect(section).not.toHaveClass('bg-card');
+      expect(section).toHaveClass('ship-ui');
+      expect(section).toHaveClass('rounded-md');
+      expect(section).not.toHaveClass('rounded-card');
       unmount();
     }
   });


### PR DESCRIPTION
## What/Why

#1359 and #1367's monochrome token payload renamed chrome classes across `packages/ui` components (`gen-shell-panel` → removed, CSS `border` → `shadow-border`/`shadow-border-strong`, hardcoded Tailwind colors → `text-success`/`text-destructive`/`text-muted-foreground`, `hover:shadow-lg` → `hover:shadow-border-strong`). These specs still asserted the pre-monochrome class names and were failing on every PR's Test Packages job.

Tests updated to assert the classes each component actually emits now (components are the source of truth; tests follow, never revert). No component behavior changed — test-only fixes.

## Files

- `packages/ui/src/components/overview/WorkspaceSurface.test.tsx` — updated frame/tone assertions to `ship-ui`, `bg-card`/`bg-secondary`, `shadow-border`/`shadow-border-strong`, `rounded-card`/`rounded-md` per `WorkspaceSurface.tsx`'s `FRAME_TONE_CLASSES`.
- `packages/ui/src/components/display/inset-surface/InsetSurface.test.tsx` — `border` → `shadow-border` per `InsetSurface.tsx`'s `TONE_CLASSES`.
- `packages/ui/src/components/analytics/cards/metric/metric-card.test.tsx` — hardcoded color classes (`text-purple-600`/`text-green-600`/`text-red-600`) → `text-muted-foreground`/`text-success`/`text-destructive`; `hover:shadow-lg` → `hover:shadow-border-strong`.
- `packages/ui/src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx` — selected-state assertion `border-primary` → `shadow-border-strong` + `bg-primary/5` per the component's selected-state className.
- `packages/ui/src/components/overview/OverviewLayout.test.tsx` — the "should apply correct styles and classes" test asserted `.gen-shell-panel`/`.ship-ui`, neither of which exists anywhere in `OverviewLayout` → `Container` → `Card` → `CardIcon`'s current render tree. Rewrote to assert the quick-action `Card`'s actual surface classes (`rounded-card`, `shadow-border`, `bg-card`) from `Card.tsx`'s `VARIANT_CLASSES[CardVariant.DEFAULT]`.

## Test plan

- [x] `bunx vitest run` per failing spec file — all pass individually
- [x] `bun run test --filter=@genfeedai/ui` — full suite green: 298 test files passed, 5 skipped (303 total); 1923 tests passed, 100 skipped (2023 total); 0 failed
- [x] `bunx biome check --write` on touched files — clean (pre-existing unrelated warning on an untouched line in metric-card.test.tsx)