### PR TITLE
fix(ci): pass full-suite workflow permissions

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -57,6 +57,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      issues: write
       packages: write
       pull-requests: write
       statuses: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      issues: write
       packages: write
       pull-requests: write
       statuses: write

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -25,6 +25,13 @@ concurrency:
 jobs:
   ci:
     name: CI Gate
+    # Nested reusable workflows cannot elevate permissions past this job's
+    # ceiling. Mirror ci.yml's requested token scopes explicitly so callers of
+    # full-suite can validate the complete workflow graph at startup.
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: ./.github/workflows/ci.yml
     # Release/full-suite path runs the full heavy test matrix. A reusable
     # workflow inherits the caller's originating event, so this must be an
@@ -35,6 +42,9 @@ jobs:
 
   build-verify:
     name: Build & Boot Check
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-verify.yml
     # No `secrets: inherit` — build-verify.yml only uses GITHUB_TOKEN (GHCR
     # login), which every called workflow gets automatically. Inheriting the full
@@ -43,6 +53,9 @@ jobs:
   e2e:
     name: E2E Suite
     needs: [ci, build-verify]
+    permissions:
+      contents: read
+      issues: write
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- pass CI/build/e2e token ceilings through full-suite nested reusable workflow calls
- grant issue write scope to deploy and docker-publish full-suite callers for the E2E nightly reporter job contract

## Verification
- actionlint -ignore 'SC2129' on deploy/docker/full-suite reusable workflow graph

## Release note
- Fixes GitHub Actions startup_failure for release Docker publish and production deploy workflows.