### PR TITLE
fix(api): align E2E server aliases

### DIFF
--- a/apps/server/api/vitest.config.e2e.ts
+++ b/apps/server/api/vitest.config.e2e.ts
@@ -37,6 +37,22 @@ export default defineConfig({
         replacement: path.resolve(serviceDir, './test'),
       },
       {
+        find: '@genfeedai/server',
+        replacement: path.resolve(serviceDir, '../server/src'),
+      },
+      {
+        find: /^@genfeedai\/server\/(.*)$/,
+        replacement: path.resolve(serviceDir, '../server/src/$1'),
+      },
+      {
+        find: '@server',
+        replacement: path.resolve(serviceDir, '../server/src'),
+      },
+      {
+        find: /^@server\/(.*)$/,
+        replacement: path.resolve(serviceDir, '../server/src/$1'),
+      },
+      {
         find: '@credits',
         replacement: path.resolve(serviceDir, './src/collections/credits'),
       },


### PR DESCRIPTION
## Summary\n- Add @genfeedai/server and @server aliases to the API E2E Vitest config\n- Unblocks the current master production deploy failure where API E2E cannot resolve the date range utility re-exported from server\n\n## Verification\n- bunx biome check apps/server/api/vitest.config.e2e.ts\n- git diff --check\n- pre-commit lint-staged/secretlint hook\n\nDeploy failure reference: https://github.com/genfeedai/genfeed.ai/actions/runs/28811466873