### PR TITLE
refactor(webhooks): isolate stripe webhook module

### DIFF
--- a/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.spec.ts
@@ -1,0 +1,44 @@
+import { StripeAttributionTrackerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-attribution-tracker.service';
+import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
+import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
+import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
+import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
+import { StripeWebhooksModule } from '@api/endpoints/webhooks/stripe/stripe-webhooks.module';
+import { StripeWebhookController } from '@api/endpoints/webhooks/stripe/webhooks.stripe.controller';
+import { StripeWebhookService } from '@api/endpoints/webhooks/stripe/webhooks.stripe.service';
+import { MODULE_METADATA } from '@nestjs/common/constants';
+
+describe('StripeWebhooksModule', () => {
+  it('owns the Stripe webhook controller and dispatcher boundary', () => {
+    const controllers =
+      Reflect.getMetadata(MODULE_METADATA.CONTROLLERS, StripeWebhooksModule) ??
+      [];
+    const providers =
+      Reflect.getMetadata(MODULE_METADATA.PROVIDERS, StripeWebhooksModule) ??
+      [];
+    const exports =
+      Reflect.getMetadata(MODULE_METADATA.EXPORTS, StripeWebhooksModule) ?? [];
+
+    expect(controllers).toEqual([StripeWebhookController]);
+    expect(providers).toContain(StripeWebhookService);
+    expect(exports).toContain(StripeWebhookService);
+  });
+
+  it('registers the per-concern Stripe webhook handlers', () => {
+    const providers =
+      Reflect.getMetadata(MODULE_METADATA.PROVIDERS, StripeWebhooksModule) ??
+      [];
+
+    for (const provider of [
+      StripeAttributionTrackerService,
+      StripeCheckoutWebhookHandler,
+      StripeCustomerWebhookHandler,
+      StripeInvoiceWebhookHandler,
+      StripeSubscriptionWebhookHandler,
+      StripeWebhookSupportService,
+    ]) {
+      expect(providers).toContain(provider);
+    }
+  });
+});

--- a/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.ts
@@ -1,0 +1,64 @@
+import { ActivitiesModule } from '@api/collections/activities/activities.module';
+import { ApiKeysModule } from '@api/collections/api-keys/api-keys.module';
+import { BrandsModule } from '@api/collections/brands/brands.module';
+import { CreditsModule } from '@api/collections/credits/credits.module';
+import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
+import { OrganizationsModule } from '@api/collections/organizations/organizations.module';
+import { SubscriptionAttributionsModule } from '@api/collections/subscription-attributions/subscription-attributions.module';
+import { SubscriptionsModule } from '@api/collections/subscriptions/subscriptions.module';
+import { UserSubscriptionsModule } from '@api/collections/user-subscriptions/user-subscriptions.module';
+import { UserSetupModule } from '@api/collections/users/user-setup.module';
+import { UsersModule } from '@api/collections/users/users.module';
+import { CommonModule } from '@api/common/common.module';
+import { StripeAttributionTrackerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-attribution-tracker.service';
+import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
+import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
+import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
+import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
+import { StripeWebhookController } from '@api/endpoints/webhooks/stripe/webhooks.stripe.controller';
+import { StripeWebhookService } from '@api/endpoints/webhooks/stripe/webhooks.stripe.service';
+import { StripeModule } from '@api/services/integrations/stripe/stripe.module';
+import { createServiceModule } from '@api/shared/service-module.factory';
+import { ConfigModule } from '@libs/config/config.module';
+import { ConfigService } from '@libs/config/config.service';
+import { RedisModule } from '@libs/redis/redis.module';
+import { forwardRef, Module, type Provider } from '@nestjs/common';
+
+const BaseModule = createServiceModule(StripeWebhookService, {
+  additionalImports: [
+    forwardRef(() => ActivitiesModule),
+    forwardRef(() => ApiKeysModule),
+    forwardRef(() => BrandsModule),
+    forwardRef(() => CommonModule),
+    forwardRef(() => CreditsModule),
+    forwardRef(() => OrganizationSettingsModule),
+    forwardRef(() => OrganizationsModule),
+    forwardRef(() => StripeModule),
+    forwardRef(() => SubscriptionAttributionsModule),
+    forwardRef(() => SubscriptionsModule),
+    forwardRef(() => UserSubscriptionsModule),
+    forwardRef(() => UserSetupModule),
+    forwardRef(() => UsersModule),
+    RedisModule.forRoot({
+      configModule: ConfigModule,
+      configService: ConfigService,
+    }),
+  ],
+  additionalProviders: [
+    StripeAttributionTrackerService,
+    StripeCheckoutWebhookHandler,
+    StripeCustomerWebhookHandler,
+    StripeInvoiceWebhookHandler,
+    StripeSubscriptionWebhookHandler,
+    StripeWebhookSupportService,
+  ],
+});
+
+@Module({
+  controllers: [StripeWebhookController],
+  exports: BaseModule.exports ?? [],
+  imports: BaseModule.imports ?? [],
+  providers: (BaseModule.providers ?? []) as Provider[],
+})
+export class StripeWebhooksModule {}

--- a/apps/server/api/src/endpoints/webhooks/webhooks.module.ts
+++ b/apps/server/api/src/endpoints/webhooks/webhooks.module.ts
@@ -41,14 +41,7 @@ import { AutoMergeService } from '@api/endpoints/webhooks/services/auto-merge.se
 import { MediaUploadService } from '@api/endpoints/webhooks/services/media-upload.service';
 import { MetadataLookupService } from '@api/endpoints/webhooks/services/metadata-lookup.service';
 import { PostProcessingOrchestratorService } from '@api/endpoints/webhooks/services/post-processing-orchestrator.service';
-import { StripeAttributionTrackerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-attribution-tracker.service';
-import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
-import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
-import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
-import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
-import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
-import { StripeWebhookController } from '@api/endpoints/webhooks/stripe/webhooks.stripe.controller';
-import { StripeWebhookService } from '@api/endpoints/webhooks/stripe/webhooks.stripe.service';
+import { StripeWebhooksModule } from '@api/endpoints/webhooks/stripe/stripe-webhooks.module';
 import { VercelWebhookController } from '@api/endpoints/webhooks/vercel/webhooks.vercel.controller';
 import { VercelWebhookService } from '@api/endpoints/webhooks/vercel/webhooks.vercel.service';
 import { WebhooksService } from '@api/endpoints/webhooks/webhooks.service';
@@ -71,7 +64,6 @@ import { forwardRef, Module } from '@nestjs/common';
     LeonardoaiWebhookController,
     OpusProWebhookController,
     ReplicateWebhookController,
-    StripeWebhookController,
     VercelWebhookController,
   ],
   exports: [WebhooksService],
@@ -100,6 +92,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => RolesModule),
     forwardRef(() => SettingsModule),
     forwardRef(() => StripeModule),
+    forwardRef(() => StripeWebhooksModule),
     forwardRef(() => SubscriptionAttributionsModule),
     forwardRef(() => SubscriptionsModule),
     forwardRef(() => TrainingsModule),
@@ -122,13 +115,6 @@ import { forwardRef, Module } from '@nestjs/common';
     OpusProWebhookService,
     PostProcessingOrchestratorService,
     ReplicateWebhookService,
-    StripeAttributionTrackerService,
-    StripeCheckoutWebhookHandler,
-    StripeCustomerWebhookHandler,
-    StripeInvoiceWebhookHandler,
-    StripeSubscriptionWebhookHandler,
-    StripeWebhookService,
-    StripeWebhookSupportService,
     VercelWebhookService,
     WebhooksService,
   ],


### PR DESCRIPTION
## Summary
- Add a dedicated `StripeWebhooksModule` that owns the Stripe webhook controller, thin dispatcher, per-concern handlers, attribution tracker, and shared support service.
- Compose the Stripe webhook dispatcher with `createServiceModule` and wire Redis with the repo's `ConfigService` provider pattern so the #1398 webhook idempotency controller path stays intact.
- Keep `WebhooksModule` as the aggregate webhook module by importing the Stripe module instead of directly registering Stripe providers.

Closes #707.

## Verification
- `bunx biome check --write apps/server/api/src/endpoints/webhooks/webhooks.module.ts apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.ts apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.spec.ts`
- `bun run --filter=@genfeedai/api test:file src/endpoints/webhooks/stripe/stripe-webhooks.module.spec.ts src/endpoints/webhooks/stripe/webhooks.stripe.service.spec.ts src/endpoints/webhooks/stripe/webhooks.stripe.controller.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-attribution-tracker.service.spec.ts` (9 files, 95 tests)
- `bun run check:di-value-imports`
- `git diff --check`
- staged secret scan + commit hook secretlint

## CI / local-scope note
- Did not intentionally run workspace `bun type-check` or package-wide `bun run test --filter=@genfeedai/api` locally per repo memory: heavier validation routes through PR CI.
- While preparing this PR, an initial shell-quoted PR command accidentally started Markdown command substitution and began the workspace type-check; it was interrupted immediately before completion.
