### PR TITLE
fix(pricing): declare @genfeedai/interfaces project reference

### DIFF
--- a/packages/pricing/tsconfig.json
+++ b/packages/pricing/tsconfig.json
@@ -10,11 +10,16 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "outDir": "./dist",
+    "paths": {
+      "@genfeedai/interfaces": ["../interfaces/src/index.ts"],
+      "@genfeedai/interfaces/*": ["../interfaces/src/*"]
+    },
     "rootDir": "./src",
     "skipLibCheck": true,
     "sourceMap": true,
     "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../interfaces" }]
 }


### PR DESCRIPTION
## Problem

The v0.5.0 self-hosted Docker Publish (run 28807121090) failed its Build & Boot Check: `@genfeedai/config build` → TS2307 `Cannot find module '@genfeedai/interfaces'` from `../pricing/src/plans-pricing.ts` and `pricing-config.ts`.

Root cause: `packages/pricing` imports `@genfeedai/interfaces` but is the **only consumer without a tsconfig project reference** (`client`, `helpers`, `ui` all declare it). Turbo's package-graph ordering hides this in normal CI; the self-hosted Dockerfile's hand-ordered `bun --filter <pkg> build` stage exposes it because `tsc --build` has no reference telling it to build interfaces first.

## Fix

Mirror the established consumer pattern in `packages/pricing/tsconfig.json`: `paths` mapping + `references: [{ path: "../interfaces" }]`. `tsc --build` now constructs the chain (constants/enums → interfaces → pricing → config) from source.

## Verification

`bunx tsc --build --force packages/config` → exit 0, all chain dists produced (cold-build simulation of the Docker stage entry point).

Note: v0.5.0 also needs #1414 (MCP artifact drift) — after **both** merge, re-cut the v0.5.0 tag (third cut, same version per release policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)