### PR TITLE
[codex] Replace homepage hero wall with CDN grid

### DIFF
--- a/apps/website/packages/components/home/_assets.ts
+++ b/apps/website/packages/components/home/_assets.ts
@@ -17,5 +17,31 @@ export const HOME_ASSETS = {
     reels: home('formats/reels.webp'),
     voice: home('formats/voice.webp'),
   },
-  outputWall: home('generated-output-wall.png'),
 } as const;
+
+export const HOME_OUTPUT_WALL_ASSETS = [
+  {
+    alt: 'Generated product photography contact sheet for a launch campaign',
+    src: HOME_ASSETS.formats.images,
+  },
+  {
+    alt: 'Generated short-form video frame staged for a reels campaign',
+    src: HOME_ASSETS.formats.reels,
+  },
+  {
+    alt: 'Generated ad creative variations in multiple campaign ratios',
+    src: HOME_ASSETS.formats.ads,
+  },
+  {
+    alt: 'Generated article layout with hero imagery and editorial blocks',
+    src: HOME_ASSETS.formats.articles,
+  },
+  {
+    alt: 'Generated avatar clip frame for a spoken campaign asset',
+    src: HOME_ASSETS.formats.avatars,
+  },
+  {
+    alt: 'Generated voiceover campaign asset with audio production visuals',
+    src: HOME_ASSETS.formats.voice,
+  },
+] as const;

--- a/apps/website/packages/components/home/_hero.spec.tsx
+++ b/apps/website/packages/components/home/_hero.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { HOME_OUTPUT_WALL_ASSETS } from '@web-components/home/_assets';
 import type { ImgHTMLAttributes } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import HomeHero from './_hero';
@@ -51,10 +52,27 @@ describe('HomeHero', () => {
     );
   });
 
-  it('renders the generated output wall instead of the old card deck', () => {
+  it('renders a CDN-backed generated output wall instead of static wall art', () => {
     render(<HomeHero />);
 
     expect(screen.getByTestId('home-hero-output-wall')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('home-hero-content-wall-grid'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId('home-hero-output-wall-item')).toHaveLength(
+      HOME_OUTPUT_WALL_ASSETS.length,
+    );
     expect(screen.queryByTestId('home-hero-card-deck')).not.toBeInTheDocument();
+
+    const imageSources = screen
+      .getAllByRole('img')
+      .map((image) => image.getAttribute('data-src'));
+
+    expect(imageSources).toEqual(
+      HOME_OUTPUT_WALL_ASSETS.map((asset) => asset.src),
+    );
+    expect(
+      imageSources.some((src) => src?.includes('generated-output-wall.png')),
+    ).toBe(false);
   });
 });

--- a/apps/website/packages/components/home/_hero.tsx
+++ b/apps/website/packages/components/home/_hero.tsx
@@ -6,7 +6,7 @@ import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
 import { HStack } from '@ui/layout/stack';
 import { Heading } from '@ui/typography/heading';
 import { Text } from '@ui/typography/text';
-import { HOME_ASSETS } from '@web-components/home/_assets';
+import { HOME_OUTPUT_WALL_ASSETS } from '@web-components/home/_assets';
 import Image from 'next/image';
 import { LuArrowRight } from 'react-icons/lu';
 
@@ -21,6 +21,57 @@ const HERO_METRICS: HeroMetric[] = [
   { label: 'estimated output cost', value: '$184' },
   { label: 'best hook rate', value: '31%' },
 ];
+
+const HERO_WALL_ITEMS = [
+  {
+    ...HOME_OUTPUT_WALL_ASSETS[0],
+    className:
+      'col-span-6 row-span-3 sm:col-span-5 sm:row-span-5 sm:col-start-1 sm:row-start-1',
+    imageClassName: 'object-[50%_50%]',
+    priority: true,
+    sizes: '(max-width: 640px) 100vw, (max-width: 1024px) 45vw, 360px',
+  },
+  {
+    ...HOME_OUTPUT_WALL_ASSETS[1],
+    className:
+      'col-span-3 row-span-4 sm:col-span-3 sm:row-span-9 sm:col-start-6 sm:row-start-1',
+    imageClassName: 'object-[50%_50%]',
+    priority: true,
+    sizes: '(max-width: 640px) 50vw, (max-width: 1024px) 28vw, 220px',
+  },
+  {
+    ...HOME_OUTPUT_WALL_ASSETS[2],
+    className:
+      'col-span-3 row-span-4 sm:col-span-4 sm:row-span-4 sm:col-start-9 sm:row-start-1',
+    imageClassName: 'object-[50%_50%]',
+    priority: true,
+    sizes: '(max-width: 640px) 50vw, (max-width: 1024px) 35vw, 300px',
+  },
+  {
+    ...HOME_OUTPUT_WALL_ASSETS[3],
+    className:
+      'col-span-4 row-span-3 sm:col-span-5 sm:row-span-4 sm:col-start-1 sm:row-start-6',
+    imageClassName: 'object-[48%_42%]',
+    priority: false,
+    sizes: '(max-width: 640px) 66vw, (max-width: 1024px) 42vw, 360px',
+  },
+  {
+    ...HOME_OUTPUT_WALL_ASSETS[4],
+    className:
+      'col-span-2 row-span-3 sm:col-span-4 sm:row-span-5 sm:col-start-9 sm:row-start-5',
+    imageClassName: 'object-[50%_50%]',
+    priority: false,
+    sizes: '(max-width: 640px) 34vw, (max-width: 1024px) 35vw, 300px',
+  },
+  {
+    ...HOME_OUTPUT_WALL_ASSETS[5],
+    className:
+      'col-span-6 row-span-2 sm:col-span-12 sm:row-span-3 sm:col-start-1 sm:row-start-10',
+    imageClassName: 'object-[50%_50%]',
+    priority: false,
+    sizes: '(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 860px',
+  },
+] as const;
 
 export default function HomeHero(): React.ReactElement {
   const signUpHref = `${EnvironmentService.apps.app}/sign-up?plan=payg`;
@@ -85,15 +136,27 @@ export default function HomeHero(): React.ReactElement {
             data-testid="home-hero-output-wall"
           >
             <div className="relative overflow-hidden rounded-lg bg-card shadow-border-strong">
-              <Image
-                alt="A premium Genfeed output wall showing generated images, video frames, audio clips, ads, articles, and social carousel assets"
-                className="h-auto w-full object-cover"
-                width={1693}
-                height={929}
-                priority
-                sizes="(max-width: 1024px) 100vw, 860px"
-                src={HOME_ASSETS.outputWall}
-              />
+              <div
+                className="grid aspect-[4/5] grid-cols-6 grid-rows-[repeat(12,minmax(0,1fr))] gap-2 p-2 sm:aspect-[860/620] sm:grid-cols-12 sm:p-3"
+                data-testid="home-hero-content-wall-grid"
+              >
+                {HERO_WALL_ITEMS.map((item) => (
+                  <div
+                    key={item.alt}
+                    className={`group relative min-h-0 overflow-hidden rounded-md bg-background ${item.className}`}
+                    data-testid="home-hero-output-wall-item"
+                  >
+                    <Image
+                      alt={item.alt}
+                      className={`object-cover transition-transform duration-700 group-hover:scale-[1.03] ${item.imageClassName}`}
+                      fill
+                      priority={item.priority}
+                      sizes={item.sizes}
+                      src={item.src}
+                    />
+                  </div>
+                ))}
+              </div>
               <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,transparent_54%,rgba(5,6,7,0.82))]" />
             </div>
 


### PR DESCRIPTION
## Summary

Fixes #1348.

- Replaces the homepage hero's single `generated-output-wall.png` image with a manifest-driven grid of CDN-hosted generated output assets.
- Adds `HOME_OUTPUT_WALL_ASSETS` so the hero consumes the established homepage CDN assets without adding binaries.
- Strengthens the hero spec to assert multiple CDN-backed wall items render and the old baked wall path is absent.

## Validation

- `bunx biome check --write apps/website/packages/components/home/_assets.ts apps/website/packages/components/home/_hero.tsx apps/website/packages/components/home/_hero.spec.tsx`
- `bun --filter @genfeedai/website test packages/components/home/_hero.spec.tsx`
- Browser smoke via local Next dev server + system Chrome at 1440x1000 and 390x900: 6/6 wall images loaded, 0 `generated-output-wall.png` refs.
- Pre-commit hooks ran `secretlint`, Biome staged check, `lint-no-raw-html`, and `lint-no-bespoke-card`.