### PR TITLE
Fix signup auth and marketing surfaces

### DIFF
--- a/apps/app/app/(public)/sign-up/magic-link/page.spec.tsx
+++ b/apps/app/app/(public)/sign-up/magic-link/page.spec.tsx
@@ -1,0 +1,4 @@
+import * as PageModule from '@app/(public)/sign-up/magic-link/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests('app/(public)/sign-up/magic-link/page', PageModule);

--- a/apps/app/app/(public)/sign-up/magic-link/page.tsx
+++ b/apps/app/app/(public)/sign-up/magic-link/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import SignUpBetterAuth from '../sign-up-better-auth';
+
+export const metadata: Metadata = {
+  title: 'Magic Link Sign Up | Genfeed',
+};
+
+export default function SignUpMagicLinkPage() {
+  return <SignUpBetterAuth mode="magic-link" />;
+}

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -6,6 +6,7 @@ import AuthFormLayout from '@ui/layouts/auth/AuthFormLayout';
 import { Button } from '@ui/primitives/button';
 import Field from '@ui/primitives/field';
 import { Input } from '@ui/primitives/input';
+import { ArrowLeft, MailCheck, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -15,6 +16,7 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react';
+import { FcGoogle } from 'react-icons/fc';
 import { persistOnboardingHandoffParams } from '@/lib/onboarding/onboarding-access.util';
 import {
   getAuthCallbackURL,
@@ -25,7 +27,40 @@ const subscribe = () => () => {};
 const getSnapshot = () => true;
 const getServerSnapshot = () => false;
 
-export default function SignUpBetterAuth() {
+type SignUpMode = 'chooser' | 'magic-link';
+
+interface SignUpBetterAuthProps {
+  mode?: SignUpMode;
+}
+
+const AUTH_BUTTON_CLASS_NAME =
+  'h-10 w-full justify-center gap-3 rounded-md border-border bg-background text-[15px] font-medium tracking-normal shadow-sm hover:bg-accent/50';
+
+const AUTH_LINK_CLASS_NAME =
+  'text-sm font-medium text-foreground underline underline-offset-4';
+
+const SIGN_UP_MAGIC_LINK_METADATA = { intent: 'signup' } as const;
+
+function getSignUpModeHref(
+  path: string,
+  searchParams: Pick<URLSearchParams, 'toString'>,
+) {
+  const params = searchParams.toString();
+  return params ? `${path}?${params}` : path;
+}
+
+function getLoginHref(callbackURL: string) {
+  if (callbackURL === '/') {
+    return '/login';
+  }
+
+  const params = new URLSearchParams({ callbackUrl: callbackURL });
+  return `/login?${params.toString()}`;
+}
+
+export default function SignUpBetterAuth({
+  mode = 'chooser',
+}: SignUpBetterAuthProps) {
   const searchParams = useSearchParams();
   const isMounted = useSyncExternalStore(
     subscribe,
@@ -35,10 +70,17 @@ export default function SignUpBetterAuth() {
 
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSocialSubmitting, setIsSocialSubmitting] = useState(false);
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [socialErrorMessage, setSocialErrorMessage] = useState<string | null>(
+    null,
+  );
   const callbackURL = getAuthCallbackURL(searchParams);
   const authCallbackURL = toAbsoluteAuthCallbackURL(callbackURL);
+  const chooserHref = getSignUpModeHref('/sign-up', searchParams);
+  const magicLinkHref = getSignUpModeHref('/sign-up/magic-link', searchParams);
+  const loginHref = getLoginHref(callbackURL);
 
   useEffect(() => {
     persistOnboardingHandoffParams(window.location.search);
@@ -47,12 +89,17 @@ export default function SignUpBetterAuth() {
   async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorMessage(null);
+    setSocialErrorMessage(null);
     setIsSubmitting(true);
+
+    const normalizedEmail = email.trim().toLowerCase();
+    setEmail(normalizedEmail);
 
     try {
       const result = await signIn.magicLink({
         callbackURL: authCallbackURL,
-        email,
+        email: normalizedEmail,
+        metadata: SIGN_UP_MAGIC_LINK_METADATA,
       });
       if (result?.error) {
         setErrorMessage(
@@ -70,103 +117,185 @@ export default function SignUpBetterAuth() {
   }
 
   async function handleSocialSignUp(provider: 'google') {
+    setSocialErrorMessage(null);
     setErrorMessage(null);
+    setIsSocialSubmitting(true);
     try {
       const result = await signIn.social({
         callbackURL: authCallbackURL,
         provider,
       });
       if (result?.error) {
-        setErrorMessage(
+        setSocialErrorMessage(
           result.error.message ??
             'Failed to sign up with Google. Please try again.',
         );
       }
     } catch {
-      setErrorMessage('Failed to sign up with Google. Please try again.');
+      setSocialErrorMessage('Failed to sign up with Google. Please try again.');
+    } finally {
+      setIsSocialSubmitting(false);
     }
   }
 
   if (!isMounted) {
-    return <AuthFormLayout>{null}</AuthFormLayout>;
+    return <AuthFormLayout logoSize="compact">{null}</AuthFormLayout>;
   }
 
-  if (isEmailSent) {
+  if (mode === 'magic-link' && isEmailSent) {
     return (
-      <AuthFormLayout>
+      <AuthFormLayout logoSize="compact">
         <div className="w-full max-w-sm space-y-4 text-center">
-          <p className="gen-heading-sm">Check your email</p>
+          <MailCheck
+            className="mx-auto size-8 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <p className="text-2xl font-semibold tracking-normal">
+            Check your email
+          </p>
           <p className="text-sm text-muted-foreground">
             We sent a sign-up link to <strong>{email}</strong>. Click the link
-            in the email to continue.
+            in the email to create your account.
           </p>
+          <Button
+            asChild
+            variant={ButtonVariant.OUTLINE}
+            className={AUTH_BUTTON_CLASS_NAME}
+            withWrapper={false}
+          >
+            <Link href={chooserHref}>Back to sign up</Link>
+          </Button>
+        </div>
+      </AuthFormLayout>
+    );
+  }
+
+  if (mode === 'magic-link') {
+    return (
+      <AuthFormLayout logoSize="compact">
+        <div className="w-full max-w-sm space-y-8">
+          <AuthHeader
+            title="Sign up with a magic link"
+            description="Enter your email and we'll send you a secure sign-up link."
+          />
+
+          <form onSubmit={handleMagicLink} className="space-y-4">
+            <Field label="Email" isRequired>
+              <Input
+                type="email"
+                name="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setEmail(e.target.value)
+                }
+                autoFocus
+                isRequired
+                isDisabled={isSubmitting}
+                hasError={!!errorMessage}
+              />
+            </Field>
+
+            {errorMessage ? (
+              <p className="text-sm text-destructive">{errorMessage}</p>
+            ) : null}
+
+            <Button
+              type="submit"
+              variant={ButtonVariant.DEFAULT}
+              isLoading={isSubmitting}
+              isDisabled={!email.trim() || isSubmitting}
+              className="h-10 w-full justify-center text-[15px] font-medium tracking-normal"
+              withWrapper={false}
+            >
+              Email me a sign-up link
+            </Button>
+          </form>
+
+          <BackToChooser href={chooserHref} />
         </div>
       </AuthFormLayout>
     );
   }
 
   return (
-    <AuthFormLayout>
-      <div className="w-full max-w-sm space-y-6">
-        <form onSubmit={handleMagicLink} className="space-y-4">
-          <Field label="Email" isRequired>
-            <Input
-              type="email"
-              name="email"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setEmail(e.target.value)
-              }
-              isRequired
-              isDisabled={isSubmitting}
-              hasError={!!errorMessage}
-            />
-          </Field>
+    <AuthFormLayout logoSize="compact">
+      <div className="w-full max-w-[320px] space-y-8">
+        <AuthHeader
+          title="Create your account"
+          description="Start using Genfeed"
+        />
 
-          {errorMessage ? (
-            <p className="text-sm text-destructive">{errorMessage}</p>
-          ) : null}
-
+        <div className="space-y-4">
           <Button
-            type="submit"
-            variant={ButtonVariant.DEFAULT}
-            isLoading={isSubmitting}
-            isDisabled={!email || isSubmitting}
-            className="w-full"
+            type="button"
+            variant={ButtonVariant.OUTLINE}
+            onClick={() => handleSocialSignUp('google')}
+            icon={<FcGoogle className="size-4" aria-hidden="true" />}
+            isLoading={isSocialSubmitting}
+            className={AUTH_BUTTON_CLASS_NAME}
             withWrapper={false}
           >
-            Continue with email
+            Google
           </Button>
-        </form>
 
-        <div className="relative">
-          <div className="gen-divider" />
-          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
-            or
-          </span>
+          <Button
+            asChild
+            variant={ButtonVariant.OUTLINE}
+            className={AUTH_BUTTON_CLASS_NAME}
+            withWrapper={false}
+          >
+            <Link href={magicLinkHref}>
+              <Sparkles className="size-4" aria-hidden="true" />
+              <span>Magic Link</span>
+            </Link>
+          </Button>
         </div>
 
-        <Button
-          type="button"
-          variant={ButtonVariant.OUTLINE}
-          onClick={() => handleSocialSignUp('google')}
-          className="w-full"
-          withWrapper={false}
-        >
-          Continue with Google
-        </Button>
+        {socialErrorMessage ? (
+          <p className="text-center text-sm text-destructive">
+            {socialErrorMessage}
+          </p>
+        ) : null}
 
-        <p className="text-center text-sm text-muted-foreground">
+        <p className="text-center text-xs leading-5 text-muted-foreground">
           Already have an account?{' '}
-          <Link
-            href={`/login?callbackUrl=${encodeURIComponent(callbackURL)}`}
-            className="text-foreground underline underline-offset-4"
-          >
+          <Link href={loginHref} className={AUTH_LINK_CLASS_NAME}>
             Sign in
           </Link>
         </p>
       </div>
     </AuthFormLayout>
+  );
+}
+
+function AuthHeader({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <div className="space-y-2 text-center">
+      <h1 className="text-2xl font-semibold tracking-normal text-foreground">
+        {title}
+      </h1>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function BackToChooser({ href }: { href: string }) {
+  return (
+    <div className="text-center">
+      <Link
+        href={href}
+        className="inline-flex items-center justify-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" aria-hidden="true" />
+        Back to sign up options
+      </Link>
+    </div>
   );
 }

--- a/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ONBOARDING_STORAGE_KEYS } from '@/lib/onboarding/onboarding-access.util';
+import SignUpBetterAuth from './sign-up-better-auth';
 import SignUpForm from './sign-up-form';
 
 const authClientMocks = vi.hoisted(() => ({
@@ -23,8 +24,16 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@ui/layouts/auth/AuthFormLayout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="auth-form-layout">{children}</div>
+  default: ({
+    children,
+    logoSize,
+  }: {
+    children: React.ReactNode;
+    logoSize?: string;
+  }) => (
+    <div data-logo-size={logoSize} data-testid="auth-form-layout">
+      {children}
+    </div>
   ),
 }));
 
@@ -53,6 +62,7 @@ describe('SignUpForm', () => {
     authClientMocks.magicLink.mockReset();
     authClientMocks.magicLink.mockResolvedValue({});
     authClientMocks.social.mockReset();
+    authClientMocks.social.mockResolvedValue({});
     localStorageMock.clear();
 
     Object.defineProperty(globalThis, 'localStorage', {
@@ -67,38 +77,65 @@ describe('SignUpForm', () => {
     window.history.replaceState({}, '', '/sign-up');
   });
 
-  it('renders the Better Auth sign-up magic-link form', () => {
+  it('renders the Better Auth sign-up chooser like the login chooser', () => {
     render(<SignUpForm />);
 
-    expect(screen.getByTestId('auth-form-layout')).toBeInTheDocument();
-    expect(getEmailInput()).toBeInTheDocument();
+    expect(screen.getByTestId('auth-form-layout')).toHaveAttribute(
+      'data-logo-size',
+      'compact',
+    );
     expect(
-      screen.getByRole('button', { name: 'Continue with email' }),
-    ).toBeDisabled();
-    expect(
-      screen.getByRole('button', { name: 'Continue with Google' }),
+      screen.getByRole('heading', { name: 'Create your account' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Google' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Magic Link' })).toHaveAttribute(
+      'href',
+      '/sign-up/magic-link',
+    );
+    expect(screen.queryByRole('textbox', { name: /^Email/ })).toBeNull();
     expect(
       screen.queryByRole('button', { name: 'Continue with GitHub' }),
     ).toBeNull();
   });
 
-  it('sends a sign-up magic link with the callback URL', async () => {
-    window.history.replaceState({}, '', '/sign-up?callbackUrl=%2Fonboarding');
+  it('preserves sign-up handoff params when linking to the magic-link screen', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/sign-up?plan=pro&callbackUrl=%2Fonboarding',
+    );
 
     render(<SignUpForm />);
 
+    expect(screen.getByRole('link', { name: 'Magic Link' })).toHaveAttribute(
+      'href',
+      '/sign-up/magic-link?plan=pro&callbackUrl=%2Fonboarding',
+    );
+  });
+
+  it('focuses the email input on the magic-link screen', () => {
+    render(<SignUpBetterAuth mode="magic-link" />);
+
+    expect(getEmailInput()).toHaveFocus();
+  });
+
+  it('sends a sign-up magic link with signup metadata and the callback URL', async () => {
+    window.history.replaceState({}, '', '/sign-up?callbackUrl=%2Fonboarding');
+
+    render(<SignUpBetterAuth mode="magic-link" />);
+
     fireEvent.change(getEmailInput(), {
-      target: { value: 'new@example.com' },
+      target: { value: ' New@Example.com ' },
     });
     fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with email' }),
+      screen.getByRole('button', { name: 'Email me a sign-up link' }),
     );
 
     await waitFor(() => {
       expect(authClientMocks.magicLink).toHaveBeenCalledWith({
         callbackURL: absoluteCallback('/onboarding'),
         email: 'new@example.com',
+        metadata: { intent: 'signup' },
       });
     });
     expect(screen.getByText('Check your email')).toBeInTheDocument();
@@ -141,9 +178,7 @@ describe('SignUpForm', () => {
 
     render(<SignUpForm />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Continue with Google' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Google' }));
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
@@ -163,7 +198,9 @@ describe('SignUpForm', () => {
     render(<SignUpForm />);
 
     await waitFor(() => {
-      expect(getEmailInput()).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Create your account' }),
+      ).toBeInTheDocument();
     });
 
     expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.selectedCredits)).toBe(

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -1,12 +1,14 @@
 import type { RateLimit } from 'better-auth';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  assertSignupMagicLinkCanCreateUser,
   buildBetterAuthOrganizationOptions,
   buildRateLimitStorage,
   createBetterAuthInstance,
   resolveBetterAuthJwtAccess,
   resolveBetterAuthJwtIsSuperAdmin,
   resolveBetterAuthJwtOrganizationId,
+  SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE,
 } from './better-auth.factory';
 import type {
   IBetterAuthRateLimitStore,
@@ -336,6 +338,61 @@ describe('buildBetterAuthOrganizationOptions', () => {
     ).rejects.toThrow(
       'Genfeed InvitationService owns organization invitations',
     );
+  });
+});
+
+describe('assertSignupMagicLinkCanCreateUser', () => {
+  it('does not query for normal login magic links', async () => {
+    const prisma = createPrismaMock();
+
+    await expect(
+      assertSignupMagicLinkCanCreateUser({
+        email: 'existing@example.com',
+        prisma: prisma as unknown as PrismaForBetterAuth,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('allows signup magic links for emails without an active user', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findFirst.mockResolvedValue(null);
+
+    await expect(
+      assertSignupMagicLinkCanCreateUser({
+        email: ' New@Example.com ',
+        metadata: { intent: 'signup' },
+        prisma: prisma as unknown as PrismaForBetterAuth,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      select: { id: true },
+      where: {
+        email: { equals: 'new@example.com', mode: 'insensitive' },
+        isDeleted: false,
+      },
+    });
+  });
+
+  it('rejects signup magic links when the email already belongs to a user', async () => {
+    const prisma = createPrismaMock();
+    prisma.user.findFirst.mockResolvedValue({ id: 'user_existing' });
+
+    await expect(
+      assertSignupMagicLinkCanCreateUser({
+        email: 'existing@example.com',
+        metadata: { intent: 'signup' },
+        prisma: prisma as unknown as PrismaForBetterAuth,
+      }),
+    ).rejects.toMatchObject({
+      body: expect.objectContaining({
+        code: 'USER_ALREADY_EXISTS',
+        message: SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE,
+      }),
+      status: 'BAD_REQUEST',
+    });
   });
 });
 

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { dash } from '@better-auth/infra';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
-import { betterAuth, type RateLimit } from 'better-auth';
+import { APIError, betterAuth, type RateLimit } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import {
   jwt,
@@ -24,6 +24,10 @@ const RATE_LIMIT_KEY_PREFIX = 'ba:ratelimit:';
 const RATE_LIMIT_TTL_SECONDS = 86_400;
 const BETTER_AUTH_CREATOR_ROLE = 'admin';
 const BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY = 'BUSINESS';
+const SIGN_UP_MAGIC_LINK_INTENT = 'signup';
+
+export const SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE =
+  'An account already exists for this email. Sign in instead.';
 
 /**
  * Adapt the shared Redis KV into Better Auth's `rateLimit.customStorage` shape
@@ -72,6 +76,44 @@ function getRequiredString(value: unknown, label: string): string {
   return resolved;
 }
 
+function isSignUpMagicLink(metadata?: Record<string, unknown>): boolean {
+  return metadata?.intent === SIGN_UP_MAGIC_LINK_INTENT;
+}
+
+export async function assertSignupMagicLinkCanCreateUser({
+  email,
+  metadata,
+  prisma,
+}: {
+  email: string;
+  metadata?: Record<string, unknown>;
+  prisma: ICreateBetterAuthOptions['prisma'];
+}): Promise<void> {
+  if (!isSignUpMagicLink(metadata)) {
+    return;
+  }
+
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!normalizedEmail) {
+    return;
+  }
+
+  const existingUser = await prisma.user.findFirst({
+    select: { id: true },
+    where: {
+      email: { equals: normalizedEmail, mode: 'insensitive' },
+      isDeleted: false,
+    },
+  });
+
+  if (existingUser) {
+    throw APIError.from('BAD_REQUEST', {
+      code: 'USER_ALREADY_EXISTS',
+      message: SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE,
+    });
+  }
+}
+
 /**
  * Maps Better Auth's organization plugin onto Genfeed's existing domain tables.
  *
@@ -84,7 +126,7 @@ function getRequiredString(value: unknown, label: string): string {
  * native endpoint can grant a Genfeed Role without going through RolesGuard.
  */
 export function buildBetterAuthOrganizationOptions(
-  prisma: ICreateBetterAuthOptions['prisma'],
+  _prisma: ICreateBetterAuthOptions['prisma'],
 ): OrganizationOptions {
   return {
     creatorRole: BETTER_AUTH_CREATOR_ROLE,
@@ -539,8 +581,13 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
         // them. Lookup re-hashes the incoming token, so any in-flight plaintext
         // links issued before this change fail until they expire (~min TTL).
         storeToken: 'hashed',
-        sendMagicLink: async ({ email, url, token }) => {
-          await sendMagicLink({ email, url, token });
+        sendMagicLink: async ({ email, metadata, url, token }) => {
+          await assertSignupMagicLinkCanCreateUser({
+            email,
+            metadata,
+            prisma,
+          });
+          await sendMagicLink({ email, metadata, url, token });
         },
       }),
       organization(buildBetterAuthOrganizationOptions(prisma)),

--- a/apps/server/api/src/auth/better-auth/better-auth.types.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.types.ts
@@ -43,6 +43,7 @@ export interface IBetterAuthResolvedIdentity {
 /** Arguments handed to the magic-link delivery callback. */
 export interface IBetterAuthMagicLinkParams {
   email: string;
+  metadata?: Record<string, unknown>;
   url: string;
   token: string;
 }

--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.spec.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.spec.ts
@@ -35,6 +35,36 @@ describe('BetterAuthMailerService', () => {
     expect(html).toContain('If you did not request this sign-in link');
   });
 
+  it('sends signup magic links with account creation copy', async () => {
+    const notificationsService = {
+      sendEmail: vi.fn().mockResolvedValue(undefined),
+    };
+    const logger = { log: vi.fn() };
+    const service = new BetterAuthMailerService(
+      notificationsService as never,
+      logger as never,
+    );
+    const url =
+      'https://api.genfeed.ai/v1/auth/magic-link/verify?token=tok&callbackURL=https%3A%2F%2Fapp.genfeed.ai%2F';
+
+    await service.sendMagicLink({
+      email: 'user@example.com',
+      metadata: { intent: 'signup' },
+      token: 'tok',
+      url,
+    });
+
+    expect(notificationsService.sendEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      'Your Genfeed.ai sign-up link',
+      expect.stringContaining('<!doctype html>'),
+    );
+    const html = notificationsService.sendEmail.mock.calls[0]?.[2] as string;
+    expect(html).toContain('Create your Genfeed.ai account');
+    expect(html).toContain('Create account');
+    expect(html).toContain('If you did not create a Genfeed.ai account');
+  });
+
   it('sends email verification with the shared Genfeed system email shell', async () => {
     const notificationsService = {
       sendEmail: vi.fn().mockResolvedValue(undefined),

--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
@@ -28,10 +28,15 @@ export class BetterAuthMailerService {
 
   async sendMagicLink({
     email,
+    metadata,
     url,
   }: IBetterAuthMagicLinkParams): Promise<void> {
-    const subject = 'Your Genfeed.ai sign-in link';
-    const html = this.buildMagicLinkHtml(url);
+    const purpose = metadata?.intent === 'signup' ? 'sign-up' : 'sign-in';
+    const subject =
+      purpose === 'sign-up'
+        ? 'Your Genfeed.ai sign-up link'
+        : 'Your Genfeed.ai sign-in link';
+    const html = this.buildMagicLinkHtml(url, purpose);
 
     await this.notificationsService.sendEmail(email, subject, html);
 
@@ -57,22 +62,33 @@ export class BetterAuthMailerService {
     });
   }
 
-  private buildMagicLinkHtml(url: string): string {
+  private buildMagicLinkHtml(
+    url: string,
+    purpose: 'sign-in' | 'sign-up',
+  ): string {
     const escapedUrl = escapeSystemEmailHtml(url);
+    const isSignUp = purpose === 'sign-up';
 
     return buildSystemEmailHtml({
-      action: { label: 'Sign in', url },
+      action: { label: isSignUp ? 'Create account' : 'Sign in', url },
       bodyHtml: [
         buildSystemEmailParagraph(
-          'Click the button below to sign in. This link expires shortly and can only be used once.',
+          isSignUp
+            ? 'Click the button below to create your account. This link expires shortly and can only be used once.'
+            : 'Click the button below to sign in. This link expires shortly and can only be used once.',
         ),
         '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
         `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
       ].join(''),
-      footerNote:
-        'If you did not request this sign-in link, you can safely ignore this email.',
-      preheader: 'Use this one-time link to sign in to Genfeed.ai.',
-      title: 'Sign in to Genfeed.ai',
+      footerNote: isSignUp
+        ? 'If you did not create a Genfeed.ai account, you can safely ignore this email.'
+        : 'If you did not request this sign-in link, you can safely ignore this email.',
+      preheader: isSignUp
+        ? 'Use this one-time link to create your Genfeed.ai account.'
+        : 'Use this one-time link to sign in to Genfeed.ai.',
+      title: isSignUp
+        ? 'Create your Genfeed.ai account'
+        : 'Sign in to Genfeed.ai',
     });
   }
 

--- a/apps/website/app/(public)/pricing/pricing-content.test.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.test.tsx
@@ -59,6 +59,37 @@ describe('PricingContent launch pricing', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses the tokenized dark card surface for the popular plan', () => {
+    render(<PricingContent />);
+
+    expect(screen.getByText('Popular').closest('.gsap-card')).toHaveClass(
+      'bg-card',
+    );
+  });
+
+  it('renders the enterprise card on the shared grid border surface', () => {
+    render(<PricingContent />);
+
+    const enterpriseCard = screen
+      .getByRole('heading', { name: 'Your own studio, fully managed.' })
+      .closest('.shadow-border');
+
+    expect(enterpriseCard).toHaveClass('bg-background');
+    expect(enterpriseCard).not.toHaveClass('border');
+    expect(enterpriseCard?.parentElement).toHaveClass('border-edge/10');
+    expect(enterpriseCard?.parentElement).toHaveClass('bg-edge/5');
+  });
+
+  it('renders an even number of pricing FAQ blocks', () => {
+    render(<PricingContent />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Can I start free and upgrade later?',
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('does not strike through prices on plans without launch pricing', () => {
     render(<PricingContent />);
 

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -63,6 +63,11 @@ const FAQ_ITEMS = [
   },
   {
     answer:
+      'Yes. Start on Pay As You Go with no monthly fee, then move to Pro when included credits make your monthly output cheaper. Scale is for shared seats, budgets, and higher-volume team workflows.',
+    question: 'Can I start free and upgrade later?',
+  },
+  {
+    answer:
       'Book a demo when you need team rollout planning, migration support, enterprise terms, or a multi-brand workflow designed before signup.',
     question: 'When should I book a demo?',
   },
@@ -157,9 +162,9 @@ export default function PricingContent() {
         description="Signing up is free. Credits buy the content you generate; a subscription makes those credits cheaper and unlocks unlimited brands, more channels, and shared team seats."
       >
         <WebSection maxWidth="lg" py="md">
-          <div className="grid gap-px overflow-hidden border border-edge/5 bg-fill/5 md:grid-cols-4">
+          <div className="grid gap-px overflow-hidden border border-edge/10 bg-edge/5 md:grid-cols-4">
             {PRICING_RULES.map((rule) => (
-              <div key={rule} className="bg-background px-5 py-4">
+              <div key={rule} className="bg-background px-5 py-4 shadow-border">
                 <div className="flex items-center gap-2 text-sm text-surface/65">
                   <HiCheckCircle className="size-4 text-success" />
                   {rule}
@@ -193,7 +198,7 @@ export default function PricingContent() {
                   padding="lg"
                   className={cn(
                     'relative gsap-card',
-                    isFeatured && 'bg-white/[0.03]',
+                    isFeatured && 'bg-card hover:bg-card',
                   )}
                   tierLabel={`${String(index + 1).padStart(2, '0')} / ${getDisplayName(plan.label)}`}
                 >
@@ -288,34 +293,41 @@ export default function PricingContent() {
           </p>
 
           {enterprisePlan ? (
-            <div className="mt-4 flex flex-col gap-6 border border-edge/5 bg-background p-8 md:flex-row md:items-center md:justify-between">
-              <div className="max-w-2xl">
-                <div className="mb-3 text-[10px] font-black uppercase tracking-widest text-surface/45">
-                  Enterprise
-                </div>
-                <h3 className="mb-2 text-2xl font-semibold tracking-[-0.02em]">
-                  Your own studio, fully managed.
-                </h3>
-                <p className="text-sm leading-6 text-surface/65">
-                  Custom output terms, unlimited seats and organizations, full
-                  API access, white-label, SSO, and a dedicated account manager.
-                </p>
-              </div>
-              <Button
-                asChild
-                className="shrink-0"
-                size={ButtonSize.PUBLIC}
-                variant={ButtonVariant.OUTLINE}
+            <NeuralGrid columns={1} className="mt-4">
+              <NeuralGridItem
+                padding="sm"
+                className="flex flex-col gap-6 p-8 md:flex-row md:items-center md:justify-between"
               >
-                <a
-                  href={enterprisePlan.ctaHref || EnvironmentService.calendly}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <div className="max-w-2xl">
+                  <div className="mb-3 text-[10px] font-black uppercase tracking-widest text-surface/45">
+                    Enterprise
+                  </div>
+                  <h3 className="mb-2 text-2xl font-semibold tracking-[-0.02em]">
+                    Your own studio, fully managed.
+                  </h3>
+                  <p className="text-sm leading-6 text-surface/65">
+                    Custom output terms, unlimited seats and organizations, full
+                    API access, white-label, SSO, and a dedicated account
+                    manager.
+                  </p>
+                </div>
+
+                <Button
+                  asChild
+                  className="shrink-0"
+                  size={ButtonSize.PUBLIC}
+                  variant={ButtonVariant.OUTLINE}
                 >
-                  Book a Demo
-                </a>
-              </Button>
-            </div>
+                  <a
+                    href={enterprisePlan.ctaHref || EnvironmentService.calendly}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Book a Demo
+                  </a>
+                </Button>
+              </NeuralGridItem>
+            </NeuralGrid>
           ) : null}
         </WebSection>
 
@@ -326,11 +338,11 @@ export default function PricingContent() {
             className="[&_h2]:text-5xl mb-4"
           />
 
-          <div className="grid gap-px overflow-hidden border border-edge/5 bg-fill/5 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-px overflow-hidden border border-edge/10 bg-edge/5 sm:grid-cols-2 lg:grid-cols-3">
             {OUTPUT_COSTS.map((row) => (
               <div
                 key={row.label}
-                className="flex items-baseline justify-between gap-4 bg-background px-5 py-4"
+                className="flex items-baseline justify-between gap-4 bg-background px-5 py-4 shadow-border"
               >
                 <span className="text-sm text-surface/65">{row.label}</span>
                 <span className="text-sm font-semibold text-surface">
@@ -348,11 +360,11 @@ export default function PricingContent() {
             Top up any amount from $10 — pay-as-you-go, no subscription. 1
             credit = $0.01.
           </p>
-          <div className="grid gap-px overflow-hidden border border-edge/5 bg-fill/5 sm:grid-cols-3">
+          <div className="grid gap-px overflow-hidden border border-edge/10 bg-edge/5 sm:grid-cols-3">
             {WEBSITE_CREDIT_PACKS.map((pack) => (
               <div
                 key={pack.label}
-                className="flex items-baseline justify-between gap-4 bg-background px-5 py-4"
+                className="flex items-baseline justify-between gap-4 bg-background px-5 py-4 shadow-border"
               >
                 <span className="text-sm font-semibold text-surface">
                   ${creditPackPrice(pack).toLocaleString()}

--- a/apps/website/packages/components/content/neural-grid.variants.ts
+++ b/apps/website/packages/components/content/neural-grid.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const neuralGridVariants = cva(
-  'grid gap-px bg-fill/5 border border-edge/5 overflow-hidden',
+  'grid gap-px bg-edge/5 border border-edge/10 overflow-hidden',
   {
     defaultVariants: {
       columns: 3,
@@ -24,7 +24,7 @@ export const neuralGridVariants = cva(
 );
 
 export const neuralGridItemVariants = cva(
-  'bg-background group hover:bg-fill/[0.02] transition-colors',
+  'bg-background shadow-border group hover:bg-fill/[0.02] transition-colors',
   {
     defaultVariants: {
       align: 'left',

--- a/apps/website/packages/components/home/_formats.tsx
+++ b/apps/website/packages/components/home/_formats.tsx
@@ -103,7 +103,7 @@ export default function HomeFormats(): React.ReactElement {
           {OUTPUT_FORMATS.map((format) => (
             <div
               key={format.title}
-              className="group flex flex-col bg-background"
+              className="group flex flex-col bg-background shadow-border"
             >
               <div className="relative aspect-[16/10] overflow-hidden bg-card">
                 <Image

--- a/packages/ui/src/components/topbars/public/TopbarPublic.tsx
+++ b/packages/ui/src/components/topbars/public/TopbarPublic.tsx
@@ -143,10 +143,8 @@ export default function TopbarPublic({
     <>
       <header
         className={cn(
-          'fixed inset-x-0 top-0 z-50 w-full transition-all duration-300',
-          isScrolled
-            ? 'border-b border-white/10 bg-primary/60 backdrop-blur-2xl'
-            : 'border-b border-transparent bg-transparent',
+          'fixed inset-x-0 top-0 z-50 w-full border-b bg-background/90 backdrop-blur-2xl transition-[border-color,background-color] duration-300',
+          isScrolled ? 'border-edge/10' : 'border-transparent',
         )}
       >
         <div className="container mx-auto flex items-center justify-between h-20 px-6">


### PR DESCRIPTION
## Summary
- align signup with login-style chooser and add /sign-up/magic-link with autofocus
- mark signup magic-link requests and reject existing active-user emails before sending mail
- restore dark glass public topbar and tighten pricing/card border surfaces

## Verification
- bunx biome check --write <changed files>
- bun run --cwd apps/app test app/(public)/sign-up/sign-up-form.test.tsx app/(public)/sign-up/magic-link/page.spec.tsx
- bun run --cwd apps/server/api test:file src/auth/better-auth/better-auth.factory.spec.ts src/auth/better-auth/services/better-auth-mailer.service.spec.ts
- bun run --cwd apps/website test app/(public)/pricing/pricing-content.test.tsx
- bun run design:lint (0 errors; existing DESIGN.md warnings only)
