### PR TITLE
docs(sessions): log 2026-07-06 session 2 (red-PR triage)

### DIFF
--- a/.agents/SESSIONS/2026-07-06.md
+++ b/.agents/SESSIONS/2026-07-06.md
@@ -53,3 +53,47 @@ local dirty brands.controller.ts (`import type` on DI services)
 - [ ] Merge rebased PRs as CI greens; re-rebase remaining siblings after each (openapi.json regen)
 - [ ] UNSTABLE PRs need CI fixes: #1311, #1313, #1325, #1329, #1339, #1349, #1350, #1352, #1359, #1368
 - [ ] Possible duplicate family to reconcile: #1326 vs draft #1312 (MCP tools from OpenAPI); #1337 vs #1329 (unlimited seats)
+
+## Session 2 — Red-PR triage: stale-base react-icons failure + #1408 conflict resolution
+
+### Flow
+
+```
+gh pr list (6 open) ──► 2 green (#1417 #1416) ──► merge attempt ──► classifier blocked ──► left for Vincent
+                    └─► 4 red (#1405 #1406 #1407 #1408) ──► log dig ──► shared root cause:
+                          base f8d900888 "chore: update dependencies" bumped react-icons→5.7.0
+                          (dropped SiOpenai export) ──► @genfeedai/constants#build fails ──► cascades
+                          into Lint/Typecheck/all test jobs. Master fix d8fcf0476 (#1404) landed
+                          ~15 min AFTER their CI runs ──► stale merge refs, not PR bugs.
+                          ├─► #1405 #1406 #1407: gh pr update-branch ──► CI green
+                          └─► #1408 (CONFLICTING): merge master locally; only conflict =
+                              mcp-tools.generated.ts (both sides regenerated) ──► re-ran
+                              generate:mcp-tools on merged tree (1019 tools + operations bindings),
+                              freshness check ✅, tools 35/35 + mcp 244/244 ──► pushed 93df6e31c
+```
+
+### Affected components
+
+- CI only (no product code authored); PR branches `codex/1397-mcp-tools-freshness-gate`, `codex/941-self-hosted-e2e`, `codex/1379-app-design-coverage`, `codex/1249-1250-generated-mcp-dispatch`
+
+### What was done
+
+- [x] Verified #1417 (pricing tsconfig ref) + #1416 (Stripe webhook module) fully green across all 24 checks, mergeable
+- [x] Root-caused all 4 red PRs to one stale-base failure: react-icons 5.7.0 removed `SiOpenai` used by `packages/constants/src/model-brands.constant.ts`; master fix `d8fcf0476` (#1404) postdated their CI runs
+- [x] `gh pr update-branch` on #1405/#1406/#1407 → all re-ran green
+- [x] Resolved #1408 conflict: merged master, regenerated MCP artifacts (`generate:mcp-tools`, 1019 tools), focused tests green (`@genfeedai/tools` 35/35, `@genfeedai/mcp` 244/244), pushed merge commit `93df6e31c`
+- [x] Background-monitored CI to completion: all 4 PRs 0 failing, 0 pending
+
+### Key decisions
+
+- **Regenerate, don't pick a side**, for generated-artifact conflicts (`mcp-tools.generated.ts`): run the generator on the merged tree so output matches both parents' inputs; validated with `generate:mcp-tools:check`.
+- **Diagnose before touching branches**: compared merge-bases + fix-commit timestamps to prove failures were stale-base, avoiding needless per-PR "fixes".
+
+### Mistakes and fixes
+
+- `gh pr merge` denied by auto-mode permission classifier (no visible human approval) — did not work around; merges left for Vincent.
+
+### Next steps
+
+- [ ] Vincent merges 6 verified-green PRs: #1417, #1416, #1405, #1406, #1407, #1408
+- [ ] New PRs #1420 (homepage hero CDN grid) + #1422 (signup auth) — CI was still running, nothing failing; out of this session's scope


### PR DESCRIPTION
## Summary
- Append Session 2 entry to `.agents/SESSIONS/2026-07-06.md`: red-PR triage (#1405–#1408 stale-base react-icons 5.7.0 / `SiOpenai` failure), branch updates, and the #1408 generated-artifact conflict resolution.

## Verification
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)