### PR TITLE
Fix Sentry slow workflow queries

### DIFF
--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
@@ -206,9 +206,54 @@ describe('WorkflowExecutionsService', () => {
             progress: 50,
           }),
         }),
+        select: { id: true, result: true },
         where: { id: 'execution-1' },
       }),
     );
+  });
+
+  it('reads only runtime state needed for delay resume ETA updates', async () => {
+    const { prisma, service } = makeService();
+    const startedAt = new Date('2026-06-29T00:00:00.000Z');
+    prisma.workflowExecution.findUnique.mockResolvedValue({
+      isDeleted: false,
+      result: {
+        metadata: {
+          eta: {
+            currentPhase: 'Waiting',
+            estimatedDurationMs: 12_000,
+          },
+        },
+        progress: 37,
+      },
+      startedAt,
+    });
+
+    await expect(service.getRuntimeState('execution-1')).resolves.toEqual({
+      metadata: {
+        eta: {
+          currentPhase: 'Waiting',
+          estimatedDurationMs: 12_000,
+        },
+      },
+      progress: 37,
+      startedAt,
+    });
+    expect(prisma.workflowExecution.findUnique).toHaveBeenCalledWith({
+      select: { isDeleted: true, result: true, startedAt: true },
+      where: { id: 'execution-1' },
+    });
+  });
+
+  it('treats deleted execution runtime state as missing', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findUnique.mockResolvedValue({
+      isDeleted: true,
+      result: { progress: 50 },
+      startedAt: new Date('2026-06-29T00:00:00.000Z'),
+    });
+
+    await expect(service.getRuntimeState('execution-1')).resolves.toBeNull();
   });
 
   it('narrows result-only void patch updates to the id return field', async () => {
@@ -263,5 +308,28 @@ describe('WorkflowExecutionsService', () => {
       where: { id: 'missing-execution' },
     });
     expect(prisma.workflowExecution.update).not.toHaveBeenCalled();
+  });
+
+  it('updates execution metadata with a narrow return payload', async () => {
+    const { prisma, service } = makeService();
+    prisma.workflowExecution.findUnique.mockResolvedValue({
+      result: { metadata: { retained: true }, progress: 20 },
+    });
+
+    await service.updateExecutionMetadata('execution-1', { phase: 'running' });
+
+    expect(prisma.workflowExecution.update).toHaveBeenCalledWith({
+      data: {
+        result: {
+          metadata: {
+            phase: 'running',
+            retained: true,
+          },
+          progress: 20,
+        },
+      },
+      select: { id: true, result: true },
+      where: { id: 'execution-1' },
+    });
   });
 });

--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
@@ -38,10 +38,21 @@ type WorkflowExecutionResultRow = {
   result: unknown;
 };
 
+type WorkflowExecutionRuntimeStateRow = WorkflowExecutionResultRow & {
+  isDeleted: boolean;
+  startedAt: Date | null;
+};
+
 type WorkflowExecutionCompletionRow = WorkflowExecutionResultRow & {
   startedAt: Date | null;
   workflowId: string;
 };
+
+export interface WorkflowExecutionRuntimeState {
+  metadata?: Record<string, unknown>;
+  progress?: number;
+  startedAt: Date | null;
+}
 
 @Injectable()
 export class WorkflowExecutionsService extends BaseService<
@@ -63,6 +74,32 @@ export class WorkflowExecutionsService extends BaseService<
     ],
   ): Promise<WorkflowExecutionDocument | null> {
     return await super.findOne(params, populate);
+  }
+
+  @HandleErrors('get execution runtime state', 'workflow-executions')
+  async getRuntimeState(
+    executionId: string,
+  ): Promise<WorkflowExecutionRuntimeState | null> {
+    const execution = (await this.prisma.workflowExecution.findUnique({
+      select: { isDeleted: true, result: true, startedAt: true },
+      where: { id: executionId },
+    })) as WorkflowExecutionRuntimeStateRow | null;
+
+    if (!execution || execution.isDeleted) {
+      return null;
+    }
+
+    const result = parseResult(execution.result);
+    const metadata =
+      result.metadata && typeof result.metadata === 'object'
+        ? (result.metadata as Record<string, unknown>)
+        : undefined;
+
+    return {
+      metadata,
+      progress: typeof result.progress === 'number' ? result.progress : 0,
+      startedAt: execution.startedAt,
+    };
   }
 
   @HandleErrors('create execution', 'workflow-executions')
@@ -253,10 +290,11 @@ export class WorkflowExecutionsService extends BaseService<
       data: {
         result: updatedResult as never,
       } as never,
+      select: { id: true, result: true },
       where: { id: executionId },
     });
 
-    return result as unknown as WorkflowExecutionDocument | null;
+    return this.normalizeDocument(result) as WorkflowExecutionDocument | null;
   }
 
   @HandleErrors('set failed node', 'workflow-executions')
@@ -335,10 +373,11 @@ export class WorkflowExecutionsService extends BaseService<
       data: {
         result: updatedResult as never,
       } as never,
+      select: { id: true, result: true },
       where: { id: executionId },
     });
 
-    return result as unknown as WorkflowExecutionDocument | null;
+    return this.normalizeDocument(result) as WorkflowExecutionDocument | null;
   }
 
   @HandleErrors('get execution stats', 'workflow-executions')

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.spec.ts
@@ -1,4 +1,7 @@
-import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
+import {
+  EXECUTABLE_WORKFLOW_SELECT,
+  WorkflowExecutorService,
+} from '@api/collections/workflows/services/workflow-executor.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('WorkflowExecutorService', () => {
@@ -22,6 +25,7 @@ describe('WorkflowExecutorService', () => {
   const executionsService = {
     completeExecution: vi.fn(),
     findOne: vi.fn(),
+    getRuntimeState: vi.fn(),
     setCreditsUsed: vi.fn(),
     setFailedNodeId: vi.fn(),
     updateExecutionMetadata: vi.fn(),
@@ -73,8 +77,7 @@ describe('WorkflowExecutorService', () => {
       executableWorkflow,
     );
     engineAdapter.applyRuntimeInputValues.mockReturnValue(executableWorkflow);
-    executionsService.findOne.mockResolvedValue({
-      id: 'exec-1',
+    executionsService.getRuntimeState.mockResolvedValue({
       metadata: {
         eta: {
           currentPhase: 'Waiting to resume',
@@ -135,6 +138,16 @@ describe('WorkflowExecutorService', () => {
       workflowId: 'workflow-1',
     });
 
+    expect(prisma.workflow.findFirst).toHaveBeenCalledWith({
+      select: EXECUTABLE_WORKFLOW_SELECT,
+      where: {
+        id: 'workflow-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(executionsService.getRuntimeState).toHaveBeenCalledWith('exec-1');
+    expect(executionsService.findOne).not.toHaveBeenCalled();
     expect(executionsService.updateExecutionMetadata).toHaveBeenCalledWith(
       'exec-1',
       {

--- a/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-executor.service.ts
@@ -17,6 +17,7 @@ import {
   WorkflowLifecycle,
   WorkflowStatus,
 } from '@genfeedai/enums';
+import type { Prisma } from '@genfeedai/prisma';
 import type {
   ExecutableEdge,
   ExecutableNode,
@@ -154,6 +155,25 @@ const EVENT_TYPE_TO_NODE_TYPE: Record<string, string> = {
   trendTrigger: 'trendTrigger',
 };
 
+export const EXECUTABLE_WORKFLOW_SELECT = {
+  config: true,
+  description: true,
+  edges: true,
+  id: true,
+  inputVariables: true,
+  label: true,
+  metadata: true,
+  mongoId: true,
+  nodes: true,
+  organizationId: true,
+  steps: true,
+  userId: true,
+} satisfies Prisma.WorkflowSelect;
+
+export type ExecutableWorkflowRow = Prisma.WorkflowGetPayload<{
+  select: typeof EXECUTABLE_WORKFLOW_SELECT;
+}>;
+
 // =============================================================================
 // SERVICE
 // =============================================================================
@@ -288,11 +308,32 @@ export class WorkflowExecutorService {
   ): Promise<WorkflowExecutionResult> {
     const workflowDoc = await findOrThrow(
       this.prisma.workflow,
-      { where: { id: workflowId, isDeleted: false, organizationId } },
+      {
+        select: EXECUTABLE_WORKFLOW_SELECT,
+        where: { id: workflowId, isDeleted: false, organizationId },
+      },
       'Workflow',
       workflowId,
     );
 
+    return this.executeManualWorkflowDocument(
+      workflowDoc,
+      userId,
+      organizationId,
+      inputValues,
+      metadata,
+      trigger,
+    );
+  }
+
+  async executeManualWorkflowDocument(
+    workflowDoc: WorkflowDocument | ExecutableWorkflowRow,
+    userId: string,
+    organizationId: string,
+    inputValues: Record<string, unknown> = {},
+    metadata?: Record<string, unknown>,
+    trigger: WorkflowExecutionTrigger = WorkflowExecutionTrigger.MANUAL,
+  ): Promise<WorkflowExecutionResult> {
     return this.executeWorkflowDocument(
       this.normalizeWorkflowDocument(workflowDoc),
       {
@@ -334,7 +375,10 @@ export class WorkflowExecutorService {
 
     const workflowDoc = await findOrThrow(
       this.prisma.workflow,
-      { where: { id: workflowId, isDeleted: false, organizationId } },
+      {
+        select: EXECUTABLE_WORKFLOW_SELECT,
+        where: { id: workflowId, isDeleted: false, organizationId },
+      },
       'Workflow',
       workflowId,
     );
@@ -921,7 +965,12 @@ export class WorkflowExecutorService {
     });
 
     const workflowDoc = await this.prisma.workflow.findFirst({
-      where: { id: workflowId, isDeleted: false },
+      select: EXECUTABLE_WORKFLOW_SELECT,
+      where: {
+        id: workflowId,
+        isDeleted: false,
+        organizationId: jobData.organizationId,
+      },
     });
 
     if (!workflowDoc) {
@@ -964,10 +1013,8 @@ export class WorkflowExecutorService {
       executableWorkflow,
       triggerEvent.data,
     );
-    const existingExecution = await this.executionsService.findOne({
-      id: executionId,
-      isDeleted: false,
-    });
+    const existingExecution =
+      await this.executionsService.getRuntimeState(executionId);
     const baselineEstimatedDurationMs = this.extractEstimatedDurationMs(
       existingExecution?.metadata,
     );
@@ -1787,6 +1834,7 @@ export class WorkflowExecutorService {
 
     // Query for published workflows in this organization
     const workflows = await this.prisma.workflow.findMany({
+      select: EXECUTABLE_WORKFLOW_SELECT,
       where: {
         isDeleted: false,
         lifecycle: WorkflowLifecycle.PUBLISHED,

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts
@@ -1,7 +1,8 @@
 import type { WorkflowDocument } from '@api/collections/workflows/schemas/workflow.schema';
+import { EXECUTABLE_WORKFLOW_SELECT } from '@api/collections/workflows/services/workflow-executor.service';
 import { WorkflowSchedulerService } from '@api/collections/workflows/services/workflow-scheduler.service';
 import { buildSystemWorkflowMetadata } from '@api/collections/workflows/system-workflow.contract';
-import { WorkflowExecutionTrigger } from '@genfeedai/enums';
+import { WorkflowExecutionTrigger, WorkflowStatus } from '@genfeedai/enums';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 function createMockLogger() {
@@ -36,6 +37,7 @@ function createService(
     queueService?: ReturnType<typeof createMockQueueService>;
     workflowExecutorService?: {
       executeManualWorkflow: ReturnType<typeof vi.fn>;
+      executeManualWorkflowDocument: ReturnType<typeof vi.fn>;
     };
     isDevSchedulersEnabled?: boolean;
   } = {},
@@ -51,6 +53,7 @@ function createService(
   };
   const workflowExecutorService = overrides.workflowExecutorService ?? {
     executeManualWorkflow: vi.fn().mockResolvedValue({}),
+    executeManualWorkflowDocument: vi.fn().mockResolvedValue({}),
   };
   const queueService = overrides.queueService ?? createMockQueueService();
 
@@ -208,6 +211,21 @@ describe('WorkflowSchedulerService — boot sync', () => {
 
     await service.onModuleInit();
 
+    expect(prisma.workflow.findMany).toHaveBeenCalledWith({
+      select: {
+        id: true,
+        isScheduleEnabled: true,
+        metadata: true,
+        schedule: true,
+        timezone: true,
+      },
+      where: {
+        isDeleted: false,
+        isScheduleEnabled: true,
+        schedule: { not: null },
+        status: WorkflowStatus.ACTIVE,
+      },
+    });
     expect(queueService.upsertWorkflowScheduler).toHaveBeenCalledTimes(2);
     expect(queueService.upsertWorkflowScheduler).toHaveBeenCalledWith({
       cronExpression: '0 7 * * *',
@@ -234,14 +252,25 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
     });
     const workflowExecutorService = {
       executeManualWorkflow: vi.fn().mockResolvedValue({}),
+      executeManualWorkflowDocument: vi.fn().mockResolvedValue({}),
     };
     const { service } = createService({ prisma, workflowExecutorService });
 
     await service.executeScheduledWorkflow('wf-1');
 
+    expect(prisma.workflow.findFirst).toHaveBeenCalledWith({
+      select: EXECUTABLE_WORKFLOW_SELECT,
+      where: {
+        id: 'wf-1',
+        isDeleted: false,
+        status: WorkflowStatus.ACTIVE,
+      },
+    });
     expect(prisma.workflow.update).toHaveBeenCalledTimes(1);
-    expect(workflowExecutorService.executeManualWorkflow).toHaveBeenCalledWith(
-      'wf-1',
+    expect(
+      workflowExecutorService.executeManualWorkflowDocument,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-1' }),
       'user-1',
       'org-1',
       {},
@@ -280,6 +309,7 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
     prisma.workflow.findFirst.mockResolvedValue(null);
     const workflowExecutorService = {
       executeManualWorkflow: vi.fn().mockResolvedValue({}),
+      executeManualWorkflowDocument: vi.fn().mockResolvedValue({}),
     };
     const { logger, queueService, service } = createService({
       prisma,
@@ -292,7 +322,7 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
       'wf-gone',
     );
     expect(
-      workflowExecutorService.executeManualWorkflow,
+      workflowExecutorService.executeManualWorkflowDocument,
     ).not.toHaveBeenCalled();
     expect(prisma.workflow.update).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
@@ -309,6 +339,7 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
     });
     const workflowExecutorService = {
       executeManualWorkflow: vi.fn().mockResolvedValue({}),
+      executeManualWorkflowDocument: vi.fn().mockResolvedValue({}),
     };
     const { queueService, service } = createService({
       prisma,
@@ -321,7 +352,7 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
       'wf-template',
     );
     expect(
-      workflowExecutorService.executeManualWorkflow,
+      workflowExecutorService.executeManualWorkflowDocument,
     ).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
@@ -2,7 +2,10 @@ import { WorkflowExecutionsService } from '@api/collections/workflow-executions/
 import type { WorkflowDocument } from '@api/collections/workflows/schemas/workflow.schema';
 import { LegacyWorkflowStepRunner } from '@api/collections/workflows/services/legacy-workflow-step-runner.service';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
-import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
+import {
+  EXECUTABLE_WORKFLOW_SELECT,
+  WorkflowExecutorService,
+} from '@api/collections/workflows/services/workflow-executor.service';
 import { getSystemWorkflowMetadata } from '@api/collections/workflows/system-workflow.contract';
 import { ConfigService } from '@api/config/config.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -61,6 +64,13 @@ export class WorkflowSchedulerService implements OnModuleInit {
   async syncAllWorkflowSchedulers(): Promise<void> {
     try {
       const workflows = await this.prisma.workflow.findMany({
+        select: {
+          id: true,
+          isScheduleEnabled: true,
+          metadata: true,
+          schedule: true,
+          timezone: true,
+        },
         where: {
           isDeleted: false,
           isScheduleEnabled: true,
@@ -170,6 +180,7 @@ export class WorkflowSchedulerService implements OnModuleInit {
   async executeScheduledWorkflow(workflowId: string): Promise<void> {
     try {
       const workflow = await this.prisma.workflow.findFirst({
+        select: EXECUTABLE_WORKFLOW_SELECT,
         where: {
           id: workflowId,
           isDeleted: false,
@@ -229,8 +240,8 @@ export class WorkflowSchedulerService implements OnModuleInit {
       // Node-based workflows run through the newer workflow engine executor;
       // legacy step-based workflows keep the existing execution path.
       const executePromise = usesNodeExecutor
-        ? this.workflowExecutorService.executeManualWorkflow(
-            workflowId,
+        ? this.workflowExecutorService.executeManualWorkflowDocument(
+            toWorkflowDocument(workflow),
             wUserId,
             wOrgId,
             this.getDefaultInputValues(toWorkflowDocument(workflow)),
@@ -289,6 +300,7 @@ export class WorkflowSchedulerService implements OnModuleInit {
     isEnabled: boolean = true,
   ): Promise<WorkflowDocument | null> {
     const existing = await this.prisma.workflow.findFirst({
+      select: { id: true },
       where: { id: workflowId, isDeleted: false },
     });
 

--- a/packages/helpers/src/content/schema-org.helper.test.ts
+++ b/packages/helpers/src/content/schema-org.helper.test.ts
@@ -46,6 +46,33 @@ describe('schema-org helpers', () => {
     });
   });
 
+  it('omits malformed Article text fields instead of throwing', () => {
+    const jsonLd = buildArticleJsonLd({
+      body: undefined,
+      description: undefined,
+      headline: undefined,
+      imageUrls: [undefined, '', 'https://example.com/cover.png'],
+      keywords: ['geo', undefined, ''],
+      publisher: {
+        logoUrl: null,
+        name: undefined as unknown as string,
+      },
+    });
+
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      image: ['https://example.com/cover.png'],
+      keywords: 'geo',
+      publisher: {
+        '@type': 'Organization',
+      },
+    });
+    expect(jsonLd).not.toHaveProperty('headline');
+    expect(jsonLd).not.toHaveProperty('articleBody');
+    expect(jsonLd).not.toHaveProperty('description');
+  });
+
   it('drops empty FAQ rows and emits Question/Answer entities', () => {
     const jsonLd = buildFaqJsonLd({
       items: [

--- a/packages/helpers/src/content/schema-org.helper.ts
+++ b/packages/helpers/src/content/schema-org.helper.ts
@@ -22,10 +22,10 @@ export interface ArticleJsonLdInput {
   dateModified?: Date | string | null;
   datePublished?: Date | string | null;
   description?: string | null;
-  headline: string;
-  imageUrls?: string[];
+  headline?: string | null;
+  imageUrls?: Array<string | null | undefined>;
   inLanguage?: string | null;
-  keywords?: string[];
+  keywords?: Array<string | null | undefined>;
   mainEntityUrl?: string | null;
   publisher?: SchemaOrgOrganizationInput | string | null;
   url?: string | null;
@@ -74,7 +74,7 @@ export function buildArticleJsonLd(
     dateModified: toIsoDate(input.dateModified),
     datePublished: toIsoDate(input.datePublished),
     description: normaliseText(input.description),
-    headline: input.headline.trim(),
+    headline: normaliseText(input.headline),
     image: normaliseStringArray(input.imageUrls),
     inLanguage: normaliseText(input.inLanguage),
     keywords: normaliseStringArray(input.keywords)?.join(', '),
@@ -100,10 +100,10 @@ export function buildFaqJsonLd(
 ): Record<string, JsonLdValue> {
   const mainEntity = input.items
     .map((item) => ({
-      answer: item.answer.trim(),
-      question: item.question.trim(),
+      answer: normaliseText(item.answer),
+      question: normaliseText(item.question),
     }))
-    .filter((item) => item.answer.length > 0 && item.question.length > 0)
+    .filter((item) => item.answer && item.question)
     .map((item) =>
       compactJsonLdRecord({
         '@type': 'Question',
@@ -130,10 +130,10 @@ export function buildHowToJsonLd(
   const steps = input.steps
     .map((step) => ({
       name: normaliseText(step.name),
-      text: step.text.trim(),
+      text: normaliseText(step.text),
       url: normaliseText(step.url),
     }))
-    .filter((step) => step.text.length > 0)
+    .filter((step) => step.text)
     .map((step, index) =>
       compactJsonLdRecord({
         '@type': 'HowToStep',
@@ -149,7 +149,7 @@ export function buildHowToJsonLd(
     '@type': 'HowTo',
     description: normaliseText(input.description),
     estimatedCost: normaliseText(input.estimatedCost),
-    name: input.name.trim(),
+    name: normaliseText(input.name),
     step: steps,
     totalTime: normaliseText(input.totalTime),
     url: normaliseText(input.url),
@@ -176,7 +176,7 @@ function buildAuthorEntity(
   if (typeof input === 'string') {
     return compactJsonLdRecord({
       '@type': 'Person',
-      name: input.trim(),
+      name: normaliseText(input),
     });
   }
 
@@ -189,7 +189,7 @@ function buildAuthorEntity(
             url: input.logoUrl,
           })
         : undefined,
-    name: input.name.trim(),
+    name: normaliseText(input.name),
     url: normaliseText(input.url),
   });
 }
@@ -200,7 +200,7 @@ function buildOrganizationEntity(
   if (typeof input === 'string') {
     return compactJsonLdRecord({
       '@type': 'Organization',
-      name: input.trim(),
+      name: normaliseText(input),
     });
   }
 
@@ -212,7 +212,7 @@ function buildOrganizationEntity(
           url: input.logoUrl,
         })
       : undefined,
-    name: input.name.trim(),
+    name: normaliseText(input.name),
     url: normaliseText(input.url),
   });
 }
@@ -250,12 +250,16 @@ function normaliseText(value?: string | null): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function normaliseStringArray(value?: string[]): string[] | undefined {
+function normaliseStringArray(
+  value?: Array<string | null | undefined>,
+): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
 
-  const items = value.map((item) => item.trim()).filter(Boolean);
+  const items = value
+    .map((item) => normaliseText(item))
+    .filter((item): item is string => Boolean(item));
   return items.length > 0 ? items : undefined;
 }
 


### PR DESCRIPTION
## Summary
- reduce workflow DB payloads on Sentry slow-query paths by using a shared executable workflow select
- avoid the extra scheduled-workflow refetch by executing the prefetched workflow document
- add a narrow workflow execution runtime-state reader for delay resume ETA updates
- harden article JSON-LD helpers against missing runtime text fields causing `trim` crashes

## Sentry
- Fixes production slow DB query issues `API-GENFEED-AI-6F`, `API-GENFEED-AI-6E`, and `API-GENFEED-AI-6A`
- Fixes production website article crash `GENFEED-AI-44`
- Observed `API-GENFEED-AI-6G` and `API-GENFEED-AI-6H` as development-only local worktree fatals, not production issues

## Verification
- `bunx biome check --write apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-executor.service.ts apps/server/api/src/collections/workflows/services/workflow-executor.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts packages/helpers/src/content/schema-org.helper.ts packages/helpers/src/content/schema-org.helper.test.ts`
- `bun run --cwd apps/server/api test:file -- src/collections/workflow-executions/services/workflow-executions.service.spec.ts src/collections/workflows/services/workflow-executor.service.spec.ts src/collections/workflows/services/workflow-scheduler.service.spec.ts`
- `bun run --cwd packages/helpers test -- src/content/schema-org.helper.test.ts`
- `bun run --cwd apps/website test -- app/'(content)'/articles/'[slug]'/page.spec.tsx`
- `git diff --check`
- staged secret scan and pre-commit `secretlint`

Full workspace gates are left to PR CI per repo/local CPU policy.
