### PR TITLE
test: re-baseline openapi surface floor + sync audiences launch-price spec

### DIFF
--- a/apps/server/api/src/helpers/utils/openapi/openapi-artifact.spec.ts
+++ b/apps/server/api/src/helpers/utils/openapi/openapi-artifact.spec.ts
@@ -32,7 +32,16 @@ describe('committed OpenAPI artifact', () => {
   ) as IOpenApiInternalRouteAllowlist;
 
   it('covers the full API surface', () => {
-    expect(Object.keys(document.paths).length).toBeGreaterThan(900);
+    // Floor re-baselined 2026-07-06: the REST audit (#1354/#1380 family,
+    // merged today) deliberately deleted/collapsed dozens of RPC-style and
+    // duplicate routes, taking the committed artifact from >900 paths down
+    // to ~897. This assertion exists to catch *accidental* truncation (a
+    // whole controller or module silently dropped from the Swagger scan),
+    // not to pin an exact count — so the floor sits comfortably below the
+    // post-audit count with headroom for further deliberate consolidation,
+    // while still being high enough that losing a real controller's worth
+    // of routes would trip it.
+    expect(Object.keys(document.paths).length).toBeGreaterThan(850);
   });
 
   it('has a unique operationId on every operation and a live allowlist', () => {

--- a/apps/website/packages/components/home/_audiences.spec.tsx
+++ b/apps/website/packages/components/home/_audiences.spec.tsx
@@ -61,12 +61,10 @@ describe('HomeAudiences', () => {
     ).toHaveAttribute('href', '/use-cases/agencies');
   });
 
-  it('quotes the Creator launch price, not the standard price', () => {
+  it('quotes the Pro launch price, not the standard price', () => {
     render(<HomeAudiences />);
 
-    expect(screen.getByText(/then \$39\/mo creator/i)).toBeInTheDocument();
-    expect(
-      screen.queryByText(/then \$49\/mo creator/i),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText(/then \$39\/mo pro/i)).toBeInTheDocument();
+    expect(screen.queryByText(/then \$49\/mo pro/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/website/packages/components/home/_credits.spec.tsx
+++ b/apps/website/packages/components/home/_credits.spec.tsx
@@ -54,7 +54,9 @@ describe('HomeCredits', () => {
     render(<HomeCredits />);
 
     expect(
-      screen.getByText(/launch pricing — first 12 months, then \$49\/month/i),
+      screen.getByText(
+        /launch pricing \(code earlygenfeed\) — first 12 months, then \$49\/month/i,
+      ),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Two master-level test drifts fixed (both pre-existing tests, no product code changed):

**1. `apps/server/api/src/helpers/utils/openapi/openapi-artifact.spec.ts`**

Root cause: the REST audit (#1354/#1380 family, merged 2026-07-06) legitimately deleted/collapsed dozens of RPC-style and duplicate routes, dropping the committed `openapi.json` from >900 paths to ~897. The `>900` floor was stale, not the artifact.

Fix: re-baselined the floor to `>850`. This still catches accidental truncation (losing a whole controller/module from the Swagger scan) while tolerating further deliberate consolidation, with a comment explaining the intent and citing the REST-audit context.

**2. `apps/website/packages/components/home/_audiences.spec.tsx`**

Root cause: the pricing model was reconciled twice today (#1327 launch coupon + Pro/Scale labels, #1337 unlimited seats + EARLYGENFEED launch note via #1339). The "Creator" tier was renamed to "Pro" in `packages/pricing/src/plans-pricing.ts`. The component (`_audiences.tsx`) already correctly sources `$39/mo Pro` from `getProPlan().launchPrice` — the component was **not** drifted. Only the spec's assertion/title still said "Creator".

Fix: updated the spec to assert `$39/mo Pro` instead of `$39/mo creator`.

**Bonus (same drift class, caught by the required sibling-spec run):** `apps/website/packages/components/home/_credits.spec.tsx` also broke from the same pricing wave — the launch note gained the `(code EARLYGENFEED)` suffix (#1339) and the spec's regex didn't match. Updated the assertion to the current copy so `bunx vitest run packages/components/home` is green.

## Test plan

- [x] `bunx vitest run src/helpers/utils/openapi/openapi-artifact.spec.ts` (apps/server/api) — 4/4 passed
- [x] `bunx vitest run packages/components/home/_audiences.spec.tsx` (apps/website) — 3/3 passed
- [x] `bunx vitest run packages/components/home` (apps/website, all sibling home specs) — 9 files / 22 tests passed
- [x] `bunx biome check --write` on all three touched files — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)