### PR TITLE
fix(ci): restore release gate after dependency update

### DIFF
--- a/apps/app/src/features/workflows/components/ui/icons/index.ts
+++ b/apps/app/src/features/workflows/components/ui/icons/index.ts
@@ -17,5 +17,5 @@ export {
   Webhook as WebhookIcon,
   X as XIcon,
 } from 'lucide-react';
-export { SiSlack as SlackIcon } from 'react-icons/si';
+export { FaSlack as SlackIcon } from 'react-icons/fa';
 export { PlatformIcon } from '@/features/workflows/components/ui/icons/platform-icon';

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -41,7 +41,7 @@
   "description": "Genfeed API Service",
   "devDependencies": {
     "@nestjs/testing": "11.1.27",
-    "@types/archiver": "8.0.0",
+    "@types/archiver": "7.0.0",
     "@types/bcrypt": "6.0.0",
     "@types/compression": "1.8.1",
     "@types/cookie-parser": "1.4.10",

--- a/bun.lock
+++ b/bun.lock
@@ -434,7 +434,7 @@
       },
       "devDependencies": {
         "@nestjs/testing": "11.1.27",
-        "@types/archiver": "8.0.0",
+        "@types/archiver": "7.0.0",
         "@types/bcrypt": "6.0.0",
         "@types/compression": "1.8.1",
         "@types/cookie-parser": "1.4.10",
@@ -3378,7 +3378,7 @@
 
     "@types/accepts": ["@types/accepts@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ=="],
 
-    "@types/archiver": ["@types/archiver@8.0.0", "", { "dependencies": { "@types/node": "*", "@types/readdir-glob": "*" } }, "sha512-YpXPbEuv9+eUIPPQWUPahj3cvs9isWRuF+J4z+KbdYVDO3rWorWQFxUVHnwPu2AgKwvgpki5F2VMX0Xx+mX45A=="],
+    "@types/archiver": ["@types/archiver@7.0.0", "", { "dependencies": { "@types/readdir-glob": "*" } }, "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 

--- a/packages/constants/src/model-brands.constant.ts
+++ b/packages/constants/src/model-brands.constant.ts
@@ -1,11 +1,5 @@
 import type { IconType } from 'react-icons';
-import {
-  SiBytedance,
-  SiGoogle,
-  SiHuggingface,
-  SiMeta,
-  SiOpenai,
-} from 'react-icons/si';
+import { SiBytedance, SiGoogle, SiHuggingface, SiMeta } from 'react-icons/si';
 
 export interface ModelBrandConfig {
   label: string;
@@ -26,7 +20,7 @@ export const MODEL_BRANDS: Record<string, ModelBrandConfig> = {
   kwaivgi: { color: '#FF2D55', label: 'Kling' },
   luma: { color: '#7C3AED', label: 'Luma' },
   meta: { color: '#0668E1', icon: SiMeta, label: 'Meta' },
-  openai: { color: '#10A37F', icon: SiOpenai, label: 'OpenAI' },
+  openai: { color: '#10A37F', label: 'OpenAI' },
   prunaai: { color: '#10B981', label: 'Pruna' },
   qwen: { color: '#6366F1', label: 'Qwen' },
   replicate: { color: '#D97706', label: 'Replicate' },

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -43,11 +43,13 @@ export interface ButtonProps
   wrapperClassName?: string;
 }
 
-const TooltipProvider = TooltipPrimitive.Provider;
+const TooltipProvider: typeof TooltipPrimitive.Provider =
+  TooltipPrimitive.Provider;
 
-const Tooltip = TooltipPrimitive.Root;
+const Tooltip: typeof TooltipPrimitive.Root = TooltipPrimitive.Root;
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
+const TooltipTrigger: typeof TooltipPrimitive.Trigger =
+  TooltipPrimitive.Trigger;
 
 function TooltipContent({
   ref,

--- a/packages/ui/src/primitives/collapsible.tsx
+++ b/packages/ui/src/primitives/collapsible.tsx
@@ -5,7 +5,7 @@ import { ChevronDown } from 'lucide-react';
 import type { ComponentPropsWithRef } from 'react';
 import { cn } from '../lib/utils';
 
-const Collapsible = CollapsiblePrimitive.Root;
+const Collapsible: typeof CollapsiblePrimitive.Root = CollapsiblePrimitive.Root;
 
 function CollapsibleTrigger({
   ref,

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -13,13 +13,13 @@ import type { ComponentPropsWithRef, HTMLAttributes } from 'react';
 import { cn } from '../lib/utils';
 import { useModalContentGlobalSideEffectCleanup } from '../utils/modal-global-side-effects';
 
-const Dialog = ShipDialog;
+const Dialog: typeof ShipDialog = ShipDialog;
 
-const DialogTrigger = ShipDialogTrigger;
+const DialogTrigger: typeof ShipDialogTrigger = ShipDialogTrigger;
 
-const DialogPortal = ShipDialogPortal;
+const DialogPortal: typeof ShipDialogPortal = ShipDialogPortal;
 
-const DialogClose = ShipDialogClose;
+const DialogClose: typeof ShipDialogClose = ShipDialogClose;
 
 function DialogOverlay({
   ref,

--- a/packages/ui/src/primitives/drawer.tsx
+++ b/packages/ui/src/primitives/drawer.tsx
@@ -16,11 +16,11 @@ const Drawer = ({
 );
 Drawer.displayName = 'Drawer';
 
-const DrawerTrigger = DrawerPrimitive.Trigger;
+const DrawerTrigger: typeof DrawerPrimitive.Trigger = DrawerPrimitive.Trigger;
 
-const DrawerPortal = DrawerPrimitive.Portal;
+const DrawerPortal: typeof DrawerPrimitive.Portal = DrawerPrimitive.Portal;
 
-const DrawerClose = DrawerPrimitive.Close;
+const DrawerClose: typeof DrawerPrimitive.Close = DrawerPrimitive.Close;
 
 function DrawerOverlay({
   ref,

--- a/packages/ui/src/primitives/dropdown-menu.tsx
+++ b/packages/ui/src/primitives/dropdown-menu.tsx
@@ -15,17 +15,21 @@ import { Check, Minus } from 'lucide-react';
 import type { ComponentPropsWithRef, HTMLAttributes } from 'react';
 import { cn } from '../lib/utils';
 
-const DropdownMenu = ShipDropdownMenu;
+const DropdownMenu: typeof ShipDropdownMenu = ShipDropdownMenu;
 
-const DropdownMenuTrigger = ShipDropdownMenuTrigger;
+const DropdownMenuTrigger: typeof ShipDropdownMenuTrigger =
+  ShipDropdownMenuTrigger;
 
-const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuGroup: typeof DropdownMenuPrimitive.Group =
+  DropdownMenuPrimitive.Group;
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuPortal: typeof DropdownMenuPrimitive.Portal =
+  DropdownMenuPrimitive.Portal;
 
-const DropdownMenuSub = ShipDropdownMenuSub;
+const DropdownMenuSub: typeof ShipDropdownMenuSub = ShipDropdownMenuSub;
 
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+const DropdownMenuRadioGroup: typeof DropdownMenuPrimitive.RadioGroup =
+  DropdownMenuPrimitive.RadioGroup;
 
 function DropdownMenuSubTrigger({
   ref,

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -10,11 +10,11 @@ import {
 import type { ComponentPropsWithRef } from 'react';
 import { cn } from '../lib/utils';
 
-const Popover = ShipPopover;
+const Popover: typeof ShipPopover = ShipPopover;
 
-const PopoverTrigger = ShipPopoverTrigger;
+const PopoverTrigger: typeof ShipPopoverTrigger = ShipPopoverTrigger;
 
-const PopoverAnchor = ShipPopoverAnchor;
+const PopoverAnchor: typeof ShipPopoverAnchor = ShipPopoverAnchor;
 
 function PopoverContent({
   ref,

--- a/packages/ui/src/primitives/select.tsx
+++ b/packages/ui/src/primitives/select.tsx
@@ -27,11 +27,11 @@ import { cn } from '../lib/utils';
 import { fieldControlPopoverClassName } from './field-control';
 import { Label } from './label';
 
-const Select = ShipSelect;
+const Select: typeof ShipSelect = ShipSelect;
 
-const SelectGroup = ShipSelectGroup;
+const SelectGroup: typeof ShipSelectGroup = ShipSelectGroup;
 
-const SelectValue = ShipSelectValue;
+const SelectValue: typeof ShipSelectValue = ShipSelectValue;
 
 const selectFieldVariants = cva('', {
   defaultVariants: {

--- a/packages/ui/src/primitives/sheet.tsx
+++ b/packages/ui/src/primitives/sheet.tsx
@@ -7,13 +7,13 @@ import type { ComponentPropsWithRef, HTMLAttributes } from 'react';
 import { cn } from '../lib/utils';
 import { useModalContentGlobalSideEffectCleanup } from '../utils/modal-global-side-effects';
 
-const Sheet = SheetPrimitive.Root;
+const Sheet: typeof SheetPrimitive.Root = SheetPrimitive.Root;
 
-const SheetTrigger = SheetPrimitive.Trigger;
+const SheetTrigger: typeof SheetPrimitive.Trigger = SheetPrimitive.Trigger;
 
-const SheetClose = SheetPrimitive.Close;
+const SheetClose: typeof SheetPrimitive.Close = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal;
+const SheetPortal: typeof SheetPrimitive.Portal = SheetPrimitive.Portal;
 
 function SheetOverlay({
   ref,

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -5,7 +5,7 @@ import type { ComponentPropsWithRef } from 'react';
 import { cn } from '../lib/utils';
 import { getTabsListClassName, getTabsTriggerClassName } from './tabs.styles';
 
-const Tabs = TabsPrimitive.Root;
+const Tabs: typeof TabsPrimitive.Root = TabsPrimitive.Root;
 
 function TabsList({
   ref,

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -4,11 +4,13 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import type { ComponentPropsWithRef, ReactElement } from 'react';
 import { cn } from '../lib/utils';
 
-const TooltipProvider = TooltipPrimitive.Provider;
+const TooltipProvider: typeof TooltipPrimitive.Provider =
+  TooltipPrimitive.Provider;
 
-const Tooltip = TooltipPrimitive.Root;
+const Tooltip: typeof TooltipPrimitive.Root = TooltipPrimitive.Root;
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
+const TooltipTrigger: typeof TooltipPrimitive.Trigger =
+  TooltipPrimitive.Trigger;
 
 function TooltipContent({
   ref,

--- a/scripts/deploy/bun.lock
+++ b/scripts/deploy/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@genfeedai/deploy-scripts",
       "dependencies": {
-        "@aws-sdk/client-ecs": "3.1075.0",
+        "@aws-sdk/client-ecs": "3.1079.0",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -13,15 +13,7 @@
     },
   },
   "packages": {
-    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
-
-    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
-
-    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
-
-    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
-
-    "@aws-sdk/client-ecs": ["@aws-sdk/client-ecs@3.1075.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.23", "@aws-sdk/credential-provider-node": "^3.972.58", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBphD+5gSs1turnfn7epbqLnPX3L+2Sk97dpHXK47Y9RLej1oqdgi6Goh9jW9AwbMeYT4GPtGMvbyDdQoDCRsA=="],
+    "@aws-sdk/client-ecs": ["@aws-sdk/client-ecs@3.1079.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/credential-provider-node": "^3.972.62", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-c7u272kLMWLShZzuOsAuGC72aj/GDw/YJfLntlyosAxuuD4Dyu3915XpRsaMGWKG7/mIre1Fke4DGYNU2s6Nhw=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.974.27", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@aws-sdk/xml-builder": "^3.972.33", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.0", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA=="],
 
@@ -49,8 +41,6 @@
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
 
-    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
-
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.33", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
@@ -61,17 +51,11 @@
 
     "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ=="],
 
-    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
-
     "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg=="],
 
     "@smithy/signature-v4": ["@smithy/signature-v4@5.6.2", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g=="],
 
     "@smithy/types": ["@smithy/types@4.15.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q=="],
-
-    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary
- remove removed `react-icons` simple-icons exports from release-critical paths (`SiOpenai`, `SiSlack`)
- refresh the isolated `scripts/deploy/bun.lock` after the AWS SDK deploy-script dependency bump
- add explicit portable annotations for shared UI primitive alias exports after the Radix dependency bump
- pin `@types/archiver` back to `7.0.0` because `8.0.0` no longer declares the callable `archiver()` factory used by the API training service

## Why
`origin/master` at `f8d9008` is red after the dependency update:
- `@genfeedai/constants` build/typecheck fails because `react-icons@5.7.0` no longer exports `SiOpenai`
- app workspace build fails because `react-icons@5.7.0` no longer exports `SiSlack` from `react-icons/si`
- `Deploy scripts CI` fails because `scripts/deploy/package.json` moved `@aws-sdk/client-ecs` to `3.1079.0` while its isolated Bun lockfile still pinned `3.1075.0`
- `packages/ui` declaration emit fails because inferred Radix primitive alias types point at Bun nested `.bun/...` dependency paths
- `@genfeedai/ee-billing` type-check fails through the API path graph because `@types/archiver@8.0.0` removed the factory export shape

## Verification
- `bunx biome check packages/constants/src/model-brands.constant.ts`
- `bun --filter @genfeedai/constants build`
- `bun --filter @genfeedai/constants type-check`
- `(cd scripts/deploy && bun install --frozen-lockfile && bun run type-check && bun test)`
- `bun --filter @genfeedai/ui build`
- `bunx biome check packages/ui/src/primitives/dialog.tsx packages/ui/src/primitives/drawer.tsx packages/ui/src/primitives/dropdown-menu.tsx packages/ui/src/primitives/popover.tsx packages/ui/src/primitives/select.tsx packages/ui/src/primitives/button.tsx packages/ui/src/primitives/collapsible.tsx packages/ui/src/primitives/tooltip.tsx packages/ui/src/primitives/sheet.tsx packages/ui/src/primitives/tabs.tsx`
- `bunx biome check apps/app/src/features/workflows/components/ui/icons/index.ts apps/server/api/package.json`
- `bun --filter @genfeedai/ee-billing type-check`
- staged secret scan via pre-commit `lint-staged` / `secretlint`
