### PR TITLE
fix(app): unblock platform-settings form submit + stabilize test mocks

### DIFF
--- a/apps/app/app/(protected)/admin/administration/platform-settings/platform-settings-page.test.tsx
+++ b/apps/app/app/(protected)/admin/administration/platform-settings/platform-settings-page.test.tsx
@@ -15,11 +15,15 @@ const mocks = vi.hoisted(() => ({
   warning: vi.fn(),
 }));
 
-vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
-  useAuthedService: () => async () => ({
+const getPlatformSettingsService = vi.hoisted(() =>
+  vi.fn(async () => ({
     getSettings: mocks.getSettings,
     updateSettings: mocks.updateSettings,
-  }),
+  })),
+);
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => getPlatformSettingsService,
 }));
 
 vi.mock('@services/core/logger.service', () => ({
@@ -28,13 +32,15 @@ vi.mock('@services/core/logger.service', () => ({
   },
 }));
 
+const notificationsServiceInstance = vi.hoisted(() => ({
+  error: mocks.error,
+  success: mocks.success,
+  warning: mocks.warning,
+}));
+
 vi.mock('@services/core/notifications.service', () => ({
   NotificationsService: {
-    getInstance: () => ({
-      error: mocks.error,
-      success: mocks.success,
-      warning: mocks.warning,
-    }),
+    getInstance: () => notificationsServiceInstance,
   },
 }));
 
@@ -130,12 +136,12 @@ describe('PlatformSettingsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
 
     await waitFor(() => {
-      expect(mocks.updateSettings).toHaveBeenCalledWith({
-        marginMultiplier: 1.5,
-      });
+      expect(mocks.success).toHaveBeenCalledWith('Platform settings saved');
+    });
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      marginMultiplier: 1.5,
     });
     expect(input).toHaveValue(1.5);
-    expect(mocks.success).toHaveBeenCalledWith('Platform settings saved');
   });
 
   it('blocks invalid and excessive multipliers before saving', async () => {

--- a/apps/app/app/(protected)/admin/administration/platform-settings/platform-settings-page.tsx
+++ b/apps/app/app/(protected)/admin/administration/platform-settings/platform-settings-page.tsx
@@ -126,7 +126,7 @@ export default function PlatformSettingsPage() {
       {isLoading ? (
         <SkeletonCard showImage={false} />
       ) : (
-        <form onSubmit={handleSubmit} className="max-w-xl space-y-6">
+        <form onSubmit={handleSubmit} noValidate className="max-w-xl space-y-6">
           <Field
             label="Model-cost margin multiplier"
             htmlFor="platform-margin-multiplier"


### PR DESCRIPTION
## Summary

`Test App (changed)` was red on `master` for `platform-settings-page.test.tsx`. Root-caused as a **latent bug in #1333, not a cross-PR merge collision** — the `min`/`max`/`step` JSX attributes and the test file have been byte-identical since #1333 originally merged, and no vitest/jsdom/testing-library versions changed across the intervening pricing PRs (#1337, #1350, #1352). The bug was there from the start; it just hadn't been exercised by CI in this combination before.

### Root cause 1 — component bug (verdict: **component regressed/was buggy**, fix the component)

The margin-multiplier `<input type="number" min="0.01" max={10} step="0.05">` relies on HTML5 native constraint validation attributes, but the `<form>` never opted out of native validation. In jsdom (matching real browsers), submitting a value that fails `stepMismatch`/`rangeUnderflow`/`rangeOverflow` (e.g. `1.5`, `0`, `11` against `step="0.05"`) silently blocks the native `submit` event — so React's `onSubmit`/`handleSubmit` never runs, and the component's own custom validation (which produces the intended toast messages) never executes either. Fixed by adding `noValidate` to the `<form>`, making the component's existing custom validation logic the single source of truth as originally intended.

### Root cause 2 — test-mock fidelity bugs (verdict: **test mocks were unstable**, fix the test)

Once `noValidate` let the form actually submit, a second bug surfaced: the "submits a valid multiplier" test still failed, with the input snapping back to the pre-save value (`1.25`) instead of showing the saved value (`1.5`). Debug logging confirmed `setMarginInput('1.5')` was called correctly and `success` toast fired, yet the DOM value stayed `1.25` even on a freshly re-queried element.

Traced to two mocks that don't replicate real referential-stability guarantees:
- `useAuthedService` mock returned a **brand-new closure per invocation** — the real hook (`packages/hooks/auth/use-authed-service/use-authed-service.ts`) is `useCallback`-memoized and stable.
- `NotificationsService.getInstance` mock returned a **fresh object literal per call** — the real implementation (`packages/services/core/notifications.service.ts`) is a proper singleton (`private static classInstance`).

Both broke `loadSettings`'s `useCallback` dependency stability (`[getPlatformSettingsService, notificationsService]`), so its `useEffect([loadSettings])` re-fired on every render — including after the save's re-render — re-invoking the mocked `getSettings()` (still resolving `1.25`) and clobbering the just-saved `1.5` back onto the input. Fixed by making both mocks return stable, memoized references, matching the real implementations' contracts.

### Noisy `TypeError` lines in the original CI log

The `TypeError: Cannot read properties of undefined (reading 'ok'/'findAll'/'findOne')` lines mentioned in the CI log do **not** reproduce when running this file alone, nor across the full `app/(protected)/admin` suite (81 files / 144 tests, all green, zero TypeErrors). These are pre-existing noise from unrelated suites in the same job and are out of scope for this fix — left untouched.

## Test plan

- [x] `bunx vitest run 'app/(protected)/admin/administration/platform-settings/platform-settings-page.test.tsx'` — 3/3 passing
- [x] `bunx vitest run 'app/(protected)/admin'` — 81 files / 144 tests passing, no adjacent breakage
- [x] `bunx biome check --write` on touched files
- [x] Pre-commit hooks (secretlint, biome, lint-no-raw-html, lint-no-bespoke-card) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)